### PR TITLE
Fixes #5808: Handle missing techniques with active techniques in trees

### DIFF
--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayDirectiveTree.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayDirectiveTree.scala
@@ -170,7 +170,8 @@ object DisplayDirectiveTree extends Loggable {
               <h3>{technique.name}</h3>
               <div>{technique.description}</div>
             </div>
-          case None => <span class="error">No technique available for that active technique</span>
+          case None =>
+            <span class="error">The technique with id ''{activeTechnique.techniqueName}'' is missing from repository</span>
         }
 
         onClickTechnique match {

--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/JsTreeUtilService.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/JsTreeUtilService.scala
@@ -44,6 +44,7 @@ import com.normation.cfclerk.domain.TechniqueCategoryId
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueCategory
 import com.normation.rudder.domain.policies.ActiveTechniqueCategory
+import com.normation.cfclerk.domain.TechniqueName
 
 /**
  * An utility service for Directive* trees.
@@ -67,14 +68,12 @@ class JsTreeUtilService(
       }
     }
 
-    // get the Active Technique, loqg on error
-    def getActiveTechnique(id : ActiveTechniqueId,logger:Logger) : Option[(ActiveTechnique,Technique)] = {
+    // get the Active Technique, log on error
+    def getActiveTechnique(id : ActiveTechniqueId,logger:Logger) : Box[(ActiveTechnique, Option[Technique])] = {
       (for {
         activeTechnique <- directiveRepository.getActiveTechnique(id) ?~! "Error while fetching Active Technique %s".format(id)
-        technique <- Box(techniqueRepository.getLastTechniqueByName(activeTechnique.techniqueName)) ?~!
-              "Can not find referenced Technique '%s' in reference library".format(activeTechnique.techniqueName.value)
       } yield {
-        (activeTechnique,technique)
+        (activeTechnique, techniqueRepository.getLastTechniqueByName(activeTechnique.techniqueName))
       }) match {
         case Full(pair) => Some(pair)
         case e:EmptyBox =>
@@ -133,8 +132,8 @@ class JsTreeUtilService(
       sort(x.techniqueName.value , y.techniqueName.value)
     }
 
-    def sortPt(x:Technique,y:Technique) : Boolean = {
-      sort(x.name , y.name)
+    def sortPt(x:TechniqueName, y:TechniqueName) : Boolean = {
+      sort(x.value , y.value)
     }
 
     def sortPi(x:Directive,y:Directive) : Boolean = {


### PR DESCRIPTION
The goal is to let the user have a chance to actually be able to generate policies, even if a technique was removed from the git repos but still have active techniques. 

=> correct displaying of active techniques in directive/technique trees in that case, 
=> on the technique library management screen, disable active technique with missing techniques. 
