### PR TITLE
Fixes #12209: metadata.xml not generated when saving a technique from editor

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/api/DataStructures.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/api/DataStructures.scala
@@ -76,11 +76,11 @@ sealed trait HttpAction { def name: String }
 final case object HttpAction {
 
   final case object HEAD   extends HttpAction { val name = "head" }
-  final case object GET    extends HttpAction { val name = "get" }
+  final case object GET    extends HttpAction { val name = "get"  }
   // perhaps we should have an "accepted content type"
   // for update verbs
-  final case object PUT    extends HttpAction { val name = "put" }
-  final case object POST   extends HttpAction { val name = "post" }
+  final case object PUT    extends HttpAction { val name = "put"    }
+  final case object POST   extends HttpAction { val name = "post"   }
   final case object DELETE extends HttpAction { val name = "delete" }
 
   //no PATCH for now

--- a/rudder-rest/src/main/scala/com/normation/rudder/UserService.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/UserService.scala
@@ -35,18 +35,43 @@
 *************************************************************************************
 */
 
-package com.normation.rudder.service.user
+package com.normation.rudder
 
 import com.normation.eventlog.EventActor
-import com.normation.rudder.AuthorizationType
+import com.normation.rudder.api.ApiAccount
 import com.normation.rudder.api.ApiAuthorization
 
-trait UserService {
-  def getCurrentUser: User
+/*
+ * This file define data type around what is a User in Rudder,
+ * and a servive to access it.
+ */
+
+
+/**
+ * Rudder user details must know if the account is for a
+ * rudder user or an api account, and in the case of an
+ * api account, what sub-case of it.
+ */
+sealed trait RudderAccount
+final object RudderAccount {
+  final case class User(login: String, password: String) extends RudderAccount
+  final case class Api(api: ApiAccount)                  extends RudderAccount
 }
 
+
 trait User {
-  def actor: EventActor
+  def account: RudderAccount
   def checkRights(auth : AuthorizationType): Boolean
-  def getApiAutz: ApiAuthorization
+  def getApiAuthz: ApiAuthorization
+  final def actor  = EventActor(account match {
+    case RudderAccount.User(login, _) => login
+    case RudderAccount.Api(api)       => api.name.value
+  })
+}
+
+/**
+ * A minimalistic definition of a service that give access to currently logged user .
+ */
+trait UserService {
+  def getCurrentUser: User
 }

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
@@ -172,6 +172,16 @@ object ApiPath {
   }
 }
 
+/**
+ * A bag of endpoints schema is provided by an ApiModuleProvider
+ */
+trait ApiModuleProvider[A <: EndpointSchema] {
+  def endpoints: List[A]
+}
+
+/**
+ * The actual definition of what is an endpoint schema.
+ */
 trait EndpointSchema {
 
   // canonical path of that api
@@ -205,6 +215,7 @@ trait EndpointSchema {
   type RESOURCES
   def getResources(path: ApiPath): Either[ApiError.BadParam, RESOURCES]
 }
+
 
 trait EndpointSchema0 extends EndpointSchema {
   type RESOURCES = Unit

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -64,7 +64,7 @@ trait SortIndex {
 }
 
 sealed trait ComplianceApi extends EndpointSchema with GeneralApi with SortIndex
-object ComplianceApi {
+object ComplianceApi extends ApiModuleProvider[ComplianceApi] {
 
   final case object GetRulesCompliance extends ComplianceApi with ZeroParam with StartsAtVersion7 with SortIndex { val z = zz
     val description = "Get compliance information for all rules"
@@ -91,7 +91,7 @@ object ComplianceApi {
 }
 
 sealed trait GroupApi extends EndpointSchema with GeneralApi with SortIndex
-object GroupApi {
+object GroupApi extends ApiModuleProvider[GroupApi] {
   // API v2
   final case object ListGroups extends GroupApi with ZeroParam with StartsAtVersion2 with SortIndex { val z = zz
     val description = "List all groups with their information"
@@ -144,7 +144,7 @@ object GroupApi {
 }
 
 sealed trait ChangeRequestApi extends EndpointSchema with GeneralApi with SortIndex
-object ChangeRequestApi {
+object ChangeRequestApi extends ApiModuleProvider[ChangeRequestApi] {
 
   final case object ListChangeRequests extends ChangeRequestApi with ZeroParam with StartsAtVersion3 with SortIndex { val z = zz
     val description = "List all change requests"
@@ -171,7 +171,7 @@ object ChangeRequestApi {
 }
 
 sealed trait DirectiveApi extends EndpointSchema with GeneralApi with SortIndex
-object DirectiveApi {
+object DirectiveApi extends ApiModuleProvider[DirectiveApi] {
 
   final case object ListDirectives extends DirectiveApi with ZeroParam with StartsAtVersion2 with SortIndex { val z = zz
     val description = "List all directives"
@@ -202,7 +202,7 @@ object DirectiveApi {
 }
 
 sealed trait NcfApi extends EndpointSchema with GeneralApi with SortIndex
-object NcfApi {
+object NcfApi extends ApiModuleProvider[NcfApi] {
 
   final case object UpdateTechnique extends NcfApi with ZeroParam with StartsAtVersion9 with SortIndex { val z = zz
     val description = "Update technique created with technique editor"
@@ -217,7 +217,7 @@ object NcfApi {
 }
 
 sealed trait NodeApi extends EndpointSchema with GeneralApi with SortIndex
-object NodeApi {
+object NodeApi extends ApiModuleProvider[NodeApi] {
 
   final case object ListAcceptedNodes extends NodeApi with ZeroParam with StartsAtVersion2 with SortIndex { val z = zz
     val description = "List all accepted nodes with configurable details level"
@@ -264,7 +264,7 @@ object NodeApi {
   def endpoints = ca.mrvisser.sealerate.values[NodeApi].toList.sortBy( _.z )
 }
 sealed trait ParameterApi extends EndpointSchema with GeneralApi with SortIndex
-object ParameterApi {
+object ParameterApi extends ApiModuleProvider[ParameterApi] {
 
   final case object ListParameters extends ParameterApi with ZeroParam with StartsAtVersion2 with SortIndex { val z = zz
     val description = "List all global parameters"
@@ -291,7 +291,7 @@ object ParameterApi {
 }
 
 sealed trait SettingsApi extends EndpointSchema with GeneralApi with SortIndex
-object SettingsApi {
+object SettingsApi extends ApiModuleProvider[SettingsApi] {
   final case object GetAllSettings extends SettingsApi with ZeroParam with StartsAtVersion6 with SortIndex { val z = zz
     val description = "Get information about all Rudder settings"
     val (action, path)  = GET / "settings"
@@ -313,7 +313,7 @@ object SettingsApi {
 }
 
 sealed trait UserApi extends EndpointSchema with InternalApi with SortIndex
-object UserApi {
+object UserApi extends ApiModuleProvider[UserApi] {
   final case object GetApiToken extends UserApi with ZeroParam with StartsAtVersion10 with SortIndex { val z = zz
     val description = "Get information about user personal API token"
     val (action, path)  = GET / "user" / "api" / "token"
@@ -331,7 +331,7 @@ object UserApi {
 }
 
 sealed trait TechniqueApi extends EndpointSchema with GeneralApi with SortIndex
-object TechniqueApi {
+object TechniqueApi extends ApiModuleProvider[TechniqueApi] {
 
   final case object ListTechniques extends TechniqueApi with ZeroParam with StartsAtVersion6 with SortIndex { val z = zz
     val description = "List all techniques"
@@ -350,7 +350,7 @@ object TechniqueApi {
 }
 
 sealed trait RuleApi extends EndpointSchema with GeneralApi with SortIndex
-object RuleApi {
+object RuleApi extends ApiModuleProvider[RuleApi] {
 
   final case object ListRules extends RuleApi with ZeroParam with StartsAtVersion2 with SortIndex { val z = zz
     val description = "List all rules with their information"
@@ -397,7 +397,7 @@ object RuleApi {
 }
 
 sealed trait InfoApi extends EndpointSchema with GeneralApi with SortIndex
-object InfoApi {
+object InfoApi extends ApiModuleProvider[InfoApi] {
 
   final case object ApiGeneralInformations extends InfoApi with ZeroParam with StartsAtVersion6 with SortIndex { val z = zz
     val description = "Get information about Rudder public API"

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/RestAuthentication.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/RestAuthentication.scala
@@ -42,7 +42,7 @@ import net.liftweb.http.JsonResponse
 import net.liftweb.http.LiftSession
 import net.liftweb.http.rest.RestHelper
 import net.liftweb.json.JsonDSL._
-import com.normation.rudder.service.user.UserService
+import com.normation.rudder.UserService
 import com.normation.rudder.AuthorizationType
 
 class RestAuthentication(

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/RestUtils.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/RestUtils.scala
@@ -37,22 +37,22 @@
 
 package com.normation.rudder.rest
 
-import net.liftweb.common.EmptyBox
-import net.liftweb.common.Full
-import net.liftweb.http.Req
 import com.normation.eventlog.EventActor
-import net.liftweb.json._
-import net.liftweb.http._
-import net.liftweb.json.JsonDSL._
-import net.liftweb.http.js.JsExp
-import net.liftweb.common.Loggable
-import net.liftweb.common.Box
-import net.liftweb.common.Failure
-import net.liftweb.util.Helpers.tryo
 import com.normation.eventlog.ModificationId
+import com.normation.rudder.UserService
 import com.normation.utils.StringUuidGenerator
+import net.liftweb.common.Box
+import net.liftweb.common.EmptyBox
+import net.liftweb.common.Failure
+import net.liftweb.common.Full
+import net.liftweb.common.Loggable
+import net.liftweb.http.Req
+import net.liftweb.http._
+import net.liftweb.http.js.JsExp
 import net.liftweb.json.JsonAST.RenderSettings
-import com.normation.rudder.service.user.UserService
+import net.liftweb.json.JsonDSL._
+import net.liftweb.json._
+import net.liftweb.util.Helpers.tryo
 
 /**
  */

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestApiAccounts.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestApiAccounts.scala
@@ -1,18 +1,21 @@
 package com.normation.rudder.rest
 
-import net.liftweb.http.rest.RestHelper
-import net.liftweb.common.Loggable
-import com.normation.rudder.api.{ApiAuthorization => ApiAuthz, RoApiAccountRepository, WoApiAccountRepository, _}
-import com.normation.rudder.rest.RestUtils._
-import net.liftweb.json.JsonDSL._
-import net.liftweb.common._
-import net.liftweb.json.JArray
-import org.joda.time.DateTime
-import net.liftweb.http.LiftResponse
-import com.normation.utils.StringUuidGenerator
 import com.normation.eventlog.ModificationId
-import com.normation.rudder.service.user.UserService
+import com.normation.rudder.UserService
+import com.normation.rudder.api.RoApiAccountRepository
+import com.normation.rudder.api.WoApiAccountRepository
+import com.normation.rudder.api._
+import com.normation.rudder.api.{ApiAuthorization => ApiAuthz}
 import com.normation.rudder.rest.ApiAccountSerialisation._
+import com.normation.rudder.rest.RestUtils._
+import com.normation.utils.StringUuidGenerator
+import net.liftweb.common.Loggable
+import net.liftweb.common._
+import net.liftweb.http.LiftResponse
+import net.liftweb.http.rest.RestHelper
+import net.liftweb.json.JArray
+import net.liftweb.json.JsonDSL._
+import org.joda.time.DateTime
 
 class RestApiAccounts (
     readApi        : RoApiAccountRepository

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestQuicksearch.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestQuicksearch.scala
@@ -37,19 +37,20 @@
 
 package com.normation.rudder.rest.internal
 
+import com.normation.rudder.AuthorizationType
+import com.normation.rudder.UserService
 import com.normation.rudder.rest.RestUtils._
+import com.normation.rudder.services.quicksearch.FullQuickSearchService
+import com.normation.rudder.services.quicksearch.QSObject
+import com.normation.rudder.services.quicksearch.QuickSearchResult
+import com.normation.rudder.web.model.LinkUtil
 import net.liftweb.common._
 import net.liftweb.http.rest.RestHelper
 import net.liftweb.json.JArray
 import net.liftweb.json.JsonAST._
 import net.liftweb.json.JsonDSL._
-import com.normation.rudder.services.quicksearch.FullQuickSearchService
-import com.normation.rudder.services.quicksearch.QuickSearchResult
-import com.normation.rudder.services.quicksearch.QSObject
-import com.normation.rudder.service.user.UserService
-import com.normation.rudder.web.model.LinkUtil
+
 import scala.collection.Seq
-import com.normation.rudder.AuthorizationType
 
 /**
  * A class for the Quicksearch rest endpoint.
@@ -191,11 +192,10 @@ class RestQuicksearch (
 
   private[this] implicit class JsonSearchResult(r: QuickSearchResult) {
     import com.normation.inventory.domain.NodeId
-    import com.normation.rudder.domain.policies.DirectiveId
-    import com.normation.rudder.domain.policies.RuleId
     import com.normation.rudder.domain.nodes.NodeGroupId
     import com.normation.rudder.domain.parameters.ParameterName
-    import com.normation.rudder.services.quicksearch.QSAttribute._
+    import com.normation.rudder.domain.policies.DirectiveId
+    import com.normation.rudder.domain.policies.RuleId
     import com.normation.rudder.services.quicksearch.QuickSearchResultId._
 
     def toJson(): JObject = {

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ChangeRequestApi.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ChangeRequestApi.scala
@@ -37,36 +37,37 @@
 
 package com.normation.rudder.rest.lift
 
+import com.normation.cfclerk.services.TechniqueRepository
+import com.normation.rudder.domain.workflows.ChangeRequest
+import com.normation.rudder.domain.workflows.ChangeRequestId
+import com.normation.rudder.domain.workflows.WorkflowNodeId
+import com.normation.rudder.repository.RoChangeRequestRepository
+import com.normation.rudder.repository.RoWorkflowRepository
+import com.normation.rudder.repository.WoChangeRequestRepository
+import com.normation.rudder.repository.WoWorkflowRepository
+import com.normation.rudder.rest.RestUtils._
 import com.normation.rudder.rest.RestUtils.toJsonError
+import com.normation.rudder.rest.ApiModuleProvider
+import com.normation.rudder.rest.ApiPath
+import com.normation.rudder.rest.ApiVersion
+import com.normation.rudder.rest.AuthzToken
+import com.normation.rudder.rest.RestDataSerializer
 import com.normation.rudder.rest.RestExtractorService
+import com.normation.rudder.rest.{ChangeRequestApi => API}
+import com.normation.rudder.services.workflows.ChangeRequestService
+import com.normation.rudder.services.workflows.CommitAndDeployChangeRequestService
+import com.normation.rudder.services.workflows.WorkflowService
+import com.normation.utils.Control.boxSequence
+import net.liftweb.common.Box
 import net.liftweb.common.EmptyBox
+import net.liftweb.common.Failure
 import net.liftweb.common.Full
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
 import net.liftweb.json.JString
-import com.normation.rudder.domain.workflows.ChangeRequestId
-import com.normation.rudder.rest.ApiVersion
-import com.normation.rudder.rest.ApiPath
-import com.normation.rudder.repository.RoChangeRequestRepository
-import com.normation.rudder.repository.RoWorkflowRepository
-import com.normation.rudder.repository.WoWorkflowRepository
-import com.normation.rudder.services.workflows.ChangeRequestService
-import com.normation.rudder.services.workflows.WorkflowService
-import com.normation.rudder.services.workflows.CommitAndDeployChangeRequestService
-import com.normation.rudder.repository.WoChangeRequestRepository
-import com.normation.cfclerk.services.TechniqueRepository
-import com.normation.rudder.rest.RestDataSerializer
-import net.liftweb.common.Box
 import net.liftweb.json.JsonAST.JArray
 import net.liftweb.json.JsonAST.JValue
-import com.normation.rudder.domain.workflows.WorkflowNodeId
-import net.liftweb.common.Failure
-import com.normation.rudder.rest.RestUtils._
-import com.normation.utils.Control.boxSequence
-import com.normation.rudder.domain.workflows.ChangeRequest
 import net.liftweb.json.JsonDSL._
-import com.normation.rudder.rest.AuthzToken
-
 
 class ChangeRequestApi (
     restExtractorService : RestExtractorService
@@ -80,7 +81,9 @@ class ChangeRequestApi (
   , commitRepository     : CommitAndDeployChangeRequestService
   , restDataSerializer   : RestDataSerializer
   , workflowEnabled      : () => Box[Boolean]
-) extends LiftApiModuleProvider {
+) extends LiftApiModuleProvider[API] {
+
+  override def schemas: ApiModuleProvider[API] = API
 
   def checkWorkflow = {
     if (workflowEnabled().getOrElse(false))
@@ -109,8 +112,6 @@ class ChangeRequestApi (
 
   // While there is no authorisation on API, they got all rights.
   private[this] def apiUserRights = Seq("deployer","validator")
-
-  import com.normation.rudder.rest.{ChangeRequestApi => API}
 
   def getLiftEndpoints(): List[LiftApiModule] = {
     API.endpoints.map(e => e match {

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -37,42 +37,36 @@
 
 package com.normation.rudder.rest.lift
 
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
+import com.normation.rudder.domain.reports.ComplianceLevel
+import com.normation.rudder.reports.GlobalComplianceMode
+import com.normation.rudder.repository.RoDirectiveRepository
+import com.normation.rudder.repository.RoNodeGroupRepository
+import com.normation.rudder.repository.RoRuleRepository
+import com.normation.rudder.rest.ApiVersion
+import com.normation.rudder.rest.RestExtractorService
 import com.normation.rudder.rest.RestUtils._
+import com.normation.rudder.rest._
+import com.normation.rudder.rest.data._
+import com.normation.rudder.rest.{ComplianceApi => API}
+import com.normation.rudder.services.nodes.NodeInfoService
+import com.normation.rudder.services.reports.ReportingService
 import net.liftweb.common._
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
+import net.liftweb.json.JsonDSL._
 import net.liftweb.json._
-import net.liftweb.json.JsonDSL._
-import com.normation.rudder.rest.RestExtractorService
-import com.normation.rudder.rest.ApiVersion
-import com.normation.rudder.rest._
-import com.normation.inventory.domain.NodeId
-import com.normation.inventory.domain.NodeId
-import com.normation.rudder.domain.policies.RuleId
-import com.normation.rudder.domain.reports._
-import net.liftweb.json.JsonDSL._
-import com.normation.inventory.domain.NodeId
-import com.normation.rudder.domain.policies.RuleId
-import com.normation.rudder.domain.reports.ComplianceLevel
-import com.normation.rudder.repository.RoNodeGroupRepository
-import com.normation.rudder.repository.RoRuleRepository
-import com.normation.rudder.services.nodes.NodeInfoService
-import com.normation.rudder.services.reports.ReportingService
-import net.liftweb.common.Box
-import com.normation.rudder.domain.policies.Rule
-import net.liftweb.common.Full
-import com.normation.rudder.reports.GlobalComplianceMode
-import com.normation.rudder.repository.RoDirectiveRepository
-import com.normation.rudder.rest.data._
 
 class ComplianceApi(
     restExtractorService: RestExtractorService
   , complianceService   : ComplianceAPIService
-) extends LiftApiModuleProvider {
+) extends LiftApiModuleProvider[API] {
 
-  import com.normation.rudder.rest.{ComplianceApi => API}
   import JsonCompliance._
+
+  def schemas = API
 
   /*
    * The actual builder for the compliance API.

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
@@ -37,17 +37,9 @@
 
 package com.normation.rudder.rest.lift
 
-import com.normation.rudder.repository.RoDirectiveRepository
-import com.normation.rudder.rest.RestExtractorService
-import net.liftweb.common.Box
-import net.liftweb.http.LiftResponse
-import net.liftweb.http.Req
-import com.normation.rudder.rest.ApiVersion
-import com.normation.rudder.domain.policies.DirectiveId
-import net.liftweb.json.JsonAST.JValue
-import com.normation.rudder.rest.RestUtils
-import com.normation.utils.StringUuidGenerator
 import com.normation.cfclerk.domain.Technique
+import com.normation.cfclerk.domain.TechniqueId
+import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
 import com.normation.rudder.batch.AsyncDeploymentAgent
@@ -61,37 +53,37 @@ import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.ModifyToDirectiveDiff
 import com.normation.rudder.repository.RoDirectiveRepository
 import com.normation.rudder.repository.WoDirectiveRepository
+import com.normation.rudder.rest.ApiPath
+import com.normation.rudder.rest.ApiVersion
+import com.normation.rudder.rest.AuthzToken
+import com.normation.rudder.rest.RestDataSerializer
+import com.normation.rudder.rest.RestExtractorService
+import com.normation.rudder.rest.RestUtils
+import com.normation.rudder.rest.data._
+import com.normation.rudder.rest.{DirectiveApi => API}
 import com.normation.rudder.services.workflows.ChangeRequestService
 import com.normation.rudder.services.workflows.WorkflowService
 import com.normation.rudder.web.model.DirectiveEditor
 import com.normation.rudder.web.services.DirectiveEditorService
-import com.normation.rudder.rest.RestExtractorService
 import com.normation.utils.Control._
 import com.normation.utils.StringUuidGenerator
 import net.liftweb.common._
+import net.liftweb.http.LiftResponse
+import net.liftweb.http.Req
 import net.liftweb.json.JArray
-import net.liftweb.json.JValue
-import net.liftweb.json.JsonDSL._
-import com.normation.rudder.rest.RestDataSerializer
-import com.normation.cfclerk.domain.TechniqueId
-import com.normation.cfclerk.services.TechniqueRepository
 import net.liftweb.json.JsonAST.JValue
-import com.normation.rudder.web.services.DirectiveEditorService
-import com.normation.rudder.web.model.DirectiveEditor
-import com.normation.rudder.rest.ApiPath
-import com.normation.rudder.rest.AuthzToken
-import net.liftweb.common.Full
-import com.normation.eventlog.EventActor
-import com.normation.rudder.rest.data._
+import net.liftweb.json.JsonDSL._
 
 class DirectiveApi (
     readDirective       : RoDirectiveRepository
   , restExtractorService: RestExtractorService
   , apiV2               : DirectiveAPIService2
   , uuidGen             : StringUuidGenerator
-) extends LiftApiModuleProvider {
+) extends LiftApiModuleProvider[API] {
 
   val dataName = "directives"
+
+  def schemas = API
 
   def response ( function : Box[JValue], req : Req, errorMessage : String, id : Option[String])(implicit action : String) : LiftResponse = {
     RestUtils.response(restExtractorService, dataName, id)(function, req, errorMessage)
@@ -107,7 +99,6 @@ class DirectiveApi (
     RestUtils.workflowResponse2(restExtractorService, dataName, uuidGen, id)(function, req, errorMessage, defaultName)(action, actor)
   }
 
-  import com.normation.rudder.rest.{DirectiveApi => API}
 
   def getLiftEndpoints(): List[LiftApiModule] = {
     API.endpoints.map(e => e match {

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -37,37 +37,28 @@
 
 package com.normation.rudder.rest.lift
 
+import com.normation.eventlog.EventActor
+import com.normation.eventlog.ModificationId
+import com.normation.rudder.UserService
+import com.normation.rudder.batch.AsyncDeploymentAgent
+import com.normation.rudder.batch.AutomaticStartDeployment
+import com.normation.rudder.domain.nodes._
 import com.normation.rudder.repository.RoNodeGroupRepository
-import com.normation.rudder.rest._
+import com.normation.rudder.repository.WoNodeGroupRepository
 import com.normation.rudder.rest.ApiVersion
 import com.normation.rudder.rest.RestExtractorService
 import com.normation.rudder.rest.RestUtils._
-import com.normation.rudder.repository._
-import com.normation.utils.StringUuidGenerator
-import com.normation.rudder.batch.AsyncDeploymentAgent
-import com.normation.rudder.services.workflows._
-import com.normation.rudder.rest.RestExtractorService
-import com.normation.eventlog.EventActor
-import net.liftweb.common._
-import net.liftweb.json._
-import net.liftweb.json.JsonDSL._
 import com.normation.rudder.rest._
-import net.liftweb.http.Req
-import com.normation.eventlog.ModificationId
-import com.normation.rudder.batch.AutomaticStartDeployment
-import com.normation.rudder.domain.nodes.NodeGroup
-import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.rest.data._
+import com.normation.rudder.rest.{GroupApi => API}
 import com.normation.rudder.services.queries.QueryProcessor
-import com.normation.rudder.domain.nodes._
-import com.normation.rudder.service.user.UserService
+import com.normation.rudder.services.workflows._
 import com.normation.utils.StringUuidGenerator
 import net.liftweb.common._
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
 import net.liftweb.json.JsonDSL._
-import com.normation.rudder.domain.nodes.NodeGroupCategoryId
-import com.normation.eventlog.EventActor
-import com.normation.rudder.rest.data._
+import net.liftweb.json._
 
 class GroupsApi(
     readGroup           : RoNodeGroupRepository
@@ -76,9 +67,10 @@ class GroupsApi(
   , serviceV2           : GroupApiService2
   , serviceV5           : GroupApiService5
   , serviceV6           : GroupApiService6
-) extends LiftApiModuleProvider {
+) extends LiftApiModuleProvider[API] {
 
-  import com.normation.rudder.rest.{GroupApi => API}
+
+  def schemas = API
 
   /*
    * The actual builder for the compliance API.
@@ -108,7 +100,7 @@ class GroupsApi(
     }
   }
   object Get extends LiftApiModule {
-    val schema = API.GetGroupCategoryDetails
+    val schema = API.GroupDetails
     val restExtractor = restExtractorService
     def process(version: ApiVersion, path: ApiPath, id: String, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
       serviceV2.groupDetails(id, req, version)
@@ -294,8 +286,8 @@ class GroupApiService2 (
   , restDataSerializer   : RestDataSerializer
 ) ( implicit userService : UserService ) extends Loggable {
 
-  import restDataSerializer._
   import RestUtils._
+  import restDataSerializer._
 
   private[this] def createChangeRequestAndAnswer (
       id           : String

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InfoApi.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InfoApi.scala
@@ -37,19 +37,15 @@
 
 package com.normation.rudder.rest.lift
 
-import com.normation.rudder.rest.ApiPath
-import com.normation.rudder.rest.ApiVersion
-import com.normation.rudder.rest.AuthzToken
-import com.normation.rudder.rest.Endpoint
-import com.normation.rudder.rest.RestExtractorService
-import com.normation.rudder.rest.RestUtils
+import com.normation.rudder.api.HttpAction
+import com.normation.rudder.rest._
+import com.normation.rudder.rest.{InfoApi => API}
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
-import net.liftweb.json._
 import net.liftweb.json.JsonDSL._
+import net.liftweb.json._
+
 import scala.language.implicitConversions
-import com.normation.rudder.api.HttpAction
-import com.normation.rudder.rest.ApiKind
 
 /*
  * Information about the API
@@ -58,10 +54,10 @@ class InfoApi(
     restExtractor    : RestExtractorService
   , supportedVersions: List[ApiVersion]
   , endpoints        : List[Endpoint]
-) extends LiftApiModuleProvider {
+) extends LiftApiModuleProvider[API] {
   api =>
 
-  import com.normation.rudder.rest.{ InfoApi => API }
+  def schemas = API
 
   def getLiftEndpoints(): List[LiftApiModule] = {
     API.endpoints.map(e => e match {

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NcfApi.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NcfApi.scala
@@ -37,26 +37,27 @@
 
 package com.normation.rudder.rest.lift
 
-import net.liftweb.common.Box
-import com.normation.rudder.rest.RestExtractorService
-import net.liftweb.json.JsonAST.JValue
-import net.liftweb.http.Req
-import net.liftweb.http.LiftResponse
-import com.normation.utils.StringUuidGenerator
-import com.normation.rudder.rest.ApiVersion
-import com.normation.rudder.ncf.TechniqueWriter
-import net.liftweb.common.Full
-import com.normation.eventlog.ModificationId
 import com.normation.eventlog.EventActor
+import com.normation.eventlog.ModificationId
+import com.normation.rudder.ncf.TechniqueWriter
 import com.normation.rudder.rest.ApiPath
+import com.normation.rudder.rest.ApiVersion
 import com.normation.rudder.rest.AuthzToken
+import com.normation.rudder.rest.RestExtractorService
+import com.normation.rudder.rest.{NcfApi => API}
+import com.normation.utils.StringUuidGenerator
+import net.liftweb.common.Box
+import net.liftweb.common.Full
+import net.liftweb.http.LiftResponse
+import net.liftweb.http.Req
+import net.liftweb.json.JsonAST.JValue
 
 class NcfApi(
     techniqueWriter     : TechniqueWriter
   , restExtractorService: RestExtractorService
   , uuidGen             : StringUuidGenerator
-) extends LiftApiModuleProvider {
- val kind = "ncf"
+) extends LiftApiModuleProvider[API] {
+  val kind = "ncf"
 
   import com.normation.rudder.ncf.ResultHelper.resultToBox
   import com.normation.rudder.rest.RestUtils._
@@ -70,8 +71,8 @@ class NcfApi(
     actionResponse2(restExtractorService, dataName, uuidGen, None)(function, req, errorMessage)(action, actor)
   }
 
-  import com.normation.rudder.rest.{NcfApi => API}
 
+  def schemas = API
   def getLiftEndpoints(): List[LiftApiModule] = {
     API.endpoints.map(e => e match {
         case API.UpdateTechnique => UpdateTechnique
@@ -101,7 +102,7 @@ class NcfApi(
   }
 
   object CreateTechnique extends LiftApiModule0 {
-    val schema = API.UpdateTechnique
+    val schema = API.CreateTechnique
     val restExtractor = restExtractorService
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
       val modId = ModificationId(uuidGen.newUuid)

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
@@ -37,47 +37,41 @@
 
 package com.normation.rudder.rest.lift
 
-import com.normation.rudder.rest.RestUtils.toJsonError
-import com.normation.rudder.rest.RestExtractorService
-import net.liftweb.common.EmptyBox
-import net.liftweb.common.Full
-import net.liftweb.http.LiftResponse
-import net.liftweb.http.Req
-import net.liftweb.json.JString
-import net.liftweb.json.JsonDSL._
-import com.normation.rudder.rest.ApiVersion
-import com.normation.rudder.rest.AuthzToken
-import com.normation.rudder.rest.ApiPath
 import com.normation.eventlog.EventActor
+import com.normation.rudder.UserService
 import com.normation.rudder.domain.parameters._
 import com.normation.rudder.repository.RoParameterRepository
 import com.normation.rudder.repository.WoParameterRepository
-import com.normation.rudder.services.workflows.ChangeRequestService
-import com.normation.rudder.services.workflows.WorkflowService
+import com.normation.rudder.rest.ApiPath
+import com.normation.rudder.rest.ApiVersion
+import com.normation.rudder.rest.AuthzToken
+import com.normation.rudder.rest.RestDataSerializer
+import com.normation.rudder.rest.RestExtractorService
 import com.normation.rudder.rest.RestUtils
 import com.normation.rudder.rest.RestUtils.getActor
 import com.normation.rudder.rest.RestUtils.toJsonError
 import com.normation.rudder.rest.RestUtils.toJsonResponse
-import com.normation.rudder.rest.RestExtractorService
+import com.normation.rudder.rest.data.RestParameter
+import com.normation.rudder.rest.{ParameterApi => API}
+import com.normation.rudder.services.workflows.ChangeRequestService
+import com.normation.rudder.services.workflows.WorkflowService
 import com.normation.utils.StringUuidGenerator
 import net.liftweb.common.Box
 import net.liftweb.common.EmptyBox
 import net.liftweb.common.Full
+import net.liftweb.common.Loggable
+import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
 import net.liftweb.json.JArray
+import net.liftweb.json.JString
 import net.liftweb.json.JsonDSL._
-import net.liftweb.common.Loggable
-import com.normation.rudder.rest.RestDataSerializer
-import com.normation.rudder.service.user.UserService
-import com.normation.rudder.rest.data.RestParameter
 
 class ParameterApi (
     restExtractorService: RestExtractorService
   , apiV2               : ParameterApiService2
-) extends LiftApiModuleProvider {
+) extends LiftApiModuleProvider[API] {
 
-
-  import com.normation.rudder.rest.{ParameterApi => API}
+  def schemas = API
 
   def getLiftEndpoints(): List[LiftApiModule] = {
     API.endpoints.map(e => e match {
@@ -85,7 +79,7 @@ class ParameterApi (
       case API.CreateParameter  => CreateParameter
       case API.DeleteParameter  => DeleteParameter
       case API.ParameterDetails => ParameterDetails
-      case API.UpdateParameter  => ParameterDetails
+      case API.UpdateParameter  => UpdateParameter
     }).toList
   }
 
@@ -185,7 +179,7 @@ class ParameterApiService2 (
 ) ( implicit userService : UserService )
 extends Loggable {
 
-  import restDataSerializer.{ serializeParameter => serialize}
+  import restDataSerializer.{serializeParameter => serialize}
 
   private[this] def createChangeRequestAndAnswer (
       id           : String

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -37,40 +37,40 @@
 
 package com.normation.rudder.rest.lift
 
-import net.liftweb.common.Box
-import net.liftweb.http.LiftResponse
-import net.liftweb.http.Req
-import net.liftweb.json.JsonAST.JValue
-import com.normation.rudder.rest.RestExtractorService
-import com.normation.rudder.rest.RestUtils
-import com.normation.rudder.rest.ApiVersion
-import com.normation.rudder.appconfig._
 import com.normation.eventlog.EventActor
-import net.liftweb.common.Full
-import net.liftweb.common.Failure
-import net.liftweb.json.JsonAST.JString
-import com.normation.rudder.domain.policies.PolicyMode
-import com.normation.utils.StringUuidGenerator
-import net.liftweb.json.JsonAST.JBool
-import com.normation.rudder.batch.AsyncDeploymentAgent
 import com.normation.eventlog.ModificationId
+import com.normation.rudder.appconfig.ReadConfigService
+import com.normation.rudder.appconfig.UpdateConfigService
+import com.normation.rudder.batch.AsyncDeploymentAgent
 import com.normation.rudder.batch.AutomaticStartDeployment
-import net.liftweb.json.JsonAST.JInt
+import com.normation.rudder.domain.appconfig.FeatureSwitch
+import com.normation.rudder.domain.nodes.NodeState
+import com.normation.rudder.domain.policies.PolicyMode
+import com.normation.rudder.reports.ComplianceModeName
 import com.normation.rudder.reports.SyslogProtocol
 import com.normation.rudder.reports.SyslogTCP
 import com.normation.rudder.reports.SyslogUDP
-import com.normation.rudder.domain.appconfig.FeatureSwitch
-import com.normation.rudder.reports.ComplianceModeName
-import net.liftweb.common.EmptyBox
-import net.liftweb.json.JsonAST._
-import com.normation.rudder.appconfig.ReadConfigService
-import com.normation.rudder.appconfig.UpdateConfigService
-import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.rest.ApiPath
+import com.normation.rudder.rest.ApiVersion
 import com.normation.rudder.rest.AuthzToken
-import net.liftweb.json.JsonDSL._
-import com.normation.rudder.services.servers.RelaySynchronizationMethod._
+import com.normation.rudder.rest.RestExtractorService
+import com.normation.rudder.rest.RestUtils
+import com.normation.rudder.rest.{SettingsApi => API}
 import com.normation.rudder.services.servers.RelaySynchronizationMethod
+import com.normation.rudder.services.servers.RelaySynchronizationMethod._
+import com.normation.utils.StringUuidGenerator
+import net.liftweb.common.Box
+import net.liftweb.common.EmptyBox
+import net.liftweb.common.Failure
+import net.liftweb.common.Full
+import net.liftweb.http.LiftResponse
+import net.liftweb.http.Req
+import net.liftweb.json.JsonAST.JBool
+import net.liftweb.json.JsonAST.JInt
+import net.liftweb.json.JsonAST.JString
+import net.liftweb.json.JsonAST.JValue
+import net.liftweb.json.JsonAST._
+import net.liftweb.json.JsonDSL._
 
 
 class SettingsApi(
@@ -78,7 +78,7 @@ class SettingsApi(
   , val configService       : ReadConfigService with UpdateConfigService
   , val asyncDeploymentAgent: AsyncDeploymentAgent
   , val uuidGen             : StringUuidGenerator
-) extends LiftApiModuleProvider {
+) extends LiftApiModuleProvider[API] {
 
   val allSettings_v10: List[RestSetting[_]] =
       RestPolicyMode ::
@@ -119,7 +119,7 @@ class SettingsApi(
   val kind = "settings"
 
 
-  import com.normation.rudder.rest.{SettingsApi => API}
+  def schemas = API
 
   def getLiftEndpoints(): List[LiftApiModule] = {
     API.endpoints.map(e => e match {

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
@@ -37,46 +37,41 @@
 
 package com.normation.rudder.rest.lift
 
-import scala.util.{ Failure => TryFailure }
-import scala.util.Success
-import scala.util.Try
-
-import com.normation.cfclerk.domain.TechniqueName
-import com.normation.cfclerk.domain.TechniqueVersion
-import com.normation.rudder.rest.RestExtractorService
-import com.normation.rudder.rest.RestUtils.response
-import com.normation.rudder.rest.ApiVersion
-
-import net.liftweb.common.Failure
-import net.liftweb.http.LiftResponse
-import net.liftweb.http.Req
-import com.normation.rudder.rest.ApiPath
-import com.normation.rudder.rest.AuthzToken
-import scala.collection.SortedMap
-
 import com.normation.cfclerk.domain.Technique
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.rudder.domain.policies.Directive
 import com.normation.rudder.repository.RoDirectiveRepository
+import com.normation.rudder.rest.ApiPath
+import com.normation.rudder.rest.ApiVersion
+import com.normation.rudder.rest.AuthzToken
 import com.normation.rudder.rest.RestDataSerializer
+import com.normation.rudder.rest.RestExtractorService
+import com.normation.rudder.rest.RestUtils.response
+import com.normation.rudder.rest.{TechniqueApi => API}
 import com.normation.utils.Control.boxSequence
 import com.normation.utils.Control.sequence
-
 import net.liftweb.common.Box
 import net.liftweb.common.Failure
 import net.liftweb.common.Full
 import net.liftweb.common.Loggable
+import net.liftweb.http.LiftResponse
+import net.liftweb.http.Req
 import net.liftweb.json.JsonAST.JValue
 import net.liftweb.json.JsonDSL.seq2jvalue
+
+import scala.collection.SortedMap
+import scala.util.Success
+import scala.util.Try
+import scala.util.{Failure => TryFailure}
 
 class TechniqueApi (
     restExtractorService: RestExtractorService
   , apiV6               : TechniqueAPIService6
-) extends LiftApiModuleProvider {
+) extends LiftApiModuleProvider[API] {
 
-  import com.normation.rudder.rest.{TechniqueApi => API}
+  def schemas = API
 
   def getLiftEndpoints(): List[LiftApiModule] = {
     API.endpoints.map(e => e match {

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserApi.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserApi.scala
@@ -37,23 +37,24 @@
 
 package com.normation.rudder.rest.lift
 
-import com.normation.rudder.rest.RestExtractorService
-import net.liftweb.http.Req
-import net.liftweb.http.LiftResponse
-import com.normation.utils.StringUuidGenerator
-import com.normation.rudder.rest.ApiVersion
-import net.liftweb.common.Full
 import com.normation.eventlog.ModificationId
-import com.normation.rudder.rest.ApiPath
-import com.normation.rudder.rest.AuthzToken
 import com.normation.rudder.api._
-import net.liftweb.json.JsonAST.JArray
-import net.liftweb.common.EmptyBox
-import org.joda.time.DateTime
 import com.normation.rudder.rest.ApiAccountSerialisation._
+import com.normation.rudder.rest.ApiPath
+import com.normation.rudder.rest.ApiVersion
+import com.normation.rudder.rest.AuthzToken
+import com.normation.rudder.rest.RestExtractorService
 import com.normation.rudder.rest.RestUtils
+import com.normation.rudder.rest.{UserApi => API}
+import com.normation.utils.StringUuidGenerator
+import net.liftweb.common.EmptyBox
+import net.liftweb.common.Full
+import net.liftweb.http.LiftResponse
+import net.liftweb.http.Req
+import net.liftweb.json.JsonAST.JArray
 import net.liftweb.json.JsonDSL._
 import net.liftweb.json._
+import org.joda.time.DateTime
 
 class UserApi(
     restExtractor : RestExtractorService
@@ -61,10 +62,10 @@ class UserApi(
   , writeApi      : WoApiAccountRepository
   , tokenGenerator: TokenGenerator
   , uuidGen       : StringUuidGenerator
-) extends LiftApiModuleProvider {
+) extends LiftApiModuleProvider[API] {
   api =>
 
-  import com.normation.rudder.rest.{UserApi => API}
+  def schemas = API
 
   def getLiftEndpoints(): List[LiftApiModule] = {
     API.endpoints.map(e => e match {

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/v1/RestArchiving.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/v1/RestArchiving.scala
@@ -37,21 +37,21 @@
 
 package com.normation.rudder.rest
 
+import com.normation.eventlog.EventActor
+import com.normation.eventlog.ModificationId
+import com.normation.rudder.UserService
 import com.normation.rudder.repository._
 import com.normation.rudder.repository.xml._
 import com.normation.rudder.services.user.PersonIdentService
+import com.normation.utils.StringUuidGenerator
+import net.liftweb.common._
 import net.liftweb.http._
 import net.liftweb.http.rest._
-import net.liftweb.common._
-import net.liftweb.json._
 import net.liftweb.json.JsonDSL._
-import org.joda.time.DateTime
+import net.liftweb.json._
 import net.liftweb.util.Helpers.tryo
 import org.eclipse.jgit.lib.PersonIdent
-import com.normation.eventlog.EventActor
-import com.normation.eventlog.ModificationId
-import com.normation.utils.StringUuidGenerator
-import com.normation.rudder.service.user.UserService
+import org.joda.time.DateTime
 
 /**
  * A rest api that allows to deploy promises.

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/v1/RestDeploy.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/v1/RestDeploy.scala
@@ -37,14 +37,14 @@
 
 package com.normation.rudder.rest.v1
 
-import net.liftweb.http._
-import net.liftweb.http.rest._
+import com.normation.eventlog.ModificationId
+import com.normation.rudder.UserService
 import com.normation.rudder.batch.AsyncDeploymentAgent
 import com.normation.rudder.batch.ManualStartDeployment
-import com.normation.utils.StringUuidGenerator
-import com.normation.eventlog.ModificationId
-import com.normation.rudder.service.user.UserService
 import com.normation.rudder.rest.RestUtils
+import com.normation.utils.StringUuidGenerator
+import net.liftweb.http._
+import net.liftweb.http.rest._
 
 /**
  * A rest api that allows to deploy promises.

--- a/rudder-rest/src/main/scala/com/normation/rudder/rest/v1/RestTechniqueReload.scala
+++ b/rudder-rest/src/main/scala/com/normation/rudder/rest/v1/RestTechniqueReload.scala
@@ -37,14 +37,14 @@
 
 package com.normation.rudder.rest.v1
 
-import net.liftweb.http.rest.RestHelper
-import net.liftweb.http.PlainTextResponse
-import net.liftweb.common._
 import com.normation.cfclerk.services.UpdateTechniqueLibrary
 import com.normation.eventlog.ModificationId
-import com.normation.utils.StringUuidGenerator
-import com.normation.rudder.service.user.UserService
+import com.normation.rudder.UserService
 import com.normation.rudder.rest.RestUtils
+import com.normation.utils.StringUuidGenerator
+import net.liftweb.common._
+import net.liftweb.http.PlainTextResponse
+import net.liftweb.http.rest.RestHelper
 
 /**
  * A rest api that allows to deploy promises.

--- a/rudder-rest/src/test/scala/com/normation/rudder/web/rest/RestTestSetUp.scala
+++ b/rudder-rest/src/test/scala/com/normation/rudder/web/rest/RestTestSetUp.scala
@@ -57,9 +57,10 @@ import net.liftweb.util.NamedPF
 import net.liftweb.http.S
 import net.liftweb.common.EmptyBox
 import net.liftweb.json.JsonAST.JValue
-import com.normation.rudder.service.user.UserService
-import com.normation.rudder.service.user.User
+import com.normation.rudder.UserService
+import com.normation.rudder.User
 import com.normation.rudder.AuthorizationType
+import com.normation.rudder.RudderAccount
 import com.normation.rudder.api.{ApiAuthorization => ApiAuthz}
 import com.normation.rudder.rest.v1.RestTechniqueReload
 import com.normation.rudder.rest.v1.RestStatus
@@ -74,9 +75,9 @@ object RestTestSetUp {
   val uuidGen = new StringUuidGeneratorImpl()
   implicit val userService = new UserService {
     val user = new User{
-      val actor = new EventActor("test-user")
+      val account = RudderAccount.User("test-user", "pass")
       def checkRights(auth : AuthorizationType) = true
-      def getApiAutz = ApiAuthz.allAuthz
+      def getApiAuthz = ApiAuthz.allAuthz
     }
     val getCurrentUser = user
 

--- a/rudder-web/src/main/resources/logback.xml
+++ b/rudder-web/src/main/resources/logback.xml
@@ -300,10 +300,10 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
   <!--
     SQL Queries
     ===========
-    Information about SQL queries executed (timing, status, etc). 
+    Information about SQL queries executed (timing, status, etc).
     At debug level, you only get queries that returned a bad status or
-    takes more than 100ms to complete. 
-    At trace, you get them all. 
+    takes more than 100ms to complete.
+    At trace, you get them all.
   -->
   <logger name="sql" level="off" additivity="false">
     <appender-ref ref="OPSLOG" />
@@ -327,7 +327,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
   <!--
     Schechuled Jobs
     ================
-    This logger is in charge of all scheduled jobs and batches 
+    This logger is in charge of all scheduled jobs and batches
   -->
   <logger name="scheduledJob" level="info" additivity="false">
     <appender-ref ref="OPSLOG" />
@@ -410,10 +410,10 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
   <!--
     Hooks
     ==========
-    Information about hooks execution. 
-    This log allow to see what hooks are executed. 
-    
-    Debug level will display hooks with their parameter (may be quite noisy when there 
+    Information about hooks execution.
+    This log allow to see what hooks are executed.
+
+    Debug level will display hooks with their parameter (may be quite noisy when there
     is a lot of nodes implied). Trace add system information (like environment variables).
   -->
   <logger name="hooks" level="info" additivity="false">
@@ -421,6 +421,20 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     <!-- comment the following appender if you don't want to have logs about report in both stdout and opslog -->
     <appender-ref ref="STDOUT" />
   </logger>
+
+
+  <!--
+    API
+    ===
+    Information about API processing.
+
+    This log write information about API processing:
+    - on trace mode, at bootstrap, what API are registered and to which version they are mapped
+    - on debug and trace, various information about API processing (what, who, timing, etc).
+      Trace level is quite verbose and print for each request result for ALL path tested (100 of lines)
+
+  -->
+  <logger name="api-processing" level="info" />
 
 
   <!-- ==================================================== -->
@@ -465,5 +479,5 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
   <!-- Uncomment to have precise log about LDAP queries done by the node search engine -->
 <!--   <logger name="com.normation.rudder.services.queries.InternalLDAPQueryProcessor" level="debug" /> -->
 
-   
+
 </configuration>

--- a/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
@@ -174,7 +174,7 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
     <lift:authz role="deployment_write"> {
       SHtml.a( {
         () =>
-          asyncDeploymentAgent ! ManualStartDeployment(ModificationId(uuidGen.newUuid), CurrentUser.getActor, "User requested a manual policy update") //TODO: let the user fill the cause
+          asyncDeploymentAgent ! ManualStartDeployment(ModificationId(uuidGen.newUuid), CurrentUser.actor, "User requested a manual policy update") //TODO: let the user fill the cause
           Noop
       }
       , Text("Update policies")

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/ChangeRequestEditForm.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/ChangeRequestEditForm.scala
@@ -96,7 +96,7 @@ class ChangeRequestEditForm (
   }
   private[this] val isEditable = {
     val authz = CurrentUser.getRights.authorizationTypes.toSeq.collect{case right:ActionType.Edit => right.authzKind}
-    val isOwner = creator == CurrentUser.getActor.name
+    val isOwner = creator == CurrentUser.actor.name
     step.map(workflowService.isEditable(authz,_,isOwner))
     }.openOr(false)
 

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
@@ -200,7 +200,7 @@ class NodeGroupCategoryForm(
   }
 
   private[this] def onDelete() : JsCmd = {
-    woGroupCategoryRepository.delete(_nodeGroupCategory.id, ModificationId(uuidGen.newUuid), CurrentUser.getActor, Some("Node Group category deleted by user from UI")) match {
+    woGroupCategoryRepository.delete(_nodeGroupCategory.id, ModificationId(uuidGen.newUuid), CurrentUser.actor, Some("Node Group category deleted by user from UI")) match {
       case Full(id) =>
         JsRaw("""$('#removeActionDialog').bsModal('hide');""") &
         SetHtml(htmlIdCategory, NodeSeq.Empty) &
@@ -293,7 +293,7 @@ class NodeGroupCategoryForm(
           newNodeGroup
         , NodeGroupCategoryId(container.get)
         , ModificationId(uuidGen.newUuid)
-        , CurrentUser.getActor
+        , CurrentUser.actor
         , Some("Node Group category saved by user from UI")
       ) match {
         case Full(x) =>

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/PendingChangeRequestDisplayer.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/PendingChangeRequestDisplayer.scala
@@ -73,7 +73,7 @@ object PendingChangeRequestDisplayer extends Loggable{
         val pendingChangeRequestLink =( NodeSeq.Empty /: crs) {
           (res,cr) => res ++
           {
-            if (CurrentUser.checkRights(AuthorizationType.Validator.Read)||CurrentUser.checkRights(AuthorizationType.Deployer.Read)||cr.owner == CurrentUser.getActor.name) {
+            if (CurrentUser.checkRights(AuthorizationType.Validator.Read)||CurrentUser.checkRights(AuthorizationType.Deployer.Read)||cr.owner == CurrentUser.actor.name) {
               <li><a href={linkUtil.baseChangeRequestLink(cr.id)}>CR #{cr.id}: {cr.info.name}</a></li>
             } else {
               <li>CR #{cr.id}</li>

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleCategoryTree.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleCategoryTree.scala
@@ -165,7 +165,7 @@ class RuleCategoryTree(
                           category
                         , destCatId
                         , ModificationId(uuidGen.newUuid)
-                        , CurrentUser.getActor
+                        , CurrentUser.actor
                         , reason = None
                       ) ?~! s"Error while trying to move category with requested id '${sourceCatId}' to category id '${destCatId}'"
             newRoot <- roRuleCategoryRepository.getRootCategory

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/ShowNodeDetailsFromNode.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/ShowNodeDetailsFromNode.scala
@@ -126,9 +126,9 @@ class ShowNodeDetailsFromNode(
     val modId = ModificationId(uuidGen.newUuid)
     boxNodeInfo = Full(Some(nodeInfo.copy( nodeInfo.node.copy( nodeReportingConfiguration = nodeInfo.node.nodeReportingConfiguration.copy(heartbeatConfiguration = Some(heartbeatConfiguration))))))
     for {
-      result <- nodeRepo.updateNode(nodeInfo.node, modId, CurrentUser.getActor, None)
+      result <- nodeRepo.updateNode(nodeInfo.node, modId, CurrentUser.actor, None)
     } yield {
-      asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.getActor)
+      asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.actor)
     }
   }
 
@@ -148,14 +148,14 @@ class ShowNodeDetailsFromNode(
 
   def saveNodeState(nodeId: NodeId)(nodeState: NodeState): Box[NodeState] = {
     val modId =  ModificationId(uuidGen.newUuid)
-    val user  =  CurrentUser.getActor
+    val user  =  CurrentUser.actor
 
     for {
       oldNode <- nodeInfoService.getNode(nodeId)
       newNode =  oldNode.copy(state = nodeState)
       result  <- nodeRepo.updateNode(newNode, modId, user, None)
     } yield {
-      asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.getActor)
+      asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.actor)
       nodeState
     }
   }
@@ -184,14 +184,14 @@ class ShowNodeDetailsFromNode(
 
   def saveSchedule(nodeInfo : NodeInfo)( schedule: AgentRunInterval) : Box[Unit] = {
     val modId =  ModificationId(uuidGen.newUuid)
-    val user  =  CurrentUser.getActor
+    val user  =  CurrentUser.actor
     val newNodeInfo = nodeInfo.copy( nodeInfo.node.copy( nodeReportingConfiguration = nodeInfo.node.nodeReportingConfiguration.copy(agentRunInterval = Some(schedule))))
     boxNodeInfo = Full(Some(newNodeInfo))
     for {
       oldNode <- nodeInfoService.getNode(nodeId)
       result  <- nodeRepo.updateNode(newNodeInfo.node, modId, user, None)
     } yield {
-      asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.getActor)
+      asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.actor)
     }
   }
 

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueCategoryEditForm.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueCategoryEditForm.scala
@@ -115,7 +115,7 @@ class TechniqueCategoryEditForm(
   }
 
   private[this] def deleteCategory() : JsCmd = {
-    activeTechniqueCategoryRepository.delete(currentCategory.id, ModificationId(uuidGen.newUuid),CurrentUser.getActor, Some("User deleted technique category from UI")) match {
+    activeTechniqueCategoryRepository.delete(currentCategory.id, ModificationId(uuidGen.newUuid),CurrentUser.actor, Some("User deleted technique category from UI")) match {
       case Full(id) =>
         //update UI
         JsRaw("$('#removeCategoryActionDialog').bsModal('hide');") &
@@ -205,7 +205,7 @@ class TechniqueCategoryEditForm(
                    name = categoryName.get,
                    description = categoryDescription.get
                )
-               activeTechniqueCategoryRepository.saveActiveTechniqueCategory(updatedCategory, ModificationId(uuidGen.newUuid), CurrentUser.getActor, Some("User updated category from UI")) match {
+               activeTechniqueCategoryRepository.saveActiveTechniqueCategory(updatedCategory, ModificationId(uuidGen.newUuid), CurrentUser.actor, Some("User updated category from UI")) match {
                  case Failure(m,_,_) =>
                    categorFormTracker.addFormError(  error("An error occured: " + m) )
                  case Empty =>

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueEditForm.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueEditForm.scala
@@ -352,7 +352,7 @@ class TechniqueEditForm(
         {
           val modId = ModificationId(uuidGen.newUuid)
           (for {
-            deleted <- dependencyService.cascadeDeleteTechnique(id, modId, CurrentUser.getActor, crReasonsRemovePopup.map (_.get))
+            deleted <- dependencyService.cascadeDeleteTechnique(id, modId, CurrentUser.actor, crReasonsRemovePopup.map (_.get))
             deploy <- {
               asyncDeploymentAgent ! AutomaticStartDeployment(modId, RudderEventActor)
               Full("Policy update request sent")
@@ -458,7 +458,7 @@ class TechniqueEditForm(
                     , technique.id.name
                     , techniqueRepository.getTechniqueVersions(technique.id.name).toSeq
                     , ModificationId(uuidGen.newUuid)
-                    , CurrentUser.getActor
+                    , CurrentUser.actor
                     , Some("User added a technique from UI")
                   )
 
@@ -550,7 +550,7 @@ class TechniqueEditForm(
     val modId = ModificationId(uuidGen.newUuid)
     (for {
       save <- rwActiveTechniqueRepository.changeStatus(uactiveTechniqueId, status,
-                modId, CurrentUser.getActor, crReasonsDisablePopup.map(_.get))
+                modId, CurrentUser.actor, crReasonsDisablePopup.map(_.get))
       deploy <- {
         asyncDeploymentAgent ! AutomaticStartDeployment(modId, RudderEventActor)
         Full("Policy update request sent")

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateActiveTechniqueCategoryPopup.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateActiveTechniqueCategoryPopup.scala
@@ -141,7 +141,7 @@ class CreateActiveTechniqueCategoryPopup(onSuccessCallback : () => JsCmd = { () 
           )
          , ActiveTechniqueCategoryId(categoryContainer.get)
          , ModificationId(uuidGen.newUuid)
-         , CurrentUser.getActor
+         , CurrentUser.actor
          , Some("user created a new category")
       ) match {
           case Failure(m,_,_) =>

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
@@ -245,7 +245,7 @@ class CreateCategoryOrGroupPopup(
             )
           , NodeGroupCategoryId(piContainer.get)
           , ModificationId(uuidGen.newUuid)
-          , CurrentUser.getActor
+          , CurrentUser.actor
           , piReasons.map(_.get)
         ) match {
           case Full(x) => closePopup() & onSuccessCallback(x.id.value) & onSuccessCategory(x)
@@ -274,7 +274,7 @@ class CreateCategoryOrGroupPopup(
             nodeGroup
           , NodeGroupCategoryId(piContainer.get)
           , ModificationId(uuidGen.newUuid)
-          , CurrentUser.getActor
+          , CurrentUser.actor
           , piReasons.map(_.get)
         ) match {
           case Full(x) =>

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneDirectivePopup.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneDirectivePopup.scala
@@ -194,7 +194,7 @@ class CreateCloneDirectivePopup(
         )
       roDirectiveRepository.getActiveTechniqueAndDirective(directive.id) match {
         case Full((activeTechnique, _)) =>
-          woDirectiveRepository.saveDirective(activeTechnique.id, cloneDirective, ModificationId(uuidGen.newUuid), CurrentUser.getActor, reasons.map(_.get)) match {
+          woDirectiveRepository.saveDirective(activeTechnique.id, cloneDirective, ModificationId(uuidGen.newUuid), CurrentUser.actor, reasons.map(_.get)) match {
             case Full(directive) => {
                closePopup() & onSuccessCallback(cloneDirective)
             }

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
@@ -99,7 +99,7 @@ class CreateCloneGroupPopup(
             )
           , NodeGroupCategoryId(groupContainer.get)
           , ModificationId(uuidGen.newUuid)
-          , CurrentUser.getActor
+          , CurrentUser.actor
           , Some("Node Group category created by user from UI")
         ) match {
           case Full(x) => closePopup() & onSuccessCallback(x.id.value) & onSuccessCategory(x)
@@ -125,7 +125,7 @@ class CreateCloneGroupPopup(
             clone
           , parentCategoryId
           , ModificationId(uuidGen.newUuid)
-          , CurrentUser.getActor
+          , CurrentUser.actor
           , groupReasons.map(_.get)
         ) match {
           case Full(x) =>

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
@@ -126,10 +126,10 @@ class CreateOrUpdateGlobalParameterPopup(
                        , newParameter
                        , parameter
                        , diff
-                       , CurrentUser.getActor
+                       , CurrentUser.actor
                        , paramReasons.map( _.get )
                        )
-          wfStarted <- workflowService.startWorkflow(cr.id, CurrentUser.getActor, paramReasons.map(_.get))
+          wfStarted <- workflowService.startWorkflow(cr.id, CurrentUser.actor, paramReasons.map(_.get))
         } yield {
           cr.id
         }

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateRulePopup.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateRulePopup.scala
@@ -206,7 +206,7 @@ class CreateOrCloneRulePopup(
           , isEnabledStatus = !clonedRule.isDefined
       )
 
-      woRuleRepository.create(rule, ModificationId(uuidGen.newUuid),CurrentUser.getActor, reason.map( _.get )) match {
+      woRuleRepository.create(rule, ModificationId(uuidGen.newUuid),CurrentUser.actor, reason.map( _.get )) match {
           case Full(x) =>
             onSuccessCallback(rule) & closePopup()
           case Empty =>

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/GiveReasonPopup.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/GiveReasonPopup.scala
@@ -149,7 +149,7 @@ class GiveReasonPopup(
                       ptName,
                       techniqueRepository.getTechniqueVersions(ptName).toSeq,
                       ModificationId(uuidGen.newUuid),
-                      CurrentUser.getActor,
+                      CurrentUser.actor,
                       crReasons.map (_.get)
                    )
                    ?~! errorMess.format(sourceActiveTechniqueId.value, destCatId.value)

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ModificationValidationPopup.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ModificationValidationPopup.scala
@@ -509,7 +509,7 @@ class ModificationValidationPopup(
           changeRequestService.createChangeRequestFromRules(
                 changeRequestName.get
               , crReasons.map( _.get ).getOrElse("")
-              , CurrentUser.getActor
+              , CurrentUser.actor
               , crReasons.map( _.get )
               , baseRules
               , updatedRules
@@ -528,7 +528,7 @@ class ModificationValidationPopup(
               , directive.id
               , optOriginal
               , diff
-              , CurrentUser.getActor
+              , CurrentUser.actor
               , crReasons.map( _.get )
               , baseRules
               , updatedRules
@@ -544,7 +544,7 @@ class ModificationValidationPopup(
               nodeGroup.id
             , parentCategoryId
             , ModificationId(uuidGen.newUuid)
-            , CurrentUser.getActor
+            , CurrentUser.actor
             , crReasons.map( _.get )
           ) match {
             case Full(_) => //ok, continue
@@ -567,14 +567,14 @@ class ModificationValidationPopup(
           , nodeGroup
           , optOriginal
           , _
-          , CurrentUser.getActor
+          , CurrentUser.actor
           , crReasons.map(_.get))
         )
     }
 
     (for {
       crId <- cr.map(_.id)
-      wf <- workflowService.startWorkflow(crId, CurrentUser.getActor, crReasons.map(_.get))
+      wf <- workflowService.startWorkflow(crId, CurrentUser.actor, crReasons.map(_.get))
     } yield {
       crId
     }) match {
@@ -620,7 +620,7 @@ class ModificationValidationPopup(
     , why:Option[String]
     ): JsCmd = {
     val modId = ModificationId(uuidGen.newUuid)
-    woDirectiveRepository.saveDirective(activeTechniqueId, directive, modId, CurrentUser.getActor, why) match {
+    woDirectiveRepository.saveDirective(activeTechniqueId, directive, modId, CurrentUser.actor, why) match {
       case Full(optChanges) =>
         optChanges match {
           case Some(diff) if diff.needDeployment =>

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleCategoryPopup.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleCategoryPopup.scala
@@ -195,7 +195,7 @@ class RuleCategoryPopup(
     targetCategory match {
       case Some(category) =>
         val modId = new ModificationId(uuidGen.newUuid)
-        woRulecategoryRepository.delete(category.id, modId , CurrentUser.getActor, None, true) match {
+        woRulecategoryRepository.delete(category.id, modId , CurrentUser.actor, None, true) match {
           case Full(x) =>
             closePopup() &
             onSuccessCallback(x.value) &
@@ -230,7 +230,7 @@ class RuleCategoryPopup(
 
           val parent = RuleCategoryId(categoryParent.get)
           val modId = new ModificationId(uuidGen.newUuid)
-          woRulecategoryRepository.create(newCategory, parent,modId , CurrentUser.getActor, None)
+          woRulecategoryRepository.create(newCategory, parent,modId , CurrentUser.actor, None)
         case Some(category) =>
           val updated = category.copy(
                             name        =  categoryName.get
@@ -242,7 +242,7 @@ class RuleCategoryPopup(
             Failure("There are no modifications to save")
           } else {
             val modId = new ModificationId(uuidGen.newUuid)
-            woRulecategoryRepository.updateAndMove(updated, parent,modId , CurrentUser.getActor, None)
+            woRulecategoryRepository.updateAndMove(updated, parent,modId , CurrentUser.actor, None)
           }
       }) match {
           case Full(x) => closePopup() & onSuccessCallback(x.id.value) & onSuccessCategory(x)

--- a/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleModificationValidationPopup.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleModificationValidationPopup.scala
@@ -288,10 +288,10 @@ class RuleModificationValidationPopup(
                        , rule
                        , initialState
                        , diff
-                       , CurrentUser.getActor
+                       , CurrentUser.actor
                        , crReasons.map( _.get )
                        )
-            wfStarted <- workflowService.startWorkflow(cr.id, CurrentUser.getActor, crReasons.map(_.get))
+            wfStarted <- workflowService.startWorkflow(cr.id, CurrentUser.actor, crReasons.map(_.get))
           } yield {
             cr.id
           }

--- a/rudder-web/src/main/scala/com/normation/rudder/web/model/CurrentUser.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/model/CurrentUser.scala
@@ -37,14 +37,15 @@
 
 package com.normation.rudder.web.model
 
-import org.springframework.security.core.context.SecurityContextHolder
-import com.normation.eventlog.EventActor
-import net.liftweb.http.SessionVar
 import bootstrap.liftweb.RudderUserDetail
+import com.normation.eventlog.EventActor
 import com.normation.rudder.AuthorizationType
-import com.normation.rudder.service.user.User
 import com.normation.rudder.Rights
-import com.normation.rudder.api.{ApiAclElement, ApiAuthorization}
+import com.normation.rudder.RudderAccount
+import com.normation.rudder.User
+import com.normation.rudder.api.ApiAuthorization
+import net.liftweb.http.SessionVar
+import org.springframework.security.core.context.SecurityContextHolder
 
 /**
  * An utility class that get the currently logged user
@@ -67,12 +68,10 @@ object CurrentUser extends SessionVar[Option[RudderUserDetail]] ({
     case None => new Rights(AuthorizationType.NoRights)
   }
 
-  def getActor : EventActor = this.get match {
-    case Some(u) => EventActor(u.getUsername)
-    case None => EventActor("unknown")
+  def account : RudderAccount = this.get match {
+    case None    => RudderAccount.User("unknown", "")
+    case Some(u) => u.account
   }
-
-  def actor = getActor
 
   def checkRights(auth:AuthorizationType) : Boolean = {
     val authz = getRights.authorizationTypes
@@ -83,7 +82,7 @@ object CurrentUser extends SessionVar[Option[RudderUserDetail]] ({
     }
   }
 
-  def getApiAutz: ApiAuthorization = {
+  def getApiAuthz: ApiAuthorization = {
     this.get match {
       case None    => ApiAuthorization.None
       case Some(u) => u.apiAuthz

--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -828,9 +828,9 @@ object DisplayNode extends Loggable {
   private[this] def removeNode(nodeId: NodeId) : JsCmd = {
     val modId = ModificationId(uuidGen.newUuid)
     import com.normation.rudder.services.servers.DeletionResult._
-    removeNodeService.removeNode(nodeId, modId, CurrentUser.getActor) match {
+    removeNodeService.removeNode(nodeId, modId, CurrentUser.actor) match {
       case Full(Success) =>
-        asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.getActor)
+        asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.actor)
         onSuccess
       case Full(PostHookFailed(postHook)) =>
         val message = s"Node '${nodeId.value}' was deleted, but an error occured while running post-deletion hooks"

--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/EventListDisplayer.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/EventListDisplayer.scala
@@ -405,7 +405,7 @@ class EventListDisplayer(
     }
 
     def addRestoreAction() =
-      personIdentService.getPersonIdentOrDefault(CurrentUser.getActor.name) match {
+      personIdentService.getPersonIdentOrDefault(CurrentUser.actor.name) match {
       case Full(commiter) =>
         var rollbackAction : RollBackAction = null
 

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/SendMetricsPopup.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/SendMetricsPopup.scala
@@ -64,7 +64,7 @@ class SendMetricsPopup extends DispatchSnippet with Loggable {
             SHtml.ajaxInvoke(() =>
               value match {
                 case _ : Some[Boolean] =>
-                  configService.set_send_server_metrics(value,CurrentUser.getActor,Some("Property modified from 'Send metrics' popup")) match {
+                  configService.set_send_server_metrics(value,CurrentUser.actor,Some("Property modified from 'Send metrics' popup")) match {
                     case Full(_) => JsRaw(s"""$$("#sendMetricsPopup").bsModal('hide')""")
                     case eb : EmptyBox =>
                       val msg = eb ?~! "Could not update 'metrics' property"
@@ -73,7 +73,7 @@ class SendMetricsPopup extends DispatchSnippet with Loggable {
                     }
                 case None =>
                   val modId = ModificationId(uuidGen.newUuid)
-                  val actor = CurrentUser.getActor
+                  val actor = CurrentUser.actor
                   val property = RudderWebProperty(RudderWebPropertyName("send_server_metrics"),"none","")
                     eventLogRepo.saveModifyGlobalProperty(modId, actor, property, property, ModifySendServerMetricsEventType, Some("Ask later for 'send metrics' value"))
                     JsRaw(s"""$$("#sendMetricsPopup").bsModal('hide')""")

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/Archives.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/Archives.scala
@@ -226,8 +226,8 @@ class Archives extends DispatchSnippet with Loggable {
     def archive(): JsCmd = {
       S.clearCurrentNotices
       (for {
-        commiter <- personIdentService.getPersonIdentOrDefault(CurrentUser.getActor.name)
-        archive  <- archiveFunction(commiter, ModificationId(uuidGen.newUuid), CurrentUser.getActor, Some("User requested archive creation"), false)
+        commiter <- personIdentService.getPersonIdentOrDefault(CurrentUser.actor.name)
+        archive  <- archiveFunction(commiter, ModificationId(uuidGen.newUuid), CurrentUser.actor, Some("User requested archive creation"), false)
       } yield {
         archive
       }) match {
@@ -242,8 +242,8 @@ class Archives extends DispatchSnippet with Loggable {
         case None    => error(Empty, "A valid archive must be chosen")
         case Some(commit) => (
           for {
-            commiter <- personIdentService.getPersonIdentOrDefault(CurrentUser.getActor.name)
-            archive <- restoreFunction(commit, commiter, ModificationId(uuidGen.newUuid), CurrentUser.getActor, Some("User requested archive restoration to commit %s".format(commit.value)), false)
+            commiter <- personIdentService.getPersonIdentOrDefault(CurrentUser.actor.name)
+            archive <- restoreFunction(commit, commiter, ModificationId(uuidGen.newUuid), CurrentUser.actor, Some("User requested archive restoration to commit %s".format(commit.value)), false)
           } yield
             archive ) match {
           case eb:EmptyBox => error(eb, restoreErrorMessage)

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ChangeRequestManagement.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ChangeRequestManagement.scala
@@ -99,7 +99,7 @@ class ChangeRequestManagement extends DispatchSnippet with Loggable {
   }
 
   def getLines() = {
-    val changeRequests = if (currentUser) roCrRepo.getAll else roCrRepo.getByContributor(CurrentUser.getActor)
+    val changeRequests = if (currentUser) roCrRepo.getAll else roCrRepo.getByContributor(CurrentUser.actor)
     JsTableData(changeRequests match {
       case Full(changeRequests) =>
 

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ClearCache.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ClearCache.scala
@@ -80,7 +80,7 @@ class ClearCache extends DispatchSnippet with Loggable {
             , ClearCacheEventLog(
                 EventLogDetails(
                     modificationId = Some(modId)
-                  , principal = CurrentUser.getActor
+                  , principal = CurrentUser.actor
                   , details = EventLog.emptyDetails
                   , reason = Some("Node configuration cache deleted on user request")
                 )
@@ -93,7 +93,7 @@ class ClearCache extends DispatchSnippet with Loggable {
             case _ => //ok
           }
           logger.debug("Deleting node configurations on user clear cache request")
-          asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.getActor)
+          asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.actor)
         }
         Full(set)
     }
@@ -122,7 +122,7 @@ class ClearCache extends DispatchSnippet with Loggable {
               , ClearCacheEventLog(
                   EventLogDetails(
                       modificationId = Some(modId)
-                    , principal = CurrentUser.getActor
+                    , principal = CurrentUser.actor
                     , details = EventLog.emptyDetails
                     , reason = Some("Clearing cache for: node configuration, recent changes, compliance and node info at user request")
                   )
@@ -138,7 +138,7 @@ class ClearCache extends DispatchSnippet with Loggable {
         e
       case Full(set) => //ok
         logger.debug("Deleting node configurations on user clear cache request")
-        asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.getActor)
+        asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.actor)
         Full("ok")
     }
   }

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/EditPolicyServerAllowedNetwork.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/EditPolicyServerAllowedNetwork.scala
@@ -158,18 +158,18 @@ class EditPolicyServerAllowedNetwork extends DispatchSnippet with Loggable {
         val modId = ModificationId(uuidGen.newUuid)
         (for {
           currentNetworks <- psService.getAuthorizedNetworks(policyServerId) ?~! s"Error when getting the list of current authorized networks for policy server ${policyServerId.value}"
-          changeNetwork   <- psService.setAuthorizedNetworks(policyServerId, goodNets, modId, CurrentUser.getActor) ?~! "Error when saving new allowed networks for policy server ${policyServerId.value}"
+          changeNetwork   <- psService.setAuthorizedNetworks(policyServerId, goodNets, modId, CurrentUser.actor) ?~! "Error when saving new allowed networks for policy server ${policyServerId.value}"
           modifications   =  UpdatePolicyServer.buildDetails(AuthorizedNetworkModification(currentNetworks, goodNets))
           eventSaved      <- eventLogService.saveEventLog(modId,
                                UpdatePolicyServer(EventLogDetails(
                                  modificationId = None
-                               , principal = CurrentUser.getActor
+                               , principal = CurrentUser.actor
                                , details = modifications
                                , reason = None))) ?~! "Unable to save the user event log for modification on authorized networks for policy server ${policyServerId.value}"
         } yield {
         }) match {
           case Full(_) =>
-            asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.getActor)
+            asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.actor)
 
             Replace(allowedNetworksFormId, outerXml.applyAgain) &
             successPopup

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/PropertiesManagement.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/PropertiesManagement.scala
@@ -81,7 +81,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
 
   def startNewPolicyGeneration() = {
     val modId = ModificationId(uuidGen.newUuid)
-    asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.getActor)
+    asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.actor)
   }
 
   def disableInputs = {
@@ -632,7 +632,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
       }
 
       def submit = {
-        val actor = CurrentUser.getActor
+        val actor = CurrentUser.actor
         configService.set_rudder_syslog_protocol(reportProtocol,actor,None) match {
           case Full(_) =>
             // Update the initial value of the form
@@ -670,7 +670,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
         networkForm(value)
       case eb: EmptyBox =>
         // We could not read current protocol, try repairing by setting protocol to UDP and warn user
-        val actor = CurrentUser.getActor
+        val actor = CurrentUser.actor
         configService.set_rudder_syslog_protocol(SyslogUDP,actor,Some("Property automatically reset to 'UDP' due to an error"))
         S.error("updateNetworkProtocol","Error when fetching 'Syslog protocol' property, Setting it to UDP")
         networkForm(SyslogUDP)
@@ -688,7 +688,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
     new ComplianceModeEditForm[GlobalComplianceMode](
         globalMode
       , (complianceMode) => {
-          configService.set_rudder_compliance_mode(complianceMode,CurrentUser.getActor,genericReasonMessage)
+          configService.set_rudder_compliance_mode(complianceMode,CurrentUser.actor,genericReasonMessage)
         }
       , () => startNewPolicyGeneration
       , globalMode
@@ -716,7 +716,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
 
   def saveSchedule(schedule: AgentRunInterval) : Box[Unit] = {
 
-    val actor = CurrentUser.getActor
+    val actor = CurrentUser.actor
     for {
       _ <- configService.set_agent_run_interval(schedule.interval,actor,genericReasonMessage)
       _ <- configService.set_agent_run_start_hour(schedule.startHour,actor,genericReasonMessage)
@@ -873,7 +873,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
           Run(s"""$$("#sendMetricsSubmit").button( "option", "disabled",${noModif()});""")
         }
         def submit() = {
-          val save = configService.set_send_server_metrics(currentSendMetrics,CurrentUser.getActor,genericReasonMessage)
+          val save = configService.set_send_server_metrics(currentSendMetrics,CurrentUser.actor,genericReasonMessage)
           S.notice("sendMetricsMsg", save match {
             case Full(_)  =>
               initSendMetrics = currentSendMetrics

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/TechniqueLibraryManagement.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/TechniqueLibraryManagement.scala
@@ -383,7 +383,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
         case (sourceactiveTechniqueId, destCatId) :: Nil =>
           (for {
             activeTechnique <- roActiveTechniqueRepository.getActiveTechnique(TechniqueName(sourceactiveTechniqueId)).flatMap(Box(_)) ?~! "Error while trying to find Active Technique with requested id %s".format(sourceactiveTechniqueId)
-            result <- rwActiveTechniqueRepository.move(activeTechnique.id, ActiveTechniqueCategoryId(destCatId), ModificationId(uuidGen.newUuid), CurrentUser.getActor, Some("User moved active technique from UI"))?~! "Error while trying to move Active Technique with requested id '%s' to category id '%s'".format(sourceactiveTechniqueId,destCatId)
+            result <- rwActiveTechniqueRepository.move(activeTechnique.id, ActiveTechniqueCategoryId(destCatId), ModificationId(uuidGen.newUuid), CurrentUser.actor, Some("User moved active technique from UI"))?~! "Error while trying to move Active Technique with requested id '%s' to category id '%s'".format(sourceactiveTechniqueId,destCatId)
           } yield {
             result
           }) match {
@@ -415,7 +415,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
                           ActiveTechniqueCategoryId(sourceCatId)
                         , ActiveTechniqueCategoryId(destCatId)
                         , ModificationId(uuidGen.newUuid)
-                        , CurrentUser.getActor
+                        , CurrentUser.actor
                         , Some("User moved Active Technique Category from UI")) ?~! "Error while trying to move category with requested id %s into new parent: %s".format(sourceCatId,destCatId)
           } yield {
             result
@@ -459,7 +459,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
                           ptName,
                           techniqueRepository.getTechniqueVersions(ptName).toSeq,
                           ModificationId(uuidGen.newUuid),
-                          CurrentUser.getActor,
+                          CurrentUser.actor,
                           Some("Active Technique added by user from UI")
                        )
                       ?~! errorMess.format(sourceactiveTechniqueId,destCatId)
@@ -774,7 +774,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
 
       def initJs = SetHtml("techniqueLibraryUpdateInterval" , <span>{updateTecLibInterval}</span>)
       def process = {
-        updatePTLibService.update(ModificationId(uuidGen.newUuid), CurrentUser.getActor, Some("Technique library reloaded by user")) match {
+        updatePTLibService.update(ModificationId(uuidGen.newUuid), CurrentUser.actor, Some("Technique library reloaded by user")) match {
           case Full(x) =>
             S.notice("updateLib", "The Technique library was successfully reloaded")
           case e:EmptyBox =>

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
@@ -384,7 +384,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
                     RudderConfig.woDirectiveRepository.delete(
                         directive.id
                       , ModificationId(RudderConfig.stringUuidGenerator.newUuid)
-                      , CurrentUser.getActor
+                      , CurrentUser.actor
                       , Some(s"Deleting directive '${directive.name}' (${directive.id}) because its Technique isn't available anymore")
                     ) match {
                       case Full(diff)   =>

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
@@ -142,7 +142,7 @@ class AcceptNode extends Loggable {
     S.clearCurrentNotices
     listNode.foreach { id =>
       val now = System.currentTimeMillis
-      val accept = newNodeManager.accept(id, modId, CurrentUser.getActor)
+      val accept = newNodeManager.accept(id, modId, CurrentUser.actor)
       if(TimingDebugLogger.isDebugEnabled) {
         TimingDebugLogger.debug(s"Accepting node ${id.value}: ${System.currentTimeMillis - now}ms")
       }
@@ -194,7 +194,7 @@ class AcceptNode extends Loggable {
     //TODO : manage error message
     S.clearCurrentNotices
     val modId = ModificationId(uuidGen.newUuid)
-    listNode.foreach { id => newNodeManager.refuse(id, modId, CurrentUser.getActor) match {
+    listNode.foreach { id => newNodeManager.refuse(id, modId, CurrentUser.actor) match {
       case e:EmptyBox =>
         logger.error("Refuse node '%s' lead to Failure.".format(id.value.toString), e)
         S.error(<span class="error">Error while refusing node(s).</span>)

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
@@ -351,7 +351,7 @@ class Groups extends StatefulSnippet with SpringExtendableSnippet[Groups] with L
        }) match {
         case (sourceGroupId, destCatId) :: Nil =>
           (for {
-            result <- woNodeGroupRepository.move(NodeGroupId(sourceGroupId), NodeGroupCategoryId(destCatId), ModificationId(uuidGen.newUuid), CurrentUser.getActor, Some("Group moved by user"))?~! "Error while trying to move group with requested id '%s' to category id '%s'".format(sourceGroupId,destCatId)
+            result <- woNodeGroupRepository.move(NodeGroupId(sourceGroupId), NodeGroupCategoryId(destCatId), ModificationId(uuidGen.newUuid), CurrentUser.actor, Some("Group moved by user"))?~! "Error while trying to move group with requested id '%s' to category id '%s'".format(sourceGroupId,destCatId)
             group  <- Box(lib.allGroups.get(NodeGroupId(sourceGroupId))) ?~! s"No such group: ${sourceGroupId}"
           } yield {
             (group.nodeGroup, lib.categoryByGroupId(group.nodeGroup.id))
@@ -391,7 +391,7 @@ class Groups extends StatefulSnippet with SpringExtendableSnippet[Groups] with L
                           category.toNodeGroupCategory
                         , NodeGroupCategoryId(destCatId)
                         , ModificationId(uuidGen.newUuid)
-                        , CurrentUser.getActor
+                        , CurrentUser.actor
                         , reason = None)?~! "Error while trying to move category with requested id '%s' to category id '%s'".format(sourceCatId,destCatId)
           } yield {
             (category.id.value, result)


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12209

The main correction is the addition of a RudderAccount data type, which can `User` or `Api` and is know in `getCurrentUser`. This allows to choose the behiavior for when the ACL plugin is disabled based on the actual account type, because now we can discriminate between a User (who need full ACL when accessing internal API) and an API token link to a user (which can be disable if the plugin is so). These check are done in `ApiAuthorization.scala`.

All the remaining changes are:
- update in logback.xml to add api logger entry,
- repercussion of `UserService / User` move and update,
- imports cleaning (because of previous point, I had to clean a lot of imports in all cases),
- and the build of a system to enforce that all endpoint schema implementation actually match the schema definition. We had 3 cases where it wasn't the case (ncf create technique, group details, update parameters), and so obviously, the result wasn't the one expected for them.
