### PR TITLE
Fixes #19487: Directive details display is broken if the name of a directive is too long.

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/style/rudder/rudder-template.css
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/style/rudder/rudder-template.css
@@ -115,6 +115,9 @@
   margin: 0;
   font-size: 26px;
 }
+.rudder-template .header-buttons {
+  white-space: nowrap;
+}
 .rudder-template .header-buttons .btn {
   margin-left: 10px;
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/19487