### PR TITLE
Fixes #20603: Reports on method using iterator are wrong in the cli output

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/1.0/technique.cf
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/1.0/technique.cf
@@ -12,9 +12,13 @@ bundle agent technique_any(version)
     "pass2" expression => "pass1";
     "pass1" expression => "any";
   methods:
-    "id_${report_data.directive_id}" usebundle => _method_reporting_context_v4("Test component$&é)à\\'\"", "${node.properties[apache_package_name]}","id"),
-                                            if => concat("any");
-    "id_${report_data.directive_id}" usebundle => package_install_version("${node.properties[apache_package_name]}", "2.2.11"),
+    "id_${report_data.directive_id}" usebundle => technique_any_gm_0("Test component$&é)à\\'\"", "${node.properties[apache_package_name]}", "id", "${node.properties[apache_package_name]}", "2.2.11"),
                                             if => concat("any");
 
+}
+
+bundle agent technique_any_gm_0(c_name, c_key, report_id, package_name, package_version) {
+  methods:
+    "id_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}","${c_key}","${report_id}");
+    "id_${report_data.directive_id}" usebundle => package_install_version("${package_name}","${package_version}");
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/2.0/technique.cf
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/2.0/technique.cf
@@ -12,9 +12,13 @@ bundle agent technique_any(version)
     "pass2" expression => "pass1";
     "pass1" expression => "any";
   methods:
-    "id_${report_data.directive_id}" usebundle => _method_reporting_context_v4("Test component$&é)à\\'\"", "${node.properties[apache_package_name]}","id"),
-                                            if => concat("any");
-    "id_${report_data.directive_id}" usebundle => package_install_version("${node.properties[apache_package_name]}", "2.2.11"),
+    "id_${report_data.directive_id}" usebundle => technique_any_gm_0("Test component$&é)à\\'\"", "${node.properties[apache_package_name]}", "id", "${node.properties[apache_package_name]}", "2.2.11"),
                                             if => concat("any");
 
+}
+
+bundle agent technique_any_gm_0(c_name, c_key, report_id, package_name, package_version) {
+  methods:
+    "id_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}","${c_key}","${report_id}");
+    "id_${report_data.directive_id}" usebundle => package_install_version("${package_name}","${package_version}");
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/rudder_reporting.cf
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/rudder_reporting.cf
@@ -7,24 +7,36 @@ bundle agent technique_by_Rudder_rudder_reporting(technique_parameter)
     "class_prefix"      string => string_head("${full_class_prefix}", "1000");
 
   methods:
