### PR TITLE
Fixes #16382: Improve performance of policy generation writer

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -360,6 +360,7 @@ limitations under the License.
     <jodatime-version>2.10.3</jodatime-version>
     <jodaconvert-version>2.2.1</jodaconvert-version>
     <commons-io-version>2.6</commons-io-version>
+    <commons-lang-version>2.6</commons-lang-version>
     <commons-codec-version>1.13</commons-codec-version>
     <spring-version>5.1.9.RELEASE</spring-version>
     <spring-security-version>5.1.6.RELEASE</spring-security-version>

--- a/webapp/sources/rudder/rudder-core/pom.xml
+++ b/webapp/sources/rudder/rudder-core/pom.xml
@@ -112,11 +112,6 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
-    </dependency>
 
     <dependency>
       <groupId>commons-codec</groupId>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/HashAlgoConstraint.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/HashAlgoConstraint.scala
@@ -61,7 +61,6 @@ sealed trait HashAlgoConstraint {
     case Right((algo,_))                  => Left(Inconsistancy(s"Bad algorithm prefix: found ${algo.prefix}, was expecting ${this.prefix}"))
     case Left(eb)                         => Left(eb)
   }
-
 }
 
 object HashAlgoConstraint {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueReader.scala
@@ -39,8 +39,11 @@ package com.normation.cfclerk.services
 
 import com.normation.cfclerk.domain._
 import java.io.InputStream
+
+import com.normation.errors.IOResult
+
 import scala.collection.immutable.SortedMap
-import scala.collection.mutable.{ Map => MutMap }
+import scala.collection.mutable.{Map => MutMap}
 
 
 final case class TechniquesInfo(
@@ -93,7 +96,7 @@ trait TechniqueReader {
    * The implementation must take care of correct closing of the input
    * stream and any I/O exception.
    */
-  def getMetadataContent[T](techniqueId: TechniqueId)(useIt : Option[InputStream] => T) : T
+  def getMetadataContent[T](techniqueId: TechniqueId)(useIt : Option[InputStream] => IOResult[T]) : IOResult[T]
 
 
   /**
@@ -109,7 +112,7 @@ trait TechniqueReader {
    * The implementation must take care of correct closing of the input
    * stream and any I/O exception.
    */
-  def getResourceContent[T](techniqueResourceId: TechniqueResourceId, postfixName: Option[String])(useIt : Option[InputStream] => T) : T
+  def getResourceContent[T](techniqueResourceId: TechniqueResourceId, postfixName: Option[String])(useIt : Option[InputStream] => IOResult[T]) : IOResult[T]
 
   /**
    * An indicator that the underlying policy template library changed and that the content

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueRepository.scala
@@ -54,17 +54,17 @@ trait TechniqueRepository {
    * Retrieve the metadata file content
    * (for example,to display it)
    */
-  def getMetadataContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => T): T
+  def getMetadataContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => IOResult[T]): IOResult[T]
 
   /**
    * Get the template content for the given id
    */
-  def getTemplateContent[T](techniqueResourceId: TechniqueResourceId)(useIt: Option[InputStream] => T): T
+  def getTemplateContent[T](techniqueResourceId: TechniqueResourceId)(useIt: Option[InputStream] => IOResult[T]): IOResult[T]
 
   /**
    * Get the file content for the given id
    */
-  def getFileContent[T](techniqueResourceId: TechniqueResourceId)(useIt: Option[InputStream] => T): T
+  def getFileContent[T](techniqueResourceId: TechniqueResourceId)(useIt: Option[InputStream] => IOResult[T]): IOResult[T]
 
 
   /*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/TechniqueRepositoryImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/TechniqueRepositoryImpl.scala
@@ -199,13 +199,13 @@ class TechniqueRepositoryImpl(
   }
 
 
-  override def getMetadataContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => T): T =
+  override def getMetadataContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => IOResult[T]): IOResult[T] =
     techniqueReader.getMetadataContent(techniqueId)(useIt)
 
-  override def getFileContent[T](techniqueResourceId: TechniqueResourceId)(useIt: Option[InputStream] => T): T =
+  override def getFileContent[T](techniqueResourceId: TechniqueResourceId)(useIt: Option[InputStream] => IOResult[T]): IOResult[T] =
     techniqueReader.getResourceContent(techniqueResourceId, None)(useIt)
 
-  override def getTemplateContent[T](techniqueResourceId: TechniqueResourceId)(useIt: Option[InputStream] => T): T =
+  override def getTemplateContent[T](techniqueResourceId: TechniqueResourceId)(useIt: Option[InputStream] => IOResult[T]): IOResult[T] =
     techniqueReader.getResourceContent(techniqueResourceId, Some(TechniqueTemplate.templateExtension))(useIt)
 
   /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/PolicyGenerationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/PolicyGenerationLogger.scala
@@ -50,6 +50,10 @@ object PolicyGenerationLogger extends Logger {
     override protected def _logger = LoggerFactory.getLogger("policy.generation.expected_reports")
   }
 
+  object update extends Logger {
+    override protected def _logger = LoggerFactory.getLogger("policy.generation.update")
+  }
+
   object timing extends Logger {
     override protected def _logger = LoggerFactory.getLogger("policy.generation.timing")
     object buildNodeConfig extends Logger {
@@ -70,6 +74,9 @@ object PolicyGenerationLoggerPure extends NamedZioLogger {
     override def loggerName: String = "policy.generation.timing"
     object buildNodeConfig extends NamedZioLogger {
       override def loggerName: String = "policy.generation.timing.buildNodeConfig"
+    }
+    object hooks extends NamedZioLogger {
+      override def loggerName: String = "policy.generation.timing.hooks"
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunNuCommand.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunNuCommand.scala
@@ -196,7 +196,7 @@ object RunNuCommand {
       _              <- if(process == null) {
                           Unexpected(s"Error: unable to start native command ${cmdInfo}").fail
                         } else {
-                          //that class#method does not accept interactive mode
+                          // that class#method does not accept interactive mode
                           // this part can block, waiting for things to complete
                           IOResult.effect(errorMsg) {
                             process.closeStdin(true)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
@@ -408,7 +408,7 @@ final object Policy {
                 existingVariable.copyWithAppendedValues(newVar.values) match {
                   case Left(err) =>
                     PolicyGenerationLogger.error(s"Error when merging variables '${existingVariable.spec.name}' (init: ${existingVariable.values.toString} ; " +
-                                       s"new val: ${newVar.values.toString}. This is most likely a bug, please report it")
+                                                 s"new val: ${newVar.values.toString}. This is most likely a bug, please report it")
                     existingVariable
                   case Right(v) => v
                 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -810,7 +810,7 @@ trait PromiseGeneration_BuildNodeContext {
         } yield {
           (param.name, p)
         }
-      }.map( _.toMap)
+      }.map(_.toMap)
     }
 
     for {
@@ -1201,7 +1201,8 @@ trait PromiseGeneration_updateAndWriteRule extends PromiseGenerationService {
     }
 
     if(notUpdatedConfig.nonEmpty) {
-      PolicyGenerationLogger.debug(s"Not updating non-modified node configuration: [${notUpdatedConfig.map( _.id.value).mkString(", ")}]")
+      PolicyGenerationLogger.update.debug(s"Configuration of ${notUpdatedConfig.size} nodes were already OK, not updating them")
+      PolicyGenerationLogger.update.trace(s" -> not updating nodes: [${notUpdatedConfig.map( _.id.value).mkString(", ")}]")
     }
 
     if(updatedConfig.isEmpty) {
@@ -1210,7 +1211,7 @@ trait PromiseGeneration_updateAndWriteRule extends PromiseGenerationService {
     } else {
       val nodeToKeep = updatedConfig.map( _.id ).toSet
       PolicyGenerationLogger.info(s"Configuration of ${updatedConfig.size} nodes were updated, their policies are going to be written")
-      PolicyGenerationLogger.debug(s" -> update nodes and policies: [${updatedConfig.map(_.id.value).mkString(", ")}]")
+      PolicyGenerationLogger.update.debug(s" -> updating nodes: [${updatedConfig.map(_.id.value).mkString(", ")}]")
       nodeConfigurations.keySet.intersect(nodeToKeep)
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/MergePolicyService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/MergePolicyService.scala
@@ -233,8 +233,8 @@ final object MergePolicyService {
 
       if(seq.lengthCompare(1) > 0) {
         PolicyGenerationLogger.error(s"The directive '${seq.head.id.directiveId.value}' on rule '${seq.head.id.ruleId.value}' was added several times on node " +
-                     s"'${nodeInfo.id.value}' WITH DIFFERENT PARAMETERS VALUE. It's a bug, please report it. Taking one set of parameter "+
-                     s"at random for the policy generation.")
+                                     s"'${nodeInfo.id.value}' WITH DIFFERENT PARAMETERS VALUE. It's a bug, please report it. Taking one set of parameter " +
+                                     s"at random for the policy generation.")
         import net.liftweb.json._
         implicit val formats = Serialization.formats(NoTypeHints)
         def r(j:JValue) = if(j == JNothing) "{}" else prettyRender(j)
@@ -319,14 +319,14 @@ final object MergePolicyService {
       val differentDirectives = samePriority.groupBy(_.id.directiveId)
       if(differentDirectives.size > 1) {
         PolicyGenerationLogger.warn(s"Unicity check: NON STABLE POLICY ON NODE '${nodeInfo.hostname}' for mono-instance (unique) technique " +
-            s"'${keep.technique.id}'. Several directives with same priority '${keep.priority}' are applied. "+
-            s"Keeping (ruleId@@directiveId) '${keep.id.ruleId.value}@@${keep.id.directiveId.value}' (order: ${keep.ruleOrder.value}/"+
-            s"${keep.directiveName}, discarding: ${samePriority.tail.map(x => s"${x.id.ruleId.value}@@${x.id.directiveId.value}:"+
+                                    s"'${keep.technique.id}'. Several directives with same priority '${keep.priority}' are applied. " +
+                                    s"Keeping (ruleId@@directiveId) '${keep.id.ruleId.value}@@${keep.id.directiveId.value}' (order: ${keep.ruleOrder.value}/" +
+                                    s"${keep.directiveName}, discarding: ${samePriority.tail.map(x => s"${x.id.ruleId.value}@@${x.id.directiveId.value}:"+
             s"${x.ruleName}/${x.directiveName}").mkString("'", "', ", "'")}")
       }
       PolicyGenerationLogger.trace(s"Unicity check: on node '${nodeInfo.id.value}' for mono-instance (unique) technique '${keep.technique.id}': " +
-          s"keeping (ruleId@@directiveId) '${keep.id.ruleId.value}@@${keep.id.directiveId.value}', discarding less priorize: "+
-          s"${lesserPriority.map(x => x.id.ruleId.value+"@@"+x.id.directiveId.value).mkString("'", "', ", "'")}")
+                                   s"keeping (ruleId@@directiveId) '${keep.id.ruleId.value}@@${keep.id.directiveId.value}', discarding less priorize: " +
+                                   s"${lesserPriority.map(x => x.id.ruleId.value+"@@"+x.id.directiveId.value).mkString("'", "', ", "'")}")
 
       setOverrides(keep, samePriority.tail ++ lesserPriority)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/BuildBundleSequence.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/BuildBundleSequence.scala
@@ -270,7 +270,7 @@ class BuildBundleSequence(
       //split system and user directive (technique)
       (systemBundle, userBundle) =  techniquesBundles.toList.removeEmptyBundle.partition( _.isSystem )
       bundleVars                 <- writeAllAgentSpecificFiles.getBundleVariables(agentNodeProps, systemInputFiles, systemBundle, userInputFiles, userBundle, runHooks).toIO.chainError(
-                                    s"Error for node '${agentNodeProps.nodeId.value}' bundle creation"
+                                      s"Error for node '${agentNodeProps.nodeId.value}' bundle creation"
                                     )
       // map to correct variables
       vars                       <- ZIO.sequence(List(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PromiseWriteDataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PromiseWriteDataStructures.scala
@@ -66,7 +66,7 @@ import com.normation.rudder.services.policies.PolicyId
 final case class AgentNodeConfiguration(
     config   : NodeConfiguration
   , agentType: AgentType
-  , paths    : NodePromisesPaths
+  , paths    : NodePoliciesPaths
 )
 
 
@@ -92,7 +92,7 @@ final case class AgentNodeProperties(
  */
 final case class AgentNodeWritableConfiguration(
     agentNodeProps    : AgentNodeProperties
-  , paths             : NodePromisesPaths
+  , paths             : NodePoliciesPaths
   , preparedTechniques: Seq[PreparedTechnique]
   , systemVariables   : Map[String, Variable]
   , policies          : List[Policy]
@@ -103,9 +103,9 @@ final case class AgentNodeWritableConfiguration(
  * from their generation directory to their final directory.
  * A back-up folder is also provided to save a copy.
  */
-final case class NodePromisesPaths(
+final case class NodePoliciesPaths(
     nodeId      : NodeId
-  , baseFolder  : String //directory where the file have to in the end
+  , baseFolder  : String //directory where the file have to be in the end
   , newFolder   : String //poclicies are temporarly store in a policyName.new directory
   , backupFolder: String
 )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/RemoveNodeService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/RemoveNodeService.scala
@@ -78,7 +78,7 @@ import com.normation.rudder.repository.ldap.LDAPEntityMapper
 import com.normation.rudder.repository.ldap.ScalaReadWriteLock
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.services.nodes.NodeInfoService.A_MOD_TIMESTAMP
-import com.normation.rudder.services.policies.write.NodePromisesPaths
+import com.normation.rudder.services.policies.write.NodePoliciesPaths
 import com.normation.rudder.services.policies.write.PathComputer
 import com.unboundid.ldap.sdk.Modification
 import com.unboundid.ldap.sdk.ModificationType
@@ -143,7 +143,7 @@ class RemoveNodeServiceImpl(
    * This method is an helper that does the policy server lookup for
    * you.
    */
-  def getNodePath(node: NodeInfo): Box[NodePromisesPaths] = {
+  def getNodePath(node: NodeInfo): Box[NodePoliciesPaths] = {
     //accumumate all the node infos from node id to root throught relay servers
     def recGetParent(node: NodeInfo): Box[Map[NodeId, NodeInfo]] = {
       if(node.id == Constants.ROOT_POLICY_SERVER_ID) {
@@ -160,7 +160,7 @@ class RemoveNodeServiceImpl(
     }
     for {
       nodeInfos <- recGetParent(node)
-      paths     <- pathComputer.computeBaseNodePath(node.id, Constants.ROOT_POLICY_SERVER_ID, nodeInfos)
+      paths     <- pathComputer.computeBaseNodePath(node.id, Constants.ROOT_POLICY_SERVER_ID, nodeInfos).toBox
     } yield {
       paths
     }
@@ -180,7 +180,7 @@ class RemoveNodeServiceImpl(
    */
   def removeNode(nodeId : NodeId, modId: ModificationId, actor:EventActor) : Box[DeletionResult] = {
     import DeletionResult._
-    def effectiveDeletion( nodeInfo : NodeInfo, optNodePaths: Option[NodePromisesPaths], preHooks : Hooks, startPreHooks : Long) : Box[DeletionResult]  = {
+    def effectiveDeletion( nodeInfo: NodeInfo, optNodePaths: Option[NodePoliciesPaths], preHooks: Hooks, startPreHooks: Long) : Box[DeletionResult]  = {
       val systemEnv = {
         import scala.jdk.CollectionConverters._
         HookEnvPairs.build(System.getenv.asScala.toSeq:_*)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/DummyTechniqueRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/DummyTechniqueRepository.scala
@@ -72,9 +72,9 @@ class DummyTechniqueRepository(policies: Seq[Technique] = Seq()) extends Techniq
 
   def this() = this(Seq()) //Spring need that...
 
-  override def getMetadataContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => T): T = ???
-  override def getTemplateContent[T](id: TechniqueResourceId)(useIt: Option[InputStream] => T): T = ???
-  override def getFileContent[T](id: TechniqueResourceId)(useIt: Option[InputStream] => T): T = ???
+  override def getMetadataContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => IOResult[T]): IOResult[T] = ???
+  override def getTemplateContent[T](id: TechniqueResourceId)(useIt: Option[InputStream] => IOResult[T]): IOResult[T] = ???
+  override def getFileContent[T](id: TechniqueResourceId)(useIt: Option[InputStream] => IOResult[T]): IOResult[T] = ???
   override def getAll(): Map[TechniqueId, Technique] = { policyMap }
 
   override def get(policyName: TechniqueId): Option[Technique] = {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitPackageReaderTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitPackageReaderTest.scala
@@ -61,6 +61,7 @@ import org.joda.time.DateTime
 import java.nio.charset.StandardCharsets
 
 import com.normation.zio._
+import zio.syntax._
 
 /**
  * Details of tests executed in each instances of
@@ -157,9 +158,9 @@ trait JGitPackageReaderSpec extends Specification with Loggable with AfterAll {
   def assertResourceContent(id: TechniqueResourceId, isTemplate: Boolean, expectedContent: String) = {
     val ext = if(isTemplate) Some(TechniqueTemplate.templateExtension) else None
     reader.getResourceContent(id, ext) {
-        case None => ko("Can not open an InputStream for " + id.toString)
-        case Some(is) => IOUtils.toString(is, StandardCharsets.UTF_8) === expectedContent
-      }
+        case None => ko("Can not open an InputStream for " + id.toString).succeed
+        case Some(is) => (IOUtils.toString(is, StandardCharsets.UTF_8) === expectedContent).succeed
+      }.runNow
   }
 
   "The test lib" should {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestTechniqueWriter.scala
@@ -173,9 +173,9 @@ class TestTechniqueWriter extends Specification with ContentMatchers with Loggab
   }
 
   def techRepo : TechniqueRepository = new TechniqueRepository {
-    override def getMetadataContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => T): T = ???
-    override def getTemplateContent[T](techniqueResourceId: TechniqueResourceId)(useIt: Option[InputStream] => T): T = ???
-    override def getFileContent[T](techniqueResourceId: TechniqueResourceId)(useIt: Option[InputStream] => T): T = ???
+    override def getMetadataContent[T](techniqueId: TechniqueId)(useIt: Option[InputStream] => IOResult[T]): IOResult[T] = ???
+    override def getTemplateContent[T](techniqueResourceId: TechniqueResourceId)(useIt: Option[InputStream] => IOResult[T]): IOResult[T] = ???
+    override def getFileContent[T](techniqueResourceId: TechniqueResourceId)(useIt: Option[InputStream] => IOResult[T]): IOResult[T] = ???
     override def getTechniquesInfo(): TechniquesInfo = ???
     override def getAll(): Map[TechniqueId, domain.Technique] = ???
     override def get(techniqueId: TechniqueId): Option[domain.Technique] = ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
@@ -125,7 +125,7 @@ class TestBuildNodeConfiguration extends Specification {
   val jsTimeout                 = FiniteDuration(5, "minutes")
   val generationContinueOnError = false
 
-  org.slf4j.LoggerFactory.getLogger("debug_timing.generation.buildNodeConfig").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.TRACE)
+  org.slf4j.LoggerFactory.getLogger("policy.generation.timing.buildNodeConfig").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.TRACE)
 
   "build node configuration" in {
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestNodeAndParameterLookup.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestNodeAndParameterLookup.scala
@@ -533,6 +533,8 @@ class TestNodeAndParameterLookup extends Specification {
       )
     }
 
+
+
     "fails when the curly brace after ${rudder. is not closed" in {
       getError(lookupService.lookupNodeParameterization(Seq(badUnclosed))(context)) must beMatching(
         """.*On variable 'empty'.* end of input expected.*""".r

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PathComputerTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PathComputerTest.scala
@@ -36,12 +36,11 @@
 
 package com.normation.rudder.services.policies.write
 
+import com.normation.errors.Inconsistancy
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-import net.liftweb.common.Full
 import com.normation.rudder.domain.Constants
-import net.liftweb.common.Failure
 
 @RunWith(classOf[JUnitRunner])
 class PathComputerTest extends Specification {
@@ -62,12 +61,12 @@ class PathComputerTest extends Specification {
 
   "The paths for " should {
     "the root node should raise an error" in {
-      pathComputer.computeBaseNodePath(root.id, root.id, allNodeConfig.view.mapValues(_.nodeInfo).toMap) must beAnInstanceOf[Failure]
+      pathComputer.computeBaseNodePath(root.id, root.id, allNodeConfig.view.mapValues(_.nodeInfo).toMap) must beAnInstanceOf[Left[Inconsistancy, _]]
     }
 
     "the nodeConfig should be " in {
       pathComputer.computeBaseNodePath(node1.id, root.id, allNodeConfig.view.mapValues(_.nodeInfo).toMap) must
-      beEqualTo(Full(NodePromisesPaths(node1.id,"/var/rudder/share/node1/rules", "/var/rudder/share/node1/rules.new", "/var/rudder/backup/node1/rules")))
+      beEqualTo(Right(NodePoliciesPaths(node1.id,"/var/rudder/share/node1/rules", "/var/rudder/share/node1/rules.new", "/var/rudder/backup/node1/rules")))
     }
 
     // #TODO: migrate in scale-out relay plugin
@@ -82,7 +81,7 @@ class PathComputerTest extends Specification {
       val badNode1 = node1NodeConfig.copy(nodeInfo = node1NodeConfig.nodeInfo.copy(policyServerId = node2.id) )
       val badNode2 = node2NodeConfig.copy(nodeInfo = node2NodeConfig.nodeInfo.copy(policyServerId = node1.id) )
       val badConfig = allNodeConfig + (node1.id -> badNode1) + (node2.id -> badNode2)
-      pathComputer.computeBaseNodePath(node1.id, root.id, badConfig.view.mapValues(_.nodeInfo).toMap) must beAnInstanceOf[Failure]
+      pathComputer.computeBaseNodePath(node1.id, root.id, badConfig.view.mapValues(_.nodeInfo).toMap) must beAnInstanceOf[Left[Inconsistancy, _]]
     }
   }
 

--- a/webapp/sources/rudder/rudder-templates-cli/src/test/scala/com/normation/templates/cli/JsonVariablesTest.scala
+++ b/webapp/sources/rudder/rudder-templates-cli/src/test/scala/com/normation/templates/cli/JsonVariablesTest.scala
@@ -38,12 +38,12 @@
 package com.normation.templates.cli
 
 import com.normation.templates.STVariable
-
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-
 import com.normation.zio._
+
+import scala.collection.immutable.ArraySeq
 
 @RunWith(classOf[JUnitRunner])
 class JsonVariablesTest extends Specification {
@@ -65,14 +65,14 @@ class JsonVariablesTest extends Specification {
          }
         """
       val variables = Seq(
-          STVariable("key1", true,  Seq(true), false)
-        , STVariable("key2", true,  Seq("some value"), false)
-        , STVariable("key3", true,  Seq("42"), false)
-        , STVariable("key4", true,  Seq("some", "more", "values", true, false), false)
-        , STVariable("key5", false, Seq("k5"), true)
-        , STVariable("key6", true,  Seq("a1", "a2", "a3"), false)
-        , STVariable("key7", true,  Seq(""), false)
-        , STVariable("key8", true,  Seq(), false)
+          STVariable("key1", true,  ArraySeq(true), false)
+        , STVariable("key2", true,  ArraySeq("some value"), false)
+        , STVariable("key3", true,  ArraySeq("42"), false)
+        , STVariable("key4", true,  ArraySeq("some", "more", "values", true, false), false)
+        , STVariable("key5", false, ArraySeq("k5"), true)
+        , STVariable("key6", true,  ArraySeq("a1", "a2", "a3"), false)
+        , STVariable("key7", true,  ArraySeq(""), false)
+        , STVariable("key8", true,  ArraySeq(), false)
       )
 
       ParseVariables.fromString(json).runNow must containTheSameElementsAs(variables)

--- a/webapp/sources/rudder/rudder-templates/pom.xml
+++ b/webapp/sources/rudder/rudder-templates/pom.xml
@@ -52,6 +52,12 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
   <dependencies>
 
     <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>${commons-lang-version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.normation</groupId>
       <artifactId>utils</artifactId>
       <version>${rudder-version}</version>


### PR DESCRIPTION
https://issues.rudder.io/issues/16382

This PR try to make the abysmal performances of policy generation in 6.0 less abysmal. 

Most of that PR was split in smaller amount, but there is a big part remaining: I change (most) of the the write logic, and that part can't really be done in smaller bit. 

The big changes are:
- port a bit more GitTemplateReader & friends to ZIO to avoid switching from in/out ZIO;
- change the way policies are done so that now, it' not by node but by template, which avoid to lock on them 
- add A LOT of timing information, which are now pretty cool
- use atomic move when possible, but it doesn't yield a lot of perf, 
- parallelise move of policies to their final place, 
- use ArraySeq for string template values, which avoid to switch between list and array which cost a lot in ZIO. 

It can be merded. 

--- for records, what was done before --

Here, we explore three paths to earn some performances:

- 1/ try to use OS atomic move operation in place of copy+delete for moving policies from `rules.new` to `rules`
- 2/ adapt ZIO blocking thread executor, giving it a bit more chance to reuse existing threads
- 3/ refactoring from `Box` to `PureResult` and `IOResult`. There is something extremely costly with `toIO` and `toBox` (and even more for layers of them). 
- 4/ add a parrallel call in `prepareTechniqueTemplate`

Tests and measure were done on `WriteSystemTechniquesTest`, so the test case is rather specific and small (even for the 500 nodes cases). So the experiment should be replicated in real load testing environment to draw any conclusions. 

1/ That change does not seems to change anything, but my test case didn't exibited the big problems seen elsewhere. It could be an easy win. 

2/ Changing the threadpool ergonomics leads to ~7% better perf, but it may be due to the very specific patterns in the unit test. 

3/ This change is the biggest in number of lines. The most dramatic improvement is due to the changes in `STVariable` for validation, which drives on itself a ~7% improvement. Validation is called a lot of time. Other changes leads to 5-7% improvment. 

4/ This last change lead to ~30% improvment (but uniquely on `prepareTechniqueTemplate` phase)

All in all, we get a consistant 20-22% improvment compared to 6.0.0. 

--- oups, I did a rebase, I wanted to just do an added commit :/ ----

Some more change, and we are now near what we had in 5.0 (still 25% worse for writting techniques) but on the other hand, we are 50 times faster on `move promise to final position`. 

New changes: 

- use `Promise` for parsing template (to put it in cache) which allows to block less in semaphore,
- change the way we fill template and use `IOResult.effectNonBlocking` to minimize time in semaphore. This (especially avoiding thread creation with `effectNonBlocking`) leads to a 4x improvement on the most costly step. 
- remove parallelisation below the first level (ie all `traversePar`). It leads to more stable result overall. 

It's also intersting to see that almost nothing change when we add nodes to the test (until we reach memory/gc limit, and then things go to a stop).

Results in images: 

![2019-12-17_21 23 33-Untitled_spreadsheet_-_Google_Sheets](https://user-images.githubusercontent.com/44649/71031388-8ce2f200-2113-11ea-8193-129375b11a6c.png)


![2019-12-17_20 25 58-Untitled_spreadsheet_-_Google_Sheets](https://user-images.githubusercontent.com/44649/71027990-b1879b80-210c-11ea-91ad-b36c23ff417a.png)

