### PR TITLE
Fixes #17683: Error in technique editor "could not get generic method metadata" after upgrade from 6.0

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/ncf/TechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/ncf/TechniqueReader.scala
@@ -69,7 +69,9 @@ class TechniqueReader(
       needsUpdate <- if (metadataFileExists) {
                        IOResult.effect("An error occurs while checking if generic methods metadata needs to be updated") {
                          val methodsFileModifiedTime = methodsFile.lastModifiedTime()
-                         checkNeedsUpdate(methodsFileModifiedTime, baseDir :: userDir :: Nil)
+                         val dirsToCheck = (baseDir :: userDir :: Nil).filter(_.exists)
+                         // Not sure what to do if empty; here it will be false, and we don't update, but updating would surely be an error
+                         checkNeedsUpdate(methodsFileModifiedTime, dirsToCheck)
                        }
                      } else true.succeed
     } yield {


### PR DESCRIPTION
https://issues.rudder.io/issues/17683