### PR TITLE
Fixes #9122: Use hostname for Nodes instead of name in compliance api names

### DIFF
--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/compliance/ComplianceAPIService.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/compliance/ComplianceAPIService.scala
@@ -125,7 +125,7 @@ class ComplianceAPIService(
                               byNode.map { case (nodeId, components) =>
                                 ByRuleNodeCompliance(
                                     nodeId
-                                  , nodeInfos.get(nodeId).map(_.name).getOrElse("Unknown node")
+                                  , nodeInfos.get(nodeId).map(_.hostname).getOrElse("Unknown node")
                                   , components.toSeq.sortBy(_._2.componentName).flatMap(_._2.componentValues.values)
                                 )
                               }.toSeq
@@ -198,7 +198,7 @@ class ComplianceAPIService(
 
           (nodeId, ByNodeNodeCompliance(
               nodeId
-            , nodeInfos.get(nodeId).map(_.name).getOrElse("Unknown node")
+            , nodeInfos.get(nodeId).map(_.hostname).getOrElse("Unknown node")
             , ComplianceLevel(noAnswer = rulesForNode.size)
             , (rulesForNode.map { rule =>
                 ByNodeRuleCompliance(
@@ -219,7 +219,7 @@ class ComplianceAPIService(
           nodeId,
           ByNodeNodeCompliance(
               nodeId
-            , nodeInfos.get(nodeId).map(_.name).getOrElse("Unknown node")
+            , nodeInfos.get(nodeId).map(_.hostname).getOrElse("Unknown node")
             , ComplianceLevel.sum(ruleNodeStatusReports.map(_.compliance))
             , ruleNodeStatusReports.toSeq.map(r =>
                ByNodeRuleCompliance(


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9122