### PR TITLE
Fixes #4403: allow to configure LDAP authentication from property file

### DIFF
--- a/rudder-web/src/main/resources/applicationContext-security-auth-file.xml
+++ b/rudder-web/src/main/resources/applicationContext-security-auth-file.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Copyright 2014 Normation SAS
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+In accordance with the terms of section 7 (7. Additional Terms.) of
+the GNU Affero GPL v3, the copyright holders add the following
+Additional permissions:
+Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU Affero GPL v3
+licence, when you create a Related Module, this Related Module is
+not considered as a part of the work and may be distributed under the
+license agreement of your choice.
+A "Related Module" means a set of sources files including their
+documentation that, without modification of the Source Code, enables
+supplementary functions or services in addition to those offered by
+the Software.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
+-->
+
+<beans:beans xmlns="http://www.springframework.org/schema/security"
+    xmlns:beans="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+                        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd">
+
+
+    <authentication-manager>
+        <authentication-provider ref="demoAuthenticationProvider"/>
+    </authentication-manager>
+
+</beans:beans>

--- a/rudder-web/src/main/resources/applicationContext-security-auth-ldap.xml
+++ b/rudder-web/src/main/resources/applicationContext-security-auth-ldap.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Copyright 2014 Normation SAS
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+In accordance with the terms of section 7 (7. Additional Terms.) of
+the GNU Affero GPL v3, the copyright holders add the following
+Additional permissions:
+Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU Affero GPL v3
+licence, when you create a Related Module, this Related Module is
+not considered as a part of the work and may be distributed under the
+license agreement of your choice.
+A "Related Module" means a set of sources files including their
+documentation that, without modification of the Source Code, enables
+supplementary functions or services in addition to those offered by
+the Software.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
+-->
+
+<beans:beans xmlns="http://www.springframework.org/schema/security"
+    xmlns:beans="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+                        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd">
+
+    <!-- 
+      The properties in that file are read from rudder-web.properties, then translated into
+      system properties in LiftInitContextListener class. 
+    -->
+    
+    <beans:bean id="corePlaceHolder" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+      <beans:property name="ignoreUnresolvablePlaceholders" value="true"/>
+      <beans:property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE"/>
+      <beans:property name="searchSystemEnvironment" value="true"/>
+    </beans:bean>     
+
+    <authentication-manager>
+        <authentication-provider ref="ldapAuthenticationProvider"/>
+    </authentication-manager>
+
+    <beans:bean id="contextSource" class="org.springframework.security.ldap.DefaultSpringSecurityContextSource">
+      <beans:constructor-arg value="${rudder.auth.ldap.connection.url}"/>
+      <beans:property name="userDn" value="${rudder.auth.ldap.connection.bind.dn}"/>
+      <beans:property name="password" value="${rudder.auth.ldap.connection.bind.password}"/>
+    </beans:bean>
+    
+    
+    <beans:bean id="userLookup" class="org.springframework.security.ldap.search.FilterBasedLdapUserSearch">
+      <beans:constructor-arg index="0" value="${rudder.auth.ldap.searchbase}"/>
+      <beans:constructor-arg index="1" value="${rudder.auth.ldap.filter}"/>
+      <beans:constructor-arg index="2" ref="contextSource" />
+    </beans:bean>
+    
+    <beans:bean id="ldapAuthenticationProvider" class="org.springframework.security.ldap.authentication.LdapAuthenticationProvider">
+       <beans:constructor-arg>
+         <beans:bean class="org.springframework.security.ldap.authentication.BindAuthenticator">
+           <beans:constructor-arg ref="contextSource"/>
+           <beans:property name="userSearch" ref="userLookup"/>
+         </beans:bean>
+       </beans:constructor-arg>
+     <beans:property name="userDetailsContextMapper" ref="rudderXMLUserDetails"/>
+    </beans:bean>
+
+
+</beans:beans>

--- a/rudder-web/src/main/resources/applicationContext-security.xml
+++ b/rudder-web/src/main/resources/applicationContext-security.xml
@@ -33,7 +33,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
 <beans:beans xmlns="http://www.springframework.org/schema/security"
     xmlns:beans="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
                         http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd">
 
 <!--    <global-method-security pre-post-annotations="enabled">-->
@@ -80,12 +80,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
 
     </http>
 
