### PR TITLE
Fixes #1411: Node (hostname,policyserver,...) modification should trigger promises regeneration

### DIFF
--- a/rudder-web/src/main/resources/logback.xml
+++ b/rudder-web/src/main/resources/logback.xml
@@ -323,6 +323,17 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     <appender-ref ref="STDOUT" />
   </logger>
 
+
+  <!--
+    Schechuled Jobs
+    ================
+    This logger is in charge of all scheduled jobs and batches 
+  -->
+  <logger name="scheduledJob" level="info" additivity="false">
+    <appender-ref ref="OPSLOG" />
+    <appender-ref ref="STDOUT" />
+  </logger>
+
   <!--
     Migration of data format
     ========================

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -126,6 +126,7 @@ import com.normation.rudder.services.quicksearch.FullQuickSearchService
 import com.normation.rudder.db.Doobie
 import com.normation.rudder.web.rest.settings.SettingsAPI8
 import com.normation.rudder.web.rest.sharedFiles.SharedFilesAPI
+import scala.concurrent.duration._
 
 /**
  * Define a resource for configuration.
@@ -385,6 +386,7 @@ object RudderConfig extends Loggable {
   val asyncDeploymentAgent: AsyncDeploymentAgent = asyncDeploymentAgentImpl
   val policyServerManagementService: PolicyServerManagementService = psMngtService
   val updateDynamicGroups: UpdateDynamicGroups = dyngroupUpdaterBatch
+  val checkInventoryUpdate = new CheckInventoryUpdate(nodeInfoServiceImpl, asyncDeploymentAgent, stringUuidGenerator, 15.seconds)
   val databaseManager: DatabaseManager = databaseManagerImpl
   val automaticReportsCleaning: AutomaticReportsCleaning = dbCleaner
   val checkTechniqueLibrary: CheckTechniqueLibrary = techniqueLibraryUpdater


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/1411

Be careful to notice that only a SUBSET of inventories are observed, ie only node properties, node main information (what is in node summary), machine type. 

Other inventory information are not important aspect for policy generation (appart for groups of course, but that is covered in dynamic group update scheduled job). So it should be fine. 