### PR TITLE
Fixes #6206: On policy server, we do override the run interval, and the ...

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
@@ -304,17 +304,22 @@ class SystemVariableServiceImpl(
       }
 
     val heartBeatFrequency = {
-      globalComplianceMode match {
-        case FullCompliance =>
-          1
-        case ChangesOnly(globalFrequency) =>
-          nodeInfo.nodeReportingConfiguration.heartbeatConfiguration match {
-            // It overrides! use it to compute the new heartbeatInterval
-            case Some(heartbeatConf) if heartbeatConf.overrides =>
-              heartbeatConf.heartbeatPeriod
-            case _ =>
-              globalFrequency
-          }
+      if (nodeInfo.isPolicyServer) {
+        // A policy server is always sending heartbeat
+        1
+      } else {
+        globalComplianceMode match {
+          case FullCompliance =>
+            1
+          case ChangesOnly(globalFrequency) =>
+            nodeInfo.nodeReportingConfiguration.heartbeatConfiguration match {
+              // It overrides! use it to compute the new heartbeatInterval
+              case Some(heartbeatConf) if heartbeatConf.overrides =>
+                heartbeatConf.heartbeatPeriod
+              case _ =>
+                globalFrequency
+            }
+        }
       }
     }
 


### PR DESCRIPTION
...expected frequency for reports, but the generated promises don't override the heartbeat frequency, causing non answer in the webapp