### PR TITLE
Fixes #16077: Rudder-pkg fails to build since subprocess.DEVNULL is undefined before python 3.3

### DIFF
--- a/relay/sources/rudder-pkg/lib/rudder-pkg/rudderPkgUtils.py
+++ b/relay/sources/rudder-pkg/lib/rudder-pkg/rudderPkgUtils.py
@@ -3,9 +3,13 @@ import distutils.spawn
 import logging.handlers
 from pprint import pprint
 from pkg_resources import parse_version
-from subprocess import Popen, PIPE, DEVNULL
 import fcntl, termios, struct, traceback
 
+try:
+    from subprocess import Popen, PIPE, DEVNULL
+except:
+    from subprocess import Popen, PIPE
+    DEVNULL = open(os.devnull, 'wb')
 try:
     import ConfigParser as configparser
 except Exception:


### PR DESCRIPTION
https://issues.rudder.io/issues/16077