### PR TITLE
Fixes #12937: When receiving an inventory, the merge_uuid part can be painfully slow

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/services/core/SoftwareDAO.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/services/core/SoftwareDAO.scala
@@ -67,5 +67,5 @@ trait WriteOnlySoftwareDAO {
   /**
     * Delete softwares in ou=Software,ou=Inventories
     */
-  def deleteSoftwares(softwares: Seq[SoftwareUuid]): IOResult[Seq[String]]
+  def deleteSoftwares(softwares: Seq[SoftwareUuid], batchSize: Int = 1000): IOResult[Unit]
 }

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/SoftwareService.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/SoftwareService.scala
@@ -5,41 +5,58 @@ import com.normation.inventory.domain.InventoryProcessingLogger
 import com.normation.inventory.services.core.ReadOnlySoftwareDAO
 import com.normation.inventory.services.core.WriteOnlySoftwareDAO
 import com.normation.errors._
+import com.normation.utils.DateFormaterService
 import com.normation.zio._
+import org.joda.time.DateTime
 
 trait SoftwareService {
-  def deleteUnreferencedSoftware() : IOResult[Seq[String]]
+  def deleteUnreferencedSoftware() : IOResult[Int]
 }
 
 class SoftwareServiceImpl(
-    readOnlySoftware    : ReadOnlySoftwareDAO
-  , writeOnlySoftware   : WriteOnlySoftwareDAO)
-extends SoftwareService {
+    readOnlySoftware : ReadOnlySoftwareDAO
+  , writeOnlySoftware: WriteOnlySoftwareDAO
+  , softwareDIT      : InventoryDit
+) extends SoftwareService {
 
   /** Delete all unreferenced softwares
     * First search in software, and then in nodes, so that if a node arrives in between (new inventory)
     * its software wont be deleted
     */
-  def deleteUnreferencedSoftware() : IOResult[Seq[String]] = {
+  def deleteUnreferencedSoftware() : IOResult[Int] = {
     val t1 = System.currentTimeMillis
     for {
       allSoftwares      <- readOnlySoftware.getAllSoftwareIds()
       t2                <- currentTimeMillis
-      _                 <- InventoryProcessingLogger.debug(s"All softwares id in ou=software fetched: ${allSoftwares.size} softwares id in ${t2 - t1}ms")
+      _                 <- InventoryProcessingLogger.debug(s"[purge unreferenced software] All softwares id in ou=software fetched: ${allSoftwares.size} softwares id in ${t2 - t1}ms")
 
       allNodesSoftwares <- readOnlySoftware.getSoftwaresForAllNodes()
       t3                <- currentTimeMillis
-      _                 <- InventoryProcessingLogger.debug(s"All softwares id in nodes fetched: ${allNodesSoftwares.size} softwares id in ${t3 - t2}ms")
+      _                 <- InventoryProcessingLogger.debug(s"[purge unreferenced software] All softwares id in nodes fetched: ${allNodesSoftwares.size} softwares id in ${t3 - t2}ms")
 
 
       extraSoftware     =  allSoftwares -- allNodesSoftwares
-      _                 <- InventoryProcessingLogger.debug(s"Found ${extraSoftware.size} unreferenced software in ou=software, going to delete them")
-
+      _                 <- InventoryProcessingLogger.info(s"[purge unreferenced software] Found ${extraSoftware.size} unreferenced software in ou=software, going to delete them")
+      _                 <- InventoryProcessingLogger.ifDebugEnabled {
+                             import better.files._
+                             import better.files.Dsl._
+                             (for {
+                               f <- IOResult.effect {
+                                      val dir = File("/var/rudder/tmp/purgeSoftware")
+                                      dir.createDirectories()
+                                      File(dir, s"${DateFormaterService.serialize(DateTime.now())}-unreferenced-software-dns.txt")
+                                    }
+                               _ <- IOResult.effect {
+                                      extraSoftware.foreach(x => (f  << softwareDIT.SOFTWARE.SOFT.dn(x).toString))
+                                    }
+                               _ <- InventoryProcessingLogger.debug(s"[purge unreferenced software] List of unreferenced software DN available in file: ${f.pathAsString}")
+                             } yield ()).catchAll(err => InventoryProcessingLogger.error(s"Error while writting unreference software DN in debug file: ${err.fullMsg}"))
+                           }
       deletedSoftware   <- writeOnlySoftware.deleteSoftwares(extraSoftware.toSeq)
       t4                <- currentTimeMillis
-      _                 <- InventoryProcessingLogger.timing.debug(s"Deleted ${deletedSoftware.size} software in ${t4 - t3}ms")
+      _                 <- InventoryProcessingLogger.timing.info(s"[purge unreferenced software] Deleted ${extraSoftware.size} software in ${t4 - t3}ms")
     } yield {
-      deletedSoftware.map(x => x.toString).toSeq
+      extraSoftware.size
     }
   }
 }

--- a/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestInventory.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestInventory.scala
@@ -140,7 +140,7 @@ class TestInventory extends Specification {
   val writeOnlySoftware = new WriteOnlySoftwareDAOImpl(acceptedNodesDitImpl, ldap)
 
 
-  val softwareService = new SoftwareServiceImpl(readOnlySoftware, writeOnlySoftware)
+  val softwareService = new SoftwareServiceImpl(readOnlySoftware, writeOnlySoftware, acceptedNodesDitImpl)
 
   val allStatus = Seq(RemovedInventory, PendingInventory, AcceptedInventory)
 
@@ -436,7 +436,7 @@ class TestInventory extends Specification {
 
     "Purge one unreferenced software with the SoftwareService" in {
       val purgedSoftwares = softwareService.deleteUnreferencedSoftware().either.runNow
-      purgedSoftwares.map(_.size) must beEqualTo(Right(1))
+      purgedSoftwares must beEqualTo(Right(1))
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeUnreferencedSoftwares.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeUnreferencedSoftwares.scala
@@ -58,17 +58,15 @@ class PurgeUnreferencedSoftwares(
   val logger = ScheduledJobLogger
 
   if (updateInterval < 1.hour) {
-    logger.info(s"Disable automatic purge of unreferenced softwares (update interval cannot be less than 1 hour)")
+    logger.info(s"[purge unreferenced software] Disable automatic purge of unreferenced softwares (update interval cannot be less than 1 hour)")
   } else {
-    logger.debug(s"***** starting batch that purge unreferenced softwares, every ${updateInterval.toString()} *****")
+    logger.debug(s"[purge unreferenced software] starting batch that purge unreferenced softwares, every ${updateInterval.toString()} *****")
     val prog = softwareService.deleteUnreferencedSoftware().either.flatMap { _ match {
       case Right(softwares) =>
-        ScheduledJobLoggerPure.info(s"Purged ${softwares.length} unreferenced softwares") *>
-        ZIO.when(softwares.length > 0)  {
-          ScheduledJobLoggerPure.ifDebugEnabled(ScheduledJobLoggerPure.debug(s"Purged following software: ${softwares.mkString(",")}"))
-        }
+        ScheduledJobLoggerPure.info(s"[purge unreferenced software] Purged ${softwares} unreferenced softwares")
+
       case Left(err) =>
-        ScheduledJobLoggerPure.error(Chained(s"Error when deleting unreferenced softwares", err).fullMsg)
+        ScheduledJobLoggerPure.error(Chained(s"[purge unreferenced software] Error when deleting unreferenced softwares", err).fullMsg)
     }}
 
     import zio.duration.Duration.{fromScala => zduration}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryFileWatcher.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryFileWatcher.scala
@@ -252,7 +252,7 @@ class InventoryFileWatcher(
     , ZioRuntime.environment
   )
   // service that will actually process files (queue for event from inotify/cron for missed files)
-  val fileProcessor = new ProcessFile(inventoryProcessor, received, failed, waitForSig, sigExtension, HOOKS_D, HOOKS_IGNORE_SUFFIXES)
+  val fileProcessor = new ProcessFile(inventoryProcessor, incoming, received, failed, waitForSig, sigExtension, HOOKS_D, HOOKS_IGNORE_SUFFIXES)
   // That reference holds watcher instance and scheduler fiber to be able to stop them if asked
   val ref = RefM.make(Option.empty[(Watchers,Fiber[Nothing, Nothing])]).runNow
   def startWatcher() = semaphore.withPermit(
@@ -322,6 +322,7 @@ final case class SaveInventoryInfo(
  */
 class ProcessFile(
     inventoryProcessor   : InventoryProcessor
+  , prioIncomingDir      : File
   , received             : File
   , failed               : File
   , waitForSig           : Duration
@@ -381,9 +382,10 @@ class ProcessFile(
    */
   val saveInventoryBufferProcessing = {
     for {
-      inv <- saveInventoryBuffer.take
-      // deduplicate. TakeAll is not blocking
+      fst <- saveInventoryBuffer.take
+      // deduplicate and priorize file in 'incoming', which are new inventories. TakeAll is not blocking
       all <- saveInventoryBuffer.takeAll
+      inv =  (fst::all).find { case (f,_) => f.parent == prioIncomingDir }.getOrElse(fst)
       _   <- saveInventoryBuffer.offerAll(all.filterNot { case (f, _) => inv._1.name == f.name })
       // process
       _ <- sendToProcessorBlocking(inv._1, inv._2)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -655,6 +655,12 @@ object SystemApi extends ApiModuleProvider[SystemApi] {
     val (action, path) = GET / "system" / "healthcheck"
   }
 
+  final case object PurgeSoftware extends SystemApi with ZeroParam with StartsAtVersion13 with SortIndex { val z = implicitly[Line].value
+    val description    = "Trigger an async purge of softwares"
+    val (action, path) = POST / "system" / "maintenance" / "purgeSoftware"
+  }
+
+
   def endpoints = ca.mrvisser.sealerate.values[SystemApi].toList.sortBy( _.z )
 }
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -356,6 +356,7 @@ object RestTestSetUp {
       fakeHealthcheckService
     , fakeHcNotifService
     , restDataSerializer
+    , null
   )
 
   val ruleApiService2 = new RuleApiService2(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -992,6 +992,7 @@ object RudderConfig extends Loggable {
       healthcheckService
     , healthcheckNotificationService
     , restDataSerializer
+    , softwareService
   )
 
   private[this] val complianceAPIService = new ComplianceAPIService(
@@ -1556,7 +1557,7 @@ object RudderConfig extends Loggable {
   private[this] lazy val databaseManagerImpl = new DatabaseManagerImpl(reportsRepositoryImpl, updateExpectedRepo)
   private[this] lazy val softwareInventoryDAO: ReadOnlySoftwareDAO = new ReadOnlySoftwareDAOImpl(inventoryDitService, roLdap, inventoryMapper)
   private[this] lazy val softwareInventoryRWDAO: WriteOnlySoftwareDAO = new WriteOnlySoftwareDAOImpl(acceptedNodesDitImpl, rwLdap)
-  private[this] lazy val softwareService: SoftwareService = new SoftwareServiceImpl(softwareInventoryDAO, softwareInventoryRWDAO)
+  private[this] lazy val softwareService: SoftwareService = new SoftwareServiceImpl(softwareInventoryDAO, softwareInventoryRWDAO, acceptedNodesDit)
 
   private[this] lazy val nodeSummaryServiceImpl = new NodeSummaryServiceImpl(inventoryDitService, inventoryMapper, roLdap)
   private[this] lazy val diffRepos: InventoryHistoryLogRepository =


### PR DESCRIPTION
https://issues.rudder.io/issues/12937

This PR correct the core problem in merge_uuid in rudder 6.2: we weren't requesting `sourceName` and `sourceVersion` attribute in the search request for software, but we were using them for comparison. So as soon as we had an inventory with non null value for these attribute, the merge alway failed: they were non empty in inventory, but all existing soft had them empty (from the point of view of the request). So new soft created each time, and so explosion of their number, of indexes, etc. 

That PR also addresses the following points: 

- add logs when unreference software are purged (+ batch deletion by 1000 software, so that user can see that something happens), 
- add an API endpoint to trigger software delete (`POST on .../api/latest/system/maintenance/purgeSoftware`)
- make new inventory (ie the one in `incoming`) be processed before the other ones, even if they arrived after, so that new nodes appear more quickly in rudder UI. 