### PR TITLE
Fixes #13695: Authentication providers are not loaded before authentication is initialized

### DIFF
--- a/rudder-web/src/main/resources/applicationContext-security-auth-rootAdmin.xml
+++ b/rudder-web/src/main/resources/applicationContext-security-auth-rootAdmin.xml
@@ -33,7 +33,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
 
-<!-- do not delete - this is the empty configuration file for spring bean for file backend -->
+<!-- do not delete - this is the empty configuration file for spring bean for rootAdmin backend -->
 
 <beans:beans xmlns="http://www.springframework.org/schema/security"
   xmlns:beans="http://www.springframework.org/schema/beans"

--- a/rudder-web/src/main/scala/bootstrap/liftweb/DynamicRudderProviderManager.java
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/DynamicRudderProviderManager.java
@@ -1,0 +1,55 @@
+/*
+*************************************************************************************
+* Copyright 2018 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package bootstrap.liftweb;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+
+import java.util.List;
+
+/*
+ * A RudderProviderManger is a class that allows to get the list of spring bean
+ * from the list of requested provider names.
+ * It can add/remove beans from the list (for ex for root which is always added,
+ * or if a module is not available anymore)
+ */
+interface DynamicRudderProviderManager {
+    /*
+     * Always return a non-null list of authentication provider
+     */
+    public AuthenticationProvider[] getEnabledProviders();
+}

--- a/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -130,12 +130,6 @@ sealed trait ConfigResource
 final case class ClassPathResource(name: String) extends ConfigResource
 final case class FileSystemResource(file: File) extends ConfigResource
 
