### PR TITLE
Fixes #10599: Impossible to search or build groups based on JSON values in node properties

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
@@ -56,9 +56,7 @@ import net.liftweb.json._
 import JsonDSL._
 import com.normation.exceptions.TechnicalException
 import com.normation.utils.HashcodeCaching
-import com.normation.rudder.services.queries.RegexFilter
-import net.liftweb.common.EmptyBox
-import com.normation.rudder.services.queries.NotRegexFilter
+import com.normation.rudder.services.queries._
 
 sealed trait CriterionComparator {
   val id:String
@@ -137,8 +135,8 @@ sealed trait CriterionType  extends ComparatorList {
   //transform the given value to its LDAP string value
   def toLDAP(value:String) : Box[String]
 
-  def buildRegex(attribute:String,value:String): Box[RegexFilter] = Full(RegexFilter(attribute,value))
-  def buildNotRegex(attribute:String,value:String): Box[NotRegexFilter] = Full(NotRegexFilter(attribute,value))
+  def buildRegex(attribute:String,value:String): Box[RegexFilter] = Full(SimpleRegexFilter(attribute,value))
+  def buildNotRegex(attribute:String,value:String): Box[NotRegexFilter] = Full(SimpleNotRegexFilter(attribute,value))
 
   //build the ldap filter for given attribute name and comparator
   def buildFilter(attributeName:String,comparator:CriterionComparator,value:String) : Filter =
@@ -448,22 +446,22 @@ case object EditorComparator extends CriterionType {
  *
  * Used for "process" attribute
  */
-case class JsonFixedKeyComparator(ldapAttr:String, jsonKey: String, numericvalue: Boolean) extends TStringComparator with Loggable {
+case class JsonFixedKeyComparator(ldapAttr:String, jsonKey: String, quoteValue: Boolean) extends TStringComparator with Loggable {
   override val comparators = BaseComparators.comparators
 
   def format(attribute:String, value:String) = {
-    val v = if (numericvalue) value else s""""$value""""
+    val v = if (quoteValue) s""""$value"""" else value
     s""""${attribute}":${v}"""
   }
   def regex(attribute: String, value: String) = {
     s".*${format(attribute, value)}.*"
   }
   override def buildRegex(attribute:String,value:String) : Box[RegexFilter] = {
-    Full(RegexFilter(ldapAttr,regex(attribute, value)))
+    Full(SimpleRegexFilter(ldapAttr,regex(attribute, value)))
   }
 
   override def buildNotRegex(attribute:String,value:String) : Box[NotRegexFilter] = {
-    Full(NotRegexFilter(ldapAttr,regex(attribute, value)))
+    Full(SimpleNotRegexFilter(ldapAttr,regex(attribute, value)))
   }
 
   override def buildFilter(key: String, comparator:CriterionComparator,value: String) : Filter = {
@@ -516,25 +514,25 @@ case class NameValueComparator(ldapAttr: String) extends TStringComparator with 
 
   //the first arg is "name.value", not interesting here
   override def buildRegex(_x: String, value: String) : Box[RegexFilter] = {
-    Full(RegexFilter(ldapAttr,"""\{"""+formatKV(splitInput(value))+"""\}""" ))
+    Full(SimpleRegexFilter(ldapAttr,"""\{"""+formatKV(splitInput(value))+"""\}""" ))
   }
 
   //the first arg is "name.value", not interesting here
   override def buildNotRegex(_x: String, value: String) : Box[NotRegexFilter] = {
-    Full(NotRegexFilter(ldapAttr,"""\{"""+formatKV(splitInput(value))+"""\}"""))
+    Full(SimpleNotRegexFilter(ldapAttr,"""\{"""+formatKV(splitInput(value))+"""\}"""))
   }
 
   //the first arg is "name.value", not interesting here
   override def buildFilter(_x:String, comparator:CriterionComparator, value:String) : Filter = {
     val kv = splitInput(value)
-    val sub = SUB(ldapAttr, null, Array(formatKV(kv).getBytes("UTF-8")), null)
+    val sub = SUB(ldapAttr, ("{"+formatKV(kv)).getBytes("UTF-8"s), null, null)
     comparator match {
       case Equals    => sub
       case NotEquals => NOT(sub)
       case NotExists => NOT(HAS(ldapAttr))
       case Regex     => HAS(ldapAttr) //default, non interpreted regex
       case NotRegex  => HAS(ldapAttr) //default, non interpreted regex
-      case HasKey    => SUB(ldapAttr, null, Array(s""""${kv._1}"""".getBytes("UTF-8") ), null)
+      case HasKey    => SUB(ldapAttr, s"""{"name":"${kv._1}"""".getBytes("UTF-8"), null, null)
       case _         => HAS(ldapAttr) //default to Exists
     }
   }
@@ -542,86 +540,82 @@ case class NameValueComparator(ldapAttr: String) extends TStringComparator with 
 
 
 /*
- * This class is used to look in a JSON key/value pair for an LDAPAttribute (with a JSON value) when neither the key nor
- * tha value is known before hand (i.e: it's what one would expect for a json search).
+ * This comparator is used for "node properties"-like attribute, i.e:
+ * - the properties has a name and a value;
+ * - the name is a simple quoted string;
+ * - the value is either a quoted string or a valid JSON values (we
+ *   always minify json, but forcing our user to rely on that is
+ *   *extremelly* brittle and we will need a real json parsing in place of
+ *   that as soon as we will propose matching sub "k":"v" in "value")
  *
- * The expected value has the format: "key=value", and we split at the "=" to get each parts.
  *
- * The json is expected to be like:
- * {"name":"key", "value": VALUE }
- *
- * with VALUE either a string or a JSON object.
- *
- * How to search for k/v pair in VALUE ?
+ * The serialisation is done as follow:
+ *   {("provider":"someone",)?"name":"k","value":VALUE}
+ * With VALUE either a quoted string or a json:
+ *   {"name":"k","value":"v"}
+ *   {"name":"k","value":{ "any":"json","here":"here"}}
  *
  */
-case class JsonComparator(key:String, splitter:String = "", numericvalue:Boolean = false) extends TStringComparator with Loggable {
+case class NodePropertyComparator(ldapAttr: String) extends TStringComparator with Loggable {
   override val comparators = HasKey +: BaseComparators.comparators
 
-  def splitJson(attribute:String, value:String) = {
-    val (splittedattribute,splittedvalue) =
-      if (splitter!="")
-        (attribute.split('.'), value.split(splitter))
-      else
-        (Array(attribute), Array(value))
-
-    if (splittedvalue.size == splittedattribute.size) {
-      val keyvalue = (splittedattribute.toList,splittedvalue.toList).zipped map( (attribute,value) => (attribute,value))
-      Full(keyvalue.map(attval =>
-        if (numericvalue)
-          s""""${attval._1}":${attval._2}"""
-        else
-          s""""${attval._1}":"${attval._2}""""
-      ) )
-    } else {
-      Failure(s"Could not  split attribute '${attribute}'  of value '${value}' with splitter '${splitter}'")
+  // split k=v (v may not exists if there is no '='
+  // is there is several '=', we consider they are part of the value
+  def splitInput(value: String): (String, Option[String]) = {
+    val array = value.split('=')
+    val k = array(0) //always exists with split
+    val v = array.toList.tail match {
+      case Nil => None
+      case t   => Some(t.mkString("="))
     }
+    (k, v)
   }
 
-  private[this] def getAttributeKey(attribute: String) = {
-    if(splitter != "") {
-      attribute.split('.')(0)
-    } else {
-      attribute
-    }
+  // produce the correct "serialized" JSON to look for value is string
+  // for regex - format awaited by NodePropertyRegexFilter is exactly minified json with
+  // only name and value fieds (in that order)
+  def formatKV3(kv: (String, Option[String])): String = {
+    s"""\\{"name":"${kv._1}","value":["{]?${kv._2.getOrElse("")}["}]?\\}"""
   }
 
-  override def buildRegex(attribute:String,value:String) : Box[RegexFilter] = {
-    for {
-      splitted <- splitJson(attribute,value)
-      regexp = s".*${splitted.mkString(".*")}.*"
-    } yield {
-      RegexFilter(key,regexp)
-    }
+  //the first arg is "name.value", not interesting here
+  override def buildRegex(_x: String, value: String) : Box[RegexFilter] = {
+    //here, we need to parse json and extract the value part
+    Full(NodePropertyRegexFilter(ldapAttr,formatKV3(splitInput(value))))
   }
 
-  override def buildNotRegex(attribute:String,value:String) : Box[NotRegexFilter] = {
-    for {
-      splitted <- splitJson(attribute,value)
-      regexp = s".*${splitted.mkString(".*")}.*"
-    } yield {
-      NotRegexFilter(key,regexp)
-    }
+  //the first arg is "name.value", not interesting here
+  override def buildNotRegex(_x: String, value: String) : Box[NotRegexFilter] = {
+    Full(NodePropertyNotRegexFilter(ldapAttr,formatKV3(splitInput(value))))
   }
 
-  override def buildFilter(attributeName:String, comparator:CriterionComparator,value:String) : Filter = {
-    def JsonQueryfromkeyvalues (attributeName:String,value:String): Filter = {
-      splitJson(attributeName,value) match {
-        case e:EmptyBox => HAS(key)
-        case Full(x)    => SUB(key,null,x.toArray ,null)
-      }
+  //the first arg is "name.value", not interesting here
+  override def buildFilter(_x:String, comparator:CriterionComparator, value:String) : Filter = {
+    val kv = splitInput(value)
+    def buildEq = {
+      // value is a string
+      val kv1  = s"""{"name":"${kv._1}","value":"${kv._2.getOrElse("")}""""
+      // value is unquoted: number, boolean, array, object
+      val kv2  = s"""{"name":"${kv._1}","value":${kv._2.getOrElse("")}}"""
+
+      OR(SUB(ldapAttr, kv1.getBytes("UTF-8"), null, null)
+        ,SUB(ldapAttr, kv2.getBytes("UTF-8"), null, null)
+      )
     }
+
     comparator match {
-      case Equals    => JsonQueryfromkeyvalues(attributeName, value)
-      case NotEquals => NOT(JsonQueryfromkeyvalues(attributeName, value))
-      case NotExists => NOT(HAS(key))
-      case Regex     => HAS(key) //default, non interpreted regex
-      case NotRegex  => HAS(key) //default, non interpreted regex
-      case HasKey    => SUB(key, null, Array(s""""${getAttributeKey(attributeName)}":"${value}"""".getBytes), null)
-      case _ => HAS(key) //default to Exists
+      case Equals    => buildEq
+      case NotEquals => NOT(buildEq)
+      case NotExists => NOT(HAS(ldapAttr))
+      case Regex     => HAS(ldapAttr) //default, non interpreted regex
+      case NotRegex  => HAS(ldapAttr) //default, non interpreted regex
+      case HasKey    => OR(SUB(ldapAttr, s"""{"name":"${kv._1}"""".getBytes("UTF-8"), null, null)
+                          ,SUB(ldapAttr, s"""{"provider":"""".getBytes("UTF-8"), Array(s"""","name":"${kv._1}"""".getBytes("UTF-8")), null))
+      case _         => HAS(ldapAttr) //default to Exists
     }
   }
 }
+
 
 case class Criterion(val name:String, val cType:CriterionType) extends HashcodeCaching {
   require(name != null && name.length > 0, "Criterion name must be defined")

--- a/rudder-core/src/main/scala/com/normation/rudder/domain/queries/DitQueryData.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/queries/DitQueryData.scala
@@ -233,14 +233,14 @@ class DitQueryData(dit:InventoryDit, nodeDit: NodeDit) {
       Criterion(A_TOTAL_SPACE, MemoryComparator)
     )),
     ObjectCriterion(A_PROCESS, Seq(
-      Criterion("pid", JsonFixedKeyComparator(A_PROCESS, "pid", true)),
-      Criterion("commandName", JsonFixedKeyComparator(A_PROCESS, "commandName", false)),
-      Criterion("cpuUsage", JsonFixedKeyComparator(A_PROCESS, "cpuUsage",true)),
-      Criterion("memory", JsonFixedKeyComparator(A_PROCESS, "memory",true)),
-      Criterion("tty", JsonFixedKeyComparator(A_PROCESS, "tty", false)),
-      Criterion("virtualMemory", JsonFixedKeyComparator(A_PROCESS, "virtualMemory", true)),
-      Criterion("started", JsonFixedKeyComparator(A_PROCESS, "started", false)),
-      Criterion("user", JsonFixedKeyComparator(A_PROCESS, "user", false))
+      Criterion("pid", JsonFixedKeyComparator(A_PROCESS, "pid", false)),
+      Criterion("commandName", JsonFixedKeyComparator(A_PROCESS, "commandName", true)),
+      Criterion("cpuUsage", JsonFixedKeyComparator(A_PROCESS, "cpuUsage",false)),
+      Criterion("memory", JsonFixedKeyComparator(A_PROCESS, "memory",false)),
+      Criterion("tty", JsonFixedKeyComparator(A_PROCESS, "tty", true)),
+      Criterion("virtualMemory", JsonFixedKeyComparator(A_PROCESS, "virtualMemory", false)),
+      Criterion("started", JsonFixedKeyComparator(A_PROCESS, "started", true)),
+      Criterion("user", JsonFixedKeyComparator(A_PROCESS, "user", true))
     )),
     ObjectCriterion(OC_VM_INFO, leObjectCriterion.criteria ++ Seq(
       Criterion(A_VM_TYPE, StringComparator),
@@ -256,7 +256,7 @@ class DitQueryData(dit:InventoryDit, nodeDit: NodeDit) {
       Criterion("name.value", NameValueComparator(A_EV) )
     ))
   , ObjectCriterion(A_NODE_PROPERTY, Seq(
-      Criterion("name.value", JsonComparator(A_NODE_PROPERTY,"=") )
+      Criterion("name.value", NodePropertyComparator(A_NODE_PROPERTY) )
     ))
   )
 

--- a/rudder-core/src/main/scala/com/normation/rudder/domain/queries/DitQueryData.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/queries/DitQueryData.scala
@@ -233,14 +233,14 @@ class DitQueryData(dit:InventoryDit, nodeDit: NodeDit) {
       Criterion(A_TOTAL_SPACE, MemoryComparator)
     )),
     ObjectCriterion(A_PROCESS, Seq(
-      Criterion("pid", JsonComparator(A_PROCESS,"",true)),
-      Criterion("commandName", JsonComparator(A_PROCESS)),
-      Criterion("cpuUsage", JsonComparator(A_PROCESS,"",true)),
-      Criterion("memory", JsonComparator(A_PROCESS,"",true)),
-      Criterion("tty", JsonComparator(A_PROCESS)),
-      Criterion("virtualMemory", JsonComparator(A_PROCESS,"",true)),
-      Criterion("datetime", JsonComparator(A_PROCESS)),
-      Criterion("user", JsonComparator(A_PROCESS))
+      Criterion("pid", JsonFixedKeyComparator(A_PROCESS, "pid", true)),
+      Criterion("commandName", JsonFixedKeyComparator(A_PROCESS, "commandName", false)),
+      Criterion("cpuUsage", JsonFixedKeyComparator(A_PROCESS, "cpuUsage",true)),
+      Criterion("memory", JsonFixedKeyComparator(A_PROCESS, "memory",true)),
+      Criterion("tty", JsonFixedKeyComparator(A_PROCESS, "tty", false)),
+      Criterion("virtualMemory", JsonFixedKeyComparator(A_PROCESS, "virtualMemory", true)),
+      Criterion("started", JsonFixedKeyComparator(A_PROCESS, "started", false)),
+      Criterion("user", JsonFixedKeyComparator(A_PROCESS, "user", false))
     )),
     ObjectCriterion(OC_VM_INFO, leObjectCriterion.criteria ++ Seq(
       Criterion(A_VM_TYPE, StringComparator),
@@ -253,7 +253,7 @@ class DitQueryData(dit:InventoryDit, nodeDit: NodeDit) {
       Criterion(A_VM_NAME, StringComparator)
     )),
     ObjectCriterion(A_EV, Seq(
-      Criterion("name.value", JsonComparator(A_EV,"=") )
+      Criterion("name.value", NameValueComparator(A_EV) )
     ))
   , ObjectCriterion(A_NODE_PROPERTY, Seq(
       Criterion("name.value", JsonComparator(A_NODE_PROPERTY,"=") )

--- a/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
@@ -55,6 +55,7 @@ import com.normation.utils.HashcodeCaching
 import net.liftweb.util.Helpers
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.services.nodes.LDAPNodeInfo
+import net.liftweb.json.JsonAST.JObject
 
 /*
  * We have two type of filters:
@@ -67,9 +68,17 @@ sealed trait ExtendedFilter
 final case class LDAPFilter(f:Filter) extends ExtendedFilter with HashcodeCaching
 
 //special ones
-sealed trait SpecialFilter extends ExtendedFilter
-final case class RegexFilter(attributeName:String, regex:String) extends SpecialFilter with HashcodeCaching
-final case class NotRegexFilter(attributeName:String, regex:String) extends SpecialFilter with HashcodeCaching
+sealed trait SpecialFilter  extends ExtendedFilter
+sealed trait GeneralRegexFilter extends SpecialFilter {
+  def attributeName:String
+  def regex:String
+}
+sealed trait RegexFilter    extends GeneralRegexFilter
+sealed trait NotRegexFilter extends GeneralRegexFilter
+final case class SimpleRegexFilter         (attributeName:String, regex:String) extends RegexFilter    with HashcodeCaching
+final case class SimpleNotRegexFilter      (attributeName:String, regex:String) extends NotRegexFilter with HashcodeCaching
+final case class NodePropertyRegexFilter   (attributeName:String, regex:String) extends RegexFilter    with HashcodeCaching
+final case class NodePropertyNotRegexFilter(attributeName:String, regex:String) extends NotRegexFilter with HashcodeCaching
 
 /*
  * An NodeQuery differ a little from a Query because its components are sorted in two ways:
@@ -449,14 +458,7 @@ class InternalLDAPQueryProcessor(
 
       //special filter can modify the filter and the attributes to get
       val params = ( (filter,attributes) /: addedSpecialFilters) {
-            case ( (f, currentAttributes), r:RegexFilter) =>
-              val filterToApply = composition match {
-                case Or => Some(ALL)
-                case And => f.orElse(Some(ALL))             }
-
-              (filterToApply, currentAttributes ++ getAdditionnalAttributes(Set(r)))
-
-            case ( (f, currentAttributes), r:NotRegexFilter) =>
+            case ( (f, currentAttributes), r:GeneralRegexFilter) =>
               val filterToApply = composition match {
                 case Or => Some(ALL)
                 case And => f.orElse(Some(ALL))             }
@@ -591,9 +593,8 @@ class InternalLDAPQueryProcessor(
   private[this] def unspecialiseFilters(filters:Set[ExtendedFilter]) : Box[(Set[Filter], Set[SpecialFilter])] = {
     val start = (Set[Filter](), Set[SpecialFilter]())
     Full((start /: filters) {
-      case (  (ldapFilters,specials), LDAPFilter(f) ) => (ldapFilters + f, specials)
-      case (  (ldapFilters,specials), r:RegexFilter ) => (ldapFilters, specials + r)
-      case (  (ldapFilters,specials), r:NotRegexFilter ) => (ldapFilters, specials + r)
+      case (  (ldapFilters,specials), LDAPFilter(f)        ) => (ldapFilters + f, specials)
+      case (  (ldapFilters,specials), r:GeneralRegexFilter ) => (ldapFilters, specials + r)
       case (x, f) => return Failure("Can not handle filter type: '%s', abort".format(f))
     })
   }
@@ -604,8 +605,7 @@ class InternalLDAPQueryProcessor(
    */
   private[this] def getAdditionnalAttributes(filters:Set[SpecialFilter]) : Set[String] = {
     filters.flatMap {
-      case RegexFilter(attr,v) => Set(attr)
-      case NotRegexFilter(attr,v) => Set(attr)
+      case f:GeneralRegexFilter => Set(f.attributeName)
     }
   }
 
@@ -624,40 +624,94 @@ class InternalLDAPQueryProcessor(
         }
       }
 
+      /*
+       * Apply the regex match filter on entries-> attribute after applying the valueFormatter function
+       * (which can be used to normalized the value)
+       */
+      def regexMatch(attr: String, regexText: String, entries: Seq[LDAPEntry], valueFormatter: String => Box[String]) = {
+        for {
+          pattern <- getRegex(regexText)
+        } yield {
+          /*
+           * We want to match "OK" an entry if any of the values for
+           * the given attribute matches the regex.
+           */
+          entries.filter { entry =>
+            val res = entry.valuesFor(attr).exists { value =>
+              valueFormatter(value) match {
+                case Full(v) => pattern.matcher( v ).matches
+                case _       => false
+              }
+            }
+            logger.trace("[%5s] for regex check '%s' on attribute %s of entry: %s:%s".format(res, regexText, attr, entry.dn,entry.valuesFor(attr).mkString(",")))
+            res
+          }
+        }
+      }
+
+      /*
+       * Apply the regex NOT match filter on entries-> attribute after applying the valueFormatter function
+       * (which can be used to normalized the value)
+       */
+      def regexNotMatch(attr: String, regexText: String, entries: Seq[LDAPEntry], valueFormatter: String => Box[String]) = {
+        for {
+          pattern <- getRegex(regexText)
+        } yield {
+          /*
+           * We want to match "OK" an entry if the entry does not
+           * have the attribute or NONE of the value matches the regex.
+           */
+          entries.filter { entry =>
+            logger.trace("Filtering with regex not matching '%s' entry: %s:%s".format(regexText,entry.dn,entry.valuesFor(attr).mkString(",")))
+            val res = entry.valuesFor(attr).forall { value =>
+              valueFormatter(value) match {
+                case Full(v) => !pattern.matcher( v ).matches
+                case _       => false
+              }
+            }
+            logger.trace("Entry matches: " + res)
+            res
+          }
+        }
+      }
+
+      /*
+       * Parse the value as json and write it back as wanted.
+       * Perf won't be amazing, but it's the only sane way
+       * to do it.
+       */
+      def normalizeJsonNodeProperty(value: String): Box[String] = {
+        import net.liftweb.json._
+        import net.liftweb.json.JsonDSL._
+
+        for {
+          j <- parseOpt(value) match {
+                 case Some(j:JObject) => Full(j)
+                 case _               => Failure("The node property can not be parsed as JSON")
+               }
+          n =  j \ "name"
+          v =  j \ "value"
+        } yield {
+         compactRender((( "name" -> n) ~ ("value" -> v)))
+        }
+      }
+
       specialFilter match {
-        case RegexFilter(attr,regexText) =>
-          for {
-            pattern <- getRegex(regexText)
-          } yield {
-            /*
-             * We want to match "OK" an entry if any of the values for
-             * the given attribute matches the regex.
-             */
-            entries.filter { entry =>
-              val res = entry.valuesFor(attr).exists { value =>
-                pattern.matcher( value ).matches
-              }
-              logger.trace("[%5s] for regex check '%s' on attribute %s of entry: %s:%s".format(res, regexText, attr, entry.dn,entry.valuesFor(attr).mkString(",")))
-              res
-            }
-          }
-        case NotRegexFilter(attr,regexText) =>
-          for {
-            pattern <- getRegex(regexText)
-          } yield {
-            /*
-             * We want to match "OK" an entry if the entry does not
-             * have the attribute or NONE of the value matches the regex.
-             */
-            entries.filter { entry =>
-              logger.trace("Filtering with regex not matching '%s' entry: %s:%s".format(regexText,entry.dn,entry.valuesFor(attr).mkString(",")))
-              val res = entry.valuesFor(attr).forall { value =>
-                !pattern.matcher( value ).matches
-              }
-              logger.trace("Entry matches: " + res)
-              res
-            }
-          }
+        case SimpleRegexFilter(attr, regexText) =>
+          regexMatch(attr, regexText, entries, x => Full(x))
+
+        case SimpleNotRegexFilter(attr, regexText) =>
+          regexNotMatch(attr, regexText, entries, x => Full(x))
+
+        case NodePropertyRegexFilter(attr, regexText) =>
+          //here, we need to put the value in expected {"name":"k","value":v} minified format (and only name & value field)
+          regexMatch(attr, regexText, entries, normalizeJsonNodeProperty)
+
+        case NodePropertyNotRegexFilter(attr, regexText) =>
+          //here, we need to put the value in expected {"name":"k","value":v} minified format (and only name & value field)
+          regexMatch(attr, regexText, entries,normalizeJsonNodeProperty)
+
+
         case x => Failure("Don't know how to post process query results for filter '%s'".format(x))
       }
     }

--- a/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
@@ -72,8 +72,8 @@ final case class RegexFilter(attributeName:String, regex:String) extends Special
 final case class NotRegexFilter(attributeName:String, regex:String) extends SpecialFilter with HashcodeCaching
 
 /*
- * An NodeQuery differ a little from a Query because it's component are sorted in two way :
- * - the server is apart with it's possible filter from criteria;
+ * An NodeQuery differ a little from a Query because its components are sorted in two ways:
+ * - the server is apart with its possible filter from criteria
  * - other criteria are sorted by group of things that share the same dependency path to server,
  *   and the attribute on witch join are made.
  *   The attribute must be on server.
@@ -82,7 +82,7 @@ final case class NotRegexFilter(attributeName:String, regex:String) extends Spec
  *   - Machine and physical element : get the Machine DN
  *   - Logical Element : get the Node DN
  *
- *   More over, we need a "DN to filter" function for the requested object type
+ *   Moreover, we need a "DN to filter" function for the requested object type
  */
 case class LDAPNodeQuery(
     //filter on the return type.
@@ -229,8 +229,6 @@ class InternalLDAPQueryProcessor(
    * relevant logics.
    * Sub classes should call that method to
    * implement process&check method
-   *
-   * TODO: there is a lot of room to be smarter here.
    */
   def internalQueryProcessor(
       query:Query,

--- a/rudder-core/src/test/resources/ldap-data/inventory-sample-data.ldif
+++ b/rudder-core/src/test/resources/ldap-data/inventory-sample-data.ldif
@@ -42,6 +42,7 @@ cn:has software
 isSystem: false
 isBroken: false
 createTimestamp: 20070101000000Z
+serializedNodeProperty: {"name":"datacenter", "value":{ "country" : "France" , "id" : 1234, "replicated" : true } }
 
 dn: nodeId=node3,ou=Nodes,cn=rudder-configuration
 objectClass: top
@@ -51,6 +52,7 @@ cn:has logical elements
 isSystem: false
 isBroken: false
 createTimestamp: 20070101000000Z
+serializedNodeProperty: {"name":"datacenter", "value":{ "country" : "Germany" , "id" : 12345, "replicated" : true } }
 
 dn: nodeId=node4,ou=Nodes,cn=rudder-configuration
 objectClass: top
@@ -189,6 +191,12 @@ policyServerId:root-policy-server
 ipHostNumber: 192.168.56.101
 ipHostNumber: 127.0.0.1
 environmentVariable: {"name":"SHELL","value":"/bin/sh"}
+process: {"pid":1,"commandName":"init [2]","cpuUsage":0.0,"memory":0.2000000
+ 0298023224,"started":"2015-01-21 17:24","tty":"?","user":"root","virtualMem
+ ory":10648}
+process: {"pid":10,"commandName":"[kdevtmpfs]","cpuUsage":0.0,"memory":0.0,"
+ started":"2015-01-21 17:24","tty":"?","user":"root","virtualMemory":0}
+
 
 # Example of a node
 dn: nodeId=node2,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
@@ -210,6 +218,8 @@ policyServerId:root-policy-server
 nodeHostname: node2.normation.com
 ipHostNumber: 192.168.56.102
 ipHostNumber: 127.0.0.1
+environmentVariable: {"name":"PWD","value":"/var/rudder"}
+environmentVariable: {"name":"SUDO_GID","value":"1000"}
 
 dn: nodeId=node3,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
 objectClass: top
@@ -227,6 +237,8 @@ policyServerId:root-policy-server
 nodeHostname: node3.normation.com
 ipHostNumber: 192.168.56.103
 ipHostNumber: 127.0.0.1
+environmentVariable: {"name":"PATH","value":"/usr/local/sbin:/usr/local/bin:
+ /usr/sbin:/usr/bin:/sbin:/bin:/var/rudder/cfengine-community/bin"}
 
 dn: nodeId=node4,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
 objectClass: top

--- a/rudder-core/src/test/resources/ldap-data/inventory-sample-data.ldif
+++ b/rudder-core/src/test/resources/ldap-data/inventory-sample-data.ldif
@@ -32,7 +32,7 @@ description: #54-Ubuntu SMP Thu Dec 10 17:23:29 UTC 2009
 isSystem: false
 isBroken: false
 createTimestamp: 20070101000000Z
-serializedNodeProperty: {"name":"foo", "value":"bar" }
+serializedNodeProperty: {"name":"foo","value":"bar"}
 
 dn: nodeId=node2,ou=Nodes,cn=rudder-configuration
 objectClass: top
@@ -42,7 +42,7 @@ cn:has software
 isSystem: false
 isBroken: false
 createTimestamp: 20070101000000Z
-serializedNodeProperty: {"name":"datacenter", "value":{ "country" : "France" , "id" : 1234, "replicated" : true } }
+serializedNodeProperty: {"name":"datacenter","value":{"country":"France","id":1234,"replicated":true},"provider":"datasources"}
 
 dn: nodeId=node3,ou=Nodes,cn=rudder-configuration
 objectClass: top
@@ -52,7 +52,8 @@ cn:has logical elements
 isSystem: false
 isBroken: false
 createTimestamp: 20070101000000Z
-serializedNodeProperty: {"name":"datacenter", "value":{ "country" : "Germany" , "id" : 12345, "replicated" : true } }
+serializedNodeProperty: {"name":"datacenter","value":{"country":"Germany","id":12345,"replicated":true,"provider":"user value"}}
+serializedNodeProperty: {"name":"number","value":42}
 
 dn: nodeId=node4,ou=Nodes,cn=rudder-configuration
 objectClass: top
@@ -62,6 +63,9 @@ cn: has machine with nothing
 isSystem: false
 isBroken: false
 createTimestamp: 20070101000000Z
+serializedNodeProperty: {"name":"foo","value":""}
+serializedNodeProperty: {"name":"liar","value":{"k":"v","name":"datacenter","value":"I'm not a datacenter!"}}
+serializedNodeProperty: {"name":"number","value":42,"provider":"datasources"}
 
 dn: nodeId=node5,ou=Nodes,cn=rudder-configuration
 objectClass: top

--- a/rudder-core/src/test/resources/logback-test.xml
+++ b/rudder-core/src/test/resources/logback-test.xml
@@ -43,7 +43,7 @@
   </logger>
   -->
   
-  <logger name="com.normation.rudder.services.queries" level="info" /> 
+  <logger name="com.normation.rudder.services.queries" level="trace" /> 
   
   
 <!--   

--- a/rudder-core/src/test/resources/logback-test.xml
+++ b/rudder-core/src/test/resources/logback-test.xml
@@ -43,7 +43,7 @@
   </logger>
   -->
   
-  <logger name="com.normation.rudder.services.queries" level="trace" /> 
+  <logger name="com.normation.rudder.services.queries" level="info" /> 
   
   
 <!--   

--- a/rudder-core/src/test/scala/com/normation/rudder/domain/queries/CmdbQueryTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/domain/queries/CmdbQueryTest.scala
@@ -38,16 +38,8 @@ class CmdbQueryTest extends Specification {
 class JsonQueryTest extends Specification {
 
   "JsonComparator " should {
-    "Convert a search request to a valid json request on one attribute " in {
-      JsonComparator("attribute").buildFilter("key",Equals,"value") must beEqualTo(SUB("attribute",null,("\"key\":\"value\""::Nil).toArray,null))
-    }
-
     "Convert a search request to a valid json request on 2 attributes" in {
-      JsonComparator("attribute","=").buildFilter("key.key2",Equals,"value=value2") must beEqualTo(SUB("attribute",null,("\"key\":\"value\""::"\"key2\":\"value2\""::Nil).toArray,null))
-    }
-
-    "Convert a search request to a valid json request on one numeric attribute" in {
-      JsonComparator("attribute","",true).buildFilter("key",Equals,"1") must beEqualTo(SUB("attribute",null,("\"key\":1"::Nil).toArray,null))
+      NodePropertyComparator("attribute").buildFilter("name.value",Equals,"value=value2") must beEqualTo(SUB("attribute",null,("\"name\":\"value\",\"value\":\"value2\""::Nil).toArray,null))
     }
   }
 }

--- a/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
@@ -479,9 +479,35 @@ class TestQueryProcessor extends Loggable {
   }
 
   /**
+   * Test environment variable
+   */
+  @Test def nodeJsonFixedKeyQueries() {
+
+    val q1 = TestQuery(
+      "q1",
+      parser("""
+      {"select":"node","composition":"And","where":[
+        {"objectType":"process","attribute":"started","comparator":"eq","value":"2015-01-21 17:24"}
+      ]}
+      """).openOrThrowException("For tests"),
+      s(1) :: Nil)
+
+    val q2 = TestQuery(
+      "q2",
+      parser("""
+      {"select":"node","composition":"And","where":[
+        {"objectType":"process","attribute":"commandName","comparator":"regex","value":".*vtmp.*"}
+      ]}
+      """).openOrThrowException("For tests"),
+      s(1) :: Nil)
+
+    testQueries(q1 :: q2 :: Nil)
+  }
+
+  /**
    * Test environment variable and nodeProperty
    */
-  @Test def nodeKeyValuesPairsPropertiesQueries() {
+  @Test def nodeNameValueQueries() {
 
     val q1 = TestQuery(
       "q1",
@@ -495,13 +521,26 @@ class TestQueryProcessor extends Loggable {
     val q2 = TestQuery(
       "q2",
       parser("""
+      {"select":"node","composition":"And","where":[
+        {"objectType":"environmentVariable","attribute":"name.value","comparator":"regex","value":".+=/.*/rudder.*"}
+      ]}
+      """).openOrThrowException("For tests"),
+      s(2) :: s(3) :: Nil)
+
+    testQueries(q1 :: q2 :: Nil)
+  }
+
+  @Test def nodeProperties() {
+    val q1 = TestQuery(
+      "q2",
+      parser("""
       { "select":"node", "where":[
         { "objectType":"serializedNodeProperty", "attribute":"name.value", "comparator":"eq", "value":"foo=bar" }
       ] }
       """).openOrThrowException("For tests"),
       s(1) :: Nil)
 
-    val q3 = TestQuery(
+    val q2 = TestQuery(
       "q3",
       parser("""
       { "select":"node", "where":[
@@ -510,10 +549,10 @@ class TestQueryProcessor extends Loggable {
       """).openOrThrowException("For tests"),
       s(1) :: Nil)
 
-    testQueries(q1 :: q2 :: q3 :: Nil)
+     testQueries(q1 :: q2 :: Nil)
   }
 
-  @Test def failingRequestOnProperties() {
+  @Test def nodePropertiesFailingReq() {
     // Failing request, see #10570
     val failingRegexRequest =
       parser("""
@@ -578,15 +617,6 @@ class TestQueryProcessor extends Loggable {
       assertEquals("[%s]Size differ between awaited entry and found entry set when setting expected entries (process)\n Found: %s\n Wants: %s".
           format(name,foundWithLimit,ids),ids.size.toLong,foundWithLimit.size.toLong)
   }
-
-//  private def testQueryResultChecker(name:String,query:Query, ids:Seq[NodeId]) = {
-//      val checked = queryProcessor.check(query,s).openOrThrowException("For tests")
-//
-//      assertEquals("[%s]Size differ between awaited and found entry set (check)\n Found: %s\n Wants: %s".
-//          format(name,checked,ids),ids.size,checked.size)
-//      assertTrue("[%s]Entries differ between awaited and found entry set (check)\n Found: %s\n Wants: %s".
-//          format(name,checked,ids),checked.forall { f => ids.exists( f == _) })
-//  }
 
   @After def after() {
     ldap.server.shutDown(true)

--- a/rudder-web/src/main/resources/ldapObjectAndAttributes.properties
+++ b/rudder-web/src/main/resources/ldapObjectAndAttributes.properties
@@ -217,7 +217,7 @@ ldap.attr.user = User
 ldap.attr.cpuUsage = CPU Usage
 ldap.attr.pid = PID
 ldap.attr.virtualMemory = Virtual Memory
-ldap.attr.datetime = Started on
+ldap.attr.started = Started on
 ldap.attr.tty = tty
 ldap.attr.name.value = Name=Value
 ldap.attr.rudderServerRole = Server role


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10599
This PR allows to corretly process JSON values stored in LDAP for the three kind of object needed to be search for in group: Process, Environment variables, and Node properties. 
The first commit split the common JsonComparator in three specialized one, one for each case, which allows to simplify the simple case, and make a special case for node properties. 

The strategie to correctly handle node properties is to make precise filter for eq/not eq for both quoted and quoted values. It means that we are now extremelly dependant of serialization format (we already were, now it is consumed). 

And for regex case, we had a pre-regex JSON parsing which allows to filter out other field than name/value so that we are sure to not return false positive with provider case. 

That last technique can be adoted in the future to create a real JSON query in place of regex. 