### PR TITLE
Fixes #16629: Use only one ZIO threadpool to enhance performances

### DIFF
--- a/webapp/sources/utils/src/main/scala/zio/internal/RudderBlockingService.scala
+++ b/webapp/sources/utils/src/main/scala/zio/internal/RudderBlockingService.scala
@@ -1,5 +1,8 @@
 package zio.internal
 
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ForkJoinPool
+import java.util.concurrent.ForkJoinWorkerThread
 import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
@@ -20,30 +23,101 @@ import zio.blocking.Blocking.Service
  */
 trait RudderBlockingService extends Blocking {
   val blocking: Service[Any] = new Service[Any] {
-
-    val zio = ZIO.succeed(Executor.fromThreadPoolExecutor(_ => Int.MaxValue) {
-      val corePoolSize  = Math.max(1, Runtime.getRuntime.availableProcessors()/2) // default is 0
-      val maxPoolSize   = Int.MaxValue
-      val keepAliveTime = 5*1000L // default is 1000
-      val timeUnit      = TimeUnit.MILLISECONDS
-      val workQueue     = new SynchronousQueue[Runnable]()
-      val threadFactory = new NamedThreadFactory("zio-default-blocking", true)
-
-      val threadPool = new ThreadPoolExecutor(
-        corePoolSize,
-        maxPoolSize,
-        keepAliveTime,
-        timeUnit,
-        workQueue,
-        threadFactory
-      )
-
-      threadPool
-    })
-
-    // this doesn't yield better results
-    // val scalaGobal: UIO[Executor] = ZIO.succeed(Executor.fromExecutionContext(Int.MaxValue)(scala.concurrent.ExecutionContext.global))
-
-    val blockingExecutor: UIO[Executor] = zio
+    val blockingExecutor: UIO[Executor] = ZIO.succeed(RudderExecutor.executor)
   }
+}
+
+object RudderExecutor {
+
+  final def fromForkJoinPool(yieldOpCount0: ExecutionMetrics => Int)(
+    fjp: ForkJoinPool
+  ): Executor =
+    new Executor {
+      private[this] def metrics0 = new ExecutionMetrics {
+        def concurrency: Int = fjp.getParallelism
+        def capacity: Int = Int.MaxValue // don't know how to get it from pool
+        def size: Int = fjp.getQueuedSubmissionCount
+        def workersCount: Int = fjp.getPoolSize()
+        def enqueuedCount: Long = -1 // can't know ?
+        def dequeuedCount: Long = -1 // can't know ?
+      }
+
+      def metrics = Some(metrics0)
+      def yieldOpCount = yieldOpCount0(metrics0)
+      def submit(runnable: Runnable): Boolean =
+        try {
+          fjp.execute(runnable)
+          true
+        } catch {
+          case _: RejectedExecutionException => false
+        }
+
+      def here = false
+    }
+
+  /**
+   * A named fork-join pool
+   */
+
+  lazy val factory: ForkJoinPool.ForkJoinWorkerThreadFactory = new ForkJoinPool.ForkJoinWorkerThreadFactory() {
+    override def newThread(pool: ForkJoinPool): ForkJoinWorkerThread = {
+      val worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool)
+      worker.setName("zio-rudder-mix-" + worker.getPoolIndex)
+      worker
+    }
+  }
+
+  /*
+   * We must set a max capacity
+   */
+  lazy val forkJoinPool = {
+    // in FJP from jdk8, we can't control liveliness. On one or two processors, we need some room
+    val parallelism = Integer.max(4, Runtime.getRuntime.availableProcessors)
+    new ForkJoinPool(
+        parallelism
+      , factory
+      , null // default UncaughtExceptionHandler
+      , false // asyncMode: set to true for event style workload, better locality
+// these are jdk11 specific
+//      , 2*parallelism  // corePoolSize, ie thread to keep in the pool. We a lot of blocking tasks
+//      , Int.MaxValue // maximumPoolSize: no up limit to number of thread
+//      , if(parallelism == 1)  1 else 2 //  minimumRunnable: 1 to ensure liveliness
+//      , null // use default for Predicate<? super ForkJoinPool> saturate
+//      , 60 //keepAliveTime,
+//      , TimeUnit.SECONDS // unit for keepAliveTime
+    )
+  }
+  // the yield count must be relatively small with a common thread pool, else we almost have no
+  // parallelism on CPU constraint task: they never yield by themselve, and they don't give a chance to the
+  // scheduler to see that parallelism was wanted.
+
+  //
+  // WARNING: on all our tests, FJP from JDK8 leads to deadlock with ZIO.
+  // Perhaps JDK 11 pool, where livelyness can be specified, would yield another result.
+  //
+  def fjpExecutor  = fromForkJoinPool(_ => 5000)(forkJoinPool)
+
+  // a unbounded pool
+  def blockingExecutor = Executor.fromThreadPoolExecutor(_ => 5000) { // same than for FJP yield
+    val corePoolSize  = Math.max(5, Runtime.getRuntime.availableProcessors()/2)
+    val maxPoolSize   = 500 // if we exhauste 500 thread, Rudder is most likely dead, no need to take the server with it
+    val keepAliveTime = 30*1000L // default is 1000
+    val timeUnit      = TimeUnit.MILLISECONDS
+    val workQueue     = new SynchronousQueue[Runnable]()
+    val threadFactory = new NamedThreadFactory("zio-rudder-mix", true)
+
+    val threadPool = new ThreadPoolExecutor(
+        corePoolSize
+      , maxPoolSize
+      , keepAliveTime
+      , timeUnit
+      , workQueue
+      , threadFactory
+    )
+
+    threadPool
+  }
+
+  lazy val executor = blockingExecutor
+
 }

--- a/webapp/sources/utils/src/test/scala/com/normation/ZioCommonsTest.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/ZioCommonsTest.scala
@@ -498,7 +498,7 @@ import _root_.zio.system.{System => ZSystem}
 
   def main(args: Array[String]): Unit = {
 
-    val runtime = new DefaultRuntime() {
+    object runtime extends DefaultRuntime() {
       object ForkJoinBlockin extends Blocking {
         val blocking: Blocking.Service[Any] = new Blocking.Service[Any] {
           val blockingExecutor: UIO[Executor] = Executor.fromExecutionContext(Int.MaxValue)(scala.concurrent.ExecutionContext.global).succeed


### PR DESCRIPTION
https://issues.rudder.io/issues/16629

This change leads to a 20% improvement in Rudder policy generation time, from around 25 minutes to below 20 minutes. 

This change allowed to workaround three things described here: https://github.com/zio/zio/issues/1275#issuecomment-578734553

- 1/ switching from a thread to an other cost a bit, 
- 2/ switching on the same threadpool is idempotent but all the fixe costs, like fiber pause etc, are paid (while it should be `identity`)
- 3/ `effectBlocking` manage the discarding of the underlying thread, which we generally don't want. 

The last two are already corrected in ZIO-RC18! And the first one is not that bad anymore.
So, I'm not sure I we should commit that complicated PR or just wait for RC18 (which is stabilising and will likely be ZIO 1.0.0)