### PR TITLE
Fixes #12719: Some reports are duplicated between agent and postgres leading to "unexpected" compliance 

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -68,8 +68,9 @@ class ReportingServiceImpl(
   , val runIntervalService  : AgentRunIntervalService
   , val nodeInfoService     : NodeInfoService
   , val directivesRepo      : RoDirectiveRepository
-  , val getGlobalComplianceMode : () => Box[GlobalComplianceMode]
-  , val getGlobalPolicyMode     : () => Box[GlobalPolicyMode]
+  , val getGlobalComplianceMode    : () => Box[GlobalComplianceMode]
+  , val getGlobalPolicyMode        : () => Box[GlobalPolicyMode]
+  , val getUnexpectedInterpretation: () => Box[UnexpectedReportInterpretation]
 ) extends ReportingService with RuleOrNodeReportingServiceImpl with DefaultFindRuleNodeStatusReports
 
 class CachedReportingServiceImpl(
@@ -249,14 +250,11 @@ trait CachedFindRuleNodeStatusReports extends ReportingService with CachedReposi
 
 trait DefaultFindRuleNodeStatusReports extends ReportingService {
 
-  def confExpectedRepo  : FindExpectedReportRepository
-  def reportsRepository : ReportsRepository
-  def agentRunRepository: RoReportsExecutionRepository
-  def runIntervalService: AgentRunIntervalService
-  def getGlobalComplianceMode : () => Box[GlobalComplianceMode]
-  def getGlobalPolicyMode     : () => Box[GlobalPolicyMode]
-  def nodeInfoService         : NodeInfoService
-  def directivesRepo          : RoDirectiveRepository
+  def confExpectedRepo           : FindExpectedReportRepository
+  def reportsRepository          : ReportsRepository
+  def agentRunRepository         : RoReportsExecutionRepository
+  def getGlobalComplianceMode    : () => Box[GlobalComplianceMode]
+  def getUnexpectedInterpretation: () => Box[UnexpectedReportInterpretation]
 
   override def findRuleNodeStatusReports(nodeIds: Set[NodeId], ruleIds: Set[RuleId]) : Box[Map[NodeId, NodeStatusReport]] = {
     /*
@@ -291,6 +289,7 @@ trait DefaultFindRuleNodeStatusReports extends ReportingService {
     val t0 = System.currentTimeMillis
     for {
       complianceMode      <- getGlobalComplianceMode()
+      unexpectedMode      <- getUnexpectedInterpretation()
       // we want compliance on these nodes
       runInfos            <- getNodeRunInfos(nodeIds, complianceMode)
       t1                  =  System.currentTimeMillis
@@ -307,7 +306,7 @@ trait DefaultFindRuleNodeStatusReports extends ReportingService {
       _                   =  TimingDebugLogger.debug(s"Compliance: get run infos: ${t2-t0}ms")
 
       // compute the status
-      nodeStatusReports   <- buildNodeStatusReports(runInfos, ruleIds, complianceMode.mode)
+      nodeStatusReports   <- buildNodeStatusReports(runInfos, ruleIds, complianceMode.mode, unexpectedMode)
 
       t2                  =  System.currentTimeMillis
       _                   =  TimingDebugLogger.debug(s"Compliance: compute compliance reports: ${t2-t1}ms")
@@ -353,9 +352,10 @@ trait DefaultFindRuleNodeStatusReports extends ReportingService {
    * So runInfos.keySet == returnedMap.keySet holds.
    */
   private[this] def buildNodeStatusReports(
-      runInfos          : Map[NodeId, RunAndConfigInfo]
-    , ruleIds           : Set[RuleId]
-    , complianceModeName: ComplianceModeName
+      runInfos                : Map[NodeId, RunAndConfigInfo]
+    , ruleIds                 : Set[RuleId]
+    , complianceModeName      : ComplianceModeName
+    , unexpectedInterpretation: UnexpectedReportInterpretation
   ): Box[Map[NodeId, NodeStatusReport]] = {
 
     val t0 = System.currentTimeMillis
@@ -389,7 +389,7 @@ trait DefaultFindRuleNodeStatusReports extends ReportingService {
       val t2 = System.currentTimeMillis
       //we want to have nodeStatus for all asked node, not only the ones with reports
       val nodeStatusReports = runInfos.map { case (nodeId, runInfo) =>
-        val status = ExecutionBatch.getNodeStatusReports(nodeId, runInfo, reports.getOrElse(nodeId, Seq()))
+        val status = ExecutionBatch.getNodeStatusReports(nodeId, runInfo, reports.getOrElse(nodeId, Seq()), unexpectedInterpretation)
         (status.nodeId, status)
       }
       val t3 = System.currentTimeMillis

--- a/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -65,7 +65,6 @@ import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.reports.GlobalComplianceMode
 import com.normation.rudder.reports.GlobalComplianceMode
 import com.normation.rudder.services.reports.NodeChangesServiceImpl
-
 import scalaz.{Failure => _, _}
 import doobie.imports._
 import com.normation.BoxSpecMatcher
@@ -82,8 +81,10 @@ import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.rudder.repository.CategoryWithActiveTechniques
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.Technique
+
 import scala.collection.SortedMap
 import com.normation.rudder.repository.ComplianceRepository
+import com.normation.rudder.services.reports.UnexpectedReportInterpretation
 
 
 /**
@@ -316,6 +317,7 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
     , directivesRepos
     , () => Full(compliance)
     , () => Full(GlobalPolicyMode(PolicyMode.Audit, PolicyModeOverrides.Always))
+    , () => Full(UnexpectedReportInterpretation(Set()))
   )
 
   sequential

--- a/rudder-core/src/test/scala/com/normation/rudder/services/reports/ComplianceTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/reports/ComplianceTest.scala
@@ -212,7 +212,7 @@ class ComplianceTest extends Specification {
       //here, we assume "compute compliance", i.e we are only testing the compliance engine, not
       //the meta-analysis on run consistancy (correct run, at the correct time, etc)
       val runinfo = ComputeCompliance(runTime, config, runTime)
-      val status = ExecutionBatch.getNodeStatusReports(config.nodeId, runinfo, reports)
+      val status = ExecutionBatch.getNodeStatusReports(config.nodeId, runinfo, reports, UnexpectedReportInterpretation(Set()))
 
       status.compliance must beEqualTo(ComplianceLevel(success=18, notApplicable = 8))
     }

--- a/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/AppConfig.scala
@@ -1537,6 +1537,7 @@ object RudderConfig extends Loggable {
         , roDirectiveRepository
         , globalComplianceModeService.getGlobalComplianceMode _
         , configService.rudder_global_policy_mode _
+        , configService.rudder_compliance_unexpected_report_interpretation _
       )
     , nodeInfoServiceImpl
   )

--- a/rudder-web/src/main/scala/com/normation/rudder/appconfig/ConfigService.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/appconfig/ConfigService.scala
@@ -62,12 +62,15 @@ import com.normation.rudder.domain.eventlog.ModifyAgentRunStartMinuteEventType
 import com.normation.rudder.domain.eventlog.ModifyAgentRunSplaytimeEventType
 import com.normation.rudder.reports._
 import com.normation.rudder.domain.eventlog.ModifyRudderSyslogProtocolEventType
+
 import scala.language.implicitConversions
 import com.normation.rudder.domain.appconfig.FeatureSwitch
 import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.domain.policies.PolicyMode._
 import com.normation.rudder.domain.policies.GlobalPolicyMode
 import com.normation.rudder.domain.policies.PolicyModeOverrides
+import com.normation.rudder.services.reports.UnexpectedReportBehavior
+import com.normation.rudder.services.reports.UnexpectedReportInterpretation
 import com.normation.rudder.services.servers.RelaySynchronizationMethod._
 import com.normation.rudder.services.servers.RelaySynchronizationMethod
 
@@ -182,6 +185,11 @@ trait ReadConfigService {
    * Should we activate the script engine bar ?
    */
   def rudder_featureSwitch_directiveScriptEngine(): Box[FeatureSwitch]
+
+  /**
+   * What is the behavior to adopt regarding unexpected reports ?
+   */
+  def rudder_compliance_unexpected_report_interpretation(): Box[UnexpectedReportInterpretation]
 }
 
 /**
@@ -293,6 +301,8 @@ trait UpdateConfigService {
   def set_rudder_policy_mode_name(name : PolicyMode, actor : EventActor, reason: Option[String]) : Box[Unit]
 
   def set_rudder_policy_overridable(overridable : Boolean, actor: EventActor, reason: Option[String]) : Box[Unit]
+
+  def set_rudder_compliance_unexpected_report_interpretation(mode: UnexpectedReportInterpretation) : Box[Unit]
 }
 
 class LDAPBasedConfigService(configFile: Config, repos: ConfigRepository, workflowUpdate: AsyncWorkflowInfo) extends ReadConfigService with UpdateConfigService with Loggable {
@@ -329,6 +339,8 @@ class LDAPBasedConfigService(configFile: Config, repos: ConfigRepository, workfl
        rudder.policy.mode.name=${Enforce.name}
        rudder.policy.mode.overridable=true
        rudder.featureSwitch.directiveScriptEngine=enabled
+       rudder.compliance.unexpectedReportAllowsDuplicate=true
+       rudder.compliance.unexpectedReportUnboundedVarValues=true
     """
 
   val configWithFallback = configFile.withFallback(ConfigFactory.parseString(defaultConfig))
@@ -542,4 +554,22 @@ class LDAPBasedConfigService(configFile: Config, repos: ConfigRepository, workfl
    */
   def rudder_featureSwitch_directiveScriptEngine(): Box[FeatureSwitch] = get("rudder_featureSwitch_directiveScriptEngine")
   def set_rudder_featureSwitch_directiveScriptEngine(status: FeatureSwitch): Box[Unit] = save("rudder_featureSwitch_directiveScriptEngine", status)
+
+  def rudder_compliance_unexpected_report_interpretation(): Box[UnexpectedReportInterpretation] = {
+    for {
+      duplicate <- get[Boolean]("rudder_compliance_unexpectedReportAllowsDuplicate")
+      iterators <- get[Boolean]("rudder_compliance_unexpectedReportUnboundedVarValues")
+    } yield {
+      UnexpectedReportInterpretation(
+        (if(duplicate) Set(UnexpectedReportBehavior.AllowsDuplicate) else Set() ) ++
+        (if(iterators) Set(UnexpectedReportBehavior.UnboundVarValues) else Set())
+      )
+    }
+  }
+  def set_rudder_compliance_unexpected_report_interpretation(mode: UnexpectedReportInterpretation) : Box[Unit] = {
+    for {
+      _ <- save("rudder_compliance_unexpectedReportAllowsDuplicate", mode.isSet(UnexpectedReportBehavior.AllowsDuplicate))
+      _ <- save("rudder_compliance_unexpectedReportUnboundedVarValues", mode.isSet(UnexpectedReportBehavior.UnboundVarValues))
+    } yield ()
+  }
 }

--- a/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/PropertiesManagement.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/PropertiesManagement.scala
@@ -44,6 +44,7 @@ import net.liftweb.http.js._
 import JsCmds._
 import JE._
 import com.normation.eventlog.ModificationId
+
 import scala.xml.NodeSeq
 import net.liftweb.util._
 import net.liftweb.util.Helpers._
@@ -58,6 +59,7 @@ import com.normation.rudder.reports.SyslogUDP
 import com.normation.rudder.reports.SyslogTCP
 import com.normation.rudder.reports.SyslogProtocol
 import com.normation.rudder.reports.GlobalComplianceMode
+import com.normation.rudder.services.reports.UnexpectedReportBehavior
 import com.normation.rudder.web.components.AgentPolicyModeEditForm
 import com.normation.rudder.services.servers.RelaySynchronizationMethod._
 import com.normation.rudder.services.servers.RelaySynchronizationMethod
@@ -83,8 +85,10 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
   def disableInputs = {
     import com.normation.rudder.authorization.Edit
     //If user does not have the Edit("administration") right, all inputs are disabled
-    val disable = !CurrentUser.checkRights(Edit("administration"))
-    S.appendJs(JsRaw(s"""$$("input, select").prop("disabled",${disable})"""))
+    // else nothing is done because it enables what should not be.
+    if(!CurrentUser.checkRights(Edit("administration"))) {
+      S.appendJs(JsRaw(s"""$$("input, select").prop("disabled", "true")"""))
+    }
     NodeSeq.Empty
   }
 
@@ -103,6 +107,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
     case "displayGraphsConfiguration" => displayGraphsConfiguration
     case "displayRuleColumnConfiguration" => displayRuleColumnConfiguration
     case "directiveScriptEngineConfiguration" => directiveScriptEngineConfiguration
+    case "unexpectedReportInterpretation" => unexpectedReportInterpretation
     case "onloadScript" => _ => disableInputs
   }
 
@@ -1048,6 +1053,65 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
       case eb: EmptyBox =>
         ( "#directiveScriptEngine" #> {
           val fail = eb ?~ "there was an error while fetching value of property: 'directive script engine'"
+          logger.error(fail.messageChain)
+          <div class="error">{fail.messageChain}</div>
+        } )
+    } ) apply xml
+  }
+
+  def unexpectedReportInterpretation = { xml : NodeSeq =>
+    import com.normation.rudder.services.reports.UnexpectedReportBehavior._
+
+    ( configService.rudder_compliance_unexpected_report_interpretation() match {
+      case Full(initialValue) =>
+
+        var initSavedValued = initialValue
+        var x = initialValue
+        def noModif() = x == initSavedValued
+        def check() = {
+          S.notice("unexpectedReportInterpretationFormMessage","")
+
+          Run(s"""$$("#unexpectedReportInterpretationFormSubmit").prop("disabled",${noModif()});""")
+        }
+
+        def submit() = {
+          val save = configService.set_rudder_compliance_unexpected_report_interpretation(x)
+          S.notice("unexpectedReportInterpretationFormMessage", save match {
+            case Full(_)  =>
+              initSavedValued = x
+              // If we disable this feature we want to start policy generation because some data may be invalid
+              "'interpretation of unexpected compliance reports' property updated."
+            case eb: EmptyBox =>
+              "There was an error when updating the value of the 'interpretation of unexpected compliance reports' property"
+          } )
+          check()
+        }
+
+        ( "#allowsDuplicate" #> {
+            SHtml.ajaxCheckbox(
+                x.isSet(AllowsDuplicate)
+              , (b : Boolean) => { if(b) { x = x.set(AllowsDuplicate) } else { x = x.unset(AllowsDuplicate) }; check}
+              , ("id","allowsDuplicate")
+            )
+          } &
+          "#unboundVarValues" #> {
+            SHtml.ajaxCheckbox(
+                x.isSet(UnboundVarValues)
+              , (b : Boolean) => { if(b) { x = x.set(UnboundVarValues) } else { x = x.unset(UnboundVarValues) }; check}
+              , ("id","unboundVarValues")
+            )
+          } &
+          "#unexpectedReportInterpretationFormSubmit " #> {
+              val x = SHtml.ajaxSubmit("Save changes", submit _, ("class","btn btn-default"), ("disabled", "disabled"))
+              println(x)
+              x
+//              ++ Script(check())
+          }
+        )
+
+      case eb: EmptyBox =>
+        ( "#unexpectedReportInterpretation" #> {
+          val fail = eb ?~ "there was an error while fetching value of property: 'interpretation of unexpected compliance reports'"
           logger.error(fail.messageChain)
           <div class="error">{fail.messageChain}</div>
         } )

