### PR TITLE
Fixes #20989: Serialization to JSON from compliance/rules api is really slow

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -846,7 +846,7 @@ object JsonResponseObjects {
 
   object JRReportType {
     def fromMap(percents: Map[String, Double]) = {
-      percents.map{ case (k, v) => JRReportType(k, v) }.toSeq
+      percents.toSeq.map{ case (k, v) => JRReportType(k, v) }
     }
   }
   final case class JRByRuleNodeCompliance(
@@ -1113,7 +1113,6 @@ trait RudderJsonEncoders {
   implicit val messageStatusReport: JsonEncoder[JRMessageStatusReport] = DeriveJsonEncoder.gen
   implicit val componentValueStatusReport: JsonEncoder[JRComponentValueStatusReport] = DeriveJsonEncoder.gen
   implicit val byRuleNodeCompliance: JsonEncoder[JRByRuleNodeCompliance] = DeriveJsonEncoder.gen
-  implicit lazy val optSeqJRByRuleComponentCompliance: JsonEncoder[Option[Seq[JRByRuleComponentCompliance]]] =  DeriveJsonEncoder.gen
 
   implicit lazy val byRuleComponentCompliance: JsonEncoder[JRByRuleComponentCompliance] = DeriveJsonEncoder.gen
   implicit val byRuleDirectiveCompliance: JsonEncoder[JRByRuleDirectiveCompliance] = DeriveJsonEncoder.gen

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/Compliance.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/Compliance.scala
@@ -35,17 +35,13 @@
 *************************************************************************************
 */
 
-package com.normation.rudder.rest.data
+package com.normation.rudder.domain.reports
 
-import net.liftweb.json._
-import com.normation.rudder.domain.reports._
-import net.liftweb.json.JsonDSL._
-import net.liftweb.json.JsonAST
-import com.normation.rudder.reports.ComplianceModeName
 import com.normation.inventory.domain.NodeId
-import com.normation.rudder.domain.policies.DirectiveId
-import com.normation.rudder.domain.policies.RuleId
-import com.normation.rudder.domain.reports.ComplianceLevel
+import com.normation.rudder.domain.policies.{DirectiveId, RuleId}
+import com.normation.rudder.reports.ComplianceModeName
+import net.liftweb.json.JsonDSL._
+import net.liftweb.json._
 
 
 
@@ -506,7 +502,7 @@ object JsonCompliance {
 
   }
 
-  private[this] def statusDisplayName(r: ReportType): String = {
+  def statusDisplayName(r: ReportType): String = {
     import ReportType._
 
     r match {
@@ -534,7 +530,7 @@ object JsonCompliance {
    * the semantic of unexpected / missing and no answer is not clear at all.
    *
    */
-  private[this] def percents(c: ComplianceLevel, precision: Int): Map[String, Double] = {
+  def percents(c: ComplianceLevel, precision: Int): Map[String, Double] = {
     import ReportType._
 
     //we want at most `precision` decimals

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -140,6 +140,7 @@ class ComplianceApi(
 
       (for {
         level <- restExtractor.extractComplianceLevel(req.params)
+        t0 <- currentTimeMillis.toBox
         precision <- restExtractor.extractPercentPrecision(req.params)
         id    <- RuleId.parse(ruleId).toBox
         rule  <- complianceService.getRuleCompliance(id, level)
@@ -152,6 +153,8 @@ class ComplianceApi(
           val t2            = System.currentTimeMillis
           TimingDebugLogger.trace(s"getRuleCompliance - getting  rule.toJson in ${t2 - t1} ms")
 machin
+          TimingDebugLogger.trace(s"getRuleCompliance v13 - total time before reponse  in ${t2 - t0} ms")
+          machin
         }
       }) match {
         case Full(rule) =>
@@ -170,10 +173,13 @@ machin
 
 
       (for {
+        t1      <- currentTimeMillis
         level     <- zioJsonExtractor.extractComplianceLevel(req.params).toIO
         precision <- zioJsonExtractor.extractPercentPrecision(req.params).toIO
         id        <- RuleId.parse(ruleId).toIO
         rule      <- complianceServiceV14.getRuleCompliance(id, level, precision)
+        t2      <- currentTimeMillis
+        _       <- TimingDebugLoggerPure.trace(s"getRuleCompliance V14 - making all ByRuleRuleCompliance in ${t2 - t1} ms")
       } yield rule).toLiftResponseOne(params, schema, s => Some(s.id))
     }
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1157,6 +1157,14 @@ object RudderConfig extends Loggable {
         , () => globalComplianceModeService.getGlobalComplianceMode
       )
 
+  private[this] val complianceAPIService14 = new ComplianceAPIService14(
+          roRuleRepository
+        , nodeInfoService
+        , roNodeGroupRepository
+        , reportingService
+        , roDirectiveRepository
+        , () => globalComplianceModeService.getGlobalComplianceMode
+      )
   val techniqueArchiver = new TechniqueArchiverImpl(gitConfigRepo, prettyPrinter, gitModificationRepository, personIdentService, RUDDER_GROUP_OWNER_CONFIG_REPO)
   val techniqueCompiler = new RudderCRunner("/opt/rudder/etc/rudderc.conf","/opt/rudder/bin/rudderc",RUDDER_GIT_ROOT_CONFIG_REPO)
   val ncfTechniqueWriter = new TechniqueWriter(
@@ -1316,7 +1324,7 @@ object RudderConfig extends Loggable {
     val groupInheritedProperties = new GroupApiInheritedProperties(roNodeGroupRepository, roLDAPParameterRepository)
 
     val modules = List(
-        new ComplianceApi(restExtractorService, complianceAPIService)
+        new ComplianceApi(restExtractorService, zioJsonExtractor, complianceAPIService, complianceAPIService14)
       , new GroupsApi(roLdapNodeGroupRepository, restExtractorService, zioJsonExtractor, stringUuidGenerator, groupApiService2, groupApiService6, groupApiService14, groupInheritedProperties)
       , new DirectiveApi(roDirectiveRepository, restExtractorService, zioJsonExtractor, stringUuidGenerator, directiveApiService2, directiveApiService14)
       , new NodeApi(restExtractorService, restDataSerializer, nodeApiService2, nodeApiService4, nodeApiService6, nodeApiService8, nodeApiService12, nodeApiService13, nodeInheritedProperties, RUDDER_DEFAULT_DELETE_NODE_MODE)


### PR DESCRIPTION
https://issues.rudder.io/issues/20989

Perf of API for compliance is not so great: about 3s to convert to JSON the object
So I figured: hey, why not switch to zio-json.
Hundreds of lines later, I have exactly the same perf between both, and the zio-json doesn't work as expected:
instead of "complianceDetails":{"noReport":100.0} I have "complianceDetails":[{"status":"noReport","value":100.0}]

and there's a loop in the tree of result, and it fails with an error too long for my terminal

Timings:
v13
[2022-04-14 20:16:54+0000] TRACE debug_timing - getRuleCompliance - getting  ByRuleRuleCompliance in 795 ms
[2022-04-14 20:16:56+0000] TRACE debug_timing - getRuleCompliance - getting  rule.toJson in 2560 ms
[2022-04-14 20:16:56+0000] TRACE debug_timing - getRuleCompliance v13 - total time before reponse  in 3355 ms

v14
[2022-04-14 20:17:12+0000] TRACE debug_timing - getRuleCompliance - getting  ByRuleRuleCompliance in 825 ms
[2022-04-14 20:17:15+0000] TRACE debug_timing - getRuleCompliance V14 - making all ByRuleRuleCompliance in 3601 ms

I suspect doing all these object is pretty costly