### PR TITLE
Fixes #19308: rudder.auth.admin.pass should be stored in bcrypt format

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -506,6 +506,10 @@ rudder.batch.storeAgentRunTimes.updateInterval=5
 # By default, the accound is disabled (either by letting the
 # the login or the password empty, or by commenting it).
 #
+# The password is a bcrypt hash, you can create it for example with the following command:
+#  htpasswd -nBC 12 "" | tr -d ':\n'
+# Where htpasswd is provided by apache tools.
+#
 
 #rudder.auth.admin.login=rootadmin
 #rudder.auth.admin.password=secret


### PR DESCRIPTION
https://issues.rudder.io/issues/19308