### PR TITLE
Fixes #18169: rudder-lang fails to test its documentation examples

### DIFF
--- a/rudder-lang/docs/examples/statements.rl
+++ b/rudder-lang/docs/examples/statements.rl
@@ -1,13 +1,13 @@
 @format=0
 
-let rights = "g+x"
-
 resource deb()
 
 deb state technique()
 {
   # list of possible statements
   @info="i am a metadata"
+  let rights = "g+x"
+
 
   permissions("/tmp").dirs("root", "x$${root}i${user}2","g+w") as outvar
   


### PR DESCRIPTION
https://issues.rudder.io/issues/18169