### PR TITLE
Fixes #2543: Allow to make a group with only 32bits or 64bits nodes

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/domain/queries/DitQueryData.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/queries/DitQueryData.scala
@@ -4,12 +4,12 @@
 *************************************************************************************
 *
 * This file is part of Rudder.
-* 
+*
 * Rudder is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * In accordance with the terms of section 7 (7. Additional Terms.) of
 * the GNU General Public License version 3, the copyright holders add
 * the following Additional permissions:
@@ -22,12 +22,12 @@
 * documentation that, without modification of the Source Code, enables
 * supplementary functions or services in addition to those offered by
 * the Software.
-* 
+*
 * Rudder is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -163,6 +163,7 @@ class DitQueryData(dit:InventoryDit) {
       Criterion(A_OS_VERSION, OrderedStringComparator),
       Criterion(A_OS_SERVICE_PACK, OrderedStringComparator),
       Criterion(A_OS_KERNEL_VERSION , OrderedStringComparator),
+      Criterion(A_ARCH, StringComparator),
       Criterion(A_NODE_UUID, StringComparator),
       Criterion(A_HOSTNAME, StringComparator),
       Criterion(A_SERVER_ROLE, StringComparator),

--- a/rudder-web/src/main/resources/ldapObjectAndAttributes.properties
+++ b/rudder-web/src/main/resources/ldapObjectAndAttributes.properties
@@ -3,12 +3,12 @@
 #####################################################################################
 #
 # This file is part of Rudder.
-# 
+#
 # Rudder is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # In accordance with the terms of section 7 (7. Additional Terms.) of
 # the GNU General Public License version 3, the copyright holders add
 # the following Additional permissions:
@@ -21,12 +21,12 @@
 # documentation that, without modification of the Source Code, enables
 # supplementary functions or services in addition to those offered by
 # the Software.
-# 
+#
 # Rudder is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -111,6 +111,7 @@ ldap.attr.osFullName=Operating System Detailed Name
 ldap.attr.osVersion=Operating System Version
 ldap.attr.osKernelVersion=Kernel version
 ldap.attr.osServicePack=Operating System Service Pack
+ldap.attr.osArchitectureType=Operating System Architecture Description
 ldap.attr.cn = Name
 ldap.attr.description = Description
 ldap.attr.componentSerialNumber = Serial Number

--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -373,6 +373,7 @@ $$("#${detailsId}").bind( "show", function(event, ui) {
           <b>Operating System Name:</b> {S.?("os.name."+sm.node.main.osDetails.os.name)}<br/>
           <b>Operating System Version:</b> {sm.node.main.osDetails.version.value}<br/>
           <b>Operating System Service Pack:</b> {sm.node.main.osDetails.servicePack.getOrElse("None")}<br/>
+          <b>Operating System Architecture Description:</b> {sm.node.archDescription.getOrElse("None")}<br/>
         </div>
 
       <h4 class="tablemargin">Rudder information</h4>


### PR DESCRIPTION
See http://www.rudder-project.org/redmine/issues/2543

There is litterary only 3 things added:
- the attribute is added as a searcheable one, 
- configure its name in the dropdown, 
- add a line in the "OS" part of node details to show it. 