### PR TITLE
Fixes #18846: Agent run schedule problem

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
@@ -334,9 +334,9 @@ object ExpectedReportsSerialisation {
         , json \ "splayHour"
         , json \ "splaytime"
       ) match {
-        case (JInt(i), JInt(sm), JInt(sph), JInt(spt)) =>
+        case (JInt(i), JInt(minute), JInt(hour), JInt(splay)) =>
           try {
-            Some(AgentRunInterval(overrides, i.toValidInt, sm.toValidInt, spt.toValidInt, spt.toValidInt))
+            Some(AgentRunInterval(overrides, i.toValidInt, minute.toValidInt, hour.toValidInt, splay.toValidInt))
           } catch {
             case ex: NumberFormatException => None
           }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/ReportingConfiguration.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/ReportingConfiguration.scala
@@ -121,7 +121,7 @@ class AgentRunIntervalServiceImpl (
       splaytime <- readGlobalSplaytime()
     } yield {
       AgentRunInterval(
-        None, interval, startHour, startMinute, splaytime
+        None, interval, startMinute, startHour, splaytime
       )
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -430,10 +430,6 @@ trait PromiseGenerationService {
   def getAllInventories(): Box[Map[NodeId, NodeInventory]]
   def getGlobalComplianceMode(): Box[GlobalComplianceMode]
   def getGlobalAgentRun() : Box[AgentRunInterval]
-  def getAgentRunInterval    : () => Box[Int]
-  def getAgentRunSplaytime   : () => Box[Int]
-  def getAgentRunStartHour   : () => Box[Int]
-  def getAgentRunStartMinute : () => Box[Int]
   def getScriptEngineEnabled : () => Box[FeatureSwitch]
   def getGlobalPolicyMode    : () => Box[GlobalPolicyMode]
   def getComputeDynGroups    : () => Box[Boolean]
@@ -666,10 +662,6 @@ class PromiseGenerationServiceImpl (
   , override val complianceCache  : CachedFindRuleNodeStatusReports
   , override val promisesFileWriterService: PolicyWriterService
   , override val writeNodeCertificatesPem: WriteNodeCertificatesPem
-  , override val getAgentRunInterval         : () => Box[Int]
-  , override val getAgentRunSplaytime        : () => Box[Int]
-  , override val getAgentRunStartHour        : () => Box[Int]
-  , override val getAgentRunStartMinute      : () => Box[Int]
   , override val getScriptEngineEnabled      : () => Box[FeatureSwitch]
   , override val getGlobalPolicyMode         : () => Box[GlobalPolicyMode]
   , override val getComputeDynGroups         : () => Box[Boolean]

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestComputeSchedule.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestComputeSchedule.scala
@@ -37,6 +37,7 @@
 
 package com.normation.rudder.services.policies
 
+import com.normation.errors.Inconsistency
 import org.junit.runner.RunWith
 import net.liftweb.common.Full
 import org.specs2.mutable.Specification
@@ -51,22 +52,22 @@ import org.specs2.runner.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class TestComputeSchedule extends Specification {
 
-  "A squedule with 5 minutes interval" should {
+  "A schedule with 5 minutes interval" should {
     "be the default one when starting at 0:00" in {
       ComputeSchedule.computeSchedule(0,0,5) must beEqualTo (
-          Full(""""Min00", "Min05", "Min10", "Min15", "Min20", "Min25", "Min30", "Min35", "Min40", "Min45", "Min50", "Min55"""")
+          Right(""""Min00", "Min05", "Min10", "Min15", "Min20", "Min25", "Min30", "Min35", "Min40", "Min45", "Min50", "Min55"""")
       )
     }
 
    "be the default one when starting at 4:00" in {
       ComputeSchedule.computeSchedule(4,0,5) must beEqualTo (
-          Full(""""Min00", "Min05", "Min10", "Min15", "Min20", "Min25", "Min30", "Min35", "Min40", "Min45", "Min50", "Min55"""")
+          Right(""""Min00", "Min05", "Min10", "Min15", "Min20", "Min25", "Min30", "Min35", "Min40", "Min45", "Min50", "Min55"""")
       )
     }
 
    "be the default one of by 2 minutes when starting at 4:02" in {
       ComputeSchedule.computeSchedule(4,2,5) must beEqualTo (
-          Full(""""Min02", "Min07", "Min12", "Min17", "Min22", "Min27", "Min32", "Min37", "Min42", "Min47", "Min52", "Min57"""")
+          Right(""""Min02", "Min07", "Min12", "Min17", "Min22", "Min27", "Min32", "Min37", "Min42", "Min47", "Min52", "Min57"""")
       )
     }
   }
@@ -74,18 +75,18 @@ class TestComputeSchedule extends Specification {
   "A squedule with non trivial interval" should {
     "fail if a mix of hours and minutes" in {
       ComputeSchedule.computeSchedule(0,0, 63) must beEqualTo (
-        Failure("Agent execution interval can only be defined as minutes (less than 60) or complete hours, (1 hours 3 minutes is not supported)")
+        Left(Inconsistency("Agent execution interval can only be defined as minutes (less than 60) or complete hours, (1 hours 3 minutes is not supported)"))
       )
     }
 
     "be every hours if defined with an interval of 1 hour" in {
       ComputeSchedule.computeSchedule(0,0,60) must beEqualTo (
-          Full(""""Hr00.Min00", "Hr01.Min00", "Hr02.Min00", "Hr03.Min00", "Hr04.Min00", "Hr05.Min00", "Hr06.Min00", "Hr07.Min00", "Hr08.Min00", "Hr09.Min00", "Hr10.Min00", "Hr11.Min00", "Hr12.Min00", "Hr13.Min00", "Hr14.Min00", "Hr15.Min00", "Hr16.Min00", "Hr17.Min00", "Hr18.Min00", "Hr19.Min00", "Hr20.Min00", "Hr21.Min00", "Hr22.Min00", "Hr23.Min00"""")
+          Right(""""Hr00.Min00", "Hr01.Min00", "Hr02.Min00", "Hr03.Min00", "Hr04.Min00", "Hr05.Min00", "Hr06.Min00", "Hr07.Min00", "Hr08.Min00", "Hr09.Min00", "Hr10.Min00", "Hr11.Min00", "Hr12.Min00", "Hr13.Min00", "Hr14.Min00", "Hr15.Min00", "Hr16.Min00", "Hr17.Min00", "Hr18.Min00", "Hr19.Min00", "Hr20.Min00", "Hr21.Min00", "Hr22.Min00", "Hr23.Min00"""")
       )
     }
     "be every two hours if defined with an interval of 2 hours, and off by some minutes" in {
       ComputeSchedule.computeSchedule(3,12,120) must beEqualTo (
-          Full(""""Hr01.Min12", "Hr03.Min12", "Hr05.Min12", "Hr07.Min12", "Hr09.Min12", "Hr11.Min12", "Hr13.Min12", "Hr15.Min12", "Hr17.Min12", "Hr19.Min12", "Hr21.Min12", "Hr23.Min12"""")
+          Right(""""Hr01.Min12", "Hr03.Min12", "Hr05.Min12", "Hr07.Min12", "Hr09.Min12", "Hr11.Min12", "Hr13.Min12", "Hr15.Min12", "Hr17.Min12", "Hr19.Min12", "Hr21.Min12", "Hr23.Min12"""")
       )
     }
   }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -113,7 +113,6 @@ import org.eclipse.jgit.lib.PersonIdent
 import org.joda.time.DateTime
 import org.specs2.matcher.MatchResult
 import zio._
-import zio.duration.durationInt
 import zio.syntax._
 
 import scala.concurrent.duration.FiniteDuration
@@ -272,10 +271,6 @@ object RestTestSetUp {
     override def getAllInventories(): Box[Map[NodeId, NodeInventory]] = ???
     override def getGlobalComplianceMode(): Box[GlobalComplianceMode] = ???
     override def getGlobalAgentRun(): Box[AgentRunInterval] = ???
-    override def getAgentRunInterval: () => Box[Int] = ???
-    override def getAgentRunSplaytime: () => Box[Int] = ???
-    override def getAgentRunStartHour: () => Box[Int] = ???
-    override def getAgentRunStartMinute: () => Box[Int] = ???
     override def getScriptEngineEnabled: () => Box[FeatureSwitch] = ???
     override def getGlobalPolicyMode: () => Box[GlobalPolicyMode] = ???
     override def getComputeDynGroups: () => Box[Boolean] = ???

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1823,10 +1823,6 @@ object RudderConfig extends Loggable {
       , reportingServiceImpl
       , rudderCf3PromisesFileWriterService
       , new WriteNodeCertificatesPemImpl(Some(RUDDER_RELAY_RELOAD))
-      , () => configService.agent_run_interval().toBox
-      , () => configService.agent_run_splaytime().toBox
-      , () => configService.agent_run_start_hour().toBox
-      , () => configService.agent_run_start_minute().toBox
       , () => configService.rudder_featureSwitch_directiveScriptEngine().toBox
       , () => configService.rudder_global_policy_mode().toBox
       , () => configService.rudder_generation_compute_dyngroups().toBox


### PR DESCRIPTION
https://issues.rudder.io/issues/18846

The main problem was that there was two places where we mixed up start minutes / start hours / splay time after getting values from json. 

Other part of the PR is removing dead code:
- an Empty case that was never reachable (and so I changed it to a pure result);
- call to `getAgentRunInterval` etc in `PromiseGenerationService` which were never use (we directly use `agentRun`)