### PR TITLE
Fixes #20261: Add a warning in plugin page if a version mismatches rudder patch one

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -50,13 +50,13 @@ import com.normation.rudder.web.model.CurrentUser
 import com.normation.rudder.AuthorizationType
 import com.normation.rudder.domain.logger.ApplicationLogger
 import com.normation.eventlog.ModificationId
-import java.util.Locale
 
+import java.util.Locale
 import net.liftweb.http.rest.RestHelper
 import org.joda.time.DateTime
 import com.normation.rudder.web.snippet.WithCachedResource
-import java.net.URLConnection
 
+import java.net.URLConnection
 import com.normation.inventory.domain.InventoryProcessingLogger
 import com.normation.plugins.AlwaysEnabledPluginStatus
 import com.normation.plugins.RudderPluginModule
@@ -70,11 +70,12 @@ import com.normation.rudder.rest.EndpointSchema
 import com.normation.rudder.rest.{InfoApi => InfoApiDef}
 import com.normation.rudder.rest.lift.InfoApi
 import com.normation.rudder.rest.lift.LiftApiModuleProvider
+
 import net.liftweb.sitemap.Loc.LocGroup
 import net.liftweb.sitemap.Loc.TestAccess
 import org.reflections.Reflections
-import com.normation.zio._
 
+import com.normation.zio._
 import scala.xml.NodeSeq
 import scala.xml.NodeSeq.seqToNodeSeq
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/PluginManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/PluginManagement.scala
@@ -45,6 +45,7 @@ import scala.xml.NodeSeq
 import com.normation.plugins.RudderPluginDef
 
 import bootstrap.liftweb.PluginsInfo
