### PR TITLE
Fixes #20607: Make possible to choose precision in compliance percent API

### DIFF
--- a/webapp/sources/api-doc/components/parameters/compliance-percent-precision.yml
+++ b/webapp/sources/api-doc/components/parameters/compliance-percent-precision.yml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2020 Normation SAS
+name: "precision"
+in: query
+schema:
+  type: integer
+  example: 0
+  default: 2
+description: Number of digits after comma in compliance percent figures

--- a/webapp/sources/api-doc/paths/compliance/global.yml
+++ b/webapp/sources/api-doc/paths/compliance/global.yml
@@ -4,6 +4,8 @@ get:
   summary: Global compliance
   description: Get current global compliance of a Rudder server
   operationId: getGlobalCompliance
+  parameters:
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
   responses:
     "200":
       description: Success

--- a/webapp/sources/api-doc/paths/compliance/node.yml
+++ b/webapp/sources/api-doc/paths/compliance/node.yml
@@ -6,6 +6,7 @@ get:
   operationId: getNodeCompliance
   parameters:
     - $ref: ../../components/parameters/compliance-level.yml
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
     - $ref: ../../components/parameters/node-id.yml
   responses:
     "200":

--- a/webapp/sources/api-doc/paths/compliance/nodes.yml
+++ b/webapp/sources/api-doc/paths/compliance/nodes.yml
@@ -6,6 +6,7 @@ get:
   operationId: getNodesCompliance
   parameters:
     - $ref: ../../components/parameters/compliance-level.yml
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
   responses:
     "200":
       description: Success

--- a/webapp/sources/api-doc/paths/compliance/rule.yml
+++ b/webapp/sources/api-doc/paths/compliance/rule.yml
@@ -6,6 +6,7 @@ get:
   operationId: getRuleCompliance
   parameters:
     - $ref: ../../components/parameters/compliance-level.yml
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
     - $ref: ../../components/parameters/rule-id.yml
   responses:
     "200":

--- a/webapp/sources/api-doc/paths/compliance/rules.yml
+++ b/webapp/sources/api-doc/paths/compliance/rules.yml
@@ -6,6 +6,7 @@ get:
   operationId: getRulesCompliance
   parameters:
     - $ref: ../../components/parameters/compliance-level.yml
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
   responses:
     "200":
       description: Success

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
@@ -245,11 +245,7 @@ object Doobie {
     )
   }
 
