### PR TITLE
Fixes #21102: Update scala dependencies for rudder 7.2

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -103,7 +103,7 @@ limitations under the License.
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-ssh</artifactId>
-        <version>2.6</version>
+        <version>3.5.1</version>
       </extension>
     </extensions>
     <plugins>
@@ -159,6 +159,7 @@ limitations under the License.
         </compilerPlugins>
           <args>
             <arg>-target:11</arg>
+            <arg>-Xsource:3</arg> <!-- check for scala 3 removed features -->
             <arg>-dependencyfile</arg>
             <arg>${basedir}/.scala_dependencies</arg>
             <!-- standard warning, most of the one from https://tpolecat.github.io/2017/04/25/scalac-flags.html -->
@@ -236,7 +237,7 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.10.1</version>
         <configuration>
           <release>11</release>
         </configuration>
@@ -252,7 +253,7 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -270,7 +271,7 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.2</version>
         <configuration>
           <archive>
             <addMavenDescriptor>false</addMavenDescriptor>
@@ -286,7 +287,7 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.2</version>
         <configuration>
           <archive>
             <addMavenDescriptor>false</addMavenDescriptor>
@@ -362,59 +363,67 @@ limitations under the License.
     <rudder-major-version>7.2</rudder-major-version>
     <rudder-version>7.2.0~alpha1-SNAPSHOT</rudder-version>
 
-    <scala-version>2.13.6</scala-version>
+    <scala-version>2.13.8</scala-version>
+    <silencer-lib-version>1.7.8</silencer-lib-version>
     <scala-binary-version>2.13</scala-binary-version>
