### PR TITLE
Fixes #20460: Invalid attribute 'special:all_servers_with_role' (or special:all_nodes_without_role) for entry ruleTarget

### DIFF
--- a/webapp/sources/api-doc/components/schemas/rule-target.yml
+++ b/webapp/sources/api-doc/components/schemas/rule-target.yml
@@ -6,7 +6,6 @@ example: policyServer:root
 enum:
   - special:all
   - special:all_exceptPolicyServers
-  - special:all_servers_with_role
-  - special:all_nodes_without_role
+  - special:all_policyServers
   - policyServer:${policyServerId}
   - group:${nodeGroupId}

--- a/webapp/sources/api-doc/paths/rules/tree.yml
+++ b/webapp/sources/api-doc/paths/rules/tree.yml
@@ -94,7 +94,7 @@ get:
                             or:
                               - special:all
                               - special:all_exceptPolicyServers
-                              - special:all_nodes_without_role
+                              - special:all_policyServers
                           exclude:
                             or: []
                       enabled: false

--- a/webapp/sources/rudder/rudder-core/src/main/resources/ldap/bootstrap.ldif
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/ldap/bootstrap.ldif
@@ -130,6 +130,15 @@ description: All nodes known by Rudder (excluding Rudder policy servers)
 isEnabled: TRUE
 isSystem: TRUE
 
+dn: ruleTarget=special:all_policyServers,groupCategoryId=SystemGroups,groupCategoryId=GroupRoot,ou=Rudder,cn=rudder-configuration
+objectClass: specialRuleTarget
+objectClass: top
+ruleTarget: special:all_policyServers
+cn: All policy servers
+description: All policy servers (root policy server and relays)
+isEnabled: TRUE
+isSystem: TRUE
+
 dn: nodeGroupId=all-nodes-with-cfengine-agent,groupCategoryId=SystemGroups,groupCategoryId=GroupRoot,ou=Rudder,cn=rudder-configuration
 objectClass: nodeGroup
 objectClass: top

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
@@ -86,6 +86,11 @@ final case object AllTargetExceptPolicyServers extends NonGroupRuleTarget {
   def r = "special:all_exceptPolicyServers".r
 }
 
