### PR TITLE
Fixes #16222: Exception "fiberFailed" when running agent from UI

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
@@ -80,6 +80,9 @@ object NodeLogger extends Logger {
     }
   }
 }
+object NodeLoggerPure extends NamedZioLogger {
+  def loggerName = "nodes"
+}
 
 /*
  * A logger to log information about the JS script eval for directives


### PR DESCRIPTION
https://issues.rudder.io/issues/16222

So, it works, but with some caveats: 

- it's synchrone
- there is something very strange happening during execution. It seems that the request result is processed two times (the part in `request.exec`), but the second time, there is a problem with (likely) piped input stream, and so all write to pipe output stream wait forever. I added a timeout, which allows to break the lock and display the result (which is correct!). 