### PR TITLE
Fixes #20716: Correct dynamic group computation onf properties and improve speed

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
@@ -222,7 +222,122 @@ final case object NodeStateComparator extends NodeCriterionType {
     )
 }
 
+final case object NodeOstypeComparator extends NodeCriterionType {
+  val osTypes = List("AIX", "BSD", "Linux", "Solaris", "Windows")
+  override def comparators = Seq(Equals, NotEquals)
+  override protected def validateSubCase(v:String,comparator:CriterionComparator) = {
+    if(null == v || v.isEmpty) Left(Inconsistency("Empty string not allowed")) else Right(v)
+  }
 
+  override def matches(comparator: CriterionComparator, value: String): NodeInfoMatcher = {
+    comparator match {
+      case Equals => NodeInfoMatcher(s"Prop equals '${value}'", (node: NodeInfo) => node.osDetails.os.kernelName == value )
+      case _      => NodeInfoMatcher(s"Prop not equals '${value}'", (node: NodeInfo) => node.osDetails.os.kernelName != value )
+    }
+  }
+
+  override def toForm(value: String, func: String => Any, attrs: (String, String)*) : Elem =
+    SHtml.select(
+        (osTypes map (e => (e,e))).toSeq
+      , { if(osTypes.contains(value)) Full(value) else Empty}
+      , func
+      , attrs:_*
+    )
+}
+
+final case object NodeOsNameComparator extends NodeCriterionType {
+
+  import net.liftweb.http.S
+
+  val osNames = AixOS ::
+                BsdType.allKnownTypes.sortBy { _.name } :::
+                LinuxType.allKnownTypes.sortBy { _.name } :::
+                (SolarisOS :: Nil) :::
+                WindowsType.allKnownTypes
+
+
+  override def comparators = Seq(Equals, NotEquals)
+  override protected def validateSubCase(v:String,comparator:CriterionComparator) = {
+    if(null == v || v.isEmpty) Left(Inconsistency("Empty string not allowed")) else Right(v)
+  }
+
+  override def matches(comparator: CriterionComparator, value: String): NodeInfoMatcher = {
+    comparator match {
+      case Equals => NodeInfoMatcher(s"Prop equals '${value}'", (node: NodeInfo) => node.osDetails.os.name == value )
+      case _      => NodeInfoMatcher(s"Prop not equals '${value}'", (node: NodeInfo) => node.osDetails.os.name != value )
+    }
+  }
+
+  private[this] def distribName(x: OsType): String = {
+    x match {
+      //add linux: for linux
+      case _: LinuxType   => "Linux - " + S.?("os.name."+x.name)
+      case _: BsdType     => "BSD - " + S.?("os.name."+x.name)
+      //nothing special for windows, Aix and Solaris
+      case _              => S.?("os.name."+x.name)
+    }
+  }
+
+  override def toForm(value: String, func: String => Any, attrs: (String, String)*) : Elem =
+    SHtml.select(
+      osNames.map(e => (e.name,distribName(e))).toSeq,
+      {osNames.find(x => x.name == value).map( _.name)},
+      func,
+      attrs:_*
+    )
+}
+
+
+final case class NodeStringComparator(access: NodeInfo => String) extends NodeCriterionType {
+  override val comparators = BaseComparators.comparators
+
+  override protected def validateSubCase(v: String, comparator: CriterionComparator) = {
+    if(null == v || v.isEmpty) Left(Inconsistency("Empty string not allowed")) else {
+      comparator match {
+        case Regex | NotRegex => validateRegex(v)
+        case x                => Right(v)
+      }
+    }
+  }
+
+  override def matches(comparator: CriterionComparator, value: String): NodeInfoMatcher = {
+
+    comparator match {
+      case Equals    => NodeInfoMatcher(s"Prop equals '${value}'", (node: NodeInfo) => access(node) == value )
+      case NotEquals => NodeInfoMatcher(s"Prop not equals '${value}'", (node: NodeInfo) => access(node) != value )
+      case Regex     => NodeInfoMatcher(s"Prop matches regex '${value}'", (node: NodeInfo) => access(node).matches(value) )
+      case NotRegex  => NodeInfoMatcher(s"Prop matches not regex '${value}'", (node: NodeInfo) => !access(node).matches(value) )
+      case Exists    => NodeInfoMatcher(s"Prop exists", (node: NodeInfo) => access(node).nonEmpty )
+      case NotExists => NodeInfoMatcher(s"Prop doesn't exists", (node: NodeInfo) => access(node).isEmpty )
+
+    }
+  }
+
+}
+
+final case object NodeIpListComparator extends NodeCriterionType {
+  override val comparators = BaseComparators.comparators
+
+  override protected def validateSubCase(v: String, comparator: CriterionComparator) = {
+    if(null == v || v.isEmpty) Left(Inconsistency("Empty string not allowed")) else {
+      comparator match {
+        case Regex | NotRegex => validateRegex(v)
+        case x                => Right(v)
+      }
+    }
+  }
+
+  override def matches(comparator: CriterionComparator, value: String): NodeInfoMatcher = {
+    comparator match {
+      case Equals    => NodeInfoMatcher(s"Prop equals '${value}'", (node:NodeInfo) => node.ips.contains(value) )
+      case NotEquals => NodeInfoMatcher(s"Prop not equals '${value}'", (node: NodeInfo) => !node.ips.contains(value) )
+      case Regex     => NodeInfoMatcher(s"Prop matches regex '${value}'", (node: NodeInfo) => node.ips.exists(_.matches(value)) )
+      case NotRegex  => NodeInfoMatcher(s"Prop matches not regex '${value}'", (node: NodeInfo) => !node.ips.exists(_.matches(value)) )
+      case Exists    => NodeInfoMatcher(s"Prop exists", (node:NodeInfo) => node.ips.nonEmpty )
+      case NotExists => NodeInfoMatcher(s"Prop doesn't exists", (node:NodeInfo) => node.ips.isEmpty )
+    }
+  }
+}
 
 /*
  * This comparator is used for "node properties"-like attribute, i.e:
@@ -550,82 +665,6 @@ final case object MachineComparator extends LDAPCriterionType {
       , { if(machineTypes.contains(value)) Full(value) else Empty}
       , func
       , attrs:_*
-    )
-}
-
-final case object OstypeComparator extends LDAPCriterionType {
-  val osTypes = List("AIX", "BSD", "Linux", "Solaris", "Windows")
-  override def comparators = Seq(Equals, NotEquals)
-  override protected def validateSubCase(v:String,comparator:CriterionComparator) = {
-    if(null == v || v.isEmpty) Left(Inconsistency("Empty string not allowed")) else Right(v)
-  }
-  override def toLDAP(value:String) = Right(value)
-
-  override def buildFilter(attributeName:String,comparator:CriterionComparator,value:String) : Filter = {
-    val v = value match {
-      case "Windows" => OC_WINDOWS_NODE
-      case "Linux"   => OC_LINUX_NODE
-      case "Solaris" => OC_SOLARIS_NODE
-      case "AIX"     => OC_AIX_NODE
-      case "BSD"     => OC_BSD_NODE
-      case _         => OC_UNIX_NODE
-    }
-    comparator match {
-      //for equals and not equals, check value for jocker
-      case Equals => IS(v)
-      case _ => NOT(IS(v))
-    }
-  }
-
-  override def toForm(value: String, func: String => Any, attrs: (String, String)*) : Elem =
-    SHtml.select(
-        (osTypes map (e => (e,e))).toSeq
-      , { if(osTypes.contains(value)) Full(value) else Empty}
-      , func
-      , attrs:_*
-    )
-}
-
-final case object OsNameComparator extends LDAPCriterionType {
-  import net.liftweb.http.S
-
-  val osNames = AixOS ::
-                BsdType.allKnownTypes.sortBy { _.name } :::
-                LinuxType.allKnownTypes.sortBy { _.name } :::
-                (SolarisOS :: Nil) :::
-                WindowsType.allKnownTypes
-
-  override def comparators = Seq(Equals, NotEquals)
-  override protected def validateSubCase(v:String,comparator:CriterionComparator) = {
-    if(null == v || v.isEmpty) Left(Inconsistency("Empty string not allowed")) else Right(v)
-  }
-  override def toLDAP(value:String) = Right(value)
-
-  override def buildFilter(attributeName:String,comparator:CriterionComparator,value:String) : Filter = {
-    val osName = comparator match {
-      //for equals and not equals, check value for jocker
-      case Equals => EQ(A_OS_NAME, value)
-      case _ => NOT(EQ(A_OS_NAME, value))
-    }
-    AND(EQ(A_OC,OC_NODE),osName)
-  }
-
-  private[this] def distribName(x: OsType): String = {
-    x match {
-      //add linux: for linux
-      case _: LinuxType   => "Linux - " + S.?("os.name."+x.name)
-      case _: BsdType     => "BSD - " + S.?("os.name."+x.name)
-      //nothing special for windows, Aix and Solaris
-      case _              => S.?("os.name."+x.name)
-    }
-  }
-
-  override def toForm(value: String, func: String => Any, attrs: (String, String)*) : Elem =
-    SHtml.select(
-      osNames.map(e => (e.name,distribName(e))).toSeq,
-      {osNames.find(x => x.name == value).map( _.name)},
-      func,
-      attrs:_*
     )
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/DitQueryData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/DitQueryData.scala
@@ -190,10 +190,10 @@ class DitQueryData(dit: InventoryDit, nodeDit: NodeDit, rudderDit: RudderDit, ge
       Criterion(A_MEMORY_CAPACITY, MemoryComparator)
     )),
     ObjectCriterion(OC_NODE, Seq(
-        Criterion("OS",OstypeComparator)
-      , Criterion(A_NODE_UUID, StringComparator)
-      , Criterion(A_HOSTNAME, StringComparator)
-      , Criterion(A_OS_NAME,OsNameComparator)
+        Criterion("OS",NodeOstypeComparator)
+      , Criterion(A_NODE_UUID, NodeStringComparator(node => node.node.id.value))
+      , Criterion(A_HOSTNAME, NodeStringComparator(node => node.hostname))
+      , Criterion(A_OS_NAME,NodeOsNameComparator)
       , Criterion(A_OS_FULL_NAME, OrderedStringComparator)
       , Criterion(A_OS_VERSION, OrderedStringComparator)
       , Criterion(A_OS_SERVICE_PACK, OrderedStringComparator)
@@ -205,10 +205,10 @@ class DitQueryData(dit: InventoryDit, nodeDit: NodeDit, rudderDit: RudderDit, ge
       , Criterion(A_OS_SWAP, MemoryComparator)
       , Criterion(A_AGENTS_NAME, AgentComparator)
       , Criterion(A_ACCOUNT, StringComparator)
-      , Criterion(A_LIST_OF_IP, StringComparator)
-      , Criterion(A_ROOT_USER, StringComparator)
+      , Criterion(A_LIST_OF_IP, NodeIpListComparator)
+      , Criterion(A_ROOT_USER, NodeStringComparator(node => node.localAdministratorAccountName))
       , Criterion(A_INVENTORY_DATE, DateComparator)
-      , Criterion(A_POLICY_SERVER_UUID, StringComparator)
+      , Criterion(A_POLICY_SERVER_UUID, NodeStringComparator(node => node.policyServerId.value))
     )),
     ObjectCriterion(OC_SOFTWARE, Seq(
       Criterion(A_NAME, StringComparator),

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
@@ -94,16 +94,14 @@ class DynGroupUpdaterServiceImpl(
 
   override def computeDynGroup (group : NodeGroup): Box[NodeGroup] = {
     for {
-      _              <- if(group.isDynamic) Full("OK") else Failure("Can not update a not dynamic group")
-      timePreCompute =  System.currentTimeMillis
-      query          <- Box(group.query) ?~! s"No query defined for group '${group.name}' (${group.id.value})"
-      newMembers     <- queryProcessor.processOnlyId(query) ?~! s"Error when processing request for updating dynamic group '${group.name}' (${group.id.value})"
-      //save
-      newMemberIdsSet = newMembers.toSet
-      timeGroupCompute=  (System.currentTimeMillis - timePreCompute)
-      _               =  logger.debug(s"Dynamic group ${group.id.value} with name ${group.name} computed in ${timeGroupCompute} ms")
+      _               <- if(group.isDynamic) Full("OK") else Failure("Can not update a not dynamic group")
+      timePreCompute  =  System.currentTimeMillis
+      query           <- Box(group.query) ?~! s"No query defined for group '${group.name}' (${group.id.value})"
+      newMembers      <- queryProcessor.processOnlyId(query) ?~! s"Error when processing request for updating dynamic group '${group.name}' (${group.id.value})"
+      timeGroupCompute = (System.currentTimeMillis - timePreCompute)
+      _                = logger.debug(s"Dynamic group ${group.id.value} with name ${group.name} computed in ${timeGroupCompute} ms")
     } yield {
-      group.copy(serverList = newMemberIdsSet)
+      group.copy(serverList = newMembers)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/QueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/QueryProcessor.scala
@@ -47,7 +47,6 @@ trait QueryProcessor {
    /**
    * Process a query and (hopefully) return the list of entry that match it.
    * @param query - the query to process
-   * @param select - attributes to fetch in the ldap entry. If empty, all attributes are fetched
    * @return
    */
   def process(query:QueryTrait) : Box[Seq[NodeInfo]]
