### PR TITLE
Fixes #8626: Adapt DirectiveEditor for master-slave password fields

### DIFF
--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -1696,6 +1696,9 @@ object RudderConfig extends Loggable {
           case BooleanVType => new CheckboxField(id)
           case TextareaVType(r) => new TextareaField(id)
           case PasswordVType(algos) => new PasswordField(id, input.constraint.mayBeEmpty, algos)
+          case MasterPasswordVType(algos) => new MasterPasswordField(id, input.constraint.mayBeEmpty, algos)
+          case AixDerivedPasswordVType => new DerivedPasswordField(id, HashAlgoConstraint.DerivedPasswordType.AIX)
+          case LinuxDerivedPasswordVType => new DerivedPasswordField(id, HashAlgoConstraint.DerivedPasswordType.Linux)
           case _ => default(id)
         }
         case predefinedField: PredefinedValuesVariableSpec => new ReadOnlyTextField(id)

--- a/rudder-web/src/main/scala/com/normation/rudder/web/model/DirectiveEditor.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/model/DirectiveEditor.scala
@@ -122,6 +122,14 @@ trait DirectiveField extends BaseField with SectionChildField {
   //update list error accordingly
   def parseClient(s: String): Unit
 
+
+  //reference to other fields used by that field
+  protected var _usedFields = Seq[DirectiveField]()
+  def usedFields_=(fields: Seq[DirectiveField]): Unit = {
+    _usedFields = fields
+  }
+  def usedFields = _usedFields
+
   private var description: String = ""
   override def displayName = description
   def displayName_=(s: String): Unit = description = s
@@ -227,6 +235,23 @@ trait SectionField extends SectionChildField {
   // - the user want to have the section displayed
   // - the user want to have the section hidden
   var displayed : Option[Boolean] = Option.empty[Boolean]
+
+  def collectVariables(onlyDirect: Boolean): Map[String, DirectiveField] = {
+    childFields.flatMap { x => x match {
+        case v: DirectiveField => Seq((v.id -> v))
+        case s: SectionField   =>
+          if(onlyDirect) {
+            Seq[(String, DirectiveField)]()
+          } else {
+            s.collectVariables(onlyDirect)
+      }
+    } }.toMap
+  }
+
+  // get all variables in that section
+  def getAllDirectVariables: Map[String, DirectiveField] = collectVariables(true)
+  //get all sub-variables
+  def getAllVariables: Map[String, DirectiveField] = collectVariables(false)
 
   def isMultivalued = this match {
     case _: MultivaluedSectionField => true

--- a/rudder-web/src/main/scala/com/normation/rudder/web/model/RudderBaseField.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/model/RudderBaseField.scala
@@ -50,32 +50,6 @@ import net.liftweb.http.js._
 import JsCmds._
 
 
-
-//ignore for now
-//class ErrorHolder extends Bindable with FieldContainer {
-//  type GlobalError = NodeSeq
-//
-//  private val errorHtml =
-//   <div class="errors">
-//      <errors:header/>
-//      <errors:globalErrors>
-//        <div class="globalErrors">
-//          <ul>
-//            <globalErrors:item><li class="globalErrorItem"><globalErrorItem:content/></li></globalErrors:item>
-//          </ul>
-//        </div>
-//      </errors:globalErrors>
-//    </div>
-//
-//  private[this] val fields = Buffer[BaseField]()
-//  private[this] val _validations = Buffer[Seq[BaseField] => List[GlobalError]]
-//
-//  def registerField(field:BaseField) : Unit = fields += field
-//
-//  def registerValidation(validation:Seq[BaseField] => List[GlobalError]) : Unit = _validations += validation
-//}
-
-
 /**
  * A simple class that allows to register error information
  * about a form and its fields

--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/DirectiveFieldFactory.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/DirectiveFieldFactory.scala
@@ -54,7 +54,7 @@ trait DirectiveFieldFactory {
    * should be never null.
    * If the required type is not known, return a default field
    */
-  def forType(fieldType:VariableSpec,id:String) : DirectiveField
+  def forType(fieldType:VariableSpec, id: String) : DirectiveField
 
   def default(id:String) : DirectiveField
 }


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8626

There is two main part in that pull request: 
- add masterPassword and slavePassword field. MasterPassword is almost a verbatim copy of the old Password field, but it feeds slassPasswords from its constructor with user inputs, and display more generic names for algo choice in the select box.
- handle the plumbing to make use of the ```<USES>``` constraint. Its almost all in  Section2FieldService.scala