+import bootstrap.liftweb.RudderConfig
 
 class PluginManagement extends DispatchSnippet with Loggable {
 
@@ -62,6 +63,14 @@ class PluginManagement extends DispatchSnippet with Loggable {
   }
 
   private[this] def displayPlugin(p:RudderPluginDef)(xml:NodeSeq) : NodeSeq = {
+    val rudderPluginVersion = p.version.rudderAbi.toVersionStringNoEpoch
+    // we compare on string, since we are just looking for an exact match.
+    val versionWarning = if(RudderConfig.rudderFullVersion != rudderPluginVersion) {
+      <span style="margin-left: 4px;" class="text-danger"><strong>
+        WARNING! This plugin was not build for current Rudder ABI version ({RudderConfig.rudderFullVersion}). You should update it to avoid code incompatibilities.
+      </strong></span>
+    } else NodeSeq.Empty
+
     (
       "data-plugin=name" #>  {
         p.versionInfo match {
@@ -76,7 +85,9 @@ class PluginManagement extends DispatchSnippet with Loggable {
       } &
       "data-plugin=fullid" #> p.name.value &
       "data-plugin=baseclass" #> p.id &
-      "data-plugin=version" #> p.version.toString &
+      "data-plugin=version" #> p.version.pluginVersion.toVersionStringNoEpoch &
+      "data-plugin=rudderVersion" #> p.version.rudderAbi.toVersionStringNoEpoch &
+      "data-plugin=versionWarning" #> versionWarning &
       "data-plugin=description" #> p.description &
       "data-plugin=statusInformation" #> p.statusInformation()
     )(xml)

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/plugins/pluginInformation.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/plugins/pluginInformation.html
@@ -32,7 +32,10 @@
             <p class="description" data-plugin="description">[Here comes the plugin description]</p>
             <ul class="plugin-details">
               <li><b>Plugin ID:</b> <span data-plugin="fullid">[Here comes the plugin full id]</span></li>
-              <li><b>Plugin version:</b> <span data-plugin="version">[Here comes the plugin version]</span></li>
+              <li><b>Plugin version:</b> <span data-plugin="version">[Here comes the plugin version]</li>
+              <li><b>Rudder ABI version:</b> <span data-plugin="rudderVersion">[Here comes the rudder version used by the plugin]</span>
+                  <span data-plugin="versionWarning">[warning message if patch version of the plugin is not the same as Rudder]</span>
+              </li>
             </ul>
 
             <div class="plugin-description" class="pluginpadd">

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/plugins/RudderPluginJsonTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/plugins/RudderPluginJsonTest.scala
@@ -37,15 +37,24 @@
 
 package com.normation.plugins
 
+import com.normation.utils.ParseVersion
+
 import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
+
 import com.normation.zio._
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 
 @RunWith(classOf[JUnitRunner])
 class RudderPluginJsonTest extends Specification {
+  implicit class ForceParse(s: String) {
+    def toVersion = ParseVersion.parse(s) match {
+      case Left(err) => throw new IllegalArgumentException(s"Can not parse '${s}' as a version in test: ${err}")
+      case Right(v)  => v
+    }
+  }
 
   val index_json = """{
                      |  "plugins": {
@@ -110,7 +119,7 @@ class RudderPluginJsonTest extends Specification {
   val expected = List(
     JsonPluginDef(
       "rudder-plugin-branding"
-    , PluginVersion(1, 3, 0, "5.0-")
+    , PluginVersion("5.0.0".toVersion, "1.3.0".toVersion)
     , List(
         "/opt/rudder/share/plugins/",
         "/opt/rudder/share/plugins/branding/",
@@ -122,7 +131,7 @@ class RudderPluginJsonTest extends Specification {
     )
   , JsonPluginDef(
       "rudder-plugin-centreon"
-    , PluginVersion(1, 1, 0, "5.0-")
+    , PluginVersion("5.0.0".toVersion, "1.1.0".toVersion)
     , List(
         "/opt/rudder//",
         "/opt/rudder//bin/",

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/plugins/RudderPluginTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/plugins/RudderPluginTest.scala
@@ -1,0 +1,172 @@
+/*
+*************************************************************************************
+* Copyright 2019 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.plugins
+
+import org.joda.time.DateTime
+import org.joda.time.format.ISODateTimeFormat
+import org.junit.runner.RunWith
+import org.specs2.mutable._
+import org.specs2.runner.JUnitRunner
+
+import com.normation.zio._
+
+@RunWith(classOf[JUnitRunner])
+class RudderPluginTest extends Specification {
+
+  val index_json = """{
+                     |  "plugins": {
+                     |    "rudder-plugin-branding": {
+                     |      "files": [
+                     |        "/opt/rudder/share/plugins/",
+                     |        "/opt/rudder/share/plugins/branding/",
+                     |        "/opt/rudder/share/plugins/branding/branding.jar"
+                     |      ],
+                     |      "name": "rudder-plugin-branding",
+                     |      "jar-files": [
+                     |        "/opt/rudder/share/plugins/branding/branding.jar"
+                     |      ],
+                     |      "content": {
+                     |        "files.txz": "/opt/rudder/share/plugins"
+                     |      },
+                     |      "version": "5.0-1.3",
+                     |      "build-commit": "81edd3edf4f28c13821af8014da0520b72b9df94",
+                     |      "build-date": "2018-10-11T12:23:40+02:00",
+                     |      "type": "plugin"
+                     |    },
+                     |    "rudder-plugin-centreon": {
+                     |      "files": [
+                     |        "/opt/rudder//",
+                     |        "/opt/rudder//bin/",
+                     |        "/opt/rudder//bin/centreon-plugin",
+                     |        "/opt/rudder//share/",
+                     |        "/opt/rudder//share/python/",
+                     |        "/opt/rudder//share/python/centreonapi/",
+                     |        "/opt/rudder//share/python/centreonapi/__init__.py",
+                     |        "/opt/rudder//share/python/centreonapi/webservice/",
+                     |        "/opt/rudder//share/python/centreonapi/webservice/__init__.py",
+                     |        "/opt/rudder//share/python/centreonapi/webservice/configuration/",
+                     |        "/opt/rudder//share/python/centreonapi/webservice/configuration/__init__.py",
+                     |        "/opt/rudder//share/python/centreonapi/webservice/configuration/hostgroups.py",
+                     |        "/opt/rudder//share/python/centreonapi/webservice/configuration/service.py",
+                     |        "/opt/rudder//share/python/centreonapi/webservice/configuration/templates.py",
+                     |        "/opt/rudder//share/python/centreonapi/webservice/configuration/poller.py",
+                     |        "/opt/rudder//share/python/centreonapi/webservice/configuration/host.py",
+                     |        "/opt/rudder//share/python/centreonapi/centreon.py",
+                     |        "/opt/rudder//share/python/centreonapi/__init__.pyc",
+                     |        "/opt/rudder//share/python/ipaddress.py",
+                     |        "/opt/rudder//etc/",
+                     |        "/opt/rudder//etc/hooks.d/",
+                     |        "/opt/rudder//etc/hooks.d/node-pre-deletion/",
+                     |        "/opt/rudder//etc/hooks.d/node-pre-deletion/centreon-pre-deletion.sh",
+                     |        "/opt/rudder//etc/hooks.d/node-post-acceptance/",
+                     |        "/opt/rudder//etc/hooks.d/node-post-acceptance/centreon-post-acceptance.sh"
+                     |      ],
+                     |      "name": "rudder-plugin-centreon",
+                     |      "content": {
+                     |        "files.txz": "/opt/rudder/"
+                     |      },
+                     |      "version": "5.0-1.1",
+                     |      "build-commit": "5c4592d93912ef56de0c506295d22fb2a86146ac",
+                     |      "build-date": "2018-10-29T18:34:16+01:00",
+                     |      "type": "plugin"
+                     |    }
+                     |  }
+                     |}""".stripMargin
+
+  val expected = List(
+    JsonPluginDef(
+      "rudder-plugin-branding"
+    , PluginVersion(1, 3, 0, "5.0-")
+    , List(
+        "/opt/rudder/share/plugins/",
+        "/opt/rudder/share/plugins/branding/",
+        "/opt/rudder/share/plugins/branding/branding.jar"
+      )
+    , List("/opt/rudder/share/plugins/branding/branding.jar")
+    , "81edd3edf4f28c13821af8014da0520b72b9df94"
+    , DateTime.parse("2018-10-11T12:23:40+02:00", ISODateTimeFormat.dateTimeNoMillis())
+    )
+  , JsonPluginDef(
+      "rudder-plugin-centreon"
+    , PluginVersion(1, 1, 0, "5.0-")
+    , List(
+        "/opt/rudder//",
+        "/opt/rudder//bin/",
+        "/opt/rudder//bin/centreon-plugin",
+        "/opt/rudder//share/",
+        "/opt/rudder//share/python/",
+        "/opt/rudder//share/python/centreonapi/",
+        "/opt/rudder//share/python/centreonapi/__init__.py",
+        "/opt/rudder//share/python/centreonapi/webservice/",
+        "/opt/rudder//share/python/centreonapi/webservice/__init__.py",
+        "/opt/rudder//share/python/centreonapi/webservice/configuration/",
+        "/opt/rudder//share/python/centreonapi/webservice/configuration/__init__.py",
+        "/opt/rudder//share/python/centreonapi/webservice/configuration/hostgroups.py",
+        "/opt/rudder//share/python/centreonapi/webservice/configuration/service.py",
+        "/opt/rudder//share/python/centreonapi/webservice/configuration/templates.py",
+        "/opt/rudder//share/python/centreonapi/webservice/configuration/poller.py",
+        "/opt/rudder//share/python/centreonapi/webservice/configuration/host.py",
+        "/opt/rudder//share/python/centreonapi/centreon.py",
+        "/opt/rudder//share/python/centreonapi/__init__.pyc",
+        "/opt/rudder//share/python/ipaddress.py",
+        "/opt/rudder//etc/",
+        "/opt/rudder//etc/hooks.d/",
+        "/opt/rudder//etc/hooks.d/node-pre-deletion/",
+        "/opt/rudder//etc/hooks.d/node-pre-deletion/centreon-pre-deletion.sh",
+        "/opt/rudder//etc/hooks.d/node-post-acceptance/",
+        "/opt/rudder//etc/hooks.d/node-post-acceptance/centreon-post-acceptance.sh"
+      )
+    , List()
+    , "5c4592d93912ef56de0c506295d22fb2a86146ac"
+    , DateTime.parse("2018-10-29T18:34:16+01:00", ISODateTimeFormat.dateTimeNoMillis())
+    )
+  )
+
+  val packageService = new ReadPluginPackageInfo("/tmp/foo")
+
+  "Plugins JSON service" should {
+    "be able to read json file format" in {
+      val all = packageService.parseJson(index_json).runNow
+      val success = all.collect { case Right(x) => x }
+      val errors  = all.collect { case Left(x)  => x }
+
+      (errors must beEmpty) and
+      (success must containTheSameElementsAs(expected))
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/plugins/RudderPluginTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/plugins/RudderPluginTest.scala
@@ -1,6 +1,6 @@
 /*
 *************************************************************************************
-* Copyright 2019 Normation SAS
+* Copyright 2022 Normation SAS
 *************************************************************************************
 *
 * This file is part of Rudder.
@@ -37,136 +37,31 @@
 
 package com.normation.plugins
 
-import org.joda.time.DateTime
-import org.joda.time.format.ISODateTimeFormat
+import com.normation.utils.ParseVersion
+
 import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
 
-import com.normation.zio._
-
 @RunWith(classOf[JUnitRunner])
 class RudderPluginTest extends Specification {
 
-  val index_json = """{
-                     |  "plugins": {
-                     |    "rudder-plugin-branding": {
-                     |      "files": [
-                     |        "/opt/rudder/share/plugins/",
-                     |        "/opt/rudder/share/plugins/branding/",
-                     |        "/opt/rudder/share/plugins/branding/branding.jar"
-                     |      ],
-                     |      "name": "rudder-plugin-branding",
-                     |      "jar-files": [
-                     |        "/opt/rudder/share/plugins/branding/branding.jar"
-                     |      ],
-                     |      "content": {
-                     |        "files.txz": "/opt/rudder/share/plugins"
-                     |      },
-                     |      "version": "5.0-1.3",
-                     |      "build-commit": "81edd3edf4f28c13821af8014da0520b72b9df94",
-                     |      "build-date": "2018-10-11T12:23:40+02:00",
-                     |      "type": "plugin"
-                     |    },
-                     |    "rudder-plugin-centreon": {
-                     |      "files": [
-                     |        "/opt/rudder//",
-                     |        "/opt/rudder//bin/",
-                     |        "/opt/rudder//bin/centreon-plugin",
-                     |        "/opt/rudder//share/",
-                     |        "/opt/rudder//share/python/",
-                     |        "/opt/rudder//share/python/centreonapi/",
-                     |        "/opt/rudder//share/python/centreonapi/__init__.py",
-                     |        "/opt/rudder//share/python/centreonapi/webservice/",
-                     |        "/opt/rudder//share/python/centreonapi/webservice/__init__.py",
-                     |        "/opt/rudder//share/python/centreonapi/webservice/configuration/",
-                     |        "/opt/rudder//share/python/centreonapi/webservice/configuration/__init__.py",
-                     |        "/opt/rudder//share/python/centreonapi/webservice/configuration/hostgroups.py",
-                     |        "/opt/rudder//share/python/centreonapi/webservice/configuration/service.py",
-                     |        "/opt/rudder//share/python/centreonapi/webservice/configuration/templates.py",
-                     |        "/opt/rudder//share/python/centreonapi/webservice/configuration/poller.py",
-                     |        "/opt/rudder//share/python/centreonapi/webservice/configuration/host.py",
-                     |        "/opt/rudder//share/python/centreonapi/centreon.py",
-                     |        "/opt/rudder//share/python/centreonapi/__init__.pyc",
-                     |        "/opt/rudder//share/python/ipaddress.py",
-                     |        "/opt/rudder//etc/",
-                     |        "/opt/rudder//etc/hooks.d/",
-                     |        "/opt/rudder//etc/hooks.d/node-pre-deletion/",
-                     |        "/opt/rudder//etc/hooks.d/node-pre-deletion/centreon-pre-deletion.sh",
-                     |        "/opt/rudder//etc/hooks.d/node-post-acceptance/",
-                     |        "/opt/rudder//etc/hooks.d/node-post-acceptance/centreon-post-acceptance.sh"
-                     |      ],
-                     |      "name": "rudder-plugin-centreon",
-                     |      "content": {
-                     |        "files.txz": "/opt/rudder/"
-                     |      },
-                     |      "version": "5.0-1.1",
-                     |      "build-commit": "5c4592d93912ef56de0c506295d22fb2a86146ac",
-                     |      "build-date": "2018-10-29T18:34:16+01:00",
-                     |      "type": "plugin"
-                     |    }
-                     |  }
-                     |}""".stripMargin
+  implicit class ForceParse(s: String) {
+    def toVersion = ParseVersion.parse(s) match {
+      case Left(err) => throw new IllegalArgumentException(s"Can not parse '${s}' as a version in test: ${err}")
+      case Right(v)  => v
+    }
+  }
 
-  val expected = List(
-    JsonPluginDef(
-      "rudder-plugin-branding"
-    , PluginVersion(1, 3, 0, "5.0-")
-    , List(
-        "/opt/rudder/share/plugins/",
-        "/opt/rudder/share/plugins/branding/",
-        "/opt/rudder/share/plugins/branding/branding.jar"
-      )
-    , List("/opt/rudder/share/plugins/branding/branding.jar")
-    , "81edd3edf4f28c13821af8014da0520b72b9df94"
-    , DateTime.parse("2018-10-11T12:23:40+02:00", ISODateTimeFormat.dateTimeNoMillis())
-    )
-  , JsonPluginDef(
-      "rudder-plugin-centreon"
-    , PluginVersion(1, 1, 0, "5.0-")
-    , List(
-        "/opt/rudder//",
-        "/opt/rudder//bin/",
-        "/opt/rudder//bin/centreon-plugin",
-        "/opt/rudder//share/",
-        "/opt/rudder//share/python/",
-        "/opt/rudder//share/python/centreonapi/",
-        "/opt/rudder//share/python/centreonapi/__init__.py",
-        "/opt/rudder//share/python/centreonapi/webservice/",
-        "/opt/rudder//share/python/centreonapi/webservice/__init__.py",
-        "/opt/rudder//share/python/centreonapi/webservice/configuration/",
-        "/opt/rudder//share/python/centreonapi/webservice/configuration/__init__.py",
-        "/opt/rudder//share/python/centreonapi/webservice/configuration/hostgroups.py",
-        "/opt/rudder//share/python/centreonapi/webservice/configuration/service.py",
-        "/opt/rudder//share/python/centreonapi/webservice/configuration/templates.py",
-        "/opt/rudder//share/python/centreonapi/webservice/configuration/poller.py",
-        "/opt/rudder//share/python/centreonapi/webservice/configuration/host.py",
-        "/opt/rudder//share/python/centreonapi/centreon.py",
-        "/opt/rudder//share/python/centreonapi/__init__.pyc",
-        "/opt/rudder//share/python/ipaddress.py",
-        "/opt/rudder//etc/",
-        "/opt/rudder//etc/hooks.d/",
-        "/opt/rudder//etc/hooks.d/node-pre-deletion/",
-        "/opt/rudder//etc/hooks.d/node-pre-deletion/centreon-pre-deletion.sh",
-        "/opt/rudder//etc/hooks.d/node-post-acceptance/",
-        "/opt/rudder//etc/hooks.d/node-post-acceptance/centreon-post-acceptance.sh"
-      )
-    , List()
-    , "5c4592d93912ef56de0c506295d22fb2a86146ac"
-    , DateTime.parse("2018-10-29T18:34:16+01:00", ISODateTimeFormat.dateTimeNoMillis())
-    )
-  )
-
-  val packageService = new ReadPluginPackageInfo("/tmp/foo")
-
-  "Plugins JSON service" should {
-    "be able to read json file format" in {
-      val all = packageService.parseJson(index_json).runNow
-      val success = all.collect { case Right(x) => x }
-      val errors  = all.collect { case Left(x)  => x }
-
-      (errors must beEmpty) and
-      (success must containTheSameElementsAs(expected))
+  "Parsing a plugin version" should {
+    "be able to read simple rudder version" in {
+      PluginVersion.from("7.1.0-2.3.0") must_!= (PluginVersion("7.1.0".toVersion, "2.3.0".toVersion))
+    }
+    "automatically add a patch level (eq 0)" in {
+      PluginVersion.from("7.1-2.3") must_!= (PluginVersion("7.1.0".toVersion, "2.3.0".toVersion))
+    }
+    "understand complicated format with rc" in {
+      PluginVersion.from("7.0.0~rc2-SNAPSHOT-2.1-nightly") must_!= (PluginVersion("7.0.0~rc2-SNAPSHOT".toVersion, "2.1.0-nightly".toVersion))
     }
   }
 }

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/Version.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/Version.scala
@@ -169,7 +169,8 @@ sealed trait VersionPart extends ToVersionString with Ordered[VersionPart] {
 
   override def toVersionString: String = separator.toVersionString + value.toVersionString
   override def compare(other: VersionPart): Int = VersionPart.compare(this, other)
-  }
+}
+
 object VersionPart {
   final case class Before(separator: Separator, value: PartType) extends VersionPart //we can have before with "-" separator for ex with alpha, etc
   final case class After (separator: Separator, value: PartType) extends VersionPart
@@ -181,7 +182,7 @@ object VersionPart {
       val c = Separator.compare(a.separator, b.separator) // not sure? Does 1.0~alpha < 1.0.alpha ?
       if(c == 0) PartType.compare(a.value, b.value) else c
     }
-  }
+}
 
 object ParseVersion {
   import fastparse._, NoWhitespace._


### PR DESCRIPTION
https://issues.rudder.io/issues/20261

This change needs https://github.com/Normation/rudder-plugins/pull/433 to work. 

It brings back the old version format to Plugin version (in the code at least). 

The main changes are: 

- it needs `main-build.conf` in the classpath at the same place as `build.conf` to have access to rudder ABI version (ie the version of rudder used to build that plugin jar)
- simplify `PluginVersion`: in place of being some kind of poor copy of  `Version` from utils, it's now just two `Version`s: one for the rudder ABI, the other for the plugin version
- normalize each version on at least 3 dot separated numbers, adding "0" for missing parts
- use the full plugin version (ie `rudderABI-pluginOwnVersion`) for the plugin object field `version`
- compare between `plugin.version.rudderAbi` and `RudderConfig.rudderFullVersion` (ie current rudder) to check if a warning message should be displayed (see below):

![image](https://user-images.githubusercontent.com/44649/148279392-5ae570cf-536b-4770-83ab-f6562a5fabc6.png)

