### PR TITLE
Fixes #20099: Add a feature switch for rudderc use during generation

### DIFF
--- a/webapp/sources/api-doc/components/schemas/settings.yml
+++ b/webapp/sources/api-doc/components/schemas/settings.yml
@@ -169,6 +169,14 @@ settings:
       type: boolean
       default: true
       description: Recompute all dynamic groups at the start of policy generation
+    rudder_generation_rudderc_enabled_targets:
+      type: array
+      items:
+        type: string
+        enum:
+          - cfengine
+          - dsc
+      description: target agent languages for which rudderc will be tried first (with fallback to old generation method on error). Other targets will use fallback directly.
     rudder_compute_dyngroups_max_parallelism:
       type: string
       default: "1"

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -42,14 +42,17 @@ import com.normation.GitVersion.RevisionInfo
 import com.normation.rudder.apidata.JsonResponseObjects.JRPropertyHierarchy.JRPropertyHierarchyHtml
 import com.normation.rudder.apidata.JsonResponseObjects.JRPropertyHierarchy.JRPropertyHierarchyJson
 import com.normation.cfclerk.domain.Technique
+import com.normation.inventory.domain.RuddercTarget
 import com.normation.rudder.domain.policies._
 import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.rudder.rule.category.RuleCategory
+
 import zio.json.DeriveJsonEncoder
 import zio.json._
 import zio.json.internal.Write
 import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.repository.FullActiveTechnique
+
 import com.typesafe.config.ConfigRenderOptions
 import com.typesafe.config.ConfigValue
 import com.normation.rudder.domain.nodes.NodeGroup
@@ -66,6 +69,7 @@ import com.normation.rudder.domain.queries.QueryTrait
 import com.normation.rudder.domain.queries.ResultTransformation
 import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.utils.DateFormaterService
+
 import com.softwaremill.quicklens._
 import io.scalaland.chimney.dsl._
 
@@ -536,6 +540,8 @@ object JsonResponseObjects {
     }
   }
 
+  // used to encode RuddercTargets in settings into an json array of strings
+  final case class JRRuddercTargets(values: Set[RuddercTarget])
 
 }
 //////////////////////////// zio-json encoders ////////////////////////////
