### PR TITLE
Fixes #7055: Reporting cannot be used when there is several component with the same value and several messages

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
@@ -82,12 +82,12 @@ case class ReportComponent(
 ) extends HashcodeCaching {
   // Utilitary method to returns componentValues along with unexpanded values
   // The unexpanded may be none, for older version of Rudder didn't have this
-  def groupedComponentValues : Seq[(String, Option[String])] = {
-    if (componentsValues.size != unexpandedComponentsValues.size) {
+  def groupedComponentValues : Set[(String, Option[String])] = {
+    (if (componentsValues.size != unexpandedComponentsValues.size) {
       componentsValues.map((_, None))
     } else {
       componentsValues.zip(unexpandedComponentsValues.map(Some(_)))
-    }
+    }).toSet
   }
 }
 

--- a/rudder-core/src/main/scala/com/normation/rudder/domain/reports/bean/ReportType.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/reports/bean/ReportType.scala
@@ -80,7 +80,7 @@ case object PendingReportType extends ReportType{
 
 object ReportType {
 
-  def getWorseType(reportTypes : Seq[ReportType]) : ReportType = {
+  def getWorseType(reportTypes : Iterable[ReportType]) : ReportType = {
     if (reportTypes.isEmpty) {
       NoAnswerReportType
     } else {

--- a/rudder-core/src/test/scala/com/normation/rudder/domain/reports/bean/ExecutionBatchTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/domain/reports/bean/ExecutionBatchTest.scala
@@ -413,70 +413,47 @@ class ExecutionBatchTest extends Specification {
      , 5)
 
 
-    "return a component globally repaired " in {
-      executionBatch.checkExpectedComponentWithReports(
+    val validBatch = executionBatch.
+      checkExpectedComponentWithReports(
           expectedComponent
         , reports
-        , NodeId("nodeId")).reportType == RepairedReportType
+        , NodeId("nodeId")
+      )
+    val badBatch = executionBatch.
+      checkExpectedComponentWithReports(
+          expectedComponent
+        , badReports
+        , NodeId("nodeId")
+      )
+
+    "return a component globally repaired " in {
+      validBatch.reportType == RepairedReportType
     }
     "return a component with two key values " in {
-      executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , reports
-        , NodeId("nodeId")).componentValues.size == 2
+      validBatch.componentValues.size === 2
     }
     "return a component with the key values foo which is repaired " in {
-      executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , reports
-        , NodeId("nodeId")).componentValues.filter(x => x.componentValue == "foo").size == 1 &&
-       executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , reports
-        , NodeId("nodeId")).componentValues.filter(x => x.componentValue == "foo").head.reportType ==  RepairedReportType
+      validBatch.componentValues.filter(x => x.componentValue == "foo").size == 1 &&
+      validBatch.componentValues.filter(x => x.componentValue == "foo").head.reportType ==  RepairedReportType
      }
      "return a component with the key values bar which is a success " in {
-      executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , reports
-        , NodeId("nodeId")).componentValues.filter(x => x.componentValue == "bar").size == 1 &&
-       executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , reports
-        , NodeId("nodeId")).componentValues.filter(x => x.componentValue == "bar").head.reportType ==  SuccessReportType
+      validBatch.componentValues.filter(x => x.componentValue == "bar").size == 1 &&
+      validBatch.componentValues.filter(x => x.componentValue == "bar").head.reportType ==  SuccessReportType
      }
 
      " with bad reports return a component globally unknwon" in {
-      executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , badReports
-        , NodeId("nodeId")).reportType == UnknownReportType
+      badBatch.reportType == UnknownReportType
      }
      "with bad reports return a component with two key values " in {
-      executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , badReports
-        , NodeId("nodeId")).componentValues.size == 2
+      badBatch.componentValues.size == 2
     }
