### PR TITLE
Fixes #3881: API : URL ending with / are seen like /[empty string parameter]

### DIFF
--- a/webapp/sources/api-doc/introduction.md
+++ b/webapp/sources/api-doc/introduction.md
@@ -202,6 +202,11 @@ Parameters in URLs are used to indicate which resource you want to interact with
     # Get the Rule of ID "id"
     curl -H "X-API-Token: yourToken" https://rudder.example.com/rudder/api/latest/rules/id
 
+
+
+CAUTION: To avoid suprising behavior, do not put a '/' at the end of an URL: it would be interpreted as '/[empty string parameter]' and redirected to '/index', likely not what you wanted to do.
+
+
 #### Sending data for POST/PUT requests
 
 ##### Directly in JSON format


### PR DESCRIPTION
https://issues.rudder.io/issues/3881