### PR TITLE
Fixes #3967 : Improve change request merge check:

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisation.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisation.scala
@@ -48,6 +48,13 @@ import com.normation.rudder.domain.workflows.ChangeRequest
 import com.normation.rudder.domain.workflows.ConfigurationChangeRequest
 
 
+trait XmlSerializer {
+
+  val rule      : RuleSerialisation
+  val directive : DirectiveSerialisation
+  val group     : NodeGroupSerialisation
+
+}
 
 /**
  * That trait allow to serialise

--- a/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
@@ -85,6 +85,12 @@ import com.normation.rudder.domain.policies.DeleteRuleDiff
 import com.normation.rudder.domain.policies.ModifyToRuleDiff
 
 
+case class XmlSerializerImpl (
+    val rule      : RuleSerialisation
+  , val directive : DirectiveSerialisation
+  , val group     : NodeGroupSerialisation
+) extends XmlSerializer
+
 class RuleSerialisationImpl(xmlVersion:String) extends RuleSerialisation {
   def serialise(rule:Rule):  Elem = {
     createTrimedElem(XML_TAG_RULE, xmlVersion) {

--- a/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisation.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisation.scala
@@ -57,6 +57,15 @@ import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.workflows.RuleChanges
 
 
+trait XmlUnserializer {
+
+  val rule      : RuleUnserialisation
+  val directive : DirectiveUnserialisation
+  val group     : NodeGroupUnserialisation
+
+}
+
+
 trait DeploymentStatusUnserialisation {
   /**
    * Version 2:

--- a/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -95,6 +95,13 @@ import scala.util.{Failure => Catch}
 import com.normation.rudder.domain.logger.ApplicationLogger
 
 
+case class XmlUnserializerImpl (
+    val rule      : RuleUnserialisation
+  , val directive : DirectiveUnserialisation
+  , val group     : NodeGroupUnserialisation
+) extends XmlUnserializer
+
+
 class DirectiveUnserialisationImpl extends DirectiveUnserialisation {
 
   override def parseSectionVal(xml:NodeSeq) : Box[SectionVal] = {

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -344,6 +344,17 @@ object RudderConfig extends Loggable {
   val changeRequestEventLogService : ChangeRequestEventLogService = new ChangeRequestEventLogServiceImpl(eventLogRepository)
 
 
+  val xmlSerializer = XmlSerializerImpl(
+      ruleSerialisation
+    , directiveSerialisation
+    , nodeGroupSerialisation
+  )
+
+  val xmlUnserializer = XmlUnserializerImpl(
+      ruleUnserialisation
+    , directiveUnserialisation
+    , nodeGroupUnserialisation
+  )
   val workflowEventLogService =    new WorkflowEventLogServiceImpl(eventLogRepository,uuidGen)
   val diffService: DiffService = new DiffServiceImpl(roDirectiveRepository)
   val commitAndDeployChangeRequest : CommitAndDeployChangeRequestService =
@@ -360,6 +371,9 @@ object RudderConfig extends Loggable {
       , asyncDeploymentAgent
       , dependencyAndDeletionService
       , RUDDER_ENABLE_APPROVAL_WORKFLOWS
+      , xmlSerializer
+      , xmlUnserializer
+      , sectionSpecParser
     )
   val asyncWorkflowInfo = new AsyncWorkflowInfo
   val workflowService: WorkflowService = RUDDER_ENABLE_APPROVAL_WORKFLOWS match {


### PR DESCRIPTION
Ldap datas are transformed in XML, then checked, before being
unserialised to their types

http://www.rudder-project.org/redmine/issues/3967
