### PR TITLE
Fixes #5764: List of impacted rules when accepting nodes or modifing directives is not accurate

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/domain/servers/Srv.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/servers/Srv.scala
@@ -34,41 +34,28 @@
 
 package com.normation.rudder.domain.servers
 
-import com.normation.inventory.domain._
-import com.normation.inventory.ldap.core._
-import LDAPConstants._
-import com.normation.utils.Utils._
-import org.slf4j.LoggerFactory
 import org.joda.time.DateTime
-import com.normation.rudder.domain.RudderLDAPConstants._
 import com.normation.utils.HashcodeCaching
-
-
-
-// TODO : merge with NodeInventory.NodeSummary
+import com.normation.inventory.domain.NodeId
+import com.normation.inventory.domain.ServerRole
+import com.normation.inventory.domain.InventoryStatus
+import com.normation.rudder.domain.RudderLDAPConstants._
 
 
 /**
  * Class that only contains most meaningfull data about a server (a non registered node)
- * (it's a server, shorten, so its name)
- * Properties are "web friendly" (i.e: string, never null, perhaps empty)
- * @param id - uuid of the server, ex: 27e0e8e8-dfc4-487e-975f-065b073f0b1f
- * @param hostname - full hostname of the server, ex: foobox1.example.com
- * @param osType - os description of the server, ex: Linux
- * @param osName - linux distribution, windows version, etc
- * @param osFullName - long description about the os (distribution, type, version, etc)
- * @param ips : the server's list of ip
- * @param creationDate : the creation date of the object
  */
 case class Srv(
-    id          : NodeId
-  , status      : InventoryStatus
-  , hostname    : String
-  , osType      : String
-  , osName      : String
-  , osFullName  : String
-  , ips         : List[String]
-  , creationDate: DateTime
+    id            : NodeId
+  , status        : InventoryStatus
+  , hostname      : String
+  , osType        : String
+  , osName        : String
+  , osFullName    : String
+  , ips           : List[String]
+  , creationDate  : DateTime
+  , isPolicyServer: Boolean
+  , serverRoles   : Set[ServerRole]
 ) extends HashcodeCaching
 
 
@@ -92,5 +79,6 @@ object Srv {
    , A_NAME
    , A_LIST_OF_IP
    , A_OBJECT_CREATION_DATE
+   , A_SERVER_ROLE
   )
 }

--- a/rudder-core/src/main/scala/com/normation/rudder/services/servers/ServerSummaryService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/servers/ServerSummaryService.scala
@@ -85,14 +85,16 @@ class NodeSummaryServiceImpl(
       }}
 
       Srv(
-          id           = node.main.id
-        , status       = node.main.status
-        , hostname     = node.main.hostname
-        , osType       = node.main.osDetails.os.kernelName
-        , osName       = node.main.osDetails.os.name
-        , osFullName   = node.main.osDetails.fullName
-        , ips          = node.serverIps.toList
-        , creationDate = dateTime
+          id             = node.main.id
+        , status         = node.main.status
+        , hostname       = node.main.hostname
+        , osType         = node.main.osDetails.os.kernelName
+        , osName         = node.main.osDetails.os.name
+        , osFullName     = node.main.osDetails.fullName
+        , ips            = node.serverIps.toList
+        , creationDate   = dateTime
+        , isPolicyServer = e.isA(OC_POLICY_SERVER_NODE)
+        , serverRoles    = node.serverRoles
       )
     }
   }

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ExpectedPolicyPopup.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ExpectedPolicyPopup.scala
@@ -34,30 +34,20 @@
 
 package com.normation.rudder.web.components.popup
 
-import com.normation.rudder.services.servers.NodeSummaryService
-import com.normation.rudder.domain.policies._
-import com.normation.inventory.domain.NodeId
-import com.normation.rudder.services.queries.DynGroupService
-import com.normation.rudder.services.policies._
-import com.normation.utils.Control.sequence
-import com.normation.inventory.ldap.core.InventoryDit
-import com.normation.exceptions.TechnicalException
-import scala.xml._
-import net.liftweb.common._
-import net.liftweb.http._
-import net.liftweb.util._
-import Helpers._
-import net.liftweb.http.js._
-import JsCmds._
-import JE._
-import net.liftweb.http.SHtml._
-import org.joda.time.DateTime
-import org.slf4j.LoggerFactory
-import com.normation.rudder.domain.RudderDit
-import com.normation.rudder.web.services.NodeGrid
-import com.normation.rudder.web.components.RuleGrid
-import bootstrap.liftweb.RudderConfig
 
