### PR TITLE
Fixes #20998: Performance of compliance computation in ComplianceLevel can be improved

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/TestComplianceLevel.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/TestComplianceLevel.scala
@@ -41,6 +41,8 @@ import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
+import scala.collection.mutable.ArrayBuffer
+
 
 /**
  * Test properties about Compliance Level,
@@ -57,18 +59,24 @@ class TestComplianceLevel extends Specification {
 
     "sort smallest first" in {
 
-      val c = ComplianceLevel(12,1,3,4,9,11,0,8,5,2,6,13,10,7)
+      val c = ComplianceLevel(12, 1, 3, 4, 9, 11, 0, 8, 5, 2, 6, 13, 10, 7)
 
-      CompliancePercent.sortLevels(c).map(_._1) === List(0,1,2,3,4,5,6,7,8,9,10,11,12,13)
+      CompliancePercent.sortLevels(c).map(_._1) === List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
 
     }
 
     "sort equals in order of worse last" in {
-      val c = ComplianceLevel(4,4,4,4,9,11,1,4,5,2,6,13,10,7)
+      val c = ComplianceLevel(4, 4, 4, 4, 9, 11, 1, 4, 5, 2, 6, 13, 10, 7)
       // interresting part is the 5 '4', where:
       // (4, 7 = not applicable) < (4, 1 = success) < (4, 0 = pending) < (4, 2 = repaired) < (4, 3 = error)
       CompliancePercent.sortLevels(c) ===
-      List((1,6), (2,9), (4,7), (4,1), (4,0), (4,2), (4,3), (5,8), (6,10), (7,13), (9,4), (10,12), (11,5), (13,11))
+        List((1, 6), (2, 9), (4, 7), (4, 1), (4, 0), (4, 2), (4, 3), (5, 8), (6, 10), (7, 13), (9, 4), (10, 12), (11, 5), (13, 11))
+    }
+
+    "sort error after missing " in {
+      val c = ComplianceLevel(0, 2, 0, 2, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0)
+      CompliancePercent.sortLevels(c) ===
+        List((0,7), (0,10), (0,9), (0,0), (0,8), (0,6), (0,2), (0,11), (0,12), (0,4), (0,13), (2,1), (2,5), (2,3))
     }
   }
 
@@ -95,23 +103,220 @@ class TestComplianceLevel extends Specification {
 
   }
 
-  "compliance when there is no report is 0" >> {
+  "new compliance system must never be rounded below its precision" >> {
 
-    ComplianceLevel().computePercent().compliance === 0
+    "which is 0.01 by default" >> {
+      val c = ComplianceLevel(success = 1, error = 100000)
+      val pc = c.computeCorrectPercent()
+      (pc.repaired === 0) and (pc.success === 0.01) and (pc.error === 99.99)
+    }
+
+    "and can be 0" >> {
+      val c = ComplianceLevel(success = 1, error = 100000)
+      val pc = CompliancePercent.correctFromLevels(c, 0)
+      (pc.repaired === 0) and (pc.success === 1) and (pc.error === 99)
+    }
+
+    "or a lot" >> {
+      val c = ComplianceLevel(success = 1, error = 1000000000)
+      val pc = CompliancePercent.correctFromLevels(c, 5)
+      (pc.repaired === 0) and (pc.success === 0.00001) and (pc.error === 99.99999)
+    }
+
+  }
+  "compliance when there is no report is 0" >> {
+    ComplianceLevel().computeCorrectPercent().compliance === 0
   }
 
-  "Compliance must sum to 100 percent" >> {
+  "Compliance with old method must sum to 100 percent" >> {
 
     "when using default precision" >> {
-      val c = ComplianceLevel(0,1,1,1)
+      val c = ComplianceLevel(0, 1, 1, 1)
       val pc = c.computePercent()
       (pc.success === 33.33) and (pc.repaired === 33.33) and (pc.error === 33.34)
     }
 
+    "when using default precision and having ignore pending" >> {
+      val c = ComplianceLevel(12, 1, 1, 1)
+      val pc = c.withoutPending.computePercent()
+      (pc.success === 33.33) and (pc.repaired === 33.33) and (pc.error === 33.34)
+    }
+
     "when using 0 digits" >> {
-      val c = ComplianceLevel(0,1,1,1)
+      val c = ComplianceLevel(0, 1, 1, 1)
       val pc = c.computePercent(0)
       (pc.success === 33) and (pc.repaired === 33) and (pc.error === 34)
+    }
+
+    "when using 0 digits and ignoring pending" >> {
+      val c = ComplianceLevel(5, 1, 1, 1)
+      val pc = c.withoutPending.computePercent(0)
+      (pc.success === 33) and (pc.repaired === 33) and (pc.error === 34)
+    }
+
+    "when using 0 digits and ignoring pending with small error" >> {
+      val c = ComplianceLevel(5, 1000, 1000, 1)
+      val pc = c.withoutPending.computePercent(0)
+      (pc.success === 50) and (pc.repaired === 49) and (pc.error === 1)
+    }
+
+    " when using 0 digits, should round keep ordering" >> {
+      val c = ComplianceLevel(0, 200, 199, 1, 1, 1, 1)
+      val pc = c.withoutPending.computePercent(0)
+      (pc.success === 50) and (pc.repaired === 49) and (pc.error === 1) and (pc.unexpected === 1) and (pc.missing === 1)
+    }
+  }
+
+  "Compliance with correct method must sum to 100 percent" >> {
+
+    "when using default precision" >> {
+      val c = ComplianceLevel(0, 1, 1, 1)
+      println("****************************************")
+      val pc = c.computeCorrectPercent()
+      val compliance = c.complianceWithoutPending()
+
+      (pc.success === 33.33) and (pc.repaired === 33.33) and (pc.error === 33.34) and (compliance === 66.66)
+    }
+
+    "when using default precision and having ignore pending" >> {
+      val c = ComplianceLevel(12, 1, 1, 1)
+      val pc = c.withoutPending.computeCorrectPercent()
+      val compliance = c.complianceWithoutPending()
+      (pc.success === 33.33) and (pc.repaired === 33.33) and (pc.error === 33.34) and (compliance === 66.66)
+    }
+
+    "when using 0 digits" >> {
+      val c = ComplianceLevel(0, 1, 1, 1)
+      val pc = c.computeCorrectPercent(0)
+      val compliance = c.complianceWithoutPending()
+      (pc.success === 33) and (pc.repaired === 33) and (pc.error === 34) and (compliance === 66)
+    }
+
+    "when using 0 digits and ignoring pending" >> {
+      val c = ComplianceLevel(5, 1, 1, 1)
+      val pc = c.withoutPending.computeCorrectPercent(0)
+      val compliance = c.complianceWithoutPending()
+      (pc.success === 33) and (pc.repaired === 33) and (pc.error === 34) and (compliance === 66)
+    }
+
+    "when using 0 digits and ignoring pending with small error" >> {
+      val c = ComplianceLevel(5, 1000, 1000, 1)
+      val pc = c.withoutPending.computeCorrectPercent(0)
+      val compliance = c.complianceWithoutPending()
+      (pc.success === 49) and (pc.repaired === 50) and (pc.error === 1) and (compliance === 99)
+    }
+
+    " when using 0 digits, should round keep ordering" >> {
+      val c = ComplianceLevel(0, 200, 199, 1, 1, 1, 1)
+      val pc = c.withoutPending.computeCorrectPercent(0)
+      val compliance = c.complianceWithoutPending()
+      println(pc)
+      (pc.success === 49) and (pc.repaired === 47) and (pc.error === 1) and (pc.unexpected === 1) and (pc.missing === 1) and (compliance === 96)
+    }
+  }
+
+  "Compliance computation must" >> {
+    "return 66.66 with default precision" >> {
+      val c = ComplianceLevel(0, 1, 1, 1)
+      val pc = c.computePercent().compliance
+      pc === 66.66
+    }
+    "when not round up the error with default precision" >> {
+      val c = ComplianceLevel(0, 1, 1, 4)
+      val pc = c.computePercent().compliance
+      pc === 33.34
+    }
+    "when not round up the error with default precision and ignoring pending" >> {
+      val c = ComplianceLevel(1, 2, 2, 8)
+      val pc = c.withoutPending.computePercent().compliance
+      pc === 33.34
+    }
+    "return correctly rounded values" >> {
+      val c = ComplianceLevel(0, 1000, 1000, 1)
+      val pc = c.computePercent().compliance
+      pc === 99.95
+    }
+
+    "when not round up the error with default precision and ignoring pending using direct computation" >> {
+      val c = ComplianceLevel(1, 2, 2, 8)
+      val pc = c.withoutPending.computePercent().compliance
+      pc === 33.34
+    }
+    "return correctly with direct computation and rounded values" >> {
+      val c = ComplianceLevel(0, 1000, 1000, 1)
+      val pc = c.complianceWithoutPending()
+      pc === 99.95
+    }
+  }
+
+  "Compliance without pending computation must" >> {
+    val complianceLevel:ArrayBuffer[ComplianceLevel] = new ArrayBuffer[ComplianceLevel](100000)
+    "return the same" >> {
+      println("starting list")
+      for (s <- 0 to 9) {
+        for (r <- 0 to 9) {
+          for (e <- 0 to 9) {
+            for (m <- 0 to 9) {
+              for (nc <- 0 to 9) {
+                complianceLevel.addOne(ComplianceLevel(success = s, repaired = r, error = e, missing = m, nonCompliant = nc))
+              }
+            }
+          }
+        }
+      }
+      println("arraybuffer completed")
+
+
+      // dummy completion to supercharge
+      var equals = true
+      for (s <- 0 to 9) {
+        for (r <- 0 to 9) {
+          for (e <- 0 to 9) {
+            for (m <- 0 to 9) {
+              val c = ComplianceLevel(success = (s+2), repaired = r, error = e, missing = m)
+              if ((c.computePercent().compliance) != CompliancePercent.correctFromLevels(c, 2).compliance) {
+                equals = false
+              //  println(s"${(c.computePercent().compliance)} is not ${CompliancePercent.correctFromLevels(c, 2).compliance} ")
+              }
+            }
+          }
+        }
+      }
+
+
+      // ease on the GC
+      System.gc()
+
+      val t0 = System.nanoTime
+      val source = complianceLevel.map(_.computePercent().compliance)
+      val t1 = System.nanoTime
+      // ease on the GC
+      System.gc()
+      val t4 = System.nanoTime
+      val destination2 = complianceLevel.map(_.computeCorrectPercent().compliance)
+      val t5 = System.nanoTime
+
+      /*
+      // ease on the GC
+      System.gc()
+      val t2 = System.nanoTime
+      val destination = complianceLevel.map(_.complianceWithoutPending())
+      val t3 = System.nanoTime
+*/
+
+
+
+      println(s"Historic compliance computation for ${source.size} completed in ${(t1-t0)/1000} µs")
+
+
+
+//      println(s"Direct compliance computation for ${destination.size} completed in ${(t3-t2)/1000} µs")
+
+      println(s"Correct compliance computation for ${destination2.size} completed in ${(t5-t4)/1000} µs")
+
+      (equals === true)
+      //and (source === destination)
+
     }
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -109,6 +109,7 @@ import com.normation.rudder.domain.properties.InheritMode
 import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.domain.properties.PropertyProvider
 import com.normation.rudder.domain.queries.QueryTrait
