### PR TITLE
Fixes #19151: add caching for NodeExpectedReports

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/metrics/HistorizeNodeCountService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/metrics/HistorizeNodeCountService.scala
@@ -155,7 +155,7 @@ class FetchDataServiceImpl(nodeInfoService: NodeInfoService, reportingService: R
     (for {
       accepted   <- nodeInfoService.getAll()
       pending    <- nodeInfoService.getPendingNodeInfos()
-      compliance <- reportingService.getUserNodeStatusReports()
+      compliance <- reportingService.getUserNodeStatusReports().toIO
     } yield {
       val modes = compliance.values.groupMapReduce(r => mode(r.compliance))(_ => 1)(_+_)
       FrequentNodeMetrics(
@@ -165,7 +165,7 @@ class FetchDataServiceImpl(nodeInfoService: NodeInfoService, reportingService: R
         , modes.getOrElse(Mode.Enforce, 0)
         , modes.getOrElse(Mode.Mixed, 0)
       )
-    }).toIO
+    })
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/ReportingConfiguration.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/ReportingConfiguration.scala
@@ -44,6 +44,7 @@ import org.joda.time.Duration
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.domain.Constants
+import com.normation.box._
 
 /**
  * Class that contains all relevant information about the reporting configuration:
@@ -130,7 +131,7 @@ class AgentRunIntervalServiceImpl (
     for {
       gInterval  <- readGlobalInterval()
       gHeartbeat <- readGlobalHeartbeat()
-      nodeInfos  <- nodeInfoService.getAll()
+      nodeInfos  <- nodeInfoService.getAll().toBox
     } yield {
       nodeIds.map { nodeId =>
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ExpectedReportsRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ExpectedReportsRepository.scala
@@ -106,6 +106,13 @@ trait FindExpectedReportRepository {
    */
   def findCurrentNodeIds(rule : RuleId) : Box[Set[NodeId]]
 
