### PR TITLE
Fixes #15295: Move /opt/rudder/etc/ssl/nodeslist.cert to /var/rudder/lib/ssl

### DIFF
--- a/relay/sources/Makefile
+++ b/relay/sources/Makefile
@@ -88,7 +88,7 @@ install: build
 	mkdir -p $(DESTDIR)/opt/rudder/share/man/man1/
 	mkdir -p $(DESTDIR)/var/rudder/inventories/incoming
 	mkdir -p $(DESTDIR)/var/rudder/inventories/accepted-nodes-updates
-	mkdir -p /$(DESTDIR)var/rudder/lib/ssl
+	mkdir -p $(DESTDIR)var/rudder/lib/ssl
 	mkdir -p $(DESTDIR)/var/rudder/reports/incoming
 	mkdir -p $(DESTDIR)/var/rudder/shared-files
 	mkdir -p $(DESTDIR)/var/rudder/share


### PR DESCRIPTION
https://issues.rudder.io/issues/15295