### PR TITLE
Fixes #16773: Batch of new nodes can overflow rudder server with inventories

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/inventory/TestCertificate.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/inventory/TestCertificate.scala
@@ -136,6 +136,7 @@ class TestCertificate extends Specification with Loggable {
         "linux-cfe-sign"
       , () => Resource.getAsStream("certificates/linux-cfe-sign.ocs")
       , None
+      , true.succeed
     )).either.runNow
 
     (res must beLeft)
@@ -148,6 +149,7 @@ class TestCertificate extends Specification with Loggable {
         "linux-cfe-sign"
       , () => Resource.getAsStream("certificates/linux-cfe-sign.ocs")
       , Some(() => Resource.getAsStream("certificates/linux-cfe-sign.ocs.sign"))
+      , true.succeed
     )).runNow
 
     waitSaveDone
@@ -168,6 +170,7 @@ class TestCertificate extends Specification with Loggable {
         "windows-same-certificate"
       , () => Resource.getAsStream("certificates/windows-same-certificate.ocs")
       , None
+      , true.succeed
     )).either.runNow
 
     (res must beLeft)
@@ -180,6 +183,7 @@ class TestCertificate extends Specification with Loggable {
         "windows-same-certificate"
       , () => Resource.getAsStream("certificates/windows-same-certificate.ocs")
       , Some(() => Resource.getAsStream("certificates/windows-same-certificate.ocs.sign"))
+      , true.succeed
     )).runNow
 
     waitSaveDone
@@ -199,6 +203,7 @@ class TestCertificate extends Specification with Loggable {
         "windows-same-certificate"
       , () => Resource.getAsStream("certificates/windows-same-certificate.ocs")
       , Some(() => Resource.getAsStream("certificates/windows-same-certificate.ocs.sign"))
+      , true.succeed
     )).runNow
 
     waitSaveDone
@@ -215,6 +220,7 @@ class TestCertificate extends Specification with Loggable {
         "windows-same-certificate"
       , () => Resource.getAsStream("certificates/windows-same-certificate.ocs")
       , None
+      , true.succeed
     )).either.runNow
 
     (res must beLeft)
@@ -228,6 +234,7 @@ class TestCertificate extends Specification with Loggable {
         "windows-new-certificate"
       , () => Resource.getAsStream("certificates/windows-new-certificate.ocs")
       , Some(() => Resource.getAsStream("certificates/windows-new-certificate.ocs.sign"))
+      , true.succeed
     )).runNow
 
     waitSaveDone
@@ -245,6 +252,7 @@ class TestCertificate extends Specification with Loggable {
         "windows-bad-certificate"
       , () => Resource.getAsStream("certificates/windows-bad-certificate.ocs")
       , Some(() => Resource.getAsStream("certificates/windows-bad-certificate.ocs.sign"))
+      , true.succeed
     )).mapError(_.fullMsg).either.runNow
 
     (res must beLeft(beMatching(".*subject doesn't contain same node ID in 'UID' attribute as inventory node ID.*")))

--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -219,8 +219,15 @@ inventories.watcher.period.garbage.old=5 minutes
 # For a rough estimation, you can consider that an inventory in queue
 # takes 5 MB, so to handle 50 (default), the application will
 # need around 250 MB of spare memory.
+# You don't need to make that queue big is you don't send inventories
+# through REST API endpoint: inventories coming from agent by usual
+# way wait on disk.
+# In the case of inventories sent via REST API, a bigger queue will allows to
+# send API response more quickly (just after inventory parsing, before saving it)
+# while in the same time not making new invetory rejected.
+# Minimal size is 1.
 #
-waiting.inventory.queue.size=50
+waiting.inventory.queue.size=5
 
 #
 # You may want to limit the number of inventory files parsed in parallele.


### PR DESCRIPTION
https://issues.rudder.io/issues/16773

Add a `saveInventoryBuffer` that stays between inotify watcher (in charge of the complexe logic of making sense of inotify events and waiting for signature) and the part that [parse inventory, check signature, forward to backend] and is heavy on CPU and RAM. 
That buffer can be big (chose 1024 without much rationnal safe that it's big and a power of 2, as asked in ZQueue comment).

The main benefits are: 
- info about the file to process are cheap (a string with name, 3 functions to open stream or test if the file exists)
- we can deduplicate files while they are in the buffer super easily (and so avoid starvation case where some node goes made and send a lot of inventory). 

Only the code path for inventories coming from file system has the buffer, because for REST, the API await the pre-processing status. So we need to wait for signature check etc, and so that part must be synchronous. A better API would be to just move uploaded inventory/signature to `/var/rudder/inventories/incoming` (or a dedicated incoming directory) and from that point, let them follow the usual path - but it's an API change which will need a major version for change. 

Other important code changes: 
- in `InventoryFileWatcher.scala`, `sendToProcessor` was renamed to `sendToProcessorBlocking` and moved out of `processFile`. `processFile` now send files to process to the buffer. 
- in `InventoryProcessor.scala`, the backend waiting queue, `queue` was renamed to `blockingQueue` and as the name implies, it is now a BLOCKING queue. Its default size is reduced in `configurations.properties.sample` because now, the only interest of a big queue would be for people using A LOT rest endpoint, 
- a latch which dismiss new incoming requests when one is pending is added in front of `blockingQueue` in the REST API code path to keep previous, non-blocking behavior.

![image](https://user-images.githubusercontent.com/44649/99188163-d9d3ac00-275a-11eb-9426-2d9725124456.png)
