### PR TITLE
Fixes #20602: rpm python API incompatible in python3

### DIFF
--- a/relay/sources/rudder-pkg/lib/rudder-pkg/rudderPkgUtils.py
+++ b/relay/sources/rudder-pkg/lib/rudder-pkg/rudderPkgUtils.py
@@ -479,7 +479,7 @@ def install_dependencies(metadata):
                                 mi = ts.dbMatch('name', package)
                                 packageManagerQueried = True
                                 try:
-                                    h = mi.next()
+                                    h = mi.__next__()
                                 except StopIteration:
                                     logger.warning(
                                         'The rpm package '


### PR DESCRIPTION
https://issues.rudder.io/issues/20602