### PR TITLE
Fixes #16301: Add JSON support for global parameters

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
@@ -155,6 +155,9 @@ object GenericPropertyUtils {
   import net.liftweb.json.JsonAST.JString
   import net.liftweb.json.{parse => jsonParse}
 
+  /**
+   * Parse a value that can be a string or some json.
+   */
   def parseValue(value: String): JValue = {
     try {
       jsonParse(value) match {
@@ -169,6 +172,21 @@ object GenericPropertyUtils {
     }
   }
 
+  /**
+   * Write back a value as a string. There is
+   * some care to take, because simple jvalue (string, boolean, etc)
+   * must be written directly as string without quote.
+   */
+  def serializeValue(value: JValue): String = {
+    value match {
+      case JNothing | JNull => ""
+      case JString(s)       => s
+      case JBool(v)         => v.toString
+      case JDouble(v)       => v.toString
+      case JInt(v)          => v.toString
+      case json             => compactRender(json)
+    }
+  }
 }
 
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/parameters/GlobalParameter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/parameters/GlobalParameter.scala
@@ -37,6 +37,9 @@
 package com.normation.rudder.domain.parameters
 import java.util.regex.Pattern
 
+import com.normation.rudder.domain.nodes.GenericPropertyUtils
+import net.liftweb.json._
+
 final case class ParameterName(value:String) extends AnyVal
 
 object ParameterName {
@@ -44,25 +47,26 @@ object ParameterName {
 }
 
 /**
- * A Parameter is an object that has a name and a value, to store and reuse
- * values at different places within Rudder
- */
-sealed trait Parameter {
-  def name        : ParameterName
-  def value       : String
-  def description : String
-  def overridable : Boolean
-}
-
-/**
  * A Global Parameter is a parameter globally defined, that may be overriden
  */
 final case class GlobalParameter(
-    override val name       : ParameterName
-  , override val value      : String
-  , override val description: String
-  , override val overridable: Boolean
-) extends Parameter {
+    name       : ParameterName
+  , value      : JValue
+  , description: String
+)
 
+object GlobalParameter {
+
+  /**
+   * A builder with the logic to handle the value part.
+   *
+   * For compatibity reason, we want to be able to process
+   * empty (JNothing) and primitive types, especially string, specificaly as
+   * a JString *but* a string representing an actual JSON should be
+   * used as json.
+   */
+  def apply(name: String, value: String, description: String =""): GlobalParameter = {
+    GlobalParameter(ParameterName(name), GenericPropertyUtils.parseValue(value), description)
+  }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/parameters/ParameterDiff.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/parameters/ParameterDiff.scala
@@ -39,6 +39,7 @@ package com.normation.rudder.domain.parameters
 
 import com.normation.rudder.domain.policies.SimpleDiff
 import com.normation.rudder.domain.policies.TriggerDeploymentDiff
+import net.liftweb.json.JsonAST.JValue
 
 sealed trait ParameterDiff extends TriggerDeploymentDiff
 
@@ -57,12 +58,11 @@ final case class DeleteGlobalParameterDiff(parameter:GlobalParameter) extends Pa
 
 final case class ModifyGlobalParameterDiff(
     name                : ParameterName
-  , modValue            : Option[SimpleDiff[String]] = None
+  , modValue            : Option[SimpleDiff[JValue]] = None
   , modDescription      : Option[SimpleDiff[String]] = None
-  , modOverridable      : Option[SimpleDiff[Boolean]] = None
 ) extends ParameterDiff {
   def needDeployment : Boolean = {
-    modValue.isDefined || modOverridable.isDefined
+    modValue.isDefined
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
@@ -410,15 +410,11 @@ class LDAPDiffMapper(
               mod.getAttributeName() match {
                 case A_PARAMETER_VALUE =>
                   nonNull(diff, mod.getAttribute().getValue) { (d, value) =>
-                    d.copy(modValue = Some(SimpleDiff(oldParam.value, value)))
+                    d.copy(modValue = Some(SimpleDiff(oldParam.value, GenericPropertyUtils.parseValue(value))))
                   }
                 case A_DESCRIPTION =>
                   nonNull(diff, mod.getAttribute().getValue) { (d, value) =>
                     d.copy(modDescription = Some(SimpleDiff(oldParam.description, value)))
-                  }
-                case A_PARAMETER_OVERRIDABLE =>
-                  nonNull(diff, mod.getAttribute().getValueAsBoolean) { (d, value) =>
-                    d.copy(modOverridable = Some(SimpleDiff(oldParam.overridable, value)))
                   }
                 case x => Left(Err.UnexpectedObject("Unknown diff attribute: " + x))
               }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -961,13 +961,11 @@ class LDAPEntityMapper(
         name        <- e.required(A_PARAMETER_NAME)
         value       =  e(A_PARAMETER_VALUE).getOrElse("")
         description =  e(A_DESCRIPTION).getOrElse("")
-        overridable =  e.getAsBoolean(A_PARAMETER_OVERRIDABLE).getOrElse(true)
       } yield {
         GlobalParameter(
             ParameterName(name)
           , value
           , description
-          , overridable
         )
       }
     } else Left(Err.UnexpectedObject("The given entry is not of the expected ObjectClass '%s'. Entry details: %s".format(OC_PARAMETER, e)))
@@ -977,8 +975,7 @@ class LDAPEntityMapper(
     val entry = rudderDit.PARAMETERS.parameterModel(
         parameter.name
     )
-    entry +=! (A_PARAMETER_VALUE, parameter.value)
-    entry +=! (A_PARAMETER_OVERRIDABLE, parameter.overridable.toLDAPString)
+    entry +=! (A_PARAMETER_VALUE, GenericPropertyUtils.serializeValue(parameter.value))
     entry +=! (A_DESCRIPTION, parameter.description)
     entry
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
@@ -75,6 +75,7 @@ import com.normation.inventory.domain.Certificate
 import com.normation.inventory.domain.KeyStatus
 import com.normation.inventory.domain.PublicKey
 import com.normation.inventory.domain.SecurityToken
+import net.liftweb.json.JsonAST.JValue
 
 /**
  * A service that helps mapping event log details to there structured data model.
@@ -791,7 +792,8 @@ class EventLogDetailsServiceImpl(
                             (s"Entry type is not a Global Parameter: ${entry}")
       name               <- (globalParam \ "name").headOption.map( _.text ) ?~!
                            ("Missing attribute 'name' in entry type Global Parameter: ${entry}")
-      modValue           <- getFromToString((globalParam \ "value").headOption)
+      modValue           <- getFromTo[JValue]((globalParam \ "value").headOption,
+                             { s => Full(GenericPropertyUtils.parseValue(s.text)) })
       modDescription     <- getFromToString((globalParam \ "description").headOption)
       modOverridable     <- getFromTo[Boolean]((globalParam \ "overridable").headOption,
                              { s => tryo { s.text.toBoolean } } )
@@ -799,9 +801,8 @@ class EventLogDetailsServiceImpl(
     } yield {
       ModifyGlobalParameterDiff(
           name = ParameterName(name)
-        , modValue = modValue
+        , modValue = (modValue)
         , modDescription = modDescription
-        , modOverridable = modOverridable
       )
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -709,9 +709,8 @@ class EventLogFactoryImpl(
     val details = EventLog.withContent{
       scala.xml.Utility.trim(<globalParameter changeType="modify" fileFormat={Constants.XML_CURRENT_FILE_FORMAT.toString}>
         <name>{modifyDiff.name.value}</name>{
-          modifyDiff.modValue.map(x => SimpleDiff.stringToXml(<value/>, x) ) ++
-          modifyDiff.modDescription.map(x => SimpleDiff.stringToXml(<description/>, x ) ) ++
-          modifyDiff.modOverridable.map(x => SimpleDiff.booleanToXml(<overridable/>, x ) )
+          modifyDiff.modValue.map(x => SimpleDiff.toXml(<value/>, x){v => Text(GenericPropertyUtils.serializeValue(v))}) ++
+          modifyDiff.modDescription.map(x => SimpleDiff.stringToXml(<description/>, x ) )
         }
       </globalParameter>)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
@@ -296,7 +296,6 @@ class GlobalParameterSerialisationImpl(xmlVersion:String) extends GlobalParamete
        <name>{param.name.value}</name>
        <value>{param.value}</value>
        <description>{param.description}</description>
-       <overridable>{param.overridable}</overridable>
     )
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -641,10 +641,9 @@ class GlobalParameterUnserialisationImpl extends GlobalParameterUnserialisation 
       overridable      <- (globalParam \ "overridable").headOption.flatMap(s => tryo { s.text.toBoolean } ) ?~! ("Missing attribute 'overridable' in entry type globalParameter : " + entry)
     } yield {
       GlobalParameter(
-          ParameterName(name)
+          name
         , value
         , description
-        , overridable
       )
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/modification/DiffService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/modification/DiffService.scala
@@ -164,13 +164,11 @@ class DiffServiceImpl extends DiffService {
   def diffGlobalParameter(reference:GlobalParameter, newItem:GlobalParameter) : ModifyGlobalParameterDiff = {
     val diffValue = if (reference.value == newItem.value) None else Some(SimpleDiff(reference.value,newItem.value))
     val diffDescription = if (reference.description == newItem.description) None else Some(SimpleDiff(reference.description,newItem.description))
-    val diffOverridable = if (reference.overridable == newItem.overridable) None else Some(SimpleDiff(reference.overridable,newItem.overridable))
 
     ModifyGlobalParameterDiff(
         reference.name
       , diffValue
       , diffDescription
-      , diffOverridable
     )
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/ParameterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/ParameterService.scala
@@ -45,7 +45,6 @@ import com.normation.rudder.repository.RoParameterRepository
 import com.normation.rudder.repository.WoParameterRepository
 import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
-import com.normation.inventory.domain.NodeId
 
 import com.normation.box._
 
@@ -60,11 +59,6 @@ trait RoParameterService {
    * Returns all defined Global Parameters
    */
   def getAllGlobalParameters() : Box[Seq[GlobalParameter]]
-
-  /**
-   * Returns all parameters applicable for a given node
-   */
-  def getParametersByNode(nodeId: NodeId) : Box[Seq[Parameter]]
 }
 
 trait WoParameterService {
@@ -125,14 +119,6 @@ class RoParameterServiceImpl(
         logger.error("Error while trying to fetch all parameters : %s".format(e.messageChain))
         e
     }
-  }
-
-  /**
-   * Returns all parameters applicable for a given node
-   * Hyper naive implementation : all parameters !
-   */
-  def getParametersByNode(nodeId: NodeId) : Box[Seq[Parameter]] = {
-    getAllGlobalParameters()
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
@@ -482,10 +482,6 @@ final case object CheckGlobalParameter extends CheckChanges[GlobalParameter]  {
           debugLog(s"Global Parameter '${initialFixed.name}' value has changed: original state from CR: ${initialFixed.value}, current value: ${currentFixed.value}")
         }
 
-        if ( initialFixed.overridable != currentFixed.overridable) {
-          debugLog(s"Global Parameter '${initialFixed.name}' overridable status has changed: original state from CR: ${initialFixed.overridable}, current value: ${currentFixed.overridable}")
-        }
-
         //return
         false
       }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestDataSerializer.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestDataSerializer.scala
@@ -80,7 +80,7 @@ trait RestDataSerializer {
   def serializeGroup(group : NodeGroup, crId: Option[ChangeRequestId]): JValue
   def serializeGroupCategory (category:FullNodeGroupCategory, parent: NodeGroupCategoryId, detailLevel : DetailLevel, apiVersion: ApiVersion): JValue
 
-  def serializeParameter (parameter:Parameter , crId: Option[ChangeRequestId]): JValue
+  def serializeParameter (parameter:GlobalParameter , crId: Option[ChangeRequestId]): JValue
 
   def serializeRule (rule:Rule , crId: Option[ChangeRequestId]): JValue
   def serializeRuleCategory (category:RuleCategory, parent: RuleCategoryId, rules : Map[RuleCategoryId,Seq[Rule]], detailLevel : DetailLevel): JValue
@@ -197,12 +197,11 @@ final case class RestDataSerializerImpl (
     )
   }
 
-  def serializeParameter (parameter:Parameter, crId: Option[ChangeRequestId]): JValue = {
+  def serializeParameter (parameter:GlobalParameter, crId: Option[ChangeRequestId]): JValue = {
    (   ( "changeRequestId" -> crId.map(_.value.toString))
      ~ ( "id"              -> parameter.name.value )
      ~ ( "value"           -> parameter.value )
      ~ ( "description"     -> parameter.description )
-     ~ ( "overridable"     -> parameter.overridable )
    )
   }
 
@@ -356,12 +355,10 @@ final case class RestDataSerializerImpl (
 
       val description :JValue = diff.modDescription.map(displaySimpleDiff(_)).getOrElse(initialState.description)
       val value :JValue       = diff.modValue.map(displaySimpleDiff(_)).getOrElse(initialState.value)
-      val overridable :JValue = diff.modOverridable.map(displaySimpleDiff(_)).getOrElse(initialState.overridable)
 
       (   ("name"        -> initialState.name)
         ~ ("value"       -> value)
         ~ ("description" -> description)
-        ~ ("overridable" -> overridable)
       )
     }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -599,9 +599,9 @@ final case class RestExtractorService (
     for {
       description <- extractOneValue(params, "description")()
       overridable <- extractOneValue(params, "overridable")( toBoolean)
-      value       <- extractOneValue(params, "value")()
+      value       <- extractOneValue(params, "value")(s => Full(GenericPropertyUtils.parseValue(s)))
     } yield {
-      RestParameter(value,description,overridable)
+      RestParameter(value, description, overridable)
     }
   }
 
@@ -899,9 +899,12 @@ final case class RestExtractorService (
     for {
       description <- extractJsonString(json, "description")
       overridable <- extractJsonBoolean(json, "overridable")
-      value       <- extractJsonString(json, "value")
+      value       <- Full((json \ "value") match {
+                       case JNothing => None
+                       case x        => Some(x)
+                     })
     } yield {
-      RestParameter(value,description,overridable)
+      RestParameter(value, description, overridable)
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/RestData.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/RestData.scala
@@ -60,6 +60,7 @@ import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleTarget
 import com.normation.rudder.domain.workflows.ChangeRequestInfo
+import net.liftweb.json.JsonAST.JValue
 
 
 sealed trait DetailLevel {
@@ -272,7 +273,7 @@ final case object RefuseNode extends NodeStatusAction
 final case object DeleteNode extends NodeStatusAction
 
 final case class RestParameter(
-      value       : Option[String] = None
+      value       : Option[JValue] = None
     , description : Option[String] = None
     , overridable : Option[Boolean] = None
   ) {
@@ -281,11 +282,9 @@ final case class RestParameter(
     def updateParameter(parameter: GlobalParameter) = {
       val updateValue = value.getOrElse(parameter.value)
       val updateDescription = description.getOrElse(parameter.description)
-      val updateOverridable = overridable.getOrElse(parameter.overridable)
       parameter.copy(
           value       = updateValue
         , description = updateDescription
-        , overridable = updateOverridable
       )
 
     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
@@ -243,7 +243,7 @@ extends Loggable {
 
     restParameter match {
       case Full(restParameter) =>
-            val parameter = restParameter.updateParameter(GlobalParameter(parameterName,"","",false))
+            val parameter = restParameter.updateParameter(GlobalParameter(parameterName,"",""))
 
             val diff = AddGlobalParameterDiff(parameter)
             createChangeRequestAndAnswer(

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -775,8 +775,7 @@ class EventLogDetailsGenerator(
                 {(
                 "#name" #> modDiff.name.value &
                   "#value" #>  mapSimpleDiff(modDiff.modValue) &
-                  "#description *" #> mapSimpleDiff(modDiff.modDescription) &
-                  "#overridable *" #> mapSimpleDiff(modDiff.modOverridable)
+                  "#description *" #> mapSimpleDiff(modDiff.modDescription)
                 )(globalParamModDetailsXML)
                 }
                 { reasonHtml }
@@ -1123,9 +1122,8 @@ class EventLogDetailsGenerator(
 
   private[this] def globalParameterDetails(xml: NodeSeq, globalParameter: GlobalParameter) = (
     "#name" #> globalParameter.name.value &
-      "#value" #> globalParameter.value &
-      "#description" #> globalParameter.description &
-      "#overridable" #> globalParameter.overridable
+      "#value" #> GenericPropertyUtils.serializeValue(globalParameter.value) &
+      "#description" #> globalParameter.description
     )(xml)
 
   private[this] def apiAccountDetails(xml: NodeSeq, apiAccount: ApiAccount) = (

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
@@ -51,6 +51,7 @@ import com.normation.rudder.web.model.CurrentUser
 import com.normation.rudder.web.model._
 import java.util.regex.Pattern
 
+import com.normation.rudder.domain.nodes.GenericPropertyUtils
 import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.rudder.services.workflows.ChangeRequestService
 import com.normation.rudder.services.workflows.GlobalParamChangeRequest
@@ -113,9 +114,8 @@ class CreateOrUpdateGlobalParameterPopup(
     } else {
       val newParameter = new GlobalParameter(
         name        = ParameterName(parameterName.get),
-        value       = parameterValue.get,
+        value       = GenericPropertyUtils.parseValue(parameterValue.get),
         description = parameterDescription.get,
-        overridable = parameterOverridable
       )
       val savedChangeRequest = {
         for {
@@ -194,7 +194,7 @@ class CreateOrUpdateGlobalParameterPopup(
   }
 
   // The value may be empty
-  private[this] val parameterValue = new WBTextAreaField("Value", change.previousGlobalParam.map(_.value).getOrElse("")) {
+  private[this] val parameterValue = new WBTextAreaField("Value", change.previousGlobalParam.map(p => GenericPropertyUtils.serializeValue(p.value)).getOrElse("")) {
     override def setFilter = trim _ :: Nil
     override def inputField = ( change.action match {
       case GlobalParamModAction.Delete => super.inputField % ("disabled" -> "true")

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/ParameterManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/ParameterManagement.scala
@@ -48,6 +48,7 @@ import net.liftweb.http.js._
 import net.liftweb.http.js.JsCmds._
 import bootstrap.liftweb.RudderConfig
 import com.normation.rudder.AuthorizationType
+import com.normation.rudder.domain.nodes.GenericPropertyUtils
 import com.normation.rudder.domain.parameters.GlobalParameter
 import net.liftweb.http.js.JE.JsRaw
 import com.normation.rudder.web.components.popup.CreateOrUpdateGlobalParameterPopup
@@ -93,10 +94,9 @@ class ParameterManagement extends DispatchSnippet with Loggable {
         ".parameterLine [jsuuid]" #> lineHtmlId &
         ".parameterLine [class]" #> Text("curspoint") &
         ".name *" #> <b>{param.name.value}</b> &
-        ".value *" #> <pre class="json-beautify">{param.value}</pre> &
+        ".value *" #> <pre class="json-beautify">{GenericPropertyUtils.serializeValue(param.value)}</pre> &
         ".description *" #> <span><ul class="evlogviewpad"><li><b>Description:</b> {Text(param.description)}</li></ul></span> &
         ".description [id]" #> ("description-" + lineHtmlId) &
-        ".overridable *" #> param.overridable &
         ".change *" #> <div>{
           (if(CurrentUser.checkRights(AuthorizationType.Parameter.Edit)) {
             ajaxButton("Edit", () => showPopup(GlobalParamModAction.Update, Some(param)), ("class", "btn btn-default btn-sm"), ("style", "min-width:50px;"))


### PR DESCRIPTION
https://issues.rudder.io/issues/16301

This commit is based on `groups properties` one, PR https://github.com/Normation/rudder/pull/2890 need to be review/merged first. Also, you should only look at last commit for that PR until that time. 

This PR main changes are: 

- GlobalParameter value is now a `JValue` to be homogeneous with `GroupProperties` and `NodeProperties`
- also, removed `overridable` since that field wasn't ever used, and overriding logic don't match it. 

Then, the other big change is about inheritance logic. To be able to use `parameters` value when we build `NodeProperties` in `getNodeContexts > buildParams`, we need to evaluate `Param` interpollation there. It's ok, because we have all needed info for that at that point, and we could have done it all along here, but it means that we need to split `InterpollationContext` in two: one for params (with param not yet evaluated, to use when parsing params), and one for nodes (with all params value evaluated, ie they are just plain string, to use everywhere else). 
That part is a bit verbose because it need to add a type parameter and change "what it means to get a parameter value" in the evaluation, and it needed to split the evaluation part of the compiler from the compilation part. But the code is rather automatic and guided by types. 
