### PR TITLE
Fixes #20984: Two same envvar modulo a space at begining of name leads to LDAP error when saving inventory

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionReportUnmarshaller.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionReportUnmarshaller.scala
@@ -1176,13 +1176,14 @@ class FusionReportUnmarshaller(
   }
 
   def processEnvironmentVariable(ev : NodeSeq) : Option[EnvironmentVariable] = {
-    optText(ev\"KEY")  match {
-    case None =>
-      InventoryProcessingLogger.logEffect.debug("Ignoring entry Envs because tag KEY is empty")
-      InventoryProcessingLogger.logEffect.debug(ev.toString())
-      None
-    case Some(key) =>
-      Some (
+    // we need to keep the key exactly as it is, see https://issues.rudder.io/issues/20984
+    (ev\"KEY").text match {
+      case null | "" =>
+        InventoryProcessingLogger.logEffect.debug("Ignoring entry Envs because tag KEY is empty")
+        InventoryProcessingLogger.logEffect.debug(ev.toString())
+        None
+      case key => // even accept only blank key, if the OS accepted it
+        Some (
           EnvironmentVariable (
               name = key
               , value = optText(ev\"VAL")


### PR DESCRIPTION
https://issues.rudder.io/issues/20984