### PR TITLE
Fixes #19588: Missing lint section in rudderc config file

### DIFF
--- a/language/tools/rudderc-prod.conf
+++ b/language/tools/rudderc-prod.conf
@@ -9,6 +9,10 @@ stdlib ="/opt/rudder/share/language/lib/"
 input="/var/rudder/configuration-repository/techniques/ncf_techniques/"
 output="/tmp/rudderc/tester/"
 
+[lint]
+input="/var/rudder/configuration-repository/techniques/ncf_techniques/"
+output="/tmp/rudderc/tester/"
+
 [save]
 input="/tmp/rudderc/tester/"
 output="/tmp/rudderc/tester/"


### PR DESCRIPTION
https://issues.rudder.io/issues/19588