### PR TITLE
Fixes #5982: In API/rules include/exclude is ordered for target parameter

### DIFF
--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/RestExtractorService.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/RestExtractorService.scala
@@ -299,7 +299,7 @@ case class RestExtractorService (
 
   private[this] def mergeTarget(seq: Seq[RuleTarget]): Box[Option[RuleTarget]] = {
     seq match {
-      case Seq() => Failure(s"Can not extract targets from parameters")
+      case Seq() => Full(None)
       case head +: Seq() => Full(Some(head))
       case several =>
         //if we have only simple target, build a composite including


### PR DESCRIPTION
The main idea here is that we are much more lenient about empty/missing part of the target, and in the same go we remove the mandatory ordering.
Also add a human understandable view of the json in an error message. 
