### PR TITLE
Fixes #9836: Deprecate API v5, v6 and v7, and remove API v2,3,4

### DIFF
--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -819,16 +819,10 @@ object RudderConfig extends Loggable {
 
   val apis = {
     Map (
-        //Rudder 2.7
-        ( ApiVersion(2,true) -> apiV2 )
-        //Rudder 2.8
-      , ( ApiVersion(3,true) -> apiV3 )
-        //Rudder 2.10
-      , ( ApiVersion(4,true) -> apiV4 )
         //Rudder 3.0
-      , ( ApiVersion(5,false) -> apiV5 )
+        ( ApiVersion(5,true) -> apiV5 )
         //Rudder 3.1
-      , ( ApiVersion(6,false) -> apiV6 )
+      , ( ApiVersion(6,true) -> apiV6 )
         //Rudder 3.2
       , ( ApiVersion(7,false) -> apiV7 )
         //Rudder 4.0


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9836