### PR TITLE
Fixes #9057: Allow the use of node properties info in Directive parameters

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
@@ -46,6 +46,8 @@ import com.normation.rudder.reports.AgentRunInterval
 import com.normation.rudder.reports.HeartbeatConfiguration
 import com.normation.rudder.domain.policies.SimpleDiff
 import com.normation.inventory.domain.FullInventory
+import net.liftweb.json.JsonAST.JValue
+import net.liftweb.json.JsonAST.JString
 
 /**
  * The entry point for a REGISTERED node in Rudder.
@@ -81,7 +83,12 @@ case object Node {
   }
 }
 
-case class NodeProperty(name: String, value: String)
+case class NodeProperty(name: String, value: JValue) {
+  def renderValue: String = value match {
+    case JString(s) => s
+    case v          => net.liftweb.json.compactRender(v)
+  }
+}
 
 /**
  * Node diff for event logs:

--- a/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleVal.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleVal.scala
@@ -90,7 +90,7 @@ object InterpolationContext {
         //must be a case insensitive Map !!!!
       , nodeContext     : Map[String, Variable]
         // parameters for this node
-        //must be a case insensitive Map !!!!
+        //must be a case SENSITIVE Map !!!!
       , parameters      : Map[ParameterName, InterpolationContext => Box[String]]
         //the depth of the interpolation context evaluation
         //used as a lazy, trivial, mostly broken way to detect cycle in interpretation

--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/InterpolatedValueCompiler.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/InterpolatedValueCompiler.scala
@@ -45,6 +45,9 @@ import com.normation.utils.Control._
 import net.liftweb.common.{Failure => FailedBox, _}
 import com.normation.rudder.domain.parameters.ParameterName
 import com.normation.inventory.domain.NodeInventory
+import com.normation.rudder.domain.nodes.NodeProperty
+import com.normation.rudder.domain.appconfig.FeatureSwitch
+import net.liftweb.json.JsonAST.JValue
 
 /**
  * A parser that handle parameterized value of
@@ -59,18 +62,40 @@ import com.normation.inventory.domain.NodeInventory
  * ${rudder.xxx}
  * were "xxx" is the parameter to lookup.
  *
- * We handle 2 kinds of parameterizations:
+ * We handle 3 kinds of parameterizations:
  * 1/ ${rudder.param.XXX}
  *    where:
  *    - XXX is a parameter configured in Rudder
  *      (for now global, but support for node-contextualised is implemented)
  *    - XXX is case sensisite
  *    - XXX's value can contains other interpolation
+ *
  * 2/ ${rudder.node.ACCESSOR}
  *    where:
  *    - "node" is a keyword ;
  *    - ACCESSOR is an accessor for that node, explained below.
  *    - the value can not contains other interpolation
+ *
+ * 3/ ${node.properties[keyone][keytwo]} or
+ *   ${node.properties[keyone][keytwo] | node } or
+ *    ${node.properties[keyone][keytwo] | default = XXXX }
+ *
+ *    where:
+ *    - keyone, keytwo are path on json values
+ *    - the return value is the string representation, in compact mode, of the resulting access
+ *    - if the key is not found, we raise an error
+ *    - spaces are authorized around separators ([,],|,}..)
+ *    - options can be given by adding "| option", with available option:
+ *      - "node" : mean that the interpolation will be done on the node,
+ *        and so the parameter must be outputed as an equivalent string
+ *        parameter for the node (the same without "| node")
+ *      - default = XXX mean that if the properties is not found, "XXX" must
+ *        be used in place, with XXX one of:
+ *        - a double-quoted string, like: "default value",
+ *        - a triple-double quoted string, like: """ some "default" must be used""",
+ *        - an other parameter among the 3 described here.
+ *        Quoted string may contain parameters, like in:
+ *        ${node.properties[charge] | default = """Node "color" is: ${node.properties[color] | "blue" }""" }
  *
  * Accessor are keywords which allows to reach value in a context, exactly like
  * properties in object oriented programming.
@@ -105,13 +130,41 @@ trait InterpolatedValueCompiler {
    * Return a Box, where Full denotes a successful
    * parsing of all values, and EmptyBox. an error.
    */
