### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/rudder-relay/Dockerfile
+++ b/docker/rudder-relay/Dockerfile
@@ -15,6 +15,9 @@ RUN \
 
 COPY rudder-relay.sh .
 
+# change +x mod to rudder-relay.sh script
+RUN chmod u+x rudder-relay.sh
+
 # https://github.com/gdraheim/docker-systemctl-replacement/blob/1bb5768abbf68245b7b6a8bd9d6ac4df4d78044f/files/docker/systemctl3.py
 COPY systemctl3.py /usr/bin/systemctl
 


### PR DESCRIPTION
bug : rudder-relay.sh is not executable (git don't always keep permissions)

```
docker: Error response from daemon: OCI runtime create failed: container_linux.go:370: starting container process caused: exec: "./rudder-relay.sh": permission denied: unknown.
ERRO[0001] error waiting for container: context canceled
```