### PR TITLE
Fixes #17549: Property error message for group with parent group

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -852,7 +852,7 @@ trait PromiseGeneration_BuildNodeContext {
                           }.toBox
           nodeTargets  =  allGroups.getTarget(info).map(_._2).toList
           timeMerge    =  System.nanoTime
-          mergedProps  <- MergeNodeProperties.withDefaults(info, nodeTargets, nodeParam.map{case(k,v) => (k, v)}.toMap).toBox
+          mergedProps  <- MergeNodeProperties.forNode(info, nodeTargets, nodeParam.map{case(k,v) => (k, v)}.toMap).toBox
           _            =  {timeNanoMergeProp = timeNanoMergeProp + System.nanoTime - timeMerge}
           nodeInfo     =  info.modify(_.node.properties).setTo(mergedProps.map(_.prop))
           nodeContext  <- systemVarService.getSystemVariables(nodeInfo, allNodeInfos, nodeTargets, globalSystemVariables, globalAgentRun, globalComplianceMode: ComplianceMode)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
@@ -69,7 +69,7 @@ class TestMergeGroupProperties extends Specification {
   implicit class ToNodePropertyHierarchy(groups: List[NodeGroup]) {
     def toParents(name: String) = {
       groups.flatMap { g =>
-        g.properties.find(_.name == name).map(p => FullParentProperty.Group(g.name, g.id, p.value))
+        g.properties.find(_.name == name).map(p => ParentProperty.Group(g.name, g.id, p.value))
       }
     }
     // use first parent to build a fully inherited prop
@@ -83,12 +83,12 @@ class TestMergeGroupProperties extends Specification {
       NodePropertyHierarchy(prop, toParents(prop.name))
     }
     def toH3(name: String, globalParam: ConfigValue) = {
-      toH1(name).modify(_.parents).using( _ :+ FullParentProperty.Global(globalParam))
+      toH1(name).modify(_.parents).using( _ :+ ParentProperty.Global(globalParam))
     }
   }
   implicit class ToNodeProp(global: ConfigValue) {
     def toG(name: String) = {
-      NodePropertyHierarchy(NodeProperty(name, global, Some(GroupProp.INHERITANCE_PROVIDER)), FullParentProperty.Global(global) :: Nil)
+      NodePropertyHierarchy(NodeProperty(name, global, Some(GroupProp.INHERITANCE_PROVIDER)), ParentProperty.Global(global) :: Nil)
     }
   }
   implicit class ToConfigValue(s: String) {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -358,7 +358,7 @@ class NodeApiInheritedProperties(
       groups       <- groupRepo.getFullGroupLibrary()
       nodeTargets  =  groups.getTarget(nodeInfo).map(_._2).toList
       params       <- paramRepo.getAllGlobalParameters()
-      properties   <- MergeNodeProperties.withDefaults(nodeInfo, nodeTargets, params.map(p => (p.name, p.value)).toMap).toIO
+      properties   <- MergeNodeProperties.forNode(nodeInfo, nodeTargets, params.map(p => (p.name, p.value)).toMap).toIO
     } yield {
       import com.normation.rudder.domain.nodes.JsonPropertySerialisation._
       JArray((


### PR DESCRIPTION
https://issues.rudder.io/issues/17549

There was some renaming/moving things around which make the PR seems harder than it is really. 

The renaming/moving allow to create a method similar to the one that merge properties for node but for group, and the only really interesting piece is in that method: before that, we were not getting parents of group, and so when the merge occured, they weren't found (suprisingly). So the new method `getParents` before doing the merge. 

Renaming are: 
- remove useless parameter for `ParentProperty`, since we only have `ConfigValue` and all these parameters were starting to be confusing (and remove corresponding useless trait level)
- extract logic that change a group to a `GroupProp` so that it can be used (also) in new method
- rename `withDefaults` to `forNode` so that we also have `forGroup`
