### PR TITLE
Fixes #9157: JS Script, Node Properties expansion and Quicksearch should be disabled on migration

### DIFF
--- a/rudder-core/src/main/resources/Migration/ldapMigration-3.1.x-3.1.14-3.2.7-disable-js-directive.ldif
+++ b/rudder-core/src/main/resources/Migration/ldapMigration-3.1.x-3.1.14-3.2.7-disable-js-directive.ldif
@@ -1,0 +1,39 @@
+###############################################################################
+# Copyright 2016 Normation SAS
+###############################################################################
+#
+# This file is part of Rudder.
+# 
+# Rudder is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# In accordance with the terms of section 7 (7. Additional Terms.) of
+# the GNU General Public License version 3, the copyright holders add
+# the following Additional permissions:
+# Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+# Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+# Public License version 3, when you create a Related Module, this
+# Related Module is not considered as a part of the work and may be
+# distributed under the license agreement of your choice.
+# A "Related Module" means a set of sources files including their
+# documentation that, without modification of the Source Code, enables
+# supplementary functions or services in addition to those offered by
+# the Software.
+# 
+# Rudder is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+# Disable js engine feature added in 3.1.14 and 3.2.7 to keep previous behavior
+
+dn: propertyName=rudder_featureSwitch_directiveScriptEngine,ou=Application Properties,cn=rudder-configuration
+objectClass: property
+objectClass: top
+propertyName: rudder_featureSwitch_directiveScriptEngine
+propertyValue: disabled

--- a/rudder-core/src/main/resources/Migration/ldapMigration-3.1.x-3.1.14-3.2.7-disable-json-properties.ldif
+++ b/rudder-core/src/main/resources/Migration/ldapMigration-3.1.x-3.1.14-3.2.7-disable-json-properties.ldif
@@ -1,0 +1,39 @@
+###############################################################################
+# Copyright 2016 Normation SAS
+###############################################################################
+#
+# This file is part of Rudder.
+# 
+# Rudder is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# In accordance with the terms of section 7 (7. Additional Terms.) of
+# the GNU General Public License version 3, the copyright holders add
+# the following Additional permissions:
+# Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+# Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+# Public License version 3, when you create a Related Module, this
+# Related Module is not considered as a part of the work and may be
+# distributed under the license agreement of your choice.
+# A "Related Module" means a set of sources files including their
+# documentation that, without modification of the Source Code, enables
+# supplementary functions or services in addition to those offered by
+# the Software.
+# 
+# Rudder is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+# Disable json properties feature added in 3.1.14 and 3.2.7 to keep previous behavior
+
+dn: propertyName=rudder_featureSwitch_directiveNodeProperties,ou=Application Properties,cn=rudder-configuration
+objectClass: property
+objectClass: top
+propertyName: rudder_featureSwitch_directiveNodeProperties
+propertyValue: disabled

--- a/rudder-core/src/main/resources/Migration/ldapMigration-3.1.x-3.1.14-3.2.7-disable-quicksearch.ldif
+++ b/rudder-core/src/main/resources/Migration/ldapMigration-3.1.x-3.1.14-3.2.7-disable-quicksearch.ldif
@@ -1,0 +1,39 @@
+###############################################################################
+# Copyright 2016 Normation SAS
+###############################################################################
+#
+# This file is part of Rudder.
+# 
+# Rudder is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# In accordance with the terms of section 7 (7. Additional Terms.) of
+# the GNU General Public License version 3, the copyright holders add
+# the following Additional permissions:
+# Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+# Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+# Public License version 3, when you create a Related Module, this
+# Related Module is not considered as a part of the work and may be
+# distributed under the license agreement of your choice.
+# A "Related Module" means a set of sources files including their
+# documentation that, without modification of the Source Code, enables
+# supplementary functions or services in addition to those offered by
+# the Software.
+# 
+# Rudder is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+# Disable quicksearch feature added in 3.1.14 and 3.2.7 to keep previous behavior
+
+dn: propertyName=rudder_featureSwitch_quicksearchEverything,ou=Application Properties,cn=rudder-configuration
+objectClass: property
+objectClass: top
+propertyName: rudder_featureSwitch_quicksearchEverything
+propertyValue: disabled

--- a/rudder-core/src/main/resources/ldap/bootstrap.ldif
+++ b/rudder-core/src/main/resources/ldap/bootstrap.ldif
@@ -342,3 +342,21 @@ objectClass: property
 objectClass: top
 propertyName: api_compatibility_mode
 propertyValue: false
+
+dn: propertyName=rudder_featureSwitch_directiveScriptEngine,ou=Application Properties,cn=rudder-configuration
+objectClass: property
+objectClass: top
+propertyName: rudder_featureSwitch_directiveScriptEngine
+propertyValue: enabled
+
+dn: propertyName=rudder_featureSwitch_directiveNodeProperties,ou=Application Properties,cn=rudder-configuration
+objectClass: property
+objectClass: top
+propertyName: rudder_featureSwitch_directiveNodeProperties
+propertyValue: enabled
+
+dn: propertyName=rudder_featureSwitch_quicksearchEverything,ou=Application Properties,cn=rudder-configuration
+objectClass: property
+objectClass: top
+propertyName: rudder_featureSwitch_quicksearchEverything
+propertyValue: enabled

--- a/rudder-web/src/main/scala/com/normation/rudder/appconfig/ConfigService.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/appconfig/ConfigService.scala
@@ -296,9 +296,9 @@ class LDAPBasedConfigService(configFile: Config, repos: ConfigRepository, workfl
        rudder.syslog.protocol=UDP
        display.changes.graph=true
        api.compatibility.mode=false
-       rudder.featureSwitch.directiveScriptEngine=disabled
+       rudder.featureSwitch.directiveScriptEngine=enabled
        rudder.featureSwitch.quicksearchEverything=enabled
-       rudder.featureSwitch.directiveNodeProperties=disabled
+       rudder.featureSwitch.directiveNodeProperties=enabled
     """
 
   val configWithFallback = configFile.withFallback(ConfigFactory.parseString(defaultConfig))


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9157