### PR TITLE
Fixes #19920: root inventory is missing and need to be resent after install

### DIFF
--- a/webapp/sources/api-doc/paths/inventories/upload.yml
+++ b/webapp/sources/api-doc/paths/inventories/upload.yml
@@ -13,9 +13,11 @@ post:
             file:
               type: string
               format: binary
+              description: The inventory file. The original file name is used to check extension, that should be .xml[.gz] or .ocs[.gz]
             signature:
               type: string
               format: binary
+              description: The signature file. The original file name is used to check extension, that should be ${originalInventoryFileName}.sign[.gz]
   responses:
     "200":
       description: Inventory uploaded

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
@@ -48,22 +48,83 @@ import com.normation.inventory.services.provisioning.InventoryDigestServiceV1
 import com.normation.inventory.services.provisioning.InventoryParser
 import com.normation.inventory.services.provisioning.InventorySaver
 import com.normation.rudder.domain.logger.ApplicationLogger
+import com.normation.rudder.hooks.HookEnvPairs
+import com.normation.rudder.hooks.PureHooksLogger
+import com.normation.rudder.hooks.RunHooks
 
+import better.files.File
 import com.unboundid.ldif.LDIFChangeRecord
 import org.joda.time.Duration
 import org.joda.time.format.PeriodFormat
 
 import java.io.InputStream
+import java.nio.file.NoSuchFileException
 import java.security.{PublicKey => JavaSecPubKey}
 
 import zio._
 import zio.syntax._
+import com.normation.box.IOManaged
 import com.normation.errors.Chained
 import com.normation.errors.IOResult
-import com.normation.errors.SystemError
 import com.normation.errors._
 import com.normation.zio.ZioRuntime
 import com.normation.zio._
