### PR TITLE
Fixes #20302: Repair compliance display in Rules page

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -336,7 +336,8 @@ class ComplianceAPIService(
                     ByRuleNodeCompliance(
                       nodeId
                       , nodeInfos.get(nodeId).map(_.hostname).getOrElse("Unknown node")
-                      , components.toSeq.sortBy(_._2.componentName).flatMap(_._2.componentValues.values)
+                      , ComplianceLevel.sum(components.map(_._2.compliance))
+                      , components.sortBy(_._2.componentName).flatMap(_._2.componentValues.values)
                     )
                   }.toSeq
                 }
@@ -407,8 +408,8 @@ class ComplianceAPIService(
       val t10 = System.currentTimeMillis()
       TimingDebugLoggerPure.logEffect.trace(s"getByRulesCompliance - Compute result in ${t10 - t9} ms")
       result
-    }
-  }
+   }
+ }
 
   def getRuleCompliance(ruleId: RuleId, level: Option[Int]): Box[ByRuleRuleCompliance] = {
     for {

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/elm.json
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/elm.json
@@ -12,33 +12,33 @@
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
-            "elm/http": "1.0.0",
+            "elm/http": "2.0.0",
             "elm/json": "1.1.3",
             "elm/random": "1.0.0",
             "elm/url": "1.0.0",
             "elm-community/dict-extra": "2.4.0",
-            "elm-community/list-extra": "8.1.0",
-            "elm-community/maybe-extra": "5.2.0",
-            "mcordova47/elm-natural-ordering": "1.0.5"
+            "elm-community/list-extra": "8.5.1",
+            "elm-community/maybe-extra": "5.2.1",
+            "mcordova47/elm-natural-ordering": "1.0.5",
+            "toastal/either": "3.6.3",
+            "webbhuset/elm-json-decode": "1.1.0"
         },
         "indirect": {
             "TSFoster/elm-bytes-extra": "1.3.0",
-            "TSFoster/elm-md5": "2.0.0",
+            "TSFoster/elm-md5": "2.0.1",
             "TSFoster/elm-sha1": "2.1.1",
             "danfishgold/base64-bytes": "1.1.0",
             "elm/bytes": "1.0.8",
+            "elm/file": "1.0.5",
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2",
             "kuon/elm-string-normalize": "1.0.2",
-            "rtfeldman/elm-hex": "1.0.0",
-            "zwilias/elm-utf-tools": "2.0.1"
+            "rtfeldman/elm-hex": "1.0.0"
         }
     },
     "test-dependencies": {
         "direct": {},
-        "indirect": {
-            "elm/file": "1.0.5"
-        }
+        "indirect": {}
     }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ApiCalls.elm
@@ -32,12 +32,12 @@ getRulesTree model =
         , headers         = []
         , url             = getUrl model "/rules/tree"
         , body            = emptyBody
-        , expect          = expectJson decodeGetRulesTree
+        , expect          = expectJson GetRulesResult decodeGetRulesTree
         , timeout         = Nothing
-        , withCredentials = False
+        , tracker = Nothing
         }
   in
-    send GetRulesResult req
+    req
 
 
 getPolicyMode : Model -> Cmd Msg
@@ -49,12 +49,12 @@ getPolicyMode model =
         , headers         = []
         , url             = getUrl model "/settings/global_policy_mode"
         , body            = emptyBody
-        , expect          = expectJson decodeGetPolicyMode
+        , expect          = expectJson GetPolicyModeResult decodeGetPolicyMode
         , timeout         = Nothing
-        , withCredentials = False
+        , tracker = Nothing
         }
   in
-    send GetPolicyModeResult req
+    req
 
 getGroupsTree : Model -> Cmd Msg
 getGroupsTree model =
@@ -65,12 +65,12 @@ getGroupsTree model =
         , headers         = []
         , url             = getUrl model "/groups/tree"
         , body            = emptyBody
-        , expect          = expectJson decodeGetGroupsTree
+        , expect          = expectJson GetGroupsTreeResult decodeGetGroupsTree
         , timeout         = Nothing
-        , withCredentials = False
+        , tracker = Nothing
         }
   in
-    send GetGroupsTreeResult req
+    req
 
 getTechniquesTree : Model -> Cmd Msg
 getTechniquesTree model =
