### PR TITLE
Fixes #6276: The \"+\" button to add a group to a Rule redirects to the group edition page instead of adding the group to the Rule

### DIFF
--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNodeGroupTree.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNodeGroupTree.scala
@@ -184,8 +184,8 @@ object DisplayNodeGroupTree extends Loggable {
 
         val editButton = {
           if (!targetActions.isEmpty && ! targetInfo.isSystem) {
-              <img src="/images/icPen.png" class="treeActions treeAction noRight" /> ++ Script(JsRaw(s"""
-                $$('#${jsId} .treeActions').on("mouseup", function(e) {
+              <img src="/images/icPen.png" class="treeActions treeAction noRight groupDetails" /> ++ Script(JsRaw(s"""
+                $$('#${jsId} .groupDetails').on("mouseup", function(e) {
                   redirectTo('${S.contextPath}/secure/nodeManager/groups#{"groupId":"${groupId}"}',e);
                 } );"""))
           } else {


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/6276