### PR TITLE
Fixes #8427: Parallel traversal of new promises directories causes rules.new to remain after generation

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/RudderPromiseWriterServiceImpl.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/RudderPromiseWriterServiceImpl.scala
@@ -170,7 +170,7 @@ class RudderCf3PromisesFileWriterServiceImpl(
 
                            prepareRulesForAgents(nodePromisePath, newNodePromisePath, backupNodePath, node, rootNodeId, templates) match {
                              case Full(x) =>
-                               folders ++= x
+                               folders.synchronized(folders ++= x)
                              case e: EmptyBox => return (e ?~! "Error when preparing rules for agents")
                            }
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8427