### PR TITLE
Fixes #19720: when clicking on "show docs" on a generic method in the middle part of technique editor, it doesn't unfold the right part

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/DataTypes.elm
@@ -234,6 +234,7 @@ type Msg =
   | UpdateTechniqueFilter TreeFilters
   | UpdateMethodFilter MethodFilter
   | ToggleDoc MethodId
+  | ShowDoc MethodId
   | OpenMethods
   | OpenTechniques
   | NewTechnique TechniqueId

--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewMethod.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewMethod.elm
@@ -309,7 +309,7 @@ methodDetail method call parentId ui model =
                 classes = "btn btn-sm btn-primary " ++
                           if List.member method.id model.methodsUI.docsOpen then "doc-opened" else ""
               in
-                button [ class classes, type_ "button", onClick (ToggleDoc call.methodName) ] [
+                button [ class classes, type_ "button", onClick (ShowDoc call.methodName) ] [
                   text "Show docs "
                 , i [ class "fa fa-book"] []
                 ]

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/style/rudder/rudder-technique-editor.css
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/style/rudder/rudder-technique-editor.css
@@ -922,6 +922,7 @@ button.btn.clipboard:hover {
 #methods-list-container{
   position: relative;
   scrollbar-width: thin;
+  scroll-behavior: smooth;
 }
 
 #methods-list-container::-webkit-scrollbar{
@@ -998,6 +999,11 @@ ul.list-unstyled > li{
 }
 .method-elmt {
   border: 1px solid #e5e5e5;
+  /*
+    This is useful for auto scroll to show method doc when the right panel is closed
+    see https://issues.rudder.io/issues/19720
+  */
+  min-width:350px;
 }
 ul li.hide-method {
   margin-bottom : 0px !important;


### PR DESCRIPTION
https://issues.rudder.io/issues/19720


When the panel of method is closed and we click on "Show doc" it seems that the auto scroll doesn't go to the right location (see gif at the end) but we can double click (to close the doc and reopen) to trigger the scroll in the right location.


![toggle_doc](https://user-images.githubusercontent.com/23410978/151056633-c83d9eba-165c-49df-942b-0a04e8f1c2f2.gif)

