### PR TITLE
Fixes #19729: Secret variable engine 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/secret/Secret.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/secret/Secret.scala
@@ -1,0 +1,3 @@
+package com.normation.rudder.domain.secret
+
+final case class Secret(name: String, value: String, description: String)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/PropertyEngineService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/PropertyEngineService.scala
@@ -1,9 +1,16 @@
 package com.normation.rudder.services.nodes
 
+import better.files.File
 import com.normation.errors._
+import com.normation.rudder.domain.logger.NodePropertiesLoggerPure
+import com.normation.rudder.domain.secret.Secret
 import com.normation.zio._
+import net.liftweb.json.JsonParser
 import zio.Ref
 import zio.UIO
+import zio.syntax.ToZio
+
+import java.nio.charset.StandardCharsets
 
 final case class EngineOption(name: String, value: String)
 
@@ -40,5 +47,65 @@ class PropertyEngineServiceImpl(listOfEngine: List[RudderPropertyEngine]) extend
     for {
       _ <- engines.update(_ + (engine.name.toLowerCase -> engine))
     } yield ()
+  }
+}
+
+/*   Secret variable engine
+ *   -----------------------------------
+ *
+ *   To use this engine, the private plugin `secret-management` should be installed
+ *   or at least the configuration file should be present.
+ *
+ *   This engine check the in /var/rudder/configuration-repository/secrets/secrets.json
+ *   to interpolated in a node property a format like :
+ *        ${engine.secret[variable_name]}
+ *   by the `variable_name` value from this file.
+ *
+ *   + This engine doesn't take any options
+ *   + Only one namespace is allowed
+ */
+object SecretVariableEngine extends RudderPropertyEngine {
+  def name = "secret"
+
+  private [this] def verifyEntries(namespace: List[String], opt: Option[List[EngineOption]]): UIO[Unit] = {
+    for {
+      // Verify that there is no option provided with the secret engine
+      _       <- opt match {
+                   case Some(options) =>
+                     val optuple = options.map(e => (e.name, e.value)).map{ case (name, value) => s"($name = $value)"}.mkString(", ")
+                     NodePropertiesLoggerPure.error(s"Options has been given for engine `$name` but he don't accept any option : $optuple")
+                   case None          =>
+                     NodePropertiesLoggerPure.debug(s"Engine `$name` doesn't receive any options")
+                 }
+      // Verify that there is only one namespace provided
+      _ <- if (namespace.length != 1) {
+             NodePropertiesLoggerPure
+               .error(s"Engine `$name` required only one namespace, the name of the secret variable, but found : " +
+                 s"${namespace.mkString(",")}")
+           } else {
+             NodePropertiesLoggerPure.debug(s"Valid engine `$name` with namespace `${namespace.head}`")
+           }
+    } yield ()
+  }
+
+  def process(namespace: List[String], opt: Option[List[EngineOption]]): IOResult[String] = {
+    implicit val formats = net.liftweb.json.DefaultFormats
+
+    val secretsFile = File(s"/var/rudder/configuration-repository/secrets/secrets.json")
+    (for {
+      _       <- verifyEntries(namespace, opt)
+      content <- IOResult.effect(s"File ${secretsFile.pathAsString} not found. Please make sure `secret-management` plugin is installed") {
+                   secretsFile.contentAsString(StandardCharsets.UTF_8)
+                 }
+      json    <- IOResult.effect(JsonParser.parse(content)).chainError(s"Parsing JSON in $secretsFile have failed")
+      secrets <- IOResult.effect((json \ "secrets").extract[List[Secret]])
+                   .chainError(s"Unable to find parameter `secrets` in $secretsFile. Verify that the file is well formatted")
+
+    } yield {
+      secrets.find(_.name == namespace.head) match {
+        case None            => Inconsistency(s"Unable to find secret variable : `${namespace.head}` in `${secretsFile}`").fail
+        case Some(secretVal) => secretVal.value.succeed
+      }
+    }).flatten
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1369,7 +1369,9 @@ object RudderConfig extends Loggable {
 
   private[this] lazy val ruleApplicationStatusImpl: RuleApplicationStatusService = new RuleApplicationStatusServiceImpl()
   private[this] lazy val propertyEngineServiceImpl: PropertyEngineService = new PropertyEngineServiceImpl(
-    List.empty
+    List(
+      SecretVariableEngine
+    )
   )
 
   def DN(rdn: String, parent: DN) = new DN(new RDN(rdn),  parent)


### PR DESCRIPTION
https://issues.rudder.io/issues/19729

### :warning: This part have been moved in https://github.com/Normation/rudder-plugins-private/pull/190

# How to test it
1. Install `secret-management` plugin or create `/var/rudder/configuration-repository/secrets/secrets.json` with this content :
```JSON
{
  "formatVersion" : "1.0",
  "secrets":[
      {
          "name" : "password",
          "description":"#markdown supported",
          "value" : "password-remplaced-yeeeah"
      }
  ]
}
```
2. Create a secret (or skip it if you create manually the file previously)
![image](https://user-images.githubusercontent.com/23410978/128582423-523c6ef6-dff7-4efe-b3cd-9c8e89806b9d.png)
3. Create a node property `testengine` with a recognized format, like this :
```JSON
{
  "login": "admin",
  "password": {
    "value": "${engine.secret[password]}"
  }
}
```
4. Create a technique using this node property (I used `File content` with `${node.properties[testengine][password]}` as lines parameter)
5. Apply this technique through directives
6. Check if the interpolation worked
___
# Todo
- [x] Move this part in `rudder-plugins-private`
