### PR TITLE
Fixes #21117: Moving create node plugin into Rudder

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/NodeInventory.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/NodeInventory.scala
@@ -317,6 +317,113 @@ final case class Windows(
   , productId                  : Option[String] = None
 ) extends OsDetails(os, fullName, version, servicePack, kernelVersion)
 
+
+object ParseOSType {
+
+  def getType(osType: String, osName: String, fullName: String): OsType = {
+    (osType, osName) match {
+        case ("mswin32", _ ) =>
+          val x = fullName.toLowerCase
+          //in windows, relevant information are in the fullName string
+          if     (x contains  "xp"     )   WindowsXP
+          else if(x contains  "vista"  )   WindowsVista
+          else if(x contains  "seven"  )   WindowsSeven
+          else if(x contains  "10"  )      Windows10
+          else if(x contains  "2000"   )   Windows2000
+          else if(x contains  "2003"   )   Windows2003
+          else if(x contains  "2008 r2")   Windows2008R2 //must be before 2008 for obvious reason
+          else if(x contains  "2008"   )   Windows2008
+          else if(x contains  "2012 r2")   Windows2012R2
+          else if(x contains  "2012"   )   Windows2012
+          else if(x contains  "2016 r2")   Windows2016R2
+          else if(x contains  "2016"   )   Windows2016
+          else if(x contains  "2019"   )   Windows2019
+          else                             UnknownWindowsType
+
+        case ("linux"  , x ) =>
+          if     (x contains "debian"      ) Debian
+          else if(x contains "ubuntu"      ) Ubuntu
+          else if(x contains "kali"        ) Kali
+          else if(x contains "redhat"      ) Redhat
+          else if(x contains "centos"      ) Centos
+          else if(x contains "fedora"      ) Fedora
+          else if(x contains "suse"        ) Suse
+          else if(x contains "android"     ) Android
+          else if(x contains "oracle"      ) Oracle
+          else if(x contains "scientific"  ) Scientific
+          else if(x contains "slackware"   ) Slackware
+          else if(x contains "mint"        ) Mint
+          else if(x contains "amazon linux") AmazonLinux
+          else if(x contains "rocky"       ) RockyLinux
+          else if(x contains "almalinux"   ) AlmaLinux
+          else                               UnknownLinuxType
+
+        case("solaris", _) => SolarisOS
+
+        case("aix", _) => AixOS
+
+        case ("freebsd", _) => FreeBSD
+
+        case _  => UnknownOSType
+      }
+  }
+
+  def getDetails(osType: OsType, fullName: String, version: Version, servicePack: Option[String], kernelVersion: Version): OsDetails = {
+      osType match {
+        case w:WindowsType =>
+          Windows(
+              os = w
+            , fullName = fullName
+            , version = version
+            , servicePack = servicePack
+            , kernelVersion = kernelVersion
+            , userDomain = None
+            , registrationCompany = None
+            , productId = None
+            , productKey = None
+          )
+
+        case distrib:LinuxType =>
+          Linux(
+              os = distrib
+            , fullName = fullName
+            , version = version
+            , servicePack = servicePack
+            , kernelVersion = kernelVersion
+          )
+
+        case FreeBSD =>
+          Bsd(
+              os = FreeBSD
+            , fullName = fullName
+            , version = version
+            , servicePack = servicePack
+            , kernelVersion = kernelVersion
+          )
+
+        case SolarisOS =>
+          Solaris(
+              fullName = fullName
+            , version = version
+            , servicePack = servicePack
+            , kernelVersion = kernelVersion
+          )
+
+        case AixOS =>
+
+          Aix(
+              fullName = fullName
+            , version = version
+            , servicePack = servicePack
+            , kernelVersion = kernelVersion
+          )
+
+        case _  => UnknownOS(fullName, version, servicePack, kernelVersion)
+      }
+  }
+}
+
+
 final case class NodeSummary(
     id : NodeId
   , status:InventoryStatus

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestPreParsing.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestPreParsing.scala
@@ -109,4 +109,8 @@ class TestPreParsing extends Specification {
     inventories must beRight
   }
 
+  "AIX version should be correctly set in OPERATINSYSTEM" in {
+    val aix = post.check("fusion-inventories/sovma136-2014-02-10-07-13-43.ocs").map(xml => (xml \\ "OPERATINGSYSTEM" \ "KERNEL_VERSION").text)
+    aix must beRight[String]( ===("5300-12"))
+  }
 }

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestReportParsing.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestReportParsing.scala
@@ -276,8 +276,16 @@ class TestInventoryParsing extends Specification with Loggable {
 
   "Parsing Windows 2012" should {
     "parse as windows 2012" in {
-      val os = parseRun("fusion-inventories/WIN-AI8CLNPLOV5-2014-06-20-18-15-49.ocs").node.main.osDetails.os
-      os === Windows2012
+      val os = parseRun("fusion-inventories/WIN-AI8CLNPLOV5-2014-06-20-18-15-49.ocs").node.main.osDetails
+      os match {
+        case Windows(osType, _, _, _, _, ud, rc, pk, pid) =>
+          (osType === Windows2012) and
+          (ud === None) and
+          (rc === Some("Amazon.com")) and
+          (pk === Some("T3VD8-82QFK-QCFB9-WV3TF-QGJ3F")) and
+          (pid === Some("00184-30000-00001-AA420"))
+        case x => ko(s"I was expecting a windows 2012, got: ${x}")
+      }
     }
     "parse as windows 2012" in {
       val os = parseRun("fusion-inventories/windows2012r2.ocs").node.main.osDetails.os

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
@@ -957,10 +957,10 @@ class NodeInfoServiceCachedImpl(
    * and inventory nodes under ou=RemovedInventories
    *  Reason:
    * - only these three entries are used for node info (and none of their
-   *   subentries)
+   *   sub-entries)
    * - if a node is deleted, it either go to RemovedInventories (and so the
    *   machine, but we don't care as soon as we know a node went there) and we
-   *   will see its based on modifity timestamps, or if "node full erase" is enabled,
+   *   will see its based on modify timestamps, or if "node full erase" is enabled,
    *   a special call to "remove node from cache" must be done
    * - for ou=Node, all modifications happen in the entry, so the modifyTimestamp
    *   is changed accordingly.
@@ -981,8 +981,8 @@ class NodeInfoServiceCachedImpl(
    * at least one exists.
    *
    * A cleaner implementation could use a two persistent search which would notify
-   * when a cache becomes invalide and reset it, but the rationnal for that implementation is:
-   * - it's extremelly simple to understand the logic (if(cache is uptodate) use it else update cache)
+   * when a cache becomes invalid and reset it, but the rational for that implementation is:
+   * - it's extremely simple to understand the logic (if(cache is up-to-date) use it else update cache)
    * - most of the time (99.99% of it), the search will return 0 result and will be cache on OpenLDAP,
    *   whatever the number of entries. So we talking of a request taking a couple of ms on the server
    *   (with a vagrant VM on the same host (so, almost no network), it takes from client to server and

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -278,6 +278,10 @@ object NodeApi extends ApiModuleProvider[NodeApi] {
     val description = "Ask given node to start a run with the given policy"
     val (action, path)  = POST / "nodes" / "{id}" / "applyPolicy"
   }
+  final case object CreateNodes extends NodeApi with GeneralApi with ZeroParam with StartsAtVersion15 with SortIndex {val z = implicitly[Line].value
+    val description    = "Create one of more new nodes"
+    val (action, path) = PUT / "nodes"
+  }
   def endpoints = ca.mrvisser.sealerate.values[NodeApi].toList.sortBy( _.z )
 }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -693,7 +693,7 @@ final case class RestExtractorService (
    * ] }
    */
 
-  private[this] def extractNodeProperty(json : JValue) : Box[NodeProperty] = {
+  def extractNodeProperty(json : JValue) : Box[NodeProperty] = {
     ( (json \ "name"), (json \ "value") ) match {
       case ( JString(nameValue), value ) =>
         val provider = (json \ "provider") match {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
@@ -110,7 +110,7 @@ final case object OnlyAdmin extends AuthorizationApiMapping {
                                      SettingsApi.GetAllowedNetworks.x :: SettingsApi.GetAllAllowedNetworks.x :: HookApi.GetHooks.x :: InfoApi.endpoints.map(_.x)
         case Administration.Write => PluginApi.UpdatePluginsSettings.x :: SettingsApi.ModifySettings.x :: SettingsApi.ModifySetting.x ::
                                      InventoryApi.FileWatcherRestart.x :: InventoryApi.FileWatcherStart.x :: InventoryApi.FileWatcherStop.x ::
-                                     SystemApi.endpoints.map(_.x)
+                                     NodeApi.CreateNodes.x :: SystemApi.endpoints.map(_.x)
         case Administration.Edit  => PluginApi.UpdatePluginsSettings.x :: SettingsApi.ModifySettings.x :: SettingsApi.ModifySetting.x ::
                                      SettingsApi.ModifyAllowedNetworks.x :: SettingsApi.ModifyDiffAllowedNetworks.x ::
                                      Nil

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/CreateNodeData.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/CreateNodeData.scala
@@ -1,0 +1,439 @@
+/*
+*************************************************************************************
+* Copyright 2019 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.rest.data
+
+import com.normation.NamedZioLogger
+import com.normation.inventory.domain.AgentType.CfeCommunity
+import com.normation.inventory.domain.AgentType.Dsc
+import com.normation.inventory.domain._
+import com.normation.rudder.domain.nodes.NodeState
+import com.normation.rudder.domain.policies.PolicyMode
+import com.normation.rudder.domain.properties.GenericProperty
+import com.normation.rudder.domain.properties.NodeProperty
+import com.normation.rudder.rest.RestExtractorService
+import com.normation.rudder.rest.data.Creation.CreationError
+import com.normation.rudder.rest.data.NodeTemplate.AcceptedNodeTemplate
+import com.normation.rudder.rest.data.NodeTemplate.PendingNodeTemplate
+
+import cats.data._
+import cats.implicits._
+import com.typesafe.config.ConfigValue
+import net.liftweb.json.JArray
+import net.liftweb.json.JField
+import net.liftweb.json.JObject
+import net.liftweb.json.JString
+import net.liftweb.json.JValue
+
+import com.normation.errors._
+
+/**
+ * Applicative log of interest for Rudder ops.
+ */
+object CreateNodeApiLogger extends NamedZioLogger {
+  override def loggerName: String ="create-node-api"
+}
+
+
+
+/*
+ * This is the RestNodeDetails as provided by RestDataSerializer, but in a Scala format.
+ * Do not change it without versionning, it's an actual API definition.
+ */
+object Rest {
+
+  final case class OS(
+    `type`       : String
+    , name         : String
+    , version      : String
+    , fullName     : String
+    , servicePack  : Option[String]
+  )
+
+  final case class AgentKey(
+    value : String
+    , status: Option[String]
+  )
+
+  final case class NodeProp(name: String, value: ConfigValue)
+
+  final case class NodeDetails(
+      id              : String
+    , hostname        : String
+    , status          : String
+    , os              : OS
+    , policyServerId  : Option[String]
+    , machineType     : String
+    , state           : Option[String]
+    , policyMode      : Option[String]
+    , agentKey        : Option[AgentKey]
+    , properties      : List[NodeProp]
+    , ipAddresses     : List[String]
+    , timezone        : Option[NodeTimezone]
+  )
+}
+
+
+/*
+ * We need to be able to identify what the user actually asked
+ * for in the rudder part of the node (state, policy mode, properties)
+ * so that we can set that correctly after acceptation, or else let
+ * default as they are.
+ */
+final case class NodeSetup(
+    properties: List[NodeProperty]
+  , policyMode: Option[PolicyMode]
+  , state     : Option[NodeState]
+)
+
+/*
+ * An object that hold the will-be-created node:
+ * - inventory
+ * - node info like properties, etc
+ * - the target node status (it's created in "pending" but can be accepted)
+ */
+sealed trait NodeTemplate {
+  def inventory : FullInventory
+  def properties: List[NodeProperty]
+}
+
+object NodeTemplate {
+  final case class PendingNodeTemplate(
+      inventory : FullInventory
+    , properties: List[NodeProperty]
+  ) extends NodeTemplate
+
+  final case class AcceptedNodeTemplate(
+    inventory : FullInventory
+  , properties: List[NodeProperty]
+  , policyMode: Option[PolicyMode]
+  , state     : Option[NodeState]
+  ) extends NodeTemplate
+}
+
+
+/*
+ * for each will-be-created node, we want to store if the result is success
+ * of error. We will decide what to return from the API based on that.
+ */
+final case class ResultHolder(
+  //lists because we want to be able to have several time the same id
+  created: List[NodeId]
+  , failed : List[(String, CreationError)] // string because perhaps it's not yet a nodeId
+)
+
+
+object ResultHolder {
+
+  implicit class ResultHolderToJson(res: ResultHolder) {
+
+    def toJson(): JValue = {
+      import net.liftweb.json.JsonDSL._
+      (
+          ("created" -> JArray(res.created.map(id => JString(id.value))))
+        ~ ("failed"  ->
+           JArray(res.failed.map { case (id, error) =>
+            JObject(JField(id, errorToJson(error)))
+           })
+          )
+      )
+    }
+
+    def errorToJson(error: CreationError): JValue = {
+      error match {
+        case CreationError.OnAcceptation(msg)   => JString(s"[accept] ${msg}")
+        case CreationError.OnSaveInventory(msg) => JString(s"[save inventory] ${msg}")
+        case CreationError.OnSaveNode(msg)      => JString(s"[save node] ${msg}")
+        case CreationError.OnValidation(nel)    => JArray(nel.map(e => JString(s"[validation] ${e.msg}")).toList)
+      }
+    }
+  }
+}
+
+class NodeDetailsSerialize(
+  restExtractorService: RestExtractorService
+) {
+  import net.liftweb.json._
+
+  implicit val formats = DefaultFormats + new ConfigValueSerializer
+
+  class ConfigValueSerializer extends Serializer[ConfigValue] {
+    private val ConfigValueClass = classOf[ConfigValue]
+
+    def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, JValue), ConfigValue] = {
+      case (TypeInfo(ConfigValueClass, _), json) => GenericProperty.fromJsonValue(json)
+    }
+
+    def serialize(implicit format: Formats): PartialFunction[Any, JValue] = {
+      case x: ConfigValue => net.liftweb.json.parse(GenericProperty.serializeToJson(x))
+    }
+  }
+
+  def parseAll(json: JValue): IOResult[List[Rest.NodeDetails]] = {
+    IOResult.effect(s"Error when deserializing a nodes for creation API")(json.extract[List[Rest.NodeDetails]])
+  }
+}
+
+object Creation {
+
+  sealed trait CreationError
+
+  object CreationError {
+
+    final case class OnValidation(validations: NonEmptyList[Validation.NodeValidationError]) extends CreationError
+    final case class OnSaveInventory(message: String)                                        extends CreationError
+    final case class OnSaveNode(message: String)                                             extends CreationError
+    final case class OnAcceptation(message: String)                                          extends CreationError
+  }
+
+}
+
+object Validation {
+  import Rest._
+  import com.normation.inventory.domain.AcceptedInventory
+  import com.normation.inventory.domain.PendingInventory
+  import com.normation.rudder.domain.policies.{PolicyMode => PM}
+
+  import Validated._
+
+  type Validation[T] = ValidatedNel[NodeValidationError, T]
+
+
+  /*
+   * Validate user provided node details and create the corresponding inventory
+   */
+  def toNodeTemplate(nodeDetails: Rest.NodeDetails): ValidatedNel[NodeValidationError, NodeTemplate] = {
+    val os = getos(nodeDetails.os.`type`, nodeDetails.os.name, nodeDetails.os.version, nodeDetails.os.fullName, nodeDetails.os.servicePack)
+
+    val checkedAgent : Validation[AgentInfo] = nodeDetails.agentKey match {
+      case Some(a) => checkAgent(os.os, a)
+      case None    => AgentInfo(AgentType.CfeCommunity, None, PublicKey("placeholder-value - not a real key"), Set.empty).validNel
+    }
+
+
+    ( checkId(nodeDetails.id.toLowerCase)
+      , checkStatus(nodeDetails.status)
+      ).mapN(Tuple2(_,_)) andThen { case (id, status) =>
+
+      val machine = getMachine(id, PendingInventory, nodeDetails.machineType)
+
+      ( checkSummary(nodeDetails, id, PendingInventory, os)
+      , checkedAgent
+      , checkPolicyMode(status, nodeDetails.policyMode)
+      , checkState(status, nodeDetails.state)
+      ).mapN { case(summary, agent, mode, state) =>
+        val inventory = FullInventory(
+            NodeInventory(summary, agents = Seq(agent), machineId = Some((machine.id, PendingInventory)), timezone = nodeDetails.timezone)
+          , Some(machine)
+        )
+        val properties = nodeDetails.properties
+        if(status == PendingInventory) {
+          PendingNodeTemplate(inventory, properties.map(p => NodeProperty(p.name, p.value, None, None)))
+        } else {
+          AcceptedNodeTemplate(inventory, properties.map(p => NodeProperty(p.name, p.value, None, None)), mode, state)
+        }
+      }
+    }
+  }
+
+
+
+  sealed trait Machine {
+    def tpe: MachineType
+    final def name: String = tpe match {
+      case PhysicalMachineType               => "physical"
+      case VirtualMachineType(UnknownVmType) => "vm"
+      case VirtualMachineType(vm)            => vm.name
+    }
+  }
+  object Machine {
+    case object MPhysical      extends Machine { val tpe = PhysicalMachineType               }
+    case object MUnknownVmType extends Machine { val tpe = VirtualMachineType(UnknownVmType) }
+    case object MSolarisZone   extends Machine { val tpe = VirtualMachineType(SolarisZone)   }
+    case object MVirtualBox    extends Machine { val tpe = VirtualMachineType(VirtualBox)    }
+    case object MVMWare        extends Machine { val tpe = VirtualMachineType(VMWare)        }
+    case object MQEmu          extends Machine { val tpe = VirtualMachineType(QEmu)          }
+    case object MXen           extends Machine { val tpe = VirtualMachineType(Xen)           }
+    case object MAixLPAR       extends Machine { val tpe = VirtualMachineType(AixLPAR)       }
+    case object MHyperV        extends Machine { val tpe = VirtualMachineType(HyperV)        }
+    case object MBSDJail       extends Machine { val tpe = VirtualMachineType(BSDJail)       }
+
+    val values = ca.mrvisser.sealerate.values[Machine]
+  }
+
+  sealed trait NodeValidationError { def msg: String }
+  object NodeValidationError {
+    def names[T](values: Iterable[T])(show: T => String) = values.toSeq.map(show).sorted.mkString("'", ", ", "'")
+    final case class  UUID(x: String)          extends NodeValidationError {val msg = s"Only ID matching the shape of an UUID (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) are authorized but '${x}' provided" }
+    final case object Hostname                 extends NodeValidationError {val msg = "Hostname can't be empty" }
+    final case class  Status(x: String)        extends NodeValidationError {val msg = s"Node 'status' must be one of ${names(allStatus)(_.name)} but '${x}' provided" }
+    final case class  PolicyMode(x: String)    extends NodeValidationError {val msg = s"Node's policy mode must be one of ${names(PM.allModes)(_.name)} but '${x}' provided" }
+    final case object PolicyModeOnBadStatus    extends NodeValidationError {val msg = s"Policy mode can not be specified when status=pending" }
+    final case class  State(x: String)         extends NodeValidationError {val msg = s"Node 'state' must be one of ${names(NodeState.values)(_.name)} but '${x}' provided" }
+    final case object StateOnBadStatus         extends NodeValidationError {val msg = s"Node 'state' can not be specified when status=pending" }
+    final case class  Ram(x: String)           extends NodeValidationError {val msg = s"Provided RAM '${x}'can not be parsed as a memory amount" }
+    final case class  MachineTpe(x: String)    extends NodeValidationError {val msg = s"Machine type must be one of ${names(Machine.values)(_.name)} but '${x}' provided" }
+    final case class  Agent(x: String)         extends NodeValidationError {val msg = s"Management technologie agent must be one of ${names(AgentType.allValues)(_.id)} but '${x}' provided" }
+    final case class  KeyStatus(x: String)     extends NodeValidationError {val msg = s"Key status must be '${CertifiedKey.value}' or '${UndefinedKey.value}' but '${x}' provided" }
+    final case class  SecurityVal(msg: String) extends NodeValidationError
+  }
+
+  // only check shape alike bd645dfe-b4ce-4475-8d52-b7cfa106e333
+  // but with any chars in [a-z0-9]
+  val idregex = """[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}""".r.pattern
+  def checkId(id: String): ValidatedNel[NodeValidationError, NodeId] =
+    if(idregex.matcher(id).matches()) NodeId(id).validNel
+    else NodeValidationError.UUID(id).invalidNel
+
+  def checkPolicyId(id: String): Validation[NodeId] = if(id == "root") NodeId("root").validNel else checkId(id)
+
+  def checkHostname(h: String): Validation[String] = if(h.nonEmpty) h.validNel else NodeValidationError.Hostname.invalidNel
+
+  def checkSummary(nodeDetails: NodeDetails, id: NodeId, status: InventoryStatus, os: OsDetails): Validation[NodeSummary] = {
+    val root = os.os match {
+      case _: WindowsType => "administrator"
+      case _              => "root"
+    }
+
+    val policyServerId = nodeDetails.policyServerId.getOrElse("root")
+
+    ( checkHostname(nodeDetails.hostname)
+    , checkPolicyId(policyServerId.toLowerCase)
+    , nodeDetails.agentKey.flatMap( _.status ) match {
+      case None    => UndefinedKey.validNel
+      case Some(x) => checkKeyStatus(x)
+    }
+    ).mapN(NodeSummary(id, status, root, _, os, _, _))
+  }
+
+  def getMachine(id: NodeId, status: InventoryStatus, machineType: String): MachineInventory = {
+    val machineId = MachineUuid(IdGenerator.md5Hash(id.value))
+    val machine = machineType.toLowerCase
+    MachineInventory(
+        machineId
+      , status
+      , Machine.values.find(_.name == machine).getOrElse(Machine.MPhysical).tpe
+      , Some(machineId.value)
+    )
+  }
+
+  def checkAgent(osType: OsType, agent: AgentKey): Validation[AgentInfo] = {
+    def checkSecurityToken(agent: AgentType, token: String) : Validation[SecurityToken] = {
+      import net.liftweb.json.JsonDSL._
+      val tpe = if(token.contains("BEGIN CERTIFICATE")) Certificate.kind else PublicKey.kind
+      AgentInfoSerialisation.parseSecurityToken(agent, ("type" -> tpe) ~ ("value" -> token), None) match {
+        case Left(err) => NodeValidationError.SecurityVal(err.fullMsg).invalidNel
+        case Right(x)  => x.validNel
+      }
+    }
+    val tpe = osType match {
+      case _: WindowsType => Dsc
+      case _              => CfeCommunity
+    }
+
+    checkSecurityToken(tpe, agent.value) andThen { token =>
+      AgentInfo(tpe, None, token, Set.empty).validNel
+    }
+  }
+
+  def checkKeyStatus(s: String): Validation[KeyStatus] = KeyStatus(s) match {
+    case Left(_) => NodeValidationError.KeyStatus(s).invalidNel
+    case Right(x)  => x.validNel
+  }
+
+  /*
+   * Check is string can be transformed to a T
+   */
+  def checkFind[T](input: String, error: NodeValidationError)(find: String => Option[T]): ValidatedNel[NodeValidationError, T] = {
+    val i = input.toLowerCase()
+    find(i) match {
+      case None    => error.invalidNel
+      case Some(x) => x.validNel
+    }
+  }
+
+
+  // we only accept node in pending / accepted
+  val allStatus = Set(AcceptedInventory, PendingInventory)
+  def checkStatus(status: String): Validation[InventoryStatus] = checkFind(status, NodeValidationError.Status(status)){ x =>
+    allStatus.find(_.name == x)
+  }
+
+  // state can not be set on pending status
+  def checkState(status: InventoryStatus, state: Option[String]) : Validation[Option[NodeState]] = state match {
+    case None    => None.validNel
+    case Some(s) =>
+      if(status == PendingInventory) NodeValidationError.StateOnBadStatus.invalidNel
+      else checkFind(s, NodeValidationError.State(s)){ x =>
+        NodeState.values.find(_.name == x)
+      }.map(Some(_))
+  }
+
+  def checkPolicyMode(status: InventoryStatus, mode: Option[String]) : Validation[Option[PolicyMode]] = mode match {
+    case None     => None.validNel
+    case Some(pm) =>
+      if(status == PendingInventory) NodeValidationError.PolicyModeOnBadStatus.invalidNel
+      else checkFind(pm, NodeValidationError.PolicyMode(pm)){ x =>
+        PM.allModes.find( _.name == x).map(Some(_))
+      }
+  }
+
+  // this part is adapted from inventory extraction. It should be factored out
+  // and not duplicated, obviously
+  def getos(tpe: String, name: String, vers: String, fullName: String, srvPk: Option[String]): OsDetails = {
+    val osType = tpe.toLowerCase
+    val osName = name.toLowerCase
+
+    val kernelVersion = new Version("N/A")
+
+    val version = new Version(vers match {
+      case "" => "N/A"
+      case x  => x
+    })
+
+    val servicePack = srvPk match {
+      case None     => None
+      case Some("") => None
+      case Some(x)  => Some(x)
+    }
+
+    //find os type, and name
+    val os = ParseOSType.getType(osType, osName, osName + " "+ fullName.toLowerCase)
+    ParseOSType.getDetails(os, fullName, version, servicePack, kernelVersion)
+  }
+}
+

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
@@ -6,16 +6,13 @@ import com.normation.rudder.apidata.JsonResponseObjects.JRRuleNodesDirectives
 import com.normation.rudder.domain.logger.TimingDebugLoggerPure
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.repository.{RoNodeGroupRepository, RoRuleRepository}
-import com.normation.rudder.rest.{ApiPath, AuthzToken, RestExtractorService, RestUtils, RuleInternalApi => API}
+import com.normation.rudder.rest.{ApiPath, AuthzToken, RestExtractorService, RuleInternalApi => API}
 import com.normation.rudder.rest.lift.{DefaultParams, LiftApiModule, LiftApiModuleProvider, LiftApiModuleString}
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.zio.currentTimeMillis
-import net.liftweb.common.Box
 import net.liftweb.http.{LiftResponse, Req}
 import com.normation.rudder.rest.implicits._
-import net.liftweb.json.JValue
 import com.normation.rudder.apidata.implicits._
-import zio._
 import zio.syntax._
 
 class RulesInternalApi(

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -37,8 +37,102 @@
 
 package com.normation.rudder.rest.lift
 
+import com.normation.eventlog.EventActor
+import com.normation.eventlog.ModificationId
+import com.normation.inventory.domain.NodeId
+import com.normation.inventory.domain._
+import com.normation.inventory.ldap.core.InventoryDit
+import com.normation.inventory.ldap.core.LDAPFullInventoryRepository
+import com.normation.inventory.services.core.ReadOnlySoftwareDAO
+import com.normation.ldap.sdk.LDAPConnectionProvider
+import com.normation.ldap.sdk.RwLDAPConnection
+import com.normation.rudder.UserService
+import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.apidata.NodeDetailLevel
+import com.normation.rudder.apidata.RenderInheritedProperties
 import com.normation.rudder.apidata.RestDataSerializer
+import com.normation.rudder.batch.AsyncDeploymentActor
+import com.normation.rudder.batch.AutomaticStartDeployment
+import com.normation.rudder.domain.NodeDit
+import com.normation.rudder.domain.logger.NodeLogger
+import com.normation.rudder.domain.logger.NodeLoggerPure
+import com.normation.rudder.domain.logger.TimingDebugLoggerPure
+import com.normation.rudder.domain.nodes.Node
+import com.normation.rudder.domain.nodes.NodeInfo
+import com.normation.rudder.domain.nodes.NodeState
+import com.normation.rudder.domain.policies.GlobalPolicyMode
+import com.normation.rudder.domain.policies.PolicyModeOverrides.Always
+import com.normation.rudder.domain.policies.PolicyModeOverrides.Unoverridable
+import com.normation.rudder.domain.properties.CompareProperties
+import com.normation.rudder.domain.properties.NodeProperty
+import com.normation.rudder.domain.properties.NodePropertyHierarchy
+import com.normation.rudder.domain.queries.QueryTrait
+import com.normation.rudder.domain.reports.ComplianceLevel
+import com.normation.rudder.reports.ReportingConfiguration
+import com.normation.rudder.reports.execution.AgentRunWithNodeConfig
+import com.normation.rudder.reports.execution.RoReportsExecutionRepository
+import com.normation.rudder.repository.RoNodeGroupRepository
+import com.normation.rudder.repository.RoParameterRepository
+import com.normation.rudder.repository.WoNodeRepository
+import com.normation.rudder.repository.json.DataExtractor.CompleteJson
+import com.normation.rudder.repository.json.DataExtractor.OptionnalJson
+import com.normation.rudder.repository.ldap.LDAPEntityMapper
+import com.normation.rudder.rest.ApiPath
+import com.normation.rudder.rest.AuthzToken
+import com.normation.rudder.rest.NotFoundError
+import com.normation.rudder.rest.RestExtractorService
+import com.normation.rudder.rest.RestUtils
+import com.normation.rudder.rest.RestUtils.effectiveResponse
+import com.normation.rudder.rest.RestUtils.toJsonError
+import com.normation.rudder.rest.RestUtils.toJsonResponse
+import com.normation.rudder.rest.data.Creation.CreationError
+import com.normation.rudder.rest.data.NodeDetailsSerialize
+import com.normation.rudder.rest.data.NodeSetup
+import com.normation.rudder.rest.data.NodeTemplate
+import com.normation.rudder.rest.data.NodeTemplate.AcceptedNodeTemplate
+import com.normation.rudder.rest.data.NodeTemplate.PendingNodeTemplate
+import com.normation.rudder.rest.data.Rest
+import com.normation.rudder.rest.data.Validation
+import com.normation.rudder.rest.data.Validation.NodeValidationError
+import com.normation.rudder.rest.data._
+import com.normation.rudder.rest.{NodeApi => API}
+import com.normation.rudder.services.nodes.MergeNodeProperties
+import com.normation.rudder.services.nodes.NodeInfoService
+import com.normation.rudder.services.queries._
+import com.normation.rudder.services.reports.ReportingService
+import com.normation.rudder.services.servers.DeleteMode
+import com.normation.rudder.services.servers.NewNodeManager
+import com.normation.rudder.services.servers.RemoveNodeService
+import com.normation.utils.Control._
+import com.normation.utils.DateFormaterService
+import com.normation.utils.StringUuidGenerator
+
+import cats.data.Validated.Invalid
+import cats.data.Validated.Valid
+import cats.data.ValidatedNel
+import net.liftweb.common.Box
+import net.liftweb.common.EmptyBox
+import net.liftweb.common.Failure
+import net.liftweb.common.Full
+import net.liftweb.common.Loggable
+import net.liftweb.http.JsonResponse
+import net.liftweb.http.LiftResponse
+import net.liftweb.http.OutputStreamResponse
+import net.liftweb.http.Req
+import net.liftweb.http.js.JsExp
+import net.liftweb.json.JArray
+import net.liftweb.json.JValue
+import net.liftweb.json.JsonAST.JDouble
+import net.liftweb.json.JsonAST.JField
+import net.liftweb.json.JsonAST.JInt
+import net.liftweb.json.JsonAST.JObject
+import net.liftweb.json.JsonAST.JString
+import net.liftweb.json.JsonDSL._
+import net.liftweb.json.JsonDSL.pair2jvalue
+import net.liftweb.json.JsonDSL.string2jvalue
+import org.joda.time.DateTime
+import scalaj.http.Http
+import scalaj.http.HttpOptions
 
 import java.io.ByteArrayInputStream
 import java.io.IOException
@@ -49,84 +143,14 @@ import java.io.PipedOutputStream
 import java.net.ConnectException
 import java.nio.charset.StandardCharsets
 import java.util.Arrays
-import com.normation.eventlog.EventActor
-import com.normation.eventlog.ModificationId
-import com.normation.inventory.domain.NodeId
-import com.normation.inventory.domain._
-import com.normation.inventory.ldap.core.LDAPFullInventoryRepository
-import com.normation.inventory.services.core.ReadOnlySoftwareDAO
-import com.normation.rudder.UserService
-import com.normation.rudder.batch.AsyncDeploymentActor
-import com.normation.rudder.batch.AutomaticStartDeployment
-import com.normation.rudder.domain.nodes.Node
-import com.normation.rudder.reports.execution.RoReportsExecutionRepository
-import com.normation.rudder.repository.WoNodeRepository
-import com.normation.rudder.rest.ApiPath
-import com.normation.rudder.rest.AuthzToken
-import com.normation.rudder.rest.RestExtractorService
-import com.normation.rudder.rest.RestUtils.toJsonError
-import com.normation.rudder.rest.RestUtils.toJsonResponse
-import com.normation.rudder.rest.data._
-import com.normation.rudder.rest.{NodeApi => API}
-import com.normation.rudder.services.nodes.NodeInfoService
-import com.normation.rudder.services.queries._
-import com.normation.rudder.services.servers.NewNodeManager
-import com.normation.rudder.services.servers.RemoveNodeService
-import com.normation.utils.Control._
-import com.normation.utils.StringUuidGenerator
-import net.liftweb.common.Box
-import net.liftweb.common.EmptyBox
-import net.liftweb.common.Failure
-import net.liftweb.common.Full
-import net.liftweb.common.Loggable
-import net.liftweb.http.LiftResponse
-import net.liftweb.http.OutputStreamResponse
-import net.liftweb.http.Req
-import net.liftweb.json.JArray
-import net.liftweb.json.JValue
-import net.liftweb.json.JsonDSL._
-import net.liftweb.json.JsonDSL.pair2jvalue
-import net.liftweb.json.JsonDSL.string2jvalue
-import scalaj.http.Http
-import scalaj.http.HttpOptions
-import com.normation.box._
-import com.normation.zio._
-import com.normation.errors._
-import com.normation.rudder.api.ApiVersion
-import com.normation.rudder.apidata.RenderInheritedProperties
-import com.normation.rudder.domain.logger.NodeLogger
-import com.normation.rudder.domain.logger.NodeLoggerPure
-import com.normation.rudder.domain.logger.TimingDebugLoggerPure
-import com.normation.rudder.domain.nodes.NodeInfo
-import com.normation.rudder.domain.policies.GlobalPolicyMode
-import com.normation.rudder.domain.policies.PolicyModeOverrides.Always
-import com.normation.rudder.domain.policies.PolicyModeOverrides.Unoverridable
-import com.normation.rudder.domain.properties.CompareProperties
-import com.normation.rudder.domain.properties.NodeProperty
-import com.normation.rudder.domain.properties.NodePropertyHierarchy
-import com.normation.rudder.domain.queries.QueryTrait
-import com.normation.rudder.domain.reports.ComplianceLevel
-import com.normation.rudder.reports.execution.AgentRunWithNodeConfig
-import com.normation.rudder.repository.RoNodeGroupRepository
-import com.normation.rudder.repository.RoParameterRepository
-import com.normation.rudder.repository.json.DataExtractor.CompleteJson
-import com.normation.rudder.repository.json.DataExtractor.OptionnalJson
-import com.normation.rudder.rest.NotFoundError
-import com.normation.rudder.rest.RestUtils.effectiveResponse
-import com.normation.rudder.services.nodes.MergeNodeProperties
-import com.normation.rudder.services.servers.DeleteMode
-import com.normation.rudder.services.reports.ReportingService
-import com.normation.utils.DateFormaterService
-import net.liftweb.http.JsonResponse
-import net.liftweb.http.js.JsExp
-import net.liftweb.json.JsonAST.JDouble
-import net.liftweb.json.JsonAST.JField
-import net.liftweb.json.JsonAST.JInt
-import net.liftweb.json.JsonAST.JObject
-import net.liftweb.json.JsonAST.JString
-import zio.duration._
+
 import zio._
+import zio.duration._
 import zio.syntax._
+import com.normation.box._
+import com.normation.errors._
+import com.normation.zio._
+
 
 
 /*
@@ -144,9 +168,12 @@ class NodeApi (
   , apiV8service        : NodeApiService8
   , apiV12              : NodeApiService12
   , apiV13              : NodeApiService13
+  , apiV15              : NodeApiService15
   , inheritedProperties : NodeApiInheritedProperties
   , deleteDefaultMode   : DeleteMode
 ) extends LiftApiModuleProvider[API] {
+
+  val serializeNodeDetails = new NodeDetailsSerialize(restExtractorService)
 
   def schemas = API
 
@@ -160,7 +187,7 @@ class NodeApi (
       case API.DeleteNode                     => DeleteNode
       case API.ChangePendingNodeStatus        => ChangePendingNodeStatus
       case API.ChangePendingNodeStatus2       => ChangePendingNodeStatus2
-      case API.ApplyPolicyAllNodes            => ApplyPocicyAllNodes
+      case API.ApplyPolicyAllNodes            => ApplyPolicyAllNodes
       case API.UpdateNode                     => UpdateNode
       case API.ListAcceptedNodes              => ListAcceptedNodes
       case API.ApplyPolicy                    => ApplyPolicy
@@ -168,7 +195,47 @@ class NodeApi (
       case API.NodeDetailsTable               => NodeDetailsTable
       case API.NodeDetailsSoftware            => NodeDetailsSoftware
       case API.NodeDetailsProperty            => NodeDetailsProperty
+      case API.CreateNodes                    => CreateNodes
     })
+  }
+
+  /*
+   * Return a Json Object that list available backend,
+   * their state of configuration, and what are the current
+   * enabled ones.
+   */
+  object CreateNodes extends LiftApiModule0 { //
+    val schema        = API.CreateNodes
+    val restExtractor = restExtractorService
+
+    import ResultHolder._
+
+    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      import com.softwaremill.quicklens._
+      (for {
+        json  <- (req.json ?~! "This API only Accept JSON request").toIO
+        nodes <- serializeNodeDetails.parseAll(json)
+        res   <- ZIO.foldLeft(nodes)(ResultHolder(Nil, Nil)) { case (res, node) =>
+                   apiV15.saveNode(node, authzToken.actor).either.map {
+                     case Right(id) => res.modify(_.created).using(_ :+ id)
+                     case Left(err) => res.modify(_.failed).using(_ :+ ((node.id, err)))
+                   }
+                 }
+      } yield res).toBox match {
+        case Full(resultHolder) =>
+          // if all success, return success.
+          // Or if at least one is not failed, return success ?
+          val json = resultHolder.toJson()
+          if (resultHolder.failed.isEmpty) {
+            RestUtils.toJsonResponse(None, json)(schema.name, params.prettify)
+          } else {
+            RestUtils.toJsonError(None, json)(schema.name, params.prettify)
+          }
+        case eb: EmptyBox       =>
+          val err = eb ?~! "Error when trying to parse node creation request"
+          RestUtils.toJsonError(None, JString(err.messageChain))(schema.name, params.prettify)
+      }
+    }
   }
 
   object NodeDetails extends LiftApiModule {
@@ -262,7 +329,7 @@ class NodeApi (
         case Full(response) =>
           response
         case eb : EmptyBox =>
-          val fail = eb ?~! s"An error occured while updating Node '${id}'"
+          val fail = eb ?~! s"An error occurred while updating Node '${id}'"
           toJsonError(Some(id), fail.messageChain)
       }
     }
@@ -355,7 +422,7 @@ class NodeApi (
     }
   }
 
-  object ApplyPocicyAllNodes extends LiftApiModule0 {
+  object ApplyPolicyAllNodes extends LiftApiModule0 {
     val schema = API.ApplyPolicyAllNodes
     val restExtractor = restExtractorService
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
@@ -424,7 +491,7 @@ class NodeApi (
           val status = {
             if(accepted.contains(id))     AcceptedInventory.name
             else if(pending.contains(id)) PendingInventory.name
-            else if(deleted.contains(id)) "deleted" // RemovedInventory would output "removed" which is inconsistant with other API
+            else if(deleted.contains(id)) "deleted" // RemovedInventory would output "removed" which is inconsistent with other API
             else                          "unknown"
           }
           JObject(JField("id", id) :: JField("status", status) :: Nil)
@@ -469,7 +536,7 @@ class NodeApi (
         response
       }) match {
         case Full(res) => res
-        case eb: EmptyBox =>  JsonResponse(JObject(JField("error", (eb ?~! s"An error occurred while fetching verions of '${software}' software for nodes").messageChain)))
+        case eb: EmptyBox =>  JsonResponse(JObject(JField("error", (eb ?~! s"An error occurred while fetching versions of '${software}' software for nodes").messageChain)))
       }
     }
   }
@@ -518,10 +585,6 @@ class NodeApiInheritedProperties(
       ) :: Nil)
     }
   }
-
-
-
-
 }
 
 class NodeApiService12(
@@ -542,6 +605,131 @@ class NodeApiService12(
       case eb: EmptyBox => val message = (eb ?~ ("Error when deleting Nodes")).msg
         toJsonError(None, message)
     }
+  }
+}
+class NodeApiService15(
+    inventoryRepos      : LDAPFullInventoryRepository
+  , ldapConnection      : LDAPConnectionProvider[RwLDAPConnection]
+  , ldapEntityMapper    : LDAPEntityMapper
+  , newNodeManager      : NewNodeManager
+  , uuidGen             : StringUuidGenerator
+  , nodeDit             : NodeDit
+  , pendingDit          : InventoryDit
+  , acceptedDit         : InventoryDit
+) {
+  /// utility functions ///
+
+  /*
+   * for a given nodedetails, we:
+   * - try to convert it to inventory/node setup info
+   * - save inventory
+   * - if needed, accept
+   * - now, setup node info (property, state, etc)
+   */
+  def saveNode(nodeDetails: Rest.NodeDetails, eventActor: EventActor): IO[CreationError, NodeId] = {
+    def toCreationError(res: ValidatedNel[NodeValidationError, NodeTemplate]) = {
+      res match {
+        case Invalid(nel) => CreationError.OnValidation(nel).fail
+        case Valid(r)     => r.succeed
+      }
+    }
+
+    for {
+      validated <- toCreationError(Validation.toNodeTemplate(nodeDetails))
+      _         <- checkUuid(validated.inventory.node.main.id)
+      created   <- saveInventory(validated.inventory)
+      nodeSetup <- accept(validated, eventActor)
+      nodeId    <- saveRudderNode(validated.inventory.node.main.id, nodeSetup)
+    } yield {
+      nodeId
+    }
+  }
+
+  /*
+   * You can't use an existing UUID (neither pending nor accepted)
+   */
+  def checkUuid(nodeId: NodeId): IO[CreationError, Unit] = {
+    // we don't want a node in pending/accepted
+    def inventoryExists(con: RwLDAPConnection, id:NodeId) = {
+      ZIO.foldLeft(Seq((acceptedDit, AcceptedInventory), (pendingDit, PendingInventory)))(Option.empty[InventoryStatus]) { case(current, (dit, s)) =>
+        current match {
+          case None    => con.exists(dit.NODES.NODE.dn(id)).map(exists => if(exists) Some(s) else None)
+          case Some(v) => Some(v).succeed
+        }
+      }.flatMap {
+        case None => // ok, it doesn't exists
+          UIO.unit
+        case Some(s) => // oups, already present
+          Inconsistency(s"A node with id '${nodeId.value}' already exists with status '${s.name}'").fail
+      }
+    }
+
+    (for {
+      con <- ldapConnection
+      _   <- inventoryExists(con, nodeId)
+    } yield ()).mapError(err => CreationError.OnSaveInventory(s"Error during node ID check: ${err.fullMsg}"))
+  }
+
+  /*
+   * Save the inventory part. Always save in "pending", acceptation
+   * is done afterward if needed.
+   */
+  def saveInventory(inventory: FullInventory): IO[CreationError, NodeId] = {
+    inventoryRepos.save(inventory).map(_ => inventory.node.main.id).mapError(err => CreationError.OnSaveInventory(s"Error during node creation: ${err.fullMsg}"))
+  }
+
+  def accept(template: NodeTemplate, eventActor: EventActor): IO[CreationError, NodeSetup] = {
+    val id = template.inventory.node.main.id
+
+    // only nodes with status "accepted" need to be accepted
+    template match {
+      case AcceptedNodeTemplate(_, properties, policyMode, state) =>
+        newNodeManager.accept(id, ModificationId(uuidGen.newUuid), eventActor).toIO.mapError(err => CreationError.OnAcceptation((s"Can not accept node '${id.value}': ${err.fullMsg}"))) *>
+        NodeSetup(properties, policyMode, state).succeed
+      case PendingNodeTemplate(_, properties) =>
+        NodeSetup(properties, None, None).succeed
+    }
+  }
+
+  def mergeNodeSetup(node: Node, changes: NodeSetup): Node = {
+    import com.softwaremill.quicklens._
+
+    // for properties, we don't want to modify any of the existing one because
+    // we were put during acceptation (or since node is live).
+    val keep = node.properties.map(p => (p.name, p)).toMap
+    val user = changes.properties.map(p => (p.name, p)).toMap
+    // override user prop with keep
+    val properties = (user ++ keep).values.toList
+
+    node.modify(_.policyMode).using(x => changes.policyMode.fold(x)(Some(_)))
+      .modify(_.state     ).using(x => changes.state.fold(x)(identity))
+      .modify(_.properties).setTo(properties)
+  }
+
+  /*
+   * Save rudder node part. Must be done after acceptation if
+   * acceptation is needed. If no acceptation is wanted, then
+   * we provide a default node context but we can't ensure that
+   * policyMode / node state will be set (validation must forbid that)
+   */
+  def saveRudderNode(id: NodeId, setup: NodeSetup): IO[CreationError, NodeId] = {
+    // a default Node
+    def default() = Node(id, id.value, "", NodeState.Enabled, false, false, DateTime.now, ReportingConfiguration(None, None, None), Nil, None)
+
+    (for {
+      ldap    <- ldapConnection
+      // try t get node
+      entry   <- ldap.get(nodeDit.NODES.NODE.dn(id.value), NodeInfoService.nodeInfoAttributes:_*)
+      current <- entry match {
+        case Some(x) => ldapEntityMapper.entryToNode(x).toIO
+        case None    => default().succeed
+      }
+      merged  =  mergeNodeSetup(current, setup)
+      // we ony want to touch things that were asked by the user
+      nSaved  <- ldap.save(ldapEntityMapper.nodeToEntry(merged))
+    } yield {
+      merged.id
+    }).mapError(err => CreationError.OnSaveNode(s"Error during node creation: ${err.fullMsg}"))
   }
 }
 
@@ -639,7 +827,7 @@ class NodeApiService13 (
       ~  ("os"                  -> nodeInfo.osDetails.fullName)
       ~  ("state"               -> nodeInfo.state.name)
       ~  ("compliance"          -> userCompliance )
-      ~ ("systemError"         -> sysCompliance.map(_.computePercent().compliance < 100 ).getOrElse(true))
+      ~  ("systemError"         -> sysCompliance.map(_.computePercent().compliance < 100 ).getOrElse(true))
       ~  ("ipAddresses"         -> nodeInfo.ips.filter(ip => ip != "127.0.0.1" && ip != "0:0:0:0:0:0:0:1").map(escapeHTML(_)))
       ~  ("lastRun"             -> agentRunWithNodeConfig.map(d => DateFormaterService.getDisplayDate(d.agentRunId.date)).getOrElse("Never"))
       ~  ("lastInventory"       -> DateFormaterService.getDisplayDate(nodeInfo.inventoryDate))
@@ -1167,7 +1355,7 @@ class NodeApiService8 (
       }
     }
 
-    def errorMessageWithHint(s: String) = s"Error occured when contacting internal remote-run API to apply classes on Node '${nodeId.value}': ${s}"
+    def errorMessageWithHint(s: String) = s"Error occurred when contacting internal remote-run API to apply classes on Node '${nodeId.value}': ${s}"
 
     // buffer size for file I/O
     val pipeSize = 4096
@@ -1182,7 +1370,7 @@ class NodeApiService8 (
         _   <- NodeLoggerPure.debug(s"Executing remote run call: ${request.toString}")
         opt <- IOResult.effect {
                 request.exec{ case (status,headers,is) =>
-                  NodeLogger.debug(s"Processing remore-run on ${nodeId.value}: HTTP status ${status}") // this one is written two times - why ??
+                  NodeLogger.debug(s"Processing remote-run on ${nodeId.value}: HTTP status ${status}") // this one is written two times - why ??
                   if (status >= 200 && status < 300) {
                     copyStreamTo(pipeSize, is)(os)
                   } else {
@@ -1222,7 +1410,7 @@ class NodeApiService8 (
       out <- IOResult.effect(new PipedOutputStream(in))
       _   <- NodeLoggerPure.trace("remote-run: reading stream from remote API")
       _   <- copy(out, readTimeout).forkDaemon // read from HTTP request
-      res <- IOResult.effect(copyStreamTo(pipeSize, in) _) // give the writter function waiting for out
+      res <- IOResult.effect(copyStreamTo(pipeSize, in) _) // give the writer function waiting for out
       // don't close out here, it was closed inside `copy`
     } yield res).catchAll { err =>
       NodeLoggerPure.error(errorMessageWithHint(err.fullMsg)) *>
@@ -1249,7 +1437,7 @@ class NodeApiService8 (
                 if (result.isSuccess) {
                   "Started"
                 } else {
-                  s"An error occured when applying policy on Node '${node.id.value}', cause is: ${result.body}"
+                  s"An error occurred when applying policy on Node '${node.id.value}', cause is: ${result.body}"
                 }
               } catch {
                 case ex: ConnectException =>

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/NodeApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/NodeApiTest.scala
@@ -1,0 +1,101 @@
+package com.normation.rudder.rest
+
+import com.normation.inventory.domain.AcceptedInventory
+import com.normation.inventory.domain.NodeId
+import com.normation.inventory.domain.PendingInventory
+
+import net.liftweb.common.Full
+import net.liftweb.common.Loggable
+import net.liftweb.http.InMemoryResponse
+import net.liftweb.json.JsonParser
+import net.liftweb.json.compactRender
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+import com.normation.zio._
+
+@RunWith(classOf[JUnitRunner])
+class NodeApiTest extends Specification with Loggable {
+  sequential
+  isolated
+  val restTestSetUp = RestTestSetUp.newEnv
+  val restTest = new RestTest(restTestSetUp.liftRules)
+
+
+  val node1     = "88888888-c0a9-4874-8485-478e7e999999"
+  val hostname1 = "hostname.node1"
+  val node2     = "aaaaaaaa-c0a9-4874-8485-478e7e999999"
+  val hostname2 = "hostname.node2"
+
+  "Node API" should {
+
+
+    "Create node" in {
+      val json = s"""
+          |   [
+          |     {
+          |        "id": "$node1"
+          |      , "hostname": "$hostname1"
+          |      , "status"  : "pending"
+          |      , "os": { "type": "linux", "name": "debian", "version": "9.5", "fullName": "Debian GNU/Linux 9 (stretch)"}
+          |      , "policyServerId": "root"
+          |      , "machineType": "vmware"
+          |      , "agentKey" : {
+          |        "value" : "----BEGIN CERTIFICATE---- ...."
+          |      }
+          |      , "properties": [
+          |        { "name": "tags",
+          |          "value": ["some","tags"]
+          |        },
+          |        { "name": "env",
+          |          "value": "prod"
+          |        },
+          |        { "name": "vars",
+          |          "value": {"var1": "value1","var2": "value2"}
+          |        }
+          |      ]
+          |      , "ipAddresses": ["192.168.180.90", "127.0.0.1"]
+          |      , "timezone": { "name":"CEST", "offset": "+0200" }
+          |    }
+          |  , {
+          |        "id": "$node2"
+          |      , "hostname": "$hostname2"
+          |      , "status"  : "accepted"
+          |      , "os": { "type": "linux", "name": "debian", "version": "11", "fullName": "Debian GNU/Linux 11"}
+          |      , "policyServerId": "root"
+          |      , "machineType": "physical"
+          |      , "agentKey" : {
+          |        "value" : "----BEGIN CERTIFICATE---- ...."
+          |      }
+          |      , "properties": [
+          |        { "name": "env",
+          |          "value": "test"
+          |        }
+          |      ]
+          |      , "ipAddresses": ["192.168.23.21", "127.0.0.1"]
+          |      , "timezone": { "name":"CEST", "offset": "+0200" }
+          |    }
+          | ]
+          |""".stripMargin
+
+      val jsonRes = s"""{"action":"createNodes","result":"success","data":{"created":["${node1}","${node2}"],"failed":[]}}"""
+
+      restTest.testPUTResponse(s"/api/latest/nodes", JsonParser.parse(json)) { resp =>
+        resp match {
+          case Full(JsonResponsePrettify(content, _, _, 200, _)) =>
+            val jsonString = compactRender(content)
+            val nodes = restTestSetUp.mockNodes.nodeInfoService.nodeBase.get.runNow
+            val n1 = nodes.get(NodeId(node1)).getOrElse(throw new IllegalArgumentException("error: node1"))
+            val n2 = nodes.get(NodeId(node2)).getOrElse(throw new IllegalArgumentException("error: node2"))
+
+            (jsonString must beEqualTo(jsonRes)) and
+            (n1.nInv.main.status must beEqualTo(PendingInventory) ) and
+            (n2.nInv.main.status must beEqualTo(AcceptedInventory) )
+
+          case _ => ko("unexpected answer")
+        }
+      }
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1115,6 +1115,18 @@ object RudderConfig extends Loggable {
       nodeInfoService, cachedAgentRunRepository, readOnlySoftwareDAO, restExtractorService
     , () => configService.rudder_global_policy_mode().toBox, reportingServiceImpl, roNodeGroupRepository, roLDAPParameterRepository
   )
+
+  val nodeApiService16 = new NodeApiService15(
+      fullInventoryRepository
+    , rwLdap
+    , ldapEntityMapper
+    , newNodeManager
+    , stringUuidGenerator
+    , nodeDit
+    , pendingNodesDit
+    , acceptedNodesDit
+  )
+
   val parameterApiService2 =
     new ParameterApiService2 (
         roLDAPParameterRepository
@@ -1327,11 +1339,22 @@ object RudderConfig extends Loggable {
     )
   }
 
+  /*
+   * API versions are incremented each time incompatible changes are made (like adding or deleting endpoints - modification
+   * of an existing endpoint, if done in a purely compatible way, don't change api version).
+   * It may happen that some rudder branches don't have a version bump, and other have several (in case of
+   * horrible breaking bugs). We avoid the case where a previous release need a version bump.
+   * For ex:
+   * - 7.0: 14
+   * - 7.1: 14 (no change)
+   * - 7.2[.0~.4]: 15
+   * - 7.2.5: 16
+   */
   val ApiVersions =
     ApiVersion(12 , true) :: // rudder 6.0, 6.1
     ApiVersion(13 , true) :: // rudder 6.2
     ApiVersion(14 , false) :: // rudder 7.0
-    ApiVersion(16 , false) :: // rudder 7.2
+    ApiVersion(15 , false) :: // rudder 7.2
     Nil
 
   val jsonPluginDefinition = new ReadPluginPackageInfo("/var/rudder/packages/index.json")
@@ -1348,7 +1371,7 @@ object RudderConfig extends Loggable {
         new ComplianceApi(restExtractorService, complianceAPIService)
       , new GroupsApi(roLdapNodeGroupRepository, restExtractorService, zioJsonExtractor, stringUuidGenerator, groupApiService2, groupApiService6, groupApiService14, groupInheritedProperties)
       , new DirectiveApi(roDirectiveRepository, restExtractorService, zioJsonExtractor, stringUuidGenerator, directiveApiService2, directiveApiService14)
-      , new NodeApi(restExtractorService, restDataSerializer, nodeApiService2, nodeApiService4, nodeApiService6, nodeApiService8, nodeApiService12, nodeApiService13, nodeInheritedProperties, RUDDER_DEFAULT_DELETE_NODE_MODE)
+      , new NodeApi(restExtractorService, restDataSerializer, nodeApiService2, nodeApiService4, nodeApiService6, nodeApiService8, nodeApiService12, nodeApiService13, nodeApiService16, nodeInheritedProperties, RUDDER_DEFAULT_DELETE_NODE_MODE)
       , new ParameterApi(restExtractorService, zioJsonExtractor, parameterApiService2, parameterApiService14)
       , new SettingsApi(restExtractorService, configService, asyncDeploymentAgent, stringUuidGenerator, policyServerManagementService, nodeInfoService)
       , new TechniqueApi(restExtractorService, techniqueApiService6, techniqueApiService14, ncfTechniqueWriter, ncfTechniqueReader, techniqueRepository, techniqueSerializer, stringUuidGenerator, resourceFileService)


### PR DESCRIPTION
https://issues.rudder.io/issues/21117

Add the node create API to Rudder. 
Also refactored out of InventoryParsing the OS detection part so that the code is not duplicated, it's already brittle enought like that, we really don't want to have an other place to change when we add support for new OS. 