-  def compile(value: String): Box[InterpolationContext => Box[String]]
+  def compile(value: String, switch: FeatureSwitch): Box[InterpolationContext => Box[String]]
 
 }
 
+object InterpolatedValueCompilerImpl {
+
+  /*
+   * Our AST for interpolated variable:
+   * A string to look for interpolation is a list of token.
+   * A token can be a plain string with no variable, or something
+   * to interpolate. For now, we can interpolate two kind of variables:
+   * - node information (thanks to a pointed path to the intersting property)
+   * - rudder parameters (only globals for now)
+   */
+  sealed trait Token //could be Either[CharSeq, Interpolation]
+
+  case class   CharSeq(s:String) extends Token
+  sealed trait Interpolation     extends Token
+
+  //everything is expected to be lower case
+  final case class NodeAccessor(path:List[String]) extends Interpolation
+  //everything is expected to be lower case
+  final case class Param(name:String)              extends Interpolation
+  //here, we keep the case as it is given
+  final case class Property(path: List[String], opt: Option[PropertyOption])    extends Interpolation
+
+  //here, we have node property option
+  sealed trait PropertyOption
+  final case object InterpreteOnNode                 extends PropertyOption
+  final case class  DefaultValue(value: List[Token]) extends PropertyOption
+}
 
 class InterpolatedValueCompilerImpl extends RegexParsers with InterpolatedValueCompiler {
 
+  import InterpolatedValueCompilerImpl._
 
   /*
    * Number of time we allows to recurse for interpolated variable
@@ -143,30 +196,17 @@ class InterpolatedValueCompilerImpl extends RegexParsers with InterpolatedValueC
   override val skipWhitespace = false
 
   /*
-   * Our AST for interpolated variable:
-   * A string to look for interpolation is a list of token.
-   * A token can be a plain string with no variable, or something
-   * to interpolate. For now, we can interpolate two kind of variables:
-   * - node information (thanks to a pointed path to the intersting property)
-   * - rudder parameters (only globals for now)
-   */
-  sealed trait Token //could be Either[CharSeq, Interpolation]
-  case class CharSeq(s:String) extends Token
-  sealed trait Interpolation extends Token
-  //everything is expected to be lower case
-  case class NodeAccessor(path:List[String]) extends Interpolation
-  //everything is expected to be lower case
-  case class Param(name:String) extends Interpolation
-
-
-
-  /*
    * just call the parser on a value, and in case of successful parsing, interprete
    * the resulting AST (seq of token)
    */
-  def compile(value: String): Box[InterpolationContext => Box[String]] = {
-    parseAll(all, value) match {
-      case NoSuccess(msg, remaining) => FailedBox(s"""Error when parsing value "${value}", error message is: ${msg}""")
+  def compile(value: String, switch: FeatureSwitch): Box[InterpolationContext => Box[String]] = {
+    val parsed = switch match {
+      case FeatureSwitch.Enabled  => parseAll(all       , value)
+      case FeatureSwitch.Disabled => parseAll(noNodeProp, value)
+    }
+
+    parsed match {
+      case NoSuccess(msg, remaining)  => FailedBox(s"""Error when parsing value "${value}", error message is: ${msg}""")
       case Success(tokens, remaining) => Full(parseToken(tokens))
     }
   }
@@ -199,13 +239,32 @@ class InterpolatedValueCompilerImpl extends RegexParsers with InterpolatedValueC
    */
   def analyse(context: InterpolationContext, token:Token): Box[String] = {
     token match {
-      case CharSeq(s) => Full(s)
-      case NodeAccessor(path) => checkNodeAccessor(context, path)
-      case Param(name) => checkParam(context, ParameterName(name))
+      case CharSeq(s)          => Full(s)
+      case NodeAccessor(path)  => getNodeAccessorTarget(context, path)
+      case Param(name)         => getRudderGlobalParam(context, ParameterName(name))
+      case Property(path, opt) => opt match {
+        case None =>
+          getNodeProperty(context, path)
+        case Some(InterpreteOnNode) =>
+          //in that case, we want to exactly output the agent-compatible string. For now, easy, only one string
+          Full("${node.properties[" + path.mkString("][") + "]}")
+        case Some(DefaultValue(optionTokens)) =>
+          //in that case, we want to find the default value.
+          //we authorize to have default value = ${node.properties[bla][bla][bla]|node},
+          //because we may want to use prop1 and if node set, prop2 at run time.
+          for {
+            default <- parseToken(optionTokens)(context)
+          } yield {
+            getNodeProperty(context, path).openOr(default)
+          }
+      }
     }
   }
 
-  def checkParam(context: InterpolationContext, paramName: ParameterName): Box[String] = {
+  /**
+   * Retrieve the global parameter from the node context.
+   */
+  def getRudderGlobalParam(context: InterpolationContext, paramName: ParameterName): Box[String] = {
     context.parameters.get(paramName) match {
       case Some(value) =>
         if(context.depth >= maxEvaluationDepth) {
@@ -216,14 +275,10 @@ class InterpolatedValueCompilerImpl extends RegexParsers with InterpolatedValueC
     }
   }
 
-  def checkNodeAccessor(context: InterpolationContext, path: List[String]): Box[String] = {
-    def environmentVariable(node: NodeInventory, envVarName: String): String = {
-      node.environmentVariables.find( _.name == envVarName) match {
-        case None => ""
-        case Some(v) => v.value.getOrElse("")
-      }
-    }
-
+  /**
+   * Get the targeted accessed node information, checking that it exists.
+   */
+  def getNodeAccessorTarget(context: InterpolationContext, path: List[String]): Box[String] = {
     val error = FailedBox(s"Unknow interpolated variable $${node.${path.mkString(".")}}" )
     path match {
       case Nil => FailedBox("In node interpolated variable, at least one accessor must be provided")
@@ -242,6 +297,48 @@ class InterpolatedValueCompilerImpl extends RegexParsers with InterpolatedValueC
     }
   }
 
+  /**
+   * Get the node property value, or fails if it does not exists.
+   * If the path length is 1, only check that the property exists and
+   * returned the corresponding string value.
+   * If the path length is more than one, try to parse the string has a
+   * json value and access the remaining part as a json path.
+   */
+  def getNodeProperty(context: InterpolationContext, path: List[String]): Box[String] = {
+    val errmsg = s"Missing property '$${node.properties[${path.mkString("][")}]}' on node '${context.nodeInfo.hostname}' [${context.nodeInfo.id.value}]"
+    path match {
+      //we should not reach that case since we enforce at leat one match of [...] in the parser
+      case Nil       => FailedBox(s"The syntax $${node.properties} is invalid, only $${node.properties[propertyname]} is accepted")
+      case h :: tail => context.nodeInfo.properties.find(p => p.name == h) match {
+        case None       => FailedBox(errmsg)
+        case Some(prop) => tail match {
+          case Nil     => Full(prop.renderValue)
+          //here, we need to parse the value in json and try to find the asked path
+          case subpath => getJsonProperty(subpath, prop.value) ?~! errmsg
+        }
+      }
+    }
+  }
+
+  def getJsonProperty(path: List[String], json: JValue): Box[String] = {
+    import net.liftweb.json._
+
+    def access(json: => JValue, path: List[String]): JValue = path match {
+      case Nil       => json
+      case h :: tail => access( json \ h, tail)
+    }
+
+    for {
+      prop <- access(json, path) match {
+                case JNothing   => FailedBox(s"Can not find property in JSON '${compactRender(json)}'")
+                case JString(s) => Full(s) //needed to special case to not have '\"' everywhere
+                case x          => Full(compactRender(x))
+              }
+    } yield {
+      prop
+    }
+  }
+
   //// parsing language
 
   //make a case insensitive regex from the parameter
@@ -253,30 +350,57 @@ class InterpolatedValueCompilerImpl extends RegexParsers with InterpolatedValueC
   //exactly quote s - no regex authorized in
   def id(s: String) = ("""(?iu)\Q""" + s + """\E""").r
 
-  def all: Parser[List[Token]] = (rep1(interpol | plainString) | emptyVar)
+  def all       : Parser[List[Token]] = (rep1(interpol   | plainString ) | emptyVar)
+  def noNodeProp: Parser[List[Token]] = (rep1(rudderProp | oldString   ) | emptyVar)
+
+  def space = """\s*""".r
 
   //empty string is a special case that must be look appart from plain string.
   //also parse full blank string, because no need to look for more case for them.
-  def emptyVar: Parser[List[CharSeq]] = """(?iums)(\s)*""".r ^^ { x => List(CharSeq(x)) }
+  def emptyVar    : Parser[List[CharSeq]] = """(?iums)(\s)*""".r ^^ { x => List(CharSeq(x)) }
 
-  def plainString: Parser[CharSeq] = ("""(?iums)((?!\Q${rudder.\E).)+""").r  ^^ { CharSeq(_) }
+  // plain string must not match our identifier, ${rudder.* and ${node.properties.*}
+  // here we defined a function to build them, with the possibility to
+  def plainString : Parser[CharSeq] = ("""(?iums)((?!(\Q${\E\s*rudder\s*\.|\Q${\E\s*node\s*\.\s*properties)).)+""").r  ^^ { CharSeq(_) }
+
+  // plain string old must not match our identifier, ${rudder.*
+  def oldString   : Parser[CharSeq] = ("""(?iums)((?!(\Q${rudder.\E)).)+""").r  ^^ { CharSeq(_) }
 
   //identifier for step in the path or param names
-  def propId: Parser[String] = """[\-_a-zA-Z0-9]+""".r
+  def propId      : Parser[String] = """[\-_a-zA-Z0-9]+""".r
+
+  // all interpolation
+  def interpol    : Parser[Interpolation] = rudderProp | nodeProp
 
   //an interpolated variable looks like: ${rudder.XXX}, or ${RuDder.xXx}
-  def interpol: Parser[Interpolation] = "${" ~> id("rudder") ~> "." ~> (nodeProp | parameter ) <~ "}"
+  def rudderProp  : Parser[Interpolation] = "${" ~> space ~> id("rudder") ~> space ~> id(".") ~> space ~>(nodeAccess | parameter ) <~ space <~ "}"
 
   //a node path looks like: ${rudder.node.HERE.PATH}
-  def nodeProp: Parser[Interpolation] = {
-    id("node") ~> "." ~> repsep(propId, ".") ^^ { seq => NodeAccessor(seq) }
-  }
+  def nodeAccess  : Parser[Interpolation] = { id("node") ~> space ~> id(".") ~> space ~> repsep(propId, space ~> id(".") ~> space) ^^ { seq => NodeAccessor(seq) } }
 
   //a parameter looks like: ${rudder.PARAM_NAME}
-  def parameter: Parser[Interpolation] = {
-    id("param") ~> "." ~> propId ^^ { p => Param(p) }
-  }
+  def parameter   : Parser[Interpolation] = { id("param") ~> space ~> id(".") ~> space ~> propId ^^ { p => Param(p) } }
 
+  //an interpolated variable looks like: ${rudder.XXX}, or ${RuDder.xXx}
+  def nodeProp    : Parser[Interpolation] = "${" ~> space ~> id("node") ~> space ~> id(".") ~> space ~> id("properties") ~> rep1( space ~> "[" ~> space ~>
+                                            propId <~ space <~ "]" ) ~ opt(propOption) <~ space <~ "}" ^^ { case ~(path, opt) => Property(path, opt) }
+
+  //here, the number of " must be strictly decreasing - ie. triple quote before
+  def propOption  : Parser[PropertyOption] = space ~> "|" ~> space ~>  ( onNodeOpt |  "default" ~> space ~> "=" ~> space ~>
+                                             ( interpolOpt | emptyTQuote | tqString | emptySQuote | sqString )  )
+
+  def onNodeOpt   : Parser[InterpreteOnNode.type] = id("node") ^^^ InterpreteOnNode
+
+  def interpolOpt : Parser[DefaultValue] = interpol ^^ { x => DefaultValue(x::Nil) }
+  def emptySQuote : Parser[DefaultValue] = id("\"\"")         ^^   { _ => DefaultValue(CharSeq("")::Nil) }
+  def emptyTQuote : Parser[DefaultValue] = id("\"\"\"\"\"\"") ^^   { _ => DefaultValue(CharSeq("")::Nil) }
+
+  //string must be simple or triple quoted string
+  def sqString    : Parser[DefaultValue] = id("\"")  ~> rep1(sqplainStr | interpol )<~ id("\"") ^^ { case x => DefaultValue(x) }
+  def sqplainStr  : Parser[Token]        = ("""(?iums)((?!(\Q${\E\s*rudder\s*\.|\Q${\E\s*node\s*\.\s*properties|")).)+""").r  ^^ { str => CharSeq(str) }
+
+  def tqString    : Parser[DefaultValue]   = id("\"\"\"")  ~> rep1(tqplainStr | interpol )<~ id("\"\"\"") ^^ { case x => DefaultValue(x) }
+  def tqplainStr  : Parser[Token]          = ("""(?iums)((?!(\Q${\E\s*rudder\s*\.|\Q${\E\s*node\s*\.\s*properties|"""+"\"\"\""+ """)).)+""").r  ^^ { str => CharSeq(str) }
 
 }
 

--- a/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
@@ -55,6 +55,7 @@ import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.GroupTarget
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.rule.category.RuleCategoryId
+import com.normation.rudder.domain.appconfig.FeatureSwitch
 
 /**
  * Test how RuleVal and DirectiveVal are constructed, and if they
@@ -181,7 +182,7 @@ class RuleValServiceTest extends Specification {
     // Ok, now I can test
     "The RuleValService, with one directive, one Meta-technique " should {
 
-      val ruleVal = ruleValService.buildRuleVal(rule, fullActiveTechniqueCategory)
+      val ruleVal = ruleValService.buildRuleVal(rule, fullActiveTechniqueCategory, FeatureSwitch.Enabled)
 
       "return a Full(RuleVal)" in {
         ruleVal.isDefined == true
@@ -220,7 +221,7 @@ class RuleValServiceTest extends Specification {
     }
 
     "The cardinality computed " should {
-      val ruleVal = ruleValService.buildRuleVal(rule, fullActiveTechniqueCategory)
+      val ruleVal = ruleValService.buildRuleVal(rule, fullActiveTechniqueCategory, FeatureSwitch.Enabled)
       val directivesVals = ruleVal.openOrThrowException("Should have been full for test").directiveVals
 
       val cardinality = directivesVals.head.toExpandedDirectiveVal(null).map { x =>

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -1353,6 +1353,7 @@ object RudderConfig extends Loggable {
         , configService.agent_run_start_hour
         , configService.agent_run_start_minute
         , configService.rudder_featureSwitch_directiveScriptEngine
+        , configService.rudder_featureSwitch_directiveNodeProperties
     )}
     val agent = new AsyncDeploymentAgent(
         deploymentService

--- a/rudder-web/src/main/scala/com/normation/rudder/appconfig/ConfigService.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/appconfig/ConfigService.scala
@@ -165,6 +165,10 @@ trait ReadConfigService {
    * Should we display the new quicksearch everything bar ?
    */
   def rudder_featureSwitch_quicksearchEverything(): Box[FeatureSwitch]
+  /*
+   * Should we allow ${node.properties[key]} in directive
+   */
+  def rudder_featureSwitch_directiveNodeProperties(): Box[FeatureSwitch]
 }
 
 /**
@@ -257,6 +261,10 @@ trait UpdateConfigService {
    * Should we display the new quicksearch everything bar ?
    */
   def set_rudder_featureSwitch_quicksearchEverything(status: FeatureSwitch): Box[Unit]
+  /**
+   * Should we allow ${node.properties[key]} in directive
+   */
+  def set_rudder_featureSwitch_directiveNodeProperties(status: FeatureSwitch): Box[Unit]
 }
 
 class LDAPBasedConfigService(configFile: Config, repos: ConfigRepository, workflowUpdate: AsyncWorkflowInfo) extends ReadConfigService with UpdateConfigService with Loggable {
@@ -290,6 +298,7 @@ class LDAPBasedConfigService(configFile: Config, repos: ConfigRepository, workfl
        api.compatibility.mode=false
        rudder.featureSwitch.directiveScriptEngine=disabled
        rudder.featureSwitch.quicksearchEverything=enabled
+       rudder.featureSwitch.directiveNodeProperties=disabled
     """
 
   val configWithFallback = configFile.withFallback(ConfigFactory.parseString(defaultConfig))
@@ -504,4 +513,9 @@ class LDAPBasedConfigService(configFile: Config, repos: ConfigRepository, workfl
    */
   def rudder_featureSwitch_quicksearchEverything(): Box[FeatureSwitch] = get("rudder_featureSwitch_quicksearchEverything")
   def set_rudder_featureSwitch_quicksearchEverything(status: FeatureSwitch): Box[Unit] = save("rudder_featureSwitch_quicksearchEverything", status)
+  /*
+   * Should we allow ${node.properties[key]} in directive
+   */
+  def rudder_featureSwitch_directiveNodeProperties(): Box[FeatureSwitch] = get("rudder_featureSwitch_directiveNodeProperties")
+  def set_rudder_featureSwitch_directiveNodeProperties(status: FeatureSwitch): Box[Unit] = save("rudder_featureSwitch_directiveNodeProperties", status)
 }

--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/RestExtractorService.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/RestExtractorService.scala
@@ -629,10 +629,24 @@ case class RestExtractorService (
    * ] }
    */
   def extractNodePropertiesrFromJSON (json : JValue) : Box[RestNode] = {
-    import net.liftweb.json.JsonParser._
-    implicit val formats = DefaultFormats
+    import com.normation.utils.Control.sequence
 
-    Box(json.extractOpt[RestNode]) ?~! "Error when extracting node information"
+    for {
+      props <- json \ "properties" match {
+        case JArray(props) => Full(props)
+        case x             => Failure(s"""Error: the given parameter is not a JSON object with a 'properties' key""")
+      }
+      seq   <- sequence(props) { p =>
+                 p match {
+                   case JObject(JField("name", JString(nameValue)):: JField("value", value) :: Nil) =>
+                     Full(NodeProperty(nameValue, value))
+                   case _  => Failure(s"""Error when trying to parse new property: '${compact(render(p))
+                                          }'. The awaited format is: {"name": string, "value": json}""")
+                 }
+               }
+    } yield {
+      RestNode(Some(seq))
+    }
   }
 
   def extractDirective(req : Req) : Box[RestDirective] = {

--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/node/NodeAPIService5.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/node/NodeAPIService5.scala
@@ -106,12 +106,12 @@ class NodeApiService5 (
         val values = u.map { case NodeProperty(k, v) => (k, v)}.toMap
         val existings = props.map(_.name).toSet
         //for news values, don't keep empty
-        val news = (values -- existings).collect { case(k,v) if(v.nonEmpty) => NodeProperty(k,v) }
+        val news = (values -- existings).collect { case(k,v) if(v != JString("")) => NodeProperty(k,v) }
         props.flatMap { case p@NodeProperty(name, value)  =>
           values.get(name) match {
-            case None => Some(p)
-            case Some("") => None
-            case Some(x)  => Some(NodeProperty(name, x))
+            case None              => Some(p)
+            case Some(JString("")) => None
+            case Some(x)           => Some(NodeProperty(name, x))
           }
         } ++ news
     }

--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -622,7 +622,7 @@ $$("#${detailsId}").bind( "show", function(event, ui) {
     private def displayTabProperties(jsId:JsNodeId, node: NodeInfo) : NodeSeq = {
     displayTabGrid(jsId)("props", Full(node.properties)){
         ("Name", {x:NodeProperty => Text(x.name)}) ::
-        ("Value", {x:NodeProperty => Text(x.value)}) ::
+        ("Value", {x:NodeProperty => Text(net.liftweb.json.compactRender(x.value))}) ::
         Nil
     }
     }

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/PropertiesManagement.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/PropertiesManagement.scala
@@ -95,6 +95,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
     case "apiMode" => apiComptabilityMode
     case "directiveScriptEngineConfiguration" => directiveScriptEngineConfiguration
     case "quickSearchConfiguration" => quickSearchConfiguration
+    case "directiveNodePropertiesConfiguration" => directiveNodePropertiesConfiguration
   }
 
   def changeMessageConfiguration = { xml : NodeSeq =>
@@ -931,6 +932,53 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
       case eb: EmptyBox =>
         ( "#quickSearchEverything" #> {
           val fail = eb ?~ "there was an error while fetching value of property: 'quick search everything'"
+          logger.error(fail.messageChain)
+          <div class="error">{fail.messageChain}</div>
+        } )
+    } ) apply xml
+  }
+
+  def directiveNodePropertiesConfiguration = { xml : NodeSeq =>
+    import com.normation.rudder.domain.appconfig.FeatureSwitch._
+
+    ( configService.rudder_featureSwitch_directiveNodeProperties() match {
+      case Full(initialValue) =>
+
+        var x = initialValue
+        def noModif() = x == initialValue
+        def check() = {
+          S.notice("directiveNodePropertiesMsg","")
+          Run(s"""$$("#directiveNodePropertiesSubmit").button( "option", "disabled",${noModif()});""")
+        }
+
+        def submit() = {
+          val save = configService.set_rudder_featureSwitch_directiveNodeProperties(x)
+          S.notice("directiveNodePropertiesMsg", save match {
+            case Full(_)  =>
+              "'directive node properties' property updated. The feature will be loaded as soon as you go to another page or reload this one."
+            case eb: EmptyBox =>
+              "There was an error when updating the value of the 'directive node properties' property"
+          } )
+        }
+
+        ( "#directiveNodePropertiesCheckbox" #> {
+            SHtml.ajaxCheckbox(
+                x == Enabled
+              , (b : Boolean) => { if(b) { x = Enabled } else { x = Disabled }; check}
+              , ("id","directiveNodePropertiesCheckbox")
+            )
+          } &
+          "#directiveNodePropertiesSubmit " #> {
+            SHtml.ajaxSubmit("Save changes", submit _)
+          } &
+          "#directiveNodePropertiesSubmit *+" #> {
+            Script(Run("correctButtons();") & check())
+          }
+        )
+
+      case eb: EmptyBox =>
+        ( "#directiveNodeProperties" #> {
+          val fail = eb ?~ "there was an error while fetching value of property: 'directive node properties'"
           logger.error(fail.messageChain)
           <div class="error">{fail.messageChain}</div>
         } )

