### PR TITLE
Fixes #3703: Add user manual link in page header

### DIFF
--- a/rudder-web/src/main/webapp/style/rudder.css
+++ b/rudder-web/src/main/webapp/style/rudder.css
@@ -1223,6 +1223,7 @@ div#logo {
   float:right;
   width:200px;
   padding:10px;
+  padding-right:25px;
   font-size:0.9em;
   color:white;
 }
@@ -1249,7 +1250,7 @@ header - haut de page
   width:130px;
 }
 div#infosUser {
-   padding: 7px 5px;
+   padding: 10px 5px;
    height: 30px;
    color: #f79d10;
 }
@@ -1284,6 +1285,19 @@ div#infosUser {
    text-decoration: underline;
    cursor: pointer;
 }
+
+#documentation {
+  float: right;
+  font-size: 14px;
+  font-weight: bold;  
+  padding-right: 20px;
+}
+
+#documentation a {
+    color: #999; 
+}
+
+
 .automaticCleanDetail {
 	padding : 5px 5px 0;
 } 

--- a/rudder-web/src/main/webapp/templates-hidden/common-layout.html
+++ b/rudder-web/src/main/webapp/templates-hidden/common-layout.html
@@ -93,8 +93,13 @@
       </div>
     </div>
     <!--Fin popin Login-->
-  </div>
   <!--Fin infos utilisateurs-->  
+  
+  <!-- documentation link -->
+  <div id="documentation">
+    <a href="/rudder-doc">User manual</a>
+  </div>
+  </div>
   
   <!--Début Logo-->
   <div id="logo"> 


### PR DESCRIPTION
Add the "User manual" link in header. 

Also correct right spacing of Deployment status div, and vertical alignement of both user information and user manual.
