### PR TITLE
Fixes #4771: Rule grid, now stored as Json

### DIFF
--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/JsTableData.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/JsTableData.scala
@@ -1,0 +1,61 @@
+/*
+*************************************************************************************
+* Copyright 2014 Normation SAS
+*************************************************************************************
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU Affero GPL v3, the copyright holders add the following
+* Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU Affero GPL v3
+* licence, when you create a Related Module, this Related Module is
+* not considered as a part of the work and may be distributed under the
+* license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.web.services
+
+import net.liftweb.http.js.JsExp
+import net.liftweb.http.js.JsObj
+import scala.collection.TraversableLike
+import net.liftweb.http.js.JE.JsArray
+
+
+/*
+ * That class represent a Line in a DataTable.
+ */
+trait JsTableLine {
+
+  def json : JsObj
+
+}
+
+/*
+ * That class a set of Data to use in datatable
+ * It should be used as data parameter when creating datatable in javascript
+ */
+case class JsTableData[T <: JsTableLine] ( lines : List[T] ) {
+
+  def json = JsArray(lines.map(_.json))
+
+}
+

--- a/rudder-web/src/main/webapp/javascript/rudder/rudder-datatable.js
+++ b/rudder-web/src/main/webapp/javascript/rudder/rudder-datatable.js
@@ -1,0 +1,222 @@
+
+/* Create Rule table
+ *
+ *   data:
+ *   { "name" : Rule name [String]
+ *   , "id" : Rule id [String]
+ *   , "description" : Rule (short) description [String]
+ *   , "applying": Is the rule applying the Directive, used in Directive page [Boolean]
+ *   , "category" : Rule category [String]
+ *   , "status" : Status of the Rule, "enabled", "disabled" or "N/A" [String]
+ *   , "compliance" : Percent of compliance of the Rule [String]
+ *   , "complianceClass" : Class to apply on the compliance td [String]
+ *   , "trClass" : Class to apply on the whole line (disabled ?) [String]
+ *   , "callback" : Function to use when clicking on one of the line link, takes a parameter to define which tab to open, not always present [ Function ]
+ *   , "checkboxCallback": Function used when clicking on the checkbox to apply/not apply the Rule to the directive, not always present [ Function ]
+ *   , "reasons": Reasons why a Rule is a not applied, empty if there is no reason [ String ]
+ *   }
+ */
+function createRuleTable (gridId, data, needCheckbox, isPopup, allCheckboxCallback, contextPath) {
+
+  // Define which columns should be sorted by default
+  var sortingDefault;
+  if (needCheckbox) {
+    sortingDefault = 1;
+  } else {
+    sortingDefault = 0;
+  }
+
+  // Define all columns of the table
+
+  // Checkbox used in check if a Directive is applied by the Rule
+  var checkbox =
+    { "mDataProp": "applying"
+    , "sTitle" : "<input id='checkAll' type='checkbox'></input>"
+    , "sWidth": "30px"
+    , "bSortable": false
+    , "fnCreatedCell" : function (nTd, sData, oData, iRow, iCol) {
+        var data = oData;
+        var elem = $("<input type='checkbox'></input>");
+        elem.prop("checked", data.applying);
+        elem.click( function () {
+          data.checkboxCallback(elem.prop("checked"));
+        } );
+        elem.attr("id",data.id+"Checkbox");
+        $(nTd).empty();
+        $(nTd).prepend(elem);
+      }
+    };
+
+  // Name of the rule
+  // First mandatory row, so do general thing on the row ( line css, description tooltip ...)
+  var name = 
+    { "mDataProp": "name"
+    , "sWidth": "90px"
+    , "sTitle": "Name"
+    , "fnCreatedCell" : function (nTd, sData, oData, iRow, iCol) {
+        var data = oData;
+        // Define the elem and its callback
+        var elem = $("<a></a>");
+        if("callback" in data) {
+            elem.click(function() {data.callback("showForm");});
+            elem.attr("href","javascript://");
+        } else {
+            elem.attr("href",contextPath+'/secure/configurationManager/ruleManagement#{"ruleId":"'+data.id+'"}');
+        }
+        elem.text(data.name);
+
+        // Row parameters
+        var parent = $(nTd).parent()
+        // Add Class on the row, and id
+        parent.addClass(data.trClass);
+        parent.attr("id",data.id);
+
+        // Description tooltip over the row
+        if ( data.description.length > 0) {
+          var tooltipId = data.id+"-description";
+          parent.attr("tooltipid",tooltipId);
+          parent.attr("title","");
+          parent.addClass("tooltip tooltipabletr");
+          var tooltip= $("<div></div>");
+          var toolTipContainer = $("<div><h3>"+data.name+"</h3></div>");
+          toolTipContainer.addClass("tooltipContent");
+          toolTipContainer.attr("id",tooltipId);
+          tooltip.text(data.description);
+          toolTipContainer.append(tooltip);
+          elem.append(toolTipContainer);
+        }
+
+        // Append the content to the row
+        $(nTd).empty();
+        $(nTd).prepend(elem);
+      }
+    };
+
+  // Rule Category
+  var category =
+    { "mDataProp": "category"
+    , "sWidth": "120px"
+    , "sTitle": "Category"
+    };
+
+  // Status of the rule (disabled) add reson tooltip if needed
+  var status=
+    { "mDataProp": "status"
+    , "sWidth": "60px"
+    , "sTitle": "Status"
+    , "sClass" : "statusCell"
+    , "fnCreatedCell" : function (nTd, sData, oData, iRow, iCol) {
+        var data = oData;
+        $(nTd).empty();
+        var elem = $("<span></span>");
+        elem.text(data.status);
+        // If there a reasons field, add the tooltip
+        if ("reasons" in data) {
+          var tooltipId = data.id+"-status";
+          elem.attr("tooltipid",tooltipId);
+          elem.attr("title","");
+          elem.addClass("tooltip tooltipable");
+          var tooltip= $("<div></div>");
+          var toolTipContainer = $("<div><h3>Reason(s)</h3></div>");
+          toolTipContainer.addClass("tooltipContent");
+          toolTipContainer.attr("id",tooltipId);
+          tooltip.text(data.reasons);
+          toolTipContainer.append(tooltip);
+          $(nTd).prepend(toolTipContainer);
+        }
+        $(nTd).prepend(elem);
+      }
+    };
+
+  // Compliance, with link to the edit form
+  var compliance =
+    { "mDataProp": "compliance"
+    , "sWidth": "40px"
+    , "sTitle": "Compliance"
+    , "fnCreatedCell" : function (nTd, sData, oData, iRow, iCol) {
+        var data = oData;
+        var elem = $("<a></a>");
+        if("callback" in data) {
+            elem.click( function() {
+                data.callback("showForm");
+              } );
+            elem.attr("href","javascript://");
+        } else {
+            elem.attr("href",contextPath+'/secure/configurationManager/ruleManagement#{"ruleId":"'+data.id+'"}');
+        }
+        elem.text(sData);
+        $(nTd).empty();
+        $(nTd).addClass(data.complianceClass+ " compliance");
+        $(nTd).prepend(elem);
+      }
+    };
+
+  // Action buttons, use id a dataprop as its is always present
+  var actions =
+    { "mDataProp": "id"
+    , "sWidth": "20px"
+    , "bSortable" : false
+    , "sClass" : "parametersTd"
+    , "fnCreatedCell" :    function (nTd, sData, oData, iRow, iCol) {
+        var data = oData;
+        var elem = $("<buton></button>");
+        elem.button();
+        elem.addClass("smallButton");
+        elem.click( function() { 
+          data.callback("showEditForm");
+        } );
+        elem.text("Edit");
+        $(nTd).empty();
+        $(nTd).prepend(elem);
+      }
+    };
+
+  // Choose which columns should be included
+  var columns = [];
+  if (needCheckbox) {
+    columns.push(checkbox);
+  }
+  columns.push(name);
+  columns.push(category);
+  columns.push(status);
+  columns.push(compliance);
+  if (!isPopup) {
+    columns.push(actions);
+  }
+
+  createTable(gridId,data,columns, sortingDefault);
+
+  createTooltip();
+
+  // Add callback to checkbox column
+  $("#checkAll").prop("checked", false);
+  $("#checkAll").click( function () {
+      var checked = $("#checkAll").prop("checked");
+      allCheckboxCallback(checked);
+  } );
+}
+
+// Create a table from its id, data, columns, maybe the last one need to be all specific attributes, but for now only sorting
+function createTable(gridId,data,columns, sortingDefault) {
+  $('#'+gridId).dataTable(
+    { "asStripeClasses": [ 'color1', 'color2' ]
+    , "bAutoWidth": false
+    , "bFilter" : true
+    , "bPaginate" : true
+    , "bLengthChange": true
+    , "sPaginationType": "full_numbers"
+    , "bJQueryUI": true
+    , "bStateSave": true
+    , "sCookiePrefix": "Rudder_DataTables_"
+    , "oLanguage": {
+          "sZeroRecords": "No matching rules!"
+        , "sSearch": ""
+        }
+    , "aaData": data
+    , "aaSorting": [[ sortingDefault, "asc" ]]
+    , "aoColumns": columns
+    , "sDom": '<"dataTables_wrapper_top"fl>rt<"dataTables_wrapper_bottom"ip>'
+    }
+  );
+  $('.dataTables_filter input').attr("placeholder", "Search");
+}

--- a/rudder-web/src/main/webapp/style/rudder.css
+++ b/rudder-web/src/main/webapp/style/rudder.css
@@ -149,6 +149,11 @@ div.intro div ul {
 form a {
    color: #f79d10;
 }
+
+form table a {
+   color: black;
+}
+
 form h2 {
    padding: 0 10px;
    font-size: 1.2em;
@@ -2024,7 +2029,10 @@ color: #FF0000 !important;
 
 .smallButton {
   width: 40px !important;
-  height: 22px !important;
+  margin-top: 0 !important;
+  margin-down: 0 !important;
+  padding-top: 2px !important;
+  padding-down: 2px !important;
   font-size : 11px !important;
   font-weight:100 !important;
 }


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/4771

All datas to describe the row in a datatable are now contained in a javascript variable.
all javascript is now in a javascript file so we don't mix lot of javascript/html in Scala code.

The Scala code is now dedicated to generate the javascript datas, and send them directly to a javascript function

In rudder-datatable.js we will be able to use reuse code and have DRY datatables.
