### PR TITLE
Fixes #19470: Relayd does not start since some keys are missing from its logging.conf file

### DIFF
--- a/relay/sources/relayd/tools/config/logging.conf
+++ b/relay/sources/relayd/tools/config/logging.conf
@@ -6,7 +6,7 @@
 # Global log level
 # Can be "error", "warning", "info", "debug" or "trace"
 
-#level = "info"
+level = "info"
 
 # Allows filtering logs
 # You can filter on a specific component with "[component]=LEVEL",
@@ -14,4 +14,4 @@
 # Filter by node id using "[component{node=root}]".
 # Multiple filters can be separated by commas.
 
-#filter = ""
+filter = ""


### PR DESCRIPTION
https://issues.rudder.io/issues/19470