### PR TITLE
Fixes #4933: Display rudder server role in node details

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/domain/eventlog/AssetsEventLog.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/eventlog/AssetsEventLog.scala
@@ -182,7 +182,7 @@ object NodeEventLog {
         <creationDate>{node.creationDate}</creationDate>
         <isBroken>{node.isBroken}</isBroken>
         <isSystem>{node.isSystem}</isSystem>
-        <isPolicyServer>{node.id.value=="root"}</isPolicyServer>
+        <isPolicyServer>{node.isPolicyServer}</isPolicyServer>
       </node>
     )
   }

--- a/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
@@ -39,8 +39,9 @@ import com.normation.utils.HashcodeCaching
 
 
 /**
- * The Node is a basic object, the entry point for the application
- * @author Nicolas CHARLES
+ * The entry point for a REGISTERED node in Rudder.
+ *
+ * This is independant from inventory, and can exist without one.
  *
  */
 case class Node(id:NodeId, name:String, description:String, isBroken : Boolean, isSystem : Boolean, isPolicyServer: Boolean) extends HashcodeCaching

--- a/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeInfo.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeInfo.scala
@@ -38,12 +38,11 @@ import com.normation.inventory.domain.AgentType
 import org.joda.time.DateTime
 import com.normation.inventory.domain.NodeId
 import com.normation.utils.HashcodeCaching
+import com.normation.inventory.domain.ServerRole
 
 /**
  * A NodeInfo is a read only object containing the information that will be
  * always useful about a node
- * @author Nicolas CHARLES
- *
  */
 case class NodeInfo(
     id            : NodeId
@@ -64,4 +63,9 @@ case class NodeInfo(
   , isBroken      : Boolean
   , isSystem      : Boolean
   , isPolicyServer: Boolean
+  //for now, isPolicyServer and server role ARE NOT
+  //dependant. So EXPECTS inconsistencies.
+  //TODO: remove isPolicyServer, and pattern match on
+  //      on role everywhere.
+  , serverRoles   : Set[ServerRole]
 ) extends HashcodeCaching

--- a/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -144,8 +144,9 @@ class LDAPEntityMapper(
       date        <- nodeEntry.getAsGTime(A_OBJECT_CREATION_DATE) ?~!
                       "Can not find mandatory attribute '%s' in entry".format(A_OBJECT_CREATION_DATE)
       osVersion   = inventoryEntry(A_OS_VERSION).getOrElse("N/A")
-      osName  = inventoryEntry(A_OS_NAME).getOrElse("N/A")
+      osName      = inventoryEntry(A_OS_NAME).getOrElse("N/A")
       servicePack = inventoryEntry(A_OS_SERVICE_PACK)
+      serverRoles = inventoryEntry.valuesFor(A_SERVER_ROLE).map(ServerRole(_)).toSet
     } yield {
       // fetch the inventory datetime of the object
       val dateTime = inventoryEntry.getAsGTime(A_INVENTORY_DATE) map(_.dateTime) getOrElse(DateTime.now)
@@ -170,6 +171,7 @@ class LDAPEntityMapper(
         , nodeEntry.getAsBoolean(A_IS_BROKEN).getOrElse(false)
         , nodeEntry.getAsBoolean(A_IS_SYSTEM).getOrElse(false)
         , nodeEntry.isA(OC_POLICY_SERVER_NODE)
+        , serverRoles
       )
     }
   }

--- a/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
@@ -33,7 +33,7 @@ class RuleTargetTest extends Specification with Loggable {
         , None, Nil, DateTime.now
         , "", Seq(), NodeId("root")
         , "", DateTime.now
-        , false, false, false
+        , false, false, false, Set()
       )
     )
   }.toMap

--- a/rudder-core/src/test/scala/com/normation/rudder/services/nodes/NodeConfigurationChangeDetectServiceTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/nodes/NodeConfigurationChangeDetectServiceTest.scala
@@ -143,6 +143,7 @@ class NodeConfigurationChangeDetectServiceTest extends Specification {
   , isBroken      = false
   , isSystem      = false
   , isPolicyServer= false
+  , serverRoles   = Set()
   )
 
   private val nodeInfo2 = nodeInfo.copy(name = "name2")

--- a/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestNodeAndParameterLookup.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestNodeAndParameterLookup.scala
@@ -99,6 +99,7 @@ class TestNodeAndParameterLookup extends Specification {
     , isBroken      = false
     , isSystem      = false
     , isPolicyServer= true
+    , serverRoles   = Set()
   )
   val root = NodeInfo(
       id            = rootId
@@ -119,6 +120,7 @@ class TestNodeAndParameterLookup extends Specification {
     , isBroken      = false
     , isSystem      = false
     , isPolicyServer= true
+    , serverRoles   = Set()
   )
 
   val context = InterpolationContext(


### PR DESCRIPTION
The only real modification are in NodeInfo.scala, LDAPEntityMapper.scala (add an understand roles) and DisplayNode.scala (display them, trying to be somehow consistent with the time before roles). 

Other modification are cleaning around isPolicyServer not used (so that we don't have even more inconsistencies than between isPolicyServer and roles) and cleaning of dead code that would have had to be modified if not removed. 
