### PR TITLE
Fixes #20342: Add a worst-case, weighted 1 for block compliance mode

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/DataTypes.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/DataTypes.scala
@@ -37,7 +37,6 @@
 
 package com.normation.inventory.domain
 
-import com.normation.utils.Utils._
 import org.bouncycastle.openssl.PEMParser
 import java.io.StringReader
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/VariableAndSectionSpec.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/VariableAndSectionSpec.scala
@@ -457,9 +457,11 @@ object DisplayPriority {
  *    compliance value will have the same level as the worst case, and will have weight equals
  *    to the sum of weight of all sub components.
  */
-sealed  trait ReportingLogic {
+sealed trait ReportingLogic {
   def value : String
 }
+
+sealed trait WorstReportReportingLogic extends ReportingLogic
 
 object ReportingLogic {
 
@@ -469,10 +471,10 @@ object ReportingLogic {
   final case class FocusReport(component : String) extends ReportingLogic {
     val value = s"${FocusReport.key}:${component}"
   }
-  final case object WorstReportWeightedOne extends ReportingLogic {
+  final case object WorstReportWeightedOne extends WorstReportReportingLogic {
     val value = "worst-case-weighted-one"
   }
-  final case object WorstReportWeightedSum extends ReportingLogic {
+  final case object WorstReportWeightedSum extends WorstReportReportingLogic {
     val value = "worst-case-weighted-sum"
   }
   final case object WeightedReport extends ReportingLogic {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/SectionSpecParser.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/SectionSpecParser.scala
@@ -140,7 +140,7 @@ class SectionSpecParser(variableParser:VariableSpecParser) extends Loggable {
 
     val composition = (root \ ("@reporting")).headOption.map( _.text) match {
       case null | Some("") | None => None
-      case Some(x) => ReportingLogic(x) match {
+      case Some(x) => ReportingLogic.parse(x) match {
         case Right(x) => Some(x)
         case Left(error) =>
           logger.error(s"There was an error when parsing reporting logic in technique ${id.name.value}/${id.version.debugString}, error is : ${error.msg} for element ${root}")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
@@ -460,7 +460,7 @@ object ExpectedReportsSerialisation {
           Full(ValueExpectedReport(name, values, unexpanded))
         case (JString(name), _, _, Some(Full(sub)), Some(composition) )=>
           for {
-            reportingLogic <-  ReportingLogic(composition).toBox
+            reportingLogic <-  ReportingLogic.parse(composition).toBox
           } yield {
             BlockExpectedReport(name, reportingLogic, sub.toList)
           }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -39,12 +39,15 @@ package com.normation.rudder.domain.reports
 
 import com.normation.cfclerk.domain.ReportingLogic
 import com.normation.cfclerk.domain.ReportingLogic.FocusReport
-import com.normation.cfclerk.domain.ReportingLogic.SumReport
-import com.normation.cfclerk.domain.ReportingLogic.WorstReport
+import com.normation.cfclerk.domain.ReportingLogic.WeightedReport
+import com.normation.cfclerk.domain.ReportingLogic.WorstReportWeightedOne
+import com.normation.cfclerk.domain.ReportingLogic.WorstReportWeightedSum
+
 import org.joda.time.DateTime
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.RuleId
+
 import net.liftweb.common.Loggable
 import com.normation.rudder.services.reports._
 
@@ -300,11 +303,15 @@ final case class BlockStatusReport (
   def compliance: ComplianceLevel = {
     import ReportingLogic._
     reportingLogic match {
-      case WorstReport =>
+      // simple weighted compliance, as usual
+      case WeightedReport         => ComplianceLevel.sum(subComponents.map(_.compliance))
+      // worst case bubble up, and its weight can be either 1 or the sum of sub-component weight
+      case WorstReportWeightedOne | WorstReportWeightedSum =>
         val worstReport = ReportType.getWorseType(subComponents.map(_.status))
         val allReports = getValues(_ => true).flatMap(_._2.messages.map(_ => worstReport))
-        ComplianceLevel.compute(allReports)
-      case SumReport => ComplianceLevel.sum(subComponents.map(_.compliance))
+        val kept = if(reportingLogic == WorstReportWeightedOne) allReports.take(1) else allReports
+        ComplianceLevel.compute(kept)
+      // focus on a given sub-component name (can be present several time, or 0 which leads to N/A)
       case FocusReport(component) => ComplianceLevel.sum(findChildren(component).map(_.compliance))
     }
   }
@@ -323,11 +330,10 @@ final case class BlockStatusReport (
 
   def status: ReportType = {
     reportingLogic match {
-      case WorstReport =>
+      case WorstReportWeightedOne | WorstReportWeightedSum | WeightedReport =>
         ReportType.getWorseType(subComponents.map(_.status))
-      case SumReport =>
-        ReportType.getWorseType(subComponents.map(_.status))
-      case FocusReport(component) => ReportType.getWorseType(findChildren(component).map(_.status))
+      case FocusReport(component)                                           =>
+        ReportType.getWorseType(findChildren(component).map(_.status))
     }
   }
 }
@@ -358,6 +364,12 @@ final case class ValueStatusReport  (
   }
 }
 
+/**
+ * Merge component status reports.
+ * We assign a arbitrary preponderance order for reporting logic mode:
+ * WorstReportWeightedOne > WorstReportWeightedSum > WeightedReport > FocusReport
+ * In the case of two focus, the focust for first component is kept.
+ */
 object ComponentStatusReport extends Loggable {
 
   def merge(components: Iterable[ComponentStatusReport]): Map[String, ComponentStatusReport] = {
@@ -375,20 +387,19 @@ object ComponentStatusReport extends Loggable {
           import ReportingLogic._
           val reportingLogic = r.map(_.reportingLogic).reduce(
             (a,b) => (a,b) match {
-                       case(WorstReport, _)    => WorstReport
-                       case(_, WorstReport)    => WorstReport
-                       case(SumReport, _)      => SumReport
-                       case(_, SumReport)      => SumReport
-                       case(FocusReport(a), _) => FocusReport(a)
+              case (WorstReportWeightedOne, _) | (_, WorstReportWeightedOne) => WorstReportWeightedOne
+              case (WorstReportWeightedSum, _) | (_, WorstReportWeightedSum) => WorstReportWeightedSum
+              case (WeightedReport, _)         | (_, WeightedReport)         => WeightedReport
+              case (FocusReport(a), _)                                       => FocusReport(a)
             }
           )
           Some(BlockStatusReport(cptName, reportingLogic, ComponentStatusReport.merge(r.flatMap(_.subComponents)).values.toList))
       }
 
       (valueComponents,groupComponent) match {
-        case (None, None) => Nil
-        case (Some(v),None) => (cptName, v) :: Nil
-        case (None,Some(v)) => (cptName, v) :: Nil
+        case (None       , None       ) => Nil
+        case (Some(v)    , None       ) => (cptName, v) :: Nil
+        case (None       , Some(v)    ) => (cptName, v) :: Nil
         case (Some(value), Some(group)) => (cptName, group.copy(subComponents = value :: group.subComponents)) :: Nil
       }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechnique.scala
@@ -350,8 +350,8 @@ class TechniqueSerializer(parameterTypeService: ParameterTypeService) {
       import ReportingLogic._
 
       reportingLogic match {
-        case WorstReport | SumReport=>  ("type"-> reportingLogic.value)
-        case FocusReport(component)  => ("type"  -> FocusReport.key) ~ ("value" -> component)
+        case FocusReport(component) => ("type" -> FocusReport.key) ~ ("value" -> component)
+        case _                      => ("type" -> reportingLogic.value)
       }
     }
     def serializeMethodBlock(block: MethodBlock): JValue = {

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/metadata.xml
@@ -28,7 +28,7 @@
     </FILES>
   </AGENT>
   <SECTIONS>
-    <SECTION component="true" multivalued="true" name="block component" reporting="worst">
+    <SECTION component="true" multivalued="true" name="block component" reporting="worst-case-weighted-sum">
       <SECTION component="true" multivalued="true" name="Customized component">
         <REPORTKEYS>
           <VALUE>${node.properties[apache_package_name]}</VALUE>

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_with_blocks/1.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_with_blocks/1.0/metadata.xml
@@ -22,8 +22,8 @@
     </FILES>
   </AGENT>
   <SECTIONS>
-    <SECTION component="true" multivalued="true" name="First block" reporting="sum">
-      <SECTION component="true" multivalued="true" name="inner block" reporting="sum">
+    <SECTION component="true" multivalued="true" name="First block" reporting="weighted">
+      <SECTION component="true" multivalued="true" name="inner block" reporting="weighted">
         <SECTION component="true" multivalued="true" name="Command execution">
           <REPORTKEYS>
             <VALUE>/bin/true</VALUE>

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
@@ -330,7 +330,7 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
       , MethodBlock (
             "id_method"
           , "block component"
-          , ReportingLogic.WorstReport
+          , ReportingLogic.WorstReportWeightedSum
           , "debian"
           , MethodCall(
                 BundleName("package_install_version")

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeExpectedReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeExpectedReportTest.scala
@@ -387,7 +387,7 @@ class NodeExpectedReportTest extends Specification {
                    }
                  , {
                      "componentName":"First block"
-                   , "reportingLogic":"sum"
+                   , "reportingLogic":"weighted"
                    , "subComponents": [
                        {
                          "componentName":"File absent"
@@ -396,7 +396,7 @@ class NodeExpectedReportTest extends Specification {
                        }
                      , {
                          "componentName":"inner block"
-                       , "reportingLogic":"sum"
+                       , "reportingLogic":"weighted"
                        , "subComponents": [
                          {
                            "componentName":"File absent"

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -1273,21 +1273,15 @@ final case class RestExtractorService (
   }
 
   def extractCompositionRule(json : JValue) : Box[ReportingLogic] = {
-    import ReportingLogic._
     for {
-      type_  <- CompleteJson.extractJsonString(json, "type")
-      optValue  <- OptionnalJson.extractJsonString(json, "value")
-      result <-
-        type_ match {
-          case WorstReport.value => Full(WorstReport)
-          case SumReport.value => Full(SumReport)
-          case FocusReport.key => Full(FocusReport(optValue.getOrElse("")))
-          case _ => Failure("")
-        }
+      type_    <- CompleteJson.extractJsonString(json, "type")
+      optValue <- OptionnalJson.extractJsonString(json, "value")
+      result   <- ReportingLogic.parse(type_, optValue.getOrElse("")).toBox
     } yield {
       result
     }
   }
+
   def extractMethodConstraint(json : JValue) : Box[List[Constraint]] = {
     for {
       allowEmpty <- CompleteJson.extractJsonBoolean(json, "allow_empty_string")

--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/DataTypes.elm
@@ -69,8 +69,9 @@ type alias Technique =
 type MethodElem = Call (Maybe CallId) MethodCall | Block (Maybe CallId) MethodBlock
 
 
+type WorstReportKind = WorstReportWeightedOne | WorstReportWeightedSum
 
-type ReportingLogic = WorstReportWeightedSum | WorstReportWeightedOne | WeightedReport | FocusReport String
+type ReportingLogic = WorstReport WorstReportKind | WeightedReport | FocusReport String
 
 type alias MethodBlock =
   { id : CallId

--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/DataTypes.elm
@@ -70,7 +70,7 @@ type MethodElem = Call (Maybe CallId) MethodCall | Block (Maybe CallId) MethodBl
 
 
 
-type ReportingLogic = WorstReport | SumReport | FocusReport String
+type ReportingLogic = WorstReportWeightedSum | WorstReportWeightedOne | WeightedReport | FocusReport String
 
 type alias MethodBlock =
   { id : CallId

--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/Editor.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/Editor.elm
@@ -592,7 +592,7 @@ update msg model =
     AddBlock newId ->
       if model.hasWriteRights then
       let
-        newCall = MethodBlock newId "" (Condition Nothing "") SumReport []
+        newCall = MethodBlock newId "" (Condition Nothing "") WeightedReport []
         newModel =
           case model.mode of
             TechniqueDetails t o ui ->
@@ -792,7 +792,7 @@ update msg model =
             (baseCalls, newElem) =
               case draggedItemId of
                 Move b ->  ( removeElem (getId >> (==) (getId b)) t.elems, b)
-                NewBlock -> (t.elems, Block Nothing (MethodBlock (CallId "") "" (Condition Nothing "") SumReport []))
+                NewBlock -> (t.elems, Block Nothing (MethodBlock (CallId "") "" (Condition Nothing "") WeightedReport []))
                 NewMethod method ->
                  let
                    disableReporting = String.contains "variable" method.name || String.contains "condition" method.name

--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/JsonDecoder.elm
@@ -52,11 +52,12 @@ decodeCompositionRule =
     innerDecoder =
       \v ->
         case v of
-          "worst" -> succeed WorstReport
-          "sum"   -> succeed SumReport
-          "focus" -> succeed FocusReport
-                       |> required "value" string
-          _       -> fail (v ++ " is not a valid reporting logic")
+          "worst-case-weighted-sum" -> succeed WorstReportWeightedSum
+          "worst-case-weighted-one" -> succeed WorstReportWeightedOne
+          "weighted"                -> succeed WeightedReport
+          "focus"                   -> succeed FocusReport
+                                       |> required "value" string
+          _                         -> fail (v ++ " is not a valid reporting logic")
   in succeed innerDecoder
     |> required "type" string
     |> resolve

--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/JsonDecoder.elm
@@ -52,8 +52,8 @@ decodeCompositionRule =
     innerDecoder =
       \v ->
         case v of
-          "worst-case-weighted-sum" -> succeed WorstReportWeightedSum
-          "worst-case-weighted-one" -> succeed WorstReportWeightedOne
+          "worst-case-weighted-sum" -> succeed (WorstReport WorstReportWeightedSum)
+          "worst-case-weighted-one" -> succeed (WorstReport WorstReportWeightedOne)
           "weighted"                -> succeed WeightedReport
           "focus"                   -> succeed FocusReport
                                        |> required "value" string

--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/JsonEncoder.elm
@@ -76,9 +76,9 @@ encodeMethodCall call =
 encodeCompositionRule: ReportingLogic -> Value
 encodeCompositionRule composition =
   case composition of
-    WorstReportWeightedSum ->
+    (WorstReport WorstReportWeightedSum) ->
       object [ ("type", string "worst-case-weighted-sum")]
-    WorstReportWeightedOne ->
+    (WorstReport WorstReportWeightedOne) ->
       object [ ("type", string "worst-case-weighted-one")]
     WeightedReport ->
       object [ ("type", string "weighted")]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/JsonEncoder.elm
@@ -76,10 +76,12 @@ encodeMethodCall call =
 encodeCompositionRule: ReportingLogic -> Value
 encodeCompositionRule composition =
   case composition of
-    WorstReport ->
-      object [ ("type", string "worst")]
-    SumReport ->
-      object [ ("type", string "sum")]
+    WorstReportWeightedSum ->
+      object [ ("type", string "worst-case-weighted-sum")]
+    WorstReportWeightedOne ->
+      object [ ("type", string "worst-case-weighted-one")]
+    WeightedReport ->
+      object [ ("type", string "weighted")]
     FocusReport value ->
       object [ ("type", string "focus"), ("value", string value)]
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewBlock.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewBlock.elm
@@ -203,18 +203,19 @@ showBlockTab model parentId block uiInfo techniqueUi =
     Children -> showChildren model block  { uiInfo | showChildDetails = True } techniqueUi parentId
     BlockReporting ->
       let
+        -- main select
         compositionText  = (\reportingLogic ->
                                case reportingLogic of
-                                 WorstReportWeightedSum -> "Worst report (weighted sum)"
-                                 WorstReportWeightedOne -> "Worst report (weighted 1)"
+                                 WorstReport _ -> "Worst report"
                                  WeightedReport -> "Weighted sum of reports"
                                  FocusReport _ -> "Focus on one child method report"
                              )
         liCompositionRule =  \rule -> element "li"
                                            |> addActionStopAndPrevent ("click", MethodCallModified (Block parentId {block | reportingLogic = rule }))
                                            |> appendChild (element "a" |> addAttribute (href "#") |> appendText (compositionText rule))
-        availableComposition = List.map liCompositionRule [ WeightedReport, FocusReport "", WorstReportWeightedOne, WorstReportWeightedSum ]
+        availableComposition = List.map liCompositionRule [ WeightedReport, FocusReport "", WorstReport WorstReportWeightedSum ]
 
+        -- sub-select - focus
         liFocus =  \child ->
                      let
                        componentValue = getComponent child
@@ -224,76 +225,67 @@ showBlockTab model parentId block uiInfo techniqueUi =
                                        Call _ c -> Maybe.withDefault (c.methodName.value) (Maybe.map .name (Dict.get c.methodName.value model.methods))
                                    else
                                      componentValue
-
                      in
                        element "li"
                                |> addActionStopAndPrevent ("click", MethodCallModified (Block parentId {block | reportingLogic = FocusReport (getId child).value }))
                                |> appendChild (element "a" |> addAttribute (href "#") |> appendText component)
+
         availableFocus = List.map liFocus block.calls
+
+        -- sub-select - worst case
+        labelWorst = \weight -> case weight of
+                         WorstReportWeightedOne -> "Use a weight of '1' for component"
+                         WorstReportWeightedSum -> "Use sum of sub-components for weight"
+
+        liWorst = \weight -> element "li"
+                    |> addActionStopAndPrevent ("click", MethodCallModified (Block parentId {block | reportingLogic = (WorstReport weight) }))
+                    |> appendChild (element "a" |> addAttribute (href "#") |> appendText (labelWorst weight))
+
+        availableWorst = List.map liWorst [ WorstReportWeightedOne, WorstReportWeightedSum]
 
       in
          element "div"
            |> appendChildList
-                        [ element "div"
-                          |> addClass "form-group"
-                          |> appendChildList
-                             [ element "label"
-                               |> addAttribute (for "reporting-rule")
-                               |> appendText "Reporting based on:"
-                             , element "div"
-                               |> addStyleList [ ("display","inline-block") , ("width", "auto"), ("margin-left", "5px") ]
-                               |> addClass "btn-group"
-                               |> appendChildList
-                                  [ element "button"
-                                    |> addClass "btn btn-default dropdown-toggle"
-                                    |> Dom.setId  "reporting-rule"
-                                    |> addAttributeList
-                                         [ attribute  "data-toggle" "dropdown"
-                                         , attribute  "aria-haspopup" "true"
-                                         , attribute "aria-expanded" "true"
-                                         ]
-                                    |> appendText ((compositionText block.reportingLogic) ++ " ")
-                                    |> appendChild (element "span" |> addClass "caret")
-                                  , element "ul"
-                                    |> addClass "dropdown-menu"
-                                    |> addAttribute  (attribute "aria-labelledby" "reporting-rule")
-                                    |> addStyle ("margin-left", "0px")
-                                    |> appendChildList availableComposition
-                                   ]
-                            ]
+                        [ buildSelectReporting "reporting-rule" "Reporting based on:" availableComposition ((compositionText block.reportingLogic) ++ " ")
                         ]
                      |> appendChild
                           ( case block.reportingLogic of
                               FocusReport value ->
-                                element "div"
-                                |> addClass "form-group"
-                                |> appendChildList
-                                   [ element "label"
-                                     |> addAttribute (for "reporting-rule-focus")
-                                     |> appendText "Focus reporting on method:"
-                                   , element "div"
-                                     |> addStyleList [ ("display","inline-block") , ("width", "auto"), ("margin-left", "5px") ]
-                                     |> addClass "btn-group"
-                                     |> appendChildList
-                                        [ element "button"
-                                          |> addClass "btn btn-default dropdown-toggle"
-                                          |> Dom.setId  "reporting-rule-focus"
-                                          |> addAttributeList
-                                               [ attribute  "data-toggle" "dropdown"
-                                               , attribute  "aria-haspopup" "true"
-                                               , attribute "aria-expanded" "true"
-                                               ]
-                                          |> appendText value
-                                          |> appendChild (element "span" |> addClass "caret")
-                                        , element "ul"
-                                          |> addClass "dropdown-menu"
-                                          |> addAttribute  (attribute "aria-labelledby" "reporting-rule-focus")
-                                          |> addStyle ("margin-left", "0px")
-                                          |> appendChildList availableFocus
-                                         ]
-                                     ]
+                                buildSelectReporting "reporting-rule-subselect" "Focus reporting on method:" availableFocus value
+                              (WorstReport weight) ->
+                                buildSelectReporting "reporting-rule-subselect" "Select weight of worst case:" availableWorst (labelWorst weight)
                               _ -> element "span"
                             )
+
+buildSelectReporting: String -> String -> (List (Element Msg)) -> String -> Element Msg
+buildSelectReporting id label items value =
+  element "div"
+  |> addClass "form-group"
+  |> appendChildList
+     [ element "label"
+       |> addAttribute (for id)
+       |> appendText label
+     , element "div"
+       |> addStyleList [ ("display","inline-block") , ("width", "auto"), ("margin-left", "5px") ]
+       |> addClass "btn-group"
+       |> appendChildList
+          [ element "button"
+            |> addClass "btn btn-default dropdown-toggle"
+            |> Dom.setId id
+            |> addAttributeList
+                 [ attribute  "data-toggle" "dropdown"
+                 , attribute  "aria-haspopup" "true"
+                 , attribute "aria-expanded" "true"
+                 ]
+            |> appendText value
+            |> appendChild (element "span" |> addClass "caret")
+          , element "ul"
+            |> addClass "dropdown-menu"
+            |> addAttribute  (attribute "aria-labelledby" "reporting-rule-focus")
+            |> addStyle ("margin-left", "0px")
+            |> appendChildList items
+           ]
+       ]
 
 
 blockBody : Model -> Maybe CallId -> MethodBlock -> MethodBlockUiInfo -> TechniqueUiInfo -> Element Msg


### PR DESCRIPTION
https://issues.rudder.io/issues/20342

Implemented with a sub-select for worst case: 

![image](https://user-images.githubusercontent.com/44649/144916291-30fc3507-e5c3-4fe8-ad07-d9c5f7145d4c.png)
