### PR TITLE
Fixes #12390: Doubled "\" in GM call

### DIFF
--- a/rudder-core/src/main/scala/com/normation/cfclerk/domain/VariableAndSection.scala
+++ b/rudder-core/src/main/scala/com/normation/cfclerk/domain/VariableAndSection.scala
@@ -73,9 +73,9 @@ sealed trait Variable extends Loggable {
    */
 
 
-  def getTypedValues(): Box[Seq[Any]] = {
+  def getValidatedValue(escape: String => String): Box[Seq[Any]] = {
     bestEffort(values) { x =>
-      castValue(x)
+      castValue(x, escape)
     }
   }
 
@@ -178,11 +178,13 @@ sealed trait Variable extends Loggable {
   def copyWithAppendedValues(seq: Seq[String]): Variable
 
 
-  protected def castValue(x: String) : Box[Any] = {
+  protected def castValue(x: String, escape: String => String) : Box[Any] = {
     //we don't want to check constraint on empty value
-    // when the variable is optionnal
+    // when the variable is optionnal.
+    // But I'm not sure if I understand what is happening with a an optionnal
+    // boolean, since we are returning a string in that case :/
     if(this.spec.constraint.mayBeEmpty && x.length < 1) Full("")
-    else spec.constraint.typeName.getTypedValue(x,spec.name)
+    else spec.constraint.typeName.getFormatedValidated(x, spec.name, escape)
   }
 }
 
@@ -360,7 +362,7 @@ object Variable {
    * Check the value we intend to put in the variable
    */
   def checkValue(variable: Variable, value: String): Boolean = {
-    variable.castValue(value).isDefined
+    variable.castValue(value, identity).isDefined // here we are not interested in the escape part
   }
 }
 

--- a/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
@@ -311,8 +311,8 @@ object JsonSerialisation {
 
   implicit class JsonParameter(x: ParameterEntry) {
     def toJson(): JObject = (
-        ( "name"     , x.parameterName  )
-      ~ ( "value"    , x.parameterValue )
+        ( "name"     , x.parameterName )
+      ~ ( "value"    , x.escapedValue  )
     )
   }
 
@@ -320,7 +320,7 @@ object JsonSerialisation {
     implicit val formats = DefaultFormats
 
     def dataJson(x: ParameterEntry) : JField = {
-      JField(x.parameterName, x.parameterValue)
+      JField(x.parameterName, x.escapedValue)
     }
 
     def toDataJson(): JObject = {

--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/BuildBundleSequence.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/BuildBundleSequence.scala
@@ -449,7 +449,7 @@ object CfengineBundleVariables extends AgentFormatBundleVariables {
     //the promiser value (may) comes from user input, so we need to escape
     //also, get the list of bundle for each promiser.
     //and we don't need isSystem anymore
-    val escapedSeq = bundleSeq.map(x => (ParameterEntry.escapeString(x.promiser.value, AgentType.CfeCommunity), x.bundleSequence) )
+    val escapedSeq = bundleSeq.map(x => (CFEngineAgentSpecificGeneration.escape(x.promiser.value), x.bundleSequence) )
 
     //that's the length to correctly vertically align things. Most important
     //number in all Rudder !

--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/Cf3PolicyDraft.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/Cf3PolicyDraft.scala
@@ -221,7 +221,7 @@ final case class Cf3PolicyDraft(
  */
 case class ParameterEntry(
     parameterName : String
-  , parameterValue: String
+  , escapedValue : String
   , agentType     : AgentType
 ) {
   // returns the name of the parameter
@@ -229,44 +229,13 @@ case class ParameterEntry(
     parameterName
   }
 
-  // returns the _escaped_ value of the parameter,
-  // compliant with the syntax of CFEngine
+  // Returns the escaped value of the paramter
+  // The value must have been escaped at ParameterEntry construction
   def getEscapedValue() : String = {
-    ParameterEntry.escapeString(parameterValue,agentType)
+    escapedValue
   }
 
-  // Returns the unescaped (raw) value of the paramter
-  def getUnescapedValue() : String = {
-    parameterValue
-  }
 }
-
-object ParameterEntry {
-  def escapeString(x: String, agentType: AgentType) : String = {
-    // The parameter may be null (for legacy reason), and it should be checked
-    if (x == null)
-      x
-    else
-      agentType match {
-        case AgentType.Dsc => 
-          /* Escape string to be DSC compliant
-          * a ` will be escaped to ``
-          * a " will be escaped to `"
-          */
-          x.replaceAll("""`""", """``""").
-            replaceAll(""""""", """`"""")
-        case _             =>
-          /* Escape string to be CFEngine compliant
-           * a \ will be escaped to \\
-           * a " will be escaped to \"
-           */
-          x.replaceAll("""\\""", """\\\\""").
-            replaceAll(""""""" , """\\"""" )
-      }
-  }
-}
-
-
 
 /**
  * A container is just a set of key/value parameter and cf3policyDrafts

--- a/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PolicyInstanceAgregationTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PolicyInstanceAgregationTest.scala
@@ -100,11 +100,15 @@ class DirectiveAgregationTest {
       )
   ) )
 
+  //the class that keep the list of known agents
+  lazy val agentRegiter = new AgentRegister()
+
   val systemVariableServiceSpec = new SystemVariableSpecServiceImpl()
   val prepareTemplate = new PrepareTemplateVariablesImpl(
       techniqueRepository
     , systemVariableServiceSpec
-    , new BuildBundleSequence(systemVariableServiceSpec, new WriteAllAgentSpecificFiles())
+    , new BuildBundleSequence(systemVariableServiceSpec, new WriteAllAgentSpecificFiles(agentRegiter))
+    , agentRegiter
   )
 
   def createInstance(activeTechniqueId:TechniqueId, id: String) = {

--- a/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PrepareTemplateVariableTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PrepareTemplateVariableTest.scala
@@ -45,6 +45,10 @@ import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.cfclerk.domain.TechniqueName
+import com.normation.inventory.domain.AgentType
+import com.normation.templates.FillTemplatesService
+import com.normation.templates.STVariable
+import net.liftweb.common.Full
 
 @RunWith(classOf[JUnitRunner])
 class PrepareTemplateVariableTest extends Specification {
@@ -58,6 +62,9 @@ class PrepareTemplateVariableTest extends Specification {
     , (raw"""Nodes only/Package \"management\" for Debian"""                              , Bundle(ReportId("not used"), BundleName("check_apt_package_installation")))
     , (raw"""Nodes only/Package \\"management\\" for Debian - again"""                    , Bundle(ReportId("not used"), BundleName("check_apt_package_installation2")))
   ).map { case(x,y) => TechniqueBundles(Directive(x), TID("not-used-here"), Nil, y::Nil, Nil, false, false, PolicyMode.Enforce) }
+
+val fillTemplate = new FillTemplatesService()
+
 
   // Ok, now I can test
   "Preparing the string for writting usebundle of directives" should {

--- a/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteSystemTechniquesTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteSystemTechniquesTest.scala
@@ -206,11 +206,13 @@ object TestSystemData {
     , getSyslogProtocol               = () => Full(SyslogUDP)
   )
 
-  lazy val writeAllAgentSpecificFiles = new WriteAllAgentSpecificFiles()
+  lazy val agentRegister = new AgentRegister()
+  lazy val writeAllAgentSpecificFiles = new WriteAllAgentSpecificFiles(agentRegister)
   val prepareTemplateVariable = new PrepareTemplateVariablesImpl(
       techniqueRepository
     , systemVariableServiceSpec
     , new BuildBundleSequence(systemVariableServiceSpec, writeAllAgentSpecificFiles)
+    , agentRegister
   )
 
   /*

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -51,7 +51,7 @@ import com.normation.rudder.services.reports._
 import com.normation.rudder.domain.queries._
 import bootstrap.liftweb.checks._
 import com.normation.cfclerk.services._
-import org.springframework.context.annotation.{ Bean, Configuration, Import }
+import org.springframework.context.annotation._
 import com.normation.ldap.sdk._
 import com.normation.rudder.domain._
 import com.normation.rudder.web.services._
@@ -59,6 +59,7 @@ import com.normation.utils.StringUuidGenerator
 import com.normation.utils.StringUuidGeneratorImpl
 import com.normation.rudder.repository.ldap._
 import java.io.File
+
 import com.normation.rudder.services.eventlog._
 import com.normation.cfclerk.xmlparsers._
 import com.normation.cfclerk.services.impl._
@@ -82,6 +83,7 @@ import com.normation.rudder.repository._
 import com.normation.rudder.services.modification.ModificationService
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+
 import scala.util.Try
 import com.normation.rudder.repository.inmemory.InMemoryChangeRequestRepository
 import com.normation.cfclerk.xmlwriters.SectionSpecWriter
@@ -163,12 +165,14 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
 import java.io.File
+
 import net.liftweb.common._
 import net.liftweb.common.Loggable
 import org.apache.commons.io.FileUtils
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
+
 import scala.util.Try
 import com.normation.rudder.services.policies.write.WriteAllAgentSpecificFiles
 import com.normation.rudder.api.RoApiAccountRepository
@@ -176,6 +180,8 @@ import com.normation.rudder.web.rest.ncf.NcfApi9
 import com.normation.rudder.ncf.TechniqueWriter
 import com.normation.rudder.ncf.TechniqueArchiver
 import com.normation.rudder.ncf.TechniqueArchiverImpl
+import com.normation.rudder.services.policies.write.AgentRegister
+
 import scala.concurrent.duration._
 
 /**
@@ -468,7 +474,8 @@ object RudderConfig extends Loggable {
   lazy val woAgentRunsRepository : WoReportsExecutionRepository = cachedAgentRunRepository
 
   //used in plugins, so init may be needed in strange time to avoid NPE
-  lazy val writeAllAgentSpecificFiles = new WriteAllAgentSpecificFiles()
+  lazy val agentRegister = new AgentRegister()
+  lazy val writeAllAgentSpecificFiles = new WriteAllAgentSpecificFiles(agentRegister)
 
   //all cache that need to be cleared are stored here
   lazy val clearableCache: Seq[CachedRepository] = Seq(
@@ -1460,7 +1467,7 @@ object RudderConfig extends Loggable {
       techniqueRepositoryImpl
     , pathComputer
     , new NodeConfigurationLoggerImpl(RUDDER_DEBUG_NODE_CONFIGURATION_PATH)
-    , new PrepareTemplateVariablesImpl(techniqueRepositoryImpl, systemVariableSpecService, new BuildBundleSequence(systemVariableSpecService, writeAllAgentSpecificFiles))
+    , new PrepareTemplateVariablesImpl(techniqueRepositoryImpl, systemVariableSpecService, new BuildBundleSequence(systemVariableSpecService, writeAllAgentSpecificFiles), agentRegister)
     , new FillTemplatesService()
     , writeAllAgentSpecificFiles
     , HOOKS_D


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12390

This is an API breaking change for Windows DSC plugin. 

So, the main problem was that we escaped value set in Directive only for a CFEngine Agent. 
The pull request change two majors things.  

First, it changes where the escape logic is in the code: 

- now, each agent has its own "escape" method bundled in its "agent specific generation" (where the agent-specific policy writing was stored). 
- this change make the fact that we needed an "agent register" apparent. So that `AgentRegister` is now a standalone class, with utility method to find what agent matches an `AgentType`/`osDetails` and does things with it. 

Secondly, it changes the types of values in string template. Until now, we were allowing values of type `Any`. But we don't actually use anything but string, and I can't apply string escape logic on `Any`. So now, we only deal with strings (which will certainly allow to simplify things in the long term - because yes, `String` is better than `Any`, especially when we don't use other things).
