### PR TITLE
Fixes #5982: In API/rules include/exclude is ordered for target parameter

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
@@ -214,6 +214,8 @@ object RuleTarget extends Loggable {
 
     def unserComposition(json : JValue) : Box[TargetComposition] = {
       json match {
+        case JObject(Nil) =>
+          Full(TargetUnion())
         case JObject(JField("or",JArray(content)) :: Nil) =>
           for {
             targets <- sequence(content)(unserJson)
@@ -227,17 +229,28 @@ object RuleTarget extends Loggable {
             TargetIntersection(targets.toSet)
           }
       case _ =>
-        Failure(s"${json.toString} is not a valid rule target")
+        Failure(s"'${compact(render(json))}' is not a valid rule target")
       }
     }
 
     json match {
       case JString(s) =>
         unser(s)
-      case JObject(JField("include",includedJson) :: JField("exclude",excludedJson) :: Nil) =>
+      //we want to be able to have field in both order, but I don't know how to do it in an other way
+      case JObject(fields) =>
+        //look for include and exclude. We accept to not have each one,
+        //and if several are given, just take one
+
+        val include = fields.collect {
+          case JField("include", inc) => inc
+        }.headOption.getOrElse(JObject(Nil))
+        val exclude = fields.collect {
+          case JField("exclude", inc) => inc
+        }.headOption.getOrElse(JObject(Nil))
+
         for {
-          includeTargets <- unserComposition(includedJson)
-          excludeTargets <- unserComposition(excludedJson)
+          includeTargets <- unserComposition(include)
+          excludeTargets <- unserComposition(exclude)
         } yield {
           TargetExclusion(includeTargets,excludeTargets)
         }

--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/RestExtractorService.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/RestExtractorService.scala
@@ -299,7 +299,7 @@ case class RestExtractorService (
 
   private[this] def mergeTarget(seq: Seq[RuleTarget]): Box[Option[RuleTarget]] = {
     seq match {
-      case Seq() => Failure(s"Can not extract targets from parameters")
+      case Seq() =>Full(None)
       case head +: Seq() => Full(Some(head))
       case several =>
         //if we have only simple target, build a composite including


### PR DESCRIPTION
The main idea here is that we are much more lenient about empty/missing part of the target, and in the same go we remove the mandatory ordering
