### PR TITLE
Fixes #17426: Use hocon as an internal format for node properties

### DIFF
--- a/webapp/sources/rudder/rudder-core/pom.xml
+++ b/webapp/sources/rudder/rudder-core/pom.xml
@@ -104,6 +104,11 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     </dependency>
 
     <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+      <version>${config-version}</version>
+    </dependency>
+    <dependency>
         <groupId>com.lihaoyi</groupId>
         <artifactId>fastparse_${scala-binary-version}</artifactId>
         <version>${fastparse-version}</version>

--- a/webapp/sources/rudder/rudder-core/src/main/resources/ldap/rudder.schema
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/ldap/rudder.schema
@@ -316,6 +316,8 @@ attributetype ( RudderAttributes:302
   SUBSTR caseIgnoreSubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
+# this attribute isn't use anymore in rudder 6.1
+# but we need to wait for rudder 7.0 before removing it
 attributetype ( RudderAttributes:303
   NAME 'overridable'
   DESC 'Define if the parameter may be overriden'

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/parameters/GlobalParameter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/parameters/GlobalParameter.scala
@@ -36,36 +36,34 @@
 */
 package com.normation.rudder.domain.parameters
 
-import com.normation.rudder.domain.nodes.GenericPropertyUtils
-import com.normation.rudder.domain.nodes.Property
+import com.normation.errors.PureResult
+import com.normation.rudder.domain.nodes.GenericProperty
 import com.normation.rudder.domain.nodes.PropertyProvider
-import net.liftweb.json._
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigValue
 
 /**
  * A Global Parameter is a parameter globally defined, that may be overriden
  */
-final case class GlobalParameter(
-    name       : String
-  , value      : JValue
-  , description: String
-  , provider   : Option[PropertyProvider] // optional, default "rudder"
-) extends Property[GlobalParameter] {
-  override def setValue(v: JValue) = GlobalParameter(name, v, description, provider)
+final case class GlobalParameter(config: Config) extends GenericProperty[GlobalParameter] {
+  override def fromConfig(c: Config) = GlobalParameter(c)
 }
 
 object GlobalParameter {
 
   /**
    * A builder with the logic to handle the value part.
-   *
+   *,
    * For compatibity reason, we want to be able to process
    * empty (JNothing) and primitive types, especially string, specificaly as
    * a JString *but* a string representing an actual JSON should be
    * used as json.
    */
-  def apply(name: String, value: String, description: String, provider: Option[PropertyProvider]): GlobalParameter = {
-    new GlobalParameter(name, GenericPropertyUtils.parseValue(value), description, provider)
+  def parse(name: String, value: String, description: String, provider: Option[PropertyProvider]): PureResult[GlobalParameter] = {
+    GenericProperty.parseConfig(name, value, provider, Some(description)).map(c => new GlobalParameter(c))
+  }
+  def apply(name: String, value: ConfigValue, description: String, provider: Option[PropertyProvider]): GlobalParameter = {
+    new GlobalParameter(GenericProperty.toConfig(name, value, provider, Some(description)))
   }
 
 }
-

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/parameters/ParameterDiff.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/parameters/ParameterDiff.scala
@@ -40,7 +40,7 @@ package com.normation.rudder.domain.parameters
 import com.normation.rudder.domain.nodes.PropertyProvider
 import com.normation.rudder.domain.policies.SimpleDiff
 import com.normation.rudder.domain.policies.TriggerDeploymentDiff
-import net.liftweb.json.JsonAST.JValue
+import com.typesafe.config.ConfigValue
 
 sealed trait ParameterDiff extends TriggerDeploymentDiff
 
@@ -59,7 +59,7 @@ final case class DeleteGlobalParameterDiff(parameter:GlobalParameter) extends Pa
 
 final case class ModifyGlobalParameterDiff(
     name          : String
-  , modValue      : Option[SimpleDiff[JValue]] = None
+  , modValue      : Option[SimpleDiff[ConfigValue]] = None
   , modDescription: Option[SimpleDiff[String]] = None
   , modProvider   : Option[SimpleDiff[Option[PropertyProvider]]] = None
 ) extends ParameterDiff {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
@@ -279,12 +279,12 @@ final case class NodePropertyComparator(ldapAttr: String) extends NodeCriterionT
 
 
   def matchJsonPath(key: String, path: PureResult[JsonPath])(p: NodeProperty): Boolean = {
-    (p.name == key) && path.flatMap(JsonSelect.exists(_, p.renderValue).toPureResult).getOrElse(false)
+    (p.name == key) && path.flatMap(JsonSelect.exists(_, p.valueAsString).toPureResult).getOrElse(false)
   }
 
   val regexMatcher = (value: String) => new NodeInfoMatcher {
                             val predicat = (p: NodeProperty) => try {
-                                value.r.pattern.matcher(s"${p.name}=${p.renderValue}").matches()
+                                value.r.pattern.matcher(s"${p.name}=${p.valueAsString}").matches()
                               } catch { //malformed patterned should not be saved, but never let an exception be silent
                                 case ex: PatternSyntaxException => false
                               }
@@ -298,7 +298,7 @@ final case class NodePropertyComparator(ldapAttr: String) extends NodeCriterionT
       // equals mean: the key is equals to kv._1 and the value is defined and the value is equals to kv._2.get
       case Equals         => {
                                val kv = splitInput(value, "=")
-                               NodeInfoMatcher((node: NodeInfo) => node.properties.find(p => p.name == kv.key && p.renderValue == kv.value).isDefined)
+                               NodeInfoMatcher((node: NodeInfo) => node.properties.find(p => p.name == kv.key && p.valueAsString == kv.value).isDefined)
       }
       // not equals mean: the key is not equals to kv._1 or the value is not defined or the value is defined but equals to kv._2.get
       case NotEquals      => NodeInfoMatcher((node: NodeInfo) => !matches(Equals, value).matches(node))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/metrics/HistorizeNodeCountService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/metrics/HistorizeNodeCountService.scala
@@ -159,11 +159,11 @@ class FetchDataServiceImpl(nodeInfoService: NodeInfoService, reportingService: R
     } yield {
       val modes = compliance.values.groupMapReduce(r => mode(r.compliance))(_ => 1)(_+_)
       FrequentNodeMetrics(
-          pending     = pending.size
-        , accepted    = accepted.size
-        , modeAudit   = modes.getOrElse(Mode.Audit, 0)
-        , modeEnforce = modes.getOrElse(Mode.Enforce, 0)
-        , modeMixed   = modes.getOrElse(Mode.Mixed, 0)
+          accepted.size
+        , pending.size
+        , modes.getOrElse(Mode.Audit, 0)
+        , modes.getOrElse(Mode.Enforce, 0)
+        , modes.getOrElse(Mode.Mixed, 0)
       )
     }).toIO
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPParameterRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPParameterRepository.scala
@@ -46,7 +46,8 @@ import com.normation.rudder.domain.RudderDit
 import com.normation.rudder.domain.RudderLDAPConstants._
 import com.normation.rudder.domain.archives.ParameterArchiveId
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
-import com.normation.rudder.domain.nodes.GenericPropertyUtils
+import com.normation.rudder.domain.nodes.GenericProperty
+import com.normation.rudder.domain.nodes.PropertyProvider
 import com.normation.rudder.domain.parameters.GlobalParameter
 import com.normation.rudder.domain.parameters._
 import com.normation.rudder.repository.EventLogRepository
@@ -155,10 +156,10 @@ class WoLDAPParameterRepository(
       for {
         con             <- ldap
         oldParameter    <- roLDAPParameterRepository.getGlobalParameter(parameter.name).notOptional(s"Cannot update Global Parameter '${parameter.name}': there is no parameter with that name")
-        _               <- if(GenericPropertyUtils.canBeUpdated(oldParameter.provider, parameter.provider)) UIO.unit
+        _               <- if(GenericProperty.canBeUpdated(oldParameter.provider, parameter.provider)) UIO.unit
                            else {
-                             val newProvider = parameter.provider.getOrElse(GenericPropertyUtils.defaultPropertyProvider).value
-                             val oldProvider = oldParameter.provider.getOrElse(GenericPropertyUtils.defaultPropertyProvider).value
+                             val newProvider = parameter.provider.getOrElse(PropertyProvider.defaultPropertyProvider).value
+                             val oldProvider = oldParameter.provider.getOrElse(PropertyProvider.defaultPropertyProvider).value
                              Inconsistency(s"Parameter with name '${parameter.name}' can not be updated by provider '${newProvider}' since its current provider is '${oldProvider}'").fail
                            }
         paramEntry      =  mapper.parameter2Entry(parameter)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -564,7 +564,7 @@ class EventLogFactoryImpl(
           modifyDiff.modIsActivated.map(x => SimpleDiff.booleanToXml(<isEnabled/>, x ) ) ++
           modifyDiff.modIsSystem.map(x => SimpleDiff.booleanToXml(<isSystem/>, x ) ) ++
           modifyDiff.modProperties.map(x => SimpleDiff.toXml[List[GroupProperty]](<properties/>, x)(props =>
-              props.flatMap { p => <property><name>{ p.name }</name><value>{Unparsed(net.liftweb.json.compactRender(p.value))}</value></property> }
+              props.flatMap { p => <property><name>{ p.name }</name><value>{Unparsed(p.valueAsString)}</value></property> }
           ))
         }
       </nodeGroup>)
@@ -708,8 +708,8 @@ class EventLogFactoryImpl(
     val details = EventLog.withContent{
       scala.xml.Utility.trim(<globalParameter changeType="modify" fileFormat={Constants.XML_CURRENT_FILE_FORMAT.toString}>
         <name>{modifyDiff.name}</name>{
-          modifyDiff.modValue.map(x => SimpleDiff.toXml(<value/>, x){v => Text(GenericPropertyUtils.serializeValue(v))}) ++
-          modifyDiff.modDescription.map(x => SimpleDiff.stringToXml(<description/>, x ) )
+        modifyDiff.modValue.map(x => SimpleDiff.toXml(<value/>, x){v => Text(GenericProperty.serializeToHocon(v))}) ++
+        modifyDiff.modDescription.map(x => SimpleDiff.stringToXml(<description/>, x ) )
         }
       </globalParameter>)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
@@ -244,7 +244,7 @@ class NodeGroupSerialisationImpl(xmlVersion:String) extends NodeGroupSerialisati
           // value parsing of properties is a bit messy and semantically linked
           // to json, since value part can be a string or json object.
           // Parsing that back from xml would be tedious.
-          <property><name>{p.name}</name><value>{Unparsed(net.liftweb.json.compactRender(p.value))}</value></property>
+          <property><name>{p.name}</name><value>{Unparsed(p.valueAsString)}</value></property>
         }}</properties>
     )
   }
@@ -279,7 +279,7 @@ class GlobalParameterSerialisationImpl(xmlVersion:String) extends GlobalParamete
   def serialise(param:GlobalParameter):  Elem = {
     createTrimedElem(XML_TAG_GLOBAL_PARAMETER, xmlVersion) (
        <name>{param.name}</name>
-       <value>{param.value}</value>
+       <value>{param.valueAsString}</value>
        <description>{param.description}</description>
        <provider>{param.provider.map(_.value).getOrElse("")}</provider>
     )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -231,11 +231,11 @@ class NodeGroupUnserialisationImpl(
       isSystem        <- (group \ "isSystem").headOption.flatMap(s => tryo { s.text.toBoolean } ) ?~! ("Missing attribute 'isSystem' in entry type nodeGroup : " + entry)
       properties      <- sequence((group \ "properties").toList) {
                            case <property>{p @ _*}</property> =>
-                             Full(GroupProperty(
+                             GroupProperty.parse(
                                  (p\"name").text.trim
                                , (p\"value").text.trim
                                , (p\"provider").headOption.map(p => PropertyProvider(p.text.trim))
-                             ))
+                             ).toBox
                            case xml                           => Failure(s"Found unexpected xml under <properties> tag: ${xml}")
                          }
     } yield {
@@ -639,13 +639,9 @@ class GlobalParameterUnserialisationImpl extends GlobalParameterUnserialisation 
       value            <- (globalParam \ "value").headOption.map( _.text ) ?~! ("Missing attribute 'value' in entry type globalParameter : " + entry)
       description      <- (globalParam \ "description").headOption.map( _.text ) ?~! ("Missing attribute 'description' in entry type globalParameter : " + entry)
       provider         =  (globalParam \ "provider").headOption.map(x => PropertyProvider(x.text))
+      g                <- GlobalParameter.parse(name, value, description, provider).toBox
     } yield {
-      GlobalParameter(
-          name
-        , value
-        , description
-        , provider
-      )
+      g
     }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodePropertiesOverridingService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodePropertiesOverridingService.scala
@@ -42,12 +42,12 @@ import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.nodes.NodePropertyHierarchy
 import com.normation.rudder.repository.RoNodeGroupRepository
 import com.normation.rudder.repository.RoParameterRepository
-import net.liftweb.json._
+import com.typesafe.config.ConfigValue
 
 
 trait NodePropertiesOverridingService {
 
-  def getNodePropertiesTree(nodeInfo: NodeInfo): IOResult[List[NodePropertyHierarchy[JValue]]]
+  def getNodePropertiesTree(nodeInfo: NodeInfo): IOResult[List[NodePropertyHierarchy[ConfigValue]]]
 
 }
 
@@ -55,7 +55,7 @@ class NodePropertiesOverridingServiceImpl(
     groupRepo: RoNodeGroupRepository
   , paramRepo: RoParameterRepository
 ) extends NodePropertiesOverridingService {
-  override def getNodePropertiesTree(nodeInfo: NodeInfo): IOResult[List[NodePropertyHierarchy[JValue]]] = {
+  override def getNodePropertiesTree(nodeInfo: NodeInfo): IOResult[List[NodePropertyHierarchy[ConfigValue]]] = {
     for {
       groups       <- groupRepo.getFullGroupLibrary()
       nodeTargets  =  groups.getTarget(nodeInfo).map(_._2).toList

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
@@ -62,8 +62,7 @@ import com.normation.cfclerk.domain.AgentConfig
 import com.normation.cfclerk.domain.TechniqueGenerationMode
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.errors._
-import com.normation.rudder.domain.nodes.GenericPropertyUtils
-import net.liftweb.json.JValue
+import com.typesafe.config.ConfigValue
 
 /*
  * This file contains all the specific data structures used during policy generation.
@@ -163,13 +162,13 @@ final case class InterpolationContext(
       , nodeContext     : TreeMap[String, Variable]
         // parameters for this node
         //must be a case SENSITIVE Map !!!!
-      , parameters      : Map[String, JValue]
+      , parameters      : Map[String, ConfigValue]
         //the depth of the interpolation context evaluation
         //used as a lazy, trivial, mostly broken way to detect cycle in interpretation
         //for ex: param a => param b => param c => ..... => param a
         //should not be evaluated
       , depth           : Int
-) extends GenericInterpolationContext[JValue]
+) extends GenericInterpolationContext[ConfigValue]
 
 object InterpolationContext {
   implicit val caseInsensitiveString = new Ordering[String] {
@@ -185,7 +184,7 @@ object InterpolationContext {
       , nodeContext     : Map[String, Variable]
         // parameters for this node
         //must be a case SENSITIVE Map !!!!
-      , parameters      : Map[String, JValue]
+      , parameters      : Map[String, ConfigValue]
         //the depth of the interpolation context evaluation
         //used as a lazy, trivial, mostly broken way to detect cycle in interpretation
         //for ex: param a => param b => param c => ..... => param a
@@ -203,7 +202,7 @@ final case object ParameterForConfiguration {
   def fromParameter(param: GlobalParameter) : ParameterForConfiguration = {
     // here, we need to go back to a string for resolution of
     // things like ${rudder.param[foo] | default = ... }
-    ParameterForConfiguration(param.name, GenericPropertyUtils.serializeValue(param.value))
+    ParameterForConfiguration(param.name, param.valueAsString)
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -233,7 +233,7 @@ trait CachedFindRuleNodeStatusReports extends ReportingService with CachedReposi
       (for {
         updated <- defaultFindRuleNodeStatusReports.findRuleNodeStatusReports(nodeIds.toSet, Set()).toIO
         _       <- IOResult.effectNonBlocking { cache = cache ++ updated }
-        _       <- complianceRepository.saveRunCompliance(updated.values.toList).toIO
+        _       <- complianceRepository.saveRunCompliance(cache.values.toList).toIO
         _       <- ReportLoggerPure.Cache.debug(s"Compliance cache updated for nodes: ${nodeIds.map(_.value).mkString(", ")}")
       } yield ()).catchAll(err => ReportLoggerPure.Cache.error(s"Error when updating compliance cache for nodes: [${nodeIds.map(_.value).mkString(", ")}]: ${err.fullMsg}"))
     )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
@@ -449,12 +449,12 @@ final case object CheckGlobalParameter extends CheckChanges[GlobalParameter]  {
     }
 
     def compareGlobalParameter(initial:GlobalParameter, current:GlobalParameter) : Boolean = {
-      val initialFixed = initial.copy(
-          description = normalizeString(initial.description)
+      val initialFixed = initial.withDescription(
+          normalizeString(initial.description)
       )
 
-      val currentFixed = current.copy(
-          description = normalizeString(current.description)
+      val currentFixed = current.withDescription(
+          normalizeString(current.description)
       )
 
       if (initialFixed == currentFixed) {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/nodes/GenericPropertiesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/nodes/GenericPropertiesTest.scala
@@ -1,0 +1,133 @@
+/*
+*************************************************************************************
+* Copyright 2020 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.domain.nodes
+
+import com.normation.BoxSpecMatcher
+import com.normation.rudder.domain.nodes.GenericProperty._
+import com.typesafe.config.ConfigValueFactory
+import net.liftweb.common._
+import org.junit.runner.RunWith
+import org.specs2.mutable._
+import org.specs2.runner._
+import java.util.{HashMap => JMap}
+
+@RunWith(classOf[JUnitRunner])
+class GenericPropertiesTest extends Specification with Loggable with BoxSpecMatcher {
+
+  def jmap[A, B](tuples: (A,B)*) : JMap[A, B] = {
+    val jmap = new JMap[A,B]()
+    tuples.foreach { case (a,b) => jmap.put(a, b) }
+    jmap
+  }
+
+  sequential
+
+  "parsing" should {
+    "recognize empty string" in {
+      GenericProperty.parseValue("") must beRight(ConfigValueFactory.fromAnyRef(""))
+    }
+    "correctly parse a json like file" in {
+      GenericProperty.parseValue("""{"a":"b"}""") must beRight(ConfigValueFactory.fromMap(jmap(("a", "b"))))
+    }
+    "correctly parse in a empty json-like structure" in {
+      GenericProperty.parseValue("""{}""") must beRight
+    }
+    "correctly parse non json-like structure as a string" in {
+      GenericProperty.parseValue("""hello, world!""") must beRight(ConfigValueFactory.fromAnyRef("hello, world!"))
+    }
+    "correctly accept comments in json-like, wherever they are" in {
+      val s = """//here, a comment
+          |# another
+          |  { // start of value
+          |  "a": # comment in line
+          |  # comment new line
+          |  "b" // another
+          |  // again
+          |} // after end of value
+          | # even on new lines
+          |""".stripMargin
+      (firstNonCommentChar(s) must_=== Some('{')) and
+      (GenericProperty.parseValue(s) must beRight(ConfigValueFactory.fromMap(jmap(("a", "b")))))
+    }
+    "fails in a badly eneded json-like structure" in {
+      GenericProperty.parseValue("""{"a":"b" """) must beLeft
+    }
+    "fails in a non key/value property structure" in {
+      GenericProperty.parseValue("""{"a"} """) must beLeft
+    }
+  }
+
+  "serialization / deserialisation" should {
+    val check = (s: String) => GenericProperty.parseValue(s).map(GenericProperty.serializeToHocon) must beRight(s)
+
+    "be idempotent for string" in {
+      val strings = List(
+        ""
+      , "some string"
+      , """
+        |# some things
+        |plop
+        |""".stripMargin
+      , "strange char: ${plop} $ @ ¹ \n [fsj] (abc) $foo"
+      )
+      strings must contain(check).foreach
+    }
+
+    "be idempotent for values" in {
+      val strings = List(
+        """{"a":"b"}"""
+      , """{"a":[1,2,3],"b":true,"c":{"d":"e"}}"""
+      , "{}"
+      )
+      strings must contain(check).foreach
+    }
+
+    "hocon does not keep comment out of value and remove/reorder spaces/comments" in {
+      val s = """
+        |# some things
+        |{ "a" :
+        |  # comments!
+        |  "b"
+        |}// comment
+        |""".stripMargin
+      val t = """{# comments!
+        |"a":"b"}""".stripMargin
+       GenericProperty.parseValue(s).map(GenericProperty.serializeToHocon) must beRight(t)
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/eventlog/NodeEventLogFormatV6Test.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/eventlog/NodeEventLogFormatV6Test.scala
@@ -44,11 +44,10 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.policies.SimpleDiff
 import net.liftweb.common.Full
 import com.normation.rudder.reports.AgentRunInterval
-import com.normation.rudder.domain.nodes.NodeProperty
+import com.normation.rudder.domain.nodes.GenericProperty._
 import com.normation.rudder.domain.nodes.ModifyNodeDiff
+import com.normation.rudder.domain.nodes.NodeProperty
 import com.normation.rudder.reports.HeartbeatConfiguration
-import net.liftweb.json.JsonAST.JString
-import net.liftweb.json.JsonDSL._
 import scala.collection.mutable.ArrayBuffer
 import com.normation.rudder.domain.eventlog.EventTypeFactory
 import com.normation.rudder.domain.eventlog.ModifyNodeEventType
@@ -100,14 +99,16 @@ class NodeEventLogFormatV6Test extends Specification {
           , modAgentRun   = None
           , modProperties = Some(SimpleDiff(
                               ArrayBuffer(
-                                NodeProperty("env_type", JString("production"), None)
-                              , NodeProperty("shell", JString("/bin/sh"), None)
+                                NodeProperty("env_type", "production".toConfigValue, None)
+                              , NodeProperty("shell", "/bin/sh".toConfigValue, None)
                               ).toList
                             , ArrayBuffer(
-                                NodeProperty("shell", JString("/bin/sh"), None)
-                              , NodeProperty("env", JString("PROD"), None)
-                              , NodeProperty("datacenter", ("Europe" -> ("France" -> true) ), None)
-                              ).toList
+                                NodeProperty("shell", "/bin/sh".toConfigValue, None)
+                              , NodeProperty("env", "PROD".toConfigValue, None)
+                              , NodeProperty.parse("datacenter", """{"Europe":{"France":true}}""", None).fold(
+                                  err => throw new IllegalArgumentException("Error in test: " + err.fullMsg)
+                                , res => res
+                              )).toList
                             ))
           , modPolicyMode = None
           , modKeyValue   = None

--- a/webapp/sources/rudder/rudder-rest/pom.xml
+++ b/webapp/sources/rudder/rudder-rest/pom.xml
@@ -109,12 +109,6 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <artifactId>rudder-core</artifactId>
       <version>${rudder-version}</version>
     </dependency>
-
-    <dependency>
-      <groupId>com.typesafe</groupId>
-      <artifactId>config</artifactId>
-      <version>${config-version}</version>
-    </dependency>
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestDataSerializer.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestDataSerializer.scala
@@ -198,7 +198,7 @@ final case class RestDataSerializerImpl (
   def serializeParameter (parameter:GlobalParameter, crId: Option[ChangeRequestId]): JValue = {
    (   ( "changeRequestId" -> crId.map(_.value.toString))
      ~ ( "id"              -> parameter.name )
-     ~ ( "value"           -> parameter.value )
+     ~ ( "value"           -> parameter.valueAsString)
      ~ ( "description"     -> parameter.description )
    )
   }
@@ -350,7 +350,7 @@ final case class RestDataSerializerImpl (
 
     def serializeGlobalParameterDiff(diff:ModifyGlobalParameterDiff,initialState:GlobalParameter) : JValue= {
       val description :JValue = diff.modDescription.map(displaySimpleDiff(_)).getOrElse(initialState.description)
-      val value :JValue       = diff.modValue.map(displaySimpleDiff(_)).getOrElse(initialState.value)
+      val value :JValue       = diff.modValue.map(displaySimpleDiff(_)(x => JString(GenericProperty.serializeToHocon(x)))).getOrElse(GenericProperty.serializeToHocon(initialState.value))
 
       (   ("name"        -> initialState.name)
         ~ ("value"       -> value)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
@@ -243,18 +243,19 @@ extends Loggable {
 
     restParameter match {
       case Full(restParameter) =>
-            val parameter = restParameter.updateParameter(GlobalParameter(parameterName,"","",None))
+        import com.normation.rudder.domain.nodes.GenericProperty._
+        val parameter = restParameter.updateParameter(GlobalParameter(parameterName,"".toConfigValue,"",None))
 
-            val diff = AddGlobalParameterDiff(parameter)
-            createChangeRequestAndAnswer(
-                parameterName
-              , diff
-              , parameter
-              , None
-              , actor
-              , req
-              , GlobalParamModAction.Create
-            )
+        val diff = AddGlobalParameterDiff(parameter)
+        createChangeRequestAndAnswer(
+            parameterName
+          , diff
+          , parameter
+          , None
+          , actor
+          , req
+          , GlobalParamModAction.Create
+        )
 
       case eb : EmptyBox =>
         val fail = eb ?~ (s"Could extract values from request" )

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -1122,7 +1122,7 @@ class EventLogDetailsGenerator(
 
   private[this] def globalParameterDetails(xml: NodeSeq, globalParameter: GlobalParameter) = (
     "#name" #> globalParameter.name &
-      "#value" #> GenericPropertyUtils.serializeValue(globalParameter.value) &
+      "#value" #> globalParameter.valueAsString &
       "#description" #> globalParameter.description
     )(xml)
 

--- a/webapp/sources/rudder/rudder-web/pom.xml
+++ b/webapp/sources/rudder/rudder-web/pom.xml
@@ -180,12 +180,6 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     </dependency>
 
     <dependency>
-      <groupId>com.typesafe</groupId>
-      <artifactId>config</artifactId>
-      <version>1.3.1</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.normation.rudder</groupId>
       <artifactId>rudder-rest</artifactId>
       <version>${rudder-version}</version>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/CheckRudderGlobalParameter.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/CheckRudderGlobalParameter.scala
@@ -52,7 +52,7 @@ import com.normation.rudder.repository.WoParameterRepository
 import com.normation.utils.StringUuidGenerator
 import net.liftweb.json._
 import com.normation.rudder.domain.eventlog._
-import com.normation.rudder.domain.nodes.GenericPropertyUtils
+import com.normation.rudder.domain.nodes.GenericProperty
 import com.normation.rudder.domain.nodes.PropertyProvider
 import com.normation.zio.ZioRuntime
 
@@ -92,11 +92,11 @@ class CheckRudderGlobalParameter(
       saved <- roParamRepo.getGlobalParameter(p.name)
       _     <- saved match {
                 case None =>
-                  BootstrapLogger.info(s"Creating missing global parameter '${p.name}' with value: ${compactRender(p.value)}") *>
+                  BootstrapLogger.info(s"Creating missing global parameter '${p.name}' with value: '${p.valueAsString}''") *>
                   woParamRepo.saveParameter(p, modId, RudderEventActor, Some(s"Creating global system parameter '${p.name}' to its default value"))
                 case Some(s) if(p.value != s.value || p.provider != s.provider) =>
-                  val provider = p.provider.getOrElse(GenericPropertyUtils.systemPropertyProvider).value
-                  BootstrapLogger.info(s"Reseting global parameter '${p.name}' from ${provider} provider to value: ${compactRender(p.value)}") *>
+                  val provider = p.provider.getOrElse(PropertyProvider.systemPropertyProvider).value
+                  BootstrapLogger.info(s"Reseting global parameter '${p.name}' from ${provider} provider to value: ${p.valueAsString}") *>
                   woParamRepo.updateParameter(p, modId, RudderEventActor, Some(s"Reseting global system parameter '${p.name}' to its default value"))
                 case _ => UIO.unit
               }
@@ -122,5 +122,5 @@ class CheckRudderGlobalParameter(
 
 // lift json need that to be topevel
 private[checks] final case class JsonParam(name: String, description: String, value: JValue, provider: Option[String]) {
-  def toGlobalParam = new GlobalParameter(name, value, description, provider.map(PropertyProvider))
+  def toGlobalParam = GlobalParameter(name, GenericProperty.fromJsonValue(value), description, provider.map(PropertyProvider.apply))
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/ParameterManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/ParameterManagement.scala
@@ -48,7 +48,7 @@ import net.liftweb.http.js._
 import net.liftweb.http.js.JsCmds._
 import bootstrap.liftweb.RudderConfig
 import com.normation.rudder.AuthorizationType
-import com.normation.rudder.domain.nodes.GenericPropertyUtils
+import com.normation.rudder.domain.nodes.PropertyProvider
 import com.normation.rudder.domain.parameters.GlobalParameter
 import net.liftweb.http.js.JE.JsRaw
 import com.normation.rudder.web.components.popup.CreateOrUpdateGlobalParameterPopup
@@ -94,11 +94,11 @@ class ParameterManagement extends DispatchSnippet with Loggable {
         ".parameterLine [jsuuid]" #> lineHtmlId &
         ".parameterLine [class]" #> Text("curspoint") &
         ".name *" #> <b>{param.name}</b> &
-        ".value *" #> <pre class="json-beautify">{GenericPropertyUtils.serializeValue(param.value)}</pre> &
+        ".value *" #> <pre class="json-beautify">{param.valueAsString}</pre> &
         ".description *" #> <span><ul class="evlogviewpad"><li><b>Description:</b> {Text(param.description)}</li></ul></span> &
         ".description [id]" #> ("description-" + lineHtmlId) &
         ".change *" #> <div>{
-          if(param.provider.isEmpty || param.provider == Some(GenericPropertyUtils.defaultPropertyProvider)) {
+          if(param.provider.isEmpty || param.provider == Some(PropertyProvider.defaultPropertyProvider)) {
             (if(CurrentUser.checkRights(AuthorizationType.Parameter.Edit)) {
               ajaxButton("Edit", () => showPopup(GlobalParamModAction.Update, Some(param)), ("class", "btn btn-default btn-sm"), ("style", "min-width:50px;"))
             } else NodeSeq.Empty) ++

--- a/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
@@ -113,6 +113,29 @@ object errors {
     }
   }
 
+  object PureResult {
+    def effect[A](error: String)(effect: => A): Either[SystemError, A] = {
+      try {
+        Right(effect)
+      } catch {
+        case ex: Exception =>
+          Left(SystemError(error, ex))
+      }
+    }
+    def effect[A](effect: => A): Either[SystemError, A] = {
+      this.effect("An error occured")(effect)
+    }
+    def effectM[A](error: String)(effect: => PureResult[A]): PureResult[A] = {
+      PureResult.effect(error)(effect) match {
+        case Left(err)  => Left(err)
+        case Right(res) => res
+      }
+    }
+    def effectM[A](effect: => PureResult[A]): PureResult[A] = {
+      this.effectM("An error occured")(effect)
+    }
+  }
+
   object RudderError {
 
     /*


### PR DESCRIPTION
https://issues.rudder.io/issues/17426
That PR replace the `JValue` used for node/group properties and global parameter by a `ConfigValue` from `lightbent.config` lib which accepts comments but is still a strict superset of json able to parse/write pur json. 

The behavior after the change should be the same as before safe for two points:
- on override, arrays are replaced in place of being concatenated,
- now, a value is `parsed` and can fail, while before it was always a success. The failure case is if the value starts by `{`, we assume the user want it to be a json-like property, and so we fail if it is not the case. Before, we were accepting things like `{"a":"b"` while there was no chance it's not a typo.

From an implementation point of view, that PR unify the three properties (node, group, global) behind a common `GenericProperty`. They are all backed by a standard `Config` object, with a mandatory `name:String` field, and optionnal `value: ConfigValue`, `provider: String` (mapped to an `Option[PropertyProvider]` and `description: String`. 
The PR mainly replace occurence of the old lib names/types by the new ones. 
A particular attention was put in parsing and serialisation, since it's where there is the most chance that something can change without notice. 
