### PR TITLE
Fixes #8856: JS engine tests broken due to security exeception when using jdk 1.8

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/JavascriptEngine.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/JavascriptEngine.scala
@@ -608,7 +608,6 @@ final object JsEngine {
       }
     }
   }
-
   /*
    * An exception marker class to handle thread related error cases
    */
@@ -669,7 +668,7 @@ final object JsEngine {
             // We need to authorize access to a lot of jar/classes for crypto (lot of dependencies). However listing all
             // classes is impossible, causing a stackoverflow error see: http://stackoverflow.com/questions/2510683/securitymanager-stackoverflowerror
             // so we work-around by authorizing a lot of stuff
-          case x: FilePermission     if( x.getActions == "read" && (x.getName.contains(".class") || x.getName.endsWith(".jar")  || x.getName.endsWith(".so")   || x.getName.endsWith(".cfg") || x.getName.endsWith(".properties") ) )  => // ok
+          case x: FilePermission     if( x.getActions == "read" && (x.getName.contains(".class") || x.getName.endsWith(".jar")  || x.getName.endsWith(".so")   || x.getName.endsWith(".cfg") || x.getName.endsWith(".properties") || x.getName.endsWith(".certs") ) )  => // ok
           case x: SecurityPermission if( securityPerms.exists( p => x.getName.startsWith(p) )       ) => // ok
           case x: RuntimePermission  if( x.getName.startsWith("accessClassInPackage.jdk.nashorn")   ) => // ok
           case x: RuntimePermission  if( x.getName.startsWith("accessClassInPackage.sun.security.") ) => // ok


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/8856