### PR TITLE
Fixes #20437: Error when writing techniques via the technique editor

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
@@ -120,7 +120,7 @@ trait RuddercOptionsForTarget[T <: RuddercTarget] {
 object RuddercOptionsForTarget {
   // the compile line is common to both target, only the file extension type for agent changes
   def buildOptions(extension: String, techniquePath: String)(implicit ruddercConfig: RuddercConfig) = {
-    "compile" :: "--json-logs" :: "-f" :: extension ::
+    "compile" :: "--json-logs" :: "--format" :: extension ::
     "-input" :: s"""${ruddercConfig.outputPath}/${techniquePath}/technique.rd""" ::
     s"--config-file=${ruddercConfig.configFilePath}" :: Nil
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
@@ -143,7 +143,7 @@ object RuddercOptionsForTarget {
 object RuddercOptionForSave {
   def options(techniquePath: String)(implicit ruddercConfig: RuddercConfig): List[String] = {
     "save" :: "--json-logs" ::
-    "-input" :: s"""${ruddercConfig.outputPath}/${techniquePath}/technique.json""" ::
+    "--input" :: s"""${ruddercConfig.outputPath}/${techniquePath}/technique.json""" ::
     s"--config-file=${ruddercConfig.configFilePath}" :: Nil
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
@@ -121,7 +121,7 @@ object RuddercOptionsForTarget {
   // the compile line is common to both target, only the file extension type for agent changes
   def buildOptions(extension: String, techniquePath: String)(implicit ruddercConfig: RuddercConfig) = {
     "compile" :: "--json-logs" :: "--format" :: extension ::
-    "-input" :: s"""${ruddercConfig.outputPath}/${techniquePath}/technique.rd""" ::
+    "--input" :: s"""${ruddercConfig.outputPath}/${techniquePath}/technique.rd""" ::
     s"--config-file=${ruddercConfig.configFilePath}" :: Nil
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -169,7 +169,6 @@ import com.normation.rudder.ncf.TechniqueReader
 import com.normation.rudder.ncf.TechniqueSerializer
 import com.normation.rudder.ncf.TechniqueWriter
 import com.normation.rudder.services.policies.RuleApplicationStatusServiceImpl
-import com.normation.rudder.services.queries.PendingNodesLDAPQueryChecker
 
 /*
  * This file provides all the necessary plumbing to allow test REST API.


### PR DESCRIPTION
https://issues.rudder.io/issues/20437

There was (at least) three problem in previous code: 
- we duplicated the use of `outputpath`, and it was hard to see because we duplicated much code in path creation => factor out common path in an object specific to a compiler instance, and use it to remove some boilerplate
- we we using bad extension for compilation => corrected 
- we were always using the cfengine extension, whatever current target was => corrected