### PR TITLE
Fixes #17702: When there is a serialisation error for parameter, their edit screen is unavaible

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ParameterRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ParameterRepository.scala
@@ -40,8 +40,8 @@ import com.normation.rudder.domain.parameters._
 import com.normation.eventlog.ModificationId
 import com.normation.eventlog.EventActor
 import com.normation.rudder.domain.archives.ParameterArchiveId
-
 import com.normation.errors._
+import com.normation.rudder.domain.nodes.PropertyProvider
 
 /**
  * The Parameter Repository (Read Only) to read parameters from LDAP
@@ -58,7 +58,7 @@ trait WoParameterRepository {
 
   def updateParameter(parameter : GlobalParameter, modId: ModificationId, actor:EventActor, reason:Option[String]) : IOResult[Option[ModifyGlobalParameterDiff]]
 
-  def delete(parameterName:String, modId: ModificationId, actor:EventActor, reason:Option[String]) : IOResult[DeleteGlobalParameterDiff]
+  def delete(parameterName:String, provider: Option[PropertyProvider], modId: ModificationId, actor:EventActor, reason:Option[String]) : IOResult[Option[DeleteGlobalParameterDiff]]
 
   /**
    * A (dangerous) method that replace all existing parameters

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -957,7 +957,6 @@ class LDAPEntityMapper(
   //////////////////////////////    Parameters    //////////////////////////////
 
 
-
   /*
    * We need to know if the format is 6.0 and before or 6.1.
    * For that, we look if attribute `overridable` is present: if so, it's 6.0 or before
@@ -969,13 +968,12 @@ class LDAPEntityMapper(
       //OK, translate
       for {
         name        <- e.required(A_PARAMETER_NAME)
-        value       =  e(A_PARAMETER_VALUE).getOrElse("")
         description =  e(A_DESCRIPTION).getOrElse("")
         provider    =  e(A_PROPERTY_PROVIDER).map(PropertyProvider.apply)
-        parsed      <- value.parseGlobalParameter(e.hasAttribute("overridable")).left.map(err => Err.UnexpectedObject(err.fullMsg))
-      } yield {
-        GlobalParameter(name, parsed, description, provider)
-      }
+        parsed      =  e(A_PARAMETER_VALUE).getOrElse("").parseGlobalParameter(name, e.hasAttribute("overridable"))
+    } yield {
+      GlobalParameter(name, parsed, description, provider)
+    }
     } else Left(Err.UnexpectedObject("The given entry is not of the expected ObjectClass '%s'. Entry details: %s".format(OC_PARAMETER, e)))
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/ParameterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/ParameterService.scala
@@ -45,8 +45,8 @@ import com.normation.rudder.repository.RoParameterRepository
 import com.normation.rudder.repository.WoParameterRepository
 import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
-
 import com.normation.box._
+import com.normation.rudder.domain.nodes.PropertyProvider
 
 trait RoParameterService {
 
@@ -89,7 +89,7 @@ trait WoParameterService {
   /**
    * Delete a global parameter
    */
-  def delete(parameterName:String, modId: ModificationId, actor:EventActor, reason:Option[String]) : Box[String]
+  def delete(parameterName:String, provider: Option[PropertyProvider], modId: ModificationId, actor:EventActor, reason:Option[String]) : Box[String]
 }
 
 class RoParameterServiceImpl(
@@ -201,8 +201,8 @@ class WoParameterServiceImpl(
     }
   }
 
-  def delete(parameterName:String, modId: ModificationId, actor:EventActor, reason:Option[String]) : Box[String] = {
-    woParamRepo.delete(parameterName, modId, actor, reason).toBox match {
+  def delete(parameterName:String, provider: Option[PropertyProvider], modId: ModificationId, actor:EventActor, reason:Option[String]) : Box[String] = {
+    woParamRepo.delete(parameterName, provider, modId, actor, reason).toBox match {
       case e:Failure =>
         logger.error("Error while trying to delete param %s : %s".format(parameterName, e.messageChain))
         e


### PR DESCRIPTION
https://issues.rudder.io/issues/17702

Main changes:

- if parsing of serialized global value fails, get value as string. It should be an extremely rare case (likely due to direct modification of LDAP), 
- make delete not fails if the param is not found and use provider, so that we can't delete a parameter with a different provider than our