### PR TITLE
Fixes #20459: Value 'focus:48137400-7f48-48bd-a888-9522167b5b81' is not a valid reporting composition rule

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/VariableAndSectionSpec.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/VariableAndSectionSpec.scala
@@ -485,7 +485,7 @@ object ReportingLogic {
       case WorstReportWeightedOne.value => Right(WorstReportWeightedOne)
       case WorstReportWeightedSum.value => Right(WorstReportWeightedSum)
       case WeightedReport.value         => Right(WeightedReport)
-      case s"FocusReport.key}:${a}"     => Right(FocusReport(a))
+      case s"${FocusReport.key}:${a}"   => Right(FocusReport(a))
       case FocusReport.key              => Right(FocusReport(defaultFocusKey))
       case _                            => Left(Unexpected(s"Value '${value}' is not a valid reporting composition rule."))
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/20459