### PR TITLE
Fixes #19597: Properties tab is broken in rudder 7.0

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/javascript/rudder/angular/nodeProperties.js
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/javascript/rudder/angular/nodeProperties.js
@@ -131,7 +131,7 @@ nodePropertiesApp.controller('nodePropertiesCtrl', function ($scope, $http, DTOp
     var getUrlAPI = contextPath + '/secure/api/'+ objectName +'s/' + nodeId + '/displayInheritedProperties';
     $scope.fetchProperties = function() {
       return $http.get(getUrlAPI).success( function (result) {
-        $scope.properties = result.data[objectName +'s'][0].properties
+        $scope.properties = result.data[0].properties
       }).error(function(){createErrorNotification("Error while fetching "+objectName+" properties")});
     };
     $scope.fetchProperties();


### PR DESCRIPTION
https://issues.rudder.io/issues/19597

It's a bad merge from https://issues.rudder.io/issues/18879 which revert change from 6.2 https://issues.rudder.io/issues/19085