### PR TITLE
Fixes #6381: File /var/log/rudder/compliance/non-compliant-reports.log is not correctly rotated

### DIFF
--- a/rudder-web/src/main/resources/logback.xml
+++ b/rudder-web/src/main/resources/logback.xml
@@ -79,9 +79,15 @@ along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
     
     'report' is expected to be the ops logger name.
    -->
-  <appender name="OPSLOG" class="ch.qos.logback.core.FileAppender">
+  <appender name="OPSLOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>${OPSLOG_DIR}/rudder-webapp.log</file>
     <append>true</append>
+
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${OPSLOG_DIR}/rudder-webapp-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+    
     <encoder>
       <pattern>%d{MMM dd HH:mm:ss} ${HOSTNAME} rudder[%logger]: [%level] %msg%n</pattern>
     </encoder>
@@ -90,13 +96,20 @@ along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
   <!--
     A file log appender for exploitation logs about failure reports.
   -->
-    <appender name="REPORTLOG" class="ch.qos.logback.core.FileAppender">
+  <appender name="REPORTLOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>${REPORT_DIR}/non-compliant-reports.log</file>
     <append>true</append>
-        <encoder>
+
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${REPORT_DIR}/non-compliant-reports-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+      <maxHistory>365</maxHistory>
+    </rollingPolicy>
+
+    <encoder>
       <pattern>%msg%n</pattern>
     </encoder>
   </appender>
+  
 
   <!-- 
     Manage the global log level of the application.


### PR DESCRIPTION
This ticket only add the log rotation from logback. We still need to remove the log rotation done by logrotate, and the two pull request must be merged together. 

It superseeds https://github.com/Normation/rudder/pull/836