### PR TITLE
Fixes #19872: Rules can't be accessed directly by url, all redirection broken

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/JsInitContextLinkUtil.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/JsInitContextLinkUtil.scala
@@ -87,7 +87,7 @@ class LinkUtil (
     RedirectTo(baseTargetLink(target))
 
   def baseRuleLink(id:RuleId) =
-    s"""/secure/configurationManager/ruleManagement#{"ruleId":"${id.value}"}"""
+    s"""/secure/configurationManager/ruleManagement/rule/${id.value}"""
 
   def ruleLink(id:RuleId) =
     s"""${S.contextPath}${baseRuleLink(id)}"""

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/elm.json
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/elm.json
@@ -14,6 +14,7 @@
             "elm/http": "1.0.0",
             "elm/json": "1.1.3",
             "elm/random": "1.0.0",
+            "elm/url": "1.0.0",
             "elm-community/list-extra": "8.1.0",
             "elm-community/maybe-extra": "5.2.0",
             "mcordova47/elm-natural-ordering": "1.0.5"
@@ -26,7 +27,6 @@
             "elm/bytes": "1.0.8",
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2",
             "kuon/elm-string-normalize": "1.0.2",
             "rtfeldman/elm-hex": "1.0.0",

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ApiCalls.elm
@@ -104,6 +104,22 @@ getRuleDetails model ruleId =
   in
     send GetRuleDetailsResult req
 
+getRulesCategoryDetails : Model -> String -> Cmd Msg
+getRulesCategoryDetails model catId =
+  let
+    req =
+      request
+        { method          = "GET"
+        , headers         = []
+        , url             = getUrl model ("/rules/categories/" ++ catId)
+        , body            = emptyBody
+        , expect          = expectJson decodeGetCategoryDetails
+        , timeout         = Nothing
+        , withCredentials = False
+        }
+  in
+    send GetCategoryDetailsResult req
+
 getRulesCompliance : Model -> Cmd Msg
 getRulesCompliance model =
   let

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/DataTypes.elm
@@ -188,8 +188,8 @@ type alias Model =
 
 type Msg
   = GenerateId (String -> Msg)
-  | OpenRuleDetails RuleId
-  | OpenCategoryDetails (Category Rule)
+  | OpenRuleDetails RuleId Bool
+  | OpenCategoryDetails String Bool
   | CloseDetails
   | SelectGroup RuleTarget Bool
   | UpdateRuleForm RuleDetails
@@ -199,6 +199,7 @@ type Msg
   | CallApi                  (Model -> Cmd Msg)
   | GetRuleDetailsResult     (Result Error Rule)
   | GetPolicyModeResult      (Result Error String)
+  | GetCategoryDetailsResult (Result Error (Category Rule))
   | GetRulesComplianceResult (Result Error (List RuleCompliance))
   | SaveRuleDetails          (Result Error Rule)
   | SaveDisableAction        (Result Error Rule)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/Init.elm
@@ -4,10 +4,7 @@ import ApiCalls exposing (..)
 import DataTypes exposing (..)
 
 
-subscriptions : Model -> Sub Msg
-subscriptions model =
-    Sub.none
-
+-- PORTS
 init : { contextPath : String, hasWriteRights : Bool } -> ( Model, Cmd Msg )
 init flags =
   let
@@ -19,10 +16,10 @@ init flags =
 
     listInitActions =
       [ getPolicyMode      initModel
-      , getRulesTree       initModel
+      , getRulesCompliance initModel
       , getGroupsTree      initModel
       , getTechniquesTree  initModel
-      , getRulesCompliance initModel
+      , getRulesTree       initModel
       ]
   in
     ( initModel

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/View.elm
@@ -26,7 +26,7 @@ view model =
       in
         li [class "jstree-node jstree-leaf"]
         [ i[class "jstree-icon jstree-ocl"][]
-        , a[href "#", class ("jstree-anchor"++classDisabled), onClick (OpenRuleDetails item.id)]
+        , a[class ("jstree-anchor"++classDisabled), onClick (OpenRuleDetails item.id True)]
           [ i [class "jstree-icon jstree-themeicon fa fa-sitemap jstree-themeicon-custom"][]
           , span [class "treeGroupName tooltipable"]
             [ text item.name
@@ -50,7 +50,7 @@ view model =
       in
         li[class "jstree-node jstree-open"]
         [ i[class "jstree-icon jstree-ocl"][]
-        , a[href "#", class "jstree-anchor", onClick (OpenCategoryDetails item)]
+        , a[class "jstree-anchor", onClick (OpenCategoryDetails item.id True)]
           [ i [class "jstree-icon jstree-themeicon fa fa-folder jstree-themeicon-custom"][]
           , span [class "treeGroupCategoryName tooltipable"][text item.name]
           ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewRulesTable.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewRulesTable.elm
@@ -94,7 +94,7 @@ buildRulesTable model =
 
               Nothing -> text "No report"
       in
-            tr[onClick (OpenRuleDetails r.id)]
+            tr[onClick (OpenRuleDetails r.id True)]
             [ td[][ text r.name ]
             , td[][ text (getCategoryName model r.categoryId) ]
             , td[][ text (if r.enabled == True then "Enabled" else "Disabled") ]

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -395,6 +395,20 @@ class Boot extends Loggable {
             >> LocGroup(name+"Group")
             >> TestAccess( () => userIsAllowed("/secure/index",AuthorizationType.Rule.Read ) )
 
+        , Menu("Rule Details", <span>Rule</span>) /
+          "secure" / (name+"Manager") / "ruleManagement" / "rule" / *
+          >> TemplateBox {case _ => Templates("secure" :: (name+"Manager") :: "ruleManagement" :: Nil)}
+          >> LocGroup (name+"Group")
+          >> TestAccess( () => userIsAllowed("/secure/index", AuthorizationType.Rule.Read) )
+          >> Hidden
+
+        , Menu("Rule Category Details", <span>Rule Category</span>) /
+          "secure" / (name+"Manager") / "ruleManagement" / "ruleCategory" / *
+          >> TemplateBox {case _ => Templates("secure" :: (name+"Manager") :: "ruleManagement" :: Nil)}
+          >> LocGroup (name+"Group")
+          >> TestAccess( () => userIsAllowed("/secure/index",AuthorizationType.Rule.Read ) )
+          >> Hidden
+
         ,Menu(name+"DirectiveManagement", <span>Directives</span>) /
             "secure" / (name+"Manager") / "directiveManagement"
             >> LocGroup(name+"Group")

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/javascript/rudder/rudder-datatable.js
@@ -289,7 +289,7 @@ function createRuleTable(gridId, data, checkboxColumn, actionsColumn, compliance
         elem.click(function() {oData.callback(action);});
         elem.attr("href","javascript://");
     } else {
-        elem.attr("href",contextPath+'/secure/configurationManager/ruleManagement#{"ruleId":"'+oData.id+'","action":"'+action+'"}');
+        elem.attr("href",contextPath+'/secure/configurationManager/ruleManagement/rule/'+oData.id);
     }
     return elem;
   }
@@ -568,7 +568,7 @@ function createRuleComplianceTable(gridId, data, contextPath, refresh) {
         var editIcon = $("<i>");
         editIcon.addClass("fa fa-pencil");
         var editLink = $("<a />");
-        editLink.attr("href",contextPath + '/secure/configurationManager/ruleManagement#{"ruleId":"'+oData.id+'"}');
+        editLink.attr("href",contextPath + '/secure/configurationManager/ruleManagement/rule/'+oData.id);
         editLink.click(function(e) {e.stopPropagation();});
         editLink.append(editIcon);
         editLink.addClass("reportIcon");
@@ -714,7 +714,7 @@ function createExpectedReportTable(gridId, data, contextPath, refresh) {
       displayTags(nTd, oData.tags)
       if (! oData.isSystem) {
         var editLink = $("<a />");
-        editLink.attr("href",contextPath + '/secure/configurationManager/ruleManagement#{"ruleId":"'+oData.id+'"}');
+        editLink.attr("href",contextPath + '/secure/configurationManager/ruleManagement/rule/'+oData.id);
         var editIcon = $("<i>");
         editIcon.addClass("fa fa-pencil");
         editLink.click(function(e) {e.stopPropagation();});

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/ruleManagement.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/ruleManagement.html
@@ -7,7 +7,6 @@
   </head>
 
   <div id="rules-app" ></div>
-
   <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-rules.js"></script>
   <script>
     var hasWriteRights = false;
@@ -18,6 +17,18 @@
     </script>
   </lift:authz>
   <script>
+    function getRuleRedirection(app){
+      var path = window.location.pathname.split("/")
+      if (path.length > 2) {
+        var id = path[path.length -1];
+        var kind = path[path.length -2];
+        if (id !== "ruleManagement") {
+          app.ports.readUrl.send([kind,id]);
+
+        }
+      }
+
+    }
     $(document).ready(function(){
       var main = document.getElementById("rules-app")
       var initValues = {
@@ -31,7 +42,22 @@
       app.ports.errorNotification.subscribe(function(str) {
         createErrorNotification(str)
       });
+
+      // Change the URL upon request, inform app of the change.
+      app.ports.pushUrl.subscribe(function(url) {
+        var kind = url[0];
+        var id = url[1];
+        var url = "/rudder/secure/configurationManager/ruleManagement"
+        if (kind !== "") {
+          url += "/" + kind + "/" + id
+        }
+        history.pushState({}, '', url);
+      });
+
+      getRuleRedirection(app);
+
     });
+
   </script>
 
 </lift:surround>


### PR DESCRIPTION
https://issues.rudder.io/issues/19872

So, there is apparently no turnkey solution to set up a URL system the way we want it. Here is my workaround, which I think can be highly improved: 

I used 2 new ports:
  - `pushUrl` which updates the url based on what happens in the Elm app (e.g. when a rule is selected):
<pre>
OpenRuleDetails rId ->
      (model, Cmd.batch [(getRuleDetails model rId), (pushUrl ((getUrl model) ++ "/rule/" ++rId.value))])
</pre>      
  - `onUrlChange` which updates the Elm app when the page loads and when the url is changed. This port calls the `UrlChanged` function, which parses the url and determines what action to take based on the result. (All the Url rewriting logic is done on the Elm side.
  
I also added redirections to avoid 404 errors when the url looks like **[...]/secure/configurationManager/ruleManagement/rule/1234-5678-1234-5678.**  

I think this workaround could be more robust. For example by giving a type to the URLs to avoid manipulating strings. 
And I didn't deal with the case of Rule / Category creation, for the moment, the url is not updated in these cases. But for now I'm waiting for your feedback on this!