### PR TITLE
Fixes #9530: Each policy generation lead to a new nodeconnfigid even without promise written

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfiguration.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfiguration.scala
@@ -70,7 +70,6 @@ case class NodeConfiguration(
     //environment variable for that server
   , nodeContext : Map[String, Variable]
   , parameters  : Set[ParameterForConfiguration]
-  , writtenDate : Option[DateTime] = None
   , isRootServer: Boolean = false
 ) extends HashcodeCaching with Loggable {
 

--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepository.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepository.scala
@@ -76,17 +76,17 @@ case class PolicyHash(
  *
  */
 case class NodeConfigurationHash(
-    id: NodeId
-  , writtenDate: Option[DateTime]
-  , nodeInfoHash: Int
-  , parameterHash: Int
+    id             : NodeId
+  , writtenDate    : DateTime
+  , nodeInfoHash   : Int
+  , parameterHash  : Int
   , nodeContextHash: Int
-  , policyHash: Set[PolicyHash]
+  , policyHash     : Set[PolicyHash]
 ) {
   // We need a method to correctly compare a NodeConfigurationHash that was serialized
   // from a NodeConfigurationHash created from a NodeConfiguration (so without writtenDate)
   def equalWithoutWrittenDate(other: NodeConfigurationHash) : Boolean = {
-    id               == other.id &&
+    id              == other.id &&
     nodeInfoHash    == other.nodeInfoHash &&
     parameterHash   == other.parameterHash &&
     nodeContextHash == other.nodeContextHash &&
@@ -100,7 +100,7 @@ object NodeConfigurationHash {
    * Build the hash from a node configuration.
    *
    */
-  def apply(nodeConfig: NodeConfiguration): NodeConfigurationHash = {
+  def apply(nodeConfig: NodeConfiguration, writtenDate: DateTime): NodeConfigurationHash = {
 
 
     /*
@@ -205,7 +205,7 @@ object NodeConfigurationHash {
 
     new NodeConfigurationHash(
         id = nodeConfig.nodeInfo.id
-      , writtenDate = nodeConfig.writtenDate
+      , writtenDate = writtenDate
       , nodeInfoHash = nodeInfoHashValue
       , parameterHash = parameterHash
       , nodeContextHash = nodeContextHash

--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationService.scala
@@ -43,6 +43,7 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.NodeConfigId
+import org.joda.time.DateTime
 
 trait NodeConfigurationService {
 
@@ -83,7 +84,7 @@ trait NodeConfigurationService {
   /**
    * Cache these node configurations.
    */
-  def cacheNodeConfiguration(nodeConfigurations: Set[NodeConfiguration]): Box[Set[NodeId]]
+  def cacheNodeConfiguration(nodeConfigurations: Set[NodeConfiguration], writtenDate: DateTime): Box[Set[NodeId]]
 
   /**
    * Look what are the node configuration updated compared to information in cache

--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationServiceImpl.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationServiceImpl.scala
@@ -69,7 +69,7 @@ class NodeConfigurationServiceImpl(
   def deleteNodeConfigurations(nodeIds:Set[NodeId]) :  Box[Set[NodeId]] = repository.deleteNodeConfigurations(nodeIds)
   def deleteAllNodeConfigurations() : Box[Unit] = repository.deleteAllNodeConfigurations
   def onlyKeepNodeConfiguration(nodeIds:Set[NodeId]) : Box[Set[NodeId]] = repository.onlyKeepNodeConfiguration(nodeIds)
-  def cacheNodeConfiguration(nodeConfigurations: Set[NodeConfiguration]): Box[Set[NodeId]] = repository.save(nodeConfigurations.map(x => NodeConfigurationHash(x)))
+  def cacheNodeConfiguration(nodeConfigurations: Set[NodeConfiguration], writtenDate: DateTime): Box[Set[NodeId]] = repository.save(nodeConfigurations.map(x => NodeConfigurationHash(x, writtenDate)))
   def getNodeConfigurationHash(): Box[Map[NodeId, NodeConfigurationHash]] = repository.getAll
 
   def sanitize(targets : Seq[NodeConfiguration]) : Box[Map[NodeId, NodeConfiguration]] = {
@@ -170,7 +170,8 @@ class NodeConfigurationServiceImpl(
   }
 
   def selectUpdatedNodeConfiguration(nodeConfigurations: Map[NodeId, NodeConfiguration], cache: Map[NodeId, NodeConfigurationHash]): Set[NodeId] = {
-    val newConfigCache = nodeConfigurations.map{ case (_, conf) => NodeConfigurationHash(conf) }
+    val notUsedTime = new DateTime(0) //this seems to tell us the nodeConfigurationHash should be refactor to split time frome other properties
+    val newConfigCache = nodeConfigurations.map{ case (_, conf) => NodeConfigurationHash(conf, notUsedTime) }
 
     val (updatedConfig, notUpdatedConfig) = newConfigCache.toSeq.partition{ p =>
       cache.get(p.id) match {

--- a/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
@@ -237,7 +237,6 @@ object NodeConfigData {
     , policyDrafts= Set[Cf3PolicyDraft]()
     , nodeContext = Map[String, Variable]()
     , parameters  = Set[ParameterForConfiguration]()
-    , writtenDate = None
     , isRootServer= true
   )
 
@@ -247,7 +246,6 @@ object NodeConfigData {
     , policyDrafts= Set[Cf3PolicyDraft]()
     , nodeContext = Map[String, Variable]()
     , parameters  = Set[ParameterForConfiguration]()
-    , writtenDate = None
     , isRootServer= false
   )
 
@@ -257,7 +255,6 @@ object NodeConfigData {
     , policyDrafts= Set[Cf3PolicyDraft]()
     , nodeContext = Map[String, Variable]()
     , parameters  = Set[ParameterForConfiguration]()
-    , writtenDate = None
     , isRootServer= false
   )
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9530


There was several problems:

- the nodeconfigId was regenerated too many times, 
- the date used in the new hashcode was not consistent, 
- there was a missing case in run analysis when the runConfigId and expectedConfigId were not the same, 
-  there was a missing case in compare/merge when directives were added to an existing rule. 