### PR TITLE
Fixes #21068: Make user login not case sensitive

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/resources/demo-rudder-users.xml
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/demo-rudder-users.xml
@@ -76,7 +76,7 @@
   systemctl restart rudder-jetty
 -->
 
-<authentication hash="bcrypt">
+<authentication hash="bcrypt" case-sensitivity="true">
   <!--
     <user name="NAME" password="REPLACE_BY_HASH" role="ROLE" />
   -->

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -343,7 +343,8 @@ object LogFailedLogin {
 class RudderInMemoryUserDetailsService(val authConfigProvider: UserDetailListProvider) extends UserDetailsService {
   @throws(classOf[UsernameNotFoundException])
   override def loadUserByUsername(username:String) : RudderUserDetail = {
-    authConfigProvider.authConfig.users.getOrElse(username, throw new UsernameNotFoundException(s"User with username '${username}' was not found"))
+    val u = if(RudderConfig.rudderUsernameCaseSensitive) username else username.toLowerCase()
+    authConfigProvider.authConfig.users.getOrElse(u, throw new UsernameNotFoundException(s"User with username '${username}' was not found"))
   }
 }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -829,6 +829,21 @@ object RudderConfig extends Loggable {
 
   lazy val roleApiMapping = new RoleApiMapping(authorizationApiMapping)
 
+  lazy val rudderUsernameCaseSensitive: Boolean = {
+    (for {
+      resource <- UserFileProcessing.getUserResourceFile()
+      test <- UserFileProcessing.parseCaseSensitivityOpt(resource)
+    } yield {
+      test
+    }) match {
+      case Right(resource) => resource
+      case Left(UserConfigFileError(msg, exception)) =>
+        ApplicationLogger.error(msg, Box(exception))
+        //make the application not available
+        throw new javax.servlet.UnavailableException(s"Error when triyng to parse Rudder users file, aborting.")
+    }
+  }
+
   // rudder user list
   lazy val rudderUserListProvider : FileUserDetailListProvider = {
     (for {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
@@ -344,9 +344,15 @@ object UserFileProcessing {
       root = (xml \\ "authentication")
     } yield {
       (root(0) \ "@case-sensitivity").text.toLowerCase match {
-        case "true" => true
-        // error if not "true" or "false" ?
-        case _      => false
+        case "true"  => true
+        case "false" => false
+        case str     =>
+          if(str.isEmpty) {
+            ApplicationLogger.warn(s"Case sensitivity: in file /opt/rudder/etc/rudder-users.xml parameter `case-sensitivity` is missing, set by default on `true`")
+          } else {
+            ApplicationLogger.warn(s"Case sensitivity: unknown case-sensitivity parameter `$str` in file /opt/rudder/etc/rudder-users.xml, set by default on `true`")
+          }
+          true
       }
     }
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/21068
## Todo
#### Case sensitivity 
- [x] Option parameter `case-sensitivity` in XML file
- [x] Log a warning when parameter `case-sensitivity` is missing or the value si different from `true` or `false` 
- [x] By default case-sensitivity is set to `true` even if the parameter is missing or unknown
- [x] Parsing XML file and setup parameter for case sensivity in `RudderConfig`
- [x] Find where login comparison is made to .lowercase the login send from the login form 
- [x] lowercase the stored user's login 
- [x] Login as `ToTO` and `toto` is working
 
#### Sanity check
- [x] Log warning message when case sensitivity is enable and usernames are similar
- [x] Log error message when there is user with same username (according to case-sensitivity)
- [x] Ignore users with same username
#### Documentation
- [ ] Add documentation (in User-management)
## Screenshots
![admin_case](https://user-images.githubusercontent.com/23410978/167129672-fb433194-e417-42ad-a32a-3b575a90d62a.gif)