-    "with bad reports return a component with the key values foo which is unknwon " in {
-      executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , badReports
-        , NodeId("nodeId")).componentValues.filter(x => x.componentValue == "foo").size == 1 &&
-       executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , badReports
-        , NodeId("nodeId")).componentValues.filter(x => x.componentValue == "foo").head.reportType ==  UnknownReportType
+    "with bad reports return a component with the key values foo which is unknown " in {
+      badBatch.componentValues.filter(x => x.componentValue == "foo").size == 1 &&
+      badBatch.componentValues.filter(x => x.componentValue == "foo").head.reportType ==  UnknownReportType
      }
      "with bad reports return a component with the key values bar which is a success " in {
-      executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , badReports
-        , NodeId("nodeId")).componentValues.filter(x => x.componentValue == "bar").size == 1 &&
-       executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , badReports
-        , NodeId("nodeId")).componentValues.filter(x => x.componentValue == "bar").head.reportType ==  SuccessReportType
+      badBatch.componentValues.filter(x => x.componentValue == "bar").size == 1 &&
+      badBatch.componentValues.filter(x => x.componentValue == "bar").head.reportType ==  SuccessReportType
      }
 
   }
@@ -485,21 +462,19 @@ class ExecutionBatchTest extends Specification {
   "A component, with a None keys" should {
     val executionTimestamp = new DateTime()
     val reports = Seq[Reports](
-        new ResultRepairedReport(executionTimestamp, "cr", "policy", "nodeId", 12, "component", "None", executionTimestamp, "message"),
-        new ResultSuccessReport(executionTimestamp, "cr", "policy", "nodeId", 12, "component", "None", executionTimestamp, "message")
+        new ResultRepairedReport(executionTimestamp, "cr", "policy", "nodeId", 12, "component", "None", executionTimestamp, "message")
               )
 
     val badReports = Seq[Reports](
-        new ResultRepairedReport(executionTimestamp, "cr", "policy", "nodeId", 12, "component", "None", executionTimestamp, "message"),
         new ResultRepairedReport(executionTimestamp, "cr", "policy", "nodeId", 12, "component", "None", executionTimestamp, "message"),
         new ResultSuccessReport(executionTimestamp, "cr", "policy", "nodeId", 12, "component", "None", executionTimestamp, "message")
               )
 
     val expectedComponent = new ReportComponent(
                       "component"
-                    , 2
-                    , Seq("None", "None")
-                    , Seq("None", "None"))
+                    , 1
+                    , Seq("None")
+                    , Seq("None"))
 
     val executionBatch = new ConfigurationExecutionBatch(
        "cr",
@@ -521,51 +496,144 @@ class ExecutionBatchTest extends Specification {
      , None
      , 5)
 
+    val validBatch = executionBatch.
+      checkExpectedComponentWithReports(
+          expectedComponent
+        , reports
+        , NodeId("nodeId")
+      )
+    val badBatch = executionBatch.
+      checkExpectedComponentWithReports(
+          expectedComponent
+        , badReports
+        , NodeId("nodeId")
+      )
 
     "return a component globally repaired " in {
-      executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , reports
-        , NodeId("nodeId")).reportType == RepairedReportType
+      validBatch.reportType == RepairedReportType
     }
-    "return a component with two key values " in {
-      executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , reports
-        , NodeId("nodeId")).componentValues.size == 2
+    "return a component with one key value " in {
+      validBatch.componentValues.size == 1
     }
-    "return a component with both None key repaired " in {
-      executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , reports
-        , NodeId("nodeId")).componentValues.filter(x => x.componentValue == "None").size == 2 &&
-       executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , reports
-        , NodeId("nodeId")).componentValues.filter(x => x.componentValue == "None").forall(x => x.reportType == RepairedReportType)
+    "return a component with None key repaired " in {
+      validBatch.componentValues.filter(x => x.componentValue == "None").size == 1 &&
+      validBatch.componentValues.filter(x => x.componentValue == "None").forall(x => x.reportType == RepairedReportType)
     }
 
     "with bad reports return a component globally unknown " in {
-      executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , badReports
-        , NodeId("nodeId")).reportType == UnknownReportType
+      badBatch.reportType == UnknownReportType
     }
-    "with bad reports return a component with two key values " in {
-      executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
-        , badReports
-        , NodeId("nodeId")).componentValues.size == 2
+    "with bad reports return a component with one key value " in {
+      badBatch.componentValues.size == 1
     }
