### PR TITLE
Fixes #15483: rudder-pkg python lib are missplaced on the server

### DIFF
--- a/relay/sources/Makefile
+++ b/relay/sources/Makefile
@@ -125,7 +125,7 @@ install: build
 	install -m 755 rudder-pkg/rudder-pkg $(DESTDIR)/opt/rudder/bin/
 	install -m 755 rudder-pkg/rudder-pkg.conf $(DESTDIR)/opt/rudder/etc/rudder-pkg/rudder-pkg.conf
 	install -m 755 rudder-pkg/rudder_plugins_key.pub $(DESTDIR)/opt/rudder/etc/rudder-pkg/rudder_plugins_key.pub
-	cp -r rudder-pkg/lib $(DESTDIR)/opt/rudder/share/python/
+	cp -r rudder-pkg/lib/* $(DESTDIR)/opt/rudder/share/python/
 	
 	# Apache
 	install -m 644 apache/rudder-vhost.conf $(DESTDIR)/etc/$(APACHE_VHOSTDIR)/rudder.conf


### PR DESCRIPTION
https://issues.rudder.io/issues/15483