### PR TITLE
Fixes #13014: StackOverflowError during policy generation in JavascriptEngine - debian 9.5 with jdk 1.8.0_181

### DIFF
--- a/rudder-core/src/main/resources/rudder-js.policy
+++ b/rudder-core/src/main/resources/rudder-js.policy
@@ -1,15 +1,15 @@
 //
-// This is the permession given to the JS engine in Rudder. 
-// We try to limit the obvious kind of errors, like 
+// This is the permession given to the JS engine in Rudder.
+// We try to limit the obvious kind of errors, like
 // "exit(0)" and unwanted file access. But Nashorn need a big
 // deal of permission to just run, and any malicious code could
-// escape the VM without much difficulties. 
+// escape the VM without much difficulties.
 //
-// The main goal here is really to avoid Rudder crash because of a JS typo. 
+// The main goal here is really to avoid Rudder crash because of a JS typo.
 //
 
 // We only use the default permissions granted to all domains
-// because that file is only used in the JS context. 
+// because that file is only used in the JS context.
 
 grant {
     // allows anyone to listen on dynamic ports
@@ -26,6 +26,7 @@ grant {
     permission java.lang.RuntimePermission "loadLibrary.j2pkcs11";
     permission java.lang.RuntimePermission "loadLibrary.nio";
     // lots of runtime permission needed by nashorn
+    permission java.lang.RuntimePermission "getProtectionDomain";
     permission java.lang.RuntimePermission "loadLibrary.net";
     permission java.lang.RuntimePermission "nashorn.createGlobal";
     permission java.lang.RuntimePermission "createClassLoader";
@@ -45,6 +46,6 @@ grant {
     permission java.io.FilePermission "/dev/random" , "read";
     permission java.io.FilePermission "/dev/urandom", "read";
     // other specific files based on extension are handled in Rudder directly
-  
+
     permission java.net.NetPermission "specifyStreamHandler";
 };

--- a/rudder-core/src/main/scala/com/normation/rudder/batch/AsyncDeploymentAgent.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/batch/AsyncDeploymentAgent.scala
@@ -355,7 +355,7 @@ final class AsyncDeploymentAgent(
 
           result match {
             case Full(_) => // nothing to report
-            case m: Failure => logger.error(s"Error when updating policy, reason ${m.messageChain}")
+            case m: Failure => logger.error(s"Error when updating policy, reason is: ${m.messageChain}")
             case Empty => logger.error("Error when updating policy (no reason given)")
           }
 

--- a/rudder-web/src/main/resources/logback.xml
+++ b/rudder-web/src/main/resources/logback.xml
@@ -223,14 +223,36 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
      Set to info to only have macro information, debug to have timing information about
      each step (good default), trace to have more information.
    -->
-   <!-- Rudder 3.2 and above -->
   <logger name="com.normation.rudder.services.policies.PromiseGenerationServiceImpl" level="debug" />
-
   <!--
     The following logger take care of promises writing. Set to debug or trace to
     have these information.
   -->
-  <logger name="com.normation.rudder.services.policies.RudderCf3PromisesFileWriterServiceImpl" level="debug" />
+  <logger name="com.normation.rudder.services.policies.write" level="info" />
+
+
+  <!--
+    This logger may help debug cases in JS Directive engine, like ticket #13014.
+    Set to debug to get stack traces and more details errors.
+  -->
+  <logger name="jsDirectiveParam" level="info" />
+
+
+  <!--
+      This logger allows to log information about policy generation
+  -->
+  <logger name="policy.generation" level="info" additivity="false">
+    <appender-ref ref="OPSLOG" />
+    <appender-ref ref="STDOUT" />
+  </logger>
+  <!--
+      This logger allows to log information about expected reports in policy generation
+  -->
+  <logger name="policy.generation.expected_reports" level="info" additivity="false">
+    <appender-ref ref="OPSLOG" />
+    <appender-ref ref="STDOUT" />
+  </logger>
+
 
   <!--
     Cache (nodes, compliance)
@@ -398,23 +420,6 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     quicksearch: what is the parsed query, how many results come from each backend, etc.
    -->
   <logger name="com.normation.rudder.services.quicksearch" level="info" />
-
-  <!--
-      This logger allows to log information about policy generation
-  -->
-  <logger name="policy.generation" level="info" additivity="false">
-    <appender-ref ref="OPSLOG" />
-    <appender-ref ref="STDOUT" />
-  </logger>
-
-  <!--
-      This logger allows to log information about expected reports in policy generation
-  -->
-  <logger name="policy.generation.expected_reports" level="info" additivity="false">
-    <appender-ref ref="OPSLOG" />
-    <appender-ref ref="STDOUT" />
-  </logger>
-
 
   <!--
     Hooks


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/13014

So, more information: the problem is due to security check that are initiated during other security checks. Typically, trying to execute:
```
             ....
681          case x: FilePermission if( x.getActions == "read" && (x.getName.contains(".class") || x.getName.endsWith(".jar")  || x.getName.endsWith(".so") ) ) => // ok
```
needs to load FilePermission class file, and that need to resolve URL (more permission), and then load a file from fs (more perm).
It seems that something changed in later JVM 1.8 JDK releases about what classes are loaded when. And that results in infinite loops due to impossibility to linearize the graphe of dependance check.

I thought about two resolutions, a correct one and a hacky one. Unfortunatly, I'm not able to implement the correct one for now, and I'm not sure I want to amass the quantity of java priviledges & security to be able to do it.
So, the correct solution is to be able to make the check permission implementation logic not subject to the permission check. This would be correct because the code for the check is statically knows and immutable, so we can assess its security. But I don't know of a way to escape the current security contexte (and it seems logical, since it's kind of the goal of the security context...)
S, the hacky one is to preload relevant classes out of the security context so that we don't have to do the resolution check later on. Of course, this is extremelly fragile.