--- a/rudder-web/src/main/webapp/secure/administration/policyServerManagement.html
+++ b/rudder-web/src/main/webapp/secure/administration/policyServerManagement.html
@@ -234,6 +234,91 @@
     <div id="agentPolicyMode" class="lift:administration.PropertiesManagement.agentPolicyMode"></div>
     <div id="complianceMode" class="lift:administration.PropertiesManagement.complianceMode"></div>
 
+    <div class="inner-portlet">
+      <div class="page-title">Unexpected reports interpretation</div>
+      <div class="portlet-content">
+        <div class="lift:administration.PropertiesManagement.unexpectedReportInterpretation" id="unexpectedReportInterpretation">
+        <div class="tw-bs">
+        <form class="lift:form.ajax form-horizontal tw-bs" >
+          <div class="col-lg-12 callout-fade callout-warning">
+            <div class="marker">
+              <span class="glyphicon glyphicon-info-sign"></span>
+            </div>
+            The two following settings affect the interpretation given to some type of unexpected reports when computing compliance.
+
+            These options will take effects when the next reports are received from a node or if you "clear caches" below.
+          </div>
+          <div class="col-lg-12 callout-fade callout-warning">
+            <div class="marker">
+              <span class="glyphicon glyphicon-info-sign"></span>
+            </div>
+            <dl>
+              <dt>Duplicated reports</dt>
+              <dd>
+                Due to the underlying protocol used to send compliance reports back to the policy server (syslog),
+                it may happen that some reports, for an unitary control point, are duplicated. In that case, compliance for
+                the corresponding element will be "unexpected": Rudder was awaiting one report, but it got two.
+                The risk to have a real error reported as a duplicated messages is very low, as messages need to have the
+                same timestamp and information message to be considered duplicated on a given node.
+                <br>That option will ignore the duplicated message in compliance computation and log an information level
+                message about that duplication. A double duplication will still be ignored but with a warning log, and more
+                duplicates will lead to an error log and an unexpected compliance.
+                <br/>It is safe to ignore duplicated reports and you should check that option.
+              </dd>
+            </dl>
+          </div>
+          <div class="wbBaseField">
+            <label class="threeCol textright" style="font-weight:bold;width: 20%;">Ignore duplicated compliance report:</label><input id="allowsDuplicate" type="checkbox">
+          </div>
+          <hr class="spacer"/>
+          <div class="col-lg-12 callout-fade callout-warning">
+            <div class="marker">
+              <span class="glyphicon glyphicon-info-sign"></span>
+            </div>
+            <dl>
+              <dt>Unbounded reports by elements when a variable is used</dt>
+              <dd>
+                Rudder await exactly one compliance report for each configuration point of control. If it gets more than one,
+                the leftover reports will be considered as unexpected. This is not what one want in the case where:
+                <ul>
+                  <li>
+                    the point of control is parametrized by a variable,
+                  </li>
+                  <li>
+                    that variable is multivalued.
+                  </li>
+                </ul>
+                For example, if you build a technique in editor with the generic method "Variable iterator" to define a list of
+                packages and you use the resulting variable in "Package present" generic method for the "name" parameter,
+                it is normal and expected to get several compliance reports, one for each configuration value.
+                <br>
+                That option allows to increase the number of expected reports to the number of configuration values and so
+                it avoids to get and "unexpected" compliance in that case.
+                <br>Unless it is more important for you to get "unexpected" compliance than the actual compliance of each
+                configuration value, you should check that option.
+              </dd>
+            </dl>
+          </div>
+          <div class="wbBaseField">
+            <label class="threeCol textright" style="font-weight:bold;width: 20%;">Allows multiple reports for configuration based on a multivalued variable:</label><input id="unboundVarValues" type="checkbox">
+          </div>
+
+          <hr class="spacer"/>
+          <lift:authz role="administration_write">
+            <span class="tw-bs">
+               <input type="submit" value="[save]" id="unexpectedReportInterpretationFormSubmit"/>
+            </span>
+            <div id="unexpectedReportInterpretationFormMessage" class="pull-right control-label">
+              <span class="lift:Msg?unexpectedReportInterpretationFormMessage">[messages]</span>
+            </div>
+          </lift:authz>
+        </form>
+        </div>
+        </div>
+      </div>
+    </div>
+
+
     <div id="cfagentSchedule" class="lift:administration.PropertiesManagement.cfagentSchedule"></div>
 
     <div class="inner-portlet">
