### PR TITLE
Fixes #9645: Add a table for node compliance

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
@@ -53,6 +53,7 @@ import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.inventory.domain.NodeId
 import net.liftweb.common._
 import scala.language.implicitConversions
+import com.normation.rudder.services.reports.RunAndConfigInfo
 
 /**
  *
@@ -145,6 +146,32 @@ object Doobie {
     )
   }
 
+  implicit val CompliancePercentComposite: Composite[CompliancePercent] = {
+    import ComplianceLevelSerialisation._
+    import net.liftweb.json._
+    Composite[String].xmap(
+        json => parsePercent(parse(json))
+      , x    => compactRender(x.toJson)
+    )
+  }
+
+  implicit val ComplianceRunInfoComposite: Composite[(RunAndConfigInfo, RunComplianceInfo)] = {
+    import NodeStatusReportSerialization._
+    import net.liftweb.json._
+    Composite[String].xmap(
+        json => throw new RuntimeException(s"You can deserialize run compliance info for now")
+      , x    => x.toJson
+    )
+  }
+
+  implicit val AggregatedStatusReportComposite: Composite[AggregatedStatusReport] = {
+    import NodeStatusReportSerialization._
+    import net.liftweb.json._
+    Composite[String].xmap(
+        json => throw new RuntimeException(s"You can deserialize aggredatedStatusReport for now")
+      , x    => x.toJson
+    )
+  }
 
   implicit val XmlMeta: Meta[Elem] =
     Meta.advanced[Elem](

--- a/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ComplianceLevel.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ComplianceLevel.scala
@@ -45,6 +45,9 @@ import net.liftweb.common.Loggable
 import com.normation.rudder.reports.ReportsDisabled
 import net.liftweb.http.js.JE
 import net.liftweb.http.js.JE.JsArray
+import net.liftweb.json.JsonAST.JObject
+import net.liftweb.json.JsonAST.JValue
+import net.liftweb.json.JsonAST.JInt
 
 /**
  * That file define a "compliance level" object, which store
@@ -54,9 +57,30 @@ import net.liftweb.http.js.JE.JsArray
  * This file also define simple addition on such compliance level.
  */
 
+
+//simple summary that only store percents - no intelligence at all
+//here, see ComplianceLevel to understand how percent are calculated.
+final case class CompliancePercent(
+    pending           : Double = 0
+  , success           : Double = 0
+  , repaired          : Double = 0
+  , error             : Double = 0
+  , unexpected        : Double = 0
+  , missing           : Double = 0
+  , noAnswer          : Double = 0
+  , notApplicable     : Double = 0
+  , reportsDisabled   : Double = 0
+  , compliant         : Double = 0
+  , auditNotApplicable: Double = 0
+  , nonCompliant      : Double = 0
+  , auditError        : Double = 0
+  , badPolicyMode     : Double = 0
+)
+
+
 //simple data structure to hold percentages of different compliance
 //the ints are actual numbers, percents are computed with the pc_ variants
