### PR TITLE
Fixes #20462: Delay policy generation until rudder app is fully boot

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/PolicyGenerationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/PolicyGenerationLogger.scala
@@ -71,6 +71,11 @@ object PolicyGenerationLogger extends Logger {
 object PolicyGenerationLoggerPure extends NamedZioLogger {
   override def loggerName  = "policy.generation"
 
+  // async deployment agent
+  object manager extends NamedZioLogger {
+    override def loggerName = "policy.generation.manager"
+  }
+
   object expectedReports extends NamedZioLogger {
     override def loggerName = "policy.generation.expected_reports"
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
@@ -190,6 +190,7 @@ final case class FullNodeGroupCategory(
       case FullOtherTarget(t) => t match {
         case AllTarget => true
         case AllTargetExceptPolicyServers => !node.isPolicyServer
+        case AllPolicyServers => node.isPolicyServer
         case PolicyServerTarget(id) => id == node.id
       }
     } }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -554,6 +554,10 @@ class Boot extends Loggable {
         ApplicationLogger.error(s"Error when trying to save the EventLog for application start: ${err.fullMsg}")
       case Right(_)  => ApplicationLogger.info("Application Rudder started")
     }
+
+    // release guard for promise generation awaiting end of boot
+    RudderConfig.policyGenerationBootGuard.succeed(()).runNow
+
   }
 
   // Run a health check

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2066,6 +2066,9 @@ object RudderConfig extends Loggable {
       , POSTGRESQL_IS_LOCAL
   )}
 
+
+  lazy val policyGenerationBootGuard = zio.Promise.make[Nothing, Unit].runNow
+
   private[this] lazy val asyncDeploymentAgentImpl: AsyncDeploymentActor = {
     val agent = new AsyncDeploymentActor(
         deploymentService
@@ -2073,6 +2076,7 @@ object RudderConfig extends Loggable {
       , deploymentStatusSerialisation
       , () => configService.rudder_generation_delay()
       , () => configService.rudder_generation_trigger()
+      , policyGenerationBootGuard
     )
     techniqueRepositoryImpl.registerCallback(
         new DeployOnTechniqueCallback("DeployOnPTLibUpdate", 1000, agent)


### PR DESCRIPTION
https://issues.rudder.io/issues/20462

That PR add a promise (ie something that can be done exactly once, and that other things can wait for it to be done) that is checked for completion before actually starting policy generation.

The promise is completed at end of `Boot.boot` method, ie once lift knows rudder is started.

To be able to use the `promise.await` in policy generation agent, I needed to transform the code into a ZIO effect.

Also remove a warning for missing pattern match which would lead to a runtime exception, likely introduced in pr #4065 