### PR TITLE
Fixes #14568: Exception at Rudder start: com.typesafe.config.ConfigException$Missing: No configuration setting found for key 'rudder.jvm'

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -276,7 +276,6 @@ object RudderConfig extends Loggable {
       splitProperty(config.getString("rudder.jvm.fatal.exceptions")).toSet
     } catch {
       case ex:ConfigException =>
-        ex.printStackTrace()
         ApplicationLogger.info("Property 'rudder.jvm.fatal.exceptions' is missing or empty in rudder.configFile. Only java.lang.Error will be fatal.")
         Set[String]()
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/14568