### PR TITLE
Fixes #7378: Test no passing in Rudder 3.1 since #7331 and #7357

### DIFF
--- a/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
@@ -116,7 +116,7 @@ class StatusReportTest extends Specification {
     "correctly add them by directive" in {
       val a = aggregate(d1c1v1_s ++ d1c2v21_s ++ d2c2v21_e)
 
-      (a.compliance.pc_success === 66.67.toFloat) and
+      (a.compliance.pc_success === 66.67.toDouble) and
       (a.directives("d1").compliance.pc_success === 100) and
       (a.directives("d2").compliance.pc_error === 100)
     }

--- a/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
@@ -135,7 +135,7 @@ class TestQueryProcessor extends Loggable {
       con.search("cn=rudder-configuration", Sub, BuildFilter.ALL).size
     }).openOrThrowException("For tests")
 
-    val expected = 37+28  //37 in bootstrap and 28 in inventory-sample
+    val expected = 37+30  //bootstrap + inventory-sample
     assert(expected == s, s"Not found the expected number of entries in test LDAP directory [expected: ${expected}, found: ${s}], perhaps the demo entries where not correctly loaded")
   }
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7378