### PR TITLE
Fixes #4796: Node API V4 now fallback to api V2 is query is missing

### DIFF
--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/node/NodeAPI4.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/node/NodeAPI4.scala
@@ -53,7 +53,7 @@ class NodeAPI4 (
 ) extends RestHelper with NodeAPI with Loggable{
 
 
-  val requestDispatch : PartialFunction[Req, () => Box[LiftResponse]] = {
+  val v4Dispatch : PartialFunction[Req, () => Box[LiftResponse]] = {
 
    case Get(id :: Nil, req) if id != "pending" => {
       restExtractor.extractNodeDetailLevel(req.params) match {
@@ -66,6 +66,8 @@ class NodeAPI4 (
     }
   }
 
+  // Node API Version 4 fallback to Node api2 if request is not handled in V4
+  val requestDispatch : PartialFunction[Req, () => Box[LiftResponse]] = v4Dispatch orElse apiV2.requestDispatch
 
   serve( "api" / "4" / "nodes" prefix (requestDispatch orElse apiV2.requestDispatch))
 


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/4796

Mkae the partial function of V4 fallback to V2, so if the function is not defined in V4, it fallback to v2
