### PR TITLE
Fixes #20727: Maven needs <version> tag even if version is in <dependency-management>

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -775,6 +775,7 @@ limitations under the License.
     <dependency>
       <groupId>com.softwaremill.quicklens</groupId>
       <artifactId>quicklens_${scala-binary-version}</artifactId>
+      <version>${quicklens-version}</version>
     </dependency>
     <!-- this is now standard -->
     <dependency>


### PR DESCRIPTION
https://issues.rudder.io/issues/20727