### PR TITLE
Fixes #16294: Set HTTP reporting protocol by default on new rudder 6.0 installation

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
@@ -473,10 +473,10 @@ class LDAPBasedConfigService(
     case _ => SyslogUDP
   }
 
+  // default is HTTPS, in particular for ""
   private[this] implicit def toReportProtocol(p: RudderWebProperty): AgentReportingProtocol = p.value match {
-    case AgentReportingHTTPS.value => // value is TCP
-      AgentReportingHTTPS
-    case _ => AgentReportingSyslog
+    case AgentReportingSyslog.value => AgentReportingSyslog
+    case _                          => AgentReportingHTTPS
   }
 
   private[this] implicit def toOptionPolicyMode(p: RudderWebProperty): Option[PolicyMode] = {


### PR DESCRIPTION
https://issues.rudder.io/issues/16294