### PR TITLE
Fixes #4950: move node quicksearch to top-right of rudder

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/services/nodes/QuickSearchService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/nodes/QuickSearchService.scala
@@ -146,9 +146,9 @@ def matchNodeInfoPairs( serverPairs:Map[NodeId,LDAPEntry], allNodePairs:Map[Node
 }
 
 
-  //filter for ou=nodes based on attributes to look for in quicksearch
+  //filter for ou=nodes based on attributes to look for in quick search
   private[this] def nodeFilter(in:String) = OR( nodeAttributes.map(attr =>  SUB(attr, null, Array(in), null) ) :_* )
-  //filter for ou=severs in inventory based on attributes to look for in quicksearch
+  //filter for ou=severs in inventory based on attributes to look for in quick search
   private[this] def serverFilter(in:String, nodeIds:scala.collection.Set[NodeId]) = {
     val sub = serverAttributes.map(attr =>  SUB(attr, null, Array(in), null) )
     val otherNodes = nodeIds.map(id => EQ(A_NODE_UUID,id.value))

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -1310,11 +1310,15 @@ object RudderConfig extends Loggable {
   private[this] lazy val quickSearchServiceImpl = new QuickSearchServiceImpl(
     roLdap, nodeDitImpl, acceptedNodesDitImpl, ldapEntityMapper,
     //nodeAttributes
-    Seq(LDAPConstants.A_NAME, LDAPConstants.A_NODE_UUID),
+    Seq(
+        LDAPConstants.A_NAME
+      , LDAPConstants.A_NODE_UUID
+      , LDAPConstants.A_MANUFACTURER
+      , LDAPConstants.A_LIST_OF_IP
+    ),
     //serverAttributes
     Seq(
         LDAPConstants.A_HOSTNAME
-      , LDAPConstants.A_LIST_OF_IP
       , LDAPConstants.A_OS_NAME
       , LDAPConstants.A_OS_FULL_NAME
       , LDAPConstants.A_OS_VERSION

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/AutoCompleteAutoSubmit.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/AutoCompleteAutoSubmit.scala
@@ -223,6 +223,7 @@ class AutoCompleteAutoSubmit {
      /* merge the options that the user wants */
       val jqOptions =  ("minChars","0") ::
                        ("matchContains","true") ::
+                       ("selectFirst", "false") ::
                        Nil ::: jsonOptions
       val json = jqOptions.map(t => t._1 + ":" + t._2).mkString("{", ",", "}")
       val autocompleteOptions = JsRaw(json)
@@ -234,6 +235,7 @@ class AutoCompleteAutoSubmit {
           jQuery("#"""+hidden+"""").val(formatted);
           jQuery("#"""+hidden+"""").parents('form:first').submit();
         });
+        jQuery("#"""+id+"""").click(function() { $(this).select(); });
       });""")
 
       <span>

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/QuickSearchNode.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/QuickSearchNode.scala
@@ -1,0 +1,104 @@
+/*
+*************************************************************************************
+* Copyright 2011 Normation SAS
+*************************************************************************************
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU Affero GPL v3, the copyright holders add the following
+* Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU Affero GPL v3
+* licence, when you create a Related Module, this Related Module is
+* not considered as a part of the work and may be distributed under the
+* license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.web.snippet
+
+import scala.xml._
+import net.liftweb.http._
+import net.liftweb.http.js.JsCmds._
+import net.liftweb.http.js.JE._
+import net.liftweb.util._
+import com.normation.rudder.web.services.GetBaseUrlService
+import bootstrap.liftweb.RudderConfig
+import net.liftweb.http.js.JsCmd
+import net.liftweb.common._
+import com.normation.rudder.web.components.ShowNodeDetailsFromNode
+import net.liftmodules.widgets.autocomplete._
+import Helpers._
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.web.components.AutoCompleteAutoSubmit
+import com.normation.rudder.web.model.JsInitContextLinkUtil
+
+/**
+ * This snippet allow to display the node "quick search" field.
+ * It autocompletes on node hostname or id, and redirect
+ * to the search node page to display node details.
+ */
+class QuickSearchNode extends DispatchSnippet with Loggable {
+
+  private[this] val quickSearchService = RudderConfig.quickSearchService
+
+  def dispatch = {
+    case "render" => quickSearch
+  }
+
+  def quickSearch(html:NodeSeq) : NodeSeq = {
+    def buildQuery(current: String, limit: Int): Seq[String] = {
+      quickSearchService.lookup(current,100) match {
+        case Full(seq) => seq.map(nodeInfo => "%s [%s]".format(nodeInfo.hostname, nodeInfo.id.value))
+        case e:EmptyBox => {
+          logger.error("Error in quick search request",e)
+          Seq()
+        }
+      }
+    }
+
+    /*
+     * parse the return of the text show in autocomplete, build
+     * in buildQuery ( hostname name [uuuid] )
+     */
+    def parse(s:String) : JsCmd = {
+      val regex = """.+\[(.+)\]""".r
+      s match {
+        case regex(id) =>
+          RedirectTo(JsInitContextLinkUtil.nodeLink(NodeId(id)))
+        case _ =>
+          Alert("No node was selected")
+      }
+    }
+
+
+    <div class="topQuickSearch"><lift:form>{
+      AutoCompleteAutoSubmit(
+          ""
+        , buildQuery _
+        , { s:String => parse(s) }
+          //json option, see: https://code.google.com/p/jquery-autocomplete/wiki/Options
+        , ("resultsClass", "'topQuickSearchResults ac_results '") :: Nil
+        , ("placeholder" -> "Search nodes")
+      )
+    }</lift:form></div>
+
+  }
+}

--- a/rudder-web/src/main/webapp/secure/nodeManager/searchNodes.html
+++ b/rudder-web/src/main/webapp/secure/nodeManager/searchNodes.html
@@ -9,13 +9,18 @@
    <div class="portlet-content">
     <div class="intro">
      <div>
-       Make a quick search or a query base search.
+       Make a query base search and display node details
      </div>
     </div>
   
     <lift:node.SearchNodes.head />
   
-    <lift:node.SearchNodes.serverPorlet />
+    <div class="inner-portlet">
+      <div class="inner-portlet-content">  
+       <hr class="spacer"/> 
+       <div id="serverDetails" />
+      </div>
+    </div>
   
     <div class="inner-portlet">
      <div class="inner-portlet-header">Query based search</div>

--- a/rudder-web/src/main/webapp/style/rudder.css
+++ b/rudder-web/src/main/webapp/style/rudder.css
@@ -2599,12 +2599,38 @@ tr.unfoldable {
 }
 
 /***********************************
- * Quicksearch
+ * Quick search
 ************************************/
 
-.quicksearch {
+.quickSearch {
   text-align: center;
   margin-top: 5px;	
+}
+
+.topQuickSearch {
+  float: right;
+  margin-right: 10px;
+  margin-top: -3px;
+}
+
+.topQuickSearch .ac_input {
+  width:200px;
+  font-size:10px;
+  background: url("../images/icMagnify.png") no-repeat scroll left center white;
+  padding: 5px 3px 5px 30px;
+}
+
+.topQuickSearch .ac_input:focus {
+  width:400px;
+}
+  
+
+.topQuickSearchResults ul li {
+  font-size: 10px;
+}
+
+div.topQuickSearchResults.ac_results {
+  width: 404px !important;  
 }
 
 /***********************************

--- a/rudder-web/src/main/webapp/templates-hidden/common-layout.html
+++ b/rudder-web/src/main/webapp/templates-hidden/common-layout.html
@@ -96,10 +96,15 @@
     <!--Fin popin Login-->
   <!--Fin infos utilisateurs-->  
   
+  
   <!-- documentation link -->
   <div id="documentation">
     <a href="/rudder-doc">User manual</a>
   </div>
+  
+  <!-- top right quick search -->
+  <lift:QuickSearchNode />
+  
   </div>
   
   <!--Début Logo-->

--- a/rudder-web/src/main/webapp/templates-hidden/server/server_details.html
+++ b/rudder-web/src/main/webapp/templates-hidden/server/server_details.html
@@ -40,32 +40,6 @@
   </div>
 </query:SearchNodes>
      
-
-<lift:ignore>This part is the node detail portlet</lift:ignore>
-<server:portlet>
-
-<div class="inner-portlet">
-  <div class="inner-portlet-header">Quick search</div>
-   <div class="intro">
-     <div>Start typing a hostname or Rudder ID.</div>
-   </div>
-  <div class="inner-portlet-content">  
-     <lift:form>
-       <div class="quicksearch">
-         <server:quicksearch />
-         <server:quicksearchSubmit />
-       </div>
-     </lift:form>
-   
-   <hr class="spacer"/> 
-   <div id="serverDetails">
-     <server:details/>
-   </div>  
-  </div>
-</div>
-</server:portlet>
-
-
 <lift:ignore>This part is the detail of a node</lift:ignore>
 <detail:server>
 <div id="node_tabs" class="tabs">


### PR DESCRIPTION
Move the node quicksearch field to top right of Rudder. 
Take the occasion to clean the nodeSearch page: now, a node details is always displayed from an ajax call. 
Also, that ajax call is ALWAYS triggered from the "on hashchange" event, which is now supported for a long time (IE8, Chrome 5, FF3.6, etc). That simplifies a lot the logic of the page. 

The stilling was a little *****\* to get right. 
