### PR TITLE
Fixes #7757: Blue colour in \"Nodes by overall compliance\" chart is confusingly the same as \"No report\" blue

### DIFF
--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -90,7 +90,7 @@ case class GreenChart (value : Int) extends ComplianceLevelPieChart{
 
 case class BlueChart (value : Int) extends ComplianceLevelPieChart{
   val label = "Good (> 75%)"
-  val color = "#5bc0de"
+  val color = "#B2DE5B"
 }
 
 case class OrangeChart (value : Int) extends ComplianceLevelPieChart{


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7757