### PR TITLE
Fixes #20009: In CI, technique migration test sometimes throw an NPE

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/PolicyServerManagementService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/PolicyServerManagementService.scala
@@ -61,7 +61,6 @@ import zio._
 import zio.syntax._
 import com.normation.errors._
 import com.normation.eventlog.EventLogDetails
-import com.normation.ldap.sdk.LDAPEntry
 import com.normation.rudder.domain.RudderLDAPConstants
 import com.normation.rudder.domain.appconfig.RudderWebPropertyName
 import com.normation.rudder.domain.eventlog.AuthorizedNetworkModification

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LoadDemoDataTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LoadDemoDataTest.scala
@@ -68,7 +68,7 @@ class LoadDemoDataTest extends Specification {
     i + x
   }
 
-  val ldap = InitTestLDAPServer.newLdapConnectionProvider(bootstrapLDIFs)
+  val ldap = InitTestLDAPServer.newLdapConnectionProvider(InitTestLDAPServer.schemaLDIFs, bootstrapLDIFs)
 
   "The in memory LDAP directory" should {
 
@@ -95,10 +95,10 @@ object InitTestLDAPServer {
 
   val baseDN = "cn=rudder-configuration"
 
-  def newLdapConnectionProvider(fullLdifPaths: List[String]) = {
+  def newLdapConnectionProvider(schema: List[String], fullLdifPaths: List[String]) = {
     InMemoryDsConnectionProvider[RwLDAPConnection with RoLDAPConnection](
         baseDNs = baseDN :: Nil
-      , schemaLDIFPaths = schemaLDIFs
+      , schemaLDIFPaths = schema
       , bootstrapLDIFPaths = fullLdifPaths
       , ldifFileLogger = new DummyLDIFFileLogger()
     )

--- a/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/00-core.ldif
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/00-core.ldif
@@ -1,0 +1,648 @@
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at
+# trunk/opends/resource/legal-notices/OpenDS.LICENSE
+# or https://OpenDS.dev.java.net/OpenDS.LICENSE.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at
+# trunk/opends/resource/legal-notices/OpenDS.LICENSE.  If applicable,
+# add the following below this CDDL HEADER, with the fields enclosed
+# by brackets "[]" replaced with your own identifying information:
+#      Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+#      Copyright 2006-2009 Sun Microsystems, Inc.
+#
+#
+# This file contains a core set of attribute type and objectlass definitions
+# from several standard LDAP documents (primarily RFCs and IETF Internet
+# Drafts).  The X-ORIGIN component of each name should provide the
+# specification in which that attribute type or objectclass is defined.
+dn: cn=schema
+objectClass: top
+objectClass: ldapSubentry
+objectClass: subschema
+attributeTypes: ( 2.5.4.41 NAME 'name' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{32768}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.49 NAME 'distinguishedName'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.0 NAME 'objectClass' EQUALITY objectIdentifierMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.4.1 NAME 'aliasedObjectName'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  SINGLE-VALUE X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.4.2 NAME 'knowledgeInformation' EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{32768} X-ORIGIN 'RFC 2256' )
+attributeTypes: ( 2.5.4.3 NAME ( 'cn' 'commonName' ) SUP name
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.4 NAME ( 'sn' 'surname' ) SUP name
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.5 NAME 'serialNumber' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.44{64}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.6 NAME ( 'c' 'countryName' ) SUP name SINGLE-VALUE
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.7 NAME ( 'l' 'localityName' ) SUP name
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.8 NAME ( 'st' 'stateOrProvinceName' ) SUP name
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.9 NAME ( 'street' 'streetAddress' )
+  EQUALITY caseIgnoreMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{128}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.10 NAME ( 'o' 'organizationName' ) SUP name
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.11 NAME ( 'ou' 'organizationalUnitName' ) SUP name
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.12 NAME 'title' SUP name X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.13 NAME 'description' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{1024}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.14 NAME 'searchGuide'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.25 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.15 NAME 'businessCategory' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{128}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.16 NAME 'postalAddress' EQUALITY caseIgnoreListMatch
+  SUBSTR caseIgnoreListSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.41
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.17 NAME 'postalCode' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{40}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.18 NAME 'postOfficeBox' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{40}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.19 NAME 'physicalDeliveryOfficeName'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{128} X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.20 NAME 'telephoneNumber' EQUALITY telephoneNumberMatch
+  SUBSTR telephoneNumberSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.50{32}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.21 NAME 'telexNumber'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.52 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.22 NAME 'teletexTerminalIdentifier'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.51 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.23 NAME 'facsimileTelephoneNumber'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.22 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.24 NAME 'x121Address' EQUALITY numericStringMatch
+  SUBSTR numericStringSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.36{15}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.25 NAME 'internationaliSDNNumber'
+  EQUALITY numericStringMatch SUBSTR numericStringSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.36{16} X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.26 NAME 'registeredAddress' SUP postalAddress
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.41 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.27 NAME 'destinationIndicator' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.44{128}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.28 NAME 'preferredDeliveryMethod'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.14 SINGLE-VALUE X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.29 NAME 'presentationAddress'
+  EQUALITY presentationAddressMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.43
+  SINGLE-VALUE X-ORIGIN 'RFC 2256' )
+attributeTypes: ( 2.5.4.30 NAME 'supportedApplicationContext'
+  EQUALITY objectIdentifierMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.38
+  X-ORIGIN 'RFC 2256' )
+attributeTypes: ( 2.5.4.31 NAME 'member' SUP distinguishedName
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.32 NAME 'owner' SUP distinguishedName
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.33 NAME 'roleOccupant' SUP distinguishedName
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.34 NAME 'seeAlso' SUP distinguishedName
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.35 NAME 'userPassword'
+  SYNTAX 1.3.6.1.4.1.26027.1.3.1 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.36 NAME 'userCertificate'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.8 X-ORIGIN 'RFC 4523' )
+attributeTypes: ( 2.5.4.37 NAME 'cACertificate'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.8 X-ORIGIN 'RFC 4523' )
+attributeTypes: ( 2.5.4.38 NAME 'authorityRevocationList'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.9 X-ORIGIN 'RFC 4523' )
+attributeTypes: ( 2.5.4.39 NAME 'certificateRevocationList'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.9 X-ORIGIN 'RFC 4523' )
+attributeTypes: ( 2.5.4.40 NAME 'crossCertificatePair'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.10 X-ORIGIN 'RFC 4523' )
+attributeTypes: ( 2.5.4.42 NAME 'givenName' SUP name X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.43 NAME 'initials' SUP name X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.44 NAME 'generationQualifier' SUP name
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.45 NAME 'x500UniqueIdentifier' EQUALITY bitStringMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.6 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.46 NAME 'dnQualifier' EQUALITY caseIgnoreMatch
+  ORDERING caseIgnoreOrderingMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.44 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.47 NAME 'enhancedSearchGuide'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.21 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 1.3.6.1.1.16.4 NAME 'entryUUID'
+  DESC 'UUID of the entry' EQUALITY uuidMatch ORDERING uuidOrderingMatch
+  SYNTAX 1.3.6.1.1.16.1 SINGLE-VALUE NO-USER-MODIFICATION
+  USAGE directoryOperation X-ORIGIN 'RFC 4530' )
+attributeTypes: ( 2.5.4.48 NAME 'protocolInformation'
+  EQUALITY protocolInformationMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.42
+  X-ORIGIN 'RFC 2256' )
+attributeTypes: ( 2.5.4.50 NAME 'uniqueMember' EQUALITY uniqueMemberMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.34 X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 1.3.6.1.4.1.26027.1.1.585 NAME 'lastExternalChangelogCookie'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 X-ORIGIN 'OpenDS Directory Node' )
+attributeTypes: ( 1.3.6.1.4.1.26027.1.1.593 NAME 'firstChangeNumber'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 X-ORIGIN 'OpenDS Directory Node' )
+attributeTypes: ( 1.3.6.1.4.1.26027.1.1.594 NAME 'lastChangeNumber'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 X-ORIGIN 'OpenDS Directory Node' )
+attributeTypes: ( 2.5.4.51 NAME 'houseIdentifier' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{32768}
+  X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.5.4.52 NAME 'supportedAlgorithms'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.49 X-ORIGIN 'RFC 4523' )
+attributeTypes: ( 2.5.4.53 NAME 'deltaRevocationList'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.9 X-ORIGIN 'RFC 4523' )
+attributeTypes: ( 2.5.4.54 NAME 'dmdName' SUP name X-ORIGIN 'RFC 2256' )
+attributeTypes: ( 2.5.18.1 NAME 'createTimestamp' EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.18.2 NAME 'modifyTimestamp' EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.18.3 NAME 'creatorsName' EQUALITY distinguishedNameMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 SINGLE-VALUE NO-USER-MODIFICATION
+  USAGE directoryOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.18.4 NAME 'modifiersName' EQUALITY distinguishedNameMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 SINGLE-VALUE NO-USER-MODIFICATION
+  USAGE directoryOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.18.9 NAME 'hasSubordinates' EQUALITY booleanMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE NO-USER-MODIFICATION
+  USAGE directoryOperation X-ORIGIN 'X.501' )
+attributeTypes: ( 2.5.18.10 NAME 'subschemaSubentry'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.5 NAME 'attributeTypes' EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.3 USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.6 NAME 'objectClasses' EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.37 USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.4 NAME 'matchingRules' EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.30 USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.8 NAME 'matchingRuleUse' EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.31 USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.9 NAME 'structuralObjectClass' EQUALITY objectIdentifierMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 SINGLE-VALUE NO-USER-MODIFICATION
+  USAGE directoryOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.10 NAME 'governingStructureRule' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE NO-USER-MODIFICATION
+  USAGE directoryOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 1.3.6.1.4.1.1466.101.120.5 NAME 'namingContexts'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 USAGE dSAOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 1.3.6.1.4.1.1466.101.120.6 NAME 'altNode'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 USAGE dSAOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 1.3.6.1.4.1.1466.101.120.7 NAME 'supportedExtension'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 USAGE dSAOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 1.3.6.1.4.1.1466.101.120.13 NAME 'supportedControl'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 USAGE dSAOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 1.3.6.1.4.1.1466.101.120.14 NAME 'supportedSASLMechanisms'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 USAGE dSAOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 1.3.6.1.4.1.1466.101.120.15 NAME 'supportedLDAPVersion'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 USAGE dSAOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 1.3.6.1.4.1.4203.1.3.5 NAME 'supportedFeatures'
+  EQUALITY objectIdentifierMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.38
+  USAGE dSAOperation X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 1.3.6.1.4.1.1466.101.120.16 NAME 'ldapSyntaxes'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.54 USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.1 NAME 'dITStructureRules' EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.17 USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.7 NAME 'nameForms' EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.35 USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 2.5.21.2 NAME 'dITContentRules' EQUALITY caseIgnoreMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.16 USAGE directoryOperation
+  X-ORIGIN 'RFC 4512' )
+attributeTypes: ( 0.9.2342.19200300.100.1.25 NAME ( 'dc' 'domainComponent' )
+  EQUALITY caseIgnoreIA5Match SUBSTR caseIgnoreIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 2.16.840.1.113730.3.1.1 NAME 'carLicense'
+  DESC 'vehicle license or registration plate' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 2.16.840.1.113730.3.1.2 NAME 'departmentNumber'
+  DESC 'identifies a department within an organization'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 2.16.840.1.113730.3.1.241 NAME 'displayName'
+  DESC 'preferred name of a person to be used when displaying entries'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 2.16.840.1.113730.3.1.3 NAME 'employeeNumber'
+  DESC 'numerically identifies an employee within an organization'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 2.16.840.1.113730.3.1.4 NAME 'employeeType'
+  DESC 'type of employment for a person' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 0.9.2342.19200300.100.1.60 NAME 'jpegPhoto'
+  DESC 'a JPEG image' SYNTAX 1.3.6.1.4.1.1466.115.121.1.28
+  X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 2.16.840.1.113730.3.1.39 NAME 'preferredLanguage'
+  DESC 'preferred written or spoken language for a person'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 2.16.840.1.113730.3.1.40 NAME 'userSMIMECertificate'
+  DESC 'PKCS#7 SignedData used to support S/MIME'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.5 X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 2.16.840.1.113730.3.1.216 NAME 'userPKCS12'
+  DESC 'PKCS #12 PFX PDU for exchange of personal identity information'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.5 X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 0.9.2342.19200300.100.1.37 NAME 'associatedDomain'
+  EQUALITY caseIgnoreIA5Match SUBSTR caseIgnoreIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.38 NAME 'associatedName'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.48 NAME 'buildingName'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.43 NAME ( 'co' 'friendlyCountryName' )
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.14 NAME 'documentAuthor'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.11 NAME 'documentIdentifier'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.15 NAME 'documentLocation'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.56 NAME 'documentPublisher'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.12 NAME 'documentTitle'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.13 NAME 'documentVersion'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.5 NAME ( 'drink' 'favouriteDrink' )
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.20
+  NAME ( 'homePhone' 'homeTelephoneNumber' ) EQUALITY telephoneNumberMatch
+  SUBSTR telephoneNumberSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.50
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.39 NAME 'homePostalAddress'
+  EQUALITY caseIgnoreListMatch SUBSTR caseIgnoreListSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.41 X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.9 NAME 'host' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256}
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.4 NAME 'info' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{2048}
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.3 NAME ( 'mail' 'rfc822Mailbox' )
+  EQUALITY caseIgnoreIA5Match SUBSTR caseIgnoreIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.10 NAME 'manager'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.41
+  NAME ( 'mobile' 'mobileTelephoneNumber' ) EQUALITY telephoneNumberMatch
+  SUBSTR telephoneNumberSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.50
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.45 NAME 'organizationalStatus'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.42
+  NAME ( 'pager' 'pagerTelephoneNumber' ) EQUALITY telephoneNumberMatch
+  SUBSTR telephoneNumberSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.50
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.40 NAME 'personalTitle'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.6 NAME 'roomNumber'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.21 NAME 'secretary'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.44 NAME 'uniqueIdentifier'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 0.9.2342.19200300.100.1.8 NAME 'userClass'
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4524' )
+attributeTypes: ( 1.3.6.1.4.1.250.1.57 NAME 'labeledURI'
+  DESC 'Uniform Resource Identifier with optional label'
+  EQUALITY caseExactMatch SUBSTR caseExactSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 2079' )
+attributeTypes: ( 1.3.6.1.4.1.250.1.41 NAME 'labeledURL'
+  DESC 'Uniform Resource Locator with optional label'
+  EQUALITY caseExactMatch SUBSTR caseExactSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 2079' )
+attributeTypes: ( 0.9.2342.19200300.100.1.55 NAME 'audio'
+  EQUALITY octetStringMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.40{250000}
+  X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 0.9.2342.19200300.100.1.7 NAME 'photo'
+  EQUALITY octetStringMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.40
+  X-ORIGIN 'RFC 2798' )
+attributeTypes: ( 0.9.2342.19200300.100.1.1 NAME ( 'uid' 'userid' )
+  EQUALITY caseIgnoreMatch SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} X-ORIGIN 'RFC 4519' )
+attributeTypes: ( 1.3.6.1.1.4 NAME 'vendorName'
+  EQUALITY 1.3.6.1.4.1.1466.109.114.1 SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE dSAOperation X-ORIGIN 'RFC 3045' )
+attributeTypes: ( 1.3.6.1.1.5 NAME 'vendorVersion'
+  EQUALITY 1.3.6.1.4.1.1466.109.114.1 SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE dSAOperation X-ORIGIN 'RFC 3045' )
+attributeTypes: ( 2.16.840.1.113730.3.1.34 NAME 'ref'
+  DESC 'named reference - a labeledURI' EQUALITY caseExactMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 USAGE distributedOperation
+  X-ORIGIN 'RFC 3296' )
+attributeTypes: ( 1.3.6.1.4.1.7628.5.4.1 NAME 'inheritable'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE NO-USER-MODIFICATION
+  USAGE dSAOperation X-ORIGIN 'draft-ietf-ldup-subentry' )
+attributeTypes: ( 1.3.6.1.4.1.7628.5.4.2 NAME 'blockInheritance'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE NO-USER-MODIFICATION
+  USAGE dSAOperation X-ORIGIN 'draft-ietf-ldup-subentry' )
+attributeTypes: ( 2.16.840.1.113730.3.1.55 NAME 'aci'
+  DESC 'Sun-defined access control information attribute type'
+  EQUALITY octetStringMatch
+  SYNTAX 1.3.6.1.4.1.26027.1.3.4 USAGE directoryOperation
+  X-ORIGIN 'Sun Java System Directory Node' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.9.1.39 NAME 'aclRights'
+  DESC 'Sun-defined access control effective rights attribute type'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'Sun Java System Directory Node' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.9.1.40 NAME 'aclRightsInfo'
+  DESC 'Sun-defined access control effective rights information attribute type'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'Sun Java System Directory Node' )
+attributeTypes: ( 2.16.840.1.113730.3.1.542 NAME 'nsUniqueId'
+  DESC 'Sun-defined unique identifier' SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'Sun Java System Directory Node' )
+attributeTypes: ( 1.3.6.1.4.1.1466.101.120.1 NAME 'administratorsAddress'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 USAGE directoryOperation
+  X-ORIGIN 'draft-wahl-ldap-adminaddr' )
+attributeTypes: ( 2.16.840.1.113730.3.1.198 NAME 'memberURL'
+  DESC 'Sun-defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  X-ORIGIN 'Sun Java System Directory Node' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.9.1.792 NAME 'isMemberOf'
+  DESC 'Sun-defined attribute type' SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'Sun Java System Directory Node' )
+attributeTypes: ( 0.9.2342.19200300.100.1.54 NAME 'dITRedirect'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.49 NAME 'dSAQuality'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.46 NAME 'janetMailbox'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.24 NAME 'lastModifiedBy'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.23 NAME 'lastModifiedTime'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.47 NAME 'mailPreferenceOption'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.53 NAME 'personalSignature'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.5 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.50 NAME 'singleLevelQuality'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.51 NAME 'subtreeMinimumQuality'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.52 NAME 'subtreeMaximumQuality'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 SINGLE-VALUE X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.2 NAME 'textEncodedORAddress'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.22 NAME 'otherMailbox'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.26 NAME 'aRecord'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.27 NAME 'mDRecord'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.28 NAME 'mxRecord'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.29 NAME 'nSRecord'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.30 NAME 'sOARecord'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 0.9.2342.19200300.100.1.31 NAME 'cNAMERecord'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'RFC 1274' )
+attributeTypes: ( 1.3.6.1.1.20 NAME 'entryDN' DESC 'DN of the entry'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'RFC 5020' )
+attributeTypes: ( 1.3.6.1.4.1.453.16.2.103 NAME 'numSubordinates'
+  DESC 'Count of immediate subordinates'
+  EQUALITY integerMatch ORDERING integerOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'draft-ietf-boreham-numsubordinates' )
+attributeTypes: ( 2.16.840.1.113730.3.1.35 NAME 'changelog' 
+  DESC 'the distinguished name of the entry which contains
+  the set of entries comprising this server's changelog'
+  EQUALITY distinguishedNameMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'draft-good-ldap-changelog' )
+objectClasses: ( 2.5.6.0 NAME 'top' ABSTRACT MUST objectClass
+  X-ORIGIN 'RFC 4512' )
+objectClasses: ( 2.5.6.1 NAME 'alias' SUP top STRUCTURAL MUST aliasedObjectName
+  X-ORIGIN 'RFC 4512' )
+objectClasses: ( 2.5.6.2 NAME 'country' SUP top STRUCTURAL MUST c
+  MAY ( searchGuide $ description ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.3 NAME 'locality' SUP top STRUCTURAL
+  MAY ( street $ seeAlso $ searchGuide $ st $ l $ description )
+  X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.4 NAME 'organization' SUP top STRUCTURAL MUST o
+  MAY ( userPassword $ searchGuide $ seeAlso $ businessCategory $ x121Address $
+  registeredAddress $ destinationIndicator $ preferredDeliveryMethod $
+  telexNumber $ teletexTerminalIdentifier $ telephoneNumber $
+  internationaliSDNNumber $ facsimileTelephoneNumber $ street $ postOfficeBox $
+  postalCode $ postalAddress $ physicalDeliveryOfficeName $ st $ l $
+  description ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.5 NAME 'organizationalUnit' SUP top STRUCTURAL MUST ou
+  MAY ( userPassword $ searchGuide $ seeAlso $ businessCategory $ x121Address $
+  registeredAddress $ destinationIndicator $ preferredDeliveryMethod $
+  telexNumber $ teletexTerminalIdentifier $ telephoneNumber $
+  internationaliSDNNumber $ facsimileTelephoneNumber $ street $ postOfficeBox $
+  postalCode $ postalAddress $ physicalDeliveryOfficeName $ st $ l $
+  description ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.6 NAME 'person' SUP top STRUCTURAL MUST ( sn $ cn )
+  MAY ( userPassword $ telephoneNumber $ seeAlso $ description )
+  X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.7 NAME 'organizationalPerson' SUP person STRUCTURAL
+  MAY ( title $ x121Address $ registeredAddress $ destinationIndicator $
+  preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+  telephoneNumber $ internationaliSDNNumber $ facsimileTelephoneNumber $
+  street $ postOfficeBox $ postalCode $ postalAddress $
+  physicalDeliveryOfficeName $ ou $ st $ l ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.8 NAME 'organizationalRole' SUP top STRUCTURAL MUST cn
+  MAY ( x121Address $ registeredAddress $ destinationIndicator $
+  preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+  telephoneNumber $ internationaliSDNNumber $ facsimileTelephoneNumber $
+  seeAlso $ roleOccupant $ preferredDeliveryMethod $ street $ postOfficeBox $
+  postalCode $ postalAddress $ physicalDeliveryOfficeName $ ou $ st $ l $
+  description ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.9 NAME 'groupOfNames' SUP top STRUCTURAL
+  MUST cn MAY ( member $ businessCategory $ seeAlso $ owner $ ou $ o $
+  description ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.10 NAME 'residentialPerson' SUP person STRUCTURAL MUST l
+  MAY ( businessCategory $ x121Address $ registeredAddress $
+  destinationIndicator $ preferredDeliveryMethod $ telexNumber $
+  teletexTerminalIdentifier $ telephoneNumber $ internationaliSDNNumber $
+  facsimileTelephoneNumber $ street $ postOfficeBox $ postalCode $
+  postalAddress $ physicalDeliveryOfficeName $ st ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.11 NAME 'applicationProcess' SUP top STRUCTURAL MUST cn
+  MAY ( seeAlso $ ou $ l $ description ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.12 NAME 'applicationEntity' SUP top STRUCTURAL
+  MUST ( presentationAddress $ cn ) MAY ( supportedApplicationContext $
+  seeAlso $ ou $ o $ l $ description ) X-ORIGIN 'RFC 2256' )
+objectClasses: ( 2.5.6.13 NAME 'dSA' SUP applicationEntity STRUCTURAL
+  MAY knowledgeInformation X-ORIGIN 'RFC 2256' )
+objectClasses: ( 2.5.6.14 NAME 'device' SUP top STRUCTURAL MUST cn
+  MAY ( serialNumber $ seeAlso $ owner $ ou $ o $ l $ description )
+  X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.15 NAME 'strongAuthenticationUser' SUP top AUXILIARY
+  MUST userCertificate X-ORIGIN 'RFC 4523' )
+objectClasses: ( 2.5.6.16 NAME 'certificationAuthority' SUP top AUXILIARY
+  MUST ( authorityRevocationList $ certificateRevocationList $ caCertificate )
+  MAY crossCertificatePair X-ORIGIN 'RFC 4523' )
+objectClasses: ( 2.5.6.16.2 NAME 'certificationAuthority-V2'
+  SUP certificationAuthority AUXILIARY MAY deltaRevocationList
+  X-ORIGIN 'RFC 4523' )
+objectClasses: ( 2.5.6.17 NAME 'groupOfUniqueNames' SUP top STRUCTURAL
+  MUST cn MAY ( uniqueMember $ businessCategory $ seeAlso $ owner $ ou $ o $
+  description ) X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.5.6.18 NAME 'userSecurityInformation' SUP top AUXILIARY
+  MAY ( supportedAlgorithms ) X-ORIGIN 'RFC 4523' )
+objectClasses: ( 2.5.6.19 NAME 'cRLDistributionPoint' SUP top STRUCTURAL
+  MUST cn MAY ( certificateRevocationList $ authorityRevocationList $
+  deltaRevocationList ) X-ORIGIN 'RFC 4523' )
+objectClasses: ( 2.5.6.20 NAME 'dmd' SUP top STRUCTURAL MUST dmdName
+  MAY ( userPassword $ searchGuide $ seeAlso $ businessCategory $ x121Address $
+  registeredAddress $ destinationIndicator $ preferredDeliveryMethod $
+  telexNumber $ teletexTerminalIdentifier $ telephoneNumber $
+  internationaliSDNNumber $ facsimileTelephoneNumber $ street $ postOfficeBox $
+  postalCode $ postalAddress $ physicalDeliveryOfficeName $ st $ l $
+  description ) X-ORIGIN 'RFC 2256' )
+objectClasses: ( 1.3.6.1.4.1.1466.101.120.111 NAME 'extensibleObject' SUP top
+  AUXILIARY X-ORIGIN 'RFC 4512' )
+objectClasses: ( 2.5.20.1 NAME 'subschema' AUXILIARY MAY ( dITStructureRules $
+  nameForms $ ditContentRules $ objectClasses $ attributeTypes $ matchingRules $
+  matchingRuleUse ) X-ORIGIN 'RFC 4512' )
+objectClasses: ( 0.9.2342.19200300.100.4.5 NAME 'account' SUP top STRUCTURAL
+  MUST uid MAY ( description $ seeAlso $ l $ o $ ou $ host )
+  X-ORIGIN 'RFC 4524' )
+objectClasses: ( 0.9.2342.19200300.100.4.6 NAME 'document' SUP top STRUCTURAL
+  MUST documentIdentifier MAY ( cn $ description $ seeAlso $ l $ o $ ou $
+  documentTitle $ documentVersion $ documentAuthor $ documentLocation $
+  documentPublisher ) X-ORIGIN 'RFC 4524' )
+objectClasses: ( 0.9.2342.19200300.100.4.9 NAME 'documentSeries' SUP top
+  STRUCTURAL MUST cn MAY ( description $ l $ o $ ou $ seeAlso $
+  telephoneNumber ) X-ORIGIN 'RFC 4524' )
+objectClasses: ( 0.9.2342.19200300.100.4.13 NAME 'domain' SUP top STRUCTURAL
+  MUST dc MAY ( userPassword $ searchGuide $ seeAlso $ businessCategory $
+  x121Address $ registeredAddress $ destinationIndicator $
+  preferredDeliveryMethod $ telexNumber $ teletexTerminalIdentifier $
+  telephoneNumber $ internationaliSDNNumber $ facsimileTelephoneNumber $
+  street $ postOfficeBox $ postalCode $ postalAddress $
+  physicalDeliveryOfficeName $ st $ l $ description $ o $ associatedName )
+  X-ORIGIN 'RFC 4524' )
+objectClasses: ( 0.9.2342.19200300.100.4.17 NAME 'domainRelatedObject' SUP top
+  AUXILIARY MUST associatedDomain X-ORIGIN 'RFC 4524' )
+objectClasses: ( 0.9.2342.19200300.100.4.18 NAME 'friendlyCountry' SUP country
+  STRUCTURAL MUST co X-ORIGIN 'RFC 4524' )
+objectClasses: ( 0.9.2342.19200300.100.4.14 NAME 'rFC822LocalPart' SUP domain
+  STRUCTURAL MAY ( cn $ description $ destinationIndicator $
+  facsimileTelephoneNumber $ internationaliSDNNumber $
+  physicalDeliveryOfficeName $ postalAddress $ postalCode $ postOfficeBox $
+  preferredDeliveryMethod $ registeredAddress $ seeAlso $ sn $ street $
+  telephoneNumber $ teletexTerminalIdentifier $ telexNumber $ x121Address )
+  X-ORIGIN 'RFC 4524' )
+objectClasses: ( 0.9.2342.19200300.100.4.7 NAME 'room' SUP top STRUCTURAL
+  MUST cn MAY ( roomNumber $ description $ seeAlso $ telephoneNumber )
+  X-ORIGIN 'RFC 4524' )
+objectClasses: ( 0.9.2342.19200300.100.4.19 NAME 'simpleSecurityObject' SUP top
+  AUXILIARY MUST userPassword X-ORIGIN 'RFC 4524' )
+objectClasses: ( 1.3.6.1.4.1.1466.344 NAME 'dcObject' SUP top AUXILIARY MUST dc
+  X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.16.840.1.113730.3.2.2 NAME 'inetOrgPerson'
+  SUP organizationalPerson STRUCTURAL MAY ( audio $ businessCategory $
+  carLicense $ departmentNumber $ displayName $ employeeNumber $ employeeType $
+  givenName $ homePhone $ homePostalAddress $ initials $ jpegPhoto $
+  labeledURI $ mail $ manager $ mobile $ o $ pager $ photo $ roomNumber $
+  secretary $ uid $ userCertificate $ x500UniqueIdentifier $
+  preferredLanguage $ userSMIMECertificate $ userPKCS12 ) X-ORIGIN 'RFC 2798' )
+objectClasses: ( 1.3.6.1.4.1.250.3.15 NAME 'labeledURIObject'
+  DESC 'object that contains the URI attribute type' SUP top AUXILIARY
+  MAY labeledURI X-ORIGIN 'RFC 2079' )
+objectClasses: ( 1.3.6.1.4.1.5322.13.1.1 NAME 'namedObject' SUP top STRUCTURAL
+  MAY cn X-ORIGIN 'draft-howard-namedobject' )
+objectClasses: ( 1.3.6.1.4.1.26027.1.2.900 NAME 'untypedObject'
+  DESC 'Entry of no particular type' SUP top STRUCTURAL MAY ( c $ cn $ dc $ l $
+  o $ ou $ st $ street $ uid $ description $ owner $ seeAlso )
+  X-ORIGIN 'draft-furuseth-ldap-untypedobject' )
+objectClasses: ( 1.3.6.1.1.3.1 NAME 'uidObject' SUP top AUXILIARY MUST uid
+  X-ORIGIN 'RFC 4519' )
+objectClasses: ( 2.16.840.1.113730.3.2.6 NAME 'referral'
+  DESC 'named subordinate reference object' STRUCTURAL MUST ref
+  X-ORIGIN 'RFC 3296' )
+objectClasses: ( 2.16.840.1.113719.2.142.6.1.1 NAME 'ldapSubEntry'
+  DESC 'LDAP Subentry class, version 1'  SUP top STRUCTURAL  MAY ( cn )
+  X-ORIGIN 'draft-ietf-ldup-subentry' )
+objectClasses: ( 1.3.6.1.4.1.7628.5.6.1.1 NAME 'inheritableLDAPSubEntry'
+  DESC 'Inheritable LDAP Subentry class, version 1'  SUP ldapSubEntry
+  STRUCTURAL  MUST ( inheritable )  MAY  ( blockInheritance )
+  X-ORIGIN 'draft-ietf-ldup-subentry' )
+objectClasses: ( 2.16.840.1.113730.3.2.33 NAME 'groupOfURLs'
+  DESC 'Sun-defined objectclass' SUP top STRUCTURAL MUST ( cn )
+  MAY ( memberURL $ businessCategory $ description $ o $ ou $ owner $ seeAlso )
+  X-ORIGIN 'Sun Java System Directory Node' )
+objectClasses: ( 0.9.2342.19200300.100.4.3 NAME 'pilotObject'
+  SUP top MAY ( audio $ dITRedirect $ info $ jpegPhoto $ lastModifiedBy $
+  lastModifiedTime $ manager $ photo $ uniqueIdentifier ) X-ORIGIN 'RFC 1274' )
+objectClasses: ( 0.9.2342.19200300.100.4.4 NAME 'pilotPerson'
+  SUP person MAY ( userid $ textEncodedORAddress $ rfc822Mailbox $
+  favouriteDrink $ roomNumber $ userClass $ homeTelephoneNumber $
+  homePostalAddress $ secretary $ personalTitle $ preferredDeliveryMethod $
+  businessCategory $ janetMailbox $ otherMailbox $ mobileTelephoneNumber $
+  pagerTelephoneNumber $ organizationalStatus $ mailPreferenceOption $
+  personalSignature ) X-ORIGIN 'RFC 1274' )
+objectClasses: ( 0.9.2342.19200300.100.4.20 NAME 'pilotOrganization' SUP top
+  MUST ( ou $ o ) MAY ( buildingName $ businessCategory $ description $
+  destinationIndicator $ facsimileTelephoneNumber $ internationaliSDNNumber $
+  l $ physicalDeliveryOfficeName $ postOfficeBox $ postalAddress $ postalCode $
+  preferredDeliveryMethod $ registeredAddress $ searchGuide $ seeAlso $ st $
+  street $ telephoneNumber $ teletexTerminalIdentifier $ telexNumber $
+  userPassword $ x121Address ) X-ORIGIN 'RFC 1274' )
+objectClasses: ( 0.9.2342.19200300.100.4.15 NAME 'dNSDomain' SUP domain
+  MAY ( ARecord $ MDRecord $ MXRecord $ NSRecord $ SOARecord $ CNAMERecord )
+  X-ORIGIN 'RFC 1274' )
+objectClasses: ( 0.9.2342.19200300.100.4.21 NAME 'pilotDSA' SUP dSA
+  MUST dSAQuality X-ORIGIN 'RFC 1274' )
+objectClasses: ( 0.9.2342.19200300.100.4.22 NAME 'qualityLabelledData' SUP top
+  MUST dSAQuality MAY ( subtreeMinimumQuality $ subtreeMaximumQuality )
+  X-ORIGIN 'RFC 1274' )
+objectClasses: ( 1.2.826.0.1.3458854.2.1.1 NAME 'groupOfEntries' SUP top
+  STRUCTURAL MUST cn MAY ( member $ businessCategory $ seeAlso $ owner $ ou $
+  o $ description ) X-ORIGIN 'draft-findlay-ldap-groupofentries' )
+

--- a/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/01-pwpolicy.ldif
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/01-pwpolicy.ldif
@@ -1,0 +1,118 @@
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at
+# trunk/opends/resource/legal-notices/OpenDS.LICENSE
+# or https://OpenDS.dev.java.net/OpenDS.LICENSE.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at
+# trunk/opends/resource/legal-notices/OpenDS.LICENSE.  If applicable,
+# add the following below this CDDL HEADER, with the fields enclosed
+# by brackets "[]" replaced with your own identifying information:
+#      Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+#      Copyright 2006-2008 Sun Microsystems, Inc.
+#
+#
+# This file contains schema definitions from draft-behera-ldap-password-policy,
+# which defines a mechanism for storing password policy information in an LDAP
+# directory server.
+dn: cn=schema
+objectClass: top
+objectClass: ldapSubentry
+objectClass: subschema
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.1 NAME 'pwdAttribute'
+  EQUALITY objectIdentifierMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.38
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.2 NAME 'pwdMinAge'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.3 NAME 'pwdMaxAge'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.4 NAME 'pwdInHistory'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.5 NAME 'pwdCheckQuality'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.6 NAME 'pwdMinLength'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.7 NAME 'pwdExpireWarning'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.8 NAME 'pwdGraceAuthNLimit'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.9 NAME 'pwdLockout'
+  EQUALITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.10 NAME 'pwdLockoutDuration'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.11 NAME 'pwdMaxFailure'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.12 NAME 'pwdFailureCountInterval'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.13 NAME 'pwdMustChange'
+  EQUALITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.14 NAME 'pwdAllowUserChange'
+  EQUALITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.15 NAME 'pwdSafeModify'
+  EQUALITY booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.16 NAME 'pwdChangedTime'
+  DESC 'The time the password was last changed' EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.17 NAME 'pwdAccountLockedTime'
+  DESC 'The time an user account was locked' EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.19 NAME 'pwdFailureTime'
+  DESC 'The timestamps of the last consecutive authentication failures'
+  EQUALITY generalizedTimeMatch ORDERING generalizedTimeOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 NO-USER-MODIFICATION
+  USAGE directoryOperation X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.20 NAME 'pwdHistory'
+  DESC 'The history of user s passwords' EQUALITY octetStringMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 NO-USER-MODIFICATION
+  USAGE directoryOperation X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.21 NAME 'pwdGraceUseTime'
+  DESC 'The timestamps of the grace authentication after the password has
+  expired' EQUALITY generalizedTimeMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes: ( 1.3.6.1.4.1.42.2.27.8.1.22 NAME 'pwdReset'
+  DESC 'The indication that the password has been reset' EQUALITY booleanMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE USAGE directoryOperation
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+attributeTypes:  ( 1.3.6.1.4.1.42.2.27.8.1.23 NAME 'pwdPolicySubentry'
+  DESC 'The pwdPolicy subentry in effect for this object'
+  EQUALITY distinguishedNameMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+objectClasses: ( 1.3.6.1.4.1.42.2.27.8.2.1 NAME 'pwdPolicy' SUP top AUXILIARY
+  MUST ( pwdAttribute ) MAY ( pwdMinAge $ pwdMaxAge $ pwdInHistory $
+  pwdCheckQuality $ pwdMinLength $ pwdExpireWarning $ pwdGraceAuthNLimit $
+  pwdLockout $ pwdLockoutDuration $ pwdMaxFailure $ pwdFailureCountInterval $
+  pwdMustChange $ pwdAllowUserChange $ pwdSafeModify )
+  X-ORIGIN 'draft-behera-ldap-password-policy' )
+

--- a/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/04-rfc2307bis.ldif
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/04-rfc2307bis.ldif
@@ -1,0 +1,216 @@
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at
+# trunk/opends/resource/legal-notices/OpenDS.LICENSE
+# or https://OpenDS.dev.java.net/OpenDS.LICENSE.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at
+# trunk/opends/resource/legal-notices/OpenDS.LICENSE.  If applicable,
+# add the following below this CDDL HEADER, with the fields enclosed
+# by brackets "[]" replaced with your own identifying information:
+#      Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+#      Copyright 2006-2008 Sun Microsystems, Inc.
+#
+#
+# This file contains schema definitions from the draft-howard-rfc2307bis
+# specification, used to store naming service information in the Directory
+# Node.
+dn: cn=schema
+objectClass: top
+objectClass: ldapSubentry
+objectClass: subschema
+attributeTypes: ( 1.3.6.1.1.1.1.0 NAME 'uidNumber'
+  DESC 'An integer uniquely identifying a user in an administrative domain'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.1 NAME 'gidNumber'
+  DESC 'An integer uniquely identifying a group in an administrative domain'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.2 NAME 'gecos'
+  DESC 'The GECOS field; the common name' EQUALITY caseIgnoreIA5Match
+  SUBSTR caseIgnoreIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.3 NAME 'homeDirectory'
+  DESC 'The absolute path to the home directory' EQUALITY caseExactIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.4 NAME 'loginShell'
+  DESC 'The path to the login shell' EQUALITY caseExactIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.5 NAME 'shadowLastChange' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.6 NAME 'shadowMin' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.7 NAME 'shadowMax' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.8 NAME 'shadowWarning' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.9 NAME 'shadowInactive' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.10 NAME 'shadowExpire' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.11 NAME 'shadowFlag' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.12 NAME 'memberUid' EQUALITY caseExactIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.13 NAME 'memberNisNetgroup'
+  EQUALITY caseExactIA5Match SUBSTR caseExactIA5SubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.14 NAME 'nisNetgroupTriple'
+  DESC 'Netgroup triple' EQUALITY caseIgnoreIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.15 NAME 'ipServicePort'
+  DESC 'Service port number' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.16 NAME 'ipServiceProtocol'
+  DESC 'Service protocol name' SUP name X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.17 NAME 'ipProtocolNumber'
+  DESC 'IP protocol number' EQUALITY integerMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.18 NAME 'oncRpcNumber' DESC 'ONC RPC number'
+  EQUALITY integerMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.19 NAME 'ipHostNumber'
+  DESC 'IPv4 addresses as a dotted decimal omitting leading zeros or IPv6
+  addresses as defined in RFC2373' SUP name
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.20 NAME 'ipNetworkNumber'
+  DESC 'IP network as a dotted decimal, eg. 192.168, omitting leading zeros'
+  SUP name SINGLE-VALUE X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.21 NAME 'ipNetmaskNumber'
+  DESC 'IP netmask as a dotted decimal, eg. 255.255.255.0, omitting leading
+  zeros' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.22 NAME 'macAddress'
+  DESC 'MAC address in maximal, colon separated hex notation, eg.
+  00:00:92:90:ee:e2' EQUALITY caseIgnoreIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.23 NAME 'bootParameter'
+  DESC 'rpc.bootparamd parameter' EQUALITY caseExactIA5Match
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.24 NAME 'bootFile' DESC 'Boot image name'
+  EQUALITY caseExactIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.26 NAME 'nisMapName'
+  DESC 'Name of a A generic NIS map' SUP name
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.27 NAME 'nisMapEntry'
+  DESC 'A generic NIS entry' EQUALITY caseExactIA5Match
+  SUBSTR caseExactIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.28 NAME 'nisPublicKey' DESC 'NIS public key'
+  EQUALITY octetStringMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.29 NAME 'nisSecretKey' DESC 'NIS secret key'
+  EQUALITY octetStringMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 SINGLE-VALUE
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.30 NAME 'nisDomain' DESC 'NIS domain'
+  EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.31 NAME 'automountMapName'
+  DESC 'automount Map Name' EQUALITY caseExactIA5Match
+  SUBSTR caseExactIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.32 NAME 'automountKey'
+  DESC 'Automount Key value' EQUALITY caseExactIA5Match
+  SUBSTR caseExactIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE X-ORIGIN 'draft-howard-rfc2307bis' )
+attributeTypes: ( 1.3.6.1.1.1.1.33 NAME 'automountInformation'
+  DESC 'Automount information' EQUALITY caseExactIA5Match
+  SUBSTR caseExactIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  SINGLE-VALUE X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.0 NAME 'posixAccount' SUP top AUXILIARY
+  DESC 'Abstraction of an account with POSIX attributes'
+  MUST ( cn $ uid $ uidNumber $ gidNumber $ homeDirectory )
+  MAY ( authPassword $ userPassword $ loginShell $ gecos $ description )
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.1 NAME 'shadowAccount' SUP top AUXILIARY
+  DESC 'Additional attributes for shadow passwords' MUST uid
+  MAY ( authPassword $ userPassword $ description $ shadowLastChange $
+  shadowMin $ shadowMax $ shadowWarning $ shadowInactive $ shadowExpire $
+  shadowFlag ) X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.2 NAME 'posixGroup' SUP top AUXILIARY
+  DESC 'Abstraction of a group of accounts' MUST gidNumber
+  MAY ( authPassword $ userPassword $ memberUid $ description )
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.3 NAME 'ipService' SUP top STRUCTURAL
+  DESC 'Abstraction an Internet Protocol service.  Maps an IP port and protocol
+  (such as tcp or udp) to one or more names; the distinguished value of the cn
+  attribute denotes the canonical name of the service'
+  MUST ( cn $ ipServicePort $ ipServiceProtocol ) MAY description
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.4 NAME 'ipProtocol' SUP top STRUCTURAL
+  DESC 'Abstraction of an IP protocol. Maps a protocol number to one or more
+  names. The distinguished value of the cn attribute denotes the canonical name
+  of the protocol' MUST ( cn $ ipProtocolNumber ) MAY description
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.5 NAME 'oncRpc' SUP top STRUCTURAL
+  DESC 'Abstraction of an Open Network Computing (ONC) [RFC1057] Remote
+  Procedure Call (RPC) binding.  This class maps an ONC RPC number to a name.
+  The distinguished value of the cn attribute denotes the canonical name of the
+  RPC service' MUST ( cn $ oncRpcNumber ) MAY description
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.6 NAME 'ipHost' SUP top AUXILIARY
+  DESC 'Abstraction of a host, an IP device. The distinguished value of the cn
+  attribute denotes the canonical name of the host. Device SHOULD be used as a
+  structural class' MUST ( cn $ ipHostNumber )
+  MAY ( authPassword $ userPassword $ l $ description $ manager )
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.7 NAME 'ipNetwork' SUP top STRUCTURAL
+  DESC 'Abstraction of a network. The distinguished value of the cn attribute
+  denotes the canonical name of the network' MUST ipNetworkNumber
+  MAY ( cn $ ipNetmaskNumber $ l $ description $ manager )
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.8 NAME 'nisNetgroup' SUP top STRUCTURAL
+  DESC 'Abstraction of a netgroup. May refer to other netgroups' MUST cn
+  MAY ( nisNetgroupTriple $ memberNisNetgroup $ description )
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.9 NAME 'nisMap' SUP top STRUCTURAL
+  DESC 'A generic abstraction of a NIS map' MUST nisMapName MAY description
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.10 NAME 'nisObject' SUP top STRUCTURAL
+  DESC 'An entry in a NIS map' MUST ( cn $ nisMapEntry $ nisMapName )
+  MAY description X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.11 NAME 'ieee802Device' SUP top AUXILIARY
+  DESC 'A device with a MAC address; device SHOULD be used as a structural
+  class' MAY macAddress X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.12 NAME 'bootableDevice' SUP top AUXILIARY
+  DESC 'A device with boot parameters; device SHOULD be used as a structural
+  class' MAY ( bootFile $ bootParameter ) X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.14 NAME 'nisKeyObject' SUP top AUXILIARY
+  DESC 'An object with a public and secret key'
+  MUST ( cn $ nisPublicKey $ nisSecretKey ) MAY ( uidNumber $ description )
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.15 NAME 'nisDomainObject' SUP top AUXILIARY
+  DESC 'Associates a NIS domain with a naming context' MUST nisDomain
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.16 NAME 'automountMap' SUP top STRUCTURAL
+  MUST ( automountMapName ) MAY description
+  X-ORIGIN 'draft-howard-rfc2307bis' )
+objectClasses: ( 1.3.6.1.1.1.2.17 NAME 'automount' SUP top STRUCTURAL
+  DESC 'Automount information' MUST ( automountKey $ automountInformation )
+  MAY description X-ORIGIN 'draft-howard-rfc2307bis' )
+

--- a/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/05-rfc4876.ldif
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/05-rfc4876.ldif
@@ -1,0 +1,127 @@
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at
+# trunk/opends/resource/legal-notices/OpenDS.LICENSE
+# or https://OpenDS.dev.java.net/OpenDS.LICENSE.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at
+# trunk/opends/resource/legal-notices/OpenDS.LICENSE.  If applicable,
+# add the following below this CDDL HEADER, with the fields enclosed
+# by brackets "[]" replaced with your own identifying information:
+#      Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+#      Copyright 2008 Sun Microsystems, Inc.
+#
+#
+# This file contains schema definitions from RFC 4876, which defines a schema # for storing Directory User Agent (DUA) profiles and preferences in the
+# Directory Node.
+#
+# Example profile
+# dn: ou=profile,dc=example,dc=com
+# objectClass: top
+# objectClass: organizationalUnit
+# ou: profile
+# 
+# dn: cn=Solaris,ou=profile,dc=example,dc=com
+# objectClass: top
+# objectClass: DUAConfigProfile
+# cn: Solaris
+# defaultNodeList: ldap1.example.com ldap2.example.com
+# defaultSearchBase: dc=example,dc=com
+# defaultSearchScope: one
+# searchTimeLimit: 30
+# bindTimeLimit: 2
+# credentialLevel: anonymous
+# authenticationMethod: simple
+# followReferrals: TRUE
+# profileTTL: 43200
+#
+dn: cn=schema
+objectClass: top
+objectClass: ldapSubentry
+objectClass: subschema
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.0 NAME 'defaultNodeList'
+  DESC 'List of default servers' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.1 NAME 'defaultSearchBase'
+  DESC 'Default base for searches' EQUALITY distinguishedNameMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.2 NAME 'preferredNodeList'
+  DESC 'List of preferred servers' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.3 NAME 'searchTimeLimit'
+  DESC 'Maximum time an agent or service allows for a search to complete'
+  EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX
+  1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.4 NAME 'bindTimeLimit'
+  DESC 'Maximum time an agent or service allows for a bind operation to
+  complete' EQUALITY integerMatch ORDERING integerOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.5 NAME 'followReferrals'
+  DESC 'An agent or service does or should follow referrals' EQUALITY
+  booleanMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE X-ORIGIN
+  'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.6 NAME 'authenticationMethod'
+  DESC 'Identifies the types of authentication methods either used,
+  required, or provided by a service or peer' EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.7 NAME 'profileTTL'
+  DESC 'Time to live, in seconds, before a profile is considered stale'
+  EQUALITY integerMatch ORDERING integerOrderingMatch SYNTAX
+  1.3.6.1.4.1.1466.115.121.1.27 SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.9 NAME 'attributeMap'
+  DESC 'Attribute mappings used, required, or supported by an agent or
+  service' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
+  X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.10 NAME 'credentialLevel'
+  DESC 'Identifies type of credentials either used, required, or supported
+  by an agent or service' EQUALITY caseIgnoreIA5Match SYNTAX
+  1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.11 NAME 'objectclassMap'
+  DESC 'Object class mappings used, required, or supported by an agent or
+  service' EQUALITY caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 
+  X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.12 NAME 'defaultSearchScope'
+  DESC 'Default scope used when performing a search' EQUALITY
+  caseIgnoreIA5Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 SINGLE-VALUE
+  X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.13 NAME 'serviceCredentialLevel'
+  DESC 'Specifies the type of credentials either used, required, or
+  supported by a specific service' EQUALITY caseIgnoreIA5Match SYNTAX
+  1.3.6.1.4.1.1466.115.121.1.26 X-ORIGIN 'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.14 NAME 'serviceSearchDescriptor'
+  DESC 'Specifies search descriptors required, used, or supported by a
+  particular service or agent' EQUALITY caseExactMatch SUBSTR
+  caseExactSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN
+  'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.15 NAME 'serviceAuthenticationMethod'
+  DESC 'Specifies types authentication methods either used, required, or
+  supported by a particular service' EQUALITY caseIgnoreMatch SUBSTR
+  caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 X-ORIGIN
+  'RFC 4876' )
+attributeTypes: ( 1.3.6.1.4.1.11.1.3.1.1.16 NAME 'dereferenceAliases'
+  DESC 'Specifies if a service or agent either requires, supports, or uses
+  dereferencing of aliases.' EQUALITY booleanMatch SYNTAX
+  1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE X-ORIGIN 'RFC 4876' )
+objectClasses: ( 1.3.6.1.4.1.11.1.3.1.2.5 NAME 'DUAConfigProfile'
+  SUP top STRUCTURAL DESC 'Abstraction of a base configuration for a DUA'
+  MUST ( cn ) MAY ( defaultNodeList $ preferredNodeList $
+  defaultSearchBase $ defaultSearchScope $ searchTimeLimit $ bindTimeLimit $
+  credentialLevel $ authenticationMethod $ followReferrals $
+  dereferenceAliases $ serviceSearchDescriptor $ serviceCredentialLevel $
+  serviceAuthenticationMethod $ objectclassMap $ attributeMap $ profileTTL )
+  X-ORIGIN 'RFC 4876' )

--- a/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/099-0-inventory.ldif
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/099-0-inventory.ldif
@@ -1,0 +1,891 @@
+dn: cn=schema
+objectclass: top
+#*************************************************************************
+# Copyright 2011 Normation SAS
+#*************************************************************************
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#*************************************************************************
+# CMDB schema
+#
+# Depends upon core.schema, cosine.schema, nis.schema and dyngroup.schema
+# Inventory OID
+#######################################################
+################## Attributes #########################
+#######################################################
+### UUIDs ###
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.1
+  NAME 'uuid'
+  DESC 'A generic UUID'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.1.1
+  NAME 'machineId'
+  DESC 'Unique identifier for a machine'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.1.2
+  NAME 'nodeId'
+  DESC 'Unique identifier for a node'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.1.3
+  NAME 'softwareId'
+  DESC 'Unique identifier for software'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.1.4
+  NAME 'motherBoardUuid'
+  DESC 'Mother board UUID'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.1.5
+  NAME 'policyServerId'
+  DESC 'Unique identifier for the policy server of a node'
+  SUP uuid )
+#######################################################################
+#
+# Top level objects: nodes and machines.
+#
+# A "node" is the logical part of a server. It knows
+# things like the OS, available RAM, installed software,
+# users, network interface, file system, etc.
+#
+# A "machine" is the physical part of a server.
+# It contains things like CPU, memory slots, hark disk, etc
+#
+#
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.2.1
+  NAME 'node'
+  DESC 'DN of a node'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  EQUALITY distinguishedNameMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.2.2
+  NAME 'machine'
+  DESC 'DN of a machine'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  EQUALITY distinguishedNameMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.2.3
+  NAME 'hostedVm'
+  DESC 'A machine known to be an Hosted VM in a server'
+  SUP machine )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.2.4
+  NAME 'container'
+  DESC 'A machine which is the container (physical or virtual) for a server'
+  SUP machine )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.2.5
+  NAME 'software'
+  DESC 'DN of software'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
+  EQUALITY distinguishedNameMatch )
+#
+# A node and a machine can be composed of elements.
+#
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200
+  NAME 'elementName'
+  DESC 'Slot number of a ram chipset'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+#
+# Node information
+#
+#
+# The first information for a node is its
+# Operating System
+#
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.1
+  NAME 'osName'
+  DESC 'os name of the node'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.2
+  NAME 'osFullName'
+  DESC 'os full name of the node'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.3
+  NAME 'osVersion'
+  DESC 'os version of the node'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  ORDERING caseIgnoreOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.4
+  NAME 'osServicePack'
+  DESC 'os service pack name of the node'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  ORDERING caseIgnoreOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.5
+  NAME 'osKernelVersion'
+  DESC 'kernel version of the os of the node'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  ORDERING caseIgnoreOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.6
+  NAME 'osArchitectureType'
+  DESC 'Details of the OS architecture (x86, x86-64, etc)'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+### windows specific information
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.21
+  NAME 'windowsUserDomain'
+  DESC 'User for the window system'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.22
+  NAME 'windowsRegistrationCompany'
+  DESC 'Company registered for that windows'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.23
+  NAME 'windowsKey'
+  DESC 'The registration KEY'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.100.24
+  NAME 'windowsId'
+  DESC 'The unique id of that windows instance'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+#
+# Other information for a node
+#
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.1
+  NAME 'nodeHostname'
+  DESC 'Host name of the server'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.2
+  NAME 'localAdministratorAccountName'
+  DESC 'The local administrator account name (login) on the node'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.3
+  NAME 'ram'
+  DESC 'Total RAM of the machine, in megabytes'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.4
+  NAME 'swap'
+  DESC 'Total SWAP of the machine, in megabytes'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.5
+  NAME 'localAccountName'
+  DESC 'A local account name (login) on the server'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.6
+  NAME 'lastLoggedUser'
+  DESC 'Login of the last logged user'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.7
+  NAME 'lastLoggedUserTime'
+  DESC 'Date and time of the last user login'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.8
+  NAME 'publicKey'
+  DESC 'A public key in PEM representation'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.9
+  NAME 'nodeTechniques'
+  DESC 'Name of techniques applied to that node'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.10
+  NAME 'confirmed'
+  DESC 'Flag to indicate a newly detected machine, not yet confirmed as real'
+  EQUALITY booleanMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
+  SINGLE-VALUE )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.11
+  NAME 'inventoryDate'
+  DESC 'Last time an inventory was done for that element'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.12
+  NAME 'receiveDate'
+  DESC 'Last time an inventory was received for that element'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.13
+  NAME 'agentName'
+  DESC 'List of name of the agent (Nova, Community, ...)'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.14
+  NAME 'environmentVariable'
+  DESC 'List of environnement variable'
+  EQUALITY caseExactMatch
+  SUBSTR caseExactSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.15
+  NAME 'process'
+  DESC 'List of processes'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+# prefix that one with rudder to avoid
+# name clashes with windows schema / server-role attribute
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.16
+  NAME 'rudderServerRole'
+  DESC 'List of rudder server role (rudder-webapp, etc)'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.17
+  NAME 'keyStatus'
+  DESC 'Status of security key of the Node'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.18
+  NAME 'timezoneName'
+  DESC 'Timezone name of the Node (potentially in local lang)'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.19
+  NAME 'timezoneOffset'
+  DESC 'Timezone offset of the Node (for ex +0200)'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+# A custom inventory property from a inventory hook.
+# It has the exact same serialisaton than a Rudder
+# Node Property in serializedNodeProperty (in rudder.schema)
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.300.20
+  NAME 'customProperty'
+  DESC 'A custom property from and agent intentory hook'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+#
+# A node can have some complex "logical" elements:
+# * network interfaces
+# * file systems
+# * vm
+#
+### network interfaces
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.1
+  NAME 'networkInterface'
+  DESC 'Name of a network interface'
+  SUP elementName )
+### network interfaces attributes
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.1
+  NAME 'networkInterfaceGateway'
+  DESC 'Network interface gateway address'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.2
+  NAME 'networkInterfaceDhcpServer'
+  DESC 'Network interface DHCP provider address'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.3
+  NAME 'networkInterfaceMask'
+  DESC 'Network interface subnet'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.4
+  NAME 'networkInterfaceMacAddress'
+  DESC 'Network interface MAC address'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.5
+  NAME 'networkInterfaceType'
+  DESC 'Network interface type'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.6
+  NAME 'networkInterfaceTypeMib'
+  DESC 'Network interface type mib'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+### file systems
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.2
+  NAME 'mountPoint'
+  DESC 'A mount point for a file system'
+  SUP elementName )
+### file system attributes
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.7
+  NAME 'fileCount'
+  DESC 'Number of file descriptor in the filesystem'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.8
+  NAME 'fileSystemFreeSpace'
+  DESC 'Free space in the filesystem, in megabytes'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.9
+  NAME 'fileSystemTotalSpace'
+  DESC 'Total space of the filesystem, in megabytes'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch )
+### VM
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.42
+  NAME 'virtualMachineUuid'
+  DESC 'vm unique identifier'
+  SUP elementName )
+### VM attributes
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.10
+  NAME 'vmType'
+  DESC 'kind of VM'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.11
+  NAME 'subsystem'
+  DESC 'VM susbsystem'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.12
+  NAME 'vmOwner'
+  DESC 'VM owner'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.13
+  NAME 'vmName'
+  DESC 'VM name'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.14
+  NAME 'vmStatus'
+  DESC 'VM status'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.15
+  NAME 'vmCpu'
+  DESC 'VM cpu'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.16
+  NAME 'vmMemory'
+  DESC 'process virtual memory'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+#
+# A machine can have some complex "physicale" elements:
+# * bios
+# * controllers
+# * cpus
+# * memory slots
+# * ports
+# * slots
+# * sound cards
+# * storages (hard drives, etc)
+# * video cards
+#
+### generic attributes
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.1
+  NAME 'speed'
+  DESC 'A speed, unit should be given in the attribute value, i.e: 5400MHz'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.2
+  NAME 'status'
+  DESC 'a status'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.3
+  NAME 'model'
+  DESC 'A model version of a (physical) component'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.4
+  NAME 'quantity'
+  DESC 'Number of occurence of the element (should always be >=0'
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.5
+  NAME 'smeType'
+  DESC 'Type of a system managed element'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.6
+  NAME 'manufacturer'
+  DESC 'Builder of a physical component'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.7
+  NAME 'firmware'
+  DESC 'Firmware related information'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.8
+  NAME 'componentSerialNumber'
+  DESC 'Serial number of a physical component'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+### physical element and attributes
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.3
+  NAME 'biosName'
+  DESC 'Name of a BIOS'
+  SUP elementName )
+### controller
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.4
+  NAME 'controllerName'
+  DESC 'Name of a controller interface'
+  SUP elementName )
+### cpu
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.5
+  NAME 'cpuName'
+  DESC 'Name of a CPU'
+  SUP elementName )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.9
+  NAME 'cpuSpeed'
+  DESC 'CPU speed, in mhz'
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.10
+  NAME 'cpuStepping'
+  DESC 'Number of CPU mode to reduce speed'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{16} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.11
+  NAME 'cpuFamily'
+  DESC 'Family number of the CPU'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.12
+  NAME 'cpuCore'
+  DESC 'Number of cores'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.13
+  NAME 'cpuThread'
+  DESC 'Number of threads'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.14
+  NAME 'cpuFamilyName'
+  DESC 'family name of the CPU'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.15
+  NAME 'cpuArchitecture'
+  DESC 'Achitecture of CPU'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.16
+  NAME 'cpuID'
+  DESC 'CPU ID'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.17
+  NAME 'cpuExternalClock'
+  DESC 'Number of cores'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+### memorySlot
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.6
+  NAME 'memorySlotNumber'
+  DESC 'Slot number of a ram chipset'
+  SUP elementName )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.18
+  NAME 'memoryCapacity'
+  DESC 'A memory capacity (ram, video, etc)'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.19
+  NAME 'memoryCaption'
+  DESC 'Information about a memory chip'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.20
+  NAME 'memorySpeed'
+  DESC 'Speed of a memory chipset'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.21
+  NAME 'memoryType'
+  DESC 'Memory type'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+### port
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.7
+  NAME 'portName'
+  DESC 'Name of a port'
+  SUP elementName )
+### slot
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.8
+  NAME 'slotName'
+  DESC 'Name of a Slot'
+  SUP elementName )
+### sound card
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.9
+  NAME 'soundCardName'
+  DESC 'Name of a sound card'
+  SUP elementName )
+### storage
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.10
+  NAME 'storageName'
+  DESC 'Name of a storage element (hard drive, etc)'
+  SUP elementName )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.22
+  NAME 'storageSize'
+  DESC 'The size of a storage unit'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+### video
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.200.11
+  NAME 'videoCardName'
+  DESC 'Name of a video card'
+  SUP elementName )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.23
+  NAME 'videoChipset'
+  DESC 'Information '
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.500.24
+  NAME 'videoResolution'
+  DESC 'Max resolution for a video chipset'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+#
+# Software related information
+#
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.50
+  NAME 'releaseDate'
+  DESC 'Release date of the element'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.51
+  NAME 'licenseExpirationDate'
+  DESC 'Expiration date of the license of the element'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.52
+  NAME 'licenseName'
+  DESC 'Name of the license of the element'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.53
+  NAME 'licenseDescription'
+  DESC 'Description of the license of the element'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.54
+  NAME 'licenseProductId'
+  DESC 'Product ID of the element on whom license applies'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.55
+  NAME 'licenseProductKey'
+  DESC 'Product Key of the element on whom license applies'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.56
+  NAME 'editor'
+  DESC 'Editor (or manufacturer) of the element'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.1.1.400.57
+  NAME 'softwareVersion'
+  DESC 'Version of the software, for ex: v3.0.34-pre4'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+#######################################################
+################  Object Classes ######################
+#######################################################
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.0
+  NAME 'configurationRoot'
+  DESC 'The object used as root of Rudder DIT'
+  SUP top
+  STRUCTURAL
+  MUST ( cn )
+  MAY ( description ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.1
+  NAME 'machine'
+  DESC 'A container for servers, ie a physical machine or a virtual machine'
+  SUP device
+  MUST ( machineId )
+  MAY ( cn $ description $ motherBoardUuid $ confirmed $ inventoryDate $ receiveDate $
+  manufacturer $ componentSerialNumber) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.2
+  NAME 'physicalMachine'
+  DESC 'A real, physical machine'
+  SUP top
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.3
+  NAME 'virtualMachine'
+  DESC 'A virtual machine'
+  SUP top
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.80.1
+  NAME 'vmWare'
+  DESC 'A VMWare VM'
+  SUP VirtualMachine
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.80.2
+  NAME 'virtualBox'
+  DESC 'A VirtualBox VM'
+  SUP VirtualMachine
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.80.3
+  NAME 'xen'
+  DESC 'A Xen VM'
+  SUP VirtualMachine
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.80.4
+  NAME 'solarisZone'
+  DESC 'A Zone in Solaris OS'
+  SUP VirtualMachine
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.80.5
+  NAME 'qemu'
+  DESC 'A Qemu VM'
+  SUP VirtualMachine
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.80.6
+  NAME 'aixLpar'
+  DESC 'An LPAR partition on AIX'
+  SUP VirtualMachine
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.80
+  NAME 'hyperV'
+  DESC 'A Hyper-V VM'
+  SUP VirtualMachine
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.80.7
+  NAME 'BSDJail'
+  DESC 'A BSD Jail'
+  SUP VirtualMachine
+  AUXILIARY )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.4
+  NAME 'physicalElement'
+  DESC 'A physical element, ie a component of a machine (network card, memory slots, etc)'
+  SUP top
+  ABSTRACT
+  MAY ( machineId $ machine $ description $ model $ componentSerialNumber $ firmware $
+  quantity $ smeType $ status $ manufacturer ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.5
+  NAME 'memoryPhysicalElement'
+  DESC 'A memory chipset (ram, etc)'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( memorySlotNumber )
+  MAY ( cn $ memoryCapacity $ memoryCaption $ memorySpeed $ memoryType ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.6
+  NAME 'storagePhysicalElement'
+  DESC 'A storage unit (hard disk, etc)'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( storageName )
+  MAY ( storageSize $ firmware ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.7
+  NAME 'biosPhysicalElement'
+  DESC 'A bios'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( biosName )
+  MAY ( releaseDate $ editor $ softwareVersion $ licenseExpirationDate $
+  licenseName $ licenseProductId $ licenseProductKey ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.8
+  NAME 'controllerPhysicalElement'
+  DESC 'A controller chipset'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( controllerName ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.9
+  NAME 'portPhysicalElement'
+  DESC 'A port element'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( portName ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.10
+  NAME 'processorPhysicalElement'
+  DESC 'A processor unit'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( cpuName )
+  MAY ( cpuSpeed $ cpuStepping $ cpuFamily $ cpuCore $ cpuThread $ cpuFamilyName $ cpuArchitecture $ cpuID $ cpuExternalClock ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.11
+  NAME 'slotPhysicalElement'
+  DESC 'A slot for external cards'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( slotName ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.12
+  NAME 'soundCardPhysicalElement'
+  DESC 'A sound card'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( soundCardName ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.13
+  NAME 'videoCardPhysicalElement'
+  DESC 'A video card'
+  SUP physicalElement
+  STRUCTURAL
+  MUST ( videoCardName )
+  MAY ( videoChipset $ videoResolution $ memoryCapacity) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.14
+  NAME 'node'
+  DESC 'A node entity. This is a logical server, such as an OS installation, may be on a virtual machine or a physical machine.'
+  SUP top
+  ABSTRACT
+  MUST ( nodeId $ localAdministratorAccountName $ nodeHostname $
+  policyServerId $ osName $ osVersion $ osKernelVersion )
+  MAY ( description $ cn $ publicKey $ agentName $ hostedVm $ container $
+  software $  localAccountName $ osServicePack $
+  nodeTechniques $ ram $ swap $ confirmed $
+  inventoryDate $ receiveDate $ ipHostNumber $ osFullName $
+  osArchitectureType $ lastLoggedUser $ lastLoggedUserTime $
+  environmentVariable $ process $ rudderServerRole $ keyStatus $
+  timezoneName $ timezoneOffset $ customProperty) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.15
+  NAME 'windowsNode'
+  DESC 'A node running Microsoft Windows as an operating system'
+  SUP node
+  STRUCTURAL
+  MAY ( windowsUserDomain $ windowsRegistrationCompany $ windowsKey $ windowsId ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.16
+  NAME 'unixNode'
+  DESC 'A node running a UNIX-like operating system'
+  SUP node
+  STRUCTURAL )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.17
+  NAME 'linuxNode'
+  DESC 'A node running GNU/Linux as an operating system'
+  SUP unixNode
+  STRUCTURAL )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.23
+  NAME 'solarisNode'
+  DESC 'A node running with Solaris as operating system'
+  SUP unixNode
+  STRUCTURAL )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.24
+  NAME 'aixNode'
+  DESC 'A node running with AIX as operating system'
+  SUP unixNode
+  STRUCTURAL )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.25
+  NAME 'bsdNode'
+  DESC 'A node running with BSD as operating system'
+  SUP unixNode
+  STRUCTURAL )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.18
+  NAME 'logicalElement'
+  DESC 'A logical element, ie a component of a node (network interface, file system, etc)'
+  SUP top
+  ABSTRACT
+  MAY ( nodeId $ node $ description ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.19
+  NAME 'fileSystemLogicalElement'
+  DESC 'A file system in an Operating System'
+  SUP logicalElement
+  STRUCTURAL
+  MUST ( mountPoint )
+  MAY ( cn $ fileCount $ fileSystemFreeSpace $ fileSystemTotalSpace ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.20
+  NAME 'networkInterfaceLogicalElement'
+  DESC 'A file system in an Operating System'
+  SUP logicalElement
+  STRUCTURAL
+  MUST ( networkInterface )
+  MAY ( status $ speed $ ipHostNumber $ networkInterfaceMacAddress $
+  networkInterfaceGateway $ ipNetworkNumber $ networkInterfaceDhcpServer $
+  networkInterfaceMask $ networkInterfaceType $ networkInterfaceTypeMib) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.21
+  NAME 'software'
+  DESC 'A software package'
+  SUP top
+  STRUCTURAL
+  MUST ( softwareId )
+  MAY ( cn $ description $ releaseDate $ editor $ softwareVersion $
+  licenseExpirationDate $ licenseName $ licenseProductId $ licenseProductKey ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.22
+  NAME 'virtualMachineLogicalElement'
+  DESC 'A VM installed on that node'
+  SUP logicalElement
+  STRUCTURAL
+  MUST ( virtualMachineUuid )
+  MAY (  vmType $ subsystem $ vmOwner $ vmName $ vmStatus $ vmCpu $ vmMemory ) )
+objectClasses: ( 1.3.6.1.4.1.35061.1.2.31
+  NAME 'dynGroup'
+  DESC 'Auxiliary objectClass to turn any entry into a dynamic group'
+  SUP top
+  AUXILIARY
+  MUST ( memberURL )
+  MAY ( description ) )

--- a/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/099-1-rudder.ldif
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/099-1-rudder.ldif
@@ -1,0 +1,451 @@
+dn: cn=schema
+objectclass: top
+#*************************************************************************
+# Copyright 2011 Normation SAS
+#*************************************************************************
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#*************************************************************************
+# CMDB schema
+#
+# Depends upon core.schema, cosine.schema, nis.schema and cmdb.schema
+# CMDB OID
+#######################################################
+####################### WARNING #######################
+#######################################################
+# This OID is necessary for OpenLDAP -> OpenDS schema tool,
+# but makes OpenLDAP crashes with a non-meaningfull error message
+# if cmdb.schema (where it is already declared) is included
+#######################################################
+####################### /WARNING ######################
+#######################################################
+#######################################################
+################## Attributes #########################
+#######################################################
+### UUIDs ###
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.102
+  NAME 'directiveId'
+  DESC 'Unique identifier for a directive'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.103
+  NAME 'targetDirectiveId'
+  DESC 'Unique identifier for a directive'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.104
+  NAME 'groupCategoryId'
+  DESC 'Unique identifier for a group category'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.105
+  NAME 'techniqueCategoryId'
+  DESC 'Unique identifier for a rudder category'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.106
+  NAME 'techniqueId'
+  DESC 'Unique identifier for a technique from Reference technique library'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.107
+  NAME 'activeTechniqueId'
+  DESC 'Unique identifier for a technique in Active technique library'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.108
+  NAME 'nodeGroupId'
+  DESC 'Unique identifier for a node group'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.109
+  NAME 'ruleId'
+  DESC 'Unique identifier for a rule'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.110
+  NAME 'apiAccountId'
+  DESC 'Unique identifier for an API Account'
+  SUP uuid )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.111
+  NAME 'ruleCategoryId'
+  DESC 'Unique identifier for a Rule category'
+  SUP uuid )
+#######################################################################
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.201
+  NAME 'techniqueLibraryVersion'
+  DESC 'The version'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.202
+  NAME 'techniqueVersion'
+  DESC 'The version'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.203
+  NAME 'initTimestamp'
+  DESC 'Date and time of initialization of the object'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.204
+  NAME 'jsonNodeGroupQuery'
+  DESC 'JSON structure that represent a query for a group of nodes'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.205
+  NAME 'ruleTarget'
+  DESC 'Target of the directive. It is something of the form targetType:targetUuid'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.206
+  NAME 'creationDate'
+  DESC 'Creation date of the item'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch )
+#
+# A policy variable and its values.
+# The expected format is:
+# variableName[index]:variableValue
+#
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.208
+  NAME 'directiveVariable'
+  DESC 'Pair of variable:value'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.210
+  NAME 'acceptationTimestamp'
+  DESC 'Creation date of a user policy'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.211.0
+  NAME 'state'
+  DESC 'Define the state of an item '
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.212
+  NAME 'isEnabled'
+  DESC 'Define if the object is currently activated or not (and so should be ignore)'
+  EQUALITY booleanMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7  )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.213
+  NAME 'isDynamic'
+  DESC 'Define if the group is dynamic'
+  EQUALITY booleanMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7  )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.214
+  NAME 'isSystem'
+  DESC 'Define if the CR/Group/PI/UPT/Node is created by the system'
+  EQUALITY booleanMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7  )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.215
+  NAME 'isBroken'
+  DESC 'Define if the node is broken'
+  EQUALITY booleanMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7  )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.216
+  NAME 'isPolicyServer'
+  DESC 'Define if this node configuration refers to a policy server'
+  EQUALITY booleanMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.7  )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.217
+  NAME 'directivePriority'
+  DESC 'The priority of the object compare to other. Higher has more priority'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.218
+  NAME 'longDescription'
+  DESC 'A long field for text (HTLM expected)'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.219
+  NAME 'serial'
+  DESC 'The serial of the Rule'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
+  EQUALITY integerMatch
+  ORDERING integerOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.226
+  NAME 'creationTimestamp'
+  DESC 'Creation date of an object - can be different than the createTimestamp operational attribute'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.229
+  NAME 'tag'
+  DESC 'ID of tag'
+  SUP uuid )
+### node configuration
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.230
+  NAME 'nodeConfig'
+  DESC 'Attribute used to store a structured hash of a node configuration'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{4096} )
+### Policy mode, common for Nodes/Directive at first, Surely Rules and groups later
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.231
+  NAME 'policyMode'
+  DESC 'Policy mode (Enforce/Verify) for this element '
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch )
+### Tags key=value, stored in JSON
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.235
+  NAME 'serializedTags'
+  DESC 'key=value tags stored in JSON'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+### API principal and tokens
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.250
+  NAME 'apiToken'
+  DESC 'The token used to authenticate an API principal'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15{256} )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.251
+  NAME 'apiTokenCreationTimestamp'
+  DESC 'Last creation date of the API Token'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.252
+  NAME 'expirationTimestamp'
+  DESC 'Date and time on which the token expires'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
+  EQUALITY generalizedTimeMatch
+  ORDERING generalizedTimeOrderingMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.253
+  NAME 'apiAcl'
+  DESC 'JSON serialization of ACL for an API token'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.254
+  NAME 'apiAccountKind'
+  DESC 'Kind of API account (public API, user-bounded, system)'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.255
+  NAME 'apiAuthorizationKind'
+  DESC 'Kind of API account (public API, user-bounded, system)'
+  EQUALITY caseIgnoreMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.301
+  NAME 'parameterName'
+  DESC 'Name of parameter that matches [a-zA-Z0-9_]+'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.302
+  NAME 'parameterValue'
+  DESC 'Value of a parameter'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.304
+  NAME 'propertyName'
+  DESC 'Name of property that matches [a-zA-Z0-9_]+'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.305
+  NAME 'propertyValue'
+  DESC 'Value of a property'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.307
+  NAME 'propertyProvider'
+  DESC 'Provider for properties and parameter'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+#
+# A key=value serialisation, with being json.
+# It's the same than serializedNodeProperty but for
+# other elements (like groups).
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.306
+  NAME 'serializedProperty'
+  DESC 'Serialization of a property, typically a key=value pair)'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch )
+#### Nodes
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.351
+  NAME 'serializedAgentRunInterval'
+  DESC 'Serialization of the defined agent run interval (interval in minutes, start minutes, start hour, splay in minutes)'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.352
+  NAME 'serializedNodeProperty'
+  DESC 'Serialization of a node property, typically a key=value pair)'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.353
+  NAME 'serializedHeartbeatRunConfiguration'
+  DESC 'Serialization of the defined heartbeat configuration defined for that node'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch )
+attributeTypes: ( 1.3.6.1.4.1.35061.2.1.354
+  NAME 'agentReportingProtocol'
+  DESC 'Protocol used by agent for reporting'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch )
+#######################################################
+################  Object Classes ######################
+#######################################################
+#
+# Rudder mains objects:
+# * nodes and policy server
+# * node group categories
+# * node groups
+# * library of active technique categories
+# * activeTechnique
+# * directive
+# * rules
+#
+### nodes (simple and policy server) for Rudder ###
+objectClasses: ( 1.3.6.1.4.1.35061.2.2.1
+  NAME 'rudderNode'
+  DESC 'The Node itself'
+  SUP top
+  STRUCTURAL
+  MUST ( nodeId $ cn $ isSystem )
+  MAY ( description $ serializedNodeProperty $ serializedAgentRunInterval $
+  serializedHeartbeatRunConfiguration $ agentReportingProtocol $ policyMode $ state $ isBroken) )
+objectClasses: ( 1.3.6.1.4.1.35061.2.2.2
+  NAME 'rudderPolicyServer'
+  DESC 'The Node representation of a policy server'
+  SUP rudderNode
+  STRUCTURAL )
+### groups ###
+objectClasses: ( 1.3.6.1.4.1.35061.2.2.10
+  NAME 'groupCategory'
+  DESC 'The group category'
+  SUP top
+  STRUCTURAL
+  MUST ( groupCategoryId $ cn )
+  MAY ( description $ isSystem ) )
+objectClasses: ( 1.3.6.1.4.1.35061.2.2.11
+  NAME 'nodeGroup'
+  DESC 'A node group representation'
+  SUP top
+  STRUCTURAL
+  MUST ( nodeGroupId $
+  cn $ isDynamic )
+  MAY ( nodeId $ description $ jsonNodeGroupQuery $
+  isEnabled $ isSystem $ serializedProperty ) )
+objectClasses: ( 1.3.6.1.4.1.35061.2.2.12
+  NAME 'specialRuleTarget'
+  DESC 'A special target (other than a nodeGroup), for example: all servers'
+  SUP top
+  STRUCTURAL
+  MUST ( ruleTarget $ cn )
+  MAY (  description $ isEnabled $ isSystem ) )
+### active technique library ###
+objectClasses: ( 1.3.6.1.4.1.35061.2.2.20
+  NAME 'activeTechniqueLibraryVersion'
+  DESC 'An object class to contain information about the user library (version, initialisation timestamp)'
+  SUP top
+  AUXILIARY
+  MAY ( initTimestamp $ techniqueLibraryVersion ) )
+objectClasses: ( 1.3.6.1.4.1.35061.2.2.21
+  NAME 'techniqueCategory'
+  DESC 'The Rudder category'
+  SUP top
+  STRUCTURAL
+  MUST ( techniqueCategoryId $ cn )
+  MAY ( description $ isSystem ) )
+objectClasses: ( 1.3.6.1.4.1.35061.2.2.22
+  NAME 'activeTechnique'
+  DESC 'The Rudder category'
+  SUP top
+  STRUCTURAL
+  MUST ( activeTechniqueId $ techniqueId $ acceptationTimestamp)
+  MAY ( isEnabled $ isSystem ) )
+objectClasses: ( 1.3.6.1.4.1.35061.2.2.23
+  NAME 'directive'
+  DESC 'Rudder Directive (real)'
+  SUP top
+  STRUCTURAL
+  MUST ( directiveId $ techniqueVersion )
+  MAY ( cn $ description $ longDescription $ isEnabled $ isSystem $
+  directivePriority $ directiveVariable $ policyMode $ serializedTags) )
+### rules ###
+objectClasses: ( 1.3.6.1.4.1.35061.2.2.30
+  NAME 'rule'
+  DESC 'A rule'
+  SUP top
+  STRUCTURAL
+  MUST ( ruleId )
+  MAY ( cn $ description $ longDescription $
+  isEnabled $ isSystem $
+  ruleTarget $ serial $
+  directiveId $ tag $ serializedTags ) )
+objectClasses: ( 1.3.6.1.4.1.35061.2.2.31
+  NAME 'ruleCategory'
+  DESC 'Rule categories'
+  SUP top
+  STRUCTURAL
+  MUST ( ruleCategoryId $ cn )
+  MAY ( description $ isSystem ) )
+#
+# Node configurations (structured hashes about node configuration)
+#
+objectClasses: ( 1.3.6.1.4.1.35061.2.2.110
+  NAME 'nodeConfigurations'
+  DESC 'Store node configurations'
+  SUP top
+  STRUCTURAL
+  MUST ( cn )
+  MAY ( description $ nodeConfig  ) )
+#
+# API Accounts
+#
+objectClasses: ( 1.3.6.1.4.1.35061.2.2.106
+  NAME 'apiAccount'
+  DESC 'A principal for the REST API'
+  SUP top
+  STRUCTURAL
+  MUST ( apiAccountId $ cn $ creationTimestamp $
+  apiToken $ apiTokenCreationTimestamp)
+  MAY ( description  $ isEnabled $ apiAccountKind $
+  apiAuthorizationKind $ apiAcl $ expirationTimestamp ) )
+#
+# Parameters
+#
+objectClasses: ( 1.3.6.1.4.1.35061.2.2.120
+  NAME 'parameter'
+  DESC 'A parameter of the format key - value'
+  SUP top
+  STRUCTURAL
+  MUST ( parameterName )
+  MAY ( parameterValue $ description $ propertyProvider) )
+#
+# Application properties
+#
+objectClasses: ( 1.3.6.1.4.1.35061.2.2.121
+  NAME 'property'
+  DESC 'A property of the format key - value'
+  SUP top
+  STRUCTURAL
+  MUST ( propertyName )
+  MAY ( propertyValue $ description ) )

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
@@ -135,12 +135,23 @@ class TestMigrateSystemTechniques7_0 extends Specification {
 
   // initialize test environnement - long and painful //
 
-  val bootstrapLDIFs = ("ldap-data/bootstrap-6_2.ldif" ::
-                        "ldap-data/init-root-server-6_2.ldif" ::
-                        "ldap-data/init-relay1-server-6_2.ldif" ::
+  val schema = (
+      "00-core" ::
+      "01-pwpolicy" ::
+      "04-rfc2307bis" ::
+      "05-rfc4876" ::
+      "099-0-inventory" ::
+      "099-1-rudder" :: Nil) map { name =>
+    // toURI is needed for https://issues.rudder.io/issues/19186
+    this.getClass.getClassLoader.getResource("ldap-data/schema/"+name+".ldif").toURI.getPath
+  }
+
+  val bootstrapLDIFs = ("bootstrap-6_2.ldif" ::
+                        "init-root-server-6_2.ldif" ::
+                        "init-relay1-server-6_2.ldif" ::
                         Nil) map { name =>
     // toURI is needed for https://issues.rudder.io/issues/19186
-    this.getClass.getClassLoader.getResource(name).toURI.getPath
+    this.getClass.getClassLoader.getResource("ldap-data/"+name).toURI.getPath
   }
 
   val root = NodeConfigData.root
@@ -189,7 +200,7 @@ class TestMigrateSystemTechniques7_0 extends Specification {
     }
   }
 
-  val ldap = InitTestLDAPServer.newLdapConnectionProvider(bootstrapLDIFs)
+  val ldap = InitTestLDAPServer.newLdapConnectionProvider(schema, bootstrapLDIFs)
   val roLdap = ldap.asInstanceOf[LDAPConnectionProvider[RoLDAPConnection]]
 
   val policyServerService = new PolicyServerManagementServiceImpl(ldap, rudderDit, eventLogRepos)


### PR DESCRIPTION
https://issues.rudder.io/issues/20009

So, the problem is that we tried to use a generic "InMemoryLdap" for test whose class is in `rudder-core`. That server need files, in `src/main/resources/ldap-data` to work. They are loaded with a `getClass/classloader/getResource/getpath`.

That works great when you use it for tests from `rudder-core`. That works well when used from `rudder-web` and maven knows that `rudder-core` is in the build task and so knows that it can actually access classes there. 
That does not work when maven try to build `rudder-web` autonoumously, because in that case, it gets `rudder-core-test.jar`, and files can't be accessed with a `getPath` in a jar. And java being what it is in expressivity, it does not say so but prefer a very informative NPE.
This PR just copy all needed files into `rudder-web` too, and change the ldap server to accept schema as parameter, and too bad for duplication. 
