### PR TITLE
Fixes #18149: Upgrade to ZIO 1.0.1

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionReportUnmarshaller.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionReportUnmarshaller.scala
@@ -355,6 +355,7 @@ class FusionReportUnmarshaller(
       }
     }
 
+
     /*
      * Process agents. We want to keep the maximum number of agents,
      * ie if there's two agents, and XML for one is not valid, still
@@ -364,7 +365,7 @@ class FusionReportUnmarshaller(
      * agent is ignored).
      *
      */
-    val agentList = ZIO.foreach(xml \\ "AGENT") { agentXML =>
+    val agentList = ZIO.foreach((xml \\ "AGENT").toList) { agentXML =>
       val agent = for {
          agentName <- boxFromOption(optText(agentXML \ "AGENT_NAME"), "could not parse agent name (tag AGENT_NAME) from rudder specific inventory")
          agentType <- ZIO.fromEither(AgentType.fromValue(agentName))
@@ -530,6 +531,9 @@ class FusionReportUnmarshaller(
       }
     }
   }
+
+
+
 
   // ******************************************** //
   // parsing implementation details for each tags //

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryMapper.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryMapper.scala
@@ -1017,7 +1017,7 @@ class InventoryMapper(
          , process
          , serverRoles = serverRoles
          , timezone = timezone
-         , customProperties = customProperties.flatten
+         , customProperties = customProperties.toList.flatten
        )
     }
   }

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/ReadOnlySoftwareInventoryDAOImpl.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/ReadOnlySoftwareInventoryDAOImpl.scala
@@ -57,7 +57,7 @@ class ReadOnlySoftwareDAOImpl(
   mapper:InventoryMapper
 ) extends ReadOnlySoftwareDAO {
 
-  private[this] def search(con: RoLDAPConnection, ids: Seq[SoftwareUuid]): IOResult[List[Software]] = {
+  private[this] def search(con: RoLDAPConnection, ids: Seq[SoftwareUuid]): IOResult[Seq[Software]] = {
     for {
       entries <- con.searchOne(inventoryDitService.getSoftwareBaseDN, OR(ids map {x:SoftwareUuid => EQ(A_SOFTWARE_UUID,x.value) }:_*)).map(_.toVector)
       soft    <- ZIO.foreach(entries) { entry =>

--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -387,16 +387,15 @@ limitations under the License.
       We declare cats in "test" here, because it is not directly needed
       in any project before rudder.
     -->
-    <monix-version>3.0.0</monix-version>
-    <cats-version>2.0.0</cats-version>
+    <cats-version>2.1.1</cats-version>
     <specs2-version>4.9.3</specs2-version>
-    <doobie-version>0.8.8</doobie-version>
-    <fs2-version>2.1.0</fs2-version>
-    <http4s-version>0.21.0-M6</http4s-version>
+    <doobie-version>0.9.0</doobie-version>
+    <fs2-version>2.3.0</fs2-version>
+    <http4s-version>0.21.4</http4s-version>
     <shapeless-version>2.3.3</shapeless-version>
-    <cats-effect-version>2.0.0</cats-effect-version>
-    <dev-zio-version>1.0.0-RC18-2</dev-zio-version>
-    <zio-cats-version>2.0.0.0-RC12</zio-cats-version>
+    <cats-effect-version>2.1.4</cats-effect-version>
+    <dev-zio-version>1.0.1</dev-zio-version>
+    <zio-cats-version>2.1.4.0</zio-cats-version>
 
     <!--
       Hack to make scalac jvm parameters like RAM configurable.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportsCleaner.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportsCleaner.scala
@@ -384,10 +384,11 @@ class AutomaticReportsCleaning(
       }
     }
   }
+  import zio.duration._
 
   (for {
     ttl   <- deleteLogttl
-    dur   =  zio.duration.Duration(ttl.toLong, scala.concurrent.duration.MINUTES)
+    dur   =  ttl.toLong.minutes
     batch <- if(ttl < 1) {
                ScheduledJobLoggerPure.info(s"Disable automatic database deletion of log reports sinces property '${deleteLogReportPropertyName}' is 0 or negative") *>
                UIO.unit

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/metrics/Scheduler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/metrics/Scheduler.scala
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit
 import com.normation.errors._
 import zio._
 import zio.clock.Clock
-import zio.duration.Duration
+import zio.duration._
 import zio.syntax._
 
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
@@ -282,7 +282,7 @@ trait RoNodeGroupRepository {
    * Return all categories
    * @return
    */
-  def getAllGroupCategories(includeSystem: Boolean = false) : IOResult[List[NodeGroupCategory]]
+  def getAllGroupCategories(includeSystem: Boolean = false) : IOResult[Seq[NodeGroupCategory]]
 
   /**
    * Get a group category by its id

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -270,7 +270,7 @@ class LDAPEntityMapper(
     val keys =  inventoryEntry.valuesFor(A_PKEYS).map(Some(_))
     for {
       agentsName     <- {
-                         val agents = inventoryEntry.valuesFor(A_AGENTS_NAME).toSeq.map(Some(_))
+                         val agents = inventoryEntry.valuesFor(A_AGENTS_NAME).toSeq.map(Some(_)).toList
                          ZIO.foreach(agents.zipAll(keys,None,None)) {
                            case (Some(agent),key) => AgentInfoSerialisation.parseCompatNonJson(agent,key)
                            case (None,key)        => (Err.MissingMandatory(s"There was a public key defined for Node ${nodeId.value},"+
@@ -329,7 +329,7 @@ class LDAPEntityMapper(
       // fetch the inventory datetime of the object
       val dateTime = inventoryEntry.getAsGTime(A_INVENTORY_DATE) map(_.dateTime) getOrElse(DateTime.now)
       NodeInfo(
-          node.copy(properties = overrideProperties(node.id, node.properties, properties.flatten))
+          node.copy(properties = overrideProperties(node.id, node.properties, properties.toList.flatten))
         , inventoryEntry(A_HOSTNAME).getOrElse("")
         , machineInfo
         , osDetails

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
@@ -184,7 +184,7 @@ class RoLDAPNodeGroupRepository(
     }
   }
 
-  def getAllGroupCategories(includeSystem:Boolean = false) : IOResult[List[NodeGroupCategory]] = {
+  def getAllGroupCategories(includeSystem:Boolean = false) : IOResult[Seq[NodeGroupCategory]] = {
     groupLibMutex.readLock { for {
       con             <- ldap
       filter          =  if(includeSystem) IS(OC_GROUP_CATEGORY) else AND(NOT(EQ(A_IS_SYSTEM, true.toLDAPString)),IS(OC_GROUP_CATEGORY))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
@@ -95,14 +95,14 @@ class WoLDAPNodeRepository(
   }
 
   def updateNodeKeyInfo(nodeId: NodeId, agentKey: Option[SecurityToken], agentKeyStatus: Option[KeyStatus], modId: ModificationId, actor:EventActor, reason:Option[String]) : IOResult[Unit] = {
-    def updateInfo(oldInfo: (List[AgentInfo], KeyStatus), agentKey: Option[SecurityToken], agentKeyStatus: Option[KeyStatus]): (List[AgentInfo], KeyStatus) = {
+    def updateInfo(oldInfo: (Seq[AgentInfo], KeyStatus), agentKey: Option[SecurityToken], agentKeyStatus: Option[KeyStatus]): (List[AgentInfo], KeyStatus) = {
       val agents = agentKey match {
         case None    => oldInfo._1
         case Some(k) => oldInfo._1.map { _.copy(securityToken = k) }
       }
       val status = agentKeyStatus.getOrElse(oldInfo._2)
 
-      (agents, status)
+      (agents.toList, status)
     }
     import com.normation.inventory.ldap.core.LDAPConstants.{A_KEY_STATUS, A_AGENTS_NAME}
     if(agentKey.isEmpty && agentKeyStatus.isEmpty) UIO.unit

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchiverImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchiverImpl.scala
@@ -373,7 +373,7 @@ class GitActiveTechniqueArchiverImpl(
     for {
       uptFile   <- newActiveTechniqueFile(activeTechnique.techniqueName, parents)
       gitPath   =  toGitPath(uptFile)
-      archive   <- writeXml(
+      _         <- writeXml(
                        uptFile
                      , activeTechniqueSerialisation.serialise(activeTechnique)
                      , "Archived technique library template: " + uptFile.getPath
@@ -381,13 +381,13 @@ class GitActiveTechniqueArchiverImpl(
       //strategy for callbaack:
       //if at least one callback is in error, we don't execute the others and the full ActiveTechnique is in error.
       //if none is in error, we are going to next step
-      callbacks <- ZIO.foreach(uptModificationCallback) { _.onArchive(activeTechnique, parents, gitCommit) }
-      commit    <- gitCommit match {
+      callbacks <- ZIO.foreach(uptModificationCallback.toList) { _.onArchive(activeTechnique, parents, gitCommit) }
+      _         <- gitCommit match {
                      case Some((modId, commiter, reason)) => commitAddFile(modId, commiter, gitPath, s"Archive of technique library template for technique name '${activeTechnique.techniqueName.value}'${GET(reason)}")
                      case None => UIO.unit
                    }
     } yield {
-      (GitPath(gitPath), callbacks.flatten)
+      (GitPath(gitPath), callbacks.toSeq.flatten)
     }
   }
 
@@ -401,7 +401,7 @@ class GitActiveTechniqueArchiverImpl(
                     deleted <- IOResult.effect(FileUtils.forceDelete(atFile))
                     _       =  logPure.debug(s"Deleted archived technique library template: ${atFile.getPath}")
                     gitPath =  toGitPath(atFile)
-                    callbacks <- ZIO.foreach(uptModificationCallback) { _.onDelete(ptName, parents, None) }
+                    callbacks <- ZIO.foreach(uptModificationCallback.toList) { _.onDelete(ptName, parents, None) }
                     commited <- gitCommit match {
                                   case Some((modId, commiter, reason)) =>
                                     commitRmFile(modId, commiter, gitPath, s"Delete archive of technique library template for technique name '${ptName.value}'${GET(reason)}")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitParseRudderObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitParseRudderObjects.scala
@@ -128,7 +128,7 @@ class GitParseRules(
                  }
                }
     } yield {
-      rules
+      rules.toList
     }
   }
 }
@@ -153,7 +153,7 @@ class GitParseGlobalParameters(
                    p.startsWith(root.directoryPath) &&
                    p.endsWith(".xml")
                  }
-      xmls   <- ZIO.foreach(paths.toSeq) { paramPath =>
+      xmls   <- ZIO.foreach(paths) { paramPath =>
                   GitFindUtils.getFileContent(repo.db, revTreeId, paramPath){ inputStream =>
                     ParseXml(inputStream, Some(paramPath))
                   }
@@ -167,7 +167,7 @@ class GitParseGlobalParameters(
                     }
                 }
     } yield {
-      params
+      params.toList
     }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DependencyAndDeletionService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DependencyAndDeletionService.scala
@@ -401,7 +401,7 @@ class DependencyAndDeletionServiceImpl(
           case rule if(rule.isEnabledStatus && rule.directiveIds.size > 0) => rule.directiveIds.map(id => (rule, id))
         }.flatten
         //group by target, and check if target is enable
-        ZIO.foreach(enabledCr.groupBy { case (rule,id) => id }) { case (id, seq) =>
+        ZIO.foreach(enabledCr.groupBy { case (rule,id) => id }.toSeq) { case (id, seq) =>
           for {
             optPair <- roDirectiveRepository.getActiveTechniqueAndDirective(id).chainError(s"Error when retrieving directive with ID ${id.value}'")
             // here, if we don't have a directive for the ID, we assume it's a directive that was

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -1045,7 +1045,7 @@ object BuildNodeConfiguration extends Loggable {
 
       val nodeConfigsProg = for {
         counters          <- Counters.make()
-        ncp               <- ZIO.foreachParN(maxParallelism)(nodeContexts.toIterable) { case (nodeId, context) =>
+        ncp               <- ZIO.foreachParN(maxParallelism)(nodeContexts.toSeq) { case (nodeId, context) =>
 
                               (for {
                                 t1_0           <- nanoTime

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PrepareTemplateVariables.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PrepareTemplateVariables.scala
@@ -178,7 +178,7 @@ class PrepareTemplateVariablesImpl(
       preparedTemplate <- prepareTechniqueTemplate(
                               agentNodeProps
                             , agentNodeConfig.config.policies
-                            , parameters
+                            , parameters.toList
                             , allSystemVars
                             , templates
                             , generationTime.getMillis

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
@@ -419,7 +419,7 @@ class InternalLDAPQueryProcessor(
         case Some(dms) => for {
           // Ok, do the computation here
           _      <- logPure.ifTraceEnabled {
-                      ZIO.foreach(dms) { case (dnType, dns) =>
+                      ZIO.foreach_(dms) { case (dnType, dns) =>
                         logPure.trace(s"/// ${dnType} ==> ${dns.map(_.getRDN).mkString(", ")}")
                       }
                     }
@@ -483,7 +483,7 @@ class InternalLDAPQueryProcessor(
    */
   private[this] def createLDAPObjects(query: LDAPNodeQuery, debugId: Long) : IOResult[Map[DnType, Map[String, LDAPObjectType]]] = {
     ZIO.foreach(query.objectTypesFilters) { case(dnType, mapOtSubQueries) =>
-      val sq = ZIO.foreach(mapOtSubQueries) { case (ot, listSubQueries) =>
+      val sq = ZIO.foreach(mapOtSubQueries.toSeq) { case (ot, listSubQueries) =>
 
         val subqueries = ZIO.foreach(listSubQueries) { case SubQuery(subQueryId, dnType, objectTypeName, filters) =>
           (unspecialiseFilters(filters) match {
@@ -624,7 +624,7 @@ class InternalLDAPQueryProcessor(
                  //now, each filter individually
         _        <- logPure.debug("[%s] |--- or (base filter): %s".format(debugId, entries.size))
         _        <- logPure.trace("[%s] |--- or (base filter): %s".format(debugId, entries.map( _.dn.getRDN  ).mkString(", ")))
-        specials <- ZIO.foreach(sf){ case (k, filters) => baseQuery(con, filters) }
+        specials <- ZIO.foreach(sf.toSeq){ case (k, filters) => baseQuery(con, filters) }
         sFlat    =  specials.flatten
         _        <- logPure.debug("[%s] |--- or (special filter): %s".format(debugId, sFlat.size))
         _        <- logPure.trace("[%s] |--- or (special filter): %s".format(debugId, sFlat.map( _.dn.getRDN  ).mkString(", ")))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/metrics/NodeCountHistorizationTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/metrics/NodeCountHistorizationTest.scala
@@ -101,8 +101,8 @@ class NodeCountHistorizationTest extends Specification with BeforeAfter  {
     val prog = ZIO.accessM[Clock with TestClock] { testClock =>
       for {
         refMetrics <- Ref.make(FrequentNodeMetrics(1,2,3,4,5))
+        _          <- testClock.get[Clock.Service].sleep(t).fork
         _          <- testClock.get[TestClock.Service].setTime(t)
-        _          <- testClock.get[Clock.Service].sleep(t)
         service    <- makeService(rootDir, refMetrics, testClock)
         commit     <- service.fetchDataAndLog("initilize logs")
       } yield commit

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/metrics/SchedulerTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/metrics/SchedulerTest.scala
@@ -64,8 +64,7 @@ class SchedulerTest extends Specification {
       val prog = ZIO.accessM[Clock with TestClock] { testClock =>
         // in RC18-2, we need to sleep as long as we adjusted
         def adjust(d: Duration) = {
-          testClock.get[TestClock.Service].adjust(d) *>
-          testClock.get[Clock.Service].sleep(d)
+          testClock.get[TestClock.Service].adjust(d)
         }
         def take(q: Queue[Long], r: Ref[List[Long]]): UIO[Unit] = {
           for {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -104,7 +104,7 @@ import com.normation.rudder.domain.nodes.GroupProperty
 import com.normation.rudder.ncf.ParameterType.ParameterTypeService
 import com.normation.rudder.services.policies.PropertyParser
 import org.bouncycastle.cert.X509CertificateHolder
-import zio._
+import zio.{Tag => _, _}
 import zio.syntax._
 
 final case class RestExtractorService (

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NcfApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NcfApi.scala
@@ -57,7 +57,6 @@ import com.normation.box._
 import com.normation.cfclerk.services.GitRepositoryProvider
 import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.errors.IOResult
-import com.normation.errors.effectUioUnit
 import com.normation.rudder.ncf.ResourceFile
 import com.normation.rudder.ncf.ResourceFileState
 import net.liftweb.json.JsonAST.JArray

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPluginJson.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPluginJson.scala
@@ -113,7 +113,7 @@ class ReadPluginPackageInfo(path: String) {
   }
 
   def decode(plugin: JsonPluginFile): IOResult[List[Either[RudderError, JsonPluginDef]]] = {
-    ZIO.foreach(plugin.plugins) { case (name, jvalue) =>
+    ZIO.foreach(plugin.plugins.toList) { case (name, jvalue) =>
       decodeOne(jvalue).mapError(err => Chained(s"Error when decoding plugin information for entry '${name}'", err)).either
     }
   }
@@ -128,4 +128,6 @@ class ReadPluginPackageInfo(path: String) {
       else List().succeed
     }
   }
+
+
 }

--- a/webapp/sources/utils/src/test/scala/com/normation/ZioCommonsTest.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/ZioCommonsTest.scala
@@ -350,7 +350,7 @@ object TestJavaLockWithZio {
           .mapError(ex => SystemError(s"Error when trying to get LDAP lock", ex))
       )(_ =>
         log(s"Release lock '${name}'") *>
-        blocking.blocking(IO.effect(this.unlock())).provideLayer(blockingEnv).catchAll(t => log(s"${t.getClass.getName}:${t.getMessage}") *> ZIO.foreach(t.getStackTrace) { s => log(s.toString) }).unit
+        blocking.blocking(IO.effect(this.unlock())).provideLayer(blockingEnv).catchAll(t => log(s"${t.getClass.getName}:${t.getMessage}") *> ZIO.foreach(t.getStackTrace.toList) { s => log(s.toString) }).unit
       )(_ =>
         log(s"Do things in lock '${name}'") *>
         block


### PR DESCRIPTION
https://issues.rudder.io/issues/18149
Update went smoothly, three noticable changes: 

- update cats dependencies because of `zio-compatc-cats`. I think I found back a consistent set of lib for `fs2` etc, 
- change in `TestClock.sleep`. Now it actually sleep the fiber, so it needs a `fork`. Also, `TestClock.adjust` doesn't need a sleep to notify the adjust anymore (good!);
- the biggest change is a change in `foreach` signature, which used to take only a `items: Iterable[A]` parameter and was *always* returning a `List[A]` and that now takes 5 differents parameters (`Option[A]`, `Map[A, B]`, `Set[A]`, `NonEmptyChunk[A]`, and `Collection[+Element] <: Iterable[Element]` and return the same type). That need some `.toList` or spelling to scalac that no, really, I want an iteration on map paires, not building a new map all around to make everyone happy, but I think the experience will be more `traverse`-like in the end, so for the better. 

All that being said, I didn't found any deadlock, even with only one thread available, and I did see a noticable perf improvement (around 15% in policy writting test, which is big (on three iteration, we now have `870 ms / 793 ms / 760 ms` versus `1089 ms / 872 ms / 944 ms` - of course, it will need to be tested in real life / real load)
