### PR TITLE
Fixes #21028: The way groups are fetched when responding to API compliance is inefficient

### DIFF
--- a/api-doc/Dockerfile
+++ b/api-doc/Dockerfile
@@ -5,5 +5,5 @@ ARG USER_ID=1000
 COPY ci/user.sh .
 RUN ./user.sh $USER_ID
 
-RUN npm install --global @redocly/openapi-cli@1.0.0-beta.69 redoc-cli@0.13.0
+RUN npm install --global @redocly/openapi-cli@1.0.0-beta.79 redoc-cli@0.13.2
 RUN apt-get update && apt-get install -y rsync python3-yaml && rm -rf /var/lib/apt/lists/*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
@@ -230,6 +230,12 @@ trait RoNodeGroupRepository {
   def getAll() : IOResult[Seq[NodeGroup]]
 
   /**
+   * Get all the node group id and the set of ndoes within
+   * Goal is to be more efficient
+   */
+  def getAllNodeIds(): IOResult[Map[NodeGroupId, Set[NodeId]]]
+
+  /**
    * Get all pairs of (category details, Set(node groups) )
    * in a map in which keys are the parent category of the groups.
    * The map is sorted by category:
@@ -314,6 +320,16 @@ trait RoNodeGroupRepository {
    */
   def getAllNonSystemCategories() : IOResult[Seq[NodeGroupCategory]]
 
+}
+
+object RoNodeGroupRepository {
+  /**
+   * Return all node ids that match the set of target.
+   */
+  def getNodeIds(allGroups: Map[NodeGroupId, Set[NodeId]], targets: Set[RuleTarget], allNodeInfos: Map[NodeId, NodeInfo]) : Set[NodeId] = {
+    val allNodes = allNodeInfos.view.mapValues { x => (x.isPolicyServer, x.serverRoles) }
+    RuleTarget.getNodeIds(targets, allNodes.toMap, allGroups)
+  }
 }
 
 trait WoNodeGroupRepository {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -610,6 +610,20 @@ class LDAPEntityMapper(
     }
   }
 
+  // Lightweight implementation, returns only the nodegroupid, and list of nodes
+  def entryToGroupNodeIds(e:LDAPEntry) : InventoryMappingPure[(NodeGroupId, Set[NodeId])] = {
+    if(e.isA(OC_RUDDER_NODE_GROUP)) {
+      for {
+        id <- e.required(A_NODE_GROUP_UUID)
+        nodeIds = e.valuesFor(A_NODE_UUID).map(x => NodeId(x))
+      } yield {
+        (NodeGroupId(id), nodeIds)
+      }
+    } else {
+      Thread.currentThread().getStackTrace.foreach(println)
+      Left(Err.UnexpectedObject("The given entry is not of the expected ObjectClass '%s'. Entry details: %s".format(OC_RUDDER_NODE_GROUP, e)))
+    }
+  }
   def nodeGroupToLdap(group: NodeGroup, parentDN: DN): LDAPEntry = {
     val entry = rudderDit.GROUP.groupModel(
         group.id.value

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -249,7 +249,7 @@ class ComplianceAPIService(
     val computedLevel = level.getOrElse(10)
     val t1 = System.currentTimeMillis()
     for {
-      groupLib      <- nodeGroupRepo.getFullGroupLibrary().toBox
+      allGroups      <- nodeGroupRepo.getAllNodeIds().toBox
       t2             = System.currentTimeMillis()
       _              = logger.trace(s"getByRulesCompliance - getFullGroupLibrary in ${t2 - t1} ms")
 
@@ -352,7 +352,7 @@ class ComplianceAPIService(
         } else {
           rulesWithoutCompliance.toSeq.map { case ruleId =>
             val rule = ruleObjects(ruleId) // we know by construct that it exists
-            val nodeIds = groupLib.getNodeIds(rule.targets, nodeInfos)
+            val nodeIds = RoNodeGroupRepository.getNodeIds(allGroups, rule.targets, nodeInfos)
             ByRuleRuleCompliance(
                 rule.id
                 , rule.name
@@ -402,7 +402,7 @@ class ComplianceAPIService(
 
     for {
       rules        <- rulesRepo.getAll().toBox
-      groupLib     <- nodeGroupRepo.getFullGroupLibrary().toBox
+      allGroups    <- nodeGroupRepo.getAllNodeIds().toBox
       directiveLib <- directiveRepo.getFullDirectiveLibrary().map(_.allDirectives).toBox
       allNodeInfos <- nodeInfoService.getAll()
       nodeInfos    <- onlyNode match {
@@ -417,7 +417,7 @@ class ComplianceAPIService(
 
       //get nodeIds by rules
       val nodeByRules = rules.map { rule =>
-        (rule, groupLib.getNodeIds(rule.targets, allNodeInfos) )
+        (rule, RoNodeGroupRepository.getNodeIds(allGroups, rule.targets, allNodeInfos) )
       }
 
       val ruleMap = rules.map(r => (r.id,r)).toMap

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -1741,6 +1741,8 @@ class MockNodeGroups(nodesRepo: MockNodes) {
     }
     override def getAll(): IOResult[Seq[NodeGroup]] = categories.get.map(_.allGroups.values.map(_.nodeGroup).toSeq)
 
+    override def getAllNodeIds(): IOResult[Map[NodeGroupId, Set[NodeId]]] = categories.get.map(_.allGroups.values.map(_.nodeGroup).map(g => (g.id, g.serverList)).toMap)
+
     override def getGroupsByCategory(includeSystem: Boolean): IOResult[immutable.SortedMap[List[NodeGroupCategoryId], CategoryAndNodeGroup]] = {
       def getChildren(parents: List[NodeGroupCategoryId], root: FullNodeGroupCategory) : immutable.SortedMap[List[NodeGroupCategoryId], CategoryAndNodeGroup] = {
         val c = immutable.SortedMap((root.id :: parents, CategoryAndNodeGroup(root.toNodeGroupCategory, root.ownGroups.values.map(_.nodeGroup).toSet)))


### PR DESCRIPTION
https://issues.rudder.io/issues/21028

This change makes the lock more tight on getting all groups, and introduce a method that only get the NodeGroupId, Set[NodeId] to make the fetching of nodes per group faster.
Impact is minimal (from 400-800ms to 300-500ms) but nonetheless wlecomed