### PR TITLE
Fixes #16334: More generic lib linding of the rudder-lang tester script

### DIFF
--- a/rudder-lang/README.adoc
+++ b/rudder-lang/README.adoc
@@ -10,7 +10,7 @@ This language is not:
 
 It has no:
 
-- recussion
+- recursion
 - generator / generic iterator
 - way of looping except on finite list
 
@@ -57,3 +57,11 @@ The compiler is very pedantic to avoid defining invalid states as much as possib
 - an `if` is a single condition
 
 
+== Tests
+
+=== Required modules
+- perl (script: *src/generate-lib*)
+    `cpan Config::IniFiles`
+    
+=== Configuration
+- *cfg.ini* to define the cfengine and ncf binaries paths

--- a/rudder-lang/src/cfg.ini
+++ b/rudder-lang/src/cfg.ini
@@ -1,0 +1,3 @@
+[default_paths]
+    ncf=/usr/share/ncf
+    cfengine=/opt/rudder/bin/cf-promises

--- a/rudder-lang/src/generate-lib
+++ b/rudder-lang/src/generate-lib
@@ -8,7 +8,7 @@ my %resource = ();
 my @state = ();
 my @config_lines=();
 
-foreach my $file (glob "/home/bpeccatte/Rudder/ncf/tree/30_generic_methods/*") {
+foreach my $file (glob "/usr/share/ncf/tree/30_generic_methods/*") {
   # file exclusion
   next if $file=~ /\/_/;
   next if $file=~ /README/;

--- a/rudder-lang/src/generate-lib
+++ b/rudder-lang/src/generate-lib
@@ -2,13 +2,18 @@
 
 use warnings;
 use strict;
-
+use warnings;
+use strict;
+use Config::IniFiles;
 
 my %resource = ();
 my @state = ();
 my @config_lines=();
 
-foreach my $file (glob "/usr/share/ncf/tree/30_generic_methods/*") {
+my $cfg = Config::IniFiles->new( -file => "cfg.ini" );
+my $ncf_methods = $cfg->val( 'default_paths', 'ncf' ) . "/tree/30_generic_methods/*";
+
+foreach my $file (glob $ncf_methods) {
   # file exclusion
   next if $file=~ /\/_/;
   next if $file=~ /README/;

--- a/rudder-lang/src/ncf
+++ b/rudder-lang/src/ncf
@@ -10,11 +10,14 @@ Usage:
 
 """
 
-
-NCF='/usr/share/ncf'
+import configparser
+cfg = configparser.ConfigParser()
+cfg.read('cfg.ini')
+ncf_dir = cfg['default_paths']['ncf']
+cfengine_path = cfg['default_paths']['cfengine']
 
 import sys
-sys.path.append(NCF+'/tools')
+sys.path.append(ncf_dir+'/tools')
 import ncf
 import codecs
 import json
@@ -25,8 +28,8 @@ import re
 import jsondiff
 from subprocess import check_output
 
-ncf.CFENGINE_PATH="/opt/rudder/bin/cf-promises"
-ncf_path=NCF+'/tree/30_generic_methods'
+ncf.CFENGINE_PATH=cfengine_path
+ncf_path=ncf_dir+'/tree/30_generic_methods'
 
 def ncf_to_json(cf_file):
   methods_data = ncf.get_all_generic_methods_metadata(ncf_path)

--- a/rudder-lang/src/ncf
+++ b/rudder-lang/src/ncf
@@ -11,7 +11,7 @@ Usage:
 """
 
 
-NCF='/home/bpeccatte/Rudder/ncf'
+NCF='/usr/share/ncf'
 
 import sys
 sys.path.append(NCF+'/tools')
@@ -25,7 +25,7 @@ import re
 import jsondiff
 from subprocess import check_output
 
-ncf.CFENGINE_PATH="/home/bpeccatte/Rudder/ncf/cfe/usr/sbin/cf-promises"
+ncf.CFENGINE_PATH="/opt/rudder/bin/cf-promises"
 ncf_path=NCF+'/tree/30_generic_methods'
 
 def ncf_to_json(cf_file):

--- a/rudder-lang/src/tester.sh
+++ b/rudder-lang/src/tester.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 set -xe
-name="xx"
-
-export LD_LIBRARY_PATH=/home/bpeccatte/Rudder/ncf/cfe/usr/lib
+name=$1
 
 # Take original technique an make a json
 ./ncf ncf-to-json ${name}.cf


### PR DESCRIPTION
Should work on Rudder servers as I only installed a server/agent on a clean debian distro. The script works on it.
Did not moove paths to external config files as I am unsure it would have been cleaner