### PR TITLE
Fixes #16651: Change in maven repository URL from http://repo1.maven.org/maven2/ to https://repo1.maven.org/maven2/

### DIFF
--- a/webapp/sources/rudder-parent-pom/pom.xml
+++ b/webapp/sources/rudder-parent-pom/pom.xml
@@ -60,7 +60,7 @@ limitations under the License.
     <repository>
       <id>maven_central</id>
       <name>Default maven repository</name>
-      <url>http://repo1.maven.org/maven2/</url>
+      <url>https://repo1.maven.org/maven2/</url>
       <snapshots><enabled>true</enabled></snapshots>
     </repository>
     <repository>


### PR DESCRIPTION
https://issues.rudder.io/issues/16651