### PR TITLE
Fixes #15324: Webapp fails to boot (several time)

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/DataTypes.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/DataTypes.scala
@@ -213,7 +213,7 @@ final class Version(val value:String) extends Comparable[Version] {
 }
 
 
-object InventoryLogger extends NamedZioLogger(){ val loggerName = "inventory-logger"}
+object InventoryLogger extends NamedZioLogger(){ def loggerName = "inventory-logger"}
 
 
 sealed trait InventoryError extends RudderError

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionReportUnmarshaller.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionReportUnmarshaller.scala
@@ -818,7 +818,7 @@ class FusionReportUnmarshaller(
     letter.orElse(mount_point).orElse(volume) match {
       case None =>
         InventoryLogger.logEffect.debug("Ignoring FileSystem entry because missing tag TYPE and LETTER")
-        InventoryLogger.logEffect.debug(d)
+        InventoryLogger.logEffect.debug(d.toString())
         None
       case Some(mountPoint) =>
         Some(FileSystem(
@@ -850,7 +850,7 @@ class FusionReportUnmarshaller(
     optText(n\"DESCRIPTION").orElse(optText(n\"TYPE")) match {
       case None =>
         InventoryLogger.logEffect.debug("Ignoring entry Network because tag DESCRIPTION is empty")
-        InventoryLogger.logEffect.debug(n)
+        InventoryLogger.logEffect.debug(n.toString())
         None
       case Some(desc) =>
         // in a single NETWORK element, we can have both IPV4 and IPV6
@@ -912,7 +912,7 @@ class FusionReportUnmarshaller(
     val bios = optText(b\"SMODEL") match {
       case None =>
         InventoryLogger.logEffect.debug("Ignoring entry Bios because SMODEL is empty")
-        InventoryLogger.logEffect.debug(b)
+        InventoryLogger.logEffect.debug(b.toString())
         None
       case Some(model) =>
         val date = try {
@@ -938,7 +938,7 @@ class FusionReportUnmarshaller(
     optText(c\"NAME") match {
       case None =>
         InventoryLogger.logEffect.debug("Ignoring entry Controller because tag NAME is empty")
-        InventoryLogger.logEffect.debug(c)
+        InventoryLogger.logEffect.debug(c.toString())
         None
       case Some(name) =>
         Some(Controller(
@@ -962,7 +962,7 @@ class FusionReportUnmarshaller(
     val slot = optText(m\"NUMSLOTS") match {
       case None =>
         InventoryLogger.logEffect.debug("Memory is missing tag NUMSLOTS, assigning a negative value for num slot")
-        InventoryLogger.logEffect.debug(m)
+        InventoryLogger.logEffect.debug(m.toString())
         DUMMY_MEM_SLOT_NUMBER
       case Some(slot) =>  slot
     }
@@ -987,7 +987,7 @@ class FusionReportUnmarshaller(
     optText(p\"NAME") match {
       case None =>
         InventoryLogger.logEffect.debug("Ignoring entry Port because tag NAME is empty")
-        InventoryLogger.logEffect.debug(p)
+        InventoryLogger.logEffect.debug(p.toString())
         None
       case Some(name) =>
         /*It seems that CAPTION and DESCRIPTION
@@ -1040,7 +1040,7 @@ class FusionReportUnmarshaller(
     name match {
       case None =>
         InventoryLogger.logEffect.debug("Ignoring entry Slot because tags NAME and DESIGNATION are empty")
-        InventoryLogger.logEffect.debug(s)
+        InventoryLogger.logEffect.debug(s.toString())
         None
       case Some(sl) =>
         Some( Slot (
@@ -1065,7 +1065,7 @@ class FusionReportUnmarshaller(
     name match {
       case None =>
         InventoryLogger.logEffect.debug("Ignoring entry Sound because tags NAME and MANUFACTURER are empty")
-        InventoryLogger.logEffect.debug(s)
+        InventoryLogger.logEffect.debug(s.toString())
         None
       case Some(so) =>
         Some( Sound (
@@ -1084,7 +1084,7 @@ class FusionReportUnmarshaller(
     optText(s\"NAME") match {
       case None =>
         InventoryLogger.logEffect.debug("Ignoring entry Storage because tag NAME is empty")
-        InventoryLogger.logEffect.debug(s)
+        InventoryLogger.logEffect.debug(s.toString())
         None
       case Some(name) =>
         Some( Storage(
@@ -1110,7 +1110,7 @@ class FusionReportUnmarshaller(
     optText(v\"NAME").orElse(optText(v\"RESOLUTION")) match {
       case None =>
         InventoryLogger.logEffect.debug("Ignoring entry Video because tag NAME is empty")
-        InventoryLogger.logEffect.debug(v)
+        InventoryLogger.logEffect.debug(v.toString())
         None
       case Some(name) => Some( Video(
           name        = name
@@ -1126,7 +1126,7 @@ class FusionReportUnmarshaller(
     optText(c\"NAME") match{
       case None =>
         InventoryLogger.logEffect.debug("Ignoring entry CPU because tag MANIFACTURER and ARCH are empty")
-        InventoryLogger.logEffect.debug(c)
+        InventoryLogger.logEffect.debug(c.toString())
         None
       case Some(name) =>
         Some (
@@ -1151,7 +1151,7 @@ class FusionReportUnmarshaller(
     optText(ev\"KEY")  match {
     case None =>
       InventoryLogger.logEffect.debug("Ignoring entry Envs because tag KEY is empty")
-      InventoryLogger.logEffect.debug(ev)
+      InventoryLogger.logEffect.debug(ev.toString())
       None
     case Some(key) =>
       Some (
@@ -1166,7 +1166,7 @@ class FusionReportUnmarshaller(
     optText(vm\"UUID") match {
     case None =>
       InventoryLogger.logEffect.debug("Ignoring entry VirtualMachine because tag UUID is empty")
-      InventoryLogger.logEffect.debug(vm)
+      InventoryLogger.logEffect.debug(vm.toString())
       None
     case Some(uuid) =>
         Some(
@@ -1187,7 +1187,7 @@ class FusionReportUnmarshaller(
      optInt(proc, "PID") match {
     case None =>
       InventoryLogger.logEffect.debug("Ignoring entry Process because tag PID is invalid")
-      InventoryLogger.logEffect.debug(proc)
+      InventoryLogger.logEffect.debug(proc.toString())
       None
     case Some(pid) =>
       Some (

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestPreUnmarshaller.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestPreUnmarshaller.scala
@@ -38,9 +38,7 @@ package com.normation.inventory.provisioning.fusion
 
 import java.io.InputStream
 
-import com.normation.errors.IOResult
-import com.normation.errors.RudderError
-import com.normation.errors.SystemError
+import com.normation.errors._
 import com.normation.inventory.services.provisioning.PreUnmarshall
 import com.normation.zio._
 import org.junit.runner._
@@ -74,7 +72,7 @@ class TestPreUnmarshaller extends Specification {
           url.openStream()
         }
       } { is =>
-       IOResult.effectUioUnit(is.close)
+       effectUioUnit(is.close)
       } {
         is => fromXml("check", is).flatMap[Any, RudderError, NodeSeq](pre.apply)
       }).either.runNow

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestSignatureService.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestSignatureService.scala
@@ -100,7 +100,7 @@ class TestSignatureService extends Specification with Loggable {
   val parser = new FusionReportUnmarshaller(new StringUuidGeneratorImpl)
 
   def parseSignature(path: String): IOResult[InventoryDigest] = {
-     IO.bracket(getInputStream(path))(is => IOResult.effectUioUnit(is.close))(TestInventoryDigestServiceV1.parse)
+     IO.bracket(getInputStream(path))(is => effectUioUnit(is.close))(TestInventoryDigestServiceV1.parse)
   }
 
   val boxedSignature = parseSignature("fusion-report/signed_inventory.ocs.sign")

--- a/webapp/sources/ldap-inventory/inventory-provisioning-web/pom.xml
+++ b/webapp/sources/ldap-inventory/inventory-provisioning-web/pom.xml
@@ -59,10 +59,6 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <artifactId>commons-fileupload</artifactId>
       <version>1.3.3</version>
     </dependency>
-    <dependency>
-      <groupId>io.monix</groupId>
-      <artifactId>monix-reactive_${scala-binary-version}</artifactId>
-    </dependency>
     <!-- Needed for fileupload -->
     <dependency>
       <groupId>commons-io</groupId>

--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -138,6 +138,7 @@ limitations under the License.
         </executions>
         <configuration>
           <scalaCompatVersion>${scala-binary-version}</scalaCompatVersion>
+<!--          <recompileMode>incremental</recompileMode>-->
           <compilerPlugins>
             <compilerPlugin>
               <groupId>com.github.ghik</groupId>
@@ -349,7 +350,7 @@ limitations under the License.
     <rudder-major-version>5.1</rudder-major-version>
     <rudder-version>5.1.0~alpha1-SNAPSHOT</rudder-version>
 
-    <scala-version>2.12.7</scala-version>
+    <scala-version>2.12.8</scala-version>
     <scala-binary-version>2.12</scala-binary-version>
     <lift-version>3.3.0</lift-version>
     <slf4j-version>1.7.25</slf4j-version>

--- a/webapp/sources/rudder/rudder-core/pom.xml
+++ b/webapp/sources/rudder/rudder-core/pom.xml
@@ -173,13 +173,6 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <version>2.3.0</version>
     </dependency>
 
-    <!-- Task: monix -->
-    <dependency>
-      <groupId>io.monix</groupId>
-      <artifactId>monix-eval_${scala-binary-version}</artifactId>
-      <version>${monix-version}</version>
-    </dependency>
-
     <!-- cache used in compliance logger -->
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/GitUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/GitUtils.scala
@@ -56,7 +56,7 @@ trait GitRepositoryProvider {
   def db: IOResult[Repository]
 }
 
-object GitRepositoryLogger extends NamedZioLogger() { val loggerName = "git-repository" }
+object GitRepositoryLogger extends NamedZioLogger() { def loggerName = "git-repository" }
 
 /**
  * A service that allows to know what is the

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/TechniqueParser.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/TechniqueParser.scala
@@ -58,7 +58,7 @@ class TechniqueParser(
   , systemVariableSpecService    : SystemVariableSpecService
 ) extends NamedZioLogger {
 
-  val loggerName = "technique-parser"
+  def loggerName = "technique-parser"
 
   def parseXml(xml: Node, id: TechniqueId): Either[LoadTechniqueError, Technique] = {
     def nonEmpty(s: String) = if(null == s || s == "") None else Some(s)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
@@ -63,7 +63,7 @@ object ScheduledJobLogger extends Logger {
 }
 
 object ScheduledJobLoggerPure extends NamedZioLogger {
-  val loggerName = "scheduledJob"
+  def loggerName = "scheduledJob"
 }
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/PolicyLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/PolicyLogger.scala
@@ -36,6 +36,7 @@
 */
 package com.normation.rudder.domain.logger
 
+import com.normation.NamedZioLogger
 import org.slf4j.LoggerFactory
 import net.liftweb.common.Logger
 
@@ -50,10 +51,15 @@ object PolicyLogger extends Logger {
   }
 }
 
-object PolicyLoggerPure extends Logger {
-  override protected def _logger = LoggerFactory.getLogger("policy.generation")
+object PolicyLoggerPure extends NamedZioLogger {
+  override def loggerName  = "policy.generation"
 
-  object expectedReports extends Logger {
-    override protected def _logger = LoggerFactory.getLogger("policy.generation.expected_reports")
+  object expectedReports extends NamedZioLogger {
+    override def loggerName = "policy.generation.expected_reports"
   }
+}
+
+
+object GitArchiveLogger extends NamedZioLogger {
+  override def loggerName: String = "git-policy-archive"
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
@@ -625,7 +625,6 @@ class TechniqueArchiverImpl (
   , personIdentservice : PersonIdentService
 ) extends GitArchiverUtils with TechniqueArchiver {
 
-  override def loggerName: String = this.getClass.getName
   import ResourceFileState._
 
   override val encoding : String = "UTF-8"

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionService.scala
@@ -52,7 +52,6 @@ import org.joda.time.format.PeriodFormat
 import net.liftweb.common._
 import com.normation.rudder.db.DB
 import com.normation.rudder.repository.ComplianceRepository
-import monix.execution.schedulers.ExecutorScheduler
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -70,10 +69,6 @@ class ReportsExecutionService (
   , catchupFromDuration    : FiniteDuration
   , catchupInterval        : FiniteDuration
 ) {
-
-  //use that threadpool for changes. It's single threaded because everything is blocking
-  //below, so it's better to add task in a queue that thread everywhere
-  val changesThreadPool = monix.execution.Scheduler.singleThread("rudder-changes-hook").asInstanceOf[ExecutorScheduler]
 
   val logger = ReportLogger
   var idForCheck: Long = 0

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ReportsJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ReportsJdbcRepository.scala
@@ -434,13 +434,17 @@ class ReportsJdbcRepository(doobie: Doobie) extends ReportsRepository with Logga
     for {
       all <- box.map(_.flatten)
     } yield {
-      val highest = all.iterator.map(_._4).max
-      val byRules = all.groupBy(_._1).map { case (id, seq) =>
-        (id, seq.groupBy(_._2).map { case (int, seq2) =>
-          (int, seq.map(_._3).head) // seq == 1 by query
-        })
+      if(all.isEmpty) {
+        (0, Map())
+      } else {
+        val highest = all.iterator.map(_._4).max
+        val byRules = all.groupBy(_._1).map { case (id, seq) =>
+          (id, seq.groupBy(_._2).map { case (int, seq2) =>
+            (int, seq.map(_._3).head) // seq == 1 by query
+          })
+        }
+        (highest, byRules)
       }
-      (highest, byRules)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/RudderDatasourceProvider.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/RudderDatasourceProvider.scala
@@ -67,6 +67,7 @@ class RudderDatasourceProvider(
   config.setUsername(username)
   config.setPassword(password)
   config.setMaximumPoolSize(if(maxPoolSize < 1) 1 else maxPoolSize)
+  config.setMinimumIdle(Math.max(java.lang.Runtime.getRuntime.availableProcessors()/2, 1))
   config.setAutoCommit(false)
 
   // since we use JDBC4 driver, we MUST NOT set `setConnectionTestQuery("SELECT 1")`

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/Lock.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/Lock.scala
@@ -59,7 +59,7 @@ trait ScalaLock {
         .mapError(ex => SystemError(s"Error when trying to get LDAP lock", ex))
     )(_ =>
       LdapLockLogger.logPure.error("Release lock") *>
-      IOResult.effectUioUnit(this.unlock())
+      effectUioUnit(this.unlock())
     )(_ =>
       LdapLockLogger.logPure.error("Do things in lock") *>
       block

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitFindUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitFindUtils.scala
@@ -119,7 +119,7 @@ object GitFindUtils extends NamedZioLogger {
           case Nil =>
             Inconsistancy(s"No file were found at path '${filePath}}'").fail
           case h :: Nil =>
-            ZIO.bracket(IOResult.effect(db.open(h).openStream()))(s => IOResult.effectUioUnit(s.close()))(useIt)
+            ZIO.bracket(IOResult.effect(db.open(h).openStream()))(s => effectUioUnit(s.close()))(useIt)
           case _ =>
             Inconsistancy(s"More than exactly one matching file were found in the git tree for path '${filePath}', I can not know which one to choose. IDs: ${ids}}").fail
       }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/ItemArchiveManagerImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/ItemArchiveManagerImpl.scala
@@ -317,7 +317,7 @@ class ItemArchiveManagerImpl(
       _          <- woRuleRepository.deleteSavedRuleArchiveId(imported).catchAll(err =>
                       logPure.warn(s"Error when trying to delete saved archive of old rule: ${err.fullMsg}")
                     )
-      _          <- IOResult.effectUioUnit(if(deploy) {asyncDeploymentAgent ! AutomaticStartDeployment(modId, actor)})
+      _          <- effectUioUnit(if(deploy) {asyncDeploymentAgent ! AutomaticStartDeployment(modId, actor)})
     } yield {
       if(deploy) { asyncDeploymentAgent ! AutomaticStartDeployment(modId, actor) }
       archiveId
@@ -385,7 +385,7 @@ class ItemArchiveManagerImpl(
       _        <- woParameterRepository.deleteSavedParametersArchiveId(imported).catchAll(err =>
                     logPure.warn(s"Error when trying to delete saved archive of old parameters: ${err.fullMsg}")
                   )
-      _        <- IOResult.effectUioUnit(if(deploy) {asyncDeploymentAgent ! AutomaticStartDeployment(modId, actor)})
+      _        <- effectUioUnit(if(deploy) {asyncDeploymentAgent ! AutomaticStartDeployment(modId, actor)})
     } yield {
       archiveId
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/ZipUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/ZipUtils.scala
@@ -64,7 +64,7 @@ object ZipUtils {
    */
 
   def zip(zipout:OutputStream, toAdds:Seq[Zippable]) : IOResult[Unit] = {
-    ZIO.bracket(IOResult.effect(new ZipOutputStream(zipout)))(zout => IOResult.effectUioUnit(zout.close())) { zout =>
+    ZIO.bracket(IOResult.effect(new ZipOutputStream(zipout)))(zout => effectUioUnit(zout.close())) { zout =>
       val addToZout = (is:InputStream) => IOResult.effect("Error when copying file")(IOUtils.copy(is, zout))
 
       ZIO.foreach(toAdds) { x =>
@@ -128,7 +128,7 @@ object ZipUtils {
         }
       } else {
         def buildContent(use: InputStream => Any) : IOResult[Any] = {
-          ZIO.bracket(IOResult.effect(new FileInputStream(f)))(is => IOResult.effectUioUnit(is.close)){ is =>
+          ZIO.bracket(IOResult.effect(new FileInputStream(f)))(is => effectUioUnit(is.close)){ is =>
             IOResult.effect("Error when using file")(use(is))
           }
         }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -331,7 +331,7 @@ trait PromiseGenerationService {
 
       /// now, if there was failed config or failed write, time to show them
       //invalidate compliance may be very very long - make it async
-      _                     =  ZioRuntime.runNow(zio.blocking.blocking { IOResult.effect(invalidateComplianceCache (updatedNodeConfigs.keySet)) }.run.unit.fork.provide(ZioRuntime.Environment))
+      _                     =  ZioRuntime.runNow(IOResult.effect(invalidateComplianceCache (updatedNodeConfigs.keySet)).run.unit.fork)
       _                     =  {
                                  PolicyLogger.info("Timing summary:")
                                  PolicyLogger.info("Run pre-gen scripts hooks     : %10s ms".format(timeRunPreGenHooks))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LoadDemoDataTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LoadDemoDataTest.scala
@@ -97,7 +97,7 @@ class LoadDemoDataTest extends Specification {
       val dn = new DN("biosName=bios1,machineId=machine2,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration")
       val newParent = new DN("machineId=machine-does-not-exists,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration")
 
-      val res = ldap.newConnection.move(dn, newParent).either.runNow
+      val res = ldap.newConnection.flatMap(_.move(dn, newParent)).either.runNow
       /*
        * Failure message is:
        * Can not move 'biosName=bios1,machineId=machine2,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration' to new parent
@@ -106,7 +106,7 @@ class LoadDemoDataTest extends Specification {
        * 'biosName=bios1,machineId=machine-does-not-exists,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration' does not exist.
        */
       res must beAnInstanceOf[Left[LDAPRudderError, _]] and (
-        ldap.newConnection.exists(dn).runNow must beTrue
+        ldap.newConnection.flatMap(_.exists(dn)).runNow must beTrue
       )
 
     }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestWriteNodeCertificatesPem.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestWriteNodeCertificatesPem.scala
@@ -153,7 +153,7 @@ class TestWriteNodeCertificatesPem extends Specification {
 
     import scala.collection.JavaConverters._
 
-    val log = writer.logger.logEffect._internal.asInstanceOf[ch.qos.logback.classic.Logger]
+    val log = writer.logger.logEffect.asInstanceOf[ch.qos.logback.classic.Logger]
 
     val ctx = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
     import ch.qos.logback.classic.encoder.PatternLayoutEncoder

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
@@ -586,7 +586,7 @@ class SystemApiService11(
   private[this] val allFiles = "groups" :: ruleFiles ::: directiveFiles
 
   private[this] def getZip(commitId:String, paths:List[String], archiveType: String) : Either[String, (Array[Byte], List[(String, String)])] = {
-    (ZIO.bracket(repo.db.map(db => new RevWalk(db)))(rw => IOResult.effectUioUnit(rw.dispose)) { rw =>
+    (ZIO.bracket(repo.db.map(db => new RevWalk(db)))(rw => effectUioUnit(rw.dispose)) { rw =>
       for {
         db        <- repo.db
         revCommit <- IOResult.effect(s"Error when retrieving commit revision for '${commitId}'") {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/LiftInitContextListener.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/LiftInitContextListener.scala
@@ -41,8 +41,9 @@ import net.liftweb.common._
 import javax.servlet.ServletContextEvent
 import org.springframework.web.context.ContextLoaderListener
 import org.springframework.web.context.support.WebApplicationContextUtils
-import org.springframework.core.io.{ClassPathResource => CPResource,FileSystemResource => FSResource}
+import org.springframework.core.io.{ClassPathResource => CPResource, FileSystemResource => FSResource}
 import java.io.File
+
 import com.normation.rudder.domain.logger.ApplicationLogger
 
 /**
@@ -82,6 +83,10 @@ class LiftInitContextListener extends ContextLoaderListener {
   override def contextInitialized(sce:ServletContextEvent) : Unit = {
 
     Logger.setup = Full(() => Logback.withFile(logbackFile)())
+
+    val pid = new File("/proc/self").getCanonicalFile().getName()
+    ApplicationLogger.info(s"Rudder starts with PID ${pid} on ${java.lang.Runtime.getRuntime().availableProcessors()} cores")
+
     /// init all our non-spring services ///
 
     /*

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/CheckInitUserTemplateLibrary.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/CheckInitUserTemplateLibrary.scala
@@ -97,7 +97,7 @@ class CheckInitUserTemplateLibrary(
               val e = eb ?~! "Some error where encountered during the initialization of the user library"
               val msg = e.messageChain.split("<-").mkString("\n ->")
               BootraspLogger.logEffect.warn(msg)
-              BootraspLogger.logEffect.debug(e.exceptionChain)
+              e.rootExceptionCause.foreach(ex => BootraspLogger.logEffect.debug("cause was:", ex))
               // Even if complete reload failed, we need to trigger a policy deployment, as otherwise it will never be done
               asyncDeploymentAgent ! AutomaticStartDeployment(ModificationId(uuidGen.newUuid), RudderEventActor)
           }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/CheckInitXmlExport.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/CheckInitXmlExport.scala
@@ -84,7 +84,7 @@ class CheckInitXmlExport(
     }).toBox match {
       case eb:EmptyBox =>
         val fail = eb ?~! "Error when trying to initialise to configuration-repository sub-system with a first full archive"
-        BootraspLogger.logEffect.error(fail)
+        BootraspLogger.logEffect.error(fail.messageChain)
         fail.rootExceptionCause.foreach { t =>
           BootraspLogger.logEffect.error("Root exception was:", t)
         }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/CheckSystemGroups.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/CheckSystemGroups.scala
@@ -152,10 +152,9 @@ class CheckSystemGroups(
 
         }
       }
-      case eb =>
-        val message = "Could not migrate system groups"
-        val fail = eb ?~ message
-        BootraspLogger.logEffect.error(fail)
+      case eb: EmptyBox =>
+        val fail = eb ?~! "Could not migrate system groups"
+        BootraspLogger.logEffect.error(fail.messageChain)
     }
   }
 }

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/ldif/LDIFFileLogger.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/ldif/LDIFFileLogger.scala
@@ -63,7 +63,7 @@ trait LDIFFileLogger {
 }
 
 class DummyLDIFFileLogger extends LDIFFileLogger {
-  val loggerName = "dummy logger - no output"
+  def loggerName = "dummy logger - no output"
   val ldifTraceRootDir = "no a real ldifTraceRootDir"
   def tree(tree:LDAPTree): Unit = {}
   def record(LDIFRecord: => LDIFRecord,comment:Option[String] = None): Unit = {}

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPConnection.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPConnection.scala
@@ -49,7 +49,7 @@ import com.normation.ldap.sdk.syntax._
 /*
  * Logger for LDAP connection related information.
  */
-object LDAPConnectionLogger extends NamedZioLogger(){val loggerName = "ldap-connection"}
+object LDAPConnectionLogger extends NamedZioLogger(){def loggerName = "ldap-connection"}
 
 trait ReadOnlyEntryLDAPConnection {
 
@@ -500,7 +500,7 @@ class RwLDAPConnection(
   private def applyMods[MOD <: ReadOnlyLDAPRequest](modName: String, toLDIFChangeRecord:MOD => LDIFChangeRecord, backendAction: MOD => LDAPResult, onlyReportThat: ResultCode => Boolean)(reqs: List[MOD]) : LDAPIOResult[Seq[LDIFChangeRecord]] = {
     if(reqs.size < 1) IO.succeed(Seq())
     else {
-      ldifFileLogger.records(reqs map ( toLDIFChangeRecord (_) ))
+      UIO.effectTotal(ldifFileLogger.records(reqs map (toLDIFChangeRecord (_)))) *>
       IO.foreach(reqs) { req =>
         applyMod(modName, toLDIFChangeRecord, backendAction, onlyReportThat)(req)
       }

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPIOResult.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPIOResult.scala
@@ -21,6 +21,7 @@
 package com.normation.ldap.sdk
 
 import cats.data.NonEmptyList
+import com.normation.errors.IOResult
 import com.normation.errors.RudderError
 import zio._
 import zio.syntax._
@@ -45,6 +46,13 @@ object LDAPRudderError {
 
 object LDAPIOResult{
   type LDAPIOResult[T] = IO[LDAPRudderError, T]
+
+
+  def effect[A](effect: => A): IO[LDAPRudderError.BackendException, A] = {
+    IOResult.effect(effect).mapError(err =>
+      LDAPRudderError.BackendException(err.msg, err.cause)
+    )
+  }
 
   // transform an Option[T] into an error
   implicit class StrictOption[T](opt: LDAPIOResult[Option[T]]) {

--- a/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
@@ -26,7 +26,7 @@
 package com.normation
 
 
-import net.liftweb.common._
+import net.liftweb.common.{Logger => _, _}
 import cats.data._
 import cats.implicits._
 import cats.kernel.Order
@@ -36,6 +36,8 @@ import com.normation.errors.RudderError
 import com.normation.errors.SystemError
 import _root_.zio._
 import _root_.zio.syntax._
+import com.normation.zio.ZioRuntime
+import org.slf4j.Logger
 
 /**
  * This is our based error for Rudder. Any method that can
@@ -46,25 +48,54 @@ import _root_.zio.syntax._
  */
 object errors {
 
+  /*
+   * Two methods which helps to transform effect to `UIO[Unit]` (ie don't care
+   * about the result type, and manage all errors in some way).
+   * This is particularly needed in `Bracket` construction where the finalizer
+   * must be of that type.
+   */
+  def effectUioUnit[A](effect: => A): UIO[Unit] = {
+    def printError(t: Throwable): UIO[Unit] = {
+      val print = (s:String) => IO.effect(System.err.println(s))
+      //here, we must run.unit, because if it fails we can't do much more (and the app is certainly totally broken)
+      (print(s"${t.getClass.getName}:${t.getMessage}") *> IO.foreach(t.getStackTrace)(st => print(st.toString))).run.unit
+    }
+    effectUioUnit(printError(_))(effect)
+  }
+  def effectUioUnit[A](error: Throwable => UIO[Unit])(effect: => A): UIO[Unit] = {
+    ZioRuntime.effectBlocking(effect).unit.catchAll(error)
+  }
 
+  /*
+   * Our result types are isomorphique to a disjoint RudderError | A
+   * one. We have two case: one for which we are sure that all
+   * operation are pure and don't modelize effects (that can be fully
+   * reiffied at compule time), and one for effect encapsulation (that need to
+   * be runned to know the result).
+   */
   type PureResult[A] = Either[RudderError, A]
   type IOResult[A] = ZIO[Any, RudderError, A]
 
-
-  def runUnit[R, A](effect: ZIO[R, Throwable, A]): ZIO[R, Nothing, Unit] = {
-    def printError(t: Throwable): UIO[Unit] = {
-      val print = (s:String) => IO.effect(System.err.println(s))
-      //here, we must run.void, because if it fails we can't do much more (and the app is certainly totally broken)
-      (print(s"${t.getClass.getName}:${t.getMessage}") *> IO.foreach(t.getStackTrace)(st => print(st.toString))).run.unit
-    }
-    effect.unit.catchAll(printError)
-  }
-
+  /*
+   * An object that provides utility methods to import effectful
+   * methods into rudder IOResult type.
+   * By default, we consider that all imports have blocking
+   * effects, and need to be run on an according threadpool.
+   * If you want to import non blocking effects (but really, in
+   * that case, you should just use `PureResult`), you can
+   * use `IOResult.effectTotal`).
+   */
   object IOResult {
-    def effect[A](error: String)(effect: => A): IOResult[A] = {
+    def effectNonBlocking[A](error: String)(effect: => A): IO[SystemError, A] = {
       IO.effect(effect).mapError(ex => SystemError(error, ex))
     }
-    def effect[A](effect: => A): IOResult[A] = {
+    def effectNonBlocking[A](effect: => A): IO[SystemError, A] = {
+      this.effectNonBlocking("An error occured")(effect)
+    }
+    def effect[A](error: String)(effect: => A): IO[SystemError, A] = {
+      ZioRuntime.effectBlocking(effect).mapError(ex => SystemError(error, ex))
+    }
+    def effect[A](effect: => A): IO[SystemError, A] = {
       this.effect("An error occured")(effect)
     }
     def effectM[A](error: String)(ioeffect: => IOResult[A]): IOResult[A] = {
@@ -76,11 +107,8 @@ object errors {
     def effectM[A](ioeffect: => IOResult[A]): IOResult[A] = {
       effectM("An error occured")(ioeffect)
     }
-
-    def effectUioUnit[A](effect: => A): UIO[Unit] = {
-      runUnit(IO.effect(effect))
-    }
   }
+
 
   trait RudderError {
     // All error have a message which explains what cause the error.
@@ -94,7 +122,8 @@ object errors {
   // a common error for system error not specificaly bound to
   // a domain context.
   final case class SystemError(msg: String, cause: Throwable) extends RudderError {
-    override def fullMsg: String = super.fullMsg + s"; cause was: ${cause.getMessage}"
+    override def fullMsg: String = super.fullMsg + s"; cause was: ${cause.getClass.getName}: ${cause.getMessage} " +
+                                   s"(${cause.getStackTrace.find(_.getClassName.startsWith("com.normation")).map(_.toString).getOrElse("no stack trace available")})"
   }
 
   // a generic error to tell "I wasn't expecting that value"
@@ -262,15 +291,26 @@ object zio {
      */
     val internal = new DefaultRuntime(){}
 
+    /*
+     * use the blocking thread pool provided by that runtime.
+     */
+    def blocking[E,A](io: ZIO[Any,E,A]): ZIO[Any,E,A] = {
+      _root_.zio.blocking.blocking(io).provide(internal.Environment)
+    }
+
+    def effectBlocking[A](effect: => A): ZIO[Any, Throwable, A] = {
+      _root_.zio.blocking.effectBlocking(effect).provide(internal.Environment)
+    }
+
     def runNow[A](io: IOResult[A]): A = {
-      internal.unsafeRunSync(blocking.blocking(io)).fold(cause => throw cause.squashWith(err => new RuntimeException(err.fullMsg)), a => a)
+      internal.unsafeRunSync(blocking(io)).fold(cause => throw cause.squashWith(err => new RuntimeException(err.fullMsg)), a => a)
     }
 
     /*
      * An unsafe run that is always started on a growing threadpool and its
      * effect marked as blocking.
      */
-    def unsafeRun[E, A](zio: => ZIO[Any, E, A]): A = internal.unsafeRun(blocking.blocking(zio).provide(internal.Environment))
+    def unsafeRun[E, A](zio: => ZIO[Any, E, A]): A = internal.unsafeRun(blocking(zio))
 
     def Environment = internal.Environment
   }
@@ -336,20 +376,20 @@ trait ZioLogger {
    * that something went badly. Obviously, we won't use the logger for that.
    */
   final def logAndForgetResult[T](log: Logger => T): UIO[Unit] = {
-    com.normation.errors.runUnit(IO.effect(log(logEffect)))
+    com.normation.errors.effectUioUnit(log(logEffect))
   }
 
-  final def trace(msg: => AnyRef): UIO[Unit] = logAndForgetResult(_.trace(msg))
-  final def debug(msg: => AnyRef): UIO[Unit] = logAndForgetResult(_.debug(msg))
-  final def info (msg: => AnyRef): UIO[Unit] = logAndForgetResult(_.info (msg))
-  final def error(msg: => AnyRef): UIO[Unit] = logAndForgetResult(_.error(msg))
-  final def warn (msg: => AnyRef): UIO[Unit] = logAndForgetResult(_.warn (msg))
+  final def trace(msg: => String): UIO[Unit] = logAndForgetResult(_.trace(msg))
+  final def debug(msg: => String): UIO[Unit] = logAndForgetResult(_.debug(msg))
+  final def info (msg: => String): UIO[Unit] = logAndForgetResult(_.info (msg))
+  final def error(msg: => String): UIO[Unit] = logAndForgetResult(_.error(msg))
+  final def warn (msg: => String): UIO[Unit] = logAndForgetResult(_.warn (msg))
 
-  final def trace(msg: => AnyRef, t: Throwable): UIO[Unit] = logAndForgetResult(_.trace(msg, t))
-  final def debug(msg: => AnyRef, t: Throwable): UIO[Unit] = logAndForgetResult(_.debug(msg, t))
-  final def info (msg: => AnyRef, t: Throwable): UIO[Unit] = logAndForgetResult(_.info (msg, t))
-  final def warn (msg: => AnyRef, t: Throwable): UIO[Unit] = logAndForgetResult(_.warn (msg, t))
-  final def error(msg: => AnyRef, t: Throwable): UIO[Unit] = logAndForgetResult(_.error(msg, t))
+  final def trace(msg: => String, t: Throwable): UIO[Unit] = logAndForgetResult(_.trace(msg, t))
+  final def debug(msg: => String, t: Throwable): UIO[Unit] = logAndForgetResult(_.debug(msg, t))
+  final def info (msg: => String, t: Throwable): UIO[Unit] = logAndForgetResult(_.info (msg, t))
+  final def warn (msg: => String, t: Throwable): UIO[Unit] = logAndForgetResult(_.warn (msg, t))
+  final def error(msg: => String, t: Throwable): UIO[Unit] = logAndForgetResult(_.error(msg, t))
 
   final def ifTraceEnabled[T](action: UIO[T]): UIO[Unit] = logAndForgetResult(logger => if(logger.isTraceEnabled) action else () )
   final def ifDebugEnabled[T](action: UIO[T]): UIO[Unit] = logAndForgetResult(logger => if(logger.isDebugEnabled) action else () )
@@ -363,20 +403,15 @@ trait ZioLogger {
 trait NamedZioLogger extends ZioLogger {
   import org.slf4j.LoggerFactory
 
+  // ensure that children use def or lazy val - val leads to UnitializedFieldError.
   def loggerName: String
 
-  lazy val logEffect = new LogEffect() {
-    override protected def _logger = LoggerFactory.getLogger(loggerName)
-  }
+  final val logEffect = LoggerFactory.getLogger(loggerName)
 
   // for compatibility with current Lift convention, use logger = this
   def logPure = this
 }
 
-trait LogEffect extends Logger {
-  def _internal = _logger
-}
-
 object NamedZioLogger {
-  def apply(name: String): NamedZioLogger = new NamedZioLogger(){val loggerName = name}
+  def apply(name: String): NamedZioLogger = new NamedZioLogger(){def loggerName = name}
 }

--- a/webapp/sources/utils/src/test/scala/com/normation/ZioCommonsTest.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/ZioCommonsTest.scala
@@ -136,7 +136,7 @@ object TestImplicits {
      */
     object service {
 
-      def trace(msg: => AnyRef): UIO[Unit] = IOResult.effectUioUnit(println(msg))
+      def trace(msg: => AnyRef): UIO[Unit] = effectUioUnit(println(msg))
 
       def test0(a: String): IOResult[String] = service1.doStuff(a)
 


### PR DESCRIPTION
https://issues.rudder.io/issues/15324

So, there is a lot of little things going on:
- remove monix to avoid multiple threadpools and use less threads, 
- work on logger to avoid several lazy val and deadlock (see https://issues.rudder.io/issues/15324#note-5)
- rework `LdapConnectionProvider` to avoid `synchronized`
- make `IOResult.effect` use the blocking thread pool by default (see https://twitter.com/fanf42/status/1155925196814970880)