### PR TITLE
Fixes #3702: excludes rudder-doc from URL rewriting

### DIFF
--- a/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -85,6 +85,11 @@ class Boot extends Loggable {
     // where to search snippet
     LiftRules.addToPackages("com.normation.rudder.web")
 
+    //exclude Rudder doc from context-path rewriting
+    LiftRules.excludePathFromContextPathRewriting.default.set(() => (path:String) => {
+      path.startsWith("/rudder-doc")
+    })
+
     // REST API
     LiftRules.statelessDispatch.append(RestStatus)
     LiftRules.statelessDispatch.append(RudderConfig.restDeploy)


### PR DESCRIPTION
As we want to add Rudder doc in package and serve it from Apache, we need to be able in Rudder to redirect to outside the webapp. 
