### PR TITLE
Fixes #18740: rudder package now detect new version, but still install old package during upgrade on CentOS

### DIFF
--- a/relay/sources/rudder-pkg/lib/rudder-pkg/rudderPkg.py
+++ b/relay/sources/rudder-pkg/lib/rudder-pkg/rudderPkg.py
@@ -197,13 +197,13 @@ def package_install_specific_version(name, longVersion, mode="release"):
     Install the latest available and compatible package for a given plugin.
     If no release mode is given, it will only look in the released rpkg.
 """
-def package_install_latest(name, mode="release"):
+def package_install_latest(name, mode="release", version = None):
     pkgs = plugin.Plugin(name[0])
     pkgs.getAvailablePackages()
     if mode == "release":
-        rpkg = pkgs.getLatestCompatibleRelease(None)
+        rpkg = pkgs.getLatestCompatibleRelease(version)
     else:
-        rpkg = pkgs.getLatestCompatibleNightly(None)
+        rpkg = pkgs.getLatestCompatibleNightly(version)
     if rpkg is not None:
         rpkgPath = utils.downloadByRpkg(rpkg)
         install_file([rpkgPath])
@@ -365,6 +365,6 @@ def upgrade_all(mode, version):
                 latestVersion = latest_packages.version
         if currentVersion < latestVersion:
             logger.info("The plugin %s is installed in version %s. The version %s %s is available, the plugin will be upgraded."%(p, currentVersion.pluginLongVersion, mode, latestVersion.pluginLongVersion))
-            package_install_latest([p], mode)
+            package_install_latest([p], mode, version)
         else:
             logger.info("No newer %s compatible versions found for the plugin %s, disabling it."%(mode, p))

--- a/relay/sources/rudder-pkg/rudder-pkg
+++ b/relay/sources/rudder-pkg/rudder-pkg
@@ -143,9 +143,9 @@ if __name__ == "__main__":
                 rudderPkg.package_install_specific_version(args['<package>'], args['--version'], "release")
         else:
             if args['--nightly']:
-                rudderPkg.package_install_latest(args['<package>'], "nightly")
+                rudderPkg.package_install_latest(args['<package>'], "nightly", None)
             else:
-                rudderPkg.package_install_latest(args['<package>'],)
+                rudderPkg.package_install_latest(args['<package>'], "release", None)
     elif args['remove']:
         rudderPkg.remove(args['<package>'])
     elif args['rudder-postupgrade']:


### PR DESCRIPTION
https://issues.rudder.io/issues/18740