### PR TITLE
Fixes #19639: Updgrade zio-json to last version for rudder 7.0

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -416,7 +416,7 @@ limitations under the License.
     <cats-effect-version>2.5.1</cats-effect-version>
     <dev-zio-version>1.0.10</dev-zio-version>
     <zio-cats-version>2.3.1.0</zio-cats-version>
-    <zio-json-version>0.1</zio-json-version>
+    <zio-json-version>0.2.0-M1</zio-json-version>
 
     <!--
       Hack to make scalac jvm parameters like RAM configurable.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
@@ -56,7 +56,6 @@ import com.normation.inventory.domain.SecurityToken
 import com.normation.inventory.ldap.core.InventoryDit
 import com.normation.rudder.services.reports.CacheComplianceQueueAction
 import com.normation.rudder.services.reports.CacheExpectedReportAction
-import com.normation.rudder.services.reports.CachedNodeConfigurationService
 import com.normation.rudder.services.reports.InvalidateCache
 import zio._
 import zio.syntax._

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/JsonSchema.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/JsonSchema.scala
@@ -56,8 +56,7 @@ import net.liftweb.http.InMemoryResponse
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
 import zio.json.DeriveJsonEncoder
-import zio.json.JsonCodec._
-import zio.json.{EncoderOps => _, _}
+import zio.json._
 import zio.json.internal.Write
 import com.normation.errors._
 import com.normation.rudder.domain.properties.GlobalParameter


### PR DESCRIPTION
https://issues.rudder.io/issues/19639

- *lot* of security / decoding problem fixed
- amazing perf boost thanks to jsoniter author, 
- availability of an `Json` ast from/to which we can parse objects. Much more flexible for complexe cases. 