+    <!-- lift force us to remain with 1.3.0 because of
+         java.lang.NoSuchMethodError: 'scala.collection.mutable.Stack scala.xml.parsing.NoBindingFactoryAdapter.scopeStack()'net.liftweb.util.Html5Parser.$anonfun$parse$1(HtmlParser.scala:373)
+          And scala-xml 2.1.0 has non-trivial change on parsing semantic, can't
+         upgrade without much care and correcting how we parse XML doc (xml
+         parser option - see https://github.com/scala/scala-xml/releases/tag/v2.1.0 -->
     <scala-xml-version>1.3.0</scala-xml-version>
-    <lift-version>3.4.3</lift-version>
-    <slf4j-version>1.7.32</slf4j-version>
-    <logback-version>1.2.9</logback-version>
-    <junit-version>4.13.2</junit-version>
-    <jodatime-version>2.10.10</jodatime-version>
-    <jodaconvert-version>2.2.1</jodaconvert-version>
+    <lift-version>3.5.0</lift-version>
+    <slf4j-version>1.7.36</slf4j-version>
+    <logback-version>1.2.11</logback-version>
+    <jodatime-version>2.10.14</jodatime-version>
+    <jodaconvert-version>2.2.2</jodaconvert-version>
     <commons-io-version>2.11.0</commons-io-version>
     <commons-lang-version>3.12.0</commons-lang-version>
     <commons-codec-version>1.15</commons-codec-version>
     <commons-fileupload>1.4</commons-fileupload>
-    <spring-version>5.3.19</spring-version>
-    <spring-security-version>5.5.6</spring-security-version>
-    <jgit-version>5.12.0.202106070339-r</jgit-version>
+    <spring-version>5.3.20</spring-version>
+    <spring-security-version>5.6.3</spring-security-version>
+    <jgit-version>6.1.0.202203080745-r</jgit-version>
     <cglib-version>3.3.0</cglib-version>
-    <asm-version>5.2</asm-version>
-    <bcpkix-jdk15on-version>1.69</bcpkix-jdk15on-version>
-    <silencer-lib-version>1.7.5</silencer-lib-version>
+    <asm-version>9.3</asm-version>
+    <bcpkix-jdk15on-version>1.70</bcpkix-jdk15on-version>
     <better-files-version>3.9.1</better-files-version>
-    <sourcecode-version>0.2.7</sourcecode-version>
-    <quicklens-version>1.7.4</quicklens-version>
-    <hikaricp-version>4.0.3</hikaricp-version>
-    <nuprocess-version>2.0.1</nuprocess-version> <!-- 2.0.2 doesn't work with Java8 -->
-    <postgresql-version>42.2.25</postgresql-version>
-    <json-path-version>2.6.0</json-path-version>
+    <sourcecode-version>0.2.8</sourcecode-version>
+    <quicklens-version>1.8.8</quicklens-version>
+    <hikaricp-version>5.0.1</hikaricp-version>
+    <nuprocess-version>2.0.3</nuprocess-version>
+    <postgresql-version>42.3.5</postgresql-version>
+    <json-path-version>2.7.0</json-path-version>
     <scalaj-version>2.4.2</scalaj-version>
-    <unboundid-version>6.0.0</unboundid-version>
-    <fastparse-version>2.3.2</fastparse-version>
-    <config-version>1.4.1</config-version>
-    <cafeine-version>2.8.6</cafeine-version>
-    <jgrapht-version>1.4.0</jgrapht-version>
-    <reflections-version>0.9.12</reflections-version>
-    <graalvm-version>21.2.0</graalvm-version>
+    <unboundid-version>6.0.5</unboundid-version>
+    <fastparse-version>2.3.3</fastparse-version>
+    <config-version>1.4.2</config-version>
+    <caffeine-version>3.1.0</caffeine-version>
+    <jgrapht-version>1.5.1</jgrapht-version>
+    <reflections-version>0.10.2</reflections-version>
+    <graalvm-version>22.1.0</graalvm-version>
     <chimney-version>0.6.1</chimney-version>
     <cron4s-version>0.6.1</cron4s-version>
+    <ipaddress-version>5.3.3</ipaddress-version>
+    <snakeyaml-version>1.30</snakeyaml-version>
+
+    <zhttp-version>1.0.0.0-RC27</zhttp-version> <!-- used in datasources -->
 
     <!--
       These one must be updated to work together
       We declare cats in "test" here, because it is not directly needed
       in any project before rudder.
     -->
-    <cats-version>2.6.1</cats-version>
-    <specs2-version>4.12.3</specs2-version>
-    <doobie-version>0.13.4</doobie-version>
-    <fs2-version>2.5.0</fs2-version>
-    <http4s-version>1.0-232-85dadc2</http4s-version>
+    <specs2-version>4.15.0</specs2-version>
+    <junit-version>4.13.2</junit-version>
+    <cats-version>2.7.0</cats-version>
+    <doobie-version>1.0.0-RC2</doobie-version>
+    <fs2-version>3.2.4</fs2-version>
     <shapeless-version>2.3.7</shapeless-version>
-    <cats-effect-version>2.5.1</cats-effect-version>
+    <cats-effect-version>3.3.4</cats-effect-version>
     <dev-zio-version>1.0.10</dev-zio-version>
-    <zio-cats-version>2.3.1.0</zio-cats-version>
-    <zio-json-version>0.2.0-M1</zio-json-version>
+    <zio-cats-version>3.2.9.1</zio-cats-version> <!-- gives fs2 3.1.6, but doobie 1.0.0-RC1 is in 3.0.3 -->
+    <zio-json-version>0.2.0-M4</zio-json-version>
 
     <!--
       Hack to make scalac jvm parameters like RAM configurable.

--- a/webapp/sources/rudder/rudder-core/pom.xml
+++ b/webapp/sources/rudder/rudder-core/pom.xml
@@ -188,7 +188,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>${cafeine-version}</version>
+      <version>${caffeine-version}</version>
     </dependency>
 
     <!-- High performance, low memory native process fork/exec -->
@@ -259,7 +259,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     <dependency>
       <groupId>com.github.seancfoley</groupId>
       <artifactId>ipaddress</artifactId>
-      <version>5.3.3</version>
+      <version>${ipaddress-version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
@@ -42,28 +42,31 @@ import org.joda.time.DateTime
 
 import scala.xml.XML
 import java.sql.SQLXML
-
 import scala.xml.Elem
 import com.normation.rudder.domain.reports._
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.inventory.domain.NodeId
+
 import net.liftweb.common._
 import com.normation.rudder.services.reports.RunAndConfigInfo
+
 import org.slf4j.LoggerFactory
 import doobie.util.log.ExecFailure
 import doobie.util.log.ProcessingFailure
 import doobie.postgres.implicits._  // it is necessary whatever intellij/scalac tells
 import doobie.implicits.javasql._
 import cats.data._
-import cats.effect.{IO => _, _}
 import doobie._
+
 import zio._
 import zio.interop.catz._
 import com.normation.errors._
 import com.normation.zio._
 import com.normation.box._
 import com.normation.rudder.domain.policies.DirectiveId
+
 import zio.blocking.Blocking
+import zio.interop.catz.implicits.rts
 
 /**
  *
@@ -78,7 +81,7 @@ class Doobie(datasource: DataSource) {
     // our transaction EC: wait for aquire/release connections, must accept blocking operations
     te <- ZIO.access[Blocking](_.get.blockingExecutor.asEC)
   } yield {
-    Transactor.fromDataSource[Task](datasource, te, Blocker.liftExecutionContext(te))
+    Transactor.fromDataSource[Task](datasource, te)
   }).provide(ZioRuntime.environment).runNow
 
   def transactTask[T](query: Transactor[Task] => Task[T]): Task[T] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
@@ -210,7 +210,7 @@ object ExpectedReportsSerialisation {
    * This object will be used for the JSON serialisation
    * to / from database
    */
-  final case class JsonNodeExpectedReports private (
+  final case class JsonNodeExpectedReports protected (
       modes              : NodeModeConfig
     , ruleExpectedReports: List[RuleExpectedReports]
     , overrides          : List[OverridenPolicy]

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
@@ -67,7 +67,6 @@ import com.normation.rudder.services.policies.ParameterForConfiguration
 import com.normation.rudder.services.policies.Policy
 
 import java.nio.charset.StandardCharsets
-import com.github.ghik.silencer.silent
 import com.normation.GitVersion.Revision
 import com.normation.cfclerk.domain.TechniqueResourceIdByName
 import com.normation.cfclerk.domain.TechniqueResourceIdByPath
@@ -299,7 +298,6 @@ class WriteSystemTechniquesTest extends TechniquesTest{
 
     "correctly write the expected policies files with defauls installation but `.new` files exists" in {
 
-      @silent("local val .* in method addCrap is never used")
       def addCrap(path: String): Unit = {
         val f = better.files.File(path)
         f.parent.createDirectories()

--- a/webapp/sources/rudder/rudder-rest/pom.xml
+++ b/webapp/sources/rudder/rudder-rest/pom.xml
@@ -159,7 +159,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.26</version>
+      <version>${snakeyaml-version}</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
https://issues.rudder.io/issues/21102

Update dependencies for Rudder 7.2. The notable updates are:

- we don't change to `scala3` obviously, but last minor in `2.13` branch gives hint about what won't work anymore
- updates on mvn plugin, but AFAIS no API changes
- no major changes in the complicated framework: `zio`, `spring`
- `spring-security` has major upgrade, but it seems to continue to work as before (some deprecation warning in oauth module, they can be traited with oauth updates),
- `liftweb`: a minor version update, but given the readme, it's just a deprecation of squeryl record, that we don't use, 
- `doobie`: major update, but it seems to change... Nothing for us.
- but it made the upgrade of `fs2`/`http4s`/`zio-cats-compat` impossible; since `http4s` is only used in one test file for datasource, I just removed it and replaced it by a similar framework from zio ecosystem (`zio-http`)