### PR TITLE
Fixes #19492: Add policy server certificate information to policies

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/SystemVariableSpecServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/SystemVariableSpecServiceImpl.scala
@@ -174,6 +174,11 @@ class SystemVariableSpecServiceImpl extends SystemVariableSpecService {
                                            , multivalued = false
                                            , constraint = Constraint(mayBeEmpty=true)
                         )
+    , SystemVariableSpec(
+                       "POLICY_SERVER_KEY_HASH" , "Base64 encoding of SHA-256 DER encoding of KEY of the policy server prefixed with sha256//"
+                                           , multivalued = false
+                                           , constraint = Constraint(mayBeEmpty=true)
+                        )
       // end
       //
       // The following variables contains information about all the nodes managed by

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
@@ -266,7 +266,6 @@ object ExpectedReportsSerialisation {
           ~ ("unexpanded" -> c.unexpandedComponentsValues)
           )
       case c: BlockExpectedReport =>
-        import ReportingLogic._
         (("componentName" -> c.componentName)
           ~ ("reportingLogic" -> (c.reportingLogic.value))
           ~ ("subComponents" -> c.subComponents.map(jsonComponentExpectedReport))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/RemoveNodeService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/RemoveNodeService.scala
@@ -588,7 +588,7 @@ class CleanUpCFKeys extends PostNodeDeleteAction {
    * key hash to use in a hook.
    */
   def deleteCfengineKey(nodeInfo: NodeInfo): UIO[Unit] = {
-    nodeInfo.securityTokenHash match {
+    nodeInfo.keyHashCfengine match {
       case null | "" => // no key or not a cfengine agent
         UIO.unit
       case key =>

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-cfe-with-500-directives/rules/cfengine-community/rudder.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-cfe-with-500-directives/rules/cfengine-community/rudder.json
@@ -18,6 +18,7 @@
   "MODIFIED_FILES_TTL":"30",
   "NODEROLE":"# This node doesn't have any specific role",
   "POLICY_SERVER_KEY":"MD5=eec3a3c2cf41b2736b7a0a9dece02142",
+  "POLICY_SERVER_KEY_HASH":"sha256//QdgYBhJETcbCgKyRibjJVZQCm6mgaXzXKxrziLS5SEQ=",
   "RELAY_SYNC_METHOD":"classic",
   "RELAY_SYNC_PROMISES":"false",
   "RELAY_SYNC_SHAREDFILES":"false",

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-cfe-with-two-directives/rules/cfengine-community/rudder.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-cfe-with-two-directives/rules/cfengine-community/rudder.json
@@ -18,6 +18,7 @@
   "MODIFIED_FILES_TTL":"30",
   "NODEROLE":"# This node doesn't have any specific role",
   "POLICY_SERVER_KEY":"MD5=eec3a3c2cf41b2736b7a0a9dece02142",
+  "POLICY_SERVER_KEY_HASH":"sha256//QdgYBhJETcbCgKyRibjJVZQCm6mgaXzXKxrziLS5SEQ=",
   "RELAY_SYNC_METHOD":"classic",
   "RELAY_SYNC_PROMISES":"false",
   "RELAY_SYNC_SHAREDFILES":"false",

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-gen-var-def-override/rules/cfengine-community/rudder.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-gen-var-def-override/rules/cfengine-community/rudder.json
@@ -18,6 +18,7 @@
   "MODIFIED_FILES_TTL":"30",
   "NODEROLE":"# This node doesn't have any specific role",
   "POLICY_SERVER_KEY":"MD5=eec3a3c2cf41b2736b7a0a9dece02142",
+  "POLICY_SERVER_KEY_HASH":"sha256//QdgYBhJETcbCgKyRibjJVZQCm6mgaXzXKxrziLS5SEQ=",
   "RELAY_SYNC_METHOD":"classic",
   "RELAY_SYNC_PROMISES":"false",
   "RELAY_SYNC_SHAREDFILES":"false",

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-default-install/distributePolicy/1.0/nodeslist.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-default-install/distributePolicy/1.0/nodeslist.json
@@ -1,7 +1,7 @@
 {
       "root": {
         "hostname": "server.rudder.local",
-        "key-hash": "sha256:41d8180612444dc6c280ac9189b8c95594029ba9a0697cd72b1af388b4b94844",
+        "key-hash": "sha256//QdgYBhJETcbCgKyRibjJVZQCm6mgaXzXKxrziLS5SEQ=",
         "policy-server": "root"
       }
     

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-default-install/rudder.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-default-install/rudder.json
@@ -18,6 +18,7 @@
   "MODIFIED_FILES_TTL":"30",
   "NODEROLE":"  classes: \n    \"rudder-ldap\" expression => \"any\";\n    \"policy_server\" expression => \"any\";\n    \"rudder-inventory-ldap\" expression => \"any\";\n    \"rudder-db\" expression => \"any\";\n    \"rudder-jetty\" expression => \"any\";\n    \"rudder-webapp\" expression => \"any\";\n    \"rudder-inventory-endpoint\" expression => \"any\";\n    \"root_server\" expression => \"any\";\n    \"rudder-reports\" expression => \"any\";\n    \"rudder-server-root\" expression => \"any\";",
   "POLICY_SERVER_KEY":"MD5=eec3a3c2cf41b2736b7a0a9dece02142",
+  "POLICY_SERVER_KEY_HASH":"sha256//QdgYBhJETcbCgKyRibjJVZQCm6mgaXzXKxrziLS5SEQ=",
   "RELAY_SYNC_METHOD":"classic",
   "RELAY_SYNC_PROMISES":"false",
   "RELAY_SYNC_SHAREDFILES":"false",

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-sys-var-false/distributePolicy/1.0/nodeslist.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-sys-var-false/distributePolicy/1.0/nodeslist.json
@@ -1,13 +1,13 @@
 {
       "c8813416-316f-4307-9b6a-ca9c109a9fb0": {
         "hostname": "node1.localhost",
-        "key-hash": "sha256:cf621af57886d614617b2c8187d1db9d18c93ee0674c9985fb06fa17705ed4f0",
+        "key-hash": "sha256//z2Ia9XiG1hRheyyBh9HbnRjJPuBnTJmF+wb6F3Be1PA=",
         "policy-server": "root"
       }
     ,
       "root": {
         "hostname": "server.rudder.local",
-        "key-hash": "sha256:41d8180612444dc6c280ac9189b8c95594029ba9a0697cd72b1af388b4b94844",
+        "key-hash": "sha256//QdgYBhJETcbCgKyRibjJVZQCm6mgaXzXKxrziLS5SEQ=",
         "policy-server": "root"
       }
     

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-sys-var-false/rudder.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-sys-var-false/rudder.json
@@ -18,6 +18,7 @@
   "MODIFIED_FILES_TTL":"30",
   "NODEROLE":"  classes: \n    \"rudder-ldap\" expression => \"any\";\n    \"policy_server\" expression => \"any\";\n    \"rudder-inventory-ldap\" expression => \"any\";\n    \"rudder-db\" expression => \"any\";\n    \"rudder-jetty\" expression => \"any\";\n    \"rudder-webapp\" expression => \"any\";\n    \"rudder-inventory-endpoint\" expression => \"any\";\n    \"root_server\" expression => \"any\";\n    \"rudder-reports\" expression => \"any\";\n    \"rudder-server-root\" expression => \"any\";",
   "POLICY_SERVER_KEY":"MD5=eec3a3c2cf41b2736b7a0a9dece02142",
+  "POLICY_SERVER_KEY_HASH":"sha256//QdgYBhJETcbCgKyRibjJVZQCm6mgaXzXKxrziLS5SEQ=",
   "RELAY_SYNC_METHOD":"classic",
   "RELAY_SYNC_PROMISES":"false",
   "RELAY_SYNC_SHAREDFILES":"false",

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-one-multipolicy/distributePolicy/1.0/nodeslist.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-one-multipolicy/distributePolicy/1.0/nodeslist.json
@@ -1,7 +1,7 @@
 {
       "root": {
         "hostname": "server.rudder.local",
-        "key-hash": "sha256:41d8180612444dc6c280ac9189b8c95594029ba9a0697cd72b1af388b4b94844",
+        "key-hash": "sha256//QdgYBhJETcbCgKyRibjJVZQCm6mgaXzXKxrziLS5SEQ=",
         "policy-server": "root"
       }
     

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-one-multipolicy/rudder.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-one-multipolicy/rudder.json
@@ -18,6 +18,7 @@
   "MODIFIED_FILES_TTL":"30",
   "NODEROLE":"  classes: \n    \"rudder-ldap\" expression => \"any\";\n    \"policy_server\" expression => \"any\";\n    \"rudder-inventory-ldap\" expression => \"any\";\n    \"rudder-db\" expression => \"any\";\n    \"rudder-jetty\" expression => \"any\";\n    \"rudder-webapp\" expression => \"any\";\n    \"rudder-inventory-endpoint\" expression => \"any\";\n    \"root_server\" expression => \"any\";\n    \"rudder-reports\" expression => \"any\";\n    \"rudder-server-root\" expression => \"any\";",
   "POLICY_SERVER_KEY":"MD5=eec3a3c2cf41b2736b7a0a9dece02142",
+  "POLICY_SERVER_KEY_HASH":"sha256//QdgYBhJETcbCgKyRibjJVZQCm6mgaXzXKxrziLS5SEQ=",
   "RELAY_SYNC_METHOD":"classic",
   "RELAY_SYNC_PROMISES":"false",
   "RELAY_SYNC_SHAREDFILES":"false",

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-two-directives/distributePolicy/1.0/nodeslist.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-two-directives/distributePolicy/1.0/nodeslist.json
@@ -1,7 +1,7 @@
 {
       "root": {
         "hostname": "server.rudder.local",
-        "key-hash": "sha256:41d8180612444dc6c280ac9189b8c95594029ba9a0697cd72b1af388b4b94844",
+        "key-hash": "sha256//QdgYBhJETcbCgKyRibjJVZQCm6mgaXzXKxrziLS5SEQ=",
         "policy-server": "root"
       }
     

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-two-directives/rudder.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-two-directives/rudder.json
@@ -18,6 +18,7 @@
   "MODIFIED_FILES_TTL":"30",
   "NODEROLE":"  classes: \n    \"rudder-ldap\" expression => \"any\";\n    \"policy_server\" expression => \"any\";\n    \"rudder-inventory-ldap\" expression => \"any\";\n    \"rudder-db\" expression => \"any\";\n    \"rudder-jetty\" expression => \"any\";\n    \"rudder-webapp\" expression => \"any\";\n    \"rudder-inventory-endpoint\" expression => \"any\";\n    \"root_server\" expression => \"any\";\n    \"rudder-reports\" expression => \"any\";\n    \"rudder-server-root\" expression => \"any\";",
   "POLICY_SERVER_KEY":"MD5=eec3a3c2cf41b2736b7a0a9dece02142",
+  "POLICY_SERVER_KEY_HASH":"sha256//QdgYBhJETcbCgKyRibjJVZQCm6mgaXzXKxrziLS5SEQ=",
   "RELAY_SYNC_METHOD":"classic",
   "RELAY_SYNC_PROMISES":"false",
   "RELAY_SYNC_SHAREDFILES":"false",

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/nodes/NodeKeyHashTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/nodes/NodeKeyHashTest.scala
@@ -42,9 +42,10 @@ import org.specs2.mutable._
 import org.specs2.runner._
 import net.liftweb.common._
 import com.normation.inventory.domain.PublicKey
+import com.normation.zio._
 
 @RunWith(classOf[JUnitRunner])
-class CFEngineRSAKeyHashTest extends Specification with Loggable {
+class NodeKeyHashTest extends Specification with Loggable {
 
   // Keys are sanitized in LDAP, we remove header and footer
   val key = PublicKey("""
@@ -70,19 +71,25 @@ eDCco6N4drw5BsJTUdW59N4KSbg/VRGWpwIDAQAB
 
   "Producing the magic MD5 hash" should {
     "give the same result as CFEngine" in {
-      CFEngineKey.getCfengineMD5Digest(key) must beEqualTo(Full("8d3270d42486e8d6436d06ed5cc5034f"))
+      NodeKeyHash.getCfengineMD5Digest(key).runNow must beEqualTo("8d3270d42486e8d6436d06ed5cc5034f")
     }
   }
 
   "Producing the magic SHA256 hash" should {
     "give the same result as CFEngine" in {
-      CFEngineKey.getCfengineSHA256Digest(key2) must beEqualTo(Full("7be4ef500c22672a67e56a48c00dc29db1131a1e6be044c794f63a6f854f6dec"))
+      NodeKeyHash.getCfengineSHA256Digest(key2).runNow must beEqualTo("7be4ef500c22672a67e56a48c00dc29db1131a1e6be044c794f63a6f854f6dec")
     }
   }
 
   "Producing the standard sha-256 hash" should {
     "give the same result as the relay server API" in {
-      CFEngineKey.getSha256Digest(key) must beEqualTo(Full("02dee6f141495cad9813183696d0e66f8e8b2939af0d801e368f3873ed632276"))
+      NodeKeyHash.getHexSha256Digest(key).runNow must beEqualTo("02dee6f141495cad9813183696d0e66f8e8b2939af0d801e368f3873ed632276")
+    }
+  }
+
+    "Producing the standard sha-256 hash" should {
+    "give the same result as the relay server API" in {
+      NodeKeyHash.getB64Sha256Digest(key2).runNow must beEqualTo("eNiEhcP+Lsk4lL6OhBTuFdCtWi+PXnHIGbawpDfMQqQ=")
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -467,7 +467,7 @@ object DisplayNode extends Loggable {
               val nodeId      = sm.node.main.id
               val publicKeyId = s"publicKey-${nodeId.value}"
               val cfKeyHash   = nodeInfoService.getNodeInfo(nodeId) match {
-                case Full(Some(nodeInfo)) if(nodeInfo.securityTokenHash.nonEmpty) => <div><label>Key hash:</label> <samp>{nodeInfo.securityTokenHash}</samp></div>
+                case Full(Some(nodeInfo)) if(nodeInfo.keyHashCfengine.nonEmpty) => <div><label>Key hash:</label> <samp>{nodeInfo.keyHashCfengine}</samp></div>
                 case _                                                            => NodeSeq.Empty
               }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/19492

Main changes: 
- output for the root server hash in nodelist is now base64 encoded and starts with `sha256//` in place of being hex encoded and start by `sha256:`
- renamed `CfengineKey` utility class to `NodeKeyHash`, since it deals with all kind of hashes
- refactor a bit key crypto processing to factor out common parts, even if bouncy castle and java api try hard to make that difficult, 
- add `POLICY_SERVER_KEY_HASH` which holds the base64 encoded string. This one also has the prefix `sha256//` - is it what we want ?

Also, in node details, we are displaying certificate "fingerprint", which is yet something different: `SHA1 Fingerprint: </label> <samp>{SHA1.hash(cert.getEncoded).grouped(2).mkString(":")}`. Do we want to also display the base64 string, since it's the one that will be usefull for debugging ? Also, shouldn't we have in `rudder agent` a command (in `check` ?) that display the base64 cert string with the correct openssl incantation ?