### PR TITLE
Fixes #17634: Group description button should not be clickable in read_only

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
@@ -64,7 +64,9 @@
        <group-name></group-name>
       <div id="longDescriptionFieldMarkdownContainer" class="row form-group wbBaseFieldLabel">
         <label class="wbBaseFieldLabel"><span class="text-fit">Description</span>
-          <i class="fa fa-pencil text-primary cursorPointer half-opacity" onmouseenter="toggleOpacity(this)" title="Edit description" onmouseout="toggleOpacity(this)" onclick="toggleMarkdownEditor('longDescriptionField')"></i>
+          <lift:authz role="group_write">
+            <i class="fa fa-pencil text-primary cursorPointer half-opacity" onmouseenter="toggleOpacity(this)" title="Edit description" onmouseout="toggleOpacity(this)" onclick="toggleMarkdownEditor('longDescriptionField')"></i>
+          </lift:authz>
         </label>
         <div class="markdown">
           <div id="longDescriptionFieldMarkdown"></div>


### PR DESCRIPTION
https://issues.rudder.io/issues/17634

Replacing previous PR: https://github.com/Normation/rudder/pull/3284
