### PR TITLE
Fixes #3735 - Change link to rudder-doc from /usr/share/rudder to /usr/s...

### DIFF
--- a/rudder-web/src/main/resources/apache2-default.conf
+++ b/rudder-web/src/main/resources/apache2-default.conf
@@ -83,8 +83,8 @@
 	</Location>
 
 	# Link to Rudder documentation
-	Alias /rudder-doc /usr/share/doc/rudder
-	<Directory /usr/share/doc/rudder>
+	Alias /rudder-doc /usr/share/doc/rudder/html
+	<Directory /usr/share/doc/rudder/html>
 		DirectoryIndex rudder-doc.html
 		Order deny,allow
 		Allow from all


### PR DESCRIPTION
...hare/rudder/html