--- a/rudder-web/src/main/webapp/secure/administration/policyServerManagement.html
+++ b/rudder-web/src/main/webapp/secure/administration/policyServerManagement.html
@@ -449,7 +449,39 @@ These files are automatically removed to save on disk space. You can configure t
         </div>
       </div>
     </div>
+    <div class="inner-portlet">
+      <div class="page-title">Allows ${node.properties[key]} expansion in Directives for key-&gt;value and key-&gt;json</div>
+      <div class="portlet-content">
 
+        <div class="lift:administration.PropertiesManagement.directiveNodePropertiesConfiguration" id="directiveNodeProperties">
+          <div class="intro">
+            <div>
+            If enabled, you can use the syntax ${node.properties[propertyName]} in directive parameters to use the corresponding
+            value of the node property. If the value is a JSON data string, you can reach sub entry with their key, for
+            example with: ${node.properties[propertyName][jsonKey][jsonSubKey]}.
+            Read the <a href="/rudder-doc/#_node_properties_in_directives">node properties expansion in directives documentation</a>for more information.
+            </div>
+          </div>
+
+          <hr class="spacer" />
+          <div class="deca">
+            <form class="lift:form.ajax">
+              <div class="wbBaseField">
+                <label class="threeCol textright" for="directiveNodePropertiesCheckbox" style="font-weight:bold;width: 30%;">Enable node properties expansion in Directives:</label>
+                <input id="directiveNodePropertiesCheckbox" type="checkbox"/>
+              </div>
+              <hr class="spacer"/>
+              <lift:authz role="administration_write">
+                <input type="submit" value="Save Changes" id="directiveNodePropertiesSubmit"/>
+                <lift:Msg id="directiveNodePropertiesMsg">[messages]</lift:Msg>
+              </lift:authz>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="inner-portlet">
       <div class="inner-portlet-header">Enable QuickSearch on Everything</div>
       <div class="inner-portlet">
         <div class="lift:administration.PropertiesManagement.quickSearchConfiguration" id="quickSearchConfiguration">


