### PR TITLE
Fixes #19405: rudder-pkg test should use python3

### DIFF
--- a/relay/sources/rudder-pkg/lib/rudder-pkg/tests/testall
+++ b/relay/sources/rudder-pkg/lib/rudder-pkg/tests/testall
@@ -21,5 +21,5 @@ set -xe
 OUR_DIR=`dirname "$0"`
 
 export PYTHONPATH=../:$PYTHONPATH
-python test.py
+python3 test.py
 


### PR DESCRIPTION
https://issues.rudder.io/issues/19405