### PR TITLE
Fixes #18829: rudder package should now look for rpkg.index in the dedicated plugin repository instead of its root

### DIFF
--- a/relay/sources/rudder-pkg/lib/rudder-pkg/rudderPkg.py
+++ b/relay/sources/rudder-pkg/lib/rudder-pkg/rudderPkg.py
@@ -333,7 +333,7 @@ def update():
     if os.path.isfile(utils.INDEX_PATH):
         os.rename(utils.INDEX_PATH, utils.INDEX_PATH + ".bkp")
     try:
-        utils.download(utils.URL + "/" + "rpkg.index")
+        utils.download(utils.URL + "/" + utils.RUDDER_VERSION + "/" + "rpkg.index")
     except Exception as e:
         traceback.print_exc(file=sys.stdout)
         if os.path.isfile(utils.INDEX_PATH + ".bkp"):


### PR DESCRIPTION
https://issues.rudder.io/issues/18829