### PR TITLE
Fixes #15909: Disable lto for relayd release builds

### DIFF
--- a/relay/sources/relayd/Cargo.toml
+++ b/relay/sources/relayd/Cargo.toml
@@ -52,7 +52,3 @@ warp = { version = "0.1", default-features = false }
 criterion = "0.3"
 filetime = "0.2"
 tempfile = "3.1"
-
-[profile.release]
-# Smaller binaries
-lto = true


### PR DESCRIPTION
https://issues.rudder.io/issues/15909