### PR TITLE
Fixes #9724: Query HTTP datasource

### DIFF
--- a/rudder-core/pom.xml
+++ b/rudder-core/pom.xml
@@ -125,6 +125,39 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <version>0.2.4</version>
       <scope>test</scope>
     </dependency>
+    
+    <!-- Doing HTTP requests -->
+    <!-- rapture dev seems to have stop -->
+    <dependency>
+      <groupId>org.scalaj</groupId>
+      <artifactId>scalaj-http_${scala-binary-version}</artifactId>
+      <version>2.3.0</version>
+    </dependency> 
+    <dependency>
+      <groupId>org.http4s</groupId>
+      <artifactId>http4s-dsl_${scala-binary-version}</artifactId>
+      <version>0.8.6</version>
+      <scope>test</scope>
+    </dependency> 
+    <dependency>
+      <groupId>org.http4s</groupId>
+      <artifactId>http4s-blazeserver_${scala-binary-version}</artifactId>
+      <version>0.8.6</version>
+      <scope>test</scope>
+    </dependency> 
+    <dependency>
+      <groupId>io.monix</groupId>
+      <artifactId>monix_${scala-binary-version}</artifactId>
+      <version>2.1.1</version>
+    </dependency>
+
+    
+    <!-- selecting sub-json -->
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <version>2.2.0</version>
+    </dependency>
 
     <!-- pool connection: https://github.com/brettwooldridge/HikariCP -->
     <!-- http://blog.trustiv.co.uk/2014/06/battle-connection-pools -->

--- a/rudder-core/src/main/scala/com/normation/rudder/datasources/DataSourceLogger.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/datasources/DataSourceLogger.scala
@@ -4,7 +4,7 @@
 *************************************************************************************
 *
 * This file is part of Rudder.
-* 
+*
 * Rudder is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
@@ -35,7 +35,7 @@
 *************************************************************************************
 */
 
-package com.normation.rudder.domain.logger
+package com.normation.rudder.datasources
 
 import org.slf4j.LoggerFactory
 import net.liftweb.common.Logger
@@ -43,6 +43,10 @@ import net.liftweb.common.Logger
 /**
  * Applicative log of interest for Rudder ops.
  */