-final case class AuthenticationMethods(name: String) {
-  val path = s"applicationContext-security-auth-${name}.xml"
-  val configFile = s"classpath:${path}"
-  val springBean = s"${name}AuthenticationProvider"
-}
-
 /**
  * User defined configuration variable
  * (from properties file or alike)
@@ -414,7 +408,7 @@ object RudderConfig extends Loggable {
   ))
 
   // Plugin input interface for alternative authentication providers
-  lazy val authenticationProviders = new DefaultAuthBackendProviders()
+  lazy val authenticationProviders = new AuthBackendProvidersManager()
 
   // Plugin input interface for user management plugin
   lazy val userAuthorisationLevel = new DefaultUserAuthorisationLevel()

--- a/rudder-web/src/main/scala/bootstrap/liftweb/RudderProviderManager.java
+++ b/rudder-web/src/main/scala/bootstrap/liftweb/RudderProviderManager.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bootstrap.liftweb;
+
+import com.normation.rudder.domain.logger.ApplicationLogger;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.MessageSource;
+import org.springframework.context.MessageSourceAware;
+import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.security.authentication.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.CredentialsContainer;
+import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.util.Assert;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * This is a copy of spring ProviderManager that changes the following things:
+ * - the list of provider is a Rudder list of provider (with their name, config, etc)
+ * - it dynamically obtained (ie, even if a plugin add some providers after construction)
+ * - provider are tested for enablement (license ok or whatever)
+ */
+public class RudderProviderManager implements AuthenticationManager, MessageSourceAware,
+		InitializingBean {
+	// ~ Static fields/initializers
+	// =====================================================================================
+
+	private static final Log logger = LogFactory.getLog(RudderProviderManager.class);
+
+	// ~ Instance fields
+	// ================================================================================================
+
+	private AuthenticationEventPublisher eventPublisher = new NullEventPublisher();
+	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	private AuthenticationManager parent;
+	private boolean eraseCredentialsAfterAuthentication = true;
+
+    // the rudder provider
+    private DynamicRudderProviderManager dynamicProvider;
+
+	public RudderProviderManager(DynamicRudderProviderManager dynamicProvider) {
+	    this.dynamicProvider = dynamicProvider;
+	}
+
+	// ~ Methods
+	// ========================================================================================================
+
+	public void afterPropertiesSet() throws Exception {
+	}
+
+
+	/**
+	 * Attempts to authenticate the passed {@link Authentication} object.
+	 * <p>
+	 * The list of {@link AuthenticationProvider}s will be successively tried until an
+	 * <code>AuthenticationProvider</code> indicates it is capable of authenticating the
+	 * type of <code>Authentication</code> object passed. Authentication will then be
+	 * attempted with that <code>AuthenticationProvider</code>.
+	 * <p>
+	 * If more than one <code>AuthenticationProvider</code> supports the passed
+	 * <code>Authentication</code> object, the first one able to successfully
+	 * authenticate the <code>Authentication</code> object determines the
+	 * <code>result</code>, overriding any possible <code>AuthenticationException</code>
+	 * thrown by earlier supporting <code>AuthenticationProvider</code>s.
+	 * On successful authentication, no subsequent <code>AuthenticationProvider</code>s
+	 * will be tried.
+	 * If authentication was not successful by any supporting
+	 * <code>AuthenticationProvider</code> the last thrown
+	 * <code>AuthenticationException</code> will be rethrown.
+	 *
+	 * @param authentication the authentication request object.
+	 *
+	 * @return a fully authenticated object including credentials.
+	 *
+	 * @throws AuthenticationException if authentication fails.
+	 */
+	public Authentication authenticate(Authentication authentication)
+			throws AuthenticationException {
+		Class<? extends Authentication> toTest = authentication.getClass();
+		AuthenticationException lastException = null;
+		Authentication result = null;
+		boolean debug = logger.isDebugEnabled();
+
+		for (AuthenticationProvider provider : getProviders()) {
+			if (!provider.supports(toTest)) {
+				continue;
+			}
+
+			if (debug) {
+				logger.debug("Authentication attempt using "
+						+ provider.getClass().getName());
+			}
+
+			try {
+				result = provider.authenticate(authentication);
+
+				if (result != null) {
+					copyDetails(authentication, result);
+					break;
+				}
+			}
+			catch (AccountStatusException e) {
+				prepareException(e, authentication);
+				// SEC-546: Avoid polling additional providers if auth failure is due to
+				// invalid account status
+				throw cleanException(e);
+			}
+			catch (InternalAuthenticationServiceException e) {
+				prepareException(e, authentication);
+				throw cleanException(e);
+			}
+			catch (AuthenticationException e) {
+				lastException = e;
+			}
+		}
+
+		if (result == null && parent != null) {
+			// Allow the parent to try.
+			try {
+				result = parent.authenticate(authentication);
+			}
+			catch (ProviderNotFoundException e) {
+				// ignore as we will throw below if no other exception occurred prior to
+				// calling parent and the parent
+				// may throw ProviderNotFound even though a provider in the child already
+				// handled the request
+			}
+			catch (AuthenticationException e) {
+				lastException = e;
+			}
+		}
+
+		if (result != null) {
+			if (eraseCredentialsAfterAuthentication
+					&& (result instanceof CredentialsContainer)) {
+				// Authentication is complete. Remove credentials and other secret data
+				// from authentication
+				((CredentialsContainer) result).eraseCredentials();
+			}
+
+			eventPublisher.publishAuthenticationSuccess(result);
+			return result;
+		}
+
+		// Parent was null, or didn't authenticate (or throw an exception).
+
+		if (lastException == null) {
+			lastException = new ProviderNotFoundException(messages.getMessage(
+					"ProviderManager.providerNotFound",
+					new Object[] { toTest.getName() },
+					"No AuthenticationProvider found for {0}"));
+		}
+
+		prepareException(lastException, authentication);
+
+        //throw authentication exception without the stack trace.
+        throw cleanException(lastException);
+	}
+
+
+	// a version of the exception is thrown without stack trace to avoid having pages and pages of exception
+    // in logs. Only keep information if debug mode is enabled.
+	private AuthenticationException cleanException(AuthenticationException t) {
+        if(ApplicationLogger.isDebugEnabled()) {
+            return t;
+        } else {
+            return new AuthenticationException(t.getMessage(), t.getCause()) {
+                @Override
+                public synchronized Throwable fillInStackTrace() {
+                    return this;
+                }
+            };
+        }
+    }
+
+
+	@SuppressWarnings("deprecation")
+	private void prepareException(AuthenticationException ex, Authentication auth) {
+		eventPublisher.publishAuthenticationFailure(ex, auth);
+	}
+
+	/**
+	 * Copies the authentication details from a source Authentication object to a
+	 * destination one, provided the latter does not already have one set.
+	 *
+	 * @param source source authentication
+	 * @param dest the destination authentication object
+	 */
+	private void copyDetails(Authentication source, Authentication dest) {
+		if ((dest instanceof AbstractAuthenticationToken) && (dest.getDetails() == null)) {
+			AbstractAuthenticationToken token = (AbstractAuthenticationToken) dest;
+
+			token.setDetails(source.getDetails());
+		}
+	}
+
+	public List<AuthenticationProvider> getProviders() {
+		return Arrays.asList(dynamicProvider.getEnabledProviders());
+	}
+
+	public void setMessageSource(MessageSource messageSource) {
+		this.messages = new MessageSourceAccessor(messageSource);
+	}
+
+	public void setAuthenticationEventPublisher(
+			AuthenticationEventPublisher eventPublisher) {
+		Assert.notNull(eventPublisher, "AuthenticationEventPublisher cannot be null");
+		this.eventPublisher = eventPublisher;
+	}
+
+	/**
+	 * If set to, a resulting {@code Authentication} which implements the
+	 * {@code CredentialsContainer} interface will have its
+	 * {@link CredentialsContainer#eraseCredentials() eraseCredentials} method called
+	 * before it is returned from the {@code authenticate()} method.
+	 *
+	 * @param eraseSecretData set to {@literal false} to retain the credentials data in
+	 * memory. Defaults to {@literal true}.
+	 */
+	public void setEraseCredentialsAfterAuthentication(boolean eraseSecretData) {
+		this.eraseCredentialsAfterAuthentication = eraseSecretData;
+	}
+
+	public boolean isEraseCredentialsAfterAuthentication() {
+		return eraseCredentialsAfterAuthentication;
+	}
+
+	private static final class NullEventPublisher implements AuthenticationEventPublisher {
+		public void publishAuthenticationFailure(AuthenticationException exception,
+				Authentication authentication) {
+		}
+
+		public void publishAuthenticationSuccess(Authentication authentication) {
+		}
+	}
+}


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/13695

As we can't control when and how spring is initializing its beans, I changed the spring authentication provider that is in charge of asking to backends is authentication is OK and did one for Rudder which dynamically get the list of beans depending of plugin status. 

The part that give the list of allowed backends is controled by Rudder, and is independant from the spring init part. So it accpets latter binding of plugins. 

Still, that means that all the code/config files must be present at boot time. To restrict the scope of possible unwanted error, we only look (and let spring load) code for plugins in the `rudder.auth.provider` list. 

(that also mean that allowing runtime change of authentication is still out of reach)