### PR TITLE
Fixes #16483: nonblocking errors parser, more precise context capture

### DIFF
--- a/rudder-lang/src/data/corelib.rl
+++ b/rudder-lang/src/data/corelib.rl
@@ -1,6 +1,6 @@
 @format=0
 
-global enum os {
+global enm os {
   ubuntu,
   debian
 }
@@ -22,4 +22,3 @@ enum outcome {
   repaired,
   error
 }
-

--- a/rudder-lang/src/data/test.rl.cf
+++ b/rudder-lang/src/data/test.rl.cf
@@ -1,7 +1,7 @@
 #
 # @version 1.0
-# @parameters [  ]
 # @name Configure NTP
+# @parameters [  ]
 # @description test
 
 bundle agent Configure_NTP_technique 

--- a/rudder-lang/src/error.rs
+++ b/rudder-lang/src/error.rs
@@ -113,7 +113,7 @@ macro_rules! err {
         Error::User(format!(
                 "{}:\n{} {}",
                 $origin.position_str().bright_yellow(),
-                "-->".bright_blue(),
+                "!-->".bright_blue(),
                 format!( $ ( $ arg ) * )
         ))
     });
@@ -234,7 +234,7 @@ pub fn get_suggestion_message<'src, I>(unmatched_token_fragment: &str, list: I) 
 where 
     I: Iterator<Item = &'src Token<'src>>,
 {
-    let separator = ".\n";
+    let separator = ". ";
     let mut output_str = String::new();
     output_str.push_str(separator);
     match list.size_hint() {

--- a/rudder-lang/src/parser/error.rs
+++ b/rudder-lang/src/parser/error.rs
@@ -48,20 +48,21 @@ pub enum PErrorKind<I> {
     Nom(VerboseError<I>),
     #[cfg(test)]
     NomTest(String), // cannot be use outside of tests
-    InvalidFormat,                 // in header
-    InvalidName(I),                // in identifier expressions (type of expression)
-    UnexpectedToken(&'static str), // anywhere (expected token)
-    UnterminatedDelimiter(I),      // after an opening delimiter (first delimiter)
+    ExpectedKeyword(&'static str), // anywhere (keyword type)
+    ExpectedReservedWord(&'static str), // anywhere (keyword that does not exist)
+    ExpectedToken(&'static str), // anywhere (expected token)
     InvalidEnumExpression,         // in enum expression
     InvalidEscapeSequence,         // in string definition
+    InvalidFormat,                 // in header
+    InvalidName(I),                // in identifier expressions (type of expression)
     InvalidVariableReference,      // during string interpolation
-    ExpectedKeyword(&'static str), // anywhere (keyword type)
     UnsupportedMetadata(I), // metadata or comments are not supported everywhere (metadata key)
+    UnterminatedDelimiter(I),      // after an opening delimiter (first delimiter)
 }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct PError<I> {
-    pub context: I,
+    pub context: Option<I>,
     pub kind: PErrorKind<I>,
 }
 
@@ -73,18 +74,18 @@ impl<I: Clone> ParseError<I> for PError<I> {
     /// creates an error from the input position and an [ErrorKind]
     fn from_error_kind(input: I, kind: ErrorKind) -> Self {
         PError {
-            context: input.clone(),
+            context: None,
             kind: PErrorKind::Nom(VerboseError::from_error_kind(input, kind)),
         }
     }
 
     /// combines an existing error with a new one created from the input
-    /// positionsition and an [ErrorKind]. This is useful when backtracking
+    /// position and an [ErrorKind]. This is useful when backtracking
     /// through a parse tree, accumulating error context on the way
     fn append(input: I, kind: ErrorKind, other: Self) -> Self {
         match other.kind {
             PErrorKind::Nom(e) => PError {
-                context: input.clone(),
+                context: None,
                 kind: PErrorKind::Nom(VerboseError::append(input, kind, e)),
             },
             _ => other,
@@ -94,7 +95,7 @@ impl<I: Clone> ParseError<I> for PError<I> {
     /// creates an error from an input position and an expected character
     fn from_char(input: I, c: char) -> Self {
         PError {
-            context: input.clone(),
+            context: None,
             kind: PErrorKind::Nom(VerboseError::from_char(input, c)),
         }
     }
@@ -123,27 +124,41 @@ impl<I: Clone> ParseError<I> for PError<I> {
 impl<'src> fmt::Display for PError<PInput<'src>> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let message = match &self.kind {
-            PErrorKind::Nom(e) => format!("Unprocessed parsing error: {:?}.\nPlease fill a BUG with context on when this happened!", e),
+            PErrorKind::Nom(e) => format!("Unprocessed parsing error: '{:#?}'.\nPlease fill a BUG with context on when this happened!", e),
             #[cfg(test)]
             PErrorKind::NomTest(msg) => format!("Testing only error message, this should never happen {}.\nPlease fill a BUG with context on when this happened!", msg),
-            PErrorKind::InvalidFormat => "Invalid header format, it must contain a single line '@format=x' where x is an integer. Shebang accepted.".to_string(),
-            PErrorKind::InvalidName(i) => format!("The identifier is invalid in a {}.", i.fragment.bright_magenta()),
-            PErrorKind::UnexpectedToken(s) => format!("Unexpected token, expecting '{}', found", s.bright_magenta()),
-            PErrorKind::UnterminatedDelimiter(i) => format!("Missing closing delimiter for '{}'", i.fragment.bright_magenta()),
+            PErrorKind::ExpectedKeyword(s) => format!("The following value kind was expected: '{}'.", s.bright_magenta()),
+            PErrorKind::ExpectedReservedWord(s) => format!("The following reserved keyword was expected: '{}'.", s.bright_magenta()),
+            PErrorKind::ExpectedToken(s) => format!("The following token was expected '{}'.", s.bright_magenta()),
             PErrorKind::InvalidEnumExpression => "This enum expression is invalid".to_string(),
             PErrorKind::InvalidEscapeSequence => "This escape sequence cannot be used in a string".to_string(),
+            PErrorKind::InvalidFormat => "Invalid header format, it must contain a single line '@format=x' where x is an integer. Shebang accepted.".to_string(),
+            PErrorKind::InvalidName(i) => format!("The identifier is invalid in a {}.", i.fragment.bright_magenta()),
             PErrorKind::InvalidVariableReference => "This variable reference is invalid".to_string(),
-            PErrorKind::ExpectedKeyword(s) => format!("Token not found, expected '{}'", s.bright_magenta()),
             PErrorKind::UnsupportedMetadata(i) => format!("Parsed comment or metadata not supported at this place: '{}' fount at {}", i.fragment.bright_magenta(), Token::from(*i).position_str().bright_yellow()),
+            PErrorKind::UnterminatedDelimiter(i) => format!("Missing closing delimiter for '{}'", i.fragment.bright_magenta()),
         };
-        f.write_str(&format!(
-            "{}, near\n{}{} {}",
-            Token::from(self.context).position_str().bright_yellow(),
-            self.context.fragment,
-            "-->".bright_blue(),
-            message.bold(),
-            
-        ))
+
+        // simply removes superfluous line return (prettyfication)
+        match self.context {
+            Some(ctx) => {
+                let context = ctx.fragment.trim_end_matches('\n');
+                // Formats final error output
+                f.write_str(&format!(
+                    "{}, near '{}'\n{} {}",
+                    Token::from(context.as_ref()).position_str().bright_yellow(),
+                    context,
+                    "-->".bright_blue(),
+                    message.bold(),
+                ))
+            },
+            None => f.write_str(&format!(
+                "{}\n{} {}",
+                "undefined context".bright_yellow(),
+                "-->".bright_blue(),
+                message.bold(),
+            ))
+        }
     }
 }
 
@@ -166,27 +181,94 @@ where
     E: Fn() -> PErrorKind<PInput<'src>>,
 {
     move |input| {
-        let x = f(input);
-        match x {
+        match f(input) {
             // a non nom error cannot be superseded
             // keep original context when possible
             Err(Err::Failure(err)) => match err.kind {
                 PErrorKind::Nom(_) => Err(Err::Failure(PError {
-                    context: err.context,
+                    context: None,
                     kind: e(),
                 })),
                 _ => Err(Err::Failure(err)),
             },
-            Err(Err::Error(err)) => Err(Err::Failure(PError {
-                context: err.context,
+            Err(Err::Error(_)) => Err(Err::Failure(PError {
+                context: None,
                 kind: e(),
             })),
-            Err(Err::Incomplete(_)) => Err(Err::Failure(PError {
-                context: input,
-                kind: e(),
-            })),
+            Err(Err::Incomplete(_)) => panic!("Incomplete should never happen"),
             Ok(y) => Ok(y),
         }
+    }
+}
+
+/// Similar code to `or_fail()` yet usage and behavior differ:
+/// primarly it is non-terminating as it does not turn Errors into Failures
+/// but rather gives it a PError context (E parameter) therefore updating the generic Nom::ErrorKind
+pub fn or_err<'src, O, F, E>(f: F, e: E) -> impl Fn(PInput<'src>) -> PResult<'src, O>
+where
+    F: Fn(PInput<'src>) -> PResult<'src, O>,
+    E: Fn() -> PErrorKind<PInput<'src>>,
+{
+    move |input| {
+        match f(input) {
+            Err(Err::Failure(err)) => Err(Err::Failure(err)),
+            Err(Err::Error(_)) => Err(Err::Error(PError {
+                context: None,
+                kind: e(),
+            })),
+            Err(Err::Incomplete(_)) => panic!("Incomplete should never happen"),
+            Ok(y) => Ok(y)
+        }
+    }
+}
+
+/// This function turns our own `Error`s (not nom ones) into `Failure`s so they are properly handled
+/// by the `nom::multi::many0()` function which abstracts Errors, only breaking on failures which was an issue
+pub fn or_fail_perr<'src, O, F>(f: F) -> impl Fn(PInput<'src>) -> PResult<'src, O>
+where
+    F: Fn(PInput<'src>) -> PResult<'src, O>,
+{
+    move |input| {    
+        match f(input) {
+            Err(Err::Failure(e)) => Err(Err::Failure(e)),
+            Err(Err::Error(e)) => match &e.kind {
+                PErrorKind::Nom(_) => Err(Err::Error(PError{
+                    context: None,
+                    kind: e.kind
+                })),
+                _ => Err(Err::Failure(e)),
+            },
+            Err(Err::Incomplete(_)) => panic!("Incomplete should never happen"),
+            Ok(y) => Ok(y)
+        }
+    }
+}
+
+/// Updates content of an error to fit and capture a better context
+/// Solely exists for (w)sequence macro
+pub fn update_error_context<'src>(e: Err<PError<PInput<'src>>>, new_ctx: PInput<'src>) -> Err<PError<PInput<'src>>> {
+    match e {
+        Err::Failure(err) => {
+            let context = match err.context {
+                None => Some(new_ctx),
+                Some(context_to_keep) => Some(context_to_keep)
+            };
+            Err::Failure(PError {
+                context,
+                kind: err.kind,
+            })
+        },
+        Err::Error(err) => {
+            let context = match err.context {
+                None => Some(new_ctx),
+                Some(context_to_keep) => Some(context_to_keep)
+            };
+            Err::Error(PError {
+                context,
+                kind: err.kind,
+            })
+        },
+        Err::Incomplete(_) => panic!("Incomplete should never happen"),
     }
 }
 

--- a/rudder-lang/src/parser/tests.rs
+++ b/rudder-lang/src/parser/tests.rs
@@ -60,7 +60,7 @@ fn map_err(err: PError<PInput>) -> (&str, PErrorKind<&str>) {
         PErrorKind::NomTest(e) => PErrorKind::NomTest(e),
         PErrorKind::InvalidFormat => PErrorKind::InvalidFormat,
         PErrorKind::InvalidName(i) => PErrorKind::InvalidName(i.fragment),
-        PErrorKind::UnexpectedToken(i) => PErrorKind::UnexpectedToken(i),
+        PErrorKind::ExpectedToken(i) => PErrorKind::ExpectedToken(i),
         PErrorKind::UnterminatedDelimiter(i) => PErrorKind::UnterminatedDelimiter(i.fragment),
         PErrorKind::InvalidEnumExpression => PErrorKind::InvalidEnumExpression,
         PErrorKind::InvalidEscapeSequence => PErrorKind::InvalidEscapeSequence,
@@ -632,7 +632,7 @@ fn test_pmetadata() {
     );
     assert_eq!(
         map_res(pmetadata, "@key value"),
-        Err(("value", PErrorKind::UnexpectedToken("=")))
+        Err(("value", PErrorKind::ExpectedToken("=")))
     );
 }
 


### PR DESCRIPTION
Integration of a non-blocking error parser
Integration of another way to implement and catch error contexts allowing to catch more accurate informations about errors

https://issues.rudder.io/issues/16483