@@ -621,5 +627,7 @@ trait RudderJsonEncoders {
   implicit val objectInheritedObjectProperties: JsonEncoder[JRGroupInheritedProperties] = DeriveJsonEncoder.gen
 
   implicit val revisionInfoEncoder: JsonEncoder[JRRevisionInfo] = DeriveJsonEncoder.gen
+
+  implicit val ruddercTargetsEncoder: JsonEncoder[JRRuddercTargets] = JsonEncoder[List[String]].contramap[JRRuddercTargets](_.values.map(_.name).toList.sorted)
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
@@ -127,6 +127,15 @@ object TechniqueReaderLoggerPure extends NamedZioLogger {
   def loggerName = "techniques.reader"
 }
 
+/*
+ * Things related to transforming technique from editor
+ * to final agent specific files
+ */
+object TechniqueWriterLoggerPure extends NamedZioLogger {
+  def loggerName = "techniques.writer"
+}
+
+
 /**
  * Logger about change request and other workflow thing.
  */

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/2.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/2.0/metadata.xml
@@ -1,0 +1,44 @@
+<TECHNIQUE name="Test Technique created through Rudder API">
+  <POLICYGENERATION>separated-with-parameters</POLICYGENERATION>
+  <MULTIINSTANCE>true</MULTIINSTANCE>
+  <DESCRIPTION>This Technique exists only to see if Rudder creates Technique correctly.</DESCRIPTION>
+  <USEMETHODREPORTING>true</USEMETHODREPORTING>
+  <AGENT type="cfengine-community,cfengine-nova">
+    <BUNDLES>
+      <NAME>technique_any</NAME>
+    </BUNDLES>
+    <FILES>
+      <FILE name="RUDDER_CONFIGURATION_REPOSITORY/techniques/ncf_techniques/technique_any/2.0/technique.cf">
+        <INCLUDED>true</INCLUDED>
+      </FILE>
+    </FILES>
+  </AGENT>
+  <AGENT type="dsc">
+    <BUNDLES>
+      <NAME>Technique-Any</NAME>
+    </BUNDLES>
+    <FILES>
+      <FILE name="RUDDER_CONFIGURATION_REPOSITORY/techniques/ncf_techniques/technique_any/2.0/technique.ps1">
+        <INCLUDED>true</INCLUDED>
+      </FILE>
+    </FILES>
+  </AGENT>
+  <SECTIONS>
+    <SECTION component="true" multivalued="true" name="Test component$&amp;é)à\'&quot;">
+      <REPORTKEYS>
+        <VALUE>${node.properties[apache_package_name]}</VALUE>
+      </REPORTKEYS>
+    </SECTION>
+    <SECTION name="Technique parameters">
+      <INPUT>
+        <NAME>PACKAGE_VERSION</NAME>
+        <DESCRIPTION>version</DESCRIPTION>
+        <LONGDESCRIPTION>Package version to install</LONGDESCRIPTION>
+        <CONSTRAINT>
+          <TYPE>textarea</TYPE>
+          <MAYBEEMPTY>false</MAYBEEMPTY>
+        </CONSTRAINT>
+      </INPUT>
+    </SECTION>
+  </SECTIONS>
+</TECHNIQUE>

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/2.0/technique.cf
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/2.0/technique.cf
@@ -1,0 +1,16 @@
+# @name Test Technique created through Rudder API
+# @description This Technique exists only to see if Rudder creates Technique correctly.
+# @version 2.0
+# @parameter {"name":"version","id":"package_version","description":"Package version to install"}
+
+bundle agent technique_any(version)
+{
+  vars:
+    "resources_dir" string => "${this.promise_dirname}/resources";
+  methods:
+    "id" usebundle => _method_reporting_context("Test component$&é)à\\'\"", "${node.properties[apache_package_name]}"),
+                if => concat("any");
+    "id" usebundle => package_install_version("${node.properties[apache_package_name]}", "2.2.11"),
+                if => concat("any");
+
+}

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/2.0/technique.ps1
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/2.0/technique.ps1
@@ -1,0 +1,18 @@
+﻿function Technique-Any {
+  [CmdletBinding()]
+  param (
+      [parameter(Mandatory=$true)]
+      [string]$reportId,
+      [parameter(Mandatory=$true)]
+      [string]$techniqueName,
+      [parameter(Mandatory=$true)]
+      [string]$Version,
+      [switch]$auditOnly
+  )
+
+  $local_classes = New-ClassContext
+  $resources_dir = $PSScriptRoot + "\resources"
+
+  $local_classes = Merge-ClassContext $local_classes $(Package-Install-Version -PackageName "$($node.properties[apache_package_name])" -PackageVersion "2.2.11" -componentName "Test component$&é)à\'`"" -reportId $reportId -techniqueName $techniqueName -auditOnly:$auditOnly).get_item("classes")
+
+}

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_settings.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_settings.yml
@@ -55,6 +55,7 @@ response:
           "rudder_generation_js_timeout":30,
           "rudder_generation_max_parallelism":"x0.5",
           "rudder_generation_policy":"all",
+          "rudder_generation_rudderc_enabled_targets":["cfengine"],
           "rudder_report_protocol_default":"HTTPS",
           "rudder_save_db_compliance_details":false,
           "rudder_save_db_compliance_levels":true,
@@ -65,6 +66,27 @@ response:
           "unexpected_allows_duplicate":true,
           "unexpected_unbound_var_values":true
         }
+      }
+    }
+---
+description: Modify rudderc target
+method: POST
+url: /api/latest/settings/rudder_generation_rudderc_enabled_targets
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "value": ["dsc"]
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action":"modifySetting",
+      "id":"rudder_generation_rudderc_enabled_targets",
+      "result":"success",
+      "data":{
+        "settings":{"rudder_generation_rudderc_enabled_targets":["dsc"]}
       }
     }
 ---

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_techniques.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_techniques.yml
@@ -28,7 +28,7 @@ response:
           },
           {
             "name":"technique_any",
-            "versions":["1.0"]
+            "versions":["1.0","2.0"]
           },
           {
             "name":"rpmPackageInstallation",

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1143,6 +1143,7 @@ object RudderConfig extends Loggable {
     , techniqueSerializer
     , techniqueCompiler
     , "/var/log/rudder"
+    , configService.rudder_generation_rudderc_enabled_targets()
   )
   val ncfTechniqueReader : ncf.TechniqueReader = new ncf.TechniqueReader(
       restExtractorService


### PR DESCRIPTION
https://issues.rudder.io/issues/20099

Add the possibility to restrict rudderc enabled target via API (and only API in that PR, we will need an other one for UI, but at least it does not block beta2 anymore). 

Use by default only "cfengine" target. 

Test both API and writing files. 