### PR TITLE
Fixes #21293: Allow overriding rudder-web.properties parameters with files in rudder-web.properties.d

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -222,7 +222,18 @@ final case class FileSystemResource(file: File) extends AnyVal with ConfigResour
  */
 object RudderProperties {
 
+  // extension used in overriding files
+  val configFileExtensions = Set("properties", "prop", "config")
+
+  // by default, used and configured to /opt/rudder/etc/rudder-web.properties
   val JVM_CONFIG_FILE_KEY = "rudder.configFile"
+
+  // We have config overrides in a directory whose named is based on JVM_CONFIG_FILE_KEY
+  // if defined, with a ".d" after it. It can be overridden with that key.
+  // File in dir are sorted by name and the latter override the former.
+  // Default: ${JVM_CONFIG_FILE_KEY}.d
+  val JVM_CONFIG_DIR_KEY = "rudder.configDir"
+
   val DEFAULT_CONFIG_FILE_NAME = "configuration.properties"
 
   // Set security provider with bouncy castle one
@@ -231,31 +242,98 @@ object RudderProperties {
   /**
    * Where to go to look for properties
    */
-  val configResource = System.getProperty(JVM_CONFIG_FILE_KEY) match {
+  val (configResource, overrideDir) = System.getProperty(JVM_CONFIG_FILE_KEY) match {
       case null | "" => //use default location in classpath
-        ApplicationLogger.info("JVM property -D%s is not defined, use configuration file in classpath".format(JVM_CONFIG_FILE_KEY))
-        ClassPathResource(DEFAULT_CONFIG_FILE_NAME)
+        ApplicationLogger.info(s"JVM property -D${JVM_CONFIG_FILE_KEY} is not defined, use configuration file in classpath")
+        (ClassPathResource(DEFAULT_CONFIG_FILE_NAME), None)
+
       case x => //so, it should be a full path, check it
         val config = new File(x)
         if(config.exists && config.canRead) {
-          ApplicationLogger.info("Use configuration file defined by JVM property -D%s : %s".format(JVM_CONFIG_FILE_KEY, config.getPath))
-          FileSystemResource(config)
+          ApplicationLogger.info(s"Rudder application parameters are read from file defined by JVM property -D${JVM_CONFIG_FILE_KEY}: ${config.getPath}")
+          val configFile = FileSystemResource(config)
+
+          val overrideDir = System.getProperty(JVM_CONFIG_DIR_KEY) match {
+            case null | "" =>
+              val path = configFile.file.getPath + ".d"
+              ApplicationLogger.info(s"-> files for overriding configuration parameters are read from directory ${path} (that path can be overridden with JVM property -D${JVM_CONFIG_DIR_KEY})")
+              Some(path)
+            case x =>
+              val d = better.files.File(x)
+              if(d.exists) {
+                if(d.isDirectory) {
+                  Some(d.pathAsString)
+                } else {
+                  ApplicationLogger.warn(s"JVM property -D${JVM_CONFIG_DIR_KEY} is defined to '${d.pathAsString}' which is not a directory: ignoring directory for overriding configurations")
+                  None
+                }
+              } else {
+                // we will create it
+                Some(d.pathAsString)
+              }
+          }
+          (configFile, overrideDir)
         } else {
-          ApplicationLogger.error("Can not find configuration file specified by JVM property %s: %s ; abort".format(JVM_CONFIG_FILE_KEY, config.getPath))
-          throw new javax.servlet.UnavailableException("Configuration file not found: %s".format(config.getPath))
+          ApplicationLogger.error(s"Can not find configuration file specified by JVM property '${JVM_CONFIG_FILE_KEY}': '${config.getPath}' ; abort")
+          throw new javax.servlet.UnavailableException(s"Configuration file not found: ${config.getPath}")
         }
     }
+
+  // Sorting is done here for meaningful debug log, but we need to reverse it
+  // because in typesafe Config, we have "withDefault" (ie the opposite of overrides)
+  val overrideConfigs = overrideDir match {
+    case None => // no additional config to add
+      Nil
+    case Some(x) =>
+      val d = better.files.File(x)
+      try {
+        d.createDirectoryIfNotExists(true)
+      } catch {
+        case ex: Exception =>
+          ApplicationLogger.error(s"The configuration directory '${d.pathAsString}' for overriding file config can't be created: ${ex.getMessage}")
+      }
+      val overrides = d.children.collect {
+        case f if(configFileExtensions.contains(f.extension(false, false).getOrElse(""))) => FileSystemResource(f.toJava)
+      }.toList.sortBy(_.file.getPath)
+      ApplicationLogger.debug(s"Overriding configuration files in '${d.pathAsString}': ${overrides.map(_.file.getName).mkString(", ")}")
+      overrides
+  }
 
   // some value used as defaults for migration
   val migrationConfig =
     s"""rudder.batch.reportscleaner.compliancelevels.delete.TTL=15
     """
 
+  // the Config lib does not define overriding but fallback, so we are starting with the directory, sorted last first
+  // then default file, then migration things.
+  val empty = ConfigFactory.empty()
+
   val config : Config = {
-    (configResource match {
-      case ClassPathResource(name) => ConfigFactory.load(name)
-      case FileSystemResource(file) => ConfigFactory.load(ConfigFactory.parseFile(file))
-    }).withFallback(ConfigFactory.parseString(migrationConfig))
+    (
+      (overrideConfigs.reverse :+ configResource).foldLeft(ConfigFactory.empty()) { case (current, fallback) =>
+        ApplicationLogger.debug(s"loading configuration from " + fallback)
+        val conf = fallback match {
+          case ClassPathResource(name) => ConfigFactory.load(name)
+          case FileSystemResource(file) => ConfigFactory.load(ConfigFactory.parseFile(file))
+        }
+        current.withFallback(conf)
+      }
+    ).withFallback(ConfigFactory.parseString(migrationConfig))
+  }
+
+  if(ApplicationLogger.isDebugEnabled) {
+    // if override Dir is non empty, add the resolved config file with debug info in it
+    overrideDir.foreach { d =>
+      val dest = better.files.File(d) / "rudder-web.properties-resolved-debug"
+      ApplicationLogger.debug(s"Writing resolved configuration file to ${dest.pathAsString}")
+      import java.nio.file.attribute.PosixFilePermission._
+      try {
+        dest.setPermissions(Set(OWNER_READ, GROUP_READ)).writeText(config.root().render())
+      } catch {
+        case ex: Exception =>
+          ApplicationLogger.error(s"The debug file for configuration resolution '${dest.pathAsString}' can't be created: ${ex.getMessage}")
+      }
+    }
   }
 
   def splitProperty(s: String): List[String] = {


### PR DESCRIPTION
https://issues.rudder.io/issues/21293

Add the use of an overriding configuration directory. By default, it is the name of the config file with `d.`  appended to it but can be overridden if needed with a JVM parameter.

Log info for such things are important, they looks like: 
```
[2022-06-20 10:42:57+0200] INFO  application - Use configuration file defined by JVM property -Drudder.configFile : /home/fanf/java/workspaces/rudder-project/static-config/configuration-rudder-7.1.properties
[2022-06-20 10:42:57+0200] INFO  application - JVM property -Drudder.configDir is not defined: using /home/fanf/java/workspaces/rudder-project/static-config/configuration-rudder-7.1.properties.d directory
[2022-06-20 10:42:57+0200] DEBUG application - Overriding configuration files in '/home/fanf/java/workspaces/rudder-project/static-config/configuration-rudder-7.1.properties.d': 10-low-override.properties, 90-high-override.properties
[2022-06-20 10:42:57+0200] DEBUG application - loading configuration from FileSystemResource(/home/fanf/java/workspaces/rudder-project/static-config/configuration-rudder-7.1.properties.d/90-high-override.properties)
[2022-06-20 10:42:57+0200] DEBUG application - loading configuration from FileSystemResource(/home/fanf/java/workspaces/rudder-project/static-config/configuration-rudder-7.1.properties.d/10-low-override.properties)
[2022-06-20 10:42:57+0200] DEBUG application - loading configuration from FileSystemResource(/home/fanf/java/workspaces/rudder-project/static-config/configuration-rudder-7.1.properties)
[2022-06-20 10:42:57+0200] DEBUG application - Writing resolved configuration file to /home/fanf/java/workspaces/rudder-project/static-config/configuration-rudder-7.1.properties.d/rudder-web.properties-resolved-debug
```

The `rudder-web.properties-resolved-debug` file is a debbuging file with origin info looking like:

```
...
            },
            # merge of /.../configuration-rudder-7.1.properties.d/90-high-override.properties,/.../configuration-rudder-7.1.properties
            "reportscleaner" : {
                # /.../configuration-rudder-7.1.properties.d/90-high-override.properties
                "archive" : {
                    # /.../configuration-rudder-7.1.properties.d/90-high-override.properties
                    "TTL" : "2"
                },
                # /.../configuration-rudder-7.1.properties
                "compliancelevels" : {
                    # /.../configuration-rudder-7.1.properties
                    "delete" : {
                        # /.../configuration-rudder-7.1.properties
                        "TTL" : "8"
                    }
                },
...
```

