### PR TITLE
Fixes #18338: Rudder SSL default configuration should follow the system default one

### DIFF
--- a/relay/sources/apache/rudder-vhost.conf
+++ b/relay/sources/apache/rudder-vhost.conf
@@ -34,3 +34,10 @@
 
   IncludeOptional /opt/rudder/etc/rudder-apache-*-ssl.conf
 </VirtualHost>
+
+#Lines below where taken from https://ssl-config.mozilla.org/#server=apache&version=2.4.23&config=intermediate&openssl=1.0.2p&hsts=false&ocsp=false&guideline=5.6
+#Based on the oldest version of apache/openssl available in the Rudder server supported OS, in this case taken from a SLES12 SP4
+SSLProtocol             all -SSLv3 -TLSv1 -TLSv1.1
+SSLCipherSuite          ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+SSLHonorCipherOrder     off
+SSLSessionTickets       off


### PR DESCRIPTION
https://issues.rudder.io/issues/18338

Replacing previous PR: https://github.com/Normation/rudder/pull/3263
