### PR TITLE
Fixes #20638: Reccent changes count on rule tab

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewRuleDetails.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewRuleDetails.elm
@@ -1,6 +1,7 @@
 module ViewRuleDetails exposing (..)
 
 import DataTypes exposing (..)
+import Dict
 import Html exposing (Html, button, div, i, span, text, h1, ul, li,  a, p)
 import Html.Attributes exposing (id, class, type_,  style, attribute, disabled)
 import Html.Events exposing (onClick)
@@ -10,7 +11,7 @@ import String
 import ApiCalls exposing (..)
 import ViewTabContent exposing (tabContent)
 import Maybe.Extra
-import ViewUtils exposing (badgePolicyMode, getRuleNbNodes, getRuleNbGroups)
+import ViewUtils exposing (badgePolicyMode, countRecentChanges, getRuleNbGroups, getRuleNbNodes)
 
 --
 -- This file contains all methods to display the details of the selected rule.
@@ -165,7 +166,11 @@ editionTemplate model details =
           ]
         , li[class ("ui-tabs-tab" ++ (if details.tab == TechnicalLogs       then " ui-tabs-active" else ""))]
           [ a[onClick (UpdateRuleForm {details | tab = TechnicalLogs })]
-            [ text "Recent Changes" ]
+            [ text "Recent Changes"
+            , span[class "badge badge-secondary badge-resources tooltip-bs"]
+              [ span [class "nb-resources"] [text (String.fromFloat (countRecentChanges details.rule.id model.changes))]
+              ]
+            ]
           ]
         ]
       ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewRulesTable.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewRulesTable.elm
@@ -9,7 +9,7 @@ import List.Extra
 import List
 import String
 import NaturalOrdering exposing (compareOn)
-import ViewUtils exposing (getCategoryName, getListRules, filterSearch, searchFieldRules, buildTagsTree, badgePolicyMode, buildTooltipContent, buildComplianceBar)
+import ViewUtils exposing (badgePolicyMode, buildComplianceBar, buildTagsTree, buildTooltipContent, countRecentChanges, filterSearch, getCategoryName, getListRules, searchFieldRules)
 import ComplianceUtils exposing (getAllComplianceValues, getRuleCompliance)
 
 --
@@ -23,13 +23,7 @@ getSortFunction model r1 r2 =
       Name       -> NaturalOrdering.compare r1.name r2.name
       RuleChanges->
         let
-          getChanges = \r ->
-            case Dict.get r.id.value model.changes of
-              Just cl ->
-                case List.Extra.last cl of
-                  Just c -> c.changes
-                  Nothing -> 0
-              Nothing -> 0
+          getChanges = \r -> countRecentChanges r.id model.changes
           r1Changes = getChanges r1
           r2Changes = getChanges r2
         in
@@ -94,14 +88,7 @@ buildRulesTable model =
               buildComplianceBar co.complianceDetails
             Nothing -> text "No report"
 
-        changes =
-          case Dict.get r.id.value model.changes of
-            Just cl ->
-              case List.Extra.last cl of
-                Just c -> text (String.fromFloat c.changes)
-                Nothing -> text "0"
-            Nothing -> text "0"
-
+        changes = text (String.fromFloat (countRecentChanges r.id model.changes))
 
         displayStatus : Html Msg
         displayStatus =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewUtils.elm
@@ -538,3 +538,12 @@ generateLoadingList =
     ]
   , li[][i[][], span[][]]
   ]
+
+countRecentChanges: RuleId -> (Dict String (List Changes)) -> Float
+countRecentChanges rId changes =
+  case Dict.get rId.value changes of
+    Just cl ->
+      case List.Extra.last cl of
+        Just c -> c.changes
+        Nothing -> 0
+    Nothing -> 0


### PR DESCRIPTION
https://issues.rudder.io/issues/20638

Maybe i'm wrong, is the count of recent changes should be the same as "changes"  count displayed in table rows ?