### PR TITLE
Fixes #7524: Java OOM during Java's log migration

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/migration/EventLogMigration_2_3.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/migration/EventLogMigration_2_3.scala
@@ -4,12 +4,12 @@
 *************************************************************************************
 *
 * This file is part of Rudder.
-* 
+*
 * Rudder is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * In accordance with the terms of section 7 (7. Additional Terms.) of
 * the GNU General Public License version 3, the copyright holders add
 * the following Additional permissions:
@@ -22,12 +22,12 @@
 * documentation that, without modification of the Source Code, enables
 * supplementary functions or services in addition to those offered by
 * the Software.
-* 
+*
 * Rudder is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -102,38 +102,7 @@ class EventLogsMigration_2_3(
     override val jdbcTemplate       : JdbcTemplate
   , override val individualMigration: EventLogMigration_2_3
   , override val batchSize          : Int = 1000
-) extends BatchElementMigration[MigrationEventLog] with Migration_2_3_Definition {
-
-
-  override val elementName = "EventLog"
-  override val rowMapper = MigrationEventLogMapper
-  override val selectAllSqlRequest = "SELECT id, eventType, data FROM eventlog"
-
-  override protected def save(logs:Seq[MigrationEventLog]) : Box[Seq[MigrationEventLog]] = {
-    val UPDATE_SQL = "UPDATE EventLog set eventType = ?, data = ? where id = ?"
-
-    val ilogs = logs match {
-      case x:IndexedSeq[_] => logs
-      case seq => seq.toIndexedSeq
-    }
-
-    tryo { jdbcTemplate.batchUpdate(
-               UPDATE_SQL
-             , new BatchPreparedStatementSetter() {
-                 override def setValues(ps: PreparedStatement, i: Int): Unit = {
-                   ps.setString(1, ilogs(i).eventType )
-                   val sqlXml = ps.getConnection.createSQLXML()
-                   sqlXml.setString(ilogs(i).data.toString)
-                   ps.setSQLXML(2, sqlXml)
-                   ps.setLong(3, ilogs(i).id )
-                 }
-
-                 override def getBatchSize() = ilogs.size
-               }
-    ) }.map( _ => ilogs )
-  }
-
-}
+) extends EventLogsMigration with Migration_2_3_Definition
 
 
 /**

--- a/rudder-core/src/main/scala/com/normation/rudder/migration/XmlFileFormatMigration_3_4.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/migration/XmlFileFormatMigration_3_4.scala
@@ -4,12 +4,12 @@
 *************************************************************************************
 *
 * This file is part of Rudder.
-* 
+*
 * Rudder is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * In accordance with the terms of section 7 (7. Additional Terms.) of
 * the GNU General Public License version 3, the copyright holders add
 * the following Additional permissions:
@@ -22,12 +22,12 @@
 * documentation that, without modification of the Source Code, enables
 * supplementary functions or services in addition to those offered by
 * the Software.
-* 
+*
 * Rudder is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -97,35 +97,7 @@ class EventLogsMigration_3_4(
   , override val individualMigration: EventLogMigration_3_4
   , val eventLogsMigration_2_3      : EventLogsMigration_2_3
   , override val batchSize          : Int = 1000
-) extends BatchElementMigration[MigrationEventLog] with Migration_3_4_Definition {
-
-  override val elementName = "EventLog"
-  override val rowMapper = MigrationEventLogMapper
-  override val selectAllSqlRequest = "SELECT id, eventType, data FROM eventlog"
-
-  override protected def save(logs:Seq[MigrationEventLog]) : Box[Seq[MigrationEventLog]] = {
-    val UPDATE_SQL = "UPDATE EventLog set data = ? where id = ?"
-
-    val ilogs = logs match {
-      case x:IndexedSeq[_] => logs
-      case seq => seq.toIndexedSeq
-    }
-
-    tryo { jdbcTemplate.batchUpdate(
-               UPDATE_SQL
-             , new BatchPreparedStatementSetter() {
-                 override def setValues(ps: PreparedStatement, i: Int): Unit = {
-                   val sqlXml = ps.getConnection.createSQLXML()
-                   sqlXml.setString(ilogs(i).data.toString)
-                   ps.setSQLXML(1, sqlXml)
-                   ps.setLong(2, ilogs(i).id )
-                 }
-
-                 override def getBatchSize() = ilogs.size
-               }
-    ) }.map( _ => ilogs )
-  }
-}
+) extends EventLogsMigration with Migration_3_4_Definition
 
 
 /**
@@ -225,36 +197,7 @@ class ChangeRequestsMigration_3_4(
     override val jdbcTemplate       : JdbcTemplate
   , override val individualMigration: ChangeRequestMigration_3_4
   , override val batchSize          : Int = 1000
-) extends BatchElementMigration[MigrationChangeRequest] with Migration_3_4_Definition {
-
-  override val elementName = "ChangeRequest"
-  override val rowMapper = MigrationChangeRequestMapper
-  override val selectAllSqlRequest = "SELECT id, name, content FROM changerequest"
-
-
-  override protected def save(logs:Seq[MigrationChangeRequest]) : Box[Seq[MigrationChangeRequest]] = {
-    val UPDATE_SQL = "UPDATE changerequest set content = ? where id = ?"
-
-    val ilogs = logs match {
-      case x:IndexedSeq[_] => logs
-      case seq => seq.toIndexedSeq
-    }
-
-    tryo { jdbcTemplate.batchUpdate(
-               UPDATE_SQL
-             , new BatchPreparedStatementSetter() {
-                 override def setValues(ps: PreparedStatement, i: Int): Unit = {
-                   val sqlXml = ps.getConnection.createSQLXML()
-                   sqlXml.setString(ilogs(i).data.toString)
-                   ps.setSQLXML(1, sqlXml)
-                   ps.setLong(2, ilogs(i).id )
-                 }
-
-                 override def getBatchSize() = ilogs.size
-               }
-    ) }.map( _ => ilogs )
-  }
-}
+) extends ChangeRequestsMigration with Migration_3_4_Definition
 
 /**
  * Migrate an event log from fileFormat 2 to 3

--- a/rudder-core/src/main/scala/com/normation/rudder/migration/XmlFileFormatMigration_4_5.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/migration/XmlFileFormatMigration_4_5.scala
@@ -4,12 +4,12 @@
 *************************************************************************************
 *
 * This file is part of Rudder.
-* 
+*
 * Rudder is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * In accordance with the terms of section 7 (7. Additional Terms.) of
 * the GNU General Public License version 3, the copyright holders add
 * the following Additional permissions:
@@ -22,12 +22,12 @@
 * documentation that, without modification of the Source Code, enables
 * supplementary functions or services in addition to those offered by
 * the Software.
-* 
+*
 * Rudder is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -97,35 +97,7 @@ class EventLogsMigration_4_5(
   , override val individualMigration: EventLogMigration_4_5
   , val eventLogsMigration_3_4      : EventLogsMigration_3_4
   , override val batchSize          : Int = 1000
-) extends BatchElementMigration[MigrationEventLog] with Migration_4_5_Definition {
-
-  override val elementName = "EventLog"
-  override val rowMapper = MigrationEventLogMapper
-  override val selectAllSqlRequest = "SELECT id, eventType, data FROM eventlog"
-
-  override protected def save(logs:Seq[MigrationEventLog]) : Box[Seq[MigrationEventLog]] = {
-    val UPDATE_SQL = "UPDATE EventLog set data = ? where id = ?"
-
-    val ilogs = logs match {
-      case x:IndexedSeq[_] => logs
-      case seq => seq.toIndexedSeq
-    }
-
-    tryo { jdbcTemplate.batchUpdate(
-               UPDATE_SQL
-             , new BatchPreparedStatementSetter() {
-                 override def setValues(ps: PreparedStatement, i: Int): Unit = {
-                   val sqlXml = ps.getConnection.createSQLXML()
-                   sqlXml.setString(ilogs(i).data.toString)
-                   ps.setSQLXML(1, sqlXml)
-                   ps.setLong(2, ilogs(i).id )
-                 }
-
-                 override def getBatchSize() = ilogs.size
-               }
-    ) }.map( _ => ilogs )
-  }
-}
+) extends EventLogsMigration with Migration_4_5_Definition
 
 
 /**
@@ -244,36 +216,7 @@ class ChangeRequestsMigration_4_5(
     override val jdbcTemplate       : JdbcTemplate
   , override val individualMigration: ChangeRequestMigration_4_5
   , override val batchSize          : Int = 1000
-) extends BatchElementMigration[MigrationChangeRequest] with Migration_4_5_Definition {
-
-  override val elementName = "ChangeRequest"
-  override val rowMapper = MigrationChangeRequestMapper
-  override val selectAllSqlRequest = "SELECT id, name, content FROM changerequest"
-
-
-  override protected def save(logs:Seq[MigrationChangeRequest]) : Box[Seq[MigrationChangeRequest]] = {
-    val UPDATE_SQL = "UPDATE changerequest set content = ? where id = ?"
-
-    val ilogs = logs match {
-      case x:IndexedSeq[_] => logs
-      case seq => seq.toIndexedSeq
-    }
-
-    tryo { jdbcTemplate.batchUpdate(
-               UPDATE_SQL
-             , new BatchPreparedStatementSetter() {
-                 override def setValues(ps: PreparedStatement, i: Int): Unit = {
-                   val sqlXml = ps.getConnection.createSQLXML()
-                   sqlXml.setString(ilogs(i).data.toString)
-                   ps.setSQLXML(1, sqlXml)
-                   ps.setLong(2, ilogs(i).id )
-                 }
-
-                 override def getBatchSize() = ilogs.size
-               }
-    ) }.map( _ => ilogs )
-  }
-}
+) extends ChangeRequestsMigration with Migration_4_5_Definition
 
 /**
  * Migrate an event log from fileFormat 4 to 5

--- a/rudder-core/src/test/scala/com/normation/rudder/migration/TestDbMigration.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/migration/TestDbMigration.scala
@@ -4,12 +4,12 @@
 *************************************************************************************
 *
 * This file is part of Rudder.
-* 
+*
 * Rudder is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * In accordance with the terms of section 7 (7. Additional Terms.) of
 * the GNU General Public License version 3, the copyright holders add
 * the following Additional permissions:
@@ -22,12 +22,12 @@
 * documentation that, without modification of the Source Code, enables
 * supplementary functions or services in addition to those offered by
 * the Software.
-* 
+*
 * Rudder is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -143,9 +143,9 @@ CREATE TEMP TABLE EventLog (
   "Event Logs" should {
 
     "be all found" in {
-      val logs = migration.findAll.openOrThrowException("For tests")
+      val logs = migration.findBatch.openOrThrowException("For tests")
 
-      logs.size must beEqualTo(logs2WithId.size) and
+      logs.size must beEqualTo(migration.batchSize) and
       forallWhen(logs) {
         case MigrationEventLog(id, eventType, data) =>
           val l = logs2WithId.values.find(x => x.id.get == id).get
@@ -157,7 +157,7 @@ CREATE TEMP TABLE EventLog (
 
     "be correctly migrated" in {
 
-      migration.process
+      val MigrationProcessResult(migrated, nbBataches) = migration.process.openOrThrowException("Bad migration in test")
 
       val logs = jdbcTemplate.query("select * from eventlog", testLogRowMapper).asScala.filter(log =>
                    //only actually migrated file format
@@ -168,7 +168,9 @@ CREATE TEMP TABLE EventLog (
                    }
                  )
 
-      logs.size must beEqualTo(logs3WithId.size) and
+      (logs.size must beEqualTo(logs3WithId.size)) and
+      (logs.size must beEqualTo(migrated)) and
+      (nbBataches must beEqualTo(logs.size/migration.batchSize)) and
       forallWhen(logs) {
         case MigrationTestLog(Some(id), eventType, timestamp, principal, cause, severity, data) =>
           val l = logs3WithId.find(x => x.id.get == id).get


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7524

There is two main point of that change: 

- make each migration be only by step of "max batch", so that we can't explose the memory consumption. I set up the batch size to 1000, because eventlog object use ~10kb, but can use to up to ~50kb for very big events (say, group update with thousand of nodes). So with that, we should keep the memory consumption below 100Mo for the migration

- make the process async so that the event log migration, which is not necessary for Rudder to work, is done in background. It can be stop and restart as many time as needed, so no problem if Rudder stop before the end of migration