### PR TITLE
Fixes #17313: Upgrading Rudder from 5.0.18 to 6.1-nightly does not update techniques

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/SystemVariableSpecServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/SystemVariableSpecServiceImpl.scala
@@ -59,6 +59,12 @@ class SystemVariableSpecServiceImpl extends SystemVariableSpecService {
                                             , multivalued = true
                                             , constraint = Constraint(mayBeEmpty=true)
                                           )
+      // we need to keep CMDBENDPOINT for rudder version where upgrade from 5.0 is allowed,
+      // so likely remove it on 7.0, not before.
+    , SystemVariableSpec(
+                             "CMDBENDPOINT" , "The cmdb endpoint"
+                                            , multivalued  = false
+                        )
     , SystemVariableSpec(
                             "COMMUNITYPORT" , "The port used by the community edition"
                                             , multivalued  = false


### PR DESCRIPTION
https://issues.rudder.io/issues/17313