+  /**
+   * Return node ids associated to the rule (based on expectedreports (the one still pending)) for this Rule,
+   * only limited on the nodeIds in parameter (used when cache is incomplete)
+   */
+  def findCurrentNodeIdsForRule(ruleId : RuleId, nodeIds: Set[NodeId]) : IOResult[Set[NodeId]]
+
+
   /*
    * Retrieve the expected reports by config version of the nodes.
    *

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeRepository.scala
@@ -56,8 +56,6 @@ trait WoNodeRepository {
   def updateNode(node: Node, modId: ModificationId, actor:EventActor, reason:Option[String]) : IOResult[Node]
 
   def createNode(node: Node, modId: ModificationId, actor:EventActor, reason:Option[String]) : IOResult[Node]
-  def deleteNode(node: Node, modId: ModificationId, actor:EventActor, reason:Option[String]) : IOResult[Node]
-
 
 
   /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
@@ -193,15 +193,4 @@ class WoLDAPNodeRepository(
       node
     })
   }
-
-  // this method is unused
-  override def deleteNode(node: Node, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Node] = {
-    val entry = mapper.nodeToEntry(node)
-    nodeLibMutex.writeLock(for {
-      con <- ldap
-      _   <- con.delete(entry.dn).chainError(s"Error when trying to delete node '${node.id.value}'")
-    } yield {
-      node
-    })
-  }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
@@ -177,7 +177,7 @@ class AcceptedNodesLDAPQueryProcessor(
       res            <- processor.internalQueryProcessor(query,select,limitToNodeIds,debugId).toBox
       timeres        =  (System.currentTimeMillis - timePreCompute)
       _              =  logger.debug(s"LDAP result: ${res.entries.size} entries obtained in ${timeres}ms for query ${query.toString}")
-      ldapEntries    <- nodeInfoService.getLDAPNodeInfo(res.entries.flatMap(x => x(A_NODE_UUID).map(NodeId(_))).toSet, res.nodeFilters, query.composition)
+      ldapEntries    <- nodeInfoService.getLDAPNodeInfo(res.entries.flatMap(x => x(A_NODE_UUID).map(NodeId(_))).toSet, res.nodeFilters, query.composition).toBox
       ldapEntryTime  =  (System.currentTimeMillis - timePreCompute - timeres)
       _              =  logger.debug(s"[post-filter:rudderNode] Found ${ldapEntries.size} nodes when filtering for info service existence and properties (${ldapEntryTime} ms)")
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchBackendImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchBackendImpl.scala
@@ -65,7 +65,6 @@ import scala.util.control.NonFatal
 import net.liftweb.common.Loggable
 
 import com.normation.box._
-import com.normation.errors._
 
 /**
  * Correctly quote a token
@@ -226,7 +225,7 @@ object QSLdapBackend {
 
     for {
       connection  <- ldap
-      nodeIds     <- nodeInfos.getAll().map(_.keySet.map(_.value)).toIO
+      nodeIds     <- nodeInfos.getAllNodesIds()
       entries     <- connection.search(nodeDit.BASE_DN, Sub, filter, returnedAttributes:_*)
     } yield {
 
@@ -238,7 +237,7 @@ object QSLdapBackend {
         //and we get node always with a hostname
         val (nodes, others) = entries.partition { x => x.isA(OC_NODE) || x.isA(OC_RUDDER_NODE) }
         // merge node attribute for node entries with same node id
-        val merged = nodes.groupBy( _.value_!(A_NODE_UUID)).filter(e => nodeIds.contains(e._1)).map { case (_, samenodes) =>
+        val merged = nodes.groupBy( _.value_!(A_NODE_UUID)).filter(e => nodeIds.map(_.value).contains(e._1)).map { case (_, samenodes) =>
           samenodes.reduce[LDAPEntry] { case (n1, n2) =>
             n2.attributes.foreach( a => n1 mergeAttribute a)
             n1

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeConfigurationService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeConfigurationService.scala
@@ -1,0 +1,318 @@
+/*
+*************************************************************************************
+* Copyright 2021 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.services.reports
+
+import com.normation.errors._
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.logger.ReportLoggerPure
+import com.normation.rudder.domain.policies.RuleId
+import com.normation.rudder.domain.reports.NodeAndConfigId
+import com.normation.rudder.domain.reports.NodeExpectedReports
+import com.normation.rudder.repository.CachedRepository
+import com.normation.rudder.repository.FindExpectedReportRepository
+import com.normation.rudder.services.nodes.NodeInfoService
+import com.normation.zio._
+import zio._
+import zio.syntax._
+
+/**
+ * That service retrieve node configurations (nodeexpectedreports) from the expectedreportsjdbcrepository, unless its already in cache
+ * cache is driven by reporting serviceimpl
+ * init add all nodes, withtout anything attached
+ * initial setting of nodeexpectedreport is less prioritary than update
+ * deletion removes the entry
+ * if an entry exists but without anything, then it will query the database
+ * if an entry exists but wthout the right nodeconfigid, it will query the database (but not update the cache)
+ */
+trait NodeConfigurationService {
+  /**
+   * retrieve expected reports by config version
+   */
+  def findNodeExpectedReports(
+         nodeConfigIds: Set[NodeAndConfigId]
+      ): IOResult[Map[NodeAndConfigId, Option[NodeExpectedReports]]]
+
+  /**
+   * get the current expected reports
+   * fails if request expected reports for a non existent node
+   */
+  def getCurrentExpectedReports(nodeIds: Set[NodeId]): IOResult[Map[NodeId, Option[NodeExpectedReports]]]
+
+  /**
+   * get the nodes applying the rule
+   *
+   */
+  def findNodesApplyingRule(ruleId: RuleId): IOResult[Set[NodeId]]
+}
+
+class CachedNodeConfigurationService(
+    val confExpectedRepo: FindExpectedReportRepository
+  , val nodeInfoService : NodeInfoService
+) extends NodeConfigurationService with CachedRepository {
+
+
+  val semaphore = Semaphore.make(1).runNow
+
+  val logger = ReportLoggerPure.Cache
+
+
+  /**
+   * The cache is managed node by node.
+   * A missing nodeId mean that the cache wasn't initialized for
+   * that node, and should fail
+   *
+   * This cache is populated by ReportingServiceImpl:
+   * * init by adding all existing nodes (and NodeExpectedReports if available)
+   * * update after a policy generation to change the value for a nodeid
+   * * add a new node when accepting a node
+   * * deleting a node
+   *
+   * Note that a clear cache will None the cache
+   *
+   * A query to fetch nodeexpectedreports that is not in the cache will return None
+   * (if node exists), or fail if node does not exists.
+   *
+   * Ref allows atomic action on the map, but concurrent non-atomic changes (ex: if
+   * you need to something iterativelly to update the cache) still need to be behind a semaphore.
+   */
+  private[this] val cache = Ref.make(Map.empty[NodeId, Option[NodeExpectedReports]]).runNow
+
+  /**
+   * The queue of invalidation request.
+   * The queue size is 1 and new request need to merge with existing request
+   * It's a List and not a Set, because we want to keep the precedence in
+   * invalidation request.
+   * // unsure if its a CacheComplianceQueueAction or another queueaction
+   */
+  private[this] val invalidateNodeConfigurationRequest = Queue.dropping[List[(NodeId, CacheExpectedReportAction)]](1).runNow
+
+  /**
+   * We need a semaphore to protect queue content merge-update
+   */
+  private[this] val invalidateMergeUpdateSemaphore = Semaphore.make(1).runNow
+
+
+  // Init to do
+  // what's the best method ? init directly from db, fetching all nodeconfigurations
+  // that are empty
+  // or initing it with all nodes, and nothing in it, and only then fetching by batch
+  // batching saves memory, but is slower
+  // i think it's safer to do the batching part, but i'd like to be sure of that
+  def init() : IOResult[Unit] = {
+    for {
+      _       <- logger.debug("Init cache in NodeConfigurationService")
+      // first, get all nodes
+      nodeIds <- nodeInfoService.getAllNodesIds()
+                 // void the cache
+      _       <- semaphore.withPermit(cache.set(nodeIds.map(_ -> None).toMap))
+    } yield ()
+  }
+
+  /**
+   * Update logic. We take message from queue one at a time, and process.
+   * we need to keep order
+   */
+  val updateCacheFromRequest: IO[Nothing, Unit] = invalidateNodeConfigurationRequest.take.flatMap(invalidatedIds =>
+    ZIO.foreach_(invalidatedIds.map(_._2) : List[CacheExpectedReportAction])(action =>
+      performAction(action).catchAll(err =>
+        // when there is an error with an action on the cache, it can becomes inconsistant and we need to (try to) reinit it
+        logger.error(s"Error when updating NodeConfiguration cache for node: [${action.nodeId.value}]: ${err.fullMsg}")) *>
+        init().catchAll(err => logger.error(s"NoceConfiguration cache re-init after error failed, please try to restart app"))
+    )
+  )
+
+  // start updating
+  updateCacheFromRequest.forever.forkDaemon.runNow
+
+  /**
+   * Clear cache. Try a reload asynchronously, disregarding
+   * the result
+   */
+  override def clearCache(): Unit = {
+    init().runNow
+    logger.logEffect.debug("Node expected reports cache cleared")
+  }
+
+
+  /**
+   * Do something with the action we received
+   */
+  private[this] def performAction(action: CacheExpectedReportAction): IOResult[Unit] = {
+    import CacheExpectedReportAction._
+    // in a semaphore
+    semaphore.withPermit(
+       action match {
+                          case insert: InsertNodeInCache => cache.update( _ + (insert.nodeId -> None))
+                          case delete: RemoveNodeInCache => cache.update( _.removed(delete.nodeId) )
+                          case update: UpdateNodeConfiguration => cache.update( _ + (update.nodeId -> Some(update.nodeConfiguration)))
+                   }
+    )
+  }
+
+  /**
+   * invalidate with an action to do something
+   * order is important
+   */
+  def invalidateWithAction(actions: Seq[(NodeId, CacheExpectedReportAction)]): IOResult[Unit] = {
+    ZIO.when(actions.nonEmpty) {
+      logger.debug(s"Node Configuration cache: invalidation request for nodes with action: [${actions.map(_._1).map { _.value }.mkString(",")}]") *>
+        invalidateMergeUpdateSemaphore.withPermit(for {
+          elements     <- invalidateNodeConfigurationRequest.takeAll
+          allActions   =  (elements.flatten ++ actions)
+          _            <- invalidateNodeConfigurationRequest.offer(allActions)
+        } yield ())
+    }
+  }
+
+  /**
+   * get the current expected reports
+   */
+  def getCurrentExpectedReports(nodeIds: Set[NodeId]): IOResult[Map[NodeId, Option[NodeExpectedReports]]] = {
+    // add logging, to ensure that semaphoring the whole is not too blocking
+    logger.logEffect.trace(s"Calling getCurrentExpectedReports - before semaphore")
+    val before_semaphoreTime = System.currentTimeMillis
+
+    // In a semaphore, nothing should change the cache
+    semaphore.withPermit(for {
+      timeInSemaphore <- currentTimeMillis
+      _               <- logger.trace(s"Entered the semaphore after ${timeInSemaphore - before_semaphoreTime} ms")
+
+      // First, get all nodes from cache (even the none)
+      dataFromCache <- cache.get.map(_.filter{  case (nodeId, _) => nodeIds.contains(nodeId) })
+      // now fetch others from database, if necessary
+      // if the configuration is none, then cache isn't inited for it
+      dataUninitialized = dataFromCache.filter{ case (nodeId, option) => option.isEmpty}.keySet
+      fromDb     <- confExpectedRepo.getCurrentExpectedsReports(dataUninitialized).toIO
+      _          <- logger.trace(s"Fetch from DB ${fromDb.size} current expected reports")
+
+      // ? question ?
+      // how to properly ensure that cache is synchro ?
+      // We only process uninitialized nodes conf here, so we can only get better - ie, if
+      // it a "none" config from db, well it was already that in `dataUninitialized`
+      // All updates which could insert newer data in cache are processed in `performAction`, but blocked by the semaphore
+      // So we can just merge the cache here
+      _         <- cache.updateAndGet(_ ++ fromDb)
+    } yield {
+      // returns only the requested nodes
+      dataFromCache ++ fromDb
+    })
+  }
+
+  /**
+   * get the nodes applying the rule
+   *
+   */
+  def findNodesApplyingRule(ruleId: RuleId): IOResult[Set[NodeId]] = {
+    // this don't need to be in a semaphore, since it's only one atomic cache read
+    for {
+      nodeConfs       <- cache.get
+      nodesNotInCache =  nodeConfs.collect { case (k, value) if(value.isEmpty) => k }.toSet
+      dataFromCache   =  nodeConfs.collect { case (k, Some(nodeExpectedReports)) if(nodeExpectedReports.ruleExpectedReports.map(_.ruleId).contains(ruleId)) => k}.toSet
+      fromRepo        <- if (nodesNotInCache.isEmpty) {
+                           Set.empty[NodeId].succeed
+                         } else { // query the repo
+                           confExpectedRepo.findCurrentNodeIdsForRule(ruleId, nodesNotInCache)
+                         }
+    } yield {
+      dataFromCache ++ fromRepo
+    }
+  }
+
+  /**
+   * retrieve expected reports by config version
+   */
+  def findNodeExpectedReports(nodeConfigIds: Set[NodeAndConfigId]): IOResult[Map[NodeAndConfigId, Option[NodeExpectedReports]]] = {
+    // first get the config which are current (no enddate) from cache. It should be the majority, hopefully
+    for {
+      allCached <- cache.get
+      inCache   =  allCached.map { case (id, expected) => expected match {
+                    case None => None
+                    case Some(nodeExpectedReport) =>
+                      val nodeAndConfigId = NodeAndConfigId(id, nodeExpectedReport.nodeConfigId)
+                      if (nodeConfigIds.contains(nodeAndConfigId)) {
+                        Some((nodeAndConfigId, expected)) // returns from the cache if it match
+                      } else {
+                        None
+                      }
+                  }}.flatten.toMap
+      // search for all others in repo
+      // here, we could do something clever by filtering all those with None enddate and add them in repo
+      // but I don't want to be double clever
+      missingNodeConfigIds = nodeConfigIds -- inCache.keySet
+      fromDb <- confExpectedRepo.getExpectedReports(missingNodeConfigIds).toIO
+    } yield {
+      fromDb ++ inCache
+    }
+  }
+}
+
+
+
+/**
+ * simple implementation
+ * simply call the repo, as a passthrough
+ */
+class NodeConfigurationServiceImpl(
+  confExpectedRepo: FindExpectedReportRepository
+) extends NodeConfigurationService {
+  /**
+   * retrieve expected reports by config version
+   */
+  def findNodeExpectedReports(
+        nodeConfigIds: Set[NodeAndConfigId]
+      ): IOResult[Map[NodeAndConfigId, Option[NodeExpectedReports]]] = {
+    confExpectedRepo.getExpectedReports(nodeConfigIds).toIO
+  }
+
+  /**
+   * get the current expected reports
+   * fails if request expected reports for a non existent node
+   */
+  def getCurrentExpectedReports(nodeIds: Set[NodeId]): IOResult[Map[NodeId, Option[NodeExpectedReports]]] = {
+    confExpectedRepo.getCurrentExpectedsReports(nodeIds).toIO
+  }
+
+  /**
+   * get the nodes applying the rule
+   *
+   */
+  def findNodesApplyingRule(ruleId: RuleId): IOResult[Set[NodeId]] = {
+    confExpectedRepo.findCurrentNodeIds(ruleId).toIO
+  }
+}
+

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
@@ -37,6 +37,7 @@
 
 package com.normation.rudder.services.reports
 
