### PR TITLE
Fixes #14533: Build fails in 4.3 after correcting " Error about fail move of machine doesn't give sufficient context information"

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/FullInventoryRepositoryImpl.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/FullInventoryRepositoryImpl.scala
@@ -42,6 +42,7 @@ import com.normation.utils.Control.{bestEffort, sequence}
 import LDAPConstants.{A_CONTAINER_DN, A_NODE_UUID}
 import com.normation.inventory.services.core._
 import com.normation.inventory.domain._
+import com.normation.ldap.ldif.LDIFNoopChangeRecord
 import com.normation.ldap.sdk._
 import net.liftweb.common._
 import com.unboundid.ldif.LDIFChangeRecord


### PR DESCRIPTION
https://issues.rudder.io/issues/14533