### PR TITLE
Fixes #20065: After migrating from 6.2 to 7.0, techniques that were totally valid may become invalid because of name collision in rudderc

### DIFF
--- a/language/src/generator/cfengine.rs
+++ b/language/src/generator/cfengine.rs
@@ -488,6 +488,21 @@ impl Generator for CFEngine {
                     // means it's a lib file, not the file we are interested to generate
                     continue;
                 }
+                let resource_name = resource_name
+                    .strip_prefix("technique_")
+                    .or_else(|| {
+                        if policy_metadata {
+                            Some(resource_name)
+                        } else {
+                            None
+                        }
+                    })
+                    .ok_or_else(|| {
+                        err!(
+                            Token::new(resource.name, ""),
+                            "Technique resource must start with 'technique_'"
+                        )
+                    })?;
 
                 self.reset_context();
 
@@ -495,9 +510,9 @@ impl Generator for CFEngine {
                 let bundle_name = if state_name.fragment() == "technique" {
                     // special cases to be compatible with bundles produced by the webapp
                     // and called in the generated policies
-                    resource_name.fragment().to_owned()
+                    resource_name.to_owned()
                 } else {
-                    format!("{}_{}", resource_name.fragment(), state_name.fragment())
+                    format!("{}_{}", resource_name, state_name.fragment())
                 };
                 let parameters = resource
                     .parameters

--- a/language/src/generator/dsc.rs
+++ b/language/src/generator/dsc.rs
@@ -508,6 +508,21 @@ impl Generator for DSC {
                     // means it's a lib file, not the file we want to generate
                     continue;
                 }
+                let resource_name = resource_name
+                    .strip_prefix("technique_")
+                    .or_else(|| {
+                        if policy_metadata {
+                            Some(resource_name)
+                        } else {
+                            None
+                        }
+                    })
+                    .ok_or_else(|| {
+                        err!(
+                            Token::new(resource.name, ""),
+                            "Technique resource must start with 'technique_'"
+                        )
+                    })?;
                 self.reset_context();
 
                 // get parameters, default params are hardcoded for now
@@ -535,9 +550,9 @@ impl Generator for DSC {
                 formatted_parameters.push("[Switch]$AuditOnly".to_owned());
 
                 let fn_name = if state_name.fragment() == "technique" {
-                    resource_name.fragment().to_owned()
+                    resource_name.to_owned()
                 } else {
-                    format!("{} {}", resource_name.fragment(), state_name.fragment(),)
+                    format!("{} {}", resource_name, state_name.fragment(),)
                 };
 
                 let mut function = Function::agent(fn_name.clone())

--- a/language/src/technique.rs
+++ b/language/src/technique.rs
@@ -164,9 +164,9 @@ impl Technique {
 @category = "{category}"
 @parameters = [{parameters_meta}]
 
-resource {bundle_name}({parameter_list})
+resource technique_{bundle_name}({parameter_list})
 
-{bundle_name} state technique() {{{calls}}}
+technique_{bundle_name} state technique() {{{calls}}}
 "#,
             name = self.name,
             description = self.description,

--- a/language/tests/techniques/simplest/technique.rd
+++ b/language/tests/techniques/simplest/technique.rd
@@ -7,9 +7,9 @@
 @category = "ncf_techniques"
 @parameters = []
 
-resource simplest()
+resource technique_simplest()
 
-simplest state technique() {
+technique_simplest state technique() {
     @component = "File absent"
   @id = "aeca6c93-47af-41ee-ba4a-8772f4ce7dd8"
   file("""tmp""").absent() as file_absent_tmp


### PR DESCRIPTION
https://issues.rudder.io/issues/20065