### PR TITLE
Fixes #20886: Add name for spring security main auth configuration bean to be used by oauth2 

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/resources/applicationContext-security.xml
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/applicationContext-security.xml
@@ -58,7 +58,8 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <csrf disabled="true"/>
     </http>
 
-    <http use-expressions="true" disable-url-rewriting="true">
+    <http use-expressions="true" disable-url-rewriting="true" name="mainHttpSecurityFilters">
+
         <csrf disabled="true"/>
         <session-management session-fixation-protection="migrateSession">
           <!--
@@ -99,6 +100,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
         />
 <!--        <remember-me />-->
 
+      <!--authorization-code/callback-->
     </http>
 
 
@@ -106,6 +108,4 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       Other authentication beans, especially <authentication-manager>,
       are defined or imported in class bootstrap.liftweb.AppConfigAuth
     -->
-
-
 </beans:beans>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -450,7 +450,7 @@ class AuthBackendProvidersManager() extends DynamicRudderProviderManager {
   }
 
   /*
-   * get the list of providers currently configured by user. Array because used from spring
+   * set the list of providers currently configured by user. Array because used from spring
    */
   def setConfiguredProviders(providers: Array[AuthenticationMethods]): Unit = {
     this.authenticationMethods = providers

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderProviderManager.java
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderProviderManager.java
@@ -55,8 +55,8 @@ public class RudderProviderManager implements AuthenticationManager, MessageSour
 	private AuthenticationManager parent;
 	private boolean eraseCredentialsAfterAuthentication = true;
 
-    // the rudder provider
-    private DynamicRudderProviderManager dynamicProvider;
+  // the rudder provider
+  private DynamicRudderProviderManager dynamicProvider;
 
 	public RudderProviderManager(DynamicRudderProviderManager dynamicProvider) {
 	    this.dynamicProvider = dynamicProvider;


### PR DESCRIPTION
https://issues.rudder.io/issues/20886

We need to set a name to the main http configuration filter chain so that we can change it programmatically in a plugin at runtime to add Oauthv2 filters 