+import com.normation.errors.IOResult
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.logger.TimingDebugLogger
 import com.normation.rudder.domain.policies.RuleId
@@ -62,7 +63,7 @@ trait ReportingService {
   /**
    * A specialised version of `findRuleNodeStatusReports` to find node status reports for a given rule.
    */
-  def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): Box[Map[NodeId, NodeStatusReport]]
+  def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): IOResult[Map[NodeId, NodeStatusReport]]
 
   /**
     * find node status reports for a given node.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -37,12 +37,11 @@
 
 package com.normation.rudder.services.reports
 
-import com.normation.box._
-import com.normation.errors._
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.logger.ReportLogger
 import com.normation.rudder.domain.logger.ReportLoggerPure
 import com.normation.rudder.domain.logger.TimingDebugLogger
+import com.normation.rudder.domain.logger.TimingDebugLoggerPure
 import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.domain.policies.GlobalPolicyMode
 import com.normation.rudder.domain.policies.RuleId
@@ -61,6 +60,8 @@ import net.liftweb.common._
 import org.joda.time._
 import zio._
 import zio.syntax._
+import com.normation.box._
+import com.normation.errors._
 
 object ReportingServiceUtils {
 
@@ -91,16 +92,22 @@ object ReportingServiceUtils {
  * * remove a node from the cache (when the node is deleted)
  * * initialize compliance
  * * update compliance with a new run (with the new compliance)
+ * * init node configuration (at application startup for example - if an existing node configuration is stored for this node, this is discared)
  * * update node configuration (after a policy generation, with new nodeconfiguration)
  * * set the node in node answer state (with the new compliance?)
  */
+sealed trait CacheExpectedReportAction { def nodeId:NodeId }
+object CacheExpectedReportAction {
+  final case class InsertNodeInCache      (nodeId: NodeId                                          ) extends CacheExpectedReportAction
+  final case class RemoveNodeInCache      (nodeId: NodeId                                          ) extends CacheExpectedReportAction
+  final case class UpdateNodeConfiguration(nodeId: NodeId, nodeConfiguration: NodeExpectedReports  ) extends CacheExpectedReportAction // convert the nodestatursreport to pending, with info from last run
+}
+
 sealed trait CacheComplianceQueueAction { def nodeId:NodeId }
 object CacheComplianceQueueAction {
-  final case class InsertNodeInCache      (nodeId: NodeId                                          ) extends CacheComplianceQueueAction
-  final case class RemoveNodeInCache      (nodeId: NodeId                                          ) extends CacheComplianceQueueAction
+  final case class ExpectedReportAction   (action: CacheExpectedReportAction                       )  extends CacheComplianceQueueAction { def nodeId = action.nodeId }
   final case class InitializeCompliance   (nodeId: NodeId, nodeCompliance: Option[NodeStatusReport]) extends CacheComplianceQueueAction // do we need this?
   final case class UpdateCompliance       (nodeId: NodeId, nodeCompliance: NodeStatusReport        ) extends CacheComplianceQueueAction
-  final case class UpdateNodeConfiguration(nodeId: NodeId, nodeConfiguration: NodeExpectedReports  ) extends CacheComplianceQueueAction // convert the nodestatursreport to pending, with info from last run
   final case class SetNodeNoAnswer        (nodeId: NodeId, actionDate: DateTime                    ) extends CacheComplianceQueueAction
   final case class ExpiredCompliance      (nodeId: NodeId                                          ) extends CacheComplianceQueueAction
 }
