### PR TITLE
Fixes #3687: Check if the version exists before trying to use it, display an error otherwise

### DIFF
--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
@@ -243,12 +243,15 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
       case Some((fullActiveTechnique,version)) =>
         fullActiveTechnique.techniques.get(version) match {
           case None =>
+            val m = s"There was an error when trying to read version ${version.toString} of the Technique." +
+                 "This is bad. Please check if that version exists on the filesystem and is correctly registered in the Technique Library."
+
+            logger.error(m)
+
             "*" #> {
               <div id="techniqueDetails">
               <div class="deca">
-              <p class="error">There was an error when trying to read version {version.toString} of the Technique.
-                 This is bad. Please check if that version exists on the filesystem and is correctly registered in the Technique Library.
-              </p>
+              <p class="error">{m}</p>
               </div>
               </div>
             }


### PR DESCRIPTION
The comparison is more clear without space, as a block of code was indented. 

I'm not sur about the behaviour in case of error, because that means that the matching directive can not be used anymore, not even to just change the technique version it is applied to. 

Perhaps we should have a "degraded directive edition screen", where only the Technique version can be change into a valid one ? Note that building that screen is far more involving than the proposed correction. 

That's some work to do, because the Directive edit form is in error to, so we have A LOT of logic to change. 
