### PR TITLE
Fixes #2613: Problem when updating a category name for Technique Management in /var/rudder

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueLibraryUpdateNotification.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueLibraryUpdateNotification.scala
@@ -37,12 +37,22 @@
 
 package com.normation.cfclerk.services
 
+import com.normation.cfclerk.domain.TechniqueCategory
+import com.normation.cfclerk.domain.TechniqueCategoryId
+import com.normation.cfclerk.domain.TechniqueCategoryName
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
 import net.liftweb.common.Box
 
+sealed trait TechniqueCategoryModType
+object TechniqueCategoryModType {
+  case class Updated(id: TechniqueCategory) extends TechniqueCategoryModType // change in name, description
+  case class Added(cat: TechniqueCategory, parentId: TechniqueCategoryId) extends TechniqueCategoryModType
+  case class Deleted(cat: TechniqueCategory) extends TechniqueCategoryModType
+  case class Moved(id: TechniqueCategoryName, oldParentId: TechniqueCategoryId, newParentId: TechniqueCategoryId) extends TechniqueCategoryModType
+}
 
 sealed trait TechniqueVersionModType
 case object VersionDeleted extends TechniqueVersionModType
@@ -97,6 +107,6 @@ trait TechniquesLibraryUpdateNotification {
    * Description is a log description to explain why techniques should be updated
    * (user action, commit, etc).
    */
-  def updatedTechniques(gitRev: String, techniqueIds: Map[TechniqueName, TechniquesLibraryUpdateType], modId: ModificationId, actor: EventActor, reason: Option[String]) : Box[Unit]
+  def updatedTechniques(gitRev: String, techniqueIds: Map[TechniqueName, TechniquesLibraryUpdateType], updatedCategories: Set[TechniqueCategoryModType], modId: ModificationId, actor: EventActor, reason: Option[String]) : Box[Unit]
 
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueReloadingCallbacks.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueReloadingCallbacks.scala
@@ -47,6 +47,7 @@ import net.liftweb.common._
 import com.normation.eventlog.ModificationId
 import com.normation.cfclerk.services.TechniquesLibraryUpdateType
 import com.normation.cfclerk.domain.TechniqueName
+import com.normation.cfclerk.services.TechniqueCategoryModType
 import com.normation.rudder.repository.EventLogRepository
 
 class DeployOnTechniqueCallback(
@@ -55,7 +56,7 @@ class DeployOnTechniqueCallback(
   , asyncDeploymentAgent: AsyncDeploymentActor
 ) extends TechniquesLibraryUpdateNotification with Loggable {
 
-  override def updatedTechniques(gitRev: String, techniqueIds:Map[TechniqueName, TechniquesLibraryUpdateType], modId:ModificationId, actor:EventActor, reason: Option[String]) : Box[Unit] = {
+  override def updatedTechniques(gitRev: String, techniqueIds:Map[TechniqueName, TechniquesLibraryUpdateType], updatedCategories: Set[TechniqueCategoryModType], modId: ModificationId, actor:EventActor, reason: Option[String]) : Box[Unit] = {
     reason.foreach( msg => logger.info(msg) )
     if(techniqueIds.nonEmpty) {
       logger.debug(s"Ask for a policy update since technique library was reloaded (git revision tree: ${gitRev}")
@@ -71,7 +72,7 @@ class LogEventOnTechniqueReloadCallback(
   , eventLogRepos     : EventLogRepository
 ) extends TechniquesLibraryUpdateNotification with Loggable {
 
-  override def updatedTechniques(gitRev: String, techniqueMods: Map[TechniqueName, TechniquesLibraryUpdateType], modId:ModificationId, actor:EventActor, reason: Option[String]) : Box[Unit] = {
+  override def updatedTechniques(gitRev: String, techniqueMods: Map[TechniqueName, TechniquesLibraryUpdateType], updatedCategories: Set[TechniqueCategoryModType], modId:ModificationId, actor:EventActor, reason: Option[String]) : Box[Unit] = {
     eventLogRepos.saveEventLog(modId, ReloadTechniqueLibrary(EventLogDetails(
         modificationId = None
       , principal      = actor

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/TechniqueReloadingCallbacks.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/TechniqueReloadingCallbacks.scala
@@ -39,6 +39,7 @@ package com.normation.rudder.web.services
 
 import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.domain.TechniqueName
+import com.normation.cfclerk.services.TechniqueCategoryModType
 import com.normation.cfclerk.services.TechniquesLibraryUpdateNotification
 import com.normation.cfclerk.services.TechniquesLibraryUpdateType
 import com.normation.eventlog.EventActor
@@ -68,7 +69,7 @@ class SaveDirectivesOnTechniqueCallback(
   , woDirectiveRepo       : WoDirectiveRepository
 ) extends TechniquesLibraryUpdateNotification with Loggable {
 
-  override def updatedTechniques(gitRevId: String, techniqueIds: Map[TechniqueName, TechniquesLibraryUpdateType], modId:ModificationId, actor:EventActor, reason: Option[String]) : Box[Unit] = {
+  override def updatedTechniques(gitRevId: String, techniqueIds: Map[TechniqueName, TechniquesLibraryUpdateType], updatedCategories: Set[TechniqueCategoryModType], modId:ModificationId, actor:EventActor, reason: Option[String]) : Box[Unit] = {
 
     for {
       techLib  <- roDirectiveRepo.getFullDirectiveLibrary()


### PR DESCRIPTION
https://issues.rudder.io/issues/2613

This pr allow to create, update, move categories (delete is not supported for non empty directories).
Hypothesis: all category directory name are unique in the tree.