### PR TITLE
Arc 4478/impl 4781 remove rudder rule variables

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportLogger.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportLogger.scala
@@ -42,6 +42,7 @@ import net.liftweb.actor._
 import net.liftweb.common._
 import com.normation.utils.UuidRegex
 import com.normation.rudder.domain.nodes.NodeInfo
+import com.normation.inventory.domain.NodeId
 
 
 
@@ -167,7 +168,7 @@ class AutomaticReportLogger(
     /*
      * Transform to log line and log a report with the appropriate kind
      */
-    def logReport(report:Reports, allNodes: Set[NodeInfo]) = {
+    def logReport(report:Reports, allNodes: Map[NodeId, NodeInfo]) = {
       val execDate = report.executionDate.toString("yyyy-MM-dd HH:mm:ssZ")
 
       val ruleId =
@@ -189,7 +190,7 @@ class AutomaticReportLogger(
 
       val node :String = "%s [%s]".format(
             nodeId
-          , allNodes.find( _.id == report.nodeId).map(_.hostname).getOrElse("Unknown node")
+          , allNodes.get(report.nodeId).map(_.hostname).getOrElse("Unknown node")
           )
 
       val directiveId =

--- a/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
@@ -160,13 +160,13 @@ final case class FullNodeGroupCategory(
   /**
    * Return all node ids that match the set of target.
    */
-  def getNodeIds(targets: Set[RuleTarget], allNodeInfos: Set[NodeInfo]) : Set[NodeId] = {
-    val allNodeIds = allNodeInfos.map(_.id)
+  def getNodeIds(targets: Set[RuleTarget], allNodeInfos: Map[NodeId, NodeInfo]) : Set[NodeId] = {
+    val allNodeIds = allNodeInfos.keySet
     (Set[NodeId]()/:targets) {
       case (nodes, t:NonGroupRuleTarget) =>
         t match {
-          case AllTarget => return allNodeInfos.map( _.id )
-          case AllTargetExceptPolicyServers => nodes ++ allNodeInfos.collect { case(n) if(!n.isPolicyServer) => n.id }
+          case AllTarget => return allNodeIds
+          case AllTargetExceptPolicyServers => nodes ++ allNodeInfos.collect { case(k,n) if(!n.isPolicyServer) => n.id }
           case PolicyServerTarget(nodeId) => nodes + nodeId
         }
       //here, if we don't find the group, we consider it's an error in the

--- a/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
@@ -100,7 +100,7 @@ trait NodeInfoService {
    * missing (but the corresponding nodeInfos won't be present)
    * So it is possible that getAllIds.size > getAll.size
    */
-  def getAll() : Box[Set[NodeInfo]]
+  def getAll() : Box[Map[NodeId, NodeInfo]]
 
   /**
    * Get all "simple" node ids (i.e, all user nodes,
@@ -178,7 +178,7 @@ class NodeInfoServiceImpl(
    * missing (but the corresponding nodeInfos won't be present)
    * So it is possible that getAllIds.size > getAll.size
    */
-  def getAll() : Box[Set[NodeInfo]] = {
+  def getAll() : Box[Map[NodeId, NodeInfo]] = {
 
     /*
      * The goal of that implementation is to be quick, so we prefer to
@@ -210,9 +210,9 @@ class NodeInfoServiceImpl(
                        }
           nodeInfo <- ldapMapper.convertEntriesToNodeInfos(nodeEntry, nodeInv, machineInv.map( _.valuesFor("objectClass").toSeq))
         } yield {
-          nodeInfo
+          (nodeInfo.id, nodeInfo)
         }
-      }.toSet
+      }.toMap
     }
   }
 

--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/RuleApplicationStatusService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/RuleApplicationStatusService.scala
@@ -38,13 +38,14 @@ import com.normation.rudder.domain.policies._
 import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.repository.FullActiveTechniqueCategory
+import com.normation.inventory.domain.NodeId
 
 trait RuleApplicationStatusService {
     def isApplied(
       rule        : Rule
     , groupLib    : FullNodeGroupCategory
     , directiveLib: FullActiveTechniqueCategory
-    , allNodeInfos: Set[NodeInfo]
+    , allNodeInfos: Map[NodeId, NodeInfo]
   ) : ApplicationStatus
 }
 
@@ -58,7 +59,7 @@ class RuleApplicationStatusServiceImpl extends RuleApplicationStatusService {
       rule        : Rule
     , groupLib    : FullNodeGroupCategory
     , directiveLib: FullActiveTechniqueCategory
-    , allNodeInfos: Set[NodeInfo]
+    , allNodeInfos: Map[NodeId, NodeInfo]
   ) : ApplicationStatus = {
 
     if(rule.isEnabled) {

--- a/rudder-core/src/main/scala/com/normation/rudder/services/servers/PolicyServerManagementService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/servers/PolicyServerManagementService.scala
@@ -75,7 +75,6 @@ trait PolicyServerManagementService {
 class PolicyServerManagementServiceImpl(
     roDirectiveRepository: RoDirectiveRepository
   , woDirectiveRepository: WoDirectiveRepository
-  , asyncDeploymentAgent : AsyncDeploymentAgent
 ) extends PolicyServerManagementService with Loggable {
 
   /**
@@ -113,8 +112,6 @@ class PolicyServerManagementServiceImpl(
       msg = Some("Automatic update of system directive due to modification of accepted networks ")
       saved <- woDirectiveRepository.saveSystemDirective(activeTechnique.id, newPi, modId, actor, msg) ?~! "Can not save directive for Active Technique '%s'".format(activeTechnique.id.value)
     } yield {
-      //ask for a new policy deployment
-      asyncDeploymentAgent ! AutomaticStartDeployment(modId, RudderEventActor)
       networks
     }
   }

--- a/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
@@ -25,17 +25,18 @@ class RuleTargetTest extends Specification with Loggable {
   val allNodeIds = nodeIds + NodeId("root")
   val nodes = allNodeIds.map {
     id =>
-      NodeInfo (
-        id, s"Node-${id}"
-      , "" ,"" ,"" ,"" ,""
-      , None, Nil, DateTime.now
-      , "", Seq(), NodeId("root")
-      , "", DateTime.now
-      , false, false, false
+      (
+        id
+      , NodeInfo (
+          id, s"Node-${id}"
+        , "" ,"" ,"" ,"" ,""
+        , None, Nil, DateTime.now
+        , "", Seq(), NodeId("root")
+        , "", DateTime.now
+        , false, false, false
+      )
     )
-  }
-
-
+  }.toMap
 
   val g1 = NodeGroup (
     NodeGroupId("1"), "Empty group", "", None, false, Set(), true

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -1112,12 +1112,13 @@ object RudderConfig extends Loggable {
     , gitModificationRepository
   )
   private[this] lazy val parameterizedValueLookupService: ParameterizedValueLookupService =
-    new ParameterizedValueLookupServiceImpl(ruleValService)
+    new ParameterizedValueLookupServiceImpl()
 
   private[this] lazy val systemVariableService: SystemVariableService = new SystemVariableServiceImpl(
       licenseRepository
     , parameterizedValueLookupService
     , systemVariableSpecService
+    , psMngtService
     , RUDDER_DIR_DEPENDENCIES
     , RUDDER_ENDPOINT_CMDB
     , RUDDER_COMMUNITY_PORT
@@ -1164,7 +1165,7 @@ object RudderConfig extends Loggable {
   private[this] lazy val ruleValService: RuleValService = new RuleValServiceImpl(variableBuilderService)
 
   private[this] lazy val psMngtService: PolicyServerManagementService = new PolicyServerManagementServiceImpl(
-    roLdapDirectiveRepository, woLdapDirectiveRepository, asyncDeploymentAgentImpl)
+    roLdapDirectiveRepository, woLdapDirectiveRepository)
   private[this] lazy val historizationService = new HistorizationServiceImpl(historizationJdbcRepository)
 
   private[this] lazy val asyncDeploymentAgentImpl: AsyncDeploymentAgent = {

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -114,7 +114,7 @@ class NodeGroupForm(
   private[this] val searchNodeComponent = new LocalSnippet[SearchNodeComponent]
 
   private[this] var query : Option[Query] = nodeGroup.query
-  private[this] var srvList : Box[Seq[NodeInfo]] = nodeInfoService.getAll.map( _.filter( (x:NodeInfo) => nodeGroup.serverList.contains( x.id ) ).toSeq )
+  private[this] var srvList : Box[Seq[NodeInfo]] = nodeInfoService.getAll.map( _.values.filter( (x:NodeInfo) => nodeGroup.serverList.contains( x.id ) ).toSeq )
 
   private def setNodeGroupCategoryForm : Unit = {
     searchNodeComponent.set(Full(new SearchNodeComponent(

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleEditForm.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleEditForm.scala
@@ -183,7 +183,6 @@ class RuleEditForm(
   private[this] def showForm(tab :Int = 0) : NodeSeq = {
     (getFullNodeGroupLib(), getFullDirectiveLib(), getAllNodeInfos()) match {
       case (Full(groupLib), Full(directiveLib), Full(nodeInfos)) =>
-        val allNodeInfos = nodeInfos.map( x => (x.id -> x) ).toMap
 
         val form = {
           if(CurrentUser.checkRights(Read("rule"))) {
@@ -195,7 +194,7 @@ class RuleEditForm(
 
             (
               "#editForm" #> formContent &
-              "#details"  #> showRuleDetails(directiveLib, allNodeInfos)
+              "#details"  #> showRuleDetails(directiveLib, nodeInfos)
             ).apply(body)
 
           } else {
@@ -203,7 +202,7 @@ class RuleEditForm(
           }
         }
 
-        val ruleComplianceTabAjax = SHtml.ajaxCall(JsRaw("'"+rule.id.value+"'"), (v:String) => Replace("details",showRuleDetails(directiveLib, allNodeInfos)))._2.toJsCmd
+        val ruleComplianceTabAjax = SHtml.ajaxCall(JsRaw("'"+rule.id.value+"'"), (v:String) => Replace("details",showRuleDetails(directiveLib, nodeInfos)))._2.toJsCmd
 
         form ++
         Script(

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
@@ -177,7 +177,7 @@ class RuleGrid(
   }
 
   def rulesGrid(
-      allNodeInfos: Box[Set[NodeInfo]]
+      allNodeInfos: Box[Map[NodeId, NodeInfo]]
     , groupLib    : Box[FullNodeGroupCategory]
     , directiveLib: Box[FullActiveTechniqueCategory]
     , popup       : Boolean = false
@@ -279,7 +279,7 @@ class RuleGrid(
       popup:Boolean
     , rules:Seq[Rule]
     , linkCompliancePopup:Boolean
-    , allNodeInfos: Box[Set[NodeInfo]]
+    , allNodeInfos: Box[Map[NodeId, NodeInfo]]
     , groupLib    : Box[FullNodeGroupCategory]
     , directiveLib: Box[FullActiveTechniqueCategory]) : Box[NodeSeq] = {
     sealed trait Line { val rule:Rule }
@@ -310,7 +310,7 @@ class RuleGrid(
 
 
 
-    def displayGridLines(directivesLib: FullActiveTechniqueCategory, groupsLib: FullNodeGroupCategory, nodes: Set[NodeInfo]) : NodeSeq = {
+    def displayGridLines(directivesLib: FullActiveTechniqueCategory, groupsLib: FullNodeGroupCategory, nodes: Map[NodeId, NodeInfo]) : NodeSeq = {
     //for each rule, get all the required info and display them
     val lines:Seq[Line] = rules.map { rule =>
 
@@ -423,7 +423,7 @@ class RuleGrid(
 
       def compliance(line:Line) = {
         line match {
-          case line : OKLine => buildComplianceChart(line.compliance, line.rule, linkCompliancePopup, nodes)
+          case line : OKLine => buildComplianceChart(line.compliance, line.rule, linkCompliancePopup)
           case _ => <td class="compliance noCompliance"> N/A</td>
         }
       }
@@ -557,7 +557,7 @@ class RuleGrid(
     }
   }
 
-  private[this] def buildComplianceChart(level:Option[ComplianceLevel], rule: Rule, linkCompliancePopup:Boolean, allNodes: Set[NodeInfo]) : NodeSeq = {
+  private[this] def buildComplianceChart(level:Option[ComplianceLevel], rule: Rule, linkCompliancePopup:Boolean) : NodeSeq = {
 
     val (complianceClass,content) =
       level match {

--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/node/NodeAPIService2.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/node/NodeAPIService2.scala
@@ -85,7 +85,7 @@ case class NodeApiService2 (
     implicit val action = "listAcceptedNodes"
       nodeInfoService.getAll match {
         case Full(nodes) =>
-          val acceptedNodes = nodes.map(serializeNodeInfo(_,"accepted",fixedTag))
+          val acceptedNodes = nodes.values.map(serializeNodeInfo(_,"accepted",fixedTag))
           toJsonResponse(None, ( "nodes" -> JArray(acceptedNodes.toList)))
 
         case eb: EmptyBox => val message = (eb ?~ ("Could not fetch accepted Nodes")).msg

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ClearCache.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ClearCache.scala
@@ -43,7 +43,6 @@ import JsCmds._
 import JE._
 import scala.xml.NodeSeq
 import collection.mutable.Buffer
-import com.normation.rudder.services.servers.PolicyServerManagementService
 import com.normation.utils.NetUtils.isValidNetwork
 import com.normation.rudder.domain.Constants
 import com.normation.rudder.web.model.CurrentUser

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DyngroupReloading.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DyngroupReloading.scala
@@ -43,7 +43,6 @@ import JsCmds._
 import JE._
 import scala.xml.NodeSeq
 import collection.mutable.Buffer
-import com.normation.rudder.services.servers.PolicyServerManagementService
 import com.normation.utils.NetUtils.isValidNetwork
 import com.normation.rudder.domain.Constants
 import com.normation.rudder.web.model.CurrentUser

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/EditPolicyServerAllowedNetwork.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/EditPolicyServerAllowedNetwork.scala
@@ -43,7 +43,6 @@ import JsCmds._
 import JE._
 import scala.xml.NodeSeq
 import collection.mutable.Buffer
-import com.normation.rudder.services.servers.PolicyServerManagementService
 import com.normation.utils.NetUtils.isValidNetwork
 import com.normation.rudder.domain.Constants
 import com.normation.rudder.web.model.CurrentUser

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Nodes.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Nodes.scala
@@ -51,7 +51,7 @@ class Nodes extends StatefulSnippet with Loggable {
 
   def table(html:NodeSeq)= {
     val nodes = nodeInfoService.getAll match {
-      case Full(infos) => infos.toSeq
+      case Full(infos) => infos.values.toSeq
       case eb:EmptyBox => val fail = eb?~ s"could not find Nodes "
           logger.error(fail.msg)
           Seq()


### PR DESCRIPTION
This PR must be merged after https://github.com/Normation/rudder/pull/500. 

This PR do some refactoring and remove the use of ${rudder.ruleId...} variable. 

The main refactoring points are:
- use Map[NodeId, NodeInfo] to change find by get
- remove lookupRuleParameterization and its call sites
- change the way buildNodeConfigurations are built to make the process based on immutable datas

In itselve, it does not gain much speed, but it allows to do https://github.com/Normation/rudder/pull/507 which brings a 10x improvment. 
