### PR TITLE
Fixes #16291: Deadlock when application starts

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -387,8 +387,8 @@ limitations under the License.
     <http4s-version>0.19.0</http4s-version>
     <shapeless-version>2.3.3</shapeless-version>
     <cats-effect-version>2.0.0</cats-effect-version>
-    <dev-zio-version>1.0.0-RC17</dev-zio-version>
-    <zio-cats-version>2.0.0.0-RC8</zio-cats-version>
+    <dev-zio-version>1.0.0-RC16</dev-zio-version>
+    <zio-cats-version>2.0.0.0-RC7</zio-cats-version>
 
     <!--
       Hack to make scalac jvm parameters like RAM configurable.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
@@ -69,6 +69,8 @@ import zio.syntax._
 import GitTechniqueReader._
 import com.normation.rudder.domain.logger.TechniqueReaderLoggerPure
 import org.eclipse.jgit.lib.Repository
+import com.github.ghik.silencer.silent
+
 
 /**
  *
@@ -199,7 +201,7 @@ class GitTechniqueReader(
                             )
                         }
     } yield res
-  ).flatMap(Ref.make(_)).runNow
+  ).flatMap(Ref.make(_)).runNow: @silent // inferred Any - yes, that's what we want
 
   private[this] val nextTechniquesInfoCache: Ref[(ObjectId,TechniquesInfo)] = {
     (for {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
@@ -47,6 +47,7 @@ import java.io.File
 import net.liftweb.common._
 
 import scala.collection.immutable.SortedMap
+import scala.collection.JavaConverters._
 import java.io.InputStream
 
 import org.eclipse.jgit.treewalk.TreeWalk
@@ -56,7 +57,6 @@ import scala.collection.mutable.{Map => MutMap}
 import com.normation.cfclerk.xmlparsers.TechniqueParser
 import com.normation.cfclerk.services._
 
-import scala.collection.JavaConverters._
 import org.eclipse.jgit.diff.DiffFormatter
 import org.eclipse.jgit.errors.MissingObjectException
 import org.eclipse.jgit.diff.DiffEntry.ChangeType
@@ -67,6 +67,8 @@ import com.normation.zio._
 import zio._
 import zio.syntax._
 import GitTechniqueReader._
+import com.normation.rudder.domain.logger.TechniqueReaderLoggerPure
+import org.eclipse.jgit.lib.Repository
 
 /**
  *
@@ -140,7 +142,6 @@ class GitTechniqueReader(
   // semaphore to have consistent read
   val semaphore = Semaphore.make(1).runNow
 
-
   //the path of the PT lib relative to the git repos
   //withtout leading and trailing /.
   val canonizedRelativePath = relativePathToGitRepos.flatMap { path =>
@@ -172,119 +173,151 @@ class GitTechniqueReader(
   //can not set private because of "outer ref cannot be checked" scalac bug
   private case class NoRootCategory(msg: String) extends Exception(msg)
 
-  private[this] var currentTechniquesInfoCache : TechniquesInfo = semaphore.withPermit(IOResult.effect {
-    val currentRevTree = revisionProvider.currentRevTreeId.runNow
-    try {
-      processRevTreeId(currentRevTree)
-    } catch {
-      case NoRootCategory(msg) =>
-        logger.error(s"The stored Git revision '${currentRevTree}' does not provide a root category.xml, which is mandatory. Error message was: ${msg}")
-        val newRevTreeId = revisionProvider.getAvailableRevTreeId.runNow
-        if(newRevTreeId != currentRevTree) {
-          logger.error(s"Trying to load last available revision of the technique library to unstuck the situation.")
-          revisionProvider.setCurrentRevTreeId(newRevTreeId).runNow
-          processRevTreeId(newRevTreeId)
-        } else {
-          sys.error("Please add a root category.xml and commit it before restarting Rudder.")
-        }
-      case e:MissingObjectException => //ah, that commit is not know on our repos
-        logger.error("The stored Git revision for the last version of the known Technique Library was not found in the local Git repository. " +
-            "That may happen if a commit was reverted, the Git repository was deleted and created again, or if LDAP datas where corrupted. Loading the last available Techique library version.")
-        val newRevTreeId = revisionProvider.getAvailableRevTreeId.runNow
-        revisionProvider.setCurrentRevTreeId(newRevTreeId).runNow
-        processRevTreeId(newRevTreeId)
-    }
-  }).runNow
+  private[this] val currentTechniquesInfoCache: Ref[TechniquesInfo] = semaphore.withPermit(
+    for {
+      currentRevTree <- revisionProvider.currentRevTreeId
+      db             <- repo.db
+      res            <- processRevTreeId(db, currentRevTree).catchAll {
+                          case err @ SystemError(m, NoRootCategory(msg)) =>
+                            for {
+                              _            <- TechniqueReaderLoggerPure.error(s"The stored Git revision '${currentRevTree}' does not provide a root category.xml, which is mandatory. Error message was: ${err.fullMsg}")
+                              newRevTreeId <- revisionProvider.getAvailableRevTreeId
+                              res <- if(newRevTreeId != currentRevTree) {
+                                        TechniqueReaderLoggerPure.error(s"Trying to load last available revision of the technique library to unstuck the situation.") *>
+                                        revisionProvider.setCurrentRevTreeId(newRevTreeId) *>
+                                        processRevTreeId(db, newRevTreeId)
+                                      } else {
+                                        Inconsistancy("Please add a root category.xml and commit it before restarting Rudder.").fail
+                                      }
+                            } yield res
+                          case e:MissingObjectException => //ah, that commit is not know on our repos
+                            TechniqueReaderLoggerPure.error("The stored Git revision for the last version of the known Technique Library was not found in the local Git repository. " +
+                                "That may happen if a commit was reverted, the Git repository was deleted and created again, or if LDAP datas where corrupted. Loading the last available Techique library version.") *>
+                            revisionProvider.getAvailableRevTreeId.flatMap(newRevTreeId =>
+                              revisionProvider.setCurrentRevTreeId(newRevTreeId) *>
+                              processRevTreeId(db, newRevTreeId)
+                            )
+                        }
+    } yield res
+  ).flatMap(Ref.make(_)).runNow
 
-  private[this] var nextTechniquesInfoCache : (ObjectId,TechniquesInfo) = (revisionProvider.currentRevTreeId.runNow, currentTechniquesInfoCache)
+  private[this] val nextTechniquesInfoCache: Ref[(ObjectId,TechniquesInfo)] = {
+    (for {
+      a <- revisionProvider.currentRevTreeId
+      b <- currentTechniquesInfoCache.get
+      r <- Ref.make((a, b))
+    } yield r).runNow
+  }
+
   //a non empty list IS the indicator of differences between current and next
-  private[this] var modifiedTechniquesCache : Map[TechniqueName, TechniquesLibraryUpdateType] = Map()
+  private[this] val modifiedTechniquesCache: Ref[Map[TechniqueName, TechniquesLibraryUpdateType]] = Ref.make(Map[TechniqueName, TechniquesLibraryUpdateType]()).runNow
 
   override def getModifiedTechniques : Map[TechniqueName, TechniquesLibraryUpdateType] = {
-    val nextId = revisionProvider.getAvailableRevTreeId.runNow
-      if(nextId == nextTechniquesInfoCache._1) modifiedTechniquesCache
-      else semaphore.withPermit(IOResult.effect { //update next and calculate diffs
-        val nextTechniquesInfo = processRevTreeId(nextId)
 
-        //get the list of ALL valid package infos, both in current and in next version,
-        //so we have both deleted package (from current) and new one (from next)
-        val allKnownTechniquePaths = getTechniquePath(currentTechniquesInfoCache) ++ getTechniquePath(nextTechniquesInfo)
+    def buildTechniqueMods(
+        diffPathEntries      : Set[(TechniquePath, ChangeType)]
+      , currentTechniquesInfo: TechniquesInfo
+      , nextTechniquesInfo   : TechniquesInfo
+    ): Map[TechniqueName, TechniquesLibraryUpdateType] = {
+      //get the list of ALL valid package infos, both in current and in next version,
+      //so we have both deleted package (from current) and new one (from next)
+      val allKnownTechniquePaths = getTechniquePath(currentTechniquesInfo) ++ getTechniquePath(nextTechniquesInfo)
 
-        val diffFmt = new DiffFormatter(null)
-        diffFmt.setRepository(repo.db.runNow)
-        val diffPathEntries : Set[(TechniquePath, ChangeType)] =
-          diffFmt.scan(nextTechniquesInfoCache._1, nextId).asScala.flatMap { diffEntry =>
-            Seq( (toTechniquePath(diffEntry.getOldPath), diffEntry.getChangeType), (toTechniquePath(diffEntry.getNewPath), diffEntry.getChangeType))
-          }.toSet
-        diffFmt.close
-
-        /*
-         * now, group diff entries by TechniqueId to find which were updated
-         * we take into account any modifications, as anything among a
-         * delete, rename, copy, add, modify must be accepted and the matching
-         * datetime saved.
-         */
-        val modifiedTechnique : Set[(TechniqueId, ChangeType)] = diffPathEntries.flatMap { case (path, changeType) =>
-          allKnownTechniquePaths.find { case (techniquePath, _) =>
-            path.path.startsWith(techniquePath.path)
-          }.map { case (n, techniqueId) =>
-            (techniqueId, changeType)
-          }
+      /*
+       * now, group diff entries by TechniqueId to find which were updated
+       * we take into account any modifications, as anything among a
+       * delete, rename, copy, add, modify must be accepted and the matching
+       * datetime saved.
+       */
+      val modifiedTechnique : Set[(TechniqueId, ChangeType)] = diffPathEntries.flatMap { case (path, changeType) =>
+        allKnownTechniquePaths.find { case (techniquePath, _) =>
+          path.path.startsWith(techniquePath.path)
+        }.map { case (n, techniqueId) =>
+          (techniqueId, changeType)
         }
+      }
 
-        //now, build the actual modification by techniques:
-        val techniqueMods = modifiedTechnique.groupBy( _._1.name ).map { case (name, mods) =>
-          //deduplicate mods by ids:
-          val versionsMods: Map[TechniqueVersion, TechniqueVersionModType] = mods.groupBy( _._1.version).map { case(version, pairs) =>
-            val modTypes = pairs.map( _._2 ).toSet
+      //now, build the actual modification by techniques:
+      modifiedTechnique.groupBy( _._1.name ).map { case (name, mods) =>
+        //deduplicate mods by ids:
+        val versionsMods: Map[TechniqueVersion, TechniqueVersionModType] = mods.groupBy( _._1.version).map { case(version, pairs) =>
+          val modTypes = pairs.map( _._2 ).toSet
 
-            //merge logic
-            //delete + add (+mod) => have to check if still present
-            //delete (+ mod) => delete
-            //add (+ mod) => add
-            //other: mod
-            if(modTypes.contains(ChangeType.DELETE)) {
-              if(modTypes.contains(ChangeType.ADD)) {
-                if(currentTechniquesInfoCache.techniquesCategory.isDefinedAt(TechniqueId(name, version))) {
-                  //it was present before mod, so can't have been added first, so
-                  //it was deleted then added (certainly a move), so it is actually mod
-                  (version, VersionUpdated)
-                } else {
-                  //it was not here, so was added then deleted, so it's a noop.
-                  //not sure we want to trace that ? As a deletion perhaps ?
-                  (version, VersionDeleted)
-                }
+          //merge logic
+          //delete + add (+mod) => have to check if still present
+          //delete (+ mod) => delete
+          //add (+ mod) => add
+          //other: mod
+          if(modTypes.contains(ChangeType.DELETE)) {
+            if(modTypes.contains(ChangeType.ADD)) {
+              if(currentTechniquesInfo.techniquesCategory.isDefinedAt(TechniqueId(name, version))) {
+                //it was present before mod, so can't have been added first, so
+                //it was deleted then added (certainly a move), so it is actually mod
+                (version, VersionUpdated)
               } else {
+                //it was not here, so was added then deleted, so it's a noop.
+                //not sure we want to trace that ? As a deletion perhaps ?
                 (version, VersionDeleted)
               }
-            } else if(modTypes.contains(ChangeType.ADD)) {
-              //add
-              (version, VersionAdded)
             } else {
-              //mod
-              (version, VersionUpdated)
+              (version, VersionDeleted)
             }
-          }.toMap
-
-          //now, build the technique mod.
-          //distinguish the case where all mod are deletion AND they represent the whole set of known version
-          //from other case (just simple updates)
-
-          if(versionsMods.values.forall( _ == VersionDeleted)
-             && currentTechniquesInfoCache.techniques.get(name).map( _.size) == Some(versionsMods.size)
-          ) {
-            (name, TechniqueDeleted(name, versionsMods.keySet))
+          } else if(modTypes.contains(ChangeType.ADD)) {
+            //add
+            (version, VersionAdded)
           } else {
-            (name, TechniqueUpdated(name, versionsMods))
+            //mod
+            (version, VersionUpdated)
           }
         }.toMap
 
-        //Ok, now rebuild Technique !
-        modifiedTechniquesCache = techniqueMods
-        nextTechniquesInfoCache = (nextId, nextTechniquesInfo)
-        modifiedTechniquesCache
-      }).runNow
+        //now, build the technique mod.
+        //distinguish the case where all mod are deletion AND they represent the whole set of known version
+        //from other case (just simple updates)
+
+        if(versionsMods.values.forall( _ == VersionDeleted)
+           && currentTechniquesInfo.techniques.get(name).map( _.size) == Some(versionsMods.size)
+        ) {
+          (name, TechniqueDeleted(name, versionsMods.keySet))
+        } else {
+          (name, TechniqueUpdated(name, versionsMods))
+        }
+      }.toMap
     }
+
+    (for {
+      nextId   <- revisionProvider.getAvailableRevTreeId
+      cached   <- nextTechniquesInfoCache.get
+      db       <- repo.db
+      mods     <- if(nextId == cached._1) modifiedTechniquesCache.get
+                  else for {
+                    nextTechniquesInfo <- processRevTreeId(db, nextId)
+                    managedDiffFmt     =  ZManaged.make(IOResult.effect{
+                                            val diffFmt = new DiffFormatter(null)
+                                            diffFmt.setRepository(db)
+                                            diffFmt
+                                          })(diffFmt => effectUioUnit(diffFmt.close))
+                    diffPathEntries    <- managedDiffFmt.use(diffFmt => IOResult.effect {
+                                            diffFmt.scan(cached._1, nextId).asScala.flatMap { diffEntry =>
+                                              Seq( (toTechniquePath(diffEntry.getOldPath), diffEntry.getChangeType), (toTechniquePath(diffEntry.getNewPath), diffEntry.getChangeType))
+                                            }.toSet
+                                          })
+                    next               <- processRevTreeId(db, nextId)
+                    mods               =  buildTechniqueMods(diffPathEntries, cached._2, next)
+                    nextCache          =  (nextId, next)
+                    _                  <- semaphore.withPermit(
+                                            modifiedTechniquesCache.set(mods) *> nextTechniquesInfoCache.set(nextCache)
+                                          )
+                  } yield mods
+    } yield {
+      mods
+    }).runNow
+  }
+
+  private[this] final def getDBAndCurrentId() = (for {
+        a <- repo.db
+        b <- revisionProvider.currentRevTreeId
+      } yield (a, b)).runNow
 
   override def getMetadataContent[T](techniqueId: TechniqueId)(useIt : Option[InputStream] => T) : T = {
     //build a treewalk with the path, given by metadata.xml
@@ -294,12 +327,13 @@ class GitTechniqueReader(
 
     var is : InputStream = null
     try {
+      val (db, currentId) = getDBAndCurrentId()
       useIt {
         //now, the treeWalk
-        val tw = new TreeWalk(repo.db.runNow)
+        val tw = new TreeWalk(db)
         tw.setFilter(new FileTreeFilter(canonizedRelativePath, path))
         tw.setRecursive(true)
-        tw.reset(revisionProvider.currentRevTreeId.runNow)
+        tw.reset(currentId)
         var ids = List.empty[ObjectId]
         while(tw.next) {
           ids = tw.getObjectId(0) :: ids
@@ -309,7 +343,7 @@ class GitTechniqueReader(
             logger.error("Metadata file %s was not found for technique with id %s.".format(techniqueDescriptorName, techniqueId))
             None
           case h :: Nil =>
-            is = repo.db.runNow.open(h).openStream
+            is = db.open(h).openStream
             Some(is)
           case _ =>
             logger.error(s"There is more than one Technique with ID '${techniqueId}', what is forbidden. Please check if several categories have that Technique, and rename or delete the clones.")
@@ -345,12 +379,13 @@ class GitTechniqueReader(
 
     var is : InputStream = null
     try {
+      val (db, currentId) = getDBAndCurrentId()
       useIt {
         //now, the treeWalk
-        val tw = new TreeWalk(repo.db.runNow)
+        val tw = new TreeWalk(db)
         tw.setFilter(filenameFilter)
         tw.setRecursive(true)
-        tw.reset(revisionProvider.currentRevTreeId.runNow)
+        tw.reset(currentId)
         var ids = List.empty[ObjectId]
         while(tw.next) {
           ids = tw.getObjectId(0) :: ids
@@ -360,7 +395,7 @@ class GitTechniqueReader(
             logger.error(s"Template with id ${techniqueResourceId.toString} was not found")
             None
           case h :: Nil =>
-            is = repo.db.runNow.open(h).openStream
+            is = db.open(h).openStream
             Some(is)
           case _ =>
             logger.error(s"There is more than one Technique with name '${techniqueResourceId.name}' which is forbidden. Please check if several categories have that Technique and rename or delete the clones")
@@ -386,20 +421,35 @@ class GitTechniqueReader(
    * commit were done in git repository.
    */
   override def readTechniques : TechniquesInfo = {
-    semaphore.withPermit(IOResult.effect {
-      if(needReload) {
-        currentTechniquesInfoCache = nextTechniquesInfoCache._2
-        revisionProvider.setCurrentRevTreeId(nextTechniquesInfoCache._1).runNow
-        modifiedTechniquesCache = Map()
+    semaphore.withPermit(
+      for {
+        needed <- needReloadPure
+        info   <- if(needed) {
+                    for {
+                      next <- nextTechniquesInfoCache.get
+                      _    <- currentTechniquesInfoCache.set(next._2)
+                      _    <- revisionProvider.setCurrentRevTreeId(next._1)
+                      _    <- modifiedTechniquesCache.set(Map())
+                    } yield {
+                      next._2
+                    }
+                  } else {
+                    currentTechniquesInfoCache.get
+                  }
+      } yield {
+        info
       }
-      currentTechniquesInfoCache
-    }).runNow
+    ).runNow
   }
 
+  private[this] def needReloadPure = for {
+    nextId  <- revisionProvider.currentRevTreeId
+    cache   <- nextTechniquesInfoCache.get
+  } yield nextId != cache._1
 
-  override def needReload() = revisionProvider.currentRevTreeId.runNow != nextTechniquesInfoCache._1
+  override def needReload() = needReloadPure.runNow
 
-  private[this] def processRevTreeId(id:ObjectId, parseDescriptor:Boolean = true) : TechniquesInfo = {
+  private[this] def processRevTreeId(db: Repository, id: ObjectId, parseDescriptor: Boolean = true) : IOResult[TechniquesInfo] = {
     /*
      * Global process : the logic is completly different
      * from a standard "directory then subdirectoies" walk, because
@@ -423,29 +473,35 @@ class GitTechniqueReader(
      * - we are always looking for a category
      * - and so we have to found the matching catId in the category map.
      */
-      val techniqueInfos = new InternalTechniquesInfo()
+
+    for {
+      techniqueInfosRef <- Ref.make(new InternalTechniquesInfo())
       //we only want path ending by a descriptor file
 
       //start to process all categories related information
-      processCategories(id,techniqueInfos, parseDescriptor)
+      _                 <- processCategories(db, id, techniqueInfosRef, parseDescriptor)
 
       //now, build techniques
-      processTechniques(id,techniqueInfos,parseDescriptor)
+      _                 <- processTechniques(db, id, techniqueInfosRef, parseDescriptor)
+      techniqueInfos    <- techniqueInfosRef.get
+      defaulName        <- IOResult.effect( processDirectiveDefaultName(db, id))
+    } yield {
 
       //ok, return the result in its immutable format
       TechniquesInfo(
-        rootCategory = techniqueInfos.rootCategory.get,
-        gitRevId = id.name(),
-        techniquesCategory = techniqueInfos.techniquesCategory.toMap,
-        techniques = techniqueInfos.techniques.map { case(k,v) => (k, SortedMap.empty[TechniqueVersion,Technique] ++ v)}.toMap,
-        subCategories = Map[SubTechniqueCategoryId, SubTechniqueCategory]() ++ techniqueInfos.subCategories,
-        processDirectiveDefaultName(id)
+          rootCategory       = techniqueInfos.rootCategory.get
+        , gitRevId           = id.name()
+        , techniquesCategory = techniqueInfos.techniquesCategory.toMap
+        , techniques         = techniqueInfos.techniques.map { case(k,v) => (k, SortedMap.empty[TechniqueVersion,Technique] ++ v)}.toMap
+        , subCategories      = Map[SubTechniqueCategoryId, SubTechniqueCategory]() ++ techniqueInfos.subCategories
+        , defaulName
       )
+    }
   }
 
-  private[this] def processDirectiveDefaultName(revTreeId: ObjectId) : Map[String, String] = {
+  private[this] def processDirectiveDefaultName(db: Repository, revTreeId: ObjectId) : Map[String, String] = {
       //a first walk to find categories
-      val tw = new TreeWalk(repo.db.runNow)
+      val tw = new TreeWalk(db)
       tw.setFilter(new FileTreeFilter(canonizedRelativePath, directiveDefaultName))
       tw.setRecursive(true)
       tw.reset(revTreeId)
@@ -459,7 +515,7 @@ class GitTechniqueReader(
         if(tw.getNameString == directiveDefaultName) {
           var is : InputStream = null
           try {
-            is = repo.db.runNow.open(tw.getObjectId(0)).openStream
+            is = db.open(tw.getObjectId(0)).openStream
             prop.load(is)
           } catch {
             case ex: Exception =>
@@ -479,80 +535,115 @@ class GitTechniqueReader(
 
   }
 
-  private[this] def processTechniques(revTreeId: ObjectId, techniqueInfos : InternalTechniquesInfo, parseDescriptor:Boolean) : Unit = {
+  private[this] def processTechniques(gitRepo: Repository, revTreeId: ObjectId, techniqueInfosRef: Ref[InternalTechniquesInfo], parseDescriptor: Boolean) : IOResult[Unit] = {
       //a first walk to find categories
-      val tw = new TreeWalk(repo.db.runNow)
+    val managed = ZManaged.make(IOResult.effect {
+      val tw = new TreeWalk(gitRepo)
       tw.setFilter(new FileTreeFilter(canonizedRelativePath, techniqueDescriptorName))
       tw.setRecursive(true)
       tw.reset(revTreeId)
+      tw
+    })(tw => effectUioUnit(tw.close()))
 
-      //now, for each potential path, look if the cat or policy
-      //is valid
-      while(tw.next) {
-        val path = toTechniquePath(tw.getPathString) //we will need it to build the category id
-        processTechnique(repo.db.runNow.open(tw.getObjectId(0)).openStream, path.path, techniqueInfos, parseDescriptor, revTreeId).either.runNow match {
-          case Left(err)  => logger.error(s"Error with technique at path: '${path.path}', it will be ignored. Error: ${err.fullMsg}")
-          case Right(()) => // ok
-        }
+    def rec(tw: TreeWalk): IOResult[Unit] = {
+      IOResult.effect(tw.next()).flatMap { hasNext =>
+        if(hasNext) {
+          val path = toTechniquePath(tw.getPathString) //we will need it to build the category id
+          val stream = ZManaged.make(IOResult.effect(gitRepo.open(tw.getObjectId(0)).openStream))(is => effectUioUnit(is.close()))
+          for {
+            _       <- processTechnique(stream, path.path, techniqueInfosRef, parseDescriptor, revTreeId).foldM(
+                           err => TechniqueReaderLoggerPure.error(s"Error with technique at path: '${path.path}', it will be ignored. Error: ${err.fullMsg}")
+                         , ok  => UIO.unit
+                       )
+            _       <- rec(tw)
+          } yield ()
+        } else UIO.unit
       }
+    }
+
+    managed.use(tw => rec(tw))
   }
 
 
-  private[this] def processCategories(revTreeId: ObjectId, techniqueInfos : InternalTechniquesInfo, parseDescriptor:Boolean) : Unit = {
-      //a first walk to find categories
-      val tw = new TreeWalk(repo.db.runNow)
+  private[this] def processCategories(db: Repository, revTreeId: ObjectId, infosRef: Ref[InternalTechniquesInfo], parseDescriptor: Boolean): IOResult[Unit] = {
+    //now, for each potential path, look if the cat or policy is valid
+    def recBuildCat(db: Repository, cats: Map[TechniqueCategoryId, TechniqueCategory], tw: TreeWalk): IOResult[Map[TechniqueCategoryId, TechniqueCategory]] = {
+      for {
+        hasNext <- IOResult.effect(tw.next())
+        res     <- if(hasNext) {
+                     for {
+                       id  <- IOResult.effect(tw.getObjectId(0))
+                       path = toTechniquePath(tw.getPathString) //we will need it to build the category id
+                       opt <- extractMaybeCategory(id, db, path.path, parseDescriptor).either
+                       res <- opt match {
+                                case Left(err)  =>
+                                  TechniqueReaderLoggerPure.error(s"Error with category at path: '${path.path}', it will be ignored. Error: ${err.fullMsg}") *>
+                                  recBuildCat(db, cats, tw)
+                                case Right(cat) =>
+                                  val updated = cats + (cat.id -> cat)
+                                  recBuildCat(db, updated, tw)
+                               }
+                     } yield {
+                       res
+                     }
+                   } else {
+                     cats.succeed
+                   }
+      } yield res
+    }
+
+    @scala.annotation.tailrec
+    def recBuildRoot(root: RootTechniqueCategory, techniqueInfos: InternalTechniquesInfo, subCategories: List[SubTechniqueCategoryId]): RootTechniqueCategory = {
+      subCategories match {
+        case Nil       => root
+        case h :: tail => h match {
+                            case sId @ SubTechniqueCategoryId(_, RootTechniqueCategoryId) => //update root
+                              recBuildRoot(root.copy( subCategoryIds = root.subCategoryIds + sId ), techniqueInfos, tail)
+                            case sId @ SubTechniqueCategoryId(_, pId: SubTechniqueCategoryId) =>
+                              val cat = techniqueInfos.subCategories(pId)
+                              techniqueInfos.subCategories(pId) = cat.copy( subCategoryIds = cat.subCategoryIds + sId )
+                              recBuildRoot(root, techniqueInfos, tail)
+                          }
+      }
+    }
+
+    //a first walk to find categories
+    val managed = ZManaged.make(IOResult.effect {
+      val tw = new TreeWalk(db)
       tw.setFilter(new FileTreeFilter(canonizedRelativePath, categoryDescriptorName))
       tw.setRecursive(true)
       tw.reset(revTreeId)
+      tw
+    })(tw => effectUioUnit(tw.close()))
 
-      val maybeCategories = MutMap[TechniqueCategoryId, TechniqueCategory]()
-
-      //now, for each potential path, look if the cat or policy
-      //is valid
-      while(tw.next) {
-        val path = toTechniquePath(tw.getPathString) //we will need it to build the category id
-        extractMaybeCategory(tw.getObjectId(0), path.path, parseDescriptor).either.runNow match {
-          case Left(err)  => logger.error(s"Error with category at path: '${path.path}', it will be ignored. Error: ${err.fullMsg}")
-          case Right(cat) => maybeCategories.update(cat.id, cat)
-        }
-      }
-
-      val toRemove = new collection.mutable.HashSet[SubTechniqueCategoryId]()
-      maybeCategories.foreach {
-        case (sId:SubTechniqueCategoryId,cat:SubTechniqueCategory) =>
-          recToRemove(sId,toRemove, maybeCategories)
-
-        case _ => //ignore
-      }
-
+    for {
+      cats            <- managed.use(tw => recBuildCat(db, Map(), tw))
+      toRemove        =  cats.flatMap {
+                           case (sId:SubTechniqueCategoryId,cat:SubTechniqueCategory) =>
+                             recToRemove(sId,Set[SubTechniqueCategoryId](), cats)
+                           case _ => Set[SubTechniqueCategoryId]()
+                         }
       //now, actually remove things
-      maybeCategories --= toRemove
-
+      maybeCategories =  cats -- toRemove
       //update techniqueInfos
-      techniqueInfos.subCategories ++= maybeCategories.collect { case (sId:SubTechniqueCategoryId, cat:SubTechniqueCategory) => (sId -> cat) }
-
-      var root = maybeCategories.get(RootTechniqueCategoryId) match {
-          case None =>
-            val path = repo.db.runNow.getWorkTree.getPath + canonizedRelativePath.map( "/" + _ + "/" + categoryDescriptorName).getOrElse("")
-            throw new NoRootCategory(s"Missing techniques root category in Git, expecting category descriptor for Git path: '${path}'")
-          case Some(sub:SubTechniqueCategory) =>
-            logger.error("Bad type for root category in the Technique Library. Please check the hierarchy of categories")
-            throw new NoRootCategory(s"Bad type for root category in the Technique Library, found: '${sub}'. Please check the hierarchy of categories")
-          case Some(r:RootTechniqueCategory) => r
-      }
-
-      //update subcategories
-      techniqueInfos.subCategories.toSeq.foreach {
-        case(sId@SubTechniqueCategoryId(_,RootTechniqueCategoryId) , _ ) => //update root
-          root = root.copy( subCategoryIds = root.subCategoryIds + sId )
-        case(sId@SubTechniqueCategoryId(_,pId:SubTechniqueCategoryId) , _ ) =>
-          val cat = techniqueInfos.subCategories(pId)
-          techniqueInfos.subCategories(pId) = cat.copy( subCategoryIds = cat.subCategoryIds + sId )
-      }
-
+      techniqueInfos  <- infosRef.get
+      _               =  techniqueInfos.subCategories ++= maybeCategories.collect { case (sId: SubTechniqueCategoryId, cat: SubTechniqueCategory) => (sId -> cat) }
+      root            <- maybeCategories.get(RootTechniqueCategoryId) match {
+                          case None =>
+                            val path = db.getWorkTree.getPath + canonizedRelativePath.map( "/" + _ + "/" + categoryDescriptorName).getOrElse("")
+                            SystemError("Error when processing techniques in configuration repository",
+                              NoRootCategory(s"Missing techniques root category in Git, expecting category descriptor for Git path: '${path}'")).fail
+                          case Some(sub:SubTechniqueCategory) =>
+                            TechniqueReaderLoggerPure.error("Bad type for root category in the Technique Library. Please check the hierarchy of categories") *>
+                            SystemError("Error when processing techniques in configuration repository",
+                              NoRootCategory(s"Bad type for root category in the Technique Library, found: '${sub}'. Please check the hierarchy of categories")).fail
+                          case Some(r: RootTechniqueCategory) => r.succeed
+                        }
+      updateRoot     =  recBuildRoot(root, techniqueInfos, techniqueInfos.subCategories.keySet.toList)
       //finally, update root !
-      techniqueInfos.rootCategory = Some(root)
-
+      _              =  techniqueInfos.rootCategory = Some(updateRoot)
+      _              <- infosRef.set(techniqueInfos)
+    } yield ()
   }
 
 
@@ -561,21 +652,19 @@ class GitTechniqueReader(
    */
   @scala.annotation.tailrec
   private[this] def recToRemove(
-      catId:SubTechniqueCategoryId
-    , toRemove:collection.mutable.HashSet[SubTechniqueCategoryId]
-    , maybeCategories: MutMap[TechniqueCategoryId, TechniqueCategory]
-  ) : Boolean = {
+      catId          : SubTechniqueCategoryId
+    , toRemove       : Set[SubTechniqueCategoryId]
+    , maybeCategories: Map[TechniqueCategoryId, TechniqueCategory]
+  ) : Set[SubTechniqueCategoryId] = {
       catId.parentId match {
-        case RootTechniqueCategoryId => false
+        case RootTechniqueCategoryId => toRemove
         case sId:SubTechniqueCategoryId =>
           if(toRemove.contains(sId)) {
-            toRemove += catId
-            true
+            toRemove + catId
           } else if(maybeCategories.isDefinedAt(sId)) {
             recToRemove(sId, toRemove, maybeCategories )
           } else {
-            toRemove += catId
-            true
+            toRemove + catId
           }
       }
   }
@@ -587,25 +676,25 @@ class GitTechniqueReader(
  )
 
   private[this] def processTechnique(
-      is             : InputStream
+      is             : ZManaged[Any, RudderError, InputStream]
     , filePath       : String
-    , techniquesInfo : InternalTechniquesInfo
+    , techniquesInfo : Ref[InternalTechniquesInfo]
     , parseDescriptor: Boolean // that option is a success optimization for the case diff between old/new commit
     , revTreeId      : ObjectId
   ): IOResult[Unit] = {
-    def updateParentCat(catId: TechniqueCategoryId, techniqueId: TechniqueId, descriptorFile: File) : Boolean = {
+    def updateParentCat(info: InternalTechniquesInfo, catId: TechniqueCategoryId, techniqueId: TechniqueId, descriptorFile: File) : Boolean = {
       catId match {
         case RootTechniqueCategoryId =>
-          val cat = techniquesInfo.rootCategory.getOrElse(
+          val cat = info.rootCategory.getOrElse(
               throw new RuntimeException(s"Can not find the parent (root) category '${descriptorFile.getParent}' for package '${techniqueId.toString()}'")
           )
-          techniquesInfo.rootCategory = Some(cat.copy(techniqueIds = cat.techniqueIds + techniqueId ))
+          info.rootCategory = Some(cat.copy(techniqueIds = cat.techniqueIds + techniqueId ))
           true
 
         case sid:SubTechniqueCategoryId =>
-          techniquesInfo.subCategories.get(sid) match {
+          info.subCategories.get(sid) match {
             case Some(cat) =>
-              techniquesInfo.subCategories(sid) = cat.copy(techniqueIds = cat.techniqueIds + techniqueId )
+              info.subCategories(sid) = cat.copy(techniqueIds = cat.techniqueIds + techniqueId )
               true
             case None =>
               logger.error(s"Can not find the parent (root) category '${descriptorFile.getParent}' for package '${techniqueId.toString()}'")
@@ -622,25 +711,26 @@ class GitTechniqueReader(
 
     for {
       pack <- if(parseDescriptor) loadDescriptorFile(is, filePath).flatMap(d => ZIO.fromEither(techniqueParser.parseXml(d, techniqueId)))
-                 else dummyTechnique.succeed
+              else dummyTechnique.succeed
+      info <- techniquesInfo.get
       res  <- Task.effect {
                 //check that that package is not already know, else its an error (by id ?)
-                techniquesInfo.techniques.get(techniqueId.name) match {
+                info.techniques.get(techniqueId.name) match {
                   case None => //so we don't have any version yet, and so no id
-                    if(updateParentCat(parentCategoryId, techniqueId, descriptorFile)) {
-                      techniquesInfo.techniques(techniqueId.name) = MutMap(techniqueId.version -> pack)
-                      techniquesInfo.techniquesCategory(techniqueId) = parentCategoryId
+                    if(updateParentCat(info,parentCategoryId, techniqueId, descriptorFile)) {
+                      info.techniques(techniqueId.name) = MutMap(techniqueId.version -> pack)
+                      info.techniquesCategory(techniqueId) = parentCategoryId
                     }
                   case Some(versionMap) => //check for the version
                     versionMap.get(techniqueId.version) match {
                       case None => //add that version
-                        if(updateParentCat(parentCategoryId, techniqueId, descriptorFile)) {
-                          techniquesInfo.techniques(techniqueId.name)(techniqueId.version) = pack
-                          techniquesInfo.techniquesCategory(techniqueId) = parentCategoryId
+                        if(updateParentCat(info, parentCategoryId, techniqueId, descriptorFile)) {
+                          info.techniques(techniqueId.name)(techniqueId.version) = pack
+                          info.techniquesCategory(techniqueId) = parentCategoryId
                         }
                       case Some(v) => //error, policy package version already exsits
                         logger.error("Ignoring package for policy with ID %s and root directory %s because an other policy is already defined with that id and root path %s".format(
-                            TechniqueId, descriptorFile.getParent, techniquesInfo.techniquesCategory(techniqueId).toString)
+                            TechniqueId, descriptorFile.getParent, info.techniquesCategory(techniqueId).toString)
                         )
                     }
                 }
@@ -649,7 +739,7 @@ class GitTechniqueReader(
                 case e : ConstraintException => s"Ignoring technique '${filePath}}' because the descriptor file is malformed. Error message was: ${e.getMessage}}".fail
                 case e : Exception => s"Error when processing technique '${filePath}}': ${e.getMessage}}".fail
               }
-              , ok => ok.succeed
+              , ok => techniquesInfo.set(info)
               )
     }yield {
       ()
@@ -669,6 +759,7 @@ class GitTechniqueReader(
    */
   private[this] def extractMaybeCategory(
       descriptorObjectId: ObjectId
+    , db                : Repository
     , filePath          : String
     , parseDescriptor   : Boolean // that option is a success optimization for the case diff between old/new commit
   ) : IOResult[TechniqueCategory] = {
@@ -679,11 +770,11 @@ class GitTechniqueReader(
         case _ => Some(s)
       }
     }
-    def parse(parseDesc:Boolean, catId: TechniqueCategoryId): IOResult[(String, String, Boolean)] = {
+    def parse(db: Repository, parseDesc:Boolean, catId: TechniqueCategoryId): IOResult[(String, String, Boolean)] = {
       if(parseDesc) {
+        val managedStream = ZManaged.make(IOResult.effect(db.open(descriptorObjectId).openStream))(is => effectUioUnit(is.close()))
         for {
-          db  <- repo.db
-          xml <- loadDescriptorFile(repo.db.runNow.open(descriptorObjectId).openStream, filePath)
+          xml <- loadDescriptorFile(managedStream, filePath)
         } yield {
           val name = nonEmpty((xml \\ "name").text).getOrElse(catId.name.value)
           val description = nonEmpty((xml \\ "description").text).getOrElse("")
@@ -700,7 +791,7 @@ class GitTechniqueReader(
     val catId = TechniqueCategoryId.buildId(catPath)
     //built the category
     for {
-      triple <- parse(parseDescriptor, catId)
+      triple <- parse(db, parseDescriptor, catId)
     } yield {
       val (name, desc, system ) = triple
       catId match {
@@ -712,23 +803,23 @@ class GitTechniqueReader(
 
   /**
    * Load a descriptor document.
-   * @param file : the full filename
-   * @return the xml representation of the file
    */
-  private[this] def loadDescriptorFile(is: InputStream, filePath : String ) : IOResult[Elem] = {
-    Task.effect {
-      XML.load(is)
-    }.foldM(
-      err => err match {
-        case e: SAXParseException =>
-          LoadTechniqueError.Parsing(s"Unexpected issue with the descriptor file '${filePath}' at line ${e.getLineNumber}, column ${e.getColumnNumber}: ${e.getMessage}").fail
-        case e: java.net.MalformedURLException =>
-          LoadTechniqueError.Parsing("Descriptor file not found: " + filePath).fail
-        case ex => SystemError(s"Error when parsing ${filePath}", ex).fail
-      }
-    , doc => if(doc.isEmpty) {
-        LoadTechniqueError.Parsing(s"Error when parsing descriptor file: '${filePath}': the parsed document is empty").fail
-      } else doc.succeed
+  private[this] def loadDescriptorFile(managedStream: ZManaged[Any, RudderError, InputStream], filePath : String ) : IOResult[Elem] = {
+    managedStream.use(is =>
+      Task.effect {
+        XML.load(is)
+      }.foldM(
+        err => err match {
+          case e: SAXParseException =>
+            LoadTechniqueError.Parsing(s"Unexpected issue with the descriptor file '${filePath}' at line ${e.getLineNumber}, column ${e.getColumnNumber}: ${e.getMessage}").fail
+          case e: java.net.MalformedURLException =>
+            LoadTechniqueError.Parsing("Descriptor file not found: " + filePath).fail
+          case ex => SystemError(s"Error when parsing ${filePath}", ex).fail
+        }
+      , doc => if(doc.isEmpty) {
+          LoadTechniqueError.Parsing(s"Error when parsing descriptor file: '${filePath}': the parsed document is empty").fail
+        } else doc.succeed
+      )
     )
   }
 
@@ -740,7 +831,7 @@ class GitTechniqueReader(
    * As we may have files&templates outside technique, we
    * need to keep track of there relative id
    */
-  private[this] def getTechniquePath(techniqueInfos:TechniquesInfo) : Set[(TechniquePath, TechniqueId)] = {
+  private[this] def getTechniquePath(techniqueInfos: TechniquesInfo) : Set[(TechniquePath, TechniqueId)] = {
     val set = scala.collection.mutable.Set[(TechniquePath, TechniqueId)]()
     techniqueInfos.rootCategory.techniqueIds.foreach { id =>
       set += ((TechniquePath( "/" + id.toString), id))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportsCleaner.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportsCleaner.scala
@@ -401,7 +401,7 @@ class AutomaticReportsCleaning(
                  }
                ).catchAll(error =>
                  ReportLoggerPure.error(s"Error when trying to clean log reports from report table: ${error.fullMsg}")
-               ).delay(dur).repeat(Schedule.spaced(dur).forever).fork
+               ).delay(dur).repeat(ZSchedule.spaced(dur).forever).fork
               }
   } yield ()).provide(ZioRuntime.environment).runNow
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/CheckInventoryUpdate.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/CheckInventoryUpdate.scala
@@ -76,6 +76,6 @@ class CheckInventoryUpdate(
       IOResult.effectNonBlocking(asyncDeploymentAgent ! ManualStartDeployment(ModificationId(uuidGen.newUuid), RudderEventActor, "Main inventory information of at least one node were updated"))
   }.catchAll(err => logger.error(s"Error when trying to update node inventories information. Error is: ${err.fullMsg}"))
 
-  ZioRuntime.unsafeRun(prog.delay(30.seconds).repeat(Schedule.spaced(updateInterval)).provide(ZioRuntime.environment).fork)
+  ZioRuntime.unsafeRun(prog.delay(30.seconds).repeat(ZSchedule.spaced(updateInterval)).provide(ZioRuntime.environment).fork)
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeDeletedInventories.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeDeletedInventories.scala
@@ -78,7 +78,7 @@ class PurgeDeletedInventories(
           ScheduledJobLoggerPure.error(error.fullMsg)
       })
       import zio.duration.Duration.{fromScala => zduration}
-      ZioRuntime.unsafeRun(prog.delay(zduration(updateInterval)).repeat(Schedule.spaced(zduration(updateInterval))).provide(ZioRuntime.environment).fork)
+      ZioRuntime.unsafeRun(prog.delay(zduration(updateInterval)).repeat(ZSchedule.spaced(zduration(updateInterval))).provide(ZioRuntime.environment).fork)
     }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeUnreferencedSoftwares.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeUnreferencedSoftwares.scala
@@ -72,7 +72,7 @@ class PurgeUnreferencedSoftwares(
     }}
 
     import zio.duration.Duration.{fromScala => zduration}
-    ZioRuntime.unsafeRun(prog.delay(zduration(1.hour)).repeat(Schedule.spaced(zduration(updateInterval))).provide(ZioRuntime.environment).fork)
+    ZioRuntime.unsafeRun(prog.delay(zduration(1.hour)).repeat(ZSchedule.spaced(zduration(updateInterval))).provide(ZioRuntime.environment).fork)
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
@@ -75,7 +75,7 @@ class Doobie(datasource: DataSource) {
   // we must not leak catsIO anywhere
   private[this] def transact[T](query: Transactor[Task] => Task[T]): Task[T] = {
     val xa = ZManaged.make {
-      val ce = ZioRuntime.internal.platform.executor.asEC // our connect EC
+      val ce = ZioRuntime.internal.Platform.executor.asEC // our connect EC
       for {
         te <- zio.blocking.blockingExecutor.map(_.asEC)  // our transaction EC
       } yield {
@@ -95,7 +95,7 @@ class Doobie(datasource: DataSource) {
   }
 
   def transactRun[T](query: Transactor[Task] => Task[T]): T = {
-    ZioRuntime.unsafeRun(zio.blocking.blockingExecutor.flatMap(ex => transactTask(query).lock(ex)).provide(ZioRuntime.environment))
+    ZioRuntime.unsafeRun(transactTask(query))
   }
 
   def transactRunBox[T](q: Transactor[Task] => Task[T]): Box[T] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
@@ -55,12 +55,14 @@ import scala.language.implicitConversions
 import doobie.postgres.implicits._ // it is necessary whatever intellij/scalac tells
 import doobie._
 import cats.data._
-import cats.effect._
+import cats.effect.{IO => _, _}
 import doobie._
 
-import zio.Task
+import zio._
 import zio.interop.catz._
 import com.normation.errors._
+import com.normation.zio._
+import com.normation.box._
 
 /**
  *
@@ -70,34 +72,34 @@ import com.normation.errors._
  */
 class Doobie(datasource: DataSource) {
 
-  def transact[T](query: Transactor[IO] => IO[T]): IO[T] = {
-    implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
-    val xa: Resource[IO, DataSourceTransactor[IO]] = {
+  // we must not leak catsIO anywhere
+  private[this] def transact[T](query: Transactor[Task] => Task[T]): Task[T] = {
+    val xa = ZManaged.make {
+      val ce = ZioRuntime.internal.platform.executor.asEC // our connect EC
       for {
-        ce <- ExecutionContexts.fixedThreadPool[IO](32) // our connect EC
-        te <- ExecutionContexts.cachedThreadPool[IO]    // our transaction EC
+        te <- zio.blocking.blockingExecutor.map(_.asEC)  // our transaction EC
       } yield {
-        Transactor.fromDataSource[IO](datasource, ce, Blocker.liftExecutionContext(te))
+        Transactor.fromDataSource[Task](datasource, ce, Blocker.liftExecutionContext(te))
       }
-    }
+    }(_ => effectUioUnit(())).provide(ZioRuntime.environment)
+
     xa.use(xa => query(xa))
   }
 
-  def transactTask[T](query: Transactor[IO] => IO[T]): Task[T] = {
-    transact(query).to[Task]
+  def transactTask[T](query: Transactor[Task] => Task[T]): Task[T] = {
+    transact(query)
   }
 
-  def transactIOResult[T](errorMsg: String)(query: Transactor[IO] => IO[T]): IOResult[T] = {
-    transact(query).to[Task].mapError(ex => SystemError(errorMsg, ex))
+  def transactIOResult[T](errorMsg: String)(query: Transactor[Task] => Task[T]): IOResult[T] = {
+    transact(query).mapError(ex => SystemError(errorMsg, ex))
   }
 
-  def transactRun[T](query: Transactor[IO] => IO[T]): T = {
-    transact(query).unsafeRunSync()
+  def transactRun[T](query: Transactor[Task] => Task[T]): T = {
+    ZioRuntime.unsafeRun(zio.blocking.blockingExecutor.flatMap(ex => transactTask(query).lock(ex)).provide(ZioRuntime.environment))
   }
 
-  def transactRunBox[T](q: Transactor[IO] => IO[T]): Box[T] = {
-    import Doobie._
-    transact(q).attempt.unsafeRunSync()
+  def transactRunBox[T](q: Transactor[Task] => Task[T]): Box[T] = {
+    transactIOResult("Error running doobie transaction")(q).toBox
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
@@ -97,3 +97,7 @@ object JsDirectiveParamLoggerPure extends NamedZioLogger {
 object GenerationLoggerPure extends NamedZioLogger {
   def loggerName = "policy-generation"
 }
+
+object TechniqueReaderLoggerPure extends NamedZioLogger {
+  def loggerName = "techniques.reader"
+}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/PolicyLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/PolicyLogger.scala
@@ -60,8 +60,12 @@ object PolicyLoggerPure extends NamedZioLogger {
 }
 
 
-object GitArchiveLogger extends NamedZioLogger {
+object GitArchiveLoggerPure extends NamedZioLogger {
   override def loggerName: String = "git-policy-archive"
+}
+
+object GitArchiveLogger extends Logger {
+  override protected def _logger = LoggerFactory.getLogger("git-policy-archive")
 }
 
 object ComplianceLogger extends Logger {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
@@ -47,10 +47,8 @@ import com.normation.inventory.domain.CertifiedKey
 import com.normation.inventory.domain.InventoryLogger
 import com.normation.inventory.domain.InventoryReport
 import com.normation.errors._
-import com.normation.inventory.domain.KeyStatus
 import com.normation.inventory.domain.NodeId
 import com.normation.inventory.domain.SecurityToken
-import com.normation.inventory.domain.UndefinedKey
 import com.normation.inventory.ldap.core.InventoryDit
 import com.normation.inventory.services.core.FullInventoryRepository
 import com.normation.inventory.services.provisioning.InventoryDigestServiceV1
@@ -171,23 +169,6 @@ class InventoryProcessor(
            }
         }
       }
-    }
-
-    /*
-     * This method used to allow acceptation of nodes without signature. We will remove it in a futur
-     * minor of Rudder 6.0 if nothing blocking is found with mandatory signatures in all cases.
-     */
-    def saveNoSignature(report: InventoryReport, keyStatus: KeyStatus): IOResult[InventoryProcessStatus] = {
-      // Check if we need a signature or not
-      (keyStatus match {
-        // Status is undefined => We accept unsigned inventory
-        case UndefinedKey => checkQueueAndSave(report)
-        // We are in certified state, refuse inventory with no signature
-        case CertifiedKey => InventoryProcessStatus.MissingSignature(report.name, report.node.main.id).succeed
-      }).chainError(
-        // An error occurred while checking inventory key status
-        s"Error when trying to check inventory key status for Node '${report.node.main.id.value}'"
-      )
     }
 
     def parseSafe(newInventoryStream: () => InputStream, inventoryFileName: String): IOResult[InventoryReport] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/migration/XmlEntityMigration.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/migration/XmlEntityMigration.scala
@@ -18,7 +18,7 @@ import com.normation.rudder.db.Doobie
 import com.normation.rudder.db.Doobie._
 import doobie._, doobie.implicits._
 import cats.implicits._
-
+import zio.interop.catz._
 
 /**
  * specify from/to version
@@ -359,7 +359,7 @@ trait BatchElementMigration[T <: MigrableEntity] extends XmlFileFormatMigration 
         saved
       })
 
-      val res = doobie.transactRun(xa => exec.transact(xa).attempt)
+      val res = doobie.transactRun(xa => exec.transact(xa).either)
 
       res match {
         case Right(k) if(k.size < 1) =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/LastProcessedReportRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/LastProcessedReportRepository.scala
@@ -47,6 +47,7 @@ import org.joda.time.DateTime
 import net.liftweb.common._
 import com.normation.rudder.db.Doobie
 import com.normation.rudder.db.Doobie._
+import zio.interop.catz._
 
 
 /**
@@ -79,7 +80,7 @@ class LastProcessedReportRepositoryImpl (
         select lastid, date from statusupdate where key=${PROP_EXECUTION_STATUS}
       """.query[(Long, DateTime)].option
 
-    transactRun(xa => sql.transact(xa).attempt) match {
+    transactRun(xa => sql.transact(xa).either) match {
       case Right(x)  => Full(x)
       case Left(ex) => Failure(s"Error when retrieving '${PROP_EXECUTION_STATUS}' from db: ${ex.getMessage}", Full(ex), Empty)
     }
@@ -107,7 +108,7 @@ class LastProcessedReportRepositoryImpl (
                      }
     } yield {
       entry
-    }).transact(xa).attempt) match {
+    }).transact(xa).either) match {
       case Right(x) => Full(DB.StatusUpdate(PROP_EXECUTION_STATUS, newId, reportsDate))
       case Left(ex) => Failure(s"Error when retrieving '${PROP_EXECUTION_STATUS}' from db: ${ex.getMessage}", Full(ex), Empty)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
@@ -53,6 +53,7 @@ import com.normation.rudder.domain.reports.RunComplianceInfo
 import com.normation.rudder.domain.reports.AggregatedStatusReport
 import com.normation.rudder.domain.reports.ComplianceLevel
 import com.normation.rudder.domain.reports.CompliancePercent
+import zio.interop.catz._
 
 
 final case class RunCompliance(
@@ -174,7 +175,7 @@ class ComplianceJdbcRepository(
     } yield {
       val saved = runCompliances.map(_.nodeId)
       reports.filter(r => saved.contains(r.nodeId))
-    }).transact(xa).attempt)
+    }).transact(xa).either)
 
     res match {
       case Right(_) => // ok

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/EventLogJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/EventLogJdbcRepository.scala
@@ -54,6 +54,7 @@ import com.normation.rudder.db.Doobie
 
 import com.normation.errors._
 import zio.syntax._
+import zio.interop.catz._
 
 /**
  * The EventLog repository

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ExpectedReportsJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ExpectedReportsJdbcRepository.scala
@@ -56,6 +56,7 @@ import com.normation.rudder.domain.logger.PolicyLogger
 import com.normation.rudder.domain.logger.ReportLogger
 import com.normation.utils.Control.sequence
 import doobie.free.connection
+import zio.interop.catz._
 
 class PostgresqlInClause(
     //max number of element to switch from in (...) to in(values(...)) clause
@@ -252,7 +253,7 @@ class UpdateExpectedReportsJdbcRepository(
                            from nodeconfigurations
                            inner join tempnodeid on tempnodeid.id = nodeconfigurations.nodeid
                            where enddate is NULL"""
-            ).query[A].to[List].transact(xa).attempt)
+            ).query[A].to[List].transact(xa).either)
 
           type B = (NodeId, Vector[NodeConfigIdInfo])
           val getInfos: Either[Throwable, List[B]] = transactRun(xa => (
@@ -260,7 +261,7 @@ class UpdateExpectedReportsJdbcRepository(
                               select node_id, config_ids from nodes_info
                               inner join tempnodeid on tempnodeid.id = nodes_info.node_id
                             """
-            ).query[B].to[List].transact(xa).attempt)
+            ).query[B].to[List].transact(xa).either)
 
           val time_0 = System.currentTimeMillis
           for {
@@ -288,7 +289,7 @@ class UpdateExpectedReportsJdbcRepository(
 
         // Do the actual change
 
-        val res = resultingNodeExpectedReports.map(batch => transactRun(xa => batch.sequence.transact(xa).attempt))
+        val res = resultingNodeExpectedReports.map(batch => transactRun(xa => batch.sequence.transact(xa).either))
 
         res match {
           case Left(throwable) =>
@@ -405,7 +406,7 @@ class UpdateExpectedReportsJdbcRepository(
                  |]]""".stripMargin)
 
     (for {
-       i <- transactRun(xa => (copy :: delete :: Nil).traverse(q => Update0(q, None).run).transact(xa).attempt)
+       i <- transactRun(xa => (copy :: delete :: Nil).traverse(q => Update0(q, None).run).transact(xa).either)
     } yield {
        i
     }) match {
@@ -435,7 +436,7 @@ class UpdateExpectedReportsJdbcRepository(
                    |]]""".stripMargin)
 
     (for {
-      i <- transactRun(xa => (d1 :: d2 :: Nil).traverse(q => Update0(q, None).run).transact(xa).attempt)
+      i <- transactRun(xa => (d1 :: d2 :: Nil).traverse(q => Update0(q, None).run).transact(xa).either)
     } yield {
       i
     }) match  {
@@ -473,7 +474,7 @@ class UpdateExpectedReportsJdbcRepository(
                  |]]""".stripMargin)
 
     (for {
-       i <- transactRun(xa => (copy :: delete :: Nil).traverse(q => Update0(q, None).run).transact(xa).attempt)
+       i <- transactRun(xa => (copy :: delete :: Nil).traverse(q => Update0(q, None).run).transact(xa).either)
     } yield {
        i
     }) match {
@@ -503,7 +504,7 @@ class UpdateExpectedReportsJdbcRepository(
                    |]]""".stripMargin)
 
     (for {
-      i <- transactRun(xa => (d1 :: d2 :: Nil).traverse(q => Update0(q, None).run).transact(xa).attempt)
+      i <- transactRun(xa => (d1 :: d2 :: Nil).traverse(q => Update0(q, None).run).transact(xa).either)
     } yield {
       i
     }) match  {
@@ -530,7 +531,7 @@ class UpdateExpectedReportsJdbcRepository(
                    |]]""".stripMargin)
 
     (for {
-      i <- transactRun(xa => Update0(d1, None).run.transact(xa).attempt)
+      i <- transactRun(xa => Update0(d1, None).run.transact(xa).either)
     } yield {
       i
     }) match  {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/GitModificationRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/GitModificationRepository.scala
@@ -8,6 +8,7 @@ import com.normation.rudder.db.Doobie
 import com.normation.rudder.repository.GitCommitId
 import com.normation.rudder.repository.GitModificationRepository
 import doobie.implicits._
+import zio.interop.catz._
 
 class GitModificationRepositoryImpl(
     db : Doobie

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/RudderPropertiesRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/RudderPropertiesRepository.scala
@@ -43,6 +43,7 @@ import cats.implicits._
 import net.liftweb.common._
 import com.normation.rudder.repository.RudderPropertiesRepository
 import com.normation.rudder.db.Doobie
+import zio.interop.catz._
 
 class RudderPropertiesRepositoryImpl(
      db: Doobie
@@ -59,7 +60,7 @@ class RudderPropertiesRepositoryImpl(
   def getReportLoggerLastId: Box[Long] = {
 
     val sql = sql"select value from rudderproperties where name=${PROP_REPORT_LAST_ID}".query[Long].option
-    transactRun(xa => sql.transact(xa).attempt) match {
+    transactRun(xa => sql.transact(xa).either) match {
       case Right(None) =>
           Empty
       case Right(Some(x)) =>
@@ -97,7 +98,7 @@ class RudderPropertiesRepositoryImpl(
       result
     }
 
-    transactRun(xa => sql.transact(xa).attempt) match {
+    transactRun(xa => sql.transact(xa).either) match {
       case Right(x) => Full(newId)
       case Left(ex) => Failure(s"could not update lastId from database, cause is: ${ex.getMessage}", Full(ex), Empty)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchiverUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchiverUtils.scala
@@ -112,7 +112,7 @@ trait GitArchiverUtils {
       case Right(dir) => dir
       case Left(err) =>
         val msg = s"Error when checking required directories '${file.getPath}' to archive in git: ${err.fullMsg}"
-        GitArchiveLoggerPure.logEffect.error(msg)
+        GitArchiveLogger.error(msg)
         throw new IllegalArgumentException(msg)
     }
   }
@@ -211,7 +211,7 @@ trait GitArchiverUtils {
   def writeXml(fileName:File, elem:Elem, logMessage:String) : IOResult[File] = {
     IOResult.effect {
       FileUtils.writeStringToFile(fileName, xmlPrettyPrinter.format(elem), encoding)
-      GitArchiveLoggerPure.logEffect.debug(logMessage)
+      GitArchiveLogger.debug(logMessage)
       fileName
     }
   }
@@ -278,7 +278,7 @@ trait GitArchiverFullCommitUtils extends NamedZioLogger {
           // Store the commit the modification repository
           gitModificationRepository.addCommit(newCommitId, modId)
 
-          GitArchiveLoggerPure.debug("Restored commit %s at HEAD (commit %s)".format(commit.value,newCommitId.value))
+          GitArchiveLogger.debug("Restored commit %s at HEAD (commit %s)".format(commit.value,newCommitId.value))
           newCommitId
         }
       }
@@ -345,7 +345,7 @@ trait GitArchiverFullCommitUtils extends NamedZioLogger {
               tags.append(tag)
             } catch {
               case e:IncorrectObjectTypeException =>
-                GitArchiveLoggerPure.logEffect.debug("Ignoring object due to JGit bug: " + ref.getName, e)
+                GitArchiveLogger.debug("Ignoring object due to JGit bug: " + ref.getName, e)
             }
           }
           tags.sortWith( (o1, o2) => o1.getTagName().compareTo(o2.getTagName()) <= 0 )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchiverUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchiverUtils.scala
@@ -44,17 +44,17 @@ import com.normation.cfclerk.services.GitRepositoryProvider
 import com.normation.errors._
 import com.normation.eventlog.ModificationId
 import com.normation.rudder.domain.logger.GitArchiveLogger
+import com.normation.rudder.domain.logger.GitArchiveLoggerPure
 import com.normation.rudder.repository._
-import com.normation.zio.ZioRuntime
 import org.apache.commons.io.FileUtils
 import org.eclipse.jgit.lib.PersonIdent
 import org.eclipse.jgit.revwalk.RevTag
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import zio._
-import zio.syntax._
 
 import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
 import scala.xml.Elem
 
 /**
@@ -84,32 +84,35 @@ trait GitArchiverUtils {
 
   def newDateTimeTagString = (DateTime.now()).toString(ISODateTimeFormat.dateTime)
 
-  /**
-   * Create directory given in argument if does not exists, checking
-   * that it is writable.
-   */
-  def createDirectory(directory:File): IOResult[File] = {
-    IOResult.effectM(s"Exception when checking directory '${directory.getPath}'") {
-      if(directory.exists) {
-        if(directory.isDirectory) {
-          if(directory.canWrite) {
-            directory.succeed
-          } else Inconsistancy(s"The directory '${directory.getPath}' has no write permission, please use another directory").fail
-        } else Inconsistancy("File at '%s' is not a directory, please change configuration".format(directory.getPath)).fail
-      } else if(directory.mkdirs) {
-        GitArchiveLogger.debug(s"Creating missing directory '${directory.getPath}'") *>
-        directory.succeed
-      } else Inconsistancy(s"Directory '${directory.getPath}' does not exists and can not be created, please use another directory").fail
-    }
-  }
 
   lazy val getRootDirectory : File = {
+    /**
+     * Create directory given in argument if does not exists, checking
+     * that it is writable.
+     */
+    def createDirectory(directory:File): Either[RudderError, File] = {
+      try {
+        if(directory.exists) {
+          if(directory.isDirectory) {
+            if(directory.canWrite) {
+              Right(directory)
+            } else Left(Inconsistancy(s"The directory '${directory.getPath}' has no write permission, please use another directory"))
+          } else Left(Inconsistancy("File at '%s' is not a directory, please change configuration".format(directory.getPath)))
+        } else if(directory.mkdirs) {
+          GitArchiveLogger.debug(s"Creating missing directory '${directory.getPath}'")
+          Right(directory)
+        } else Left(Inconsistancy(s"Directory '${directory.getPath}' does not exists and can not be created, please use another directory"))
+      } catch {
+        case NonFatal(ex) => Left(SystemError(s"Exception when checking directory '${directory.getPath}'", ex))
+      }
+    }
+
     val file = new File(gitRootDirectory, relativePath)
-    ZioRuntime.runNow(createDirectory(file).either) match {
+    createDirectory(file) match {
       case Right(dir) => dir
       case Left(err) =>
         val msg = s"Error when checking required directories '${file.getPath}' to archive in git: ${err.fullMsg}"
-        GitArchiveLogger.logEffect.error(msg)
+        GitArchiveLoggerPure.logEffect.error(msg)
         throw new IllegalArgumentException(msg)
     }
   }
@@ -122,17 +125,17 @@ trait GitArchiverUtils {
     semaphoreAdd.flatMap(lock =>
       lock.withPermit(
         for {
-          _      <- GitArchiveLogger.debug(s"Add file '${gitPath}' from configuration repository")
+          _      <- GitArchiveLoggerPure.debug(s"Add file '${gitPath}' from configuration repository")
           git    <- gitRepo.git
           add    <- IOResult.effect(git.add.addFilepattern(gitPath).call)
           status <- IOResult.effect(git.status.call)
          //for debugging
           _      <- if(!(status.getAdded.contains(gitPath) || status.getChanged.contains(gitPath))) {
-                      GitArchiveLogger.warn(s"Auto-archive git failure: not found in git added files: '${gitPath}'. You can safely ignore that warning if the file was already existing in Git and was not modified by that archive.")
+                      GitArchiveLoggerPure.warn(s"Auto-archive git failure: not found in git added files: '${gitPath}'. You can safely ignore that warning if the file was already existing in Git and was not modified by that archive.")
                     } else UIO.unit
           rev    <- IOResult.effect(git.commit.setCommitter(commiter).setMessage(commitMessage).call)
           commit <- IOResult.effect(GitCommitId(rev.getName))
-          _      <- GitArchiveLogger.debug(s"file '${gitPath}' was added in commit '${commit.value}'")
+          _      <- GitArchiveLoggerPure.debug(s"file '${gitPath}' was added in commit '${commit.value}'")
           mod    <- gitModificationRepository.addCommit(commit, modId)
         } yield {
           commit
@@ -149,16 +152,16 @@ trait GitArchiverUtils {
     semaphoreDelete.flatMap(lock =>
       lock.withPermit(
         for {
-          _      <- GitArchiveLogger.debug(s"remove file '${gitPath}' from configuration repository")
+          _      <- GitArchiveLoggerPure.debug(s"remove file '${gitPath}' from configuration repository")
           git    <- gitRepo.git
           rm     <- IOResult.effect(git.rm.addFilepattern(gitPath).call)
           status <- IOResult.effect(git.status.call)
           _      <- if(!status.getRemoved.contains(gitPath)) {
-                      GitArchiveLogger.warn(s"Auto-archive git failure: not found in git removed files: '${gitPath}'. You can safely ignore that warning if the file was already existing in Git and was not modified by that archive.")
+                      GitArchiveLoggerPure.warn(s"Auto-archive git failure: not found in git removed files: '${gitPath}'. You can safely ignore that warning if the file was already existing in Git and was not modified by that archive.")
                     } else UIO.unit
           rev    <- IOResult.effect(git.commit.setCommitter(commiter).setMessage(commitMessage).call)
           commit <- IOResult.effect(GitCommitId(rev.getName))
-          _      <- GitArchiveLogger.debug(s"file '${gitPath}' was removed in commit '${commit.value}'")
+          _      <- GitArchiveLoggerPure.debug(s"file '${gitPath}' was removed in commit '${commit.value}'")
           mod    <- gitModificationRepository.addCommit(commit, modId)
         } yield {
           commit
@@ -178,7 +181,7 @@ trait GitArchiverUtils {
     semaphoreMove.flatMap(lock =>
       lock.withPermit(
         for {
-          _      <- GitArchiveLogger.debug(s"move file '${oldGitPath}' from configuration repository to '${newGitPath}'")
+          _      <- GitArchiveLoggerPure.debug(s"move file '${oldGitPath}' from configuration repository to '${newGitPath}'")
           git    <- gitRepo.git
           update <- IOResult.effect {
                       git.rm.addFilepattern(oldGitPath).call
@@ -187,11 +190,11 @@ trait GitArchiverUtils {
                     }
           status <- IOResult.effect(git.status.call)
           _      <- if(!status.getAdded.asScala.exists( path => path.startsWith(newGitPath) ) ) {
-                      GitArchiveLogger.warn(s"Auto-archive git failure when moving directory (not found in added file): '${newGitPath}'. You can safely ignore that warning if the file was already existing in Git and was not modified by that archive.")
+                      GitArchiveLoggerPure.warn(s"Auto-archive git failure when moving directory (not found in added file): '${newGitPath}'. You can safely ignore that warning if the file was already existing in Git and was not modified by that archive.")
                     } else UIO.unit
           rev    <- IOResult.effect(git.commit.setCommitter(commiter).setMessage(commitMessage).call)
           commit <- IOResult.effect(GitCommitId(rev.getName))
-          _      <- GitArchiveLogger.debug(s"file '${oldGitPath}' was moved to '${newGitPath}' in commit '${commit.value}'")
+          _      <- GitArchiveLoggerPure.debug(s"file '${oldGitPath}' was moved to '${newGitPath}' in commit '${commit.value}'")
           mod    <- gitModificationRepository.addCommit(commit, modId)
         } yield {
           commit
@@ -208,7 +211,7 @@ trait GitArchiverUtils {
   def writeXml(fileName:File, elem:Elem, logMessage:String) : IOResult[File] = {
     IOResult.effect {
       FileUtils.writeStringToFile(fileName, xmlPrettyPrinter.format(elem), encoding)
-      GitArchiveLogger.logEffect.debug(logMessage)
+      GitArchiveLoggerPure.logEffect.debug(logMessage)
       fileName
     }
   }
@@ -275,7 +278,7 @@ trait GitArchiverFullCommitUtils extends NamedZioLogger {
           // Store the commit the modification repository
           gitModificationRepository.addCommit(newCommitId, modId)
 
-          GitArchiveLogger.debug("Restored commit %s at HEAD (commit %s)".format(commit.value,newCommitId.value))
+          GitArchiveLoggerPure.debug("Restored commit %s at HEAD (commit %s)".format(commit.value,newCommitId.value))
           newCommitId
         }
       }
@@ -342,7 +345,7 @@ trait GitArchiverFullCommitUtils extends NamedZioLogger {
               tags.append(tag)
             } catch {
               case e:IncorrectObjectTypeException =>
-                GitArchiveLogger.logEffect.debug("Ignoring object due to JGit bug: " + ref.getName, e)
+                GitArchiveLoggerPure.logEffect.debug("Ignoring object due to JGit bug: " + ref.getName, e)
             }
           }
           tags.sortWith( (o1, o2) => o1.getTagName().compareTo(o2.getTagName()) <= 0 )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
@@ -507,10 +507,9 @@ trait NodeInfoServiceCached extends NodeInfoService with NamedZioLogger with Cac
   override final def getDeletedNodeInfo(nodeId: NodeId): Box[Option[NodeInfo]] = getNotAcceptedNodeInfo(nodeId, RemovedInventory).toBox
 
   /**
-   * Clear cache. Try a reload asynchronously, disregarding
-   * the result
+   * Clear cache.
    */
-  override def clearCache(): Unit = this.synchronized {
+  override def clearCache(): Unit = {
     this.nodeCache = None
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/SomeTestNonUnit.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/SomeTestNonUnit.scala
@@ -1,0 +1,115 @@
+/*
+*************************************************************************************
+* Copyright 2019 Normation SAS
+*************************************************************************************
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*************************************************************************************
+*/
+
+
+/*
+ * This class provides common usage for Zio
+ */
+
+package com.normation
+
+import java.io.File
+
+import _root_.zio.duration._
+import com.normation.box._
+import com.normation.errors.IOResult
+import com.normation.eventlog.EventActor
+import com.normation.eventlog.ModificationId
+import com.normation.rudder.services.policies.TestNodeConfiguration
+import com.normation.zio._
+import net.liftweb.actor.LAScheduler
+import _root_.zio._
+
+// -Dplease.use.only.one.core=true
+object TestAccumulate {
+  def main(args: Array[String]): Unit = {
+
+    println("here is: " + new File(".").getAbsolutePath)
+
+    val data = new TestNodeConfiguration("webapp/sources/rudder/rudder-core/")
+
+    def prog(s: String) = IOResult.effect{println(s); Thread.sleep(1*1000)}.forever.fork.unit
+
+
+    val pid = new java.io.File("/proc/self").getCanonicalFile().getName()
+    println(s"Test starts with PID ${pid} on ${java.lang.Runtime.getRuntime().availableProcessors()} cores")
+    println("start")
+
+    LAScheduler.execute(() => data.techniqueRepository.update(ModificationId("plop"), EventActor("plop"), None))
+   // on ZIO blocking threadpool
+    (1 to 10).foreach(i => prog(s"zio $i").runNow)
+    // on Lift threadpool
+    (1 to 18).foreach(i => LAScheduler.execute(() => prog (s"lift $i").toBox))
+    (1 to 5).foreach(i => IOResult.effect(prog(s"mixed $i").toBox).runNow)
+
+
+    val wait = 40.seconds
+
+    println(s"now wait ${wait.render} on main thread")
+    Thread.sleep(wait.toMillis)
+    println("done")
+    java.lang.Runtime.getRuntime.exit(0)
+  }
+}
+
+
+object ThatDoesNotBlock {
+  def main(args: Array[String]): Unit = {
+
+    def prog(s: String) = IOResult.effect{println(s); Thread.sleep(2*1000)}.forever.fork.unit
+
+    val pid = new java.io.File("/proc/self").getCanonicalFile().getName()
+    println(s"Test starts with PID ${pid} on ${java.lang.Runtime.getRuntime().availableProcessors()} cores")
+    println("start")
+    // on Lift threadpool
+    (1 to 18).foreach(i => LAScheduler.execute(() => prog (s"lift $i").toBox))
+   // on ZIO blocking threadpool
+    (1 to 10).foreach(i => prog(s"zio $i").runNow)
+    (1 to 5).foreach(i => IOResult.effect(prog(s"mixed $i").toBox).runNow)
+
+
+    val wait = 40.seconds
+
+    println(s"now wait ${wait.render} on main thread")
+    Thread.sleep(wait.toMillis)
+    println("done")
+    java.lang.Runtime.getRuntime.exit(0)
+  }
+}
+
+object SemaphoreReentrant {
+  def main(args: Array[String]): Unit = {
+
+    val sem = Semaphore.make(1).runNow
+
+    val prog1 = sem.withPermit(IOResult.effect(println("prog1")))
+    val prog2 = sem.withPermit(IOResult.effectM{
+      for {
+        _ <- IOResult.effect(println("in prog2"))
+        _ <- prog1
+      } yield ()
+    })
+
+    println("start")
+    prog2.runNow
+    println("done")
+    java.lang.Runtime.getRuntime.exit(0)
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/DBCommon.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/DBCommon.scala
@@ -39,8 +39,6 @@ package com.normation.rudder.db
 
 import java.util.Properties
 
-import cats.effect.IO
-
 import scala.io.Source
 import com.normation.rudder.db.Doobie._
 import com.normation.rudder.migration.MigrableEntity
@@ -54,7 +52,8 @@ import doobie.implicits._
 import cats.implicits._
 import com.normation.rudder.migration.MigrationTestLog
 import org.joda.time.DateTime
-
+import zio.interop.catz._
+import zio._
 
 /**
  * Here we manage all the initialisation of services and database
@@ -156,7 +155,7 @@ trait DBCommon extends Specification with Loggable with BeforeAfterAll {
   }
 
   lazy val doobie = new Doobie(dataSource)
-  def transacRun[T](query: Transactor[IO] => IO[T]) = {
+  def transacRun[T](query: Transactor[Task] => Task[T]) = {
     doobie.transactRun(xa => query(xa))
   }
   lazy val migrationEventLogRepository = new MigrationEventLogRepository(doobie)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/GenerateCompliance.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/GenerateCompliance.scala
@@ -59,6 +59,7 @@ import doobie.postgres.implicits._
 import org.joda.time.DateTime
 
 import scala.util.Random
+import zio.interop.catz._
 
 /*
  * Allow to generate false compliance for testing purpose

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/migration/TestDbMigration.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/migration/TestDbMigration.scala
@@ -52,6 +52,7 @@ import com.normation.rudder.db.Doobie._
 
 import doobie.implicits._
 import cats._
+import zio.interop.catz._
 
 final case class MigEx102(msg:String) extends Exception(msg)
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/migration/TestManageMigration.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/migration/TestManageMigration.scala
@@ -38,8 +38,6 @@
 package com.normation.rudder.migration
 
 
-import com.normation.BoxSpecMatcher
-
 import org.joda.time.DateTime
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
@@ -48,6 +46,7 @@ import com.normation.rudder.db.DBCommon
 import doobie.implicits._
 
 import com.normation.BoxSpecMatcher
+import zio.interop.catz._
 
 /**
  * Test how the migration run with a Database context

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ExpectedReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ExpectedReportTest.scala
@@ -128,7 +128,7 @@ class ExpectedReportsTest extends DBCommon {
 //            }
 //          })
 //        }.values.groupBy(_._1).mapValues(_.map{case(_, NodeConfigVersions(id,v)) => (id,v)}.toMap)
-//      }).transact(xa).attempt.attempt.unsafeRunSync
+//      }).transact(xa).either.attempt.unsafeRunSync
 //    }
 
 //    step {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/GitModificationRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/GitModificationRepositoryTest.scala
@@ -50,6 +50,7 @@ import cats.implicits._
 
 import com.normation.errors._
 import com.normation.zio._
+import zio.interop.catz._
 
 /**
  *

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportExecutionTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportExecutionTest.scala
@@ -51,6 +51,7 @@ import org.specs2.runner.JUnitRunner
 import net.liftweb.common.EmptyBox
 import net.liftweb.common.Full
 import doobie.implicits._
+import zio.interop.catz._
 
 /**
  *

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -89,6 +89,7 @@ import scala.collection.SortedMap
 import com.normation.rudder.services.reports.UnexpectedReportInterpretation
 
 import scala.concurrent.duration._
+import zio.interop.catz._
 
 /**
  *

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsProgressTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsProgressTest.scala
@@ -47,6 +47,7 @@ import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 
 import doobie.implicits._
+import zio.interop.catz._
 
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsTest.scala
@@ -54,6 +54,7 @@ import doobie.implicits._
 import cats.implicits._
 
 import com.normation.rudder.db.DB
+import zio.interop.catz._
 
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
@@ -459,7 +459,7 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
  *
  */
 
-class TestNodeConfiguration() {
+class TestNodeConfiguration(prefixTestResources: String = "") {
 
   import org.joda.time.DateTime
 
@@ -483,7 +483,7 @@ class TestNodeConfiguration() {
   val configurationRepositoryRoot = abstractRoot/"configuration-repository"
   //initialize config-repo content from our test/resources source
 
-  FileUtils.copyDirectory( new File("src/test/resources/configuration-repository") , configurationRepositoryRoot)
+  FileUtils.copyDirectory( new File(prefixTestResources + "src/test/resources/configuration-repository") , configurationRepositoryRoot)
 
   val EXPECTED_SHARE = configurationRepositoryRoot/"expected-share"
   val t1 = System.currentTimeMillis()

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InventoryApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InventoryApi.scala
@@ -195,7 +195,7 @@ class InventoryApi (
         case Right(()) =>
           toJsonResponse(None, "Incoming inventory watcher started")
         case Left(ex) =>
-          toJsonError(None, s"Error when trying to start incoming inventories file watcher. Reported exception was: ${ex.getMessage()}.")
+          toJsonError(None, s"Error when trying to start incoming inventories file watcher. Reported exception was: ${ex.fullMsg}.")
       }
     }
   }
@@ -210,7 +210,7 @@ class InventoryApi (
         case Right(()) =>
           toJsonResponse(None, "Incoming inventory watcher stopped")
         case Left(ex) =>
-          toJsonError(None, s"Error when trying to stop incoming inventories file watcher. Reported exception was: ${ex.getMessage()}.")
+          toJsonError(None, s"Error when trying to stop incoming inventories file watcher. Reported exception was: ${ex.fullMsg}.")
       }
     }
   }
@@ -228,7 +228,7 @@ class InventoryApi (
         case Right(()) =>
           toJsonResponse(None, "Incoming inventory watcher restarted")
         case Left(ex) =>
-          toJsonError(None, s"Error when trying to restart incoming inventories file watcher. Reported exception was: ${ex.getMessage()}.")
+          toJsonError(None, s"Error when trying to restart incoming inventories file watcher. Reported exception was: ${ex.fullMsg}.")
       }
     }
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -975,9 +975,9 @@ object RudderConfig extends Loggable {
       , ".sign"
     )
     if(WATCHER_ENABLE) {
-      watcher.startWatcher()
+      //watcher.startWatcher()
     } else { // don't start
-     InventoryProcessingLogger.debug(s"Not automatically incoming inventory watcher because 'inventories.watcher.enable'=${WATCHER_ENABLE}")
+     InventoryProcessingLogger.debug(s"Not automatically starting incoming inventory watcher because 'inventories.watcher.enable'=${WATCHER_ENABLE}")
     }
     watcher
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -975,7 +975,7 @@ object RudderConfig extends Loggable {
       , ".sign"
     )
     if(WATCHER_ENABLE) {
-      //watcher.startWatcher()
+      watcher.startWatcher()
     } else { // don't start
      InventoryProcessingLogger.debug(s"Not automatically starting incoming inventory watcher because 'inventories.watcher.enable'=${WATCHER_ENABLE}")
     }

--- a/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
@@ -310,7 +310,10 @@ object zio {
      * IO into an async thread pool to avoid deadlock in case of
      * a hierarchy of calls.
      */
-    val internal = new DefaultRuntime() {}
+    val internal = new DefaultRuntime() {
+
+
+    }
 
     /*
      * use the blocking thread pool provided by that runtime.

--- a/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
@@ -319,11 +319,11 @@ object zio {
      * use the blocking thread pool provided by that runtime.
      */
     def blocking[E,A](io: ZIO[Any,E,A]): ZIO[Any,E,A] = {
-      _root_.zio.blocking.blocking(io).provide(internal.environment)
+      _root_.zio.blocking.blocking(io).provide(internal.Environment)
     }
 
     def effectBlocking[A](effect: => A): ZIO[Any, Throwable, A] = {
-      _root_.zio.blocking.effectBlocking(effect).provide(internal.environment)
+      _root_.zio.blocking.effectBlocking(effect).provide(internal.Environment)
     }
 
     def runNow[A](io: IOResult[A]): A = {
@@ -345,7 +345,7 @@ object zio {
      */
     def unsafeRun[E, A](zio: => ZIO[Any, E, A]): A = internal.unsafeRun(blocking(zio))
 
-    def environment = internal.environment
+    def environment = internal.Environment
   }
 
   /*

--- a/webapp/sources/utils/src/test/scala/com/normation/ZioCommonsTest.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/ZioCommonsTest.scala
@@ -26,6 +26,11 @@
 package com.normation
 
 
+import _root_.zio._
+import _root_.zio.blocking.Blocking
+import _root_.zio.clock.Clock
+import _root_.zio.duration.Duration
+import _root_.zio.syntax._
 import com.github.ghik.silencer.silent
 import com.normation.errors.IOResult
 import com.normation.errors.RudderError
@@ -36,11 +41,6 @@ import net.liftweb.common._
 import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
-import _root_.zio._
-import _root_.zio.blocking.Blocking
-import _root_.zio.clock.Clock
-import _root_.zio.duration.Duration
-import _root_.zio.syntax._
 
 @RunWith(classOf[JUnitRunner])
 class ZioCommonsTest extends Specification {
@@ -488,13 +488,13 @@ runs with jvm arg:
 -Dscala.concurrent.context.maxExtraThreads=10000
  */
 import _root_.zio._
-import _root_.zio.syntax._
-import _root_.zio.duration._
 import _root_.zio.clock._
-import _root_.zio.random._
 import _root_.zio.console._
-import _root_.zio.system.{System => ZSystem}
+import _root_.zio.duration._
 import _root_.zio.internal._
+import _root_.zio.random._
+import _root_.zio.syntax._
+import _root_.zio.system.{System => ZSystem}
 
   def main(args: Array[String]): Unit = {
 
@@ -598,3 +598,4 @@ object TestTwoRunNow2 {
     Thread.sleep(10*1000)
   }
 }
+


### PR DESCRIPTION
https://issues.rudder.io/issues/16291
Several main parts in that PR - the main one is reverting to ZIO-1.0.0-RC16, because we seems to hit a bug in RC17 (discussed on zio chan, ticket here: https://github.com/zio/zio/issues/2373), but it also does other things that removed other (possible) deadlocks:

- rewrite GitTechniqueReader for it to be mostly immutable and pure. It makes it be created/exec a lot faster (~10x). It does not seems to be directly related with the bug but was a revelator. The new version is relatively safe to use, since we have tests on that. 

- change doobie transactor to directly work with `ZIO` `Task` in place of `cats` `IO`. Again not directly cause of the bug but a revelator, it also allowed us to see that we still had some `cats.unsafeRun`, and that we were using a yet another threadpool for that (which seem unecessary). That does change the postgres connection pool, only the threadpool on the receiving end of the connection. 

- removed last `synchronized` blocked. We should not have any synchronized block, and again I thought they were the cause (but still just a revelator). It's the part where I'm the less sure, because `semaphore` are not reintrant where `synchronize` block are, so if at some point we have a twisted call graphe that need reintrance, it may lead to a (real) deadlock. I didn't got it with my tests, but it means almost nothing. 
UPDATE: confirmed that AT LEAST for `CachedFindRuleNodeStatusReports` in `ReportingServiceImpl`, we have reentrant parts and we need to keep `synchronized`.