### PR TITLE
Fixes #16044: Remote-run starts commands with no host name

### DIFF
--- a/relay/sources/relayd/src/api/remote_run.rs
+++ b/relay/sources/relayd/src/api/remote_run.rs
@@ -340,6 +340,8 @@ impl RunParameters {
     }
 
     pub fn command(&self, cfg: &RemoteRunCfg, nodes: Vec<String>) -> Command {
+        assert!(!nodes.is_empty());
+
         let mut cmd = if cfg.use_sudo {
             let mut tmp = Command::new("sudo");
             tmp.arg(&cfg.command);
@@ -371,6 +373,12 @@ impl RunParameters {
         asynchronous: bool,
     ) -> Box<dyn Stream<Item = Chunk, Error = Error> + Send + 'static> {
         trace!("Starting local remote run on {:#?} with {:#?}", nodes, cfg);
+
+        if nodes.is_empty() {
+            debug!("No nodes to trigger locally, skipping");
+            return Box::new(futures::stream::empty());
+        }
+
         let mut cmd = self.command(cfg, nodes);
         cmd.stdout(Stdio::piped());
 


### PR DESCRIPTION
https://issues.rudder.io/issues/16044