### PR TITLE
Fixes #20716: Improve dynamic group computation speed

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
@@ -222,6 +222,31 @@ final case object NodeStateComparator extends NodeCriterionType {
 }
 
 
+final case object NodeStringComparator extends NodeCriterionType {
+  override val comparators = BaseComparators.comparators
+
+  override protected def validateSubCase(v: String, comparator: CriterionComparator) = {
+    if(null == v || v.isEmpty) Left(Inconsistency("Empty string not allowed")) else {
+      comparator match {
+        case Regex | NotRegex => validateRegex(v)
+        case x                => Right(v)
+      }
+    }
+  }
+
+  override def matches(comparator: CriterionComparator, value: String): NodeInfoMatcher = {
+    comparator match {
+      case Equals    => NodeInfoMatcher(s"Prop equals '${value}'", (node: NodeInfo) => node.hostname == value )
+      case NotEquals => NodeInfoMatcher(s"Prop not equals '${value}'", (node: NodeInfo) => node.hostname != value )
+      case Regex     => NodeInfoMatcher(s"Prop matches regex '${value}'", (node: NodeInfo) => node.hostname.matches(value) )
+      case NotRegex  => NodeInfoMatcher(s"Prop matches not regex '${value}'", (node: NodeInfo) => !node.hostname.matches(value) )
+      case Exists    => NodeInfoMatcher(s"Prop exists", (node: NodeInfo) => node.hostname.nonEmpty )
+      case NotExists => NodeInfoMatcher(s"Prop doesn't exists", (node: NodeInfo) => node.hostname.isEmpty )
+
+    }
+  }
+
+}
 
 /*
  * This comparator is used for "node properties"-like attribute, i.e:

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/DitQueryData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/DitQueryData.scala
@@ -192,7 +192,7 @@ class DitQueryData(dit: InventoryDit, nodeDit: NodeDit, rudderDit: RudderDit, ge
     ObjectCriterion(OC_NODE, Seq(
         Criterion("OS",OstypeComparator)
       , Criterion(A_NODE_UUID, StringComparator)
-      , Criterion(A_HOSTNAME, StringComparator)
+      , Criterion(A_HOSTNAME, NodeStringComparator)
       , Criterion(A_OS_NAME,OsNameComparator)
       , Criterion(A_OS_FULL_NAME, OrderedStringComparator)
       , Criterion(A_OS_VERSION, OrderedStringComparator)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/DitQueryData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/DitQueryData.scala
@@ -48,6 +48,7 @@ import com.normation.rudder.domain.RudderLDAPConstants.A_NODE_GROUP_UUID
 import com.normation.rudder.domain.RudderLDAPConstants.A_NODE_PROPERTY
 import com.normation.rudder.domain.RudderLDAPConstants.A_STATE
 import com.normation.rudder.domain.RudderLDAPConstants.OC_RUDDER_NODE_GROUP
+import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.services.queries.SpecialFilter
 import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.Filter
@@ -190,10 +191,10 @@ class DitQueryData(dit: InventoryDit, nodeDit: NodeDit, rudderDit: RudderDit, ge
       Criterion(A_MEMORY_CAPACITY, MemoryComparator)
     )),
     ObjectCriterion(OC_NODE, Seq(
-        Criterion("OS",OstypeComparator)
-      , Criterion(A_NODE_UUID, StringComparator)
-      , Criterion(A_HOSTNAME, NodeStringComparator)
-      , Criterion(A_OS_NAME,OsNameComparator)
+        Criterion("OS",NodeOstypeComparator)
+      , Criterion(A_NODE_UUID, NodeStringComparator(node => node.node.id.value))
+      , Criterion(A_HOSTNAME, NodeStringComparator(node => node.hostname))
+      , Criterion(A_OS_NAME,NodeOsNameComparator)
       , Criterion(A_OS_FULL_NAME, OrderedStringComparator)
       , Criterion(A_OS_VERSION, OrderedStringComparator)
       , Criterion(A_OS_SERVICE_PACK, OrderedStringComparator)
@@ -205,9 +206,9 @@ class DitQueryData(dit: InventoryDit, nodeDit: NodeDit, rudderDit: RudderDit, ge
       , Criterion(A_AGENTS_NAME, AgentComparator)
       , Criterion(A_ACCOUNT, StringComparator)
       , Criterion(A_LIST_OF_IP, StringComparator)
-      , Criterion(A_ROOT_USER, StringComparator)
+      , Criterion(A_ROOT_USER, NodeStringComparator(node => node.localAdministratorAccountName))
       , Criterion(A_INVENTORY_DATE, DateComparator)
-      , Criterion(A_POLICY_SERVER_UUID, StringComparator)
+      , Criterion(A_POLICY_SERVER_UUID, NodeStringComparator(node => node.policyServerId.value))
     )),
     ObjectCriterion(OC_SOFTWARE, Seq(
       Criterion(A_NAME, StringComparator),

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/DitQueryData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/DitQueryData.scala
@@ -48,7 +48,6 @@ import com.normation.rudder.domain.RudderLDAPConstants.A_NODE_GROUP_UUID
 import com.normation.rudder.domain.RudderLDAPConstants.A_NODE_PROPERTY
 import com.normation.rudder.domain.RudderLDAPConstants.A_STATE
 import com.normation.rudder.domain.RudderLDAPConstants.OC_RUDDER_NODE_GROUP
-import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.services.queries.SpecialFilter
 import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.Filter

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
@@ -754,8 +754,10 @@ class WoLDAPNodeGroupRepository(
         oldGroup     <- mapper.entry2NodeGroup(existing).toIO.chainError("Error when trying to check for the group %s".format(nodeGroup.id.value))
         // check if old group is the same as new group
         result       <- if (oldGroup.equals(nodeGroup)) {
+                          logger.info(s"Nothing to update for ${nodeGroup.id}")
                           None.succeed
                         } else {
+          logger.info(s"Check what changed for for ${nodeGroup.id}")
           for {
             systemCheck <- if (onlyUpdateNodes) {
               oldGroup.succeed

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
@@ -754,10 +754,8 @@ class WoLDAPNodeGroupRepository(
         oldGroup     <- mapper.entry2NodeGroup(existing).toIO.chainError("Error when trying to check for the group %s".format(nodeGroup.id.value))
         // check if old group is the same as new group
         result       <- if (oldGroup.equals(nodeGroup)) {
-                          logger.info(s"Nothing to update for ${nodeGroup.id}")
                           None.succeed
                         } else {
-          logger.info(s"Check what changed for for ${nodeGroup.id}")
           for {
             systemCheck <- if (onlyUpdateNodes) {
               oldGroup.succeed
@@ -766,8 +764,8 @@ class WoLDAPNodeGroupRepository(
               case (false, true) => "You can not modify a non system group (%s) with that method".format(oldGroup.name).fail
               case _ => oldGroup.succeed
             }
-            name <- checkNameAlreadyInUse(con, nodeGroup.name, nodeGroup.id)
-            exists <- ZIO.when(name && !onlyUpdateNodes) {
+            name      <- checkNameAlreadyInUse(con, nodeGroup.name, nodeGroup.id)
+            exists    <- ZIO.when(name && !onlyUpdateNodes) {
               s"Cannot change the group name to ${nodeGroup.name} : there is already a group with the same name".fail
             }
             onlyNodes <- if (!onlyUpdateNodes) {
@@ -780,7 +778,7 @@ class WoLDAPNodeGroupRepository(
                   "The group configuration changed compared to the reference group you want to change the node list for. Aborting to preserve consistency".fail
               }
             }
-            change <- saveModifyNodeGroupDiff(existing, con, nodeGroup, modId, actor, reason)
+            change    <- saveModifyNodeGroupDiff(existing, con, nodeGroup, modId, actor, reason)
           } yield {
             change
           }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
@@ -752,28 +752,37 @@ class WoLDAPNodeGroupRepository(
         con          <- ldap
         existing     <- getSGEntry(con, nodeGroup.id).notOptional("Error when trying to check for existence of group with id %s. Can not update".format(nodeGroup.id))
         oldGroup     <- mapper.entry2NodeGroup(existing).toIO.chainError("Error when trying to check for the group %s".format(nodeGroup.id.value))
-        systemCheck  <- if(onlyUpdateNodes) {
-          oldGroup.succeed
-        } else (oldGroup.isSystem, systemCall) match {
-          case (true, false) => "System group '%s' (%s) can not be modified".format(oldGroup.name, oldGroup.id.value).fail
-          case (false, true) => "You can not modify a non system group (%s) with that method".format(oldGroup.name).fail
-          case _ => oldGroup.succeed
+        // check if old group is the same as new group
+        result       <- if (oldGroup.equals(nodeGroup)) {
+                          None.succeed
+                        } else {
+          for {
+            systemCheck <- if (onlyUpdateNodes) {
+              oldGroup.succeed
+            } else (oldGroup.isSystem, systemCall) match {
+              case (true, false) => "System group '%s' (%s) can not be modified".format(oldGroup.name, oldGroup.id.value).fail
+              case (false, true) => "You can not modify a non system group (%s) with that method".format(oldGroup.name).fail
+              case _ => oldGroup.succeed
+            }
+            name <- checkNameAlreadyInUse(con, nodeGroup.name, nodeGroup.id)
+            exists <- ZIO.when(name && !onlyUpdateNodes) {
+              s"Cannot change the group name to ${nodeGroup.name} : there is already a group with the same name".fail
+            }
+            onlyNodes <- if (!onlyUpdateNodes) {
+              UIO.unit
+            } else { //check that nothing but the node list changed
+              if (nodeGroup.copy(serverList = oldGroup.serverList) == oldGroup) {
+                UIO.unit
+              } else {
+                logPure.debug(s"Inconsistency when modifying node lists for nodeGroup ${nodeGroup.name}: previous content was ${oldGroup}, new is ${nodeGroup} - only the node list should change") *>
+                  "The group configuration changed compared to the reference group you want to change the node list for. Aborting to preserve consistency".fail
+              }
+            }
+            change <- saveModifyNodeGroupDiff(existing, con, nodeGroup, modId, actor, reason)
+          } yield {
+            change
+          }
         }
-        name         <- checkNameAlreadyInUse(con, nodeGroup.name, nodeGroup.id)
-        exists       <- ZIO.when(name && !onlyUpdateNodes) {
-                          s"Cannot change the group name to ${nodeGroup.name} : there is already a group with the same name".fail
-                        }
-        onlyNodes    <- if(!onlyUpdateNodes) {
-                          UIO.unit
-                        } else { //check that nothing but the node list changed
-                          if(nodeGroup.copy(serverList = oldGroup.serverList) == oldGroup) {
-                            UIO.unit
-                          } else {
-                            logPure.debug(s"Inconsistency when modifying node lists for nodeGroup ${nodeGroup.name}: previous content was ${oldGroup}, new is ${nodeGroup} - only the node list should change") *>
-                            "The group configuration changed compared to the reference group you want to change the node list for. Aborting to preserve consistency".fail
-                          }
-                        }
-        result       <- saveModifyNodeGroupDiff(existing, con, nodeGroup, modId, actor, reason)
       } yield {
         result
       }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
@@ -147,6 +147,12 @@ trait NodeInfoService {
    */
   def getAllNodes() : IOResult[Map[NodeId, Node]]
 
