### PR TITLE
Fixes #9701: Store data sources in backend

### DIFF
--- a/rudder-core/src/main/resources/reportsSchema.sql
+++ b/rudder-core/src/main/resources/reportsSchema.sql
@@ -456,6 +456,16 @@ start_minute int,
 startTime timestamp with time zone default now(),
 endTime timestamp with time zone
 );
+
+-- Create the table for the node configuration
+CREATE TABLE dataSources (
+  id            text PRIMARY KEY NOT NULL CHECK (id <> '')  
+
+-- data source properties and status are valid json, until we can use postgres 9.2 keep text type (more details in configuration details)
+
+, properties text NOT NULL CHECK (properties <> '' )
+);
+
 /*
  *************************************************************************************
  * end

--- a/rudder-core/src/main/scala/com/normation/rudder/datasources/DataSource.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/datasources/DataSource.scala
@@ -39,8 +39,15 @@ package com.normation.rudder.datasources
 
 import org.joda.time.DateTime
 import net.liftweb.common._
+import net.liftweb.util.ControlHelpers.tryo
 import scala.concurrent.duration.FiniteDuration
 import com.normation.inventory.domain.NodeId
+import scala.concurrent.duration.Duration
+import java.util.concurrent.TimeUnit
+import com.normation.rudder.repository.json.JsonExctractorUtils
+import com.normation.rudder.repository.json.JsonExctractorUtils
+import scalaz.Monad
+import scalaz.Id
 
 object DataSource {
   val defaultDuration = FiniteDuration(5,"minutes")

--- a/rudder-core/src/main/scala/com/normation/rudder/datasources/DataSourceSerializer.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/datasources/DataSourceSerializer.scala
@@ -1,0 +1,341 @@
+/*
+*************************************************************************************
+* Copyright 2017 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.datasources
+
+import net.liftweb.common._
+import net.liftweb.util.ControlHelpers.tryo
+import scala.concurrent.duration.FiniteDuration
+import java.util.concurrent.TimeUnit
+import com.normation.rudder.repository.json.JsonExctractorUtils
+import scalaz.Monad
+import scala.concurrent.duration.Duration
+import net.liftweb.json._
+
+object DataSourceJsonSerializer{
+  def serialize(source : DataSource) : JValue = {
+    import net.liftweb.json.JsonDSL._
+    ( ( "name"        -> source.name.value  )
+    ~ ( "id"        -> source.id.value  )
+    ~ ( "description" -> source.description )
+    ~ ( "type" ->
+        ( ( "name" -> source.sourceType.name )
+        ~ ( "parameters" -> {
+            source.sourceType match {
+              case HttpDataSourceType(url,headers,method,checkSsl,path,mode,timeOut) =>
+                ( ( "url"        -> url     )
+                ~ ( "headers"    -> headers )
+                ~ ( "path"       -> path    )
+                ~ ( "checkSsl"   -> checkSsl )
+                ~ ( "requestTimeout"  -> timeOut.toMinutes )
+                ~ ( "requestMethod"  -> method )
+                ~ ( "requestMode"  ->
+                  ( ( "name" -> mode.name )
+                  ~ { mode match {
+                      case OneRequestByNode =>
+                        JObject(Nil)
+                      case OneRequestAllNodes(subPath,nodeAttribute) =>
+                        ( ( "path" -> subPath)
+                        ~ ( "attribute" -> nodeAttribute)
+                        )
+                  } } )
+                ) )
+            }
+        } ) )
+      )
+    ~ ( "runParameters" -> (
+        ( "onGeneration" -> source.runParam.onGeneration )
+      ~ ( "onNewNode"    -> source.runParam.onNewNode )
+      ~ ( "schedule"     -> (
+          ( "type" -> (source.runParam.schedule match {
+                          case _:Scheduled => "scheduled"
+                          case _:NoSchedule => "notscheduled"
+                        } ) )
+        ~ ( "duration" -> source.runParam.schedule.duration.toMinutes)
+        ) )
+      ) )
+    ~ ( "updateTimeout" -> source.updateTimeOut.toMinutes )
+    ~ ( "enabled"    -> source.enabled )
+    )
+  }
+}
+
+trait DataSourceExtractor[M[+_]] extends JsonExctractorUtils[M] {
+  import com.normation.utils.Control.sequence
+
+  case class DataSourceRunParamWrapper(
+      schedule     : M[DataSourceSchedule]
+    , onGeneration : M[Boolean]
+    , onNewNode    : M[Boolean]
+  ) {
+    def to = {
+      monad.apply3(schedule, onGeneration, onNewNode){
+        case (a,b,c) => DataSourceRunParameters(a,b,c)
+      }
+    }
+
+    def withBase (base : DataSourceRunParameters) = {
+      base.copy(
+          getOrElse(schedule, base.schedule)
+        , getOrElse(onGeneration,base.onGeneration)
+        , getOrElse(onNewNode,base.onNewNode)
+      )
+    }
+  }
+
+  case class DataSourceTypeWrapper(
+    url            : M[String]
+  , headers        : M[Map[String,String]]
+  , httpMethod     : M[String]
+  , sslCheck       : M[Boolean]
+  , path           : M[String]
+  , requestMode    : M[HttpRequestMode]
+  , requestTimeout : M[FiniteDuration]
+  ) {
+    def to = {
+      monad.apply7(url,headers,httpMethod,sslCheck,path,requestMode,requestTimeout){
+        case (a,b,c,d,e,f,g) => HttpDataSourceType(a,b,c,d,e,f,g)
+      }
+    }
+
+    def withBase (base : DataSourceType) : DataSourceType = {
+      base match {
+        case httpBase : HttpDataSourceType =>
+          httpBase.copy(
+              getOrElse(url           , httpBase.url)
+            , getOrElse(headers       , httpBase.headers)
+            , getOrElse(httpMethod    , httpBase.httpMethod)
+            , getOrElse(sslCheck      , httpBase.sslCheck)
+            , getOrElse(path          , httpBase.path)
+            , getOrElse(requestMode   , httpBase.requestMode)
+            , getOrElse(requestTimeout, httpBase.requestTimeOut)
+          )
+      }
+    }
+  }
+
+  case class DataSourceWrapper(
+    id            : DataSourceId
+  , name          : M[DataSourceName]
+  , sourceType    : M[DataSourceTypeWrapper]
+  , runParam      : M[DataSourceRunParamWrapper]
+  , description   : M[String]
+  , enabled       : M[Boolean]
+  , updateTimeout : M[FiniteDuration]
+  ) {
+    def to = {
+    val unwrapRunParam = monad.bind(runParam)(_.to)
+    val unwrapType = monad.bind(sourceType)(_.to)
+      monad.apply6(name, unwrapType, unwrapRunParam,description, enabled, updateTimeout){
+        case (a,b,c,d,e,f) => DataSource(id,a,b,c,d,e,f)
+      }
+    }
+    def withBase (base : DataSource) = {
+      val unwrapRunParam = monad.map(runParam)(_.withBase(base.runParam))
+      val unwrapType = monad.map(sourceType)(_.withBase(base.sourceType))
+      base.copy(
+          base.id
+        , getOrElse(name          , base.name)
+        , getOrElse(unwrapType    , base.sourceType)
+        , getOrElse(unwrapRunParam, base.runParam)
+        , getOrElse(description   , base.description)
+        , getOrElse(enabled       , base.enabled)
+        , getOrElse(updateTimeout , base.updateTimeOut)
+      )
+    }
+  }
+
+  def extractDuration (value : BigInt) = tryo { FiniteDuration(value.toLong, TimeUnit.MINUTES) }
+
+  def extractDataSource(id : DataSourceId, json : JValue) = {
+    for {
+      params <- extractDataSourceWrapper(id,json)
+    } yield {
+      params.to
+    }
+  }
+
+  def extractDataSourceType(json : JObject) = {
+    for {
+      params <- extractDataSourceTypeWrapper(json)
+    } yield {
+      params.to
+    }
+  }
+
+  def extractDataSourceRunParam(json : JObject) = {
+    for {
+      params <- extractDataSourceRunParameterWrapper(json)
+    } yield {
+      params.to
+    }
+  }
+
+  def extractDataSourceWrapper(id : DataSourceId, json : JValue) : Box[DataSourceWrapper] = {
+    for {
+      name         <- extractJsonString(json, "name",  x => Full(DataSourceName(x)))
+      description  <- extractJsonString(json, "description")
+      sourceType   <- extractJsonObj(json, "type", extractDataSourceTypeWrapper(_))
+      runParam     <- extractJsonObj(json, "runParameters", extractDataSourceRunParameterWrapper(_))
+      timeOut      <- extractJsonBigInt(json, "updateTimeout", extractDuration)
+      enabled      <- extractJsonBoolean(json, "enabled")
+    } yield {
+      DataSourceWrapper(
+        id
+      , name
+      , sourceType
+      , runParam
+      , description
+      , enabled
+      , timeOut
+      )
+    }
+  }
+
+  def extractDataSourceRunParameterWrapper(obj : JObject) = {
+
+    def extractSchedule(obj : JObject) = {
+        for {
+            duration <- extractJsonBigInt(obj, "duration", extractDuration)
+            scheduleBase  <- {
+
+              val t = extractJsonString(obj, "type",  _ match {
+              case "scheduled" => Full(monad.map(duration)(d => Scheduled(d)))
+              case "notscheduled" => Full(monad.map(duration)(d => NoSchedule(d)))
+              case _ => Failure("not a valid value for datasource schedule")
+              })
+              t.map( monad.join(_))
+            }
+        } yield {
+          scheduleBase
+      }
+    }
+
+    for {
+      onGeneration <- extractJsonBoolean(obj, "onGeneration")
+      onNewNode    <- extractJsonBoolean(obj, "onNewNode")
+      schedule     <- extractJsonObj(obj, "schedule", extractSchedule(_))
+    } yield {
+      DataSourceRunParamWrapper(
+          monad.join(schedule)
+        , onGeneration
+        , onNewNode
+      )
+    }
+  }
+
+  // A source type is composed of two fields : "name" and "parameters"
+  // name allow to determine which kind of datasource we are managing and how to extract paramters
+  def extractDataSourceTypeWrapper(obj : JObject) : Box[DataSourceTypeWrapper] = {
+
+    obj \ "name" match {
+      case JString(HttpDataSourceType.name) =>
+
+        def extractHttpRequestMode(obj : JObject) : Box[M[HttpRequestMode]] = {
+          obj \ "name" match {
+            case JString(OneRequestByNode.name) =>
+              Full(monad.point(OneRequestByNode))
+            case JString(OneRequestAllNodes.name) =>
+              for {
+                attribute <- extractJsonString(obj, "attribute")
+                path <- extractJsonString(obj, "path")
+              } yield {
+                monad.apply2(path, attribute){case (a,b) => OneRequestAllNodes(a,b)}
+              }
+            case x => Failure(s"Cannot extract request type from: ${x}")
+          }
+        }
+
+        def HttpDataSourceParameters (obj : JObject)  = {
+          for {
+            url      <- extractJsonString(obj, "url")
+            path     <- extractJsonString(obj, "path")
+            method   <- extractJsonString(obj, "requestMethod")
+            checkSsl <- extractJsonBoolean(obj, "checkSsl")
+            timeout  <- extractJsonBigInt(obj, "requestTimeout", extractDuration)
+            headers  <- extractJsonObj(obj, "headers", {
+                                          case container@JObject(fields) =>
+                                            val t = sequence(fields.toSeq) {
+                                              field => extractJsonString(container, field.name, value => Full((field.name,value)))
+                                            }
+                                            t
+                                       } )
+            requestMode <- extractJsonObj(obj, "requestMode", extractHttpRequestMode(_))
+
+          } yield {
+
+            import scalaz.std.list._
+            val t = monad.bind(headers)( s => monad.map(monad.sequence[(String,String),List]( s.toList))(_.toMap))
+            val unwrapMode = monad.join(requestMode)
+            (
+                url
+              , t
+              , method
+              , checkSsl
+              , path
+              , unwrapMode
+              , timeout
+            )
+          }
+        }
+
+        for {
+          parameters <- extractJsonObj(obj, "parameters", HttpDataSourceParameters)
+          url = monad.bind(parameters)(_._1)
+          headers = monad.bind(parameters)(_._2)
+          method = monad.bind(parameters)(_._3)
+          checkSsl = monad.bind(parameters)(_._4)
+          path = monad.bind(parameters)(_._5)
+          mode = monad.bind(parameters)(_._6)
+          timeout = monad.bind(parameters)(_._7)
+        } yield {
+          DataSourceTypeWrapper(
+              url
+            , headers
+            , method
+            , checkSsl
+            , path
+            , mode
+            , timeout
+          )
+        }
+
+      case x => Failure(s"Cannot extract a data source type from: ${x}")
+    }
+  }
+
+}

--- a/rudder-core/src/main/scala/com/normation/rudder/repository/json/JsonExctractorUtils.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/repository/json/JsonExctractorUtils.scala
@@ -1,0 +1,118 @@
+/*
+*************************************************************************************
+* Copyright 2017 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.repository.json
+
+import net.liftweb.json._
+import net.liftweb.common._
+import com.normation.utils.Control._
+import scalaz.Monad
+import scalaz.Id
+import scalaz.std.option._
+import com.normation.rudder.datasources.DataSourceExtractor
+
+trait JsonExctractorUtils[A[_]] {
+
+  implicit def monad : Monad[A]
+
+  def getOrElse[T](value : A[T], default : T) : T
+  def boxedIdentity[T] : T => Box[T] = Full(_)
+  protected[this] def extractJson[T, U ] (json:JValue, key:String, convertTo : U => Box[T], validJson : PartialFunction[JValue, U]) : Box[A[T]]
+
+  def extractJsonString[T](json:JValue, key:String, convertTo : String => Box[T] = boxedIdentity[String]) = {
+    extractJson(json, key, convertTo ,{ case JString(value) => value } )
+  }
+
+  def extractJsonBoolean[T](json:JValue, key:String, convertTo : Boolean => Box[T] = boxedIdentity[Boolean] ) = {
+    extractJson(json, key, convertTo ,{ case JBool(value) => value } )
+  }
+
+  def extractJsonInt(json:JValue, key:String ) = {
+    extractJsonBigInt(json,key, i => Full(i.toInt) )
+  }
+
+  def extractJsonBigInt[T](json:JValue, key:String , convertTo : BigInt => Box[T] = boxedIdentity[BigInt] )= {
+    extractJson(json, key, convertTo ,{ case JInt(value) => value } )
+  }
+
+  def extractJsonObj[T](json : JValue, key : String, jsonValueFun : JObject => Box[T])  = {
+    extractJson(json, key, jsonValueFun, { case obj : JObject => obj } ).map(x => monad.map(x)(identity))
+  }
+
+  def extractJsonListString[T] (json: JValue, key: String)( convertTo: List[String] => Box[T] ): Box[Option[T]] = {
+    json \ key match {
+      case JArray(values) =>
+        for {
+          strings <- sequence(values) { _ match {
+                        case JString(s) => Full(s)
+                        case x => Failure(s"Error extracting a string from json: '${x}'")
+                      } }
+          converted <- convertTo(strings.toList)
+        } yield {
+          Some(converted)
+        }
+      case JNothing   => Full(None)
+      case _              => Failure(s"Not a good value for parameter ${key}")
+    }
+  }
+}
+
+object OptionnalJson extends DataSourceExtractor[Option] {
+  def monad = implicitly
+  def getOrElse[T](value : Option[T], default : T) = value.getOrElse(default)
+  protected[this] def extractJson[T, U ] (json:JValue, key:String, convertTo : U => Box[T], validJson : PartialFunction[JValue, U]) = {
+    json \ key match {
+      case JNothing => Full(None)
+      case value if validJson.isDefinedAt(value) =>
+        convertTo(validJson(value)).map(Some(_))
+      case invalidJson => Failure(s"Not a good value for parameter ${key}: ${compactRender(invalidJson)}")
+    }
+  }
+}
+
+ object CompleteJson extends DataSourceExtractor[Id.Id] {
+  def monad = implicitly
+  def getOrElse[T](value : T, default : T) = value
+  protected[this] def extractJson[T, U ] (json:JValue, key:String, convertTo : U => Box[T], validJson : PartialFunction[JValue, U]) = {
+    json \ key match {
+      case value if validJson.isDefinedAt(value) =>
+        convertTo(validJson(value))
+      case JNothing => Failure(s"parameter ${key} cannot be empty")
+      case invalidJson => Failure(s"Not a good value for parameter ${key}: ${compactRender(invalidJson)}")
+    }
+  }
+}

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -140,7 +140,7 @@ import com.normation.rudder.db.Doobie
 import com.normation.rudder.web.rest.settings.SettingsAPI8
 import com.normation.rudder.web.rest.sharedFiles.SharedFilesAPI
 import com.normation.rudder.web.rest.datasource._
-import com.normation.rudder.datasources.MemoryDataSourceRepository
+import com.normation.rudder.datasources.DataSourceJdbcRepository
 import com.normation.rudder.datasources.DataSourceRepoImpl
 import com.normation.rudder.datasources.HttpQueryDataSourceService
 
@@ -398,7 +398,7 @@ object RudderConfig extends Loggable {
   val roApiAccountRepository : RoApiAccountRepository = roLDAPApiAccountRepository
   val woApiAccountRepository : WoApiAccountRepository = woLDAPApiAccountRepository
   lazy val dataSourceRepository = new DataSourceRepoImpl(
-      new MemoryDataSourceRepository
+      new DataSourceJdbcRepository(doobie)
     , new HttpQueryDataSourceService(nodeInfoServiceImpl, roLDAPParameterRepository, woLdapNodeRepository, interpolationCompiler)
     , stringUuidGenerator
   )

--- a/rudder-web/src/main/scala/com/normation/rudder/web/rest/RestDataSerializer.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/rest/RestDataSerializer.scala
@@ -594,48 +594,7 @@ case class RestDataSerializerImpl (
   }
 
   def serializeDataSource(source : DataSource): JValue = {
-    ( ( "name"        -> source.name.value  )
-    ~ ( "id"        -> source.id.value  )
-    ~ ( "description" -> source.description )
-    ~ ( "type" ->
-        ( ( "name" -> source.sourceType.name )
-        ~ ( "parameters" -> {
-            source.sourceType match {
-              case HttpDataSourceType(url,headers,method,checkSsl,path,mode,timeOut) =>
-                ( ( "url"        -> url     )
-                ~ ( "headers"    -> headers )
-                ~ ( "path"       -> path    )
-                ~ ( "checkSsl"   -> checkSsl )
-                ~ ( "requestTimeout"  -> timeOut.toMinutes )
-                ~ ( "requestMethod"  -> method )
-                ~ ( "requestMode"  ->
-                  ( ( "name" -> mode.name )
-                  ~ { mode match {
-                      case OneRequestByNode =>
-                        JObject(Nil)
-                      case OneRequestAllNodes(subPath,nodeAttribute) =>
-                        ( ( "path" -> subPath)
-                        ~ ( "attribute" -> nodeAttribute)
-                        )
-                  } } )
-                ) )
-            }
-        } ) )
-      )
-    ~ ( "runParameters" -> (
-        ( "onGeneration" -> source.runParam.onGeneration )
-      ~ ( "onNewNode"    -> source.runParam.onNewNode )
-      ~ ( "schedule"     -> (
-          ( "type" -> (source.runParam.schedule match {
-                          case _:Scheduled => "scheduled"
-                          case _:NoSchedule => "notscheduled"
-                        } ) )
-        ~ ( "duration" -> source.runParam.schedule.duration.toMinutes)
-        ) )
-      ) )
-    ~ ( "updateTimeout" -> source.updateTimeOut.toMinutes )
-    ~ ( "enabled"    -> source.enabled )
-    )
+    DataSourceJsonSerializer.serialize(source)
   }
 
 }

--- a/rudder-web/src/test/scala/com/normation/rudder/web/rest/RestDataSourceTest.scala
+++ b/rudder-web/src/test/scala/com/normation/rudder/web/rest/RestDataSourceTest.scala
@@ -61,6 +61,7 @@ import net.liftweb.common.Box
 import com.normation.rudder.web.rest.datasource.DataSourceApi
 import scala.concurrent.duration.Duration
 import java.util.concurrent.TimeUnit
+import com.normation.rudder.repository.json.CompleteJson
 
 @RunWith(classOf[JUnitRunner])
 class RestDataSourceTest extends Specification with Loggable {
@@ -84,7 +85,9 @@ class RestDataSourceTest extends Specification with Loggable {
   val baseRunParam  = DataSourceRunParameters(NoSchedule(DataSource.defaultDuration), false,false)
 
   val datasource1 = DataSource(DataSourceId( "datasource1"), DataSourceName(""), baseSourceType, baseRunParam, "", false, DataSource.defaultDuration)
+
   val d1Json = restDataSerializer.serializeDataSource(datasource1)
+
   RestTestSetUp.datasourceRepo.save(datasource1)
 
   val datasource2 = datasource1.copy(id = DataSourceId("datasource2"))
@@ -95,6 +98,7 @@ class RestDataSourceTest extends Specification with Loggable {
     , sourceType = baseSourceType.copy(headers = Map( ("new header 1" -> "new value 1") , ("new header 2" -> "new value 2")))
     , runParam = baseRunParam.copy(Scheduled(Duration(70, TimeUnit.MINUTES))))
   val d2updatedJson = restDataSerializer.serializeDataSource(dataSource2Updated)
+
   val d2modJson = {
     import net.liftweb.json.JsonDSL._
     ( ( "type" ->
@@ -112,7 +116,19 @@ class RestDataSourceTest extends Specification with Loggable {
     )
   }
 
+  val d2DeletedJson = {
+    import net.liftweb.json.JsonDSL._
+    ( ( "id" -> datasource2.id.value )
+    ~ ( "message" -> s"Data source ${datasource2.id.value} deleted" )
+    )
+  }
   sequential ^ ("Data source api" should {
+
+    "test backend serialization" in {
+       val result = CompleteJson.extractDataSource(datasource1.id, DataSourceJsonSerializer.serialize(datasource1))
+
+       result must beEqualTo(Full(datasource1))
+    }
 
     "Get all base data source" in {
       testGET("/api/latest/datasources") { req =>
@@ -188,7 +204,7 @@ class RestDataSourceTest extends Specification with Loggable {
        } yield {
          data
        }
-       result must beEqualTo(Full(d2updatedJson :: Nil))
+       result must beEqualTo(Full(d2DeletedJson :: Nil))
       }
     }
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9701

This PR consists in two things:

Adding a backend for datasources, easy part

Having one json serialization that will work both for backend and rest api. Most complicated part was that it has not the same needs (backend data must be complete, rest API may be partial)
I used some Monad magic from Scalaz (but I think i need an implicit somewere to make it much more readable) 

Two implementation on json serialization, one with monad Id (backend, fails if a data is missing), one with Option (allow to have partial data)

enjoy! 