-object ApplicationLogger extends Logger {
-  override protected def _logger = LoggerFactory.getLogger("application")
+object DataSourceLogger extends Logger {
+  override protected def _logger = LoggerFactory.getLogger("datasources")
+}
+
+object DataSourceTimingLogger extends Logger {
+  override protected def _logger = LoggerFactory.getLogger("datasources-timing")
 }

--- a/rudder-core/src/main/scala/com/normation/rudder/datasources/DataSourceRepository.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/datasources/DataSourceRepository.scala
@@ -38,6 +38,26 @@
 package com.normation.rudder.datasources
 
 import net.liftweb.common.Box
+import ch.qos.logback.core.db.DataSourceConnectionSource
+import com.normation.eventlog.EventActor
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.nodes.NodeInfo
+import org.joda.time.DateTime
+import net.liftweb.common.EmptyBox
+import net.liftweb.common.Full
+import com.normation.rudder.domain.parameters.Parameter
+import com.normation.utils.StringUuidGenerator
+import com.normation.eventlog.ModificationId
+import com.normation.rudder.domain.eventlog._
+import scala.concurrent.duration._
+import net.liftweb.common.Failure
+
+
+final case class PartialNodeUpdate(
+    nodes        : Map[NodeId, NodeInfo] //the node to update
+  , policyServers: Map[NodeId, NodeInfo] //there policy servers
+  , parameters   : Set[Parameter]
+)
 
 trait DataSourceRepository {
 
@@ -49,3 +69,211 @@ trait DataSourceRepository {
 
   def delete(id : DataSourceId) : Box[DataSource]
 }
+
+/*
+ * A trait that exposes interactive callbacks for
+ * data sources, i.e the method to call when one
+ * need to update datasources.
+ */
+trait DataSourceUpdateCallbacks {
+
+  def onNewNode(node: NodeId): Unit
+  def onGenerationStarted(generationTimeStamp: DateTime): Unit
+  def onUserAskUpdateAll(actor: EventActor): Unit
+  def onUserAskUpdateNode(actor: EventActor, nodeId: NodeId): Unit
+
+  /*
+   * Initialise all datasource so that they are ready to schedule their
+   * first data fetch or wait for other callbacks.
+   *
+   * Non periodic data source won't be updated with that call.
+   * Periodic one will be updated in a random interval between
+   * 1 minute and min(period / 2, 30 minute) to avoid to extenghish
+   * all resources on them.
+   */
+  def startAll(): Unit
+}
+
+class MemoryDataSourceRepository extends DataSourceRepository {
+
+  private[this] var sources : Map[DataSourceId,DataSource] = Map()
+
+  def getAll() = synchronized(Full(sources))
+
+  def get(id : DataSourceId) : Box[Option[DataSource]]= synchronized(Full(sources.get(id)))
+
+  def save(source : DataSource) = synchronized {
+    sources = sources +  ((source.id,source))
+    Full(source)
+  }
+
+  def delete(id : DataSourceId) : Box[DataSource] = synchronized {
+    sources.get(id) match {
+      case Some(source) =>
+        sources = sources - (id)
+        Full(source)
+      case None =>
+        Failure(s"Data source '${id}' does not exists, and thus can't be deleted")
+    }
+  }
+}
+/**
+ * This is the higher level repository facade that is managine the "live"
+ * instance of datasources, with the scheduling initialisation and update
+ * on different repository action.
+ *
+ * It doesn't deal at all with the serialisation / deserialisation of data source
+ * in data base.
+ */
+class DataSourceRepoImpl(
+    backend: DataSourceRepository
+  , fetch  : QueryDataSourceService
+  , uuidGen: StringUuidGenerator
+) extends DataSourceRepository with DataSourceUpdateCallbacks {
+
+  private[this] var datasources = Map[DataSourceId, DataSourceScheduler]()
+
+  // utility methods on datasources
+  // stop a datasource - must be called when the datasource still in "datasources"
+  private[this] def stop(id: DataSourceId) = datasources.get(id).foreach( _.cancel() )
+  // get datasource scheduler which match the condition
+  private[this] def foreachDatasourceScheduler(condition: DataSource => Boolean)(action: DataSourceScheduler => Unit): Unit = {
+    datasources.filter { case(_, dss) => condition(dss.datasource) }.foreach { case (_, dss) => action(dss) }
+  }
+  private[this] def updateDataSourceScheduler(source: DataSource, delay: Option[FiniteDuration]): Unit = {
+    //need to cancel if one exists
+    stop(source.id)
+    // create live instance
+    import monix.execution.Scheduler.Implicits.global
+    val dss = new DataSourceScheduler(
+          source
+        , global
+        , () => ModificationId(uuidGen.newUuid)
+        , (cause: UpdateCause) => fetch.queryAll(source, cause)
+    )
+    datasources = datasources + (source.id -> dss)
+    //start new
+    delay match {
+      case None    => dss.start()
+      case Some(d) => dss.startWithDelay(d)
+    }
+  }
+
+  ///
+  ///         DB READ ONLY
+  /// read only method are just forwarder to backend
+  ///
+  override def getAll : Box[Map[DataSourceId,DataSource]] = {
+    DataSourceLogger.info(s"Live data sources: ${datasources.map(_._2.datasource.name.value).mkString("; ")}")
+    backend.getAll
+  }
+  override def get(id : DataSourceId) : Box[Option[DataSource]] = backend.get(id)
+
+  ///
+  ///         DB WRITE ONLY
+  /// write methods need to manage the "live" scheduler
+  /// write methods need to be synchronised to keep consistancy in
+  /// "live" scheduler and avoid a missed add in a doube save for ex.
+  ///
+
+  /*
+   * on update, we need to stop the corresponding optionnaly existing
+   * scheduler, and update with the new one.
+   */
+  override def save(source : DataSource) : Box[DataSource] = synchronized {
+    //only create/update the "live" instance if the backend succeed
+    backend.save(source) match {
+      case eb: EmptyBox =>
+        val msg = (eb ?~! s"Error when saving data source '${source.name.value}' (${source.id.value})").messageChain
+        DataSourceLogger.error(msg)
+        eb
+      case Full(s)      =>
+        updateDataSourceScheduler(source, delay = None)
+        DataSourceLogger.debug(s"Data source '${source.name.value}' (${source.id.value}) udpated")
+        Full(s)
+    }
+  }
+
+  /*
+   * delete need to clean existing live resource
+   */
+  override def delete(id : DataSourceId) : Box[DataSource] = synchronized {
+    //start by cleaning
+    stop(id)
+    datasources = datasources - (id)
+    backend.delete(id)
+  }
+
+  ///
+  ///        CALLBACKS
+  ///
+
+  // no need to synchronize callback, they only
+  // need a reference to the immutable datasources map.
+
+  override def onNewNode(nodeId: NodeId): Unit = {
+    DataSourceLogger.info(s"Fetching data from data source for new node '${nodeId}'")
+    foreachDatasourceScheduler(ds => ds.enabled && ds.runParam.onNewNode){ dss =>
+      val msg = s"Fetching data for data source ${dss.datasource.name.value} (${dss.datasource.id.value}) for new node '${nodeId.value}'"
+      DataSourceLogger.debug(msg)
+      //no scheduler reset for new node
+      fetch.queryOne(dss.datasource, nodeId, UpdateCause(
+          ModificationId(uuidGen.newUuid)
+        , RudderEventActor
+        , Some(msg)
+      ))
+    }
+  }
+
+  override def onGenerationStarted(generationTimeStamp: DateTime): Unit = {
+    DataSourceLogger.info(s"Fetching data from data source for all node for generation ${generationTimeStamp.toString()}")
+    foreachDatasourceScheduler(ds => ds.enabled && ds.runParam.onGeneration){ dss =>
+      //for that one, do a scheduler restart
+      val msg = s"Getting data for source ${dss.datasource.name.value} for policy generation started at ${generationTimeStamp.toString()}"
+      DataSourceLogger.debug(msg)
+      dss.doActionAndSchedule(fetch.queryAll(dss.datasource, UpdateCause(ModificationId(uuidGen.newUuid), RudderEventActor, Some(msg))
+      ))
+    }
+  }
+
+  override def onUserAskUpdateAll(actor: EventActor): Unit = {
+    DataSourceLogger.info(s"Fetching data from data source for all node because ${actor.name} asked for it")
+    foreachDatasourceScheduler(ds => ds.enabled){ dss =>
+      //for that one, do a scheduler restart
+      val msg = s"Refreshing data from data source ${dss.datasource.name.value} on user ${actor.name} request"
+      DataSourceLogger.debug(msg)
+      dss.doActionAndSchedule(fetch.queryAll(dss.datasource, UpdateCause(ModificationId(uuidGen.newUuid), actor, Some(msg))
+      ))
+    }
+  }
+
+  override def onUserAskUpdateNode(actor: EventActor, nodeId: NodeId): Unit = {
+    DataSourceLogger.info(s"Fetching data from data source for node '${nodeId.value}' because '${actor.name}' asked for it")
+    foreachDatasourceScheduler(ds => ds.enabled){ dss =>
+      //for that one, no scheduler restart
+      val msg = s"Fetching data for data source ${dss.datasource.name.value} (${dss.datasource.id.value}) for node '${nodeId.value}' on user '${actor.name}' request"
+      DataSourceLogger.debug(msg)
+      fetch.queryOne(dss.datasource, nodeId, UpdateCause(ModificationId(uuidGen.newUuid), RudderEventActor, Some(msg)))
+    }
+  }
+
+
+  override def startAll() = {
+    //sort by period (the least frequent the last),
+    //then start them every minutes
+    val toStart = datasources.values.flatMap { dss =>
+      dss.datasource.runParam.schedule match {
+        case Scheduled(d) => Some((d, dss))
+        case _            => None
+      }
+    }.toList.sortBy( _._1.toMillis ).zipWithIndex
+
+    toStart.foreach { case ((period, dss), i) =>
+      dss.startWithDelay((i+1).minutes)
+    }
+  }
+
+}
+
+
+

--- a/rudder-core/src/main/scala/com/normation/rudder/datasources/DataSourceScheduler.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/datasources/DataSourceScheduler.scala
@@ -1,0 +1,180 @@
+/*
+*************************************************************************************
+* Copyright 2016 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.datasources
+
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.repository.RoParameterRepository
+
+import com.normation.rudder.domain.eventlog._
+
+import net.liftweb.common.Box
+import com.normation.rudder.services.nodes.NodeInfoService
+import com.normation.rudder.repository.WoNodeRepository
+import com.normation.rudder.services.policies.InterpolatedValueCompiler
+import com.normation.utils.Control
+import net.liftweb.common.Failure
+import com.normation.rudder.domain.parameters.Parameter
+import net.liftweb.common.Full
+import com.normation.rudder.domain.nodes.CompareProperties
+import com.normation.eventlog.EventActor
+import com.normation.eventlog.ModificationId
+import monix.eval.Task
+import monix.execution.Scheduler
+import scala.concurrent.Await
+import com.normation.rudder.domain.nodes.NodeInfo
+import net.liftweb.common.Empty
+import monix.execution.Cancelable
+import scala.util.control.NonFatal
+import org.joda.time.DateTime
+import monix.reactive.Observable
+import net.liftweb.common.Loggable
+import scala.concurrent.duration.FiniteDuration
+
+
+
+
+final case class UpdateCause(modId: ModificationId, actor:EventActor, reason:Option[String])
+
+/**
+ * This object represent a statefull scheduler for fetching (or whatever action)
+ * data from datasource.
+ * Its contract is that:
+ * - data source is immutable for that scheduler
+ * - action is call periodically accordingly to data source period
+ * - the scheduler is initially STOPPED. It can be start with the start() method.
+ * - the scheduler can be stopped (when already stopped, it's a noop) with the cancel() method.
+ * - there is callback that should be call each time a node is added / a generation is
+ *   started - the data source configuration will decide is something is to done or not.
+ */
+class DataSourceScheduler(
+             val datasource: DataSource
+  , implicit val scheduler : Scheduler
+  ,              newUuid   : ()          => ModificationId
+  ,              updateAll : UpdateCause => Unit
+) extends Loggable {
+
+  /**
+   * So, the idea is to build an observable that tick every period (if period defined)
+   * We start it when the datasource is initialized, and stop it/start it around
+   * each user-triggered event like "on new node".
+   *
+   * At each tick, we fetch data.
+   */
+
+  //for that datasource, this is the timer
+  private[this] val source = (datasource.runParam.schedule match {
+      case Scheduled(d)  =>
+        if(datasource.enabled) {
+          Observable.interval(d)
+        } else {
+          Observable.empty[Long]
+        }
+      case NoSchedule(_) => //in that case, our source does produce anything
+        Observable.empty[Long]
+    }
+  //and now, map the actual behavior to produce at each tick
+  ).mapAsync { tick =>
+    Task{
+      val msg = s"Automatically fetching data for data source '${datasource.name.value}' (${datasource.id.value})"
+      DataSourceLogger.info(msg)
+      updateAll(UpdateCause(newUuid(), RudderEventActor, Some(msg)))
+    }
+  }
+  // we add an auto restart in case a getData lead to an error
+  .onErrorRestart(5)
+
+  // here is the place where we will store the currently
+  // running time, so that we are able the stop it and restart
+  // it on user action.
+  private[this] var scheduledTask = Option.empty[Cancelable]
+
+
+  /*
+   * alias for restartScheduleTask
+   */
+  def start() = restartScheduleTask
+
+  /*
+   * start scheduling after given delay
+   * (so that the first action is actually done after that delay)
+   */
+  def startWithDelay(delay: FiniteDuration): Unit = {
+    Task(start()).delayExecution(delay).runAsync
+  }
+
+  /*
+   * This is the main interesting method, seting
+   * things up for schedule
+   */
+  def restartScheduleTask(): Unit = {
+    // clean existing
+    cancel()
+    // actually start the scheduler by subscribing to it
+    if(datasource.enabled) {
+      scheduledTask = Some(source.subscribe())
+    }
+  }
+
+  // the cancel method just stop the current time if
+  // exists, and clean things up
+  def cancel() : Unit = {
+    scheduledTask.foreach( _.cancel() )
+    scheduledTask = None
+  }
+
+  /**
+   * This is the method that actually do a fetch data and manage
+   * the scheduler restart.
+   * We must avoid exceptions.
+   */
+  def doActionAndSchedule(action: => Unit): Unit = {
+    cancel()
+    try {
+      Task(action).runAsync
+    } catch {
+      case NonFatal(ex) => logger.error(s"Error when fetching data", ex)
+    } finally {
+      datasource.runParam.schedule match {
+        case Scheduled(p)  => startWithDelay(p)
+        case NoSchedule(p) => //nothing
+      }
+    }
+  }
+
+}
+

--- a/rudder-core/src/main/scala/com/normation/rudder/datasources/DataSourceService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/datasources/DataSourceService.scala
@@ -1,0 +1,257 @@
+/*
+*************************************************************************************
+* Copyright 2016 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.datasources
+
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.repository.RoParameterRepository
+
+import net.liftweb.common.Box
+import com.normation.rudder.services.nodes.NodeInfoService
+import com.normation.rudder.repository.WoNodeRepository
+import com.normation.rudder.services.policies.InterpolatedValueCompiler
+import com.normation.utils.Control
+import net.liftweb.common.Failure
+import com.normation.rudder.domain.parameters.Parameter
+import net.liftweb.common.Full
+import com.normation.rudder.domain.nodes.CompareProperties
+import com.normation.eventlog.EventActor
+import com.normation.eventlog.ModificationId
+import monix.eval.Task
+import monix.execution.Scheduler
+import scala.concurrent.Await
+import com.normation.rudder.domain.nodes.NodeInfo
+import net.liftweb.common.Empty
+import net.liftweb.common.EmptyBox
+
+/*
+ * This file contain the hight level logic to update
+ * datasources by name:
+ * - get the datasource by name,
+ * - get the list of nodes to udpate and there context,
+ * - update all nodes
+ * - (event log are generated because we are just changing node properties,
+ *   so same behaviour)
+ */
+trait QueryDataSourceService {
+  /**
+   * Here, we query the provided datasource and update
+   * all the node with the correct logic.
+   *
+   * An other service is in charge to retrieve the datasource by
+   * name, and correctly handle the case where the datasource was
+   * deleted.
+   */
+  def queryAll(datasource: DataSource, cause: UpdateCause): Box[Set[NodeId]]
+
+  /**
+   * A version that use provided nodeinfo / parameters to only query a subpart of nodes
+   */
+  def querySubset(datasource: DataSource, info: PartialNodeUpdate, cause: UpdateCause): Box[Set[NodeId]]
+
+  /**
+   * A version that only query one node - do not use if you want to query several nodes
+   */
+  def queryOne(datasource: DataSource, nodeId: NodeId, cause: UpdateCause): Box[NodeId]
+}
+
+
+
+class HttpQueryDataSourceService(
+    nodeInfo        : NodeInfoService
+  , parameterRepo   : RoParameterRepository
+  , nodeRepository  : WoNodeRepository
+  , interpolCompiler: InterpolatedValueCompiler
+) extends QueryDataSourceService {
+
+  val getHttp = new GetDataset(interpolCompiler)
+
+  /*
+   * We need a scheduler tailored for I/O, we are mostly doing http requests and
+   * database things here
+   */
+  import monix.execution.schedulers.ExecutionModel
+  implicit lazy val scheduler = Scheduler.io(executionModel = ExecutionModel.AlwaysAsyncExecution)
+
+  override def queryAll(datasource: DataSource, cause: UpdateCause): Box[Set[NodeId]] = {
+    query[Set[NodeId]]("fetch data for all node", datasource, cause
+        , (d:HttpDataSourceType) => queryAllByNode(datasource.name, d, cause)
+        , (d:HttpDataSourceType) => queryAllByNode(datasource.name, d, cause)
+        , s"All nodes data updated from data source '${datasource.name.value}' (${datasource.id.value})"
+        , s"Error when fetching data from data source '${datasource.name.value}' (${datasource.id.value}) for all nodes"
+    )
+  }
+
+  override def querySubset(datasource: DataSource, info: PartialNodeUpdate, cause: UpdateCause): Box[Set[NodeId]] = {
+    query[Set[NodeId]](s"fetch data for a set of ${info.nodes.size}", datasource, cause
+        , (d:HttpDataSourceType) => querySubsetByNode(datasource.name, d, info, cause)
+        , (d:HttpDataSourceType) => querySubsetByNode(datasource.name, d, info, cause)
+        , s"Requested nodes data updated from data source '${datasource.name.value}' (${datasource.id.value})"
+        , s"Error when fetching data from data source '${datasource.name.value}' (${datasource.id.value}) for requested nodes"
+    )
+  }
+
+  override def queryOne(datasource: DataSource, nodeId: NodeId, cause: UpdateCause): Box[NodeId] = {
+    query[NodeId](s"fetch data for node '${nodeId.value}'", datasource, cause
+        , (d:HttpDataSourceType) => queryNodeByNode(datasource.name, d, nodeId, cause)
+        , (d:HttpDataSourceType) => queryNodeByNode(datasource.name, d, nodeId, cause)
+        , s"Data for node '${nodeId.value}' updated from data source '${datasource.name.value}' (${datasource.id.value})"
+        , s"Error when fetching data from data source '${datasource.name.value}' (${datasource.id.value}) for node '${nodeId.value}'"
+    )
+  }
+
+  private[this] def query[T](
+      actionName: String
+    , datasource: DataSource
+    , cause     : UpdateCause
+    , oneByOne  : HttpDataSourceType => Box[T]
+    , allInOne  : HttpDataSourceType => Box[T]
+    , successMsg: String
+    , errorMsg  : String
+  ): Box[T] = {
+    // We need to special case by type of datasource
+    val time_0 = System.currentTimeMillis
+    val res = datasource.sourceType match {
+      case t:HttpDataSourceType =>
+        (t.requestMode match {
+          case OneRequestByNode                        => oneByOne
+          case OneRequestAllNodes(path, nodeAttribute) => allInOne
+        })(t)
+    }
+    DataSourceTimingLogger.debug(s"[${System.currentTimeMillis-time_0} ms] '${actionName}' for data source '${datasource.name.value}' (${datasource.id.value})")
+    res match {
+      case eb: EmptyBox =>
+        val e = (eb ?~! errorMsg)
+        DataSourceLogger.error(e.messageChain)
+        e.rootExceptionCause.foreach(ex =>
+          DataSourceLogger.error("Exception was:", ex)
+        )
+      case _ =>
+        DataSourceLogger.trace(successMsg)
+    }
+    res
+  }
+
+
+  private[this] def buildOneNodeTask(
+      datasourceName: DataSourceName
+    , datasource    : HttpDataSourceType
+    , nodeInfo      : NodeInfo
+    , policyServers : Map[NodeId, NodeInfo]
+    , parameters    : Set[Parameter]
+    , cause         : UpdateCause
+  ): Task[Box[NodeId]] = {
+    Task(
+      (for {
+        policyServer <- (policyServers.get(nodeInfo.policyServerId) match {
+                          case None    => Failure(s"PolicyServer with ID '${nodeInfo.policyServerId.value}' was not found for node '${nodeInfo.hostname}' ('${nodeInfo.id.value}'). Abort.")
+                          case Some(p) => Full(p)
+                        })
+                        //connection timeout: 5s ; getdata timeout: freq ?
+        property     <- getHttp.getNode(datasourceName, datasource, nodeInfo, policyServer, parameters, datasource.requestTimeOut, datasource.requestTimeOut)
+        newNode      =  nodeInfo.node.copy(properties = CompareProperties.updateProperties(nodeInfo.properties, Some(Seq(property))))
+        nodeUpdated  <- nodeRepository.updateNode(newNode, cause.modId, cause.actor, cause.reason) ?~! s"Cannot save value for node '${nodeInfo.id.value}' for property '${property.name}'"
+      } yield {
+        nodeUpdated.id
+      }) match {
+        case Failure(msg, x, y) => Failure(s"Error when getting data from datasource '${datasourceName.value}' for node ${nodeInfo.hostname} (${nodeInfo.id.value}): ${msg}", x, y)
+        case x                  => x
+      }
+    )
+  }
+
+  def querySubsetByNode(datasourceName: DataSourceName, datasource: HttpDataSourceType, info: PartialNodeUpdate, cause: UpdateCause)(implicit scheduler: Scheduler): Box[Set[NodeId]] = {
+    import scala.concurrent.duration._
+    import net.liftweb.util.Helpers.tryo
+    import com.normation.utils.Control.bestEffort
+
+    def tasks(nodes: Map[NodeId, NodeInfo], policyServers: Map[NodeId, NodeInfo], parameters: Set[Parameter]): Task[List[Box[NodeId]]] = {
+      Task.gatherUnordered(nodes.values.map { nodeInfo =>
+        buildOneNodeTask(datasourceName, datasource, nodeInfo, policyServers, parameters, cause)
+      })
+    }
+
+    // give a timeout for the whole tasks sufficiently large, but that won't overlap too much on following runs
+    val timeout = datasource.requestTimeOut
+
+    for {
+      updated       <- tryo(Await.result(tasks(info.nodes, info.policyServers, info.parameters).runAsync, timeout))
+      gatherErrors  <- compactFailure(bestEffort(updated)(identity).map( _.toSet ))
+    } yield {
+      gatherErrors
+    }
+  }
+
+  def queryAllByNode(datasourceName: DataSourceName, datasource: HttpDataSourceType, cause: UpdateCause)(implicit scheduler: Scheduler): Box[Set[NodeId]] = {
+    for {
+      nodes         <- nodeInfo.getAll()
+      policyServers  = nodes.filter { case (_, n) => n.isPolicyServer }
+      parameters    <- parameterRepo.getAllGlobalParameters.map( _.toSet[Parameter] )
+      updated       <- querySubsetByNode(datasourceName, datasource, PartialNodeUpdate(nodes, policyServers, parameters), cause)
+    } yield {
+      updated
+    }
+  }
+
+  def queryNodeByNode(datasourceName: DataSourceName, datasource: HttpDataSourceType, nodeId: NodeId, cause: UpdateCause)(implicit scheduler: Scheduler): Box[NodeId] = {
+    import net.liftweb.util.Helpers.tryo
+    for {
+      allNodes      <- nodeInfo.getAll()
+      node          <- allNodes.get(nodeId) match {
+                         case None => Failure(s"The node with id '${nodeId.value}' was not found")
+                         case Some(n) => Full(n)
+                       }
+      policyServers  = allNodes.filterKeys( _ == node.policyServerId)
+      parameters    <- parameterRepo.getAllGlobalParameters.map( _.toSet[Parameter] )
+      updated       <- tryo(Await.result(buildOneNodeTask(datasourceName, datasource, node, policyServers, parameters, cause).runAsync, datasource.requestTimeOut))
+      result        <- updated
+    } yield {
+      result
+    }
+  }
+
+  // compact format a Failure(msg1, Failure(msg2, ...)) in to a Failure("msg1; msg2")
+  private[this] def compactFailure[T](b: Box[T]): Box[T] = {
+    b match {
+      case f:Failure =>
+        Failure(f.messageChain.replaceAll("<-", ";"), f.rootExceptionCause, Empty)
+      case x => x
+    }
+  }
+
+}
+

--- a/rudder-core/src/main/scala/com/normation/rudder/datasources/UpdateHttpDataset.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/datasources/UpdateHttpDataset.scala
@@ -1,0 +1,277 @@
+/*
+*************************************************************************************
+* Copyright 2016 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.datasources
+
+import scala.collection.immutable.TreeMap
+import scala.concurrent.duration.Duration
+import scala.util.control.NonFatal
+
+import com.jayway.jsonpath.Configuration
+import com.jayway.jsonpath.DocumentContext
+import com.jayway.jsonpath.JsonPath
+import com.normation.cfclerk.domain.Variable
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.nodes.NodeInfo
+import com.normation.rudder.domain.nodes.NodeProperty
+import com.normation.rudder.domain.parameters.Parameter
+import com.normation.rudder.domain.parameters.ParameterName
+import com.normation.rudder.services.policies.InterpolatedValueCompiler
+import com.normation.rudder.services.policies.InterpolationContext
+import com.normation.utils.Control._
+
+import net.liftweb.common.Box
+import net.liftweb.common.Empty
+import net.liftweb.common.Failure
+import net.liftweb.common.Full
+import net.liftweb.util.Helpers.tryo
+import net.minidev.json.JSONArray
+import net.minidev.json.JSONAware
+import net.minidev.json.JSONValue
+import scalaj.http.Http
+import scalaj.http.HttpOptions
+import scalaz._
+import scalaz.concurrent.Task
+
+/*
+ * This file contain the logic to update dataset from an
+ * HTTP Datasource.
+ * More specifically, it allows to:
+ * - query a node endpoint using node specific properties,
+ * - select a sub-json,
+ * - save it in the node properties.
+ */
+
+
+/*
+ * The whole service:
+ * - from a datasource and node context,
+ * - get the node datasource URL,
+ * - query it,
+ * - parse the json result,
+ * - return a rudder property with the content.
+ */
+class GetDataset(valueCompiler: InterpolatedValueCompiler) {
+
+  val compiler = new InterpolateNode(valueCompiler)
+
+  def getNode(datasourceName: DataSourceName, datasource: HttpDataSourceType, node: NodeInfo, policyServer: NodeInfo, parameters: Set[Parameter], connectionTimeout: Duration, readTimeOut: Duration): Box[NodeProperty] = {
+    for {
+      p          <- sequence(parameters.toSeq)(compiler.compileParameters) ?~! "Error when transforming Rudder Parameter for variable interpolation"
+      parameters =  p.toMap
+      url        <- compiler.compileInput(datasource.url, node, policyServer, parameters) ?~! s"Error when trying to parse URL ${datasource.url}"
+      path       <- compiler.compileInput(datasource.path, node, policyServer, parameters) ?~! s"Error when trying to compile JSON path ${datasource.path}"
+      time_0     =  System.currentTimeMillis
+      body       <- QueryHttp.GET(url, datasource.headers, datasource.sslCheck, connectionTimeout, readTimeOut) ?~! s"Error when fetching data from ${url}"
+      _          =  DataSourceTimingLogger.trace(s"[${System.currentTimeMillis - time_0} ms] node '${node.id.value}': GET ${url} // ${path}")
+      json       <- JsonSelect.fromPath(path, body) ?~! s"Error when extracting sub-json at path ${path} from ${body}"
+    } yield {
+      //we only get the first element from the path.
+      //if list is empty, return "" (remove property).
+      NodeProperty(datasourceName.value, json.headOption.getOrElse(""))
+    }
+  }
+
+
+  /**
+   * Get information for many nodes.
+   * Policy servers for each node must be in the map.
+   */
+  def getMany(datasource: DataSource, nodes: Seq[NodeId], policyServers: Map[NodeId, NodeInfo], parameters: Set[Parameter]): Box[Task[Box[NodeProperty]]] = {
+    ???
+  }
+
+}
+
+
+/*
+ * Timeout are given in Milleseconds
+ */
+object QueryHttp {
+
+  /*
+   * Simple synchronous http get, return the response
+   * body as a string.
+   */
+  def GET(url: String, headers: Map[String, String], checkSsl: Boolean, connectionTimeout: Duration, readTimeOut: Duration): Box[String] = {
+    val options = (
+        HttpOptions.connTimeout(connectionTimeout.toMillis.toInt)
+     :: HttpOptions.readTimeout(readTimeOut.toMillis.toInt)
+     :: (if(checkSsl) {
+          Nil
+        } else {
+          HttpOptions.allowUnsafeSSL :: Nil
+        })
+    )
+
+    val client = Http(url).headers(headers).options(options)
+
+    for {
+      response <- tryo { client.asString }
+      result   <- if(response.isSuccess) {
+                    Full(response.body)
+                  } else {
+                    Failure(s"Failure updating datasource with URL '${url}': code ${response.code}: ${response.body}")
+                  }
+    } yield {
+      result
+    }
+  }
+}
+
+
+/**
+ * A little service that allows the interpolation of a
+ * string with node properties given all the relevant context:
+ * - the node and its policy server infos,
+ * - rudder global parameters
+ */
+class InterpolateNode(compiler: InterpolatedValueCompiler) {
+
+  def compileParameters(parameter: Parameter): Box[(ParameterName, InterpolationContext => Box[String])] = {
+    compiler.compile(parameter.value).map(v => (parameter.name, v))
+  }
+
+  def compileInput(input: String, node: NodeInfo, policyServer: NodeInfo, parameters: Map[ParameterName, InterpolationContext => Box[String]]): Box[String] = {
+
+    //build interpolation context from node:
+    val context = InterpolationContext(node, policyServer, TreeMap[String, Variable](), parameters, 5)
+
+    for {
+      compiled <- compiler.compile(input)
+      bounded  <- compiled(context)
+    } yield {
+      bounded
+    }
+  }
+}
+
+/**
+ * Service that allows to find sub-part of JSON matching a JSON
+ * path as defined in: http://goessner.net/articles/JsonPath/
+ */
+object JsonSelect {
+
+  /*
+   * Configuration for json path:
+   * - always return list,
+   * - We don't want "SUPPRESS_EXCEPTIONS" because null are returned
+   *   in place => better to Box it.
+   * - We don't want ALWAYS_RETURN_LIST, because it blindly add an array
+   *   around the value, even if the value is already an array.
+   */
+  val config = Configuration.builder.build()
+
+  /*
+   * Return the selection corresponding to path from the string.
+   * Fails on bad json or bad path.
+   *
+   * Always return a list with normalized outputs regarding
+   * arrays and string quotation, see JsonPathTest for details.
+   *
+   * The list may be empty if 0 node matches the results.
+   */
+  def fromPath(path: String, json: String): Box[List[String]] = {
+    for {
+      p <- compilePath(path)
+      j <- parse(json)
+      r <- select(p, j)
+    } yield {
+      r
+    }
+  }
+
+  ///                                                       ///
+  /// implementation logic - protected visibility for tests ///
+  ///                                                       ///
+
+  protected[datasources] def parse(json: String): Box[DocumentContext] = {
+    tryo(JsonPath.using(config).parse(json))
+  }
+
+  /*
+   * Some remarks:
+   * - just a name "foo" is interpreted as "$.foo"
+   */
+  protected[datasources] def compilePath(path: String): Box[JsonPath] = {
+    tryo(JsonPath.compile(path))
+  }
+
+  /*
+   * not exposed to user due to risk to not use the correct config
+   */
+  protected[datasources] def select(path: JsonPath, json: DocumentContext): Box[List[String]] = {
+
+
+    // so, this lib seems to be a whole can of unconsistancies on String quoting.
+    // we would like to NEVER have quoted string if they are not in a JSON object
+    // but to have them quoted in json object.
+    def toJsonString(a: Any): String = {
+      a match {
+        case s: String => s
+        case x         => JSONValue.toJSONString(x)
+      }
+    }
+
+    // I didn't find any other way to do that:
+    // - trying to parse as Any, then find back the correct JSON type
+    //   lead to a mess of quoted strings
+    // - just parsing as JSONAware fails on string, int, etc.
+
+    import scala.collection.JavaConverters.asScalaBufferConverter
+
+    for {
+      jsonValue <- try {
+                     Full(json.read[JSONAware](path))
+                   } catch {
+                     case ex: ClassCastException =>
+                       try {
+                         Full(json.read[Any](path).toString)
+                       } catch {
+                         case NonFatal(ex2) => Failure(s"Error when trying to get path '${path.getPath}': ${ex.getMessage}", Full(ex), Empty)
+                       }
+                     case NonFatal(ex) => Failure(s"Error when trying to get path '${path.getPath}': ${ex.getMessage}", Full(ex), Empty)
+                   }
+    } yield {
+      jsonValue match {
+        case x:JSONArray  => x.asScala.toList.map(toJsonString)
+        case x            => toJsonString(x) :: Nil
+      }
+    }
+  }
+
+}

--- a/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
@@ -77,6 +77,12 @@ object Doobie {
     case -\/(e) => Failure(e.getMessage, Full(e), Empty)
     case \/-(a) => Full(a)
   }
+  implicit class XorToBox[A](res: \/[Throwable, A]) {
+    def box = res match {
+      case -\/(e) => Failure(e.getMessage, Full(e), Empty)
+      case \/-(a) => Full(a)
+    }
+  }
 
   /*
    * Doobie is missing a Query0 builder, so here is simple one.

--- a/rudder-core/src/main/scala/com/normation/rudder/hooks/RunHooks.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/hooks/RunHooks.scala
@@ -198,7 +198,6 @@ object RunHooks {
             HooksLogger.debug(s"Ignoring hook '${f.getAbsolutePath}' because it is not executable. Check permission?")
             None
           }
-        case _ => None
       } }.sorted // sort them alphanumericaly
       Hooks(basePath, files)
      }

--- a/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
@@ -89,6 +89,7 @@ import com.normation.rudder.services.queries.QueryProcessor
 import com.unboundid.ldif.LDIFChangeRecord
 import com.normation.utils.Control.sequence
 import com.normation.utils.Control.bestEffort
+import com.normation.rudder.datasources.DataSourceUpdateCallbacks
 
 /**
  * A trait to manage the acceptation of new node in Rudder
@@ -147,6 +148,7 @@ class NewNodeManagerImpl(
   , val eventLogRepository : EventLogRepository
   , override val updateDynamicGroups : UpdateDynamicGroups
   , val cacheToClear: List[CachedRepository]
+  , val datasourceCallback: DataSourceUpdateCallbacks
 ) extends NewNodeManager with ListNewNode with ComposedNewNodeManager
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -242,6 +244,8 @@ trait ComposedNewNodeManager extends NewNodeManager with Loggable {
   def updateDynamicGroups : UpdateDynamicGroups
 
   def cacheToClear: List[CachedRepository]
+
+  def datasourceCallback: DataSourceUpdateCallbacks
 
   ////////////////////////////////////////////////////////////////////////////////////
   ////////////////////////////////////// Refuse //////////////////////////////////////
@@ -566,6 +570,10 @@ trait ComposedNewNodeManager extends NewNodeManager with Loggable {
            case None =>
              logger.warn(s"Node '${id.value}' accepted, but couldn't find it's inventory")
          }
+
+         // Update datasource for the node
+         datasourceCallback.onNewNode(id)
+
          acceptationResults
        }
     )

--- a/rudder-core/src/test/scala/com/normation/rudder/datasources/JsonPathTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/datasources/JsonPathTest.scala
@@ -1,0 +1,182 @@
+/*
+*************************************************************************************
+* Copyright 2016 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.datasources
+
+import org.junit.runner.RunWith
+import org.specs2.mutable._
+import org.specs2.runner._
+import net.liftweb.common._
+import net.liftweb.json._
+import com.normation.inventory.domain.PublicKey
+import com.normation.BoxSpecMatcher
+
+@RunWith(classOf[JUnitRunner])
+class JsonPathTest extends Specification with BoxSpecMatcher with Loggable {
+
+
+
+  "These path are valid" should {
+
+    "just an identifier" in  {
+      JsonSelect.compilePath("foo").map( _.getPath ) mustFullEq( "$['foo']" )
+    }
+  }
+
+
+  "The selection" should {
+    "fail if source is not a json" in {
+      JsonSelect.fromPath("$", """{ not a json!} ,pde at all!""") mustFails
+    }
+
+    "fail if input path is not valid " in {
+      JsonSelect.fromPath("$$$..$", """not a json! missing quotes!""") mustFails
+    }
+
+    "retrieve first" in {
+      val res = JsonSelect.fromPath("$.store.book", json).map( _.head )
+
+      res mustFullEq( compactRender(parse("""
+            {
+                "category": "reference",
+                "author": "Nigel Rees",
+                "title": "Sayings of the Century",
+                "price": 8.95
+            }
+        """)) )
+    }
+  }
+
+  "get childrens" should {
+    "retrieve JSON childrens forming an array" in {
+      JsonSelect.fromPath("$.store.book[*]", json) mustFullEq(List(
+          """{
+                "category": "reference",
+                "author": "Nigel Rees",
+                "title": "Sayings of the Century",
+                "price": 8.95
+            }""",
+            """{
+                "category": "fiction",
+                "author": "Evelyn Waugh",
+                "title": "Sword of Honour",
+                "price": 12.99
+            }""",
+            """{
+                "category": "\"quotehorror\"",
+                "author": "Herman Melville",
+                "title": "Moby Dick",
+                "isbn": "0-553-21311-3",
+                "price": 8.99
+            }""",
+            """{
+                "category": "fiction",
+                "author": "J. R. R. Tolkien",
+                "title": "The Lord of the Rings",
+                "isbn": "0-395-19395-8",
+                "price": 22.99
+            }""").map(s => compactRender(parse(s))))
+    }
+    "retrieve NUMBER childrens forming an array" in {
+      JsonSelect.fromPath("$.store.book[*].price", json) mustFullEq(List("8.95", "12.99", "8.99", "22.99"))
+    }
+    "retrieve STRING childrens forming an array" in {
+      JsonSelect.fromPath("$.store.book[*].category", json) mustFullEq(List("reference", "fiction", "\"quotehorror\"", "fiction"))
+    }
+    "retrieve JSON childrens (one)" in {
+      JsonSelect.fromPath("$.store.bicycle", json) mustFullEq(List("""{"color":"red","price":19.95}"""))
+    }
+    "retrieve NUMBER childrens (one)" in {
+      JsonSelect.fromPath("$.store.bicycle.price", json) mustFullEq(List("19.95"))
+    }
+    "retrieve STRING childrens (one)" in {
+      JsonSelect.fromPath("$.store.bicycle.color", json) mustFullEq(List("red"))
+    }
+    "retrieve ARRAY INT childrens (one)" in {
+      JsonSelect.fromPath("$.intTable", json) mustFullEq(List("1", "2", "3"))
+    }
+    "retrieve ARRAY STRING childrens (one)" in {
+      JsonSelect.fromPath("$.stringTable", json) mustFullEq(List("one", "two"))
+    }
+  }
+
+
+
+
+  lazy val json = """
+  {
+    "store": {
+        "book": [
+            {
+                "category": "reference",
+                "author": "Nigel Rees",
+                "title": "Sayings of the Century",
+                "price": 8.95
+            },
+            {
+                "category": "fiction",
+                "author": "Evelyn Waugh",
+                "title": "Sword of Honour",
+                "price": 12.99
+            },
+            {
+                "category": "\"quotehorror\"",
+                "author": "Herman Melville",
+                "title": "Moby Dick",
+                "isbn": "0-553-21311-3",
+                "price": 8.99
+            },
+            {
+                "category": "fiction",
+                "author": "J. R. R. Tolkien",
+                "title": "The Lord of the Rings",
+                "isbn": "0-395-19395-8",
+                "price": 22.99
+            }
+        ],
+        "bicycle": {
+            "color": "red",
+            "price": 19.95
+        }
+    },
+    "expensive": 10,
+    "intTable": [1,2,3],
+    "stringTable": ["one", "two"]
+  }
+  """
+
+}

--- a/rudder-core/src/test/scala/com/normation/rudder/datasources/RestServer.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/datasources/RestServer.scala
@@ -1,0 +1,142 @@
+/*
+*************************************************************************************
+* Copyright 2016 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.datasources
+
+import scala.concurrent.ExecutionContext
+
+import org.http4s._
+import org.http4s.dsl._
+import org.http4s.server.HttpService
+import org.http4s.server.blaze.BlazeBuilder
+
+/*
+Corresponding datasources:
+ % cat datasource.json
+{
+  "name": "datasource number one",
+  "id": "datasource1",
+  "description": "make data source great again",
+  "type": {
+    "name": "http",
+    "url": "htt://localhost:8282/cmdb/${rudder.node.id}",
+    "headers": {},
+    "path": "$.hostnames.fqdn",
+    "checkSsl": false,
+    "requestTimeout": "5 minutes",
+    "requestMode": {
+      "name": "byNode"
+    }
+  },
+  "runParam": {
+    "onGeneration": false,
+    "onNewNode": false,
+    "schedule": {
+      "type": "scheduled",
+      "duration": "5 minutes"
+    }
+  },
+  "updateTimeOut": "5 minutes",
+  "enabled": true
+}
+
+% curl -k -H "X-API-Token: xxxxxx" -H "Content-Type: application/json" -X PUT 'http://localhost:8082/rudder-web/api/latest/datasources' -d@datasource.json
+...
+ */
+
+object RestServer {
+
+  def main(args: Array[String]): Unit = {
+
+    println("starting server on port 8282...")
+    //start server
+    val server = BlazeBuilder.bindHttp(8282)
+      .mountService(NodeDataset.service, "/cmdb")
+      .run
+      .awaitShutdown()
+  }
+
+  //create a rest server for test
+  object NodeDataset {
+
+    def service(implicit executionContext: ExecutionContext = ExecutionContext.global) = HttpService {
+      case _ -> Root =>
+        MethodNotAllowed()
+
+      case GET -> Root / x =>
+        Ok {
+          println(s"Received a request for node '${x}'")
+          nodeJson(x)
+        }
+    }
+
+    //expample of what a CMDB could return for a node.
+    def nodeJson(name: String) = s""" {
+      "hostname" : "${name}",
+      "ad_groups" : [ "ad-grp1 " ],
+      "ssh_groups" : [ "ssh-power-users" ],
+      "sudo_groups" : [ "sudo-masters" ],
+      "hostnames" : {
+       "fqdn" : "$name.some.host.com $name",
+       "local" : "localhost.localdomain localhost localhost4 localhost4.localdomain4"
+      },
+      "netfilter4_rules" : {
+       "all" : "lo",
+       "ping" : "eth0",
+       "tcpint" : "",
+       "udpint" : "",
+       "exceptions" : "",
+       "logdrop" : false,
+       "gateway" : false,
+       "extif" : "eth0",
+       "intif" : "eth1"
+      },
+    "netfilter6_rules" : {
+       "all" : "lo",
+       "ping" : "eth0",
+       "tcpint" : "",
+       "udpint" : "",
+       "exceptions" : "",
+       "logdrop" : false,
+       "gateway" : false,
+       "extif" : "eth0",
+       "intif" : "eth1"
+      }
+    }
+    """
+  }
+}

--- a/rudder-core/src/test/scala/com/normation/rudder/datasources/UpdateHttpDatasetTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/datasources/UpdateHttpDatasetTest.scala
@@ -1,0 +1,538 @@
+/*
+*************************************************************************************
+* Copyright 2016 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.datasources
+
+import org.junit.runner.RunWith
+import org.specs2.mutable._
+import org.specs2.runner._
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.util.Random
+import scala.util.control.NonFatal
+
+import com.normation.BoxSpecMatcher
+import com.normation.eventlog.EventActor
+import com.normation.eventlog.ModificationId
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.nodes.Node
+import com.normation.rudder.domain.nodes.NodeInfo
+import com.normation.rudder.domain.nodes.NodeProperty
+import com.normation.rudder.domain.parameters.ParameterName
+import com.normation.rudder.repository.RoParameterRepository
+import com.normation.rudder.repository.WoNodeRepository
+import com.normation.rudder.services.nodes.NodeInfoService
+import com.normation.rudder.services.policies.InterpolatedValueCompilerImpl
+import com.normation.rudder.services.policies.NodeConfigData
+import com.normation.utils.StringUuidGeneratorImpl
+
+import org.http4s._
+import org.http4s.dsl._
+import org.http4s.server.HttpService
+import org.http4s.server.blaze.BlazeBuilder
+import org.joda.time.DateTime
+
+import monix.eval.Task
+import monix.execution.Cancelable
+import monix.execution.Scheduler
+import monix.execution.atomic.AtomicInt
+import monix.execution.schedulers.TestScheduler
+import monix.reactive.Observable
+import net.liftweb.common._
+import net.liftweb.http.PartialUpdateMsg
+import com.normation.rudder.domain.eventlog._
+import org.specs2.specification.AfterAll
+
+
+
+@RunWith(classOf[JUnitRunner])
+class UpdateHttpDatasetTest extends Specification with BoxSpecMatcher with Loggable with AfterAll {
+
+  //utility to compact render a json string
+  //will throws exceptions if errors
+  def compact(json: String): String = {
+    import net.liftweb.json._
+    compactRender(parse(json))
+  }
+
+  //create a rest server for test
+  object NodeDataset {
+
+    //for debuging - of course works correctly only if sequential
+    val counterError   = AtomicInt(0)
+    val counterSuccess = AtomicInt(0)
+
+    def reset(): Unit = {
+      counterError.set(0)
+      counterSuccess.set(0)
+    }
+
+    def service(implicit executionContext: ExecutionContext = ExecutionContext.global) = HttpService {
+      case _ -> Root =>
+        MethodNotAllowed()
+
+      case GET -> Root / "single_node1" =>
+        Ok{
+          counterSuccess.add(1)
+          booksJson
+        }
+
+      case GET -> Root / x =>
+        Ok {
+          counterSuccess.add(1)
+          nodeJson(x)
+        }
+
+      case GET -> Root / "delay" / x =>
+        Ok {
+          counterSuccess.add(1)
+          nodeJson(x)
+        }.after(Random.nextInt(1000).millis)
+
+      case GET -> Root / "faileven" / x =>
+        // x === "nodeXX" or root
+        if(x != "root" && x.replaceAll("node", "").toInt % 2 == 0) {
+          Forbidden {
+            counterError.add(1)
+            "Not authorized"
+          }
+        } else {
+          Ok {
+            counterSuccess.add(1)
+            nodeJson(x)
+          }
+        }
+    }
+  }
+  //start server
+  var server = BlazeBuilder.bindHttp(8282)
+    .mountService(NodeDataset.service, "/datasource")
+    .run
+
+  override def afterAll(): Unit = {
+    server.shutdown
+  }
+
+  val actor = EventActor("Test-actor")
+  def modId = ModificationId("test-id-@" + System.currentTimeMillis)
+
+  val interpolation = new InterpolatedValueCompilerImpl
+  val fetch = new GetDataset(interpolation)
+
+  val parameterRepo = new RoParameterRepository() {
+    def getAllGlobalParameters() = Full(Seq())
+    def getAllOverridable() = Full(Seq())
+    def getGlobalParameter(parameterName: ParameterName) = Empty
+  }
+
+  class TestNodeRepoInfo(initNodeInfo: Map[NodeId, NodeInfo]) extends WoNodeRepository with NodeInfoService {
+
+    private[this] var nodes = initNodeInfo
+
+    //used for test
+    //number of time each node is updated
+    val updates = scala.collection.mutable.Map[NodeId, Int]()
+
+    // WoNodeRepository methods
+    def updateNode(node: Node, modId: ModificationId, actor: EventActor, reason: Option[String]): Box[Node] = this.synchronized {
+      for {
+        existing <- Box(nodes.get(node.id)) ?~! s"Missing node with key ${node.id.value}"
+      } yield {
+        this.updates += (node.id -> (1 + updates.getOrElse(node.id, 0) ) )
+        this.nodes = (nodes + (node.id -> existing.copy(node = node) ) )
+        node
+      }
+    }
+
+    // NodeInfoService
+    def getAll() = synchronized(Full(nodes))
+    def getAllNodes()                         = throw new IllegalAccessException("Thou shall not used that method here")
+    def getAllSystemNodeIds()                 = throw new IllegalAccessException("Thou shall not used that method here")
+    def getDeletedNodeInfo(nodeId: NodeId)    = throw new IllegalAccessException("Thou shall not used that method here")
+    def getDeletedNodeInfos()                 = throw new IllegalAccessException("Thou shall not used that method here")
+    def getLDAPNodeInfo(nodeIds: Set[NodeId]) = throw new IllegalAccessException("Thou shall not used that method here")
+    def getNode(nodeId: NodeId)               = throw new IllegalAccessException("Thou shall not used that method here")
+    def getNodeInfo(nodeId: NodeId)           = throw new IllegalAccessException("Thou shall not used that method here")
+    def getPendingNodeInfo(nodeId: NodeId)    = throw new IllegalAccessException("Thou shall not used that method here")
+    def getPendingNodeInfos()                 = throw new IllegalAccessException("Thou shall not used that method here")
+  }
+
+  val root = NodeConfigData.root
+  val n1 = {
+    val n = NodeConfigData.node1.node
+    NodeConfigData.node1.copy(node = n.copy(properties = NodeProperty("get-that", "book") :: Nil ))
+  }
+
+  val httpDatasourceTemplate = HttpDataSourceType(
+      "CHANGE MY URL"
+    , Map()
+    , "GET"
+    , true
+    , "CHANGE MY PATH"
+    , OneRequestByNode
+    , 5.second
+  )
+  val datasourceTemplate = DataSource(
+        DataSourceId("test-my-datasource")
+      , DataSourceName("test-my-datasource")
+      , httpDatasourceTemplate
+      , DataSourceRunParameters(
+            Scheduled(300.seconds)
+          , true
+          , true
+        )
+      , "a test datasource to test datasources"
+      , true
+      , 5.minutes
+    )
+  // create a copy of template, updating some properties
+  def NewDataSource(
+      name   : String
+    , url    : String = httpDatasourceTemplate.url
+    , path   : String = httpDatasourceTemplate.path
+    , schedule: DataSourceSchedule = datasourceTemplate.runParam.schedule
+  ) = {
+    val http = httpDatasourceTemplate.copy(url = url, path = path)
+    val run  = datasourceTemplate.runParam.copy(schedule = schedule)
+    datasourceTemplate.copy(name = DataSourceName(name), sourceType = http, runParam = run)
+
+  }
+
+  object MyDatasource {
+
+    val infos = new TestNodeRepoInfo(NodeConfigData.allNodesInfo)
+    val http = new HttpQueryDataSourceService(
+        infos
+      , parameterRepo
+      , infos
+      , interpolation
+    )
+
+
+    val uuidGen = new StringUuidGeneratorImpl()
+
+
+  }
+
+
+  sequential
+
+  "Update on datasource" should {
+    val datasource = NewDataSource(
+        name = "test-scheduler"
+      , url  = "http://localhost:8282/datasource/${rudder.node.id}"
+      , path = "$.hostname"
+      , schedule = Scheduled(5.minute)
+    )
+    val action = (c: UpdateCause) => {
+      // here we need to give him the default scheduler, not the test one,
+      // to actually have the fetch logic done
+      MyDatasource.http.queryAll(datasource, c) match {
+        case Full(res) => //ok
+        case x         => logger.error(s"oh no! Got a $x")
+      }
+    }
+
+    "does nothing is disabled scheduler" in {
+      val testScheduler = TestScheduler()
+      val dss = new DataSourceScheduler(
+          datasource.copy(enabled = false)
+        , testScheduler
+        , () => ModificationId(MyDatasource.uuidGen.newUuid)
+        , action
+     )
+
+      //reset counter
+      NodeDataset.reset()
+      // before start, nothing is done
+      val total_0 = NodeDataset.counterError.get + NodeDataset.counterSuccess.get
+      dss.start()
+      //then, event after days, nothing is done
+      testScheduler.tick(1.day)
+      val total_1d = NodeDataset.counterError.get + NodeDataset.counterSuccess.get
+
+      (total_0, total_1d) must beEqualTo(
+      (0      , 0       ))
+    }
+
+    "allows interactive updates with disabled scheduler (but not data source)" in {
+      val testScheduler = TestScheduler()
+      val dss = new DataSourceScheduler(
+          datasource.copy(runParam = datasource.runParam.copy(schedule = NoSchedule(1.second)))
+        , testScheduler
+        , () => ModificationId(MyDatasource.uuidGen.newUuid)
+        , action
+     )
+
+      //reset counter
+      NodeDataset.reset()
+      // before start, nothing is done
+      val total_0 = NodeDataset.counterError.get + NodeDataset.counterSuccess.get
+      dss.start()
+      //then, event after days, nothing is done
+      testScheduler.tick(1.day)
+      val total_1d = NodeDataset.counterError.get + NodeDataset.counterSuccess.get
+      //but updating on a generation works
+      dss.doActionAndSchedule(action(UpdateCause(ModificationId("plop"), RudderEventActor, None)))
+      val total_postGen = NodeDataset.counterError.get + NodeDataset.counterSuccess.get
+
+      (total_0, total_1d, total_postGen                   ) must beEqualTo(
+      (0      , 0       , NodeConfigData.allNodesInfo.size))
+
+    }
+
+    "create a new schedule from data source information" in {
+      val testScheduler = TestScheduler()
+      val dss = new DataSourceScheduler(
+          datasource
+        , testScheduler
+        , () => ModificationId(MyDatasource.uuidGen.newUuid)
+        , action
+     )
+
+      //reset counter
+      NodeDataset.reset()
+
+      // before start, nothing is done
+      val total_0 = NodeDataset.counterError.get + NodeDataset.counterSuccess.get
+      dss.start()
+      //then just after, we have the first exec - it still need at least a ms to tick
+      //still nothing here
+      val total_0plus = NodeDataset.counterError.get + NodeDataset.counterSuccess.get
+      testScheduler.tick(1.millis)
+      //here we have results
+      val total_1s = NodeDataset.counterError.get + NodeDataset.counterSuccess.get
+      //then nothing happens before 5 minutes
+      testScheduler.tick(4.minutes)
+      val total_4min = NodeDataset.counterError.get + NodeDataset.counterSuccess.get
+      //then all the nodes gets their info
+      testScheduler.tick(1.minute)
+      val total_5min = NodeDataset.counterError.get + NodeDataset.counterSuccess.get
+
+      //then nothing happen anymore
+      testScheduler.tick(3.minutes)
+      val total_8min = NodeDataset.counterError.get + NodeDataset.counterSuccess.get
+
+      val size = NodeConfigData.allNodesInfo.size
+      (total_0, total_0plus, total_1s, total_4min, total_5min, total_8min) must beEqualTo(
+      (0      , 0          , size    , size      ,  size*2,    size*2    ))
+    }
+
+  }
+
+  "querying a lot of nodes" should {
+
+    val nodes = (NodeConfigData.root :: List.fill(1000)(NodeConfigData.node1).zipWithIndex.map { case (n,i) =>
+      val name = "node"+i
+      n.copy(node = n.node.copy(id = NodeId(name), name = name), hostname = name+".localhost")
+    }).map( n => (n.id, n)).toMap
+    val infos = new TestNodeRepoInfo(nodes)
+    val http = new HttpQueryDataSourceService(
+        infos
+      , parameterRepo
+      , infos
+      , interpolation
+    )
+
+
+    "work even if nodes don't reply at same speed" in {
+      val ds = NewDataSource(
+          "test-lot-of-nodes"
+        , url  = "http://localhost:8282/datasource/delay/${rudder.node.id}"
+        , path = "$.hostname"
+      )
+      val nodeIds = infos.getAll().openOrThrowException("test shall not throw").keySet
+      //all node updated one time
+      infos.updates.clear()
+      val t0 = System.currentTimeMillis
+      val res = http.queryAll(ds, UpdateCause(modId, actor, None))
+      val t1 = System.currentTimeMillis
+
+      res mustFullEq(nodeIds) and (
+        infos.updates.toMap must havePairs( nodeIds.map(x => (x, 1) ).toSeq:_* )
+      )
+    }
+
+
+    "work for odd node even if even nodes fail" in {
+      val ds = NewDataSource(
+          "test-even-fail"
+        , url  = "http://localhost:8282/datasource/faileven/${rudder.node.id}"
+        , path = "$.hostname"
+      )
+      val nodeRegEx = "node(.*)".r
+      val nodeIds = infos.getAll().openOrThrowException("test shall not throw").keySet.filter(n => n.value match {
+        case "root"       => true
+        case nodeRegEx(i) => i.toInt % 2 == 1
+      })
+      //all node updated one time
+      infos.updates.clear()
+
+      val res = http.queryAll(ds, UpdateCause(modId, actor, None))
+      res mustFails() and (
+        infos.updates.toMap must havePairs( nodeIds.map(x => (x, 1) ).toSeq:_* )
+      )
+
+    }
+  }
+
+
+  "Getting a node" should {
+    val datasource = httpDatasourceTemplate.copy(
+        url  = "http://localhost:8282/datasource/single_${rudder.node.id}"
+      , path = "$.store.${node.properties[get-that]}"
+    )
+    "get the node" in  {
+
+      val res = fetch.getNode(DataSourceName("test-get-one-node"), datasource, n1, root, Set(), 1.second, 5.seconds)
+
+      res mustFullEq(
+          NodeProperty("test-get-one-node", compact("""{
+            "category": "reference",
+            "author": "Nigel Rees",
+            "title": "Sayings of the Century",
+            "price": 8.95
+          }""")))
+
+    }
+  }
+
+  "The full http service" should {
+    val datasource = NewDataSource(
+        "test-http-service"
+      , url  = "http://localhost:8282/datasource/single_node1"
+      , path = "$.store.book"
+    )
+
+    val infos = new TestNodeRepoInfo(NodeConfigData.allNodesInfo)
+    val http = new HttpQueryDataSourceService(
+        infos
+      , parameterRepo
+      , infos
+      , interpolation
+    )
+
+    "correctly update all nodes" in {
+      //all node updated one time
+      val nodeIds = infos.getAll().openOrThrowException("test shall not throw").keySet
+      infos.updates.clear()
+      val res = http.queryAll(datasource, UpdateCause(modId, actor, None))
+
+      res mustFullEq(nodeIds) and (
+        infos.updates.toMap must havePairs( nodeIds.map(x => (x, 1) ).toSeq:_* )
+      )
+    }
+  }
+
+
+  lazy val booksJson = """
+  {
+    "store": {
+        "book": [
+            {
+                "category": "reference",
+                "author": "Nigel Rees",
+                "title": "Sayings of the Century",
+                "price": 8.95
+            },
+            {
+                "category": "fiction",
+                "author": "Evelyn Waugh",
+                "title": "Sword of Honour",
+                "price": 12.99
+            },
+            {
+                "category": "fiction",
+                "author": "Herman Melville",
+                "title": "Moby Dick",
+                "isbn": "0-553-21311-3",
+                "price": 8.99
+            },
+            {
+                "category": "fiction",
+                "author": "J. R. R. Tolkien",
+                "title": "The Lord of the Rings",
+                "isbn": "0-395-19395-8",
+                "price": 22.99
+            }
+        ],
+        "bicycle": {
+            "color": "red",
+            "price": 19.95
+        }
+    },
+    "expensive": 10
+  }
+  """
+
+  //expample of what a CMDB could return for a node.
+  def nodeJson(name: String) = s""" {
+    "hostname" : "$name",
+    "ad_groups" : [ "ad-grp1 " ],
+    "ssh_groups" : [ "ssh-power-users" ],
+    "sudo_groups" : [ "sudo-masters" ],
+    "hostnames" : {
+     "fqdn" : "$name.some.host.com $name",
+     "local" : "localhost.localdomain localhost localhost4 localhost4.localdomain4"
+    },
+    "netfilter4_rules" : {
+     "all" : "lo",
+     "ping" : "eth0",
+     "tcpint" : "",
+     "udpint" : "",
+     "exceptions" : "",
+     "logdrop" : false,
+     "gateway" : false,
+     "extif" : "eth0",
+     "intif" : "eth1"
+    },
+  "netfilter6_rules" : {
+     "all" : "lo",
+     "ping" : "eth0",
+     "tcpint" : "",
+     "udpint" : "",
+     "exceptions" : "",
+     "logdrop" : false,
+     "gateway" : false,
+     "extif" : "eth0",
+     "intif" : "eth1"
+    }
+  }
+  """
+
+}

--- a/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -107,6 +107,7 @@ import com.normation.rudder.repository.ComplianceRepository
  */
 @RunWith(classOf[JUnitRunner])
 class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
+  self =>
 
   import ReportType._
   import doobie._
@@ -167,7 +168,7 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
 
   val dummyComplianceCache = new CachedFindRuleNodeStatusReports {
     def defaultFindRuleNodeStatusReports: DefaultFindRuleNodeStatusReports = null
-    def nodeInfoService: NodeInfoService = nodeInfoService
+    def nodeInfoService: NodeInfoService = self.nodeInfoService
     def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): Box[RuleStatusReport] = null
     def findNodeStatusReport(nodeId: NodeId) : Box[NodeStatusReport] = null
     override def invalidate(nodeIds: Set[NodeId]) = Full(Map())

--- a/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
@@ -98,6 +98,9 @@ import com.normation.rudder.domain.policies.GlobalPolicyMode
 import com.normation.rudder.domain.policies.PolicyModeOverrides
 import com.normation.inventory.domain.AgentInfo
 import com.normation.inventory.domain.AgentVersion
+import com.normation.rudder.services.nodes.NodeInfoService
+import net.liftweb.common.Full
+import net.liftweb.common.Box
 
 
 /*

--- a/rudder-web/src/main/resources/logback.xml
+++ b/rudder-web/src/main/resources/logback.xml
@@ -365,6 +365,29 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
    -->
   <logger name="com.normation.rudder.services.quicksearch" level="info" />
 
+  <!--
+    Datasource
+    ==========
+    Information about data source. 
+    "datasources" log what data source are fetched when (info level for updates start, 
+    error level for errors, debug/trace for non error returned value).
+    
+    "datasource-timing" give information about how long it takes to fetch data from
+    data source. Debug level is at the data source action level (ex: how long it takes
+    to update all nodes), trace times each http request individualy. It can be very
+    verbose if you have a couple of thousand of nodes with a "node by node" query type.
+  -->
+  <logger name="datasources" level="info" additivity="false">
+    <appender-ref ref="OPSLOG" />
+    <!-- comment the following appender if you don't want to have logs about report in both stdout and opslog -->
+    <appender-ref ref="STDOUT" />
+  </logger>
+  <logger name="datasources-timing" level="off" additivity="false">
+    <appender-ref ref="OPSLOG" />
+    <!-- comment the following appender if you don't want to have logs about report in both stdout and opslog -->
+    <appender-ref ref="STDOUT" />
+  </logger>
+
 
   <!-- ==================================================== -->
   <!-- YOU SHOULD NOT HAVE TO CHANGE THINGS BELOW THAT LINE -->

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/ComplianceModeEditForm.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/ComplianceModeEditForm.scala
@@ -117,6 +117,8 @@ class ComplianceModeEditForm [T <: ComplianceMode] (
             startNewPolicyGeneration()
             S.notice("complianceModeMessage", "Compliance mode saved")
         }
+      //necessary to avoid the non-exhaustive warning due to "type pattern T is unchecked since eliminated by erasure" pb above
+      case x => S.error("complianceModeMessage", s"Compliance mode is not of the awaited type (dev error): please report that error")
     }
   }
 

--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/datasource/DataSourceApiService.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/datasource/DataSourceApiService.scala
@@ -47,29 +47,6 @@ import scala.concurrent.duration.Duration
 import net.liftweb.http.Req
 import scala.concurrent.duration.FiniteDuration
 
-class MemoryDataSourceRepository extends DataSourceRepository {
-
-  private[this] var sources : Map[DataSourceId,DataSource] = Map()
-
-  def getAll() = Full(sources)
-
-  def get(id : DataSourceId) : Box[Option[DataSource]]= Full(sources.get(id))
-
-  def save(source : DataSource) = {
-    sources = sources +  ((source.id,source))
-    Full(source)
-  }
-  def delete(id : DataSourceId) : Box[DataSource] = {
-    sources.get(id) match {
-      case Some(source) =>
-        sources = sources - (id)
-        Full(source)
-      case None =>
-        Failure(s"Data source '${id}' does not exists, and thus can't be deleted")
-    }
-  }
-}
-
 class DataSourceApiService(
     dataSourceRepo     : DataSourceRepository
   , restDataSerializer : RestDataSerializer

--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/node/NodeAPI9.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/node/NodeAPI9.scala
@@ -1,0 +1,88 @@
+/*
+*************************************************************************************
+* Copyright 2016 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.web.rest.node
+
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.nodes.Node
+import com.normation.rudder.web.rest.ApiVersion
+import com.normation.rudder.web.rest.RestDataSerializer
+import com.normation.rudder.web.rest.RestExtractorService
+import com.normation.rudder.web.rest.RestUtils
+import com.normation.rudder.web.rest.RestUtils.toJsonResponse
+
+import net.liftweb.common.Box
+import net.liftweb.common.Loggable
+import net.liftweb.http.LiftResponse
+import net.liftweb.http.Req
+import net.liftweb.http.rest.RestHelper
+import net.liftweb.json.JsonAST.JString
+
+class NodeAPI9 (
+    apiV8        : NodeAPI8
+  , apiV9service : NodeApiService9
+  , extractor    : RestExtractorService
+) extends RestHelper with NodeAPI with Loggable{
+
+  val v9Dispatch : PartialFunction[Req, () => Box[LiftResponse]] = {
+
+    case Post( "fetchData" :: Nil, req) => {
+      implicit val prettify = extractor.extractPrettify(req.params)
+      implicit val action = "fetchDataAllNodes"
+      val actor = RestUtils.getActor(req)
+
+      apiV9service.fetchDataAllNodes(actor)
+
+      toJsonResponse(None, JString("Data for all nodes, for all configured data sources are going to be updated"))
+    }
+
+    case Post(id :: "fetchData" ::Nil, req) => {
+      implicit val prettify = extractor.extractPrettify(req.params)
+      implicit val action = "fetchDataOneNode"
+      val actor = RestUtils.getActor(req)
+
+      apiV9service.fetchDataOneNode(NodeId(id), actor)
+
+      toJsonResponse(None, JString(s"Data for node '${id}', for all configured data sources, is going to be updated"))
+    }
+
+  }
+
+  override def requestDispatch(apiVersion: ApiVersion) : PartialFunction[Req, () => Box[LiftResponse]] = {
+    v9Dispatch orElse apiV8.requestDispatch(apiVersion)
+  }
+}

--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/node/NodeAPIService9.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/node/NodeAPIService9.scala
@@ -1,0 +1,84 @@
+/*
+*************************************************************************************
+* Copyright 2016 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.web.rest.node
+
+import com.normation.eventlog.ModificationId
+
+import com.normation.inventory.domain._
+import com.normation.rudder.batch.AsyncDeploymentAgent
+import com.normation.rudder.batch.AutomaticStartDeployment
+import com.normation.rudder.domain.nodes.JsonSerialisation._
+import com.normation.rudder.domain.nodes.NodeProperty
+import com.normation.rudder.repository.WoNodeRepository
+import com.normation.rudder.services.nodes.NodeInfoService
+import com.normation.rudder.web.model.CurrentUser
+import com.normation.rudder.web.rest.RestExtractorService
+import com.normation.rudder.web.rest.RestUtils._
+import com.normation.rudder.web.rest.RestUtils
+import com.normation.utils.StringUuidGenerator
+
+import net.liftweb.common._
+import net.liftweb.http.Req
+import net.liftweb.json._
+import net.liftweb.json.JsonDSL._
+import com.normation.eventlog.EventActor
+import com.normation.rudder.domain.nodes.Node
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.IOException
+import com.zaxxer.nuprocess.NuAbstractProcessHandler
+import java.nio.ByteBuffer
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import com.zaxxer.nuprocess.NuProcessBuilder
+import java.util.Arrays
+import com.normation.rudder.domain.nodes.NodeInfo
+import com.normation.rudder.datasources.DataSourceUpdateCallbacks
+
+class NodeApiService9 (
+    dataSourceUpdate: DataSourceUpdateCallbacks
+) extends Loggable {
+
+  def fetchDataAllNodes(actor: EventActor): Unit = {
+    dataSourceUpdate.onUserAskUpdateAll(actor)
+  }
+
+  def fetchDataOneNode(nodeId: NodeId, actor: EventActor): Unit = {
+    dataSourceUpdate.onUserAskUpdateNode(actor, nodeId)
+  }
+
+}

--- a/rudder-web/src/test/scala/com/normation/rudder/web/rest/RestDataSourceTest.scala
+++ b/rudder-web/src/test/scala/com/normation/rudder/web/rest/RestDataSourceTest.scala
@@ -90,6 +90,10 @@ class RestDataSourceTest extends Specification with Loggable {
   val datasource2 = datasource1.copy(id = DataSourceId("datasource2"))
   val d2Json = restDataSerializer.serializeDataSource(datasource2)
 
+  println(net.liftweb.json.compactRender(d1Json))
+
+  println(net.liftweb.json.compactRender(d2Json))
+
   val dataSource2Updated = datasource2.copy(
       description = "new description"
     , sourceType = baseSourceType.copy(headers = Map( ("new header 1" -> "new value 1") , ("new header 2" -> "new value 2")))

--- a/rudder-web/src/test/scala/com/normation/rudder/web/rest/RestTestSetUp.scala
+++ b/rudder-web/src/test/scala/com/normation/rudder/web/rest/RestTestSetUp.scala
@@ -66,6 +66,7 @@ import net.liftweb.http.S
 import net.liftweb.common.EmptyBox
 import com.normation.rudder.web.rest.datasource._
 import net.liftweb.json.JsonAST.JValue
+import com.normation.rudder.datasources.MemoryDataSourceRepository
 
 /*
  * This file provides all the necessary plumbing to allow test REST API.


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9724

Work in progress about getting node dataset from Rest service. 
Current status: mostly everything work for "node by node" request. 

It can be merged as it is (it's fully functionnal) and other PRs may be done for missing parts.

## What is added by that PR 

- able to GET dataset from a datasource (getting info from repos, updating nodes in repos) + test on how it behave with 1000 nodes and timeout / errors for some nodes,
- fetch data with scheduling (or not) + triggers (on new node, on generation, on user request for one / all nodes)
- api to trigger update for one / all nodes
- logging (action and requests timing)
- repository facade which manage the update of live scheduler when datasources are modified

## Missing 
- the "one request for all node" mode. 
- the status updates on database (for now, we only have reports via logs)
- the actual database serialisation/desirialisation (current repository is only in memory)

## Open question

- do we want to start a generation after an update? I think so (in all case, the generation will see if things were changed since it's last run)
- do we want to prevent two consecutives non-interactive updates at less than "period" appart? The use case in mind is if we start generation after update, and we have "trigger data fetching on generation", at each periodic update we are going to have a new fetch just after [note also that the fetching on generation must not trigger a generation, else its a never ending game :) ]
- validate endpoints for API update (currently ..../api/latest/nodes/fetchData and .../nodes/xxx-xxx/fetchData)

## Some more  #details

The fetch logic is working, ie. 
- from a datasource and node information/contexte, 
- compile the URL to fetch, 
- fetch data, 
- select sub data, 
- create a node property. 

From that, we have a whole service for a node, with I/O for param&result:
- get datasource and node information from repositories, 
- fetch, 
- in case of success, update node property and node dataset info, 
- in all case, update datasource last updated. 

## Framework info

- I'm using https://github.com/jayway/JsonPath/ for selecting sub-json. It kind of works, but none of the seemingly interesting option were actually interesting. And I HATE JAVA, mutable, no data representation of the logic, cast.... ARG;
- for client, I'm using for now https://github.com/scalaj/scalaj-http. Extremlly simple,  but fully synchrone. It seems to not be a problem for now, but perhaps we are going to want a much more efficient (async and pooled) client that efficiently manage a ton of outgoing connexion (because one connexion by node can become huge)
- for tests, I'm using http4s (http://http4s.org/). It seems really, really nice but support for Java 7 is EOL, so I'm a little bother to add it for something else than dependency. That constraint is becoming a real mess. 
- monix (https://monix.io) for async computing and scheduling, because it's light and fast and really easy to use. 
