### PR TITLE
Fixes #4085: Really get all machine inventories for list of node displaying

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -108,11 +108,10 @@ class LDAPEntityMapper(
   /**
    * From a nodeEntry and an inventoryEntry, create a NodeInfo
    *
-   * @param nodeEntry
-   * @param inventoryEntry
-   * @return
+   * The only thing used in machineEntry is its object class.
+   *
    */
-  def convertEntriesToNodeInfos(nodeEntry:LDAPEntry, inventoryEntry:LDAPEntry, machineEntry:Option[LDAPEntry]) : Box[NodeInfo] = {
+  def convertEntriesToNodeInfos(nodeEntry:LDAPEntry, inventoryEntry:LDAPEntry, machineEntryObjectClass:Option[Seq[String]]) : Box[NodeInfo] = {
     //why not using InventoryMapper ? Some required things for node are not
     // wanted here ?
     for {
@@ -122,7 +121,7 @@ class LDAPEntityMapper(
       checkIsANode <- if(inventoryEntry.isA(OC_NODE)) Full("Ok")
                       else Failure("Bad object class, need %s and found %s".format(OC_NODE,inventoryEntry.valuesFor(A_OC)))
 
-      machineType  =  machineEntry.map(machine => if (machine.isA(OC_PM)) "Physical" else "Virtual").getOrElse("No Machine Inventory")
+      machineType  =  machineEntryObjectClass.map(machine => if (machine.exists( _ == OC_PM)) "Physical" else "Virtual").getOrElse("No Machine Inventory")
       checkSameID  <- if(nodeEntry(A_NODE_UUID).isDefined && nodeEntry(A_NODE_UUID) ==  inventoryEntry(A_NODE_UUID)) Full("Ok")
                       else Failure("Mismatch id for the node %s and the inventory %s".format(nodeEntry(A_NODE_UUID), inventoryEntry(A_NODE_UUID)))
 

--- a/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
@@ -127,7 +127,7 @@ class AccepetedNodesLDAPQueryProcessor(
   private[this] case class QueryResult(
       nodeEntry:LDAPEntry
     , inventoryEntry:LDAPEntry
-    , machineEntry:Option[LDAPEntry]
+    , machineObjectClass:Option[Seq[String]]
   ) extends HashcodeCaching
 
   /**


### PR DESCRIPTION
The problem was that we only requested machine inventories in the "accepted" branch. But sometimes, when nodes are accepted/removed/accepted, machine inventories end in the "deleted" branch. So we need to query all inventories. 
For that to not be to costly, I restrained the returned LDAP entries' attributes to only "objectClass", since it's the only one needed to decide if the machine is virtual or not. 
