### PR TITLE
Fixes #11307: There is no "node-post-deletion" hook directory but a "node-pre-deletion" one

### DIFF
--- a/rudder-core/src/main/resources/hooks.d/node-post-deletion/readme.adoc
+++ b/rudder-core/src/main/resources/hooks.d/node-post-deletion/readme.adoc
@@ -1,4 +1,4 @@
-= policy-generation-node-finished
+= node-post-deletion
 
 == When/What ?
 

--- a/rudder-core/src/main/resources/hooks.d/node-pre-deletion/readme.adoc
+++ b/rudder-core/src/main/resources/hooks.d/node-pre-deletion/readme.adoc
@@ -1,4 +1,4 @@
-= policy-generation-node-finished
+= node-pre-deletion
 
 == When/What ?
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/11307