### PR TITLE
Fixes #19873: Saving a rule with deleted directives/groups does not correct it

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewTabContent.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewTabContent.elm
@@ -151,9 +151,22 @@ tabContent model details isNewRule=
           buildListRow ids =
             let
               --Get more information about directives, to correctly sort them by displayName
-              directives = model.directives
-                |> List.filter (\d -> List.member d.id ids)
-                |> List.sortWith (compareOn .displayName)
+              directives =
+                let
+                  knownDirectives = model.directives
+                    |> List.filter (\d -> List.member d.id ids)
+                    |> List.sortWith (compareOn .displayName)
+                  in
+                    -- add missing directives
+                    let
+                      knonwIds = List.map .id knownDirectives
+                    in
+                      List.append
+                        knownDirectives
+                        (ids
+                          |> List.filter (\id -> not (List.member id knonwIds) )
+                          |> List.map (\id -> (Directive id ("Missing directive with ID "++id.value) "" "" "" False False ""))
+                        )
 
               rowDirective  : Directive -> Html Msg
               rowDirective directive =


### PR DESCRIPTION
https://issues.rudder.io/issues/19873

It adds the following display, which allows to remove the bad directive: 

![image](https://user-images.githubusercontent.com/44649/131139746-6dc3d117-e89f-4ea4-a53f-10ffed0d0a63.png)

