### PR TITLE
Fixes #7402: Add a <FILE> tag in metadata.xml to allow simple file copy into techniques

### DIFF
--- a/rudder-core/src/main/scala/com/normation/cfclerk/domain/Technique.scala
+++ b/rudder-core/src/main/scala/com/normation/cfclerk/domain/Technique.scala
@@ -85,6 +85,7 @@ case class Technique(
   , name                   : String
   , description            : String
   , templates              : Seq[TechniqueTemplate]
+  , files                  : Seq[TechniqueFile]
   , bundlesequence         : Seq[Bundle]
   , trackerVariableSpec    : TrackerVariableSpec
   , rootSection            : SectionSpec //be careful to not split it from the TechniqueId, else you will not have the good spec for the version

--- a/rudder-core/src/main/scala/com/normation/cfclerk/domain/TechniqueResource.scala
+++ b/rudder-core/src/main/scala/com/normation/cfclerk/domain/TechniqueResource.scala
@@ -66,7 +66,23 @@ final case class TechniqueResourceIdByName(techniqueId: TechniqueId, name: Strin
  */
 final case class TechniqueResourceIdByPath(parentDirectories: List[String], name: String) extends TechniqueResourceId
 
+final case class TechniqueFile(
+    /*
+     * This is the identifier of the file.
+     * Path to the file depends upon the type of resource, either
+     * relative to the technique or to the configuration-repository
+     */
+    id: TechniqueResourceId
 
+    /*
+     *  Path where to PUT the template (e.g. for resources for ips)
+     *  This path is relative to the "cf-engine" root directory on the
+     *  server.
+     *  It must be the full path, with the name of the cf-engine promise.
+     *  By default, it will be set to: ${POLICY NAME}/${template name}.cf
+     */
+  , outPath: String
+)
 
 /**
  * The Tml class holds the representation of a template, containing the template name,
@@ -83,9 +99,10 @@ final case class TechniqueTemplate(
      * This is the template identifier of the file.
      * The real file name in git will be derived from that name by adding
      * the template ".st" extension to the end of the name.
-     * Path to the file depends upon the type of Technique template
+     * Path to the file depends upon the type of resource, either
+     * relative to the technique or to the configuration-repository
      */
-  id: TechniqueResourceId
+    id: TechniqueResourceId
 
     /*
      *  Path where to PUT the template (e.g. for resources for ips)

--- a/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueReader.scala
+++ b/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueReader.scala
@@ -108,15 +108,19 @@ trait TechniqueReader {
   def checkreportingDescriptorExistence(techniqueId: TechniqueId) : Boolean
 
   /**
-   * Read the content of a template, if the template is known by that
+   * Read the content of a resource, if the resources is known by that
    * TechniqueReader.
-   * If the template exists, then a Some(input stream), open at the
+   *
+   * Optionnaly, give an extension to happen to the resource name
+   * (used for example for template)
+   *
+   * If the resources exists, then a Some(input stream), open at the
    * beginning of the template is given to the caller.
    * If not, a None is given.
    * The implementation must take care of correct closing of the input
    * stream and any I/O exception.
    */
-  def getTemplateContent[T](templateName: TechniqueResourceId)(useIt : Option[InputStream] => T) : T
+  def getResourceContent[T](techniqueResourceId: TechniqueResourceId, postfixName: Option[String])(useIt : Option[InputStream] => T) : T
 
   /**
    * An indicator that the underlying policy template library changed and that the content

--- a/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueRepository.scala
+++ b/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueRepository.scala
@@ -54,17 +54,19 @@ trait TechniqueRepository {
   def getMetadataContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => T): T
 
   /**
-   * Retrieve the template path for templateName relative to
-   * the root of the policy package category tree
+   * Get the template content for the given id
    */
-  def getTemplateContent[T](templateName: TechniqueResourceId)(useIt: Option[InputStream] => T): T
+  def getTemplateContent[T](techniqueResourceId: TechniqueResourceId)(useIt: Option[InputStream] => T): T
+
+  /**
+   * Get the file content for the given id
+   */
+  def getFileContent[T](techniqueResourceId: TechniqueResourceId)(useIt: Option[InputStream] => T): T
 
   /**
    * Retrieve the reporting descriptor file content
    */
   def getReportingDetailsContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => T): T
-
-  //  def packageDirectory : File
 
 
   /*

--- a/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
+++ b/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
@@ -384,10 +384,10 @@ class GitTechniqueReader(
     }
   }
 
-  override def getTemplateContent[T](techniqueResourceId: TechniqueResourceId)(useIt : Option[InputStream] => T) : T = {
+  override def getResourceContent[T](techniqueResourceId: TechniqueResourceId, postfixName: Option[String])(useIt : Option[InputStream] => T) : T = {
     //build a treewalk with the path, given by TechniqueTemplateId
     val filenameFilter = {
-      val name = techniqueResourceId.name + TechniqueTemplate.templateExtension
+      val name = techniqueResourceId.name + postfixName.getOrElse("")
       techniqueResourceId match {
         case TechniqueResourceIdByName(tid, _) =>
           new FileTreeFilter(canonizedRelativePath, s"${tid.name}/${tid.version.toString}/${name}")
@@ -596,7 +596,9 @@ class GitTechniqueReader(
 
   private[this] val dummyTechnique = Technique(
       TechniqueId(TechniqueName("dummy"),TechniqueVersion("1.0"))
-    , "dummy", "dummy", Seq(), Seq(), TrackerVariableSpec(), SectionSpec("ROOT"), None)
+    , "dummy", "dummy", Seq(), Seq(), Seq(), TrackerVariableSpec()
+    , SectionSpec("ROOT"), None
+ )
 
   private[this] def processTechnique(
       is:InputStream

--- a/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/TechniqueRepositoryImpl.scala
+++ b/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/TechniqueRepositoryImpl.scala
@@ -131,8 +131,11 @@ class TechniqueRepositoryImpl(
   override def getMetadataContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => T): T =
     techniqueReader.getMetadataContent(techniqueId)(useIt)
 
-  override def getTemplateContent[T](templateName: TechniqueResourceId)(useIt: Option[InputStream] => T): T =
-    techniqueReader.getTemplateContent(templateName)(useIt)
+  override def getFileContent[T](techniqueResourceId: TechniqueResourceId)(useIt: Option[InputStream] => T): T =
+    techniqueReader.getResourceContent(techniqueResourceId, None)(useIt)
+
+  override def getTemplateContent[T](techniqueResourceId: TechniqueResourceId)(useIt: Option[InputStream] => T): T =
+    techniqueReader.getResourceContent(techniqueResourceId, Some(TechniqueTemplate.templateExtension))(useIt)
 
   override def getReportingDetailsContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => T): T =
     techniqueReader.getReportingDetailsContent(techniqueId)(useIt)

--- a/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/CfclerkXmlConstants.scala
+++ b/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/CfclerkXmlConstants.scala
@@ -62,9 +62,12 @@ object CfclerkXmlConstants {
   val BUNDLES_ROOT = "BUNDLES"
   val BUNDLE_NAME = "NAME"
 
-  //promise templates
+  //promise templates / files
   val PROMISE_TEMPLATES_ROOT = "TMLS"
   val PROMISE_TEMPLATE = "TML"
+  val FILES = "FILES"
+  val FILE = "FILE"
+
   val PROMISE_TEMPLATE_NAME = "name" //attribute
   val PROMISE_TEMPLATE_OUTPATH = "OUTPATH"
   val PROMISE_TEMPLATE_INCLUDED = "INCLUDED"

--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/Cf3PolicyDraft.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/Cf3PolicyDraft.scala
@@ -260,9 +260,9 @@ protected[write] class Cf3PolicyDraftContainer(
    val parameters : Set[ParameterEntry],
    _drafts: Set[Cf3PolicyDraft]
 ) extends Loggable {
-  import scala.collection.mutable.{ Map => MutMap }
 
   val cf3PolicyDrafts = {
+    import scala.collection.mutable.{ Map => MutMap }
     /*
      * Here, for each draft, we have to update all previously processed draft.
      * So the mutmap.

--- a/rudder-core/src/test/resources/techniquesRoot/cat1/p1_1/1.0/file2.txt
+++ b/rudder-core/src/test/resources/techniquesRoot/cat1/p1_1/1.0/file2.txt
@@ -1,0 +1,1 @@
+This is the content of file 2

--- a/rudder-core/src/test/resources/techniquesRoot/cat1/p1_1/1.0/metadata.xml
+++ b/rudder-core/src/test/resources/techniquesRoot/cat1/p1_1/1.0/metadata.xml
@@ -9,4 +9,8 @@
       </TML>
       <TML name="RUDDER_CONFIGURATION_REPOSITORY/libdir/template2" />
     </TMLS>
+    <FILES>
+      <FILE name="RUDDER_CONFIGURATION_REPOSITORY/libdir/file1.txt" />
+      <FILE name="file2.txt"><OUTPATH>file2</OUTPATH></FILE>
+    </FILES>
 </TECHNIQUE>   

--- a/rudder-core/src/test/scala/com/normation/cfclerk/services/DummyTechniqueRepository.scala
+++ b/rudder-core/src/test/scala/com/normation/cfclerk/services/DummyTechniqueRepository.scala
@@ -42,19 +42,19 @@ import scala.collection.SortedSet
 class DummyTechniqueRepository(policies: Seq[Technique] = Seq()) extends TechniqueRepository {
 
   var returnedVariable = collection.mutable.Set[VariableSpec]()
-  val policy1 = Technique(TechniqueId(TechniqueName("policy1"), TechniqueVersion("1.0")), "policy1", "", Seq(), Seq(Bundle("one")), TrackerVariableSpec(), SectionSpec(name="root", children=Seq(InputVariableSpec("$variable1", "a variable1"))), None)
+  val policy1 = Technique(TechniqueId(TechniqueName("policy1"), TechniqueVersion("1.0")), "policy1", "", Seq(), Seq(), Seq(Bundle("one")), TrackerVariableSpec(), SectionSpec(name="root", children=Seq(InputVariableSpec("$variable1", "a variable1"))), None)
 
   val sections = SectionSpec(name="root", children=Seq(InputVariableSpec("$variable2", "a variable2", multivalued = true), InputVariableSpec("$variable22", "a variable22")))
-  val policy2 = Technique(TechniqueId(TechniqueName("policy2"), TechniqueVersion("1.0")), "policy2", "", Seq(), Seq(Bundle("two")), TrackerVariableSpec(), sections, None)
+  val policy2 = Technique(TechniqueId(TechniqueName("policy2"), TechniqueVersion("1.0")), "policy2", "", Seq(), Seq(), Seq(Bundle("two")), TrackerVariableSpec(), sections, None)
 
   val sections3 = SectionSpec(name="root", children=Seq(InputVariableSpec("$variable3", "a variable3")))
-  val policy3 = Technique(TechniqueId(TechniqueName("policy3"), TechniqueVersion("1.0")), "policy3", "", Seq(), Seq(Bundle("three")), TrackerVariableSpec(), sections3, None)
+  val policy3 = Technique(TechniqueId(TechniqueName("policy3"), TechniqueVersion("1.0")), "policy3", "", Seq(), Seq(), Seq(Bundle("three")), TrackerVariableSpec(), sections3, None)
 
   val sections4 = SectionSpec(name="root", children=Seq(InputVariableSpec("$variable4", "an variable4")))
-  val policy4 = Technique(TechniqueId(TechniqueName("policy4"), TechniqueVersion("1.0")), "policy4", "", Seq(), Seq(Bundle("four")), TrackerVariableSpec(), sections4, None)
+  val policy4 = Technique(TechniqueId(TechniqueName("policy4"), TechniqueVersion("1.0")), "policy4", "", Seq(), Seq(), Seq(Bundle("four")), TrackerVariableSpec(), sections4, None)
 
   val sectionsFoo = SectionSpec(name="root", children=Seq(InputVariableSpec("$bar", "bar")))
-  val foo = Technique(TechniqueId(TechniqueName("foo"), TechniqueVersion("1.0")), "foo", "", Seq(), Seq(Bundle("foo")), TrackerVariableSpec(), sectionsFoo, None)
+  val foo = Technique(TechniqueId(TechniqueName("foo"), TechniqueVersion("1.0")), "foo", "", Seq(), Seq(), Seq(Bundle("foo")), TrackerVariableSpec(), sectionsFoo, None)
 
   val policyMap = Map(policy1.id -> policy1,
     policy2.id -> policy2,
@@ -64,41 +64,32 @@ class DummyTechniqueRepository(policies: Seq[Technique] = Seq()) extends Techniq
 
   def this() = this(Seq()) //Spring need that...
 
-  def techniqueDirectory: File = new File("/")
+  override def getMetadataContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => T): T = ???
+  override def getTemplateContent[T](id: TechniqueResourceId)(useIt: Option[InputStream] => T): T = ???
+  override def getFileContent[T](id: TechniqueResourceId)(useIt: Option[InputStream] => T): T = ???
+  override def getReportingDetailsContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => T): T = ???
+  override def getAll(): Map[TechniqueId, Technique] = { policyMap }
 
-  def getTechniquePath(id: TechniqueId): Option[String] = get(id).map(_ => id.name.value)
-
-  def getTemplateContent[T](templateName: TechniqueResourceId)(useIt: Option[InputStream] => T): T = ???
-  def getMetadataContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => T): T = ???
-  def getReportingDetailsContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => T): T = ???
-  def getAll(): Map[TechniqueId, Technique] = { policyMap }
-
-  def get(policyName: TechniqueId): Option[Technique] = {
+  override def get(policyName: TechniqueId): Option[Technique] = {
     policyMap.get(policyName)
   }
 
-  def getByIds(policiesName: Seq[TechniqueId]): Seq[Technique] = {
+  override def getByIds(policiesName: Seq[TechniqueId]): Seq[Technique] = {
     policiesName.map(x => policyMap(x))
   }
 
-  def getLastTechniqueByName(policyName: TechniqueName): Option[Technique] = {
+  override def getLastTechniqueByName(policyName: TechniqueName): Option[Technique] = {
     policyMap.get(TechniqueId(policyName, TechniqueVersion("1.0")))
   }
 
-  def getByName(policyName: TechniqueName) = ???
+  override def getByName(policyName: TechniqueName) = ???
 
-  def getTechniquesInfo = ???
+  override def getTechniquesInfo = ???
 
   override def getTechniqueVersions(name:TechniqueName) : SortedSet[TechniqueVersion] = SortedSet.empty[TechniqueVersion]
 
-  def manageDependencies(chosenTemplate: Seq[TechniqueResourceId] , includeExternalDependencies : Boolean = true) : Seq[TechniqueResourceId] = {
-    Seq()
-  }
-
-  def getTechniqueLibrary: RootTechniqueCategory = null
-  def getTechniqueCategory(id: TechniqueCategoryId): Box[TechniqueCategory] = null
-  def getParentTechniqueCategory(id: TechniqueCategoryId): Box[TechniqueCategory] = null
-  def getParents_TechniqueCategory(id: TechniqueCategoryId): Box[List[TechniqueCategory]] = null
-  def getParentTechniqueCategory_forTechnique(id: TechniqueId): Box[TechniqueCategory] = null
+  override def getTechniqueLibrary: RootTechniqueCategory = null
+  override def getTechniqueCategory(id: TechniqueCategoryId): Box[TechniqueCategory] = null
+  override def getParentTechniqueCategory_forTechnique(id: TechniqueId): Box[TechniqueCategory] = null
 
 }

--- a/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ExpectedReportTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ExpectedReportTest.scala
@@ -271,6 +271,7 @@ class ExpectedReportsTest extends DBCommon {
       , "description"
       , Seq()
       , Seq()
+      , Seq()
       , TrackerVariableSpec()
       , SectionSpec("root", isComponent = true, componentKey = Some("foo"), children = Seq(fooSpec))
       , None

--- a/rudder-core/src/test/scala/com/normation/rudder/services/nodes/NodeConfigurationChangeDetectServiceTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/nodes/NodeConfigurationChangeDetectServiceTest.scala
@@ -63,7 +63,7 @@ class NodeConfigurationChangeDetectServiceTest extends Specification {
 
 
   /* Test the change in node */
-  def newTechnique(id: TechniqueId) = Technique(id, "tech" + id, "", Seq(), Seq(), TrackerVariableSpec(), SectionSpec("plop"), None, Set(), None)
+  def newTechnique(id: TechniqueId) = Technique(id, "tech" + id, "", Seq(), Seq(), Seq(), TrackerVariableSpec(), SectionSpec("plop"), None, Set(), None)
 
   val service = new DetectChangeInNodeConfiguration()
 

--- a/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
@@ -115,6 +115,7 @@ class RuleValServiceTest extends Specification {
       , ""
       , Seq()
       , Seq()
+      , Seq()
       , TrackerVariableSpec(None)
       , makeRootSectionSpec
       , None

--- a/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PolicyInstanceAgregationTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PolicyInstanceAgregationTest.scala
@@ -67,7 +67,7 @@ class DirectiveAgregationTest {
     }
   }
 
-  def newTechnique(id: TechniqueId) = Technique(id, "tech" + id, "", Seq(), Seq(), TrackerVariableSpec(), SectionSpec("plop"), None, Set(), None)
+  def newTechnique(id: TechniqueId) = Technique(id, "tech" + id, "", Seq(), Seq(), Seq(), TrackerVariableSpec(), SectionSpec("plop"), None, Set(), None)
 
   import scala.collection.immutable.Set
   val trackerVariableSpec = TrackerVariableSpec(Some("card"))
@@ -84,6 +84,7 @@ class DirectiveAgregationTest {
           , "DESCRIPTION"
           , Seq()
           , Seq()
+          , Seq()
           , trackerVariableSpec
           , SectionSpec(name="root", children=Seq())
           , None
@@ -93,6 +94,7 @@ class DirectiveAgregationTest {
             activeTechniqueId2
           , "name"
           , "DESCRIPTION"
+          , Seq()
           , Seq()
           , Seq()
           , trackerVariableSpec


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7402

This ticket add the `<FILE>` tag in Techniques for resources that we just want to copy for each node. 

It also bring some refactoring in the "write promise" pipeline, trying to make it a little clearer (create some datastructure to holds things, rename other things to denote what they actually are, and not what they were 5 years ago, etc...) and more correct (for instance, expected_reports.csv is now written only *one* time for each node/agent, not one time for each template of each technique...).