### PR TITLE
Fixes #20943: Rudder incorectly parse URL with a '+' in the path into spaces

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
@@ -12,8 +12,8 @@ response:
       "data":{
         "nodes":[
           {
-            "id":"root",
-            "hostname":"server.rudder.local",
+            "id":"node1",
+            "hostname":"node1.localhost",
             "status":"accepted"
           }
         ]
@@ -33,64 +33,120 @@ response:
       "data":{
         "nodes":[
           {
-            "id":"root",
-            "hostname":"server.rudder.local",
+            "id":"node1",
+            "hostname":"node1.localhost",
             "status":"accepted",
             "state":"enabled",
             "os":{
               "type":"Linux",
               "name":"Debian",
-              "version":"9.4",
-              "fullName":"Stretch",
-              "kernelVersion":"4.5"
+              "version":"10.6",
+              "fullName":"Buster",
+              "kernelVersion":"4.19"
             },
+            "ram":1,
             "machine":{
               "id":"machine1",
               "type":"Virtual",
               "provider":"vbox"
             },
-            "ipAddresses":["127.0.0.1","192.168.0.100"],
+            "ipAddresses":[
+              "192.168.0.10"
+            ],
             "description":"",
             "lastInventoryDate":"2021-01-30 01:20",
             "policyServerId":"root",
-            "managementTechnology":[{
-              "name":"Rudder",
-              "version":"7.0.0",
-              "capabilities":[],
-              "nodeKind":"root",
-              "rootComponents":[
-                "rudder-db",
-                "rudder-inventory-endpoint",
-                "rudder-inventory-ldap",
-                "rudder-jetty",
-                "rudder-ldap",
-                "rudder-reports",
-                "rudder-server-root",
-                "rudder-webapp"
-              ]
-            }],
-            "properties":[],
-            "policyMode":"enforce",
-            "timezone":{"name":"UTC","offset":"+00"},
-            "environmentVariables":{"THE_VAR":"THE_VAR value!"},
-            "fileSystems":[{"name":"swap"}],
-            "managementTechnologyDetails":{"cfengineKeys":[],"cfengineUser":"root"},
-            "networkInterfaces":[],
+            "managementTechnology":[
+              {
+                "name":"Rudder",
+                "version":"6.2.0",
+                "capabilities":[
+
+                ],
+                "nodeKind":"node",
+                "rootComponents":[
+
+                ]
+              }
+            ],
+            "properties":[
+
+            ],
+            "policyMode":"default",
+            "environmentVariables":{
+              "THE_VAR":"THE_VAR value!"
+            },
+            "fileSystems":[
+              {
+                "name":"swap"
+              }
+            ],
+            "managementTechnologyDetails":{
+              "cfengineKeys":[
+
+              ],
+              "cfengineUser":"root"
+            },
+            "networkInterfaces":[
+
+            ],
             "software":[
-              {"name":"s09","version":"1.0"},
-              {"name":"s06","version":"1.0"},
-              {"name":"s05","version":"1.0"},
-              {"name":"s13","version":"1.0"},
-              {"name":"s08","version":"1.0"},
-              {"name":"s02","version":"1.0"},
-              {"name":"s03","version":"1.0"},
-              {"name":"s04","version":"1.0"},
-              {"name":"s10","version":"1.0"},
-              {"name":"s11","version":"1.0"},
-              {"name":"s12","version":"1.0"},
-              {"name":"s01","version":"1.0"},
-              {"name":"s00","version":"1.0"},
-              {"name":"s07","version":"1.0"}
+              {
+                "name":"s09",
+                "version":"1.0"
+              },
+              {
+                "name":"s06",
+                "version":"1.0"
+              },
+              {
+                "name":"s05",
+                "version":"1.0"
+              },
+              {
+                "name":"s13",
+                "version":"1.0"
+              },
+              {
+                "name":"s08",
+                "version":"1.0"
+              },
+              {
+                "name":"s02",
+                "version":"1.0"
+              },
+              {
+                "name":"s03",
+                "version":"1.0"
+              },
+              {
+                "name":"s04",
+                "version":"1.0"
+              },
+              {
+                "name":"s10",
+                "version":"1.0"
+              },
+              {
+                "name":"s11",
+                "version":"1.0"
+              },
+              {
+                "name":"s12",
+                "version":"1.0"
+              },
+              {
+                "name":"s01",
+                "version":"1.0"
+              },
+              {
+                "name":"s00",
+                "version":"1.0"
+              },
+              {
+                "name":"s07",
+                "version":"1.0"
+              }
             ]
           }
         ]

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -1384,7 +1384,7 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     )).runNow
 
     def getGenericOne[A](id: NodeId, status: InventoryStatus, f:NodeDetails => Option[A]): IOResult[Option[A]] = {
-      nodeBase.get.map(_.collectFirst { case(id, n) if (id == id && n.nInv.main.status == status && f(n).isDefined) => f(n).get })
+      nodeBase.get.map(_.collectFirst { case(i, n) if (i == id && n.nInv.main.status == status && f(n).isDefined) => f(n).get })
     }
     def getGenericAll[A](status: InventoryStatus, f:NodeDetails => Option[A]): IOResult[Map[NodeId, A]] = {
       nodeBase.get.map(_.collect { case(id, n) if(n.nInv.main.status == status && f(n).isDefined) => (id, f(n).get) })

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestPlusInPath.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestPlusInPath.scala
@@ -1,0 +1,107 @@
+/*
+*************************************************************************************
+* Copyright 2022 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.rest
+
+import com.normation.inventory.domain.AcceptedInventory
+import com.normation.inventory.domain.NodeInventory
+import com.normation.inventory.domain.NodeSummary
+import com.normation.rudder.NodeDetails
+
+import org.junit.runner.RunWith
+import org.specs2.mutable._
+import org.specs2.runner.JUnitRunner
+import net.liftweb.common.Full
+import net.liftweb.http.InMemoryResponse
+import net.liftweb.mocks.MockHttpServletRequest
+import org.specs2.specification.BeforeAfterAll
+
+import zio._
+import zio.syntax._
+import com.normation.zio._
+
+// test that the "+" in path is correctly kept as a "+", not changed into " "
+// See: https://issues.rudder.io/issues/20943
+
+@RunWith(classOf[JUnitRunner])
+class TestRestPlusInPath extends Specification with BeforeAfterAll {
+
+  // we are testing error cases, so we don't want to output error log for them
+  org.slf4j.LoggerFactory.getLogger("com.normation.rudder.rest.RestUtils").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.OFF)
+
+  import com.softwaremill.quicklens._
+  val myNode = RestTestSetUp.mockNodes.node1.modify(_.node.id.value).setTo("my+node").modify(_.hostname).setTo("my+node.rudder.local")
+  override def beforeAll(): Unit = {
+    val inventory = NodeInventory(NodeSummary(myNode.id, AcceptedInventory, "root", myNode.hostname, myNode.osDetails, myNode.policyServerId, myNode.keyStatus))
+    val details = NodeDetails(myNode, inventory, None)
+    ZioRuntime.unsafeRun(RestTestSetUp.mockNodes.nodeInfoService.nodeBase.update(nodes => (nodes+(myNode.id -> details)).succeed))
+  }
+
+  override def afterAll(): Unit = {
+    ZioRuntime.unsafeRun(RestTestSetUp.mockNodes.nodeInfoService.nodeBase.update(nodes => (nodes-(myNode.id)).succeed))
+  }
+
+
+  sequential
+
+  ///// tests ////
+
+  "A plus in the path part of the url should be kept as a plus" >> {
+    val mockReq = new MockHttpServletRequest("http://localhost:8080")
+    mockReq.method = "GET"
+    mockReq.path = "/api/latest/nodes/my+node" // should be kept
+    mockReq.queryString = "include=minimal"
+    mockReq.body   = ""
+    mockReq.headers = Map()
+    mockReq.contentType = "text/plain"
+
+    // authorize space in response formating
+    val expected =
+      """{"action":"nodeDetails","id":"my+node","result":"success","data":"""+
+      """{"nodes":[{"id":"my+node","hostname":"my+node.rudder.local","status":"accepted"}]}}"""
+
+
+    RestTestSetUp.execRequestResponse(mockReq)(response =>
+      response.map { r =>
+        val rr = r.toResponse.asInstanceOf[InMemoryResponse]
+        (rr.code, new String(rr.data, "UTF-8"))
+      } must beEqualTo(Full((200, expected)))
+    )
+
+  }
+
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/20943

When on API, correct back "+" that were changed inot " " by lift 

Also correct tests that were not returning the correct node :/