### PR TITLE
Fixes #21124: rudder package cannot find version anymore -  typo

### DIFF
--- a/relay/sources/rudder-pkg/lib/rudder-pkg/rudderPkgUtils.py
+++ b/relay/sources/rudder-pkg/lib/rudder-pkg/rudderPkgUtils.py
@@ -705,7 +705,7 @@ def list_plugin_name():
 
 CONFIG_PATH = '/opt/rudder/etc/rudder-pkg/rudder-pkg.conf'
 FOLDER_PATH = '/var/rudder/tmp/plugins'
-VERSIONS_PATH = '/opt/rudder/share/versions/rudder-version'
+VERSIONS_PATH = '/opt/rudder/share/versions/rudder-server-version'
 INDEX_PATH = FOLDER_PATH + '/rpkg.index'
 GPG_HOME = '/opt/rudder/etc/rudder-pkg'
 GPG_RUDDER_KEY = '/opt/rudder/etc/rudder-pkg/rudder_plugins_key.pub'


### PR DESCRIPTION
https://issues.rudder.io/issues/21124