### PR TITLE
Fixes #7735: OOM in Rudder when there are too many repaired reports

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/repository/ReportsRepository.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/repository/ReportsRepository.scala
@@ -127,8 +127,13 @@ trait ReportsRepository {
 
 
   //nodechangesServices
-  def getChangeReports(notBefore: DateTime): Box[Seq[ResultRepairedReport]]
+  /*
+   *  Count change reports by rules on interval of intervalSizeHour hour, starting at startTime
+   *  StartTime should be a 00:00:00 time.
+   */
+  def countChangeReports(startTime: DateTime, intervalSizeHour: Int): Box[Map[RuleId, Map[Interval, Int]]]
   def getChangeReportsOnInterval(lowestId: Long, highestId: Long): Box[Seq[ResultRepairedReport]]
+  def getChangeReportsByRuleOnInterval(ruleId: RuleId, interval: Interval, limit: Option[Int]): Box[Seq[ResultRepairedReport]]
 
   //reportExecution only
   /**

--- a/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ReportsJdbcRepository.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ReportsJdbcRepository.scala
@@ -437,10 +437,23 @@ class ReportsJdbcRepository(jdbcTemplate : JdbcTemplate) extends ReportsReposito
 
 
 
-  override def getChangeReports(notBefore: DateTime): Box[Seq[ResultRepairedReport]] = {
-    val query = s"${baseQuery} and eventtype='${Reports.RESULT_REPAIRED}' and executionTimeStamp > '${new Timestamp(notBefore.getMillis)}'::timestamp order by executionTimeStamp asc"
+  override def countChangeReports(startTime: DateTime, intervalInHour: Int): Box[Map[RuleId, Map[Interval, Int]]] = {
+    //be careful, extract from 'epoch' gives seconds, not millis
+    val mod = intervalInHour * 3600
+    val start = startTime.getMillis / 1000
+    val query = s"select ruleid, count(*) as number, ( extract('epoch' from executiontimestamp)::bigint - ${start})/${mod} as interval from ruddersysevents " +
+                s"where eventtype = 'result_repaired' and executionTimeStamp > '${new Timestamp(startTime.getMillis)}'::timestamp group by ruleid, interval;"
+
+    //that query will return interval number in the "interval" column. So interval=0 mean
+    //interval from startTime to startTime + intervalInHour hours, etc.
+    //=> little function to build an interval from its number
+    def interval(t:DateTime, int: Int)(num: Int) = new Interval(t.plusHours(num*int), t.plusHours((num+1)*int))
+
     try {
-      Full(jdbcTemplate.query(query,ReportsMapper).asScala.collect{case r:ResultRepairedReport => r})
+      val res = jdbcTemplate.query(query, CountChangesMapper(interval(startTime, intervalInHour))).asScala
+      //group by ruleId, and then interval
+      val groups = res.groupBy(_._1).mapValues( _.groupBy(_._3).mapValues(_.map( _._2).head)) //head non empty due to groupBy, and seq == 1 by query
+      Full(groups)
     } catch {
       case ex: Exception =>
         val error = Failure("Error when trying to retrieve change reports", Some(ex), Empty)
@@ -449,17 +462,34 @@ class ReportsJdbcRepository(jdbcTemplate : JdbcTemplate) extends ReportsReposito
     }
   }
 
+
   override def getChangeReportsOnInterval(lowestId: Long, highestId: Long): Box[Seq[ResultRepairedReport]] = {
     val query = s"${baseQuery} and eventtype='${Reports.RESULT_REPAIRED}' and id >= ${lowestId} and id <= ${highestId} order by executionTimeStamp asc"
-    try {
-      Full(jdbcTemplate.query(query,ReportsMapper).asScala.collect{case r:ResultRepairedReport => r})
-    } catch {
-      case ex: Exception =>
-        val error = Failure("Error when trying to retrieve change reports", Some(ex), Empty)
-        logger.error(error)
-        error
-    }
+    transformJavaList(jdbcTemplate.query(query, ReportsMapper))
   }
+
+  override def getChangeReportsByRuleOnInterval(ruleId: RuleId, interval: Interval, limit: Option[Int]): Box[Seq[ResultRepairedReport]] = {
+    val l = limit match {
+      case Some(i) if(i > 0) => s"limit ${i}"
+      case _                 => ""
+    }
+    val query = s"${baseQuery} and eventtype='${Reports.RESULT_REPAIRED}' and ruleid='${ruleId.value}' " +
+                s" and executionTimeStamp >  '${new Timestamp(interval.getStartMillis)}'::timestamp " +
+                s" and executionTimeStamp <= '${new Timestamp(interval.getEndMillis)  }'::timestamp order by executionTimeStamp asc ${l}"
+
+    transformJavaList(jdbcTemplate.query(query, ReportsMapper))
+  }
+
+  private[this] def transformJavaList(l: java.util.List[Reports]) = {
+      try {
+        Full(l.asScala.collect{case r:ResultRepairedReport => r})
+      } catch {
+        case ex: Exception =>
+          val error = Failure("Error when trying to retrieve change reports", Some(ex), Empty)
+          logger.error(error)
+          error
+      }
+    }
 
 
   override def getReportsByKindBeetween(lower: Long, upper: Long, limit: Int, kinds: List[String]) : Box[Seq[(Long,Reports)]] = {
@@ -476,6 +506,16 @@ class ReportsJdbcRepository(jdbcTemplate : JdbcTemplate) extends ReportsReposito
       }
     }
   }
+}
+
+final case class CountChangesMapper(intMapper: Int => Interval) extends RowMapper[(RuleId, Int, Interval)] {
+   def mapRow(rs : ResultSet, rowNum: Int) : (RuleId, Int, Interval) = {
+        (
+          RuleId(rs.getString("ruleId"))
+        , rs.getInt("number")
+        , intMapper(rs.getInt("interval"))
+      )
+    }
 }
 
 object ReportsMapper extends RowMapper[Reports] {

--- a/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -115,8 +115,7 @@ class ReportingServiceTest extends DBCommon {
 
   lazy val dummyChangesCache = new CachedNodeChangesServiceImpl(null) {
     override def update(changes: Seq[ResultRepairedReport]): Box[Unit] = Full(())
-    override def getCurrentValidIntervals(since: Option[DateTime]) = Seq()
-    override def getChangesByInterval(since: Option[DateTime]) = Empty
+    override def countChangesByRuleByInterval() = Empty
   }
 
   lazy val updateRuns = new ReportsExecutionService(

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleCompliance.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleCompliance.scala
@@ -83,8 +83,6 @@ object RuleCompliance {
 
 class RuleCompliance (
     rule : Rule
-  , directiveLib    : FullActiveTechniqueCategory
-  , allNodeInfos    : Map[NodeId, NodeInfo]
   , rootRuleCategory: RuleCategory
 ) extends Loggable {
 
@@ -115,137 +113,176 @@ class RuleCompliance (
    * For each table : the subtable is contained in td : details
    * when + is clicked: it gets the content of td details then process it
    * as a datatable
+   *
+   * The table are empty when the page is displayed, then there is a JS call
+   * to refresh() that fill them.
    */
   def showCompliance : NodeSeq = {
+    <div id="directiveComplianceSection" class="unfoldedSection" onclick="$('#directiveCompliance').toggle(400); $('#directiveComplianceSection').toggleClass('foldedSection');$('#directiveComplianceSection').toggleClass('unfoldedSection');">
+      <div class="section-title">Compliance by Directive</div>
+    </div>
+    <div id="directiveCompliance">
+      <table id="reportsGrid" cellspacing="0">  </table>
+    </div>
+    <div id="nodeComplianceSection" class="unfoldedSection" onclick="$('#nodeCompliance').toggle(400); $('#nodeComplianceSection').toggleClass('foldedSection');$('#nodeComplianceSection').toggleClass('unfoldedSection');">
+      <div class="section-title">Compliance by Node</div>
+    </div>
+    <div id="nodeCompliance">
+       <table id="nodeReportsGrid" cellspacing="0">  </table>
+    </div>
+    <div id="recentChangesSection" class="unfoldedSection" onclick="$('#recentChanges').toggle(400); $('#recentChangesSection').toggleClass('foldedSection');$('#recentChangesSection').toggleClass('unfoldedSection');">
+      <div class="section-title">Recent changes</div>
+    </div>
+    <div id="recentChanges">
+      {SHtml.button("Refresh", () => refresh())}
+      <div id="changesChart">  </div>
+      <hr class="spacer" />
+      <table id="changesGrid" cellspacing="0">  </table>
+    </div> ++
+    Script(After(0,JsRaw(s"""
+      function refresh() {${refresh().toJsCmd}};
+      createDirectiveTable(true, false, "${S.contextPath}")("reportsGrid",[],refresh);
+      createNodeComplianceTable("nodeReportsGrid",[],"${S.contextPath}", refresh);
+      createChangesTable("changesGrid",[],"${S.contextPath}");
+      correctButtons();
+      refresh();
+    """)))
+  }
 
+  def refresh() = {
+    //we want to be able to see at least one if the other fails
+    SHtml.ajaxInvoke(() => refreshCompliance()) &
+    SHtml.ajaxInvoke(() => refreshGraphChanges()) &
+    SHtml.ajaxInvoke(() => refreshTableChanges(None))
+  }
+
+  def refreshGraphChanges() : JsCmd = {
+    try {
     ( for {
-      reports <- reportingService.findDirectiveRuleStatusReportsByRule(rule.id)
-      changesOnRule <- recentChangesService.getChangesByInterval(None).map( _.getOrElse(rule.id, Map()))
+      changesOnRule <- recentChangesService.countChangesByRuleByInterval().map( _.getOrElse(rule.id, Map()))
     } yield {
-
-        val complianceByDirective = ComplianceData.getRuleByDirectivesComplianceDetails(reports, rule, allNodeInfos, directiveLib).json
-        val complianceByNode = ComplianceData.getRuleByNodeComplianceDetails(directiveLib, reports, allNodeInfos).json
-
-        val changesData = NodeChanges.json(changesOnRule)
-        val changesLine = ChangeLine.jsonByInterval(changesOnRule, Some(rule.name), directiveLib, allNodeInfos)
-        val changesArray = changesLine.in.toList.flatMap{case a:JsArray => a.in.toList; case _ => Nil}
-        val allChanges = JsArray(changesArray)
-       <div id="directiveComplianceSection" class="unfoldedSection" onclick="$('#directiveCompliance').toggle(400); $('#directiveComplianceSection').toggleClass('foldedSection');$('#directiveComplianceSection').toggleClass('unfoldedSection');">
-         <div class="section-title">Compliance by Directive</div>
-       </div>
-       <div id="directiveCompliance">
-         <table id="reportsGrid" cellspacing="0">  </table>
-      </div>
-        <div id="nodeComplianceSection" class="unfoldedSection" onclick="$('#nodeCompliance').toggle(400); $('#nodeComplianceSection').toggleClass('foldedSection');$('#nodeComplianceSection').toggleClass('unfoldedSection');">
-         <div class="section-title">Compliance by Node</div>
-       </div>
-       <div id="nodeCompliance">
-         <table id="nodeReportsGrid" cellspacing="0">  </table>
-        </div>
-        <div id="recentChangesSection" class="unfoldedSection" onclick="$('#recentChanges').toggle(400); $('#recentChangesSection').toggleClass('foldedSection');$('#recentChangesSection').toggleClass('unfoldedSection');">
-         <div class="section-title">Recent changes</div>
-       </div>
-       <div id="recentChanges">
-         {SHtml.ajaxButton("Refresh", () => refresh())}
-         <div id="changesChart">  </div>
-          <hr class="spacer" />
-         <table id="changesGrid" cellspacing="0">  </table>
-        </div> ++
-        Script(After(0,JsRaw(s"""
-          function refresh() {${ajaxRefresh().toJsCmd}};
-          createDirectiveTable(true, false, "${S.contextPath}")("reportsGrid",[],refresh);
-          createNodeComplianceTable("nodeReportsGrid",[],"${S.contextPath}", refresh);
-          createChangesTable("changesGrid",[],"${S.contextPath}");
-          correctButtons();
-          refresh();
-        """)))
-      } ) match {
-      case Full(xml) => xml
-      case _ => <div class="error">Error while fetching report information</div>
+      JsRaw(s"""
+        var recentChanges = ${NodeChanges.json(changesOnRule, recentChangesService.getCurrentValidIntervals(None)).toJsCmd};
+        var data = recentChanges.y
+        data.splice(0,0,'Recent changes')
+        var x = recentChanges.x
+        x.splice(0,0,'x')
+        var chart = c3.generate({
+          data: {
+                x: 'x'
+              , columns: [ x , data ]
+              , type: 'bar'
+              , onclick: function (d, element) {
+                  ${SHtml.ajaxCall(JsRaw("recentChanges.t[d.index]"),  s => refreshTableChanges(Some(s.toLong)))}
+                }
+            }
+          , bar: {
+                width: {
+                    ratio: 1 // this makes bar width 50% of length between ticks
+                }
+            }
+          , axis: {
+                x: {
+                    type: 'categories'
+                }
+            }
+          , grid: {
+                x: { show: true }
+              , y: { show: true }
+            }
+        } );
+        $$('#changesChart').html(chart.element);
+        createTooltip();
+      """)
+    }) match  {
+      case Full(cmd)   => cmd
+      case eb:EmptyBox =>
+        val fail = eb ?~! "Could not refresh recent changes"
+        logger.error(fail.messageChain)
+        Noop
+    }
+    } catch {
+      case oom: OutOfMemoryError =>
+        val msg = "NodeChanges can not be retrieved du to OutOfMemory error. That mean that either your installation is missing " +
+          "RAM (see: http://www.rudder-project.org/doc-3.2/_performance_tuning.html#_java_out_of_memory_error) or that the number of recent changes is " +
+          "overwhelming, and you hit: http://www.rudder-project.org/redmine/issues/7735. Look here for workaround"
+        logger.error(msg)
+        Noop
     }
   }
 
