### PR TITLE
Fixes #8195: Correct memory profile and efficiency of error report logger

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionService.scala
@@ -139,7 +139,7 @@ class ReportsExecutionService (
       // Executions status not initialized ... initialize it!
       case Full(None) =>
         reportsRepository.getReportsWithLowestId match {
-          case Full(Some((report,id))) =>
+          case Full(Some((id, report))) =>
             logger.debug(s"Initializing the status execution update to  id ${id}, date ${report.executionTimestamp}")
             statusUpdateRepository.setExecutionStatus(id, report.executionTimestamp)
           case Full(None) =>

--- a/rudder-core/src/main/scala/com/normation/rudder/repository/ReportsRepository.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/repository/ReportsRepository.scala
@@ -117,9 +117,13 @@ trait ReportsRepository {
   def deleteEntries(date : DateTime) : Box[Int]
 
   //automaticReportLogger only
-  def getHighestId : Box[Long]
-  def getLastHundredErrorReports(kinds:List[String]) : Box[Seq[(Reports,Long)]]
-  def getErrorReportsBeetween(lower : Long, upper:Long,kinds:List[String]) : Box[Seq[Reports]]
+  /**
+   * Get the highest id of any kind of reports.
+   */
+  def getHighestId() : Box[Long]
+  def getLastHundredErrorReports(kinds:List[String]) : Box[Seq[(Long, Reports)]]
+  //return the reports between the two ids, limited to limit number of reports, in asc order of id.
+  def getReportsByKindBeetween(lower: Long, upper: Long, limit: Int, kinds: List[String]) : Box[Seq[(Long, Reports)]]
 
 
   //nodechangesServices
@@ -132,5 +136,5 @@ trait ReportsRepository {
    */
   def getReportsfromId(id : Long, endDate : DateTime) : Box[(Seq[AgentRun], Long)]
 
-  def getReportsWithLowestId : Box[Option[(Reports,Long)]]
+  def getReportsWithLowestId : Box[Option[(Long, Reports)]]
 }


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8195

Some information: 
- a lot of modification in the ReportsJdbcRepository are cosmetic and just help see what are the differences between queries
- the previous code was doing 3 i/o (get directive, rule, technique) for each log to write, which can be made more efficient by just getting all the rules/directives/techniques. There are already in Rudder memory, that doesn't change the memory profile of the app, but it won a LOT of time (from > 15min to ~10s for writting 250 000 lines)
- the whole process is split in little batch of 10 000 non-compliant-reports. I didn't see much interest in making them bigger, since it could help only for some fixes cost like getting the connection from pool, which is clearly not a big problem. 

One question remains: the actual code has a kind of local cache for the last non-compliant-report id processed. It was like that, and I didn't changed it, but I'm not sure about the gain compared to just getting it from the DB. And it may lead to inconsistencies if the value in DB is updated from an other process (like an human doing tests, or wanting to produce again the non-compliant-report from a given id). 