@@ -56,7 +55,7 @@ trait QueryProcessor {
    * Only get node ids corresponding to that request, with minimal consistency check.
    * This method is useful to maximize performance (low memory, high throughout) for ex for dynamic groups.
    */
-  def processOnlyId(query:QueryTrait) : Box[Seq[NodeId]]
+  def processOnlyId(query:QueryTrait) : Box[Set[NodeId]]
 }
 
 
@@ -74,6 +73,6 @@ trait QueryChecker {
    *   Full(seq) with seq being the list of nodeId which verify
    *   query.
    */
-  def check(query:QueryTrait, nodeIds:Option[Seq[NodeId]]) : Box[Seq[NodeId]]
+  def check(query:QueryTrait, nodeIds:Option[Seq[NodeId]]) : Box[Set[NodeId]]
 
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -51,8 +51,6 @@ import com.normation.rudder.domain.policies.GlobalPolicyMode
 import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies._
-import com.normation.rudder.domain.queries.CriterionComposition
-import com.normation.rudder.domain.queries.NodeInfoMatcher
 import com.normation.rudder.domain.reports._
 import com.normation.rudder.reports.AgentRunInterval
 import com.normation.rudder.reports.AgentRunIntervalService
@@ -60,7 +58,6 @@ import com.normation.rudder.reports.ResolvedAgentRunInterval
 import com.normation.rudder.reports.GlobalComplianceMode
 import com.normation.rudder.reports.execution._
 import com.normation.rudder.repository.{CategoryWithActiveTechniques, ComplianceRepository, FullActiveTechniqueCategory, RoDirectiveRepository, RoRuleRepository}
-import com.normation.rudder.services.nodes.LDAPNodeInfo
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.services.policies.NodeConfigData
 import com.normation.rudder.services.reports.CachedFindRuleNodeStatusReports
@@ -100,12 +97,12 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
   }
 
   object nodeInfoService extends NodeInfoService {
-    def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : Box[Set[LDAPNodeInfo]] = ???
     def getNodeInfo(nodeId: NodeId) : Box[Option[NodeInfo]] = ???
     def getNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
     def getNodeInfos(nodesId: Set[NodeId]) : IOResult[Set[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???
     def getAllNodes() : Box[Map[NodeId, Node]] = ???
+    def getAllNodeInfos():IOResult[Seq[NodeInfo]] = ???
     def getAllSystemNodeIds() : Box[Seq[NodeId]] = ???
     def getPendingNodeInfos(): Box[Map[NodeId, NodeInfo]] = ???
     def getPendingNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestPendingNodePolicies.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestPendingNodePolicies.scala
@@ -158,7 +158,7 @@ class TestPendingNodePolicies extends Specification {
 
   // a fake query checker
   val queryChecker = new QueryChecker {
-    override def check(query: QueryTrait, nodeIds: Option[Seq[NodeId]]): Box[Seq[NodeId]] = {
+    override def check(query: QueryTrait, nodeIds: Option[Seq[NodeId]]): Box[Set[NodeId]] = {
       // make a 0 criteria request raise an error like LDAP would do,
       // see: https://www.rudder-project.org/redmine/issues/12338
       if(query.criteria.isEmpty) {
@@ -168,7 +168,7 @@ class TestPendingNodePolicies extends Specification {
           case x if(x == dummyQuery0) => Set.empty[NodeId]
           case x if(x == dummyQuery1) => Set(node)
           case x                      => Set(node)
-        }).intersect(nodeIds.getOrElse(Seq(node)).toSet).toSeq)
+        }).intersect(nodeIds.getOrElse(Seq(node)).toSet))
       }
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
@@ -188,7 +188,7 @@ class TestQueryProcessor extends Loggable {
       """).openOrThrowException("For tests"),
       Nil)
 
-    testQueries( q0 :: q1 :: q2 :: Nil, true)
+    testQueries( q0 :: q1 :: q2 :: Nil, false)
   }
 
   @Test def basicQueriesOnOneNodeParameter(): Unit = {
@@ -311,7 +311,61 @@ class TestQueryProcessor extends Loggable {
       """).openOrThrowException("For tests"),
       s(0) :: s(1) :: s(2) :: s(3) :: s(4) :: s(5) :: s(6) :: s(7) :: Nil)
 
-    testQueries(q1 :: q2 :: q3 :: q4 :: q5 :: q6 :: q7 :: Nil, true)
+    testQueries(q1 :: q2 :: q3 :: q4 :: q5 :: q6 :: q7 :: Nil, false)
+  }
+
+  // group of group, with or/and composition
+  @Test def groupOfgroupsDoIntenalQueryTest(): Unit = {
+    val q1 = TestQuery(
+      "q1",
+      parser("""
+      {  "select":"node", "where":[
+        { "objectType":"group", "attribute":"nodeGroupId", "comparator":"eq", "value":"test-group-node1" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(1) :: Nil)
+
+    val q2 = TestQuery(
+      "q2",
+      parser("""
+      {  "select":"node", "composition":"or", "where":[
+        { "objectType":"group", "attribute":"nodeGroupId", "comparator":"eq", "value":"test-group-node1" }
+      , { "objectType":"group", "attribute":"nodeGroupId", "comparator":"eq", "value":"test-group-node2" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(1) :: s(2) :: Nil)
+
+    val q3 = TestQuery(
+      "q3",
+      parser("""
+      {  "select":"node", "where":[
+        { "objectType":"group", "attribute":"nodeGroupId", "comparator":"eq", "value":"test-group-node1" }
+      , { "objectType":"node", "attribute":"ram", "comparator":"gt", "value":"1" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(1) :: Nil)
+
+    val q4 = TestQuery(
+      "q4",
+      parser("""
+      {  "select":"node", "where":[
+        { "objectType":"group", "attribute":"nodeGroupId", "comparator":"eq", "value":"test-group-node1" }
+      , { "objectType":"group", "attribute":"nodeGroupId", "comparator":"eq", "value":"test-group-node12" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(1) :: Nil)
+
+    val q5 = TestQuery(
+      "q5",
+      parser("""
+      {  "select":"node", "where":[
+        { "objectType":"group", "attribute":"nodeGroupId", "comparator":"eq", "value":"test-group-node12" }
+      , { "objectType":"group", "attribute":"nodeGroupId", "comparator":"eq", "value":"test-group-node23" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(2) :: Nil)
+
+    testQueries(q1 :: q2 :: q3 :: q4 :: q5 :: Nil, true)
   }
 
   @Test def machineComponentQueries(): Unit = {
@@ -388,7 +442,7 @@ class TestQueryProcessor extends Loggable {
       """).openOrThrowException("For tests"),
       s(2) :: Nil)
 
-    testQueries(q1 :: q2 :: q3 :: Nil, true)
+    testQueries(q1 :: q2 :: q3 :: q3bis:: Nil, true)
   }
 
   @Test def networkInterfaceElementQueries(): Unit = {
@@ -576,19 +630,114 @@ class TestQueryProcessor extends Loggable {
       """).openOrThrowException("For tests"),
       s.filterNot(n => n == s(1)) )
 
+    testQueries(q0 :: q1 :: q1_ :: q2 :: q2_ :: q3 :: q3_2 :: q4 :: q5 :: q6 :: q7 :: q8 :: q9 :: q10 :: q11 :: Nil, false)
+  }
+
+  @Test def regexQueriesInventories(): Unit = {
+    // this test if for the queries that can be performed using only LDAP
+    //regex and "subqueries" for logical elements should not be contradictory
+    //here, we have to *only* search for logical elements with the regex
+    //and cn is both on node and logical elements
+    val q0 = TestQuery(
+      "q0",
+      parser("""
+      {  "select":"node", "composition":"or" , "where":[
+        , { "objectType":"fileSystemLogicalElement", "attribute":"description", "comparator":"regex", "value":"matchOnM[e]" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(3) :: Nil)
+
+
+    //on software, machine, machine element, node element
+    val q2 = TestQuery(
+      "q2",
+      parser("""
+      {  "select":"nodeAndPolicyServer", "where":[
+          { "objectType":"software", "attribute":"cn", "comparator":"regex"   , "value":"Software [0-9]" }
+        , { "objectType":"machine", "attribute":"machineId", "comparator":"regex" , "value":"machine[0-2]"  }
+        , { "objectType":"fileSystemLogicalElement", "attribute":"fileSystemFreeSpace", "comparator":"regex", "value":"[01]{2}" }
+        , { "objectType":"biosPhysicalElement", "attribute":"softwareVersion", "comparator":"regex", "value":"[6.0]+" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(7) :: Nil)
+
+    val q2_ = TestQuery("q2_", query = q2.query match { case q : Query => q.copy(composition = Or); case q : NewQuery => q.copy(composition = Or)},
+      (
+        s(2) :: s(7) :: //software
+        s(4) :: s(5) :: s(6) :: s(7) :: //machine
+        s(2) :: root :: // free space
+        s(2) :: //bios
+        Nil).distinct)
+
+    val q5 = TestQuery(
+      "q5",
+      parser("""
+      {  "select":"nodeAndPolicyServer","composition":"or",  "where":[
+        , { "objectType":"fileSystemLogicalElement" , "attribute":"mountPoint" , "comparator":"regex", "value":"[/]" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(3) :: s(7) :: root ::  Nil)
+
+    //same as q5 on IP, to test with escaping
+    //192.168.56.101 is for node3
+    val q8 = TestQuery(
+      "q8",
+      parser("""
+      {  "select":"node", "where":[
+          { "objectType":"node" , "attribute":"ipHostNumber" , "comparator":"notRegex", "value":"192.168.56.101" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s.filterNot( _ == s(1)) )
+
+    //typical use case for server on internal/dmz/both: want intenal (but not both)
+    //that test a match regex and not regex
+    val q9 = TestQuery(
+      "q9",
+      parser("""
+      {  "select":"node", "where":[
+          { "objectType":"node" , "attribute":"ipHostNumber" , "comparator":"regex", "value":"127.0.0.*" }
+        , { "objectType":"node" , "attribute":"ipHostNumber" , "comparator":"notRegex", "value":"192.168.56.10[23]" }
+      ] }
+      """).openOrThrowException("For tests"),
+      Seq(s(1), s(4)) )
+    //s0,5,6,7,8 not ok because no 127.0.0.1
+    //s1 ok because not in "not regex" pattern
+    //s2,s3 not ok because in the "not regex" pattern
+    //s4 ok because only 127.0.0.1
+
+    // test query that matches a software version
+    val q10 = TestQuery(
+      "q10",
+      parser("""
+      { "select":"node", "where":[
+        { "objectType":"software", "attribute":"softwareVersion", "comparator":"regex", "value":"1\\.0.*" }
+      ] }
+      """).openOrThrowException("For tests"),
+      Seq(s(2), s(7)) )
+
+    // test "notRegex" query: "I want node for which ram is not "100000000" (ie not node1)
+    val q11 = TestQuery(
+      "q11",
+      parser("""
+      { "select":"node", "where":[
+        { "objectType":"node", "attribute":"ram", "comparator":"notRegex", "value":"100000000" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s.filterNot(n => n == s(1)) )
+
     // test query that doesn't match a software name, ie we want all nodes on which "software 1" is not
     // installed (we don't care if there is 0 or 1000 other software)
     // THIS DOES NOT WORK DUE TO: https://issues.rudder.io/issues/19137
-//    val q12 = TestQuery(
-//      "q12",
-//      parser("""
-//      { "select":"node", "composition":"or", "where":[
-//        { "objectType":"software", "attribute":"cn", "comparator":"notRegex", "value":"Software 1" }
-//      ] }
-//      """).openOrThrowException("For tests"),
-//      s.filterNot(n => n == s(2)) )
+    //    val q12 = TestQuery(
+    //      "q12",
+    //      parser("""
+    //      { "select":"node", "composition":"or", "where":[
+    //        { "objectType":"software", "attribute":"cn", "comparator":"notRegex", "value":"Software 1" }
+    //      ] }
+    //      """).openOrThrowException("For tests"),
+    //      s.filterNot(n => n == s(2)) )
 
-    testQueries(q0 :: q1 :: q1_ :: q2 :: q2_ :: q3 :: q3_2 :: q4 :: q5 :: q6 :: q7 :: q8 :: q9 :: q10 :: q11 :: Nil, true)
+    testQueries(q0 :: q2 :: q2_ :: q5 :: q8 :: q9 :: q10 :: q11 :: Nil, true)
   }
 
   @Test def invertQueries(): Unit = {
@@ -704,7 +853,7 @@ class TestQueryProcessor extends Loggable {
       """).openOrThrowException("For tests"),
       sr)
 
-    testQueries( q0 :: q1 :: Nil, true)
+    testQueries( q0 :: q1 :: Nil, false)
   }
 
   @Test def agentTypeQueries: Unit = {
@@ -1056,7 +1205,7 @@ class TestQueryProcessor extends Loggable {
 
   private def testQueryResultProcessor(name:String,query:QueryTrait, nodes:Seq[NodeId], doInternalQueryTest : Boolean) = {
       val ids = nodes.sortBy( _.value )
-      val found = queryProcessor.process(query).openOrThrowException("For tests").map { _.id }.sortBy( _.value )
+      val found = queryProcessor.process(query).openOrThrowException("For tests").map { _.id }.toSeq.sortBy( _.value )
       //also test with requiring only the expected node to check consistancy
       //(that should not change anything)
 
@@ -1078,10 +1227,9 @@ class TestQueryProcessor extends Loggable {
       if (doInternalQueryTest) {
         logger.debug("Testing with expected entries, This test should be ignored when we are looking for Nodes with NodeInfo and inventory (ie when we are looking for property and environement variable")
         val foundWithLimit =
-          (internalLDAPQueryProcessor.internalQueryProcessor(query, limitToNodeIds = Some(ids)).runNow.entries.map {
-            entry =>
-              NodeId(entry("nodeId").get)
-          }).distinct.sortBy( _.value )
+          (internalLDAPQueryProcessor.internalQueryProcessor(query, limitToNodeIds = Some(ids), lambdaAllNodeInfos = (() => nodeInfoService.getAllNodeInfos())).runNow.map {
+            _.node.id
+          }).toSeq.distinct.sortBy( _.value )
 
         assertEquals(
           s"[${name}] Size differs between expected and found entries (InternalQueryProcessor, only inventory fields)\n Found: ${foundWithLimit}\n Expected: ${ids}"

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -42,8 +42,6 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.nodes.Node
 import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.policies.RuleId
-import com.normation.rudder.domain.queries.CriterionComposition
-import com.normation.rudder.domain.queries.NodeInfoMatcher
 import com.normation.rudder.domain.reports.ComplianceLevel
 import com.normation.rudder.domain.reports.NodeConfigId
 import com.normation.rudder.domain.reports.NodeExpectedReports
@@ -53,7 +51,6 @@ import com.normation.rudder.reports.GlobalComplianceMode
 import com.normation.rudder.reports.execution.RoReportsExecutionRepository
 import com.normation.rudder.repository.FindExpectedReportRepository
 import com.normation.rudder.repository.ReportsRepository
-import com.normation.rudder.services.nodes.LDAPNodeInfo
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.services.policies.NodeConfigData
 import net.liftweb.common.Box
@@ -131,12 +128,12 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
   )
 
   object testNodeInfoService extends NodeInfoService {
-    def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition) : Box[Set[LDAPNodeInfo]] = ???
     def getNodeInfo(nodeId: NodeId) : Box[Option[NodeInfo]] = ???
     def getNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
     def getNodeInfos(nodesId: Set[NodeId]) : IOResult[Set[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???
     def getAllNodes() : Box[Map[NodeId, Node]] = ???
+    def getAllNodeInfos():IOResult[Seq[NodeInfo]] = ???
     def getAllSystemNodeIds() : Box[Seq[NodeId]] = ???
     def getPendingNodeInfos(): Box[Map[NodeId, NodeInfo]] = ???
     def getPendingNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -1056,7 +1056,7 @@ class NodeApiService6 (
           case _ => Failure(s"Invalid branch used for nodes query, expected either AcceptedInventory or PendingInventory, got ${state}")
         }
       } yield {
-        listNodes(state,detailLevel,Some(nodeIds),version)
+        listNodes(state,detailLevel,Some(nodeIds.toSeq),version)
       }
     ) match {
       case Full(resp) => {

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -71,10 +71,8 @@ import com.normation.inventory.domain.AgentType.CfeCommunity
 import com.normation.zio._
 import com.normation.rudder.domain.archives.RuleArchiveId
 import com.normation.rudder.domain.queries.CriterionComposition
-import com.normation.rudder.domain.queries.NodeInfoMatcher
 import com.normation.rudder.repository.RoRuleRepository
 import com.normation.rudder.repository.WoRuleRepository
-import com.normation.rudder.services.nodes.LDAPNodeInfo
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.services.policies.NodeConfiguration
 import com.normation.rudder.services.policies.ParameterForConfiguration
@@ -1404,6 +1402,8 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     override def getAll(): Box[Map[NodeId, NodeInfo]] = getGenericAll(AcceptedInventory, _info).toBox
 
     override def getAllNodes(): Box[Map[NodeId, Node]] = getAll().map(_.map(kv => (kv._1, kv._2.node)))
+
+    override def getAllNodeInfos():IOResult[Seq[NodeInfo]] = getAll().map(_.values.toSeq).toIO
     override def getAllSystemNodeIds(): Box[Seq[NodeId]] = {
       nodeBase.get.map(_.collect { case (id, n)  if(n.info.isSystem) => id }.toSeq ).toBox
     }
@@ -1427,7 +1427,6 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     override def getAllNodeInventories(inventoryStatus: InventoryStatus): IOResult[Map[NodeId, NodeInventory]] = getGenericAll(inventoryStatus, _fullInventory(_).map(_.node))
 
     // not implemented yet
-    override def getLDAPNodeInfo(nodeIds: Set[NodeId], predicates: Seq[NodeInfoMatcher], composition: CriterionComposition): Box[Set[LDAPNodeInfo]] = ???
     override def getNumberOfManagedNodes: Int = ???
     override def save(serverAndMachine: FullInventory): IOResult[Seq[LDIFChangeRecord]] = ???
     override def delete(id: NodeId, inventoryStatus: InventoryStatus): IOResult[Seq[LDIFChangeRecord]] = ???
@@ -1629,7 +1628,7 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
       }
     }.toBox
 
-    override def processOnlyId(query: QueryTrait): Box[Seq[NodeId]] = process(query).map(_.map(_.id))
+    override def processOnlyId(query: QueryTrait): Box[Set[NodeId]] = process(query).map(_.map(_.id).toSet)
   }
 }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1507,7 +1507,8 @@ object RudderConfig extends Loggable {
         // here, we don't want to look for subgroups to show them in the form => always return an empty list
       , new DitQueryData(pendingNodesDitImpl, nodeDit, rudderDit, () => Nil.succeed)
       , ldapEntityMapper
-    )
+    ),
+    nodeInfoServiceImpl
   )
   private[this] lazy val dynGroupServiceImpl = new DynGroupServiceImpl(rudderDitImpl, roLdap, ldapEntityMapper)
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
@@ -55,7 +55,6 @@ import net.liftweb.util.Helpers._
 import scala.collection.mutable.ArrayBuffer
 import com.normation.inventory.ldap.core.LDAPConstants
 import LDAPConstants._
-import com.normation.rudder.domain.queries.OstypeComparator
 import bootstrap.liftweb.RudderConfig
 import com.normation.rudder.domain.RudderLDAPConstants.A_NODE_PROPERTY
 import scala.collection.mutable.{Map => MutMap}
@@ -610,7 +609,7 @@ object SearchNodeComponent {
   val defaultLine : CriterionLine = {
     //in case of further modification in ditQueryData
     require(ditQueryData.criteriaMap(OC_NODE).criteria(0).name == "OS", "Error in search node criterion default line, did you change DitQueryData ?")
-    require(ditQueryData.criteriaMap(OC_NODE).criteria(0).cType.isInstanceOf[OstypeComparator.type], "Error in search node criterion default line, did you change DitQueryData ?")
+    require(ditQueryData.criteriaMap(OC_NODE).criteria(0).cType.isInstanceOf[NodeOstypeComparator.type], "Error in search node criterion default line, did you change DitQueryData ?")
     CriterionLine(
       objectType = ditQueryData.criteriaMap(OC_NODE)
     , attribute  = ditQueryData.criteriaMap(OC_NODE).criteria(0)


### PR DESCRIPTION
https://issues.rudder.io/issues/20716

This PR corrects the computation of invertion on dynamic groups, that was failing due to the ordering of action (invert was before the properties computation)

It goes the extra mile to improve perf of dynamic group computation, by changing easy ldap search on properties available on nodeinfo to a nodeinfofilter (so that it's a post filter). The drawback is that when we only search on nodeinfo related info, there is no filter to apply, so it fetches all nodes to do the search, so it kind of kill the advantage of doing so, that's why i resolved to add a boolean that says: ok, don't compute anything, and take all from cache

Main changes in code
* in CMDBQuery, the filters on NodeInfo based on LDAP filter have been replaced to filters on NodeInfo ( `NodeCriterionType` ), as we have the NodeInfo available for free thanks to the cache. Not all filters have been changed because this is a change on patch version, and I didn't want to take too much risk for those that are not trivial
* `LDAPQueryProcessor` was significantly changed, with 
  * `internalQueryProcessor` having a lambda returning all nodes as a parameter, used when there are no LDAP filter applied, or an inversion, or an "or" query
  * postfilter on NodeInfo is done before inversion & filtering on server roles
  * `check` in `PendingNodesLDAPQueryChecker` uses the Lambda being the lis of pending nodes
  * `LdapQueryProcessorResult` class removed: it was not used in a meaningful way, and added only a layer of indirection, making it harder to understand
  * `PostFilterNodeFromInfoService` object has been changed, with `getLDAPNodeInfo` to return a Seq rather than a Set (`Set` of `NodeInfo` are realy expensive), and optimisations in place based on `And` or `Or` query types
* in `LDAPNodeGroupRepository.scala` a small change to check if the NodeGroup changed or not before going on with all other checks. As surprising as it sound, it saves ~ 15 seconds on my tests on 10 000 nodes and 464 groups, probably because of the mutex that's blocking
* Some cleaning in `NodeInfoService`, to remove unused method