@@ -81,12 +81,12 @@ getTechniquesTree model =
         , headers         = []
         , url             = getUrl model "/directives/tree"
         , body            = emptyBody
-        , expect          = expectJson decodeGetTechniquesTree
+        , expect          = expectJson GetTechniquesTreeResult decodeGetTechniquesTree
         , timeout         = Nothing
-        , withCredentials = False
+        , tracker = Nothing
         }
   in
-    send GetTechniquesTreeResult req
+    req
 
 getRuleDetails : Model -> RuleId -> Cmd Msg
 getRuleDetails model ruleId =
@@ -97,12 +97,12 @@ getRuleDetails model ruleId =
         , headers         = []
         , url             = getUrl model ("/rules/" ++ ruleId.value)
         , body            = emptyBody
-        , expect          = expectJson decodeGetRuleDetails
+        , expect          = expectJson GetRuleDetailsResult decodeGetRuleDetails
         , timeout         = Nothing
-        , withCredentials = False
+        , tracker = Nothing
         }
   in
-    send GetRuleDetailsResult req
+    req
 
 getRulesCategoryDetails : Model -> String -> Cmd Msg
 getRulesCategoryDetails model catId =
@@ -113,12 +113,12 @@ getRulesCategoryDetails model catId =
         , headers         = []
         , url             = getUrl model ("/rules/categories/" ++ catId)
         , body            = emptyBody
-        , expect          = expectJson decodeGetCategoryDetails
+        , expect          = expectJson GetCategoryDetailsResult decodeGetCategoryDetails
         , timeout         = Nothing
-        , withCredentials = False
+        , tracker = Nothing
         }
   in
-    send GetCategoryDetailsResult req
+    req
 
 getRulesCompliance : Model -> Cmd Msg
 getRulesCompliance model =
@@ -127,14 +127,31 @@ getRulesCompliance model =
       request
         { method          = "GET"
         , headers         = []
-        , url             = getUrl model "/compliance/rules?level=6"
+        , url             = getUrl model "/compliance/rules?level=1"
         , body            = emptyBody
-        , expect          = expectJson decodeGetRulesCompliance
+        , expect          = expectJson GetRulesComplianceResult decodeGetRulesCompliance
         , timeout         = Nothing
-        , withCredentials = False
+        , tracker = Nothing
         }
   in
-    send GetRulesComplianceResult req
+    req
+
+getRulesComplianceDetails : RuleId -> Model -> Cmd Msg
+getRulesComplianceDetails ruleId model =
+  let
+    req =
+      request
+        { method          = "GET"
+        , headers         = []
+        , url             = getUrl model "/compliance/rules/"++ ruleId.value ++ "?level=10"
+        , body            = emptyBody
+        , expect          = expectJson (GetRuleComplianceResult ruleId) decodeGetRulesComplianceDetails
+        , timeout         = Nothing
+        , tracker = Nothing
+        }
+  in
+    req
+
 
 getNodesList : Model -> Cmd Msg
 getNodesList model =
@@ -145,12 +162,12 @@ getNodesList model =
         , headers         = []
         , url             = getUrl model "/nodes"
         , body            = emptyBody
-        , expect          = expectJson decodeGetNodesList
+        , expect          = expectJson GetNodesList decodeGetNodesList
         , timeout         = Nothing
-        , withCredentials = False
+        , tracker = Nothing
         }
   in
-    send GetNodesList req
+    req
 
 saveRuleDetails : Rule -> Bool -> Model -> Cmd Msg
 saveRuleDetails ruleDetails creation model =
@@ -162,12 +179,12 @@ saveRuleDetails ruleDetails creation model =
         , headers = []
         , url     = getUrl model url
         , body    = encodeRuleDetails ruleDetails |> jsonBody
-        , expect  = expectJson decodeGetRuleDetails
+        , expect  = expectJson SaveRuleDetails decodeGetRuleDetails
         , timeout = Nothing
-        , withCredentials = False
+        , tracker = Nothing
         }
   in
-    send SaveRuleDetails req
+    req
 
 saveDisableAction : Rule -> Model ->  Cmd Msg
 saveDisableAction ruleDetails model =
@@ -178,12 +195,12 @@ saveDisableAction ruleDetails model =
         , headers = []
         , url     = getUrl model ("/rules/"++ruleDetails.id.value)
         , body    = encodeRuleDetails ruleDetails |> jsonBody
