### PR TITLE
Fixes #21143: Backup ca.cert like other cert files

### DIFF
--- a/relay/sources/rudder-server-relay-postinst
+++ b/relay/sources/rudder-server-relay-postinst
@@ -91,7 +91,7 @@ sed -i '/SSLCertificateKeyFile.*\/opt\/rudder\/etc\/ssl\/rudder.key/d' /etc/${AP
 
 # not used anymore
 if [ -f /opt/rudder/etc/ssl/ca.cert ]; then
-  rm -f /opt/rudder/etc/ssl/ca.cert
+  mv /opt/rudder/etc/ssl/ca.cert "${BACKUP_DIR}/ca-`date +%Y%m%d`.cert"
 fi
 
 if [ ! -f /var/rudder/lib/ssl/nodescerts.pem ]; then


### PR DESCRIPTION
https://issues.rudder.io/issues/21143