-  def ajaxRefresh() = { SHtml.ajaxInvoke(() => refresh()) }
+  /*
+   * Refresh the tables with details on events.
+   * The argument is the starting timestamp of the interval
+   * to check. If None is provided, the last current interval
+   * is used.
+   * We set a hard limit of 10 000 events by interval of 6 hours.
+   */
+  def refreshTableChanges(intervalStartTimestamp: Option[Long]) : JsCmd = {
+    val intervals = recentChangesService.getCurrentValidIntervals(None).sortBy(_.getStartMillis)
+    val failure = Failure("No interval defined. It's likelly a bug, please contact report it to rudder-project.org/redmine")
+    val int = intervalStartTimestamp.orElse(intervals.lastOption.map(_.getStartMillis)) match {
+      case Some(t) => intervals.find { i => t == i.getStartMillis } match {
+        case Some(i) => Full(i)
+        case None    => failure
+      }
+      case None    => failure
+    }
 
-  def refresh() = {
+    try {
+    ( for {
+      currentInterval <- int
+      changesOnRule   <- recentChangesService.getChangesForInterval(rule.id, currentInterval, Some(10000))
+      directiveLib    <- getFullDirectiveLib()
+      allNodeInfos    <- getAllNodeInfos()
+    } yield {
+      val changesLine = ChangeLine.jsonByInterval(Map((currentInterval, changesOnRule)), Some(rule.name), directiveLib, allNodeInfos)
+      val changesArray = changesLine.in.toList.flatMap{case a:JsArray => a.in.toList; case _ => Nil}
 
-    def refreshChanges() : JsCmd = {
-      ( for {
-        changesOnRule <- recentChangesService.getChangesByInterval(None).map( _.getOrElse(rule.id, Map()))
+      JsRaw(s"""
+        refreshTable("changesGrid", ${JsArray(changesArray).toJsCmd});
+      """)
+    }) match  {
+      case Full(cmd)   => cmd
+      case eb:EmptyBox =>
+        val fail = eb ?~! "Could not refresh recent changes"
+        logger.error(fail.messageChain)
+        Noop
+    }
+    } catch {
+      case oom: OutOfMemoryError =>
+        val msg = "NodeChanges can not be retrieved du to OutOfMemory error. That mean that either your installation is missing " +
+          "RAM (see: http://www.rudder-project.org/doc-3.2/_performance_tuning.html#_java_out_of_memory_error) or that the number of recent changes is " +
+          "overwhelming, and you hit: http://www.rudder-project.org/redmine/issues/7735. Look here for workaround"
+        logger.error(msg)
+        Noop
+    }
+  }
+
+  def refreshCompliance() : JsCmd = {
+    ( for {
+        reports      <- reportingService.findDirectiveRuleStatusReportsByRule(rule.id)
+        updatedRule  <- roRuleRepository.get(rule.id)
+        directiveLib <- getFullDirectiveLib()
+        allNodeInfos <- getAllNodeInfos()
       } yield {
-        val changesData = NodeChanges.json(changesOnRule)
-        val changesLine = ChangeLine.jsonByInterval(changesOnRule, Some(rule.name), directiveLib, allNodeInfos)
-        val changesArray = changesLine.in.toList.flatMap{case a:JsArray => a.in.toList; case _ => Nil}
-        val allChanges = JsArray(changesArray)
-        JsRaw(s"""
-          refreshTable("changesGrid",${allChanges.toJsCmd});
 
-          var recentChanges = ${changesData.toJsCmd};
-          var changes = ${changesLine.toJsCmd};
-          var data = recentChanges.y
-          data.splice(0,0,'Recent changes')
-          var x = recentChanges.x
-          x.splice(0,0,'x')
-          var chart = c3.generate({
-            data: {
-                  x: 'x'
-                , columns: [ x , data ]
-                , type: 'bar'
-                , onclick: function (d, element) {
-                    var res = changes[d.index];
-                    refreshTable("changesGrid",res);
-                  }
-              }
-            , bar: {
-                  width: {
-                      ratio: 1 // this makes bar width 50% of length between ticks
-                  }
-              }
-            , axis: {
-                  x: {
-                      type: 'categories'
-                  }
-              }
-            , grid: {
-                  x: { show: true }
-                , y: { show: true }
-              }
-          } );
-          $$('#changesChart').html(chart.element);
+        val directiveData = ComplianceData.getRuleByDirectivesComplianceDetails(reports, updatedRule, allNodeInfos, directiveLib).json.toJsCmd
+        val nodeData = ComplianceData.getRuleByNodeComplianceDetails(directiveLib, reports, allNodeInfos).json.toJsCmd
+        JsRaw(s"""
+          refreshTable("reportsGrid", ${directiveData});
+          refreshTable("nodeReportsGrid", ${nodeData});
           createTooltip();
         """)
-      }) match  {
+      }
+    ) match {
         case Full(cmd) => cmd
-        case eb:EmptyBox =>
-          val fail = eb ?~! "Could not refresh recent changes"
+        case eb : EmptyBox =>
+          val fail = eb ?~! s"Error while computing Rule ${rule.name} (${rule.id.value})"
           logger.error(fail.messageChain)
           Noop
       }
-    }
-
-    def refreshCompliance() : JsCmd = {
-      ( for {
-          reports <- reportingService.findDirectiveRuleStatusReportsByRule(rule.id)
-          updatedRule <- roRuleRepository.get(rule.id)
-          updatedNodes <- getAllNodeInfos().map(_.toMap)
-          updatedDirectives <- getFullDirectiveLib()
-        } yield {
-          val directiveData = ComplianceData.getRuleByDirectivesComplianceDetails(reports, updatedRule, allNodeInfos, directiveLib).json.toJsCmd
-          val nodeData = ComplianceData.getRuleByNodeComplianceDetails(directiveLib, reports, allNodeInfos).json.toJsCmd
-          JsRaw(s"""
-            refreshTable("reportsGrid",${directiveData});
-            refreshTable("nodeReportsGrid",${nodeData});
-            createTooltip();
-          """)
-        } ) match {
-          case Full(cmd) => cmd
-          case eb : EmptyBox =>
-            val fail = eb ?~! s"Error while computing Rule ${rule.name} (${rule.id.value})"
-            logger.error(fail.messageChain)
-            Noop
-        }
-    }
-
-    refreshCompliance() & refreshChanges()
   }
+
 }
+

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleEditForm.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleEditForm.scala
@@ -210,14 +210,13 @@ class RuleEditForm(
         def updateCompliance() = {
            roRuleRepository.get(rule.id) match {
              case Full(updatedrule) =>
-               new RuleCompliance(updatedrule,directiveLib, nodeInfos, rootRuleCategory).display
+               new RuleCompliance(updatedrule, rootRuleCategory).display
              case eb:EmptyBox =>
                logger.error("could not get updated version of the Rule")
-               <div>Could not get updated version of the Rule, please </div>
+               <div>Could not get updated version of the Rule, please try again</div>
            }
 
         }
-        val ruleComplianceTabAjax = SHtml.ajaxCall(JsRaw("'"+rule.id.value+"'"), (v:String) => Replace("details",updateCompliance()))._2.toJsCmd
 
         form ++
         Script(
@@ -229,10 +228,7 @@ class RuleEditForm(
           JsRaw(s"""
 
             $$("#editRuleZonePortlet").removeClass("nodisplay");
-            $$("#editRuleZone").bind( "show", function(event, ui) {
-              if(ui.panel.id== 'ruleComplianceTab') { ${ruleComplianceTabAjax}; }
-            });
-            ${Replace("details", new RuleCompliance(rule,directiveLib, nodeInfos, rootRuleCategory).display).toJsCmd};
+            ${Replace("details", new RuleCompliance(rule, rootRuleCategory).display).toJsCmd};
             scrollToElement("${idToScroll}", ".rudder_col");
             """
           )


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7735

For information, with the 3 patches applied (+https://www.rudder-project.org/redmine/issues/8195), with > 1.2 Millions changes in the last 3 days (with one 6h interval at 1M changes), we are able to start a Rudder with -Xmx600m, have the non-compliant report be iteratively written, login, go to rule details, see graphes, click and see details on all interval, and everything is fast - with a top heap consomption at 290MB. 

So, there is still some cleaning to do, but the general architecture of the patch is ok. It is in 3 parts, I'm letting them in three commits to make them better understandable. Perhaps it could be split in 3 tickets, to, but they are highly coupled (at least the last two), so not sure. 

1/ Today, we reload compliance each time we switch from the Rule edit form tab to the compliance one. This is useless since we have nice "reload" button on compliance tab, it is an UX strangeness because it causes delay for switch, and don't let the user choose when data should change (difficult to understand, or crazy when you were trying to analized something and clicked on the tab by mistake), and it leads to OOM when  there is a lot of reports (because even if we succeeded in calculating one time, the second one, we have much less memory, since a big part is used). 

2/ That patches allows to only load the events details (display on the bottom grid) for the last interval in rule details (and load details of other on click on the corresponding graph interval). That also means that much less data are transfered to the browser, making user happier (end rule details faster to display). More over, a hard limit of max 10 000 event for a rule, for an interval, is introduced. It is not a good solution, but the correct one (pagination on each interval) is much harder to implement, with higher risks in a released version.

3/ With the third patch, the event cache only keep a COUNT of the number of events by rule by interval, which consume much less memory than keeping all events (of course). Also rewrote some other methods to consum less memory overall. 


