### PR TITLE
Fixes #18406: Missing base class of plugins breaks `reflections` with caffeine version 2.8.2

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -382,6 +382,7 @@ limitations under the License.
     <config-version>1.4.0</config-version>
     <cafeine-version>2.8.6</cafeine-version>
     <jgrapht-version>1.4.0</jgrapht-version>
+    <reflections-version>0.9.12</reflections-version>
     <!--
       These one must be updated to work together
       We declare cats in "test" here, because it is not directly needed

--- a/webapp/sources/rudder/rudder-web/pom.xml
+++ b/webapp/sources/rudder/rudder-web/pom.xml
@@ -176,7 +176,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
-      <version>0.9.12</version>
+      <version>${reflections-version}</version>
     </dependency>
 
     <dependency>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -544,7 +544,8 @@ class Boot extends Loggable {
   private[this] def initPlugins(): List[RudderPluginDef] = {
     import scala.jdk.CollectionConverters._
 
-    val reflections = new Reflections("bootstrap.rudder.plugin")
+    val reflections = new Reflections("bootstrap.rudder.plugin", "com.normation.plugins")
+
     val modules = reflections.getSubTypesOf(classOf[RudderPluginModule]).asScala.map(c => c.getField("MODULE$").get(null).asInstanceOf[RudderPluginModule])
 
     val scalaPlugins = modules.toList.map(_.pluginDef).map(p => (p.name.value, p)).toMap


### PR DESCRIPTION
https://issues.rudder.io/issues/18406