### PR TITLE
Fixes #10636: When no reports has been received from a node for new policy, message contains unexpanded variable

### DIFF
--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -156,7 +156,7 @@ class ReportDisplayer(
               (id.endOfLife match {
                 case None =>
                   s"This is expected, the node is reporting on the previous configuration policy and should report on the new one at latest" +
-                  " ${expirationDateTime.toString(dateFormat)}. Previous known states are displayed below."
+                  s" ${expirationDateTime.toString(dateFormat)}. Previous known states are displayed below."
                 case Some(exp) =>
                   s"This is unexpected, since the node is reporting on a configuration policy that expired at ${exp.toString(dateFormat)}."
               }) +


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10636