-    "id1" usebundle => _method_reporting_context_v4("Customized component", "${node.properties[apache_package_name]}","id1"),
-             unless => concat("(debian)");
-    "id1" usebundle => log_na_rudder("Skipping method 'Package install version' with key parameter '${node.properties[apache_package_name]}' since condition 'any' is not reached", "${node.properties[apache_package_name]}", "${class_prefix}_package_install_version_${node.properties[apache_package_name]}", @{args}),
-             unless => concat("(debian)");
-    "id2" usebundle => disable_reporting,
-             unless => concat("(debian.windows)");
-    "id2" usebundle => _method_reporting_context_v4("Command execution", "Write-Host \"testing special characters ` è &é 'à é \"","id2"),
-             unless => concat("(debian.windows)");
-    "id2" usebundle => log_na_rudder("Skipping method 'Command execution' with key parameter 'Write-Host \"testing special characters ` è &é 'à é \"' since condition 'windows' is not reached", "Write-Host \"testing special characters ` è &é 'à é \"", "${class_prefix}_command_execution_Write-Host \"testing special characters ` è &é 'à é \"", @{args}),
-             unless => concat("(debian.windows)");
-    "id2" usebundle => enable_reporting,
-             unless => concat("(debian.windows)");
-    "id3" usebundle => _method_reporting_context_v4("Customized component", "${node.properties[apache_package_name]}","id3"),
-             unless => concat("package_install_version_",canonify("${node.properties[apache_package_name]}"),"_repaired");
-    "id3" usebundle => log_na_rudder("Skipping method 'Service start' with key parameter '${node.properties[apache_package_name]}' since condition 'package_install_version_${node.properties[apache_package_name]}_repaired' is not reached", "${node.properties[apache_package_name]}", "${class_prefix}_service_start_${node.properties[apache_package_name]}", @{args}),
-             unless => concat("package_install_version_",canonify("${node.properties[apache_package_name]}"),"_repaired");
-    "id4" usebundle => _method_reporting_context_v4("Package install", "openssh-server","id4"),
-             unless => concat("redhat");
-    "id4" usebundle => log_na_rudder("Skipping method 'Package install' with key parameter 'openssh-server' since condition 'redhat' is not reached", "openssh-server", "${class_prefix}_package_install_openssh-server", @{args}),
-             unless => concat("redhat");
+    "id1_${report_data.directive_id}" usebundle => technique_by_Rudder_gm_6("Customized component", "${node.properties[apache_package_name]}", "id1", "Skipping method 'Package install version' with key parameter '${node.properties[apache_package_name]}' since condition 'any' is not reached", "${node.properties[apache_package_name]}", "${class_prefix}_package_install_version_${node.properties[apache_package_name]}", @{args}),
+                                             unless => concat("(debian)");
+    "id2_${report_data.directive_id}" usebundle => technique_by_Rudder_gm_7("Command execution", "Write-Host \"testing special characters ` è &é 'à é \"", "id2", "Skipping method 'Command execution' with key parameter 'Write-Host \"testing special characters ` è &é 'à é \"' since condition 'windows' is not reached", "Write-Host \"testing special characters ` è &é 'à é \"", "${class_prefix}_command_execution_Write-Host \"testing special characters ` è &é 'à é \"", @{args}),
+                                             unless => concat("(debian.windows)");
+    "id3_${report_data.directive_id}" usebundle => technique_by_Rudder_gm_8("Customized component", "${node.properties[apache_package_name]}", "id3", "Skipping method 'Service start' with key parameter '${node.properties[apache_package_name]}' since condition 'package_install_version_${node.properties[apache_package_name]}_repaired' is not reached", "${node.properties[apache_package_name]}", "${class_prefix}_service_start_${node.properties[apache_package_name]}", @{args}),
+                                             unless => concat("package_install_version_",canonify("${node.properties[apache_package_name]}"),"_repaired");
+    "id4_${report_data.directive_id}" usebundle => technique_by_Rudder_gm_9("Package install", "openssh-server", "id4", "Skipping method 'Package install' with key parameter 'openssh-server' since condition 'redhat' is not reached", "openssh-server", "${class_prefix}_package_install_openssh-server", @{args}),
+                                             unless => concat("redhat");
+
+}
+
+bundle agent technique_by_Rudder_gm_6(c_name, c_key, report_id, message, class_parameter, unique_prefix, args) {
+  methods:
+    "id1_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}","${c_key}","${report_id}");
+    "id1_${report_data.directive_id}" usebundle => log_na_rudder("${message}","${class_parameter}","${unique_prefix}",@{args});
+}
+bundle agent technique_by_Rudder_gm_7(c_name, c_key, report_id, message, class_parameter, unique_prefix, args) {
+  methods:
+    "id2_${report_data.directive_id}" usebundle => disable_reporting;
+    "id2_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}","${c_key}","${report_id}");
+    "id2_${report_data.directive_id}" usebundle => log_na_rudder("${message}","${class_parameter}","${unique_prefix}",@{args});
+    "id2_${report_data.directive_id}" usebundle => enable_reporting;
+}
+bundle agent technique_by_Rudder_gm_8(c_name, c_key, report_id, message, class_parameter, unique_prefix, args) {
+  methods:
+    "id3_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}","${c_key}","${report_id}");
+    "id3_${report_data.directive_id}" usebundle => log_na_rudder("${message}","${class_parameter}","${unique_prefix}",@{args});
+}
+bundle agent technique_by_Rudder_gm_9(c_name, c_key, report_id, message, class_parameter, unique_prefix, args) {
+  methods:
+    "id4_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}","${c_key}","${report_id}");
+    "id4_${report_data.directive_id}" usebundle => log_na_rudder("${message}","${class_parameter}","${unique_prefix}",@{args});
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/technique.cf
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/technique.cf
@@ -13,33 +13,50 @@ bundle agent technique_by_Rudder(technique_parameter)
     "pass2" expression => "pass1";
     "pass1" expression => "any";
   methods:
-    "id1_${report_data.directive_id}" usebundle => _method_reporting_context_v4("Customized component", "${node.properties[apache_package_name]}","id1"),
+    "id1_${report_data.directive_id}" usebundle => technique_by_Rudder_gm_0("Customized component", "${node.properties[apache_package_name]}", "id1", "${node.properties[apache_package_name]}", "2.2.11"),
                                              if => concat("(debian)");
-    "id1_${report_data.directive_id}" usebundle => package_install_version("${node.properties[apache_package_name]}", "2.2.11"),
-                                             if => concat("(debian)");
-    "id2_${report_data.directive_id}" usebundle => disable_reporting,
+    "id2_${report_data.directive_id}" usebundle => technique_by_Rudder_gm_1("Command execution", "Write-Host \"testing special characters ` è &é 'à é \"", "id2", "Write-Host \"testing special characters ` è &é 'à é \""),
                                              if => concat("(debian.windows)");
