### PR TITLE
Fixes #5767: add extension point for plugins in node details

### DIFF
--- a/rudder-web/src/main/webapp/templates-hidden/server/server_details.html
+++ b/rudder-web/src/main/webapp/templates-hidden/server/server_details.html
@@ -70,7 +70,7 @@
 <detail:server>
 <div id="node_tabs" class="tabs">
 	<server:header/>
-    <ul>
+    <ul id="NodeDetailsTabMenu">
       <li><a href="#node_summary">Node summary</a></li>
       <li><a href="#node_inventory">Hardware</a></li>
       <server:extraHeader/>


### PR DESCRIPTION
Basilcally, just extends the right class. I also promoted visibitliy of nodeId, because that's something plugin want to know for node details (ideally, we should even be able to access all node inventory info, but I didn't know how to do that - we should have a component only taking node information and in charge of diplaying them). 

I had to correct the way we used dispatch/display, because we used to completly shortcut the routing logic (where plugins hook) in our use of the code. 
