### PR TITLE
Fixes #20373: compliance from API doesn't always adds up to 100%

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ReportType.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ReportType.scala
@@ -46,76 +46,39 @@ import com.normation.rudder.domain.policies.PolicyMode
  * a merge/compare with expected reports.
  */
 sealed trait ReportType {
-  val severity :String
+
+  def severity :String
+
+  // a "worsiness" level for report type relative order.
+  // A bigger number means "worse than other", as in "'error' is worse than 'repaired'"
+  // level is a positive integer starting at zero.
+  def level: Int
 }
 
 
 object ReportType {
-final case object EnforceNotApplicable extends ReportType {
-    val severity = "NotApplicable"
-  }
-final case object EnforceSuccess extends ReportType {
-    val severity = "Success"
-  }
-final case object EnforceRepaired extends ReportType{
-    val severity = "Repaired"
-  }
-final case object EnforceError extends ReportType{
-    val severity = "Error"
-  }
+  // report type are declared sorted in level to ease maintenance
 
-final case object AuditNotApplicable extends ReportType {
-    val severity = "AuditNotApplicable"
-  }
-final case object AuditCompliant extends ReportType {
-    val severity = "Compliant"
-  }
-final case object AuditNonCompliant extends ReportType{
-    val severity = "NonCompliant"
-  }
-final case object AuditError extends ReportType{
-    val severity = "AuditError"
-  }
-final case object BadPolicyMode extends ReportType{
-    val severity = "BadPolicyMode"
-  }
-final case object Unexpected extends ReportType{
-    val severity = "Unexpected"
-  }
-final case object NoAnswer extends ReportType{
-    val severity = "NoAnswer"
-  }
-final case object Disabled extends ReportType{
-    val severity = "ReportsDisabled"
-  }
-final case object Pending extends ReportType{
-    val severity = "Applying"
-  }
-final case object Missing extends ReportType{
-    val severity = "Missing"
-  }
+  final case object EnforceNotApplicable extends ReportType { val level =  0 ; val severity = "NotApplicable" }
+  final case object AuditNotApplicable   extends ReportType { val level =  1 ; val severity = "AuditNotApplicable" }
+  final case object AuditCompliant       extends ReportType { val level =  2 ; val severity = "Compliant" }
+  final case object EnforceSuccess       extends ReportType { val level =  3 ; val severity = "Success" }
+  final case object Pending              extends ReportType { val level =  4 ; val severity = "Applying" }
+  final case object Disabled             extends ReportType { val level =  5 ; val severity = "ReportsDisabled" }
+  final case object NoAnswer             extends ReportType { val level =  6 ; val severity = "NoAnswer" }
+  final case object Missing              extends ReportType { val level =  7 ; val severity = "Missing" }
+  final case object EnforceRepaired      extends ReportType { val level =  8 ; val severity = "Repaired" }
+  final case object AuditNonCompliant    extends ReportType { val level =  9 ; val severity = "NonCompliant" }
+  final case object AuditError           extends ReportType { val level = 10 ; val severity = "AuditError" }
+  final case object EnforceError         extends ReportType { val level = 11 ; val severity = "Error" }
+  final case object Unexpected           extends ReportType { val level = 12 ; val severity = "Unexpected" }
+  final case object BadPolicyMode        extends ReportType { val level = 13 ; val severity = "BadPolicyMode" }
 
   def getWorseType(reportTypes : Iterable[ReportType]) : ReportType = {
     if (reportTypes.isEmpty) {
       NoAnswer
     } else {
-      reportTypes.foldLeft(EnforceNotApplicable : ReportType) {
-        case (_, BadPolicyMode)       | (BadPolicyMode, _)        => BadPolicyMode
-        case (_, Unexpected)          | (Unexpected, _)           => Unexpected
-        case (_, EnforceError)        | (EnforceError, _)         => EnforceError
-        case (_, AuditError)          | (AuditError, _)           => AuditError
-        case (_, AuditNonCompliant)   | (AuditNonCompliant, _)    => AuditNonCompliant
-        case (_, EnforceRepaired)     | (EnforceRepaired, _)      => EnforceRepaired
-        case (_, Missing)             | (Missing, _)              => Missing
-        case (_, NoAnswer)            | (NoAnswer, _)             => NoAnswer
-        case (_, Disabled)            | (Disabled, _)             => Disabled
-        case (_, Pending)             | (Pending, _)              => Pending
-        case (_, EnforceSuccess)      | (EnforceSuccess, _)       => EnforceSuccess
-        case (_, AuditCompliant)      | (AuditCompliant, _)       => AuditCompliant
-        case (_, AuditNotApplicable)  | (AuditNotApplicable, _)   => AuditNotApplicable
-        case (_, EnforceNotApplicable)| (EnforceNotApplicable, _) => EnforceNotApplicable
-        case _ => Unexpected
-      }
+      reportTypes.maxBy(_.level)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/TestComplianceLevel.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/TestComplianceLevel.scala
@@ -1,0 +1,96 @@
+/*
+*************************************************************************************
+* Copyright 2022 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.domain.reports
+
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+
+/**
+ * Test properties about Compliance Level,
+ * especially pourcent related (sum to 100, rounding error, etc)
+ */
+
+
+@RunWith(classOf[JUnitRunner])
+class TestComplianceLevel extends Specification {
+
+  sequential
+
+  "we can sort levels" should {
+
+    "sort smallest first" in {
+
+      val c = ComplianceLevel(12,1,3,4,9,11,0,8,5,2,6,13,10,7)
+
+      CompliancePercent.sortLevels(c).map(_._1) === List(0,1,2,3,4,5,6,7,8,9,10,11,12,13)
+
+    }
+
+    "sort equals in order of worse last" in {
+      val c = ComplianceLevel(4,4,4,4,9,11,1,4,5,2,6,13,10,7)
+      // interresting part is the 5 '4', where:
+      // (4, 7 = not applicable) < (4, 1 = success) < (4, 0 = pending) < (4, 2 = repaired) < (4, 3 = error)
+      CompliancePercent.sortLevels(c) ===
+      List((1,6), (2,9), (4,7), (4,1), (4,0), (4,2), (4,3), (5,8), (6,10), (7,13), (9,4), (10,12), (11,5), (13,11))
+    }
+  }
+
+
+  "a compliance must never be rounded below 0.01%" >> {
+
+    val c = ComplianceLevel(success = 1, error = 100000)
+
+    (c.pc.repaired === 0) and (c.pc.success === 0.01) and (c.pc.error === 99.99)
+
+  }
+
+  "compliance when there is no report is 0" >> {
+
+    ComplianceLevel().compliance === 0
+  }
+
+  "Compliance must sum to 100 percent" should {
+
+    val c = ComplianceLevel(0,1,1,1)
+
+    (c.pc.success === 33.33) and (c.pc.repaired === 33.33) and (c.pc.error === 33.34)
+  }
+
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/20373

I was not able to reproduce the mentionned cases in rudder (99.99% missing) but I *believe* it was something around 3 components having each 1 missing, and so each contributed 33.33% percent. 
Nonetheless, I was able to make a failing unit test with a compliance with 1 success, 1 na, 1 error that sum to 99.99% corrected by that PR, so I believe that that PR should also correct the composition since AFAIK (and found) compliance percent are not coupounded/summed, it's always the compliane level (which is good). 

So, this PR centralize all computing of percent in the `CompliancePercent` class, and in particular it adds a `CompliancePercent.fromLevels` method that build percents with a sum of 100 by construction. It also remove any percent computing from `ComplianceLevel`.

By construction, it also ensure that a compliance is alway AT LEAST 0.01%, even if it should be 0.0000001% and rounded to 0 to avoid having https://issues.rudder.io/issues/10773 coming back.

With that, there should be no other part in Rudder that computes compliance, and compliance should always be obtained from backend. 

The logic to sum to 100 is that only the "biggest" compliance rounding and the one of small compliance below threshold are adapted, and for that, we do: 

- biggest is defined by "with the more level, or in case of equality, the WORSE kind of report according to `ReportType` sorting"
- sort compliance level by number
- when total is 0 or that level is 0, return 0 (globaly or for that level)
- for all but the biggest, compute compliance, keep two digits, use min threshold if needed, 
- for the biggest, use "100 - sum of others"