### PR TITLE
Fixes #20573: Compliance of rules should not be rounded to the nearest hundredth

### DIFF
--- a/webapp/sources/api-doc/components/parameters/compliance-percent-precision.yml
+++ b/webapp/sources/api-doc/components/parameters/compliance-percent-precision.yml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2020 Normation SAS
+name: "precision"
+in: query
+schema:
+  type: integer
+  example: 0
+  default: 2
+description: Number of digits after comma in compliance percent figures

--- a/webapp/sources/api-doc/paths/compliance/global.yml
+++ b/webapp/sources/api-doc/paths/compliance/global.yml
@@ -4,6 +4,8 @@ get:
   summary: Global compliance
   description: Get current global compliance of a Rudder server
   operationId: getGlobalCompliance
+  parameters:
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
   responses:
     "200":
       description: Success

--- a/webapp/sources/api-doc/paths/compliance/node.yml
+++ b/webapp/sources/api-doc/paths/compliance/node.yml
@@ -6,6 +6,7 @@ get:
   operationId: getNodeCompliance
   parameters:
     - $ref: ../../components/parameters/compliance-level.yml
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
     - $ref: ../../components/parameters/node-id.yml
   responses:
     "200":

--- a/webapp/sources/api-doc/paths/compliance/nodes.yml
+++ b/webapp/sources/api-doc/paths/compliance/nodes.yml
@@ -6,6 +6,7 @@ get:
   operationId: getNodesCompliance
   parameters:
     - $ref: ../../components/parameters/compliance-level.yml
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
   responses:
     "200":
       description: Success

--- a/webapp/sources/api-doc/paths/compliance/rule.yml
+++ b/webapp/sources/api-doc/paths/compliance/rule.yml
@@ -6,6 +6,7 @@ get:
   operationId: getRuleCompliance
   parameters:
     - $ref: ../../components/parameters/compliance-level.yml
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
     - $ref: ../../components/parameters/rule-id.yml
   responses:
     "200":

--- a/webapp/sources/api-doc/paths/compliance/rules.yml
+++ b/webapp/sources/api-doc/paths/compliance/rules.yml
@@ -6,6 +6,7 @@ get:
   operationId: getRulesCompliance
   parameters:
     - $ref: ../../components/parameters/compliance-level.yml
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
   responses:
     "200":
       description: Success

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
@@ -245,11 +245,7 @@ object Doobie {
     )
   }
 
