### PR TITLE
Fixes #13843:  Inventory keeps its key certified when node is deleted even is keystatus is erased

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/services/servers/RemoveNodeService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/servers/RemoveNodeService.scala
@@ -26,6 +26,7 @@ import com.normation.rudder.domain.eventlog._
 import com.normation.utils.ScalaReadWriteLock
 import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.eventlog.ModificationId
+import com.normation.inventory.domain.UndefinedKey
 import com.normation.inventory.ldap.core.InventoryDit
 import com.normation.inventory.ldap.core.LDAPConstants
 import com.normation.ldap.sdk.RwLDAPConnection
@@ -243,7 +244,7 @@ class RemoveNodeServiceImpl(
   private def removeKeyCertification(nodeId: NodeId): Box[LDIFChangeRecord] = {
     for {
       con <- ldap
-      res <- con.modify(deletedDit.NODES.NODE.dn(nodeId.value), new Modification(ModificationType.DELETE, LDAPConstants.A_KEY_STATUS))
+      res <- con.modify(deletedDit.NODES.NODE.dn(nodeId.value), new Modification(ModificationType.REPLACE, LDAPConstants.A_KEY_STATUS, UndefinedKey.value))
     } yield {
       res
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/13843