-    "id2_${report_data.directive_id}" usebundle => _method_reporting_context_v4("Command execution", "Write-Host \"testing special characters ` è &é 'à é \"","id2"),
-                                             if => concat("(debian.windows)");
-    "id2_${report_data.directive_id}" usebundle => command_execution("Write-Host \"testing special characters ` è &é 'à é \""),
-                                             if => concat("(debian.windows)");
-    "id2_${report_data.directive_id}" usebundle => enable_reporting,
-                                             if => concat("(debian.windows)");
-    "id3_${report_data.directive_id}" usebundle => _method_reporting_context_v4("Customized component", "${node.properties[apache_package_name]}","id3"),
+    "id3_${report_data.directive_id}" usebundle => technique_by_Rudder_gm_2("Customized component", "${node.properties[apache_package_name]}", "id3", "${node.properties[apache_package_name]}"),
                                              if => concat("package_install_version_",canonify("${node.properties[apache_package_name]}"),"_repaired");
-    "id3_${report_data.directive_id}" usebundle => service_start("${node.properties[apache_package_name]}"),
-                                             if => concat("package_install_version_",canonify("${node.properties[apache_package_name]}"),"_repaired");
-    "id4_${report_data.directive_id}" usebundle => _method_reporting_context_v4("Package install", "openssh-server","id4"),
+    "id4_${report_data.directive_id}" usebundle => technique_by_Rudder_gm_3("Package install", "openssh-server", "id4", "openssh-server"),
                                              if => concat("redhat");
-    "id4_${report_data.directive_id}" usebundle => package_install("openssh-server"),
-                                             if => concat("redhat");
-    "id5_${report_data.directive_id}" usebundle => _method_reporting_context_v4("Command execution", "/bin/echo \"testing special characters ` è &é 'à é \"\\","id5"),
+    "id5_${report_data.directive_id}" usebundle => technique_by_Rudder_gm_4("Command execution", "/bin/echo \"testing special characters ` è &é 'à é \"\\", "id5", "/bin/echo \"testing special characters ` è &é 'à é \"\\"),
                                              if => concat("any");
-    "id5_${report_data.directive_id}" usebundle => command_execution("/bin/echo \"testing special characters ` è &é 'à é \"\\"),
-                                             if => concat("any");
-    "id6_${report_data.directive_id}" usebundle => _method_reporting_context_v4("Not sure we should test it ...", "NA","id6"),
-                                             if => concat("any");
-    "id6_${report_data.directive_id}" usebundle => _logger("NA", "NA"),
+    "id6_${report_data.directive_id}" usebundle => technique_by_Rudder_gm_5("Not sure we should test it ...", "NA", "id6", "NA", "NA"),
                                              if => concat("any");
 
+}
+
+bundle agent technique_by_Rudder_gm_0(c_name, c_key, report_id, package_name, package_version) {
+  methods:
+    "id1_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}","${c_key}","${report_id}");
+    "id1_${report_data.directive_id}" usebundle => package_install_version("${package_name}","${package_version}");
+}
+bundle agent technique_by_Rudder_gm_1(c_name, c_key, report_id, command) {
+  methods:
+    "id2_${report_data.directive_id}" usebundle => disable_reporting;
+    "id2_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}","${c_key}","${report_id}");
+    "id2_${report_data.directive_id}" usebundle => command_execution("${command}");
+    "id2_${report_data.directive_id}" usebundle => enable_reporting;
+}
+bundle agent technique_by_Rudder_gm_2(c_name, c_key, report_id, service_name) {
+  methods:
+    "id3_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}","${c_key}","${report_id}");
+    "id3_${report_data.directive_id}" usebundle => service_start("${service_name}");
+}
+bundle agent technique_by_Rudder_gm_3(c_name, c_key, report_id, package_name) {
+  methods:
+    "id4_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}","${c_key}","${report_id}");
+    "id4_${report_data.directive_id}" usebundle => package_install("${package_name}");
+}
+bundle agent technique_by_Rudder_gm_4(c_name, c_key, report_id, command) {
+  methods:
+    "id5_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}","${c_key}","${report_id}");
+    "id5_${report_data.directive_id}" usebundle => command_execution("${command}");
+}
+bundle agent technique_by_Rudder_gm_5(c_name, c_key, report_id, message, old_class_prefix) {
+  methods:
+    "id6_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}","${c_key}","${report_id}");
+    "id6_${report_data.directive_id}" usebundle => _logger("${message}","${old_class_prefix}");
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/20603

This PR changes the way ncf techniques are generated to support (at least partially) iterators.
The main idea is to create a *bundle* that will set the context and call the effective generic method. This is necessary so that any iterator within the arguments of the generic method are not iterated once for the reporting context, and then once for the generic method

One bundle is created by generic method, named by the promiser of the generic method plus an increment id.

The resulting code looks like


```
    "id1_${report_data.directive_id}" usebundle => id1_0("Customized component", "${node.properties[apache_package_name]}", "id1", "${node.properties[apache_package_name]}", "2.2.11"),
                                             if => concat("(debian)");`
```
and the bundle doing the action being

```
bundle agent id1_0(arg_0, arg_1, arg_2, arg_3, arg_4) {
  methods:
    "id1_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${arg_0}","${arg_1}","${arg_2}");
    "id1_${report_data.directive_id}" usebundle => package_install_version("${arg_3}","${arg_4}");

}
```