### PR TITLE
Fixes #10553: Log contains debug info  "**** got string: {"start":"2017-03-09 00:00:00", "end", "2017-03-11 00:00:00"}"

### DIFF
--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/LogDisplayer.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/LogDisplayer.scala
@@ -100,8 +100,6 @@ class LogDisplayer(
 
       val format = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss")
 
-      println("**** got string: " + jsonInterval)
-
       (for {
         parsed   <- tryo(parse(jsonInterval)) ?~! s"Error when trying to parse '${jsonInterval}' as a JSON datastructure with fields 'start' and 'end'"
         startStr <- parsed \ "start" match {


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10553