### PR TITLE
Fixes #6059: Graphes in home page take ages to display

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/domain/logger/TimingDebugLogger.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/logger/TimingDebugLogger.scala
@@ -1,0 +1,47 @@
+/*
+*************************************************************************************
+* Copyright 2012 Normation SAS
+*************************************************************************************
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU Affero GPL v3, the copyright holders add the following
+* Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU Affero GPL v3
+* licence, when you create a Related Module, this Related Module is
+* not considered as a part of the work and may be distributed under the
+* license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.domain.logger
+
+import org.slf4j.LoggerFactory
+import net.liftweb.common.Logger
+
+/**
+ * Applicative log of interest for Rudder ops.
+ */
+object TimingDebugLogger extends Logger {
+  override protected def _logger = LoggerFactory.getLogger("debug_timing")
+}
+
+

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -359,6 +359,7 @@ object RudderConfig extends Loggable {
   val woAgentRunsRepository : WoReportsExecutionRepository = woAgentRunsSquerylRepository
 
   val inMemoryChangeRequestRepository : InMemoryChangeRequestRepository = new InMemoryChangeRequestRepository
+  val ldapInventoryMapper = inventoryMapper
 
   val roChangeRequestRepository : RoChangeRequestRepository = {
     //a runtime checking of the workflow to use

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -55,7 +55,16 @@ import bootstrap.liftweb.RudderConfig
 import com.normation.ldap.sdk.FALSE
 import com.normation.rudder.domain.reports.ComplianceLevel
 import com.normation.inventory.domain.AcceptedInventory
-
+import com.normation.rudder.domain.logger.TimingDebugLogger
+import com.normation.inventory.domain.NodeId
+import com.normation.inventory.domain.InventoryStatus
+import com.normation.inventory.domain.Software
+import com.normation.inventory.domain.Version
+import com.normation.rudder.domain.nodes.NodeInfo
+import com.normation.utils.Control.sequence
+import com.unboundid.ldap.sdk.SearchRequest
+import com.unboundid.ldap.sdk.controls.MatchedValuesRequestControl
+import com.unboundid.ldap.sdk.controls.MatchedValuesFilter
 
 sealed trait ComplianceLevelPieChart{
   def color : String
@@ -91,30 +100,72 @@ case class RedChart (value : Int) extends ComplianceLevelPieChart{
   val color = "#d9534f"
 }
 
+
+object HomePage {
+  private val nodeInfosService = RudderConfig.nodeInfoService
+
+  object boxNodeInfos extends RequestVar[Box[Map[NodeId, NodeInfo]]](initNodeInfos) {
+    override def doSync[F](f: => F): F = this.synchronized(f)
+  }
+
+  def initNodeInfos(): Box[Map[NodeId, NodeInfo]] = {
+    TimingDebugLogger.debug(s"Start timing homepage")
+    val n1 = System.currentTimeMillis
+    val n = nodeInfosService.getAll
+    val n2 = System.currentTimeMillis
+    TimingDebugLogger.debug(s"Getting node infos: ${n2 - n1}ms")
+    n
+  }
+
+}
+
 class HomePage extends Loggable {
 
-  private[this] val ldap            = RudderConfig.roLDAPConnectionProvider
-  private[this] val pendingNodesDit = RudderConfig.pendingNodesDit
-  private[this] val nodeDit         = RudderConfig.nodeDit
-  private[this] val rudderDit       = RudderConfig.rudderDit
-  private[this] val nodeInfosService  = RudderConfig.nodeInfoService
-  private[this] val reportingService  = RudderConfig.reportingService
+  private[this] val ldap             = RudderConfig.roLDAPConnectionProvider
+  private[this] val pendingNodesDit  = RudderConfig.pendingNodesDit
+  private[this] val acceptedNodesDit = RudderConfig.acceptedNodesDit
+  private[this] val nodeDit          = RudderConfig.nodeDit
+  private[this] val rudderDit        = RudderConfig.rudderDit
+  private[this] val reportingService = RudderConfig.reportingService
   private[this] val softwareService  = RudderConfig.readOnlySoftwareDAO
+  private[this] val mapper           = RudderConfig.ldapInventoryMapper
+
+
+  def pendingNodes(html : NodeSeq) : NodeSeq = {
+    displayCount(countPendingNodes, "pending nodes")
+  }
+
+  def acceptedNodes(html : NodeSeq) : NodeSeq = {
+    displayCount(countAcceptedNodes, "accepted nodes")
+  }
+
+  def rules(html : NodeSeq) : NodeSeq = {
+    displayCount(countAllRules, "rules")
+  }
+
+  def directives(html : NodeSeq) : NodeSeq = {
+    displayCount(countAllDirectives,"directives")
+  }
+
+  def groups(html : NodeSeq) : NodeSeq = {
+    displayCount(countAllGroups,"groups")
+  }
+
+  def techniques(html : NodeSeq) : NodeSeq = {
+    displayCount(countAllTechniques,"techniques")
+  }
 
   def getAllCompliance = {
     ( for {
-      nodeInfos <- nodeInfosService.getAll
-      reports <-  reportingService.findRuleNodeStatusReports(nodeInfos.keySet, Set())
+      nodeInfos <- HomePage.boxNodeInfos.is
+      n2 = System.currentTimeMillis
+      reports   <- reportingService.findRuleNodeStatusReports(nodeInfos.keySet, Set())
+      n3 = System.currentTimeMillis
+      _ = TimingDebugLogger.debug(s"Compute compliance: ${n3 - n2}ms")
     } yield {
 
       val compliance = ComplianceLevel.sum(reports.map(_.compliance))
 
-      val machines = nodeInfos.values.groupBy(_.machineType).mapValues(_.size).map{case (a,b) => JsArray(a, b)}
-
-      val machinesArray = JsArray(machines.toList)
-
-      val os = nodeInfos.values.groupBy(_.osName).mapValues(_.size).map{case (a,b) => JsArray(a, b)}
-      val osArray = JsArray(os.toList)
 
       val complianceByNode : List[Float] = reports.groupBy(_.nodeId).mapValues(reports => ComplianceLevel.sum(reports.map(_.compliance)).compliance).values.toList
 
@@ -131,18 +182,6 @@ class HomePage extends Loggable {
         case (_,compliance) => RedChart(compliance.size)
       }).toList
 
-     val agents = for {
-       (nodeId,_) <- nodeInfos.toSeq
-       softs <- softwareService.getSoftware(nodeId, AcceptedInventory).toSeq
-
-         soft <- softs
-         if soft.name.getOrElse("") == "rudder-agent"
-     } yield {
-         soft.version.map(_.value.split("-").head)
-     }
-
-     val agentsValue = agents.groupBy(_.getOrElse("Unknown")).mapValues(_.size).map{case (a,b) => JsArray(a, b)}
-     val agentsData =JsArray(agentsValue.toList)
      val sorted = complianceDiagram.sortWith{
         case (a:GreenChart,_) => true
         case (a:BlueChart,_:GreenChart) => false
@@ -170,16 +209,12 @@ class HomePage extends Loggable {
 
      val globalCompliance = compliance.compliance.round
 
-     <div id="globalCompliance"></div> ++
      Script(OnLoad(JsRaw(s"""
         homePage(
             ${array.toJsCmd}
           , ${globalCompliance}
           , ${diagramData.toJsCmd}
           , ${diagramColor.toJsCmd}
-          , ${machinesArray.toJsCmd}
-          , ${osArray.toJsCmd}
-          , ${agentsData.toJsCmd}
         )""")))
     } ) match {
       case Full(complianceBar) => complianceBar
@@ -189,44 +224,150 @@ class HomePage extends Loggable {
     }
   }
 
-  private def countPendingNodes() : Box[Int] = {
+  def inventoryInfo() = {
+    ( for {
+      nodeInfos <- HomePage.boxNodeInfos.is
+    } yield {
+      val machines = nodeInfos.values.groupBy(_.machineType).mapValues(_.size).map{case (a,b) => JsArray(a, b)}
+      val machinesArray = JsArray(machines.toList)
+      val os = nodeInfos.values.groupBy(_.osName).mapValues(_.size).map{case (a,b) => JsArray(a, b)}
+      val osArray = JsArray(os.toList)
+
+      Script(OnLoad(JsRaw(s"""
+        homePageInventory(
+            ${machinesArray.toJsCmd}
+          , ${osArray.toJsCmd}
+        )""")))
+    } ) match {
+      case Full(inventory) => inventory
+      case _ => NodeSeq.Empty
+    }
+  }
+
+  def rudderAgentVersion() = {
+
+     val n4 = System.currentTimeMillis
+     val agents = getRudderAgentVersion match {
+       case Full(x) => x
+       case eb: EmptyBox =>
+         val e = eb ?~! "Error when getting installed agent version on nodes"
+         logger.debug(e.messageChain)
+         e.rootExceptionCause.foreach { ex =>
+           logger.debug("Root exception was:", ex)
+         }
+         Map("Unknown" -> 1)
+     }
+     TimingDebugLogger.debug(s"Get software: ${System.currentTimeMillis-n4}ms")
+
+     val agentsValue = agents.map{case (a,b) => JsArray(a, b)}
+     val agentsData =JsArray(agentsValue.toList)
+
+     Script(OnLoad(JsRaw(s"""
+        homePageSoftware(
+            ${agentsData.toJsCmd}
+     )""")))
+  }
+
+
+  /**
+   * Get the count of agent version name -> size for accepted nodes
+   */
+  private[this] def getRudderAgentVersion() : Box[Map[String, Int]] = {
+    import com.normation.ldap.sdk._
+    import com.normation.ldap.sdk.BuildFilter.{EQ,OR}
+    import com.normation.inventory.ldap.core.LDAPConstants.{A_NAME, A_SOFTWARE_UUID, A_NODE_UUID, A_SOFTWARE_DN}
+    import com.unboundid.ldap.sdk.DN
+
+    val unknown = new Version("Unknown")
+
+    val n1 = System.currentTimeMillis
+    for {
+      con <- ldap
+      nodeInfos        <- HomePage.boxNodeInfos.is
+      n2               =  System.currentTimeMillis
+      agentSoftEntries =  con.searchOne(acceptedNodesDit.SOFTWARE.dn, EQ(A_NAME, "rudder-agent"))
+      agentSoftDn      =  agentSoftEntries.map(_.dn.toString).toSet
+      agentSoft        <- sequence(agentSoftEntries){ entry =>
+                            mapper.softwareFromEntry(entry) ?~! "Error when mapping LDAP entry %s to a software".format(entry)
+                          }
+      n3               =  System.currentTimeMillis
+      _                =  TimingDebugLogger.debug(s"Get agent software entries: ${n3-n2}ms")
+      nodeEntries      =  {
+                            val sr = new SearchRequest(
+                                acceptedNodesDit.NODES.dn.toString
+                              , One
+                              , OR(agentSoft.map(x => EQ(A_SOFTWARE_DN, acceptedNodesDit.SOFTWARE.SOFT.dn(x.id).toString)):_*)
+                              , A_NODE_UUID, A_SOFTWARE_DN
+                            )
+                            //only get interesting entries control - that make a huge difference in perf
+                            sr.addControl(new MatchedValuesRequestControl(agentSoftDn.map(dn => MatchedValuesFilter.createEqualityFilter(A_SOFTWARE_DN, dn)).toSeq:_*))
+                            con.search(sr)
+                          }
+      n4               =  System.currentTimeMillis
+      _                =  TimingDebugLogger.debug(s"Get nodes for agent: ${n4-n3}ms")
+    } yield {
+
+      val agentMap = agentSoft.map(x => (x.id.value, x)).toMap
+      val agents = agentMap.keySet
+
+      val agentVersionByNodeEntries = nodeEntries.map { e =>
+        (
+            NodeId(e.value_!(A_NODE_UUID))
+          , e.valuesFor(A_SOFTWARE_DN).intersect(agentSoftDn).flatMap { x =>
+              acceptedNodesDit.SOFTWARE.SOFT.idFromDN(new DN(x)).flatMap(s => agentMap(s.value).version)
+            }
+        )
+      }.toMap
+
+      // take back the initial set of nodes to be sure to have one agent for each
+      val allAgents = nodeInfos.keySet.toSeq.flatMap(nodeId => agentVersionByNodeEntries.getOrElse(nodeId, Set(unknown)).toSeq )
+
+      //now, count and version display
+      val res = allAgents.groupBy(identity).mapValues(_.size).map{case (a,b) => (a.value.split("-").head, b)}
+
+      TimingDebugLogger.debug(s"=> group and count agents: ${System.currentTimeMillis-n4}ms")
+      res
+    }
+  }
+
+  private[this] def countPendingNodes() : Box[Int] = {
     ldap.map { con =>
       con.searchOne(pendingNodesDit.NODES.dn, ALL, "1.1")
     }.map(x => x.size)
   }
 
-  private def countAcceptedNodes() : Box[Int] = {
+  private[this] def countAcceptedNodes() : Box[Int] = {
     ldap.map { con =>
       con.searchOne(nodeDit.NODES.dn, NOT(IS(OC_POLICY_SERVER_NODE)), "1.1")
     }.map(x => x.size)
   }
 
-  private def countAllRules() : Box[Int] = {
+  private[this] def countAllRules() : Box[Int] = {
     ldap.map { con =>
       con.searchOne(rudderDit.RULES.dn, EQ(A_IS_SYSTEM, FALSE.toLDAPString), "1.1")
     }.map(x => x.size)
   }
 
-  private def countAllDirectives() : Box[Int] = {
+  private[this] def countAllDirectives() : Box[Int] = {
     ldap.map { con =>
       con.searchSub(rudderDit.ACTIVE_TECHNIQUES_LIB.dn, AND(IS(OC_DIRECTIVE), EQ(A_IS_SYSTEM, FALSE.toLDAPString)), "1.1")
     }.map(x => x.size)
   }
 
-  private def countAllTechniques() : Box[Int] = {
+  private[this] def countAllTechniques() : Box[Int] = {
     ldap.map { con =>
       con.searchSub(rudderDit.ACTIVE_TECHNIQUES_LIB.dn, AND(IS(OC_ACTIVE_TECHNIQUE), EQ(A_IS_SYSTEM, FALSE.toLDAPString)), "1.1")
     }.map(x => x.size)
   }
 
-  private def countAllGroups() : Box[Int] = {
+  private[this] def countAllGroups() : Box[Int] = {
     ldap.map { con =>
       con.searchSub(rudderDit.GROUP.dn, AND(IS(OC_RUDDER_NODE_GROUP), EQ(A_IS_SYSTEM, FALSE.toLDAPString)), "1.1")
     }.map(x => x.size)
   }
 
 
-  def displayCount( count : () => Box[Int], name : String) ={
+  private[this] def displayCount( count : () => Box[Int], name : String) ={
     Text((count() match {
       case Empty => 0
       case m:Failure =>
@@ -236,27 +377,5 @@ class HomePage extends Loggable {
     }).toString)
   }
 
-  def pendingNodes(html : NodeSeq) : NodeSeq = {
-    displayCount(countPendingNodes, "pending nodes")
-  }
 
-  def acceptedNodes(html : NodeSeq) : NodeSeq = {
-    displayCount(countAcceptedNodes, "accepted nodes")
-  }
-
-  def rules(html : NodeSeq) : NodeSeq = {
-    displayCount(countAllRules, "rules")
-  }
-
-  def directives(html : NodeSeq) : NodeSeq = {
-    displayCount(countAllDirectives,"directives")
-  }
-
-  def groups(html : NodeSeq) : NodeSeq = {
-    displayCount(countAllGroups,"groups")
-  }
-
-  def techniques(html : NodeSeq) : NodeSeq = {
-    displayCount(countAllTechniques,"techniques")
-  }
 }

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
@@ -74,6 +74,7 @@ import com.normation.rudder.repository.EventLogRepository
 import com.normation.eventlog.ModificationId
 import com.normation.utils.StringUuidGenerator
 import bootstrap.liftweb.RudderConfig
+import com.normation.rudder.domain.logger.TimingDebugLogger
 
 /**
  * Check for server in the pending repository and propose to
@@ -171,7 +172,13 @@ class AcceptNode {
     val modId = ModificationId(uuidGen.newUuid)
     //TODO : manage error message
     S.clearCurrentNotices
-    listNode.foreach { id => newNodeManager.accept(id, modId, CurrentUser.getActor) match {
+    listNode.foreach { id =>
+      val now = System.currentTimeMillis
+      val accept = newNodeManager.accept(id, modId, CurrentUser.getActor)
+      if(TimingDebugLogger.isDebugEnabled) {
+        TimingDebugLogger.debug(s"Accepting node ${id.value}: ${System.currentTimeMillis - now}ms")
+      }
+      accept match {
       case f:Failure =>
         S.error(
           <span class="error">

--- a/rudder-web/src/main/webapp/javascript/rudder/homePage.js
+++ b/rudder-web/src/main/webapp/javascript/rudder/homePage.js
@@ -37,9 +37,6 @@ function homePage (
   , globalGauge
   , nodeCompliance
   , nodeComplianceColors
-  , nodeMachines
-  , nodeOses
-  , nodeAgents
 ) {
   $("#globalCompliance").append(buildComplianceBar(globalCompliance));
   createTooltip();
@@ -86,8 +83,13 @@ function homePage (
         }
       }
   } );
+}
 
-  var smallHeight = height / 2
+function homePageInventory (
+    nodeMachines
+  , nodeOses
+) {
+  var smallHeight =  $(window).height() / 4 ;
 
   c3.generate({
       size: { height: smallHeight }
@@ -102,9 +104,7 @@ function homePage (
         }
       }
   } );
-  
-
-  
+    
   c3.generate({
     size: { height: smallHeight }
   , bindto: '#nodeOs'
@@ -117,14 +117,20 @@ function homePage (
         show: false
       }
     }
-  } );
-  
+  } );      
+}
+
+function homePageSoftware (
+      nodeAgents
+  ) {
+  var smallHeight =  $(window).height() / 4 ;
+ 
   c3.generate({
     size: { height: smallHeight }
   , bindto: '#nodeAgents'
   , data: {
         columns: nodeAgents
-      , type : 'donut'
+      , type   : 'donut'
     }
   , donut : {
       label: {

--- a/rudder-web/src/main/webapp/secure/index.html
+++ b/rudder-web/src/main/webapp/secure/index.html
@@ -42,13 +42,14 @@
   </div>
  
   <div class="col-sm-10" style="padding-right:0">
+    
     <div class="row">
       <div class="col-sm-4">
         <div class="panel panel-default">
         <div class="panel-heading">Global compliance</div>
           <div class="text-center">
-          <canvas id="complianceGauge" width="360" height="180" class=""></canvas>
-          <span id="gauge-value"></span>
+            <canvas id="complianceGauge" width="360" height="180" class=""></canvas>
+            <span id="gauge-value"></span>
           </div>
         </div>
       </div>
@@ -56,9 +57,7 @@
       <div class="col-sm-8">
         <div class="panel panel-default" style="height:223px">
           <div class="panel-heading">Global compliance details</div>
-          <div data-lift="lazy-load">
-            <lift:HomePage.getAllCompliance/>
-          </div>
+          <div id="globalCompliance"></div>
         </div>
       </div>
     </div>
@@ -68,8 +67,10 @@
         <div id="nodeOverview" class="panel panel-default">
           <div class="panel-heading">Nodes by overall compliance</div>
           <div id="nodeCompliance" class=""></div>
+          <div data-lift="lazy-load"><lift:HomePage.getAllCompliance/></div>
         </div>    
       </div>
+
 
       <div class=" col-sm-7">
         <div class="panel panel-default">
@@ -81,10 +82,13 @@
           <div class=" col-sm-4">
             <h4>By OS</h4>
             <div id="nodeOs"></div>
+            <div data-lift="lazy-load"><lift:HomePage.inventoryInfo/></div>
           </div>
           <div class=" col-sm-4">
             <h4>By agent version</h4>
-            <div id="nodeAgents"></div>
+            <div id="nodeAgents">
+              <div data-lift="lazy-load"><lift:HomePage.rudderAgentVersion/></div>
+            </div>        
           </div>
           <div style="clear: both;"></div> 
         </div>
@@ -92,5 +96,6 @@
     </div>
   </div>
 </div>
+
 </lift:surround>
 


### PR DESCRIPTION
There is three main item here:
- the addition of a logger for Timing-related info,
- the split of the big ajax call for all graphes in 3 (one for each kind of data needed in the background: node infos, software, compliance)
- massive optimisation of software retrieval  (from O(nb_node) to O(1)) and optimisation of nodeInfo (~ time/2)
