### PR TITLE
Fixes #3472: allows to dl archives as zip

### DIFF
--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/RestGetGitCommitAsZip.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/RestGetGitCommitAsZip.scala
@@ -70,16 +70,16 @@ class RestGetGitCommitAsZip(
      * API not authenticated but restricted to localhost.
      * See http://www.rudder-project.org/redmine/issues/2990
      */
-    case Get("secure" :: "administration" :: "archiveManagement" :: "zip" :: "groups"     :: commitId :: Nil, req) =>
+    case Get("secure" :: "utilities" :: "archiveManagement" :: "zip" :: "groups"     :: commitId :: Nil, req) =>
       getZip(commitId, List("groups"))
 
-    case Get("secure" :: "administration" :: "archiveManagement" :: "zip" :: "directives" :: commitId :: Nil, req) =>
+    case Get("secure" :: "utilities" :: "archiveManagement" :: "zip" :: "directives" :: commitId :: Nil, req) =>
       getZip(commitId, List("directives"))
 
-    case Get("secure" :: "administration" :: "archiveManagement" :: "zip" :: "rules"      :: commitId :: Nil, req) =>
+    case Get("secure" :: "utilities" :: "archiveManagement" :: "zip" :: "rules"      :: commitId :: Nil, req) =>
       getZip(commitId, List("rules"))
 
-    case Get("secure" :: "administration" :: "archiveManagement" :: "zip" :: "all"        :: commitId :: Nil, req) =>
+    case Get("secure" :: "utilities" :: "archiveManagement" :: "zip" :: "all"        :: commitId :: Nil, req) =>
       getZip(commitId, List("groups", "directives", "rules"))
 
 


### PR DESCRIPTION
Missing renaming when the "utilities" tab was added. 
