### PR TITLE
Fixes #6244: Feature idea: automatic directive naming

### DIFF
--- a/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueReader.scala
+++ b/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueReader.scala
@@ -42,12 +42,13 @@ import com.normation.utils.HashcodeCaching
 
 
 case class TechniquesInfo(
-    rootCategory: RootTechniqueCategory
+    rootCategory          : RootTechniqueCategory
     //the TechniqueCategoryId is a path from the point of view of a tree
-  , techniquesCategory: Map[TechniqueId, TechniqueCategoryId]
-  , techniques: Map[TechniqueName, SortedMap[TechniqueVersion, Technique]]
+  , techniquesCategory    : Map[TechniqueId, TechniqueCategoryId]
+  , techniques            : Map[TechniqueName, SortedMap[TechniqueVersion, Technique]]
     //head of categories is the root category
-  , subCategories: Map[SubTechniqueCategoryId, TechniqueCategory]
+  , subCategories         : Map[SubTechniqueCategoryId, TechniqueCategory]
+  , directivesDefaultNames: Map[String, String]
 ) extends HashcodeCaching {
   val allCategories = Map[TechniqueCategoryId, TechniqueCategory]() ++ subCategories + (rootCategory.id -> rootCategory)
 }
@@ -125,5 +126,7 @@ trait TechniqueReader {
    * *any* change will be given
    */
   def getModifiedTechniques : Map[TechniqueName, TechniquesLibraryUpdateType]
+
+  def needReload() : Boolean
 }
 

