### PR TITLE
Fixes #9353: Adapt compliance computing to process abort message

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
@@ -55,7 +55,7 @@ trait ReportingService {
    * Optionally restrict the set to some rules if filterByRules is non empty (else,
    * find node status reports for all rules)
    */
-  def findRuleNodeStatusReports(nodeIds: Set[NodeId], filterByRules : Set[RuleId]): Box[Map[NodeId, (RunAndConfigInfo, Set[RuleNodeStatusReport])]]
+  def findRuleNodeStatusReports(nodeIds: Set[NodeId], filterByRules : Set[RuleId]): Box[Map[NodeId, NodeStatusReport]]
 
   /**
    * find rule status reports for a given rule.

--- a/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
@@ -59,6 +59,7 @@ import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.domain.policies.GlobalPolicyMode
 import com.normation.rudder.domain.policies.PolicyModeOverrides
 import com.normation.rudder.services.policies.NodeConfigData
+import com.normation.rudder.reports.NodeComplianceMode
 
 /**
  * Test properties about status reports,
@@ -235,6 +236,7 @@ class StatusReportTest extends Specification {
             NodeExpectedReports(NodeId("n1"), NodeConfigId("plop"), DateTime.now(), None, modesConfig, List()) // TODO : correct that test
           , None, DateTime.now.plusMinutes(15)
         )
+      , RunComplianceInfo.OK
     , parse("""
        n1, r1, 12, d1, c0  , v0  , "", pending   , pending msg
        n1, r1, 12, d1, c1  , v1  , "", pending   , pending msg

--- a/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -101,7 +101,7 @@ class ExecutionBatchTest extends Specification {
     , reportsParam          : Seq[Reports]
     // this is the agent execution interval, in minutes
     , complianceMode        : ComplianceMode
-  ): Map[NodeId, (RunAndConfigInfo, Set[RuleNodeStatusReport])] = {
+  ): Map[NodeId, NodeStatusReport] = {
 
     val res = (for {
       (nodeId, expected) <- nodeExpectedReports.toSeq
@@ -110,7 +110,7 @@ class ExecutionBatchTest extends Specification {
       val info = nodeExpectedReports(nodeId)
       val runInfo = ComputeCompliance(runTime, info, runTime.plusMinutes(5))
 
-      ExecutionBatch.getNodeStatusReports(nodeId, runInfo, reportsParam)
+      (nodeId, ExecutionBatch.getNodeStatusReports(nodeId, runInfo, reportsParam))
     })
 
     res.toMap
@@ -542,7 +542,7 @@ class ExecutionBatchTest extends Specification {
     val nodeStatus = (getNodeStatusReportsByRule _).tupled(param)
 
     "have one detailed reports when we create it with one report" in {
-      nodeStatus(one)._2.size === 1
+      nodeStatus(one).report.reports.size === 1
     }
 
     "have one detailed success node when we create it with one success report" in {
@@ -550,11 +550,11 @@ class ExecutionBatchTest extends Specification {
     }
 
     "have one detailed rule success directive when we create it with one success report" in {
-      nodeStatus(one)._2.head.directives.head._1 === DirectiveId("policy")
+      nodeStatus(one).report.reports.head.directives.head._1 === DirectiveId("policy")
     }
 
     "have no detailed rule non-success directive when we create it with one success report" in {
-      AggregatedStatusReport(nodeStatus(one)._2).compliance === ComplianceLevel(success = 1)
+      AggregatedStatusReport(nodeStatus(one).report.reports).compliance === ComplianceLevel(success = 1)
     }
   }
 
@@ -581,7 +581,7 @@ class ExecutionBatchTest extends Specification {
 
     "have a pending node when we create it with one wrong success report right now" in {
       (nodeStatus.keySet.head === one) and
-      AggregatedStatusReport(nodeStatus.values.flatMap(_._2).toSet).compliance === ComplianceLevel(missing = 1)
+      AggregatedStatusReport(nodeStatus.values.flatMap(_.report.reports).toSet).compliance === ComplianceLevel(missing = 1)
     }
   }
 
@@ -611,7 +611,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one unexpected node when we create it with one success report" in {
       nodeStatus.head._1 === one and
-      AggregatedStatusReport(nodeStatus.values.flatMap(_._2).toSet).compliance === ComplianceLevel(unexpected = 2)
+      AggregatedStatusReport(nodeStatus.values.flatMap(_.report.reports).toSet).compliance === ComplianceLevel(unexpected = 2)
     }
   }
 
@@ -637,7 +637,7 @@ class ExecutionBatchTest extends Specification {
     }
 
     "have one success, and one pending node, in the component detail of the rule" in {
-      AggregatedStatusReport(nodeStatus.values.flatMap(_._2).toSet).compliance === ComplianceLevel(success = 1, missing = 1)
+      AggregatedStatusReport(nodeStatus.values.flatMap(_.report.reports).toSet).compliance === ComplianceLevel(success = 1, missing = 1)
     }
   }
 
@@ -664,7 +664,7 @@ class ExecutionBatchTest extends Specification {
       nodeStatus.size === 3
     }
     "have one detailed rule report with a 67% compliance" in {
-      AggregatedStatusReport(nodeStatus.values.flatMap(_._2).toSet).compliance === ComplianceLevel(success = 2, missing = 1)
+      AggregatedStatusReport(nodeStatus.values.flatMap(_.report.reports).toSet).compliance === ComplianceLevel(success = 2, missing = 1)
     }
   }
 
@@ -696,7 +696,7 @@ class ExecutionBatchTest extends Specification {
       , fullCompliance
     )
     val nodeStatus = getNodeStatusByRule(param)
-    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_._2).toSet)
+    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_.report.reports).toSet)
 
     "have two detailed node rule report" in {
       nodeStatus.size === 3
@@ -738,7 +738,7 @@ class ExecutionBatchTest extends Specification {
       , fullCompliance
     )
     val nodeStatus = getNodeStatusByRule(param)
-    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_._2).toSet)
+    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_.report.reports).toSet)
 
     "have 3 detailed node rule report" in {
       nodeStatus.size === 3
@@ -783,7 +783,7 @@ class ExecutionBatchTest extends Specification {
       , fullCompliance
     )
     val nodeStatus = getNodeStatusByRule(param)
-    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_._2).toSet)
+    val aggregated = AggregatedStatusReport(nodeStatus.values.flatMap(_.report.reports).toSet)
 
     "have 3 detailed node rule report" in {
       nodeStatus.size === 3
@@ -828,7 +828,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
       nodeStatus.keySet.head === one and
-      nodeStatus.head._2._2.head.compliance.pc_success === 100
+      nodeStatus.head._2.report.reports.head.compliance.pc_success === 100
     }
 
   }
@@ -857,7 +857,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
      nodeStatus.keySet.head === NodeId("nodeId") and
-     nodeStatus.head._2._2.head.compliance.pc_success === 100
+     nodeStatus.head._2.report.reports.head.compliance.pc_success === 100
     }
   }
 
@@ -883,7 +883,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
      nodeStatus.keySet.head === NodeId("nodeId") and
-     nodeStatus.head._2._2.head.compliance.pc_success === 100
+     nodeStatus.head._2.report.reports.head.compliance.pc_success === 100
     }
   }
 

--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/compliance/ComplianceAPIService.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/compliance/ComplianceAPIService.scala
@@ -80,7 +80,7 @@ class ComplianceAPIService(
     } yield {
 
       //flatMap of Set is ok, since nodeRuleStatusReport are different for different nodeIds
-      val reportsByRule = reportsByNode.flatMap { case(nodeId, (runInfo, nodeRuleStatusReports)) => nodeRuleStatusReports }.groupBy( _.ruleId)
+      val reportsByRule = reportsByNode.flatMap { case(nodeId, status) => status.report.reports }.groupBy( _.ruleId)
 
       // get an empty-initialized array of compliances to be used
       // as defaults
@@ -221,15 +221,15 @@ class ComplianceAPIService(
 
       //for each rule for each node, we want to have a
       //directiveId -> reporttype map
-      val nonEmptyNodes = reports.map { case (nodeId, (runInfo, ruleNodeStatusReports)) =>
+      val nonEmptyNodes = reports.map { case (nodeId, status) =>
         (
           nodeId,
           ByNodeNodeCompliance(
               nodeId
             , nodeInfos.get(nodeId).map(_.hostname).getOrElse("Unknown node")
-            , ComplianceLevel.sum(ruleNodeStatusReports.map(_.compliance))
+            , ComplianceLevel.sum(status.report.reports.map(_.compliance))
             , compliance.mode
-            , ruleNodeStatusReports.toSeq.map(r =>
+            , status.report.reports.toSeq.map(r =>
                ByNodeRuleCompliance(
                     r.ruleId
                   , ruleMap.get(r.ruleId).map(_.name).getOrElse("Unknown rule")

--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/AsyncComplianceService.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/AsyncComplianceService.scala
@@ -120,8 +120,8 @@ class AsyncComplianceService (
       for {
         reports <- reportingService.findRuleNodeStatusReports(nodeIds, ruleIds)
       } yield {
-        reports.map { case (nodeId, (run, reports)) =>
-          toCompliance(nodeId, reports)
+        reports.map { case (nodeId, status) =>
+          toCompliance(nodeId, status.report.reports)
         }
       }
     }
@@ -142,7 +142,7 @@ class AsyncComplianceService (
         reports <- reportingService.findRuleNodeStatusReports(nodeIds, ruleIds)
       } yield {
         //flatMap on a Set is OK, since reports are different for different nodeIds
-        reports.flatMap( _._2._2 ).groupBy( _.ruleId ).map { case (ruleId, reports) =>
+        reports.flatMap( _._2.report.reports ).groupBy( _.ruleId ).map { case (ruleId, reports) =>
           toCompliance(ruleId, reports)
         }
       }

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -187,7 +187,7 @@ class HomePage extends Loggable {
       _ = TimingDebugLogger.debug(s"Compute compliance: ${n3 - n2}ms")
     } yield {
 
-      val reportsByNode = reports.mapValues { case(run, reports) => ComplianceLevel.sum(reports.map(_.compliance)) }
+      val reportsByNode = reports.mapValues { status => ComplianceLevel.sum(status.report.reports.map(_.compliance)) }
 
       /*
        * Here, for the compliance by node, we want to distinguish (but NOT ignore, like in globalCompliance) the
@@ -260,7 +260,7 @@ class HomePage extends Loggable {
       val diagramColor = JsObj(sorted.map(_.jsColor):_*)
 
       // Data used for compliance bar, compliance without pending
-      val compliance = ComplianceLevel.sum(reports.flatMap( _._2._2.toSeq.map( _.compliance))).copy(pending = 0)
+      val compliance = ComplianceLevel.sum(reports.flatMap( _._2.report.reports.toSeq.map( _.compliance))).copy(pending = 0)
 
       import com.normation.rudder.domain.reports.ComplianceLevelSerialisation._
       val complianceBar = compliance.toJsArray


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9353

There seems to be a lot of changes, but in fact we just really:

- Add a RunComplianceStatus object and add it to NodeStatusReports,
- Use NodeStatusReports as the return type for a run analysis in ExecutionBatch, 
- during the analysis, add the correct RunComplianceStatus info based on reports and statusReports, 
- display a new message in ReportsDisplayer based on that new information.

All the remaining if just modifying everywhere to change (RunAndConfigInfo, Set[RuleNodeStatusInfo]) into a NodeStatusReports.