### PR TITLE
Fixes #8051: Compliance is not correctly computed if we receive run agent right after generation

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
@@ -344,11 +344,9 @@ object ExecutionBatch extends Loggable {
               val expireTime = currentConfig.creation.plus(updateValidityTime(intervalInfo))
 
               if(expireTime.isBefore(now)) {
-                ComplianceDebugLogger.node(nodeId).trace(s"Run config for node ${nodeId.value}: NoReportInInterval")
                 runType("no run (ever or too old)", NoReportInInterval(currentConfig))
               } else {
-                ComplianceDebugLogger.node(nodeId).trace(s"Run config for node ${nodeId.value}: Pending until ${expireTime}")
-                runType("no run (ever or too old)", Pending(currentConfig, None, expireTime, missingReportType))
+                runType(s"no run (ever or too old), Pending until ${expireTime}", Pending(currentConfig, None, expireTime, missingReportType))
               }
             }
 

--- a/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -151,14 +151,11 @@ trait CachedFindRuleNodeStatusReports extends ReportingService with CachedReposi
    * Invalidate some keys in the cache. That won't charge them again
    * immediately
    */
-  def invalidate(nodeIds: Set[NodeId]): Unit = this.synchronized {
+  def invalidate(nodeIds: Set[NodeId]): Box[Map[NodeId, Set[RuleNodeStatusReport]]] = this.synchronized {
     logger.debug(s"Compliance cache: invalidate cache for nodes: [${nodeIds.map { _.value }.mkString(",")}]")
     cache = cache -- nodeIds
     //preload new results
-    future {
-      checkAndUpdateCache(nodeIds)
-    }
-    ()
+    checkAndUpdateCache(nodeIds)
   }
 
 

--- a/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -90,7 +90,7 @@ class ReportingServiceTest extends DBCommon {
     def nodeInfoService: NodeInfoService = null
     def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): Box[RuleStatusReport] = null
     def findNodeStatusReport(nodeId: NodeId) : Box[NodeStatusReport] = null
-    override def invalidate(nodeIds: Set[NodeId]) = ()
+    override def invalidate(nodeIds: Set[NodeId]) = Full(Map())
   }
 
   lazy val pgIn = new PostgresqlInClause(2)


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8051

So it seems that somehow, the calls to future { } lead to some king of deadlock, and the corresponding code was never executed. It may be linked to the fact that there was a future{} in an method called from a future{}, or not. 

At least, removing the future and making the order of execution stricter lead to a comprehensive behavior from the user. If the last run in "select * from reportsexecution order by date desc limit 5;" is marked as finished, just after - and BEFORE the next processing of runs - the compliance is reprocessed, and the debug output of ```<logger name="com.normation.rudder.services.reports.CachedReportingServiceImpl" level="debug" />``` and 
```
<logger name="explain_compliance.root" level="trace" additivity="false">
    <appender-ref ref="OPSLOG" />
    <appender-ref ref="STDOUT" />
  </logger>
```
are consitant. 