### PR TITLE
Fixes #19538: Or selector for property Name=Value selector returns 0 elements

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
@@ -56,10 +56,8 @@ import com.normation.rudder.repository.CachedRepository
 import com.normation.inventory.ldap.core.InventoryDit
 import com.normation.inventory.ldap.core.InventoryMapper
 import com.normation.rudder.domain.Constants
-import com.normation.rudder.domain.queries.And
 import com.normation.rudder.domain.queries.CriterionComposition
 import com.normation.rudder.domain.queries.NodeInfoMatcher
-import com.normation.rudder.domain.queries.Or
 import com.normation.ldap.sdk.LDAPIOResult._
 import zio._
 import zio.syntax._
@@ -69,9 +67,11 @@ import com.normation.zio._
 import com.normation.ldap.sdk.syntax._
 import com.normation.rudder.domain.logger.NodeLoggerPure
 import com.normation.rudder.domain.logger.TimingDebugLoggerPure
+import com.normation.rudder.domain.queries.And
 import com.normation.rudder.services.nodes.NodeInfoService.A_MOD_TIMESTAMP
 import com.normation.rudder.services.nodes.NodeInfoServiceCached.UpdatedNodeEntries
 import com.normation.rudder.services.nodes.NodeInfoServiceCached.buildInfoMaps
+import com.normation.rudder.services.queries.PostFilterNodeFromInfoService
 
 import scala.concurrent.duration.FiniteDuration
 import scala.collection.mutable.{Map => MutMap}
@@ -871,33 +871,13 @@ trait NodeInfoServiceCached extends NodeInfoService with NamedZioLogger with Cac
   }.toBox
 
   override def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition): Box[Set[LDAPNodeInfo]] = {
-    def comp(a: Boolean, b: Boolean) = composition match {
-        case And => a && b
-        case Or  => a || b
-    }
-    // utliity to combine predicates according to comp
-    def combine(a: NodeInfoMatcher, b: NodeInfoMatcher) = new NodeInfoMatcher {
-      override def matches(node: NodeInfo): Boolean = comp(a.matches(node), b.matches(node))
-    }
-
-    // if there is no predicates (ie no specific filter on NodeInfo), we should just keep nodes from our list
-    def predicate(nodeInfo : NodeInfo) = {
-      val contains = nodeIds.contains(nodeInfo.id)
-      if (predicates.isEmpty) {
-        contains
-      } else {
-        val validPredicates = predicates.reduceLeft(combine).matches(nodeInfo)
-        comp(contains,validPredicates)
-      }
-    }
-
-    // if nodeIds is empty, return an empty set
-    if (!nodeIds.isEmpty) {
-      withUpToDateCache(s"${nodeIds.size} ldap node info") { cache =>
-        cache.values.collect { case (x, y) if predicate(y) => x }.toSet.succeed
-      }
-    } else {
+    // if nodeIds is empty and composition is and, return an empty set; with or, we need to run it in all cases
+    if (nodeIds.isEmpty && composition == And) {
       Set[LDAPNodeInfo]().succeed
+    } else {
+      withUpToDateCache(s"${nodeIds.size} ldap node info") { cache =>
+        PostFilterNodeFromInfoService.getLDAPNodeInfo(nodeIds, predicates, composition, cache).succeed
+      }
     }
   }.toBox
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
@@ -56,6 +56,8 @@ import org.junit.runner.RunWith
 import org.junit.runners.BlockJUnit4ClassRunner
 import zio.syntax._
 
+import com.softwaremill.quicklens._
+
 /*
  * Test query parsing.
  *
@@ -800,8 +802,12 @@ class TestQueryProcessor extends Loggable {
       """).openOrThrowException("For tests"),
       s(1) :: Nil)
 
-    testQueries(q1 :: q2 :: q3 :: q4 :: q5 ::  q6 :: q7 :: q8 :: Nil, true)
+    val andQueries = q1 :: q2 :: q3 :: q4 :: q5 ::  q6 :: q7 :: q8 :: Nil
+    // And and Or must yield same results when there is only one criteria for node prop, see: #19538
+    val orQueries = andQueries.map(_.modify(_.query.composition).setTo(Or))
+    testQueries(andQueries ::: orQueries, false)
   }
+
 
   /*
    * When using JsonPath on node properties to know if the node should be return or not, what we are


### PR DESCRIPTION
https://issues.rudder.io/issues/19538

Correct two bugs:
- the filter was incorrect when there wasn't any filters for`Or` case. openldap just returns nothing in that case, which was by luck what we want, but any composition with that filter lead to the same empty result (bad for or)
- in the case where LDAP queries didn't return any nodes, if we are in `Or` case, we STILL need to do the search on all nodes for the properties case

Plus add debugging info to help spot other such errors and move the query logic for properties in the same file than other to make it more easier to look at. 