### PR TITLE
Fixes #18466: Inherited node prop arrays are replaced not merged contrary to doc

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/resources/ldap/rudder.schema
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/ldap/rudder.schema
@@ -356,6 +356,13 @@ attributetype ( RudderAttributes:307
   SUBSTR caseIgnoreSubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
+attributetype ( RudderAttributes:308
+  NAME 'inheritMode'
+  DESC 'inheritance mode like merge, override, etc for properties and parameters object/array/string'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
 #### Nodes
 
 attributetype ( RudderAttributes:351
@@ -540,7 +547,8 @@ objectclass ( RudderObjectClasses:120
   SUP top
   STRUCTURAL
   MUST ( parameterName )
-  MAY ( parameterValue $ description $ propertyProvider $ overridable ) )
+  MAY ( parameterValue $ description $ propertyProvider $
+        overridable $ inheritMode ) )
 
 #
 # Application properties

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderLDAPConstants.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderLDAPConstants.scala
@@ -123,6 +123,7 @@ object RudderLDAPConstants extends Loggable {
 
   // property provider
   val A_PROPERTY_PROVIDER = "propertyProvider"
+  val A_INHERIT_MODE = "inheritMode"
 
   //node configuration hashes
   val A_NODE_CONFIG = "nodeConfig"

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/parameters/GlobalParameter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/parameters/GlobalParameter.scala
@@ -38,6 +38,7 @@ package com.normation.rudder.domain.parameters
 
 import com.normation.errors.PureResult
 import com.normation.rudder.domain.nodes.GenericProperty
+import com.normation.rudder.domain.nodes.InheritMode
 import com.normation.rudder.domain.nodes.PropertyProvider
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigValue
@@ -59,11 +60,11 @@ object GlobalParameter {
    * a JString *but* a string representing an actual JSON should be
    * used as json.
    */
-  def parse(name: String, value: String, description: String, provider: Option[PropertyProvider]): PureResult[GlobalParameter] = {
-    GenericProperty.parseConfig(name, value, provider, Some(description)).map(c => new GlobalParameter(c))
+  def parse(name: String, value: String, mode: Option[InheritMode], description: String, provider: Option[PropertyProvider]): PureResult[GlobalParameter] = {
+    GenericProperty.parseConfig(name, value, mode, provider, Some(description)).map(c => new GlobalParameter(c))
   }
-  def apply(name: String, value: ConfigValue, description: String, provider: Option[PropertyProvider]): GlobalParameter = {
-    new GlobalParameter(GenericProperty.toConfig(name, value, provider, Some(description)))
+  def apply(name: String, value: ConfigValue, mode: Option[InheritMode], description: String, provider: Option[PropertyProvider]): GlobalParameter = {
+    new GlobalParameter(GenericProperty.toConfig(name, value, mode, provider, Some(description)))
   }
 
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/parameters/ParameterDiff.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/parameters/ParameterDiff.scala
@@ -37,6 +37,7 @@
 
 package com.normation.rudder.domain.parameters
 
+import com.normation.rudder.domain.nodes.InheritMode
 import com.normation.rudder.domain.nodes.PropertyProvider
 import com.normation.rudder.domain.policies.SimpleDiff
 import com.normation.rudder.domain.policies.TriggerDeploymentDiff
@@ -62,6 +63,7 @@ final case class ModifyGlobalParameterDiff(
   , modValue      : Option[SimpleDiff[ConfigValue]] = None
   , modDescription: Option[SimpleDiff[String]] = None
   , modProvider   : Option[SimpleDiff[Option[PropertyProvider]]] = None
+  , modInheritMode: Option[SimpleDiff[Option[InheritMode]]] = None
 ) extends ParameterDiff {
   def needDeployment : Boolean = {
     modValue.isDefined

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
@@ -433,6 +433,10 @@ class LDAPDiffMapper(
                   nonNull(diff, mod.getAttribute().getValue) { (d, value) =>
                     d.copy(modProvider = Some(SimpleDiff(oldParam.provider, Some(PropertyProvider(value)))))
                   }
+                case A_INHERIT_MODE =>
+                  nonNull(diff, mod.getAttribute().getValue) { (d, value) =>
+                    d.copy(modInheritMode = Some(SimpleDiff(oldParam.inheritMode, InheritMode.parseString(value).toOption)))
+                  }
                 case "overridable" => diff //ignore, it's for cleaning
                 case x => Left(Err.UnexpectedObject("Unknown diff attribute: " + x))
               }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -976,8 +976,9 @@ class LDAPEntityMapper(
         description =  e(A_DESCRIPTION).getOrElse("")
         provider    =  e(A_PROPERTY_PROVIDER).map(PropertyProvider.apply)
         parsed      =  e(A_PARAMETER_VALUE).getOrElse("").parseGlobalParameter(name, e.hasAttribute("overridable"))
+        mode        =  e(A_INHERIT_MODE).flatMap(InheritMode.parseString(_).toOption)
     } yield {
-      GlobalParameter(name, parsed, description, provider)
+      GlobalParameter(name, parsed, mode, description, provider)
     }
     } else Left(Err.UnexpectedObject("The given entry is not of the expected ObjectClass '%s'. Entry details: %s".format(OC_PARAMETER, e)))
   }
@@ -991,6 +992,9 @@ class LDAPEntityMapper(
     entry.resetValuesTo(A_DESCRIPTION, parameter.description)
     parameter.provider.foreach(p =>
       entry.resetValuesTo(A_PROPERTY_PROVIDER, p.value)
+    )
+    parameter.inheritMode.foreach(m =>
+      entry.resetValuesTo(A_INHERIT_MODE, m.value)
     )
     entry
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
@@ -280,8 +280,9 @@ class GlobalParameterSerialisationImpl(xmlVersion:String) extends GlobalParamete
     createTrimedElem(XML_TAG_GLOBAL_PARAMETER, xmlVersion) (
        <name>{param.name}</name>
        <value>{param.valueAsString}</value>
+       ++{param.inheritMode.map(m => <inheritMode>{m.value}</inheritMode>).getOrElse(NodeSeq.Empty)}++
        <description>{param.description}</description>
-       <provider>{param.provider.map(_.value).getOrElse("")}</provider>
+       ++{param.provider.map(p => <provider>{p.value}</provider>).getOrElse(NodeSeq.Empty)}
     )
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -238,6 +238,7 @@ class NodeGroupUnserialisationImpl(
                                GroupProperty.parse(
                                    (p\\"name").text.trim
                                  , (p\\"value").text.trim
+                                 , (p\\"inheritMode").headOption.flatMap(p => InheritMode.parseString(p.text.trim).toOption)
                                  , (p\\"provider").headOption.map(p => PropertyProvider(p.text.trim))
                                ).toBox
                              }
@@ -644,7 +645,8 @@ class GlobalParameterUnserialisationImpl extends GlobalParameterUnserialisation 
       value            <- (globalParam \ "value").headOption.map( _.text ) ?~! ("Missing attribute 'value' in entry type globalParameter : " + entry)
       description      <- (globalParam \ "description").headOption.map( _.text ) ?~! ("Missing attribute 'description' in entry type globalParameter : " + entry)
       provider         =  (globalParam \ "provider").headOption.map(x => PropertyProvider(x.text))
-      g                <- GlobalParameter.parse(name, value, description, provider).toBox
+      mode             =  (globalParam \ "inheritMode").headOption.flatMap(x => InheritMode.parseString(x.text).toOption)
+      g                <- GlobalParameter.parse(name, value, mode, description, provider).toBox
     } yield {
       g
     }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/nodes/GenericPropertiesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/nodes/GenericPropertiesTest.scala
@@ -113,7 +113,7 @@ class GenericPropertiesTest extends Specification with Loggable with BoxSpecMatc
           |} // after end of value
           | # even on new lines
           |""".stripMargin
-      (firstNonCommentChar(s) must_=== Some('{')) and
+      (firstNonCommentChar(s) must_=== (Some('{'))) and
       (GenericProperty.parseValue(s) must beRight(ConfigValueFactory.fromMap(jmap(("a", "b")))))
     }
     "fails in a badly eneded json-like structure" in {
@@ -125,7 +125,7 @@ class GenericPropertiesTest extends Specification with Loggable with BoxSpecMatc
   }
 
   "serialization / deserialisation" should {
-    val check = (s: String) => GenericProperty.parseValue(s).map(GenericProperty.serializeToHocon) must beRight(s)
+    val check = (s: String) => GenericProperty.parseValue(s).map(x => GenericProperty.serializeToHocon(x)) must beRight(s)
 
     "be idempotent for string" in {
       val strings = List(
@@ -142,7 +142,7 @@ class GenericPropertiesTest extends Specification with Loggable with BoxSpecMatc
       strings must contain(check).foreach
     }
 
-    val checkPrimitive = (s: AnyVal) => GenericProperty.parseValue(s.toString).map(GenericProperty.serializeToHocon) must beRight(s.toString)
+    val checkPrimitive = (s: AnyVal) => GenericProperty.parseValue(s.toString).map(x => GenericProperty.serializeToHocon(x)) must beRight(s.toString)
 
     "primitives like int and boolean are stringified" in {
       val primitives = List[AnyVal](1, 2.42, true)
@@ -168,7 +168,7 @@ class GenericPropertiesTest extends Specification with Loggable with BoxSpecMatc
         |""".stripMargin
       val t = """{# comments!
         |"a":"b"}""".stripMargin
-       GenericProperty.parseValue(s).map(GenericProperty.serializeToHocon) must beRight(t)
+       GenericProperty.parseValue(s).map(x => GenericProperty.serializeToHocon(x)) must beRight(t)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/nodes/NodePropertiesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/nodes/NodePropertiesTest.scala
@@ -64,10 +64,10 @@ class NodePropertiesTest extends Specification with Loggable with BoxSpecMatcher
   }
 
   val baseProps = List(
-      NodeProperty("none"   , "node".toConfigValue   , None   )
-    , NodeProperty("default", "default".toConfigValue, RudderP)
-    , NodeProperty("p1"     , "p1".toConfigValue     , P1     )
-    , NodeProperty("p2"     , "p2".toConfigValue     , P2     )
+      NodeProperty("none"   , "node".toConfigValue   , None, None   )
+    , NodeProperty("default", "default".toConfigValue, None, RudderP)
+    , NodeProperty("p1"     , "p1".toConfigValue     , None, P1     )
+    , NodeProperty("p2"     , "p2".toConfigValue     , None, P2     )
   ).sorted
 
   sequential
@@ -103,8 +103,8 @@ class NodePropertiesTest extends Specification with Loggable with BoxSpecMatcher
     "replace json value, not merge" in {
       val json = """{"root":"val1", "env1":"prod1", "merge": { "test1":"val1" } }""".forceParse
       val json2 = """{"root":"val2", "env2":"prod2", "merge": { "test2":"val2" } }""".forceParse
-      val p1 = NodeProperty("x", json, None)
-      val p2 = NodeProperty("x", json2, None)
+      val p1 = NodeProperty("x", json , None, None)
+      val p2 = NodeProperty("x", json2, None, None)
       CompareProperties.updateProperties(p1::Nil, Some(p2::Nil)).map( _.sorted ) must beRight(p2::Nil)
     }
   }
@@ -120,38 +120,38 @@ class NodePropertiesTest extends Specification with Loggable with BoxSpecMatcher
 
     "works if providers goes from default to an other" in {
       List(
-          updateAndDelete(NodeProperty("none"   , "xxx".toConfigValue, P1))
-        , updateAndDelete(NodeProperty("none"   , "xxx".toConfigValue, P2))
-        , updateAndDelete(NodeProperty("default", "xxx".toConfigValue, P1))
-        , updateAndDelete(NodeProperty("default", "xxx".toConfigValue, P2))
+          updateAndDelete(NodeProperty("none"   , "xxx".toConfigValue, None, P1))
+        , updateAndDelete(NodeProperty("none"   , "xxx".toConfigValue, None, P2))
+        , updateAndDelete(NodeProperty("default", "xxx".toConfigValue, None, P1))
+        , updateAndDelete(NodeProperty("default", "xxx".toConfigValue, None, P2))
       ).flatten must contain( (res: PureResult[List[NodeProperty]]) => res must beAnInstanceOf[Right[_,_]] ).foreach
     }
 
     "works if providers goes from anything to system" in {
       List(
-          updateAndDelete(NodeProperty("none"   , "xxx".toConfigValue, Some(PropertyProvider.systemPropertyProvider)))
-        , updateAndDelete(NodeProperty("p1"     , "xxx".toConfigValue, Some(PropertyProvider.systemPropertyProvider)))
-        , updateAndDelete(NodeProperty("default", "xxx".toConfigValue, Some(PropertyProvider.systemPropertyProvider)))
-        , updateAndDelete(NodeProperty("default", "xxx".toConfigValue, Some(PropertyProvider.systemPropertyProvider)))
+          updateAndDelete(NodeProperty("none"   , "xxx".toConfigValue, None, Some(PropertyProvider.systemPropertyProvider)))
+        , updateAndDelete(NodeProperty("p1"     , "xxx".toConfigValue, None, Some(PropertyProvider.systemPropertyProvider)))
+        , updateAndDelete(NodeProperty("default", "xxx".toConfigValue, None, Some(PropertyProvider.systemPropertyProvider)))
+        , updateAndDelete(NodeProperty("default", "xxx".toConfigValue, None, Some(PropertyProvider.systemPropertyProvider)))
       ).flatten must contain( (res: PureResult[List[NodeProperty]]) => res must beAnInstanceOf[Right[_,_]] ).foreach
     }
 
     "fails for different, non default providers" in {
       List(
-          updateAndDelete(NodeProperty("p1"     , "xxx".toConfigValue, None))
-        , updateAndDelete(NodeProperty("p1"     , "xxx".toConfigValue, RudderP))
-        , updateAndDelete(NodeProperty("p1"     , "xxx".toConfigValue, P2))
-        , updateAndDelete(NodeProperty("p2"     , "xxx".toConfigValue, None))
-        , updateAndDelete(NodeProperty("p2"     , "xxx".toConfigValue, RudderP))
-        , updateAndDelete(NodeProperty("p2"     , "xxx".toConfigValue, P1))
+          updateAndDelete(NodeProperty("p1"     , "xxx".toConfigValue, None, None))
+        , updateAndDelete(NodeProperty("p1"     , "xxx".toConfigValue, None, RudderP))
+        , updateAndDelete(NodeProperty("p1"     , "xxx".toConfigValue, None, P2))
+        , updateAndDelete(NodeProperty("p2"     , "xxx".toConfigValue, None, None))
+        , updateAndDelete(NodeProperty("p2"     , "xxx".toConfigValue, None, RudderP))
+        , updateAndDelete(NodeProperty("p2"     , "xxx".toConfigValue, None, P1))
       ).flatten must contain( (res: PureResult[List[NodeProperty]]) => res must beAnInstanceOf[Left[_,_]] ).foreach
     }
 
 
     "be ok with compatible one (default)" in {
       List(
-          updateAndDelete(NodeProperty("none"   , "xxx".toConfigValue, RudderP))
-        , updateAndDelete(NodeProperty("default", "xxx".toConfigValue, None))
+          updateAndDelete(NodeProperty("none"   , "xxx".toConfigValue, None, RudderP))
+        , updateAndDelete(NodeProperty("default", "xxx".toConfigValue, None, None))
       ).flatten must contain( (res: PureResult[List[NodeProperty]]) => res must beAnInstanceOf[Right[_,_]] ).foreach
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/GlobalParamMigration61Test.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/GlobalParamMigration61Test.scala
@@ -99,7 +99,7 @@ class GlobalParamMigration61Test extends Specification {
     new LDAPEntityMapper(rudderDit, nodeDit, acceptedNodesDitImpl, cmdbQueryParser, inventoryMapper)
   }
 
-  val baseParam = GlobalParameter.parse("test", "", "", None).forceGet
+  val baseParam = GlobalParameter.parse("test", "", None, "", None).forceGet
 
   // attribute that used to be set in GlobalParameter entry before 6.1.
   def setIs6_0(e: LDAPEntry): Unit = {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/eventlog/NodeEventLogFormatV6Test.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/eventlog/NodeEventLogFormatV6Test.scala
@@ -48,6 +48,7 @@ import com.normation.rudder.domain.nodes.GenericProperty._
 import com.normation.rudder.domain.nodes.ModifyNodeDiff
 import com.normation.rudder.domain.nodes.NodeProperty
 import com.normation.rudder.reports.HeartbeatConfiguration
+
 import scala.collection.mutable.ArrayBuffer
 import com.normation.rudder.domain.eventlog.EventTypeFactory
 import com.normation.rudder.domain.eventlog.ModifyNodeEventType
@@ -99,13 +100,13 @@ class NodeEventLogFormatV6Test extends Specification {
           , modAgentRun   = None
           , modProperties = Some(SimpleDiff(
                               ArrayBuffer(
-                                NodeProperty("env_type", "production".toConfigValue, None)
-                              , NodeProperty("shell", "/bin/sh".toConfigValue, None)
+                                NodeProperty("env_type", "production".toConfigValue, None, None)
+                              , NodeProperty("shell", "/bin/sh".toConfigValue, None, None)
                               ).toList
                             , ArrayBuffer(
-                                NodeProperty("shell", "/bin/sh".toConfigValue, None)
-                              , NodeProperty("env", "PROD".toConfigValue, None)
-                              , NodeProperty.parse("datacenter", """{"Europe":{"France":true}}""", None).fold(
+                                NodeProperty("shell", "/bin/sh".toConfigValue, None, None)
+                              , NodeProperty("env", "PROD".toConfigValue, None, None)
+                              , NodeProperty.parse("datacenter", """{"Europe":{"France":true}}""", None, None).fold(
                                   err => throw new IllegalArgumentException("Error in test: " + err.fullMsg)
                                 , res => res
                               )).toList

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
@@ -52,6 +52,7 @@ import org.junit.runner._
 import org.specs2.mutable._
 import org.specs2.runner._
 import com.normation.rudder.domain.nodes.JsonPropertySerialisation._
+import com.normation.rudder.domain.parameters.GlobalParameter
 import net.liftweb.json._
 import net.liftweb.json.JsonDSL._
 
@@ -80,7 +81,7 @@ class TestMergeGroupProperties extends Specification {
     // use first parent to build a fully inherited prop
     def toH1(name: String) = {
       toParents(name) match {
-        case h::t => NodePropertyHierarchy(NodeProperty(name, h.value, Some(GroupProp.INHERITANCE_PROVIDER)), h :: t)
+        case h::t => NodePropertyHierarchy(NodeProperty(name, h.value, None, Some(GroupProp.INHERITANCE_PROVIDER)), h :: t)
         case _ => throw new IllegalArgumentException(s"No value found for prop '${name}' in group list")
       }
     }
@@ -93,7 +94,10 @@ class TestMergeGroupProperties extends Specification {
   }
   implicit class ToNodeProp(global: ConfigValue) {
     def toG(name: String) = {
-      NodePropertyHierarchy(NodeProperty(name, global, Some(GroupProp.INHERITANCE_PROVIDER)), ParentProperty.Global(global) :: Nil)
+      NodePropertyHierarchy(NodeProperty(name, global, None, Some(GroupProp.INHERITANCE_PROVIDER)), ParentProperty.Global(global) :: Nil)
+    }
+    def toGP(name: String) = {
+      GlobalParameter(name, global, None, "", None)
     }
   }
   implicit class ToConfigValue(s: String) {
@@ -119,24 +123,24 @@ class TestMergeGroupProperties extends Specification {
    */
 
   val parent1   = NodeGroup(NodeGroupId("parent1"), "parent1", "",
-      List(GroupProperty("foo", "bar1".toConfigValue, None))
+      List(GroupProperty("foo", "bar1".toConfigValue, None, None))
     , Some(Query(NodeReturnType, And, List()))
     , true, Set(), true
   )
-  val parent2Prop = GroupProperty("foo", "bar2".toConfigValue, None)
+  val parent2Prop = GroupProperty("foo", "bar2".toConfigValue, None, None)
   val parent2   = NodeGroup(NodeGroupId("parent2"), "parent2", "",
       List(parent2Prop)
     , Some(Query(NodeReturnType, And, List()))
     , true, Set(), true
   )
-  val childProp = GroupProperty("foo", "baz".toConfigValue, None)
+  val childProp = GroupProperty("foo", "baz".toConfigValue, None, None)
   val query = Query(NodeReturnType, And, List(parent1.toCriterion))
   val child = NodeGroup(NodeGroupId("child"), "child", "",
       List(childProp)
     , Some(query)
     , true, Set(), true
   )
-  val nodeInfo = NodeConfigData.node1.modify(_.node.properties).setTo(NodeProperty("foo", "barNode".toConfigValue, None) :: Nil)
+  val nodeInfo = NodeConfigData.node1.modify(_.node.properties).setTo(NodeProperty("foo", "barNode".toConfigValue, None, None) :: Nil)
 
   "overriding a property in a hierarchy should work" >> {
     val merged = MergeNodeProperties.checkPropertyMerge(parent1.toTarget :: child.toTarget :: Nil, Map())
@@ -167,12 +171,12 @@ class TestMergeGroupProperties extends Specification {
 
     "be able to detect conflict" in {
       val parent1 = NodeGroup(NodeGroupId("parent1"), "parent1", "",
-          List(GroupProperty("dns", "1.1.1.1".toConfigValue, None))
+          List(GroupProperty("dns", "1.1.1.1".toConfigValue, None, None))
         , Some(Query(NodeReturnType, And, List()))
         , true, Set(), true
       )
       val parent2   = NodeGroup(NodeGroupId("parent2"), "parent2", "",
-          List(GroupProperty("dns", "9.9.9.9".toConfigValue, None))
+          List(GroupProperty("dns", "9.9.9.9".toConfigValue, None, None))
         , Some(Query(NodeReturnType, And, List()))
         , true, Set(), true
       )
@@ -186,12 +190,12 @@ class TestMergeGroupProperties extends Specification {
 
     "be able to correct conflict" in {
       val parent1 = NodeGroup(NodeGroupId("parent1"), "parent1", "",
-          List(GroupProperty("dns", "1.1.1.1".toConfigValue, None))
+          List(GroupProperty("dns", "1.1.1.1".toConfigValue, None, None))
         , Some(Query(NodeReturnType, And, List()))
         , true, Set(), true
       )
       val parent2   = NodeGroup(NodeGroupId("parent2"), "parent2", "",
-          List(GroupProperty("dns", "9.9.9.9".toConfigValue, None))
+          List(GroupProperty("dns", "9.9.9.9".toConfigValue, None, None))
         , Some(Query(NodeReturnType, And, List()))
         , true, Set(), true
       )
@@ -216,12 +220,12 @@ class TestMergeGroupProperties extends Specification {
      */
     "one can solve conflicts at parent level" in {
       val parent1 = NodeGroup(NodeGroupId("parent1"), "parent1", "",
-          List(GroupProperty("dns", "1.1.1.1".toConfigValue, None))
+          List(GroupProperty("dns", "1.1.1.1".toConfigValue, None, None))
         , Some(Query(NodeReturnType, And, List()))
         , true, Set(), true
       )
       val parent2   = NodeGroup(NodeGroupId("parent2"), "parent2", "",
-          List(GroupProperty("dns", "9.9.9.9".toConfigValue, None))
+          List(GroupProperty("dns", "9.9.9.9".toConfigValue, None, None))
         , Some(Query(NodeReturnType, And, List()))
         , true, Set(), true
       )
@@ -244,7 +248,7 @@ class TestMergeGroupProperties extends Specification {
 
   "global parameter are inherited" >> {
     val g = "bar".toConfigValue
-    val merged = MergeNodeProperties.checkPropertyMerge(Nil, Map("foo" -> g))
+    val merged = MergeNodeProperties.checkPropertyMerge(Nil, Map("foo" -> g.toGP("foo")))
     merged must beRight(List(g.toG("foo")))
   }
 
@@ -252,7 +256,7 @@ class TestMergeGroupProperties extends Specification {
     // empty properties, see if global is duplicated
     val p2 = parent2.copy(properties = Nil)
     val g = "bar".toConfigValue
-    val merged = MergeNodeProperties.checkPropertyMerge(List(parent1, p2, child).map(_.toTarget), Map("foo" -> g))
+    val merged = MergeNodeProperties.checkPropertyMerge(List(parent1, p2, child).map(_.toTarget), Map("foo" -> g.toGP("foo")))
     val expected = List(child, parent1).toH3("foo", g) :: Nil
     merged must beRight(expected)
   }
@@ -265,9 +269,9 @@ class TestMergeGroupProperties extends Specification {
         case Right(v) => v.map(p => (p.prop.name, GenericProperty.serializeToHocon(p.prop.value))).toMap
       }
     }
-    def getGroups(parentProps: Map[String, String], childProps: Map[String, String]) = {
+    def getGroups(parentProps: Map[String, String], childProps: Map[String, String], inheritModes: Map[String, String]) = {
       def toProps(map: Map[String, String]) = map.map { case (k, v) =>
-        GroupProperty.parse(k, v, None).fold(
+        GroupProperty.parse(k, v, InheritMode.parseString(inheritModes.getOrElse(k, "")).toOption, None).fold(
           err => throw new IllegalArgumentException("Error in test: " + err.fullMsg)
         , res => res
         )
@@ -284,8 +288,8 @@ class TestMergeGroupProperties extends Specification {
       )
       parent :: child :: Nil
     }
-    def checkOverrides(parentProps: Map[String, String], childProps: Map[String, String]) = {
-      getOverrides(getGroups(parentProps, childProps))
+    def checkOverrides(parentProps: Map[String, String], childProps: Map[String, String], inheritModes: Map[String, String] = Map()) = {
+      getOverrides(getGroups(parentProps, childProps, inheritModes))
     }
     "override whatever by simple values" in {
       val child =
@@ -297,14 +301,16 @@ class TestMergeGroupProperties extends Specification {
       props must beEqualTo(child)
     }
     "merge arr and objects" in {
+      // option can be specified only has first characters only, and behavior is inherited everywhere
       val props = checkOverrides(
-        Map("arr" -> "[1,2]", "obj" -> """{"a":"b", "i":"j1", "x":{"y1":"z"}}""")
-      , Map("arr" -> "[3,4]", "obj" -> """{"c":"d", "i":"j2", "x":{"y2":"z"}}""")
+        Map("arr" -> "[1,2]", "obj" -> """{"a":"b", "i":"j1", "x":{"y1":"z"}, "z":[2]}""")
+      , Map("arr" -> "[3,4]", "obj" -> """{"c":"d", "i":"j2", "x":{"y2":"z"}, "z":[1]}""") //
+      , Map("arr" -> "maa", "obj" -> "mpo") // inherit modes, a(ppend) for array/string in "arr", p(repend) for arr in obj
       )
       props must beEqualTo(
         Map(
-          "arr" -> "[3,4]"
-        , "obj" -> """{"a":"b","c":"d","i":"j2","x":{"y1":"z","y2":"z"}}"""
+          "arr" -> "[1,2,3,4]"
+        , "obj" -> """{"a":"b","c":"d","i":"j2","x":{"y1":"z","y2":"z"},"z":[1,2]}"""
         )
       )
     }
@@ -314,10 +320,10 @@ class TestMergeGroupProperties extends Specification {
   "preparing value for API" should {
 
     "present only node value for override" in {
-      val globals = Map(                                ("foo" -> GenericProperty.parseValue("""{"global":"global value", "override":"global"}""").forceGet) )
-      val parent  = parent1 .modify(_.properties)     .setTo(List(GroupProperty.parse("foo", """{"parent":"parent value", "override":"parent"}""", None).forceGet))
-      val child_  = child   .modify(_.properties)     .setTo(List(GroupProperty.parse("foo", """{"child" :"child value" , "override":"child" }""", None).forceGet))
-      val node    = nodeInfo.modify(_.node.properties).setTo(List(NodeProperty.parse ("foo", """{"node"  :"node value"  , "override":"node"  }""", None).forceGet))
+      val globals = Map(                                ("foo" -> GlobalParameter("foo", GenericProperty.parseValue("""{"global":"global value", "override":"global"}""").forceGet, None, "", None) ))
+      val parent  = parent1 .modify(_.properties)     .setTo(List(GroupProperty.parse("foo", """{"parent":"parent value", "override":"parent"}""", None, None).forceGet))
+      val child_  = child   .modify(_.properties)     .setTo(List(GroupProperty.parse("foo", """{"child" :"child value" , "override":"child" }""", None, None).forceGet))
+      val node    = nodeInfo.modify(_.node.properties).setTo(List(NodeProperty.parse ("foo", """{"node"  :"node value"  , "override":"node"  }""", None, None).forceGet))
       val merged = MergeNodeProperties.forNode(node, List(parent, child_).map(_.toTarget), globals).forceGet
 
       val actual = merged.toApiJsonRenderParents

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestNodeAndGlobalParameterLookup.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestNodeAndGlobalParameterLookup.scala
@@ -693,7 +693,7 @@ class TestNodeAndGlobalParameterLookup extends Specification {
         err => throw new IllegalArgumentException("Error in test: " + err.fullMsg)
       , identity
       )
-      val node = context.nodeInfo.node.copy(properties = List(NodeProperty("datacenter", v, None)))
+      val node = context.nodeInfo.node.copy(properties = List(NodeProperty("datacenter", v, None, None)))
       val c = context.copy(nodeInfo = context.nodeInfo.copy(node = node))
       lookup(Seq(multilineNodePropVariable), c.copy(parameters = p(fooParam)))( values =>
         values must containTheSameElementsAs(Seq(Seq("=\r= \nParis =\n=")))
@@ -761,7 +761,7 @@ class TestNodeAndGlobalParameterLookup extends Specification {
           err => throw new IllegalArgumentException("Error in test: " + err.fullMsg)
         , identity
         )
-        NodeProperty(k, v, None)
+        NodeProperty(k, v, None, None)
       }
       val node = context.nodeInfo.node.copy(properties = p)
       val c = context.copy(nodeInfo = context.nodeInfo.copy(node = node))
@@ -875,7 +875,7 @@ class TestNodeAndGlobalParameterLookup extends Specification {
 
       def compare(s1: String, s2: String) = {
         val i = compileAndGet(s"$${node.properties[${s1}]}")
-        val props = List(NodeProperty(s2, value, None))
+        val props = List(NodeProperty(s2, value, None, None))
         val node = context.nodeInfo.node.copy(properties = props)
         val c = context.copy(nodeInfo = context.nodeInfo.copy(node = node))
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -101,6 +101,7 @@ import com.normation.inventory.domain.KeyStatus
 import com.normation.inventory.domain.PublicKey
 import com.normation.rudder.domain.nodes.GenericProperty
 import com.normation.rudder.domain.nodes.GroupProperty
+import com.normation.rudder.domain.nodes.InheritMode
 import com.normation.rudder.ncf.ParameterType.ParameterTypeService
 import com.normation.rudder.services.policies.PropertyParser
 import org.bouncycastle.cert.X509CertificateHolder
@@ -606,14 +607,15 @@ final case class RestExtractorService (
   /*
    * Looking for parameter: "properties=foo=bar"
    * ==> set foo to bar; delete baz, set plop to plop.
+   * With that syntaxe, you can't choose override mode
    */
   def extractNodeProperties (params : Map[String, List[String]]) : Box[Option[List[NodeProperty]]] = {
     // properties coming from the API are always provider=rudder / mode=read-write
-    extractProperties(params, (k,v) => NodeProperty.parse(k, v, None))
+    extractProperties(params, (k,v) => NodeProperty.parse(k, v, None, None))
   }
   def extractGroupProperties (params : Map[String, List[String]]) : Box[Option[List[GroupProperty]]] = {
     // properties coming from the API are always provider=rudder / mode=read-write
-    extractProperties(params, (k,v) => GroupProperty.parse(k, v, None))
+    extractProperties(params, (k,v) => GroupProperty.parse(k, v, None, None))
   }
 
   def extractProperties[A](params : Map[String, List[String]], make:(String, String) => PureResult[A]): Box[Option[List[A]]] = {
@@ -681,10 +683,16 @@ final case class RestExtractorService (
           //if not defined of not a string, use default
           case _              => None
         }
+        val inheritMode = (json \ "inheritMode") match {
+          case JString(value) => InheritMode.parseString(value).toOption
+          //if not defined of not a string, use default
+          case _              => None
+        }
         (for {
           _ <- PropertyParser.validPropertyName(nameValue)
+          p <- NodeProperty.parse(nameValue, compactRender(value), inheritMode, provider)
         } yield {
-          NodeProperty(nameValue, GenericProperty.fromJsonValue(value), provider)
+          p
         }).toBox
 
       case (a, b)  =>
@@ -910,10 +918,10 @@ final case class RestExtractorService (
   def extractParameterFromJSON (json : JValue) : Box[RestParameter] = {
     for {
       description <- extractJsonString(json, "description")
-      value       <- Full((json \ "value") match {
-                       case JNothing => None
-                       case x        => Some(GenericProperty.fromJsonValue(x))
-                     })
+      value       <- (json \ "value") match {
+                       case JNothing => Full(None)
+                       case x        => GenericProperty.parseValue(compactRender(x)).map(x => Some(x)).toBox
+                     }
     } yield {
       RestParameter(value, description)
     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/RestData.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/RestData.scala
@@ -49,6 +49,7 @@ import com.normation.inventory.domain.KeyStatus
 import com.normation.inventory.domain.SecurityToken
 import com.normation.rudder.domain.nodes.CompareProperties
 import com.normation.rudder.domain.nodes.GroupProperty
+import com.normation.rudder.domain.nodes.InheritMode
 import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.domain.policies.Tags
 import com.normation.rudder.domain.policies.Directive
@@ -279,14 +280,16 @@ final case object DeleteNode extends NodeStatusAction
 final case class RestParameter(
       value       : Option[ConfigValue] = None
     , description : Option[String] = None
+    , inheritMode : Option[InheritMode] = None
   ) {
 
 
     def updateParameter(parameter: GlobalParameter) = {
       val updateValue = (p: GlobalParameter) => (value.map(x => p.withValue(x))).getOrElse(p)
       val updateDesc  = (p: GlobalParameter) => (description.map(x => p.withDescription(x))).getOrElse(p)
+      val updateMode  = (p: GlobalParameter) => (inheritMode.map(x => p.withMode(x))).getOrElse(p)
 
-      updateDesc(updateValue(parameter)).withProvider(PropertyProvider.defaultPropertyProvider)
+      updateMode(updateDesc(updateValue(parameter)).withProvider(PropertyProvider.defaultPropertyProvider))
     }
 }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -303,7 +303,7 @@ class GroupApiInheritedProperties(
     for {
       allGroups  <- groupRepo.getFullGroupLibrary().map(_.allGroups)
       params     <- paramRepo.getAllGlobalParameters()
-      properties <- MergeNodeProperties.forGroup(groupId, allGroups, params.map(p => (p.name, p.value)).toMap).toIO
+      properties <- MergeNodeProperties.forGroup(groupId, allGroups, params.map(p => (p.name, p)).toMap).toIO
     } yield {
       import com.normation.rudder.domain.nodes.JsonPropertySerialisation._
       JArray((

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -459,7 +459,7 @@ class NodeApiInheritedProperties(
       groups       <- groupRepo.getFullGroupLibrary()
       nodeTargets  =  groups.getTarget(nodeInfo).map(_._2).toList
       params       <- paramRepo.getAllGlobalParameters()
-      properties   <- MergeNodeProperties.forNode(nodeInfo, nodeTargets, params.map(p => (p.name, p.value)).toMap).toIO
+      properties   <- MergeNodeProperties.forNode(nodeInfo, nodeTargets, params.map(p => (p.name, p)).toMap).toIO
     } yield {
       import com.normation.rudder.domain.nodes.JsonPropertySerialisation._
       JArray((

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
@@ -67,7 +67,6 @@ import net.liftweb.http.Req
 import net.liftweb.json.JArray
 import net.liftweb.json.JString
 import net.liftweb.json.JsonDSL._
-
 import com.normation.box._
 
 class ParameterApi (
@@ -244,7 +243,7 @@ extends Loggable {
     restParameter match {
       case Full(restParameter) =>
         import com.normation.rudder.domain.nodes.GenericProperty._
-        val parameter = restParameter.updateParameter(GlobalParameter(parameterName,"".toConfigValue,"",None))
+        val parameter = restParameter.updateParameter(GlobalParameter(parameterName,"".toConfigValue,None,"",None))
 
         val diff = AddGlobalParameterDiff(parameter)
         createChangeRequestAndAnswer(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/CheckRudderGlobalParameter.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/CheckRudderGlobalParameter.scala
@@ -53,6 +53,7 @@ import com.normation.utils.StringUuidGenerator
 import net.liftweb.json._
 import com.normation.rudder.domain.eventlog._
 import com.normation.rudder.domain.nodes.GenericProperty
+import com.normation.rudder.domain.nodes.InheritMode
 import com.normation.rudder.domain.nodes.PropertyProvider
 import com.normation.zio.ZioRuntime
 
@@ -121,6 +122,8 @@ class CheckRudderGlobalParameter(
 }
 
 // lift json need that to be topevel
-private[checks] final case class JsonParam(name: String, description: String, value: JValue, provider: Option[String]) {
-  def toGlobalParam = GlobalParameter(name, GenericProperty.fromJsonValue(value), description, provider.map(PropertyProvider.apply))
+private[checks] final case class JsonParam(name: String, description: String, value: JValue, inheritMode: Option[String], provider: Option[String]) {
+  def toGlobalParam = {
+    GlobalParameter(name, GenericProperty.fromJsonValue(value), inheritMode.flatMap(InheritMode.parseString(_).toOption), description, provider.map(PropertyProvider.apply))
+  }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
@@ -60,6 +60,7 @@ import com.normation.rudder.services.workflows.WorkflowService
 import com.normation.box._
 import com.normation.errors.PureResult
 import com.normation.inventory.domain.InventoryError.Inconsistency
+import com.normation.rudder.domain.nodes.InheritMode
 import com.typesafe.config.ConfigValue
 import com.typesafe.config.ConfigValueType
 
@@ -137,7 +138,7 @@ class CreateOrUpdateGlobalParameterPopup(
       val savedChangeRequest = {
         for {
           value <- parseValue(parameterValue.get, jsonCheck).toBox
-          param =  GlobalParameter(parameterName.get, value, parameterDescription.get, None)
+          param =  GlobalParameter(parameterName.get, value, InheritMode.parseString(parameterInheritMode.get).toOption, parameterDescription.get, None)
           diff  <- globalParamDiffFromAction(param)
           cr    =  ChangeRequestService.createChangeRequestFromGlobalParameter(
                       changeRequestName.get
@@ -257,6 +258,18 @@ class CreateOrUpdateGlobalParameterPopup(
     override def validations = Nil
   }
 
+  private[this] val parameterInheritMode = new WBTextField("Inherit Mode", change.previousGlobalParam.flatMap(_.inheritMode.map(_.value)).getOrElse("")) {
+    override val maxLen = 3
+    override def setFilter = trim _ :: Nil
+    override def inputField =(( change.action match {
+      case GlobalParamModAction.Delete => super.inputField % ("disabled" -> "true")
+      case _ => super.inputField
+    })  % ("tabindex" -> "4"))
+    override def errorClassName = "col-lg-12 errors-container"
+    override def validations = Nil
+    override val helpAsHtml = Full(<div class="text-muted small">Define inheritance behavior for the value with 3 chars: first for
+      json object (m=merge, o=override), 2nd for array and 3rd for string (o=override, a=append, p=prepend). Default to 'moo'.</div>)
+  }
 
   private[this] def defaultClassName = change.action match {
     case GlobalParamModAction.Update => "btn-success"
@@ -268,7 +281,7 @@ class CreateOrUpdateGlobalParameterPopup(
   private[this] val changeRequestName = new WBTextField("Change request title", defaultRequestName) {
     override def setFilter = notNull _ :: trim _ :: Nil
     override def errorClassName = "col-lg-12 errors-container"
-    override def inputField = super.inputField % ("onkeydown" -> "return processKey(event , 'createDirectiveSaveButton')") % ("tabindex" -> "4")
+    override def inputField = super.inputField % ("onkeydown" -> "return processKey(event , 'createDirectiveSaveButton')") % ("tabindex" -> "5")
     override def validations =
       valMinLen(1, "Name must not be empty") _ :: Nil
   }
@@ -288,7 +301,7 @@ class CreateOrUpdateGlobalParameterPopup(
     new WBTextAreaField("Change audit message", "") {
       override def setFilter = notNull _ :: trim _ :: Nil
       override def inputField = super.inputField  %
-        ("style" -> "height:5em;")  % ("tabindex" -> "5") % ("placeholder" -> {userPropertyService.reasonsFieldExplanation})
+        ("style" -> "height:5em;")  % ("tabindex" -> "6") % ("placeholder" -> {userPropertyService.reasonsFieldExplanation})
       override def errorClassName = "col-lg-12 errors-container"
       override def validations = {
         if(mandatory){
@@ -323,6 +336,7 @@ class CreateOrUpdateGlobalParameterPopup(
       ".value"   #> parameterValue.toForm_! &
       ".format"  #> parameterFormat.toForm_! &
       ".description *"     #> parameterDescription.toForm_! &
+      ".inheritMode *"     #> parameterInheritMode.toForm_! &
       "#titleWorkflow *"   #> titleWorkflow &
       "#changeRequestName" #> {
           if (workflowEnabled) {
@@ -349,8 +363,8 @@ class CreateOrUpdateGlobalParameterPopup(
         </div>
       } } &
 
-      "#cancel"  #> (SHtml.ajaxButton("Cancel", { () => closePopup() })  % ("tabindex" -> "6") % ("class" -> "btn btn-default") ) &
-      "#save" #> (SHtml.ajaxSubmit( buttonName, onSubmit _) % ("id" -> "createParameterSaveButton")  % ("tabindex" -> "5") % ("class" -> s"btn ${classForButton}")) andThen
+      "#cancel"  #> (SHtml.ajaxButton("Cancel", { () => closePopup() })  % ("tabindex" -> "7") % ("class" -> "btn btn-default") ) &
+      "#save" #> (SHtml.ajaxSubmit( buttonName, onSubmit _) % ("id" -> "createParameterSaveButton")  % ("tabindex" -> "8") % ("class" -> s"btn ${classForButton}")) andThen
       ".notifications *"  #> { updateAndDisplayNotifications(formTracker) }
     ).apply(formXml())
 
@@ -373,6 +387,7 @@ class CreateOrUpdateGlobalParameterPopup(
                 <div class="value"/>
                 <div class="format"/>
                 <div class="description"/>
+                <div class="inheritMode"/>
                 <div id="changeRequestZone">
                     <div id="titleWorkflow"/>
                     <input type="text" id="changeRequestName" />


### PR DESCRIPTION
https://issues.rudder.io/issues/18466

Replacing previous PR: https://github.com/Normation/rudder/pull/3319

Add a "inheritMode" optionnal attribute in all properties (global param, group, node). Only global param has an UI (because it's likely where people want to change that, and because I have 0 idea about how to do one for group/node properties). 

inheritMode is a 3 char strings:
- 1: behavior for json object; m = merge (default), o = override
- 2: behavior for array: o = override (defaut), a = append, p = prepend
- 3: behavior for strings: o = override (defaut), a = append, p = prepend