-  implicit val CompliancePercentRead: Read[CompliancePercent] = {
-    import ComplianceLevelSerialisation._
-    import net.liftweb.json._
-    Read[String].map(json => parsePercent(parse(json)))
-  }
+
   implicit val CompliancePercentWrite: Write[CompliancePercent] = {
     import ComplianceLevelSerialisation._
     import net.liftweb.json._

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ComplianceLevel.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ComplianceLevel.scala
@@ -243,7 +243,7 @@ final case class ComplianceLevel(
   lazy val total_ok = success+repaired+notApplicable+compliant+auditNotApplicable
 
   def withoutPending = this.copy(pending = 0, reportsDisabled = 0)
-  def percent(precision: Int = PERCENT_PRECISION) = CompliancePercent.fromLevels(this, precision)
+  def computePercent(precision: Int = PERCENT_PRECISION) = CompliancePercent.fromLevels(this, precision)
 
   def +(compliance: ComplianceLevel): ComplianceLevel = {
     ComplianceLevel(
@@ -462,7 +462,7 @@ object ComplianceLevelSerialisation {
   implicit class ComplianceLevelToJs(val compliance: ComplianceLevel) extends AnyVal {
 
     def toJsArray: JsArray = {
-      val pc = compliance.percent()
+      val pc = compliance.computePercent()
       JsArray (
         JsArray(compliance.reportsDisabled,JE.Num(pc.reportsDisabled))    //  0
         , JsArray(compliance.notApplicable , JE.Num(pc.notApplicable))      //  1

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -573,11 +573,11 @@ object NodeStatusReportSerialization {
       c match {
         case c : ValueStatusReport =>
           ( ("componentName" -> c.componentName)
-          ~ ("compliance"    -> c.compliance.percent().toJson)
+          ~ ("compliance"    -> c.compliance.computePercent().toJson)
           ~ ("numberReports" -> c.compliance.total)
           ~ ("values"        -> c.componentValues.values.map { v =>
               ( ("value"         -> v.componentValue)
-              ~ ("compliance"    -> v.compliance.percent().toJson)
+              ~ ("compliance"    -> v.compliance.computePercent().toJson)
               ~ ("numberReports" -> v.compliance.total)
               ~ ("unexpanded"    -> v.unexpandedComponentValue)
               ~ ("messages"      -> v.messages.map { m =>
@@ -590,7 +590,7 @@ object NodeStatusReportSerialization {
           )
         case c : BlockStatusReport =>
           ( ("componentName" -> c.componentName)
-            ~ ("compliance"    -> c.compliance.percent().toJson)
+            ~ ("compliance"    -> c.compliance.computePercent().toJson)
             ~ ("numberReports" -> c.compliance.total)
             ~ ("subComponents" -> c.subComponents.map(componentValueToJson))
             ~ ("reportingLogic" -> c.reportingLogic.toString)
@@ -607,11 +607,11 @@ object NodeStatusReportSerialization {
 
       "rules" -> reports.map { r =>
         ( ("ruleId"        -> r.ruleId.serialize)
-        ~ ("compliance"    -> r.compliance.percent().toJson)
+        ~ ("compliance"    -> r.compliance.computePercent().toJson)
         ~ ("numberReports" -> r.compliance.total)
         ~ ("directives"    -> r.directives.values.map { d =>
             ( ("directiveId"   -> d.directiveId.serialize)
-            ~ ("compliance"    -> d.compliance.percent().toJson)
+            ~ ("compliance"    -> d.compliance.computePercent().toJson)
             ~ ("numberReports" -> d.compliance.total)
             ~ ("components"    -> d.components.values.map(componentValueToJson))
             )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -573,11 +573,11 @@ object NodeStatusReportSerialization {
       c match {
         case c : ValueStatusReport =>
           ( ("componentName" -> c.componentName)
-          ~ ("compliance"    -> c.compliance.pc.toJson)
+          ~ ("compliance"    -> c.compliance.percent().toJson)
           ~ ("numberReports" -> c.compliance.total)
           ~ ("values"        -> c.componentValues.values.map { v =>
               ( ("value"         -> v.componentValue)
-              ~ ("compliance"    -> v.compliance.pc.toJson)
+              ~ ("compliance"    -> v.compliance.percent().toJson)
               ~ ("numberReports" -> v.compliance.total)
               ~ ("unexpanded"    -> v.unexpandedComponentValue)
               ~ ("messages"      -> v.messages.map { m =>
@@ -590,7 +590,7 @@ object NodeStatusReportSerialization {
           )
         case c : BlockStatusReport =>
           ( ("componentName" -> c.componentName)
-            ~ ("compliance"    -> c.compliance.pc.toJson)
+            ~ ("compliance"    -> c.compliance.percent().toJson)
             ~ ("numberReports" -> c.compliance.total)
             ~ ("subComponents" -> c.subComponents.map(componentValueToJson))
             ~ ("reportingLogic" -> c.reportingLogic.toString)
@@ -607,11 +607,11 @@ object NodeStatusReportSerialization {
 
       "rules" -> reports.map { r =>
         ( ("ruleId"        -> r.ruleId.serialize)
-        ~ ("compliance"    -> r.compliance.pc.toJson)
+        ~ ("compliance"    -> r.compliance.percent().toJson)
         ~ ("numberReports" -> r.compliance.total)
         ~ ("directives"    -> r.directives.values.map { d =>
             ( ("directiveId"   -> d.directiveId.serialize)
-            ~ ("compliance"    -> d.compliance.pc.toJson)
+            ~ ("compliance"    -> d.compliance.percent().toJson)
             ~ ("numberReports" -> d.compliance.total)
             ~ ("components"    -> d.components.values.map(componentValueToJson))
             )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
@@ -71,7 +71,7 @@ final case class RunCompliance(
 object RunCompliance {
 
   def from(runTimestamp: DateTime, endOfLife: DateTime, report: NodeStatusReport) = {
-    RunCompliance(report.nodeId, runTimestamp, endOfLife, (report.runInfo, report.statusInfo), report.compliance.pc, report.reports)
+    RunCompliance(report.nodeId, runTimestamp, endOfLife, (report.runInfo, report.statusInfo), report.compliance.percent(), report.reports)
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
@@ -71,7 +71,7 @@ final case class RunCompliance(
 object RunCompliance {
 
   def from(runTimestamp: DateTime, endOfLife: DateTime, report: NodeStatusReport) = {
-    RunCompliance(report.nodeId, runTimestamp, endOfLife, (report.runInfo, report.statusInfo), report.compliance.percent(), report.reports)
+    RunCompliance(report.nodeId, runTimestamp, endOfLife, (report.runInfo, report.statusInfo), report.compliance.computePercent(), report.reports)
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -268,7 +268,7 @@ trait RuleOrNodeReportingServiceImpl extends ReportingService {
 
       Some((
       complianceLevel
-      , complianceLevel.withoutPending.percent().compliance.round
+      , complianceLevel.withoutPending.computePercent().compliance.round
       ))
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -268,7 +268,7 @@ trait RuleOrNodeReportingServiceImpl extends ReportingService {
 
       Some((
       complianceLevel
-      , complianceLevel.complianceWithoutPending.round
+      , complianceLevel.withoutPending.percent().compliance.round
       ))
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
@@ -116,15 +116,15 @@ class StatusReportTest extends Specification {
     }
 
     "correctly add them" in {
-      aggregate(d1c1v1_s ++ d1c2v21_s).compliance.pc.success === 100
+      aggregate(d1c1v1_s ++ d1c2v21_s).compliance.percent().success === 100
     }
 
     "correctly add them by directive" in {
       val a = aggregate(d1c1v1_s ++ d1c2v21_s ++ d2c2v21_e)
 
-      (a.compliance.pc.success === 66.67.toDouble) and
-      (a.directives("d1").compliance.pc.success === 100) and
-      (a.directives("d2").compliance.pc.error === 100)
+      (a.compliance.percent().success === 66.67.toDouble) and
+      (a.directives("d1").compliance.percent().success === 100) and
+      (a.directives("d2").compliance.percent().error === 100)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
@@ -116,15 +116,15 @@ class StatusReportTest extends Specification {
     }
 
     "correctly add them" in {
-      aggregate(d1c1v1_s ++ d1c2v21_s).compliance.percent().success === 100
+      aggregate(d1c1v1_s ++ d1c2v21_s).compliance.computePercent().success === 100
     }
 
     "correctly add them by directive" in {
       val a = aggregate(d1c1v1_s ++ d1c2v21_s ++ d2c2v21_e)
 
-      (a.compliance.percent().success === 66.67.toDouble) and
-      (a.directives("d1").compliance.percent().success === 100) and
-      (a.directives("d2").compliance.percent().error === 100)
+      (a.compliance.computePercent().success === 66.67.toDouble) and
+      (a.directives("d1").compliance.computePercent().success === 100) and
+      (a.directives("d2").compliance.computePercent().error === 100)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/TestComplianceLevel.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/TestComplianceLevel.scala
@@ -73,11 +73,24 @@ class TestComplianceLevel extends Specification {
   }
 
 
-  "a compliance must never be rounded below 0.01%" >> {
+  "a compliance must never be rounded below its precision" >> {
 
-    val c = ComplianceLevel(success = 1, error = 100000)
+    "which is 0.01 by default" >> {
+      val c = ComplianceLevel(success = 1, error = 100000)
+      (c.pc.repaired === 0) and (c.pc.success === 0.01) and (c.pc.error === 99.99)
+    }
 
-    (c.pc.repaired === 0) and (c.pc.success === 0.01) and (c.pc.error === 99.99)
+    "and can be 0" >> {
+      val c = ComplianceLevel(success = 1, error = 100000)
+      val pc = CompliancePercent.fromLevels(c, 0)
+      (pc.repaired === 0) and (pc.success === 1) and (pc.error === 99)
+    }
+
+    "or a lot" >> {
+      val c = ComplianceLevel(success = 1, error = 1000000000)
+      val pc = CompliancePercent.fromLevels(c, 5)
+      (pc.repaired === 0) and (pc.success === 0.00001) and (pc.error === 99.99999)
+    }
 
   }
 
@@ -86,11 +99,17 @@ class TestComplianceLevel extends Specification {
     ComplianceLevel().compliance === 0
   }
 
-  "Compliance must sum to 100 percent" should {
+  "Compliance must sum to 100 percent" >> {
 
-    val c = ComplianceLevel(0,1,1,1)
+    "when using default precision" >> {
+      val c = ComplianceLevel(0,1,1,1)
+      (c.pc.success === 33.33) and (c.pc.repaired === 33.33) and (c.pc.error === 33.34)
+    }
 
-    (c.pc.success === 33.33) and (c.pc.repaired === 33.33) and (c.pc.error === 33.34)
+    "when using 0 digits" >> {
+      val c = ComplianceLevel(0,1,1,1)
+      val pc = CompliancePercent.fromLevels(c, 0)
+      (pc.success === 33) and (pc.repaired === 33) and (pc.error === 34)
+    }
   }
-
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/TestComplianceLevel.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/TestComplianceLevel.scala
@@ -77,7 +77,8 @@ class TestComplianceLevel extends Specification {
 
     "which is 0.01 by default" >> {
       val c = ComplianceLevel(success = 1, error = 100000)
-      (c.pc.repaired === 0) and (c.pc.success === 0.01) and (c.pc.error === 99.99)
+      val pc = c.percent()
+      (pc.repaired === 0) and (pc.success === 0.01) and (pc.error === 99.99)
     }
 
     "and can be 0" >> {
@@ -96,19 +97,20 @@ class TestComplianceLevel extends Specification {
 
   "compliance when there is no report is 0" >> {
 
-    ComplianceLevel().compliance === 0
+    ComplianceLevel().percent().compliance === 0
   }
 
   "Compliance must sum to 100 percent" >> {
 
     "when using default precision" >> {
       val c = ComplianceLevel(0,1,1,1)
-      (c.pc.success === 33.33) and (c.pc.repaired === 33.33) and (c.pc.error === 33.34)
+      val pc = c.percent()
+      (pc.success === 33.33) and (pc.repaired === 33.33) and (pc.error === 33.34)
     }
 
     "when using 0 digits" >> {
       val c = ComplianceLevel(0,1,1,1)
-      val pc = CompliancePercent.fromLevels(c, 0)
+      val pc = c.percent(0)
       (pc.success === 33) and (pc.repaired === 33) and (pc.error === 34)
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/TestComplianceLevel.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/TestComplianceLevel.scala
@@ -77,7 +77,7 @@ class TestComplianceLevel extends Specification {
 
     "which is 0.01 by default" >> {
       val c = ComplianceLevel(success = 1, error = 100000)
-      val pc = c.percent()
+      val pc = c.computePercent()
       (pc.repaired === 0) and (pc.success === 0.01) and (pc.error === 99.99)
     }
 
@@ -97,20 +97,20 @@ class TestComplianceLevel extends Specification {
 
   "compliance when there is no report is 0" >> {
 
-    ComplianceLevel().percent().compliance === 0
+    ComplianceLevel().computePercent().compliance === 0
   }
 
   "Compliance must sum to 100 percent" >> {
 
     "when using default precision" >> {
       val c = ComplianceLevel(0,1,1,1)
-      val pc = c.percent()
+      val pc = c.computePercent()
       (pc.success === 33.33) and (pc.repaired === 33.33) and (pc.error === 33.34)
     }
 
     "when using 0 digits" >> {
       val c = ComplianceLevel(0,1,1,1)
-      val pc = c.percent(0)
+      val pc = c.computePercent(0)
       (pc.success === 33) and (pc.repaired === 33) and (pc.error === 34)
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -1646,7 +1646,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
       nodeStatus.keySet.head === one and
-      nodeStatus.head._2.reports.head.compliance.pc.success === 100
+      nodeStatus.head._2.reports.head.compliance.percent().success === 100
     }
 
   }
@@ -1675,7 +1675,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
      nodeStatus.keySet.head === NodeId("nodeId") and
-     nodeStatus.head._2.reports.head.compliance.pc.success === 100
+     nodeStatus.head._2.reports.head.compliance.percent().success === 100
     }
   }
 
@@ -1701,7 +1701,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
      nodeStatus.keySet.head === NodeId("nodeId") and
-     nodeStatus.head._2.reports.head.compliance.pc.success === 100
+     nodeStatus.head._2.reports.head.compliance.percent().success === 100
     }
   }
 
@@ -1728,11 +1728,11 @@ class ExecutionBatchTest extends Specification {
     }
     "return a component with the /var/cfengine in NotApplicable " in {
       withGood.componentValues("/var/cfengine").messages.size === 1 and
-      withGood.componentValues("/var/cfengine").compliance.pc.notApplicable === 100
+      withGood.componentValues("/var/cfengine").compliance.percent().notApplicable === 100
     }
     "return a component with the bar key success " in {
       withGood.componentValues("bar").messages.size == 1 and
-      withGood.componentValues("bar").compliance.pc.success === 100
+      withGood.componentValues("bar").compliance.percent().success === 100
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -1646,7 +1646,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
       nodeStatus.keySet.head === one and
-      nodeStatus.head._2.reports.head.compliance.percent().success === 100
+      nodeStatus.head._2.reports.head.compliance.computePercent().success === 100
     }
 
   }
@@ -1675,7 +1675,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
      nodeStatus.keySet.head === NodeId("nodeId") and
-     nodeStatus.head._2.reports.head.compliance.percent().success === 100
+     nodeStatus.head._2.reports.head.compliance.computePercent().success === 100
     }
   }
 
@@ -1701,7 +1701,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
      nodeStatus.keySet.head === NodeId("nodeId") and
-     nodeStatus.head._2.reports.head.compliance.percent().success === 100
+     nodeStatus.head._2.reports.head.compliance.computePercent().success === 100
     }
   }
 
@@ -1728,11 +1728,11 @@ class ExecutionBatchTest extends Specification {
     }
     "return a component with the /var/cfengine in NotApplicable " in {
       withGood.componentValues("/var/cfengine").messages.size === 1 and
-      withGood.componentValues("/var/cfengine").compliance.percent().notApplicable === 100
+      withGood.componentValues("/var/cfengine").compliance.computePercent().notApplicable === 100
     }
     "return a component with the bar key success " in {
       withGood.componentValues("bar").messages.size == 1 and
-      withGood.componentValues("bar").compliance.percent().success === 100
+      withGood.componentValues("bar").compliance.computePercent().success === 100
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -765,6 +765,16 @@ final case class RestExtractorService (
         }
     }
   }
+  def extractPercentPrecision(params: Map[String, List[String]]) : Box[Option[Int]] = {
+    params.get("precision") match {
+      case None | Some(Nil) => Full(None)
+      case Some(h :: tail) => //only take into account the first level param is several are passed
+        try { Full(Some(h.toInt)) }
+        catch {
+          case ex:NumberFormatException => Failure(s"percent precison must be an integer, was: '${h}'")
+        }
+    }
+  }
 
   def extractRule(req : Req) : Box[RestRule] = {
     req.json match {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
@@ -296,7 +296,7 @@ object JsonCompliance {
     def toJsonV6 = (
         ("id" -> rule.id.serialize)
       ~ ("name" -> rule.name)
-      ~ ("compliance" -> rule.compliance.withoutPending.percent().compliance)
+      ~ ("compliance" -> rule.compliance.withoutPending.computePercent().compliance)
       ~ ("complianceDetails" -> percents(rule.compliance, 2))
       ~ ("directives" -> directives(rule.directives, 10, 2) )
     )
@@ -312,7 +312,7 @@ object JsonCompliance {
     def toJson(level: Int, precision: Int) = (
         ("id" -> rule.id.serialize)
       ~ ("name" -> rule.name)
-      ~ ("compliance" -> rule.compliance.withoutPending.percent().compliance)
+      ~ ("compliance" -> rule.compliance.withoutPending.computePercent().compliance)
       ~ ("mode" -> rule.mode.name)
       ~ ("complianceDetails" -> percents(rule.compliance, precision))
       ~ ("directives" -> directives(rule.directives, level, precision) )
@@ -325,7 +325,7 @@ object JsonCompliance {
         (
             ("id" -> directive.id.serialize)
           ~ ("name" -> directive.name)
-          ~ ("compliance" -> directive.compliance.withoutPending.percent().compliance)
+          ~ ("compliance" -> directive.compliance.withoutPending.computePercent().compliance)
           ~ ("complianceDetails" -> percents(directive.compliance, precision))
           ~ ("components" -> components(directive.components, level, precision))
         )
@@ -337,7 +337,7 @@ object JsonCompliance {
         (
           ("id" -> node.id.value)
             ~ ("name" -> node.name)
-            ~ ("compliance" -> node.compliance.withoutPending.percent().compliance)
+            ~ ("compliance" -> node.compliance.withoutPending.computePercent().compliance)
             ~ ("complianceDetails" -> percents(node.compliance, precision))
             ~ ("directives" -> byNodesByDirectives(node.directives, level, precision))
           )
@@ -350,7 +350,7 @@ object JsonCompliance {
         (
           ("id" -> directive.id.serialize)
             ~ ("name" -> directive.name)
-            ~ ("compliance" -> directive.compliance.withoutPending.percent().compliance)
+            ~ ("compliance" -> directive.compliance.withoutPending.computePercent().compliance)
             ~ ("complianceDetails" -> percents(directive.compliance, precision))
             ~ ("components" -> byNodeByDirectiveByComponents(directive.components, level, precision))
           )
@@ -361,7 +361,7 @@ object JsonCompliance {
       else Some(comps.map { component =>
         (
             ("name" -> component.name)
-          ~ ("compliance" -> component.compliance.withoutPending.percent().compliance)
+          ~ ("compliance" -> component.compliance.withoutPending.computePercent().compliance)
           ~ ("complianceDetails" -> percents(component.compliance, precision))
           ~ (component match {
               case component : ByRuleBlockCompliance =>
@@ -378,7 +378,7 @@ object JsonCompliance {
       else Some(comps.map { component =>
         (
           ("name" -> component.name)
-            ~ ("compliance" -> component.compliance.withoutPending.percent().compliance)
+            ~ ("compliance" -> component.compliance.withoutPending.computePercent().compliance)
             ~ ("complianceDetails" -> percents(component.compliance, precision))
             ~ (component match {
             case component : ByRuleByNodeByDirectiveByBlockCompliance =>
@@ -410,7 +410,7 @@ object JsonCompliance {
         (
             ("id" -> node.id.value)
           ~ ("name" -> node.name)
-          ~ ("compliance" -> node.compliance.withoutPending.percent().compliance)
+          ~ ("compliance" -> node.compliance.withoutPending.computePercent().compliance)
           ~ ("complianceDetails" -> percents(node.compliance, precision))
           ~ ("values" -> values(node.values, level))
         )
@@ -423,7 +423,7 @@ object JsonCompliance {
   implicit class JsonByNodeCompliance(val n: ByNodeNodeCompliance) extends AnyVal {
     def toJsonV6 = (
         ("id" -> n.id.value)
-      ~ ("compliance" -> n.compliance.withoutPending.percent().compliance)
+      ~ ("compliance" -> n.compliance.withoutPending.computePercent().compliance)
       ~ ("complianceDetails" -> percents(n.compliance, 2))
       ~ ("rules" -> rules(n.nodeCompliances, 10, 2))
     )
@@ -440,7 +440,7 @@ object JsonCompliance {
     def toJson(level: Int, precision: Int) = (
         ("id" -> n.id.value)
       ~ ("name" -> n.name)
-      ~ ("compliance" -> n.compliance.withoutPending.percent().compliance)
+      ~ ("compliance" -> n.compliance.withoutPending.computePercent().compliance)
       ~ ("mode" -> n.mode.name)
       ~ ("complianceDetails" -> percents(n.compliance, precision))
       ~ ("rules" -> rules(n.nodeCompliances, level, precision))
@@ -452,7 +452,7 @@ object JsonCompliance {
         (
             ("id" -> rule.id.serialize)
           ~ ("name" -> rule.name)
-          ~ ("compliance" -> rule.compliance.withoutPending.percent().compliance)
+          ~ ("compliance" -> rule.compliance.withoutPending.computePercent().compliance)
           ~ ("complianceDetails" -> percents(rule.compliance, precision))
           ~ ("directives" -> directives(rule.directives, level, precision))
        )
@@ -465,7 +465,7 @@ object JsonCompliance {
         (
             ("id" -> directive.id.serialize)
           ~ ("name" -> directive.name)
-          ~ ("compliance" -> directive.compliance.withoutPending.percent().compliance)
+          ~ ("compliance" -> directive.compliance.withoutPending.computePercent().compliance)
           ~ ("complianceDetails" -> percents(directive.compliance, precision))
           ~ ("components" -> components(directive.components, level, precision))
         )
@@ -477,7 +477,7 @@ object JsonCompliance {
       else Some(comps.map { case (_, component) =>
         (
             ("name" -> component.componentName)
-          ~ ("compliance" -> component.compliance.withoutPending.percent().compliance)
+          ~ ("compliance" -> component.compliance.withoutPending.computePercent().compliance)
           ~ ("complianceDetails" -> percents(component.compliance, precision))
           ~ (component match {
               case component : BlockStatusReport =>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
@@ -296,7 +296,7 @@ object JsonCompliance {
     def toJsonV6 = (
         ("id" -> rule.id.serialize)
       ~ ("name" -> rule.name)
-      ~ ("compliance" -> rule.compliance.complianceWithoutPending)
+      ~ ("compliance" -> rule.compliance.withoutPending.percent().compliance)
       ~ ("complianceDetails" -> percents(rule.compliance, 2))
       ~ ("directives" -> directives(rule.directives, 10, 2) )
     )
@@ -312,7 +312,7 @@ object JsonCompliance {
     def toJson(level: Int, precision: Int) = (
         ("id" -> rule.id.serialize)
       ~ ("name" -> rule.name)
-      ~ ("compliance" -> rule.compliance.complianceWithoutPending)
+      ~ ("compliance" -> rule.compliance.withoutPending.percent().compliance)
       ~ ("mode" -> rule.mode.name)
       ~ ("complianceDetails" -> percents(rule.compliance, precision))
       ~ ("directives" -> directives(rule.directives, level, precision) )
@@ -325,7 +325,7 @@ object JsonCompliance {
         (
             ("id" -> directive.id.serialize)
           ~ ("name" -> directive.name)
-          ~ ("compliance" -> directive.compliance.complianceWithoutPending)
+          ~ ("compliance" -> directive.compliance.withoutPending.percent().compliance)
           ~ ("complianceDetails" -> percents(directive.compliance, precision))
           ~ ("components" -> components(directive.components, level, precision))
         )
@@ -337,7 +337,7 @@ object JsonCompliance {
         (
           ("id" -> node.id.value)
             ~ ("name" -> node.name)
-            ~ ("compliance" -> node.compliance.complianceWithoutPending)
+            ~ ("compliance" -> node.compliance.withoutPending.percent().compliance)
             ~ ("complianceDetails" -> percents(node.compliance, precision))
             ~ ("directives" -> byNodesByDirectives(node.directives, level, precision))
           )
@@ -350,7 +350,7 @@ object JsonCompliance {
         (
           ("id" -> directive.id.serialize)
             ~ ("name" -> directive.name)
-            ~ ("compliance" -> directive.compliance.complianceWithoutPending)
+            ~ ("compliance" -> directive.compliance.withoutPending.percent().compliance)
             ~ ("complianceDetails" -> percents(directive.compliance, precision))
             ~ ("components" -> byNodeByDirectiveByComponents(directive.components, level, precision))
           )
@@ -361,7 +361,7 @@ object JsonCompliance {
       else Some(comps.map { component =>
         (
             ("name" -> component.name)
-          ~ ("compliance" -> component.compliance.complianceWithoutPending)
+          ~ ("compliance" -> component.compliance.withoutPending.percent().compliance)
           ~ ("complianceDetails" -> percents(component.compliance, precision))
           ~ (component match {
               case component : ByRuleBlockCompliance =>
@@ -378,7 +378,7 @@ object JsonCompliance {
       else Some(comps.map { component =>
         (
           ("name" -> component.name)
-            ~ ("compliance" -> component.compliance.complianceWithoutPending)
+            ~ ("compliance" -> component.compliance.withoutPending.percent().compliance)
             ~ ("complianceDetails" -> percents(component.compliance, precision))
             ~ (component match {
             case component : ByRuleByNodeByDirectiveByBlockCompliance =>
@@ -410,7 +410,7 @@ object JsonCompliance {
         (
             ("id" -> node.id.value)
           ~ ("name" -> node.name)
-          ~ ("compliance" -> node.compliance.complianceWithoutPending)
+          ~ ("compliance" -> node.compliance.withoutPending.percent().compliance)
           ~ ("complianceDetails" -> percents(node.compliance, precision))
           ~ ("values" -> values(node.values, level))
         )
@@ -423,7 +423,7 @@ object JsonCompliance {
   implicit class JsonByNodeCompliance(val n: ByNodeNodeCompliance) extends AnyVal {
     def toJsonV6 = (
         ("id" -> n.id.value)
-      ~ ("compliance" -> n.compliance.complianceWithoutPending)
+      ~ ("compliance" -> n.compliance.withoutPending.percent().compliance)
       ~ ("complianceDetails" -> percents(n.compliance, 2))
       ~ ("rules" -> rules(n.nodeCompliances, 10, 2))
     )
@@ -440,7 +440,7 @@ object JsonCompliance {
     def toJson(level: Int, precision: Int) = (
         ("id" -> n.id.value)
       ~ ("name" -> n.name)
-      ~ ("compliance" -> n.compliance.complianceWithoutPending)
+      ~ ("compliance" -> n.compliance.withoutPending.percent().compliance)
       ~ ("mode" -> n.mode.name)
       ~ ("complianceDetails" -> percents(n.compliance, precision))
       ~ ("rules" -> rules(n.nodeCompliances, level, precision))
@@ -452,7 +452,7 @@ object JsonCompliance {
         (
             ("id" -> rule.id.serialize)
           ~ ("name" -> rule.name)
-          ~ ("compliance" -> rule.compliance.complianceWithoutPending)
+          ~ ("compliance" -> rule.compliance.withoutPending.percent().compliance)
           ~ ("complianceDetails" -> percents(rule.compliance, precision))
           ~ ("directives" -> directives(rule.directives, level, precision))
        )
@@ -465,7 +465,7 @@ object JsonCompliance {
         (
             ("id" -> directive.id.serialize)
           ~ ("name" -> directive.name)
-          ~ ("compliance" -> directive.compliance.complianceWithoutPending)
+          ~ ("compliance" -> directive.compliance.withoutPending.percent().compliance)
           ~ ("complianceDetails" -> percents(directive.compliance, precision))
           ~ ("components" -> components(directive.components, level, precision))
         )
@@ -477,7 +477,7 @@ object JsonCompliance {
       else Some(comps.map { case (_, component) =>
         (
             ("name" -> component.componentName)
-          ~ ("compliance" -> component.compliance.complianceWithoutPending)
+          ~ ("compliance" -> component.compliance.withoutPending.percent().compliance)
           ~ ("complianceDetails" -> percents(component.compliance, precision))
           ~ (component match {
               case component : BlockStatusReport =>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -102,6 +102,7 @@ class ComplianceApi(
 
       (for {
         level <- restExtractor.extractComplianceLevel(req.params)
+        precision <- restExtractor.extractPercentPrecision(req.params)
         computeLevel <- Full(if(version.value <= 6) {
                           None
                         } else {
@@ -112,7 +113,7 @@ class ComplianceApi(
         if(version.value <= 6) {
           rules.map( _.toJsonV6 )
         } else {
-          rules.map( _.toJson(level.getOrElse(10) ) ) //by default, all details are displayed
+          rules.map( _.toJson(level.getOrElse(10), precision.getOrElse(2))) //by default, all details are displayed
         }
       }) match {
         case Full(rules) =>
@@ -134,13 +135,14 @@ class ComplianceApi(
 
       (for {
         level <- restExtractor.extractComplianceLevel(req.params)
+        precision <- restExtractor.extractPercentPrecision(req.params)
         id    <- RuleId.parse(ruleId).toBox
         rule  <- complianceService.getRuleCompliance(id, level)
       } yield {
         if(version.value <= 6) {
           rule.toJsonV6
         } else {
-          rule.toJson(level.getOrElse(10) ) //by default, all details are displayed
+          rule.toJson(level.getOrElse(10), precision.getOrElse(2)) //by default, all details are displayed
         }
       }) match {
         case Full(rule) =>
@@ -162,12 +164,13 @@ class ComplianceApi(
 
       (for {
         level <- restExtractor.extractComplianceLevel(req.params)
+        precision <- restExtractor.extractPercentPrecision(req.params)
         nodes <- complianceService.getNodesCompliance()
       } yield {
         if(version.value <= 6) {
           nodes.map( _.toJsonV6 )
         } else {
-          nodes.map( _.toJson(level.getOrElse(10)) )
+          nodes.map( _.toJson(level.getOrElse(10), precision.getOrElse(2)) )
         }
       })match {
         case Full(nodes) =>
@@ -189,12 +192,13 @@ class ComplianceApi(
 
       (for {
         level <- restExtractor.extractComplianceLevel(req.params)
+        precision <- restExtractor.extractPercentPrecision(req.params)
         node  <- complianceService.getNodeCompliance(NodeId(nodeId))
       } yield {
         if(version.value <= 6) {
           node.toJsonV6
         } else {
-          node.toJson(level.getOrElse(10))
+          node.toJson(level.getOrElse(10), precision.getOrElse(2))
         }
       })match {
         case Full(node) =>
@@ -215,9 +219,10 @@ class ComplianceApi(
       implicit val prettify = params.prettify
 
       (for {
+        precision <- restExtractor.extractPercentPrecision(req.params)
         optCompliance <- complianceService.getGlobalCompliance()
       } yield {
-        optCompliance.toJson
+        optCompliance.toJson(precision.getOrElse(2))
       }) match {
         case Full(json) =>
           toJsonResponse(None, json)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -596,7 +596,7 @@ class NodeApiService13 (
 
     import net.liftweb.json.JsonDSL._
     def toComplianceArray(comp : ComplianceLevel) : JArray = {
-      val pc = comp.percent()
+      val pc = comp.computePercent()
       JArray (
         JArray(JInt(comp.reportsDisabled) :: JDouble(pc.reportsDisabled) :: Nil)  :: //0
         JArray(JInt(comp.notApplicable) :: JDouble(pc.notApplicable) :: Nil ) ::       //  1
@@ -639,7 +639,7 @@ class NodeApiService13 (
       ~  ("os"                  -> nodeInfo.osDetails.fullName)
       ~  ("state"               -> nodeInfo.state.name)
       ~  ("compliance"          -> userCompliance )
-      ~  ("systemError"         -> sysCompliance.map(_.percent().compliance < 100 ).getOrElse(true) )
+      ~ ("systemError"         -> sysCompliance.map(_.computePercent().compliance < 100 ).getOrElse(true))
       ~  ("ipAddresses"         -> nodeInfo.ips.filter(ip => ip != "127.0.0.1" && ip != "0:0:0:0:0:0:0:1").map(escapeHTML(_)))
       ~  ("lastRun"             -> agentRunWithNodeConfig.map(d => DateFormaterService.getDisplayDate(d.agentRunId.date)).getOrElse("Never"))
       ~  ("lastInventory"       -> DateFormaterService.getDisplayDate(nodeInfo.inventoryDate))

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -595,23 +595,25 @@ class NodeApiService13 (
     def escapeHTML(s: String): String = JsExp.strToJsExp(xml.Utility.escape(s)).str
 
     import net.liftweb.json.JsonDSL._
-    def toComplianceArray(comp : ComplianceLevel) : JArray =
+    def toComplianceArray(comp : ComplianceLevel) : JArray = {
+      val pc = comp.percent()
       JArray (
-        JArray(JInt(comp.reportsDisabled) :: JDouble(comp.pc.reportsDisabled) :: Nil)  :: //0
-        JArray(JInt(comp.notApplicable) :: JDouble(comp.pc.notApplicable) :: Nil ) ::       //  1
-        JArray(JInt(comp.success) :: JDouble(comp.pc.success) :: Nil ) ::         //  2
-        JArray(JInt(comp.repaired) :: JDouble(comp.pc.repaired) :: Nil ) ::            //  3
-        JArray(JInt(comp.error) :: JDouble(comp.pc.error) :: Nil ) ::               //  4
-        JArray(JInt(comp.pending) :: JDouble(comp.pc.pending) :: Nil ) ::             //  5
-        JArray(JInt(comp.noAnswer) :: JDouble(comp.pc.noAnswer) :: Nil ) ::            //  6
-        JArray(JInt(comp.missing) :: JDouble(comp.pc.missing) :: Nil ) ::             //  7
-        JArray(JInt(comp.unexpected) :: JDouble(comp.pc.unexpected) :: Nil ) ::          //  8
-        JArray(JInt(comp.auditNotApplicable) :: JDouble(comp.pc.auditNotApplicable) :: Nil ) ::  //  9
-        JArray(JInt(comp.compliant) :: JDouble(comp.pc.compliant) :: Nil ) ::           // 10
-        JArray(JInt(comp.nonCompliant) :: JDouble(comp.pc.nonCompliant) :: Nil ) ::        // 11
-        JArray(JInt(comp.auditError) :: JDouble(comp.pc.auditError) :: Nil ) ::          // 12
-        JArray(JInt(comp.badPolicyMode) :: JDouble(comp.pc.badPolicyMode) :: Nil ) :: Nil       // 13
+        JArray(JInt(comp.reportsDisabled) :: JDouble(pc.reportsDisabled) :: Nil)  :: //0
+        JArray(JInt(comp.notApplicable) :: JDouble(pc.notApplicable) :: Nil ) ::       //  1
+        JArray(JInt(comp.success) :: JDouble(pc.success) :: Nil ) ::         //  2
+        JArray(JInt(comp.repaired) :: JDouble(pc.repaired) :: Nil ) ::            //  3
+        JArray(JInt(comp.error) :: JDouble(pc.error) :: Nil ) ::               //  4
+        JArray(JInt(comp.pending) :: JDouble(pc.pending) :: Nil ) ::             //  5
+        JArray(JInt(comp.noAnswer) :: JDouble(pc.noAnswer) :: Nil ) ::            //  6
+        JArray(JInt(comp.missing) :: JDouble(pc.missing) :: Nil ) ::             //  7
+        JArray(JInt(comp.unexpected) :: JDouble(pc.unexpected) :: Nil ) ::          //  8
+        JArray(JInt(comp.auditNotApplicable) :: JDouble(pc.auditNotApplicable) :: Nil ) ::  //  9
+        JArray(JInt(comp.compliant) :: JDouble(pc.compliant) :: Nil ) ::           // 10
+        JArray(JInt(comp.nonCompliant) :: JDouble(pc.nonCompliant) :: Nil ) ::        // 11
+        JArray(JInt(comp.auditError) :: JDouble(pc.auditError) :: Nil ) ::          // 12
+        JArray(JInt(comp.badPolicyMode) :: JDouble(pc.badPolicyMode) :: Nil ) :: Nil       // 13
       )
+    }
 
     val userCompliance = compliance.map(c => toComplianceArray(c))
     val (policyMode,explanation) =
@@ -637,7 +639,7 @@ class NodeApiService13 (
       ~  ("os"                  -> nodeInfo.osDetails.fullName)
       ~  ("state"               -> nodeInfo.state.name)
       ~  ("compliance"          -> userCompliance )
-      ~  ("systemError"         -> sysCompliance.map(_.compliance < 100 ).getOrElse(true) )
+      ~  ("systemError"         -> sysCompliance.map(_.percent().compliance < 100 ).getOrElse(true) )
       ~  ("ipAddresses"         -> nodeInfo.ips.filter(ip => ip != "127.0.0.1" && ip != "0:0:0:0:0:0:0:1").map(escapeHTML(_)))
       ~  ("lastRun"             -> agentRunWithNodeConfig.map(d => DateFormaterService.getDisplayDate(d.agentRunId.date)).getOrElse("Never"))
       ~  ("lastInventory"       -> DateFormaterService.getDisplayDate(nodeInfo.inventoryDate))

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -1003,7 +1003,7 @@ class RuleApiService14 (
             case None =>
               // try to find if a rule has a category that is no longer available but still mentioned in a rule
               getMissingCategories(root, rules.toList).find(id.value == _.id.value) match {
-                case Some(cat) => Some(root, cat)
+                case Some(cat) => Some((root, cat))
                 case _         =>
                   // The root category for missing/deleted categories
                   if(id == MISSING_RULE_CAT_ID) {
@@ -1013,7 +1013,7 @@ class RuleApiService14 (
                       , "Category that regroup all the missing categories"
                       , List.empty
                     )
-                    Some(root, missingCategory)
+                    Some((root, missingCategory))
                   } else {
                     None
                   }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ApiCalls.elm
@@ -165,7 +165,7 @@ getRulesCompliance model =
       request
         { method  = "GET"
         , headers = []
-        , url     = getUrl model [ "compliance", "rules"] [ int "level" 1 ]
+        , url     = getUrl model [ "compliance", "rules"] [ int "level" 1, int "precision" 0 ]
         , body    = emptyBody
         , expect  = expectJson GetRulesComplianceResult decodeGetRulesCompliance
         , timeout = Nothing
@@ -181,7 +181,7 @@ getRulesComplianceDetails ruleId model =
       request
         { method  = "GET"
         , headers = []
-        , url     = getUrl model [ "compliance", "rules", ruleId.value ] [ int "level" 10 ]
+        , url     = getUrl model [ "compliance", "rules", ruleId.value ] [ int "level" 10 , int "precision" 0 ]
         , body    = emptyBody
         , expect  = expectJson (GetRuleComplianceResult ruleId) decodeGetRulesComplianceDetails
         , timeout = Nothing

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ComplianceData.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ComplianceData.scala
@@ -148,7 +148,7 @@ final case class RuleComplianceLine (
     JsObj (
         ( "rule"              -> escapeHTML(rule.name)       )
       , ( "compliance"        -> jsCompliance(compliance)    )
-      , ( "compliancePercent" -> compliance.percent().compliance)
+      , ( "compliancePercent" -> compliance.computePercent().compliance)
       , ( "id"                -> escapeHTML(rule.id.serialize) )
       , ( "details"           -> details.json                )
       //unique id, usable as DOM id - rules, directives, etc can
@@ -194,7 +194,7 @@ final case class DirectiveComplianceLine (
       , ( "techniqueName"    -> escapeHTML(techniqueName)             )
       , ( "techniqueVersion" -> escapeHTML(techniqueVersion.serialize))
       , ( "compliance"       -> jsCompliance(compliance)              )
-      , ( "compliancePercent"-> compliance.percent().compliance       )
+      , ( "compliancePercent"-> compliance.computePercent().compliance)
       , ( "details"          -> details.json                          )
       //unique id, usable as DOM id - rules, directives, etc can
       //appear several time in a page
@@ -228,7 +228,7 @@ final case class NodeComplianceLine (
     JsObj (
         ( "node"              -> escapeHTML(nodeInfo.hostname) )
       , ( "compliance"        -> jsCompliance(compliance)      )
-      , ( "compliancePercent" -> compliance.percent().compliance)
+      , ( "compliancePercent" -> compliance.computePercent().compliance)
       , ( "id"                -> escapeHTML(nodeInfo.id.value) )
       , ( "details"           -> details.json                  )
       //unique id, usable as DOM id - rules, directives, etc can
@@ -269,7 +269,7 @@ final case class BlockComplianceLine (
     JsObj(
       ("component" -> escapeHTML(component))
       , ("compliance" -> jsCompliance(compliance))
-      , ("compliancePercent" -> compliance.percent().compliance)
+      , ("compliancePercent" -> compliance.computePercent().compliance)
       , ("details" -> details.json)
       , ("jsid" -> nextFuncName)
       , ("composition" -> reportingLogic.toString)
@@ -288,7 +288,7 @@ final case class ValueComplianceLine (
     JsObj (
         ( "component"         -> escapeHTML(component)    )
       , ( "compliance"        -> jsCompliance(compliance) )
-      , ( "compliancePercent" -> compliance.percent().compliance)
+      , ( "compliancePercent" -> compliance.computePercent().compliance)
       , ( "details"           -> details.json             )
       , ( "noExpand"          -> noExpand                 )
       , ( "jsid"              -> nextFuncName             )
@@ -323,7 +323,7 @@ final case class ComponentValueComplianceLine (
       , ( "statusClass"       -> statusClass )
       , ( "messages"          -> JsArray(messages.map{ case(s, m) => JsObj(("status" -> s), ("value" -> escapeHTML(m)))}))
       , ( "compliance"        -> jsCompliance(compliance))
-      , ( "compliancePercent" -> compliance.percent().compliance)
+      , ( "compliancePercent" -> compliance.computePercent().compliance)
       //unique id, usable as DOM id - rules, directives, etc can
       //appear several time in a page
       , ( "jsid"              -> nextFuncName )

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ComplianceData.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ComplianceData.scala
@@ -148,7 +148,7 @@ final case class RuleComplianceLine (
     JsObj (
         ( "rule"              -> escapeHTML(rule.name)       )
       , ( "compliance"        -> jsCompliance(compliance)    )
-      , ( "compliancePercent" -> compliance.compliance       )
+      , ( "compliancePercent" -> compliance.percent().compliance)
       , ( "id"                -> escapeHTML(rule.id.serialize) )
       , ( "details"           -> details.json                )
       //unique id, usable as DOM id - rules, directives, etc can
@@ -194,7 +194,7 @@ final case class DirectiveComplianceLine (
       , ( "techniqueName"    -> escapeHTML(techniqueName)             )
       , ( "techniqueVersion" -> escapeHTML(techniqueVersion.serialize))
       , ( "compliance"       -> jsCompliance(compliance)              )
-      , ( "compliancePercent"-> compliance.compliance                 )
+      , ( "compliancePercent"-> compliance.percent().compliance       )
       , ( "details"          -> details.json                          )
       //unique id, usable as DOM id - rules, directives, etc can
       //appear several time in a page
@@ -228,7 +228,7 @@ final case class NodeComplianceLine (
     JsObj (
         ( "node"              -> escapeHTML(nodeInfo.hostname) )
       , ( "compliance"        -> jsCompliance(compliance)      )
-      , ( "compliancePercent" -> compliance.compliance         )
+      , ( "compliancePercent" -> compliance.percent().compliance)
       , ( "id"                -> escapeHTML(nodeInfo.id.value) )
       , ( "details"           -> details.json                  )
       //unique id, usable as DOM id - rules, directives, etc can
@@ -269,7 +269,7 @@ final case class BlockComplianceLine (
     JsObj(
       ("component" -> escapeHTML(component))
       , ("compliance" -> jsCompliance(compliance))
-      , ("compliancePercent" -> compliance.compliance)
+      , ("compliancePercent" -> compliance.percent().compliance)
       , ("details" -> details.json)
       , ("jsid" -> nextFuncName)
       , ("composition" -> reportingLogic.toString)
@@ -288,7 +288,7 @@ final case class ValueComplianceLine (
     JsObj (
         ( "component"         -> escapeHTML(component)    )
       , ( "compliance"        -> jsCompliance(compliance) )
-      , ( "compliancePercent" -> compliance.compliance    )
+      , ( "compliancePercent" -> compliance.percent().compliance)
       , ( "details"           -> details.json             )
       , ( "noExpand"          -> noExpand                 )
       , ( "jsid"              -> nextFuncName             )
@@ -323,7 +323,7 @@ final case class ComponentValueComplianceLine (
       , ( "statusClass"       -> statusClass )
       , ( "messages"          -> JsArray(messages.map{ case(s, m) => JsObj(("status" -> s), ("value" -> escapeHTML(m)))}))
       , ( "compliance"        -> jsCompliance(compliance))
-      , ( "compliancePercent" -> compliance.compliance)
+      , ( "compliancePercent" -> compliance.percent().compliance)
       //unique id, usable as DOM id - rules, directives, etc can
       //appear several time in a page
       , ( "jsid"              -> nextFuncName )

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -271,7 +271,7 @@ class ReportDisplayer(
             ( "bg-warning text-warning"
             , <p>{nbAttention} reports below (out of {report.compliance.total} total reports) are not in Success, and may require attention.</p>
             )
-          } else if(report.compliance.percent().pending > 0) {
+          } else if(report.compliance.computePercent().pending > 0) {
             ("bg-info text-info", NodeSeq.Empty)
 
           } else {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -271,7 +271,7 @@ class ReportDisplayer(
             ( "bg-warning text-warning"
             , <p>{nbAttention} reports below (out of {report.compliance.total} total reports) are not in Success, and may require attention.</p>
             )
-          } else if(report.compliance.pc.pending > 0) {
+          } else if(report.compliance.percent().pending > 0) {
             ("bg-info text-info", NodeSeq.Empty)
 
           } else {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -194,7 +194,7 @@ final case class ColoredChartType(value: Double) extends ChartType
                              val complianceLevel = ComplianceLevel.sum(compliancePerNodes.map(_._2))
                              Some((
                                complianceLevel
-                             , complianceLevel.complianceWithoutPending.round
+                             , complianceLevel.withoutPending.percent().compliance.round
                              ))
                            }
       n5 = System.currentTimeMillis
@@ -218,7 +218,7 @@ final case class ColoredChartType(value: Double) extends ChartType
       val complianceByNode : List[ChartType] = compliancePerNodes.values.map { r =>
         if(r.pending == r.total) { PendingChartType }
         else if(r.reportsDisabled == r.total) { DisabledChartType }
-        else { ColoredChartType(r.complianceWithoutPending) }
+        else { ColoredChartType(r.withoutPending.percent().compliance) }
       }.toList
 
       val complianceDiagram : List[ComplianceLevelPieChart] = (complianceByNode.groupBy{compliance => compliance match {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -194,7 +194,7 @@ final case class ColoredChartType(value: Double) extends ChartType
                              val complianceLevel = ComplianceLevel.sum(compliancePerNodes.map(_._2))
                              Some((
                                complianceLevel
-                             , complianceLevel.withoutPending.percent().compliance.round
+                             , complianceLevel.withoutPending.computePercent().compliance.round
                              ))
                            }
       n5 = System.currentTimeMillis
@@ -218,7 +218,7 @@ final case class ColoredChartType(value: Double) extends ChartType
       val complianceByNode : List[ChartType] = compliancePerNodes.values.map { r =>
         if(r.pending == r.total) { PendingChartType }
         else if(r.reportsDisabled == r.total) { DisabledChartType }
-        else { ColoredChartType(r.withoutPending.percent().compliance) }
+        else { ColoredChartType(r.withoutPending.computePercent().compliance) }
       }.toList
 
       val complianceDiagram : List[ComplianceLevelPieChart] = (complianceByNode.groupBy{compliance => compliance match {


### PR DESCRIPTION
https://issues.rudder.io/issues/20573

A pure backend correction of https://issues.rudder.io/issues/20573, should replace https://github.com/Normation/rudder/pull/4110 cc @RaphaelGauthier 

The idea is to be able to specify what precision we want for compliance percent in the API calls, and let the backend compute compliance with that value. Most of the pr is passing the `precision` parameter around. 

Note that we can't specify `precision` value for the  `lazy val pc` attribute in `ComplianceLevel` instance, so a default value of `2` is kept. That `pc` value does not seems to be used in the compliance displaying for UI, so it makes me wonder if we really need an heavy lazy val in each `ComplianceLevel` objects, perhaps we should only compute it when needed with `CompliancePercent.fromLevels(c, precision)` - cc @ncharles for that. 

The 2nd commit totaly remove `lazy val` from `ComplianceLevel` object. It will free 3 object alloc by compliance level object, which is not nothing given the number of short lived ones we have, and it seems that there is not many places where they are reused (and where it can't be computed before the different use place).
