### PR TITLE
Fixes #18777: Clone rule API fails with "rule already exists with that id"

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -366,7 +366,7 @@ class RuleApiService2 (
             rule <- readRule.get(sourceId).toBox ?~!
               s"Could not create rule ${name} (id:${ruleId.value}) by cloning rule '${sourceId.value}')"
           } yield {
-            RuleChangeRequest(RuleModAction.Create, restRule.updateRule(rule), Some(rule))
+            RuleChangeRequest(RuleModAction.Create, restRule.updateRule(rule).copy(id = ruleId), Some(rule))
           }
 
         case None =>


### PR DESCRIPTION
https://issues.rudder.io/issues/18777