-    "with bad reports return a component with both None key unknown " in {
-      executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
+    "with bad reports return a component with None key unknown " in {
+      badBatch.componentValues.filter(x => x.componentValue == "None").size == 1 &&
+      badBatch.componentValues.filter(x => x.componentValue == "None").forall(x => x.reportType == UnknownReportType)
+    }
+  }
+
+  // Test the component part
+  "A component, that waits two reports on an unxpandedValue that can be different on two Nodes" should {
+    val executionTimestamp = new DateTime()
+    val reports = Seq(
+        new ResultRepairedReport(executionTimestamp, "cr", "policy", "node1", 12, "component", "node1", executionTimestamp, "message")
+      , new ResultRepairedReport(executionTimestamp, "cr", "policy", "node1", 12, "component", "node1", executionTimestamp, "message")
+      , new ResultRepairedReport(executionTimestamp, "cr", "policy", "node2", 12, "component", "node2", executionTimestamp, "message")
+      , new ResultRepairedReport(executionTimestamp, "cr", "policy", "node2", 12, "component", "node2", executionTimestamp, "message")
+    )
+
+    val badReports = Seq(
+        new ResultRepairedReport(executionTimestamp, "cr", "policy", "node1", 12, "component", "node1", executionTimestamp, "message")
+      , new ResultRepairedReport(executionTimestamp, "cr", "policy", "node1", 12, "component", "node1", executionTimestamp, "message")
+      , new ResultRepairedReport(executionTimestamp, "cr", "policy", "node1", 12, "component", "node1", executionTimestamp, "message")
+      , new ResultRepairedReport(executionTimestamp, "cr", "policy", "node2", 12, "component", "node2", executionTimestamp, "message")
+    )
+
+    def expectedComponent(id: String) = new ReportComponent(
+                      "component"
+                    , 2
+                    , Seq(s"${id}", s"${id}")
+                    , Seq("${rudder.node.id}", "${rudder.node.id}"))
+
+    val executionBatch = new ConfigurationExecutionBatch(
+       "cr",
+       12,
+       Seq(
+         DirectivesOnNodeExpectedReport(
+           Seq[NodeId]("node1"),
+           Seq(
+             DirectiveExpectedReports(
+              "policy",
+               Seq(expectedComponent("node1"))
+             )
+           )
+         ),
+         DirectivesOnNodeExpectedReport(
+           Seq[NodeId]("node2"),
+           Seq(
+             DirectiveExpectedReports(
+              "policy",
+               Seq(expectedComponent("node2"))
+             )
+           )
+         )
+       ),
+       executionTimestamp,
+       reports,
+       executionTimestamp
+     , None
+     , 5)
+
+    val validBatch = executionBatch.
+      checkExpectedComponentWithReports(
+          expectedComponent("node1")
+        , reports.filter(_.nodeId.value == "node1")
+        , NodeId("node1")
+      )
+    val validBatch2 = executionBatch.
+      checkExpectedComponentWithReports(
+          expectedComponent("node2")
+        , reports.filter(_.nodeId.value == "node2")
+        , NodeId("node2")
+      )
+    val badBatch = executionBatch.
+      checkExpectedComponentWithReports(
+          expectedComponent("node1")
         , badReports
-        , NodeId("nodeId")).componentValues.filter(x => x.componentValue == "None").size == 2 &&
-       executionBatch.checkExpectedComponentWithReports(
-          expectedComponent
+        , NodeId("node1")
+      )
+    val badBatch2 = executionBatch.
+      checkExpectedComponentWithReports(
+          expectedComponent("node2")
         , badReports
-        , NodeId("nodeId")).componentValues.filter(x => x.componentValue == "None").forall(x => x.reportType == UnknownReportType)
+        , NodeId("node2")
+      )
+
+    "return a component globally repaired " in {
+      validBatch.reportType == RepairedReportType &&
+      validBatch2.reportType == RepairedReportType
+    }
+    "return a component with two key values " in {
+      (validBatch.componentValues.size + validBatch2.componentValues.size) == 2
+    }
+    "return a component with '${rudder.node.id}' key repaired " in {
+      (validBatch.componentValues ++ validBatch2.componentValues).filter(x => x.unexpandedComponentValue ==  Some("${rudder.node.id}")).size == 2 &&
+      (validBatch.componentValues ++ validBatch2.componentValues).filter(x => x.unexpandedComponentValue == Some("${rudder.node.id}")).forall(x => x.reportType == RepairedReportType)
+    }
+    "Have 4 messages in a component with '${rudder.node.id}' key " in {
+      (validBatch.componentValues ++ validBatch2.componentValues).toSeq.filter(x => x.unexpandedComponentValue ==  Some("${rudder.node.id}")).flatMap(_.message).size == 4
+    }
+
+    "with bad reports return a component globally unknown " in {
+      badBatch.reportType == UnknownReportType &&
+      badBatch2.reportType == UnknownReportType
+    }
+    "with bad reports return a component with one key value " in {
+      (badBatch.componentValues.size + badBatch2.componentValues.size) == 2
+    }
+    "with bad reports return a component with None key unknown " in {
+      (badBatch.componentValues ++ badBatch2.componentValues).filter(x => x.unexpandedComponentValue ==  Some("${rudder.node.id}")).size == 2 &&
+      (badBatch.componentValues ++ badBatch2.componentValues).filter(x => x.unexpandedComponentValue ==  Some("${rudder.node.id}")).forall(x => x.reportType == UnknownReportType)
     }
   }
 

