### PR TITLE
Fixes #21241: API to fetch nodes + software times out on large instance

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/Identifiers.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/Identifiers.scala
@@ -37,6 +37,9 @@
 
 package com.normation.inventory.domain
 
+import com.normation.errors.{IOResult, Inconsistency}
+import zio.syntax.ToZio
+
 import java.security.MessageDigest
 
 trait Uuid extends Any {
@@ -49,6 +52,16 @@ final case class MachineUuid(val value:String) extends AnyVal with Uuid
 
 final case class SoftwareUuid(val value:String) extends AnyVal with Uuid
 
+object SoftwareUuid {
+  val pattern = "softwareId=(.*),ou=Software,.*".r
+
+  def SoftwareUuidFromDnString(dnString: String): IOResult[SoftwareUuid] = {
+    dnString match {
+      case pattern(uuid) => SoftwareUuid(uuid).succeed
+      case _ => Inconsistency(s"String ${dnString} doesn't match the expected format for software").fail
+    }
+  }
+}
 final case class MotherBoardUuid(val value:String) extends AnyVal with Uuid
 
 object IdGenerator {

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryDit.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryDit.scala
@@ -145,7 +145,7 @@ final case class InventoryDit(val BASE_DN:DN, val SOFTWARE_BASE_DN:DN, val name:
             } else {
               Left(MalformedDN("Unexpected RDN for a software ID"))
             }
-          } else Left(MalformedDN(s"DN ${dn} does not belong to software inventories DN ${software.dn}"))
+          } else Left(MalformedDN(s"DN ${dn.toString} does not belong to software inventories DN ${software.dn.toString}"))
         }
     }
   }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/NodeDetailLevel.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/NodeDetailLevel.scala
@@ -288,7 +288,7 @@ object NodeDetailLevel {
         if(soft.isEmpty) {
           JNothing
         } else {
-          val softwares = soft.map{
+          val softwares = soft.toList.map{
             software =>
               ( "name"        -> software.name ) ~
               ( "editor"      -> software.editor.map(_.name) ) ~
@@ -296,7 +296,7 @@ object NodeDetailLevel {
               ( "license"     -> software.license.map(licenseJson) ) ~
               ( "description" -> software.description ) ~
               ( "releaseDate" -> software.releaseDate.map(DateFormaterService.serialize) )
-          }.toList
+          }
           JArray(softwares)
         }
     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -1028,7 +1028,7 @@ class NodeApiService6 (
                        Full(Map[NodeId, FullInventory]())
                      }
       software    <- if(detailLevel.needSoftware()) {
-                       softwareRepository.getSoftwareByNode(nodeInfos.keySet, state).toBox
+                       softwareRepository.getSoftwareByNode(nodeIds, state).toBox
                      } else {
                        Full(Map[NodeId, Seq[Software]]())
                      }


### PR DESCRIPTION
https://issues.rudder.io/issues/21241

This PR improves performance of node API when we fetch softwares, and overall some of the perfs for software related topic
However, it is not sufficient to make improvement enough to get many softwares out of Ruder with the API:
* getting inventory with software from 1 node takes 10s with this change (never ended before).
* getting inventories with software from 111 nodes don't finish

Adding an index on softwareId makes the inventory from 1 node respond in 1 second, and 20s for the 111 nodes