### PR TITLE
Fixes #16692: Authorized networks are actually called allowed networks

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -272,17 +272,17 @@ object SettingsApi extends ApiModuleProvider[SettingsApi] {
     val description = "Get information about all Rudder settings"
     val (action, path)  = GET / "settings"
   }
-  final case object GetAllAuthorizedNetworks extends SettingsApi with ZeroParam with StartsAtVersion11 with SortIndex { val z = implicitly[Line].value
-    val description = "List all authorized networks"
-    val (action, path)  = GET / "settings" / "authorized_networks"
+  final case object GetAllAllowedNetworks extends SettingsApi with ZeroParam with StartsAtVersion11 with SortIndex { val z = implicitly[Line].value
+    val description = "List all allowed networks"
+    val (action, path)  = GET / "settings" / "allowed_networks"
   }
-  final case object GetAuthorizedNetworks extends SettingsApi with OneParam with StartsAtVersion11 with SortIndex { val z = implicitly[Line].value
-    val description = "List all authorized networks for one relay"
-    val (action, path)  = GET / "settings" / "authorized_networks" / "{nodeId}"
+  final case object GetAllowedNetworks extends SettingsApi with OneParam with StartsAtVersion11 with SortIndex { val z = implicitly[Line].value
+    val description = "List all allowed networks for one relay"
+    val (action, path)  = GET / "settings" / "allowed_networks" / "{nodeId}"
   }
-  final case object ModifyAuthorizedNetworks extends SettingsApi with OneParam with StartsAtVersion11 with SortIndex { val z = implicitly[Line].value
-    val description = "Update all authorized networks for one relay"
-    val (action, path)  = POST / "settings" / "authorized_networks" / "{nodeId}"
+  final case object ModifyAllowedNetworks extends SettingsApi with OneParam with StartsAtVersion11 with SortIndex { val z = implicitly[Line].value
+    val description = "Update all allowed networks for one relay"
+    val (action, path)  = POST / "settings" / "allowed_networks" / "{nodeId}"
   }
 
   final case object GetSetting extends SettingsApi with OneParam with StartsAtVersion6 with SortIndex { val z = implicitly[Line].value


### PR DESCRIPTION
https://issues.rudder.io/issues/16692

- change "authorized networks" to "allowed networks" so that it matches UI/documentation, 
- if a policy server is missing allowed network policy, we want to return an empty list of networks in place of failing,
- if the user didn't specify "allowed_networks" param, don't erase all allowed networks but fail. 