### PR TITLE
Bug 6519/don t increase serial when adding nodes

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationServiceImpl.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationServiceImpl.scala
@@ -90,9 +90,10 @@ class DetectChangeInNodeConfiguration extends Loggable {
     logger.trace(s"Checking changes in node '${targetConfig.nodeInfo.id.value}'")
     val changedRuleIds = currentOpt match {
       case None =>
-        //what do we do if we don't have a cache for the node ? All the target rules are "changes" ?
+        //what do we do if we don't have a cache for the node ? All the target rules are "changes" ? No, we skip,
+        // as all changes will be caught later. Otherwise, it will increase the serial of all rules applied to this node
         logger.trace("`-> No node configuration cache availabe for that node")
-        targetConfig.policyDrafts.map( _.ruleId ).toSet
+        Set[RuleId]()
       case Some(current) =>
 
         val target = NodeConfigurationCache(targetConfig)
@@ -128,8 +129,9 @@ class DetectChangeInNodeConfiguration extends Loggable {
               logger.trace(s"`-> rule with ID '${ruleId.value}' was deleted")
               Set(ruleId)
             case (None, Some(PolicyCache(ruleId, _, _))) =>
-              logger.trace(s"`-> rule with ID '${ruleId.value}' was added")
-              Set(ruleId)
+              logger.trace(s"`-> rule with ID '${ruleId.value}' was added, skipping it")
+              // Ignoring nodes addition to Rules. The node will be updated, thanks to the check on change of hash of node config
+              Set[RuleId]()
             case (Some(PolicyCache(r0, d0, c0)), Some(PolicyCache(r1, d1, c1))) =>
               //d0 and d1 are equals by construction, but keep them for future-proofing
               if(d0 == d1) {

--- a/rudder-core/src/test/scala/com/normation/rudder/services/nodes/NodeConfigurationChangeDetectServiceTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/nodes/NodeConfigurationChangeDetectServiceTest.scala
@@ -247,12 +247,12 @@ class NodeConfigurationChangeDetectServiceTest extends Specification {
       ) === Set(new RuleId("ruleId1"))
     }
 
-    "have a change if nothing is different, but previous CR is not existant" in {
+    "have no change if nothing is different, but previous CR is not existant (extending a Rule should be free)" in {
       service.detectChangeInNode(
           Some(NodeConfigurationCache(emptyNodeConfig))
         , complexeNodeConfig
         , directiveLib
-      ) === Set(new RuleId("ruleId1"))
+      )  must beTheSameAs(Set())
     }
 
     "have a change if nothing is different, but previous CR is existant and current is non existant" in {


### PR DESCRIPTION
The rational here is to prevent undue serial upgrade when adding a node in a rule.
The serial change should be only for "change" of config

The huge benefit of that is that we don't lose compliance info of the rule when accepting node
The second great benefit is that promise generation is faster: less change

This picture show the rule screen after having accepted a node
![rules](https://cloud.githubusercontent.com/assets/76947/7221359/62ee98d8-e6e8-11e4-8f08-df7ba4ebd405.png)
