### PR TITLE
Fixes #6063: Performance of retrieving last node run reports time impact...

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionRepository.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionRepository.scala
@@ -37,7 +37,7 @@ package com.normation.rudder.reports.execution
 import com.normation.inventory.domain.NodeId
 import net.liftweb.common._
 import org.joda.time.DateTime
-
+import com.normation.rudder.repository.CachedRepository
 
 /**
  * Service for reading or storing execution of Nodes
@@ -71,4 +71,59 @@ trait WoReportsExecutionRepository {
    */
   def updateExecutions(executions : Seq[AgentRun]) : Box[Seq[AgentRun]]
 
+}
+
+/**
+ * A cached version of the service that only look in the underlying data (expected to
+ * be slow) when no cache available.
+ */
+class CachedReportsExecutionRepository(
+    readBackend : RoReportsExecutionRepository
+  , writeBackend: WoReportsExecutionRepository
+) extends RoReportsExecutionRepository with WoReportsExecutionRepository with CachedRepository {
+
+  /*
+   * We need to synchronise on cache to avoid the case:
+   * - initial state: RUNS_0 in backend
+   * - write RUNS_1 (cache => None) : ok, only write in backend
+   * [interrupt before actual write]
+   * - read: cache = None => update cache with RUNS_0
+   * - cache = RUNS_0
+   * [resume write]
+   * - write in backend RUNS_1
+   *
+   * => cache will never ses RUNS_1 before a clear.
+   */
+
+  /*
+   * The cache is managed node by node, i.e it can be initialized
+   * for certain and not for other.
+   * The initialization criteria (and so, the fact that the cache
+   * can be used for a given node) is given by the presence of the
+   * nodeid in map's keys.
+   */
+  private[this] var cache = Map[NodeId, Option[AgentRun]]()
+
+
+  override def clearCache(): Unit = this.synchronized {
+    cache = Map()
+  }
+
+  override def getNodesLastRun(nodeIds: Set[NodeId]): Box[Map[NodeId, Option[AgentRun]]] = this.synchronized {
+    for {
+      runs <- readBackend.getNodesLastRun(nodeIds.diff(cache.keySet))
+    } yield {
+      cache = cache ++ runs
+      cache.filterKeys { x => nodeIds.contains(x) }
+    }
+  }
+
+  override def updateExecutions(executions : Seq[AgentRun]) : Box[Seq[AgentRun]] = this.synchronized {
+    for {
+      runs <- writeBackend.updateExecutions(executions)
+    } yield {
+      cache = cache ++ runs.map(x => (x.agentRunId.nodeId, Some(x))).toMap
+      runs
+    }
+  }
 }

--- a/rudder-core/src/main/scala/com/normation/rudder/repository/CachedRepository.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/repository/CachedRepository.scala
@@ -1,0 +1,45 @@
+/*
+*************************************************************************************
+* Copyright 2015 Normation SAS
+*************************************************************************************
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU Affero GPL v3, the copyright holders add the following
+* Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU Affero GPL v3
+* licence, when you create a Related Module, this Related Module is
+* not considered as a part of the work and may be distributed under the
+* license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.repository
+
+/**
+ * A trait that allows to call a "clearCache" method on
+ * repositories which do cache
+ */
+trait  CachedRepository {
+
+  def clearCache() : Unit
+
+}

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ClearCache.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ClearCache.scala
@@ -63,6 +63,7 @@ class ClearCache extends DispatchSnippet with Loggable {
   private[this] val asyncDeploymentAgent     = RudderConfig.asyncDeploymentAgent
   private[this] val eventLogRepository       = RudderConfig.eventLogRepository
   private[this] val uuidGen                  = RudderConfig.stringUuidGenerator
+  private[this] val agentRunCache            = RudderConfig.cacheForAgentRunsRepository
 
   def dispatch = {
     case "render" => clearCache
@@ -79,6 +80,11 @@ class ClearCache extends DispatchSnippet with Loggable {
       S.clearCurrentNotices
 
       val modId = ModificationId(uuidGen.newUuid)
+
+      //clear agentRun cache
+      agentRunCache.clearCache()
+
+      //clear node configuration cache
       nodeConfigurationService.deleteAllNodeConfigurations match {
         case empty:EmptyBox =>
           val e = empty ?~! "Error when clearing caches"


### PR DESCRIPTION
The main idea is just to encapsulate the read/write of node runs into a proxy service which holds a cache. 

A little synchronisation is needed to avoid loosing some runs, but that's 20 lines of code that massively speed up things. 