### PR DESCRIPTION

Don't merge yet: we need a guard for people saving data in json, then disabling the feature. Now, it is an exception because the unserializer is lost. 
==> in fact, it's OK. It's just in a case you come back to a rudder version that does not understand json in nodeproperties. 
=> that means that you can't have migration from more recent to older with JSON values

https://www.rudder-project.org/redmine/issues/9057


This pull request allows to use node properties un directive parameters. The implemented rules are: 
- the syntax is *exactly* the same than in ncf/technique, i.e: ${node.properties[key1][key2]} 
- when there is only one level of key, the left hand side can be a simple string (as it is for now). If there is several level of keys, then the left hand side must be a valid json data string. 
- a non matching property leads to a generation error. It means that if a node does not have the property """key1 = { "key2": "value" }""", the generation will fail (it is the case for any level of key, even the first one) 
- for only one level of key, the left hand side is taken as it is. 
- for level > 1 of keys, if the subkey exists, then the whole value is taken: if it is a string, then it is used. If it is an other json value, it is compact-rendered to a string
- everything is case sensitive  
- the feature is hidden behind a feature switch, 
- space and line breaks are **authorized**  in the middle of a ${} expression around separator chars like "." or "]"

- we can add a flag that tells to generation part "don't touch this, let it go to the node"
 ```${node.properties[key1][key2]|node} ```
