### PR TITLE
Fixes #4787: Correct the is of tooltip for n/a rules

### DIFF
--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
@@ -410,8 +410,8 @@ class RuleGrid(
                   }
                 }
                 val why =  conditions.collect { case (ok, label) if(!ok) => label }.mkString(", ")
-                <span class="tooltip tooltipable" title="" tooltipid={line.rule.id.value}>Not applied</span>
-                 <div class="tooltipContent" id={line.rule.id.value}><h3>Reason(s)</h3><div>{why}</div></div>
+                <span class="tooltip tooltipable" title="" tooltipid={"na-"+line.rule.id.value}>Not applied</span>
+                 <div class="tooltipContent" id={"na-"+line.rule.id.value}><h3>Reason(s)</h3><div>{why}</div></div>
             }
         case _ : ErrorLine => "N/A"
       }


### PR DESCRIPTION
The id of tooltip was not unique in the HTML. Adding "na-" as a prefix for N/A tooltip ID. 
