### PR TITLE
Fixes #20758: Improve node computation

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
@@ -301,6 +301,7 @@ final case class NodeStringComparator(access: NodeInfo => String) extends NodeCr
 
   override def matches(comparator: CriterionComparator, value: String): NodeInfoMatcher = {
     comparator match {
+      case Equals    => NodeInfoMatcher(s"Prop equals '${value}'", (node: NodeInfo) => access(node) == value )
       case NotEquals => NodeInfoMatcher(s"Prop not equals '${value}'", (node: NodeInfo) => access(node) != value )
       case Regex     => NodeInfoMatcher(s"Prop matches regex '${value}'", (node: NodeInfo) => access(node).matches(value) )
       case NotRegex  => NodeInfoMatcher(s"Prop matches not regex '${value}'", (node: NodeInfo) => !access(node).matches(value) )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
@@ -114,6 +114,7 @@ trait NodeInfoService {
 
   def getNodeInfos(nodeIds: Set[NodeId]): IOResult[Set[NodeInfo]]
 
+  def getNodeInfosSeq(nodeIds: Seq[NodeId]): IOResult[Seq[NodeInfo]]
 
   /**
    * Return the number of managed (ie non policy server, no rudder role nodes.
@@ -874,6 +875,10 @@ trait NodeInfoServiceCached extends NodeInfoService with NamedZioLogger with Cac
 
   def getNodeInfos(nodeIds: Set[NodeId]): IOResult[Set[NodeInfo]] = withUpToDateCache(s"${nodeIds.size} nodes infos") { cache =>
     cache.filter(x => nodeIds.contains(x._1)).values.map( _._2).toSet.succeed
+  }
+
+  def getNodeInfosSeq(nodeIds: Seq[NodeId]): IOResult[Seq[NodeInfo]] = withUpToDateCache(s"${nodeIds.size} nodes infos") { cache =>
+    nodeIds.map(id => cache.get(id).map(_._2)).flatten.succeed
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
@@ -101,7 +101,7 @@ class DynGroupUpdaterServiceImpl(
       timeGroupCompute = (System.currentTimeMillis - timePreCompute)
       _                = logger.debug(s"Dynamic group ${group.id.value} with name ${group.name} computed in ${timeGroupCompute} ms")
     } yield {
-      group.copy(serverList = newMembers)
+      group.copy(serverList = newMembers.toSet)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/QueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/QueryProcessor.scala
@@ -38,7 +38,6 @@
 package com.normation.rudder.services.queries
 
 import com.normation.inventory.domain.NodeId
-import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.queries.QueryTrait
 
 import net.liftweb.common.Box
@@ -52,13 +51,13 @@ trait QueryProcessor {
    * @param query - the query to process
    * @return
    */
-  def process(query:QueryTrait) : Box[Seq[NodeInfo]]
+  def process(query:QueryTrait) : Box[Seq[NodeId]]
 
   /**
    * Only get node ids corresponding to that request, with minimal consistency check.
    * This method is useful to maximize performance (low memory, high throughout) for ex for dynamic groups.
    */
-  def processOnlyId(query:QueryTrait) : Box[Set[NodeId]]
+  def processOnlyId(query:QueryTrait) : Box[Seq[NodeId]]
 }
 
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -95,6 +95,7 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
     def getNodeInfo(nodeId: NodeId) : IOResult[Option[NodeInfo]] = ???
     def getNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
     def getNodeInfos(nodesId: Set[NodeId]) : IOResult[Set[NodeInfo]] = ???
+    def getNodeInfosSeq(nodeIds: Seq[NodeId]): IOResult[Seq[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???
     def getAllNodes() : IOResult[Map[NodeId, Node]] = ???
     def getAllNodesIds(): IOResult[Set[NodeId]] = ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestQueryProcessor.scala
@@ -311,7 +311,6 @@ class TestQueryProcessor extends Loggable {
       """).openOrThrowException("For tests"),
       s(0) :: s(1) :: s(2) :: s(3) :: s(4) :: s(5) :: s(6) :: s(7) :: Nil)
 
-
     /*
      * Testing groups and physical query
      */
@@ -1240,7 +1239,7 @@ class TestQueryProcessor extends Loggable {
 
   private def testQueryResultProcessor(name:String,query:QueryTrait, nodes:Seq[NodeId], doInternalQueryTest : Boolean) = {
       val ids = nodes.sortBy( _.value )
-      val found = queryProcessor.process(query).openOrThrowException("For tests").map { _.id }.toSeq.sortBy( _.value )
+      val found = queryProcessor.process(query).openOrThrowException("For tests").sortBy( _.value )
       //also test with requiring only the expected node to check consistancy
       //(that should not change anything)
 
@@ -1262,9 +1261,7 @@ class TestQueryProcessor extends Loggable {
       if (doInternalQueryTest) {
         logger.debug("Testing with expected entries, This test should be ignored when we are looking for Nodes with NodeInfo and inventory (ie when we are looking for property and environement variable")
         val foundWithLimit =
-          (internalLDAPQueryProcessor.internalQueryProcessor(query, limitToNodeIds = Some(ids), lambdaAllNodeInfos = (() => nodeInfoService.getAllNodeInfos())).runNow.map {
-            _.node.id
-          }).toSeq.distinct.sortBy( _.value )
+          (internalLDAPQueryProcessor.internalQueryProcessor(query, limitToNodeIds = Some(ids), lambdaAllNodeInfos = (() => nodeInfoService.getAllNodeInfos())).runNow).distinct.sortBy( _.value )
 
         assertEquals(
           s"[${name}] Size differs between expected and found entries (InternalQueryProcessor, only inventory fields)\n Found: ${foundWithLimit}\n Expected: ${ids}"

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -132,6 +132,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
     def getNodeInfo(nodeId: NodeId) : IOResult[Option[NodeInfo]] = ???
     def getNodeInfoPure(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
     def getNodeInfos(nodesId: Set[NodeId]) : IOResult[Set[NodeInfo]] = ???
+    def getNodeInfosSeq(nodeIds: Seq[NodeId]): IOResult[Seq[NodeInfo]] = ???
     def getNode(nodeId: NodeId): Box[Node] = ???
     def getAllNodes() : IOResult[Map[NodeId, Node]] = ???
     def getAllNodeInfos():IOResult[Seq[NodeInfo]] = ???

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -674,7 +674,7 @@ class NodeApiService13 (
                            case None =>
                              nodeInfoService.getAll().toBox
                            case Some(nodeIds) =>
-                             nodeInfoService.getNodeInfos(nodeIds.toSet).map(_.map(n => (n.id, n)).toMap).toBox
+                             nodeInfoService.getNodeInfosSeq(nodeIds).map(_.map(n => (n.id, n)).toMap).toBox
                          }
       n2              =  System.currentTimeMillis
       _               =  TimingDebugLoggerPure.logEffect.trace(s"Getting node infos: ${n2 - n1}ms")
@@ -729,7 +729,7 @@ class NodeApiService13 (
 
       nodes <- optNodeIds match {
         case None          => nodeInfoService.getAll().toBox
-        case Some(nodeIds) => nodeInfoService.getNodeInfos(nodeIds.toSet).map(_.map(n => (n.id, n)).toMap).toBox
+        case Some(nodeIds) => nodeInfoService.getNodeInfosSeq(nodeIds).map(_.map(n => (n.id, n)).toMap).toBox
       }
       softs <- readOnlySoftwareDAO.getNodesbySofwareName(software).toBox.map(_.toMap)
     } yield {
@@ -743,7 +743,7 @@ class NodeApiService13 (
       optNodeIds <- req.json.flatMap(restExtractor.extractNodeIdsFromJson)
       nodes      <- optNodeIds match {
                       case None          => nodeInfoService.getAll().toBox
-                      case Some(nodeIds) => nodeInfoService.getNodeInfos(nodeIds.toSet).map(_.map(n => (n.id, n)).toMap).toBox
+                      case Some(nodeIds) => nodeInfoService.getNodeInfosSeq(nodeIds).map(_.map(n => (n.id, n)).toMap).toBox
                     }
       propMap = nodes.values.groupMapReduce(_.id)(n =>  n.properties.filter(_.name == property))(_ ::: _)
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -1485,7 +1485,9 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     override def getNodeInfos(nodesId: Set[NodeId]): IOResult[Set[NodeInfo]] = ZIO.foreach(nodesId) { nodeId =>
       getGenericOne(nodeId, AcceptedInventory, _info).map(x => x.get)
     }
-
+    override def getNodeInfosSeq(nodesId: Seq[NodeId]): IOResult[Seq[NodeInfo]] = ZIO.foreach(nodeIds) { nodeId =>
+      getGenericOne(nodeId, AcceptedInventory, _info).map(x => x.get)
+    }.map(_.toSeq)
     override def getAllNodes(): IOResult[Map[NodeId, Node]] = getAll().map(_.map(kv => (kv._1, kv._2.node)))
     override def getAllNodesIds(): IOResult[Set[NodeId]] = getAllNodes().map(_.keySet)
     override def getAllNodeInfos():IOResult[Seq[NodeInfo]] = getAll().map(_.values.toSeq)
@@ -1721,16 +1723,16 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
       }
     }
 
-    override def process(query: QueryTrait): Box[Seq[NodeInfo]] = {
+    override def process(query: QueryTrait): Box[Seq[NodeId]] = {
       for {
         nodes    <- nodeInfoService.nodeBase.get
         matching <- filterForLines(query.criteria, query.composition, nodes.map(_._2).toList).toIO
       } yield {
-        matching.map(_.info)
+        matching.map(_.info.id).toSeq
       }
     }.toBox
 
-    override def processOnlyId(query: QueryTrait): Box[Set[NodeId]] = process(query).map(_.map(_.id).toSet)
+    override def processOnlyId(query: QueryTrait): Box[Seq[NodeId]] = process(query).map(_.toSeq)
   }
 }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1710,6 +1710,7 @@ object RudderConfig extends Loggable {
     , queryProcessor
     , ditQueryDataImpl
     , psMngtService
+    , nodeInfoServiceImpl
     , configService.node_accept_duplicated_hostname()
   )
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
@@ -88,6 +88,8 @@ class SearchNodeComponent(
 
   private[this] val queryProcessor  = RudderConfig.acceptedNodeQueryProcessor
 
+  private[this] val nodeInfoService = RudderConfig.nodeInfoService
+
   // The portlet for the server detail
   private[this] def searchNodes: NodeSeq = ChooseTemplate(
       List("templates-hidden", "server", "server_details")
@@ -191,7 +193,12 @@ class SearchNodeComponent(
       query = Some(newQuery)
       if(errors.isEmpty) {
         // ********* EXECUTE QUERY ***********
-        srvList = queryProcessor.process(newQuery)
+        srvList = (for {
+          nodeIds <- queryProcessor.process(newQuery)
+          nodeInfos <- nodeInfoService.getNodeInfosSeq(nodeIds).toBox
+        } yield {
+          nodeInfos
+        })
         initUpdate = true
         searchFormHasError = false
       } else {

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
@@ -163,6 +163,7 @@ class TestMigrateSystemTechniques7_0 extends Specification {
     override def getAll(): IOResult[Map[NodeId, NodeInfo]] = List(root, relay1).map(x => (x.id, x)).toMap.succeed
     override def getNodeInfo(nodeId: NodeId): IOResult[Option[NodeInfo]] = ???
     override def getNodeInfos(nodeIds: Set[NodeId]): IOResult[Set[NodeInfo]] = ???
+    override def getNodeInfosSeq(nodesId: Seq[NodeId]): IOResult[Seq[NodeInfo]] = ???
     override def getNumberOfManagedNodes: Int = ???
     override def getAllNodesIds(): IOResult[Set[NodeId]] = ???
     override def getAllNodes(): IOResult[Map[NodeId, Node]] = ???


### PR DESCRIPTION
Based on https://github.com/Normation/rudder/pull/4164

Changing the types to remove most of the hashCode computation, most notably, using Set for NodeInfo is a really bad idea
With this (unfinished) code, computation of dynamic group goes from 1m15 (pr 4164) to 35s
Do not merge for now, this is only exploration

The only relevant thing is to return nodeId rather than NodeInfos now that we don't need serverrole info