### PR TITLE
Fixes #11777: Lift-webkit has a dependency toward rhino (which conflicts with JS param eval)

### DIFF
--- a/rudder-core/pom.xml
+++ b/rudder-core/pom.xml
@@ -212,6 +212,10 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
           <artifactId>slf4j-log4j12</artifactId>
           <groupId>org.slf4j</groupId>
         </exclusion>
+        <exclusion>
+          <groupId>org.mozilla</groupId>
+          <artifactId>rhino</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/11777