### PR TITLE
Fixes #20828: Unexpected/missing for same component, same value

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
@@ -294,8 +294,12 @@ final case class PolicyId(ruleId: RuleId, directiveId: DirectiveId, techniqueVer
  * This will allow too prevent missing expected reports, because we were building a map with toMap, that only keep
  * one elem for a specific key. A component Id for now is composed of component name and a list of Parents
  * Section (and maybe blocks) that has lead to it.
+ *
+ * - since 7.1, with a reportId. The report id is optional since we don't have all techniques ported to
+ *   use it: as of 7.1, only ncf techniques (from editor) got it, so we needed a transitionnal period.
+ *
  */
-case class ComponentId(value: String, parents: List[String])
+case class ComponentId(value: String, parents: List[String], reportId: Option[String])
 
 
 /*
@@ -310,6 +314,7 @@ final case class PolicyVars(
   , originalVars   : Map[ComponentId, Variable] // variable with non-expanded ${node.prop etc} values
   , trackerVariable: TrackerVariable
 )
+
 
 /*
  * The technique bounded to a policy. It is specific to exactly one agent

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -1470,20 +1470,20 @@ object RuleExpectedReportBuilder extends Loggable {
               case (None, None) =>
                 //a section that is a component without componentKey variable: card=1, value="None"
                 ValueExpectedReport(section.name, List(ExpectedValueMatch(DEFAULT_COMPONENT_KEY, DEFAULT_COMPONENT_KEY))) :: Nil
-              case (Some(id), None) =>
+              case (Some(id), None)                 =>
                 ValueExpectedReport(section.name, List(ExpectedValueId(DEFAULT_COMPONENT_KEY, id))) :: Nil
-              case (maybeId, Some(varName)) =>
+              case (sectionReportId, Some(varName)) =>
 
                 //a section with a componentKey variable: card=variable card
                 // we are maybe not in a block, but we should only take the values matching the current parent path
                 val currentPath = section.name :: path // (varName is not in parent, but in value)
-                val refComponentId = ComponentId(varName, currentPath)
+                val refComponentId = ComponentId(varName, currentPath, sectionReportId)
 
                 // There are many cases were the variable component is not in the sections
                 // In historical techniques, we have only one componentKey for all technique, and all sections
                 // so we cannot search it in a specific path, and must rather look for it everywhere if it doesn't match
 
-                val (id, innerExpandedVars, innerUnexpandedVars) = vars.expandedVars.get(refComponentId) match {
+                val (varReportId, innerExpandedVars, innerUnexpandedVars) = vars.expandedVars.get(refComponentId) match {
                   // ok, the componentKey is in the current path, all is great
                   // this is a technique from technique editor, or an historical technique with the right section
                   case Some(innerExpandedVars) =>
@@ -1502,9 +1502,9 @@ object RuleExpectedReportBuilder extends Loggable {
                   PolicyGenerationLogger.warn("Caution, the size of unexpanded and expanded variables for autobounding variable in section %s for directive %s are not the same : %s and %s".format(
                     section.componentKey, directiveId.serialize, innerExpandedVars, innerUnexpandedVars))
 
-                val values = maybeId match {
+                val values = sectionReportId match {
                   case None =>
-                    id match {
+                    varReportId match {
                       case None =>
                         innerExpandedVars.zip( innerUnexpandedVars).map(ExpectedValueMatch.tupled)
                       case Some(id) =>

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
@@ -748,7 +748,7 @@ class TestNodeConfiguration(prefixTestResources: String = ""
      , spec("POLICYSERVER_ID").toVariable(Seq(allNodeInfos(nodeId).policyServerId.value))
      , spec("POLICYSERVER").toVariable(Seq(allNodeInfos(allNodeInfos(nodeId).policyServerId).hostname))
      , spec("POLICYSERVER_ADMIN").toVariable(Seq(allNodeInfos(allNodeInfos(nodeId).policyServerId).localAdministratorAccountName))
-     ).map(v => (ComponentId(v.spec.name, Nil), v)).toMap
+     ).map(v => (ComponentId(v.spec.name, Nil, None), v)).toMap // None because no reportId for old var
   }
 
   def draft (
@@ -877,7 +877,7 @@ class TestNodeConfiguration(prefixTestResources: String = ""
        , spec("CLOCK_NTPSERVERS").toVariable(Seq("${rudder.param.ntpserver}"))
        , spec("CLOCK_SYNCSCHED").toVariable(Seq("240"))
        , spec("CLOCK_TIMEZONE").toVariable(Seq("dontchange"))
-     ).map(v => (ComponentId(v.spec.name, Nil), v)).toMap
+     ).map(v => (ComponentId(v.spec.name, Nil, None), v)).toMap
   }
   lazy val clock = {
     val id = PolicyId(RuleId("rule1"), DirectiveId(DirectiveUid("directive1")), TechniqueVersionHelper("1.0"))
@@ -913,7 +913,7 @@ class TestNodeConfiguration(prefixTestResources: String = ""
        , spec("RPM_PACKAGE_VERSION").toVariable(Seq("","",""))
        , spec("RPM_PACKAGE_VERSION_CRITERION").toVariable(Seq("==","==","=="))
        , spec("RPM_PACKAGE_VERSION_DEFINITION").toVariable(Seq("default","default","default"))
-     ).map(v => (ComponentId(v.spec.name, Nil), v)).toMap
+     ).map(v => (ComponentId(v.spec.name, Nil, None), v)).toMap
   }
   def rpmDirective(id: String, pkg: String) = Directive(
       DirectiveId(DirectiveUid(id), GitVersion.DEFAULT_REV)
@@ -958,7 +958,7 @@ class TestNodeConfiguration(prefixTestResources: String = ""
        , spec("PACKAGE_ARCHITECTURE_SPECIFIC").toVariable(Seq(""))
        , spec("PACKAGE_MANAGER").toVariable(Seq("default"))
        , spec("PACKAGE_POST_HOOK_COMMAND").toVariable(Seq(""))
-     ).map(v => (ComponentId(v.spec.name, Nil), v)).toMap
+     ).map(v => (ComponentId(v.spec.name, Nil, None), v)).toMap
   }
   lazy val pkg = {
     val id = PolicyId(RuleId("ff44fb97-b65e-43c4-b8c2-0df8d5e8549f"), DirectiveId(DirectiveUid("16617aa8-1f02-4e4a-87b6-d0bcdfb4019f")), TechniqueVersionHelper("1.0"))
@@ -990,7 +990,7 @@ class TestNodeConfiguration(prefixTestResources: String = ""
        , spec("FILE_TEMPLATE_PERMISSIONS").toVariable(Seq("700"))
        , spec("FILE_TEMPLATE_PERSISTENT_POST_HOOK").toVariable(Seq("false"))
        , spec("FILE_TEMPLATE_TEMPLATE_POST_HOOK_COMMAND").toVariable(Seq(""))
-     ).map(v => (ComponentId(v.spec.name, Nil), v)).toMap
+     ).map(v => (ComponentId(v.spec.name, Nil, None), v)).toMap
   }
   lazy val fileTemplate1 = {
     val id = PolicyId(RuleId("ff44fb97-b65e-43c4-b8c2-0df8d5e8549f"), DirectiveId(DirectiveUid("e9a1a909-2490-4fc9-95c3-9d0aa01717c9")), TechniqueVersionHelper("1.0"))
@@ -1029,7 +1029,7 @@ class TestNodeConfiguration(prefixTestResources: String = ""
       , "60-rule-technique-std-lib"
       , "20-File template 2"
       , fileTemplateTechnique
-      , fileTemplateVariables2.map(a => (ComponentId(a._1, Nil), a._2))
+      , fileTemplateVariables2.map(a => (ComponentId(a._1, Nil, None), a._2))
       , fileTemplateTechnique.trackerVariableSpec.toVariable(Seq(id.getReportId))
       , BundleOrder("60-rule-technique-std-lib")
       , BundleOrder("20-File template 2")
@@ -1046,7 +1046,7 @@ class TestNodeConfiguration(prefixTestResources: String = ""
       , "99-rule-technique-std-lib"
       , "20-File template 2"
       , fileTemplateTechnique
-      , fileTemplateVariables2.map(a => (ComponentId(a._1, Nil), a._2))
+      , fileTemplateVariables2.map(a => (ComponentId(a._1, Nil, None), a._2))
       , fileTemplateTechnique.trackerVariableSpec.toVariable(Seq(id.getReportId))
       , BundleOrder("99-rule-technique-std-lib")
       , BundleOrder("20-File template 2")
@@ -1072,7 +1072,7 @@ class TestNodeConfiguration(prefixTestResources: String = ""
       , "50-rule-technique-ncf"
       , "Create a file"
       , ncf1Technique
-      , ncf1Variables.map(a => (ComponentId(a._1, Nil), a._2))
+      , ncf1Variables.map(a => (ComponentId(a._1, Nil, Some(s"reportId_${a._1}")), a._2))
       , ncf1Technique.trackerVariableSpec.toVariable(Seq(id.getReportId))
       , BundleOrder("50-rule-technique-ncf")
       , BundleOrder("Create a file")
@@ -1114,7 +1114,7 @@ class TestNodeConfiguration(prefixTestResources: String = ""
       , "90-copy-git-file"
       , "Copy git file"
       , copyGitFileTechnique
-      , copyGitFileVariable(i).map(a => (ComponentId(a._1, Nil), a._2))
+      , copyGitFileVariable(i).map(a => (ComponentId(a._1, Nil, None), a._2))
       , copyGitFileTechnique.trackerVariableSpec.toVariable(Seq(id.getReportId))
       , BundleOrder("90-copy-git-file")
       , BundleOrder("Copy git file")
@@ -1186,7 +1186,7 @@ class TestNodeConfiguration(prefixTestResources: String = ""
       , "10. Global configuration for all nodes"
       , "99. Generic Variable Def #1"
       , gvdTechnique
-      , gvdVariables1.map(a => (ComponentId(a._1, Nil), a._2))
+      , gvdVariables1.map(a => (ComponentId(a._1, Nil, None), a._2))
       , gvdTechnique.trackerVariableSpec.toVariable(Seq(id.getReportId))
       , BundleOrder("10. Global configuration for all nodes")
       , BundleOrder("99. Generic Variable Def #1") // the sort name tell that it comes after directive 2
@@ -1210,7 +1210,7 @@ class TestNodeConfiguration(prefixTestResources: String = ""
       , "10. Global configuration for all nodes"
       , "00. Generic Variable Def #2"
       , gvdTechnique
-      , gvdVariables2.map(a => (ComponentId(a._1, Nil), a._2))
+      , gvdVariables2.map(a => (ComponentId(a._1, Nil, None), a._2))
       , gvdTechnique.trackerVariableSpec.toVariable(Seq(id.getReportId))
       , BundleOrder("10. Global configuration for all nodes")
       , BundleOrder("00. Generic Variable Def #2") // sort name comes before sort name of directive 1

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeExpectedReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeExpectedReportTest.scala
@@ -82,12 +82,12 @@ class NodeExpectedReportTest extends Specification {
   // return the couple of (var name, var with value)
   def v(x: String, values: String*) = {
     val v = tvar(x).toVariable(values)
-    (ComponentId(v.spec.name,  v.spec.name :: "root" :: Nil), v)
+    (ComponentId(v.spec.name,  v.spec.name :: "root" :: Nil, None), v)
   }
   // same with multivalued
   def mv(x: String, values: String*) = {
     val v = tmvar(x).toVariable(values)
-    (ComponentId(v.spec.name, v.spec.name :: "root":: Nil), v)
+    (ComponentId(v.spec.name, v.spec.name :: "root":: Nil, None), v)
   }
 
   def parse(s: String) = s.fromJson[List[JsonRuleExpectedReports7_0]] match {
@@ -341,8 +341,8 @@ class NodeExpectedReportTest extends Specification {
   "The rule expected reports from a technique with blocks " should {
     def componentIdCreator(componentKey: String, parentPath: List[String], value: String) : (ComponentId, Variable)= {
       // expectedReportKey is the prefix of the variable name, so necessary
-      val componentId = ComponentId("expectedReportKey " + componentKey, parentPath)
       val variable = SectionVariableSpec("expectedReportKey " + componentKey, "", "REPORTKEYS", valueslabels = Nil, providedValues = Seq(value), id = None)
+      val componentId = ComponentId("expectedReportKey " + componentKey, parentPath, variable.id)
       (componentId, variable.toVariable(Seq(value)))
     }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
@@ -215,7 +215,7 @@ class RuleValServiceTest extends Specification {
         variables(null).either.runNow match {
           case Left(_) => ko("Error when parsing variable")
           case Right(vars) =>
-            vars.get(ComponentId(reportKeysVariableName("component1"), "component1" :: "root section" :: Nil)) match {
+            vars.get(ComponentId(reportKeysVariableName("component1"), "component1" :: "root section" :: Nil, None)) match {
             case None => ko(s"Excepted variable variable_component1, but got nothing. The variables are ${variables}")
             case Some(variable) =>
               variable.values.size === 3 and

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestNodeAndGlobalParameterLookup.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestNodeAndGlobalParameterLookup.scala
@@ -151,7 +151,7 @@ class TestNodeAndGlobalParameterLookup extends Specification {
     (for {
       params <- ZIO.foreach(lookupParam.parameters.toList) { case (k, c) => c(lookupParam).map((k, _)) }
       p      <- ZIO.foreach(params.toList) { case (k, value) => GenericProperty.parseValue(value).map(v => (k, v)).toIO}
-      res    <- lookupService.lookupNodeParameterization(variables.map(v => (ComponentId(v.spec.name, Nil),v)).toMap)(toNodeContext(lookupParam, p.toMap))
+      res    <- lookupService.lookupNodeParameterization(variables.map(v => (ComponentId(v.spec.name, Nil, v.spec.id),v)).toMap)(toNodeContext(lookupParam, p.toMap))
     } yield res)
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PolicyAgregationTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PolicyAgregationTest.scala
@@ -134,8 +134,8 @@ class PolicyAgregationTest extends Specification {
       , "directive name"
       , technique
       , DateTime.now
-      , Map(ComponentId(v.spec.name, Nil) -> v)
-      , Map(ComponentId(v.spec.name, Nil) -> v)
+      , Map(ComponentId(v.spec.name, Nil, None) -> v)
+      , Map(ComponentId(v.spec.name, Nil, None) -> v)
       , trackerVariable
       , 5
       , false


### PR DESCRIPTION
https://issues.rudder.io/issues/20828

So, as explained in the ticket, the problem was that we were building expected reports at the end of generation, we were looking at possible variables for each component expecting reporting. 
But during Policy/PolicyDraft/etc generaly earlier, we missed to differentiate variables based on reportId. So, for us, all variable with the same component name were the same, and we kept just one (adapting cardinality I think, but actually we don't care much about cardinality in any case, because of iterators and the like). 
So, we ended with just ONE variable. 
And so, the expected component creation was looking around, correctly finding its variables with report id (because they come from elsewhere), but when it tries to reconciliate with the policy to get back the component value name (I'm not sure why we don't get him throught expected reports), it finds only one available, and take that component name value for all expected reports.

So, we end up with expected reports with all the same value name. And so, the actual reports get rejected. 

The main suprise that made me lose 2h is that the `reportId` is not defined at variable level in metadata (ie in technique `rootSection`, but in its parent section. So even after threading `reportId` everywhere, they still were `None` and so the problem was still there. 