### PR TITLE
Fixes #9518: When we just apply a configuration, reports is "missing" (not "pending")

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionRepositoryImpl.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionRepositoryImpl.scala
@@ -108,12 +108,7 @@ case class RoReportsExecutionRepositoryImpl (
                               and nodeid in (${nodes : nodes.type})
                            order by nodeid, insertionid desc
                          ) as r
-                         left outer join (
-                           select distinct on (nodeid)
-                             nodeid, nodeconfigid, begindate, enddate, configuration
-                             from nodeconfigurations
-                            order by nodeid, begindate desc
-                          ) as c
+                         left outer join nodeconfigurations as c
                           on r.nodeId = c.nodeid and r.nodeconfigid = c.nodeconfigid
                      """.query[
                           //
@@ -127,6 +122,7 @@ case class RoReportsExecutionRepositoryImpl (
                           case tuple@(r, t1, t2, t3, t4, t5) => (r, unserNodeConfig(t1, t2, t3, t4, t5))
                         }.vector
         } yield {
+
           val runsMap = (runs.map { case (r, optConfig) =>
             val run = r.toAgentRun
             val config = run.nodeConfigVersion.map(c => (c, optConfig))

--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -397,7 +397,8 @@ trait PromiseGenerationService extends Loggable {
 
   protected def computeNodeConfigIdFromCache(config: NodeConfigurationHash): NodeConfigId = {
     //make it looks like a string, not an int.
-    NodeConfigId(config.hashCode.toHexString)
+    // we are adding a salt to make it unique in case of config regenerated latter
+    NodeConfigId((System.currentTimeMillis + config.hashCode).toHexString)
   }
   def calculateNodeConfigVersions(configs: Seq[NodeConfiguration]): Map[NodeId, NodeConfigId] = {
     configs.map(x => (x.nodeInfo.id, computeNodeConfigIdFromCache(NodeConfigurationHash(x)))).toMap

--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -215,7 +215,7 @@ class ReportDisplayer(
 
         case UnexpectedUnknowVersion(lastRunDateTime, lastRunConfigId, expectedConfig, expectedExpiration) =>
           (
-            <p>This node is sending reports from an unknown configuration policy (with configuration ID '${lastRunConfigId.value}'
+            <p>This node is sending reports from an unknown configuration policy (with configuration ID '{lastRunConfigId.value}'
                that is unknown to Rudder, run started at {lastRunDateTime.toString(dateFormat)}).
                Please run "rudder agent update -f" on the node to force a policy update.</p>
             <p>For information, expected node policies are displayed below.</p>


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9518


WARNING: this PR is making NodeConfigID UNIQUE EVEN IF CONFIG IS THE SAME