### PR TITLE
Fixes #21315: Add revision to node groups

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -593,7 +593,7 @@ object JsonResponseObjects {
     def fromParentProperty(p: ParentProperty) = {
       p match {
         case ParentProperty.Group(name, id, value) =>
-          JRParentGroup(name, id.value, value)
+          JRParentGroup(name, id.serialize, value)
         case _                                     =>
           JRParentGlobal(p.value)
       }
@@ -613,7 +613,7 @@ object JsonResponseObjects {
 
   object JRGroupInheritedProperties {
     def fromGroup(groupId: NodeGroupId, properties: List[NodePropertyHierarchy], renderInHtml: RenderInheritedProperties) = {
-      JRGroupInheritedProperties(groupId.value, properties.sortBy(_.prop.name).map(JRProperty.fromNodePropertyHierarchy(_, renderInHtml)))
+      JRGroupInheritedProperties(groupId.serialize, properties.sortBy(_.prop.name).map(JRProperty.fromNodePropertyHierarchy(_, renderInHtml)))
     }
   }
 
@@ -677,12 +677,12 @@ object JsonResponseObjects {
       group.into[JRGroup]
         .enableBeanGetters
         .withFieldConst(_.changeRequestId, crId.map(_.value.toString))
-        .withFieldComputed(_.id, _.id.value)
+        .withFieldComputed(_.id, _.id.serialize)
         .withFieldRenamed(_.name, _.displayName)
         .withFieldConst(_.category, catId.value)
         .withFieldComputed(_.query, _.query.map(JRQuery.fromQuery(_)))
         .withFieldComputed(_.nodeIds, _.serverList.toList.map(_.value).sorted)
-        .withFieldComputed(_.groupClass, x => List(x.id.value, x.name).map(RuleTarget.toCFEngineClassName _).sorted)
+        .withFieldComputed(_.groupClass, x => List(x.id.serialize, x.name).map(RuleTarget.toCFEngineClassName _).sorted)
         .withFieldComputed(_.properties, _.properties.map(JRProperty.fromGroupProp(_)))
         .withFieldComputed(_.target, x => GroupTarget(x.id).target)
         .withFieldComputed(_.system, _.isSystem)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
@@ -231,7 +231,7 @@ final case class RestDataSerializerImpl (
     val query = group.query.map(query => query.toJSON)
     (
         ("changeRequestId" -> crId.map(_.value.toString))
-      ~ ("id"              -> group.id.value)
+      ~ ("id"              -> group.id.serialize)
       ~ ("displayName"     -> group.name)
       ~ ("description"     -> group.description)
       ~ ("category"        -> cat.map(_.value))
@@ -239,7 +239,7 @@ final case class RestDataSerializerImpl (
       ~ ("nodeIds"         -> group.serverList.toSeq.map(_.value).sorted)
       ~ ("dynamic"         -> group.isDynamic)
       ~ ("enabled"         -> group.isEnabled)
-      ~ ("groupClass"      -> List(group.id.value, group.name).map(RuleTarget.toCFEngineClassName _).sorted)
+      ~ ("groupClass"      -> List(group.id.serialize, group.name).map(RuleTarget.toCFEngineClassName _).sorted)
       ~ ("properties"      -> group.properties.toApiJson)
       ~ ("system"          -> group.isSystem)
       ~ ("target"          -> GroupTarget(group.id).target)
@@ -247,7 +247,7 @@ final case class RestDataSerializerImpl (
   }
 
   override def serializeGroupCategory (category:FullNodeGroupCategory, parent: NodeGroupCategoryId, detailLevel : DetailLevel, apiVersion: ApiVersion): JValue = {
-    val groupList = category.ownGroups.values.toSeq.sortBy(_.nodeGroup.id.value)
+    val groupList = category.ownGroups.values.toSeq.sortBy(_.nodeGroup.id.serialize)
     val subCat = category.subCategories.sortBy(_.id.value)
 
     def serializeTarget (target: FullRuleTargetInfo): JValue = {
@@ -266,7 +266,7 @@ final case class RestDataSerializerImpl (
         , subCat.map(serializeGroupCategory(_,category.id, detailLevel, apiVersion))
         )
       case MinimalDetails =>
-        ( groupList.map(g => JString(g.nodeGroup.id.value) )
+        ( groupList.map(g => JString(g.nodeGroup.id.serialize) )
         , subCat.map(cat => JString(cat.id.value))
         )
     }
@@ -449,7 +449,7 @@ final case class RestDataSerializerImpl (
       val enabled :JValue     = diff.modIsActivated.map(displaySimpleDiff(_)).getOrElse(initialState.isEnabled)
       val properties: JValue  = diff.modProperties.map(displaySimpleDiff(_)).getOrElse(initialState.properties.toApiJson)
       val category: JValue    = diff.modCategory.map(displaySimpleDiff(_)(_.value))
-      ( ("id"          -> initialState.id.value)
+      ( ("id"          -> initialState.id.serialize)
       ~ ("displayName" -> name)
       ~ ("description" -> description)
       ~ ("category"    -> category)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/UpdateDynamicGroups.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/UpdateDynamicGroups.scala
@@ -235,15 +235,15 @@ class UpdateDynamicGroups(
         } {
           eitherRes match {
             case Left(e) =>
-              val error = (e.fullMsg + s" Error when updating dynamic group '${id.value}'")
+              val error = (e.fullMsg + s" Error when updating dynamic group '${id.serialize}'")
               logger.error(error)
             case Right(diff) =>
               val addedNodes = displayNodechange(diff.added)
               val removedNodes = displayNodechange(diff.removed)
-              logger.debug(s"Group ${id.value}: adding ${addedNodes}, removing ${removedNodes}")
+              logger.debug(s"Group ${id.serialize}: adding ${addedNodes}, removing ${removedNodes}")
               //if the diff is not empty, start a new deploy
               if(diff.added.nonEmpty || diff.removed.nonEmpty) {
-                logger.info(s"Dynamic group ${id.value}: added node with id: ${addedNodes}, removed: ${removedNodes}")
+                logger.info(s"Dynamic group ${id.serialize}: added node with id: ${addedNodes}, removed: ${removedNodes}")
                 // we need to trigger a deployment in this case
                 needDeployment = true
               }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderDit.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderDit.scala
@@ -421,7 +421,7 @@ class RudderDit(val BASE_DN:DN) extends AbstractDit {
       system =>
 
       def targetDN(target:RuleTarget) : DN = target match {
-        case GroupTarget(groupId) => group.groupDN(groupId.value, system.dn)
+        case GroupTarget(groupId) => group.groupDN(groupId.serialize, system.dn)
         case t => new DN(new RDN(A_RULE_TARGET, target.target), system.dn)
       }
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
@@ -62,7 +62,7 @@ sealed trait SimpleTarget extends RuleTarget //simple as opposed to composed
 
 object GroupTarget { def r = "group:(.+)".r }
 final case class GroupTarget(groupId:NodeGroupId) extends SimpleTarget {
-  override def target = "group:"+groupId.value
+  override def target = "group:"+groupId.serialize
 }
 
 //object NodeTarget { def r = "node:(.+)".r }
@@ -394,7 +394,7 @@ object RuleTarget extends Loggable {
   def unserOne(s: String): Option[SimpleTarget] = {
     s match {
       case GroupTarget.r(g) =>
-        Some(GroupTarget(NodeGroupId(g)))
+        NodeGroupId.parse(g).toOption.map(GroupTarget(_))
       case PolicyServerTarget.r(s) =>
         Some(PolicyServerTarget(NodeId(s)))
       case AllTarget.r() =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -775,7 +775,7 @@ object ParentProperty {
     override def displayName: String = s"${name} (${id.value})"
   }
   final case class Group(name: String, id: NodeGroupId, value: ConfigValue) extends ParentProperty {
-    override def displayName: String = s"${name} (${id.value})"
+    override def displayName: String = s"${name} (${id.serialize})"
   }
   // a global parameter has the same name as property so no need to be specific for name
   final case class Global(value: ConfigValue) extends ParentProperty {
@@ -804,7 +804,7 @@ object JsonPropertySerialisation {
           (
             ( "kind"  -> "group" )
           ~ ( "name"  -> name    )
-          ~ ( "id"    -> id.value)
+          ~ ( "id"    -> id.serialize)
           ~ ( "value" -> GenericProperty.toJsonValue(value))
           )
         case _ => JNothing

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
@@ -873,7 +873,7 @@ class SubGroupComparator(getGroups: () => IOResult[Seq[SubGroupChoice]]) extends
       (for {
         res <- getGroups()
       } yield {
-        val g = res.map { case SubGroupChoice(id, name) => SelectableOption(id.value, name) }
+        val g = res.map { case SubGroupChoice(id, name) => SelectableOption(id.serialize, name) }
         // if current value is defined but not in the list, add it with a "missing group" label
         if(value != "") {
           g.find( _.value == value ) match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
@@ -214,7 +214,7 @@ trait RoNodeGroupRepository {
    * @return
    */
   def getNodeGroup(id: NodeGroupId) : IOResult[(NodeGroup,NodeGroupCategoryId)] = {
-    getNodeGroupOpt(id).notOptional(s"Group with id '${id.value}' was not found'")
+    getNodeGroupOpt(id).notOptional(s"Group with id '${id.serialize}' was not found'")
   }
 
   /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapGroupLibrary.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapGroupLibrary.scala
@@ -254,7 +254,7 @@ class ImportGroupLibraryImpl(
         } else nodeGroupNames.get(nodeGroup.name) match {
           case Some(id) =>
             logEffect.error("Ignoring Active Technique with ID '%s' because it references technique with name '%s' already referenced by active technique with ID '%s'".format(
-                nodeGroup.id.value, nodeGroup.name, id.value
+                nodeGroup.id.serialize, nodeGroup.name, id.serialize
             ))
             None
           case None =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
@@ -703,8 +703,8 @@ class GitNodeGroupArchiverImpl(
 
   private[this] def newNgFile(ngId:NodeGroupId, parents: List[NodeGroupCategoryId]) = {
     parents match {
-      case h :: t => new File(newCategoryDirectory(h, t), ngId.value + ".xml").succeed
-      case Nil    => Inconsistency("The given parent category list for node group with id '%s' is empty, what is forbiden".format(ngId.value)).fail
+      case h :: t => new File(newCategoryDirectory(h, t), ngId.withDefaultRev.serialize + ".xml").succeed
+      case Nil    => Inconsistency("The given parent category list for node group with id '%s' is empty, what is forbidden".format(ngId.withDefaultRev.serialize)).fail
     }
   }
 
@@ -717,7 +717,7 @@ class GitNodeGroupArchiverImpl(
                       , "Archived node group: " + ngFile.getPath
                     )
       commit     <- gitCommit match {
-                      case Some((modId, commiter, reason)) => commitAddFileWithModId(modId, commiter, toGitPath(ngFile), "Archive of node group with ID '%s'%s".format(ng.id.value,GET(reason)))
+                      case Some((modId, commiter, reason)) => commitAddFileWithModId(modId, commiter, toGitPath(ngFile), "Archive of node group with ID '%s'%s".format(ng.id.withDefaultRev.serialize,GET(reason)))
                       case None => UIO.unit
                     }
     } yield {
@@ -737,7 +737,7 @@ class GitNodeGroupArchiverImpl(
                      _        <- logPure.debug(s"Deleted archived node group: ${ngFile.getPath}")
                      commited <- gitCommit match {
                                    case Some((modId, commiter, reason)) =>
-                                     commitRmFileWithModId(modId, commiter, gitPath, s"Delete archive of node group with ID '${ngId.value}'${GET(reason)}")
+                                     commitRmFileWithModId(modId, commiter, gitPath, s"Delete archive of node group with ID '${ngId.withDefaultRev.serialize}'${GET(reason)}")
                                    case None => UIO.unit
                                  }
                    } yield {
@@ -767,7 +767,7 @@ class GitNodeGroupArchiverImpl(
                            IOResult.effect(FileUtils.deleteQuietly(oldNgXmlFile))
                          }
         commit       <- gitCommit match {
-                          case Some((modId, commiter, reason)) => commitMvDirectoryWithModId(modId, commiter, toGitPath(oldNgXmlFile), toGitPath(newNgXmlFile), "Move archive of node group with ID '%s'%s".format(ng.id.value,GET(reason)))
+                          case Some((modId, commiter, reason)) => commitMvDirectoryWithModId(modId, commiter, toGitPath(oldNgXmlFile), toGitPath(newNgXmlFile), "Move archive of node group with ID '%s'%s".format(ng.id.withDefaultRev.serialize,GET(reason)))
                           case None => UIO.unit
                         }
       } yield {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
@@ -476,7 +476,8 @@ class EventLogDetailsServiceImpl(
                             else Failure("NodeGroup attribute does not have changeType=modify: " + entry.toString())
                           }
       fileFormatOk    <- TestFileFormat(group)
-      id              <- (group \ "id").headOption.map( _.text ) ?~! ("Missing attribute 'id' in entry type nodeGroup : " + entry.toString())
+      sid             <- (group \ "id").headOption.map( _.text ) ?~! ("Missing attribute 'id' in entry type nodeGroup : " + entry.toString())
+      id              <- NodeGroupId.parse(sid).toBox
       displayName     <- (group \ "displayName").headOption.map( _.text ) ?~! ("Missing attribute 'displayName' in entry type nodeGroup : " + entry.toString())
       name            <- getFromToString((group \ "name").headOption)
       description     <- getFromToString((group \ "description").headOption)
@@ -493,7 +494,7 @@ class EventLogDetailsServiceImpl(
       isSystem        <- getFromTo[Boolean]((group \ "isSystem").headOption, { s => tryo { s.text.toBoolean } } )
     } yield {
       ModifyNodeGroupDiff(
-          id = NodeGroupId(id)
+          id = id
         , name = displayName
         , modName = name
         , modDescription = description

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -602,7 +602,7 @@ class EventLogFactoryImpl(
   ) : ModifyNodeGroup = {
     val details = EventLog.withContent{
       scala.xml.Utility.trim(<nodeGroup changeType="modify" fileFormat={Constants.XML_CURRENT_FILE_FORMAT.toString}>
-        <id>{modifyDiff.id.value}</id>
+        <id>{modifyDiff.id.withDefaultRev.serialize}</id>
         <displayName>{modifyDiff.name}</displayName>{
           modifyDiff.modName.map(x => SimpleDiff.stringToXml(<name/>, x) ) ++
           modifyDiff.modDescription.map(x => SimpleDiff.stringToXml(<description/>, x ) ) ++

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
@@ -234,7 +234,7 @@ class NodeGroupCategorySerialisationImpl(xmlVersion:String) extends NodeGroupCat
 class NodeGroupSerialisationImpl(xmlVersion:String) extends NodeGroupSerialisation {
   def serialise(group:NodeGroup):  Elem = {
     createTrimedElem(XML_TAG_NODE_GROUP, xmlVersion) (
-        <id>{group.id.value}</id>
+        <id>{group.id.withDefaultRev.serialize}</id>
         <displayName>{group.name}</displayName>
         <description>{group.description}</description>
         <query>{ group.query.map( _.toJSONString ).getOrElse("") }</query>
@@ -382,7 +382,7 @@ class ChangeRequestChangesSerialisationImpl(
 
       case changeRequest : ConfigurationChangeRequest =>
         val groups = changeRequest.nodeGroups.map{ case (nodeGroupId,group) =>
-          <group id={nodeGroupId.value}>
+          <group id={nodeGroupId.withDefaultRev.serialize}>
             <initialState>
               {group.changes.initialState.map(nodeGroupSerializer.serialise(_)).getOrElse(NodeSeq.Empty)}
             </initialState>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
@@ -465,7 +465,7 @@ class SystemVariableServiceImpl(
     //build the list of nodeId -> names, taking care of special nodeIds for special target
     val nodeGroups = nodeTargets.map { info =>
       val id = info.target.target match {
-        case GroupTarget(id) => id.value
+        case GroupTarget(id) => id.serialize
         case t => t.target
       }
       (id, info.name)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
@@ -96,10 +96,10 @@ class DynGroupUpdaterServiceImpl(
     for {
       _                <- if(group.isDynamic) Full("OK") else Failure("Can not update a not dynamic group")
       timePreCompute   =  System.currentTimeMillis
-      query            <- Box(group.query) ?~! s"No query defined for group '${group.name}' (${group.id.value})"
-      newMembers       <- queryProcessor.processOnlyId(query) ?~! s"Error when processing request for updating dynamic group '${group.name}' (${group.id.value})"
+      query            <- Box(group.query) ?~! s"No query defined for group '${group.name}' (${group.id.serialize})"
+      newMembers       <- queryProcessor.processOnlyId(query) ?~! s"Error when processing request for updating dynamic group '${group.name}' (${group.id.serialize})"
       timeGroupCompute = (System.currentTimeMillis - timePreCompute)
-      _                = logger.debug(s"Dynamic group ${group.id.value} with name ${group.name} computed in ${timeGroupCompute} ms")
+      _                = logger.debug(s"Dynamic group ${group.id.serialize} with name ${group.name} computed in ${timeGroupCompute} ms")
     } yield {
       group.copy(serverList = newMembers)
     }
@@ -113,7 +113,7 @@ class DynGroupUpdaterServiceImpl(
         group =>
           for {
             newGroup   <- computeDynGroup(group)
-            savedGroup <- woNodeGroupRepository.updateDynGroupNodes(newGroup, modId, actor, reason).toBox ?~! s"Error when saving update for dynamic group '${group.name}' (${group.id.value})"
+            savedGroup <- woNodeGroupRepository.updateDynGroupNodes(newGroup, modId, actor, reason).toBox ?~! s"Error when saving update for dynamic group '${group.name}' (${group.id.serialize})"
           } yield {
             DynGroupDiff(newGroup, group)
           }
@@ -128,9 +128,9 @@ class DynGroupUpdaterServiceImpl(
     for {
       (group,_)        <- roNodeGroupRepository.getNodeGroup(dynGroupId).toBox
       newGroup         <- computeDynGroup(group)
-      savedGroup       <- woNodeGroupRepository.updateDynGroupNodes(newGroup, modId, actor, reason).toBox ?~! s"Error when saving update for dynamic group '${group.name}' (${group.id.value})"
+      savedGroup       <- woNodeGroupRepository.updateDynGroupNodes(newGroup, modId, actor, reason).toBox ?~! s"Error when saving update for dynamic group '${group.name}' (${group.id.serialize})"
       timeGroupUpdate  =  (System.currentTimeMillis - timePreUpdate)
-      _                =  logger.debug(s"Dynamic group ${group.id.value} with name ${group.name} updated in ${timeGroupUpdate} ms")
+      _                =  logger.debug(s"Dynamic group ${group.id.serialize} with name ${group.name} updated in ${timeGroupUpdate} ms")
     } yield {
       DynGroupDiff(newGroup, group)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/PolicyServerManagementService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/PolicyServerManagementService.scala
@@ -69,6 +69,7 @@ import com.normation.rudder.domain.eventlog.UpdatePolicyServer
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.Directive
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.DirectiveUid
@@ -546,7 +547,7 @@ object PolicyServerConfigurationObjects {
   def groupHasPolicyServer(nodeId: NodeId) = {
     val objectType = ObjectCriterion("node", Seq(Criterion("policyServerId", StringComparator, None),Criterion("agentName", AgentComparator, None)))
     NodeGroup(
-        NodeGroupId(s"hasPolicyServer-${nodeId.value}")
+        NodeGroupId(NodeGroupUid(s"hasPolicyServer-${nodeId.value}"))
       , s"All nodes managed by '${nodeId.value}' policy server"
       , s"All nodes known by Rudder directly connected to the '${nodeId.value}' server. This group exists only as internal purpose and should not be used to configure Nodes."
       , Nil
@@ -572,7 +573,7 @@ object PolicyServerConfigurationObjects {
         RuleId(RuleUid(s"hasPolicyServer-${nodeId.value}"))
       , s"Rudder system policy: basic setup (common) - ${nodeId.value}"
       , RuleCategoryId("rootRuleCategory")
-      , Set(GroupTarget(NodeGroupId(s"hasPolicyServer-${nodeId.value}")))
+      , Set(GroupTarget(NodeGroupId(NodeGroupUid(s"hasPolicyServer-${nodeId.value}"))))
       , Set(DirectiveId(DirectiveUid(s"common-hasPolicyServer-${nodeId.value}")))
       , "Common - Technical"
       , "This is the basic system rule which all nodes must have."

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/RemoveNodeService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/RemoveNodeService.scala
@@ -483,7 +483,7 @@ class RemoveNodeServiceImpl(
       deleted      <- ZIO.foreach(nodeGroupIds) { nodeGroupId =>
                         val msg = Some("Automatic update of group due to deletion of node " + nodeId.value)
                         woNodeGroupRepository.updateDiffNodes(nodeGroupId, add = Nil, delete = List(nodeId), modId, actor, msg).chainError(
-                          s"Could not update group '${nodeGroupId.value}' to remove node '${nodeId.value}'"
+                          s"Could not update group '${nodeGroupId.serialize}' to remove node '${nodeId.value}'"
                         )
                       }
     } yield {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
@@ -78,7 +78,7 @@ trait CommitAndDeployChangeRequestService {
   /**
    * Save and deploy a change request.
    * That method must ensure that the change request
-   * is only commited if there is no conflict between
+   * is only committed if there is no conflict between
    * the changes it contains and the actual current
    * state of configuration.
    */
@@ -164,7 +164,7 @@ class CommitAndDeployChangeRequestServiceImpl(
        * In a string, we don't want to take care of a difference in the number of spaces
        * in names / description.
        * We also remove space in the end.
-       * Do not use it in a place where space may be significative, like a template.
+       * Do not use it in a place where space may be significant, like a template.
        */
     def normalizeString(text: String) : String = {
       text.replaceAll("""\s+""", " ").trim
@@ -228,7 +228,7 @@ class CommitAndDeployChangeRequestServiceImpl(
 
 
     // For now we only check the Directive, not the SectionSpec and the TechniqueName.
-    // The SectionSpec could be a problem (ie : A mono valued param was chanegd to multi valued without changing the technique version).
+    // The SectionSpec could be a problem (ie : A mono valued param was changed to multi valued without changing the technique version).
     final case class CheckDirective(changes : DirectiveChanges) extends CheckChanges[Directive]  {
       // used in serialisation
       val directiveContext = {
@@ -253,7 +253,7 @@ class CommitAndDeployChangeRequestServiceImpl(
     }
 
     final case object CheckGroup extends CheckChanges[NodeGroup]  {
-      def failureMessage(group : NodeGroup)  = s"Group ${group.name} (id: ${group.id.value})"
+      def failureMessage(group : NodeGroup)  = s"Group ${group.name} (id: ${group.id.serialize})"
       def getCurrentValue(group : NodeGroup) = roNodeGroupRepo.getNodeGroup(group.id).map(_._1).toBox
       def compareMethod(initial:NodeGroup, current:NodeGroup) = compareGroups(initial,current)
       def xmlSerialize(group : NodeGroup) = Full(xmlSerializer.group.serialise(group))
@@ -309,7 +309,7 @@ class CommitAndDeployChangeRequestServiceImpl(
 
         def displayTarget(target : RuleTarget) = {
           target match {
-            case GroupTarget(groupId) => s"group: ${groupId.value}"
+            case GroupTarget(groupId) => s"group: ${groupId.serialize}"
             case PolicyServerTarget(nodeId) => s"policyServer: ${nodeId.value}"
             case _ => target.target
           }
@@ -384,7 +384,7 @@ class CommitAndDeployChangeRequestServiceImpl(
           currVal = currentFixed.parameters.get(key)
         } yield {
           if ( currVal != initVal) {
-            debugLog(s"Directive ID ${initialFixed.id.uid.value} parameter $key has changed : original state from CR: ${initVal.getOrElse("value is mising")}, current value: ${currVal.getOrElse("value is mising")}")
+            debugLog(s"Directive ID ${initialFixed.id.uid.value} parameter $key has changed : original state from CR: ${initVal.getOrElse("value is missing")}, current value: ${currVal.getOrElse("value is missing")}")
           }
         }
 
@@ -420,32 +420,32 @@ class CommitAndDeployChangeRequestServiceImpl(
         debugLog("Attempt to merge Change Request (CR) failed because initial state could not be rebased on current state.")
 
         if ( initialFixed.name != currentFixed.name) {
-          debugLog(s"Group ID ${initialFixed.id.value} name has changed: original state from CR: ${initialFixed.name}, current value: ${currentFixed.name}")
+          debugLog(s"Group ID ${initialFixed.id.serialize} name has changed: original state from CR: ${initialFixed.name}, current value: ${currentFixed.name}")
         }
 
         if ( initialFixed.description != currentFixed.description) {
-          debugLog(s"Group ID ${initialFixed.id.value} description has changed: original state from CR: ${initialFixed.description}, current value: ${currentFixed.description}")
+          debugLog(s"Group ID ${initialFixed.id.serialize} description has changed: original state from CR: ${initialFixed.description}, current value: ${currentFixed.description}")
         }
 
         if ( initialFixed.query != currentFixed.query) {
-          debugLog(s"Group ID ${initialFixed.id.value} query has changed: original state from CR: ${initialFixed.query}, current value: ${currentFixed.query}")
+          debugLog(s"Group ID ${initialFixed.id.serialize} query has changed: original state from CR: ${initialFixed.query}, current value: ${currentFixed.query}")
         }
 
         if ( initialFixed.isDynamic != currentFixed.isDynamic) {
-          debugLog(s"Group ID ${initialFixed.id.value} dynamic status has changed: original state from CR: ${initialFixed.isDynamic}, current value: ${currentFixed.isDynamic}")
+          debugLog(s"Group ID ${initialFixed.id.serialize} dynamic status has changed: original state from CR: ${initialFixed.isDynamic}, current value: ${currentFixed.isDynamic}")
         }
 
         if ( initialFixed.isEnabled != currentFixed.isEnabled) {
-          debugLog(s"Group ID ${initialFixed.id.value} enable status has changed: original state from CR: ${initialFixed.isEnabled}, current value: ${currentFixed.isEnabled}")
+          debugLog(s"Group ID ${initialFixed.id.serialize} enable status has changed: original state from CR: ${initialFixed.isEnabled}, current value: ${currentFixed.isEnabled}")
         }
 
         // we compare nodes only for static group, not dynamic ones
         if (!(initialFixed.isDynamic && currentFixed.isDynamic) && initialFixed.serverList != currentFixed.serverList) {
-          debugLog(s"Group ID ${initialFixed.id.value} nodes list has changed: original state from CR: ${initialFixed.serverList.map(_.value).mkString("[ ", ", ", " ]")}, current value: ${currentFixed.serverList.map(_.value).mkString("[ ", ", ", " ]")}")
+          debugLog(s"Group ID ${initialFixed.id.serialize} nodes list has changed: original state from CR: ${initialFixed.serverList.map(_.value).mkString("[ ", ", ", " ]")}, current value: ${currentFixed.serverList.map(_.value).mkString("[ ", ", ", " ]")}")
         }
 
         if( initialFixed.properties != currentFixed.properties ) {
-          debugLog(s"Group ID ${initialFixed.id.value} properties changed: original state from CR: ${initialFixed.properties.map(_.toData).mkString("[ ", ", ", " ]")}, current value: ${currentFixed.properties.map(_.toData).mkString("[ ", ", ", " ]")}")
+          debugLog(s"Group ID ${initialFixed.id.serialize} properties changed: original state from CR: ${initialFixed.properties.map(_.toData).mkString("[ ", ", ", " ]")}, current value: ${currentFixed.properties.map(_.toData).mkString("[ ", ", ", " ]")}")
         }
 
         //return
@@ -629,7 +629,7 @@ class CommitAndDeployChangeRequestServiceImpl(
      * Logic to commit Change request with multiple changes:
      *
      * - such a change request is NOT atomic, each change is
-     *   commited independently to other
+     *   committed independently to other
      * - from previous point, it may happen that a erroneous commit
      *   in a beginner element leads to other errors
      * - the commit order is DEFINED and FIXE

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
@@ -2,9 +2,11 @@ package com.normation.rudder.domain.policies
 
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.nodes.NodeInfo
+
 import org.joda.time.DateTime
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
+
 import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner._
@@ -17,6 +19,7 @@ import com.normation.inventory.domain.Debian
 import com.normation.inventory.domain.Linux
 import com.normation.inventory.domain.Version
 import com.normation.inventory.domain.UndefinedKey
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.nodes.NodeState
 
 @RunWith(classOf[JUnitRunner])
@@ -48,22 +51,22 @@ class RuleTargetTest extends Specification with Loggable {
   }.toMap
 
   val g1 = NodeGroup (
-    NodeGroupId("1"), "Empty group", "", Nil, None, false, Set(), true
+    NodeGroupId(NodeGroupUid("1")), "Empty group", "", Nil, None, false, Set(), true
   )
   val g2 = NodeGroup (
-    NodeGroupId("2"), "only root", "", Nil, None, false, Set(NodeId("root")), true
+    NodeGroupId(NodeGroupUid("2")), "only root", "", Nil, None, false, Set(NodeId("root")), true
   )
   val g3 = NodeGroup (
-    NodeGroupId("3"), "Even nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt == 2), true
+    NodeGroupId(NodeGroupUid("3")), "Even nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt == 2), true
   )
   val g4 = NodeGroup (
-    NodeGroupId("4"), "Odd nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt != 2), true
+    NodeGroupId(NodeGroupUid("4")), "Odd nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt != 2), true
   )
   val g5 = NodeGroup (
-    NodeGroupId("5"), "Nodes id divided by 3", "", Nil, None, false, nodeIds.filter(_.value.toInt == 3), true
+    NodeGroupId(NodeGroupUid("5")), "Nodes id divided by 3", "", Nil, None, false, nodeIds.filter(_.value.toInt == 3), true
   )
   val g6 = NodeGroup (
-    NodeGroupId("6"), "Nodes id divided by 5", "", Nil, None, false, nodeIds.filter(_.value.toInt == 5), true
+    NodeGroupId(NodeGroupUid("6")), "Nodes id divided by 5", "", Nil, None, false, nodeIds.filter(_.value.toInt == 5), true
   )
 
   val groups = Set(g1, g2, g3, g4, g5, g6 )

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
@@ -77,7 +77,7 @@ class TestMergeGroupProperties extends Specification {
 
   implicit class ToTarget(g: NodeGroup) {
     def toTarget = FullRuleTargetInfo(FullGroupTarget(GroupTarget(g.id), g), g.name, "", true, true)
-    def toCriterion = CriterionLine(null, Criterion("some ldap attr", new SubGroupComparator(null)), null, g.id.value)
+    def toCriterion = CriterionLine(null, Criterion("some ldap attr", new SubGroupComparator(null)), null, g.id.serialize)
   }
 
   implicit class ToNodePropertyHierarchy(groups: List[NodeGroup]) {
@@ -130,20 +130,20 @@ class TestMergeGroupProperties extends Specification {
    *    node
    */
 
-  val parent1   = NodeGroup(NodeGroupId("parent1"), "parent1", "",
+  val parent1   = NodeGroup(NodeGroupId(NodeGroupUid("parent1")), "parent1", "",
       List(GroupProperty("foo", GitVersion.DEFAULT_REV, "bar1".toConfigValue, None, None))
     , Some(NewQuery(NodeReturnType, And, Identity, List()))
     , true, Set(), true
   )
   val parent2Prop = GroupProperty("foo", GitVersion.DEFAULT_REV, "bar2".toConfigValue, None, None)
-  val parent2   = NodeGroup(NodeGroupId("parent2"), "parent2", "",
+  val parent2   = NodeGroup(NodeGroupId(NodeGroupUid("parent2")), "parent2", "",
       List(parent2Prop)
     , Some(NewQuery(NodeReturnType, And, Identity, List()))
     , true, Set(), true
   )
   val childProp = GroupProperty("foo", GitVersion.DEFAULT_REV, "baz".toConfigValue, None, None)
   val query = NewQuery(NodeReturnType, And, Identity, List(parent1.toCriterion))
-  val child = NodeGroup(NodeGroupId("child"), "child", "",
+  val child = NodeGroup(NodeGroupId(NodeGroupUid("child")), "child", "",
       List(childProp)
     , Some(query)
     , true, Set(), true
@@ -178,12 +178,12 @@ class TestMergeGroupProperties extends Specification {
   "when looking for a node property, we" should {
 
     "be able to detect conflict" in {
-      val parent1 = NodeGroup(NodeGroupId("parent1"), "parent1", "",
+      val parent1 = NodeGroup(NodeGroupId(NodeGroupUid("parent1")), "parent1", "",
           List(GroupProperty("dns", GitVersion.DEFAULT_REV, "1.1.1.1".toConfigValue, None, None))
         , Some(NewQuery(NodeReturnType, And, Identity, List()))
         , true, Set(), true
       )
-      val parent2   = NodeGroup(NodeGroupId("parent2"), "parent2", "",
+      val parent2   = NodeGroup(NodeGroupId(NodeGroupUid("parent2")), "parent2", "",
           List(GroupProperty("dns", GitVersion.DEFAULT_REV, "9.9.9.9".toConfigValue, None, None))
         , Some(NewQuery(NodeReturnType, And, Identity, List()))
         , true, Set(), true
@@ -197,17 +197,17 @@ class TestMergeGroupProperties extends Specification {
     }
 
     "be able to correct conflict" in {
-      val parent1 = NodeGroup(NodeGroupId("parent1"), "parent1", "",
+      val parent1 = NodeGroup(NodeGroupId(NodeGroupUid("parent1")), "parent1", "",
           List(GroupProperty("dns", GitVersion.DEFAULT_REV, "1.1.1.1".toConfigValue, None, None))
         , Some(NewQuery(NodeReturnType, And, Identity, List()))
         , true, Set(), true
       )
-      val parent2   = NodeGroup(NodeGroupId("parent2"), "parent2", "",
+      val parent2   = NodeGroup(NodeGroupId(NodeGroupUid("parent2")), "parent2", "",
           List(GroupProperty("dns", GitVersion.DEFAULT_REV, "9.9.9.9".toConfigValue, None, None))
         , Some(NewQuery(NodeReturnType, And, Identity, List()))
         , true, Set(), true
       )
-      val priorize   = NodeGroup(NodeGroupId("parent3"), "parent3", "",
+      val priorize   = NodeGroup(NodeGroupId(NodeGroupUid("parent3")), "parent3", "",
           Nil
         , Some(NewQuery(NodeReturnType, And, Identity, List(parent1.toCriterion, parent2.toCriterion)))
         , true, Set(), true
@@ -227,22 +227,22 @@ class TestMergeGroupProperties extends Specification {
      * node in p4 and p3
      */
     "one can solve conflicts at parent level" in {
-      val parent1 = NodeGroup(NodeGroupId("parent1"), "parent1", "",
+      val parent1 = NodeGroup(NodeGroupId(NodeGroupUid("parent1")), "parent1", "",
           List(GroupProperty("dns", GitVersion.DEFAULT_REV, "1.1.1.1".toConfigValue, None, None))
         , Some(NewQuery(NodeReturnType, And, Identity, List()))
         , true, Set(), true
       )
-      val parent2   = NodeGroup(NodeGroupId("parent2"), "parent2", "",
+      val parent2   = NodeGroup(NodeGroupId(NodeGroupUid("parent2")), "parent2", "",
           List(GroupProperty("dns", GitVersion.DEFAULT_REV, "9.9.9.9".toConfigValue, None, None))
         , Some(NewQuery(NodeReturnType, And, Identity, List()))
         , true, Set(), true
       )
-      val priorize   = NodeGroup(NodeGroupId("parent3"), "parent3", "",
+      val priorize   = NodeGroup(NodeGroupId(NodeGroupUid("parent3")), "parent3", "",
           Nil
         , Some(NewQuery(NodeReturnType, And, Identity, List(parent1.toCriterion, parent2.toCriterion)))
         , true, Set(), true
       )
-      val parent4   = NodeGroup(NodeGroupId("parent4"), "parent4", "",
+      val parent4   = NodeGroup(NodeGroupId(NodeGroupUid("parent4")), "parent4", "",
           Nil
         , Some(NewQuery(NodeReturnType, And, Identity, List(parent1.toCriterion)))
         , true, Set(), true
@@ -284,12 +284,12 @@ class TestMergeGroupProperties extends Specification {
         , res => res
         )
       }.toList
-      val parent = NodeGroup(NodeGroupId("parent1"), "parent1", "",
+      val parent = NodeGroup(NodeGroupId(NodeGroupUid("parent1")), "parent1", "",
           toProps(parentProps)
         , Some(NewQuery(NodeReturnType, And, Identity, List()))
         , true, Set(), true
       )
-      val child = NodeGroup(NodeGroupId("child"), "child", "",
+      val child = NodeGroup(NodeGroupId(NodeGroupUid("child")), "child", "",
           toProps(childProps)
         , Some(NewQuery(NodeReturnType, And, Identity, List(parent1.toCriterion)))
         , true, Set(), true

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
@@ -122,6 +122,7 @@ import com.normation.inventory.domain.PendingInventory
 import com.normation.inventory.domain.VMWare
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.Constants
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.git.GitRepositoryProviderImpl
 import com.normation.rudder.git.GitRevisionProvider
@@ -437,14 +438,14 @@ ootapja6lKOaIpqp0kmmYN7gFIhp
    *   ************************************************************************
    */
 
-  val g0id = NodeGroupId("0")
+  val g0id = NodeGroupId(NodeGroupUid("0"))
   val g0 = NodeGroup (g0id, "Real nodes", "", Nil, None, false, Set(rootId, node1.id, node2.id), true)
-  val g1 = NodeGroup (NodeGroupId("1"), "Empty group", "", Nil, None, false, Set(), true)
-  val g2 = NodeGroup (NodeGroupId("2"), "only root", "", Nil, None, false, Set(NodeId("root")), true)
-  val g3 = NodeGroup (NodeGroupId("3"), "Even nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt == 2), true)
-  val g4 = NodeGroup (NodeGroupId("4"), "Odd nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt != 2), true)
-  val g5 = NodeGroup (NodeGroupId("5"), "Nodes id divided by 3", "", Nil, None, false, nodeIds.filter(_.value.toInt == 3), true)
-  val g6 = NodeGroup (NodeGroupId("6"), "Nodes id divided by 5", "", Nil, None, false, nodeIds.filter(_.value.toInt == 5), true)
+  val g1 = NodeGroup (NodeGroupId(NodeGroupUid("1")), "Empty group", "", Nil, None, false, Set(), true)
+  val g2 = NodeGroup (NodeGroupId(NodeGroupUid("2")), "only root", "", Nil, None, false, Set(NodeId("root")), true)
+  val g3 = NodeGroup (NodeGroupId(NodeGroupUid("3")), "Even nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt == 2), true)
+  val g4 = NodeGroup (NodeGroupId(NodeGroupUid("4")), "Odd nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt != 2), true)
+  val g5 = NodeGroup (NodeGroupId(NodeGroupUid("5")), "Nodes id divided by 3", "", Nil, None, false, nodeIds.filter(_.value.toInt == 3), true)
+  val g6 = NodeGroup (NodeGroupId(NodeGroupUid("6")), "Nodes id divided by 5", "", Nil, None, false, nodeIds.filter(_.value.toInt == 5), true)
   val groups = Set(g0, g1, g2, g3, g4, g5, g6).map(g => (g.id, g))
 
   val groupTargets = groups.map{ case (id, g) => (GroupTarget(g.id), g) }
@@ -681,8 +682,8 @@ class TestNodeConfiguration(prefixTestResources: String = ""
       targetInfos = List(
           FullRuleTargetInfo(
               FullGroupTarget(
-                  GroupTarget(NodeGroupId("a-group-for-root-only"))
-                , NodeGroup(NodeGroupId("a-group-for-root-only")
+                  GroupTarget(NodeGroupId(NodeGroupUid("a-group-for-root-only")))
+                , NodeGroup(NodeGroupId(NodeGroupUid("a-group-for-root-only"))
                     , "Serveurs [€ðŋ] cassés"
                     , "Liste de l'ensemble de serveurs cassés à réparer"
                     , Nil

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
@@ -57,6 +57,7 @@ import com.normation.rudder.domain.policies.GroupTarget
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.inventory.domain.AgentType
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.services.nodes.PropertyEngineServiceImpl
@@ -154,7 +155,7 @@ class RuleValServiceTest extends Specification {
           ruleId
         , "Rule Name"
         , RuleCategoryId("cat1")
-        , Set(GroupTarget(NodeGroupId("nodeGroupId")))
+        , Set(GroupTarget(NodeGroupId(NodeGroupUid("nodeGroupId"))))
         , Set(DirectiveId(directiveId))
         , ""
         , ""

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
@@ -42,6 +42,7 @@ import com.normation.rudder.domain.appconfig.FeatureSwitch
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupCategoryId
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.ActiveTechniqueCategoryId
 import com.normation.rudder.domain.policies.ActiveTechniqueId
 import com.normation.rudder.domain.policies.FullGroupTarget
@@ -95,7 +96,7 @@ class TestBuildNodeConfiguration extends Specification {
 
   val allNodes                  = ((1 to 1000).map(newNode) :+ root).map(n => (n.id, n)).toMap
   // only one group with all nodes
-  val group                     = NodeGroup (NodeGroupId("allnodes"), "allnodes", "", Nil, None, false, allNodes.keySet, true)
+  val group                     = NodeGroup (NodeGroupId(NodeGroupUid("allnodes")), "allnodes", "", Nil, None, false, allNodes.keySet, true)
   val groupLib                  = FullNodeGroupCategory (
                                       NodeGroupCategoryId("test_root"), "", "", Nil
                                     , List(FullRuleTargetInfo(FullGroupTarget(GroupTarget(group.id), group), "", "", true, false))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestPendingNodePolicies.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestPendingNodePolicies.scala
@@ -43,6 +43,7 @@ import com.normation.inventory.ldap.core.LDAPConstants.OC_MACHINE
 import com.normation.rudder.domain.RudderLDAPConstants.A_NODE_GROUP_UUID
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.queries.Criterion
 import com.normation.rudder.domain.queries.CriterionLine
 import com.normation.rudder.domain.queries.Equals
@@ -105,7 +106,7 @@ class TestPendingNodePolicies extends Specification {
   ))
 
   //a query line for sub group
-  def sub(g: NodeGroup) = CriterionLine(groupCriterion, groupCriterion.criteria.head, Equals, g.id.value)
+  def sub(g: NodeGroup) = CriterionLine(groupCriterion, groupCriterion.criteria.head, Equals, g.id.serialize)
   // a random query that will be added as dummy content - query checker will returns pre-defined things
   val cl = CriterionLine(
       ObjectCriterion(OC_MACHINE, Seq(Criterion(A_MACHINE_UUID, StringComparator)))
@@ -124,7 +125,7 @@ class TestPendingNodePolicies extends Specification {
   val dummyQuery1 = NewQuery(null, Or , Identity, List(cl)) // will return 1 node
 
   def ng(id: String, q: QueryTrait, dyn: Boolean = true) =
-    NodeGroup(NodeGroupId(id), id, id, Nil, Some(q), dyn, Set(), true, false)
+    NodeGroup(NodeGroupId(NodeGroupUid(id)), id, id, Nil, Some(q), dyn, Set(), true, false)
 
   // groups
   val c = ng("c", dummyQuery1) // ok
@@ -190,7 +191,7 @@ class TestPendingNodePolicies extends Specification {
           e.rootExceptionCause.foreach(ex => ex.printStackTrace())
           throw new RuntimeException(e.messageChain)
         case Full(res) =>
-          res.apply(node).map(_.value).sorted
+          res.apply(node).map(_.serialize).sorted
       }
       groups must containTheSameElementsAs(List("a", "b", "c", "d", "i", "j", "k", "m", "n", "o", "p"))
     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestQuicksearch.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestQuicksearch.scala
@@ -39,6 +39,7 @@ package com.normation.rudder.rest.internal
 
 import com.normation.rudder.AuthorizationType
 import com.normation.rudder.UserService
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.rest.RestUtils._
 import com.normation.rudder.services.quicksearch.FullQuickSearchService
@@ -206,7 +207,7 @@ class RestQuicksearch (
         case QRNodeId(v)      => nodeLink(NodeId(v))
         case QRRuleId(v)      => ruleLink(RuleId(RuleUid(v)))
         case QRDirectiveId(v) => directiveLink(DirectiveUid(v))
-        case QRGroupId(v)     => groupLink(NodeGroupId(v))
+        case QRGroupId(v)     => groupLink(NodeGroupId(NodeGroupUid(v)))
         case QRParameterId(v) => globalParameterLink(v)
       }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
@@ -6,16 +6,13 @@ import com.normation.rudder.apidata.JsonResponseObjects.JRRuleNodesDirectives
 import com.normation.rudder.domain.logger.TimingDebugLoggerPure
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.repository.{RoNodeGroupRepository, RoRuleRepository}
-import com.normation.rudder.rest.{ApiPath, AuthzToken, RestExtractorService, RestUtils, RuleInternalApi => API}
+import com.normation.rudder.rest.{ApiPath, AuthzToken, RestExtractorService, RuleInternalApi => API}
 import com.normation.rudder.rest.lift.{DefaultParams, LiftApiModule, LiftApiModuleProvider, LiftApiModuleString}
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.zio.currentTimeMillis
-import net.liftweb.common.Box
 import net.liftweb.http.{LiftResponse, Req}
 import com.normation.rudder.rest.implicits._
-import net.liftweb.json.JValue
 import com.normation.rudder.apidata.implicits._
-import zio._
 import zio.syntax._
 
 class RulesInternalApi(

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/JsInitContextLinkUtil.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/JsInitContextLinkUtil.scala
@@ -69,7 +69,7 @@ class LinkUtil (
   , nodeInfoService       : NodeInfoService
 ) extends Loggable {
   def baseGroupLink(id:NodeGroupId) =
-    s"""/secure/nodeManager/groups#{"groupId":"${id.value}"}"""
+    s"""/secure/nodeManager/groups#{"groupId":"${id.serialize}"}"""
 
   def baseTargetLink(target: RuleTarget) =
     s"""/secure/nodeManager/groups#{"target":"${target.target}"}"""
@@ -142,10 +142,10 @@ class LinkUtil (
 
   def createGroupLink(id:NodeGroupId) = {
     roGroupRepository.getNodeGroup(id).either.runNow match {
-      case Right((group,_)) => <span> <a href={baseGroupLink(id)}>{group.name}</a> (Rudder ID: {id.value})</span>
+      case Right((group,_)) => <span> <a href={baseGroupLink(id)}>{group.name}</a> (Rudder ID: {id.serialize})</span>
       case Left(err)        =>
-        logger.error(s"Could not find NodeGroup with Id ${id.value}. Error was: ${err.fullMsg}")
-        <span> {id.value} </span>
+        logger.error(s"Could not find NodeGroup with Id ${id.serialize}. Error was: ${err.fullMsg}")
+        <span> {id.serialize} </span>
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -126,7 +126,7 @@ class EventLogDetailsGenerator(
       val name = (x.details \ "nodeGroup" \ "displayName").text
       Text("Group ") ++ {
         if(id.size < 1) Text(name)
-        else <a href={groupLink(NodeGroupId(id))} onclick="noBubble(event);">{name}</a> ++ actionName
+        else <a href={groupLink(NodeGroupId(NodeGroupUid(id)))} onclick="noBubble(event);">{name}</a> ++ actionName
       }
     }
 
@@ -449,7 +449,7 @@ class EventLogDetailsGenerator(
                 { generatedByChangeRequest }
                 <h4>Group overview:</h4>
                 <ul class="evlogviewpad">
-                  <li><b>Node Group ID:</b> { modDiff.id.value }</li>
+                  <li><b>Node Group ID:</b> { modDiff.id.withDefaultRev.serialize }</li>
                   <li><b>Name:</b> {
                     modDiff.modName.map(diff => diff.newValue.toString).getOrElse(modDiff.name)
                     }</li>
@@ -1168,7 +1168,7 @@ class EventLogDetailsGenerator(
     )(xml)
 
   private[this] def groupDetails(xml:NodeSeq, group: NodeGroup) = (
-    "#groupID" #> group.id.value &
+    "#groupID" #> group.id.withDefaultRev.serialize &
       "#groupName" #> group.name &
       "#shortDescription" #> group.description &
       "#shortDescription" #> group.description &

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestDataExtractorTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestDataExtractorTest.scala
@@ -45,6 +45,7 @@ import com.normation.rudder.MockTechniques
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.policies._
 import com.normation.utils.StringUuidGeneratorImpl
+
 import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
@@ -53,6 +54,7 @@ import com.normation.rudder.apidata.JsonQueryObjects._
 import com.normation.rudder.apidata.JsonResponseObjects._
 import com.normation.rudder.apidata.JsonResponseObjects.JRRuleTarget._
 import com.normation.rudder.apidata.implicits._
+import com.normation.rudder.domain.nodes.NodeGroupUid
 
 @RunWith(classOf[JUnitRunner])
 class RestDataExtractorTest extends Specification {
@@ -77,10 +79,10 @@ class RestDataExtractorTest extends Specification {
   "extract RuleTarget" >> {
     val tests = List(
       ("""group:3d5d1d6c-4ba5-4ffc-b5a4-12ce02336f52"""
-      , JRRuleTarget(GroupTarget(NodeGroupId("3d5d1d6c-4ba5-4ffc-b5a4-12ce02336f52")))
+      , JRRuleTarget(GroupTarget(NodeGroupId(NodeGroupUid("3d5d1d6c-4ba5-4ffc-b5a4-12ce02336f52"))))
       )
     , ("""group:hasPolicyServer-root"""
-      , JRRuleTarget(GroupTarget(NodeGroupId("hasPolicyServer-root")))
+      , JRRuleTarget(GroupTarget(NodeGroupId(NodeGroupUid("hasPolicyServer-root"))))
       )
     , ("""policyServer:root"""
       , JRRuleTarget(PolicyServerTarget(NodeId("root")))
@@ -89,7 +91,7 @@ class RestDataExtractorTest extends Specification {
       , JRRuleTarget(AllTarget)
       )
     , ("""{"include":{"or":["special:all"]},"exclude":{"or":["group:all-nodes-with-dsc-agent"]}}"""
-      , JRRuleTarget(TargetExclusion(TargetUnion(Set(AllTarget)), TargetUnion(Set(GroupTarget(NodeGroupId("all-nodes-with-dsc-agent"))))))
+      , JRRuleTarget(TargetExclusion(TargetUnion(Set(AllTarget)), TargetUnion(Set(GroupTarget(NodeGroupId(NodeGroupUid("all-nodes-with-dsc-agent")))))))
       )
     , ("""{"include":{"or":[]},"exclude":{"or":[]}}"""
       , JRRuleTarget(TargetExclusion(TargetUnion(Set()), TargetUnion(Set())))

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
@@ -91,8 +91,10 @@ class TestRestFromFileDef extends TraitTestApiFromYamlFiles with AfterAll {
   org.slf4j.LoggerFactory.getLogger("com.normation.rudder.rest.RestUtils").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.OFF)
 
 
-  doTest()
-
+  // you can pass a list of file to test exclusively if you don't want to test all .yml
+  // files in src/test/resource/${yamlSourceDirectory}
+//  doTest(Nil)
+  doTest("api_groups.yml" :: Nil)
 
 }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -202,12 +202,12 @@ class NodeGroupForm(
       & "group-name" #> groupName.toForm_!
       & "group-rudderid" #> <div class="form-group row">
                       <label class="wbBaseFieldLabel">Rudder ID</label>
-                      <input readonly="" class="form-control" value={nodeGroup.id.value}/>
+                      <input readonly="" class="form-control" value={nodeGroup.id.serialize}/>
                     </div>
       & "group-cfeclasses" #> <div class="form-group row">
                           <label class="wbBaseFieldLabel toggle-cond cond-hidden" onclick="$(this).toggleClass('cond-hidden')"><span class="text-fit">Agent conditions</span><i class="fa fa-chevron-down"></i></label>
-                          <div class="well" id={s"cfe-${nodeGroup.id.value}"}>
-                            {RuleTarget.toCFEngineClassName(nodeGroup.id.value)}<br/>
+                          <div class="well" id={s"cfe-${nodeGroup.id.serialize}"}>
+                            {RuleTarget.toCFEngineClassName(nodeGroup.id.serialize)}<br/>
                             {RuleTarget.toCFEngineClassName(nodeGroup.name)}
                           </div>
                         </div>
@@ -271,7 +271,7 @@ class NodeGroupForm(
   def showGroupProperties(group: NodeGroup): NodeSeq = {
     import com.normation.rudder.AuthorizationType
 
-    val groupId = group.id.value
+    val groupId = group.id.serialize
     val userHasRights = CurrentUser.checkRights(AuthorizationType.Group.Edit)
 
     val intro = (<div class="info">
@@ -398,7 +398,7 @@ class NodeGroupForm(
           case Right(g)  => g._1
           case Left(err) =>
             formTracker.addFormError(Text("Error when saving group"))
-            logger.error(s"Error when looking for group with id '${ng.id.value}': ${err.fullMsg}")
+            logger.error(s"Error when looking for group with id '${ng.id.serialize}': ${err.fullMsg}")
             ng
         }
         if(ng.copy(properties = savedGroup.properties, serverList = savedGroup.serverList) != savedGroup) {
@@ -554,7 +554,7 @@ class NodeGroupForm(
   private[this] def showGroupSection(group: Either[NonGroupRuleTarget, NodeGroup], parentCategoryId: NodeGroupCategoryId) : JsCmd = {
     val js = group match {
       case Left(target) => s"'target':'${target.target}"
-      case Right(g)     => s"'groupId':'${g.id.value}'"
+      case Right(g)     => s"'groupId':'${g.id.serialize}'"
     }
     //update UI
     onSuccessCallback(Left((group, parentCategoryId)))&

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleEditForm.scala
@@ -51,10 +51,13 @@ import com.normation.rudder.web.model.WBTextAreaField
 import com.normation.rudder.web.model.WBTextField
 import com.normation.rudder.web.services.DisplayDirectiveTree
 import com.normation.rudder.web.services.DisplayNodeGroupTree
+
 import bootstrap.liftweb.RudderConfig
 import com.normation.GitVersion
 import com.normation.GitVersion.Revision
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
+
 import net.liftweb.common._
 import net.liftweb.http.DispatchSnippet
 import net.liftweb.http.S
@@ -71,6 +74,7 @@ import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.services.workflows.RuleChangeRequest
 import com.normation.rudder.services.workflows.RuleModAction
 import com.normation.rudder.web.ChooseTemplate
+
 import com.normation.box._
 
 object RuleEditForm {
@@ -254,7 +258,7 @@ class RuleEditForm(
       } yield {
         val checkLinkType =
           if(gt.target.startsWith("group:")){
-            linkUtil.groupLink(NodeGroupId(gt.target.replaceFirst("group:", "")))
+            linkUtil.groupLink(NodeGroupId(NodeGroupUid(gt.target.replaceFirst("group:", ""))))
           }else{
             linkUtil.targetLink(gt)
           }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
@@ -270,7 +270,7 @@ class CreateCategoryOrGroupPopup(
         val query = Some(groupGenerator.flatMap(_.query).getOrElse(NewQuery(NodeReturnType,And,ResultTransformation.Identity,List(defaultLine))))
         val isDynamic = piStatic.get match { case "dynamic" => true ; case _ => false }
         val srvList =  groupGenerator.map(_.serverList).getOrElse(Set[NodeId]())
-        val nodeId = NodeGroupId(uuidGen.newUuid)
+        val nodeId = NodeGroupId(NodeGroupUid(uuidGen.newUuid))
         val nodeGroup = NodeGroup(nodeId,piName.get,piDescription.get, Nil, query,isDynamic,srvList,true)
         woNodeGroupRepository.create(
             nodeGroup
@@ -281,7 +281,7 @@ class CreateCategoryOrGroupPopup(
         ).toBox match {
           case Full(x) =>
             closePopup() &
-            onSuccessCallback(x.group.id.value) & onSuccessGroup(Right(x.group), NodeGroupCategoryId(piContainer.get)) & OnLoad(JsRaw("""$("[href='#groupCriteriaTab']").click();"""))
+            onSuccessCallback(x.group.id.serialize) & onSuccessGroup(Right(x.group), NodeGroupCategoryId(piContainer.get)) & OnLoad(JsRaw("""$("[href='#groupCriteriaTab']").click();"""))
           case Empty =>
             logger.error("An error occurred while saving the group")
             formTracker.addFormError(error("An error occurred while saving the group"))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
@@ -119,7 +119,7 @@ class CreateCloneGroupPopup(
         val parentCategoryId = NodeGroupCategoryId(groupContainer.get)
         val isDynamic = isStatic.get match { case "dynamic" => true ; case _ => false }
         val srvList =  nodeGroup.map(x => x.serverList).getOrElse(Set[NodeId]())
-        val nodeId = NodeGroupId(uuidGen.newUuid)
+        val nodeId = NodeGroupId(NodeGroupUid(uuidGen.newUuid))
         val clone = NodeGroup(
             nodeId
           , groupName.get
@@ -140,7 +140,7 @@ class CreateCloneGroupPopup(
         ).toBox match {
           case Full(x) =>
             closePopup() &
-            onSuccessCallback(x.group.id.value) &
+            onSuccessCallback(x.group.id.serialize) &
             onSuccessGroup(Right(x.group), parentCategoryId)
           case Empty =>
             logger.error("An error occurred while saving the group")

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNodeGroupTree.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNodeGroupTree.scala
@@ -43,6 +43,7 @@ import com.normation.rudder.domain.policies.FullGroupTarget
 import com.normation.rudder.domain.policies.FullRuleTargetInfo
 import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.web.model.JsTreeNode
+
 import net.liftweb.common.Loggable
 import net.liftweb.http.SHtml
 import net.liftweb.http.js._
@@ -50,7 +51,9 @@ import net.liftweb.util.Helpers
 import com.normation.rudder.domain.policies.FullRuleTarget
 import com.normation.rudder.domain.policies.RuleTarget
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.nodes.NodeInfo
+
 import bootstrap.liftweb.RudderConfig
 
 /**
@@ -126,7 +129,7 @@ object DisplayNodeGroupTree extends Loggable {
       val groupId = {
         targetInfo.target match {
           case g:FullGroupTarget =>
-            g.nodeGroup.id.value
+            g.nodeGroup.id.serialize
           case o:FullRuleTarget =>
             o.target.target
         }
@@ -157,7 +160,7 @@ object DisplayNodeGroupTree extends Loggable {
             val tooltipId = Helpers.nextFuncName
             <span class="treeActions">
               <span class="fa fa-pencil" tooltipid={tooltipId} title=""
-                onclick={linkUtil.redirectToGroupLink(NodeGroupId(groupId)).toJsCmd}
+                onclick={linkUtil.redirectToGroupLink(NodeGroupId(NodeGroupUid(groupId))).toJsCmd}
               ></span>
               <div class="tooltipContent" id={tooltipId}><div>Configure this group.</div></div>
             </span>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/SearchNodes.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/SearchNodes.scala
@@ -44,9 +44,12 @@ import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.web.components.SearchNodeComponent
 import com.normation.rudder.web.components.popup.CreateCategoryOrGroupPopup
+
 import bootstrap.liftweb.RudderConfig
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.NonGroupRuleTarget
+
 import net.liftweb.common._
 import net.liftweb.http.LocalSnippet
 import net.liftweb.http.SHtml
@@ -56,6 +59,7 @@ import net.liftweb.http.js.JE.JsRaw
 import net.liftweb.http.js.JE.JsVar
 import net.liftweb.http.js.JsCmd
 import net.liftweb.http.js.JsCmds._
+
 import com.normation.box._
 import com.normation.rudder.domain.queries.NewQuery
 import com.normation.rudder.domain.queries.Query
@@ -126,7 +130,7 @@ class SearchNodes extends StatefulSnippet with Loggable {
       creationPopup.set(Full(new CreateCategoryOrGroupPopup(
           // create a totally invalid group
           Some(new NodeGroup(
-              NodeGroupId("temporary"),
+              NodeGroupId(NodeGroupUid("temporary")),
               null,
               null,
               Nil,


### PR DESCRIPTION
https://issues.rudder.io/issues/21315

This is PR similar to the one where `revision` was added to `RuleId` etc. 

There is a lot of change from `.value` to `.serialized` to take into account that. 
I tried to keep the same logic that what was done in rule and directive for the cases where revision is ignored (xml serialization, some case in LDAP, link creation for JS, etc). There will be likely have some things that won't work in UI, but it's not the point here: UI is known to not be revision-ready (appart for some very specific cases). 