### PR TITLE
Fix #7267 Restrict WebDAV PUT via IfVersion

### DIFF
--- a/rudder-web/src/main/resources/rudder-apache-common.conf
+++ b/rudder-web/src/main/resources/rudder-apache-common.conf
@@ -64,7 +64,13 @@ Alias /inventories /var/rudder/inventories/incoming
   </IfVersion>
 
   <LimitExcept PUT>
-    Require all denied
+    <IfVersion < 2.4>
+      Order deny,allow
+      Deny from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+      Require all denied
+    </IfVersion>
   </LimitExcept>
 
 </Directory>
@@ -92,7 +98,13 @@ Alias /inventory-updates /var/rudder/inventories/accepted-nodes-updates
   </IfVersion>
 
   <LimitExcept PUT>
-    Require all denied
+    <IfVersion < 2.4>
+      Order deny,allow
+      Deny from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+      Require all denied
+    </IfVersion>
   </LimitExcept>
 
 </Directory>


### PR DESCRIPTION
Restrict for both apache versions via IfVersion for WebDAV PUT requests