### PR TITLE
Fixes #5788: Description of default Rule "Global configuration for all n...

### DIFF
--- a/rudder-core/src/main/resources/ldap/bootstrap.ldif
+++ b/rudder-core/src/main/resources/ldap/bootstrap.ldif
@@ -231,7 +231,7 @@ ruleId: 32377fd7-02fd-43d0-aab7-28460a91347b
 ruleTarget: special:all
 cn: Global configuration for all nodes
 longDescription: This Rule was created automatically when Rudder was installed.
- It can be used to target Directives to all nodes (including the Rudder root
+  It can be used to target Directives to all nodes (including the Rudder root
   server itself), or deleted if you would rather create your own set of
   Rules (it will never be created again).
 isEnabled: TRUE


### PR DESCRIPTION
...odes" is missing a space

See http://www.rudder-project.org/redmine/issues/5788
