### PR TITLE
Fixes #12832: nuProcess 1.2.0 crashes on JDK 10

### DIFF
--- a/rudder-core/pom.xml
+++ b/rudder-core/pom.xml
@@ -185,7 +185,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     <dependency>
         <groupId>com.zaxxer</groupId>
         <artifactId>nuprocess</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.4</version>
         <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12832