-        , expect  = expectJson decodeGetRuleDetails
+        , expect  = expectJson SaveDisableAction decodeGetRuleDetails
         , timeout = Nothing
-        , withCredentials = False
+        , tracker = Nothing
         }
   in
-    send SaveDisableAction req
+    req
 
 saveCategoryDetails : (Category Rule) -> String -> Bool -> Model -> Cmd Msg
 saveCategoryDetails category parentId creation model =
@@ -195,12 +212,12 @@ saveCategoryDetails category parentId creation model =
         , headers = []
         , url     = getUrl model url
         , body    = encodeCategoryDetails parentId category |> jsonBody
-        , expect  = expectJson decodeGetCategoryDetails
+        , expect  = expectJson SaveCategoryResult decodeGetCategoryDetails
         , timeout = Nothing
-        , withCredentials = False
+        , tracker = Nothing
         }
   in
-    send SaveCategoryResult req
+    req
 
 deleteRule : Rule -> Model -> Cmd Msg
 deleteRule rule model =
@@ -211,12 +228,12 @@ deleteRule rule model =
         , headers = []
         , url     = getUrl model "/rules/" ++ rule.id.value
         , body    = emptyBody
-        , expect  = expectJson decodeDeleteRuleResponse
+        , expect  = expectJson DeleteRule decodeDeleteRuleResponse
         , timeout = Nothing
-        , withCredentials = False
+        , tracker = Nothing
         }
   in
-    send DeleteRule req
+    req
 
 deleteCategory : (Category Rule) -> Model -> Cmd Msg
 deleteCategory category model =
@@ -227,9 +244,9 @@ deleteCategory category model =
         , headers = []
         , url     = getUrl model "/rules/categories/" ++ category.id
         , body    = emptyBody
-        , expect  = expectJson decodeDeleteCategoryResponse
+        , expect  = expectJson DeleteCategory decodeDeleteCategoryResponse
         , timeout = Nothing
-        , withCredentials = False
+        , tracker = Nothing
         }
   in
-    send DeleteCategory req
+   req

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/Init.elm
@@ -2,6 +2,7 @@ module Init exposing (..)
 
 import ApiCalls exposing (..)
 import DataTypes exposing (..)
+import Dict
 
 -- PORTS
 init : { contextPath : String, hasWriteRights : Bool } -> ( Model, Cmd Msg )
@@ -9,9 +10,9 @@ init flags =
   let
 
     initCategory = Category "" "" "" (SubCategories []) []
-    initFilters  = Filters (TableFilters Name True "" []) (TreeFilters "" [])
+    initFilters  = Filters (TableFilters Name Asc "" []) (TreeFilters "" [])
     initUI       = UI initFilters initFilters initFilters NoModal flags.hasWriteRights
-    initModel    = Model flags.contextPath Loading "" initCategory initCategory initCategory [] [] [] initUI
+    initModel    = Model flags.contextPath Loading "" initCategory initCategory initCategory Dict.empty Dict.empty Dict.empty initUI
 
     listInitActions =
       [ getPolicyMode      initModel

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewRulesTable.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewRulesTable.elm
@@ -48,12 +48,13 @@ getSortFunction model r1 r2 =
                   else
                     c.compliance
               Nothing -> -2.0
-          r1Compliance = getCompliance (getRuleCompliance model r1.id)
-          r2Compliance = getCompliance (getRuleCompliance model r2.id)
+          --r1Compliance = getCompliance (getRuleCompliance model r1.id)
+          --r2Compliance = getCompliance (getRuleCompliance model r2.id)
         in
-          compare r1Compliance r2Compliance
+          GT
+          --compare r1Compliance r2Compliance
   in
-    if model.ui.ruleFilters.tableFilters.sortOrder then
+    if model.ui.ruleFilters.tableFilters.sortOrder == Asc then
       order
     else
       case order of


### PR DESCRIPTION
https://issues.rudder.io/issues/20302

* rule compliance was not aware of blocks, so client side was failing on that case => added all the decoding logic for blocks in elm, + rewrite lots of structures to be able to deal with that.

* compliance for nodes from rule was done in client side, but was not always consistant with backend => done in backend

* rule list was abysmally slow => first call for API only get minimal info so that the list is quick, and compliance details are loaded when the user click on rule details
