### PR TITLE
Wip #12702: PoC for pre-loading resources

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PromiseWriteDataStructures.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PromiseWriteDataStructures.scala
@@ -126,3 +126,11 @@ case class TechniqueTemplateCopyInfo(
 ) extends HashcodeCaching {
   override def toString() = s"Promise template ${id.name}; destination ${destination}"
 }
+
+case class TechniqueResourceCopyInfo(
+                                      id         : TechniqueResourceId
+                                      , destination: String
+                                      , content    : String //template resource as a file
+                                    ) extends HashcodeCaching {
+  override def toString() = s"Promise resource ${id.name}; destination ${destination}"
+}


### PR DESCRIPTION
PoC against 4.3 (my test bench) 
Policy generation time goes from
> [2018-05-25 16:54:55] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Timing summary:
[2018-05-25 16:54:55] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Run pre-gen scripts hooks :          0 ms
[2018-05-25 16:54:55] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Run pre-gen modules hooks :          0 ms
[2018-05-25 16:54:55] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Fetch all information     :        292 ms
[2018-05-25 16:54:55] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Historize names           :        831 ms
[2018-05-25 16:54:55] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Build current rule values :         44 ms
[2018-05-25 16:54:55] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Build target configuration:       7153 ms
[2018-05-25 16:54:55] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Write node configurations :      42915 ms
[2018-05-25 16:54:55] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Save expected reports     :        710 ms
[2018-05-25 16:54:55] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Run post generation hooks :          3 ms
[2018-05-25 16:54:55] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Number of nodes updated   :       1597  
[2018-05-25 16:54:55] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Policy generation completed in 66776 ms

to

> 2018-05-25 22:38:03] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Run pre-gen scripts hooks :          1 ms
[2018-05-25 22:38:03] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Run pre-gen modules hooks :          0 ms
[2018-05-25 22:38:03] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Fetch all information     :        335 ms
[2018-05-25 22:38:03] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Historize names           :        865 ms
[2018-05-25 22:38:03] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Build current rule values :         45 ms
[2018-05-25 22:38:03] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Build target configuration:       8845 ms
[2018-05-25 22:38:03] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Write node configurations :      31243 ms
[2018-05-25 22:38:03] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Save expected reports     :        858 ms
[2018-05-25 22:38:03] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Run post generation hooks :          3 ms
[2018-05-25 22:38:03] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Number of nodes updated   :       1597  
[2018-05-25 22:38:03] DEBUG com.normation.rudder.services.policies.PromiseGenerationServiceImpl - Policy generation completed in 57744 ms

with this change (11 sec are wasted accessing the repository, for 1500 nodes)