- we can add a default value if the node is missing property. The default value can be other parameters, or string, or string with parameters. 

Some example of what is accepted:
```
${node.properties[key1][key2] | default = "foo" }
${node.properties[key1][key2] | default = """ {"foo"="bar"} """}
${node.properties[key1][key2] | default = ${node.properties[other] | node}}
${node.properties[key1][key2] | default = ${node.properties[other] | default="foo"}}
${node.properties[key1][key2] | default = ${rudder.param.key3}}
```

It does not make sens to have both "node" and "defaults", so for now we don't allow several options.

Also, there is (a lot of) tests to demonstrate the strange cases. 

The pull request also correct a problem in node properties REST API that was not correctly managing badly formatted json properties. Now, on that case, an error is returned to the user. 
It also add the support of real json Value, because before it, we only had "key=value" where "value" was a quoted string, understood as a quoted string, neither a json value, not even on the agent side. 

Finally, when https://www.rudder-project.org/redmine/issues/9118 will be merged, error are reported like:
```
⇨ Policy update error for process '285' at 2016-09-26 01:56:05
⇨ Cannot build target configuration node
⇨ Error with parameters expansion for node 'agent1.rudder.local' (e58d1658-7cae-4b10-aafa-7147b8d02095): When processing directive '15. Welcome message': On variable 'MOTD': Missing property '${node.properties[datacenter][Europe][France]}'
⇨ Error with parameters expansion for node 'agent2.rudder.local' (cc987140-c5c3-4ddb-992f-c837083ef025): When processing directive '15. Welcome message': On variable 'MOTD': Missing property '${node.properties[datacenter][Europe][France]}'
```
