### PR TITLE
Fixes #5504: remove LDAP client limit

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
@@ -107,7 +107,7 @@ case class RequestLimits (
   val requestSizeLimit:Int
 ) extends HashcodeCaching
 
-object DefaultRequestLimits extends RequestLimits(10,1000,10,1000)
+object DefaultRequestLimits extends RequestLimits(0,0,0,0)
 
 
 /**


### PR DESCRIPTION
It is not sensible to set hardcoded time/size limit in Rudder. We could enforce them from the LDAP server, but not from a point that is not modifiable for a client without the help of Normation. 