+
+
+/*
+ * The interface between whatever event and the actual saving process.
+ * We only expose a blocking interface.
+ */
+trait ProcessInventoryService {
+  def saveInventoryBlocking(info: InventoryPair): UIO[InventoryProcessStatus]
+}
+
+/*
+ * Default implementation for the process inventory service is just
+ * chaining the save and the move of inventory files
+ */
+class DefaultProcessInventoryService(
+    inventoryProcessor: InventoryProcessor
+  , inventoryMover    : InventoryMover
+) extends ProcessInventoryService {
+
+
+  override def saveInventoryBlocking(pair: InventoryPair): UIO[InventoryProcessStatus] = {
+    val info = pair.toSaveInventoryInfo
+    for {
+      _ <- InventoryProcessingLogger.trace(s"Query blocking save of '${info.fileName}'")
+      x <- inventoryProcessor.saveInventoryInternal(info)
+      _ <- inventoryMover.moveFiles(pair.inventory, pair.signature, x)
+      _ <- InventoryProcessingLogger.trace(s"Query blocking save of '${info.fileName}': done")
+    } yield x
+  }
+}
+
+
+/*
+ * A pair of an inventory file and its signature.
+ * It's the interface used by the ProcessInventoryService
+ */
+final case class InventoryPair(inventory: File, signature: File) {
+  def toSaveInventoryInfo = SaveInventoryInfo(
+      inventory.name
+    , InventoryProcessingUtils.makeManagedStream(inventory, "inventory")
+    , InventoryProcessingUtils.makeManagedStream(signature, "signature")
+    , InventoryProcessingUtils.makeFileExists(inventory)
+  )
+}
+
+/*
+ * Data needed to save an inventory.
+ * We need to use input streams because it's sometimes all
+ * we have (in test for ex).
+ */
+final case class SaveInventoryInfo(
+    fileName : String
+  , inventory: IOManaged[InputStream]
+  , signature: IOManaged[InputStream]
+  , exists   : IOManaged[Boolean]
+)
 
 
 sealed trait InventoryProcessStatus {
@@ -72,21 +133,15 @@ sealed trait InventoryProcessStatus {
 
 }
 final object InventoryProcessStatus {
-  final case class Accepted        (inventoryName: String, nodeId: NodeId) extends InventoryProcessStatus
-  final case class QueueFull       (inventoryName: String, nodeId: NodeId) extends InventoryProcessStatus
-  final case class SignatureInvalid(inventoryName: String, nodeId: NodeId) extends InventoryProcessStatus
-  final case class MissingSignature(inventoryName: String, nodeId: NodeId) extends InventoryProcessStatus
+  final case class Saved           (inventoryName: String, nodeId: NodeId                    ) extends InventoryProcessStatus
+  final case class SignatureInvalid(inventoryName: String, nodeId: NodeId                    ) extends InventoryProcessStatus
+  final case class SaveError       (inventoryName: String, nodeId: NodeId, error: RudderError) extends InventoryProcessStatus
 }
 
 
 object StatusLog {
   implicit class LogMessage(status: InventoryProcessStatus) {
     def msg: String = status match {
-      case InventoryProcessStatus.MissingSignature(inventoryName, nodeId) =>
-        s"Rejecting Inventory '${inventoryName}' for Node '${nodeId.value}' because its signature is missing. " +
-        s"You can go back to unsigned state by running the following command on the Rudder Server: " +
-        s"'/opt/rudder/bin/rudder-keys reset-status ${nodeId.value}'"
-
       case InventoryProcessStatus.SignatureInvalid(inventoryName, nodeId) =>
         s"Rejecting Inventory '${inventoryName}' for Node '${nodeId.value}' because the Inventory signature is " +
         s"not valid: the Inventory was not signed with the same agent key as the one saved within Rudder for that Node. If " +
@@ -97,11 +152,11 @@ object StatusLog {
         s"If you did not change the key, please ensure that the node sending that inventory is actually the node registered " +
         s"within Rudder"
 
-      case InventoryProcessStatus.QueueFull(inventoryName, nodeId) =>
-        s"Rejecting Inventory '${inventoryName}' for Node '${nodeId.value}' because processing queue is full."
+      case InventoryProcessStatus.Saved(inventoryName, nodeId) =>
+        s"Inventory '${inventoryName}' for Node '${nodeId.value}' was correctly saved"
 
-      case InventoryProcessStatus.Accepted(inventoryName, nodeId) =>
-        s"Inventory '${inventoryName}' for Node '${nodeId.value}' added to processing queue."
+      case InventoryProcessStatus.SaveError(inventoryName, nodeId, err) =>
+        s"Inventory '${inventoryName}' for Node '${nodeId.value}' failed to be saved in Rudder. Cause was: ${err.fullMsg}"
     }
   }
 }
@@ -111,90 +166,24 @@ object StatusLog {
 class InventoryProcessor(
     unmarshaller       : InventoryParser
   , inventorySaver     : InventorySaver[Seq[LDIFChangeRecord]]
-  , val maxQueueSize   : Int
   , val maxParallel    : Long
   , repo               : FullInventoryRepository[Seq[LDIFChangeRecord]]
   , digestService      : InventoryDigestServiceV1
   , checkAliveLdap     : () => IOResult[Unit]
   , nodeInventoryDit   : InventoryDit
 ) {
+  def logDirPerm(dir: File, name: String) = {
+    if(dir.isDirectory && dir.isWritable) {
+      InventoryProcessingLogger.logEffect.debug(s"${name} inventories directory [ok]: ${dir.pathAsString}")
+    } else {
+      InventoryProcessingLogger.logEffect.error(s"${name} inventories directory: ${dir.pathAsString} is not writable. Please check existence and file permission.")
+    }
+  }
 
-  ApplicationLogger.info(s"INFO Configure inventory processing with parallelism of '${maxParallel}' and queue size of '${maxQueueSize}'")
+  ApplicationLogger.info(s"Configure inventory processing with parallelism of '${maxParallel}'")
 
   // we want to limit the number of inventories concurrently parsed
-  lazy val xmlParsingSemaphore = ZioRuntime.unsafeRun(Semaphore.make(maxParallel))
-
-  /*
-   * We manage inventories buffering with a bounded queue.
-   * That Queue is blocking, so any caller should be careful to
-   * put in front of it a Sliding or Dropping queue of size one
-   * in fron of any "offer" call to make it non blocking.
-   */
-  protected lazy val blockingQueue = ZQueue.bounded[Inventory](maxQueueSize).runNow
-  def addInventoryToQueue(inventory: Inventory): UIO[Unit] = {
-    for {
-      _ <- InventoryProcessingLogger.trace(s"Blocking add '${inventory.name}' to backend processing queue")
-      _ <- blockingQueue.offer(inventory)
-      _ <- InventoryProcessingLogger.trace(s"Blocking add '${inventory.name}' to backend processing queue: done")
-    } yield ()
-  }
-
-  /*
-   * This latch is to here to provide an non-blocking, dropping behavior to blockingQueue:
-   * - it just `addInventoryToQueue` (which is blocking) in a loop
-   * - it drops new requests when an other one is already here (which means that
-   *   `addInventoryToQueue` from the previous action is still blocked)
-   */
-  protected lazy val latch         = ZQueue.dropping[Inventory](1).runNow
-  //start latch, it just forwards to the blocking queue when there is room
-  latch.take.flatMap(addInventoryToQueue(_)).forever.forkDaemon.runNow
-
-  def currentQueueSize: Int = ZioRuntime.unsafeRun(blockingQueue.size)
-
-  def isQueueFull: IOResult[Boolean] = {
-    // Get the current size, the remaining of the answer is based on that.
-    // The "+1" is because the fiber waiting for inventory give 1 slot,
-    // if don't "+1", we start at -1 when no inventories are here.
-
-    //must be coherent with "can do", current = 49 < max = 50 => not saturated
-    blockingQueue.size.map(_ + 1 >= maxQueueSize)
-  }
-
-  /*
-   * Saving inventorys is a loop which consume items from queue
-   */
-
-  def loop(): UIO[Nothing] = {
-    blockingQueue.take.flatMap(r =>
-      InventoryProcessingLogger.trace(s"Took inventory '${r.name}' from backend queue and saving it") *>
-      saveInventory(r)
-    ).forever
-  }
-
-  // start the inventory processing
-  ZioRuntime.unsafeRun(loop().forkDaemon)
-
-  /*
-   * This is a non blocking call to saveInventory that will try to send to back-end and
-   * return immediately with an error status if it didn't.
-   */
-  // we need something that can produce the stream several time because we are reading the file several time - not very
-  // optimized :/
-  def saveInventory(info: SaveInventoryInfo): IOResult[InventoryProcessStatus] = {
-    for {
-      _ <- InventoryProcessingLogger.trace(s"Query async save of '${info.fileName}'")
-      x <- saveInventoryInternal(info, blocking = false)
-      _ <- InventoryProcessingLogger.trace(s"Query async save of '${info.fileName}': done")
-    } yield x
-  }
-
-  def saveInventoryBlocking(info: SaveInventoryInfo): IOResult[InventoryProcessStatus] = {
-    for {
-      _ <- InventoryProcessingLogger.trace(s"Query blocking save of '${info.fileName}'")
-      x <- saveInventoryInternal(info, blocking = true)
-      _ <- InventoryProcessingLogger.trace(s"Query blocking save of '${info.fileName}': done")
-    } yield x
-  }
+  lazy val concurrentInventoryProcessingSemaphore = ZioRuntime.unsafeRun(Semaphore.make(maxParallel))
 
   /*
    * If blocking is true, that method won't complete until there is room in the backend queue.
@@ -202,11 +191,10 @@ class InventoryProcessor(
    * everything.
    * When non blocking, the return value will tell is the value was accepted.
    */
-  def saveInventoryInternal(info: SaveInventoryInfo, blocking: Boolean): IOResult[InventoryProcessStatus] = {
-    def saveWithSignature(inventory: Inventory, publicKey: JavaSecPubKey, newInventoryStream: () => InputStream, newSignature: () => InputStream): IOResult[InventoryProcessStatus] = {
-      ZIO.bracket(Task.effect(newInventoryStream()).mapError(SystemError(s"Error when reading inventory file '${inventory.name}'", _)))(is => Task.effect(is.close()).run) { inventoryStream =>
-        ZIO.bracket(Task.effect(newSignature()).mapError(SystemError(s"Error when reading signature for inventory file '${inventory.name}'", _)))(is => Task.effect(is.close()).run) { signatureStream =>
-
+  def saveInventoryInternal(info: SaveInventoryInfo): UIO[InventoryProcessStatus] = {
+    def saveWithSignature(inventory: Inventory, publicKey: JavaSecPubKey, newInventoryStream: IOManaged[InputStream], newSignature: IOManaged[InputStream]): IOResult[InventoryProcessStatus] = {
+      newInventoryStream.use(inventoryStream =>
+        newSignature.use(signatureStream =>
           for {
             digest  <- digestService.parse(signatureStream)
             checked <- digestService.check(publicKey, digest, inventoryStream)
@@ -216,7 +204,7 @@ class InventoryProcessor(
                          // For now we set the status to certified since we want pending inventories to have their inventory signed
                          // When we will have a 'pending' status for keys we should set that value instead of certified
                          val certified = inventory.copy(node = inventory.node.copyWithMain(main => main.copy(keyStatus = CertifiedKey)))
-                         checkQueueAndSave(certified, blocking)
+                         saveInventory(certified)
                        } else {
                          // Signature is not valid, reject inventory
                          InventoryProcessStatus.SignatureInvalid(inventory.name, inventory.node.main.id).succeed
@@ -224,32 +212,28 @@ class InventoryProcessor(
            } yield {
              saved
            }
-        }
-      }
+        )
+      )
     }
 
-    def parseSafe(newInventoryStream: () => InputStream, inventoryFileName: String): IOResult[Inventory] = {
-      ZIO.bracket(Task.effect(newInventoryStream()).mapError(SystemError(s"Error when trying to read inventory file '${inventoryFileName}'", _)) )(
-        is => Task.effect(is.close()).run
-      ){ is =>
+    def parseSafe(newInventoryStream: IOManaged[InputStream], inventoryFileName: String): IOResult[Inventory] = {
+      newInventoryStream.use(is =>
         for {
           r <- unmarshaller.fromXml(inventoryFileName, is)
         } yield {
           // use the provided file name as inventory name, else it's a generic one setted by fusion (like "inventory")
           r.copy(name = inventoryFileName)
         }
-      }
+      )
     }
 
-    // actuall inventory processing logic
-    val processLogic = (for {
+    // actual inventory processing logic
+    val processLogic = concurrentInventoryProcessingSemaphore.withPermit(for {
       start        <- currentTimeMillis
-      qsize        <- blockingQueue.size
-      qsaturated   <- isQueueFull
-      _            <- InventoryProcessingLogger.debug(s"Enter pre-processed inventory for ${info.fileName} with blocking='${blocking}' and current backend queue size=${qsize} (saturated=${qsaturated})")
-      inventory    <- xmlParsingSemaphore.withPermit(
+      _            <- InventoryProcessingLogger.debug(s"Enter pre-processed inventory for ${info.fileName}")
+      inventory    <- (
                         InventoryProcessingLogger.debug(s"Start parsing inventory '${info.fileName}'") *>
-                        parseSafe(info.inventoryStream, info.fileName).chainError("Can't parse the input inventory, aborting") <*
+                        parseSafe(info.inventory, info.fileName).chainError("Can't parse the input inventory, aborting") <*
                         InventoryProcessingLogger.trace(s"Parsing done for inventory '${info.fileName}'")
                       )
       secPair      <- digestService.getKey(inventory).chainError(s"Error when trying to check inventory key for Node '${inventory.node.main.id.value}'")
@@ -262,101 +246,133 @@ class InventoryProcessor(
       inventoryName= inventory.name
       nodeId       = inventory.node.main.id
       _            =  InventoryProcessingLogger.debug(s"Inventory '${inventory.name}' parsed in ${PeriodFormat.getDefault.print(new Duration(afterParsing, System.currentTimeMillis).toPeriod)} ms, now saving")
-      saved        <- info.optSignatureStream match { // Do we have a signature ?
-                        // Signature here, check it
-                        case Some(sig) =>
-                          saveWithSignature(inventory, parsed.publicKey, info.inventoryStream, sig).chainError("Error when trying to check inventory signature")
-
-                        // There is no Signature
-                        case None =>
-                          Inconsistency(s"Error, inventory '${inventory.name}' has no signature, which is not supported anymore in Rudder 6.0. " +
-                                        s"Please check that your node's agent is compatible with that version.").fail
-                      }
+      saved        <- saveWithSignature(inventory, parsed.publicKey, info.inventory, info.signature).chainError("Error when trying to check inventory signature")
       _            <- InventoryProcessingLogger.debug(s"Inventory '${inventory.name}' for node '${inventory.node.main.id.value}' pre-processed in ${PeriodFormat.getDefault.print(new Duration(start, System.currentTimeMillis).toPeriod)} ms")
     } yield {
       saved
-    }).foldM(
-      err => {
-        val fail = Chained(s"Error when trying to process inventory '${info.fileName}'", err)
-        InventoryProcessingLogger.error(fail.fullMsg) *> err.fail
-      }
-    , status => {
-        import com.normation.rudder.inventory.StatusLog.LogMessage
-        (status match {
-          case InventoryProcessStatus.MissingSignature(_,_) => InventoryProcessingLogger.error(status.msg)
-          case InventoryProcessStatus.SignatureInvalid(_,_) => InventoryProcessingLogger.error(status.msg)
-          case InventoryProcessStatus.QueueFull(_,_)        => InventoryProcessingLogger.warn(status.msg)
-          case InventoryProcessStatus.Accepted(_,_)         => InventoryProcessingLogger.trace(status.msg)
-        }) *> status.succeed
-      }
-    )
+    })
 
     // guard against missing files: as there may be a latency between file added to buffer / file processed, we
     // need to check again here.
-    for {
-      exists <- info.testExits
-      res    <- if(exists) processLogic
-                else InventoryProcessingLogger.trace(s"File '${info.fileName}' was deleted, skipping") *>
-                     InventoryProcessStatus.Accepted(info.fileName, NodeId("skipped")).succeed
-    } yield res
-  }
-
-  /*
-   * Before actually trying to save, check that LDAP is up to at least
-   * avoid the case where we are telling the use "everything is fine"
-   * but just fail after.
-   */
-  def checkQueueAndSave(inventory: Inventory, blocking: Boolean): IOResult[InventoryProcessStatus] = {
-
-    (for {
-      _     <- checkAliveLdap()
-      res   <- if(blocking) {
-                 // that's block. And so inventory is always accepted in the end
-                 addInventoryToQueue(inventory) *> InventoryProcessStatus.Accepted(inventory.name, inventory.node.main.id).succeed
-               } else {
-                 for {
-                   canDo <- latch.offer(inventory)
-                   res   <- if(canDo) {
-                              InventoryProcessStatus.Accepted(inventory.name, inventory.node.main.id).succeed
-                            } else {
-                              InventoryProcessStatus.QueueFull(inventory.name, inventory.node.main.id).succeed
-                            }
-                 } yield res
-              }
-    } yield {
-      res
-    }).catchAll { err =>
-      val e = Chained(s"There is an error with the LDAP backend preventing acceptation of inventory '${inventory.name}'", err)
-      InventoryProcessingLogger.error(err.fullMsg) *> e.fail
-    }
+    info.exists.use(exists =>
+      for {
+        res    <- if(exists) processLogic
+                  else InventoryProcessingLogger.trace(s"File '${info.fileName}' was deleted, skipping") *>
+                       InventoryProcessStatus.Saved(info.fileName, NodeId("skipped")).succeed
+      } yield res
+    ).catchAll(
+        err    => {
+          val fail = Chained(s"Error when trying to process inventory '${info.fileName}'", err)
+          InventoryProcessingLogger.error(fail.fullMsg) *> InventoryProcessStatus.SaveError(info.fileName, NodeId("unknown"), fail).succeed
+        }
+    )
   }
 
   /**
-   * Encapsulate the logic to process new incoming inventories.
-   *
-   * The processing is successlly synchrone and monothreaded,
-   * asynchronicity and multithreading are managed in the caller.
-   *
-   * It is not the consumer that manage the queue size, it only
-   * decrease it when it terminates a processing.
-   *
+   * Encapsulate the logic to finally save a new inventory in LDAP backend.
    */
-  def saveInventory(inventory:Inventory): UIO[Unit] = {
-    for {
-      _     <- InventoryProcessingLogger.trace(s"Start post processing of inventory '${inventory.name}' for node '${inventory.node.main.id.value}'")
-      start <- UIO(System.currentTimeMillis)
-      saved <- inventorySaver.save(inventory).chainError("Can't merge inventory in LDAP directory, aborting").either
-      _     <- saved match {
-                 case Left(err) =>
-                   InventoryProcessingLogger.error(s"Error when trying to process inventory: ${err.fullMsg}")
-                 case Right(_) =>
-                   InventoryProcessingLogger.debug("Inventory saved.")
-               }
-      _      <- InventoryProcessingLogger.info(s"Inventory '${inventory.name}' for node '${inventory.node.main.hostname}' [${inventory.node.main.id.value}] (signature:${inventory.node.main.keyStatus.value}) "+
-                s"processed in ${PeriodFormat.getDefault.print(new Duration(start, System.currentTimeMillis).toPeriod)}")
-    } yield ()
+  def saveInventory(inventory:Inventory): UIO[InventoryProcessStatus] = {
+    checkAliveLdap().either.flatMap {
+      case Left(err) =>
+        val full = Chained(s"There is an error with the LDAP backend preventing acceptation of inventory '${inventory.name}'", err)
+        InventoryProcessStatus.SaveError(inventory.name, inventory.node.main.id, full).succeed
+
+      case Right(_) =>
+        for {
+          _     <- InventoryProcessingLogger.trace(s"Start post processing of inventory '${inventory.name}' for node '${inventory.node.main.id.value}'")
+          start <- currentTimeMillis
+          saved <- inventorySaver.save(inventory).chainError("Can't merge inventory in LDAP directory, aborting").either
+          res   <- saved match {
+                     case Left(err) =>
+                       InventoryProcessingLogger.error(s"Error when trying to process inventory: ${err.fullMsg}") *>
+                       InventoryProcessStatus.SaveError(inventory.name, inventory.node.main.id, err).succeed
+                     case Right(_) =>
+                       InventoryProcessingLogger.debug("Inventory saved.") *>
+                       InventoryProcessStatus.Saved(inventory.name, inventory.node.main.id).succeed
+                   }
+          end    <- currentTimeMillis
+          _      <- InventoryProcessingLogger.info(s"Inventory '${inventory.name}' for node '${inventory.node.main.hostname}' [${inventory.node.main.id.value}] (signature:${inventory.node.main.keyStatus.value}) "+
+                    s"processed in ${PeriodFormat.getDefault.print(new Duration(start, end).toPeriod)}")
+        } yield res
+    }
   }
 
 }
 
 
+class InventoryFailedHook(
+    HOOKS_D              : String
+  , HOOKS_IGNORE_SUFFIXES: List[String]
+) {
+  import scala.jdk.CollectionConverters._
+  import zio.duration._
+
+  def runHooks(file: File): UIO[Unit] = {
+    (for {
+      systemEnv <- IOResult.effect(System.getenv.asScala.toSeq).map(seq => HookEnvPairs.build(seq:_*))
+      hooks     <- RunHooks.getHooksPure(HOOKS_D + "/node-inventory-received-failed", HOOKS_IGNORE_SUFFIXES)
+      _         <- for {
+                     timeHooks0 <- currentTimeMillis
+                     res        <- RunHooks.asyncRun(
+                                       hooks
+                                     , HookEnvPairs.build(
+                                         ("RUDDER_INVENTORY_PATH", file.pathAsString)
+                                     )
+                                     , systemEnv
+                                     , 1.minutes // warn if a hook took more than a minute
+                                   )
+                     timeHooks1 <- currentTimeMillis
+                     _          <- PureHooksLogger.trace(s"Inventory failed hooks ran in ${timeHooks1 - timeHooks0} ms")
+                   } yield ()
+    } yield ()).catchAll(err => PureHooksLogger.error(err.fullMsg))
+  }
+}
+
+/*
+ * This part is in charge of moving inventory files once they are processed and
+ * trigger hooks.
+ */
+trait InventoryMoveWhenProcessed {
+  def moveFiles(inventory: File, signature: File, result: InventoryProcessStatus): UIO[Unit]
+}
+
+/*
+ * This class managed what need to be done after inventories are saved
+ * in LDAP
+ */
+class InventoryMover(
+    receivedInventoryPath: String
+  , failedInventoryPath  : String
+  , failedHook           : InventoryFailedHook
+) extends InventoryMoveWhenProcessed {
+
+  val received = File(receivedInventoryPath)
+  InventoryProcessingUtils.logDirPerm(received, "Received")
+  val failed   = File(failedInventoryPath)
+  InventoryProcessingUtils.logDirPerm(failed, "Failed")
+
+
+  // we don't manage race condition very well, so we have cases where
+  // we can have two things trying to move
+  def safeMove[T](file: File, chunk: =>T): UIO[Unit] = {
+    Task.effect{chunk ; ()}.catchAll {
+      case ex: NoSuchFileException => // ignore
+        InventoryProcessingLogger.debug(s"Ignored exception '${ex.getClass.getSimpleName} ${ex.getMessage}'. The file '${file.pathAsString}' was correctly handled.")
+      case ex                      =>
+        InventoryProcessingLogger.error(s"Exception caught when processing inventory file '${file.pathAsString}': ${ex.getClass.getSimpleName} ${ex.getMessage}")
+    }
+  }
+
+  def moveFiles(inventory: File, signature: File, result: InventoryProcessStatus): UIO[Unit] = {
+    result match {
+      case InventoryProcessStatus.Saved(_,_) =>
+        //move to received dir
+        safeMove(signature, signature.moveTo(received / signature.name)(File.CopyOptions(overwrite = true))) *>
+        safeMove(inventory, inventory.moveTo(received / inventory.name)(File.CopyOptions(overwrite = true)))
+      case _:InventoryProcessStatus.SignatureInvalid | _:InventoryProcessStatus.SaveError =>
+        safeMove(signature, signature.moveTo(failed / signature.name)(File.CopyOptions(overwrite = true))) *>
+        safeMove(inventory, inventory.moveTo(failed / inventory.name)(File.CopyOptions(overwrite = true))) *>
+        failedHook.runHooks(failed / inventory.name)
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -205,19 +205,13 @@ rudder.batch.databasecleaner.runtime.day=sunday
 #########################
 
 #
-# Inventories are processed throught a file watcher
+# Inventories are processed through a file watcher
 # (inotify) which react to new
 # inventories put in ${inventories.root.directory}/incoming.
 # You can [start, stop, restart] the watcher with POST to API
 # /api/latest/inventories/watcher/[start, stop, restart].
 #
 inventories.root.directory=/var/rudder/inventories
-
-# 'inventories.watcher.waitForSignatureDuration' is the time
-# in seconds the watcher will wait for the signature file
-# in case there is only an inventory file before sending
-# only inventory to backend.
-inventories.watcher.waitForSignatureDuration=10 seconds
 
 #
 # Period for a batch to run and see if any inventories were
@@ -226,28 +220,22 @@ inventories.watcher.waitForSignatureDuration=10 seconds
 inventories.watcher.period.garbage.old=5 minutes
 
 #
-# Max number of inventories waiting to be processed internally.
-# For a rough estimation, you can consider that an inventory in queue
-# takes 5 MB, so to handle 50 (default), the application will
-# need around 250 MB of spare memory.
-# You don't need to make that queue big is you don't send inventories
-# through REST API endpoint: inventories coming from agent by usual
-# way wait on disk.
-# In the case of inventories sent via REST API, a bigger queue will allows to
-# send API response more quickly (just after inventory parsing, before saving it)
-# while in the same time not making new invetory rejected.
-# Minimal size is 1.
+# Maximum relative age for inventories before being deleted without
+# trying to add them. This can be important if Rudder was down for
+# a long time and inventories accumulated, no need to keep the older.
 #
-waiting.inventory.queue.size=5
+inventories.watcher.max.age.before.deletion=3 days
 
 #
-# You may want to limit the number of inventory files parsed in parallele.
-# The goal is to avoid parsing hundreds of XML in parallel when we prefer
-# to totally parse some (and then the others) and send them to backend.
-# You can specify a positive integer or a string formated "Nx" where
+# You may want to limit the number of inventory files parsed and save in parallel.
+# You can specify a positive integer or a string formatted "Nx" where
 # "N" is an Int and x means "number of available core".
-# A safe default is "0.5x"
-inventory.parse.parallelization=0.5x
+# By default, inventories are parsed and saved one with parallelization of 2, which allows
+# to keep a lowish LDAP write contention but still avoid a starvation in case one inventory is
+# extremely long to parse. On a big server with lots of inventories coming in parallel,
+# you can try to rise that number. In case with number of nodes < 500, you can safely set it to 1
+# which will make logs simpler to understand.
+inventory.parse.parallelization=2
 
 #
 # You can keep exhaustive information about LDAP base modification

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -533,6 +533,8 @@ class Boot extends Loggable {
     ZioRuntime.runNow(RudderConfig.historizeNodeCountBatch.catchAll(err =>
       ApplicationLoggerPure.error(s"Error when starting node historization batch: ${err.fullMsg}")
     ))
+    // start inventory garbage collector
+    RudderConfig.inventoryWatcher.startGarbageCollection
     // start inventory watchers if needed
     if(RudderConfig.WATCHER_ENABLE) {
       RudderConfig.inventoryWatcher.startWatcher()


### PR DESCRIPTION
- now, API put files in the usual directory, and they are processed as other inventories
- create `trait` to make more clear what are the public API in services and how the are used in other services (code on interfaces)
- removed the logic to have a non-blocking inventory save for API case
- remove the saveInventory queue. Now, the whole [xml parsing, signature checking, ldap save] is a blocking method with a parallelism of configured by `inventory.parse.parallelization`, default `1` because it seems that in general, there is little advantage of making it more appart stressing LDAP
- add inventory cleaning in the garbage collector: remove inventories older than `inventories.watcher.max.age.before.deletion`, remove unmatched pairs


![2022-05-19-Inventory processing 7 2](https://user-images.githubusercontent.com/44649/169305205-aca4230e-f80a-499c-97b0-8c3de8a8cb85.png)



https://issues.rudder.io/issues/19920