+  /**
+   * Get all nodes
+   * This returns a Seq for performance reasons - it is much faster
+   * to return a Seq than a Set, and for subsequent use it is also
+   * faster
+   */
   def getAllNodeInfos():IOResult[Seq[NodeInfo]]
   /**
    * Get all systen node ids, for example

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
@@ -147,7 +147,7 @@ trait NodeInfoService {
    */
   def getAllNodes() : IOResult[Map[NodeId, Node]]
 
-  def getAllNodeInfos():IOResult[Set[NodeInfo]]
+  def getAllNodeInfos():IOResult[Seq[NodeInfo]]
   /**
    * Get all systen node ids, for example
    * policy server node ids.
@@ -858,8 +858,8 @@ trait NodeInfoServiceCached extends NodeInfoService with NamedZioLogger with Cac
     cache.view.mapValues(_._2.node).toMap.succeed
   }
 
-  def getAllNodeInfos():IOResult[Set[NodeInfo]] = withUpToDateCache("all nodeinfos") { cache =>
-    cache.view.values.map(_._2).toSet.succeed
+  def getAllNodeInfos():IOResult[Seq[NodeInfo]] = withUpToDateCache("all nodeinfos") { cache =>
+    cache.view.values.map(_._2).toSeq.succeed
   }
 
   def getNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = withUpToDateCache(s"${nodeId.value} node info") { cache =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
@@ -117,7 +117,7 @@ trait NodeInfoService {
    * foundNodeInfos are the nodeinfo found by ldap query
    * allNodeInfos are all the know nodeInfos to date
    */
