### PR TITLE
Fixes #13674: Compliance error (missing) when a directive is applied by two rules on a node

### DIFF
--- a/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
@@ -884,6 +884,22 @@ class TestNodeConfiguration() {
     )
   }
 
+  // fileTemplate3 is a copy of fileTemplate2 but provided by an other rule
+  lazy val fileTemplate3 = {
+    val id = PolicyId(RuleId("ff44fb97-b65e-43c4-b8c2-000000000000"), DirectiveId("99f4ef91-537b-4e03-97bc-e65b447514cc"), TechniqueVersion("1.0"))
+    draft(
+        id
+      , fileTemplateTechnique
+      , fileTemplateVariables2
+      , fileTemplateTechnique.trackerVariableSpec.toVariable(Seq(id.getReportId))
+      , BundleOrder("99-rule-technique-std-lib")
+      , BundleOrder("20-File template 2")
+      , false
+      , Some(PolicyMode.Enforce)
+    )
+  }
+
+
   val ncf1Technique = techniqueRepository.get(TechniqueId(TechniqueName("Create_file"), TechniqueVersion("1.0"))).unsafeGet
   val ncf1Variables = {
      val spec = ncf1Technique.getAllVariableSpecs.map(s => (s.name, s)).toMap

--- a/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteSystemTechniquesTest.scala
+++ b/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteSystemTechniquesTest.scala
@@ -288,9 +288,9 @@ class WriteSystemTechniquesTest extends TechniquesTest{
       )
     }
 
-    "correctly write the expected promises files with a multi-policy configured" in {
+    "correctly write the expected promises files with a multi-policy configured, skipping fileTemplate3 from bundle order" in {
       val (rootPath, writter) = getPromiseWritter("root-1-multipolicy")
-      (writeNodeConfigWithUserDirectives(writter, fileTemplate1, fileTemplate2) mustFull) and
+      (writeNodeConfigWithUserDirectives(writter, fileTemplate1, fileTemplate2, fileTemplate3) mustFull) and
       compareWith(rootPath, "root-with-one-multipolicy",
            """.*rudder_common_report\("ntpConfiguration".*@@.*"""  //clock reports
         :: """.*add:default:==:.*"""                               //rpm reports


### PR DESCRIPTION
https://issues.rudder.io/issues/13674

In fact, we don't want to put "skipped" for the directive in other rules (meaning: already exec in previous rule) because that's not the same semantic as "skipped" for unique technique (meaning: not exec at all)