-    <authentication-manager>
-        <authentication-provider ref="demoAuthenticationProvider"/>
-    </authentication-manager>
-
-  <!-- Disallow any session check, for demo only. A real application should enable concurrent/fixation session check  -->
-  <beans:bean id="sas" class="org.springframework.security.web.authentication.session.NullAuthenticatedSessionStrategy" />
-
+    <!-- Disallow any session check, for demo only. A real application should enable concurrent/fixation session check  -->
+    <beans:bean id="sas" class="org.springframework.security.web.authentication.session.NullAuthenticatedSessionStrategy" />
+  
+    <!-- 
+      The goal of that config file is only to provide an indirection so that we are able:
+      - to use a static string in the ImportResource of AppConfigAuth (because we can't have a property here)
+      - and be able to use a dynamic resource name for the authentication. 
+     -->
+  
+    <beans:import resource="${spring.config.security}" />
+  
 
 </beans:beans>

--- a/rudder-web/src/main/resources/configuration.properties.sample
+++ b/rudder-web/src/main/resources/configuration.properties.sample
@@ -410,6 +410,71 @@ rudder.batch.storeAgentRunTimes.maxDays=5
 rudder.batch.storeAgentRunTimes.updateInterval=5
 
 #########################
+# LDAP Authentication    #############################################################
+#########################
+
+#
+# Be default, both authentication and authorization are handle in the rudder-users.xml
+# file. But you may want to rely on your existing entreprise Active Directory or LDAP
+# to take care of the authentication part. The following parameters allow to configure
+# such an LDAP authentication scheme. 
+# The chosen LDAP procedure is a typical bind/search/rebind, in which an application
+# connection (bind) is used to search (search) for an user entry given some base and 
+# filter parameters, and then, a bind (rebind) is tried on that entry with the 
+# credential provided by the user. 
+# That allows to seperate the user DN (especially RDN) from the search criteria. 
+#
+# Be careful, the authorization is still done in the rudder-user.xml, what means
+# that each user should have access to Rudder MUST have a line in that file. 
+# Without that line, the user can have a successful LDAP authentication, but
+# won't be able to do or see anything in Rudder (safe logout). 
+# 
+
+#
+# Use the LDAP authentication
+# When set to true, passwords in rudder-users.xml are ignored and the 
+# authentication is delegated to the LDAP server configured below. 
+# By convention, when LDAP authentication is enable, "password" field in
+# rudder-users.xml are set to "" 
+#
+# Boolean, default to false
+#
+rudder.auth.ldap.enable=false
+
+#
+# Connection URL to the LDAP server, in the form:
+# ldap://hostname:port/base_dn
+#
+rudder.auth.ldap.connection.url=ldap://ldap.mycorp.com:389/dc=mycorp,dc=com
+
+#
+# Bind DN used by Rudder to do the search
+# LDAP dn, no default value.
+#
+rudder.auth.ldap.connection.bind.dn=cn=admin,dc=mycorp,dc=com
+
+#
+# Bind password used by Rudder to do the search.
+# String, no default value. 
+#
+rudder.auth.ldap.connection.bind.password=secret
+
+#
+# Search base and filter to use to find the user. 
+# The search base can be left empty. 
+# In the filter, {0} denotes the value provided as
+# login by the user. 
+#
+rudder.auth.ldap.searchbase=ou=People
+rudder.auth.ldap.filter=(&(uid={0})(objectclass=person))
+
+#
+# An AD example would be:
+# 
+#rudder.auth.ldap.searchbase=
+#rudder.auth.ldap.filter=(&(sAMAccountName={0})(objectclass=user))
+
+#########################
 # DEPRECATED properties #############################################################
 #########################
 

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -202,6 +202,11 @@ object RudderConfig extends Loggable {
 
   private[this] val filteredPasswords = scala.collection.mutable.Buffer[String]()
 
+  //the LDAP password used for authentication is not used here, but should not appear nonetheless
+  filteredPasswords += "rudder.auth.ldap.connection.bind.password"
+
+  //other values
+
   val LDAP_HOST = config.getString("ldap.host")
   val LDAP_PORT = config.getInt("ldap.port")
   val LDAP_AUTHDN = config.getString("ldap.authdn")

--- a/rudder-web/src/main/scala/bootstrap/liftweb/LiftInitContextListener.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/LiftInitContextListener.scala
@@ -80,6 +80,9 @@ class LiftInitContextListener extends ContextLoaderListener {
     Logger.setup = Full(Logback.withFile(logbackFile))
     /// init all our non-spring services ///
 
+    //define system env variable for auth config
+    initSpringAuthentication()
+
     val ms = System.currentTimeMillis()
     RudderConfig.init
 
@@ -100,6 +103,34 @@ class LiftInitContextListener extends ContextLoaderListener {
   override def contextDestroyed(sce:ServletContextEvent) : Unit = {
     //nothing special to do for us, only call super
     super.contextDestroyed(sce)
+  }
+
+  private[this] def initSpringAuthentication(): Unit = {
+    import RudderProperties.{config => c}
+
+    val springConfigFile = if( c.getBoolean("rudder.auth.ldap.enable")) {
+      //define all the relevant LDAP properties as system properties
+      //so that they can be replaced in the spring xml file
+      for (
+        x <- Seq("rudder.auth.ldap.connection.url"
+                , "rudder.auth.ldap.connection.bind.dn"
+                , "rudder.auth.ldap.connection.bind.password"
+                , "rudder.auth.ldap.searchbase"
+                , "rudder.auth.ldap.filter"
+             )
+      ) {
+        System.setProperty(x, c.getString(x))
+      }
+
+      //use the LDAP auth file
+      "classpath:applicationContext-security-auth-ldap.xml"
+    } else { //use the rudder-users.xml file for authentication
+      "classpath:applicationContext-security-auth-file.xml"
+    }
+
+    System.setProperty("spring.config.security", springConfigFile)
+
+
   }
 
 }


### PR DESCRIPTION
The main painful part was to understand that we must have system properties to be able to use them at the time the import is resolve. 

Perphaps a better solution would have been to configure everything in code, but the spring-security part is awful. 