-  def getLDAPNodeInfo(foundNodeInfos: Seq[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodeInfos: Seq[NodeInfo]): Seq[NodeInfo]
+  def getLDAPNodeInfo(foundNodeInfos: Set[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodeInfos: Set[NodeInfo]): Set[NodeInfo]
 
   /**
    * Return a NodeInfo from a NodeId. First check the ou=Node, then fetch the other data
@@ -159,7 +159,7 @@ trait NodeInfoService {
    */
   def getAllNodes() : IOResult[Map[NodeId, Node]]
 
-  def getAllNodeInfos():IOResult[Seq[NodeInfo]]
+  def getAllNodeInfos():IOResult[Set[NodeInfo]]
   /**
    * Get all systen node ids, for example
    * policy server node ids.
@@ -870,14 +870,14 @@ trait NodeInfoServiceCached extends NodeInfoService with NamedZioLogger with Cac
     cache.view.mapValues(_._2.node).toMap.succeed
   }
 
-  def getAllNodeInfos():IOResult[Seq[NodeInfo]] = withUpToDateCache("all nodeinfos") { cache =>
-    cache.values.map(_._2).toSeq.succeed
+  def getAllNodeInfos():IOResult[Set[NodeInfo]] = withUpToDateCache("all nodeinfos") { cache =>
+    cache.values.map(_._2).toSet.succeed
   }
 
-  override def getLDAPNodeInfo(foundNodeInfos: Seq[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodeInfos: Seq[NodeInfo]): Seq[NodeInfo] = {
+  override def getLDAPNodeInfo(foundNodeInfos: Set[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodeInfos: Set[NodeInfo]): Set[NodeInfo] = {
     // if nodeIds is empty and composition is and, return an empty set; with or, we need to run it in all cases
     if (foundNodeInfos.isEmpty && composition == And) {
-      Seq[NodeInfo]()
+      Set[NodeInfo]()
     } else {
       PostFilterNodeFromInfoService.getLDAPNodeInfo(foundNodeInfos, predicates, composition, allNodeInfos)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
@@ -115,7 +115,7 @@ trait NodeInfoService {
    * Retrieve minimal information needed for the node info, used (only) by the
    * LDAP QueryProcessor.
    */
-  def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : IOResult[Set[LDAPNodeInfo]]
+  def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : IOResult[Seq[NodeInfo]]
 
   /**
    * Return a NodeInfo from a NodeId. First check the ou=Node, then fetch the other data
@@ -871,10 +871,10 @@ trait NodeInfoServiceCached extends NodeInfoService with NamedZioLogger with Cac
     cache.view.mapValues(_._2.node).toMap.succeed
   }
 
-  override def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition): IOResult[Set[LDAPNodeInfo]] = {
+  override def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition): IOResult[Seq[NodeInfo]] = {
     // if nodeIds is empty and composition is and, return an empty set; with or, we need to run it in all cases
     if (nodeIds.isEmpty && composition == And) {
-      Set[LDAPNodeInfo]().succeed
+      Seq[NodeInfo]().succeed
     } else {
       withUpToDateCache(s"${nodeIds.size} ldap node info") { cache =>
         PostFilterNodeFromInfoService.getLDAPNodeInfo(nodeIds, predicates, composition, cache).succeed

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
@@ -578,6 +578,10 @@ trait NodeInfoServiceCached extends NodeInfoService with NamedZioLogger with Cac
     )
   }
 
+  def getAllNodesEntry() = {
+    nodeCache.map(x => x.nodeInfos.values.toSeq.map(_._1.nodeEntry))
+  }
+
   /**
    * Update cache, without doing anything with the data
    */

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
@@ -98,12 +98,10 @@ class DynGroupUpdaterServiceImpl(
       timePreCompute  =  System.currentTimeMillis
       query           <- Box(group.query) ?~! s"No query defined for group '${group.name}' (${group.id.value})"
       newMembers      <- queryProcessor.processOnlyId(query) ?~! s"Error when processing request for updating dynamic group '${group.name}' (${group.id.value})"
-      //save
-      newMemberIdsSet  = newMembers.toSet
       timeGroupCompute = (System.currentTimeMillis - timePreCompute)
       _                = logger.debug(s"Dynamic group ${group.id.value} with name ${group.name} computed in ${timeGroupCompute} ms")
     } yield {
-      group.copy(serverList = newMemberIdsSet)
+      group.copy(serverList = newMembers)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
@@ -263,8 +263,6 @@ object PostFilterNodeFromInfoService {
         val validPredicates =  combined.matches(nodeInfo)
         val res = comp(contains, validPredicates)
 
-        println(s"${nodeInfo.id.value}: ${if(res) "OK" else "NOK"} for [${combined.debugString}]")
-
         if(logger.isTraceEnabled()) {
           logger.trace(s"${nodeInfo.id.value}: ${if(res) "OK" else "NOK"} for [${combined.debugString}]")
         }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/QueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/QueryProcessor.scala
@@ -50,13 +50,13 @@ trait QueryProcessor {
    * @param select - attributes to fetch in the ldap entry. If empty, all attributes are fetched
    * @return
    */
-  def process(query:QueryTrait) : Box[Seq[NodeInfo]]
+  def process(query:QueryTrait) : Box[Set[NodeInfo]]
 
   /**
    * Only get node ids corresponding to that request, with minimal consistency check.
    * This method is useful to maximize performance (low memory, high throughout) for ex for dynamic groups.
    */
-  def processOnlyId(query:QueryTrait) : Box[Seq[NodeId]]
+  def processOnlyId(query:QueryTrait) : Box[Set[NodeId]]
 }
 
 
@@ -74,6 +74,6 @@ trait QueryChecker {
    *   Full(seq) with seq being the list of nodeId which verify
    *   query.
    */
-  def check(query:QueryTrait, nodeIds:Option[Seq[NodeId]]) : Box[Seq[NodeId]]
+  def check(query:QueryTrait, nodeIds:Option[Seq[NodeId]]) : Box[Set[NodeId]]
 
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -95,7 +95,7 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
   }
 
   object nodeInfoService extends NodeInfoService {
-    def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : IOResult[Set[LDAPNodeInfo]] = ???
+    def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : IOResult[Seq[NodeInfo]] = ???
     def getNodeInfo(nodeId: NodeId) : IOResult[Option[NodeInfo]] = ???
     def getNodeInfos(nodesId: Set[NodeId]) : IOResult[Set[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -95,11 +95,12 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
   }
 
   object nodeInfoService extends NodeInfoService {
-    def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : IOResult[Seq[NodeInfo]] = ???
+    def getLDAPNodeInfo(foundNodeInfos: Seq[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodeInfos: Seq[NodeInfo]): Seq[NodeInfo]= ???
     def getNodeInfo(nodeId: NodeId) : IOResult[Option[NodeInfo]] = ???
     def getNodeInfos(nodesId: Set[NodeId]) : IOResult[Set[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???
     def getAllNodes() : IOResult[Map[NodeId, Node]] = ???
+    def getAllNodeInfos():IOResult[Seq[NodeInfo]] = ???
     def getAllNodesIds(): IOResult[Set[NodeId]] = ???
     def getAllSystemNodeIds() : IOResult[Seq[NodeId]] = ???
     def getPendingNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -100,7 +100,7 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
     def getNodeInfos(nodesId: Set[NodeId]) : IOResult[Set[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???
     def getAllNodes() : IOResult[Map[NodeId, Node]] = ???
-    def getAllNodeInfos():IOResult[Seq[NodeInfo]] = ???
+    def getAllNodeInfos():IOResult[Set[NodeInfo]] = ???
     def getAllNodesIds(): IOResult[Set[NodeId]] = ???
     def getAllSystemNodeIds() : IOResult[Seq[NodeId]] = ???
     def getPendingNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -61,7 +61,6 @@ import com.normation.rudder.reports.ResolvedAgentRunInterval
 import com.normation.rudder.reports.GlobalComplianceMode
 import com.normation.rudder.reports.execution._
 import com.normation.rudder.repository.{CategoryWithActiveTechniques, ComplianceRepository, FullActiveTechniqueCategory, RoDirectiveRepository, RoRuleRepository}
-import com.normation.rudder.services.nodes.LDAPNodeInfo
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.services.policies.NodeConfigData
 import com.normation.rudder.services.reports.{CachedFindRuleNodeStatusReports, CachedNodeChangesServiceImpl, DefaultFindRuleNodeStatusReports, NodeChangesServiceImpl, NodeConfigurationService, NodeConfigurationServiceImpl, ReportingServiceImpl, UnexpectedReportInterpretation}
@@ -95,7 +94,6 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
   }
 
   object nodeInfoService extends NodeInfoService {
-    def getLDAPNodeInfo(foundNodeInfos: Set[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodeInfos: Set[NodeInfo]): Set[NodeInfo]= ???
     def getNodeInfo(nodeId: NodeId) : IOResult[Option[NodeInfo]] = ???
     def getNodeInfos(nodesId: Set[NodeId]) : IOResult[Set[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -95,7 +95,7 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
   }
 
   object nodeInfoService extends NodeInfoService {
-    def getLDAPNodeInfo(foundNodeInfos: Seq[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodeInfos: Seq[NodeInfo]): Seq[NodeInfo]= ???
+    def getLDAPNodeInfo(foundNodeInfos: Set[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodeInfos: Set[NodeInfo]): Set[NodeInfo]= ???
     def getNodeInfo(nodeId: NodeId) : IOResult[Option[NodeInfo]] = ???
     def getNodeInfos(nodesId: Set[NodeId]) : IOResult[Set[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -98,7 +98,7 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
     def getNodeInfos(nodesId: Set[NodeId]) : IOResult[Set[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???
     def getAllNodes() : IOResult[Map[NodeId, Node]] = ???
-    def getAllNodeInfos():IOResult[Set[NodeInfo]] = ???
+    def getAllNodeInfos():IOResult[Seq[NodeInfo]] = ???
     def getAllNodesIds(): IOResult[Set[NodeId]] = ???
     def getAllSystemNodeIds() : IOResult[Seq[NodeId]] = ???
     def getPendingNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestPendingNodePolicies.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestPendingNodePolicies.scala
@@ -158,7 +158,7 @@ class TestPendingNodePolicies extends Specification {
 
   // a fake query checker
   val queryChecker = new QueryChecker {
-    override def check(query: QueryTrait, nodeIds: Option[Seq[NodeId]]): Box[Seq[NodeId]] = {
+    override def check(query: QueryTrait, nodeIds: Option[Seq[NodeId]]): Box[Set[NodeId]] = {
       // make a 0 criteria request raise an error like LDAP would do,
       // see: https://www.rudder-project.org/redmine/issues/12338
       if(query.criteria.isEmpty) {
@@ -168,7 +168,7 @@ class TestPendingNodePolicies extends Specification {
           case x if(x == dummyQuery0) => Set.empty[NodeId]
           case x if(x == dummyQuery1) => Set(node)
           case x                      => Set(node)
-        }).intersect(nodeIds.getOrElse(Seq(node)).toSet).toSeq)
+        }).intersect(nodeIds.getOrElse(Seq(node)).toSet))
       }
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
@@ -1238,9 +1238,8 @@ class TestQueryProcessor extends Loggable {
 
       if (doInternalQueryTest) {
         logger.debug("Testing with expected entries, This test should be ignored when we are looking for Nodes with NodeInfo and inventory (ie when we are looking for property and environement variable")
-        val allNodesInfos = nodeInfoService.getAllNodeInfos().runNow
         val foundWithLimit =
-          (internalLDAPQueryProcessor.internalQueryProcessor(query, limitToNodeIds = Some(ids), allNodeInfos= allNodesInfos).runNow.entries.map {
+          (internalLDAPQueryProcessor.internalQueryProcessor(query, limitToNodeIds = Some(ids), lambdaAllNodeInfos = (() => nodeInfoService.getAllNodeInfos())).runNow.entries.map {
             _.node.id
           }).toSeq.distinct.sortBy( _.value )
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
@@ -188,7 +188,7 @@ class TestQueryProcessor extends Loggable {
       """).openOrThrowException("For tests"),
       Nil)
 
-    testQueries( q0 :: q1 :: q2 :: Nil, true)
+    testQueries( q0 :: q1 :: q2 :: Nil, false)
   }
 
   @Test def basicQueriesOnOneNodeParameter(): Unit = {
@@ -311,7 +311,61 @@ class TestQueryProcessor extends Loggable {
       """).openOrThrowException("For tests"),
       s(0) :: s(1) :: s(2) :: s(3) :: s(4) :: s(5) :: s(6) :: s(7) :: Nil)
 
-    testQueries(q1 :: q2 :: q3 :: q4 :: q5 :: q6 :: q7 :: Nil, true)
+    testQueries(q1 :: q2 :: q3 :: q4 :: q5 :: q6 :: q7 :: Nil, false)
+  }
+
+  // group of group, with or/and composition
+  @Test def groupOfgroupsDoIntenalQueryTest(): Unit = {
+    val q1 = TestQuery(
+      "q1",
+      parser("""
+      {  "select":"node", "where":[
+        { "objectType":"group", "attribute":"nodeGroupId", "comparator":"eq", "value":"test-group-node1" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(1) :: Nil)
+
+    val q2 = TestQuery(
+      "q2",
+      parser("""
+      {  "select":"node", "composition":"or", "where":[
+        { "objectType":"group", "attribute":"nodeGroupId", "comparator":"eq", "value":"test-group-node1" }
+      , { "objectType":"group", "attribute":"nodeGroupId", "comparator":"eq", "value":"test-group-node2" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(1) :: s(2) :: Nil)
+
+    val q3 = TestQuery(
+      "q3",
+      parser("""
+      {  "select":"node", "where":[
+        { "objectType":"group", "attribute":"nodeGroupId", "comparator":"eq", "value":"test-group-node1" }
+      , { "objectType":"node", "attribute":"ram", "comparator":"gt", "value":"1" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(1) :: Nil)
+
+    val q4 = TestQuery(
+      "q4",
+      parser("""
+      {  "select":"node", "where":[
+        { "objectType":"group", "attribute":"nodeGroupId", "comparator":"eq", "value":"test-group-node1" }
+      , { "objectType":"group", "attribute":"nodeGroupId", "comparator":"eq", "value":"test-group-node12" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(1) :: Nil)
+
+    val q5 = TestQuery(
+      "q5",
+      parser("""
+      {  "select":"node", "where":[
+        { "objectType":"group", "attribute":"nodeGroupId", "comparator":"eq", "value":"test-group-node12" }
+      , { "objectType":"group", "attribute":"nodeGroupId", "comparator":"eq", "value":"test-group-node23" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(2) :: Nil)
+
+    testQueries(q1 :: q2 :: q3 :: q4 :: q5 :: Nil, true)
   }
 
   @Test def machineComponentQueries(): Unit = {
@@ -588,7 +642,114 @@ class TestQueryProcessor extends Loggable {
 //      """).openOrThrowException("For tests"),
 //      s.filterNot(n => n == s(2)) )
 
-    testQueries(q0 :: q1 :: q1_ :: q2 :: q2_ :: q3 :: q3_2 :: q4 :: q5 :: q6 :: q7 :: q8 :: q9 :: q10 :: q11 :: Nil, true)
+    testQueries(q0 :: q1 :: q1_ :: q2 :: q2_ :: q3 :: q3_2 :: q4 :: q5 :: q6 :: q7 :: q8 :: q9 :: q10 :: q11 :: Nil, false)
+  }
+
+  @Test def regexQueriesInventories(): Unit = {
+    // this test if for the queries that can be performed using only LDAP
+    //regex and "subqueries" for logical elements should not be contradictory
+    //here, we have to *only* search for logical elements with the regex
+    //and cn is both on node and logical elements
+    val q0 = TestQuery(
+      "q0",
+      parser("""
+      {  "select":"node", "composition":"or" , "where":[
+        , { "objectType":"fileSystemLogicalElement", "attribute":"description", "comparator":"regex", "value":"matchOnM[e]" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(3) :: Nil)
+
+
+    //on software, machine, machine element, node element
+    val q2 = TestQuery(
+      "q2",
+      parser("""
+      {  "select":"nodeAndPolicyServer", "where":[
+          { "objectType":"software", "attribute":"cn", "comparator":"regex"   , "value":"Software [0-9]" }
+        , { "objectType":"machine", "attribute":"machineId", "comparator":"regex" , "value":"machine[0-2]"  }
+        , { "objectType":"fileSystemLogicalElement", "attribute":"fileSystemFreeSpace", "comparator":"regex", "value":"[01]{2}" }
+        , { "objectType":"biosPhysicalElement", "attribute":"softwareVersion", "comparator":"regex", "value":"[6.0]+" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(7) :: Nil)
+
+    val q2_ = TestQuery("q2_", query = q2.query match { case q : Query => q.copy(composition = Or); case q : NewQuery => q.copy(composition = Or)},
+      (
+        s(2) :: s(7) :: //software
+        s(4) :: s(5) :: s(6) :: s(7) :: //machine
+        s(2) :: root :: // free space
+        s(2) :: //bios
+        Nil).distinct)
+
+    val q5 = TestQuery(
+      "q5",
+      parser("""
+      {  "select":"nodeAndPolicyServer","composition":"or",  "where":[
+        , { "objectType":"fileSystemLogicalElement" , "attribute":"mountPoint" , "comparator":"regex", "value":"[/]" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(3) :: s(7) :: root ::  Nil)
+
+    //same as q5 on IP, to test with escaping
+    //192.168.56.101 is for node3
+    val q8 = TestQuery(
+      "q8",
+      parser("""
+      {  "select":"node", "where":[
+          { "objectType":"node" , "attribute":"ipHostNumber" , "comparator":"notRegex", "value":"192.168.56.101" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s.filterNot( _ == s(1)) )
+
+    //typical use case for server on internal/dmz/both: want intenal (but not both)
+    //that test a match regex and not regex
+    val q9 = TestQuery(
+      "q9",
+      parser("""
+      {  "select":"node", "where":[
+          { "objectType":"node" , "attribute":"ipHostNumber" , "comparator":"regex", "value":"127.0.0.*" }
+        , { "objectType":"node" , "attribute":"ipHostNumber" , "comparator":"notRegex", "value":"192.168.56.10[23]" }
+      ] }
+      """).openOrThrowException("For tests"),
+      Seq(s(1), s(4)) )
+    //s0,5,6,7,8 not ok because no 127.0.0.1
+    //s1 ok because not in "not regex" pattern
+    //s2,s3 not ok because in the "not regex" pattern
+    //s4 ok because only 127.0.0.1
+
+    // test query that matches a software version
+    val q10 = TestQuery(
+      "q10",
+      parser("""
+      { "select":"node", "where":[
+        { "objectType":"software", "attribute":"softwareVersion", "comparator":"regex", "value":"1\\.0.*" }
+      ] }
+      """).openOrThrowException("For tests"),
+      Seq(s(2), s(7)) )
+
+    // test "notRegex" query: "I want node for which ram is not "100000000" (ie not node1)
+    val q11 = TestQuery(
+      "q11",
+      parser("""
+      { "select":"node", "where":[
+        { "objectType":"node", "attribute":"ram", "comparator":"notRegex", "value":"100000000" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s.filterNot(n => n == s(1)) )
+
+    // test query that doesn't match a software name, ie we want all nodes on which "software 1" is not
+    // installed (we don't care if there is 0 or 1000 other software)
+    // THIS DOES NOT WORK DUE TO: https://issues.rudder.io/issues/19137
+    //    val q12 = TestQuery(
+    //      "q12",
+    //      parser("""
+    //      { "select":"node", "composition":"or", "where":[
+    //        { "objectType":"software", "attribute":"cn", "comparator":"notRegex", "value":"Software 1" }
+    //      ] }
+    //      """).openOrThrowException("For tests"),
+    //      s.filterNot(n => n == s(2)) )
+
+    testQueries(q0 :: q2 :: q2_ :: q5 :: q8 :: q9 :: q10 :: q11 :: Nil, true)
   }
 
   @Test def invertQueries(): Unit = {
@@ -704,7 +865,7 @@ class TestQueryProcessor extends Loggable {
       """).openOrThrowException("For tests"),
       sr)
 
-    testQueries( q0 :: q1 :: Nil, true)
+    testQueries( q0 :: q1 :: Nil, false)
   }
 
   @Test def agentTypeQueries: Unit = {
@@ -1077,10 +1238,10 @@ class TestQueryProcessor extends Loggable {
 
       if (doInternalQueryTest) {
         logger.debug("Testing with expected entries, This test should be ignored when we are looking for Nodes with NodeInfo and inventory (ie when we are looking for property and environement variable")
+        val allNodesInfos = nodeInfoService.getAllNodeInfos().runNow
         val foundWithLimit =
-          (internalLDAPQueryProcessor.internalQueryProcessor(query, limitToNodeIds = Some(ids)).runNow.entries.map {
-            entry =>
-              NodeId(entry("nodeId").get)
+          (internalLDAPQueryProcessor.internalQueryProcessor(query, limitToNodeIds = Some(ids), allNodeInfos= allNodesInfos).runNow.entries.map {
+            _.node.id
           }).distinct.sortBy( _.value )
 
         assertEquals(

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
@@ -630,18 +630,6 @@ class TestQueryProcessor extends Loggable {
       """).openOrThrowException("For tests"),
       s.filterNot(n => n == s(1)) )
 
-    // test query that doesn't match a software name, ie we want all nodes on which "software 1" is not
-    // installed (we don't care if there is 0 or 1000 other software)
-    // THIS DOES NOT WORK DUE TO: https://issues.rudder.io/issues/19137
-//    val q12 = TestQuery(
-//      "q12",
-//      parser("""
-//      { "select":"node", "composition":"or", "where":[
-//        { "objectType":"software", "attribute":"cn", "comparator":"notRegex", "value":"Software 1" }
-//      ] }
-//      """).openOrThrowException("For tests"),
-//      s.filterNot(n => n == s(2)) )
-
     testQueries(q0 :: q1 :: q1_ :: q2 :: q2_ :: q3 :: q3_2 :: q4 :: q5 :: q6 :: q7 :: q8 :: q9 :: q10 :: q11 :: Nil, false)
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
@@ -442,7 +442,7 @@ class TestQueryProcessor extends Loggable {
       """).openOrThrowException("For tests"),
       s(2) :: Nil)
 
-    testQueries(q1 :: q2 :: q3 :: Nil, true)
+    testQueries(q1 :: q2 :: q3 :: q3bis:: Nil, true)
   }
 
   @Test def networkInterfaceElementQueries(): Unit = {
@@ -1239,7 +1239,7 @@ class TestQueryProcessor extends Loggable {
       if (doInternalQueryTest) {
         logger.debug("Testing with expected entries, This test should be ignored when we are looking for Nodes with NodeInfo and inventory (ie when we are looking for property and environement variable")
         val foundWithLimit =
-          (internalLDAPQueryProcessor.internalQueryProcessor(query, limitToNodeIds = Some(ids), lambdaAllNodeInfos = (() => nodeInfoService.getAllNodeInfos())).runNow.entries.map {
+          (internalLDAPQueryProcessor.internalQueryProcessor(query, limitToNodeIds = Some(ids), lambdaAllNodeInfos = (() => nodeInfoService.getAllNodeInfos())).runNow.map {
             _.node.id
           }).toSeq.distinct.sortBy( _.value )
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
@@ -1217,7 +1217,7 @@ class TestQueryProcessor extends Loggable {
 
   private def testQueryResultProcessor(name:String,query:QueryTrait, nodes:Seq[NodeId], doInternalQueryTest : Boolean) = {
       val ids = nodes.sortBy( _.value )
-      val found = queryProcessor.process(query).openOrThrowException("For tests").map { _.id }.sortBy( _.value )
+      val found = queryProcessor.process(query).openOrThrowException("For tests").map { _.id }.toSeq.sortBy( _.value )
       //also test with requiring only the expected node to check consistancy
       //(that should not change anything)
 
@@ -1242,7 +1242,7 @@ class TestQueryProcessor extends Loggable {
         val foundWithLimit =
           (internalLDAPQueryProcessor.internalQueryProcessor(query, limitToNodeIds = Some(ids), allNodeInfos= allNodesInfos).runNow.entries.map {
             _.node.id
-          }).distinct.sortBy( _.value )
+          }).toSeq.distinct.sortBy( _.value )
 
         assertEquals(
           s"[${name}] Size differs between expected and found entries (InternalQueryProcessor, only inventory fields)\n Found: ${foundWithLimit}\n Expected: ${ids}"

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -132,7 +132,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
   )
 
   object testNodeInfoService extends NodeInfoService {
-    def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : IOResult[Set[LDAPNodeInfo]] = ???
+    def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : IOResult[Seq[NodeInfo]] = ???
     def getNodeInfo(nodeId: NodeId) : IOResult[Option[NodeInfo]] = ???
     def getNodeInfos(nodesId: Set[NodeId]) : IOResult[Set[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -42,8 +42,6 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.nodes.Node
 import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.policies.RuleId
-import com.normation.rudder.domain.queries.CriterionComposition
-import com.normation.rudder.domain.queries.NodeInfoMatcher
 import com.normation.rudder.domain.reports.ComplianceLevel
 import com.normation.rudder.domain.reports.NodeConfigId
 import com.normation.rudder.domain.reports.NodeExpectedReports
@@ -53,7 +51,6 @@ import com.normation.rudder.reports.GlobalComplianceMode
 import com.normation.rudder.reports.execution.RoReportsExecutionRepository
 import com.normation.rudder.repository.FindExpectedReportRepository
 import com.normation.rudder.repository.ReportsRepository
-import com.normation.rudder.services.nodes.LDAPNodeInfo
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.services.policies.NodeConfigData
 import net.liftweb.common.Box
@@ -132,7 +129,6 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
   )
 
   object testNodeInfoService extends NodeInfoService {
-    def getLDAPNodeInfo(foundNodeInfos: Set[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodesInfos : Set[NodeInfo]) : Set[NodeInfo] = ???
     def getNodeInfo(nodeId: NodeId) : IOResult[Option[NodeInfo]] = ???
     def getNodeInfos(nodesId: Set[NodeId]) : IOResult[Set[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -134,7 +134,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
     def getNode(nodeId: NodeId): Box[Node] = ???
     def getAllNodes() : IOResult[Map[NodeId, Node]] = ???
     def getAllNodesIds(): IOResult[Set[NodeId]] = ???
-    def getAllNodeInfos():IOResult[Set[NodeInfo]] = ???
+    def getAllNodeInfos():IOResult[Seq[NodeInfo]] = ???
     def getAllSystemNodeIds() : IOResult[Seq[NodeId]] = ???
     def getPendingNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = ???
     def getPendingNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -132,7 +132,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
   )
 
   object testNodeInfoService extends NodeInfoService {
-    def getLDAPNodeInfo(nodeInfos: Set[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodesInfos : Set[NodeInfo]) : Seq[NodeInfo] = ???
+    def getLDAPNodeInfo(foundNodeInfos: Set[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodesInfos : Set[NodeInfo]) : Set[NodeInfo] = ???
     def getNodeInfo(nodeId: NodeId) : IOResult[Option[NodeInfo]] = ???
     def getNodeInfos(nodesId: Set[NodeId]) : IOResult[Set[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -132,12 +132,13 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
   )
 
   object testNodeInfoService extends NodeInfoService {
-    def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : IOResult[Seq[NodeInfo]] = ???
+    def getLDAPNodeInfo(nodeInfos: Seq[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodesInfos : Seq[NodeInfo]) : Seq[NodeInfo] = ???
     def getNodeInfo(nodeId: NodeId) : IOResult[Option[NodeInfo]] = ???
     def getNodeInfos(nodesId: Set[NodeId]) : IOResult[Set[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???
     def getAllNodes() : IOResult[Map[NodeId, Node]] = ???
     def getAllNodesIds(): IOResult[Set[NodeId]] = ???
+    def getAllNodeInfos():IOResult[Seq[NodeInfo]] = ???
     def getAllSystemNodeIds() : IOResult[Seq[NodeId]] = ???
     def getPendingNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = ???
     def getPendingNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -132,13 +132,13 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
   )
 
   object testNodeInfoService extends NodeInfoService {
-    def getLDAPNodeInfo(nodeInfos: Seq[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodesInfos : Seq[NodeInfo]) : Seq[NodeInfo] = ???
+    def getLDAPNodeInfo(nodeInfos: Set[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodesInfos : Set[NodeInfo]) : Seq[NodeInfo] = ???
     def getNodeInfo(nodeId: NodeId) : IOResult[Option[NodeInfo]] = ???
     def getNodeInfos(nodesId: Set[NodeId]) : IOResult[Set[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???
     def getAllNodes() : IOResult[Map[NodeId, Node]] = ???
     def getAllNodesIds(): IOResult[Set[NodeId]] = ???
-    def getAllNodeInfos():IOResult[Seq[NodeInfo]] = ???
+    def getAllNodeInfos():IOResult[Set[NodeInfo]] = ???
     def getAllSystemNodeIds() : IOResult[Seq[NodeId]] = ???
     def getPendingNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = ???
     def getPendingNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -1054,7 +1054,7 @@ class NodeApiService6 (
           case _ => Failure(s"Invalid branch used for nodes query, expected either AcceptedInventory or PendingInventory, got ${state}")
         }
       } yield {
-        listNodes(state,detailLevel,Some(nodeIds),version)
+        listNodes(state,detailLevel,Some(nodeIds.toSeq),version)
       }
     ) match {
       case Full(resp) => {

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -1513,7 +1513,7 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     override def getAllNodeInventories(inventoryStatus: InventoryStatus): IOResult[Map[NodeId, NodeInventory]] = getGenericAll(inventoryStatus, _fullInventory(_).map(_.node))
 
     // not implemented yet
-    override def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition): IOResult[Set[LDAPNodeInfo]] = ???
+    override def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition): IOResult[Seq[NodeInfo]] = ???
     override def getNumberOfManagedNodes: Int = ???
     override def save(serverAndMachine: FullInventory): IOResult[Seq[LDIFChangeRecord]] = ???
     override def delete(id: NodeId, inventoryStatus: InventoryStatus): IOResult[Seq[LDIFChangeRecord]] = ???

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -79,7 +79,6 @@ import com.normation.rudder.domain.queries.CriterionComposition
 import com.normation.rudder.domain.queries.NodeInfoMatcher
 import com.normation.rudder.repository.RoRuleRepository
 import com.normation.rudder.repository.WoRuleRepository
-import com.normation.rudder.services.nodes.LDAPNodeInfo
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.services.policies.NodeConfiguration
 import com.normation.rudder.services.policies.ParameterForConfiguration
@@ -1489,6 +1488,7 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     }
 
     override def getAllNodes(): IOResult[Map[NodeId, Node]] = getAll().map(_.map(kv => (kv._1, kv._2.node)))
+    override def getAllNodeInfos():IOResult[Seq[NodeInfo]] = getAll().map(_.values.toSeq)
     override def getAllNodesIds(): IOResult[Set[NodeId]] = getAllNodes().map(_.keySet)
     override def getAllSystemNodeIds(): IOResult[Seq[NodeId]] = {
       nodeBase.get.map(_.collect { case (id, n)  if(n.info.isSystem) => id }.toSeq )
@@ -1513,7 +1513,7 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     override def getAllNodeInventories(inventoryStatus: InventoryStatus): IOResult[Map[NodeId, NodeInventory]] = getGenericAll(inventoryStatus, _fullInventory(_).map(_.node))
 
     // not implemented yet
-    override def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition): IOResult[Seq[NodeInfo]] = ???
+    override def getLDAPNodeInfo(nodeInfos: Seq[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodesInfos : Seq[NodeInfo]): Seq[NodeInfo] = ???
     override def getNumberOfManagedNodes: Int = ???
     override def save(serverAndMachine: FullInventory): IOResult[Seq[LDIFChangeRecord]] = ???
     override def delete(id: NodeId, inventoryStatus: InventoryStatus): IOResult[Seq[LDIFChangeRecord]] = ???

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -76,7 +76,6 @@ import com.normation.inventory.domain.AgentType.CfeCommunity
 import com.normation.zio._
 import com.normation.rudder.domain.archives.RuleArchiveId
 import com.normation.rudder.domain.queries.CriterionComposition
-import com.normation.rudder.domain.queries.NodeInfoMatcher
 import com.normation.rudder.repository.RoRuleRepository
 import com.normation.rudder.repository.WoRuleRepository
 import com.normation.rudder.services.nodes.NodeInfoService
@@ -1488,7 +1487,7 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     }
 
     override def getAllNodes(): IOResult[Map[NodeId, Node]] = getAll().map(_.map(kv => (kv._1, kv._2.node)))
-    override def getAllNodeInfos():IOResult[Seq[NodeInfo]] = getAll().map(_.values.toSeq)
+    override def getAllNodeInfos():IOResult[Set[NodeInfo]] = getAll().map(_.values.toSet)
     override def getAllNodesIds(): IOResult[Set[NodeId]] = getAllNodes().map(_.keySet)
     override def getAllSystemNodeIds(): IOResult[Seq[NodeId]] = {
       nodeBase.get.map(_.collect { case (id, n)  if(n.info.isSystem) => id }.toSeq )
@@ -1513,7 +1512,6 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     override def getAllNodeInventories(inventoryStatus: InventoryStatus): IOResult[Map[NodeId, NodeInventory]] = getGenericAll(inventoryStatus, _fullInventory(_).map(_.node))
 
     // not implemented yet
-    override def getLDAPNodeInfo(nodeInfos: Set[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodesInfos : Set[NodeInfo]): Set[NodeInfo] = ???
     override def getNumberOfManagedNodes: Int = ???
     override def save(serverAndMachine: FullInventory): IOResult[Seq[LDIFChangeRecord]] = ???
     override def delete(id: NodeId, inventoryStatus: InventoryStatus): IOResult[Seq[LDIFChangeRecord]] = ???
@@ -1705,16 +1703,16 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
       }
     }
 
-    override def process(query: QueryTrait): Box[Seq[NodeInfo]] = {
+    override def process(query: QueryTrait): Box[Set[NodeInfo]] = {
       for {
         nodes    <- nodeInfoService.nodeBase.get
         matching <- filterForLines(query.criteria, query.composition, nodes.map(_._2).toList).toIO
       } yield {
-        matching.map(_.info)
+        matching.map(_.info).toSet
       }
     }.toBox
 
-    override def processOnlyId(query: QueryTrait): Box[Seq[NodeId]] = process(query).map(_.map(_.id))
+    override def processOnlyId(query: QueryTrait): Box[Set[NodeId]] = process(query).map(_.map(_.id))
   }
 }
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -1513,7 +1513,7 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     override def getAllNodeInventories(inventoryStatus: InventoryStatus): IOResult[Map[NodeId, NodeInventory]] = getGenericAll(inventoryStatus, _fullInventory(_).map(_.node))
 
     // not implemented yet
-    override def getLDAPNodeInfo(nodeInfos: Seq[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodesInfos : Seq[NodeInfo]): Seq[NodeInfo] = ???
+    override def getLDAPNodeInfo(nodeInfos: Set[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodesInfos : Set[NodeInfo]): Set[NodeInfo] = ???
     override def getNumberOfManagedNodes: Int = ???
     override def save(serverAndMachine: FullInventory): IOResult[Seq[LDIFChangeRecord]] = ???
     override def delete(id: NodeId, inventoryStatus: InventoryStatus): IOResult[Seq[LDIFChangeRecord]] = ???

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -1487,7 +1487,7 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     }
 
     override def getAllNodes(): IOResult[Map[NodeId, Node]] = getAll().map(_.map(kv => (kv._1, kv._2.node)))
-    override def getAllNodeInfos():IOResult[Set[NodeInfo]] = getAll().map(_.values.toSet)
+    override def getAllNodeInfos():IOResult[Seq[NodeInfo]] = getAll().map(_.values.toSeq)
     override def getAllNodesIds(): IOResult[Set[NodeId]] = getAllNodes().map(_.keySet)
     override def getAllSystemNodeIds(): IOResult[Seq[NodeId]] = {
       nodeBase.get.map(_.collect { case (id, n)  if(n.info.isSystem) => id }.toSeq )

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1666,7 +1666,8 @@ object RudderConfig extends Loggable {
         // here, we don't want to look for subgroups to show them in the form => always return an empty list
       , new DitQueryData(pendingNodesDitImpl, nodeDit, rudderDit, () => Nil.succeed)
       , ldapEntityMapper
-    )
+    ),
+    nodeInfoServiceImpl
   )
   private[this] lazy val dynGroupServiceImpl = new DynGroupServiceImpl(rudderDitImpl, roLdap, ldapEntityMapper)
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
@@ -610,7 +610,7 @@ object SearchNodeComponent {
   val defaultLine : CriterionLine = {
     //in case of further modification in ditQueryData
     require(ditQueryData.criteriaMap(OC_NODE).criteria(0).name == "OS", "Error in search node criterion default line, did you change DitQueryData ?")
-    require(ditQueryData.criteriaMap(OC_NODE).criteria(0).cType.isInstanceOf[OstypeComparator.type], "Error in search node criterion default line, did you change DitQueryData ?")
+    require(ditQueryData.criteriaMap(OC_NODE).criteria(0).cType.isInstanceOf[NodeOstypeComparator.type], "Error in search node criterion default line, did you change DitQueryData ?")
     CriterionLine(
       objectType = ditQueryData.criteriaMap(OC_NODE)
     , attribute  = ditQueryData.criteriaMap(OC_NODE).criteria(0)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
@@ -192,7 +192,7 @@ class SearchNodeComponent(
       query = Some(newQuery)
       if(errors.isEmpty) {
         // ********* EXECUTE QUERY ***********
-        srvList = queryProcessor.process(newQuery)
+        srvList = queryProcessor.process(newQuery).map(_.toSeq)
         initUpdate = true
         searchFormHasError = false
       } else {

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
@@ -164,12 +164,13 @@ class TestMigrateSystemTechniques7_0 extends Specification {
 
   val nodeInfoService = new NodeInfoService {
     override def getAll(): IOResult[Map[NodeId, NodeInfo]] = List(root, relay1).map(x => (x.id, x)).toMap.succeed
-    override def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition): IOResult[Seq[NodeInfo]] = ???
+    override def getLDAPNodeInfo(foundNodeInfos: Seq[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodesInfos : Seq[NodeInfo]): Seq[NodeInfo] = ???
     override def getNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
     override def getNodeInfos(nodeIds: Set[NodeId]): IOResult[Set[NodeInfo]] = ???
     override def getNumberOfManagedNodes: Int = ???
     override def getAllNodesIds(): IOResult[Set[NodeId]] = ???
     override def getAllNodes(): IOResult[Map[NodeId, Node]] = ???
+    override def getAllNodeInfos(): IOResult[Seq[NodeInfo]] = ???
     override def getAllSystemNodeIds(): IOResult[Seq[NodeId]] = ???
     override def getPendingNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = ???
     override def getPendingNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
@@ -164,7 +164,7 @@ class TestMigrateSystemTechniques7_0 extends Specification {
 
   val nodeInfoService = new NodeInfoService {
     override def getAll(): IOResult[Map[NodeId, NodeInfo]] = List(root, relay1).map(x => (x.id, x)).toMap.succeed
-    override def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition): IOResult[Set[LDAPNodeInfo]] = ???
+    override def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition): IOResult[Seq[NodeInfo]] = ???
     override def getNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
     override def getNodeInfos(nodeIds: Set[NodeId]): IOResult[Set[NodeInfo]] = ???
     override def getNumberOfManagedNodes: Int = ???

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
@@ -164,13 +164,13 @@ class TestMigrateSystemTechniques7_0 extends Specification {
 
   val nodeInfoService = new NodeInfoService {
     override def getAll(): IOResult[Map[NodeId, NodeInfo]] = List(root, relay1).map(x => (x.id, x)).toMap.succeed
-    override def getLDAPNodeInfo(foundNodeInfos: Seq[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodesInfos : Seq[NodeInfo]): Seq[NodeInfo] = ???
+    override def getLDAPNodeInfo(foundNodeInfos: Set[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodesInfos : Set[NodeInfo]): Set[NodeInfo] = ???
     override def getNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
     override def getNodeInfos(nodeIds: Set[NodeId]): IOResult[Set[NodeInfo]] = ???
     override def getNumberOfManagedNodes: Int = ???
     override def getAllNodesIds(): IOResult[Set[NodeId]] = ???
     override def getAllNodes(): IOResult[Map[NodeId, Node]] = ???
-    override def getAllNodeInfos(): IOResult[Seq[NodeInfo]] = ???
+    override def getAllNodeInfos(): IOResult[Set[NodeInfo]] = ???
     override def getAllSystemNodeIds(): IOResult[Seq[NodeId]] = ???
     override def getPendingNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = ???
     override def getPendingNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
@@ -74,8 +74,6 @@ import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.ModifyRuleDiff
 import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
-import com.normation.rudder.domain.queries.CriterionComposition
-import com.normation.rudder.domain.queries.NodeInfoMatcher
 import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.rudder.git.GitArchiveId
 import com.normation.rudder.git.GitPath
@@ -99,7 +97,6 @@ import com.normation.rudder.repository.ldap.WoLDAPRuleRepository
 import com.normation.rudder.repository.ldap.ZioTReentrantLock
 import com.normation.rudder.repository.xml.GitParseTechniqueLibrary
 import com.normation.rudder.services.eventlog.EventLogFactory
-import com.normation.rudder.services.nodes.LDAPNodeInfo
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.services.policies.NodeConfigData
 import com.normation.rudder.services.policies.TechniqueAcceptationUpdater
@@ -164,7 +161,6 @@ class TestMigrateSystemTechniques7_0 extends Specification {
 
   val nodeInfoService = new NodeInfoService {
     override def getAll(): IOResult[Map[NodeId, NodeInfo]] = List(root, relay1).map(x => (x.id, x)).toMap.succeed
-    override def getLDAPNodeInfo(foundNodeInfos: Set[NodeInfo], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition, allNodesInfos : Set[NodeInfo]): Set[NodeInfo] = ???
     override def getNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
     override def getNodeInfos(nodeIds: Set[NodeId]): IOResult[Set[NodeInfo]] = ???
     override def getNumberOfManagedNodes: Int = ???

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
@@ -166,7 +166,7 @@ class TestMigrateSystemTechniques7_0 extends Specification {
     override def getNumberOfManagedNodes: Int = ???
     override def getAllNodesIds(): IOResult[Set[NodeId]] = ???
     override def getAllNodes(): IOResult[Map[NodeId, Node]] = ???
-    override def getAllNodeInfos(): IOResult[Set[NodeInfo]] = ???
+    override def getAllNodeInfos(): IOResult[Seq[NodeInfo]] = ???
     override def getAllSystemNodeIds(): IOResult[Seq[NodeId]] = ???
     override def getPendingNodeInfos(): IOResult[Map[NodeId, NodeInfo]] = ???
     override def getPendingNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???


### PR DESCRIPTION
https://issues.rudder.io/issues/20716

This is a WIP - the code is not finished, and may land in another branch

The goal here is to explore how to do dynamic group computation with minimal LDAP queries, which are really expensive
We have many data in the nodeinfocache, we can use them

As a first approach, I changed the ldap search on hostname to a nodeinfofilter (so that it's a *post* filter). The drawback is that when we only search on hostname, there is no filter to apply, so it fetches all nodes to do the search. Kind of kill the advantage of doing so, that's why i resolve to add a boolean that says: ok, don't compute anything, and take all from cache