--- a/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/FSTechniqueReader.scala
+++ b/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/FSTechniqueReader.scala
@@ -1,0 +1,374 @@
+/*
+*************************************************************************************
+* Copyright 2011 Normation SAS
+*************************************************************************************
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU Affero GPL v3, the copyright holders add the following
+* Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU Affero GPL v3
+* licence, when you create a Related Module, this Related Module is
+* not considered as a part of the work and may be distributed under the
+* license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
+*
+*************************************************************************************
+*/
+
+package com.normation.cfclerk.services.impl
+
+import scala.xml._
+import com.normation.cfclerk.domain._
+import java.io.FileNotFoundException
+import org.xml.sax.SAXParseException
+import com.normation.cfclerk.exceptions._
+import org.slf4j.{ Logger, LoggerFactory }
+import java.io.File
+import org.apache.commons.io.FilenameUtils
+import com.normation.cfclerk.xmlparsers.TechniqueParser
+import net.liftweb.common._
+import scala.collection.mutable.{ Map => MutMap }
+import scala.collection.SortedSet
+import com.normation.utils.Utils
+import scala.collection.immutable.SortedMap
+import java.io.InputStream
+import java.io.FileInputStream
+import com.normation.cfclerk.services._
+
+/**
+ *
+ * A TechniqueReader that reads policy techniques from
+ * a directory tree.
+ *
+ *
+ * Conventions used:
+ *
+ * - all directories which contains a metadata.xml file is
+ *   considered to be a policy package.
+ *
+ * - template files are looked in the directory
+ *
+ * - a category directory contains a category.xml file, and
+ *   information are look from it, else file name is used.
+ *
+ * - directory without metadata.xml or category.xml are ignored
+ *
+ *  Category description information are stored in XML files with the expected
+ *  structure:
+ *  <xml>
+ *    <name>Name of the category</name>
+ *    <description>Description of the category</description>
+ *  </xml>
+ *
+ *  In that implementation, the name of the directory of a category
+ *  is used for the techniqueCategoryName.
+ *
+ */
+class FSTechniqueReader(
+  policyParser               : TechniqueParser,
+  val techniqueDirectoryPath : String,
+  val techniqueDescriptorName: String, //full (with extension) conventional name for policy descriptor
+  val categoryDescriptorName : String, //full (with extension) name of the descriptor for categories
+  val reportingDescriptorName: String  //the name of the file for expected_report.csv. It must be only the name, not the path.
+  ) extends TechniqueReader with Loggable {
+
+  reader =>
+
+  private def checkTechniqueDirectory(dir: File): Unit = {
+    if (!dir.exists) {
+      throw new RuntimeException("Directory %s does not exists, how do you want that I read a technique from it?".format(dir))
+    }
+    if (!dir.canRead) {
+      throw new RuntimeException("Directory %s is not readable, how do you want that I read a technique from it?".format(dir))
+    }
+  }
+
+  private[this] val techniqueDirectory: File = {
+    val dir = new File(techniqueDirectoryPath)
+    checkTechniqueDirectory(dir)
+    dir
+  }
+
+  //we never know when to read again
+  override def getModifiedTechniques : Map[TechniqueName, TechniquesLibraryUpdateType] = Map()
+
+  /**
+   * Read the policies
+   * @param doc : the xml representation of the knowledge file
+   * @return a map of policy
+   */
+  override lazy val readTechniques: TechniquesInfo = {
+    reader.synchronized {
+      val techniqueInfos = new InternalTechniquesInfo()
+
+      processDirectory(
+        null, //we have to ignore it, so if we don't, a NPE is a good idea.
+        reader.techniqueDirectory,
+        techniqueInfos)
+
+      TechniquesInfo(
+        rootCategory = techniqueInfos.rootCategory.getOrElse(throw new RuntimeException("No root category was found")),
+        techniquesCategory = techniqueInfos.techniquesCategory.toMap,
+        techniques = techniqueInfos.techniques.map { case (k, v) => (k, SortedMap.empty[TechniqueVersion, Technique] ++ v) }.toMap,
+        subCategories = techniqueInfos.subCategories.toMap,
+        Map()
+      )
+
+    }
+  }
+
+  override def getMetadataContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => T): T = {
+    var is: InputStream = null
+    try {
+      useIt {
+        readTechniques.techniquesCategory.get(techniqueId).map { catPath =>
+          is = new FileInputStream(techniqueDirectory.getAbsolutePath + "/" + catPath + "/" + techniqueDescriptorName)
+          is
+        }
+      }
+    } catch {
+      case ex: FileNotFoundException =>
+        logger.debug(() => "Can not find %s for Technique with ID %s".format(techniqueDescriptorName, techniqueId), ex)
+        useIt(None)
+    } finally {
+      if (null != is) {
+        is.close
+      }
+    }
+  }
+
+  override def checkreportingDescriptorExistence(techniqueId: TechniqueId) : Boolean = {
+    readTechniques.techniquesCategory.get(techniqueId).map { catPath =>
+      (new File(techniqueDirectory.getAbsolutePath + "/" + catPath + "/" + reportingDescriptorName)).exists
+    }.getOrElse(false)
+  }
+
+
+  override def getReportingDetailsContent[T](techniqueId: TechniqueId)(useIt : Option[InputStream] => T) : T = {
+    var is: InputStream = null
+    try {
+      useIt {
+        readTechniques.techniquesCategory.get(techniqueId).map { catPath =>
+          is = new FileInputStream(techniqueDirectory.getAbsolutePath + "/" + catPath + "/" + reportingDescriptorName)
+          is
+        }
+      }
+    } catch {
+      case ex: FileNotFoundException =>
+        logger.debug(() => "Can not find %s for Technique with ID %s".format(reportingDescriptorName, techniqueId), ex)
+        useIt(None)
+    } finally {
+      if (null != is) {
+        is.close
+      }
+    }
+  }
+  override def getTemplateContent[T](templateId: Cf3PromisesFileTemplateId)(useIt: Option[InputStream] => T): T = {
+    var is: InputStream = null
+    try {
+      useIt {
+        readTechniques.techniquesCategory.get(templateId.techniqueId).map { catPath =>
+          is = new FileInputStream(techniqueDirectory.getAbsolutePath + "/" + catPath + "/" + templateId.toString + Cf3PromisesFileTemplate.templateExtension)
+          is
+        }
+      }
+    } catch {
+      case ex: FileNotFoundException =>
+        logger.debug(() => "Template %s does not exists".format(templateId), ex)
+        useIt(None)
+    } finally {
+      if (null != is) {
+        is.close
+      }
+    }
+  }
+
+  /**
+   * Process the directory to find if it's a category
+   * or a package.
+   * f must be a directory
+   */
+  //  private def processDirectory(f: File, internalTechniquesInfo: InternalTechniquesInfo): Unit = {
+  //    val children = f.listFiles
+  //    val childrenName = children.map(_.getName)
+  //    (childrenName.exists(c => c == techniqueDescriptorName), childrenName.exists(c => c == categoryDescriptorName)) match {
+  //      case (true, true) =>
+  //        throw new RuntimeException("Directory %s contains both file %s and %s: can not know if it is a category or a policy package".
+  //          format(f.getAbsolutePath, techniqueDescriptorName, categoryDescriptorName))
+  //      case (true, false) => processTechnique(f, internalTechniquesInfo)
+  //      case (false, _) => processCategory(f, internalTechniquesInfo)
+  //    }
+  //  }
+
+  private def processDirectory(parentCategoryId: TechniqueCategoryId, f: File, internalTechniquesInfo: InternalTechniquesInfo): Unit = {
+    val children = f.listFiles
+    val childrenName = children.map(_.getName)
+    val versionsDir = children.filter(_.isDirectory).flatMap(_.listFiles).filter(f => f.getName == techniqueDescriptorName).map(_.getParentFile)
+
+    if (versionsDir.size > 0) {
+      for (d <- versionsDir) {
+        processTechnique(parentCategoryId, d, internalTechniquesInfo)
+      }
+    } else {
+      processCategory(parentCategoryId, f, internalTechniquesInfo)
+    }
+
+  }
+
+  /**
+   * Load a Technique contains in the directory packageRootDirectory.
+   * By convention, packageRootDirectory is the version of the Technique,
+   * and the parent's name directory is the Technique Name.
+   */
+  private def processTechnique(parentCategoryId: TechniqueCategoryId, packageRootDirectory: File, internalTechniquesInfo: InternalTechniquesInfo): Unit = {
+    val name = TechniqueName(packageRootDirectory.getParentFile.getName)
+    val id = TechniqueId(name, TechniqueVersion(packageRootDirectory.getName))
+
+    val descriptorFile = new File(packageRootDirectory, techniqueDescriptorName)
+    //check if the expected_report.csv file exists
+    val expectedReportCsv = new File(descriptorFile.getParentFile, reportingDescriptorName)
+
+    val pack = policyParser.parseXml(loadDescriptorFile(descriptorFile), id, expectedReportCsv.exists)
+
+      def updateParentCat() {
+        parentCategoryId match {
+          case RootTechniqueCategoryId =>
+            val cat = internalTechniquesInfo.rootCategory.getOrElse(
+              throw new RuntimeException("Can not find the parent (root) category %s for technique %s".format(packageRootDirectory.getParentFile.getAbsolutePath, pack.id)))
+            internalTechniquesInfo.rootCategory = Some(cat.copy(packageIds = cat.packageIds + pack.id))
+
+          case sid: SubTechniqueCategoryId =>
+            val cat = internalTechniquesInfo.subCategories.get(sid).getOrElse(
+              throw new RuntimeException("Can not find the parent category %s for technique %s".format(packageRootDirectory.getParentFile.getAbsolutePath, pack.id)))
+            internalTechniquesInfo.subCategories(sid) = cat.copy(packageIds = cat.packageIds + pack.id)
+
+        }
+      }
+
+    //check that that package is not already know, else its an error (by id ?)
+    internalTechniquesInfo.techniques.get(pack.id.name) match {
+      case None => //so we don't have any version yet, and so no id
+        updateParentCat()
+        internalTechniquesInfo.techniques(pack.id.name) = MutMap(pack.id.version -> pack)
+        internalTechniquesInfo.techniquesCategory(pack.id) = parentCategoryId
+      case Some(versionMap) => //check for the version
+        versionMap.get(pack.id.version) match {
+          case None => //add that version
+            updateParentCat()
+            internalTechniquesInfo.techniques(pack.id.name)(pack.id.version) = pack
+            internalTechniquesInfo.techniquesCategory(pack.id) = parentCategoryId
+          case Some(v) => //error, policy package version already exsits
+            logger.error("Ignoring package for policy with ID %s and root directory %s because an other policy is already defined with that id and root path %s".format(
+              pack.id, packageRootDirectory.getAbsolutePath, internalTechniquesInfo.techniquesCategory(pack.id).toString))
+        }
+    }
+
+  }
+
+  /**
+   * Process the categoryRootDirectory which must be a category directory.
+   * - if the file categoryDescriptorName exists, use it to find name, description,
+   *   else use file name
+   * - process all sub-directories
+   * - ignore all other files
+   *
+   * @param packageRootDirectory
+   * @param internalTechniquesInfo
+   */
+  private def processCategory(parentCategoryId: TechniqueCategoryId, categoryRootDirectory: File, internalTechniquesInfo: InternalTechniquesInfo): Unit = {
+
+    //build a category without children from file name and path
+    //    def categoryFromFile(f: File)(name: String = f.getName, desc: String = "", system: Boolean = false) = TechniqueCategory(
+    //      id = parentCategoryId / f.getName, name = name, description = desc, subCategoryIds = SortedSet(), packageIds = SortedSet(), isSystem = system)
+
+    val categoryDescriptor = new File(categoryRootDirectory, categoryDescriptorName)
+
+    if (categoryDescriptor.exists && categoryDescriptor.isFile && categoryDescriptor.canRead) {
+      logger.debug("Reading package category information from %s".format(categoryDescriptor.getAbsolutePath))
+
+      try {
+        val xml = loadDescriptorFile(categoryDescriptor)
+        val name = Utils.??!((xml \\ "name").text).getOrElse(categoryRootDirectory.getName)
+        val desc = Utils.??!((xml \\ "description").text).getOrElse("")
+        val system = (Utils.??!((xml \\ "system").text).getOrElse("false")).equalsIgnoreCase("true")
+
+        //add the category as a child to its parent (if not root) and as new category
+        val newParentId = {
+          if (null == parentCategoryId) {
+            internalTechniquesInfo.rootCategory = Some(RootTechniqueCategory(name, desc, isSystem = system))
+            RootTechniqueCategoryId
+          } else {
+            val category = SubTechniqueCategory(
+              id = parentCategoryId / categoryRootDirectory.getName, name = name, description = desc, isSystem = system)
+            parentCategoryId match {
+              case RootTechniqueCategoryId =>
+                val parent = internalTechniquesInfo.rootCategory.getOrElse(throw new RuntimeException("Missing root technique category"))
+                internalTechniquesInfo.rootCategory = Some(parent.copy(subCategoryIds = parent.subCategoryIds + category.id))
+              case sid: SubTechniqueCategoryId =>
+                val parent = internalTechniquesInfo.subCategories(sid)
+                internalTechniquesInfo.subCategories(parent.id) = parent.copy(subCategoryIds = parent.subCategoryIds + category.id)
+            }
+
+            internalTechniquesInfo.subCategories(category.id) = category
+            category.id
+          }
+        }
+
+        //process sub-directories
+        categoryRootDirectory.listFiles.foreach { f =>
+          if (f.isDirectory) {
+            processDirectory(newParentId, f, internalTechniquesInfo)
+          }
+        }
+
+      } catch {
+        case e: Exception =>
+          logger.error("Error when processing category descriptor %s, ignoring path".format(categoryDescriptor.getAbsolutePath))
+      }
+    } else {
+      logger.info("No package category descriptor '%s' for directory '%s', ignoring the path".format(categoryDescriptorName, categoryRootDirectory.getAbsolutePath))
+    }
+  }
+
+  /**
+   * Load a descriptor document.
+   * @param file : the full filename
+   * @return the xml representation of the file
+   */
+  private def loadDescriptorFile(file: File): Elem = {
+    val doc =
+      try {
+        XML.loadFile(file)
+      } catch {
+        case e: SAXParseException =>
+          throw new ParsingException("Unexpected issue with the descriptor file %s: %s".format(file,e.getMessage))
+        case e: java.net.MalformedURLException =>
+          throw new ParsingException("Descriptor file not found: " + file)
+      }
+
+    if (doc.isEmpty) {
+      throw new ParsingException("Error when parsing descriptor file: '%s': the parsed document is empty".format(file))
+    }
+
+    doc
+  }
+
+  def needReload() = false
+}

