### PR TITLE
Fixes #10973: When hooks are exiting an error we can have stackoverfloww error if there are many of them

### DIFF
--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -226,7 +226,7 @@ trait PromiseGenerationService extends Loggable {
       updatedNodeConfigs    =  getNodesConfigVersion(uptodateSerialNodeconfig, nodeConfigCaches, generationTime)
       //second time we write something in repos: updated node configuration
       writtenNodeConfigs    <- writeNodeConfigurations(rootNodeId, updatedNodeConfigs, uptodateSerialNodeconfig, allLicenses, globalPolicyMode, generationTime) ?~!
-                               "Cannot write configuration node"
+                               "Cannot write nodes configuration"
       timeWriteNodeConfig   =  (System.currentTimeMillis - writeTime)
       _                     =  logger.debug(s"Node configuration written in ${timeWriteNodeConfig} ms, start to update expected reports.")
 

--- a/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/Cf3PromisesFileWriterService.scala
+++ b/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/Cf3PromisesFileWriterService.scala
@@ -61,6 +61,7 @@ import com.normation.templates.STVariable
 import com.normation.utils.Control._
 import java.io.File
 import java.io.IOException
+
 import monix.eval.Task
 import monix.eval.TaskSemaphore
 import monix.execution.ExecutionModel
@@ -73,12 +74,15 @@ import org.apache.commons.io.FileUtils
 import org.apache.commons.io.FilenameUtils
 import org.apache.commons.io.IOUtils
 import org.joda.time.DateTime
+
 import scala.concurrent.Await
 import scala.io.Codec
-import scala.util.{ Failure => FailTry }
+import scala.util.{Failure => FailTry}
 import scala.util.Success
 import scala.util.Try
 import com.normation.rudder.domain.logger.PolicyLogger
+import com.normation.rudder.hooks.HookReturnCode
+import scalaz.NonEmptyList
 
 /**
  * Write promises for the set of nodes, with the given configs.
@@ -188,35 +192,85 @@ class Cf3PromisesFileWriterServiceImpl(
    *
    */
   def parrallelSequence[U,T](seq: Seq[U])(f:U => Box[T])(implicit scheduler: Scheduler, semaphore: TaskSemaphore): Box[Seq[T]] = {
-    import scala.concurrent.duration._
-    // compact format a Failure(msg1, Failure(msg2, ...)) in to a Failure("msg1; msg2")
-    def compactFailure[A](b: Box[A]): Box[A] = {
-      b match {
-        case f:Failure =>
-          Failure(f.messageChain.replaceAll("<-", ";"), f.rootExceptionCause, Empty)
-        case x => x
-      }
+    def boxToEither[T](f: U => Box[T])(u:U): Either[String, T] = f(u) match {
+      case Full(t)    => Right(t)
+      case Empty      => Left("Error (no message available)")
+      case f: Failure => Left(f.messageChain)
     }
+    def recover(u:U, ex: Throwable): Either[String, T] = Left(ex.getMessage)
+
+    parrallelSequenceGen(seq)(boxToEither(f) _, recover) match {
+      case Left(nel) => Failure(nel.list.toList.mkString(";"))
+      case Right(x)  => Full(x)
+    }
+  }
+
+  // a version for Hook with a nicer message accumulation
+  def parrallelSequenceNodeHook(seq: Seq[AgentNodeConfiguration])(f: AgentNodeConfiguration => HookReturnCode)(implicit scheduler: Scheduler, semaphore: TaskSemaphore): Box[Unit] = {
+
+    type RES = Either[(NodeId, HookReturnCode.Error), HookReturnCode.Success]
+
+    def codeToEither(f: AgentNodeConfiguration => HookReturnCode)(u:AgentNodeConfiguration): RES = f(u) match {
+      case s:HookReturnCode.Success => Right(s)
+      case e:HookReturnCode.Error   => Left((u.config.nodeInfo.id, e))
+    }
+
+    def recover(u: AgentNodeConfiguration, ex: Throwable): RES = Left((u.config.nodeInfo.id, HookReturnCode.SystemError(ex.getMessage)))
+
+    def limitOut(s: String) = {
+      val max = 300
+      if(s.size <= max) s else s.substring(0, max-3) + "..."
+    }
+
+    parrallelSequenceGen(seq)(codeToEither(f) _, recover) match {
+      case Right(x)  => Full(())
+      case Left(nel) =>
+        // in that case, it is extremely likely that most messages are the same. We group them together
+        val nodeErrors = nel.list.toList.map{ case (nodeid, err) => err match {
+          // we need to limit sdtout/sdterr lenght
+          case HookReturnCode.ScriptError(code, stdout, stderr, msg) => (nodeid, s"${msg} [stdout:${limitOut(stdout)}][stderr:${limitOut(stderr)}]")
+          case x                                                     => (nodeid, x.msg)
+        }}
+        val message = nodeErrors.groupBy( _._2 ).foldLeft("Error when executing hooks:") { case (s, (msg, list)) =>
+          s + s"\n ${msg} (for node(s) ${list.map(_._1.value).mkString(";")})"
+        }
+        Failure(message)
+    }
+  }
+
+  // the generic version of parrallelSeq
+  def parrallelSequenceGen[U, T, E](seq: Seq[U])(f:U => Either[E, T], recover:(U, Throwable) => Either[E, T])(implicit scheduler: Scheduler, semaphore: TaskSemaphore): Either[NonEmptyList[E], Seq[T]] = {
+    import scala.concurrent.duration._
 
     //transform the sequence in tasks, gather results unordered
     val tasks = Task.gather(seq.map { action =>
-      semaphore.greenLight(Task(f(action)))
+      semaphore.greenLight(Task(
+        try {
+          f(action)
+        } catch {
+          case ex: Throwable => recover(action, ex)
+        }
+      ))
     })
 
-   // give a timeout for the whole tasks sufficiently large.
-   // Hint: CF-promise taking 2s by node, for 10 000 nodes, on
-   // 4 cores => ~85 minutes...
-   // It is here mostly as a safeguard for generation which went wrong -
-   // we will already have timeout at the thread level for stalling threads.
-   val timeout = 2.hours
+    // give a timeout for the whole tasks sufficiently large.
+    // Hint: CF-promise taking 2s by node, for 10 000 nodes, on
+    // 4 cores => ~85 minutes...
+    // It is here mostly as a safeguard for generation which went wrong -
+    // we will already have timeout at the thread level for stalling threads.
+    val timeout = 2.hours
 
-   //exec
-   for {
-     updated       <- tryo(Await.result(tasks.runAsync, timeout))
-     gatherErrors  <- compactFailure(bestEffort(updated)(identity))
-   } yield {
-     gatherErrors
-   }
+    //exec
+    val updated = Await.result(tasks.runAsync, timeout)
+    // gather results
+    val gatherErrors = updated.foldLeft[Either[NonEmptyList[E], Seq[T]]](Right(Nil)) {
+      case (Left(nel) , Left(err)) => Left(err <:: nel)
+      case (Left(nel) , _        ) => Left(nel)
+      case (Right(_)  , Left(err)) => Left(NonEmptyList(err))
+      case (Right(seq), Right(x) ) => Right(seq :+ x)
+    }
+
+   gatherErrors
   }
 
   /**
@@ -283,7 +337,6 @@ class Cf3PromisesFileWriterServiceImpl(
     implicit val scheduler = Scheduler.io(executionModel = ExecutionModel.AlwaysAsyncExecution)
 
     //interpret HookReturnCode as a Box
-    import com.normation.rudder.hooks.HooksImplicits.hooksReturnCodeToBox
 
     val readTemplateTime1 = DateTime.now.getMillis
     for {
@@ -347,7 +400,7 @@ class Cf3PromisesFileWriterServiceImpl(
       _                  = policyLogger.debug(s"Licenses copied in ${licensesCopiedDur} ms")
 
       nodePreMvHooks   <- RunHooks.getHooks(HOOKS_D + "/policy-generation-node-ready", HOOKS_IGNORE_SUFFIXES)
-      preMvHooks       <- parrallelSequence(configAndPaths) { agentNodeConfig =>
+      preMvHooks       <- parrallelSequenceNodeHook(configAndPaths) { agentNodeConfig =>
                             val timeHooks = System.currentTimeMillis
                             val nodeId = agentNodeConfig.config.nodeInfo.node.id.value
                             val hostname = agentNodeConfig.config.nodeInfo.hostname
@@ -380,7 +433,7 @@ class Cf3PromisesFileWriterServiceImpl(
       _                  = policyLogger.debug(s"Policies moved to their final position in ${movedPromisesDur} ms")
 
       nodePostMvHooks  <- RunHooks.getHooks(HOOKS_D + "/policy-generation-node-finished", HOOKS_IGNORE_SUFFIXES)
-      postMvHooks      <- parrallelSequence(configAndPaths) { agentNodeConfig =>
+      postMvHooks      <- parrallelSequenceNodeHook(configAndPaths) { agentNodeConfig =>
                             val timeHooks = System.currentTimeMillis
                             val nodeId = agentNodeConfig.config.nodeInfo.node.id.value
                             val hostname = agentNodeConfig.config.nodeInfo.hostname


### PR DESCRIPTION
https://issues.rudder.io/issues/10973

I'm not sure it won't still explode the stack, because perhaps the problem was in the `Task.gather` part, and in that case, we can't do much. But I suspect it was in the processing of the big errors messages which were most likely done in the stack. 

I changed the way they are gathered so that all identical error messages for the hooks are group together. It should be much smaller (and it is actually far better for understanding).

The new results looks like: 

```
[2019-01-09 17:51:21] ERROR com.normation.rudder.batch.AsyncDeploymentAgent$DeployerAgent - Error when updating policy, reason Cannot write nodes configuration <- Error when executing hooks:
 Exit code=-2147483648 for hook: '/opt/rudder/etc/hooks.d/policy-generation-node-ready/10-cf-promise-check'. [stdout:][stderr:/opt/rudder/etc/hooks.d/policy-generation-node-ready/10-cf-promise-check: line 23: /var/cfengine/bin/cf-promises: No such file or directory
] (for node(s) D02D7F7A-49DC-443C-A98D-F3265E8721F9;00000WIN-49DC-443C-A98D-F3265E8721F9)
 Exit code=-2147483648 for hook: '/opt/rudder/etc/hooks.d/policy-generation-node-ready/10-cf-promise-check'. [stdout:][stderr:/opt/rudder/etc/hooks.d/policy-generation-node-ready/10-cf-promise-check: line 19: /var/rudder/cfengine-community/bin/cf-promises: No such file or directory
] (for node(s) 00000091-55a2-4b97-8529-5154cbb63a18;00000070-55a2-4b97-8529-5154cbb63a18;00000061-55a2-4b97-8529-5154cbb63a18;...many more node ids...;00000068-55a2-4b97-8529-5154cbb63a18;f13f6726-1fdc-4ddc-9563-186648636ba4)
[2019-01-09 17:51:21] ERROR com.normation.rudder.batch.AsyncDeploymentAgent - Policy update error for process '68' at 2019-01-09 17:51:21: Cannot write nodes configuration
```