+import com.normation.rudder.domain.reports.CompliancePrecision
 import com.normation.rudder.ncf.MethodBlock
 import com.normation.rudder.ncf.ParameterType.ParameterTypeService
 import com.normation.rudder.services.policies.PropertyParser
@@ -765,14 +766,20 @@ final case class RestExtractorService (
         }
     }
   }
-  def extractPercentPrecision(params: Map[String, List[String]]) : Box[Option[Int]] = {
+  def extractPercentPrecision(params: Map[String, List[String]]) : Box[Option[CompliancePrecision]] = {
     params.get("precision") match {
       case None | Some(Nil) => Full(None)
       case Some(h :: tail) => //only take into account the first level param is several are passed
-        try { Full(Some(h.toInt)) }
-        catch {
-          case ex:NumberFormatException => Failure(s"percent precison must be an integer, was: '${h}'")
+        for {
+          extracted <-  try { Full(h.toInt) }
+                        catch {
+                          case ex:NumberFormatException => Failure(s"percent precison must be an integer, was: '${h}'")
+                        }
+          level      <- CompliancePrecision.fromPrecision(extracted)
+        } yield {
+          Some(level)
         }
+
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
@@ -275,7 +275,7 @@ object JsonCompliance {
   //global compliance
 
   implicit class JsonGlobalCompliance(val optCompliance: Option[(ComplianceLevel, Long)]) extends AnyVal {
-    def toJson(precision: Int): JValue = {
+    def toJson(precision: CompliancePrecision): JValue = {
       optCompliance match {
         case Some((details, value)) =>
           ( "globalCompliance" -> (
@@ -296,9 +296,9 @@ object JsonCompliance {
     def toJsonV6 = (
         ("id" -> rule.id.serialize)
       ~ ("name" -> rule.name)
-      ~ ("compliance" -> rule.compliance.withoutPending.computeCorrectPercent().compliance)
-      ~ ("complianceDetails" -> percents(rule.compliance, 2))
-      ~ ("directives" -> directives(rule.directives, 10, 2) )
+      ~ ("compliance" -> rule.compliance.complianceWithoutPending())
+      ~ ("complianceDetails" -> percents(rule.compliance, CompliancePrecision.Level2))
+      ~ ("directives" -> directives(rule.directives, 10, CompliancePrecision.Level2) )
     )
 
     /*
@@ -309,7 +309,7 @@ object JsonCompliance {
      * - 4 and up: rules, directives, components, node and component values
      */
 
-    def toJson(level: Int, precision: Int) = (
+    def toJson(level: Int, precision: CompliancePrecision) = (
         ("id" -> rule.id.serialize)
       ~ ("name" -> rule.name)
       ~ ("compliance" -> rule.compliance.complianceWithoutPending(precision))
@@ -319,7 +319,7 @@ object JsonCompliance {
       ~ ("nodes" -> byNodes(rule.nodes, level, precision) )
     )
 
-    private[this] def directives(directives: Seq[ByRuleDirectiveCompliance], level: Int, precision: Int): Option[JsonAST.JValue] = {
+    private[this] def directives(directives: Seq[ByRuleDirectiveCompliance], level: Int, precision: CompliancePrecision): Option[JsonAST.JValue] = {
       if(level < 2) None
       else Some( directives.map { directive =>
         (
@@ -331,7 +331,7 @@ object JsonCompliance {
         )
        })
     }
-    private[this] def byNodes(nodes: Seq[ByRuleByNodeCompliance], level: Int, precision: Int): Option[JsonAST.JValue] = {
+    private[this] def byNodes(nodes: Seq[ByRuleByNodeCompliance], level: Int, precision: CompliancePrecision): Option[JsonAST.JValue] = {
       if(level < 2) None
       else Some( nodes.map { node =>
         (
@@ -344,7 +344,7 @@ object JsonCompliance {
       })
     }
 
-    private[this] def byNodesByDirectives(directives: Seq[ByRuleByNodeByDirectiveCompliance], level: Int, precision: Int): Option[JsonAST.JValue] = {
+    private[this] def byNodesByDirectives(directives: Seq[ByRuleByNodeByDirectiveCompliance], level: Int, precision: CompliancePrecision): Option[JsonAST.JValue] = {
       if(level < 3) None
       else Some( directives.map { directive =>
         (
@@ -356,7 +356,7 @@ object JsonCompliance {
           )
       })
     }
-    private[this] def components(comps: Seq[ByRuleComponentCompliance], level: Int, precision: Int): Option[JsonAST.JValue] = {
+    private[this] def components(comps: Seq[ByRuleComponentCompliance], level: Int, precision: CompliancePrecision): Option[JsonAST.JValue] = {
       if(level < 3) None
       else Some(comps.map { component =>
         (
@@ -373,7 +373,7 @@ object JsonCompliance {
       })
     }
 
-    private[this] def byNodeByDirectiveByComponents(comps: Seq[ByRuleByNodeByDirectiveByComponentCompliance], level: Int, precision: Int): Option[JsonAST.JValue] = {
+    private[this] def byNodeByDirectiveByComponents(comps: Seq[ByRuleByNodeByDirectiveByComponentCompliance], level: Int, precision: CompliancePrecision): Option[JsonAST.JValue] = {
       if(level < 4) None
       else Some(comps.map { component =>
         (
@@ -404,7 +404,7 @@ object JsonCompliance {
           )
       })
     }
-    private[this] def nodes(nodes: Seq[ByRuleNodeCompliance], level: Int, precision: Int): Option[JsonAST.JValue] = {
+    private[this] def nodes(nodes: Seq[ByRuleNodeCompliance], level: Int, precision: CompliancePrecision): Option[JsonAST.JValue] = {
       if(level < 4) None
       else Some(nodes.map { node =>
         (
@@ -424,8 +424,8 @@ object JsonCompliance {
     def toJsonV6 = (
         ("id" -> n.id.value)
       ~ ("compliance" -> n.compliance.complianceWithoutPending())
-      ~ ("complianceDetails" -> percents(n.compliance, 2))
-      ~ ("rules" -> rules(n.nodeCompliances, 10, 2))
+      ~ ("complianceDetails" -> percents(n.compliance, CompliancePrecision.Level2))
+      ~ ("rules" -> rules(n.nodeCompliances, 10, CompliancePrecision.Level2))
     )
 
     /*
@@ -437,7 +437,7 @@ object JsonCompliance {
      * - 5 and up: nodes, rules, directives, components and component values
      */
 
-    def toJson(level: Int, precision: Int) = (
+    def toJson(level: Int, precision: CompliancePrecision) = (
         ("id" -> n.id.value)
       ~ ("name" -> n.name)
       ~ ("compliance" -> n.compliance.complianceWithoutPending(precision))
@@ -446,7 +446,7 @@ object JsonCompliance {
       ~ ("rules" -> rules(n.nodeCompliances, level, precision))
     )
 
-    private[this] def rules(rules: Seq[ByNodeRuleCompliance], level: Int, precision: Int): Option[JsonAST.JValue] = {
+    private[this] def rules(rules: Seq[ByNodeRuleCompliance], level: Int, precision: CompliancePrecision): Option[JsonAST.JValue] = {
       if(level < 2) None
       else Some(rules.map { rule =>
         (
@@ -459,7 +459,7 @@ object JsonCompliance {
       })
     }
 
-    private[this] def directives(directives: Seq[ByNodeDirectiveCompliance], level: Int, precision: Int): Option[JsonAST.JValue] = {
+    private[this] def directives(directives: Seq[ByNodeDirectiveCompliance], level: Int, precision: CompliancePrecision): Option[JsonAST.JValue] = {
       if(level < 3) None
       else Some(directives.map { directive =>
         (
@@ -472,7 +472,7 @@ object JsonCompliance {
       })
     }
 
-    private[this] def components(comps: Map[String, ComponentStatusReport], level: Int, precision: Int): Option[JsonAST.JValue] = {
+    private[this] def components(comps: Map[String, ComponentStatusReport], level: Int, precision: CompliancePrecision): Option[JsonAST.JValue] = {
       if(level < 4) None
       else Some(comps.map { case (_, component) =>
         (
@@ -534,11 +534,11 @@ object JsonCompliance {
    * the semantic of unexpected / missing and no answer is not clear at all.
    *
    */
-  private[this] def percents(c: ComplianceLevel, precision: Int): Map[String, Double] = {
+  private[this] def percents(c: ComplianceLevel, precision: CompliancePrecision): Map[String, Double] = {
     import ReportType._
 
     //we want at most `precision` decimals
-    val pc = CompliancePercent.correctFromLevels(c, precision)
+    val pc = CompliancePercent.fromLevels(c, precision)
     Map(
         statusDisplayName(EnforceNotApplicable) -> pc.notApplicable
       , statusDisplayName(EnforceSuccess) -> pc.success

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
@@ -296,7 +296,7 @@ object JsonCompliance {
     def toJsonV6 = (
         ("id" -> rule.id.serialize)
       ~ ("name" -> rule.name)
-      ~ ("compliance" -> rule.compliance.withoutPending.computePercent().compliance)
+      ~ ("compliance" -> rule.compliance.withoutPending.computeCorrectPercent().compliance)
       ~ ("complianceDetails" -> percents(rule.compliance, 2))
       ~ ("directives" -> directives(rule.directives, 10, 2) )
     )
@@ -312,7 +312,7 @@ object JsonCompliance {
     def toJson(level: Int, precision: Int) = (
         ("id" -> rule.id.serialize)
       ~ ("name" -> rule.name)
-      ~ ("compliance" -> rule.compliance.withoutPending.computePercent().compliance)
+      ~ ("compliance" -> rule.compliance.complianceWithoutPending(precision))
       ~ ("mode" -> rule.mode.name)
       ~ ("complianceDetails" -> percents(rule.compliance, precision))
       ~ ("directives" -> directives(rule.directives, level, precision) )
@@ -325,7 +325,7 @@ object JsonCompliance {
         (
             ("id" -> directive.id.serialize)
           ~ ("name" -> directive.name)
-          ~ ("compliance" -> directive.compliance.withoutPending.computePercent().compliance)
+          ~ ("compliance" -> directive.compliance.complianceWithoutPending(precision))
           ~ ("complianceDetails" -> percents(directive.compliance, precision))
           ~ ("components" -> components(directive.components, level, precision))
         )
@@ -337,7 +337,7 @@ object JsonCompliance {
         (
           ("id" -> node.id.value)
             ~ ("name" -> node.name)
-            ~ ("compliance" -> node.compliance.withoutPending.computePercent().compliance)
+            ~ ("compliance" -> node.compliance.complianceWithoutPending(precision))
             ~ ("complianceDetails" -> percents(node.compliance, precision))
             ~ ("directives" -> byNodesByDirectives(node.directives, level, precision))
           )
@@ -350,7 +350,7 @@ object JsonCompliance {
         (
           ("id" -> directive.id.serialize)
             ~ ("name" -> directive.name)
-            ~ ("compliance" -> directive.compliance.withoutPending.computePercent().compliance)
+            ~ ("compliance" -> directive.compliance.complianceWithoutPending(precision))
             ~ ("complianceDetails" -> percents(directive.compliance, precision))
             ~ ("components" -> byNodeByDirectiveByComponents(directive.components, level, precision))
           )
@@ -361,7 +361,7 @@ object JsonCompliance {
       else Some(comps.map { component =>
         (
             ("name" -> component.name)
-          ~ ("compliance" -> component.compliance.withoutPending.computePercent().compliance)
+          ~ ("compliance" -> component.compliance.complianceWithoutPending(precision))
           ~ ("complianceDetails" -> percents(component.compliance, precision))
           ~ (component match {
               case component : ByRuleBlockCompliance =>
@@ -378,7 +378,7 @@ object JsonCompliance {
       else Some(comps.map { component =>
         (
           ("name" -> component.name)
-            ~ ("compliance" -> component.compliance.withoutPending.computePercent().compliance)
+            ~ ("compliance" -> component.compliance.complianceWithoutPending(precision))
             ~ ("complianceDetails" -> percents(component.compliance, precision))
             ~ (component match {
             case component : ByRuleByNodeByDirectiveByBlockCompliance =>
@@ -410,7 +410,7 @@ object JsonCompliance {
         (
             ("id" -> node.id.value)
           ~ ("name" -> node.name)
-          ~ ("compliance" -> node.compliance.withoutPending.computePercent().compliance)
+          ~ ("compliance" -> node.compliance.complianceWithoutPending(precision))
           ~ ("complianceDetails" -> percents(node.compliance, precision))
           ~ ("values" -> values(node.values, level))
         )
@@ -423,7 +423,7 @@ object JsonCompliance {
   implicit class JsonByNodeCompliance(val n: ByNodeNodeCompliance) extends AnyVal {
     def toJsonV6 = (
         ("id" -> n.id.value)
-      ~ ("compliance" -> n.compliance.withoutPending.computePercent().compliance)
+      ~ ("compliance" -> n.compliance.complianceWithoutPending())
       ~ ("complianceDetails" -> percents(n.compliance, 2))
       ~ ("rules" -> rules(n.nodeCompliances, 10, 2))
     )
@@ -440,7 +440,7 @@ object JsonCompliance {
     def toJson(level: Int, precision: Int) = (
         ("id" -> n.id.value)
       ~ ("name" -> n.name)
-      ~ ("compliance" -> n.compliance.withoutPending.computePercent().compliance)
+      ~ ("compliance" -> n.compliance.complianceWithoutPending(precision))
       ~ ("mode" -> n.mode.name)
       ~ ("complianceDetails" -> percents(n.compliance, precision))
       ~ ("rules" -> rules(n.nodeCompliances, level, precision))
@@ -452,7 +452,7 @@ object JsonCompliance {
         (
             ("id" -> rule.id.serialize)
           ~ ("name" -> rule.name)
-          ~ ("compliance" -> rule.compliance.withoutPending.computePercent().compliance)
+          ~ ("compliance" -> rule.compliance.complianceWithoutPending(precision))
           ~ ("complianceDetails" -> percents(rule.compliance, precision))
           ~ ("directives" -> directives(rule.directives, level, precision))
        )
@@ -465,7 +465,7 @@ object JsonCompliance {
         (
             ("id" -> directive.id.serialize)
           ~ ("name" -> directive.name)
-          ~ ("compliance" -> directive.compliance.withoutPending.computePercent().compliance)
+          ~ ("compliance" -> directive.compliance.complianceWithoutPending(precision))
           ~ ("complianceDetails" -> percents(directive.compliance, precision))
           ~ ("components" -> components(directive.components, level, precision))
         )
@@ -477,7 +477,7 @@ object JsonCompliance {
       else Some(comps.map { case (_, component) =>
         (
             ("name" -> component.componentName)
-          ~ ("compliance" -> component.compliance.withoutPending.computePercent().compliance)
+          ~ ("compliance" -> component.compliance.complianceWithoutPending(precision))
           ~ ("complianceDetails" -> percents(component.compliance, precision))
           ~ (component match {
               case component : BlockStatusReport =>
@@ -538,7 +538,7 @@ object JsonCompliance {
     import ReportType._
 
     //we want at most `precision` decimals
-    val pc = CompliancePercent.fromLevels(c, precision)
+    val pc = CompliancePercent.correctFromLevels(c, precision)
     Map(
         statusDisplayName(EnforceNotApplicable) -> pc.notApplicable
       , statusDisplayName(EnforceSuccess) -> pc.success


### PR DESCRIPTION
https://issues.rudder.io/issues/20998

This PR revisits the way ComplianceLevel are computed, to make it faster, and to fix issue in specific cases (ex,  200 succes, 199 repaired, 1 error, 1 missing, 1 unexpected , 1 non compliancere gives 47% success and 50% repaired with 0 precision)

All in all, the computation is ~4 times faster, mainly by using Long computation rather than BigDecimal
The drawback is that we can't go further than precision 5 (I can't seem to see which use case would need more than that), so computation are made using Long, by multiplying with the power of ten, and then truncating.

It also introduces a method to compute compliance directly without pending result, so that we can skip the duplication of ComplianceLevel and the creation of a CompliantPercent

It is *not* enough to make the display of the Nodes list instantaneous in the Rule detail page, but my tests show it's twice as fast as before. Unfortunately the way it's done computed twice by level the compliance (once without pending, and one with pending), and it's made for the Rule, and then each Directives and Nodes, and then for each components, etc etc.
The API answers on my test platform in 2.4s (from 4.5s before) - removing all compliance computation makes it answer in 1s (which is the cost of getting the Groups and Rules) 