### PR TITLE
Fixes #12111 Make fine-grained API authorization a plugin

### DIFF
--- a/rudder-core/src/main/resources/ldap/rudder.schema
+++ b/rudder-core/src/main/resources/ldap/rudder.schema
@@ -27,7 +27,7 @@
 #######################################################
 ####################### WARNING #######################
 #######################################################
-# This OID is necessary for OpenLDAP -> OpenDS schema tool, 
+# This OID is necessary for OpenLDAP -> OpenDS schema tool,
 # but makes OpenLDAP crashes with a non-meaningfull error message
 # if cmdb.schema (where it is already declared) is included
 
@@ -60,7 +60,7 @@ attributetype ( RudderAttributes:102
   NAME 'directiveId'
   DESC 'Unique identifier for a directive'
   SUP uuid )
-  
+
 attributetype ( RudderAttributes:103
   NAME 'targetDirectiveId'
   DESC 'Unique identifier for a directive'
@@ -70,12 +70,12 @@ attributetype ( RudderAttributes:104
   NAME 'groupCategoryId'
   DESC 'Unique identifier for a group category'
   SUP uuid )
-    
+
 attributetype ( RudderAttributes:105
   NAME 'techniqueCategoryId'
   DESC 'Unique identifier for a rudder category'
   SUP uuid )
-  
+
 attributetype ( RudderAttributes:106
   NAME 'techniqueId'
   DESC 'Unique identifier for a technique from Reference technique library'
@@ -100,14 +100,14 @@ attributetype ( RudderAttributes:110
   NAME 'apiAccountId'
   DESC 'Unique identifier for an API Account'
   SUP uuid )
-  
+
 attributetype ( RudderAttributes:111
   NAME 'ruleCategoryId'
   DESC 'Unique identifier for a Rule category'
   SUP uuid )
-  
+
 #######################################################################
-  
+
 attributetype ( RudderAttributes:201
   NAME 'techniqueLibraryVersion'
   DESC 'The version'
@@ -128,7 +128,7 @@ attributetype ( RudderAttributes:203
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
   EQUALITY generalizedTimeMatch
   ORDERING generalizedTimeOrderingMatch )
-  
+
 attributetype ( RudderAttributes:204
   NAME 'jsonNodeGroupQuery'
   DESC 'JSON structure that represent a query for a group of nodes'
@@ -196,13 +196,13 @@ attributetype ( RudderAttributes:211
   DESC 'Define if the server is modified and should be processed as such or if it is up to date. Default to false if not specified'
   EQUALITY booleanMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.7  )
-  
+
 attributetype ( RudderAttributes:212
   NAME 'isEnabled'
   DESC 'Define if the object is currently activated or not (and so should be ignore)'
   EQUALITY booleanMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.7  )
-  
+
 attributetype ( RudderAttributes:213
   NAME 'isDynamic'
   DESC 'Define if the group is dynamic'
@@ -233,7 +233,7 @@ attributetype ( RudderAttributes:217
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
   EQUALITY integerMatch
   ORDERING integerOrderingMatch )
-  
+
 attributetype ( RudderAttributes:218
   NAME 'longDescription'
   DESC 'A long field for text (HTLM expected)'
@@ -253,7 +253,7 @@ attributetype ( RudderAttributes:220
   DESC 'The current system variables of a node'
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
   EQUALITY caseIgnoreMatch
-  SUBSTR caseIgnoreSubstringsMatch ) 
+  SUBSTR caseIgnoreSubstringsMatch )
 
 attributetype ( RudderAttributes:221
   NAME 'targetSystemVariable'
@@ -288,7 +288,7 @@ attributetype ( RudderAttributes:225
   DESC 'The local administrator account name (login) on the node'
   EQUALITY caseIgnoreMatch
   SUBSTR caseIgnoreSubstringsMatch
-  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} ) 
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
 
 attributetype ( RudderAttributes:226
   NAME 'creationTimestamp'
@@ -302,7 +302,7 @@ attributetype ( RudderAttributes:227
   DESC 'The current parameters applied to a node'
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
   EQUALITY caseExactMatch
-  SUBSTR caseIgnoreSubstringsMatch ) 
+  SUBSTR caseIgnoreSubstringsMatch )
 
 attributetype ( RudderAttributes:228
   NAME 'targetParameter'
@@ -310,7 +310,7 @@ attributetype ( RudderAttributes:228
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
   EQUALITY caseExactMatch
   SUBSTR caseIgnoreSubstringsMatch )
-  
+
 attributetype ( RudderAttributes:229
   NAME 'tag'
   DESC 'ID of tag'
@@ -323,7 +323,7 @@ attributetype ( RudderAttributes:230
   EQUALITY caseIgnoreMatch
   SUBSTR caseIgnoreSubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{4096} )
-  
+
 ### Policy mode, common for Nodes/Directive at first, Surely Rules and groups later
 attributetype ( RudderAttributes:231
   NAME 'policyMode'
@@ -340,7 +340,7 @@ attributetype ( RudderAttributes:235
   SUBSTR caseIgnoreSubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
-### API principal and tokens 
+### API principal and tokens
 
 attributetype ( RudderAttributes:250
   NAME 'apiToken'
@@ -376,7 +376,14 @@ attributetype ( RudderAttributes:254
   EQUALITY caseIgnoreMatch
   SUBSTR caseIgnoreSubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
-  
+
+attributetype ( RudderAttributes:255
+  NAME 'apiAuthorizationKind'
+  DESC 'Kind of API account (public API, user-bounded, system)'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
 attributetype ( RudderAttributes:301
   NAME 'parameterName'
   DESC 'Name of parameter that matches [a-zA-Z0-9_]+'
@@ -442,28 +449,28 @@ attributetype ( RudderAttributes:353
 #
 # Rudder mains objects:
 # * nodes and policy server
-# * node group categories 
-# * node groups 
+# * node group categories
+# * node groups
 # * library of active technique categories
 # * activeTechnique
 # * directive
 # * rules
-# 
+#
 
 
 ### nodes (simple and policy server) for Rudder ###
 
 objectclass ( RudderObjectClasses:1
-  NAME 'rudderNode' 
+  NAME 'rudderNode'
   DESC 'The Node itself'
   SUP top
   STRUCTURAL
   MUST ( nodeId $ cn $ isSystem )
   MAY ( description $ serializedNodeProperty $ serializedAgentRunInterval $
         serializedHeartbeatRunConfiguration $ policyMode $ state $ isBroken) )
-  
+
 objectclass ( RudderObjectClasses:2
-  NAME 'rudderPolicyServer' 
+  NAME 'rudderPolicyServer'
   DESC 'The Node representation of a policy server'
   SUP rudderNode
   STRUCTURAL )
@@ -485,7 +492,7 @@ objectclass ( RudderObjectClasses:11
   STRUCTURAL
   MUST ( nodeGroupId $
    cn $ isDynamic )
-  MAY ( nodeId $ description $ jsonNodeGroupQuery $ 
+  MAY ( nodeId $ description $ jsonNodeGroupQuery $
         isEnabled $ isSystem  ) )
 
 objectclass ( RudderObjectClasses:12
@@ -494,7 +501,7 @@ objectclass ( RudderObjectClasses:12
   SUP top
   STRUCTURAL
   MUST ( ruleTarget $ cn )
-  MAY (  description $ isEnabled $ isSystem ) )  
+  MAY (  description $ isEnabled $ isSystem ) )
 
 ### active technique library ###
 
@@ -512,7 +519,7 @@ objectclass ( RudderObjectClasses:21
   STRUCTURAL
   MUST ( techniqueCategoryId $ cn )
   MAY ( description $ isSystem ) )
-  
+
 objectclass ( RudderObjectClasses:22
   NAME 'activeTechnique'
   DESC 'The Rudder category'
@@ -531,16 +538,16 @@ objectclass ( RudderObjectClasses:23
         directivePriority $ directiveVariable $ policyMode $ serializedTags) )
 
 ### rules ###
-  
+
 objectclass ( RudderObjectClasses:30
   NAME 'rule'
   DESC 'A rule'
   SUP top
   STRUCTURAL
   MUST ( ruleId )
-  MAY ( cn $ description $ longDescription $ 
-        isEnabled $ isSystem $ 
-        ruleTarget $ serial $ 
+  MAY ( cn $ description $ longDescription $
+        isEnabled $ isSystem $
+        ruleTarget $ serial $
         directiveId $ tag $ serializedTags ) )
 
 objectclass ( RudderObjectClasses:31
@@ -559,23 +566,23 @@ objectclass ( RudderObjectClasses:31
 #
 
 objectclass ( RudderObjectClasses:101
-  NAME 'nodeConfiguration' 
+  NAME 'nodeConfiguration'
   DESC 'The mapping of the node configuration, a container for promises'
   SUP top
   STRUCTURAL
   MUST ( nodeId $ isPolicyServer )
-  MAY ( cn $ description $ isModified $ 
+  MAY ( cn $ description $ isModified $
         lastUpdateTimestamp $ writtenTimestamp $
-        targetName $ 
+        targetName $
         localAdministratorAccountName $ targetLocalAdministratorAccountName $
-        nodeHostname $ targetNodeHostname $ 
-        policyServerId $ targetPolicyServerId $ 
+        nodeHostname $ targetNodeHostname $
+        policyServerId $ targetPolicyServerId $
         agentName $ targetAgentName $
         systemVariable $ targetSystemVariable $
         parameter $ targetParameter  ) )
 
 objectclass ( RudderObjectClasses:102
-  NAME 'rootPolicyServerNodeConfiguration' 
+  NAME 'rootPolicyServerNodeConfiguration'
   SUP  nodeConfiguration
   DESC 'The ROOT policy server of an Rudder Domain' )
 
@@ -587,7 +594,7 @@ objectClass ( RudderObjectClasses:103
   SUP top
   ABSTRACT
   MUST ( techniqueId )
-  MAY ( lastUpdateTimestamp $ 
+  MAY ( lastUpdateTimestamp $
         description $ ruleTarget $ directiveVariable $
         isEnabled $ isSystem $ serial $ directivePriority $
         techniqueId $ techniqueVersion $
@@ -609,7 +616,7 @@ objectclass ( RudderObjectClasses:105
 
 # all node configurations things are supersided by that:
 objectclass ( RudderObjectClasses:110
-  NAME 'nodeConfigurations' 
+  NAME 'nodeConfigurations'
   DESC 'Store node configurations'
   SUP top
   STRUCTURAL
@@ -617,7 +624,7 @@ objectclass ( RudderObjectClasses:110
   MAY ( description $ nodeConfig  ) )
 
 
-# 
+#
 # API Accounts
 #
 
@@ -627,11 +634,11 @@ objectclass ( RudderObjectClasses:106
   SUP top
   STRUCTURAL
   MUST ( apiAccountId $ cn $ creationTimestamp $
-         apiToken $ apiTokenCreationTimestamp) 
+         apiToken $ apiTokenCreationTimestamp)
   MAY ( description  $ isEnabled $ apiAccountKind $
-        apiAcl $ expirationTimestamp ) )
+        apiAuthorizationKind $ apiAcl $ expirationTimestamp ) )
 
-# 
+#
 # Parameters
 #
 

--- a/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountRepository.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountRepository.scala
@@ -103,7 +103,7 @@ final class RoLDAPApiAccountRepository(
   , val ldapConnexion: LDAPConnectionProvider[RoLDAPConnection]
   , val mapper       : LDAPEntityMapper
   , val uuidGen      : StringUuidGenerator
-  , val systemAcl    : ApiAcl
+  , val systemAcl    : List[ApiAclElement]
 ) extends RoApiAccountRepository with Loggable {
 
   val systemAPIAccount =
@@ -116,8 +116,6 @@ final class RoLDAPApiAccountRepository(
       , true
       , DateTime.now
       , DateTime.now
-      , systemAcl
-      , None // no expiration, it will be regenerated on reboot
     )
 
   override def getSystemAccount: ApiAccount = systemAPIAccount

--- a/rudder-core/src/main/scala/com/normation/rudder/domain/RudderLDAPConstants.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/RudderLDAPConstants.scala
@@ -121,6 +121,7 @@ object RudderLDAPConstants extends Loggable {
   val A_API_TOKEN = "apiToken"
   val A_API_TOKEN_CREATION_DATETIME = "apiTokenCreationTimestamp"
   val A_API_EXPIRATION_DATETIME = "expirationTimestamp"
+  val A_API_AUTHZ_KIND = "apiAuthorizationKind"
   val A_API_ACL = "apiAcl"
 
   // Parameters
@@ -224,7 +225,7 @@ object RudderLDAPConstants extends Loggable {
 
   OC += (OC_API_ACCOUNT
       , must = Set(A_API_UUID, A_NAME, A_CREATION_DATETIME, A_API_TOKEN, A_API_TOKEN_CREATION_DATETIME)
-      , may = Set(A_DESCRIPTION, A_API_EXPIRATION_DATETIME, A_API_ACL, A_IS_ENABLED)
+      , may = Set(A_DESCRIPTION, A_API_EXPIRATION_DATETIME, A_API_ACL, A_IS_ENABLED, A_API_AUTHZ_KIND)
   )
 
   OC += ( OC_PARAMETER,

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -40,8 +40,7 @@ package com.normation.rudder.rest
 import com.normation.cfclerk.domain._
 import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.inventory.domain.NodeId
-import com.normation.rudder.api.ApiAccountId
-import com.normation.rudder.api.ApiAccountName
+import com.normation.rudder.api.{ApiAccountId, ApiAccountName, ApiAuthorization => ApiAuthz}
 import com.normation.rudder.domain.nodes.NodeGroupCategoryId
 import com.normation.rudder.domain.nodes.NodeProperty
 import com.normation.rudder.domain.parameters.ParameterName
@@ -61,7 +60,6 @@ import com.normation.rudder.services.queries.StringQuery
 import com.normation.rudder.services.workflows.WorkflowService
 import com.normation.rudder.rest.data._
 import com.normation.utils.Control._
-
 import net.liftweb.common._
 import net.liftweb.http.Req
 import net.liftweb.json._
@@ -80,11 +78,10 @@ import com.normation.rudder.ncf.MethodCall
 import com.normation.rudder.ncf.ParameterId
 import com.normation.rudder.ncf.MethodParameter
 import com.normation.rudder.ncf.TechniqueParameter
-import com.normation.rudder.ncf.{ Technique => NcfTechnique }
+import com.normation.rudder.ncf.{Technique => NcfTechnique}
 import org.joda.time.format.ISODateTimeFormat
 import net.liftweb.util.Helpers
 import org.joda.time.DateTime
-import com.normation.rudder.api.ApiAcl
 
 case class RestExtractorService (
     readRule             : RoRuleRepository
@@ -823,7 +820,7 @@ case class RestExtractorService (
       expriration <- extractJsonString(json, "expiration", toDateTime)
       // TODO parse ApiAcl
     } yield {
-      RestApiAccount(id, name, description, enabled, oldId, expriration.map(Some(_)), Some(ApiAcl.noAuthz))
+      RestApiAccount(id, name, description, enabled, oldId, expriration.map(Some(_)), Some(ApiAuthz.None))
     }
   }
 

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/LiftApiDispather.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/LiftApiDispather.scala
@@ -43,7 +43,7 @@ import net.liftweb.http.rest.RestHelper
 import com.normation.rudder.api.HttpAction
 import net.liftweb.json.JsonAST.JString
 import com.normation.rudder.rest._
-import net.liftweb.common.Full
+import net.liftweb.common.{EmptyBox, Full}
 import org.slf4j.LoggerFactory
 
 final case class DefaultParams(prettify: Boolean)
@@ -105,6 +105,23 @@ class LiftHandler(
   }
   def addModules(modules: List[LiftApiModule]): Unit = {
     _apis = _apis ::: modules
+  }
+
+  def logReq(req: Req): String = {
+    val printJson = {
+      if(req.json_?) {
+        req.json match {
+          case eb: EmptyBox => "JSON request with NOT VALID JSON body"
+          case _            => "JSON request with valid JSON body"
+        }
+      } else if(req.xml_?) {
+        "XML request type"
+      } else {
+        "simple (non-JSON) request"
+      }
+    }
+
+    s"${req.requestType.method} ${req.contextPath}${req.uri} [${printJson}]"
   }
 
   def getRequestInfo(req: Req, supportedVersions: List[ApiVersion]): Either[ApiError, RequestInfo] = {

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserApi.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserApi.scala
@@ -46,20 +46,12 @@ import net.liftweb.common.Full
 import com.normation.eventlog.ModificationId
 import com.normation.rudder.rest.ApiPath
 import com.normation.rudder.rest.AuthzToken
-import com.normation.rudder.api.ApiAccount
+import com.normation.rudder.api._
 import net.liftweb.json.JsonAST.JArray
-import com.normation.rudder.api.ApiAcl
-import com.normation.rudder.api.RoApiAccountRepository
 import net.liftweb.common.EmptyBox
-import com.normation.rudder.api.WoApiAccountRepository
-import com.normation.rudder.api.ApiAccountId
-import com.normation.rudder.api.TokenGenerator
 import org.joda.time.DateTime
 import com.normation.rudder.rest.ApiAccountSerialisation._
 import com.normation.rudder.rest.RestUtils
-import com.normation.rudder.api.ApiAccountKind
-import com.normation.rudder.api.ApiAccountName
-import com.normation.rudder.api.ApiToken
 import net.liftweb.json.JsonDSL._
 import net.liftweb.json._
 
@@ -123,8 +115,6 @@ class UserApi(
         , true
         , now
         , now
-        , ApiAcl(Nil)
-        , None
       )
 
       writeApi.save(account, ModificationId(uuidGen.newUuid), authzToken.actor) match {

--- a/rudder-rest/src/main/scala/com/normation/rudder/service/user/UserService.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/service/user/UserService.scala
@@ -39,14 +39,14 @@ package com.normation.rudder.service.user
 
 import com.normation.eventlog.EventActor
 import com.normation.rudder.AuthorizationType
-import com.normation.rudder.api.ApiAcl
+import com.normation.rudder.api.ApiAuthorization
 
 trait UserService {
   def getCurrentUser: User
 }
 
 trait User {
-  def actor : EventActor
-  def checkRights(auth : AuthorizationType) : Boolean
-  def getApiAcl  : ApiAcl
+  def actor: EventActor
+  def checkRights(auth : AuthorizationType): Boolean
+  def getApiAutz: ApiAuthorization
 }

--- a/rudder-rest/src/test/scala/com/normation/rudder/web/rest/RestTestSetUp.scala
+++ b/rudder-rest/src/test/scala/com/normation/rudder/web/rest/RestTestSetUp.scala
@@ -38,7 +38,6 @@
 package com.normation.rudder.rest
 
 import org.specs2.matcher.MatchResult
-
 import net.liftweb.common.Full
 import net.liftweb.http.LiftRules
 import net.liftweb.http.LiftRulesMocker
@@ -61,9 +60,9 @@ import net.liftweb.json.JsonAST.JValue
 import com.normation.rudder.service.user.UserService
 import com.normation.rudder.service.user.User
 import com.normation.rudder.AuthorizationType
+import com.normation.rudder.api.{ApiAuthorization => ApiAuthz}
 import com.normation.rudder.rest.v1.RestTechniqueReload
 import com.normation.rudder.rest.v1.RestStatus
-import com.normation.rudder.api.ApiAcl
 
 /*
  * This file provides all the necessary plumbing to allow test REST API.
@@ -77,7 +76,7 @@ object RestTestSetUp {
     val user = new User{
       val actor = new EventActor("test-user")
       def checkRights(auth : AuthorizationType) = true
-      def getApiAcl = ApiAcl.allAuthz
+      def getApiAutz = ApiAuthz.allAuthz
     }
     val getCurrentUser = user
 

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -51,7 +51,7 @@ import com.normation.rudder.services.reports._
 import com.normation.rudder.domain.queries._
 import bootstrap.liftweb.checks._
 import com.normation.cfclerk.services._
-import org.springframework.context.annotation.{ Bean, Configuration, Import }
+import org.springframework.context.annotation.{Bean, Configuration, Import}
 import com.normation.ldap.sdk._
 import com.normation.rudder.domain._
 import com.normation.rudder.web.services._
@@ -59,6 +59,7 @@ import com.normation.utils.StringUuidGenerator
 import com.normation.utils.StringUuidGeneratorImpl
 import com.normation.rudder.repository.ldap._
 import java.io.File
+
 import com.normation.rudder.services.eventlog._
 import com.normation.cfclerk.xmlparsers._
 import com.normation.cfclerk.services.impl._
@@ -81,6 +82,7 @@ import com.normation.rudder.repository._
 import com.normation.rudder.services.modification.ModificationService
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+
 import scala.util.Try
 import com.normation.rudder.repository.inmemory.InMemoryChangeRequestRepository
 import com.normation.cfclerk.xmlwriters.SectionSpecWriter
@@ -90,10 +92,7 @@ import com.normation.rudder.services.modification.DiffService
 import com.normation.rudder.services.user.PersonIdentService
 import com.normation.rudder.services.workflows._
 import com.normation.rudder.rest.RestExtractorService
-import com.normation.rudder.api.RoLDAPApiAccountRepository
-import com.normation.rudder.api.TokenGeneratorImpl
-import com.normation.rudder.api.WoApiAccountRepository
-import com.normation.rudder.api.WoLDAPApiAccountRepository
+import com.normation.rudder.api._
 import com.normation.rudder.appconfig._
 import com.normation.rudder.batch._
 import com.normation.rudder.db.Doobie
@@ -146,20 +145,21 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
 import java.io.File
+
 import net.liftweb.common._
 import net.liftweb.common.Loggable
 import org.apache.commons.io.FileUtils
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
+
 import scala.util.Try
 import com.normation.rudder.services.policies.write.WriteAllAgentSpecificFiles
-import com.normation.rudder.api.RoApiAccountRepository
 import com.normation.rudder.service.user.UserService
 import com.normation.rudder.ncf.TechniqueWriter
 import com.normation.rudder.ncf.TechniqueArchiverImpl
+
 import scala.concurrent.duration._
-import com.normation.rudder.api.ApiAcl
 import java.nio.charset.StandardCharsets
 
 /**
@@ -733,8 +733,10 @@ object RudderConfig extends Loggable {
     Nil
 
   // new api dispatcher
-  val apiDispatcher = new RudderEndpointDispatcher(LiftApiProcessingLogger)
-  val rudderApi = {
+  lazy val apiAuthorizationLevelService = new DefaultApiAuthorizationLevel(LiftApiProcessingLogger)
+
+  lazy val apiDispatcher = new RudderEndpointDispatcher(LiftApiProcessingLogger)
+  lazy val rudderApi = {
     import com.normation.rudder.rest.lift._
 
     val modules = List(
@@ -755,7 +757,9 @@ object RudderConfig extends Loggable {
         // info api must be resolved latter, because else it misses plugin apis !
     )
 
-    val api = new LiftHandler(apiDispatcher, ApiVersions, new AclApiAuthorization(userService), None)
+
+
+    val api = new LiftHandler(apiDispatcher, ApiVersions, new AclApiAuthorization(LiftApiProcessingLogger, userService, apiAuthorizationLevelService.aclEnabled _), None)
     modules.foreach { module =>
       api.addModules(module.getLiftEndpoints)
     }
@@ -820,7 +824,7 @@ object RudderConfig extends Loggable {
     , roLdap
     , ldapEntityMapper
     , stringUuidGenerator
-    , ApiAcl.allAuthz // for system token
+    , ApiAuthorization.allAuthz.acl // for system token
   )
 
   private[this] lazy val woLDAPApiAccountRepository = new WoLDAPApiAccountRepository(
@@ -1637,7 +1641,7 @@ object RudderConfig extends Loggable {
         , uuidGen
       )
     , new CreateSystemToken(roLDAPApiAccountRepository.systemAPIAccount)
-    , new CheckApiTokenAcl(rudderDit, rwLdap, ldapEntityMapper)
+    , new CheckApiTokenAutorizationKind(rudderDit, rwLdap)
   )
 
   //////////////////////////////////////////////////////////////////////////////////////////

--- a/rudder-web/src/main/scala/com/normation/rudder/web/model/CurrentUser.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/model/CurrentUser.scala
@@ -44,7 +44,7 @@ import bootstrap.liftweb.RudderUserDetail
 import com.normation.rudder.AuthorizationType
 import com.normation.rudder.service.user.User
 import com.normation.rudder.Rights
-import com.normation.rudder.api.ApiAcl
+import com.normation.rudder.api.{ApiAclElement, ApiAuthorization}
 
 /**
  * An utility class that get the currently logged user
@@ -83,9 +83,9 @@ object CurrentUser extends SessionVar[Option[RudderUserDetail]] ({
     }
   }
 
-  def getApiAcl: ApiAcl = {
+  def getApiAutz: ApiAuthorization = {
     this.get match {
-      case None    => ApiAcl.noAuthz
+      case None    => ApiAuthorization.None
       case Some(u) => u.apiAuthz
     }
   }


### PR DESCRIPTION
Issue: https://www.rudder-project.org/redmine/issues/12111

The main changes are:
- the ApiAccounKind now holds authorization for PublicApi type, other types don't have specific authz (they are induced by account kind),
- we have 5 ApiAuthorizationKind: None, RO, RW, ACL
- ACL is interpreted only when the plugin is enable. When that kind is used without the plugin, authorization are interpreted as *RO* (but actual ACL are kept, so that re-enableling the plugin make find back ACLs)
- when migrating from 4.2, authorization are set to *RW*
- also corrected the logs so that we can have relevant information in debug mode:

```
[2018-02-16 12:17:24] DEBUG api-processing - Processing request: POST /rudder-web/api/latest/settings/node_onaccept_default_policyMode [JSON request with valid JSON body]
[2018-02-16 12:17:24] DEBUG api-processing - Found a valid endpoint handler: 'modifySetting' on [POST settings/{key}] with version '10'
[2018-02-16 12:17:24] DEBUG api-processing - User 'REST Account: "Test 1" (00000001-379a-4e96-b2e8-b1ac6f7fd4a5)' has RW authorizations.
[2018-02-16 12:17:24] DEBUG api-processing - Handler for 'POST api/latest/settings/node_onaccept_default_policyMode' executed in 27 ms

[2018-02-16 12:17:39] DEBUG api-processing - Processing request: POST /rudder-web/api/latest/settings/node_onaccept_default_policyMode [JSON request with valid JSON body]
[2018-02-16 12:17:39] DEBUG api-processing - Found a valid endpoint handler: 'modifySetting' on [POST settings/{key}] with version '10'
[2018-02-16 12:17:39] DEBUG api-processing - User 'REST Account: "Test" (a92b486d-379a-4e96-b2e8-b1ac6f7fd4a5)' has ACL authorization and a plugin allows to interpret them.
[2018-02-16 12:17:39] DEBUG api-processing - Handler for 'POST api/latest/settings/node_onaccept_default_policyMode' executed in 4 ms

[2018-02-16 12:17:53] DEBUG api-processing - Processing request: POST /rudder-web/api/latest/settings/node_onaccept_default_policyMode [JSON request with valid JSON body]
[2018-02-16 12:17:53] DEBUG api-processing - Found a valid endpoint handler: 'modifySetting' on [POST settings/{key}] with version '10'
[2018-02-16 12:17:53] DEBUG api-processing - User 'REST Account: "ServiceNow" (d5f76fda-a578-47d5-be60-f2174ad56aa7)' has RO authorization.
[2018-02-16 12:17:53] ERROR api-processing - Authorization error for 'POST api/latest/settings/node_onaccept_default_policyMode': User 'REST Account: "ServiceNow" (d5f76fda-a578-47d5-be60-f2174ad56aa7)' is not allowed to access POST api/latest/settings/{key}
[2018-02-16 12:17:53] ERROR com.normation.rudder.rest.RestUtils - "Authorization error: User 'REST Account: \"ServiceNow\" (d5f76fda-a578-47d5-be60-f2174ad56aa7)' is not allowed to access POST api/latest/settings/{key}"
```