### PR TITLE
Fixes #19319: When editing files with the technique editor resources manager, newlines at the end of file are trimmed

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/SharedFilesAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/SharedFilesAPI.scala
@@ -154,8 +154,7 @@ class SharedFilesAPI(
       if (file.exists) {
         if (file.isRegularFile) {
           import net.liftweb.json.JsonDSL._
-          val fileContent: Seq[String] = file.lines(StandardCharsets.UTF_8).toSeq
-          val result = JObject(List(JField("result", fileContent.mkString("\n"))))
+          val result = JObject(List(JField("result", file.contentAsString(StandardCharsets.UTF_8))))
           JsonResponse(result, List(), List(), 200).succeed
         } else {
           Unexpected(s"File '${file.name}' is not a regular file").fail

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates/angular/technique-editor-filemanager/modals.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates/angular/technique-editor-filemanager/modals.html
@@ -218,7 +218,7 @@
             <div class="modal-body">
                 <label class="radio bold">{{ singleSelection().model.fullPath() }}</label>
                 <span class="label label-warning" ng-show="apiMiddleware.apiHandler.inprocess">{{'loading' | translate}} ...</span>
-                <textarea class="form-control code" ng-model="singleSelection().tempModel.content" ng-show="!apiMiddleware.apiHandler.inprocess" autofocus="autofocus"></textarea>
+                <textarea class="form-control code" ng-model="singleSelection().tempModel.content" ng-show="!apiMiddleware.apiHandler.inprocess" autofocus="autofocus" ng-trim="false"></textarea>
                 <div ng-include data-src="'error-bar'" class="clearfix"></div>
             </div>
             <div class="modal-footer">


### PR DESCRIPTION
https://issues.rudder.io/issues/19319