### PR TITLE
Fixes #12450: JS sandbox permission must be defined in a file

### DIFF
--- a/rudder-core/src/main/resources/rudder-js.policy
+++ b/rudder-core/src/main/resources/rudder-js.policy
@@ -1,0 +1,50 @@
+//
+// This is the permession given to the JS engine in Rudder. 
+// We try to limit the obvious kind of errors, like 
+// "exit(0)" and unwanted file access. But Nashorn need a big
+// deal of permission to just run, and any malicious code could
+// escape the VM without much difficulties. 
+//
+// The main goal here is really to avoid Rudder crash because of a JS typo. 
+//
+
+// We only use the default permissions granted to all domains
+// because that file is only used in the JS context. 
+
+grant {
+    // allows anyone to listen on dynamic ports
+    permission java.net.SocketPermission "localhost:0", "listen";
+
+    // "standard" properies that can be read by anyone
+    permission java.util.PropertyPermission "*", "read";
+
+    // needed by thread factory to try to kill the thread
+    permission java.lang.RuntimePermission "modifyThread";
+    permission java.lang.RuntimePermission "accessDeclaredMembers";
+    // needed by Rudder JS lib
+    permission java.lang.RuntimePermission "loadLibrary.sunec";
+    permission java.lang.RuntimePermission "loadLibrary.j2pkcs11";
+    permission java.lang.RuntimePermission "loadLibrary.nio";
+    // lots of runtime permission needed by nashorn
+    permission java.lang.RuntimePermission "loadLibrary.net";
+    permission java.lang.RuntimePermission "nashorn.createGlobal";
+    permission java.lang.RuntimePermission "createClassLoader";
+    permission java.lang.RuntimePermission "accessClassInPackage.*";
+    permission java.lang.RuntimePermission "getProtectionDomain";
+    permission java.lang.RuntimePermission "shutdownHooks";
+    permission java.lang.RuntimePermission "setContextClassLoader";
+    permission java.lang.RuntimePermission "fileSystemProvider";
+    permission java.lang.RuntimePermission "getClassLoader";
+    permission java.lang.RuntimePermission "accessSystemModules";
+
+    permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+
+    permission java.security.SecurityPermission "getProperty.*";
+    permission java.security.SecurityPermission "putProviderProperty.*";
+
+    permission java.io.FilePermission "/dev/random" , "read";
+    permission java.io.FilePermission "/dev/urandom", "read";
+    // other specific files based on extension are handled in Rudder directly
+  
+    permission java.net.NetPermission "specifyStreamHandler";
+};

--- a/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
@@ -76,3 +76,11 @@ object NodeLogger extends Logger {
   }
 }
 
+/*
+ * A logger to log information about the JS script eval for directives
+ * parameter.s
+ */
+object JsDirectiveParamLogger extends Logger {
+  override protected def _logger = LoggerFactory.getLogger("jsDirectiveParam")
+}
+

--- a/rudder-web/src/test/scala/com/normation/rudder/javascript/CalculateComplianceTest.scala
+++ b/rudder-web/src/test/scala/com/normation/rudder/javascript/CalculateComplianceTest.scala
@@ -96,7 +96,7 @@ class CalculateComplianceTest extends Specification {
 
   val emptyJsBindings = new SimpleBindings()
   def js(js: String): Box[String] = {
-    JsEngine.SandboxedJsEngine.sandboxed { box =>
+    JsEngine.SandboxedJsEngine.sandboxed(this.getClass.getClassLoader.getResource("rudder-js.policy")) { box =>
       for {
         _ <- box.singleEval(imports, emptyJsBindings)
         x <- box.singleEval(js, emptyJsBindings)


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12450

This PR is done against 4.3. We will keep a basic, limited support of Java 9/10 for rudder 4.1, and we will have an extendable one in 4.3. 