### PR TITLE
Fixes #3751: Allow non authentication for API v1

### DIFF
--- a/rudder-web/src/main/resources/configuration.properties.sample
+++ b/rudder-web/src/main/resources/configuration.properties.sample
@@ -326,11 +326,27 @@ rudder.batch.dyngroup.updateInterval=5
 
 #
 # Boolean, defaults to true
-# If true, REST API urls under /api/... won't require
+# If true, REST API urls v1 won't require
 # to be authenticated to be accessed. 
-# The reason to have default=true for that is that the
-# authorization/authentication part for the REST API
+# The reason to have default=true for that is 
+# that in that use case, the authorization and 
+# authentication part for the REST API
 # will be done by a third party software, like Apache
+#
+# If false, these API will need to be authenticated
+# with a valid token managed in the 
+# "Administration => API Accounts" screen of Rudder 
+# web application.
+# 
+# API affected by that property:
+# - /api/status
+# - /api/techniqueLibrary/reload
+# - /api/dyngroup/reload
+# - /api/deploy/reload
+# - /api/archives/*
+#
+#  DEPRECATED: use of authentication token will become
+#              mandatory for all API URLs. 
 #
 rudder.rest.allowNonAuthenticatedUser=true
 


### PR DESCRIPTION
That pull request restore the possibility to have non authenticated requests for API v1 URLs. 
It also modify the documentation for the corresponding property (rudder.rest.allowNonAuthenticatedUser=true) and switch API account id / API accound token for what is considered the name (it's the API id, as it should always have been). 
