### PR TITLE
Fixes #21150: Directive and rule revision is not parsed in API

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Directive.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Directive.scala
@@ -112,7 +112,7 @@ object DirectiveId {
 
   // parse a directiveId which was serialize by "id.serialize"
   def parse(s: String) : Either[String, DirectiveId] = {
-    GitVersion.parseUidRed(s).map { case (id, rev) =>
+    GitVersion.parseUidRev(s).map { case (id, rev) =>
       DirectiveId(DirectiveUid(id), rev)
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Rule.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Rule.scala
@@ -59,7 +59,7 @@ object RuleId {
 
   // parse a directiveId which was serialize by "id.serialize"
   def parse(s: String) : Either[String, RuleId] = {
-    GitVersion.parseUidRed(s).map { case (id, rev) =>
+    GitVersion.parseUidRev(s).map { case (id, rev) =>
       RuleId(RuleUid(id), rev)
     }
   }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
@@ -38,7 +38,6 @@
 package com.normation.rudder.rest.lift
 
 import com.normation.GitVersion
-import com.normation.GitVersion.Revision
 import com.normation.rudder.apidata.JsonResponseObjects.JRDirective
 import com.normation.rudder.apidata.RestDataSerializer
 import com.normation.cfclerk.domain.Technique
@@ -243,8 +242,10 @@ class DirectiveApi (
   object DirectiveDetailsV14 extends LiftApiModuleString {
     val schema = API.DirectiveDetails
     def process(version: ApiVersion, path: ApiPath, id: String, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      val rev = req.params.get("revision").flatMap(_.headOption).map(Revision).getOrElse(GitVersion.DEFAULT_REV)
-      serviceV14.directiveDetails(DirectiveId(DirectiveUid(id), rev)).toLiftResponseOne(params, schema, d => Some(d.id))
+      (for {
+        did <- DirectiveId.parse(id).toIO
+        res <- serviceV14.directiveDetails(did)
+      } yield res).toLiftResponseOne(params, schema, d => Some(d.id))
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -38,7 +38,6 @@
 package com.normation.rudder.rest.lift
 
 import com.normation.GitVersion
-import com.normation.GitVersion.Revision
 import com.normation.rudder.apidata.RestDataSerializer
 import com.normation.eventlog.EventActor
 import com.normation.eventlog._
@@ -413,16 +412,20 @@ class RuleApi(
   object LoadRuleRevisionForGeneration extends LiftApiModuleString {
     val schema = API.LoadRuleRevisionForGeneration
     def process(version: ApiVersion, path: ApiPath, id: String, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      val rev = req.params.get("revision").flatMap(_.headOption).map(Revision).getOrElse(GitVersion.DEFAULT_REV)
-      serviceV14.loadRule(RuleId(RuleUid(id), rev), params, authzToken.actor).toLiftResponseOne(params, schema, s => Some(s.id))
+      (for {
+        rid <- RuleId.parse(id).toIO
+        res <- serviceV14.loadRule(rid, params, authzToken.actor)
+      } yield res).toLiftResponseOne(params, schema, s => Some(s.id))
     }
   }
 
   object UnloadRuleRevisionForGeneration extends LiftApiModuleString {
     val schema = API.UnloadRuleRevisionForGeneration
     def process(version: ApiVersion, path: ApiPath, id: String, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      val rev = req.params.get("revision").flatMap(_.headOption).map(Revision).getOrElse(GitVersion.DEFAULT_REV)
-      serviceV14.unloadRule(RuleId(RuleUid(id), rev), params, authzToken.actor).toLiftResponseOne(params, schema, s => Some(s.serialize))
+      (for {
+        rid <- RuleId.parse(id).toIO
+        res <- serviceV14.unloadRule(rid, params, authzToken.actor)
+      } yield res).toLiftResponseOne(params, schema, s => Some(s.serialize))
     }
   }
 }

--- a/webapp/sources/utils/src/main/scala/com/normation/ObjectVersionCommons.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/ObjectVersionCommons.scala
@@ -95,7 +95,7 @@ final object GitVersion {
   /**
    * A method to parse a standard uid+revision
    */
-  def parseUidRed(s: String): Either[String, (String, Revision)] = {
+  def parseUidRev(s: String): Either[String, (String, Revision)] = {
     s.split("\\+").toList match {
       case id :: Nil        => Right((id, GitVersion.DEFAULT_REV))
       case id :: "" :: Nil  => Right((id, GitVersion.DEFAULT_REV))


### PR DESCRIPTION
There was a typo in the method name which is used to parse ID, perhaps it's why it was not used on some API (and more likely, when I did the refactoring from request parameter to `uuid+revision` format, I forgot /some/ API endpoints).

https://issues.rudder.io/issues/21150