### PR TITLE
Fixes #17884: Error when installing relayd on root: missing file /var/rudder/configuration-repository/shared-files/*

### DIFF
--- a/relay/sources/rudder-server-relay-postinst
+++ b/relay/sources/rudder-server-relay-postinst
@@ -52,7 +52,7 @@ chmod g+s-w /var/rudder/share
 mkdir -p /var/rudder/configuration-repository/shared-files
 chown -R root:rudder /var/rudder/configuration-repository/shared-files
 chmod 2750 /var/rudder/configuration-repository/shared-files
-chmod -R u+rwx,g+rX /var/rudder/configuration-repository/shared-files/*
+chmod -R u+rwX,g+rX /var/rudder/configuration-repository/shared-files
 chown -R rudder-relayd:rudder /var/rudder/shared-files
 chmod 770 /var/rudder/shared-files
 chmod 755 /var/rudder/inventories


### PR DESCRIPTION
https://issues.rudder.io/issues/17884