### PR TITLE
Fixes #8656: Adapt Rudder project to Scala 2.11 / Lift 2.6 dependencies

### DIFF
--- a/rudder-core/pom.xml
+++ b/rudder-core/pom.xml
@@ -87,18 +87,18 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
     <dependency>
       <groupId>com.typesafe.slick</groupId>
-      <artifactId>slick_2.10</artifactId>
+      <artifactId>slick_${scala-binary-version}</artifactId>
       <version>2.1.0</version>
     </dependency>
     <!-- slick postgresql support:  https://github.com/tminglei/slick-pg -->
     <dependency>
       <groupId>com.github.tminglei</groupId>
-      <artifactId>slick-pg_2.10</artifactId>
+      <artifactId>slick-pg_${scala-binary-version}</artifactId>
       <version>0.6.3</version>
     </dependency>
     <dependency>
       <groupId>com.github.tminglei</groupId>
-      <artifactId>slick-pg_joda-time_2.10</artifactId>
+      <artifactId>slick-pg_joda-time_${scala-binary-version}</artifactId>
       <version>0.6.3</version>
     </dependency>
 

--- a/rudder-web/pom.xml
+++ b/rudder-web/pom.xml
@@ -44,6 +44,16 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     This is the web front end project that manage the CMDB
   </description>
 
+  <repositories>
+    <repository>
+      <id>Sonatype snapshot</id>
+      <name>Sonatype OSS repository - snapshots</name>
+      <url>https://oss.sonatype.org/content/groups/public</url>
+      <snapshots><enabled>true</enabled></snapshots>
+      <releases><enabled>false</enabled></releases>
+    </repository>
+  </repositories>  
+
   <build>
     <plugins>
        <!-- this is needed to have Rudder plugins access rudder-web in jar format -->
@@ -89,8 +99,8 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
     <dependency>
       <groupId>net.liftmodules</groupId>
-      <artifactId>widgets_2.5_${scala-binary-version}</artifactId>
-      <version>1.3</version>
+      <artifactId>widgets_2.6_${scala-binary-version}</artifactId>
+      <version>1.4-SNAPSHOT</version>
     </dependency>
 
     <!-- it seems to not be resolved, don't know why -->

--- a/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -71,6 +71,15 @@ class Boot extends Loggable {
 
   def boot {
 
+    //
+    // In Rudder 3.1, keep the same XHTML parser / output than we add in
+    // Lift 2.5. The work to switch to HTML 5 is done in Rudder 3.2
+    // Note that we could also use XHtmlInHtml5OutProperties to
+    // keep the XML templates but have an HTML 5 output
+    //
+    LiftRules.htmlProperties.default.set((r: Req) => new OldHtmlProperties(r.userAgent))
+
+
     // Set locale to English to prevent having localized message in some exception message (like SAXParserException in AppConfigAuth).
     // For now we don't manage locale in Rudder so setting it to English is harmless.
     // If one day we handle it in Rudder we should start from here by modifying code here..

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ChangeRequestManagement.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ChangeRequestManagement.scala
@@ -65,6 +65,7 @@ import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.rudder.domain.workflows.WorkflowNodeId
 import com.normation.rudder.domain.eventlog.ChangeRequestLogsFilter
 import com.normation.eventlog.EventLog
+import net.liftweb.http.SHtml.SelectableOption
 
 class ChangeRequestManagement extends DispatchSnippet with Loggable {
 
@@ -224,8 +225,8 @@ class ChangeRequestManagement extends DispatchSnippet with Loggable {
     }
     def unexpandedFilter(default:String):NodeSeq = {
       val multipleValues = ("","All") :: ("Pending","Open") :: ("^(?!Pending)","Closed") :: Nil
-      val select :Elem =SHtml.select(
-          multipleValues ::: selectValues
+      val select :Elem =SHtml.select (
+          (multipleValues ::: selectValues).map{ case (a,b) => SelectableOption(a,b)}
         , Full(default)
         , list => value = list
         , ("style","width:auto;")


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8656

Not that that one need to be carefully upmerge to remove the lines ine Boot.scala about the HTML parser. 