+final case object AllPolicyServers extends NonGroupRuleTarget {
+  override def target = "special:all_policyServers"
+  def r = "special:all_policyServers".r
+}
+
 /**
  * A composite target is a target composed of different target
  * This target is rendered as Json
@@ -215,6 +220,7 @@ object RuleTarget extends Loggable {
     targets.foldLeft(Set[NodeId]()) { case (nodes , target) => target match {
       case AllTarget => return allNodes.keySet
       case AllTargetExceptPolicyServers => nodes ++ allNodes.collect { case(k,isPolicyServer) if(!isPolicyServer) => k }
+      case AllPolicyServers => nodes ++ allNodes.collect{ case(k,isPolicyServer) if(isPolicyServer) => k }
       case PolicyServerTarget(nodeId) => nodes + nodeId
 
       //here, if we don't find the group, we consider it's an error in the

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
@@ -150,7 +150,7 @@ class TestQueryProcessor extends Loggable {
       res.size
     }).runNow
 
-    val expected = 42+38  //bootstrap + inventory-sample
+    val expected = 43+38  //bootstrap + inventory-sample
     assert(expected == s, s"Not found the expected number of entries in test LDAP directory [expected: ${expected}, found: ${s}], perhaps the demo entries where not correctly loaded")
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -106,7 +106,6 @@ import com.normation.rudder.inventory.InventoryProcessor
 import com.normation.rudder.inventory.PostCommitInventoryHooks
 import com.normation.rudder.metrics._
 import com.normation.rudder.migration.DefaultXmlEventLogMigration
-import com.normation.rudder.migration._
 import com.normation.rudder.ncf
 import com.normation.rudder.ncf.ParameterType.PlugableParameterTypeService
 import com.normation.rudder.ncf.ResourceFileService
@@ -173,8 +172,8 @@ import bootstrap.liftweb.checks.action.TriggerPolicyUpdate
 import bootstrap.liftweb.checks.consistency.CheckConnections
 import bootstrap.liftweb.checks.consistency.CheckDIT
 import bootstrap.liftweb.checks.consistency.CheckRudderGlobalParameter
+import bootstrap.liftweb.checks.migration.CheckAddSpecialTargetAllPolicyServers
 import bootstrap.liftweb.checks.migration.CheckMigratedSystemTechniques
-import bootstrap.liftweb.checks.migration.CheckMigrationXmlFileFormat5_6
 import bootstrap.liftweb.checks.onetimeinit.CheckInitUserTemplateLibrary
 import bootstrap.liftweb.checks.onetimeinit.CheckInitXmlExport
 
@@ -2336,18 +2335,6 @@ object RudderConfig extends Loggable {
   lazy val healthcheckNotificationService = new HealthcheckNotificationService(healthcheckService, RUDDER_HEALTHCHECK_PERIOD)
 
   /**
-   * Event log migration
-   */
-
-  private[this] lazy val migrationRepository = new MigrationEventLogRepository(doobie)
-
-  private[this] lazy val controlXmlFileFormatMigration_5_6 = new ControlXmlFileFormatMigration_5_6(
-      migrationEventLogRepository = migrationRepository
-    , doobie
-    , previousMigrationController = None
-  )
-
-  /**
    * *************************************************
    * Bootstrap check actions
    * **************************************************
@@ -2359,6 +2346,7 @@ object RudderConfig extends Loggable {
       techniqueRepositoryImpl
       , uuidGen
     )
+    , new CheckAddSpecialTargetAllPolicyServers(rwLdap)
     , new CheckMigratedSystemTechniques(policyServerManagementService, gitConfigRepo, nodeInfoService, rwLdap, techniqueRepository, techniqueRepositoryImpl, uuidGen, woDirectiveRepository, woRuleRepository)
     , new CheckDIT(pendingNodesDitImpl, acceptedNodesDitImpl, removedNodesDitImpl, rudderDitImpl, rwLdap)
     , new CheckInitUserTemplateLibrary(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/CheckAddSpecialTargetAllPolicyServers.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/CheckAddSpecialTargetAllPolicyServers.scala
@@ -1,0 +1,104 @@
+/*
+*************************************************************************************
+* Copyright 2021 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package bootstrap.liftweb.checks.migration
+
+import com.normation.inventory.ldap.core.LDAPConstants._
+import com.normation.ldap.sdk.LDAPConnectionProvider
+import com.normation.ldap.sdk.LDAPEntry
+import com.normation.ldap.sdk.RwLDAPConnection
+import com.normation.ldap.sdk.syntax._
+import com.normation.rudder.domain.RudderLDAPConstants._
+import com.normation.rudder.domain.logger.MigrationLoggerPure
+
+import bootstrap.liftweb.BootstrapChecks
+import com.unboundid.ldap.sdk.DN
+
+import zio._
+import com.normation.errors._
+import com.normation.zio._
+
+/*
+ * This migration check looks if we need to add special target "all_policyServer"
+ * added in rudder 7.0 (https://issues.rudder.io/issues/20460)
+ */
+
+class CheckAddSpecialTargetAllPolicyServers(
+    ldap                 : LDAPConnectionProvider[RwLDAPConnection]
+) extends BootstrapChecks {
+
+  val all_policyServersDN = new DN(s"ruleTarget=special:all_policyServers,groupCategoryId=SystemGroups,groupCategoryId=GroupRoot,ou=Rudder,cn=rudder-configuration")
+  val all_policyServers = {
+    val entry = LDAPEntry(all_policyServersDN)
+    entry.resetValuesTo(A_OC, OC.objectClassNames(OC_SPECIAL_TARGET).toSeq:_*)
+    entry.resetValuesTo(A_RULE_TARGET, "special:all_policyServers")
+    entry.resetValuesTo(A_NAME, "All policy servers")
+    entry.resetValuesTo(A_DESCRIPTION, "All policy servers (root policy server and relays)")
+    entry.resetValuesTo(A_IS_ENABLED, true.toLDAPString)
+    entry.resetValuesTo(A_IS_SYSTEM, true.toLDAPString)
+    entry
+  }
+
+  override def description: String = "Check if special target all_policyServer from Rudder 7.0 is present"
+
+  override def checks() : Unit = {
+    ZIO.whenM(checkMigrationNeeded())(
+      createSpecialTarget()
+    ).catchAll(err =>
+      MigrationLoggerPure.error(s"Error during addition of new special target 'all_policyServer'. You can restart Rudder to " +
+                                s"try again the migration or report it to Rudder project")
+    ).runNow
+  }
+
+
+  /*
+   * Migration is needed if target does not exists.
+   */
+  def checkMigrationNeeded(): IOResult[Boolean] = {
+    for {
+      con <- ldap
+      res <- con.exists(all_policyServersDN)
+    } yield !res
+  }
+
+  def createSpecialTarget(): IOResult[Unit] = {
+    for {
+      con <- ldap
+      res <- con.save(all_policyServers)
+    } yield ()
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/bootstrap-6_2.ldif
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/bootstrap-6_2.ldif
@@ -297,6 +297,30 @@ isSystem: FALSE
 tag: rootRuleCategory
 serial: 0
 
+# demonstration rule with special target that need to be migrated
+dn: ruleId=44444444-02fd-43d0-aab7-28460a91347b,ou=Rules,ou=Rudder,cn=rudder
+ -configuration
+objectClass: top
+objectClass: rule
+ruleId: 44444444-02fd-43d0-aab7-28460a91347b
+ruleTarget: {"include":{"or":["special:all_nodes_without_role"]},"exclude":{"or":["special:all_servers_with_role"]}}
+cn: rule1
+isEnabled: TRUE
+isSystem: FALSE
+tag: rootRuleCategory
+serial: 0
+
+dn: ruleId=55555555-02fd-43d0-aab7-28460a91347b,ou=Rules,ou=Rudder,cn=rudder
+ -configuration
+objectClass: top
+objectClass: rule
+ruleId: 55555555-02fd-43d0-aab7-28460a91347b
+ruleTarget: special:all_nodes_without_role
+cn: rule1
+isEnabled: TRUE
+isSystem: FALSE
+tag: rootRuleCategory
+serial: 0
 
 
 #######################################################################################################################


### PR DESCRIPTION
https://issues.rudder.io/issues/20460

Add migration logic for rules that were using special target related to server roles. 

That PR:
- migrate `all_nodes_without_role` to existing special target `special:all_exceptPolicyServers`
- add a new special target for "all policy servers" (not sure why we didn't have it): `special:all_policyServers`
- migrate `special:all_servers_with_role` to the new `special:all_policyServers` target
- add a new boot check to create the special target if needed. 

And add some cleaning related to previous migration enhancement: remove dead code and unused import, update API doc