### PR TITLE
Fixes #19114: Overridden directives in the same rule are missing (not even "skipped")

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -66,14 +66,16 @@ import zio._
 object ReportingServiceUtils {
 
   /*
-   * Build rule status reports from node reports, decide=ing which directive should be "skipped"
+   * Build rule status reports from node reports, deciding which directives should be "skipped"
    */
   def buildRuleStatusReport(ruleId: RuleId, nodeReports: Map[NodeId, NodeStatusReport]): RuleStatusReport = {
     val toKeep = nodeReports.values.flatMap( _.reports ).filter(_.ruleId == ruleId).toList
     // we don't keep overrides for a directive which is already in "toKeep" or that don't target that rule
     val toKeepDir = toKeep.map(_.directives.keySet).toSet.flatten
     val overrides = nodeReports.values.flatMap( _.overrides.filterNot(r => r.policy.ruleId != ruleId || toKeepDir.contains(r.policy.directiveId))).toList.distinct
-    RuleStatusReport(ruleId, toKeep, overrides)
+    // and we must make overrides unique - ie, we don't keep overridden that are overridden by directive themselve in the overridden list
+    val overrides2 = overrides.filterNot(o => overrides.exists(_.policy == o.overridenBy))
+    RuleStatusReport(ruleId, toKeep, overrides2)
   }
 }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ComplianceData.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ComplianceData.scala
@@ -552,9 +552,7 @@ object ComplianceData extends Loggable {
         , explanation
         , JsonTagSerialisation.serializeTags(rule.tags)
       )
-
     }
-
     JsTableData(ruleComplianceLine.toList)
   }
 
@@ -565,8 +563,7 @@ object ComplianceData extends Loggable {
     , onRuleScreen: Option[Rule] // if we are on a rule, we want to adapt message
   ) : List[DirectiveComplianceLine] = {
     val overridesData = for {
-      // we don't want to write an overriden directive several time for the same overriding rule/directive.
-      over                            <- overrides.groupBy(_.overridenBy).map(_._2.head)
+      over                            <- overrides
       (overridenTech , overridenDir)  <- directiveLib.allDirectives.get(over.policy.directiveId)
       overridingRule                  <- rules.find( _.id == over.overridenBy.ruleId)
       (overridingTech, overridingDir) <- directiveLib.allDirectives.get(over.overridenBy.directiveId)


### PR DESCRIPTION
https://issues.rudder.io/issues/19114

So, the problem was that we were filtering the overriden directive globally, and not by rule, so we had only one overridden for all overrides. 

So now, we filter rule by rule (in a smarter way, and at a place where we can do test, even better) and don't filter with the big axe when building the list of directive lines. 