### PR TITLE
Fixes #7006: Parameter validation in Rudder should accept rudder variables ( ${ } )

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -351,7 +351,6 @@ limitations under the License.
 
     <scala-version>2.13.2</scala-version>
     <scala-binary-version>2.13</scala-binary-version>
-    <scala-parser-combinators-version>1.1.2</scala-parser-combinators-version>
     <scala-xml-version>1.3.0</scala-xml-version>
     <lift-version>3.4.1</lift-version>
     <slf4j-version>1.7.30</slf4j-version>
@@ -437,11 +436,6 @@ limitations under the License.
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-reflect</artifactId>
         <version>${scala-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.scala-lang.modules</groupId>
-        <artifactId>scala-parser-combinators_${scala-binary-version}</artifactId>
-        <version>${scala-parser-combinators-version}</version>
       </dependency>
       <dependency>
         <groupId>org.scala-lang.modules</groupId>
@@ -769,12 +763,6 @@ limitations under the License.
       <groupId>org.specs2</groupId>
       <artifactId>specs2-junit_${scala-binary-version}</artifactId>
       <version>${specs2-version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.scala-lang.modules</groupId>
-      <artifactId>scala-parser-combinators_${scala-binary-version}</artifactId>
-      <version>${scala-parser-combinators-version}</version>
       <scope>test</scope>
     </dependency>
     <!-- zio tests -->

--- a/webapp/sources/rudder/rudder-core/pom.xml
+++ b/webapp/sources/rudder/rudder-core/pom.xml
@@ -104,10 +104,6 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     </dependency>
 
     <dependency>
-      <groupId>org.scala-lang.modules</groupId>
-      <artifactId>scala-parser-combinators_${scala-binary-version}</artifactId>
-    </dependency>
-    <dependency>
         <groupId>com.lihaoyi</groupId>
         <artifactId>fastparse_${scala-binary-version}</artifactId>
         <version>${fastparse-version}</version>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchService.scala
@@ -49,6 +49,7 @@ import net.liftweb.common.Box
 import net.liftweb.common.Loggable
 import net.liftweb.common.EmptyBox
 import net.liftweb.common.Full
+import com.normation.box._
 
 /**
  * This class allow to return a list of Rudder object given a string.
@@ -100,7 +101,7 @@ object QuickSearchService {
 
 
   implicit class QSParser(val query: String) extends AnyVal {
-    def parse(): Box[Query] = QSRegexQueryParser.parse(query)
+    def parse(): Box[Query] = QSRegexQueryParser.parse(query).toBox
   }
 
   implicit class QSBackendImpl(b: QSBackend)(implicit

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/quicksearch/QSRegexQueryParserTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/quicksearch/QSRegexQueryParserTest.scala
@@ -70,64 +70,66 @@ class QSRegexQueryParserTest extends Specification {
    * if not, with """attribute:hostname foo""", we can't look for just "foo", always for " foo"
    */
 
+  sequential
+
    //Test the component part
   "Bad queries" should {
     "be refused because empty string" in {
-      parse("").mustFails
+      parse("") must beLeft
     }
     "be refused because whitespace string" in {
-      parse(" \t  ").mustFails
+      parse(" \t  ") must beLeft
     }
     "be refused because only filters" in {
-      parse(" in:directives ").mustFails
+      parse(" in:directives ") must beLeft
     }
   }
 
   "Simple queries" should {
     "give the exact same string, but trimed" in {
       val q = """ some node """
-      parse(q).mustFull(Query(q.trim, QSObject.all, QSAttribute.all))
+      parse(q) must beRight(Query(q.trim, QSObject.all, QSAttribute.all))
     }
     "give the exact same string, but trimed, even with regexp" in {
       val q = """ some.node[0-9]+.foo """
-      parse(q).mustFull(Query(q.trim, QSObject.all, QSAttribute.all))
+      parse(q) must beRight(Query(q.trim, QSObject.all, QSAttribute.all))
     }
     "give the exact same string, but trimed, even with part of rudder variable" in {
       val q = """ /foo/${rudder. """
-      parse(q).mustFull(Query(q.trim, QSObject.all, QSAttribute.all))
+      parse(q) must beRight(Query(q.trim, QSObject.all, QSAttribute.all))
     }
   }
 
   "Queries with filter" should {
     "if only on object, give all attributes" in {
-      parse(" Is:Directives is:RuLes here, the query").mustFull(
+      parse(" Is:Directives is:RuLes here, the query") must beRight(
           Query("here, the query", Set(Directive, Rule), QSAttribute.all)
       )
     }
 
     "if only on attributes, give all objects" in {
-      parse(" iN:display_name here, the query in:Node_Id").mustFull(
+      parse(" iN:display_name here, the query in:Node_Id") must beRight(
           Query("here, the query", QSObject.all, Set(NodeId, Name))
       )
     }
 
     "on both sides works" in {
-      parse(" Is:Directive is:RuLes iN:display_Name here, the query in:Node_Id").mustFull(
+      parse(" Is:Directive is:RuLes iN:display_Name here, the query in:Node_Id") must beRight(
           Query("here, the query", Set(Directive, Rule), Set(NodeId, Name))
       )
     }
     "only at end works" in {
-      parse(" here, the query is:node in:descriptions").mustFull(
+      parse(" here, the query is:node in:descriptions") must beRight(
           Query("here, the query", Set(Node), Set(Description, LongDescription))
       )
     }
     "only at starts works" in {
-      parse(" is:Directive is:RuLes in:display_Name here, the query ").mustFull(
+      parse(" is:Directive is:RuLes in:display_Name here, the query ") must beRight(
           Query("here, the query", Set(Directive, Rule), Set(Name))
       )
     }
     "parse multiple filter comma separated" in {
-      parse(" is:Directive,rules in:display_Name here, the query in:Node_Id,Rule_Id").mustFull(
+      parse(" is:Directive,rules in:display_Name here, the query in:Node_Id,Rule_Id") must beRight(
           Query("here, the query", Set(Directive, Rule), Set(NodeId, Name, RuleId))
       )
     }

--- a/webapp/sources/rudder/rudder-web/pom.xml
+++ b/webapp/sources/rudder/rudder-web/pom.xml
@@ -201,12 +201,6 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <version>${rudder-version}</version>
     </dependency>
 
-    <!-- it seems to not be resolved, don't know why -->
-    <dependency>
-      <groupId>org.scala-lang.modules</groupId>
-      <artifactId>scala-parser-combinators_${scala-binary-version}</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/PropertiesManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/PropertiesManagement.scala
@@ -73,7 +73,6 @@ import com.normation.rudder.reports.AgentReportingProtocol
 import com.normation.rudder.reports.AgentReportingSyslog
 
 import scala.xml.Text
-import scala.xml.UnprefixedAttribute
 
 /**
  * This class manage the displaying of user configured properties.


### PR DESCRIPTION
https://issues.rudder.io/issues/7006

"oups". 

It was *really* too complicated to add non-rudder variable to our compiler with scala lib parser combintor. Since we now have `fastparse` in the path, I tried to see if it was easier... And it was thanks to its amazing log possibilities (the parsing by itself is a bit tricky). 
The most interesting is how little code changes from scala regex combinator to fastparse. And the perf are just in other league (it does not change much in our case, since node prop interpolation is in second range, but now we are in the 10s of millisec - it may still be interesting with group properties and many more parsing to do). 
So I also switch the last parser we had (the one for our "search anything" bar queries), what allows to get ride of one dependancy and use the (very cool!) same combinator parser everywhere. 