### PR TITLE
Fixes #14312: Missing eventlogs for technique editor action and technique update

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueLibraryUpdateNotification.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueLibraryUpdateNotification.scala
@@ -41,7 +41,6 @@ import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
-import com.normation.cfclerk.domain.TechniqueName
 import net.liftweb.common.Box
 
 
@@ -98,6 +97,6 @@ trait TechniquesLibraryUpdateNotification {
    * Description is a log description to explain why techniques should be updated
    * (user action, commit, etc).
    */
-  def updatedTechniques(techniqueIds: Map[TechniqueName, TechniquesLibraryUpdateType], modId: ModificationId, actor: EventActor, reason: Option[String]) : Box[Unit]
+  def updatedTechniques(gitRev: String, techniqueIds: Map[TechniqueName, TechniquesLibraryUpdateType], modId: ModificationId, actor: EventActor, reason: Option[String]) : Box[Unit]
 
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueReader.scala
@@ -46,6 +46,7 @@ import com.normation.utils.HashcodeCaching
 
 case class TechniquesInfo(
     rootCategory          : RootTechniqueCategory
+  , gitRevId              : String
     //the TechniqueCategoryId is a path from the point of view of a tree
   , techniquesCategory    : Map[TechniqueId, TechniqueCategoryId]
   , techniques            : Map[TechniqueName, SortedMap[TechniqueVersion, Technique]]

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
@@ -420,6 +420,7 @@ class GitTechniqueReader(
       //ok, return the result in its immutable format
       TechniquesInfo(
         rootCategory = techniqueInfos.rootCategory.get,
+        gitRevId = id.name(),
         techniquesCategory = techniqueInfos.techniquesCategory.toMap,
         techniques = techniqueInfos.techniques.map { case(k,v) => (k, SortedMap.empty[TechniqueVersion,Technique] ++ v)}.toMap,
         subCategories = Map[SubTechniqueCategoryId, SubTechniqueCategory]() ++ techniqueInfos.subCategories,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/TechniqueRepositoryImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/TechniqueRepositoryImpl.scala
@@ -55,7 +55,7 @@ class TechniqueRepositoryImpl(
 ) extends TechniqueRepository with UpdateTechniqueLibrary with Loggable {
 
   /**
-   * Callback to call on PTLib update
+   * Callback to call on technique lib update
    */
   private[this] var callbacks = refLibCallbacks.sortBy( _.order )
 
@@ -113,7 +113,7 @@ class TechniqueRepositoryImpl(
 
         val res = Control.bestEffort(callbacks) { callback =>
           try {
-            callback.updatedTechniques(modifiedPackages, modId, actor, reason)
+            callback.updatedTechniques(techniqueInfosCache.gitRevId, modifiedPackages, modId, actor, reason)
           } catch {
             case e: Exception =>
               Failure(s"Error when executing callback '${callback.name}' for updated techniques: '${modifiedPackages.mkString(", ")}'", Full(e), Empty)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/eventlog/EventLogCategories.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/eventlog/EventLogCategories.scala
@@ -139,6 +139,10 @@ final case object ReloadTechniqueLibraryType extends NoRollbackEventLogType {
   def serialize = "ReloadTechniqueLibrary"
 }
 
+final case object AddTechniqueEventType extends NoRollbackEventLogType {
+  def serialize = "TechniqueAdded"
+}
+
 final case object ModifyTechniqueEventType extends NoRollbackEventLogType {
   def serialize = "TechniqueModified"
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/TechniqueDiff.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/TechniqueDiff.scala
@@ -47,8 +47,12 @@ import com.normation.cfclerk.domain.TechniqueName
 
 sealed trait TechniqueDiff
 
+final case class AddTechniqueDiff(
+    technique: ActiveTechnique
+) extends TechniqueDiff with HashcodeCaching
+
 final case class DeleteTechniqueDiff(
-  technique: ActiveTechnique
+    technique: ActiveTechnique
 ) extends TechniqueDiff with HashcodeCaching
 
 final case class ModifyTechniqueDiff(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/EventLogRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/EventLogRepository.scala
@@ -37,36 +37,37 @@
 
 package com.normation.rudder.repository
 
-import net.liftweb.common._
-import com.normation.rudder.api.DeleteApiAccountDiff
-import com.normation.rudder.domain.eventlog.ChangeRequestDiff
-import com.normation.eventlog.EventLogFilter
-import com.normation.rudder.services.eventlog.EventLogFactory
-import com.normation.rudder.domain.policies.DeleteDirectiveDiff
-import com.normation.rudder.domain.policies.ModifyRuleDiff
-import com.normation.rudder.api.AddApiAccountDiff
 import com.normation.cfclerk.domain.SectionSpec
-import com.normation.rudder.domain.workflows.WorkflowStepChange
-import com.normation.rudder.domain.policies.DeleteTechniqueDiff
-import com.normation.rudder.domain.parameters.ModifyGlobalParameterDiff
+import com.normation.eventlog.EventActor
+import com.normation.eventlog.EventLog
+import com.normation.eventlog.EventLogFilter
+import com.normation.eventlog.ModificationId
+import com.normation.rudder.api.AddApiAccountDiff
+import com.normation.rudder.api.DeleteApiAccountDiff
+import com.normation.rudder.api.ModifyApiAccountDiff
+import com.normation.rudder.domain.appconfig.RudderWebProperty
+import com.normation.rudder.domain.eventlog.ChangeRequestDiff
+import com.normation.rudder.domain.eventlog.ModifyGlobalPropertyEventType
+import com.normation.rudder.domain.nodes.AddNodeGroupDiff
+import com.normation.rudder.domain.nodes.DeleteNodeGroupDiff
+import com.normation.rudder.domain.nodes.ModifyNodeDiff
+import com.normation.rudder.domain.nodes.ModifyNodeGroupDiff
 import com.normation.rudder.domain.parameters.AddGlobalParameterDiff
+import com.normation.rudder.domain.parameters.DeleteGlobalParameterDiff
+import com.normation.rudder.domain.parameters.ModifyGlobalParameterDiff
+import com.normation.rudder.domain.policies.AddDirectiveDiff
+import com.normation.rudder.domain.policies.AddRuleDiff
+import com.normation.rudder.domain.policies.AddTechniqueDiff
+import com.normation.rudder.domain.policies.DeleteDirectiveDiff
 import com.normation.rudder.domain.policies.DeleteRuleDiff
+import com.normation.rudder.domain.policies.DeleteTechniqueDiff
+import com.normation.rudder.domain.policies.ModifyDirectiveDiff
+import com.normation.rudder.domain.policies.ModifyRuleDiff
 import com.normation.rudder.domain.policies.ModifyTechniqueDiff
 import com.normation.rudder.domain.workflows.ChangeRequestId
-import com.normation.rudder.api.ModifyApiAccountDiff
-import com.normation.eventlog.EventActor
-import com.normation.rudder.domain.nodes.AddNodeGroupDiff
-import com.normation.rudder.domain.policies.ModifyDirectiveDiff
-import com.normation.rudder.domain.parameters.DeleteGlobalParameterDiff
-import com.normation.rudder.domain.eventlog.ModifyGlobalPropertyEventType
-import com.normation.rudder.domain.appconfig.RudderWebProperty
-import com.normation.rudder.domain.policies.AddRuleDiff
-import com.normation.rudder.domain.nodes.ModifyNodeGroupDiff
-import com.normation.rudder.domain.policies.AddDirectiveDiff
-import com.normation.rudder.domain.nodes.DeleteNodeGroupDiff
-import com.normation.eventlog.EventLog
-import com.normation.eventlog.ModificationId
-import com.normation.rudder.domain.nodes.ModifyNodeDiff
+import com.normation.rudder.domain.workflows.WorkflowStepChange
+import com.normation.rudder.services.eventlog.EventLogFactory
+import net.liftweb.common._
 
 trait EventLogRepository {
   def eventLogFactory : EventLogFactory
@@ -174,6 +175,17 @@ trait EventLogRepository {
       , eventLogFactory.getModifyNodeGroupFromDiff(
           principal = principal
         , modifyDiff = modifyDiff
+        , reason = reason
+      )
+    )
+  }
+
+  def saveAddTechnique(modId: ModificationId, principal: EventActor, addDiff: AddTechniqueDiff, reason:Option[String]) = {
+    saveEventLog(
+        modId
+      , eventLogFactory.getAddTechniqueFromDiff(
+          principal = principal
+        , addDiff = addDiff
         , reason = reason
       )
     )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -151,6 +151,16 @@ trait EventLogFactory {
     , reason      : Option[String]
   ) : ModifyNodeGroup
 
+  def getAddTechniqueFromDiff(
+      id          : Option[Int] = None
+    , modificationId : Option[ModificationId] = None
+    , principal   : EventActor
+    , addDiff     : AddTechniqueDiff
+    , creationDate: DateTime = DateTime.now()
+    , severity    : Int = 100
+    , reason      : Option[String]
+  ) : AddTechnique
+
   def getModifyTechniqueFromDiff(
       id          : Option[Int] = None
     , modificationId : Option[ModificationId] = None
@@ -556,6 +566,31 @@ class EventLogFactoryImpl(
       , severity = severity))
   }
 
+  def getAddTechniqueFromDiff(
+      id          : Option[Int] = None
+    , modificationId : Option[ModificationId] = None
+    , principal   : EventActor
+    , addDiff     : AddTechniqueDiff
+    , creationDate: DateTime = DateTime.now()
+    , severity    : Int = 100
+    , reason      : Option[String]
+  ) : AddTechnique = {
+    val details = EventLog.withContent{
+      scala.xml.Utility.trim(<activeTechnique changeType="add" fileFormat={Constants.XML_CURRENT_FILE_FORMAT.toString}>
+        <id>{addDiff.technique.id.value}</id>
+        <techniqueName>{addDiff.technique.techniqueName.toString}</techniqueName>
+      </activeTechnique>)
+    }
+    AddTechnique(EventLogDetails(
+        id = id
+      , modificationId = modificationId
+      , principal = principal
+      , details = details
+      , creationDate = creationDate
+      , reason = reason
+      , severity = severity))
+  }
+
   override def getModifyTechniqueFromDiff(
       id          : Option[Int] = None
     , modificationId : Option[ModificationId] = None
@@ -592,7 +627,12 @@ class EventLogFactoryImpl(
     , severity    : Int = 100
     , reason      : Option[String]
   ) : DeleteTechnique = {
-    val details = EventLog.withContent(techniqueXmlSerializer.serialise(deleteDiff.technique) % ("changeType" -> "delete"))
+    val details = EventLog.withContent{
+      scala.xml.Utility.trim(<activeTechnique changeType="delete" fileFormat={Constants.XML_CURRENT_FILE_FORMAT.toString}>
+        <id>{deleteDiff.technique.id.value}</id>
+        <techniqueName>{deleteDiff.technique.techniqueName}</techniqueName>
+      </activeTechnique>)
+    }
     DeleteTechnique(EventLogDetails(
         id = id
       , modificationId = modificationId

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueAcceptationDatetimeUpdater.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueAcceptationDatetimeUpdater.scala
@@ -79,7 +79,7 @@ class TechniqueAcceptationUpdater(
   , uuidGen               : StringUuidGenerator
 ) extends TechniquesLibraryUpdateNotification with Loggable {
 
-  override def updatedTechniques(techniqueMods: Map[TechniqueName, TechniquesLibraryUpdateType], modId: ModificationId, actor: EventActor, reason: Option[String]) : Box[Unit] = {
+  override def updatedTechniques(gitRev: String, techniqueMods: Map[TechniqueName, TechniquesLibraryUpdateType], modId: ModificationId, actor: EventActor, reason: Option[String]) : Box[Unit] = {
 
     final case class CategoryInfo(name: String, description: String)
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueReloadingCallbacks.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueReloadingCallbacks.scala
@@ -55,10 +55,10 @@ class DeployOnTechniqueCallback(
   , asyncDeploymentAgent: AsyncDeploymentActor
 ) extends TechniquesLibraryUpdateNotification with Loggable {
 
-  override def updatedTechniques(techniqueIds:Map[TechniqueName, TechniquesLibraryUpdateType], modId:ModificationId, actor:EventActor, reason: Option[String]) : Box[Unit] = {
+  override def updatedTechniques(gitRev: String, techniqueIds:Map[TechniqueName, TechniquesLibraryUpdateType], modId:ModificationId, actor:EventActor, reason: Option[String]) : Box[Unit] = {
     reason.foreach( msg => logger.info(msg) )
     if(techniqueIds.nonEmpty) {
-      logger.debug("Ask for a policy update since technique library was reloaded")
+      logger.debug(s"Ask for a policy update since technique library was reloaded (git revision tree: ${gitRev}")
       asyncDeploymentAgent ! AutomaticStartDeployment(modId, actor)
     }
     Full({})
@@ -71,12 +71,12 @@ class LogEventOnTechniqueReloadCallback(
   , eventLogRepos     : EventLogRepository
 ) extends TechniquesLibraryUpdateNotification with Loggable {
 
-  override def updatedTechniques(techniqueMods: Map[TechniqueName, TechniquesLibraryUpdateType], modId:ModificationId, actor:EventActor, reason: Option[String]) : Box[Unit] = {
+  override def updatedTechniques(gitRev: String, techniqueMods: Map[TechniqueName, TechniquesLibraryUpdateType], modId:ModificationId, actor:EventActor, reason: Option[String]) : Box[Unit] = {
     eventLogRepos.saveEventLog(modId, ReloadTechniqueLibrary(EventLogDetails(
         modificationId = None
       , principal      = actor
-      , details        = ReloadTechniqueLibrary.buildDetails(techniqueMods)
-      , reason = reason
+      , details        = ReloadTechniqueLibrary.buildDetails(gitRev, techniqueMods)
+      , reason         = reason
     ))) match {
       case eb:EmptyBox =>
         eb ?~! "Error when saving event log for techniques library reload"

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -898,7 +898,15 @@ object RudderConfig extends Loggable {
 
   ///// end /////
 
-  private[this] lazy val logRepository = new EventLogJdbcRepository(doobie, eventLogFactory)
+  private[this] lazy val logRepository = {
+    val eventLogRepo = new EventLogJdbcRepository(doobie, eventLogFactory)
+    techniqueRepositoryImpl.registerCallback(new LogEventOnTechniqueReloadCallback(
+        "LogEventTechnique"
+      , 100 // must be before most of other
+      , eventLogRepo
+    ))
+    eventLogRepo
+  }
   private[this] lazy val inventoryLogEventServiceImpl = new InventoryEventLogServiceImpl(logRepository)
   private[this] lazy val licenseRepository = new LicenseRepositoryXML(RUDDER_DIR_LICENSESFOLDER + "/" + licensesConfiguration)
   private[this] lazy val gitRepo = new GitRepositoryProviderImpl(RUDDER_DIR_GITROOT)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/EventListDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/EventListDisplayer.scala
@@ -75,8 +75,6 @@ import com.normation.rudder.api._
 import net.liftweb.json._
 import com.normation.rudder.reports.HeartbeatConfiguration
 import com.normation.rudder.reports.AgentRunInterval
-import com.normation.rudder.reports.HeartbeatConfiguration
-import com.normation.rudder.reports.HeartbeatConfiguration
 import com.normation.rudder.rule.category.RuleCategory
 import com.normation.rudder.rule.category.RoRuleCategoryRepository
 import org.joda.time.format.DateTimeFormat

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/TechniqueReloadingCallbacks.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/TechniqueReloadingCallbacks.scala
@@ -35,7 +35,7 @@
 *************************************************************************************
 */
 
-package com.normation.rudder.services.policies
+package com.normation.rudder.web.services
 
 import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.domain.TechniqueName
@@ -45,7 +45,6 @@ import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
 import com.normation.rudder.repository.RoDirectiveRepository
 import com.normation.rudder.repository.WoDirectiveRepository
-import com.normation.rudder.web.services.DirectiveEditorService
 import com.normation.utils.Control._
 import net.liftweb.common.Loggable
 import net.liftweb.common.Full
@@ -69,7 +68,7 @@ class SaveDirectivesOnTechniqueCallback(
   , woDirectiveRepo       : WoDirectiveRepository
 ) extends TechniquesLibraryUpdateNotification with Loggable {
 
-  override def updatedTechniques(techniqueIds: Map[TechniqueName, TechniquesLibraryUpdateType], modId:ModificationId, actor:EventActor, reason: Option[String]) : Box[Unit] = {
+  override def updatedTechniques(gitRevId: String, techniqueIds: Map[TechniqueName, TechniquesLibraryUpdateType], modId:ModificationId, actor:EventActor, reason: Option[String]) : Box[Unit] = {
 
     for {
       techLib  <- roDirectiveRepo.getFullDirectiveLibrary()


### PR DESCRIPTION
https://issues.rudder.io/issues/14312

the provided commitid is the revision tree one, not a real commit id. The problem is that we totally can have several git commit without a reload, and to we can only log the state of the git when the reload is done. It is not possible to change that without changing all the logic on technique library, which is extremelly dangerous. 