@@ -116,6 +123,7 @@ class ReportingServiceImpl(
   , val nodeInfoService            : NodeInfoService
   , val directivesRepo             : RoDirectiveRepository
   , val rulesRepo                  : RoRuleRepository
+  , val nodeConfigService          : NodeConfigurationService
   , val getGlobalComplianceMode    : () => Box[GlobalComplianceMode]
   , val getGlobalPolicyMode        : () => IOResult[GlobalPolicyMode]
   , val getUnexpectedInterpretation: () => Box[UnexpectedReportInterpretation]
@@ -125,6 +133,7 @@ class ReportingServiceImpl(
 class CachedReportingServiceImpl(
     val defaultFindRuleNodeStatusReports: ReportingServiceImpl
   , val nodeInfoService                 : NodeInfoService
+  , val nodeConfigService               : NodeConfigurationService
   , val batchSize                       : Int
   , val complianceRepository            : ComplianceRepository
 ) extends ReportingService with RuleOrNodeReportingServiceImpl with CachedFindRuleNodeStatusReports {
@@ -144,19 +153,20 @@ class CachedReportingServiceImpl(
 trait RuleOrNodeReportingServiceImpl extends ReportingService {
 
   def confExpectedRepo: FindExpectedReportRepository
+  def nodeConfigService: NodeConfigurationService
   def directivesRepo  : RoDirectiveRepository
   def nodeInfoService : NodeInfoService
   def rulesRepo       : RoRuleRepository
 
-  override def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): Box[Map[NodeId, NodeStatusReport]] = {
+  override def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): IOResult[Map[NodeId, NodeStatusReport]] = {
     //here, the logic is ONLY to get the node for which that rule applies and then step back
     //on the other method
-    val time_0 = System.currentTimeMillis
     for {
-      nodeIds <- confExpectedRepo.findCurrentNodeIds(ruleId)
-      time_1  =  System.currentTimeMillis
-      _       =  TimingDebugLogger.debug(s"findCurrentNodeIds: Getting node IDs for rule '${ruleId.value}' took ${time_1-time_0}ms")
-      reports <- findRuleNodeStatusReports(nodeIds, Set(ruleId))
+      time_0  <- currentTimeMillis
+      nodeIds <- nodeConfigService.findNodesApplyingRule(ruleId)
+      time_1  <- currentTimeMillis
+      _       <- TimingDebugLoggerPure.debug(s"findCurrentNodeIds: Getting node IDs for rule '${ruleId.value}' took ${time_1 - time_0}ms")
+      reports <- findRuleNodeStatusReports(nodeIds, Set(ruleId)).toIO
     } yield {
       reports
     }
@@ -217,7 +227,7 @@ trait RuleOrNodeReportingServiceImpl extends ReportingService {
   def getUserNodeStatusReports() : Box[Map[NodeId, NodeStatusReport]] = {
     val n1 = System.currentTimeMillis
     for {
-      nodeIds            <- nodeInfoService.getAll().map(_.keySet)
+      nodeIds            <- nodeInfoService.getAllNodesIds().toBox
       userRules          <- rulesRepo.getIds().toBox
       n2                 = System.currentTimeMillis
       _                  = TimingDebugLogger.trace(s"Reporting service - Get nodes and users rules in: ${n2 - n1}ms")
@@ -228,23 +238,23 @@ trait RuleOrNodeReportingServiceImpl extends ReportingService {
   }
 
   def getUserAndSystemNodeStatusReports(optNodeIds: Option[Set[NodeId]]) : Box[(Map[NodeId, NodeStatusReport], Map[NodeId, NodeStatusReport])] = {
-    val n1 = System.currentTimeMillis
     for {
+      n1      <- currentTimeMillis
       nodeIds <- optNodeIds match {
-        case None => nodeInfoService.getAll().map(_.keySet)
-        case Some(ids) => Full(ids)
-      }
-      userRules <- rulesRepo.getIds().toBox
-      allRules <- rulesRepo.getIds(true).toBox
+                    case None => nodeInfoService.getAll().map(_.keySet)
+                    case Some(ids) => ids.succeed
+                  }
+      userRules <- rulesRepo.getIds()
+      allRules <- rulesRepo.getIds(true)
       systemRules = allRules.diff(userRules)
-      n2 = System.currentTimeMillis
-      _ = TimingDebugLogger.trace(s"Reporting service - Get nodes and rules in: ${n2 - n1}ms")
-      systemReports <- findRuleNodeStatusReports(nodeIds, systemRules)
-      userReports <- findRuleNodeStatusReports(nodeIds, userRules)
+      n2 <- currentTimeMillis
+      _  <- TimingDebugLoggerPure.trace(s"Reporting service - Get nodes and rules in: ${n2 - n1}ms")
+      systemReports <- findRuleNodeStatusReports(nodeIds, systemRules).toIO
+      userReports <- findRuleNodeStatusReports(nodeIds, userRules).toIO
     } yield {
       (systemReports, userReports)
     }
-  }
+  }.toBox
 
   def computeComplianceFromReports(reports: Map[NodeId, NodeStatusReport]): Option[(ComplianceLevel, Long)] =  {
     // if we don't have any report that is not a system one, the user-rule global compliance is undefined
@@ -308,8 +318,7 @@ trait CachedFindRuleNodeStatusReports extends ReportingService with CachedReposi
 
   /**
    * The queue of invalidation request.
-   * The queue size is 1 and new request need to merge existing
-   * node id with new ones.
+   * The queue size is 1 and new request need to merge with existing request
    * It's a List and not a Set, because we want to keep the precedence in
    * invalidation request.
    */
@@ -333,7 +342,6 @@ trait CachedFindRuleNodeStatusReports extends ReportingService with CachedReposi
       // * invalidate cache: ???
       // * no report from the node (compliance expires): recompute compliance
 
-      // as a first approach, they could simply findRuleNodeStatusReports
       {
         (for {
           _  <- performAction(actions)
@@ -352,6 +360,8 @@ trait CachedFindRuleNodeStatusReports extends ReportingService with CachedReposi
    */
   private[this] def performAction(actions: List[CacheComplianceQueueAction]): IOResult[Unit] = {
     import CacheComplianceQueueAction._
+    import CacheExpectedReportAction._
+
     ReportLoggerPure.Cache.debug(s"Performing action ${actions.headOption}") *>
     // get type of action
     (actions.headOption match {
@@ -368,11 +378,11 @@ trait CachedFindRuleNodeStatusReports extends ReportingService with CachedReposi
             _       <-  IOResult.effectNonBlocking { cache = cache ++ updates }
           } yield ())
 
-        case delete: RemoveNodeInCache =>
+        case ExpectedReportAction((RemoveNodeInCache(_))) =>
           for {
             deletes <- ZIO.foreach(actions) { case a => a match {
-                         case x: RemoveNodeInCache => x.nodeId.succeed
-                         case x                    => Inconsistency(s"Error: found an action of incorrect type in a 'delete' for cache: ${x}").fail
+                         case ExpectedReportAction((RemoveNodeInCache(nodeId))) => nodeId.succeed
+                         case x                                                 => Inconsistency(s"Error: found an action of incorrect type in a 'delete' for cache: ${x}").fail
                        }}
             _       <-  IOResult.effectNonBlocking { cache = cache.removedAll(deletes) }
           } yield ()
@@ -457,9 +467,9 @@ trait CachedFindRuleNodeStatusReports extends ReportingService with CachedReposi
    * This is handled in higher level of the app and leads to "no data available" in
    * place of compliance bar.
    */
-  private[this] def checkAndGetCache(nodeIdsToCheck: Set[NodeId]) : Box[Map[NodeId, NodeStatusReport]] = {
+  private[this] def checkAndGetCache(nodeIdsToCheck: Set[NodeId]) : IOResult[Map[NodeId, NodeStatusReport]] = {
     if(nodeIdsToCheck.isEmpty) {
-      Full(Map())
+      Map[NodeId, NodeStatusReport]().succeed
     } else {
       val now = DateTime.now
 
@@ -505,7 +515,7 @@ trait CachedFindRuleNodeStatusReports extends ReportingService with CachedReposi
         // starting with nodeIds, is all accepted node passed in parameter,
         // we don't miss node ids not yet in cache
         requireUpdate =  nodeIds -- upToDate.keySet
-        _             <- invalidateWithAction(requireUpdate.toSeq.map(x => (x, CacheComplianceQueueAction.SetNodeNoAnswer(x, DateTime.now())))).unit.toBox
+        _             <- invalidateWithAction(requireUpdate.toSeq.map(x => (x, CacheComplianceQueueAction.SetNodeNoAnswer(x, DateTime.now())))).unit
       } yield {
         ReportLogger.Cache.debug(s"Compliance cache to reload (expired, missing):[${requireUpdate.map(_.value).mkString(" , ")}]")
         if (ReportLogger.Cache.isTraceEnabled) {
@@ -525,7 +535,7 @@ trait CachedFindRuleNodeStatusReports extends ReportingService with CachedReposi
   override def findRuleNodeStatusReports(nodeIds: Set[NodeId], ruleIds: Set[RuleId]) : Box[Map[NodeId, NodeStatusReport]] = {
     val n1 = System.currentTimeMillis
     for {
-      reports <- checkAndGetCache(nodeIds)
+      reports <- checkAndGetCache(nodeIds).toBox
       n2      =  System.currentTimeMillis
       _       =  ReportLogger.Cache.debug(s"Get node compliance from cache in: ${n2 - n1}ms")
     } yield {
@@ -547,6 +557,7 @@ trait CachedFindRuleNodeStatusReports extends ReportingService with CachedReposi
 trait DefaultFindRuleNodeStatusReports extends ReportingService {
 
   def confExpectedRepo           : FindExpectedReportRepository
+  def nodeConfigService          : NodeConfigurationService
   def reportsRepository          : ReportsRepository
   def agentRunRepository         : RoReportsExecutionRepository
   def getGlobalComplianceMode    : () => Box[GlobalComplianceMode]
@@ -588,7 +599,7 @@ trait DefaultFindRuleNodeStatusReports extends ReportingService {
       complianceMode      <- getGlobalComplianceMode()
       unexpectedMode      <- getUnexpectedInterpretation()
       // we want compliance on these nodes
-      runInfos            <- getNodeRunInfos(nodeIds, complianceMode)
+      runInfos            <- getNodeRunInfos(nodeIds, complianceMode).toBox
       t1                  =  System.currentTimeMillis
       _                   =  TimingDebugLogger.trace(s"Compliance: get node run infos: ${t1-t0}ms")
 
@@ -620,22 +631,22 @@ trait DefaultFindRuleNodeStatusReports extends ReportingService {
    * A value is return for ALL nodeIds, so the assertion nodeIds == returnedMap.keySet holds.
    *
    */
-  private[this] def getNodeRunInfos(nodeIds: Set[NodeId], complianceMode: GlobalComplianceMode): Box[Map[NodeId, RunAndConfigInfo]] = {
-    val t0 = System.currentTimeMillis
+  private[this] def getNodeRunInfos(nodeIds: Set[NodeId], complianceMode: GlobalComplianceMode): IOResult[Map[NodeId, RunAndConfigInfo]] = {
     for {
+      t0                <- currentTimeMillis
       runs              <- complianceMode.mode match {
                             //this is an optimisation to avoid querying the db in that case
-                             case ReportsDisabled => Full(nodeIds.map(id => (id, None)).toMap)
+                             case ReportsDisabled => nodeIds.map(id => (id, None)).toMap.succeed
                              case _ => agentRunRepository.getNodesLastRun(nodeIds)
                            }
-      t1                =  System.currentTimeMillis
-      _                 =  TimingDebugLogger.trace(s"Compliance: get nodes last run : ${t1-t0}ms")
-      currentConfigs    <- confExpectedRepo.getCurrentExpectedsReports(nodeIds)
-      t2                =  System.currentTimeMillis
-      _                 =  TimingDebugLogger.trace(s"Compliance: get current expected reports: ${t2-t1}ms")
-      nodeConfigIdInfos <- confExpectedRepo.getNodeConfigIdInfos(nodeIds)
-      t3                =  System.currentTimeMillis
-      _                 =  TimingDebugLogger.trace(s"Compliance: get Node Config Id Infos: ${t3-t2}ms")
+      t1                <- currentTimeMillis
+      _                 <- TimingDebugLoggerPure.trace(s"Compliance: get nodes last run : ${t1-t0}ms")
+      currentConfigs    <- nodeConfigService.getCurrentExpectedReports(nodeIds)
+      t2                <- currentTimeMillis
+      _                 <- TimingDebugLoggerPure.trace(s"Compliance: get current expected reports: ${t2-t1}ms")
+      nodeConfigIdInfos <- confExpectedRepo.getNodeConfigIdInfos(nodeIds).toIO
+      t3                <- currentTimeMillis
+      _                 <- TimingDebugLoggerPure.trace(s"Compliance: get Node Config Id Infos: ${t3-t2}ms")
     } yield {
       ExecutionBatch.computeNodesRunInfo(runs, currentConfigs, nodeConfigIdInfos)
     }
@@ -697,7 +708,7 @@ trait DefaultFindRuleNodeStatusReports extends ReportingService {
       t1                =  System.currentTimeMillis
       _                 =  TimingDebugLogger.trace(s"Compliance: get nodes last run : ${t1-t0}ms")
       nodeIds           = runs.keys.toSet
-      currentConfigs    <- confExpectedRepo.getCurrentExpectedsReports(nodeIds)
+      currentConfigs    <- nodeConfigService.getCurrentExpectedReports(nodeIds).toBox
       t2                =  System.currentTimeMillis
       _                 =  TimingDebugLogger.trace(s"Compliance: get current expected reports: ${t2-t1}ms")
       nodeConfigIdInfos <- confExpectedRepo.getNodeConfigIdInfos(nodeIds)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
@@ -84,6 +84,9 @@ import com.normation.rudder.repository.WoNodeGroupRepository
 import com.normation.rudder.repository.ldap.LDAPEntityMapper
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.services.queries.QueryProcessor
+import com.normation.rudder.services.reports.CacheComplianceQueueAction.ExpectedReportAction
+import com.normation.rudder.services.reports.CacheExpectedReportAction.InsertNodeInCache
+import com.normation.rudder.services.reports.{CachedFindRuleNodeStatusReports, CachedNodeConfigurationService}
 import com.normation.utils.Control.sequence
 import net.liftweb.common.Box
 import net.liftweb.common.Empty
@@ -166,7 +169,7 @@ class PostNodeAcceptanceHookScripts(
     val postHooksTime =  System.currentTimeMillis
     HooksLogger.debug(s"Executing post-node-acceptance hooks for node with id '${nodeId.value}'")
     for {
-      optNodeInfo   <- nodeInfoService.getNodeInfo(nodeId)
+      optNodeInfo   <- nodeInfoService.getNodeInfo(nodeId).toBox
       nodeInfo      <- optNodeInfo match {
                          case None    => Failure(s"Just accepted node with id '${nodeId.value}' was not found - perhaps a bug?"+
                                                   " Please report with /var/log/rudder/webapp/DATE_OF_DAY.stdout.log file attached")
@@ -197,20 +200,22 @@ class PostNodeAcceptanceHookScripts(
  * Rollback is always a "best effort" task.
  */
 class NewNodeManagerImpl(
-    override val ldap                 : LDAPConnectionProvider[RoLDAPConnection]
-  , override val pendingNodesDit      : InventoryDit
-  , override val acceptedNodesDit     : InventoryDit
-  , override val serverSummaryService : NodeSummaryServiceImpl
-  , override val smRepo               : LDAPFullInventoryRepository
-  , override val unitAcceptors        : Seq[UnitAcceptInventory]
-  , override val unitRefusors         : Seq[UnitRefuseInventory]
-  ,          val historyLogRepository : InventoryHistoryLogRepository
-  ,          val eventLogRepository   : EventLogRepository
-  , override val updateDynamicGroups  : UpdateDynamicGroups
-  ,          val cacheToClear         : List[CachedRepository]
-  ,              nodeInfoService      : NodeInfoService
-  ,              HOOKS_D              : String
-  ,              HOOKS_IGNORE_SUFFIXES: List[String]
+    override val ldap                  : LDAPConnectionProvider[RoLDAPConnection]
+  , override val pendingNodesDit       : InventoryDit
+  , override val acceptedNodesDit      : InventoryDit
+  , override val serverSummaryService  : NodeSummaryServiceImpl
+  , override val smRepo                : LDAPFullInventoryRepository
+  , override val unitAcceptors         : Seq[UnitAcceptInventory]
+  , override val unitRefusors          : Seq[UnitRefuseInventory]
+  ,          val historyLogRepository  : InventoryHistoryLogRepository
+  ,          val eventLogRepository    : EventLogRepository
+  , override val updateDynamicGroups   : UpdateDynamicGroups
+  ,          val cacheToClear          : List[CachedRepository]
+  , override val cachedNodeConfigurationService: CachedNodeConfigurationService
+  , override val cachedReportingService: CachedFindRuleNodeStatusReports
+  ,              nodeInfoService       : NodeInfoService
+  ,              HOOKS_D               : String
+  ,              HOOKS_IGNORE_SUFFIXES : List[String]
 ) extends NewNodeManager with ListNewNode with ComposedNewNodeManager with NewNodeManagerHooks {
 
   private[this] val codeHooks = collection.mutable.Buffer[NewNodeManagerHooks]()
@@ -320,6 +325,9 @@ trait ComposedNewNodeManager extends NewNodeManager with NewNodeManagerHooks {
   def eventLogRepository : EventLogRepository
 
   def updateDynamicGroups : UpdateDynamicGroups
+
+  def cachedNodeConfigurationService: CachedNodeConfigurationService
+  def cachedReportingService        : CachedFindRuleNodeStatusReports
 
   def cacheToClear: List[CachedRepository]
 
@@ -585,6 +593,14 @@ trait ComposedNewNodeManager extends NewNodeManager with NewNodeManagerHooks {
 
          // Update hooks for the node
          afterNodeAcceptedAsync(id)
+         // ping the NodeConfiguration Cache and NodeCompliance Cache about this new node
+
+         for {
+           _ <- cachedNodeConfigurationService.invalidateWithAction(Seq((id, InsertNodeInCache(id)))).toBox ?~! s"Error when adding node ${id.value} to node configuration cache"
+           _ <- cachedReportingService.invalidateWithAction(Seq((id, ExpectedReportAction(InsertNodeInCache(id))))).toBox ?~! s"Error when adding node ${id.value} to compliance cache"
+         } yield {
+           ()
+         }
          acceptationResults
        }
     )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/RemoveNodeService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/RemoveNodeService.scala
@@ -42,7 +42,6 @@ import java.nio.file.Paths
 import java.nio.file.attribute.BasicFileAttributes
 import java.util.function.BiPredicate
 import java.util.function.Consumer
-
 import com.normation.box._
 import com.normation.errors._
 import com.normation.eventlog.EventActor
@@ -86,6 +85,9 @@ import com.normation.rudder.services.nodes.NodeInfoService.A_MOD_TIMESTAMP
 import com.normation.rudder.services.nodes.NodeInfoServiceCached
 import com.normation.rudder.services.policies.write.NodePoliciesPaths
 import com.normation.rudder.services.policies.write.PathComputer
+import com.normation.rudder.services.reports.CacheComplianceQueueAction.ExpectedReportAction
+import com.normation.rudder.services.reports.CacheExpectedReportAction.RemoveNodeInCache
+import com.normation.rudder.services.reports.{CachedFindRuleNodeStatusReports, CachedNodeConfigurationService}
 import com.normation.rudder.services.servers.DeletionResult._
 import com.unboundid.ldap.sdk.Modification
 import com.unboundid.ldap.sdk.ModificationType
@@ -187,6 +189,8 @@ class RemoveNodeServiceImpl(
     , nodeLibMutex              : ScalaReadWriteLock //that's a scala-level mutex to have some kind of consistency with LDAP
     , nodeInfoServiceCache      : NodeInfoService with CachedRepository
     , nodeConfigurationsRepo    : UpdateExpectedReportsRepository
+    , nodeConfigurationService  : CachedNodeConfigurationService
+    , reportingService          : CachedFindRuleNodeStatusReports
     , pathComputer              : PathComputer
     , newNodeManager            : NewNodeManager
     , HOOKS_D                   : String
@@ -205,8 +209,9 @@ class RemoveNodeServiceImpl(
    * External services can update it.
    */
   val postNodeDeleteActions = Ref.make(
-       new RemoveFromCache(nodeInfoService)
+       new RemoveNodeInfoFromCache(nodeInfoService)
     :: new CloseNodeConfiguration(nodeConfigurationsRepo)
+    :: new RemoveNodeFromComplianceCache(nodeConfigurationService, reportingService)
     :: new DeletePolicyServerPolicies(policyServerManagement)
     :: new ResetKeyStatus(ldap, deletedDit)
     :: new CleanUpCFKeys()
@@ -244,14 +249,14 @@ class RemoveNodeServiceImpl(
           // always delete in order pending then accepted then deleted
            res1  <- if(status.contains(PendingInventory)) {
                       (for {
-                        i <- nodeInfoService.getPendingNodeInfoPure(nodeId)
+                        i <- nodeInfoService.getPendingNodeInfo(nodeId)
                         r <- deletePendingNode(nodeId, mode, modId, actor)
                         _ <- info.set(i)
                       } yield r).catchAll(err => Error(err).succeed)
                     } else Success.succeed
            res2  <- if(status.contains(AcceptedInventory)) {
                       (for {
-                        i <- nodeInfoService.getNodeInfoPure(nodeId)
+                        i <- nodeInfoService.getNodeInfo(nodeId)
                         r <- i match {
                                case None    => Success.succeed // perhaps deleted or something
                                case Some(x) => info.set(Some(x)) *> deleteAcceptedNode(x, mode, modId, actor)
@@ -260,7 +265,7 @@ class RemoveNodeServiceImpl(
                     } else Success.succeed
            res3  <- if(status.contains(RemovedInventory)) {
                       (for {
-                        i <- nodeInfoService.getDeletedNodeInfoPure(nodeId)
+                        i <- nodeInfoService.getDeletedNodeInfo(nodeId)
                         r <- deleteDeletedNode(nodeId, mode, modId, actor)
                         // only update if nodeInfo is not already set, b/c accepted has more info
                         _ <- info.update(opt => opt.orElse(i))
@@ -398,7 +403,7 @@ class RemoveNodeServiceImpl(
           Map((node.id, node)).succeed
         } else {
           for {
-            opt    <- nodeInfoService.getNodeInfoPure(node.policyServerId)
+            opt    <- nodeInfoService.getNodeInfo(node.policyServerId)
             parent <- opt.notOptional(s"The policy server '${node.policyServerId.value}' for node ${node.hostname} ('${node.id.value}') was not found in Rudder")
             rec    <- recGetParent(parent)
           } yield {
@@ -514,12 +519,28 @@ class RemoveNodeServiceImpl(
 }
 
 
-class RemoveFromCache(nodeInfoService: NodeInfoServiceCached) extends PostNodeDeleteAction {
+class RemoveNodeInfoFromCache(nodeInfoService: NodeInfoServiceCached) extends PostNodeDeleteAction {
   override def run(nodeId: NodeId, mode: DeleteMode, info: Option[NodeInfo], status: Set[InventoryStatus]): UIO[Unit] = {
     NodeLoggerPure.Delete.debug(s"  - remove node from NodeInfoService Cache'${nodeId.value}'") *>
     nodeInfoService.removeNodeFromCache(nodeId).catchAll(err =>
       NodeLoggerPure.Delete.error(s"Error when removing node ${(nodeId, info).name} from cache: ${err.fullMsg}")
     )
+  }
+}
+
+class RemoveNodeFromComplianceCache(
+       configurationService: CachedNodeConfigurationService
+     , cachedCompliance    : CachedFindRuleNodeStatusReports) extends PostNodeDeleteAction {
+  override def run(nodeId: NodeId, mode: DeleteMode, info: Option[NodeInfo], status: Set[InventoryStatus]): UIO[Unit] = {
+      for {
+        _            <- NodeLoggerPure.Delete.debug(s"  - remove node ${nodeId.value} from compliance and expected report cache")
+        _            <- configurationService.invalidateWithAction(Seq((nodeId, RemoveNodeInCache(nodeId)))).catchAll(err =>
+                          NodeLoggerPure.Delete.error(s"Error when removing node ${nodeId.value} from node configuration cache: ${err.fullMsg}"))
+        _            <- cachedCompliance.invalidateWithAction(Seq((nodeId, ExpectedReportAction(RemoveNodeInCache(nodeId))))).catchAll(err =>
+                            NodeLoggerPure.Delete.error(s"Error when removing node ${nodeId.value} from compliance cache: ${err.fullMsg}"))
+      } yield {
+        ()
+      }
   }
 }
 /*

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/NodeInfoServiceCachedTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/NodeInfoServiceCachedTest.scala
@@ -1,5 +1,6 @@
 package com.normation.rudder.services.nodes
 
+import com.normation.errors.IOResult
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.AcceptedInventory
@@ -45,7 +46,6 @@ import com.normation.rudder.services.servers.UnitAcceptInventory
 import com.normation.rudder.services.servers.UnitRefuseInventory
 import com.unboundid.ldap.sdk.Filter
 import com.unboundid.ldap.sdk.{DN, RDN}
-import net.liftweb.common.Box
 import net.liftweb.common.Full
 import org.joda.time.DateTime
 import org.junit.runner.RunWith
@@ -57,6 +57,7 @@ import scala.collection.mutable.{Map => MutMap}
 import scala.collection.mutable.Buffer
 import scala.concurrent.duration.FiniteDuration
 import com.softwaremill.quicklens._
+import net.liftweb.common.Box
 
 /*
  * Test the cache behaviour
@@ -313,10 +314,16 @@ class NodeInfoServiceCachedTest extends Specification {
       }
     }
 
-    implicit class ForceGet[A](b: Box[A]) {
+    implicit class ForceGetBox[A](b: Box[A]) {
       def forceGet = b match {
         case Full(a) => a
         case eb      => throw new IllegalArgumentException(s"Error during test, box is an erro: ${eb}")
+      }
+    }
+    implicit class ForceGetIO[A](b: IOResult[A]) {
+      def forceGet = b.either.runNow match {
+        case Right(a)  => a
+        case Left(err) => throw new IllegalArgumentException(s"Error during test, box is an erro: ${err.fullMsg}")
       }
     }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -62,6 +62,7 @@ import org.joda.time.DateTime
 import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
+import zio.syntax._
 
 /*
  * Test the cache behaviour
@@ -131,19 +132,19 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
   )
 
   object testNodeInfoService extends NodeInfoService {
-    def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : Box[Set[LDAPNodeInfo]] = ???
-    def getNodeInfo(nodeId: NodeId) : Box[Option[NodeInfo]] = ???
-    def getNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
+    def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : IOResult[Set[LDAPNodeInfo]] = ???
+    def getNodeInfo(nodeId: NodeId) : IOResult[Option[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???
-    def getAllNodes() : Box[Map[NodeId, Node]] = ???
-    def getAllSystemNodeIds() : Box[Seq[NodeId]] = ???
-    def getPendingNodeInfos(): Box[Map[NodeId, NodeInfo]] = ???
-    def getPendingNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
-    def getDeletedNodeInfos(): Box[Map[NodeId, NodeInfo]] = ???
-    def getDeletedNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
+    def getAllNodes() : IOResult[Map[NodeId, Node]] = ???
+    def getAllNodesIds(): IOResult[Set[NodeId]] = ???
+    def getAllSystemNodeIds() : IOResult[Seq[NodeId]] = ???
+    def getPendingNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = ???
+    def getPendingNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
+    def getDeletedNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = ???
+    def getDeletedNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
     def getNumberOfManagedNodes: Int = ???
-    val getAll : Box[Map[NodeId, NodeInfo]] = {
-      Full(nodes.map { case (n, _, _) => (n.id, n) }.toMap)
+    val getAll : IOResult[Map[NodeId, NodeInfo]] = {
+      nodes.map { case (n, _, _) => (n.id, n) }.toMap.succeed
     }
   }
 
@@ -160,7 +161,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
       override def agentRunRepository: RoReportsExecutionRepository = ???
       override def getGlobalComplianceMode: () => Box[GlobalComplianceMode] = ???
       override def getUnexpectedInterpretation: () => Box[UnexpectedReportInterpretation] = ???
-      override def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): Box[Map[NodeId, NodeStatusReport]] = ???
+      override def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): IOResult[Map[NodeId, NodeStatusReport]] = ???
       override def getUserNodeStatusReports(): Box[Map[NodeId, NodeStatusReport]] = ???
       override def getUserAndSystemNodeStatusReports(optNodeIds: Option[Set[NodeId]]): Box[(Map[NodeId, NodeStatusReport], Map[NodeId, NodeStatusReport])] = ???
       override def computeComplianceFromReports(reports: Map[NodeId, NodeStatusReport]): Option[(ComplianceLevel, Long)] = ???
@@ -168,7 +169,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
       override def findNodeStatusReport(nodeId: NodeId): Box[NodeStatusReport] = ???
       override def findUserNodeStatusReport(nodeId: NodeId): Box[NodeStatusReport] = ???
       override def findSystemNodeStatusReport(nodeId: NodeId): Box[NodeStatusReport] = ???
-
+      override def nodeConfigService: NodeConfigurationService = ???
       override def jdbcMaxBatchSize: Int = batchSize
       override def findRuleNodeStatusReports(nodeIds: Set[NodeId], ruleIds: Set[RuleId]): Box[Map[NodeId, NodeStatusReport]] = {
         updated = (updated ++ nodeIds)
@@ -176,7 +177,8 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
       }
     }
     override def nodeInfoService: NodeInfoService = testNodeInfoService
-    override def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): Box[Map[NodeId, NodeStatusReport]] = ???
+
+    override def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): IOResult[Map[NodeId, NodeStatusReport]] = ???
     override def findNodeStatusReport(nodeId: NodeId): Box[NodeStatusReport] = ???
     override def findUncomputedNodeStatusReports() : Box[Map[NodeId, NodeStatusReport]] = ???
     override def getUserNodeStatusReports(): Box[Map[NodeId, NodeStatusReport]] = ???

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/JsInitContextLinkUtil.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/JsInitContextLinkUtil.scala
@@ -43,7 +43,6 @@ import com.normation.rudder.domain.policies.RuleId
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.workflows.ChangeRequestId
 import net.liftweb.http.S
-import net.liftweb.common.Full
 import net.liftweb.common.Loggable
 import com.normation.rudder.domain.policies.RuleTarget
 import net.liftweb.http.js.JsCmds.RedirectTo
@@ -162,8 +161,8 @@ class LinkUtil (
   }
 
   def createNodeLink(id: NodeId) = {
-    nodeInfoService.getNodeInfo(id) match {
-      case Full(Some(node)) =>
+    nodeInfoService.getNodeInfo(id).either.runNow match {
+      case Right(Some(node)) =>
         <span>Node <a href={baseNodeLink(id)}>{node.hostname}</a> (Rudder ID: {id.value})</span>
       case _ =>
         <span>Node {id.value}</span>

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -1479,21 +1479,21 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     def _info(node: NodeDetails) = Option(node.info)
     def _fullInventory(node: NodeDetails) = Option(FullInventory(node.nInv, node.mInv))
 
-    override def getNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = getGenericOne(nodeId, AcceptedInventory, _info)
-    override def getNodeInfo(nodeId: NodeId): Box[Option[NodeInfo]] = getNodeInfoPure(nodeId).toBox
+    override def getNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = getGenericOne(nodeId, AcceptedInventory, _info)
 
-    override def getAll(): Box[Map[NodeId, NodeInfo]] = getGenericAll(AcceptedInventory, _info).toBox
+    override def getAll(): IOResult[Map[NodeId, NodeInfo]] = getGenericAll(AcceptedInventory, _info)
 
-    override def getAllNodes(): Box[Map[NodeId, Node]] = getAll().map(_.map(kv => (kv._1, kv._2.node)))
-    override def getAllSystemNodeIds(): Box[Seq[NodeId]] = {
-      nodeBase.get.map(_.collect { case (id, n)  if(n.info.isSystem) => id }.toSeq ).toBox
+    override def getAllNodes(): IOResult[Map[NodeId, Node]] = getAll().map(_.map(kv => (kv._1, kv._2.node)))
+    override def getAllNodesIds(): IOResult[Set[NodeId]] = getAllNodes().map(_.keySet)
+    override def getAllSystemNodeIds(): IOResult[Seq[NodeId]] = {
+      nodeBase.get.map(_.collect { case (id, n)  if(n.info.isSystem) => id }.toSeq )
     }
 
-    override def getPendingNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = getGenericOne(nodeId, PendingInventory, _info)
-    override def getPendingNodeInfos(): Box[Map[NodeId, NodeInfo]] = getGenericAll(PendingInventory, _info).toBox
+    override def getPendingNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = getGenericOne(nodeId, PendingInventory, _info)
+    override def getPendingNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = getGenericAll(PendingInventory, _info)
 
-    override def getDeletedNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = getGenericOne(nodeId, RemovedInventory, _info)
-    override def getDeletedNodeInfos(): Box[Map[NodeId, NodeInfo]] = getGenericAll(RemovedInventory, _info).toBox
+    override def getDeletedNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = getGenericOne(nodeId, RemovedInventory, _info)
+    override def getDeletedNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = getGenericAll(RemovedInventory, _info)
 
     override def get(id: NodeId, inventoryStatus: InventoryStatus): IOResult[Option[FullInventory]] = getGenericOne(id, inventoryStatus, _fullInventory)
     override def get(id: NodeId): IOResult[Option[FullInventory]] = {
@@ -1508,7 +1508,7 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     override def getAllNodeInventories(inventoryStatus: InventoryStatus): IOResult[Map[NodeId, NodeInventory]] = getGenericAll(inventoryStatus, _fullInventory(_).map(_.node))
 
     // not implemented yet
-    override def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition): Box[Set[LDAPNodeInfo]] = ???
+    override def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition): IOResult[Set[LDAPNodeInfo]] = ???
     override def getNumberOfManagedNodes: Int = ???
     override def save(serverAndMachine: FullInventory): IOResult[Seq[LDIFChangeRecord]] = ???
     override def delete(id: NodeId, inventoryStatus: InventoryStatus): IOResult[Seq[LDIFChangeRecord]] = ???

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -60,7 +60,6 @@ import com.normation.rudder.domain.appconfig.FeatureSwitch
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.parameters.GlobalParameter
-import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.GlobalPolicyMode
 import com.normation.rudder.domain.policies.PolicyMode.Audit
 import com.normation.rudder.domain.policies.PolicyModeOverrides
@@ -108,7 +107,6 @@ import com.normation.rudder.services.queries.CmdbQueryParser
 import com.normation.rudder.services.queries.DefaultStringQueryParser
 import com.normation.rudder.services.queries.DynGroupUpdaterServiceImpl
 import com.normation.rudder.services.queries.JsonQueryLexer
-import com.normation.rudder.services.reports.CacheComplianceQueueAction
 import com.normation.rudder.services.servers.DeleteMode
 import com.normation.rudder.services.system.DebugInfoScriptResult
 import com.normation.rudder.services.system.DebugInfoService
@@ -155,6 +153,7 @@ import com.normation.rudder.domain.policies.DirectiveUid
 import org.apache.commons.io.FileUtils
 
 import java.nio.charset.StandardCharsets
+import com.normation.rudder.services.reports.CacheExpectedReportAction
 
 
 /*
@@ -253,7 +252,7 @@ class RestTestSetUp {
   val policyGeneration = new PromiseGenerationService {
     override def deploy(): Box[Set[NodeId]] = Full(Set())
     override def getAllNodeInfos(): Box[Map[NodeId, NodeInfo]] = ???
-    override def getDirectiveLibrary(ids: Set[DirectiveId]): Box[FullActiveTechniqueCategory] = ???
+    override def getDirectiveLibrary(): Box[FullActiveTechniqueCategory] = ???
     override def getGroupLibrary(): Box[FullNodeGroupCategory] = ???
     override def getAllGlobalParameters: Box[Seq[GlobalParameter]] = ???
     override def getAllInventories(): Box[Map[NodeId, NodeInventory]] = ???
@@ -287,7 +286,7 @@ class RestTestSetUp {
     override def runPreHooks(generationTime: DateTime, systemEnv: HookEnvPairs): Box[Unit] = ???
     override def runPostHooks(generationTime: DateTime, endTime: DateTime, idToConfiguration: Map[NodeId, NodeInfo], systemEnv: HookEnvPairs, nodeIdsPath: String): Box[Unit] = ???
     override def runFailureHooks(generationTime: DateTime, endTime: DateTime, systemEnv: HookEnvPairs, errorMessage: String, errorMessagePath: String): Box[Unit] = ???
-    override def invalidateComplianceCache(actions: Seq[(NodeId, CacheComplianceQueueAction)]): Unit = ???
+    override def invalidateComplianceCache(actions: Seq[(NodeId, CacheExpectedReportAction)]): IOResult[Unit] = ???
   }
   val asyncDeploymentAgent = new AsyncDeploymentActor(policyGeneration, eventLogger, deploymentStatusSerialisation, () => Duration("0s").succeed, () => AllGeneration.succeed)
 
@@ -547,7 +546,7 @@ class RestTestSetUp {
   val nodeInfo = mockNodes.nodeInfoService
   val softDao = mockNodes.softwareDao
   val roReportsExecutionRepository = new RoReportsExecutionRepository {
-    override def getNodesLastRun(nodeIds: Set[NodeId]): Box[Map[NodeId, Option[AgentRunWithNodeConfig]]] = Full(Map())
+    override def getNodesLastRun(nodeIds: Set[NodeId]): IOResult[Map[NodeId, Option[AgentRunWithNodeConfig]]] = Map.empty[NodeId, Option[AgentRunWithNodeConfig]].succeed
 
     def getNodesAndUncomputedCompliance(): IOResult[Map[NodeId, Option[AgentRunWithNodeConfig]]] = ???
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -65,6 +65,7 @@ import com.normation.rudder.services.workflows.NodeGroupChangeRequest
 import com.normation.rudder.web.ChooseTemplate
 import net.liftweb.util.CssSel
 import com.normation.zio._
+import com.normation.box._
 
 object NodeGroupForm {
   val templatePath = "templates-hidden" :: "components" :: "NodeGroupForm" :: Nil
@@ -127,7 +128,7 @@ class NodeGroupForm(
   private[this] def getNodeList(target: Either[NonGroupRuleTarget, NodeGroup]): Box[Seq[NodeInfo]] = {
 
     for {
-      nodes  <- nodeInfoService.getAll()
+      nodes  <- nodeInfoService.getAll().toBox
       setIds =  target match {
                   case Right(nodeGroup) => nodeGroup.serverList
                   case Left(target) =>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleEditForm.scala
@@ -157,7 +157,7 @@ class RuleEditForm(
   private[this] val boxRootRuleCategory = getRootRuleCategory()
 
   private[this] def showForm(idToScroll  : String = "editRuleZonePortlet") : NodeSeq = {
-    (getFullNodeGroupLib().toBox, getFullDirectiveLib().toBox, getAllNodeInfos(), boxRootRuleCategory.toBox, configService.rudder_global_policy_mode().toBox) match {
+    (getFullNodeGroupLib().toBox, getFullDirectiveLib().toBox, getAllNodeInfos().toBox, boxRootRuleCategory.toBox, configService.rudder_global_policy_mode().toBox) match {
       case (Full(groupLib), Full(directiveLib), Full(nodeInfos), Full(rootRuleCategory), Full(globalMode)) =>
 
         val form = {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -62,7 +62,7 @@ import com.normation.box._
 import com.normation.inventory.domain.AgentType
 import com.normation.rudder.web.model.JsNodeId
 import org.joda.time.DateTime
-
+import com.normation.errors._
 
 /**
  * Display the last reports of a server
@@ -466,10 +466,11 @@ class ReportDisplayer(
     """))
   }
 
-  private[this] def getComplianceData(nodeId: NodeId, reportStatus: NodeStatusReport) = {
+  // this method cannot return an IOResult, as it uses S.
+  private[this] def getComplianceData(nodeId: NodeId, reportStatus: NodeStatusReport): Box[JsTableData[RuleComplianceLine]] = {
     for {
       directiveLib <- directiveRepository.getFullDirectiveLibrary().toBox
-      allNodeInfos <- getAllNodeInfos()
+      allNodeInfos <- getAllNodeInfos().toBox
       rules        <- ruleRepository.getAll(true).toBox
       globalMode   <- configService.rudder_global_policy_mode().toBox
     } yield {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -123,7 +123,7 @@ object HomePage {
   def initNodeInfos(): Box[Map[NodeId, NodeInfo]] = {
     TimingDebugLogger.debug(s"Start timing homepage")
     val n1 = System.currentTimeMillis
-    val n = nodeInfosService.getAll()
+    val n = nodeInfosService.getAll().toBox
     val n2 = System.currentTimeMillis
     TimingDebugLogger.debug(s"Getting node infos: ${n2 - n1}ms")
     n


### PR DESCRIPTION
https://issues.rudder.io/issues/19151

This PR adds a cache for NodeExpectedReports. This cache works as a map of [NodeId, Option]. The cache is inited with all nodes, and None for each NodeExpectedReports. 
Then once we search for *current* expected reports, cache is explored, and fetched expected reports are added to the cache.
When a policy generation happens, it also update the current expected reports for modified nodes

The rational is that it is *really* expensive to fetch these from the database, and keeping them in the cache does improve perfs.
