### PR TITLE
Fixes #4706: Correct missing promise writting date serialisation

### DIFF
--- a/rudder-core/pom.xml
+++ b/rudder-core/pom.xml
@@ -105,6 +105,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
         </exclusion>
       </exclusions>
     </dependency> 
+    <dependency>
+      <groupId>net.liftweb</groupId>
+      <artifactId>lift-json-ext_${scala-binary-version}</artifactId>
+      <version>${lift-version}</version>
+    </dependency>  
   
   </dependencies>
 </project>

--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -733,14 +733,17 @@ trait DeploymentService_updateAndWriteRule extends DeploymentService {
      * - update caches
      */
     val updated = nodeConfigurationService.selectUpdatedNodeConfiguration(allNodeConfigs, cache)
-    val fsWrite0   =  DateTime.now.getMillis
+    val writtingTime = Some(DateTime.now)
+    val fsWrite0   =  writtingTime.get.getMillis
 
     for {
       written    <- nodeConfigurationService.writeTemplate(rootNodeId, updated, allNodeConfigs)
       ldapWrite0 =  DateTime.now.getMillis
       fsWrite1   =  (ldapWrite0 - fsWrite0)
       _          =  logger.debug(s"Node configuration written on filesystem in ${fsWrite1} millisec.")
-      cached     <- nodeConfigurationService.cacheNodeConfiguration(allNodeConfigs.filterKeys(updated.contains(_)).values.toSet)
+      //before caching, update the timestamp for last written time
+      toCache    =  allNodeConfigs.filterKeys(updated.contains(_)).values.toSet.map( (x:NodeConfiguration) => x.copy(writtenDate = writtingTime))
+      cached     <- nodeConfigurationService.cacheNodeConfiguration(toCache)
       ldapWrite1 =  (DateTime.now.getMillis - ldapWrite0)
       _          =  logger.debug(s"Node configuration cached in LDAP in ${ldapWrite1} millisec.")
     } yield {

--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepository.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepository.scala
@@ -232,7 +232,7 @@ class LdapNodeConfigurationCacheRepository(
 
   import net.liftweb.json._
   import net.liftweb.json.Serialization.{read, write}
-  implicit val formats = Serialization.formats(NoTypeHints)
+  implicit val formats = Serialization.formats(NoTypeHints) ++ net.liftweb.json.ext.JodaTimeSerializers.all
 
   /*
    * Logic: there is only one object that contains all node config cache.


### PR DESCRIPTION
When changing the cache logic, I broke the writen date serialisation logic (which was silently ignore). 
Adding it back leads to correct promise generation when technique library is updated. 
It is trivially done by adding to Lift JSON the hint about how to serialize/deserialize Datetime objects. 
