### PR TITLE
Fixes #5452: Performance issue for node list

### DIFF
--- a/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
@@ -51,6 +51,7 @@ import com.normation.inventory.ldap.core._
 import com.normation.inventory.domain.NodeId
 import com.normation.utils.HashcodeCaching
 import com.normation.rudder.services.nodes.NodeInfoServiceImpl
+import com.normation.rudder.services.nodes.NodeInfoServiceCachedImpl
 
 /*
  * Test query parsing.
@@ -101,7 +102,7 @@ class TestQueryProcessor extends Loggable {
   val inventoryMapper = new InventoryMapper(ditService, pendingDIT, DIT, removedDIT)
   val internalLDAPQueryProcessor = new InternalLDAPQueryProcessor(ldap,DIT,ditQueryData,ldapMapper)
 
-  val nodeInfoService = new NodeInfoServiceImpl(nodeDit, rudderDit, DIT, ldap, ldapMapper, inventoryMapper, ditService)
+  val nodeInfoService = new NodeInfoServiceCachedImpl(ldap, nodeDit, DIT, ldapMapper)
 
   val queryProcessor = new AccepetedNodesLDAPQueryProcessor(
       nodeDit,

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -1384,14 +1384,11 @@ object RudderConfig extends Loggable {
    , groupLibReadWriteMutex
   )
   private[this] lazy val eventLogDeploymentServiceImpl = new EventLogDeploymentService(logRepository, eventLogDetailsServiceImpl)
-  private[this] lazy val nodeInfoServiceImpl: NodeInfoService = new NodeInfoServiceImpl(
-      nodeDitImpl
-    , rudderDitImpl
+  private[this] lazy val nodeInfoServiceImpl: NodeInfoService = new NodeInfoServiceCachedImpl(
+      roLdap
+    , nodeDitImpl
     , acceptedNodesDitImpl
-    , roLdap
     , ldapEntityMapper
-    , inventoryMapper
-    , inventoryDitService
   )
   private[this] lazy val dependencyAndDeletionServiceImpl: DependencyAndDeletionService = new DependencyAndDeletionServiceImpl(
         roLdap


### PR DESCRIPTION
Major performance improvment on "nodeInfo" with a "cached" implementation of the nodeInfoService in place of the dumb one. 
The propose change lead to two major perf improvment:
- for dynGroup, reduce the number of request from "Number of node in group" to one (1000x improvment with > 1000 nodes in groups)
- when getting the list of all nodeInfo, time from ~4000ms to ~20ms
