### PR TITLE
Fixes #13349: Quotes in reports are displayed as &quot; in the web interface

### DIFF
--- a/rudder-web/src/main/scala/com/normation/rudder/web/services/JsTableData.scala
+++ b/rudder-web/src/main/scala/com/normation/rudder/web/services/JsTableData.scala
@@ -51,8 +51,8 @@ trait JsTableLine extends Loggable {
 
   def json : JsObj
 
-  // this is needed because DataTable doesn't escape HTML element when using table.rows.add
-  def escapeHTML(s: String): JsExp = JsExp.strToJsExp(xml.Utility.escape(s))
+  // Convert the string to proper Js expression
+  def escapeHTML(s: String): JsExp = JsExp.strToJsExp(s)
 
   import com.normation.rudder.domain.reports.ComplianceLevelSerialisation._
   def jsCompliance(compliance: ComplianceLevel) = compliance.toJsArray()


### PR DESCRIPTION
https://issues.rudder.io/issues/13349