--- a/rudder-core/src/test/scala/com/normation/rudder/services/path/PathComputerTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/path/PathComputerTest.scala
@@ -32,7 +32,7 @@
 *************************************************************************************
 */
 
-package com.normation.rudder.services.nodes
+package com.normation.rudder.services.path
 
 import scala.collection.immutable.SortedMap
 import org.junit.runner._
@@ -50,7 +50,6 @@ import com.normation.rudder.repository.FullActiveTechnique
 import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.rudder.services.policies.nodeconfig._
 import com.normation.rudder.domain.policies.DirectiveId
-import com.normation.rudder.services.path.PathComputerImpl
 import net.liftweb.common.Box
 import net.liftweb.common.Full
 

--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/ComplianceData.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/ComplianceData.scala
@@ -245,7 +245,7 @@ case class ComplianceData(
       severity  = ReportType.getSeverityFromStatus(component.reportType)
       id        = Helpers.nextFuncName
       status    = getDisplayStatusFromSeverity(severity)
-      values    = getValuesComplianceDetails (component.componentValues, rule,includeMessage)
+      values    = getValuesComplianceDetails (component.componentValues.toSet, rule,includeMessage)
     } yield {
       val (optCallback, optNoExpand, optCompliance) = {
         if (includeMessage) {
@@ -285,7 +285,7 @@ case class ComplianceData(
       severity  = ReportType.getSeverityFromStatus(component.reportType)
       id        = Helpers.nextFuncName
       status    = getDisplayStatusFromSeverity(severity)
-      values    = getValuesComplianceDetails (component.componentValues)
+      values    = getValuesComplianceDetails (component.componentValues.toSet)
     } yield {
 
       ComponentComplianceLine (
@@ -311,7 +311,7 @@ case class ComplianceData(
    * Get compliance details of Value of a Component
    */
   def getValuesComplianceDetails (
-      values : Seq[ComponentValueRuleStatusReport]
+      values : Set[ComponentValueRuleStatusReport]
     , rule : Rule
     , includeMessage : Boolean
   ) : JsTableData[ValueComplianceLine] = {
@@ -322,7 +322,7 @@ case class ComplianceData(
         ComponentRuleStatusReport (
             entries.head.directiveId // can't fail because we are in a groupBy
           , entries.head.component  // can't fail because we are in a groupBy
-          , entries
+          , entries.toSeq
         )
       severity = ReportType.getSeverityFromStatus(component.reportType)
       status = getDisplayStatusFromSeverity(severity)
@@ -354,7 +354,7 @@ case class ComplianceData(
 
   // From Node Point of view
   def getValuesComplianceDetails (
-      values : Seq[ComponentValueStatusReport]
+      values : Set[ComponentValueStatusReport]
   ) : JsTableData[ValueComplianceLine] = {
     val valuesComplianceData = for {
       value <- values


### PR DESCRIPTION
This PR is just a version of #902 but rebased to current state of branche 2.11. 