-  implicit val CompliancePercentRead: Read[CompliancePercent] = {
-    import ComplianceLevelSerialisation._
-    import net.liftweb.json._
-    Read[String].map(json => parsePercent(parse(json)))
-  }
+
   implicit val CompliancePercentWrite: Write[CompliancePercent] = {
     import ComplianceLevelSerialisation._
     import net.liftweb.json._

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -573,11 +573,11 @@ object NodeStatusReportSerialization {
       c match {
         case c : ValueStatusReport =>
           ( ("componentName" -> c.componentName)
-          ~ ("compliance"    -> c.compliance.pc.toJson)
+          ~ ("compliance"    -> c.compliance.computePercent().toJson)
           ~ ("numberReports" -> c.compliance.total)
           ~ ("values"        -> c.componentValues.values.map { v =>
               ( ("value"         -> v.componentValue)
-              ~ ("compliance"    -> v.compliance.pc.toJson)
+              ~ ("compliance"    -> v.compliance.computePercent().toJson)
               ~ ("numberReports" -> v.compliance.total)
               ~ ("unexpanded"    -> v.unexpandedComponentValue)
               ~ ("messages"      -> v.messages.map { m =>
@@ -590,7 +590,7 @@ object NodeStatusReportSerialization {
           )
         case c : BlockStatusReport =>
           ( ("componentName" -> c.componentName)
-            ~ ("compliance"    -> c.compliance.pc.toJson)
+            ~ ("compliance"    -> c.compliance.computePercent().toJson)
             ~ ("numberReports" -> c.compliance.total)
             ~ ("subComponents" -> c.subComponents.map(componentValueToJson))
             ~ ("reportingLogic" -> c.reportingLogic.toString)
@@ -607,11 +607,11 @@ object NodeStatusReportSerialization {
 
       "rules" -> reports.map { r =>
         ( ("ruleId"        -> r.ruleId.serialize)
-        ~ ("compliance"    -> r.compliance.pc.toJson)
+        ~ ("compliance"    -> r.compliance.computePercent().toJson)
         ~ ("numberReports" -> r.compliance.total)
         ~ ("directives"    -> r.directives.values.map { d =>
             ( ("directiveId"   -> d.directiveId.serialize)
-            ~ ("compliance"    -> d.compliance.pc.toJson)
+            ~ ("compliance"    -> d.compliance.computePercent().toJson)
             ~ ("numberReports" -> d.compliance.total)
             ~ ("components"    -> d.components.values.map(componentValueToJson))
             )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
@@ -71,7 +71,7 @@ final case class RunCompliance(
 object RunCompliance {
 
   def from(runTimestamp: DateTime, endOfLife: DateTime, report: NodeStatusReport) = {
-    RunCompliance(report.nodeId, runTimestamp, endOfLife, (report.runInfo, report.statusInfo), report.compliance.pc, report.reports)
+    RunCompliance(report.nodeId, runTimestamp, endOfLife, (report.runInfo, report.statusInfo), report.compliance.computePercent(), report.reports)
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -268,7 +268,7 @@ trait RuleOrNodeReportingServiceImpl extends ReportingService {
 
       Some((
       complianceLevel
-      , complianceLevel.complianceWithoutPending.round
+      , complianceLevel.withoutPending.computePercent().compliance.round
       ))
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
@@ -116,15 +116,15 @@ class StatusReportTest extends Specification {
     }
 
     "correctly add them" in {
-      aggregate(d1c1v1_s ++ d1c2v21_s).compliance.pc.success === 100
+      aggregate(d1c1v1_s ++ d1c2v21_s).compliance.computePercent().success === 100
     }
 
     "correctly add them by directive" in {
       val a = aggregate(d1c1v1_s ++ d1c2v21_s ++ d2c2v21_e)
 
-      (a.compliance.pc.success === 66.67.toDouble) and
-      (a.directives("d1").compliance.pc.success === 100) and
-      (a.directives("d2").compliance.pc.error === 100)
+      (a.compliance.computePercent().success === 66.67.toDouble) and
+      (a.directives("d1").compliance.computePercent().success === 100) and
+      (a.directives("d2").compliance.computePercent().error === 100)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/TestComplianceLevel.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/TestComplianceLevel.scala
@@ -73,24 +73,45 @@ class TestComplianceLevel extends Specification {
   }
 
 
-  "a compliance must never be rounded below 0.01%" >> {
+  "a compliance must never be rounded below its precision" >> {
 
-    val c = ComplianceLevel(success = 1, error = 100000)
+    "which is 0.01 by default" >> {
+      val c = ComplianceLevel(success = 1, error = 100000)
+      val pc = c.computePercent()
+      (pc.repaired === 0) and (pc.success === 0.01) and (pc.error === 99.99)
+    }
 
-    (c.pc.repaired === 0) and (c.pc.success === 0.01) and (c.pc.error === 99.99)
+    "and can be 0" >> {
+      val c = ComplianceLevel(success = 1, error = 100000)
+      val pc = CompliancePercent.fromLevels(c, 0)
+      (pc.repaired === 0) and (pc.success === 1) and (pc.error === 99)
+    }
+
+    "or a lot" >> {
+      val c = ComplianceLevel(success = 1, error = 1000000000)
+      val pc = CompliancePercent.fromLevels(c, 5)
+      (pc.repaired === 0) and (pc.success === 0.00001) and (pc.error === 99.99999)
+    }
 
   }
 
   "compliance when there is no report is 0" >> {
 
-    ComplianceLevel().compliance === 0
+    ComplianceLevel().computePercent().compliance === 0
   }
 
-  "Compliance must sum to 100 percent" should {
+  "Compliance must sum to 100 percent" >> {
 
-    val c = ComplianceLevel(0,1,1,1)
+    "when using default precision" >> {
+      val c = ComplianceLevel(0,1,1,1)
+      val pc = c.computePercent()
+      (pc.success === 33.33) and (pc.repaired === 33.33) and (pc.error === 33.34)
+    }
 
-    (c.pc.success === 33.33) and (c.pc.repaired === 33.33) and (c.pc.error === 33.34)
+    "when using 0 digits" >> {
+      val c = ComplianceLevel(0,1,1,1)
+      val pc = c.computePercent(0)
+      (pc.success === 33) and (pc.repaired === 33) and (pc.error === 34)
+    }
   }
-
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -1646,7 +1646,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
       nodeStatus.keySet.head === one and
-      nodeStatus.head._2.reports.head.compliance.pc.success === 100
+      nodeStatus.head._2.reports.head.compliance.computePercent().success === 100
     }
 
   }
@@ -1675,7 +1675,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
      nodeStatus.keySet.head === NodeId("nodeId") and
-     nodeStatus.head._2.reports.head.compliance.pc.success === 100
+     nodeStatus.head._2.reports.head.compliance.computePercent().success === 100
     }
   }
 
@@ -1701,7 +1701,7 @@ class ExecutionBatchTest extends Specification {
 
     "have one detailed success node when we create it with one success report" in {
      nodeStatus.keySet.head === NodeId("nodeId") and
-     nodeStatus.head._2.reports.head.compliance.pc.success === 100
+     nodeStatus.head._2.reports.head.compliance.computePercent().success === 100
     }
   }
 
@@ -1728,11 +1728,11 @@ class ExecutionBatchTest extends Specification {
     }
     "return a component with the /var/cfengine in NotApplicable " in {
       withGood.componentValues("/var/cfengine").messages.size === 1 and
-      withGood.componentValues("/var/cfengine").compliance.pc.notApplicable === 100
+      withGood.componentValues("/var/cfengine").compliance.computePercent().notApplicable === 100
     }
     "return a component with the bar key success " in {
       withGood.componentValues("bar").messages.size == 1 and
-      withGood.componentValues("bar").compliance.pc.success === 100
+      withGood.componentValues("bar").compliance.computePercent().success === 100
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -765,6 +765,16 @@ final case class RestExtractorService (
         }
     }
   }
+  def extractPercentPrecision(params: Map[String, List[String]]) : Box[Option[Int]] = {
+    params.get("precision") match {
+      case None | Some(Nil) => Full(None)
+      case Some(h :: tail) => //only take into account the first level param is several are passed
+        try { Full(Some(h.toInt)) }
+        catch {
+          case ex:NumberFormatException => Failure(s"percent precison must be an integer, was: '${h}'")
+        }
+    }
+  }
 
   def extractRule(req : Req) : Box[RestRule] = {
     req.json match {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
@@ -275,12 +275,12 @@ object JsonCompliance {
   //global compliance
 
   implicit class JsonGlobalCompliance(val optCompliance: Option[(ComplianceLevel, Long)]) extends AnyVal {
-    def toJson: JValue = {
+    def toJson(precision: Int): JValue = {
       optCompliance match {
         case Some((details, value)) =>
           ( "globalCompliance" -> (
               ("compliance"        -> value)
-            ~ ("complianceDetails" -> percents(details) )
+            ~ ("complianceDetails" -> percents(details, precision) )
           ))
 
         case None =>
@@ -296,9 +296,9 @@ object JsonCompliance {
     def toJsonV6 = (
         ("id" -> rule.id.serialize)
       ~ ("name" -> rule.name)
-      ~ ("compliance" -> rule.compliance.complianceWithoutPending)
-      ~ ("complianceDetails" -> percents(rule.compliance))
-      ~ ("directives" -> directives(rule.directives, 10) )
+      ~ ("compliance" -> rule.compliance.withoutPending.computePercent().compliance)
+      ~ ("complianceDetails" -> percents(rule.compliance, 2))
+      ~ ("directives" -> directives(rule.directives, 10, 2) )
     )
 
     /*
@@ -309,80 +309,80 @@ object JsonCompliance {
      * - 4 and up: rules, directives, components, node and component values
      */
 
-    def toJson(level: Int) = (
+    def toJson(level: Int, precision: Int) = (
         ("id" -> rule.id.serialize)
       ~ ("name" -> rule.name)
-      ~ ("compliance" -> rule.compliance.complianceWithoutPending)
+      ~ ("compliance" -> rule.compliance.withoutPending.computePercent().compliance)
       ~ ("mode" -> rule.mode.name)
-      ~ ("complianceDetails" -> percents(rule.compliance))
-      ~ ("directives" -> directives(rule.directives, level) )
-      ~ ("nodes" -> byNodes(rule.nodes, level) )
+      ~ ("complianceDetails" -> percents(rule.compliance, precision))
+      ~ ("directives" -> directives(rule.directives, level, precision) )
+      ~ ("nodes" -> byNodes(rule.nodes, level, precision) )
     )
 
-    private[this] def directives(directives: Seq[ByRuleDirectiveCompliance], level: Int): Option[JsonAST.JValue] = {
+    private[this] def directives(directives: Seq[ByRuleDirectiveCompliance], level: Int, precision: Int): Option[JsonAST.JValue] = {
       if(level < 2) None
       else Some( directives.map { directive =>
         (
             ("id" -> directive.id.serialize)
           ~ ("name" -> directive.name)
-          ~ ("compliance" -> directive.compliance.complianceWithoutPending)
-          ~ ("complianceDetails" -> percents(directive.compliance))
-          ~ ("components" -> components(directive.components, level))
+          ~ ("compliance" -> directive.compliance.withoutPending.computePercent().compliance)
+          ~ ("complianceDetails" -> percents(directive.compliance, precision))
+          ~ ("components" -> components(directive.components, level, precision))
         )
        })
     }
-    private[this] def byNodes(nodes: Seq[ByRuleByNodeCompliance], level: Int): Option[JsonAST.JValue] = {
+    private[this] def byNodes(nodes: Seq[ByRuleByNodeCompliance], level: Int, precision: Int): Option[JsonAST.JValue] = {
       if(level < 2) None
       else Some( nodes.map { node =>
         (
           ("id" -> node.id.value)
             ~ ("name" -> node.name)
-            ~ ("compliance" -> node.compliance.complianceWithoutPending)
-            ~ ("complianceDetails" -> percents(node.compliance))
-            ~ ("directives" -> byNodesByDirectives(node.directives, level))
+            ~ ("compliance" -> node.compliance.withoutPending.computePercent().compliance)
+            ~ ("complianceDetails" -> percents(node.compliance, precision))
+            ~ ("directives" -> byNodesByDirectives(node.directives, level, precision))
           )
       })
     }
 
-    private[this] def byNodesByDirectives(directives: Seq[ByRuleByNodeByDirectiveCompliance], level: Int): Option[JsonAST.JValue] = {
+    private[this] def byNodesByDirectives(directives: Seq[ByRuleByNodeByDirectiveCompliance], level: Int, precision: Int): Option[JsonAST.JValue] = {
       if(level < 3) None
       else Some( directives.map { directive =>
         (
           ("id" -> directive.id.serialize)
             ~ ("name" -> directive.name)
-            ~ ("compliance" -> directive.compliance.complianceWithoutPending)
-            ~ ("complianceDetails" -> percents(directive.compliance))
-            ~ ("components" -> byNodeByDirectiveByComponents(directive.components, level))
+            ~ ("compliance" -> directive.compliance.withoutPending.computePercent().compliance)
+            ~ ("complianceDetails" -> percents(directive.compliance, precision))
+            ~ ("components" -> byNodeByDirectiveByComponents(directive.components, level, precision))
           )
       })
     }
-    private[this] def components(comps: Seq[ByRuleComponentCompliance], level: Int): Option[JsonAST.JValue] = {
+    private[this] def components(comps: Seq[ByRuleComponentCompliance], level: Int, precision: Int): Option[JsonAST.JValue] = {
       if(level < 3) None
       else Some(comps.map { component =>
         (
             ("name" -> component.name)
-          ~ ("compliance" -> component.compliance.complianceWithoutPending)
-          ~ ("complianceDetails" -> percents(component.compliance))
+          ~ ("compliance" -> component.compliance.withoutPending.computePercent().compliance)
+          ~ ("complianceDetails" -> percents(component.compliance, precision))
           ~ (component match {
               case component : ByRuleBlockCompliance =>
-                ("components" ->   components(component.subComponents, level))
+                ("components" ->   components(component.subComponents, level, precision))
               case component: ByRuleValueCompliance =>
-                ("nodes" -> nodes(component.nodes, level))
+                ("nodes" -> nodes(component.nodes, level, precision))
             })
         )
       })
     }
 
-    private[this] def byNodeByDirectiveByComponents(comps: Seq[ByRuleByNodeByDirectiveByComponentCompliance], level: Int): Option[JsonAST.JValue] = {
+    private[this] def byNodeByDirectiveByComponents(comps: Seq[ByRuleByNodeByDirectiveByComponentCompliance], level: Int, precision: Int): Option[JsonAST.JValue] = {
       if(level < 4) None
       else Some(comps.map { component =>
         (
           ("name" -> component.name)
-            ~ ("compliance" -> component.compliance.complianceWithoutPending)
-            ~ ("complianceDetails" -> percents(component.compliance))
+            ~ ("compliance" -> component.compliance.withoutPending.computePercent().compliance)
+            ~ ("complianceDetails" -> percents(component.compliance, precision))
             ~ (component match {
             case component : ByRuleByNodeByDirectiveByBlockCompliance =>
-              ("components" ->   byNodeByDirectiveByComponents(component.subComponents, level))
+              ("components" ->   byNodeByDirectiveByComponents(component.subComponents, level, precision))
             case component: ByRuleByNodeByDirectiveByValueCompliance =>
               ("values" -> values(component.values, level))
           })
@@ -404,14 +404,14 @@ object JsonCompliance {
           )
       })
     }
-    private[this] def nodes(nodes: Seq[ByRuleNodeCompliance], level: Int): Option[JsonAST.JValue] = {
+    private[this] def nodes(nodes: Seq[ByRuleNodeCompliance], level: Int, precision: Int): Option[JsonAST.JValue] = {
       if(level < 4) None
       else Some(nodes.map { node =>
         (
             ("id" -> node.id.value)
           ~ ("name" -> node.name)
-          ~ ("compliance" -> node.compliance.complianceWithoutPending)
-          ~ ("complianceDetails" -> percents(node.compliance))
+          ~ ("compliance" -> node.compliance.withoutPending.computePercent().compliance)
+          ~ ("complianceDetails" -> percents(node.compliance, precision))
           ~ ("values" -> values(node.values, level))
         )
       })
@@ -423,9 +423,9 @@ object JsonCompliance {
   implicit class JsonByNodeCompliance(val n: ByNodeNodeCompliance) extends AnyVal {
     def toJsonV6 = (
         ("id" -> n.id.value)
-      ~ ("compliance" -> n.compliance.complianceWithoutPending)
-      ~ ("complianceDetails" -> percents(n.compliance))
-      ~ ("rules" -> rules(n.nodeCompliances, 10))
+      ~ ("compliance" -> n.compliance.withoutPending.computePercent().compliance)
+      ~ ("complianceDetails" -> percents(n.compliance, 2))
+      ~ ("rules" -> rules(n.nodeCompliances, 10, 2))
     )
 
     /*
@@ -437,52 +437,52 @@ object JsonCompliance {
      * - 5 and up: nodes, rules, directives, components and component values
      */
 
-    def toJson(level: Int) = (
+    def toJson(level: Int, precision: Int) = (
         ("id" -> n.id.value)
       ~ ("name" -> n.name)
-      ~ ("compliance" -> n.compliance.complianceWithoutPending)
+      ~ ("compliance" -> n.compliance.withoutPending.computePercent().compliance)
       ~ ("mode" -> n.mode.name)
-      ~ ("complianceDetails" -> percents(n.compliance))
-      ~ ("rules" -> rules(n.nodeCompliances, level))
+      ~ ("complianceDetails" -> percents(n.compliance, precision))
+      ~ ("rules" -> rules(n.nodeCompliances, level, precision))
     )
 
-    private[this] def rules(rules: Seq[ByNodeRuleCompliance], level: Int): Option[JsonAST.JValue] = {
+    private[this] def rules(rules: Seq[ByNodeRuleCompliance], level: Int, precision: Int): Option[JsonAST.JValue] = {
       if(level < 2) None
       else Some(rules.map { rule =>
         (
             ("id" -> rule.id.serialize)
           ~ ("name" -> rule.name)
-          ~ ("compliance" -> rule.compliance.complianceWithoutPending)
-          ~ ("complianceDetails" -> percents(rule.compliance))
-          ~ ("directives" -> directives(rule.directives, level))
+          ~ ("compliance" -> rule.compliance.withoutPending.computePercent().compliance)
+          ~ ("complianceDetails" -> percents(rule.compliance, precision))
+          ~ ("directives" -> directives(rule.directives, level, precision))
        )
       })
     }
 
-    private[this] def directives(directives: Seq[ByNodeDirectiveCompliance], level: Int): Option[JsonAST.JValue] = {
+    private[this] def directives(directives: Seq[ByNodeDirectiveCompliance], level: Int, precision: Int): Option[JsonAST.JValue] = {
       if(level < 3) None
       else Some(directives.map { directive =>
         (
             ("id" -> directive.id.serialize)
           ~ ("name" -> directive.name)
-          ~ ("compliance" -> directive.compliance.complianceWithoutPending)
-          ~ ("complianceDetails" -> percents(directive.compliance))
-          ~ ("components" -> components(directive.components, level))
+          ~ ("compliance" -> directive.compliance.withoutPending.computePercent().compliance)
+          ~ ("complianceDetails" -> percents(directive.compliance, precision))
+          ~ ("components" -> components(directive.components, level, precision))
         )
       })
     }
 
-    private[this] def components(comps: Map[String, ComponentStatusReport], level: Int): Option[JsonAST.JValue] = {
+    private[this] def components(comps: Map[String, ComponentStatusReport], level: Int, precision: Int): Option[JsonAST.JValue] = {
       if(level < 4) None
       else Some(comps.map { case (_, component) =>
         (
             ("name" -> component.componentName)
-          ~ ("compliance" -> component.compliance.complianceWithoutPending)
-          ~ ("complianceDetails" -> percents(component.compliance))
+          ~ ("compliance" -> component.compliance.withoutPending.computePercent().compliance)
+          ~ ("complianceDetails" -> percents(component.compliance, precision))
           ~ (component match {
               case component : BlockStatusReport =>
                 val sub = component.subComponents.map(c => (c.componentName, c)).toMap
-                ("components" -> components(sub, level))
+                ("components" -> components(sub, level, precision))
               case component: ValueStatusReport => ("values" -> values(component.componentValues, level))
             })
         )
@@ -534,25 +534,26 @@ object JsonCompliance {
    * the semantic of unexpected / missing and no answer is not clear at all.
    *
    */
-  private[this] def percents(c: ComplianceLevel): Map[String, Double] = {
+  private[this] def percents(c: ComplianceLevel, precision: Int): Map[String, Double] = {
     import ReportType._
 
-    //we want at most two decimals
+    //we want at most `precision` decimals
+    val pc = CompliancePercent.fromLevels(c, precision)
     Map(
-        statusDisplayName(EnforceNotApplicable) -> c.pc.notApplicable
-      , statusDisplayName(EnforceSuccess) -> c.pc.success
-      , statusDisplayName(EnforceRepaired) -> c.pc.repaired
-      , statusDisplayName(EnforceError) -> c.pc.error
-      , statusDisplayName(Unexpected) -> c.pc.unexpected
-      , statusDisplayName(Missing) -> c.pc.missing
-      , statusDisplayName(NoAnswer) -> c.pc.noAnswer
-      , statusDisplayName(Disabled) -> c.pc.reportsDisabled
-      , statusDisplayName(Pending) -> c.pc.pending
-      , statusDisplayName(AuditCompliant) -> c.pc.compliant
-      , statusDisplayName(AuditNotApplicable) -> c.pc.auditNotApplicable
-      , statusDisplayName(AuditError) -> c.pc.auditError
-      , statusDisplayName(AuditNonCompliant) -> c.pc.nonCompliant
-      , statusDisplayName(BadPolicyMode) -> c.pc.badPolicyMode
+        statusDisplayName(EnforceNotApplicable) -> pc.notApplicable
+      , statusDisplayName(EnforceSuccess) -> pc.success
+      , statusDisplayName(EnforceRepaired) -> pc.repaired
+      , statusDisplayName(EnforceError) -> pc.error
+      , statusDisplayName(Unexpected) -> pc.unexpected
+      , statusDisplayName(Missing) -> pc.missing
+      , statusDisplayName(NoAnswer) -> pc.noAnswer
+      , statusDisplayName(Disabled) -> pc.reportsDisabled
+      , statusDisplayName(Pending) -> pc.pending
+      , statusDisplayName(AuditCompliant) -> pc.compliant
+      , statusDisplayName(AuditNotApplicable) -> pc.auditNotApplicable
+      , statusDisplayName(AuditError) -> pc.auditError
+      , statusDisplayName(AuditNonCompliant) -> pc.nonCompliant
+      , statusDisplayName(BadPolicyMode) -> pc.badPolicyMode
     ).filter { case(k, v) => v > 0 }.view.mapValues(percent => percent).toMap
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -102,6 +102,7 @@ class ComplianceApi(
 
       (for {
         level <- restExtractor.extractComplianceLevel(req.params)
+        precision <- restExtractor.extractPercentPrecision(req.params)
         computeLevel <- Full(if(version.value <= 6) {
                           None
                         } else {
@@ -112,7 +113,7 @@ class ComplianceApi(
         if(version.value <= 6) {
           rules.map( _.toJsonV6 )
         } else {
-          rules.map( _.toJson(level.getOrElse(10) ) ) //by default, all details are displayed
+          rules.map( _.toJson(level.getOrElse(10), precision.getOrElse(2))) //by default, all details are displayed
         }
       }) match {
         case Full(rules) =>
@@ -134,13 +135,14 @@ class ComplianceApi(
 
       (for {
         level <- restExtractor.extractComplianceLevel(req.params)
+        precision <- restExtractor.extractPercentPrecision(req.params)
         id    <- RuleId.parse(ruleId).toBox
         rule  <- complianceService.getRuleCompliance(id, level)
       } yield {
         if(version.value <= 6) {
           rule.toJsonV6
         } else {
-          rule.toJson(level.getOrElse(10) ) //by default, all details are displayed
+          rule.toJson(level.getOrElse(10), precision.getOrElse(2)) //by default, all details are displayed
         }
       }) match {
         case Full(rule) =>
@@ -162,12 +164,13 @@ class ComplianceApi(
 
       (for {
         level <- restExtractor.extractComplianceLevel(req.params)
+        precision <- restExtractor.extractPercentPrecision(req.params)
         nodes <- complianceService.getNodesCompliance()
       } yield {
         if(version.value <= 6) {
           nodes.map( _.toJsonV6 )
         } else {
-          nodes.map( _.toJson(level.getOrElse(10)) )
+          nodes.map( _.toJson(level.getOrElse(10), precision.getOrElse(2)) )
         }
       })match {
         case Full(nodes) =>
@@ -189,12 +192,13 @@ class ComplianceApi(
 
       (for {
         level <- restExtractor.extractComplianceLevel(req.params)
+        precision <- restExtractor.extractPercentPrecision(req.params)
         node  <- complianceService.getNodeCompliance(NodeId(nodeId))
       } yield {
         if(version.value <= 6) {
           node.toJsonV6
         } else {
-          node.toJson(level.getOrElse(10))
+          node.toJson(level.getOrElse(10), precision.getOrElse(2))
         }
       })match {
         case Full(node) =>
@@ -215,9 +219,10 @@ class ComplianceApi(
       implicit val prettify = params.prettify
 
       (for {
+        precision <- restExtractor.extractPercentPrecision(req.params)
         optCompliance <- complianceService.getGlobalCompliance()
       } yield {
-        optCompliance.toJson
+        optCompliance.toJson(precision.getOrElse(2))
       }) match {
         case Full(json) =>
           toJsonResponse(None, json)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -595,23 +595,25 @@ class NodeApiService13 (
     def escapeHTML(s: String): String = JsExp.strToJsExp(xml.Utility.escape(s)).str
 
     import net.liftweb.json.JsonDSL._
-    def toComplianceArray(comp : ComplianceLevel) : JArray =
+    def toComplianceArray(comp : ComplianceLevel) : JArray = {
+      val pc = comp.computePercent()
       JArray (
-        JArray(JInt(comp.reportsDisabled) :: JDouble(comp.pc.reportsDisabled) :: Nil)  :: //0
-        JArray(JInt(comp.notApplicable) :: JDouble(comp.pc.notApplicable) :: Nil ) ::       //  1
-        JArray(JInt(comp.success) :: JDouble(comp.pc.success) :: Nil ) ::         //  2
-        JArray(JInt(comp.repaired) :: JDouble(comp.pc.repaired) :: Nil ) ::            //  3
-        JArray(JInt(comp.error) :: JDouble(comp.pc.error) :: Nil ) ::               //  4
-        JArray(JInt(comp.pending) :: JDouble(comp.pc.pending) :: Nil ) ::             //  5
-        JArray(JInt(comp.noAnswer) :: JDouble(comp.pc.noAnswer) :: Nil ) ::            //  6
-        JArray(JInt(comp.missing) :: JDouble(comp.pc.missing) :: Nil ) ::             //  7
-        JArray(JInt(comp.unexpected) :: JDouble(comp.pc.unexpected) :: Nil ) ::          //  8
-        JArray(JInt(comp.auditNotApplicable) :: JDouble(comp.pc.auditNotApplicable) :: Nil ) ::  //  9
-        JArray(JInt(comp.compliant) :: JDouble(comp.pc.compliant) :: Nil ) ::           // 10
-        JArray(JInt(comp.nonCompliant) :: JDouble(comp.pc.nonCompliant) :: Nil ) ::        // 11
-        JArray(JInt(comp.auditError) :: JDouble(comp.pc.auditError) :: Nil ) ::          // 12
-        JArray(JInt(comp.badPolicyMode) :: JDouble(comp.pc.badPolicyMode) :: Nil ) :: Nil       // 13
+        JArray(JInt(comp.reportsDisabled) :: JDouble(pc.reportsDisabled) :: Nil)  :: //0
+        JArray(JInt(comp.notApplicable) :: JDouble(pc.notApplicable) :: Nil ) ::       //  1
+        JArray(JInt(comp.success) :: JDouble(pc.success) :: Nil ) ::         //  2
+        JArray(JInt(comp.repaired) :: JDouble(pc.repaired) :: Nil ) ::            //  3
+        JArray(JInt(comp.error) :: JDouble(pc.error) :: Nil ) ::               //  4
+        JArray(JInt(comp.pending) :: JDouble(pc.pending) :: Nil ) ::             //  5
+        JArray(JInt(comp.noAnswer) :: JDouble(pc.noAnswer) :: Nil ) ::            //  6
+        JArray(JInt(comp.missing) :: JDouble(pc.missing) :: Nil ) ::             //  7
+        JArray(JInt(comp.unexpected) :: JDouble(pc.unexpected) :: Nil ) ::          //  8
+        JArray(JInt(comp.auditNotApplicable) :: JDouble(pc.auditNotApplicable) :: Nil ) ::  //  9
+        JArray(JInt(comp.compliant) :: JDouble(pc.compliant) :: Nil ) ::           // 10
+        JArray(JInt(comp.nonCompliant) :: JDouble(pc.nonCompliant) :: Nil ) ::        // 11
+        JArray(JInt(comp.auditError) :: JDouble(pc.auditError) :: Nil ) ::          // 12
+        JArray(JInt(comp.badPolicyMode) :: JDouble(pc.badPolicyMode) :: Nil ) :: Nil       // 13
       )
+    }
 
     val userCompliance = compliance.map(c => toComplianceArray(c))
     val (policyMode,explanation) =
@@ -637,7 +639,7 @@ class NodeApiService13 (
       ~  ("os"                  -> nodeInfo.osDetails.fullName)
       ~  ("state"               -> nodeInfo.state.name)
       ~  ("compliance"          -> userCompliance )
-      ~  ("systemError"         -> sysCompliance.map(_.compliance < 100 ).getOrElse(true) )
+      ~ ("systemError"         -> sysCompliance.map(_.computePercent().compliance < 100 ).getOrElse(true))
       ~  ("ipAddresses"         -> nodeInfo.ips.filter(ip => ip != "127.0.0.1" && ip != "0:0:0:0:0:0:0:1").map(escapeHTML(_)))
       ~  ("lastRun"             -> agentRunWithNodeConfig.map(d => DateFormaterService.getDisplayDate(d.agentRunId.date)).getOrElse("Never"))
       ~  ("lastInventory"       -> DateFormaterService.getDisplayDate(nodeInfo.inventoryDate))

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -1003,7 +1003,7 @@ class RuleApiService14 (
             case None =>
               // try to find if a rule has a category that is no longer available but still mentioned in a rule
               getMissingCategories(root, rules.toList).find(id.value == _.id.value) match {
-                case Some(cat) => Some(root, cat)
+                case Some(cat) => Some((root, cat))
                 case _         =>
                   // The root category for missing/deleted categories
                   if(id == MISSING_RULE_CAT_ID) {
@@ -1013,7 +1013,7 @@ class RuleApiService14 (
                       , "Category that regroup all the missing categories"
                       , List.empty
                     )
-                    Some(root, missingCategory)
+                    Some((root, missingCategory))
                   } else {
                     None
                   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ComplianceData.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ComplianceData.scala
@@ -148,7 +148,7 @@ final case class RuleComplianceLine (
     JsObj (
         ( "rule"              -> escapeHTML(rule.name)       )
       , ( "compliance"        -> jsCompliance(compliance)    )
-      , ( "compliancePercent" -> compliance.compliance       )
+      , ( "compliancePercent" -> compliance.computePercent().compliance)
       , ( "id"                -> escapeHTML(rule.id.serialize) )
       , ( "details"           -> details.json                )
       //unique id, usable as DOM id - rules, directives, etc can
@@ -194,7 +194,7 @@ final case class DirectiveComplianceLine (
       , ( "techniqueName"    -> escapeHTML(techniqueName)             )
       , ( "techniqueVersion" -> escapeHTML(techniqueVersion.serialize))
       , ( "compliance"       -> jsCompliance(compliance)              )
-      , ( "compliancePercent"-> compliance.compliance                 )
+      , ( "compliancePercent"-> compliance.computePercent().compliance)
       , ( "details"          -> details.json                          )
       //unique id, usable as DOM id - rules, directives, etc can
       //appear several time in a page
@@ -228,7 +228,7 @@ final case class NodeComplianceLine (
     JsObj (
         ( "node"              -> escapeHTML(nodeInfo.hostname) )
       , ( "compliance"        -> jsCompliance(compliance)      )
-      , ( "compliancePercent" -> compliance.compliance         )
+      , ( "compliancePercent" -> compliance.computePercent().compliance)
       , ( "id"                -> escapeHTML(nodeInfo.id.value) )
       , ( "details"           -> details.json                  )
       //unique id, usable as DOM id - rules, directives, etc can
@@ -269,7 +269,7 @@ final case class BlockComplianceLine (
     JsObj(
       ("component" -> escapeHTML(component))
       , ("compliance" -> jsCompliance(compliance))
-      , ("compliancePercent" -> compliance.compliance)
+      , ("compliancePercent" -> compliance.computePercent().compliance)
       , ("details" -> details.json)
       , ("jsid" -> nextFuncName)
       , ("composition" -> reportingLogic.toString)
@@ -288,7 +288,7 @@ final case class ValueComplianceLine (
     JsObj (
         ( "component"         -> escapeHTML(component)    )
       , ( "compliance"        -> jsCompliance(compliance) )
-      , ( "compliancePercent" -> compliance.compliance    )
+      , ( "compliancePercent" -> compliance.computePercent().compliance)
       , ( "details"           -> details.json             )
       , ( "noExpand"          -> noExpand                 )
       , ( "jsid"              -> nextFuncName             )
@@ -323,7 +323,7 @@ final case class ComponentValueComplianceLine (
       , ( "statusClass"       -> statusClass )
       , ( "messages"          -> JsArray(messages.map{ case(s, m) => JsObj(("status" -> s), ("value" -> escapeHTML(m)))}))
       , ( "compliance"        -> jsCompliance(compliance))
-      , ( "compliancePercent" -> compliance.compliance)
+      , ( "compliancePercent" -> compliance.computePercent().compliance)
       //unique id, usable as DOM id - rules, directives, etc can
       //appear several time in a page
       , ( "jsid"              -> nextFuncName )

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -271,7 +271,7 @@ class ReportDisplayer(
             ( "bg-warning text-warning"
             , <p>{nbAttention} reports below (out of {report.compliance.total} total reports) are not in Success, and may require attention.</p>
             )
-          } else if(report.compliance.pc.pending > 0) {
+          } else if(report.compliance.computePercent().pending > 0) {
             ("bg-info text-info", NodeSeq.Empty)
 
           } else {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -194,7 +194,7 @@ final case class ColoredChartType(value: Double) extends ChartType
                              val complianceLevel = ComplianceLevel.sum(compliancePerNodes.map(_._2))
                              Some((
                                complianceLevel
-                             , complianceLevel.complianceWithoutPending.round
+                             , complianceLevel.withoutPending.computePercent().compliance.round
                              ))
                            }
       n5 = System.currentTimeMillis
@@ -218,7 +218,7 @@ final case class ColoredChartType(value: Double) extends ChartType
       val complianceByNode : List[ChartType] = compliancePerNodes.values.map { r =>
         if(r.pending == r.total) { PendingChartType }
         else if(r.reportsDisabled == r.total) { DisabledChartType }
-        else { ColoredChartType(r.complianceWithoutPending) }
+        else { ColoredChartType(r.withoutPending.computePercent().compliance) }
       }.toList
 
       val complianceDiagram : List[ComplianceLevelPieChart] = (complianceByNode.groupBy{compliance => compliance match {


### PR DESCRIPTION
https://issues.rudder.io/issues/20607

Superseed #4115 and keep #4110 for correction of https://issues.rudder.io/issues/20573

The idea is to be able to specify what precision we want for compliance percent in the API calls, and let the backend compute compliance with that value. Most of the pr is passing the `precision` parameter around. 

Note that we can't specify `precision` value for the  `lazy val pc` attribute in `ComplianceLevel` instance, so a default value of `2` is kept. That `pc` value does not seems to be used in the compliance displaying for UI, so it makes me wonder if we really need an heavy lazy val in each `ComplianceLevel` objects, perhaps we should only compute it when needed with `CompliancePercent.fromLevels(c, precision)` - cc @ncharles for that. 

The 2nd commit totaly remove `lazy val` from `ComplianceLevel` object. It will free 3 object alloc by compliance level object, which is not nothing given the number of short lived ones we have, and it seems that there is not many places where they are reused (and where it can't be computed before the different use place).