### PR TITLE
Fixes #17815: Group API compatibility broken as it now always expects "properties"

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDirectiveRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDirectiveRepository.scala
@@ -200,7 +200,7 @@ class RoLDAPDirectiveRepository(
   def containsDirective(id: ActiveTechniqueCategoryId) : UIO[Boolean] = {
     userLibMutex.readLock(for {
       con      <- ldap
-      category <- getCategoryEntry(con, id).notOptional(s"Entry with ID '${id}' was not found")
+      category <- getCategoryEntry(con, id).notOptional(s"Entry with ID '${id.value}' was not found")
       entries  <- con.searchSub(category.dn, IS(OC_DIRECTIVE), Seq[String]():_*)
       results  <- ZIO.foreach(entries)(x => mapper.entry2Directive(x).toIO)
     } yield {
@@ -806,7 +806,7 @@ class WoLDAPDirectiveRepository(
                                  archive  <- gitCatArchiver.archiveActiveTechniqueCategory(that,parents.map( _.id), Some((modId, commiter, reason)))
                                } yield archive
                              }
-      parentEntry         <- getCategoryEntry(con, into).chainError("Entry with ID '%s' was not found".format(into))
+      parentEntry         <- getCategoryEntry(con, into).chainError(s"Entry with ID '${into.value}' was not found")
       updatedParent       <- mapper.entry2ActiveTechniqueCategory(categoryEntry).chainError(s"Error when transforming LDAP entry '${categoryEntry}' into an active technique category").toIO
     } yield {
       updatedParent

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -568,7 +568,7 @@ class GroupApiService5 (
   def createGroup(restGroup: Box[RestGroup], req:Req, apiVersion: ApiVersion) = {
     val restGroupChecked =
       restGroup match {
-          case Full(RestGroup(_,_,None,_,_,_,_)) => Failure("Cannot create a group with an empty query")
+          case Full(RestGroup(_,_,_,None,_,_,_)) => Failure("Cannot create a group with an empty query")
           case a => a
       }
     apiService2.createGroup(restGroupChecked, req, apiVersion)


### PR DESCRIPTION
https://issues.rudder.io/issues/17815

The bug correction is only the change in `None` position, but while debugging I foudn some missing `id.value` for logs/errors