### PR TITLE
Fixes #7357: Inventory query test are not passing anymore in Rudder 3.0

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
@@ -117,7 +117,7 @@ class WoLDAPNodeRepository(
    * If the node is a system one, the methods fails.
    */
   private[this] def update(nodeId: NodeId, updateNode: Node => Node, logAction: (Node, Node) => Box[EventLog]) : Box[Node] = {
-    import com.normation.rudder.services.nodes.NodeInfoServiceImpl.{nodeInfoAttributes => attrs}
+    import com.normation.rudder.services.nodes.NodeInfoService.{nodeInfoAttributes => attrs}
     repo.synchronized { for {
       con           <- ldap
       existingEntry <- con.get(nodeDit.NODES.NODE.dn(nodeId.value), attrs:_*) ?~! s"Cannot update node with id ${nodeId.value} : there is no node with that id"

--- a/rudder-core/src/main/scala/com/normation/rudder/services/nodes/QuickSearchService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/nodes/QuickSearchService.scala
@@ -47,7 +47,7 @@ import com.normation.rudder.domain.RudderDit
 import com.normation.rudder.domain.NodeDit
 import com.normation.rudder.domain.RudderLDAPConstants._
 import com.normation.rudder.domain.nodes.NodeInfo
-import com.normation.rudder.services.nodes.NodeInfoServiceImpl.nodeInfoAttributes
+import com.normation.rudder.services.nodes.NodeInfoService.nodeInfoAttributes
 
 import com.normation.rudder.domain.Constants._
 import com.normation.rudder.repository.ldap.LDAPEntityMapper


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7357

Some explanation: in fact, the tests don't pass anymore because we are using OpenLDAP specific filters for efficiency, that are not available in the test directory. 

So we need to split the "nodeinfoservice" service into an efficient version used in the real web app, and a "naive" one, that is used in test. 

Of course, we must share most of the logic, else we don't test anything. So the split is done only on the way we retrieve entries, and if we should update cache (always true). 