### PR TITLE
Fixes #20308: when we edit the content of a generic method in 7.0, there is no way to know which method it is

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewMethod.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewMethod.elm
@@ -131,7 +131,7 @@ showMethodTab model method parentId call uiInfo=
     CallReporting ->
       div [ class "tab-parameters"] [
         div [ class "form-group"] [
-          label [ for "disable_reporting"] [ text "Disable reporting:"]
+          label [ for "disable_reporting", style "margin-right" "5px"] [ text "Disable reporting"]
         , input [ readonly (not model.hasWriteRights), type_ "checkbox", name "disable_reporting", checked call.disableReporting,  onCheck  (\b -> MethodCallModified (Call parentId {call  | disableReporting = b }))] []
         ]
       ]
@@ -387,9 +387,23 @@ callBody model ui techniqueUi call pid =
                         ]
                   ]
     methodName = case ui.mode of
-                   Opened -> element "input"
-                             |> addAttributeList [ readonly (not model.hasWriteRights), stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True)), onFocus DisableDragDrop, type_ "text", name "component", style "width" "calc(100% - 65px)", class "form-control", value call.component,  placeholder "Enter a component name" ]
-                             |> addInputHandler  (\s -> MethodCallModified (Call pid {call  | component = s }))
+                   Opened -> element "div"
+                             |> appendChild
+                                ( element "div"
+                                    |> addClass "component-name-wrapper"
+                                    |> appendChildList
+                                       [ element "div"
+                                         |> addClass "title-input-name"
+                                         |> appendText "Name"
+                                       , element "div"
+                                         |> addClass "gm-label-name"
+                                         |> appendText method.name
+                                       ]
+                                    |> appendChild
+                                       (element "input"
+                                         |> addAttributeList [ readonly (not model.hasWriteRights), stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True)), onFocus DisableDragDrop, type_ "text", name "component", style "width" "100%", class "form-control", value call.component,  placeholder "Enter a component name" ]
+                                         |> addInputHandler  (\s -> MethodCallModified (Call pid {call  | component = s })))
+                                )
                    Closed -> element "div"
                              |> addClass "method-name"
                              |> appendChild
@@ -398,10 +412,17 @@ callBody model ui techniqueUi call pid =
                                   |> addActionStopPropagation ("click" , DisableDragDrop)
                                 )
                              |> appendChildConditional
-                                  (element "span" |> addStyle ("opacity"," 0.4") |> appendText (" - "++ method.name) )
-                                  ((not (String.isEmpty call.component)) && call.component /= method.name )
+                                ( element "div"
+                                  |> addClass "gm-label-name"
+                                  |> appendText method.name
+                                )
+                                ((not (String.isEmpty call.component)) && call.component /= method.name )
 
-
+    methodNameId = case ui.mode of
+                     Opened -> element "span" |> appendText method.name
+                                    |> addActionStopPropagation ("mousedown" , DisableDragDrop)
+                                    |> addActionStopPropagation ("click" , DisableDragDrop)
+                     Closed -> element ""
     methodContent = element "div"
                     |> addClass  "method-param flex-form"
                     |> appendChildList
@@ -451,6 +472,7 @@ callBody model ui techniqueUi call pid =
             |> addClass "flex-column"
             |> appendChildConditional condition (call.condition.os /= Nothing || call.condition.advanced /= "")
             |> appendChild methodName
+            --|> appendChild methodNameId
             |> appendChildConditional methodContent (ui.mode == Closed)
             |> appendChildConditional
                         ( element "div"

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/style/rudder/rudder-technique-editor.css
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/style/rudder/rudder-technique-editor.css
@@ -1027,6 +1027,7 @@ ul li.hide-method {
   transition-property: opacity;
   transition-duration: .2s;
   opacity: 0;
+  margin-right: 5px;
 }
 #methods .method:hover > .method-info > .btn-holder > .method-action {
   opacity: .6;
@@ -1492,4 +1493,36 @@ ul li.hide-method {
         opacity: 0;
         transform: translateY(50px);
     }
+}
+.component-name-wrapper {
+  position: relative;
+  margin-left:10px;
+}
+.title-input-name {
+  position: absolute;
+  margin-top: 14px;
+  font-size: 14px;
+  font-weight: bold;
+}
+.gm-label-name {
+  font-size:11px;
+  opacity:0.9;
+  margin-top : -2px;
+  display: inline-block;
+  padding-left: 10px;
+  padding-right: 10px;
+  height: 25px;
+  background-color:#d3d5d9;
+  text-align: center;
+  vertical-align: middle;
+  line-height: 25px;
+  border-radius: 0 0 5px 5px;
+  z-index:10;
+  float:right;
+  margin-bottom:10px;
+  margin-right:80px;
+}
+
+.reporting-checkbox {
+  margin-left: 5px;
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/20308
Before :
![image](https://user-images.githubusercontent.com/23410978/145545209-f0a95375-0e7c-44ed-9f8a-869f23186a1e.png)
After :
![image](https://user-images.githubusercontent.com/23410978/145555826-0d44f028-56b2-4dde-ba0f-9a939ea7b3ac.png)
![image](https://user-images.githubusercontent.com/23410978/145555926-b2fed5ec-494f-4454-950c-0ee4858a885a.png)
