### PR TITLE
Fixes #21279: relayd error messages about config files are lacking path information

### DIFF
--- a/relay/sources/relayd/src/configuration/logging.rs
+++ b/relay/sources/relayd/src/configuration/logging.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later WITH GPL-3.0-linking-source-exception
 // SPDX-FileCopyrightText: 2019-2020 Normation SAS
 
-use anyhow::Error;
-use serde::Deserialize;
 use std::{fmt, fs::read_to_string, path::Path, str::FromStr};
+
+use anyhow::{Context, Error};
+use serde::Deserialize;
 use tracing::debug;
 
 #[derive(Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -22,7 +23,14 @@ impl FromStr for LogConfig {
 
 impl LogConfig {
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
-        let res = read_to_string(path.as_ref().join("logging.conf"))?.parse::<Self>();
+        let res = read_to_string(path.as_ref().join("logging.conf"))
+            .with_context(|| {
+                format!(
+                    "Could not read logging configuration file from {}",
+                    path.as_ref().join("main.conf").display()
+                )
+            })?
+            .parse::<Self>();
         if let Ok(ref cfg) = res {
             debug!("Parsed logging configuration:\n{:#?}", &cfg);
         }

--- a/relay/sources/relayd/src/main.rs
+++ b/relay/sources/relayd/src/main.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later WITH GPL-3.0-linking-source-exception
 // SPDX-FileCopyrightText: 2019-2020 Normation SAS
 
+use std::{env, process::exit};
+
 use gumdrop::Options;
+use tracing::error;
+
 use rudder_relayd::{
     configuration::{check_configuration, cli::CliConfiguration},
     init_logger, start, ExitStatus, CRATE_NAME, CRATE_VERSION,
 };
-use std::{env, process::exit};
-use tracing::error;
 
 /// Everything in a lib to allow extensive testing
 fn main() {
@@ -47,7 +49,8 @@ fn main() {
         };
 
         if let Err(e) = start(cli_cfg, reload_handle) {
-            error!("{}", e);
+            // Debug to get anyhow error stack
+            error!("{:?}", e);
             exit(ExitStatus::StartError(e).code());
         }
     }

--- a/relay/sources/relayd/tests/api_system_status.rs
+++ b/relay/sources/relayd/tests/api_system_status.rs
@@ -52,7 +52,7 @@ mod tests {
         )
         .unwrap();
 
-        let reference: serde_json::Value = serde_json::from_str("{\"data\":{\"database\":{\"status\":\"success\"},\"configuration\":{\"status\":\"error\", \"details\": \"No such file or directory (os error 2)\"}},\"result\":\"success\",\"action\":\"getStatus\"}").unwrap();
+        let reference: serde_json::Value = serde_json::from_str("{\"data\":{\"database\":{\"status\":\"success\"},\"configuration\":{\"status\":\"error\", \"details\": \"Could not read main configuration file from tests/files/config/main.conf\"}},\"result\":\"success\",\"action\":\"getStatus\"}").unwrap();
 
         assert_eq!(reference, response);
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/21279