### PR TITLE
Fixes #19786: When we delete a directive, it's not removed from the rules

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
@@ -140,7 +140,7 @@ class LDAPDiffMapper(
                               case x => Left(Err.UnexpectedObject(s"Bad change record type for requested action 'update rule': ${mod.toString}"))
                             }
                           case A_DIRECTIVE_UUID =>
-                            diff.map( _.copy(modDirectiveIds = Some(SimpleDiff(oldCr.directiveIds, mod.getValues.map(x => JsonDirectiveId.ruleParse(x).toDirectiveRId ).toSet))))
+                            diff.map( _.copy(modDirectiveIds = Some(SimpleDiff(oldCr.directiveIds, mod.getValues.map(x => DirectiveId.parse(x).getOrElse(DirectiveId(DirectiveUid(""))) ).toSet))))
                           case A_NAME =>
                             diff.map( _.copy(modName = Some(SimpleDiff(oldCr.name, mod.getOptValueDefault("")))))
                           case A_DESCRIPTION =>

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -2115,7 +2115,6 @@ object TEST {
     _         <- repo.update(g1, ModificationId("plop"), EventActor("plop"), None)
     pair2     <- repo.getNodeGroup(NodeGroupId("1111f5d3-8c61-4d20-88a7-bb947705ba8a"))
     res       =  if(pair2._1.serverList == nodes) "ok" else s"oups, list=${pair2._1.serverList}"
-    _         <- effectUioUnit(println(s"**** " + res))
   } yield (res)
 
   def main(args: Array[String]): Unit = prog.runNow


### PR DESCRIPTION
https://issues.rudder.io/issues/19786

The problem was that by changing the serialisation format in LDAP for directive ids in a rule id (from `ab459975-7116-40ad-aab7-6479694ff606` to `{"id":"ab459975-7116-40ad-aab7-6479694ff606"}` (with optionnaly `, "revision":"xxx"`), we broken LDAP search on directive IDs in rules used for cleaning-up thing when a directive was deleted. 

So I reverted to the same format that used for displaying ID (ie: `uuid+revision`). 
I also changed that format for the API case, because it will likely result in the same kind of breakages. 

But now, I'm sad because we have two formats for object ID: 
- when we talk about the object own ID, it's two fields (both in LDAP and in API): `{... "id":"xxx", "revision":... }`. 
- when we talk about IDs of objects referenced by the current object (like directives in rules), we use a string serialisation `uuid+id`

I'm not sure what to do, but we need to choose before final.