### PR TITLE
Fixes #15444: postinstall of rudder-server-relay may fail if httpd is too slow to shut down

### DIFF
--- a/relay/sources/rudder-server-relay-postinst
+++ b/relay/sources/rudder-server-relay-postinst
@@ -34,7 +34,7 @@ if [ "${FIRST_INSTALL}" -eq 1 ]; then
   systemctl enable rudder-relayd >> ${LOG_FILE}
 fi
 
-systemctl stop "${APACHE}" >> ${LOG_FILE}
+systemctl stop "${APACHE}" >> ${LOG_FILE} || true
 
 systemctl stop rudder-relayd >> ${LOG_FILE} || true
 echo " Done"


### PR DESCRIPTION
https://issues.rudder.io/issues/15444