### PR TITLE
Fixes #19085: Inherited node properties are displayed with escape

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Properties.scala
@@ -732,14 +732,14 @@ object JsonPropertySerialisation {
         case ParentProperty.Global(value) =>
           (
             ( "kind"  -> "global")
-          ~ ( "value" -> GenericProperty.serializeToJson(value))
+          ~ ( "value" -> GenericProperty.toJsonValue(value))
           )
         case ParentProperty.Group(name, id, value) =>
           (
             ( "kind"  -> "group" )
           ~ ( "name"  -> name    )
           ~ ( "id"    -> id.value)
-          ~ ( "value" -> GenericProperty.serializeToJson(value))
+          ~ ( "value" -> GenericProperty.toJsonValue(value))
           )
         case _ => JNothing
       }
@@ -749,24 +749,29 @@ object JsonPropertySerialisation {
   implicit class JsonNodePropertyHierarchy(val prop: NodePropertyHierarchy) extends AnyVal {
     implicit def formats = DefaultFormats
 
-    def toApiJson: JObject = {
-      prop.hierarchy match {
-        case Nil  => prop.prop.toJson
-        case list => prop.prop.toJson ~ ("hierarchy" -> JArray(list.map(_.toJson)))
-      }
-    }
 
-    def toApiJsonRenderParents = {
+    private def buildHierarchy(displayParents: List[ParentProperty] => JValue): JObject = {
       val (parents, origval) = prop.hierarchy match {
-        case Nil => (None, None)
-        case _   =>
+        case Nil  => (None, None)
+        case list =>
           (
-            Some(prop.hierarchy.reverse.map(p => s"<p>from <b>${p.displayName}</b>:<pre>${p.value.render(ConfigRenderOptions.defaults().setOriginComments(false))}</pre></p>").mkString(""))
+            Some(displayParents(list))
           , prop.hierarchy.headOption.map(v => GenericProperty.toJsonValue(v.value))
           )
       }
 
       prop.prop.toJson ~ ("hierarchy" -> parents) ~ ("origval" -> origval)
+
+    }
+
+    def toApiJson: JObject = {
+      buildHierarchy(list => list.reverse.map(_.toJson))
+    }
+
+    def toApiJsonRenderParents = {
+      buildHierarchy(list => list.reverse.map(p =>
+        s"<p>from <b>${p.displayName}</b>:<pre>${p.value.render(ConfigRenderOptions.defaults().setOriginComments(false))}</pre></p>"
+      ).mkString(""))
     }
 
   }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -271,6 +271,10 @@ object NodeApi extends ApiModuleProvider[NodeApi] {
   // WARNING: read_only user can access this endpoint
   //    No modifications are performed here
   //    POST over GET is required here because we can provide too many information to be passed as URL parameters
+  final case object NodeDisplayInheritedProperties extends NodeApi with InternalApi with OneParam with StartsAtVersion11 with SortIndex { val z = implicitly[Line].value
+    val description = "Get all proporeties for that node, included inherited ones, for displaying in node property tab (internal)"
+    val (action, path)  = GET / "nodes" / "{id}" / "displayInheritedProperties"
+  }
   final case object NodeDetailsTable extends NodeApi with InternalApi with ZeroParam  with StartsAtVersion13 with SortIndex { val z = implicitly[Line].value
     val description = "Getting data to build a Node table"
     val (action, path)  = POST / "nodes" / "details"

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/javascript/rudder/angular/nodeProperties.js
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/javascript/rudder/angular/nodeProperties.js
@@ -128,7 +128,7 @@ nodePropertiesApp.controller('nodePropertiesCtrl', function ($scope, $http, DTOp
     currentNodeId = nodeId
     $scope.objectName = objectName;
     $scope.urlAPI = contextPath + '/secure/api/'+ objectName +'s/' + nodeId;
-    var getUrlAPI = contextPath + '/secure/api/'+ objectName +'s/' + nodeId + '/inheritedProperties';
+    var getUrlAPI = contextPath + '/secure/api/'+ objectName +'s/' + nodeId + '/displayInheritedProperties';
     $scope.fetchProperties = function() {
       return $http.get(getUrlAPI).success( function (result) {
         $scope.properties = result.data[0].properties


### PR DESCRIPTION
https://issues.rudder.io/issues/19085

Several problems here: 

- the public api was using a json string in place of a json object leading to too many quote in json => use the correct method, 
- the update in public api to not use HTML lead to breaking node properties tab display => create an internal API with the old HTML rendering, 
- node properties "inheritedProperty" attribute was still using the HTML rendering. 