@@ -248,7 +333,7 @@
                </div>
                <p>
                  If enabled, prompt users to enter a message explaining the reason for each configuration change they make.<br/>
-                 These messages will be stored in each <a href="/secure/utilities/eventLogs">Event log</a> and as the commit message for the underlying git repository in 
+                 These messages will be stored in each <a href="/secure/utilities/eventLogs">Event log</a> and as the commit message for the underlying git repository in
                  <i><strong><span id="configurationRepoPath"></span></strong></i>
                </p>
              </div>
@@ -466,10 +551,10 @@
               <span class="glyphicon glyphicon-info-sign"></span>
             </div>
             <div>
-              In directive configuration page, we have the possibility to choose rules for the directive. The rule 
+              In directive configuration page, we have the possibility to choose rules for the directive. The rule
               are presented in a summary table which look alike the one in rule page. For performance on ascetic
-              reason, you may want to hide compliance and recent changes columns on that table. 
-              The column will still be displayed on the rule page. 
+              reason, you may want to hide compliance and recent changes columns on that table.
+              The column will still be displayed on the rule page.
             </div>
           </div>
           <div class="deca col-xs-12">


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12719

Not yet finished (remains the we selection part in Setting). But it's a fairly big change. 
I'm quite confident on it, because we have a very good test coverage on that part. 