--- a/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
+++ b/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
@@ -72,6 +72,7 @@ import scala.collection.JavaConversions._
 import org.eclipse.jgit.diff.DiffFormatter
 import org.eclipse.jgit.errors.MissingObjectException
 import org.eclipse.jgit.diff.DiffEntry.ChangeType
+import org.apache.commons.io.IOUtils
 
 /**
  *
@@ -133,7 +134,8 @@ class GitTechniqueReader(
   val techniqueDescriptorName: String, //full (with extension) conventional name for policy descriptor
   val categoryDescriptorName : String, //full (with extension) name of the descriptor for categories
   val reportingDescriptorName: String, //the name of the file for expected_report.csv. It must be only the name, not the path.
-  val relativePathToGitRepos : Option[String]
+  val relativePathToGitRepos : Option[String],
+  val directiveDefaultName   : String //full (with extension) name of the file containing default name for directive (default-directive-names.conf)
   ) extends TechniqueReader with Loggable {
 
   reader =>
@@ -445,7 +447,7 @@ class GitTechniqueReader(
    */
   override def readTechniques : TechniquesInfo = {
     reader.synchronized {
-      if(modifiedTechniquesCache.nonEmpty) {
+      if(needReload) {
         currentTechniquesInfoCache = nextTechniquesInfoCache._2
         revisionProvider.setCurrentRevTreeId(nextTechniquesInfoCache._1)
         modifiedTechniquesCache = Map()
@@ -455,6 +457,7 @@ class GitTechniqueReader(
   }
 
 
+  override def needReload() = revisionProvider.currentRevTreeId != nextTechniquesInfoCache._1
 
   private[this] def processRevTreeId(id:ObjectId, parseDescriptor:Boolean = true) : TechniquesInfo = {
     /*
@@ -494,8 +497,41 @@ class GitTechniqueReader(
         rootCategory = techniqueInfos.rootCategory.get,
         techniquesCategory = techniqueInfos.techniquesCategory.toMap,
         techniques = techniqueInfos.techniques.map { case(k,v) => (k, SortedMap.empty[TechniqueVersion,Technique] ++ v)}.toMap,
-        subCategories = Map[SubTechniqueCategoryId, SubTechniqueCategory]() ++ techniqueInfos.subCategories
+        subCategories = Map[SubTechniqueCategoryId, SubTechniqueCategory]() ++ techniqueInfos.subCategories,
+        processDirectiveDefaultName(id)
       )
+  }
+
+  private[this] def processDirectiveDefaultName(revTreeId: ObjectId) : Map[String, String] = {
+      //a first walk to find categories
+      val tw = new TreeWalk(repo.db)
+      tw.setFilter(new FileTreeFilter(canonizedRelativePath, directiveDefaultName))
+      tw.setRecursive(true)
+      tw.reset(revTreeId)
+
+      val prop = new java.util.Properties()
+
+      //now, for each potential path, look if the cat or policy
+      //is valid
+      while(tw.next) {
+        //we need to filter out directories
+        if(tw.getNameString == directiveDefaultName) {
+          var is : InputStream = null
+          try {
+            is = repo.db.open(tw.getObjectId(0)).openStream
+            prop.load(is)
+          } catch {
+            case ex: Exception =>
+              logger.error(s"Error when trying to load directive default name from '${directiveDefaultName}' No specific default naming rules will be available. ", ex)
+              Map()
+          } finally {
+            IOUtils.closeQuietly(is)
+          }
+        }
+      }
+      import scala.collection.JavaConverters._
+      prop.asScala.toMap
+
   }
 
   private[this] def processTechniques(revTreeId: ObjectId, techniqueInfos : InternalTechniquesInfo, parseDescriptor:Boolean) : Unit = {

--- a/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitUtilsImpl.scala
+++ b/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitUtilsImpl.scala
@@ -188,4 +188,3 @@ class FileTreeFilter(rootDirectory:Option[String], fileName: String) extends Tre
   override lazy val toString = "[.*/%s]".format(fileName)
 }
 
-

--- a/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/TechniqueRepositoryImpl.scala
+++ b/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/TechniqueRepositoryImpl.scala
@@ -96,7 +96,7 @@ class TechniqueRepositoryImpl(
   override def update(modId: ModificationId, actor:EventActor, reason: Option[String]) : Box[Map[TechniqueName, TechniquesLibraryUpdateType]] = {
     try {
       val modifiedPackages = techniqueReader.getModifiedTechniques
-      if (modifiedPackages.nonEmpty || /* first time init */ null == techniqueInfosCache) {
+      if (techniqueReader.needReload() || /* first time init */ null == techniqueInfosCache) {
         logger.info("Reloading technique library, " + {
           if (modifiedPackages.isEmpty) "no modified techniques found"
           else {

--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueReloadingCallbacks.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueReloadingCallbacks.scala
@@ -55,8 +55,10 @@ class DeployOnTechniqueCallback(
 
   override def updatedTechniques(techniqueIds:Map[TechniqueName, TechniquesLibraryUpdateType], modId:ModificationId, actor:EventActor, reason: Option[String]) : Unit = {
     reason.foreach( msg => logger.info(msg) )
-    logger.debug("Ask for a policy update since technique library was reloaded")
-    asyncDeploymentAgent ! AutomaticStartDeployment(modId, actor)
+    if(techniqueIds.nonEmpty) {
+      logger.debug("Ask for a policy update since technique library was reloaded")
+      asyncDeploymentAgent ! AutomaticStartDeployment(modId, actor)
+    }
   }
 }
 

--- a/rudder-core/src/test/scala/com/normation/cfclerk/services/DummyTechniqueReader.scala
+++ b/rudder-core/src/test/scala/com/normation/cfclerk/services/DummyTechniqueReader.scala
@@ -1,0 +1,81 @@
+/*
+*************************************************************************************
+* Copyright 2011 Normation SAS
+*************************************************************************************
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU Affero GPL v3, the copyright holders add the following
+* Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU Affero GPL v3
+* licence, when you create a Related Module, this Related Module is
+* not considered as a part of the work and may be distributed under the
+* license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program. If not, see <http://www.gnu.org/licenses/agpl.html>.
+*
+*************************************************************************************
+*/
+
+package com.normation.cfclerk.services
+
+import com.normation.cfclerk.domain._
+import scala.collection.mutable.{Map => MutMap}
+import java.io.InputStream
+import scala.collection.SortedSet
+
+/**
+ * Dummy knowledge reader, to test the prototyped PathComputer
+ * @author nicolas
+ *
+ */
+class DummyTechniqueReader(policies:Seq[Technique]=Seq(Technique(TechniqueId(TechniqueName("dummy"), TechniqueVersion("1.0")),"dummy", "DESCRIPTION",Seq(), Seq(), TrackerVariableSpec(), SectionSpec("ROOT"), None))) extends TechniqueReader {
+
+  def this() = this(Seq()) //Spring need that...
+
+  val rootCategoryId = RootTechniqueCategoryId / "rootCategory"
+
+  //they are all under root
+  def readTechniques(): TechniquesInfo = {
+    val packagesPath = MutMap[TechniqueId,TechniqueCategoryId]()
+    val packages = MutMap[TechniqueName , collection.immutable.SortedMap[TechniqueVersion,Technique]]()
+
+    var rootCategory = RootTechniqueCategory(
+        "Root category",
+        "The main category under witch all other are",
+        Set(), SortedSet(), true
+    )
+
+    for {
+      p <- policies
+    } {
+      packagesPath(p.id) =  rootCategoryId
+      packages(p.id.name) = (packages.getOrElse(p.id.name,collection.immutable.SortedMap.empty[TechniqueVersion,Technique]) + (p.id.version -> p))
+      rootCategory = rootCategory.copy( packageIds = rootCategory.packageIds + p.id)
+    }
+
+    TechniquesInfo(rootCategory, packagesPath.toMap, packages.toMap, Map(), Map())
+  }
+
+  def getMetadataContent[T](techniqueId: TechniqueId)(useIt : Option[InputStream] => T) : T = useIt(None)
+  def checkreportingDescriptorExistence(techniqueId: TechniqueId) : Boolean = false
+  def getReportingDetailsContent[T](techniqueId: TechniqueId)(useIt : Option[InputStream] => T) : T = useIt(None)
+  def getTemplateContent[T](templateName: Cf3PromisesFileTemplateId)(useIt : Option[InputStream] => T) : T = useIt(None)
+  def getModifiedTechniques : Map[TechniqueName, TechniquesLibraryUpdateType] = Map()
+
+}

--- a/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitPackageReaderTest.scala
+++ b/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitPackageReaderTest.scala
@@ -126,6 +126,7 @@ trait JGitPackageReaderSpec extends Specification with Loggable {
               , "category.xml"
               , "expected_reports.csv"
               , relativePathArg
+              , "default-directive-names.conf"
             )
 
   val infos = reader.readTechniques

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -143,6 +143,7 @@ import com.normation.rudder.services.policies.write.Cf3PromisesFileWriterService
 import com.normation.rudder.services.policies.write.PathComputerImpl
 import com.normation.rudder.services.policies.write.PrepareTemplateVariablesImpl
 import com.typesafe.config.ConfigException
+import org.apache.commons.io.FileUtils
 
 /**
  * Define a resource for configuration.
@@ -993,6 +994,29 @@ object RudderConfig extends Loggable {
       ApplicationLogger.error("The Technique library root directory must be a sub-directory of '%s', but it is configured to be: '%s'".format(RUDDER_DIR_GITROOT, RUDDER_DIR_TECHNIQUES))
       throw new RuntimeException("The Technique library root directory must be a sub-directory of '%s', but it is configured to be: '%s'".format(RUDDER_DIR_GITROOT, RUDDER_DIR_TECHNIQUES))
     }
+
+    //create a demo default-directive-names.conf if none exists
+    val defaultDirectiveNames = new File(RUDDER_DIR_TECHNIQUES, "default-directive-names.conf")
+    if(!defaultDirectiveNames.exists) {
+      FileUtils.writeStringToFile(defaultDirectiveNames, """
+        |#
+        |# This file contains the default name that a directive gets in Rudder UI creation pop-up.
+        |# The file format is a simple key=value file, with key being the techniqueName
+        |# or techniqueName/version and the value being the name to use.
+        |# An empty value will lead to an empty default name.
+        |# For a new Directive, we will try to lookup "TechniqueName/version" and if not
+        |# available "TechniqueName" from this file. If neither key is available, the
+        |# pop-up will use the actual Technique name as default.
+        |# Don't forget to commit the file to have modifications seen by Rudder.
+        |#
+        |
+        |# Default pattern for new directive from "userManagement" technique:
+        |userManagement=User: <name> Login: <login>
+        |# For userManagement version 2.0, prefer that pattern in new Directives:
+        |userManagement/2.0: User 2.0 [LOGIN]
+        |""".stripMargin)
+    }
+
     val relativePath = RUDDER_DIR_TECHNIQUES.substring(gitSlash.size, RUDDER_DIR_TECHNIQUES.size)
     new GitTechniqueReader(
         techniqueParser
@@ -1000,6 +1024,7 @@ object RudderConfig extends Loggable {
       , gitRepo
       , "metadata.xml", "category.xml", "expected_reports.csv"
       , Some(relativePath)
+      , "default-directive-names.conf"
     )
   }
   private[this] lazy val historizationJdbcRepository = new HistorizationJdbcRepository(squerylDatasourceProvider)

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateDirectivePopup.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateDirectivePopup.scala
@@ -89,6 +89,7 @@ class CreateDirectivePopup(
   techniqueName:String,
   techniqueDescription:String, // this field is unused
   techniqueVersion:TechniqueVersion,
+  defaultDirectiveName: String,
   onSuccessCallback : (Directive) => JsCmd = { (directive : Directive) => Noop },
   onFailureCallback : () => JsCmd = { () => Noop }
 ) extends DispatchSnippet with Loggable {
@@ -114,7 +115,7 @@ class CreateDirectivePopup(
   }
 
   ///////////// fields for category settings ///////////////////
-  private[this] val directiveName = new WBTextField("Name", "") {
+  private[this] val directiveName = new WBTextField("Name", defaultDirectiveName) {
     override def setFilter = notNull _ :: trim _ :: Nil
     override def errorClassName = ""
     override def inputField = super.inputField % ("onkeydown" , "return processKey(event , 'createDirectiveSaveButton')") % ("tabindex","1")

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
@@ -396,8 +396,10 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
   }
 
   private[this] def newCreationPopup(technique: Technique, activeTechnique: FullActiveTechnique, workflowEnabled: Boolean) : NodeSeq = {
+    val allDefaults = techniqueRepository.getTechniquesInfo.directivesDefaultNames
+    val directiveDefaultName = allDefaults.get(technique.id.toString).orElse(allDefaults.get(technique.id.name.value)).getOrElse(technique.name)
     new CreateDirectivePopup(
-        technique.name, technique.description, technique.id.version,
+        technique.name, technique.description, technique.id.version, directiveDefaultName,
         onSuccessCallback = { (directive : Directive) =>
           updateDirectiveSettingForm(activeTechnique, directive,None, workflowEnabled, true)
           //Update UI


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/6244

The feature in itself is quite simple: we add a file techniques/default-directive-names.conf (auto create it if it doesn't exists) with techniqueName[/version]=value. And when creating a new technique, we use the content of that file, or the name of the technique if no key present, to give a default name to the directive. 
So, that's around 20 lines. 

All the remaining is managing CRAP about technique library reloading that is UBER buggy and horrible. Now, the library is relaoded if the commit ids between the current and the last available are different, but we fire promise generation only if there was modified techniques. 

I had hope that this will also correct the long standing bug about the categories name & description not being updated. It is. Kind of. The name & description IN THE REFERENCE LIBRARY are modified, not the one displayed to the user. What a pile of CRAP. 
