### PR TITLE
Fixes #15475: typo in api setting: rudder.report.protocol.default rather than rudder_report_protocol_default

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -552,7 +552,7 @@ class SettingsApi(
   }
 
   case object RestReportProtocolDefault extends RestSetting[AgentReportingProtocol] {
-    var key = "rudder.report.protocol.default"
+    var key = "rudder_report_protocol_default"
     val startPolicyGeneration = false
     def get = configService.rudder_report_protocol_default()
     def set = (value : AgentReportingProtocol, _, _)  => configService.set_rudder_report_protocol_default(value)


### PR DESCRIPTION
https://issues.rudder.io/issues/15475