So, basically, I completly changed the way we pair report <-> expected component value. This was needed to allows to be more lenient in case of ducplicate keys and unbounded variable size (from iterators). 

The main modification are: 
- we have a parameter set to keep what is the unexpected interpretation: UnexpectedReportInterpretation
- we don't sort anymore the kind of component values in 3 cases (None, simple value, var pattern). In place of that, we create for each component value a Value utility class with the following info: 
  -  value / unexpanded value: the two component value
  -  cardinality: number of expected reports, most of the time '1' but can be increased for out of bound vars (with iterators)
  -  numberDuplicates: the number of dropped duplicated message for that pairing, so that we can know how bad syslog is. Should be 0. This is used to warn looder and looder the user when we have more duplicates
  -  isVar: a boolean telling us if the expected reports contains a variable pattern. 
  -  pattern: the value as a pattern. This is defined in *all* cases, even for None and simple value - they just have a very specific pattern that only match the corresponding exact value. This is the main difference compared to before, and it allows to process ALL value with the same algo. 
  - specificity: how specific the pattern is. That allows to start with more specific patterns and avoid bug https://www.rudder-project.org/redmine/issues/7758. For ex, `.*` is 0 (not specific at all), `foobarbaz` is 9.
  - matchingReports : the list of reports whose keyValue match pattern. Most of the time, we only have one. More lead to unexpected (modulo unexpected special interpretations). 

With that, and as introduced in "pattern" description, we are able to process all reports of a component in only one pass with the `recPairReports` algorithm. 
The mains ideas of the algo are: 

- we sort expected values and reports by specificy to avoid bug 7758, 
- we have two stack of values: the one not yet paired (all values at begining), and the one already paired (empty at begining)
- then, for each report we look for the first not-yet-paired value whose pattern accept report keyValue. 
- if non not-yet-paired value matches, we try the same thing with already paired (but that will lead to an unexpected modulo interpretation settings)
- if nothing matches, it's a real unexpected reports. 

Once all reports are processed, we merge the two stack of values, and we transform them in components value status (the still free value lead to missing, the one with one report get the report status, etc). And THAT'S ALL. 

There's a subpart of the algo which is in charge of finding the matching value for the current report: `recPairReports`. It's almost just a loop on all values to consider, with some special cases about what to do in case of a duplicate key or an out of bound var and Rudder settings. 
