### PR TITLE
Fixes #20095: If a rule is in a category that no longer exists, it can't be accessed in rule tree

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/DataTypes.elm
@@ -108,6 +108,21 @@ getAllCats category =
   in
     category :: (List.concatMap getAllCats subElems)
 
+-- get all missing categories
+getAllMissingCats: Category a -> List (Category a)
+getAllMissingCats category =
+  let
+    missingCategory = List.filter (\sub -> sub.id == missingCategoryId) (getSubElems category)
+  in
+  List.concatMap getAllCats missingCategory
+
+-- get all rules who as an unknown category id
+getAllMissingCatsRules: Category a -> List a
+getAllMissingCatsRules category =
+  let
+    missingCategory = List.filter (\sub -> sub.id == missingCategoryId) (getSubElems category)
+  in
+  List.concatMap getAllElems missingCategory
 
 type alias RuleComplianceGlobal =
   { id                : RuleId
@@ -260,6 +275,8 @@ type alias  Changes =
   , changes : Float
   }
 
+-- this is the Id used by the API to group missing categories with their rules
+missingCategoryId = "ui-missing-rule-category"
 
 type alias Model =
   { contextPath     : String

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/Rules.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/Rules.elm
@@ -130,13 +130,23 @@ update msg model =
           processApiError "Getting Nodes list" err model
 
     OpenRuleDetails rId True ->
-      (model, Cmd.batch [getRuleDetails model rId, pushUrl ("rule", rId.value)])
+      let
+        modelUI = model.ui
+      in
+      ({ model | ui = { modelUI | hasWriteRights = True} }, Cmd.batch [getRuleDetails model rId, pushUrl ("rule", rId.value)])
 
     OpenRuleDetails rId False ->
       (model, getRuleDetails model rId)
 
     OpenCategoryDetails category True ->
-      (model, Cmd.batch [getRulesCategoryDetails model category, pushUrl ("ruleCategory" , category)])
+      let
+        allMissingCategories = List.filter (\sub -> sub.id == missingCategoryId) (getSubElems model.rulesTree)
+        listOfCat = List.concatMap getAllCats (allMissingCategories)
+        listCatIdMissing = List.map (\r -> r.id) (listOfCat)
+        hasWriteRight = not (category == missingCategoryId) && not (List.member category listCatIdMissing)
+        modelUI = model.ui
+      in
+      ({ model | ui = { modelUI | hasWriteRights = hasWriteRight} }, Cmd.batch [getRulesCategoryDetails model category, pushUrl ("ruleCategory" , category)])
 
     OpenCategoryDetails category False ->
       (model, getRulesCategoryDetails model category)

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/style/rudder/rudder-rules.css
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/style/rudder/rudder-rules.css
@@ -401,3 +401,11 @@ form.readonly-form .form-group,
 form.readonly-form .tags-container{
   margin-bottom: 15px;
 }
+
+.missing-cat {
+  color: #222D42AA;
+}
+
+.main-missing-cat {
+  color: #f08004;
+}


### PR DESCRIPTION
- [x] We shouldn't be able to move rules under `Missing` category
- [x] Grey color on missing categories
- [x] User should not be able to edit a missing category
- [x] User should not be able to move a rule inside a missing category
- [x] Bug : in warning message for rule in missing categories, id of the category is changing according to the selected item
- [x] Bug : In select option for rule with missing category is set by default on root category, but it when we it it doesn't change anything
- [x]  It seems that the API reponse a Missing category empty, but if no rules mentionnend a missing category then we should'n return this category in the JSON
- [x] duplicate category and rules if multiple rules mentioned the same category ID

https://issues.rudder.io/issues/20095
![image](https://user-images.githubusercontent.com/23410978/149097015-182b3238-f0c7-4622-be05-cb02899902ec.png)
![image](https://user-images.githubusercontent.com/23410978/149000758-6c746c07-6cc7-404c-8579-447074ad7fb9.png)