### PR TITLE
Fixes #20979: Generation not started when modifying authorized network via API

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -939,6 +939,7 @@ final case object RestContinueGenerationOnError extends RestBooleanSetting {
                     }
         set      <- policyServerManagementService.setAuthorizedNetworks(nodeId, networks, modificationId, actor)
       } yield {
+         asyncDeploymentAgent.launchDeployment(AutomaticStartDeployment(ModificationId(uuidGen.newUuid), actor))
         JArray(networks.map(JString).toList)
       }
       RestUtils.response(restExtractorService, "settings", Some(id))(result, req, s"Error when trying to modify allowed networks for policy server '${id}'")
@@ -1004,6 +1005,7 @@ final case object RestContinueGenerationOnError extends RestBooleanSetting {
         _        <- sequence(diff.add)(checkAllowedNetwork)
         res      <- policyServerManagementService.updateAuthorizedNetworks(nodeId, diff.add, diff.delete, modificationId, actor)
       } yield {
+         asyncDeploymentAgent.launchDeployment(AutomaticStartDeployment(ModificationId(uuidGen.newUuid), actor))
         JArray(res.map(JString).toList)
       }
       RestUtils.response(restExtractorService, "settings", Some(id))(result, req, s"Error when trying to modify allowed networks for policy server '${id}'")


### PR DESCRIPTION
https://issues.rudder.io/issues/20979