### PR TITLE
Fixes #19367:  Backport typos checks to 6.2

### DIFF
--- a/relay/sources/rudder-pkg/lib/rudder-pkg/rudderPkgUtils.py
+++ b/relay/sources/rudder-pkg/lib/rudder-pkg/rudderPkgUtils.py
@@ -168,7 +168,7 @@ def check_url():
     else:
       True
   except Exception as e:
-    fail("An error occured while checking access to %s:\n%s"%(URL, e))
+    fail("An error occurred while checking access to %s:\n%s"%(URL, e))
 
 """
    From a complete url, try to download a file. The destination path will be determined by the complete url


### PR DESCRIPTION
https://issues.rudder.io/issues/19367