+import bootstrap.liftweb.RudderConfig
+import com.normation.exceptions.TechnicalException
+import com.normation.rudder.domain.policies.RuleTarget
+import com.normation.rudder.domain.policies.Rule
+import com.normation.rudder.domain.servers.Srv
+import com.normation.rudder.web.components.RuleGrid
+import net.liftweb.http.DispatchSnippet
+import net.liftweb.common._
+import net.liftweb.http.Templates
+import net.liftweb.util.ClearClearable
+import net.liftweb.util.Helpers._
+import scala.xml.NodeSeq
+import scala.xml.Text
 
 object ExpectedPolicyPopup {
 
@@ -75,27 +65,22 @@ object ExpectedPolicyPopup {
 }
 
 class ExpectedPolicyPopup(
-  htmlId_popup:String,
-  nodeId : NodeId
+  htmlId_popup: String,
+  nodeSrv     : Srv
 ) extends DispatchSnippet with Loggable {
   import ExpectedPolicyPopup._
 
-  private[this] val serverSummaryService = RudderConfig.nodeSummaryService
-  private[this] val dependenciesServices = RudderConfig.dependencyAndDeletionService
-  private[this] val dynGroupService      = RudderConfig.dynGroupService
-  private[this] val pendingNodesDit      = RudderConfig.pendingNodesDit
-
-
+  private[this] val ruleRepository  = RudderConfig.roRuleRepository
+  private[this] val dynGroupService = RudderConfig.dynGroupService
 
   def dispatch = {
     case "display" => {_ => display }
   }
 
-
   def display : NodeSeq = {
 
     //find the list of dyn groups on which that server would be and from that, the Rules
-    val rulesGrid : NodeSeq = rules match {
+    val rulesGrid : NodeSeq = getDependantRulesForNode match {
       case Full(seq) =>
         (new RuleGrid("dependentRulesGrid", seq, None, false)).rulesGridWithUpdatedInfo(popup = true,false)
       case e:EmptyBox =>
@@ -108,45 +93,28 @@ class ExpectedPolicyPopup(
         ClearClearable &
         "#dependentRulesGrid" #> rulesGrid
     )(bind("expectedPolicyPopup",expectedTechnique,
-      "node" -> displayNode(nodeId),
+      "node" -> displayNode(nodeSrv),
       "close" -> <button onClick="$.modal.close(); return false;">Close</button>
     ) )
   }
 
-
-  private[this] val rules:Box[Seq[Rule]] = {
+  private[this] val getDependantRulesForNode:Box[Seq[Rule]] = {
     for {
-      allNodesRules               <- dependenciesServices.targetDependencies(AllTarget).map(_.rules.toSeq) ?~!
-                                       "Error when building the list of Rules depending on 'All nodes' system Group"
-      allExceptPolicyServersRules <- dependenciesServices.targetDependencies(AllTargetExceptPolicyServers).map(_.rules.toSeq) ?~!
-                                       "Error when building the list of Rules depending on 'All nodes except policy servers' system Group"
-
-      groupMap       <- dynGroupService.findDynGroups(Seq(nodeId)) ?~! "Error when building the map of dynamic group to update by node"
-      seqNodeGroupId = groupMap.get(nodeId).getOrElse(Seq())
-      seqTargetDeps  <- sequence(seqNodeGroupId) { groupId =>
-                          dependenciesServices.
-                            targetDependencies(GroupTarget(groupId)) ?~!
-                              s"Error when building the list of Rules depending on Group ${groupId.value}"
-                        }
+      dynGroup     <- dynGroupService.findDynGroups(Seq(nodeSrv.id)) ?~! "Error when building the map of dynamic group to update by node"
+      groupTargets =  dynGroup.getOrElse(nodeSrv.id, Seq())
+      rules        <- ruleRepository.getAll(includeSytem = false)
     } yield {
-      (seqTargetDeps.flatMap { _.rules } ++ allExceptPolicyServersRules ++ allNodesRules).distinct
+      val allNodes = Map( (nodeSrv.id , (nodeSrv.isPolicyServer, nodeSrv.serverRoles)) )
+      val groups = groupTargets.map { x => (x, Set(nodeSrv.id)) }.toMap
+
+      rules.filter { r =>
+        RuleTarget.getNodeIds(r.targets, allNodes, groups).nonEmpty
+      }
     }
   }
 
-
-  private[this] def displayNode(nodeId : NodeId) : NodeSeq = {
-    serverSummaryService.find(pendingNodesDit,nodeId) match {
-      case Full(srv) =>
-        srv.toList match {
-          case Nil => <div>Node not found</div>
-          case head::Nil => Text(head.hostname + " - " +head.osFullName)
-          case _ => logger.error("Too many nodes returned while searching server %s".format(nodeId.value))
-                  <p class="error">ERROR - Too many nodes</p>
-        }
-      case _ => <div>No node found</div>
-    }
-
+  private[this] def displayNode(srv : Srv) : NodeSeq = {
+    Text(srv.hostname + " - " + srv.osFullName)
   }
-
 
 }

--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/NodeGrid.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/NodeGrid.scala
@@ -217,7 +217,7 @@ class NodeGrid(getNodeAndMachine:LDAPFullInventoryRepository) extends Loggable {
     <table id={tableId} class="fixedlayout" cellspacing="0">{
     bind("servergrid",tableTemplate,
       "header" -> (columns flatMap { c => <th>{c._1}<span/></th> }),
-      "lines" -> ( servers.flatMap { case s@Srv(id,status, hostname,ostype,osname,osFullName,ips,creationDate) =>
+      "lines" -> ( servers.flatMap { case s@Srv(id,status, hostname,ostype,osname,osFullName,ips,creationDate, _, _) =>
         //build all table lines
         (".hostname *" #> {(if(isEmpty(hostname)) "(Missing host name) " + id.value else hostname)} &
          ".fullos *" #> osFullName &

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
@@ -283,7 +283,7 @@ class AcceptNode {
         serverSummaryService.find(pendingNodeDit,listNode:_*) match {
           case Full(servers) =>
             bind("servergrid",template,
-              "lines" -> servers.flatMap { case s@Srv(id,status, hostname,ostype, osname, fullos, ips, _) =>
+              "lines" -> servers.flatMap { case s@Srv(id,status, hostname,ostype, osname, fullos, ips,  _, _, _) =>
                  bind("line",chooseTemplate("servergrid","lines",template),
                     "os" -> fullos,
                     "hostname" -> hostname,
@@ -325,9 +325,9 @@ class AcceptNode {
   /**
    * Display the expected Directives for a machine
    */
-  def showExpectedPolicyPopup(nodeId : NodeId) = {
+  def showExpectedPolicyPopup(node : Srv) = {
 
-    SetHtml("expectedPolicyZone", (new ExpectedPolicyPopup("expectedPolicyZone", nodeId)).display ) &
+    SetHtml("expectedPolicyZone", (new ExpectedPolicyPopup("expectedPolicyZone", node)).display ) &
     OnLoad(JsRaw("""createPopup("expectedPolicyPopup")""") )
   }
 
@@ -341,7 +341,7 @@ class AcceptNode {
                    {e => Text(DateFormaterService.getFormatedDate(e.creationDate))}),
             (Text("Directive"),
                   { e => SHtml.ajaxButton(<img src="/images/icPolicies.jpg"/>, {
-                      () =>  showExpectedPolicyPopup(e.id)
+                      () =>  showExpectedPolicyPopup(e)
                     }, ("class", "smallButton")
                    )
                   }


### PR DESCRIPTION
The main idea here is to leverage the big piece of logic from FullNodeGroupCategory that allows to get the set of nodeIds matching RuleTarget in the context of the group library, and to allows to give it an other context (and works with less information than nodeInfo). 

Once that done, we get a piece of code factored out between acceptNode and FullNodeGroupCategory (so no divergence in that touchy logic). More over, the code pattern match on sealed class, so we won't have anymore "missing" case like the one in bug #5764