-case class ComplianceLevel(
+final case class ComplianceLevel(
     pending           : Int = 0
   , success           : Int = 0
   , repaired          : Int = 0
@@ -72,7 +96,7 @@ case class ComplianceLevel(
   , auditError        : Int = 0
   , badPolicyMode     : Int = 0
 ) {
-
+  import ComplianceLevel.pc_for
   override def toString() = s"[p:${pending} s:${success} r:${repaired} e:${error} u:${unexpected} m:${missing} nr:${noAnswer} na:${notApplicable
                               } rd:${reportsDisabled} c:${compliant} ana:${auditNotApplicable} nc:${nonCompliant} ae:${auditError} bpm:${badPolicyMode}]"
 
@@ -82,23 +106,22 @@ case class ComplianceLevel(
   val complianceWithoutPending = pc_for(total_ok, total-pending-reportsDisabled)
   val compliance = pc_for(total_ok, total)
 
-  private[this] def pc_for(i:Int, total:Int) : Double = if(total == 0) 0 else (i * 100 / BigDecimal(total)).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
-  private[this] def pc(i:Int) : Double = pc_for(i, total)
-
-  val pc_pending             = pc(pending)
-  val pc_success             = pc(success)
-  val pc_repaired            = pc(repaired)
-  val pc_error               = pc(error)
-  val pc_unexpected          = pc(unexpected)
-  val pc_missing             = pc(missing)
-  val pc_reportsDisabled     = pc(reportsDisabled)
-  val pc_noAnswer            = pc(noAnswer)
-  val pc_notApplicable       = pc(notApplicable)
-  val pc_compliant           = pc(compliant)
-  val pc_auditNotApplicable  = pc(auditNotApplicable)
-  val pc_nonCompliant        = pc(nonCompliant)
-  val pc_auditError          = pc(auditError)
-  val pc_badPolicyMode       = pc(badPolicyMode)
+  val pc = CompliancePercent(
+      pc_for(pending           , total)
+    , pc_for(success           , total)
+    , pc_for(repaired          , total)
+    , pc_for(error             , total)
+    , pc_for(unexpected        , total)
+    , pc_for(missing           , total)
+    , pc_for(noAnswer          , total)
+    , pc_for(notApplicable     , total)
+    , pc_for(reportsDisabled   , total)
+    , pc_for(compliant         , total)
+    , pc_for(auditNotApplicable, total)
+    , pc_for(nonCompliant      , total)
+    , pc_for(auditError        , total)
+    , pc_for(badPolicyMode     , total)
+  )
 
   def +(compliance: ComplianceLevel): ComplianceLevel = {
     ComplianceLevel(
@@ -124,6 +147,9 @@ case class ComplianceLevel(
 }
 
 object ComplianceLevel {
+  private def pc_for(i:Int, total:Int) : Double = if(total == 0) 0 else (i * 100 / BigDecimal(total)).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
+
+
   def compute(reports: Iterable[ReportType]): ComplianceLevel = {
     import ReportType._
     if(reports.isEmpty) { ComplianceLevel(notApplicable = 1)}
@@ -155,26 +181,122 @@ object ComplianceLevel {
 
 
 object ComplianceLevelSerialisation {
+  import net.liftweb.json.JsonDSL._
+
+  //utility class to alway have the same names in JSON,
+  //even if we are refactoring ComplianceLevel at some point
+  //also remove 0
+  private def toJObject(
+      pending           : Number
+    , success           : Number
+    , repaired          : Number
+    , error             : Number
+    , unexpected        : Number
+    , missing           : Number
+    , noAnswer          : Number
+    , notApplicable     : Number
+    , reportsDisabled   : Number
+    , compliant         : Number
+    , auditNotApplicable: Number
+    , nonCompliant      : Number
+    , auditError        : Number
+    , badPolicyMode     : Number
+  ) = {
+    def POS(n: Number) = if(n.doubleValue <= 0) None else Some(JE.Num(n))
+
+    (
+        ( "pending"           -> POS(pending            ) )
+      ~ ( "success"           -> POS(success            ) )
+      ~ ( "repaired"          -> POS(repaired           ) )
+      ~ ( "error"             -> POS(error              ) )
+      ~ ( "unexpected"        -> POS(unexpected         ) )
+      ~ ( "missing"           -> POS(missing            ) )
+      ~ ( "noAnswer"          -> POS(noAnswer           ) )
+      ~ ( "notApplicable"     -> POS(notApplicable      ) )
+      ~ ( "reportsDisabled"   -> POS(reportsDisabled    ) )
+      ~ ( "compliant"         -> POS(compliant          ) )
+      ~ ( "auditNotApplicable"-> POS(auditNotApplicable ) )
+      ~ ( "nonCompliant"      -> POS(nonCompliant       ) )
+      ~ ( "auditError"        -> POS(auditError         ) )
+      ~ ( "badPolicyMode"     -> POS(badPolicyMode      ) )
+    )
+  }
+
+  private[this] def parse[T](json: JValue, convert: BigInt => T) = {
+    def N(n:JValue): T = convert(n match {
+      case JInt(i) => i
+      case _       => 0
+    })
+
+    (
+        N(json \ "pending")
+      , N(json \ "success")
+      , N(json \ "repaired")
+      , N(json \ "error")
+      , N(json \ "unexpected")
+      , N(json \ "missing")
+      , N(json \ "noAnswer")
+      , N(json \ "notApplicable")
+      , N(json \ "reportsDisabled")
+      , N(json \ "compliant")
+      , N(json \ "auditNotApplicable")
+      , N(json \ "nonCompliant")
+      , N(json \ "auditError")
+      , N(json \ "badPolicyMode")
+    )
+  }
+
+  def parseLevel(json: JValue) = {
+    (ComplianceLevel.apply _).tupled(parse(json, (i:BigInt) => i.intValue))
+  }
+
+  def parsePercent(json: JValue) = {
+    (CompliancePercent.apply _).tupled(parse(json, (i:BigInt) => i.doubleValue))
+  }
 
   //transform the compliance percent to a list with a given order:
   // pc_reportDisabled, pc_notapplicable, pc_success, pc_repaired,
   // pc_error, pc_pending, pc_noAnswer, pc_missing, pc_unknown
   implicit class ComplianceLevelToJs(compliance: ComplianceLevel) {
     def toJsArray(): JsArray = JsArray (
-        JE.Num(compliance.pc_reportsDisabled)     //  0
-      , JE.Num(compliance.pc_notApplicable)       //  1
-      , JE.Num(compliance.pc_success)             //  2
-      , JE.Num(compliance.pc_repaired)            //  3
-      , JE.Num(compliance.pc_error)               //  4
-      , JE.Num(compliance.pc_pending)             //  5
-      , JE.Num(compliance.pc_noAnswer)            //  6
-      , JE.Num(compliance.pc_missing)             //  7
-      , JE.Num(compliance.pc_unexpected)          //  8
-      , JE.Num(compliance.pc_auditNotApplicable)  //  9
-      , JE.Num(compliance.pc_compliant)           // 10
-      , JE.Num(compliance.pc_nonCompliant)        // 11
-      , JE.Num(compliance.pc_auditError)          // 12
-      , JE.Num(compliance.pc_badPolicyMode)       // 13
+        JE.Num(compliance.pc.reportsDisabled)     //  0
+      , JE.Num(compliance.pc.notApplicable)       //  1
+      , JE.Num(compliance.pc.success)             //  2
+      , JE.Num(compliance.pc.repaired)            //  3
+      , JE.Num(compliance.pc.error)               //  4
+      , JE.Num(compliance.pc.pending)             //  5
+      , JE.Num(compliance.pc.noAnswer)            //  6
+      , JE.Num(compliance.pc.missing)             //  7
+      , JE.Num(compliance.pc.unexpected)          //  8
+      , JE.Num(compliance.pc.auditNotApplicable)  //  9
+      , JE.Num(compliance.pc.compliant)           // 10
+      , JE.Num(compliance.pc.nonCompliant)        // 11
+      , JE.Num(compliance.pc.auditError)          // 12
+      , JE.Num(compliance.pc.badPolicyMode)       // 13
     )
+
+    def toJson(): JObject = {
+      import compliance._
+      toJObject(pending, success, repaired, error, unexpected, missing, noAnswer
+                 , notApplicable, reportsDisabled, compliant, auditNotApplicable
+                 , nonCompliant, auditError, badPolicyMode
+               )
+    }
   }
+
+  // transform a compliace percent to JSON.
+  // here, we are using attributes contrary to compliance level,
+  // and we only keep the one > 0 (we want the result to be
+  // human-readable and to aknolewdge the fact that there may be
+  // new fields.
+  implicit class CompliancePercentToJs(c: CompliancePercent) {
+    def toJson(): JObject = {
+      import c._
+      toJObject(pending, success, repaired, error, unexpected, missing, noAnswer
+                 , notApplicable, reportsDisabled, compliant, auditNotApplicable
+                 , nonCompliant, auditError, badPolicyMode
+               )
+    }
+  }
+
 }

--- a/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionService.scala
@@ -55,6 +55,7 @@ import org.joda.time.format.PeriodFormat
 
 import net.liftweb.common._
 import com.normation.rudder.db.DB
+import com.normation.rudder.repository.ComplianceRepository
 
 /**
  * That service contains most of the logic to merge
@@ -66,6 +67,7 @@ class ReportsExecutionService (
   , statusUpdateRepository : LastProcessedReportRepository
   , cachedChanges          : CachedNodeChangesServiceImpl
   , cachedCompliance       : CachedFindRuleNodeStatusReports
+  , complianceRepos        : ComplianceRepository
   , maxDays                : Int // in days
 ) {
 
@@ -220,6 +222,8 @@ class ReportsExecutionService (
             logger.error("Root exception was: ", ex)
           }
         case Full(x) => //youhou
+          //save compliance in DB
+          complianceRepos.saveRunCompliance(x.values.toList)
           logger.trace("Cache for compliance updates after new run received")
       }
     }

--- a/rudder-core/src/main/scala/com/normation/rudder/repository/ComplianceRepository.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/repository/ComplianceRepository.scala
@@ -1,0 +1,54 @@
+/*
+*************************************************************************************
+* Copyright 2016 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.repository
+
+
+import net.liftweb.common.Box
+import com.normation.rudder.domain.reports.NodeStatusReport
+
+
+trait ComplianceRepository {
+
+  /*
+   * Save a list of node compliance reports for runs.
+   * Any compliance not linked to a run ("no run in interval", etc) will
+   * be ignore. Only saved compliance will be returned.
+   */
+  def saveRunCompliance(compliance: List[NodeStatusReport]): Box[List[NodeStatusReport]]
+
+}

--- a/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
@@ -1,0 +1,133 @@
+/*
+*************************************************************************************
+* Copyright 2016 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.repository.jdbc
+
+
+import net.liftweb.common.Box
+import com.normation.rudder.domain.reports.NodeStatusReport
+import com.normation.rudder.repository.ComplianceRepository
+import com.normation.rudder.db.Doobie
+import com.normation.rudder.db.Doobie._
+import scalaz.{Failure => _, _}, Scalaz._
+import doobie.imports._
+import scalaz.concurrent.Task
+import doobie.contrib.postgresql.pgtypes._
+import com.normation.rudder.db.DB
+import com.normation.rudder.services.reports._
+import com.normation.inventory.domain.NodeId
+import org.joda.time.DateTime
+import com.normation.rudder.domain.reports.RunComplianceInfo
+import com.normation.rudder.domain.reports.ComplianceLevel
+import com.normation.rudder.domain.reports.AggregatedStatusReport
+import com.normation.rudder.domain.reports.CompliancePercent
+
+
+final case class RunCompliance(
+    nodeId      : NodeId
+  , runTimestamp: DateTime
+  , endOfLife   : DateTime
+  , runInfo     : (RunAndConfigInfo, RunComplianceInfo)
+  , summary     : CompliancePercent
+  , details     : AggregatedStatusReport
+)
+
+object RunCompliance {
+
+  def from(runTimestamp: DateTime, endOfLife: DateTime, report: NodeStatusReport) = {
+    RunCompliance(report.nodeId, runTimestamp, endOfLife, (report.runInfo, report.statusInfo), report.compliance.pc, report.report)
+  }
+
+}
+
+class ComplianceJdbcRepository(doobie: Doobie) extends ComplianceRepository {
+  import doobie._
+
+  /*
+   * Save a list of node compliance reports
+   */
+  override def saveRunCompliance(reports: List[NodeStatusReport]): Box[List[NodeStatusReport]] = {
+    /*
+     * some sorting of things. We must only store information about node status reports with
+     * a run
+     */
+    val runCompliances = reports.flatMap { r => r.runInfo match {
+      //ignore case with no runs
+      case _:NoReportInInterval |
+           NoRunNoExpectedReport |
+           _:ReportsDisabledInInterval => None
+
+      case x:Pending => x.optLastRun match {
+        case None =>
+          None
+        case Some((runTime, expected)) =>
+          Some(RunCompliance.from(runTime, x.expirationDateTime, r))
+      }
+
+      case x:NoExpectedReport =>
+        // here, the expiration date has not much meaning, since we don't have
+        // information on that node configuration (and so the node has most likelly no
+        // idea whatsoever of any config, even global). Take default values,
+        // ie 5min for run + 5min for grace
+        Some(RunCompliance.from(x.lastRunDateTime, x.lastRunDateTime.plusMinutes(10), r))
+      case x:UnexpectedVersion =>
+        Some(RunCompliance.from(x.lastRunDateTime, x.lastRunExpiration, r))
+      case x:UnexpectedNoVersion =>
+        Some(RunCompliance.from(x.lastRunDateTime, x.lastRunExpiration, r))
+      case x:UnexpectedUnknowVersion =>
+        // same has for NoExpectedReport, we can't now what the node
+        // thing its configuration is.
+        Some(RunCompliance.from(x.lastRunDateTime, x.lastRunDateTime.plusMinutes(10), r))
+      case x:ComputeCompliance =>
+        Some(RunCompliance.from(x.lastRunDateTime, x.expirationDateTime, r))
+
+    } }
+
+    //now, save everything
+
+    (for {
+      updated  <- Update[RunCompliance](
+                    """insert into nodecompliance (nodeid, runtimestamp, endoflife, runanalysis, summary, details)
+                       values (?, ?, ?, ?, ?, ?)
+                    """
+                  ).updateMany(runCompliances)
+    } yield {
+      val saved = runCompliances.map(_.nodeId)
+      reports.filter(r => saved.contains(r.nodeId))
+    }).attempt.transact(xa).run  }
+
+}

--- a/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -211,7 +211,7 @@ trait CachedFindRuleNodeStatusReports extends ReportingService with CachedReposi
       } else {
         reports.mapValues { status =>
           val nodeStatusReports = status.report.reports
-          NodeStatusReport(status.forNode, status.runInfo, status.statusInfo
+          NodeStatusReport(status.nodeId, status.runInfo, status.statusInfo
                          , nodeStatusReports.filter(r => ruleIds.contains(r.ruleId) )
           )
         }.filter( _._2.report.reports.nonEmpty )
@@ -371,7 +371,7 @@ trait DefaultFindRuleNodeStatusReports extends ReportingService {
       //we want to have nodeStatus for all asked node, not only the ones with reports
       runInfos.map { case (nodeId, runInfo) =>
         val status = ExecutionBatch.getNodeStatusReports(nodeId, runInfo, reports.getOrElse(nodeId, Seq()))
-        (status.forNode, status)
+        (status.nodeId, status)
       }
     }
   }

--- a/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
@@ -120,15 +120,15 @@ class StatusReportTest extends Specification {
     }
 
     "correctly add them" in {
-      aggregate(d1c1v1_s ++ d1c2v21_s).compliance.pc_success === 100
+      aggregate(d1c1v1_s ++ d1c2v21_s).compliance.pc.success === 100
     }
 
     "correctly add them by directive" in {
       val a = aggregate(d1c1v1_s ++ d1c2v21_s ++ d2c2v21_e)
 
-      (a.compliance.pc_success === 66.67.toDouble) and
-      (a.directives("d1").compliance.pc_success === 100) and
-      (a.directives("d2").compliance.pc_error === 100)
+      (a.compliance.pc.success === 66.67.toDouble) and
+      (a.directives("d1").compliance.pc.success === 100) and
+      (a.directives("d2").compliance.pc.error === 100)
     }
   }
 

--- a/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -97,6 +97,7 @@ import com.normation.rudder.repository.CategoryWithActiveTechniques
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.Technique
 import scala.collection.SortedMap
+import com.normation.rudder.repository.ComplianceRepository
 
 
 /**
@@ -196,6 +197,12 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
     override def countChangesByRuleByInterval() = Empty
   }
 
+  lazy val dummyComplianceRepos = new ComplianceRepository() {
+    override def saveRunCompliance(reports: List[NodeStatusReport]): Box[List[NodeStatusReport]] = {
+      Full(reports)
+    }
+  }
+
   lazy val updateRuns = {
     new ReportsExecutionService(
         reportsRepo
@@ -203,6 +210,7 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
       , new LastProcessedReportRepositoryImpl(doobie)
       , dummyChangesCache
       , dummyComplianceCache
+      , dummyComplianceRepos
       , 1
     )
   }

--- a/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -828,7 +828,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
       nodeStatus.keySet.head === one and
-      nodeStatus.head._2.report.reports.head.compliance.pc_success === 100
+      nodeStatus.head._2.report.reports.head.compliance.pc.success === 100
     }
 
   }
@@ -857,7 +857,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
      nodeStatus.keySet.head === NodeId("nodeId") and
-     nodeStatus.head._2.report.reports.head.compliance.pc_success === 100
+     nodeStatus.head._2.report.reports.head.compliance.pc.success === 100
     }
   }
 
@@ -883,7 +883,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
      nodeStatus.keySet.head === NodeId("nodeId") and
-     nodeStatus.head._2.report.reports.head.compliance.pc_success === 100
+     nodeStatus.head._2.report.reports.head.compliance.pc.success === 100
     }
   }
 
@@ -912,11 +912,11 @@ class ExecutionBatchTest extends Specification {
     }
     "return a component with the /var/cfengine in NotApplicable " in {
       withGood.componentValues("/var/cfengine").messages.size === 1 and
-      withGood.componentValues("/var/cfengine").compliance.pc_notApplicable === 100
+      withGood.componentValues("/var/cfengine").compliance.pc.notApplicable === 100
     }
     "return a component with the bar key success " in {
       withGood.componentValues("bar").messages.size == 1 and
-      withGood.componentValues("bar").compliance.pc_success === 100
+      withGood.componentValues("bar").compliance.pc.success === 100
     }
   }
 

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -1508,6 +1508,7 @@ object RudderConfig extends Loggable {
   private[this] lazy val findExpectedRepo = new FindExpectedReportsJdbcRepository(doobie, pgIn)
   private[this] lazy val updateExpectedRepo = new UpdateExpectedReportsJdbcRepository(doobie, pgIn)
   private[this] lazy val reportsRepositoryImpl = new ReportsJdbcRepository(doobie)
+  private[this] lazy val complianceRepositoryImpl = new ComplianceJdbcRepository(doobie)
   private[this] lazy val dataSourceProvider = new RudderDatasourceProvider(RUDDER_JDBC_DRIVER, RUDDER_JDBC_URL, RUDDER_JDBC_USERNAME, RUDDER_JDBC_PASSWORD, RUDDER_JDBC_MAX_POOL_SIZE)
   private[this] lazy val doobie = new Doobie(dataSourceProvider.datasource)
   private[this] lazy val jdbcTemplate = {
@@ -1800,6 +1801,7 @@ object RudderConfig extends Loggable {
     , updatesEntryJdbcRepository
     , recentChangesService
     , reportingServiceImpl
+    , complianceRepositoryImpl
     , max
     )
   }

--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/compliance/ComplianceAPIData.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/compliance/ComplianceAPIData.scala
@@ -339,15 +339,15 @@ object JsonCompliance {
 
     //we want at most two decimals
     Map(
-        statusDisplayName(EnforceNotApplicable) -> c.pc_notApplicable
-      , statusDisplayName(EnforceSuccess) -> c.pc_success
-      , statusDisplayName(EnforceRepaired) -> c.pc_repaired
-      , statusDisplayName(EnforceError) -> c.pc_error
-      , statusDisplayName(Unexpected) -> c.pc_unexpected
-      , statusDisplayName(Missing) -> c.pc_missing
-      , statusDisplayName(NoAnswer) -> c.pc_noAnswer
-      , statusDisplayName(Disabled) -> c.pc_reportsDisabled
-      , statusDisplayName(Pending) -> c.pc_pending
+        statusDisplayName(EnforceNotApplicable) -> c.pc.notApplicable
+      , statusDisplayName(EnforceSuccess) -> c.pc.success
+      , statusDisplayName(EnforceRepaired) -> c.pc.repaired
+      , statusDisplayName(EnforceError) -> c.pc.error
+      , statusDisplayName(Unexpected) -> c.pc.unexpected
+      , statusDisplayName(Missing) -> c.pc.missing
+      , statusDisplayName(NoAnswer) -> c.pc.noAnswer
+      , statusDisplayName(Disabled) -> c.pc.reportsDisabled
+      , statusDisplayName(Pending) -> c.pc.pending
     ).filter { case(k, v) => v > 0 }.mapValues(percent => percent )
   }
 }

--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -258,7 +258,7 @@ class ReportDisplayer(
             ( "bg-warning text-warning"
             , <p>{nbAttention} reports below (out of {report.compliance.total} total reports) are not in Success, and may require attention."</p>
             )
-          } else if(report.compliance.pc_pending > 0) {
+          } else if(report.compliance.pc.pending > 0) {
             ("bg-info text-info", NodeSeq.Empty)
 
           } else {
@@ -330,7 +330,7 @@ class ReportDisplayer(
              * In these case, filter out "unexpected" reports to only
              * keep missing ones, and do not show the "compliance" row.
              */
-            val filtered = NodeStatusReport(report.forNode, report.runInfo, report.statusInfo, report.report.reports.flatMap { x =>
+            val filtered = NodeStatusReport(report.nodeId, report.runInfo, report.statusInfo, report.report.reports.flatMap { x =>
               x.withFilteredElements(
                   _ => true   //keep all (non empty) directives
                 , _ => true   //keep all (non empty) component values


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9645

This PR add the storage of the compliance by node by run in a new Postgres Table. 

The only interesting things are: 
- when we call the store action: in ReportsExecutionService, just after having updated the node compliance cache (we use the result, all calculus are done)
- the database structure. 

## Database structure

### column

There is a good description on the table declaration of field. Some more "what/why":

- nodeId, runTimestamp, nodeConfigId: what we are interested in to do queries. We would much likely want to get the last line by runTimestamp for a nodeId. 
- endOfLife: date after which the compliance is not valide anymore. If no new runs, it means the node doesn't send reports anymore. Perhaps the name is not that good, and "endDate" should be used. 
- runAnalysis: information about the run, the same that are used in the node details screen, on the colored header (but without information already in the 3 first columns). It does not contains the "expected node configuration", because 1/ it's huge, 2/ we can get it by looking to run status, and if the run had a configId, find back the expected config from theire 3/ we almost have all the information from the compliance appart in certain (hill) cases
- summary: compliance summary at the node level - to query only that on the future for node list or in debug
- details: the whole compliance details down to the rule/directive/component/value/message. It should be sufficient to any use case in the future (ie no information destroyed, everything is kept)

**Question**: should we add a dedicated column for nodeConfigId ? It seems rather useful, even if it may be null in pathological cases. 

### Compliance Values in percent - aggregated needed ?

In Scala, we store compliance level with a count of each type of reports (and of course we have the total with the sum of each kind). That allows to manipulate ints, which is better than double for rounding error :)
A chose to store the compliance level in percent + the total number of report because if data are not normalized, it will be impossible to do queries in the future like "give me all the directive with success < 50%". 

And **I'm wondering** if we should not go even further, and store in addition to the completely detailed version also aggregated result for success (ie report success + report compliant + repaired + n/a), non-compliant, error, etc - i.e all the top level status

### it is by node by run, not by node-rule by run or aggregated on several runs. 

Aggregation is much more complexe to achieve on a node level. It needs a "Delta" logic (ie what change between a snapshot point and following runs) to be efficient. All that should be done in a different store or different module. 

So why not just use a by run by node/rule/directive(/component) table? Because it would lead to much more redondancies in the first columns between lines, and many, many more lines. 
As an example, we have ~300 runs by node by day. Addind rule and directives, we add (low estimate) a x20 number of lines. Adding componenent, and it's (low estimation) a x100.  

And it felt more logical / consistent with other part of Rudder to have a by-run-by-node result.  

### disk size

The produce json for 12 directives, including systems (so some with a large number of components), is around 75kB. 

The corresponding stored json seems to amortize toward 2.5kB - Postgres is compressing like hell :)
With that value, we get ~700MB of data by day for 1000 nodes. 

Using the JSON type format doesn't change AT ALL the disk size (certainly because postgres store json as text, only checking it's valid json). 
Using JSONB would improve the space taken, but it's only on Postgres 9.5 and up. 

