### PR TITLE
Fixes #16052: Missing /var/rudder/lib/relay dir in packaging

### DIFF
--- a/relay/sources/Makefile
+++ b/relay/sources/Makefile
@@ -90,6 +90,7 @@ install: build
 	mkdir -p $(DESTDIR)/var/rudder/inventories/incoming
 	mkdir -p $(DESTDIR)/var/rudder/inventories/accepted-nodes-updates
 	mkdir -p $(DESTDIR)/var/rudder/lib/ssl
+	mkdir -p $(DESTDIR)/var/rudder/lib/relay
 	mkdir -p $(DESTDIR)/var/rudder/reports/incoming
 	mkdir -p $(DESTDIR)/var/rudder/reports/failed
 	mkdir -p $(DESTDIR)/var/rudder/shared-files


### PR DESCRIPTION
https://issues.rudder.io/issues/16052