### PR TITLE
Fixes #17625: Group value should only display value for that element in main table

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/node.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/node.html
@@ -1,7 +1,7 @@
 <lift:surround with="common-layout" at="content">
 
 <head>
-    <title>Rudder - Search Nodes</title>
+    <title>Rudder - Node details</title>
     <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-tags.css"  media="screen">
     <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-node.css" media="screen">
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/angular/elastic.min.js"></script>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/ComponentNodeProperties.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/ComponentNodeProperties.html
@@ -68,10 +68,10 @@
                      <span ng-if="property.provider !== undefined && property.provider !== 'inherited' && property.provider !== 'overridden'" class='rudder-label label-provider label-sm' data-toggle='tooltip' data-placement='top' data-html='true' title="This property is managed by its provider <b>‘{{ property.provider }}</b>’, and can not be modified manually. Check Rudder’s settings to adjust this provider’s configuration." data-container="body" bs-tooltip>
                        {{ property.provider }}
                      </span>
-                     <span ng-if="property.provider === 'inherited'" class='rudder-label label-provider label-sm' data-toggle='tooltip' data-placement='top' data-html='true' title="This property is inherited from these group(s) or global parameter: <div>{{ property.parents }}</div>." data-container="body" bs-tooltip>
+                     <span ng-if="property.provider === 'inherited'" class='rudder-label label-provider label-sm' data-toggle='tooltip' data-placement='top' data-html='true' title="This property is inherited from these group(s) or global parameter: <div>{{ property.hierarchy }}</div>." data-container="body" bs-tooltip>
                        inherited
                      </span>
-                     <span ng-if="property.provider === 'overridden'" class='rudder-label label-provider label-sm' data-toggle='tooltip' data-placement='top' data-html='true' title="This property is overridden on this object and was inherited from these group(s) or global parameter: <div>{{ property.parents }}</div>." data-container="body" bs-tooltip>
+                     <span ng-if="property.provider === 'overridden'" class='rudder-label label-provider label-sm' data-toggle='tooltip' data-placement='top' data-html='true' title="This property is overridden on this object and was inherited from these group(s) or global parameter: <div>{{ property.hierarchy }}</div>." data-container="body" bs-tooltip>
                        overridden
                      </span>
                    </div>
@@ -101,8 +101,15 @@
                      <button class="btn btn-xs btn-default btn-clipboard" data-clipboard-text="{{formatContent(property)}}" data-toggle='tooltip' data-placement='left' data-container="html" title="Copy to clipboard"><i class="ion ion-clipboard"></i></button>
                    </div>
                    <div ng-if="isEdited(property.name)">
-                     <textarea placeholder="Value" msd-elastic rows="1" class="form-control input-sm input-value" ng-model="editedProperties[property.name].new.value"></textarea>
-                     <small class="text-danger" ng-if="!editedProperties[property.name].new.isValid">JSON check is enabled, but the value format is invalid</small>
+                     <div class="col-lg-6">
+                       <p>Current inherited, merged value:</p>
+                       <pre class="json-beautify">{{formatContent(property)}}</pre>
+                     </div>
+                     <div class="col-lg-6">
+                       <p>Overriding value:</p>
+                       <textarea placeholder="Value" msd-elastic rows="1" class="form-control input-sm input-value" ng-model="editedProperties[property.name].new.value"></textarea>
+                       <small class="text-danger" ng-if="!editedProperties[property.name].new.isValid">JSON check is enabled, but the value format is invalid</small>
+                     </div>
                    </div>
                  </td>
                  <td ng-if="$parent.hasEditRight" class="text-center" ng-class="{'default-actions':!isEdited(property.name), 'edit-actions is-edited':isEdited(property.name)}">


### PR DESCRIPTION
https://issues.rudder.io/issues/17625

This PR change a bit the logic for merge properties: 
- in a property hierarchy, we had in head of parents property the original value of the object property in the `overriden` case (when it's purely inherited, nothing change - this is done in method `MergeNodeProperties#mergeDefault`), 
- change name from `parents` to hierarchy since it doesn't hold only parents anymore, 
- for the api case, add the original value in a `origval` attribute, 
- when editing an existing property, if the provider is `overridden`, use `origval`
- for each action among `add`, `delete`, `edit`, reload all properties on save success because inheritance/overriding need to be computed again, and front end doesn't have all information to do it.

When viewing:
![image](https://user-images.githubusercontent.com/44649/83812054-2353a180-a6bb-11ea-93b9-8d350ad18791.png)


When editing: 
![image](https://user-images.githubusercontent.com/44649/83811955-ff905b80-a6ba-11ea-9c0f-725fdcd7b9fe.png)
