### PR TITLE
Fixes #8409: Explain all unexpected compliance in node details and only display expected reports when nothing else matter

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ComplianceDebugLogger.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ComplianceDebugLogger.scala
@@ -84,10 +84,10 @@ object ComplianceDebugLogger extends Logger {
   implicit class RunAndConfigInfoToLog(c: RunAndConfigInfo) {
 
     val logDetails: String = c match {
-      case NoRunNoInit =>
+      case NoRunNoExpectedReport =>
         "expected NodeConfigId: not found | last run: not found"
 
-      case VersionNotFound(lastRunDateTime, lastRunConfigId) =>
+      case NoExpectedReport(lastRunDateTime, lastRunConfigId) =>
          s"expected NodeConfigId: not found |"+
          s" last run: nodeConfigId: ${lastRunConfigId.fold("none")(_.value)} received at ${lastRunDateTime}"
 
@@ -99,31 +99,32 @@ object ComplianceDebugLogger extends Logger {
         s"until ${expirationDateTime} expected NodeConfigId: ${expectedConfigId.toLog} |"+
         s" last run: ${optLastRun.fold("none (or too old)")(x => s"nodeConfigId: ${x._2.toLog} received at ${x._1}")}"
 
-      case UnexpectedVersion(lastRunDateTime, lastRunConfigId, lastRunExpiration, expectedConfigId, expectedExpiration) =>
+      case UnexpectedVersion(lastRunDateTime, Some(lastRunConfigInfo), lastRunExpiration, expectedConfigId, expectedExpiration) =>
         s"expected NodeConfigId: ${expectedConfigId.toLog} |"+
-        s" last run: nodeConfigId: ${lastRunConfigId.toLog} received at ${lastRunDateTime} |"+
+        s" last run: nodeConfigInfo: ${lastRunConfigInfo.toLog} received at ${lastRunDateTime} |"+
         s" expired at ${lastRunExpiration}"
 
-      case UnexpectedNoVersion(lastRunDateTime, lastRunConfigId, lastRunExpiration, expectedConfigId, expectedExpiration) =>
-        s"expected NodeConfigId: ${expectedConfigId.toLog} |"+
+      case UnexpectedNoVersion(lastRunDateTime, Some(lastRunConfigInfo), lastRunExpiration, expectedConfigInfo, expectedExpiration) =>
+        s"expected NodeConfigId: ${expectedConfigInfo.toLog} |"+
         s" last run: no configId, received at ${lastRunDateTime} |"+
         s" expired at ${lastRunExpiration}"
 
-      case ComputeCompliance(lastRunDateTime, lastRunConfigId, expectedConfigId, expirationDateTime, missingStatus) =>
-        s"expected NodeConfigId: ${expectedConfigId.toLog} |"+
-        s" last run: nodeConfigId: ${lastRunConfigId.toLog} received at ${lastRunDateTime} |"+
+      case x@ComputeCompliance(lastRunDateTime, expectedConfigInfo, expirationDateTime, missingStatus) =>
+        s"expected NodeConfigId: ${expectedConfigInfo.toLog} |"+
+        s" last run: nodeConfigId: ${x.lastRunConfigId.value} received at ${lastRunDateTime} |"+
         s" expired at ${expirationDateTime}"
 
     }
 
     val logName =  c match {
-      case    NoRunNoInit         => "NoRunNoInit"
-      case _: VersionNotFound     => "VersionNotFound"
-      case _: NoReportInInterval  => "NoReportInInterval"
-      case _: Pending             => "Pending"
-      case _: UnexpectedVersion   => "UnexpectedVersion"
-      case _: UnexpectedNoVersion => "UnexpectedNoVersion"
-      case _: ComputeCompliance   => "ComputeCompliance"
+      case    NoRunNoExpectedReport   => "NoRunNoExpectedReport"
+      case _: NoExpectedReport        => "NoRunNoExpectedReport"
+      case _: NoReportInInterval      => "NoReportInInterval"
+      case _: UnexpectedVersion       => "UnexpectedVersion"
+      case _: UnexpectedNoVersion     => "UnexpectedNoVersion"
+      case _: UnexpectedUnknowVersion => "UnexpectedUnknowVersion"
+      case _: Pending                 => "Pending"
+      case _: ComputeCompliance       => "ComputeCompliance"
     }
 
     val toLog: String = logName + ": " + logDetails

--- a/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -265,7 +265,7 @@ object ComponentStatusReport extends Loggable {
  * Values are lost. They are not really used today
  */
 final case class ComponentValueStatusReport(
-    componentValue             : String
+    componentValue          : String
   , unexpandedComponentValue: String
   , messages                : List[MessageStatusReport]
 ) extends StatusReport {

--- a/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
@@ -107,7 +107,7 @@ sealed trait RunAndConfigInfo
 sealed trait ErrorNoConfigData extends RunAndConfigInfo
 
 sealed trait ExpectedConfigAvailable extends RunAndConfigInfo {
-  def expectedConfigId: NodeConfigIdInfo
+  def expectedConfigInfo: NodeConfigIdInfo
 }
 
 sealed trait NoReport extends ExpectedConfigAvailable
@@ -128,8 +128,15 @@ sealed trait LastRunAvailable extends RunAndConfigInfo {
   //config id because we must have some logic to find WHAT
   //is the applicable version in all case - it's one of the
   //major goal of ExecutionBatch#computeNodeRunInfo
-  def lastRunConfigId: NodeConfigIdInfo
+  def lastRunConfigId: NodeConfigId
+
+  // most of the time, we do have the corresponding
+  // configId in base. But not always, for example
+  // if the node configId was corrupted
+  def lastRunConfigInfo: Option[NodeConfigIdInfo]
 }
+
+
 
 /**
  * The date and time when the status expires.
@@ -151,7 +158,7 @@ sealed trait ExpiringStatus extends RunAndConfigInfo {
 /*
  * Really, that node exists ?
  */
-case object NoRunNoInit extends ErrorNoConfigData
+case object NoRunNoExpectedReport extends ErrorNoConfigData
 
 /*
  * We don't have the needed configId in the expected
@@ -160,7 +167,7 @@ case object NoRunNoInit extends ErrorNoConfigData
  * (it is some weird data lost in the server, or a node
  * not yet initialized)
  */
-case class VersionNotFound(
+case class NoExpectedReport(
     lastRunDateTime: DateTime
   , lastRunConfigId: Option[NodeConfigId]
 ) extends ErrorNoConfigData
@@ -171,13 +178,13 @@ case class VersionNotFound(
  * some but too old for our situation)
  */
 case class NoReportInInterval(
-    expectedConfigId: NodeConfigIdInfo
+    expectedConfigInfo: NodeConfigIdInfo
 ) extends NoReport
 
 
 
 case class Pending(
-    expectedConfigId   : NodeConfigIdInfo
+    expectedConfigInfo : NodeConfigIdInfo
   , optLastRun         : Option[(DateTime, NodeConfigIdInfo)]
   , expirationDateTime : DateTime
   , missingReportStatus: ReportType
@@ -191,11 +198,13 @@ case class Pending(
  */
 case class UnexpectedVersion(
     lastRunDateTime   : DateTime
-  , lastRunConfigId   : NodeConfigIdInfo
+  , lastRunConfigInfo : Some[NodeConfigIdInfo]
   , lastRunExpiration : DateTime
-  , expectedConfigId  : NodeConfigIdInfo
+  , expectedConfigInfo: NodeConfigIdInfo
   , expectedExpiration: DateTime
-) extends Unexpected with LastRunAvailable
+) extends Unexpected with LastRunAvailable {
+  val lastRunConfigId = lastRunConfigInfo.get.configId
+}
 
 /**
  * A case where we have a run without version,
@@ -204,20 +213,39 @@ case class UnexpectedVersion(
  */
 case class UnexpectedNoVersion(
     lastRunDateTime   : DateTime
-  , lastRunConfigId   : NodeConfigIdInfo
+  , lastRunConfigInfo : Some[NodeConfigIdInfo]
   , lastRunExpiration : DateTime
-  , expectedConfigId  : NodeConfigIdInfo
+  , expectedConfigInfo: NodeConfigIdInfo
   , expectedExpiration: DateTime
-) extends Unexpected with LastRunAvailable
+) extends Unexpected with LastRunAvailable {
+  val lastRunConfigId = lastRunConfigInfo.get.configId
+}
+
+/**
+ * A case where we have a run with a version,
+ * but we didn't find it in db,
+ * but we really should, because versions are init
+ * in the server for that node
+ */
+case class UnexpectedUnknowVersion(
+    lastRunDateTime   : DateTime
+  , lastRunConfigId   : NodeConfigId
+  , expectedConfigInfo: NodeConfigIdInfo
+  , expectedExpiration: DateTime
+) extends Unexpected with LastRunAvailable {
+  val lastRunConfigInfo = None
+}
 
 
 case class ComputeCompliance(
     lastRunDateTime    : DateTime
-  , lastRunConfigId    : NodeConfigIdInfo
-  , expectedConfigId   : NodeConfigIdInfo
+  , expectedConfigInfo : NodeConfigIdInfo
   , expirationDateTime : DateTime
   , missingReportStatus: ReportType
-) extends Ok with LastRunAvailable with ExpiringStatus with MissingReportStatus
+) extends Ok with LastRunAvailable with ExpiringStatus with MissingReportStatus {
+  val lastRunConfigId   = expectedConfigInfo.configId
+  val lastRunConfigInfo = Some(expectedConfigInfo)
+}
 
 
 
@@ -320,6 +348,7 @@ object ExecutionBatch extends Loggable {
     }
 
     val now = DateTime.now
+
     nodeIds.foreach { case (nodeId, runInfos) =>
       ComplianceDebugLogger.node(nodeId).debug(s"Node run configuration: ${(nodeId, complianceMode, runInfos).toLog }")
     }
@@ -346,12 +375,12 @@ object ExecutionBatch extends Loggable {
 
         (optRun, optInfo) match {
           case (None, None) =>
-            runType("", NoRunNoInit)
+            runType("", NoRunNoExpectedReport)
 
           // There is no run for this node
           case (None, Some(configs)) =>
             if(configs.isEmpty) {
-              runType("nodeId exists in DB but has no version (due to cleaning?)", NoRunNoInit)
+              runType("nodeId exists in DB but has no version (due to cleaning?)", NoRunNoExpectedReport)
             } else {
               val currentConfig = configs.maxBy(_.creation.getMillis)
               val expireTime = currentConfig.creation.plus(updateValidityTime(intervalInfo))
@@ -392,12 +421,12 @@ object ExecutionBatch extends Loggable {
     (runToCheck, nodeConfigIdInfos) match {
 
       case (AgentRun(AgentRunId(_, t), optConfigId, _, _), None) =>
-        runType("need to regenerate policies?", VersionNotFound(t, optConfigId))
+        runType("need to regenerate policies?", NoExpectedReport(t, optConfigId))
 
       //The run does not have a configId: migration, new nodes, etc.
       case (AgentRun(AgentRunId(_, t), None, _, _), Some(configs)) =>
         if(configs.isEmpty) {
-          runType("nodeId exists in DB but has no version (due to cleaning?)", VersionNotFound(t, None))
+          runType("nodeId exists in DB but has no version (due to cleaning?)", NoExpectedReport(t, None))
         } else {
           /*
            * Here, we want to check two things:
@@ -415,7 +444,7 @@ object ExecutionBatch extends Loggable {
             val currentConfig = configs.maxBy( _.creation.getMillis)
             val currentExpiration = currentConfig.creation.plus(updateValidityDuration)
             runType(s"node send reports without nodeConfigId but the oldest configId (${oldestConfigId.configId.value}) expired since ${oldestExpiration})"
-            , UnexpectedNoVersion(t, oldestConfigId, oldestExpiration, currentConfig, currentExpiration)
+            , UnexpectedNoVersion(t, Some(oldestConfigId), oldestExpiration, currentConfig, currentExpiration)
             )
           } else {
             val currentConfigId = configs.maxBy( _.creation.getMillis )
@@ -437,17 +466,20 @@ object ExecutionBatch extends Loggable {
         if(configs.isEmpty) {
           //error: we have a MISSING config id. Contrary to the case where any config id is missing
           //for the node, here we have a BAD id.
-          runType("nodeId exists in DB but has no version (due to cleaning?)", VersionNotFound(t, Some(rv)))
+          runType("nodeId exists in DB but has no version (due to cleaning?)", NoExpectedReport(t, Some(rv)))
         } else {
           configs.find { i => i.configId == rv} match {
             case None =>
-              //it's a bad version.
-              runType(s"nodeId exists in DB and has configId, but not ${rv.value} (due to cleaning?)", VersionNotFound(t, Some(rv)))
+              //it's a bad version, but we have config id in DB => likelly a corruption on node
+              val expectedVersion = configs.maxBy( _.creation.getMillis )
+              //expirationTime is the date after which we must have gotten a report for that version
+              val expirationTime = expectedVersion.creation.plus(updateValidityDuration)
+
+              runType(s"nodeId exists in DB and has configId, expected configId is ${expectedVersion.configId.value}, but ${rv.value} was not found (node corruption?)",
+                  UnexpectedUnknowVersion(t, rv, expectedVersion, expirationTime)
+              )
 
             case Some(v) => //nominal case !
-              //check if the run is not too old for the version, i.e if endOflife + grace is before run
-              val currentConfigId = configs.maxBy( _.creation.getMillis )
-
               v.endOfLife match {
                 case None =>
                   //nominal (bis)! The node is answering to current config !
@@ -458,11 +490,14 @@ object ExecutionBatch extends Loggable {
                     )
                   } else { //nominal case
                     runType(s"Last run at ${t} is for the correct configId ${v.configId.value} and not expired, compute compliance"
-                    , ComputeCompliance(t, v, currentConfigId, expirationTime, missingReportType)
+                    , ComputeCompliance(t, v, expirationTime, missingReportType)
                     )
                   }
 
                 case Some(eol) =>
+                  //check if the run is not too old for the version, i.e if endOflife + grace is before run
+                  val currentConfigId = configs.maxBy( _.creation.getMillis )
+
                   // a more recent version exists, so we are either awaiting reports
                   // for it, or in some error state (completely unexpected version or "just" no report
                   val eolExpiration = eol.plus(updateValidityDuration)
@@ -470,7 +505,7 @@ object ExecutionBatch extends Loggable {
                   if(eolExpiration.isBefore(t)) {
                     //we should have had a more recent run
                     runType(s"node sent reports at ${t} for configId ${rv.value} (which expired at ${eol}) but should have been for configId ${currentConfigId.configId.value}"
-                    , UnexpectedVersion(t, v, eolExpiration, currentConfigId, expirationTime)
+                    , UnexpectedVersion(t, Some(v), eolExpiration, currentConfigId, expirationTime)
                     )
                   } else {
                     if(expirationTime.isBefore(timeToCompareTo)) {
@@ -522,7 +557,7 @@ object ExecutionBatch extends Loggable {
       }
     }
 
-    def buildUnexpectedVersion(runTime: DateTime, runVersion: NodeConfigIdInfo, runExpiration: DateTime, expectedVersion: NodeConfigIdInfo, expectedExpiration: DateTime, nodeStatusReports: Seq[ResultReports]) = {
+    def buildUnexpectedVersion(runTime: DateTime, runVersion: Option[NodeConfigIdInfo], runExpiration: DateTime, expectedVersion: NodeConfigIdInfo, expectedExpiration: DateTime, nodeStatusReports: Seq[ResultReports]) = {
         //mark all report of run unexpected,
         //all expected missing
         buildRuleNodeStatusReport(
@@ -530,7 +565,7 @@ object ExecutionBatch extends Loggable {
           , getExpectedReports(expectedVersion.configId)
           , MissingReportType
         ) ++
-        buildUnexpectedReports(MergeInfo(nodeId, Some(runTime), Some(runVersion.configId), runExpiration), nodeStatusReports)
+        buildUnexpectedReports(MergeInfo(nodeId, Some(runTime), runVersion.map(_.configId), runExpiration), nodeStatusReports)
     }
 
     //only interesting reports: for that node, with a status
@@ -540,12 +575,12 @@ object ExecutionBatch extends Loggable {
 
     val ruleNodeStatusReports = runInfo match {
 
-      case ComputeCompliance(lastRunDateTime, lastRunConfigId, expectedConfigId, expirationTime, missingReportStatus) =>
-        ComplianceDebugLogger.node(nodeId).trace(s"Using merge/compare strategy between last reports from run ${lastRunConfigId.toLog} and expect reports ${expectedConfigId.toLog}")
+      case ComputeCompliance(lastRunDateTime, expectedConfigId, expirationTime, missingReportStatus) =>
+        ComplianceDebugLogger.node(nodeId).trace(s"Using merge/compare strategy between last reports from run at ${lastRunDateTime} and expect reports ${expectedConfigId.toLog}")
         mergeCompareByRule(
-            MergeInfo(nodeId, Some(lastRunDateTime), Some(lastRunConfigId.configId), expirationTime)
+            MergeInfo(nodeId, Some(lastRunDateTime), Some(expectedConfigId.configId), expirationTime)
           , nodeStatusReports
-          , getExpectedReports(lastRunConfigId.configId)
+          , getExpectedReports(expectedConfigId.configId)
           , getExpectedReports(expectedConfigId.configId)
           , missingReportStatus
         )
@@ -588,22 +623,26 @@ object ExecutionBatch extends Loggable {
           , NoAnswerReportType
         )
 
-      case UnexpectedVersion(runTime, runVersion, runExpiration, expectedVersion, expectedExpiration) =>
+      case UnexpectedVersion(runTime, Some(runVersion), runExpiration, expectedVersion, expectedExpiration) =>
         ComplianceDebugLogger.node(nodeId).warn(s"Received a run at ${runTime} for node '${nodeId.value}' with configId '${runVersion.configId.value}' but that node should be sending reports for configId ${expectedVersion.configId.value}")
-        buildUnexpectedVersion(runTime, runVersion, runExpiration, expectedVersion, expectedExpiration, nodeStatusReports)
+        buildUnexpectedVersion(runTime, Some(runVersion), runExpiration, expectedVersion, expectedExpiration, nodeStatusReports)
 
-      case UnexpectedNoVersion(runTime, runVersion, runExpiration, expectedVersion, expectedExpiration) => //same as unextected, different log
+      case UnexpectedNoVersion(runTime, Some(runVersion), runExpiration, expectedVersion, expectedExpiration) => //same as unextected, different log
         ComplianceDebugLogger.node(nodeId).warn(s"Received a run at ${runTime} for node '${nodeId.value}' without any configId but that node should be sending reports for configId ${expectedVersion.configId.value}")
-        buildUnexpectedVersion(runTime, runVersion, runExpiration, expectedVersion, expectedExpiration, nodeStatusReports)
+        buildUnexpectedVersion(runTime, Some(runVersion), runExpiration, expectedVersion, expectedExpiration, nodeStatusReports)
 
-      case VersionNotFound(runTime, optConfigId) =>
+      case UnexpectedUnknowVersion(runTime, runId, expectedVersion, expectedExpiration) => //same as unextected, different log
+        ComplianceDebugLogger.node(nodeId).warn(s"Received a run at ${runTime} for node '${nodeId.value}' configId '${runId.value}' which is not known by Rudder, and that node should be sending reports for configId ${expectedVersion.configId.value}")
+        buildUnexpectedVersion(runTime, None, runTime, expectedVersion, expectedExpiration, nodeStatusReports)
+
+      case NoExpectedReport(runTime, optConfigId) =>
         // these reports where not expected
         ComplianceDebugLogger.node(nodeId).warn(s"Node '${nodeId.value}' sent reports for run at '${runInfo}' (with ${
           optConfigId.map(x => s" configuration ID: '${x.value}'").getOrElse(" no configuration ID")
         }). No expected configuration matches these reports.")
         buildUnexpectedReports(MergeInfo(nodeId, Some(runTime), optConfigId, END_OF_TIME), nodeStatusReports)
 
-      case NoRunNoInit =>
+      case NoRunNoExpectedReport =>
         /*
          * Really, this node exists ? Shouldn't we just declare Ragnarök at that point ?
          */

--- a/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -274,9 +274,9 @@ trait DefaultFindRuleNodeStatusReports extends ReportingService {
       runInfos            <- getNodeRunInfos(nodeIds)
 
       // that gives us configId for runs, and expected configId (some may be in both set)
-      expectedConfigId    =  runInfos.collect { case (nodeId, x:ExpectedConfigAvailable) => NodeAndConfigId(nodeId, x.expectedConfigId.configId) }
+      expectedConfigIds   =  runInfos.collect { case (nodeId, x:ExpectedConfigAvailable) => NodeAndConfigId(nodeId, x.expectedConfigInfo.configId) }
       lastrunConfigId     =  runInfos.collect {
-                               case (nodeId, x:LastRunAvailable) => NodeAndConfigId(nodeId, x.lastRunConfigId.configId)
+                               case (nodeId, x:LastRunAvailable) => NodeAndConfigId(nodeId, x.lastRunConfigId)
                                case (nodeId, Pending(_, Some(run), _, _)) => NodeAndConfigId(nodeId, run._2.configId)
                              }
 
@@ -284,7 +284,7 @@ trait DefaultFindRuleNodeStatusReports extends ReportingService {
       _                   =  TimingDebugLogger.debug(s"Compliance: get run infos: ${t1-t0}ms")
 
       // so now, get all expected reports for these config id
-      allExpectedReports  <- confExpectedRepo.getExpectedReports(expectedConfigId.toSet++lastrunConfigId, ruleIds)
+      allExpectedReports  <- confExpectedRepo.getExpectedReports(expectedConfigIds.toSet++lastrunConfigId, ruleIds)
 
       t2                  =  System.currentTimeMillis
       _                   =  TimingDebugLogger.debug(s"Compliance: get expected reports: ${t2-t1}ms")

--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -134,108 +134,130 @@ class ReportDisplayer(
 
 
   private[this] def displayIntro(report: NodeStatusReport): NodeSeq = {
+
     def explainCompliance(info: RunAndConfigInfo): NodeSeq = {
       val dateFormat = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss")
 
-      def currentConfigId(expectedConfigId: NodeConfigIdInfo) = {
-        s"Current configuration ID for the node is '${expectedConfigId.configId.value}' (generated on ${expectedConfigId.creation.toString(dateFormat)})"
+      def currentConfigId(expectedConfigInfo: NodeConfigIdInfo) = {
+        s"Current configuration ID for this node is '${expectedConfigInfo.configId.value}' (generated on ${expectedConfigInfo.creation.toString(dateFormat)})."
       }
 
       info match {
-        case ComputeCompliance(lastRunDateTime, lastRunConfigId, expectedConfigId, expirationDateTime, missingReportStatus) =>
+        case ComputeCompliance(lastRunDateTime, expectedConfigInfo, expirationDateTime, missingReportStatus) =>
           (
-            <p>{currentConfigId(expectedConfigId)}.</p>
-            <p>Last complete agent run has correct configuration ID, started on node at {lastRunDateTime.toString(dateFormat)}.</p>
+            <p>This node has up to date policy and the agent is running. Reports below are from the latest run, which started on the node at {lastRunDateTime.toString(dateFormat)}.</p>
+            <p>{currentConfigId(expectedConfigInfo)}.</p>
           )
 
-        case Pending(expectedConfigId, optLastRun, expirationDateTime, missingReportStatus) =>
+        case Pending(expectedConfigInfo, optLastRun, expirationDateTime, missingReportStatus) =>
           val runInfo = optLastRun match {
-            case None => "No recent runs received for this node"
+            case None => "No recent reports have been received for this node. Check that the agent is running (run 'rudder agent check' on the node)."
             case Some((date, id)) =>
-              s"Last run for node started at ${date.toString(dateFormat)} for configuration ID ${id.configId.value} " +
               (id.endOfLife match {
-                case None => ""
-                case Some(exp) => s"which expired at ${exp.toString(dateFormat)}"
-              })
+                case None =>
+                  s"This is expected, the node is reporting on the previous configuration policy and should report on the new one at latest" +
+                  " ${expirationDateTime.toString(dateFormat)}. Previous known states are displayed below."
+                case Some(exp) =>
+                  s"This is unexpected, since the node is reporting on a configuration policy that expired at ${exp.toString(dateFormat)}."
+              }) +
+              s" The latest reports received for this node are from a run started at ${date.toString(dateFormat)} with configuration ID ${id.configId.value}."
           }
           (
-            <p>{currentConfigId(expectedConfigId)}.</p>
-            <p>The node is expected to send a report for that configuration ID before {expirationDateTime.toString(dateFormat)} but no reports
-               have been received yet. If that state persists, check that the agent is running.</p>
+            <p>This node has recently been assigned a new policy but no reports have been received for the new policy yet.</p>
             <p>{runInfo}</p>
+            <p>{currentConfigId(expectedConfigInfo)}.</p>
           )
 
-        case NoReportInInterval(expectedConfigId) =>
+        case NoReportInInterval(expectedConfigInfo) =>
           (
-            <p>{currentConfigId(expectedConfigId)}.</p>
-            <p>No recent runs were received for node, and the grace period to receive them expired.</p>
+            <p>No recent reports have been received for this node in the grace period since the last configuration policy change.
+               This is unexpected. Please check the status of the agent by running 'rudder agent health' on the node.</p>
+            <p>For information, expected node policies are displayed below.</p>
+            <p>{currentConfigId(expectedConfigInfo)}.</p>
           )
 
-        case NoRunNoInit =>
-          <p>No configuration ID and no run received for that node. It may have been accepted after the last policy regeneration.</p>
+        case NoRunNoExpectedReport =>
+          <p>This is a new node that does not yet have a configured policy. If a policy generation is in progress, this will apply to this node when it is done.</p>
 
-        case VersionNotFound(lastRunDateTime, lastRunConfigId) =>
+        case NoExpectedReport(lastRunDateTime, lastRunConfigId) =>
           val configIdmsg = lastRunConfigId match {
-            case None     =>  "without any configuration ID, when one was required"
-            case Some(id) => s"with configuration ID '${id.value}' that is unknown in Rudder base"
+            case None     =>  "without a configuration ID, although one is required"
+            case Some(id) => s"with configuration ID '${id.value}' that is unknown to Rudder"
           }
 
-          <p>The node sent a run (started at {lastRunDateTime.toString(dateFormat)}) {configIdmsg}. Either that configuration ID was deleted from Rudder DB or
-             the node is sending a corrupted configuration ID. You should update node policies with "rudder agent update -f", and if the problem persists,
-             try to regenerate policies with the "clear cache" action.</p>
+          <p>This node has no configuration policy assigned to it, but reports have been received for it {configIdmsg} (run started at {lastRunDateTime.toString(dateFormat)}).
+             Either this node was deleted from Rudder but still has a running agent or the node is sending a corrupted configuration ID.
+             Please run "rudder agent update -f" on the node to force a policy update and, if the problem persists,
+             force a policy regeneration with the "Clear caches" button in Administration > Settings.</p>
 
-        case UnexpectedVersion(lastRunDateTime, lastRunConfigId, lastRunExpiration, expectedConfigId, expectedExpiration) =>
+        case UnexpectedVersion(lastRunDateTime, Some(lastRunConfigInfo), lastRunExpiration, expectedConfigInfo, expectedExpiration) =>
           (
-            <p>{currentConfigId(expectedConfigId)} but we received a run, started at {lastRunDateTime.toString(dateFormat)}, with a different configuration ID ({lastRunConfigId.configId.value}).</p>
-            <p>The time since generation of the new configuration is longer than the grace period, so all received reports will be mark as unexpected.
-               Please check that the node is able to get its new policies by running 'rudder agent update' on the node.</p>
+            <p>This node is sending reports from an out-of-date configuration policy ({expectedConfigInfo.configId.value}, run started at {lastRunDateTime.toString(dateFormat)}).
+               Please check that the node is able to update it's policy by running 'rudder agent update' on the node.</p>
+            <p>For information, expected node policies are displayed below.</p>
+            <p>{currentConfigId(expectedConfigInfo)}</p>
           )
 
-        case UnexpectedNoVersion(lastRunDateTime, lastRunConfigId, lastRunExpiration, expectedConfigId, expectedExpiration) =>
+        case UnexpectedNoVersion(lastRunDateTime, Some(lastRunConfigInfo), lastRunExpiration, expectedConfigInfo, expectedExpiration) =>
           (
-            <p>{currentConfigId(expectedConfigId)} but we received a run, started at {lastRunDateTime.toString(dateFormat)}, without any configuration ID.</p>
-            <p>The time since generation of the new configuration is longer than the grace period, so all received reports will be marked as unexpected.
-               Please check that the node is able to get its new policies.</p>
+            <p>This node is sending reports without a configuration ID (run started on the node at {lastRunDateTime.toString(dateFormat)}), although one is required.</p>
+            <p>Please run "rudder agent update -f" on the node to force a policy update.</p>
+            <p>For information, expected node policies are displayed below.</p>
+            <p>{currentConfigId(expectedConfigInfo)}</p>
           )
 
+        case UnexpectedUnknowVersion(lastRunDateTime, lastRunConfigId, expectedConfigInfo, expectedExpiration) =>
+          (
+            <p>This node is sending reports from an unknown configuration policy (with configuration ID '${lastRunConfigId.value}'
+               that is unknown to Rudder, run started at {lastRunDateTime.toString(dateFormat)}).
+               Please run "rudder agent update -f" on the node to force a policy update.</p>
+            <p>For information, expected node policies are displayed below.</p>
+            <p>{currentConfigId(expectedConfigInfo)}</p>
+          )
       }
 
     }
-    import com.normation.rudder.domain.logger.ComplianceDebugLogger.RunAndConfigInfoToLog
-    //what we print before all the tables
-    val nbAttention = report.compliance.noAnswer + report.compliance.error + report.compliance.missing + report.compliance.unexpected
 
-    //depending on the kind of report, choose the background.
+    /*
+     * Number of reports requiring attention. We only display that message if we are in a case where
+     * compliance is actually meaningful.
+     */
+    val (background, lookReportsMessage) = report.runInfo match {
+      case NoRunNoExpectedReport | _:NoExpectedReport |
+           _:UnexpectedVersion | _:UnexpectedNoVersion |
+           _:UnexpectedUnknowVersion | _:NoReportInInterval =>
 
-    val background = report.runInfo match {
-      case _: Pending => "bg-info text-info"
-      case _: ComputeCompliance =>
-        if(nbAttention > 0) {
-          "bg-warning text-warning"
+        ("bg-danger text-danger", NodeSeq.Empty)
+
+      case  _:Pending =>
+        ("bg-info text-info", NodeSeq.Empty)
+
+      case _:ComputeCompliance =>
+
+        if(report.compliance.total <= 0) { //should not happen
+          ("bg-success text-success" , NodeSeq.Empty)
         } else {
-          "bg-success text-success"
+          val nbAttention = report.compliance.noAnswer + report.compliance.error + report.compliance.missing + report.compliance.unexpected
+          if(nbAttention > 0) {
+            ( "bg-warning text-warning"
+            , <p>{nbAttention} reports below (out of {report.compliance.total} total reports) are not in Success, and may require attention."</p>
+            )
+          } else if(report.compliance.pc_pending > 0) {
+            ("bg-info text-info", NodeSeq.Empty)
+
+          } else {
+            ( "bg-success text-success"
+            , <p>All reports received for this node are in Success.</p>
+            )
+          }
         }
-      case _          =>
-          "bg-danger text-danger"
     }
 
 
     <div class="tw-bs">
       <div id="node-compliance-intro" class={background}>
         <p>{explainCompliance(report.runInfo)}</p>{
-        if(report.compliance.total <= 0) {
-          NodeSeq.Empty
-        } else {
-          <p>{
-            if(nbAttention > 0) {
-              s"There are ${nbAttention} out of ${report.compliance.total} reports that require attention"
-            } else if(report.compliance.pc_pending > 0) {
-              "Policy update in progress"
-            } else {
-              "All the last execution reports for this server are ok"
-            }
-          }</p>
-        }
+          lookReportsMessage
       }</div>
     </div>
   }
@@ -248,16 +270,62 @@ class ReportDisplayer(
         directiveLib <- directiveRepository.getFullDirectiveLibrary
       } yield {
 
+        val intro = displayIntro(report)
 
-        val missing    = getComponents(MissingReportType   , report, directiveLib).toSet
-        val unexpected = getComponents(UnexpectedReportType, report, directiveLib).toSet
+        /*
+         * Now, on some case, we don't want to display 50% missing / 50% unexpected
+         * because the node config id is not correct (or related cases), we want to display
+         * what is expected config, but without the compliance part.
+         *
+         * And if don't even have expected configuration, don't display anything.
+         */
 
-        bind("lastReportGrid", reportByNodeTemplate
-          , "intro"      -> displayIntro(report)
-          , "grid"       -> showReportDetail(report, node)
-          , "missing"    -> showMissingReports(missing)
-          , "unexpected" -> showUnexpectedReports(unexpected)
-        )
+
+        report.runInfo match {
+          case NoRunNoExpectedReport | _:NoExpectedReport =>
+            bind("lastReportGrid", reportByNodeTemplate
+              , "intro"      -> intro
+              , "grid"       -> NodeSeq.Empty
+              , "missing"    -> NodeSeq.Empty
+              , "unexpected" -> NodeSeq.Empty
+            )
+
+          case _:UnexpectedVersion | _:UnexpectedNoVersion |
+               _:UnexpectedUnknowVersion | _:NoReportInInterval =>
+
+            /*
+             * In these case, filter out "unexpected" reports to only
+             * keep missing ones, and do not show the "compliance" row.
+             */
+            val filtered = NodeStatusReport(report.forNode, report.runInfo, report.report.reports.flatMap { x =>
+              x.withFilteredElements(
+                  _ => true   //keep all (non empty) directives
+                , _ => true   //keep all (non empty) component values
+                , { value =>  //filter values based on the message type - we don't want Unexpected values
+                    value.messages.forall { m => m.reportType != UnexpectedReportType }
+                  }
+              )
+            } )
+
+            bind("lastReportGrid", reportByNodeTemplate
+              , "intro"      -> intro
+              , "grid"       -> showReportDetail(filtered, node, withCompliance = false)
+              , "missing"    -> NodeSeq.Empty
+              , "unexpected" -> NodeSeq.Empty
+            )
+
+          case  _:Pending | _:ComputeCompliance =>
+
+            val missing    = getComponents(MissingReportType   , report, directiveLib).toSet
+            val unexpected = getComponents(UnexpectedReportType, report, directiveLib).toSet
+
+            bind("lastReportGrid", reportByNodeTemplate
+              , "intro"      -> intro
+              , "grid"       -> showReportDetail(report, node, withCompliance = true)
+              , "missing"    -> showMissingReports(missing)
+              , "unexpected" -> showUnexpectedReports(unexpected)
+            )
+        }
       }
     )
 
@@ -270,12 +338,18 @@ class ReportDisplayer(
     }
   }
 
-  private[this] def showReportDetail(reports: NodeStatusReport, node: NodeInfo): NodeSeq = {
+  private[this] def showReportDetail(reports: NodeStatusReport, node: NodeInfo, withCompliance: Boolean): NodeSeq = {
     val data = getComplianceData(node.id, reports).map(_.json).getOrElse(JsArray())
+
+    val jsFunctionName = if(withCompliance) {
+      "createRuleComplianceTable"
+    } else {
+      "createExpectedReportTable"
+    }
 
     <table id="reportsGrid" class="fixedlayout tablewidth" cellspacing="0"></table> ++
     Script(JsRaw(s"""
-      createRuleComplianceTable("reportsGrid",${data.toJsCmd},"${S.contextPath}", ${refreshReportDetail(node).toJsCmd});
+      ${jsFunctionName}("reportsGrid",${data.toJsCmd},"${S.contextPath}", ${refreshReportDetail(node).toJsCmd});
       createTooltip();
     """))
   }
@@ -349,7 +423,7 @@ class ReportDisplayer(
       val reportValue = report._1
 
       ( "#technique *"  #>  "%s (%s)".format(techniqueName,techniqueVersion)
-      &  "#component *" #>  reportValue._1
+      & "#component *"  #>  reportValue._1
       & "#value *"      #>  reportValue._2
       & "#message *"    #>  <ul>{reportValue._3.map(msg => <li>{msg}</li>)}</ul>
       ) (


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8409

Replace https://github.com/Normation/rudder/pull/1118 because a closed PR forced-pushed can't be reopened, see https://github.com/isaacs/github/issues/361