### PR TITLE
set sustem variable RUDDER_MINIMAL_REPORTS's value

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/reports/ComplianceMode.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/reports/ComplianceMode.scala
@@ -43,22 +43,30 @@ import net.liftweb.common._
  * - error_only: only report for repaire and error reports.
  */
 
-sealed trait ComplianceMode
+sealed trait ComplianceMode {
+  def name: String
+}
 
-final case object FullCompliance extends ComplianceMode
-final case object ErrorOnly      extends ComplianceMode
+final case object FullCompliance extends ComplianceMode {
+  val name = "full-compliance"
+}
+final case object ChangesOnly      extends ComplianceMode {
+  val name = "changes-only"
+}
 
 
-object ComplianceMode {
+object ComplianceMode extends Loggable {
 
-  private[this] val ERROR = "erroronly"
-  private[this] val FULL  = "fullcompliance"
-
-  def parse(s: String): Box[ComplianceMode] = {
+  /*
+   * If we can't parse the compliance, default to full-compliance
+   */
+  def parse(s: String): ComplianceMode = {
     s.toLowerCase match {
-      case FULL  => Full(FullCompliance)
-      case ERROR => Full(ErrorOnly)
-      case _ => Failure(s"Unable to parse the compliance mode. I was expecting '${FULL}' or '${ERROR}' (case unsensitive) and got '${s}'")
+      case FullCompliance.name  => FullCompliance
+      case ChangesOnly.name => ChangesOnly
+      case _ =>
+        logger.error(s"Unable to parse the compliance mode. I was expecting '${FullCompliance.name}' or '${ChangesOnly.name}' (case unsensitive) and got '${s}'. Defaulting to full-compliance mode")
+        FullCompliance
     }
   }
 

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -1144,6 +1144,7 @@ object RudderConfig extends Loggable {
     , configService.cfengine_modified_files_ttl _
     , configService.cfengine_outputs_ttl _
     , configService.rudder_store_all_centralized_logs_in_file _
+    , configService.rudder_compliance_mode _
   )
   private[this] lazy val rudderCf3PromisesFileWriterService = new RudderCf3PromisesFileWriterServiceImpl(
     techniqueRepositoryImpl,


### PR DESCRIPTION
It is based on the availability of the value in the LDAP backend, so it needs https://github.com/Normation/rudder/pull/587 (ticket http://www.rudder-project.org/redmine/issues/5294) to be merged before. 
