### PR TITLE
Fixes #21247: Add API endpoint to export/import a rules, their directives, techniques, groups in an archive

### DIFF
--- a/webapp/sources/api-doc/code_samples/curl/archives/export.sh
+++ b/webapp/sources/api-doc/code_samples/curl/archives/export.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" https://rudder.example.com/rudder/api/latest/archives/export/rules=8e522a3e-aa45-43cd-bf33-4e8d04a566f6

--- a/webapp/sources/api-doc/openapi.src.yml
+++ b/webapp/sources/api-doc/openapi.src.yml
@@ -48,6 +48,8 @@ tags:
     description: Inventory processing service
   - name: Parameters
     description: Global parameters
+  - name: Archives
+    description: Import and export zip of policies
   - name: Settings
     description: Server configuration
   - name: System
@@ -141,6 +143,8 @@ paths:
     $ref: paths/compliance/nodes.yml
   "/compliance/nodes/{nodeId}":
     $ref: paths/compliance/node.yml
+  "/archives/export":
+    $ref: paths/archives/export.yml
   "/system/status":
     $ref: paths/system/status.yml
   "/system/info":

--- a/webapp/sources/api-doc/paths/archives/export.yml
+++ b/webapp/sources/api-doc/paths/archives/export.yml
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2022 Normation SAS
+get:
+  summary: Get a ZIP archive of the requested items and their dependencies
+  description: Get a ZIP archive or rules, directives, techniques and groups with optionnaly their dependencies
+  operationId: export
+  parameters:
+    - in: query
+      name: rules
+      schema:
+        type: array
+      description: IDs (optionnaly with revision, '+' need to be escaped as '%2B') of rules to include
+      style: form
+      explode: false
+      examples:
+        oneId:
+          summary: Example of a single ID
+          value: [a0573b59-e5bd-441b-9031-f307aa21a61e]   # ?rules=a0573b59-e5bd-441b-9031-f307aa21a61e
+        multipleIds:
+          summary: Example of multiple IDs, some with revisions
+          value: [a0573b59-e5bd-441b-9031-f307aa21a61e, 4cba6eee-3a43-4e17-a608-a4941b6d984f%2B35177d0823791a374de9e16a6ab27e6466fbc8c2]
+    - in: query
+      name: rules
+      schema:
+        type: array
+      description: IDs (optionnaly with revision, '+' need to be escaped as '%2B') of rules to include
+      style: form
+      explode: false
+      examples:
+        oneId:
+          summary: Example of a single ID
+          value: [a0573b59-e5bd-441b-9031-f307aa21a61e]   # ?rules=a0573b59-e5bd-441b-9031-f307aa21a61e
+        multipleIds:
+          summary: Example of multiple IDs, some with revisions
+          value: [a0573b59-e5bd-441b-9031-f307aa21a61e, 4cba6eee-3a43-4e17-a608-a4941b6d984f%2B35177d0823791a374de9e16a6ab27e6466fbc8c2]
+    - in: query
+      name: directives
+      schema:
+        type: array
+      description: IDs (optionnaly with revision, '+' need to be escaped as '%2B') of directives to include
+      style: form
+      explode: false
+      examples:
+        oneId:
+          summary: Example of a single ID
+          value: [a0573b59-e5bd-441b-9031-f307aa21a61e]   # ?directives=a0573b59-e5bd-441b-9031-f307aa21a61e
+        multipleIds:
+          summary: Example of multiple IDs, some with revisions
+          value: [a0573b59-e5bd-441b-9031-f307aa21a61e, 4cba6eee-3a43-4e17-a608-a4941b6d984f%2B35177d0823791a374de9e16a6ab27e6466fbc8c2]
+    - in: query
+      name: techniques
+      schema:
+        type: array
+      description: IDs, ie technique name/technique version (optionnaly with revision, '+' need to be escaped as '%2B') of techniques to include
+      style: form
+      explode: false
+      examples:
+        oneId:
+          summary: Example of a single ID
+          value: [fileContent/3.0] 
+        multipleIds:
+          summary: Example of multiple IDs, some with revisions
+          value: [userManagement/6.3, fileContent/3.0%2B35177d0823791a374de9e16a6ab27e6466fbc8c2]
+    - in: query
+      name: groups
+      schema:
+        type: array
+      description: IDs (optionnaly with revision, '+' need to be escaped as '%2B') of groups to include
+      style: form
+      explode: false
+      examples:
+        oneId:
+          summary: Example of a single ID
+          value: [a0573b59-e5bd-441b-9031-f307aa21a61e]   # ?groups=a0573b59-e5bd-441b-9031-f307aa21a61e
+        multipleIds:
+          summary: Example of multiple IDs, some with revisions
+          value: [a0573b59-e5bd-441b-9031-f307aa21a61e, 4cba6eee-3a43-4e17-a608-a4941b6d984f%2B35177d0823791a374de9e16a6ab27e6466fbc8c2]
+    - in: query
+      name: include
+      schema:
+        type: array
+        items: 
+          type: string
+          enum: 
+            - all (default)
+            - none 
+            - directives
+            - techniques
+            - groups
+      description: >-
+        Scope of dependencies to include in archive, where rule as directives and groups dependencies, directives have techniques dependencies,
+        and techniques and groups don't have dependencies. 'none' means no dependencies will be include, 'all' means that the whole tree will, 
+        'directives' and 'groups' means to include them specifically, 'techinques' means to include both directives and techniques.
+      style: form
+      explode: false
+      examples:
+        none:
+          summary: Do not include dependencies
+          value: [none] 
+        directivesAndGroups:
+          summary: Include directives and groups, but no techniques
+          value: [directives, groups]
+  responses:
+    "200":
+      description: A zip archive with the queried content.
+      content:
+        application/octet-stream:
+          schema:
+            type: string
+            format: binary
+  tags:
+    - Archives
+  x-code-samples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/archives/export.sh
+

--- a/webapp/sources/api-doc/paths/archives/import.yml
+++ b/webapp/sources/api-doc/paths/archives/import.yml
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2022 Normation SAS
+get:
+  summary: List managed nodes
+  description: Get information about the nodes managed by the target server
+  operationId: listAcceptedNodes
+  parameters:
+    - $ref: ../../components/parameters/include.yml
+    - $ref: ../../components/parameters/node-query.yml
+    - $ref: ../../components/parameters/node-where.yml
+    - $ref: ../../components/parameters/node-composition.yml
+    - $ref: ../../components/parameters/node-select.yml
+  responses:
+    "200":
+      description: Nodes
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - listAcceptedNodes
+              data:
+                type: object
+                description: Information about the nodes
+                required:
+                  - nodes
+                properties:
+                  nodes:
+                    type: array
+                    items:
+                      $ref: ../../components/schemas/node-full.yml
+  tags:
+    - Nodes
+  x-code-samples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/nodes/all.sh
+    - lang: python
+      source:
+        $ref: ../../code_samples/python/nodes/all.py
+
+put:
+  summary: Create one or several new nodes
+  description: Use the provided array of node information to create new nodes
+  operationId: createNodes
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/node-add.yml
+  responses:
+    "200":
+      description: Creation information
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - createNode
+              data:
+                type: object
+                required:
+                  - created
+                  - failed
+                properties:
+                  created:
+                    type: array
+                    items:
+                      type: string
+                      description: created nodes ID
+                      example: 378740d3-c4a9-4474-8485-478e7e52db52
+                  failed:
+                    type: array
+                    items:
+                      type: string
+                      description: failed nodes ID
+  tags:
+    - Nodes
+  x-code-samples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/create-node/all.sh

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/Technique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/Technique.scala
@@ -45,7 +45,7 @@ import com.normation.inventory.domain.AgentType
  * A name, used as an identifier, for a policy.
  * The name must be unique among all policies!
  *
- * TODO : check case sensivity and allowed chars.
+ * TODO : check case sensitivity and allowed chars.
  *
  */
 final case class TechniqueName(value: String) extends AnyVal with Ordered[TechniqueName] {
@@ -63,7 +63,7 @@ final case class TechniqueName(value: String) extends AnyVal with Ordered[Techni
  * among all policies, and a version for that policy.
  */
 final case class TechniqueId(name: TechniqueName, version: TechniqueVersion) extends Ordered[TechniqueId] {
-  // intented for debug/log, not serialization
+  // intended for debug/log, not serialization
   def debugString = serialize
   // a technique
   def serialize = name.value + "/" + version.serialize
@@ -79,6 +79,17 @@ final case class TechniqueId(name: TechniqueName, version: TechniqueVersion) ext
   @silent("method toString overrides concrete, non-deprecated symbol")
   @deprecated(s"Please use `debugString` or `serialize` in place of toString()", "7.0")
   override def toString: String = serialize
+}
+
+object TechniqueId {
+  def parse(s: String): Either[String, TechniqueId] = {
+    s.split("/").toList match {
+      case n :: v :: Nil =>
+        TechniqueVersion.parse(v).map(x => TechniqueId(TechniqueName(n), x))
+      case _ =>
+        Left(s"Error when parsing '${s}' as a technique id. It should have format 'techniqueName/version+rev' (with +rev optional)")
+    }
+  }
 }
 
 object RunHook {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
@@ -385,15 +385,12 @@ class GitTechniqueReader(
       }
     }
 
-    //has package id are unique among the whole tree, we are able to find a
-    //template only base on the techniqueId + name.
+    // since package id are unique among the whole tree, we are able to find a
+    // template only base on the techniqueId + name.
 
     val managed = Managed.make(
       for {
-        currentId <- rev match {
-                       case GitVersion.DEFAULT_REV => revisionProvider.currentRevTreeId
-                       case r                      => GitFindUtils.findRevTreeFromRevString(repo.db, r.value)
-                     }
+        currentId <- GitFindUtils.findRevTreeFromRevision(repo.db, rev, revisionProvider.currentRevTreeId)
         optStream <- IOResult.effect {
                        try {
                          //now, the treeWalk

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -593,7 +593,7 @@ object JsonResponseObjects {
     def fromParentProperty(p: ParentProperty) = {
       p match {
         case ParentProperty.Group(name, id, value) =>
-          JRParentGroup(name, id.value, value)
+          JRParentGroup(name, id.serialize, value)
         case _                                     =>
           JRParentGlobal(p.value)
       }
@@ -613,7 +613,7 @@ object JsonResponseObjects {
 
   object JRGroupInheritedProperties {
     def fromGroup(groupId: NodeGroupId, properties: List[NodePropertyHierarchy], renderInHtml: RenderInheritedProperties) = {
-      JRGroupInheritedProperties(groupId.value, properties.sortBy(_.prop.name).map(JRProperty.fromNodePropertyHierarchy(_, renderInHtml)))
+      JRGroupInheritedProperties(groupId.serialize, properties.sortBy(_.prop.name).map(JRProperty.fromNodePropertyHierarchy(_, renderInHtml)))
     }
   }
 
@@ -677,12 +677,12 @@ object JsonResponseObjects {
       group.into[JRGroup]
         .enableBeanGetters
         .withFieldConst(_.changeRequestId, crId.map(_.value.toString))
-        .withFieldComputed(_.id, _.id.value)
+        .withFieldComputed(_.id, _.id.serialize)
         .withFieldRenamed(_.name, _.displayName)
         .withFieldConst(_.category, catId.value)
         .withFieldComputed(_.query, _.query.map(JRQuery.fromQuery(_)))
         .withFieldComputed(_.nodeIds, _.serverList.toList.map(_.value).sorted)
-        .withFieldComputed(_.groupClass, x => List(x.id.value, x.name).map(RuleTarget.toCFEngineClassName _).sorted)
+        .withFieldComputed(_.groupClass, x => List(x.id.serialize, x.name).map(RuleTarget.toCFEngineClassName _).sorted)
         .withFieldComputed(_.properties, _.properties.map(JRProperty.fromGroupProp(_)))
         .withFieldComputed(_.target, x => GroupTarget(x.id).target)
         .withFieldComputed(_.system, _.isSystem)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
@@ -231,7 +231,7 @@ final case class RestDataSerializerImpl (
     val query = group.query.map(query => query.toJSON)
     (
         ("changeRequestId" -> crId.map(_.value.toString))
-      ~ ("id"              -> group.id.value)
+      ~ ("id"              -> group.id.serialize)
       ~ ("displayName"     -> group.name)
       ~ ("description"     -> group.description)
       ~ ("category"        -> cat.map(_.value))
@@ -239,7 +239,7 @@ final case class RestDataSerializerImpl (
       ~ ("nodeIds"         -> group.serverList.toSeq.map(_.value).sorted)
       ~ ("dynamic"         -> group.isDynamic)
       ~ ("enabled"         -> group.isEnabled)
-      ~ ("groupClass"      -> List(group.id.value, group.name).map(RuleTarget.toCFEngineClassName _).sorted)
+      ~ ("groupClass"      -> List(group.id.serialize, group.name).map(RuleTarget.toCFEngineClassName _).sorted)
       ~ ("properties"      -> group.properties.toApiJson)
       ~ ("system"          -> group.isSystem)
       ~ ("target"          -> GroupTarget(group.id).target)
@@ -247,7 +247,7 @@ final case class RestDataSerializerImpl (
   }
 
   override def serializeGroupCategory (category:FullNodeGroupCategory, parent: NodeGroupCategoryId, detailLevel : DetailLevel, apiVersion: ApiVersion): JValue = {
-    val groupList = category.ownGroups.values.toSeq.sortBy(_.nodeGroup.id.value)
+    val groupList = category.ownGroups.values.toSeq.sortBy(_.nodeGroup.id.serialize)
     val subCat = category.subCategories.sortBy(_.id.value)
 
     def serializeTarget (target: FullRuleTargetInfo): JValue = {
@@ -266,7 +266,7 @@ final case class RestDataSerializerImpl (
         , subCat.map(serializeGroupCategory(_,category.id, detailLevel, apiVersion))
         )
       case MinimalDetails =>
-        ( groupList.map(g => JString(g.nodeGroup.id.value) )
+        ( groupList.map(g => JString(g.nodeGroup.id.serialize) )
         , subCat.map(cat => JString(cat.id.value))
         )
     }
@@ -449,7 +449,7 @@ final case class RestDataSerializerImpl (
       val enabled :JValue     = diff.modIsActivated.map(displaySimpleDiff(_)).getOrElse(initialState.isEnabled)
       val properties: JValue  = diff.modProperties.map(displaySimpleDiff(_)).getOrElse(initialState.properties.toApiJson)
       val category: JValue    = diff.modCategory.map(displaySimpleDiff(_)(_.value))
-      ( ("id"          -> initialState.id.value)
+      ( ("id"          -> initialState.id.serialize)
       ~ ("displayName" -> name)
       ~ ("description" -> description)
       ~ ("category"    -> category)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/UpdateDynamicGroups.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/UpdateDynamicGroups.scala
@@ -235,15 +235,15 @@ class UpdateDynamicGroups(
         } {
           eitherRes match {
             case Left(e) =>
-              val error = (e.fullMsg + s" Error when updating dynamic group '${id.value}'")
+              val error = (e.fullMsg + s" Error when updating dynamic group '${id.serialize}'")
               logger.error(error)
             case Right(diff) =>
               val addedNodes = displayNodechange(diff.added)
               val removedNodes = displayNodechange(diff.removed)
-              logger.debug(s"Group ${id.value}: adding ${addedNodes}, removing ${removedNodes}")
+              logger.debug(s"Group ${id.serialize}: adding ${addedNodes}, removing ${removedNodes}")
               //if the diff is not empty, start a new deploy
               if(diff.added.nonEmpty || diff.removed.nonEmpty) {
-                logger.info(s"Dynamic group ${id.value}: added node with id: ${addedNodes}, removed: ${removedNodes}")
+                logger.info(s"Dynamic group ${id.serialize}: added node with id: ${addedNodes}, removed: ${removedNodes}")
                 // we need to trigger a deployment in this case
                 needDeployment = true
               }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderDit.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderDit.scala
@@ -421,7 +421,7 @@ class RudderDit(val BASE_DN:DN) extends AbstractDit {
       system =>
 
       def targetDN(target:RuleTarget) : DN = target match {
-        case GroupTarget(groupId) => group.groupDN(groupId.value, system.dn)
+        case GroupTarget(groupId) => group.groupDN(groupId.serialize, system.dn)
         case t => new DN(new RDN(A_RULE_TARGET, target.target), system.dn)
       }
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
@@ -50,7 +50,14 @@ object ApplicationLogger extends Logger {
 
 object ApplicationLoggerPure extends NamedZioLogger {
   def loggerName = "application"
+
+  object Archive extends NamedZioLogger {
+    def loggerName = "application.archive"
+  }
+
 }
+
+
 
 object ApiLogger extends Logger {
   override protected def _logger = LoggerFactory.getLogger("api")
@@ -84,7 +91,7 @@ object ScheduledJobLoggerPure extends NamedZioLogger {
 }
 
 /**
- * A logger for new nodes informations
+ * A logger for new nodes information
  */
 object NodeLogger extends Logger {
   override protected def _logger = LoggerFactory.getLogger("nodes")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
@@ -62,7 +62,7 @@ sealed trait SimpleTarget extends RuleTarget //simple as opposed to composed
 
 object GroupTarget { def r = "group:(.+)".r }
 final case class GroupTarget(groupId:NodeGroupId) extends SimpleTarget {
-  override def target = "group:"+groupId.value
+  override def target = "group:"+groupId.serialize
 }
 
 //object NodeTarget { def r = "node:(.+)".r }
@@ -394,7 +394,7 @@ object RuleTarget extends Loggable {
   def unserOne(s: String): Option[SimpleTarget] = {
     s match {
       case GroupTarget.r(g) =>
-        Some(GroupTarget(NodeGroupId(g)))
+        NodeGroupId.parse(g).toOption.map(GroupTarget(_))
       case PolicyServerTarget.r(s) =>
         Some(PolicyServerTarget(NodeId(s)))
       case AllTarget.r() =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
@@ -208,6 +208,19 @@ final case class TargetExclusion(
 
 object RuleTarget extends Loggable {
 
+  // get only the node group from these target. Include all node group, be it
+  // included or excluded.
+  // All special target are ignored
+  def getNodeGroupIds(targets: Set[RuleTarget]): Chunk[NodeGroupId] = {
+    targets.foldLeft(Chunk[NodeGroupId]()) { case (groups , target) => target match {
+      case GroupTarget(groupId)        => groups :+ groupId
+      case TargetIntersection(targets) => groups ++ getNodeGroupIds(targets)
+      case TargetUnion(targets)        => groups ++ getNodeGroupIds(targets)
+      case TargetExclusion(x,y)        => groups ++ getNodeGroupIds(Set(x)) ++ getNodeGroupIds(Set(y))
+      case _                           => groups
+    } }
+  }
+
   /**
    * Return all node ids that match the set of target.
    * allNodes pair is: (nodeid, isPolicyServer)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -775,7 +775,7 @@ object ParentProperty {
     override def displayName: String = s"${name} (${id.value})"
   }
   final case class Group(name: String, id: NodeGroupId, value: ConfigValue) extends ParentProperty {
-    override def displayName: String = s"${name} (${id.value})"
+    override def displayName: String = s"${name} (${id.serialize})"
   }
   // a global parameter has the same name as property so no need to be specific for name
   final case class Global(value: ConfigValue) extends ParentProperty {
@@ -804,7 +804,7 @@ object JsonPropertySerialisation {
           (
             ( "kind"  -> "group" )
           ~ ( "name"  -> name    )
-          ~ ( "id"    -> id.value)
+          ~ ( "id"    -> id.serialize)
           ~ ( "value" -> GenericProperty.toJsonValue(value))
           )
         case _ => JNothing

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
@@ -873,7 +873,7 @@ class SubGroupComparator(getGroups: () => IOResult[Seq[SubGroupChoice]]) extends
       (for {
         res <- getGroups()
       } yield {
-        val g = res.map { case SubGroupChoice(id, name) => SelectableOption(id.value, name) }
+        val g = res.map { case SubGroupChoice(id, name) => SelectableOption(id.serialize, name) }
         // if current value is defined but not in the list, add it with a "missing group" label
         if(value != "") {
           g.find( _.value == value ) match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/ZipUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/ZipUtils.scala
@@ -114,7 +114,7 @@ object ZipUtils {
   /**
    * Create the seq of zippable from a directory or file.
    * If it's a directory, all children are added recursively,
-   * and there name are relative to the root.
+   * and their names are relative to the root.
    * For a file, only its basename is added.
    *
    * The returned Zippable are ordered from root to children (deep first),
@@ -127,6 +127,8 @@ object ZipUtils {
    * root/dir-b/file-a
    * root/dir-b/file-b
    * etc
+   *
+   * root name itself is not used.
    */
   def toZippable(file: File): Seq[Zippable] = {
     if (file.getParent == null) {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
@@ -214,7 +214,7 @@ trait RoNodeGroupRepository {
    * @return
    */
   def getNodeGroup(id: NodeGroupId) : IOResult[(NodeGroup,NodeGroupCategoryId)] = {
-    getNodeGroupOpt(id).notOptional(s"Group with id '${id.value}' was not found'")
+    getNodeGroupOpt(id).notOptional(s"Group with id '${id.serialize}' was not found'")
   }
 
   /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapGroupLibrary.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapGroupLibrary.scala
@@ -254,7 +254,7 @@ class ImportGroupLibraryImpl(
         } else nodeGroupNames.get(nodeGroup.name) match {
           case Some(id) =>
             logEffect.error("Ignoring Active Technique with ID '%s' because it references technique with name '%s' already referenced by active technique with ID '%s'".format(
-                nodeGroup.id.value, nodeGroup.name, id.value
+                nodeGroup.id.serialize, nodeGroup.name, id.serialize
             ))
             None
           case None =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
@@ -703,8 +703,8 @@ class GitNodeGroupArchiverImpl(
 
   private[this] def newNgFile(ngId:NodeGroupId, parents: List[NodeGroupCategoryId]) = {
     parents match {
-      case h :: t => new File(newCategoryDirectory(h, t), ngId.value + ".xml").succeed
-      case Nil    => Inconsistency("The given parent category list for node group with id '%s' is empty, what is forbiden".format(ngId.value)).fail
+      case h :: t => new File(newCategoryDirectory(h, t), ngId.withDefaultRev.serialize + ".xml").succeed
+      case Nil    => Inconsistency("The given parent category list for node group with id '%s' is empty, what is forbidden".format(ngId.withDefaultRev.serialize)).fail
     }
   }
 
@@ -717,7 +717,7 @@ class GitNodeGroupArchiverImpl(
                       , "Archived node group: " + ngFile.getPath
                     )
       commit     <- gitCommit match {
-                      case Some((modId, commiter, reason)) => commitAddFileWithModId(modId, commiter, toGitPath(ngFile), "Archive of node group with ID '%s'%s".format(ng.id.value,GET(reason)))
+                      case Some((modId, commiter, reason)) => commitAddFileWithModId(modId, commiter, toGitPath(ngFile), "Archive of node group with ID '%s'%s".format(ng.id.withDefaultRev.serialize,GET(reason)))
                       case None => UIO.unit
                     }
     } yield {
@@ -737,7 +737,7 @@ class GitNodeGroupArchiverImpl(
                      _        <- logPure.debug(s"Deleted archived node group: ${ngFile.getPath}")
                      commited <- gitCommit match {
                                    case Some((modId, commiter, reason)) =>
-                                     commitRmFileWithModId(modId, commiter, gitPath, s"Delete archive of node group with ID '${ngId.value}'${GET(reason)}")
+                                     commitRmFileWithModId(modId, commiter, gitPath, s"Delete archive of node group with ID '${ngId.withDefaultRev.serialize}'${GET(reason)}")
                                    case None => UIO.unit
                                  }
                    } yield {
@@ -767,7 +767,7 @@ class GitNodeGroupArchiverImpl(
                            IOResult.effect(FileUtils.deleteQuietly(oldNgXmlFile))
                          }
         commit       <- gitCommit match {
-                          case Some((modId, commiter, reason)) => commitMvDirectoryWithModId(modId, commiter, toGitPath(oldNgXmlFile), toGitPath(newNgXmlFile), "Move archive of node group with ID '%s'%s".format(ng.id.value,GET(reason)))
+                          case Some((modId, commiter, reason)) => commitMvDirectoryWithModId(modId, commiter, toGitPath(oldNgXmlFile), toGitPath(newNgXmlFile), "Move archive of node group with ID '%s'%s".format(ng.id.withDefaultRev.serialize,GET(reason)))
                           case None => UIO.unit
                         }
       } yield {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
@@ -476,7 +476,8 @@ class EventLogDetailsServiceImpl(
                             else Failure("NodeGroup attribute does not have changeType=modify: " + entry.toString())
                           }
       fileFormatOk    <- TestFileFormat(group)
-      id              <- (group \ "id").headOption.map( _.text ) ?~! ("Missing attribute 'id' in entry type nodeGroup : " + entry.toString())
+      sid             <- (group \ "id").headOption.map( _.text ) ?~! ("Missing attribute 'id' in entry type nodeGroup : " + entry.toString())
+      id              <- NodeGroupId.parse(sid).toBox
       displayName     <- (group \ "displayName").headOption.map( _.text ) ?~! ("Missing attribute 'displayName' in entry type nodeGroup : " + entry.toString())
       name            <- getFromToString((group \ "name").headOption)
       description     <- getFromToString((group \ "description").headOption)
@@ -493,7 +494,7 @@ class EventLogDetailsServiceImpl(
       isSystem        <- getFromTo[Boolean]((group \ "isSystem").headOption, { s => tryo { s.text.toBoolean } } )
     } yield {
       ModifyNodeGroupDiff(
-          id = NodeGroupId(id)
+          id = id
         , name = displayName
         , modName = name
         , modDescription = description

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -602,7 +602,7 @@ class EventLogFactoryImpl(
   ) : ModifyNodeGroup = {
     val details = EventLog.withContent{
       scala.xml.Utility.trim(<nodeGroup changeType="modify" fileFormat={Constants.XML_CURRENT_FILE_FORMAT.toString}>
-        <id>{modifyDiff.id.value}</id>
+        <id>{modifyDiff.id.withDefaultRev.serialize}</id>
         <displayName>{modifyDiff.name}</displayName>{
           modifyDiff.modName.map(x => SimpleDiff.stringToXml(<name/>, x) ) ++
           modifyDiff.modDescription.map(x => SimpleDiff.stringToXml(<description/>, x ) ) ++

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
@@ -234,7 +234,7 @@ class NodeGroupCategorySerialisationImpl(xmlVersion:String) extends NodeGroupCat
 class NodeGroupSerialisationImpl(xmlVersion:String) extends NodeGroupSerialisation {
   def serialise(group:NodeGroup):  Elem = {
     createTrimedElem(XML_TAG_NODE_GROUP, xmlVersion) (
-        <id>{group.id.value}</id>
+        <id>{group.id.withDefaultRev.serialize}</id>
         <displayName>{group.name}</displayName>
         <description>{group.description}</description>
         <query>{ group.query.map( _.toJSONString ).getOrElse("") }</query>
@@ -382,7 +382,7 @@ class ChangeRequestChangesSerialisationImpl(
 
       case changeRequest : ConfigurationChangeRequest =>
         val groups = changeRequest.nodeGroups.map{ case (nodeGroupId,group) =>
-          <group id={nodeGroupId.value}>
+          <group id={nodeGroupId.withDefaultRev.serialize}>
             <initialState>
               {group.changes.initialState.map(nodeGroupSerializer.serialise(_)).getOrElse(NodeSeq.Empty)}
             </initialState>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
@@ -465,7 +465,7 @@ class SystemVariableServiceImpl(
     //build the list of nodeId -> names, taking care of special nodeIds for special target
     val nodeGroups = nodeTargets.map { info =>
       val id = info.target.target match {
-        case GroupTarget(id) => id.value
+        case GroupTarget(id) => id.serialize
         case t => t.target
       }
       (id, info.name)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
@@ -96,10 +96,10 @@ class DynGroupUpdaterServiceImpl(
     for {
       _                <- if(group.isDynamic) Full("OK") else Failure("Can not update a not dynamic group")
       timePreCompute   =  System.currentTimeMillis
-      query            <- Box(group.query) ?~! s"No query defined for group '${group.name}' (${group.id.value})"
-      newMembers       <- queryProcessor.processOnlyId(query) ?~! s"Error when processing request for updating dynamic group '${group.name}' (${group.id.value})"
+      query            <- Box(group.query) ?~! s"No query defined for group '${group.name}' (${group.id.serialize})"
+      newMembers       <- queryProcessor.processOnlyId(query) ?~! s"Error when processing request for updating dynamic group '${group.name}' (${group.id.serialize})"
       timeGroupCompute = (System.currentTimeMillis - timePreCompute)
-      _                = logger.debug(s"Dynamic group ${group.id.value} with name ${group.name} computed in ${timeGroupCompute} ms")
+      _                = logger.debug(s"Dynamic group ${group.id.serialize} with name ${group.name} computed in ${timeGroupCompute} ms")
     } yield {
       group.copy(serverList = newMembers)
     }
@@ -113,7 +113,7 @@ class DynGroupUpdaterServiceImpl(
         group =>
           for {
             newGroup   <- computeDynGroup(group)
-            savedGroup <- woNodeGroupRepository.updateDynGroupNodes(newGroup, modId, actor, reason).toBox ?~! s"Error when saving update for dynamic group '${group.name}' (${group.id.value})"
+            savedGroup <- woNodeGroupRepository.updateDynGroupNodes(newGroup, modId, actor, reason).toBox ?~! s"Error when saving update for dynamic group '${group.name}' (${group.id.serialize})"
           } yield {
             DynGroupDiff(newGroup, group)
           }
@@ -128,9 +128,9 @@ class DynGroupUpdaterServiceImpl(
     for {
       (group,_)        <- roNodeGroupRepository.getNodeGroup(dynGroupId).toBox
       newGroup         <- computeDynGroup(group)
-      savedGroup       <- woNodeGroupRepository.updateDynGroupNodes(newGroup, modId, actor, reason).toBox ?~! s"Error when saving update for dynamic group '${group.name}' (${group.id.value})"
+      savedGroup       <- woNodeGroupRepository.updateDynGroupNodes(newGroup, modId, actor, reason).toBox ?~! s"Error when saving update for dynamic group '${group.name}' (${group.id.serialize})"
       timeGroupUpdate  =  (System.currentTimeMillis - timePreUpdate)
-      _                =  logger.debug(s"Dynamic group ${group.id.value} with name ${group.name} updated in ${timeGroupUpdate} ms")
+      _                =  logger.debug(s"Dynamic group ${group.id.serialize} with name ${group.name} updated in ${timeGroupUpdate} ms")
     } yield {
       DynGroupDiff(newGroup, group)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/PolicyServerManagementService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/PolicyServerManagementService.scala
@@ -69,6 +69,7 @@ import com.normation.rudder.domain.eventlog.UpdatePolicyServer
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.Directive
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.DirectiveUid
@@ -546,7 +547,7 @@ object PolicyServerConfigurationObjects {
   def groupHasPolicyServer(nodeId: NodeId) = {
     val objectType = ObjectCriterion("node", Seq(Criterion("policyServerId", StringComparator, None),Criterion("agentName", AgentComparator, None)))
     NodeGroup(
-        NodeGroupId(s"hasPolicyServer-${nodeId.value}")
+        NodeGroupId(NodeGroupUid(s"hasPolicyServer-${nodeId.value}"))
       , s"All nodes managed by '${nodeId.value}' policy server"
       , s"All nodes known by Rudder directly connected to the '${nodeId.value}' server. This group exists only as internal purpose and should not be used to configure Nodes."
       , Nil
@@ -572,7 +573,7 @@ object PolicyServerConfigurationObjects {
         RuleId(RuleUid(s"hasPolicyServer-${nodeId.value}"))
       , s"Rudder system policy: basic setup (common) - ${nodeId.value}"
       , RuleCategoryId("rootRuleCategory")
-      , Set(GroupTarget(NodeGroupId(s"hasPolicyServer-${nodeId.value}")))
+      , Set(GroupTarget(NodeGroupId(NodeGroupUid(s"hasPolicyServer-${nodeId.value}"))))
       , Set(DirectiveId(DirectiveUid(s"common-hasPolicyServer-${nodeId.value}")))
       , "Common - Technical"
       , "This is the basic system rule which all nodes must have."

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/RemoveNodeService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/RemoveNodeService.scala
@@ -483,7 +483,7 @@ class RemoveNodeServiceImpl(
       deleted      <- ZIO.foreach(nodeGroupIds) { nodeGroupId =>
                         val msg = Some("Automatic update of group due to deletion of node " + nodeId.value)
                         woNodeGroupRepository.updateDiffNodes(nodeGroupId, add = Nil, delete = List(nodeId), modId, actor, msg).chainError(
-                          s"Could not update group '${nodeGroupId.value}' to remove node '${nodeId.value}'"
+                          s"Could not update group '${nodeGroupId.serialize}' to remove node '${nodeId.value}'"
                         )
                       }
     } yield {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
@@ -78,7 +78,7 @@ trait CommitAndDeployChangeRequestService {
   /**
    * Save and deploy a change request.
    * That method must ensure that the change request
-   * is only commited if there is no conflict between
+   * is only committed if there is no conflict between
    * the changes it contains and the actual current
    * state of configuration.
    */
@@ -164,7 +164,7 @@ class CommitAndDeployChangeRequestServiceImpl(
        * In a string, we don't want to take care of a difference in the number of spaces
        * in names / description.
        * We also remove space in the end.
-       * Do not use it in a place where space may be significative, like a template.
+       * Do not use it in a place where space may be significant, like a template.
        */
     def normalizeString(text: String) : String = {
       text.replaceAll("""\s+""", " ").trim
@@ -228,7 +228,7 @@ class CommitAndDeployChangeRequestServiceImpl(
 
 
     // For now we only check the Directive, not the SectionSpec and the TechniqueName.
-    // The SectionSpec could be a problem (ie : A mono valued param was chanegd to multi valued without changing the technique version).
+    // The SectionSpec could be a problem (ie : A mono valued param was changed to multi valued without changing the technique version).
     final case class CheckDirective(changes : DirectiveChanges) extends CheckChanges[Directive]  {
       // used in serialisation
       val directiveContext = {
@@ -253,7 +253,7 @@ class CommitAndDeployChangeRequestServiceImpl(
     }
 
     final case object CheckGroup extends CheckChanges[NodeGroup]  {
-      def failureMessage(group : NodeGroup)  = s"Group ${group.name} (id: ${group.id.value})"
+      def failureMessage(group : NodeGroup)  = s"Group ${group.name} (id: ${group.id.serialize})"
       def getCurrentValue(group : NodeGroup) = roNodeGroupRepo.getNodeGroup(group.id).map(_._1).toBox
       def compareMethod(initial:NodeGroup, current:NodeGroup) = compareGroups(initial,current)
       def xmlSerialize(group : NodeGroup) = Full(xmlSerializer.group.serialise(group))
@@ -309,7 +309,7 @@ class CommitAndDeployChangeRequestServiceImpl(
 
         def displayTarget(target : RuleTarget) = {
           target match {
-            case GroupTarget(groupId) => s"group: ${groupId.value}"
+            case GroupTarget(groupId) => s"group: ${groupId.serialize}"
             case PolicyServerTarget(nodeId) => s"policyServer: ${nodeId.value}"
             case _ => target.target
           }
@@ -384,7 +384,7 @@ class CommitAndDeployChangeRequestServiceImpl(
           currVal = currentFixed.parameters.get(key)
         } yield {
           if ( currVal != initVal) {
-            debugLog(s"Directive ID ${initialFixed.id.uid.value} parameter $key has changed : original state from CR: ${initVal.getOrElse("value is mising")}, current value: ${currVal.getOrElse("value is mising")}")
+            debugLog(s"Directive ID ${initialFixed.id.uid.value} parameter $key has changed : original state from CR: ${initVal.getOrElse("value is missing")}, current value: ${currVal.getOrElse("value is missing")}")
           }
         }
 
@@ -420,32 +420,32 @@ class CommitAndDeployChangeRequestServiceImpl(
         debugLog("Attempt to merge Change Request (CR) failed because initial state could not be rebased on current state.")
 
         if ( initialFixed.name != currentFixed.name) {
-          debugLog(s"Group ID ${initialFixed.id.value} name has changed: original state from CR: ${initialFixed.name}, current value: ${currentFixed.name}")
+          debugLog(s"Group ID ${initialFixed.id.serialize} name has changed: original state from CR: ${initialFixed.name}, current value: ${currentFixed.name}")
         }
 
         if ( initialFixed.description != currentFixed.description) {
-          debugLog(s"Group ID ${initialFixed.id.value} description has changed: original state from CR: ${initialFixed.description}, current value: ${currentFixed.description}")
+          debugLog(s"Group ID ${initialFixed.id.serialize} description has changed: original state from CR: ${initialFixed.description}, current value: ${currentFixed.description}")
         }
 
         if ( initialFixed.query != currentFixed.query) {
-          debugLog(s"Group ID ${initialFixed.id.value} query has changed: original state from CR: ${initialFixed.query}, current value: ${currentFixed.query}")
+          debugLog(s"Group ID ${initialFixed.id.serialize} query has changed: original state from CR: ${initialFixed.query}, current value: ${currentFixed.query}")
         }
 
         if ( initialFixed.isDynamic != currentFixed.isDynamic) {
-          debugLog(s"Group ID ${initialFixed.id.value} dynamic status has changed: original state from CR: ${initialFixed.isDynamic}, current value: ${currentFixed.isDynamic}")
+          debugLog(s"Group ID ${initialFixed.id.serialize} dynamic status has changed: original state from CR: ${initialFixed.isDynamic}, current value: ${currentFixed.isDynamic}")
         }
 
         if ( initialFixed.isEnabled != currentFixed.isEnabled) {
-          debugLog(s"Group ID ${initialFixed.id.value} enable status has changed: original state from CR: ${initialFixed.isEnabled}, current value: ${currentFixed.isEnabled}")
+          debugLog(s"Group ID ${initialFixed.id.serialize} enable status has changed: original state from CR: ${initialFixed.isEnabled}, current value: ${currentFixed.isEnabled}")
         }
 
         // we compare nodes only for static group, not dynamic ones
         if (!(initialFixed.isDynamic && currentFixed.isDynamic) && initialFixed.serverList != currentFixed.serverList) {
-          debugLog(s"Group ID ${initialFixed.id.value} nodes list has changed: original state from CR: ${initialFixed.serverList.map(_.value).mkString("[ ", ", ", " ]")}, current value: ${currentFixed.serverList.map(_.value).mkString("[ ", ", ", " ]")}")
+          debugLog(s"Group ID ${initialFixed.id.serialize} nodes list has changed: original state from CR: ${initialFixed.serverList.map(_.value).mkString("[ ", ", ", " ]")}, current value: ${currentFixed.serverList.map(_.value).mkString("[ ", ", ", " ]")}")
         }
 
         if( initialFixed.properties != currentFixed.properties ) {
-          debugLog(s"Group ID ${initialFixed.id.value} properties changed: original state from CR: ${initialFixed.properties.map(_.toData).mkString("[ ", ", ", " ]")}, current value: ${currentFixed.properties.map(_.toData).mkString("[ ", ", ", " ]")}")
+          debugLog(s"Group ID ${initialFixed.id.serialize} properties changed: original state from CR: ${initialFixed.properties.map(_.toData).mkString("[ ", ", ", " ]")}, current value: ${currentFixed.properties.map(_.toData).mkString("[ ", ", ", " ]")}")
         }
 
         //return
@@ -629,7 +629,7 @@ class CommitAndDeployChangeRequestServiceImpl(
      * Logic to commit Change request with multiple changes:
      *
      * - such a change request is NOT atomic, each change is
-     *   commited independently to other
+     *   committed independently to other
      * - from previous point, it may happen that a erroneous commit
      *   in a beginner element leads to other errors
      * - the commit order is DEFINED and FIXE

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
@@ -2,9 +2,11 @@ package com.normation.rudder.domain.policies
 
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.nodes.NodeInfo
+
 import org.joda.time.DateTime
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
+
 import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner._
@@ -17,6 +19,7 @@ import com.normation.inventory.domain.Debian
 import com.normation.inventory.domain.Linux
 import com.normation.inventory.domain.Version
 import com.normation.inventory.domain.UndefinedKey
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.nodes.NodeState
 
 @RunWith(classOf[JUnitRunner])
@@ -48,22 +51,22 @@ class RuleTargetTest extends Specification with Loggable {
   }.toMap
 
   val g1 = NodeGroup (
-    NodeGroupId("1"), "Empty group", "", Nil, None, false, Set(), true
+    NodeGroupId(NodeGroupUid("1")), "Empty group", "", Nil, None, false, Set(), true
   )
   val g2 = NodeGroup (
-    NodeGroupId("2"), "only root", "", Nil, None, false, Set(NodeId("root")), true
+    NodeGroupId(NodeGroupUid("2")), "only root", "", Nil, None, false, Set(NodeId("root")), true
   )
   val g3 = NodeGroup (
-    NodeGroupId("3"), "Even nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt == 2), true
+    NodeGroupId(NodeGroupUid("3")), "Even nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt == 2), true
   )
   val g4 = NodeGroup (
-    NodeGroupId("4"), "Odd nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt != 2), true
+    NodeGroupId(NodeGroupUid("4")), "Odd nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt != 2), true
   )
   val g5 = NodeGroup (
-    NodeGroupId("5"), "Nodes id divided by 3", "", Nil, None, false, nodeIds.filter(_.value.toInt == 3), true
+    NodeGroupId(NodeGroupUid("5")), "Nodes id divided by 3", "", Nil, None, false, nodeIds.filter(_.value.toInt == 3), true
   )
   val g6 = NodeGroup (
-    NodeGroupId("6"), "Nodes id divided by 5", "", Nil, None, false, nodeIds.filter(_.value.toInt == 5), true
+    NodeGroupId(NodeGroupUid("6")), "Nodes id divided by 5", "", Nil, None, false, nodeIds.filter(_.value.toInt == 5), true
   )
 
   val groups = Set(g1, g2, g3, g4, g5, g6 )

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
@@ -77,7 +77,7 @@ class TestMergeGroupProperties extends Specification {
 
   implicit class ToTarget(g: NodeGroup) {
     def toTarget = FullRuleTargetInfo(FullGroupTarget(GroupTarget(g.id), g), g.name, "", true, true)
-    def toCriterion = CriterionLine(null, Criterion("some ldap attr", new SubGroupComparator(null)), null, g.id.value)
+    def toCriterion = CriterionLine(null, Criterion("some ldap attr", new SubGroupComparator(null)), null, g.id.serialize)
   }
 
   implicit class ToNodePropertyHierarchy(groups: List[NodeGroup]) {
@@ -130,20 +130,20 @@ class TestMergeGroupProperties extends Specification {
    *    node
    */
 
-  val parent1   = NodeGroup(NodeGroupId("parent1"), "parent1", "",
+  val parent1   = NodeGroup(NodeGroupId(NodeGroupUid("parent1")), "parent1", "",
       List(GroupProperty("foo", GitVersion.DEFAULT_REV, "bar1".toConfigValue, None, None))
     , Some(NewQuery(NodeReturnType, And, Identity, List()))
     , true, Set(), true
   )
   val parent2Prop = GroupProperty("foo", GitVersion.DEFAULT_REV, "bar2".toConfigValue, None, None)
-  val parent2   = NodeGroup(NodeGroupId("parent2"), "parent2", "",
+  val parent2   = NodeGroup(NodeGroupId(NodeGroupUid("parent2")), "parent2", "",
       List(parent2Prop)
     , Some(NewQuery(NodeReturnType, And, Identity, List()))
     , true, Set(), true
   )
   val childProp = GroupProperty("foo", GitVersion.DEFAULT_REV, "baz".toConfigValue, None, None)
   val query = NewQuery(NodeReturnType, And, Identity, List(parent1.toCriterion))
-  val child = NodeGroup(NodeGroupId("child"), "child", "",
+  val child = NodeGroup(NodeGroupId(NodeGroupUid("child")), "child", "",
       List(childProp)
     , Some(query)
     , true, Set(), true
@@ -178,12 +178,12 @@ class TestMergeGroupProperties extends Specification {
   "when looking for a node property, we" should {
 
     "be able to detect conflict" in {
-      val parent1 = NodeGroup(NodeGroupId("parent1"), "parent1", "",
+      val parent1 = NodeGroup(NodeGroupId(NodeGroupUid("parent1")), "parent1", "",
           List(GroupProperty("dns", GitVersion.DEFAULT_REV, "1.1.1.1".toConfigValue, None, None))
         , Some(NewQuery(NodeReturnType, And, Identity, List()))
         , true, Set(), true
       )
-      val parent2   = NodeGroup(NodeGroupId("parent2"), "parent2", "",
+      val parent2   = NodeGroup(NodeGroupId(NodeGroupUid("parent2")), "parent2", "",
           List(GroupProperty("dns", GitVersion.DEFAULT_REV, "9.9.9.9".toConfigValue, None, None))
         , Some(NewQuery(NodeReturnType, And, Identity, List()))
         , true, Set(), true
@@ -197,17 +197,17 @@ class TestMergeGroupProperties extends Specification {
     }
 
     "be able to correct conflict" in {
-      val parent1 = NodeGroup(NodeGroupId("parent1"), "parent1", "",
+      val parent1 = NodeGroup(NodeGroupId(NodeGroupUid("parent1")), "parent1", "",
           List(GroupProperty("dns", GitVersion.DEFAULT_REV, "1.1.1.1".toConfigValue, None, None))
         , Some(NewQuery(NodeReturnType, And, Identity, List()))
         , true, Set(), true
       )
-      val parent2   = NodeGroup(NodeGroupId("parent2"), "parent2", "",
+      val parent2   = NodeGroup(NodeGroupId(NodeGroupUid("parent2")), "parent2", "",
           List(GroupProperty("dns", GitVersion.DEFAULT_REV, "9.9.9.9".toConfigValue, None, None))
         , Some(NewQuery(NodeReturnType, And, Identity, List()))
         , true, Set(), true
       )
-      val priorize   = NodeGroup(NodeGroupId("parent3"), "parent3", "",
+      val priorize   = NodeGroup(NodeGroupId(NodeGroupUid("parent3")), "parent3", "",
           Nil
         , Some(NewQuery(NodeReturnType, And, Identity, List(parent1.toCriterion, parent2.toCriterion)))
         , true, Set(), true
@@ -227,22 +227,22 @@ class TestMergeGroupProperties extends Specification {
      * node in p4 and p3
      */
     "one can solve conflicts at parent level" in {
-      val parent1 = NodeGroup(NodeGroupId("parent1"), "parent1", "",
+      val parent1 = NodeGroup(NodeGroupId(NodeGroupUid("parent1")), "parent1", "",
           List(GroupProperty("dns", GitVersion.DEFAULT_REV, "1.1.1.1".toConfigValue, None, None))
         , Some(NewQuery(NodeReturnType, And, Identity, List()))
         , true, Set(), true
       )
-      val parent2   = NodeGroup(NodeGroupId("parent2"), "parent2", "",
+      val parent2   = NodeGroup(NodeGroupId(NodeGroupUid("parent2")), "parent2", "",
           List(GroupProperty("dns", GitVersion.DEFAULT_REV, "9.9.9.9".toConfigValue, None, None))
         , Some(NewQuery(NodeReturnType, And, Identity, List()))
         , true, Set(), true
       )
-      val priorize   = NodeGroup(NodeGroupId("parent3"), "parent3", "",
+      val priorize   = NodeGroup(NodeGroupId(NodeGroupUid("parent3")), "parent3", "",
           Nil
         , Some(NewQuery(NodeReturnType, And, Identity, List(parent1.toCriterion, parent2.toCriterion)))
         , true, Set(), true
       )
-      val parent4   = NodeGroup(NodeGroupId("parent4"), "parent4", "",
+      val parent4   = NodeGroup(NodeGroupId(NodeGroupUid("parent4")), "parent4", "",
           Nil
         , Some(NewQuery(NodeReturnType, And, Identity, List(parent1.toCriterion)))
         , true, Set(), true
@@ -284,12 +284,12 @@ class TestMergeGroupProperties extends Specification {
         , res => res
         )
       }.toList
-      val parent = NodeGroup(NodeGroupId("parent1"), "parent1", "",
+      val parent = NodeGroup(NodeGroupId(NodeGroupUid("parent1")), "parent1", "",
           toProps(parentProps)
         , Some(NewQuery(NodeReturnType, And, Identity, List()))
         , true, Set(), true
       )
-      val child = NodeGroup(NodeGroupId("child"), "child", "",
+      val child = NodeGroup(NodeGroupId(NodeGroupUid("child")), "child", "",
           toProps(childProps)
         , Some(NewQuery(NodeReturnType, And, Identity, List(parent1.toCriterion)))
         , true, Set(), true

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
@@ -122,6 +122,7 @@ import com.normation.inventory.domain.PendingInventory
 import com.normation.inventory.domain.VMWare
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.Constants
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.git.GitRepositoryProviderImpl
 import com.normation.rudder.git.GitRevisionProvider
@@ -437,14 +438,14 @@ ootapja6lKOaIpqp0kmmYN7gFIhp
    *   ************************************************************************
    */
 
-  val g0id = NodeGroupId("0")
+  val g0id = NodeGroupId(NodeGroupUid("0"))
   val g0 = NodeGroup (g0id, "Real nodes", "", Nil, None, false, Set(rootId, node1.id, node2.id), true)
-  val g1 = NodeGroup (NodeGroupId("1"), "Empty group", "", Nil, None, false, Set(), true)
-  val g2 = NodeGroup (NodeGroupId("2"), "only root", "", Nil, None, false, Set(NodeId("root")), true)
-  val g3 = NodeGroup (NodeGroupId("3"), "Even nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt == 2), true)
-  val g4 = NodeGroup (NodeGroupId("4"), "Odd nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt != 2), true)
-  val g5 = NodeGroup (NodeGroupId("5"), "Nodes id divided by 3", "", Nil, None, false, nodeIds.filter(_.value.toInt == 3), true)
-  val g6 = NodeGroup (NodeGroupId("6"), "Nodes id divided by 5", "", Nil, None, false, nodeIds.filter(_.value.toInt == 5), true)
+  val g1 = NodeGroup (NodeGroupId(NodeGroupUid("1")), "Empty group", "", Nil, None, false, Set(), true)
+  val g2 = NodeGroup (NodeGroupId(NodeGroupUid("2")), "only root", "", Nil, None, false, Set(NodeId("root")), true)
+  val g3 = NodeGroup (NodeGroupId(NodeGroupUid("3")), "Even nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt == 2), true)
+  val g4 = NodeGroup (NodeGroupId(NodeGroupUid("4")), "Odd nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt != 2), true)
+  val g5 = NodeGroup (NodeGroupId(NodeGroupUid("5")), "Nodes id divided by 3", "", Nil, None, false, nodeIds.filter(_.value.toInt == 3), true)
+  val g6 = NodeGroup (NodeGroupId(NodeGroupUid("6")), "Nodes id divided by 5", "", Nil, None, false, nodeIds.filter(_.value.toInt == 5), true)
   val groups = Set(g0, g1, g2, g3, g4, g5, g6).map(g => (g.id, g))
 
   val groupTargets = groups.map{ case (id, g) => (GroupTarget(g.id), g) }
@@ -681,8 +682,8 @@ class TestNodeConfiguration(prefixTestResources: String = ""
       targetInfos = List(
           FullRuleTargetInfo(
               FullGroupTarget(
-                  GroupTarget(NodeGroupId("a-group-for-root-only"))
-                , NodeGroup(NodeGroupId("a-group-for-root-only")
+                  GroupTarget(NodeGroupId(NodeGroupUid("a-group-for-root-only")))
+                , NodeGroup(NodeGroupId(NodeGroupUid("a-group-for-root-only"))
                     , "Serveurs [€ðŋ] cassés"
                     , "Liste de l'ensemble de serveurs cassés à réparer"
                     , Nil

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
@@ -57,6 +57,7 @@ import com.normation.rudder.domain.policies.GroupTarget
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.inventory.domain.AgentType
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.services.nodes.PropertyEngineServiceImpl
@@ -154,7 +155,7 @@ class RuleValServiceTest extends Specification {
           ruleId
         , "Rule Name"
         , RuleCategoryId("cat1")
-        , Set(GroupTarget(NodeGroupId("nodeGroupId")))
+        , Set(GroupTarget(NodeGroupId(NodeGroupUid("nodeGroupId"))))
         , Set(DirectiveId(directiveId))
         , ""
         , ""

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
@@ -42,6 +42,7 @@ import com.normation.rudder.domain.appconfig.FeatureSwitch
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupCategoryId
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.ActiveTechniqueCategoryId
 import com.normation.rudder.domain.policies.ActiveTechniqueId
 import com.normation.rudder.domain.policies.FullGroupTarget
@@ -95,7 +96,7 @@ class TestBuildNodeConfiguration extends Specification {
 
   val allNodes                  = ((1 to 1000).map(newNode) :+ root).map(n => (n.id, n)).toMap
   // only one group with all nodes
-  val group                     = NodeGroup (NodeGroupId("allnodes"), "allnodes", "", Nil, None, false, allNodes.keySet, true)
+  val group                     = NodeGroup (NodeGroupId(NodeGroupUid("allnodes")), "allnodes", "", Nil, None, false, allNodes.keySet, true)
   val groupLib                  = FullNodeGroupCategory (
                                       NodeGroupCategoryId("test_root"), "", "", Nil
                                     , List(FullRuleTargetInfo(FullGroupTarget(GroupTarget(group.id), group), "", "", true, false))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestPendingNodePolicies.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestPendingNodePolicies.scala
@@ -43,6 +43,7 @@ import com.normation.inventory.ldap.core.LDAPConstants.OC_MACHINE
 import com.normation.rudder.domain.RudderLDAPConstants.A_NODE_GROUP_UUID
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.queries.Criterion
 import com.normation.rudder.domain.queries.CriterionLine
 import com.normation.rudder.domain.queries.Equals
@@ -105,7 +106,7 @@ class TestPendingNodePolicies extends Specification {
   ))
 
   //a query line for sub group
-  def sub(g: NodeGroup) = CriterionLine(groupCriterion, groupCriterion.criteria.head, Equals, g.id.value)
+  def sub(g: NodeGroup) = CriterionLine(groupCriterion, groupCriterion.criteria.head, Equals, g.id.serialize)
   // a random query that will be added as dummy content - query checker will returns pre-defined things
   val cl = CriterionLine(
       ObjectCriterion(OC_MACHINE, Seq(Criterion(A_MACHINE_UUID, StringComparator)))
@@ -124,7 +125,7 @@ class TestPendingNodePolicies extends Specification {
   val dummyQuery1 = NewQuery(null, Or , Identity, List(cl)) // will return 1 node
 
   def ng(id: String, q: QueryTrait, dyn: Boolean = true) =
-    NodeGroup(NodeGroupId(id), id, id, Nil, Some(q), dyn, Set(), true, false)
+    NodeGroup(NodeGroupId(NodeGroupUid(id)), id, id, Nil, Some(q), dyn, Set(), true, false)
 
   // groups
   val c = ng("c", dummyQuery1) // ok
@@ -190,7 +191,7 @@ class TestPendingNodePolicies extends Specification {
           e.rootExceptionCause.foreach(ex => ex.printStackTrace())
           throw new RuntimeException(e.messageChain)
         case Full(res) =>
-          res.apply(node).map(_.value).sorted
+          res.apply(node).map(_.serialize).sorted
       }
       groups must containTheSameElementsAs(List("a", "b", "c", "d", "i", "j", "k", "m", "n", "o", "p"))
     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
@@ -193,6 +193,13 @@ trait ReadConfigService {
    */
   def rudder_featureSwitch_directiveScriptEngine(): IOResult[FeatureSwitch]
 
+
+  /**
+   * Should we activate import/export archive API
+   */
+  def rudder_featureSwitch_archiveApi(): IOResult[FeatureSwitch]
+
+
   /**
    * Default value for node properties after acceptation:
    * - policy mode
@@ -324,6 +331,11 @@ trait UpdateConfigService {
    */
   def set_rudder_featureSwitch_directiveScriptEngine(status: FeatureSwitch): IOResult[Unit]
 
+  /*
+   * Should we enable import/export archive API ?
+   */
+  def set_rudder_featureSwitch_archiveApi(status: FeatureSwitch): IOResult[Unit]
+
 /**
    * Set the compliance mode
    */
@@ -427,6 +439,7 @@ class GenericConfigService(
        rudder.policy.mode.name=${Enforce.name}
        rudder.policy.mode.overridable=true
        rudder.featureSwitch.directiveScriptEngine=enabled
+       rudder.featureSwitch.archiveApi=disabled
        rudder.node.onaccept.default.state=enabled
        rudder.node.onaccept.default.policyMode=default
        rudder.compliance.unexpectedReportUnboundedVarValues=true
@@ -710,6 +723,12 @@ class GenericConfigService(
    */
   def rudder_featureSwitch_directiveScriptEngine(): IOResult[FeatureSwitch] = get("rudder_featureSwitch_directiveScriptEngine")
   def set_rudder_featureSwitch_directiveScriptEngine(status: FeatureSwitch): IOResult[Unit] = save("rudder_featureSwitch_directiveScriptEngine", status)
+
+  /**
+   * Should we enable import/export archive API?
+   */
+  def rudder_featureSwitch_archiveApi(): IOResult[FeatureSwitch] = get("rudder_featureSwitch_archiveApi")
+  def set_rudder_featureSwitch_archiveApi(status: FeatureSwitch): IOResult[Unit] = save("rudder_featureSwitch_archiveApi", status)
 
   /**
    * Default value for node properties after acceptation:

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -891,13 +891,23 @@ sealed trait ArchiveApi extends EndpointSchema with GeneralApi with SortIndex {
   override def dataContainer: Option[String] = None
 }
 object ArchiveApi extends ApiModuleProvider[ArchiveApi] {
+  /*
+   * Request format:
+   *   ../archives/export/rules=rule_ids&directives=dir_ids&techniques=tech_ids&groups=group_ids&include=scope
+   * Where:
+   * - rule_ids = xxxx-xxxx-xxx-xxx[,other ids]
+   * - dir_ids = xxxx-xxxx-xxx-xxx[,other ids]
+   * - group_ids = xxxx-xxxx-xxx-xxx[,other ids]
+   * - tech_ids = techniqueName/1.0[,other tech ids]
+   * - scope = all (default), none, directives, techniques (implies directive), groups
+   */
   final case object ExportSimple extends ArchiveApi with ZeroParam with StartsAtVersion15 with SortIndex {val z = implicitly[Line].value
     val description    = "Export the list of objects with their dependencies"
-    val (action, path) = GET / "archive" / "export"
+    val (action, path) = GET / "archives" / "export"
   }
   final case object Import extends ArchiveApi with ZeroParam with StartsAtVersion15 with SortIndex {val z = implicitly[Line].value
     val description    = "Import an archive"
-    val (action, path) = POST / "archive" / "import"
+    val (action, path) = POST / "archives" / "import"
   }
 
   def endpoints = ca.mrvisser.sealerate.values[ArchiveApi].toList.sortBy( _.z )

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -885,6 +885,25 @@ object UserApi extends ApiModuleProvider[UserApi] {
 }
 
 /*
+ * An API for import & export of archives of objects with their dependencies
+ */
+sealed trait ArchiveApi extends EndpointSchema with GeneralApi with SortIndex {
+  override def dataContainer: Option[String] = None
+}
+object ArchiveApi extends ApiModuleProvider[ArchiveApi] {
+  final case object ExportSimple extends ArchiveApi with ZeroParam with StartsAtVersion15 with SortIndex {val z = implicitly[Line].value
+    val description    = "Export the list of objects with their dependencies"
+    val (action, path) = GET / "archive" / "export"
+  }
+  final case object Import extends ArchiveApi with ZeroParam with StartsAtVersion15 with SortIndex {val z = implicitly[Line].value
+    val description    = "Import an archive"
+    val (action, path) = POST / "archive" / "import"
+  }
+
+  def endpoints = ca.mrvisser.sealerate.values[ArchiveApi].toList.sortBy( _.z )
+}
+
+/*
  * All API.
  */
 object AllApi {
@@ -899,6 +918,7 @@ object AllApi {
     TechniqueApi.endpoints :::
     RuleApi.endpoints :::
     InventoryApi.endpoints :::
+    ArchiveApi.endpoints :::
     InfoApi.endpoints :::
     HookApi.endpoints :::
     // UserApi is not declared here, it will be contributed by plugin

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonResponse.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonResponse.scala
@@ -48,7 +48,7 @@ import com.normation.rudder.rest.lift.DefaultParams
 
 /*
  * This class deals with everything serialisation related for API.
- * Change things with care! Everything must be versionned!
+ * Change things with care! Everything must be versioned!
  * Even changing a field name can lead to an API incompatible change and
  * so will need a new API version number (and be sure that old behavior is kept
  * for previous versions).
@@ -58,7 +58,7 @@ import com.normation.rudder.rest.lift.DefaultParams
 /*
  * Rudder standard response.
  * We normalize response format to look like what is detailed here: https://docs.rudder.io/api/v/13/#section/Introduction/Response-format
- * Data are always name-spaced, so that theorically an answer can mixe several type of data. For example, for node details:
+ * Data are always name-spaced, so that theoretically an answer can mixe several type of data. For example, for node details:
  *     "data": { "nodes": [ ... list of nodes ... ] }
  * And for globalCompliance:
  *     "data": { "globalCompliance": { ... } }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestQuicksearch.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestQuicksearch.scala
@@ -39,6 +39,7 @@ package com.normation.rudder.rest.internal
 
 import com.normation.rudder.AuthorizationType
 import com.normation.rudder.UserService
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.rest.RestUtils._
 import com.normation.rudder.services.quicksearch.FullQuickSearchService
@@ -206,7 +207,7 @@ class RestQuicksearch (
         case QRNodeId(v)      => nodeLink(NodeId(v))
         case QRRuleId(v)      => ruleLink(RuleId(RuleUid(v)))
         case QRDirectiveId(v) => directiveLink(DirectiveUid(v))
-        case QRGroupId(v)     => groupLink(NodeGroupId(v))
+        case QRGroupId(v)     => groupLink(NodeGroupId(NodeGroupUid(v)))
         case QRParameterId(v) => globalParameterLink(v)
       }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
@@ -6,16 +6,13 @@ import com.normation.rudder.apidata.JsonResponseObjects.JRRuleNodesDirectives
 import com.normation.rudder.domain.logger.TimingDebugLoggerPure
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.repository.{RoNodeGroupRepository, RoRuleRepository}
-import com.normation.rudder.rest.{ApiPath, AuthzToken, RestExtractorService, RestUtils, RuleInternalApi => API}
+import com.normation.rudder.rest.{ApiPath, AuthzToken, RestExtractorService, RuleInternalApi => API}
 import com.normation.rudder.rest.lift.{DefaultParams, LiftApiModule, LiftApiModuleProvider, LiftApiModuleString}
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.zio.currentTimeMillis
-import net.liftweb.common.Box
 import net.liftweb.http.{LiftResponse, Req}
 import com.normation.rudder.rest.implicits._
-import net.liftweb.json.JValue
 import com.normation.rudder.apidata.implicits._
-import zio._
 import zio.syntax._
 
 class RulesInternalApi(

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -1,0 +1,173 @@
+/*
+*************************************************************************************
+* Copyright 2022 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.rest.lift
+
+import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.domain.appconfig.FeatureSwitch
+import com.normation.rudder.domain.logger.ApplicationLogger
+import com.normation.rudder.git.ZipUtils
+import com.normation.rudder.git.ZipUtils.Zippable
+import com.normation.rudder.rest.ApiPath
+import com.normation.rudder.rest.AuthzToken
+import com.normation.rudder.rest.RudderJsonResponse
+import com.normation.rudder.rest.RudderJsonResponse.ResponseSchema
+import com.normation.rudder.rest.implicits._
+import com.normation.rudder.rest.lift.DummyImportAnswer._
+import com.normation.rudder.rest.{ArchiveApi => API}
+
+import net.liftweb.http.LiftResponse
+import net.liftweb.http.OutputStreamResponse
+import net.liftweb.http.Req
+
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.charset.StandardCharsets
+
+import zio._
+import zio.syntax._
+import com.normation.errors._
+import com.normation.zio._
+
+/*
+ * Machinery to enable/disable the API given the value of the feature switch in config service.
+ * If disabled, always return an error with the info about how to enable it.
+ */
+final case class FeatureSwitch0[A <: LiftApiModule0](enable: A, disable: A)(featureSwitchState: IOResult[FeatureSwitch]) extends LiftApiModule0 {
+  override val schema = enable.schema
+  override def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    featureSwitchState.either.runNow match {
+      case Left(err) =>
+        ApplicationLogger.error(err.fullMsg)
+        RudderJsonResponse.internalError(ResponseSchema.fromSchema(schema), err.fullMsg)(params.prettify).toResponse
+      case Right(FeatureSwitch.Disabled) =>
+        disable.process0(version, path, req, params, authzToken)
+      case Right(FeatureSwitch.Enabled) =>
+        enable.process0(version, path, req, params, authzToken)
+    }
+  }
+}
+
+class ArchiveApi(
+  featureSwitchState: IOResult[FeatureSwitch]
+) extends LiftApiModuleProvider[API] {
+
+  def schemas = API
+
+  def getLiftEndpoints(): List[LiftApiModule] = {
+    API.endpoints.map(e => e match {
+      case API.Import       => FeatureSwitch0(Import, ImportDisabled)(featureSwitchState)
+      case API.ExportSimple => FeatureSwitch0(ExportSimple, ExportSimpleDisabled)(featureSwitchState)
+    })
+  }
+
+  /*
+   * Default answer to use when the feature is disabled
+   */
+  trait ApiDisabled extends LiftApiModule0 {
+    override def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      RudderJsonResponse.internalError(
+          ResponseSchema.fromSchema(schema)
+        , """This API is disabled. It is in beta version and no compatibility is ensured. You can enable it with """ +
+          """the setting `rudder_featureSwitch_archiveApi` in settings API set to `{"value":"enabled"}`"""
+      )(params.prettify).toResponse
+    }
+  }
+
+  object ExportSimpleDisabled extends LiftApiModule0 with ApiDisabled { val schema = API.ExportSimple }
+
+  /*
+   * This API does not returns a standard JSON response, it returns a ZIP archive.
+   */
+  object ExportSimple extends LiftApiModule0 {
+    val schema = API.ExportSimple
+    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      def getContent(use: InputStream => IOResult[Any]): IOResult[Any] = {
+         ZIO.bracket(IOResult.effect(new ByteArrayInputStream("Hello world!".getBytes(StandardCharsets.UTF_8))))(is => effectUioUnit(is.close)) { is =>
+            use(is)
+         }
+      }
+      val name = "archive"
+      val archive = Chunk(
+          Zippable(name, None)
+        , Zippable(s"${name}/placeholder", Some(getContent _))
+        , Zippable(s"${name}/placeholder2", Some(getContent _))
+      )
+
+      //do zip
+      val send = (os: OutputStream) => ZipUtils.zip(os, archive).runNow
+
+      val headers = List(
+          ("Pragma", "public")
+        , ("Expires", "0")
+        , ("Cache-Control", "must-revalidate, post-check=0, pre-check=0")
+        , ("Cache-Control", "public")
+        , ("Content-Description", "File Transfer")
+        , ("Content-type", "application/octet-stream")
+        , ("Content-Disposition", s"""attachment; filename="${name}.zip"""")
+        , ("Content-Transfer-Encoding", "binary")
+      )
+
+      new OutputStreamResponse(send, -1, headers, Nil, 200)
+
+    }
+  }
+
+  object ImportDisabled extends LiftApiModule0 with ApiDisabled { override val schema = API.Import }
+
+  object Import extends LiftApiModule0 {
+    val schema = API.Import
+    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      val res: IOResult[JRArchiveImported] = JRArchiveImported(true).succeed
+      res.toLiftResponseOne(params, schema, _ => None)
+    }
+  }
+}
+
+/*
+ * A dummy object waiting for implementation for import
+ */
+object DummyImportAnswer {
+
+  import zio.json._
+
+  case class JRArchiveImported(success: Boolean)
+
+  implicit lazy val encodeJRArchiveImported: JsonEncoder[JRArchiveImported] = DeriveJsonEncoder.gen
+
+}

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -37,11 +37,24 @@
 
 package com.normation.rudder.rest.lift
 
+import com.normation.cfclerk.domain.Technique
+import com.normation.cfclerk.domain.TechniqueId
 import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.apidata.JsonResponseObjects.JRDirective
+import com.normation.rudder.apidata.JsonResponseObjects.JRGroup
+import com.normation.rudder.apidata.JsonResponseObjects.JRRule
+import com.normation.rudder.apidata.implicits._
+import com.normation.rudder.configuration.ConfigurationRepository
 import com.normation.rudder.domain.appconfig.FeatureSwitch
 import com.normation.rudder.domain.logger.ApplicationLogger
+import com.normation.rudder.domain.logger.ApplicationLoggerPure
+import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.policies.DirectiveId
+import com.normation.rudder.domain.policies.RuleId
+import com.normation.rudder.domain.policies.RuleTarget
 import com.normation.rudder.git.ZipUtils
 import com.normation.rudder.git.ZipUtils.Zippable
+import com.normation.rudder.repository.xml.TechniqueRevisionRepository
 import com.normation.rudder.rest.ApiPath
 import com.normation.rudder.rest.AuthzToken
 import com.normation.rudder.rest.RudderJsonResponse
@@ -58,8 +71,10 @@ import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.io.OutputStream
 import java.nio.charset.StandardCharsets
+import java.text.Normalizer
 
 import zio._
+import zio.json._
 import zio.syntax._
 import com.normation.errors._
 import com.normation.zio._
@@ -83,9 +98,33 @@ final case class FeatureSwitch0[A <: LiftApiModule0](enable: A, disable: A)(feat
   }
 }
 
+sealed trait ArchiveScope { def value: String }
+object ArchiveScope {
+
+  // using nodep/alldep to avoid confusion with "none" in scala code
+  final case object AllDep     extends ArchiveScope { val value = "all"        }
+  final case object NoDep      extends ArchiveScope { val value = "none"       }
+  final case object Directives extends ArchiveScope { val value = "directives" }
+  final case object Techniques extends ArchiveScope { val value = "techniques" }
+  final case object Groups     extends ArchiveScope { val value = "groups"     }
+
+  def values =  ca.mrvisser.sealerate.values[ArchiveScope].toList.sortBy( _.value )
+  def parse(s: String): Either[String, ArchiveScope] = {
+    values.find( _.value == s.toLowerCase.strip() ) match {
+      case None    => Left(s"Error: can not parse '${s}' as a scope for dependency resolution in archive. Accepted values are: ${values.mkString(", ")}")
+      case Some(x) => Right(x)
+    }
+  }
+}
+
+
 class ArchiveApi(
-  featureSwitchState: IOResult[FeatureSwitch]
+    archiveBuilderService: ZipArchiveBuilderService
+  , featureSwitchState   : IOResult[FeatureSwitch]
+  , getArchiveName       : IOResult[String]
 ) extends LiftApiModuleProvider[API] {
+
+
 
   def schemas = API
 
@@ -100,6 +139,7 @@ class ArchiveApi(
    * Default answer to use when the feature is disabled
    */
   trait ApiDisabled extends LiftApiModule0 {
+
     override def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
       RudderJsonResponse.internalError(
           ResponseSchema.fromSchema(schema)
@@ -116,21 +156,60 @@ class ArchiveApi(
    */
   object ExportSimple extends LiftApiModule0 {
     val schema = API.ExportSimple
+    /*
+     * Request format:
+     *   ../archives/export/rules=rule_ids&directives=dir_ids&techniques=tech_ids&groups=group_ids&include=scope
+     * Where:
+     * - rule_ids = xxxx-xxxx-xxx-xxx[,other ids]
+     * - dir_ids = xxxx-xxxx-xxx-xxx[,other ids]
+     * - group_ids = xxxx-xxxx-xxx-xxx[,other ids]
+     * - tech_ids = techniqueName/1.0[,other tech ids]
+     * - scope = all (default), none, directives, techniques (implies directive), groups
+     */
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      def getContent(use: InputStream => IOResult[Any]): IOResult[Any] = {
-         ZIO.bracket(IOResult.effect(new ByteArrayInputStream("Hello world!".getBytes(StandardCharsets.UTF_8))))(is => effectUioUnit(is.close)) { is =>
-            use(is)
-         }
+
+      // we use lots of comma separated arg, factor out the splitting logic
+      def splitArg(req: Req, name: String): List[String] = req.params.getOrElse(name, Nil).flatMap(seq => seq.split(',').toList.map(_.strip()))
+      def parseRuleIds(req: Req): IOResult[List[RuleId]] = {
+
+        ZIO.foreach(splitArg(req, "rules"))(RuleId.parse(_).toIO)
       }
-      val name = "archive"
-      val archive = Chunk(
-          Zippable(name, None)
-        , Zippable(s"${name}/placeholder", Some(getContent _))
-        , Zippable(s"${name}/placeholder2", Some(getContent _))
-      )
+      def parseDirectiveIds(req: Req): IOResult[List[DirectiveId]] = {
+        ZIO.foreach(splitArg(req, "directives"))(DirectiveId.parse(_).toIO)
+      }
+      def parseTechniqueIds(req: Req): IOResult[List[TechniqueId]] = {
+        ZIO.foreach(splitArg(req, "techniques"))(TechniqueId.parse(_).toIO)
+      }
+      def parseGroupIds(req: Req): IOResult[List[NodeGroupId]] = {
+        ZIO.foreach(splitArg(req, "groups"))(NodeGroupId.parse(_).toIO)
+      }
+      def parseScopes(req: Req): IOResult[List[ArchiveScope]] = {
+        splitArg(req, "include") match {
+          case Nil => List(ArchiveScope.AllDep).succeed
+          case seq => ZIO.foreach(seq)(ArchiveScope.parse(_).toIO)
+        }
+      }
+
+      // lift is not well suited for ZIO...
+      val rootDirName = getArchiveName.runNow
 
       //do zip
-      val send = (os: OutputStream) => ZipUtils.zip(os, archive).runNow
+      val zippables = for {
+        _             <- ApplicationLoggerPure.Archive.debug(s"Building archive")
+        ruleIds       <- parseRuleIds(req)
+        groupIds      <- parseGroupIds(req)
+        directiveIds  <- parseDirectiveIds(req)
+        techniquesIds <- parseTechniqueIds(req)
+        scopes        <- parseScopes(req)
+        _             <- ApplicationLoggerPure.Archive.debug(s"Archive requested for rules: [${ruleIds.map(_.serialize).mkString(", ")}], " +
+                                                             s"directives: [${directiveIds.map(_.serialize).mkString(", ")}], " +
+                                                             s"groups: [${groupIds.map(_.serialize).mkString(", ")}], " +
+                                                             s"techniques: [${techniquesIds.map(_.serialize).mkString(", ")}], " +
+                                                             s"scope: [${scopes.map(_.value).mkString(", ")}]")
+        zippables     <- archiveBuilderService.buildArchive(rootDirName, techniquesIds, directiveIds, groupIds, ruleIds, scopes.toSet)
+      } yield {
+        zippables
+      }
 
       val headers = List(
           ("Pragma", "public")
@@ -139,12 +218,15 @@ class ArchiveApi(
         , ("Cache-Control", "public")
         , ("Content-Description", "File Transfer")
         , ("Content-type", "application/octet-stream")
-        , ("Content-Disposition", s"""attachment; filename="${name}.zip"""")
+        , ("Content-Disposition", s"""attachment; filename="${rootDirName}.zip"""")
         , ("Content-Transfer-Encoding", "binary")
       )
-
+      val send =  (os: OutputStream) => zippables.flatMap { z =>
+        ZipUtils.zip(os, z)
+      }.catchAll(err =>
+        ApplicationLoggerPure.Archive.error(s"Error when building zip archive: ${err.fullMsg}")
+      ).runNow
       new OutputStreamResponse(send, -1, headers, Nil, 200)
-
     }
   }
 
@@ -171,3 +253,211 @@ object DummyImportAnswer {
   implicit lazy val encodeJRArchiveImported: JsonEncoder[JRArchiveImported] = DeriveJsonEncoder.gen
 
 }
+
+
+/**
+ * A service that is able to build a human readable file name from a string
+ */
+class FileArchiveNameService(
+  // zip has no max length, but winzip limit to 250 because of windows - https://kb.corel.com/en/125869
+  // So 240 for extension etc
+  maxSize: Int = 240
+) {
+  def toFileName(name: String): String = {
+    Normalizer.normalize(name, Normalizer.Form.NFKD)
+      .replaceAll("""[^\p{Alnum}-]""", "_").take(maxSize)
+  }
+
+}
+
+
+/**
+ * That class is in charge of building a archive of a set of rudder objects.
+ * It knows how to get objects from their ID, serialise them to the expected
+ * string representation, and check that file name are not overriding each others,
+ * but it does not know about how to get what objects need to be retrieved.
+ *
+ * For now, I don't see any way to not load rules/etc in memory (for ex for the case
+ * where they would already be in json somewhere) since we need name.
+ * That may be changed in the future, if config repo and archive converge toward
+ * and unique file format and convention, but it's not for now.
+ */
+class ZipArchiveBuilderService(
+    fileArchiveNameService: FileArchiveNameService
+  , configRepo            : ConfigurationRepository
+  , techniqueRevisionRepo : TechniqueRevisionRepository
+) {
+
+
+  // names of directories under the root directory of the archive
+  val RULES_DIR = "rules"
+  val GROUPS_DIR = "groups"
+  val DIRECTIVES_DIR = "directives"
+  val TECHNIQUES_DIR = "techniques"
+
+  /*
+   * get the content of the JSON string in the format expected by Zippable
+   */
+  def getJsonZippableContent(json: String): (InputStream => IOResult[Any]) => IOResult[Any] = {
+    (use: InputStream => IOResult[Any]) =>
+    IOResult.effect(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))).bracket(is => effectUioUnit(is.close)) { is =>
+      use(is)
+    }
+  }
+
+
+  /*
+   * function that will find the next available name from the given string,
+   * looking in pool to check for availability (and updating said pool).
+   * Extension is an extension that should not be normalized.
+   */
+  def findName(origName: String, extension: String, usedNames: Ref[Map[String, Set[String]]], category: String): IOResult[String] = {
+    def findRecName(s: Set[String], base: String, i: Int): String = {
+      val n = base+"_"+i
+      if(s.contains(n)) findRecName(s, base, i+1) else n
+    }
+    val name = fileArchiveNameService.toFileName(origName)+extension
+
+    // find a free name, avoiding overwriting a previous similar one
+    usedNames.modify(m => {
+      val realName = if( m(category).contains(name) ) {
+        findRecName(m(category), name, 1)
+      } else name
+      ( realName, m + ((category, m(category)+realName))  )
+    } )
+  }
+
+  /*
+   * Retrieve the technique using first the cache, then the config service, and update the
+   * cache accordingly
+   */
+  def getTechnique(techniqueId: TechniqueId, techniques: RefM[Map[TechniqueId, Technique]]): IOResult[Technique] = {
+    techniques.modify(cache => cache.get(techniqueId) match {
+     case None =>
+       for {
+         t <- configRepo.getTechnique(techniqueId).notOptional(s"Technique with id ${techniqueId.serialize} was not found in Rudder")
+         c =  cache + ((t.id, t))
+       } yield (t, c)
+     case Some(t) =>
+       (t, cache).succeed
+   })
+  }
+
+  /*
+   * Getting technique zippable is more complex than other items because we can have a lot of
+   * files. The strategy used is to always copy ALL files for the given technique
+   * TechniquesDir is the path where techniques are stored, ie for technique "user/1.0", we have:
+   * techniquesDir / user/1.0/ other techniques file
+   */
+  def getTechniqueZippable(techniquesDir: String, techniqueId: TechniqueId): IOResult[Seq[Zippable]] = {
+    techniqueRevisionRepo.getTechnique(techniqueId.name, techniqueId.version.version, techniqueId.version.rev)
+    for {
+      contents <- techniqueRevisionRepo.getTechniqueFileContents(techniqueId).notOptional(s"Technique with ID '${techniqueId.serialize}' was not found in repository. Please check name and revision.")
+    } yield {
+      // we need to change root of zippable, we want techniques/myTechnique/1.0/[HERE]
+      val basePath = techniquesDir+"/" + techniqueId.withDefaultRev.serialize + "/"
+      contents.map { case (p, opt) => Zippable(basePath + p, opt.map(_.use))}
+    }
+  }
+
+  /*
+   * Prepare the archive.
+   * `rootDirName` is supposed to be normalized, no change will be done with it.
+   * Any missing object will lead to an error.
+   * For each element, an human readable name derived from the object name is used when possible.
+   *
+   * System elements are not archived
+   */
+  def buildArchive(
+      rootDirName: String
+    , techniqueIds: Seq[TechniqueId]
+    , directiveIds: Seq[DirectiveId]
+    , groupIds: Seq[NodeGroupId]
+    , ruleIds: Seq[RuleId]
+    , scopes: Set[ArchiveScope]
+  ): IOResult[Chunk[Zippable]] = {
+    // normalize to no slash at end
+    val root = rootDirName.strip().replaceAll("""/$""", "")
+    import ArchiveScope._
+    val includeDepTechniques = scopes.intersect(Set(AllDep, Techniques)).nonEmpty
+    // scope is transitive, techniques implies directives
+    val includeDepDirectives = includeDepTechniques || scopes.intersect(Set(AllDep, Directives)).nonEmpty
+    val includeDepGroups = scopes.intersect(Set(AllDep, Groups)).nonEmpty
+
+    // rule is easy and independent from other
+
+    for {
+      // for each kind, we need to keep trace of existing names to avoid overwriting
+      usedNames        <- Ref.make(Map.empty[String, Set[String]])
+      // dependency id to add at lower level
+      depDirectiveIds  <- Ref.make(List.empty[DirectiveId])
+      depGroupIds      <- Ref.make(List.empty[NodeGroupId])
+      _                <- ApplicationLoggerPure.Archive.debug(s"Building archive for rules: ${ruleIds.map(_.serialize).mkString(", ")}")
+      rootZip          <- Zippable(rootDirName, None).succeed
+      rulesDir         =  root + "/" + RULES_DIR
+      _                <- usedNames.update( _ + ((RULES_DIR, Set.empty[String])))
+      rulesDirZip      =  Zippable(rulesDir, None)
+      rulesZip         <- ZIO.foreach(ruleIds) { ruleId =>
+                            configRepo.getRule(ruleId).notOptional(s"Rule with id ${ruleId.serialize} was not found in Rudder").flatMap(rule =>
+                              if(rule.isSystem) None.succeed else {
+                                for {
+                                  _ <- depDirectiveIds.update(x => x ++ rule.directiveIds)
+                                  _ <- depGroupIds.update(x => x ++ RuleTarget.getNodeGroupIds(rule.targets))
+                                  json = JRRule.fromRule(rule, None, None, None).toJsonPretty
+                                  name <- findName(rule.name, ".json", usedNames, RULES_DIR)
+                                } yield {
+                                  Some(Zippable(rulesDir + "/" + name, Some(getJsonZippableContent(json))))
+                                }
+                              }
+                            )
+                          }.map(_.flatten)
+      groupsDir        =  root + "/" + GROUPS_DIR
+      _                <- usedNames.update( _ + ((GROUPS_DIR, Set.empty[String])))
+      groupsDirZip     =  Zippable(groupsDir, None)
+      depGroups        <- if(includeDepGroups) depGroupIds.get else Nil.succeed
+      groupsZip        <- ZIO.foreach(groupIds ++ depGroups) { groupId =>
+                            configRepo.getGroup(groupId).notOptional(s"Group with id ${groupId.serialize} was not found in Rudder").flatMap(gc =>
+                              if(gc.group.isSystem) None.succeed else {
+                                val json =  JRGroup.fromGroup(gc.group, gc.categoryId, None).toJsonPretty
+                                for {
+                                  name <- findName(gc.group.name, ".json", usedNames, GROUPS_DIR)
+                                } yield Some(Zippable(groupsDir + "/" + name, Some(getJsonZippableContent(json))))
+                              }
+                            )
+                          }.map(_.flatten)
+      // directives need access to technique, but we don't want to look up several time the same one
+      techniques       <- RefM.make(Map.empty[TechniqueId, Technique])
+
+      directivesDir    =  root + "/" + DIRECTIVES_DIR
+      _                <- usedNames.update( _ + ((DIRECTIVES_DIR, Set.empty[String])))
+      directivesDirZip =  Zippable(directivesDir, None)
+      depDirectives    <- if(includeDepDirectives) depDirectiveIds.get else Nil.succeed
+      directivesZip    <- ZIO.foreach(directiveIds ++ depDirectives) { directiveId =>
+                            configRepo.getDirective(directiveId).notOptional(s"Directive with id ${directiveId.serialize} was not found in Rudder").flatMap(ad =>
+                              if(ad.directive.isSystem) None.succeed else {
+                                for {
+                                  tech <- getTechnique(TechniqueId(ad.activeTechnique.techniqueName, ad.directive.techniqueVersion), techniques)
+                                  json =  JRDirective.fromDirective(tech, ad.directive, None).toJsonPretty
+                                  name <- findName(ad.directive.name, ".json", usedNames, DIRECTIVES_DIR)
+                                } yield Some(Zippable(directivesDir + "/" + name, Some(getJsonZippableContent(json))))
+                              }
+                            )
+                          }.map(_.flatten)
+      // Techniques don't need name normalization, their name is already normalized
+      techniquesDir    =  root + "/" + TECHNIQUES_DIR
+      techniquesDirZip =  Zippable(techniquesDir, None)
+      depTechniques    <- if(includeDepTechniques) techniques.get.map(_.keys) else Nil.succeed
+      allTech          <- ZIO.foreach(techniqueIds ++ depTechniques) { techniqueId => getTechnique(techniqueId, techniques) }
+      techniquesZip    <- ZIO.foreach(allTech.filter(_.isSystem == false)) { technique =>
+                            for {
+                              techZips  <- getTechniqueZippable(techniquesDir, technique.id)
+                            } yield techZips
+                          }
+    } yield {
+      Chunk(rootZip, rulesDirZip, groupsDirZip, directivesDirZip, techniquesDirZip) ++ rulesZip ++ techniquesZip.flatten ++ directivesZip ++ groupsZip
+    }
+  }
+
+}
+
+

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -135,6 +135,7 @@ class SettingsApi(
       RestComputeDynGroupMaxParallelism ::
       RestSetupDone ::
       RestRuddercTargets ::
+      ArchiveApiFeatureSwitch ::
       Nil
 
   val allSettings_v12 =   RestReportProtocolDefault :: allSettings_v10
@@ -598,7 +599,7 @@ final case object RestSendMetrics extends RestSetting[Option[SendMetrics]] {
   def set = configService.set_send_server_metrics _
 }
 
-final case object RestJSEngine extends RestSetting[FeatureSwitch] {
+  final case object RestJSEngine extends RestSetting[FeatureSwitch] {
     val startPolicyGeneration = true
     def toJson(value : FeatureSwitch) : JValue = value.name
     def parseJson(json: JValue) = {
@@ -615,7 +616,24 @@ final case object RestJSEngine extends RestSetting[FeatureSwitch] {
     def set = (value : FeatureSwitch, _, _) => configService.set_rudder_featureSwitch_directiveScriptEngine(value)
   }
 
-final case object RestOnAcceptPolicyMode extends RestSetting[Option[PolicyMode]] {
+  final case object ArchiveApiFeatureSwitch extends RestSetting[FeatureSwitch] {
+    val startPolicyGeneration = false
+    def toJson(value : FeatureSwitch) : JValue = value.name
+    def parseJson(json: JValue) = {
+      json match {
+        case JString(value) => FeatureSwitch.parse(value)
+        case x              => Failure("Invalid value "+x)
+      }
+    }
+    def parseParam(param : String) = {
+      FeatureSwitch.parse(param)
+    }
+    val key = "rudder_featureSwitch_archiveApi"
+    def get = configService.rudder_featureSwitch_archiveApi()
+    def set = (value : FeatureSwitch, _, _) => configService.set_rudder_featureSwitch_archiveApi(value)
+  }
+
+  final case object RestOnAcceptPolicyMode extends RestSetting[Option[PolicyMode]] {
     val startPolicyGeneration = false
     def parseParam(value: String): Box[Option[PolicyMode]] = {
       Full(PolicyMode.allModes.find( _.name == value))
@@ -631,7 +649,8 @@ final case object RestOnAcceptPolicyMode extends RestSetting[Option[PolicyMode]]
     def get = configService.rudder_node_onaccept_default_policy_mode()
     def set = (value : Option[PolicyMode], _, _) => configService.set_rudder_node_onaccept_default_policy_mode(value)
   }
-final case object RestOnAcceptNodeState extends RestSetting[NodeState] {
+
+  final case object RestOnAcceptNodeState extends RestSetting[NodeState] {
     val startPolicyGeneration = false
     def parseParam(value: String): Box[NodeState] = {
       Full(NodeState.values.find( _.name == value).getOrElse(NodeState.Enabled))

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/JsInitContextLinkUtil.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/JsInitContextLinkUtil.scala
@@ -69,7 +69,7 @@ class LinkUtil (
   , nodeInfoService       : NodeInfoService
 ) extends Loggable {
   def baseGroupLink(id:NodeGroupId) =
-    s"""/secure/nodeManager/groups#{"groupId":"${id.value}"}"""
+    s"""/secure/nodeManager/groups#{"groupId":"${id.serialize}"}"""
 
   def baseTargetLink(target: RuleTarget) =
     s"""/secure/nodeManager/groups#{"target":"${target.target}"}"""
@@ -142,10 +142,10 @@ class LinkUtil (
 
   def createGroupLink(id:NodeGroupId) = {
     roGroupRepository.getNodeGroup(id).either.runNow match {
-      case Right((group,_)) => <span> <a href={baseGroupLink(id)}>{group.name}</a> (Rudder ID: {id.value})</span>
+      case Right((group,_)) => <span> <a href={baseGroupLink(id)}>{group.name}</a> (Rudder ID: {id.serialize})</span>
       case Left(err)        =>
-        logger.error(s"Could not find NodeGroup with Id ${id.value}. Error was: ${err.fullMsg}")
-        <span> {id.value} </span>
+        logger.error(s"Could not find NodeGroup with Id ${id.serialize}. Error was: ${err.fullMsg}")
+        <span> {id.serialize} </span>
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -126,7 +126,7 @@ class EventLogDetailsGenerator(
       val name = (x.details \ "nodeGroup" \ "displayName").text
       Text("Group ") ++ {
         if(id.size < 1) Text(name)
-        else <a href={groupLink(NodeGroupId(id))} onclick="noBubble(event);">{name}</a> ++ actionName
+        else <a href={groupLink(NodeGroupId(NodeGroupUid(id)))} onclick="noBubble(event);">{name}</a> ++ actionName
       }
     }
 
@@ -449,7 +449,7 @@ class EventLogDetailsGenerator(
                 { generatedByChangeRequest }
                 <h4>Group overview:</h4>
                 <ul class="evlogviewpad">
-                  <li><b>Node Group ID:</b> { modDiff.id.value }</li>
+                  <li><b>Node Group ID:</b> { modDiff.id.withDefaultRev.serialize }</li>
                   <li><b>Name:</b> {
                     modDiff.modName.map(diff => diff.newValue.toString).getOrElse(modDiff.name)
                     }</li>
@@ -1168,7 +1168,7 @@ class EventLogDetailsGenerator(
     )(xml)
 
   private[this] def groupDetails(xml:NodeSeq, group: NodeGroup) = (
-    "#groupID" #> group.id.value &
+    "#groupID" #> group.id.withDefaultRev.serialize &
       "#groupName" #> group.name &
       "#shortDescription" #> group.description &
       "#shortDescription" #> group.description &

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_settings.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_settings.yml
@@ -49,6 +49,7 @@ response:
           "require_time_synchronization":true,
           "rudder_compute_changes":true,
           "rudder_compute_dyngroups_max_parallelism":"1",
+          "rudder_featureSwitch_archiveApi":"disabled",
           "rudder_generation_compute_dyngroups":true,
           "rudder_generation_continue_on_error":false,
           "rudder_generation_delay":"0 seconds",

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTests.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTests.scala
@@ -37,19 +37,32 @@
 
 package com.normation.rudder.rest
 
+import com.normation.eventlog.EventActor
+import com.normation.eventlog.ModificationId
+import com.normation.rudder.apidata.JsonQueryObjects.JQRule
 import com.normation.rudder.domain.appconfig.FeatureSwitch
+import com.normation.rudder.domain.policies.RuleId
+import com.normation.rudder.domain.policies.RuleUid
+import com.normation.rudder.git.ZipUtils
+import com.normation.utils.DateFormaterService
 
 import better.files.File
 import net.liftweb.common.Full
 import net.liftweb.common.Loggable
 import net.liftweb.http.InMemoryResponse
+import net.liftweb.http.OutputStreamResponse
 import org.apache.commons.io.FileUtils
+import org.eclipse.jgit.revwalk.RevWalk
+import org.joda.time.DateTime
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import org.specs2.specification.AfterAll
 
+import java.io.FileOutputStream
 import java.nio.charset.StandardCharsets
+import java.util.zip.ZipFile
+
 import com.normation.zio._
 
 @RunWith(classOf[JUnitRunner])
@@ -58,7 +71,7 @@ class ArchiveApiTests extends Specification with AfterAll with Loggable {
   val restTestSetUp = RestTestSetUp.newEnv
   val restTest = new RestTest(restTestSetUp.liftRules)
 
-  val testDir = File("/tmp/response-content")
+  val testDir = File(s"/tmp/test-rudder-response-content-${DateFormaterService.serialize(DateTime.now())}")
   testDir.createDirectoryIfNotExists(true)
 
   override def afterAll(): Unit = {
@@ -70,43 +83,291 @@ class ArchiveApiTests extends Specification with AfterAll with Loggable {
     }
   }
 
+  def children(f: File) = f.children.toList.map(_.name)
+
+  org.slf4j.LoggerFactory.getLogger("application.archive").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.TRACE)
+  org.slf4j.LoggerFactory.getLogger("configuration").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.TRACE)
+
   sequential
 
   "when the feature switch is disabled, request" should {
-    "error in GET /archive/export" in {
-      restTest.testGETResponse("/api/archive/export") {
+    "error in GET /archives/export" in {
+      restTest.testGETResponse("/api/archives/export") {
         case Full(InMemoryResponse(json, _, _, 500)) => new String(json, StandardCharsets.UTF_8) must beMatching(".*This API is disabled.*")
         case err                                     => ko(s"I got an error in test: ${err}")
       }
     }
 
-    "error in POST /archive/export" in {
-      restTest.testEmptyPostResponse("/api/archive/import") {
+    "error in POST /archives/export" in {
+      restTest.testEmptyPostResponse("/api/archives/import") {
         case Full(InMemoryResponse(json, _, _, 500)) => new String(json, StandardCharsets.UTF_8) must beMatching(".*This API is disabled.*")
         case err                                     => ko(s"I got an error in test: ${err}")
       }
     }
   }
 
+  // FROM THERE, FEATURE IS ENABLED
+
   "when the feature switch is enabled, request" should {
-
-
-    "error in GET /archive/export" in {
+    "succeed in GET /archives/export" in {
       // feature switch change needs to be at that level and not under "should" directly,
       // else it contaminated all tests, even with the sequential annotation
       restTestSetUp.archiveAPIModule.featureSwitchState.set(FeatureSwitch.Enabled).runNow
-      restTest.testGETResponse("/api/archive/export") {
+      restTest.testGETResponse("/api/archives/export") {
         case Full(resp) => resp.toResponse.code must beEqualTo(200)
         case err        => ko(s"I got an error in test: ${err}")
       }
     }
 
-    "error in POST /archive/export" in {
-      restTest.testEmptyPostResponse("/api/archive/import") {
+    "succeed in POST /archives/export" in {
+      restTest.testEmptyPostResponse("/api/archives/import") {
         case Full(resp) => resp.toResponse.code must beEqualTo(200)
         case err        => ko(s"I got an error in test: ${err}")
       }
     }
   }
 
+  "correctly build an archive of one rule, no deps" >> {
+
+    // rule with ID rule1 defined in com/normation/rudder/MockServices.scala has name:
+    // 10. Global configuration for all nodes
+    // so: 10__Global_configuration_for_all_nodes
+    val fileName = "10__Global_configuration_for_all_nodes.json"
+
+    val archiveName = "archive-rule-no-dep"
+    restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+
+    restTest.testGETResponse("/api/archives/export?rules=rule1&include=none") {
+      case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+        val zipFile = testDir/s"${archiveName}.zip"
+        val zipOut = new FileOutputStream(zipFile.toJava)
+        out(zipOut)
+        zipOut.close()
+        // unzip
+        ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+        (children(testDir/s"${archiveName}/rules") must containTheSameElementsAs(List(fileName))) and
+        (children(testDir/s"${archiveName}/groups").isEmpty must beTrue) and
+        (children(testDir/s"${archiveName}/directives").isEmpty must beTrue) and
+        (children(testDir/s"${archiveName}/techniques").isEmpty must beTrue)
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+
+  "correctly build an archive with one rule, dep: group and technique (and implied directives)" in {
+    val fileName = "10__Global_configuration_for_all_nodes.json"
+
+    val archiveName = "archive-rule-with-dep"
+    restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+
+    restTest.testGETResponse("/api/archives/export?rules=rule1&include=groups,techniques") {
+      case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+        val zipFile = testDir/s"${archiveName}.zip"
+        val zipOut = new FileOutputStream(zipFile.toJava)
+        out(zipOut)
+        zipOut.close()
+        // unzip
+        ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+        (children(testDir/s"${archiveName}/rules") must containTheSameElementsAs(List(fileName))) and
+        // only system group => none exported
+        (children(testDir/s"${archiveName}/groups") must containTheSameElementsAs(Nil)) and
+        (children(testDir/s"${archiveName}/directives") must containTheSameElementsAs(List("10__Clock_Configuration.json"))) and
+        (children(testDir/s"${archiveName}/techniques") must containTheSameElementsAs(List("clockConfiguration"))) and
+        (children(testDir/s"${archiveName}/techniques/clockConfiguration/3.0") must containTheSameElementsAs(List("changelog", "clockConfiguration.st", "metadata.xml")))
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+  "correctly build an archive of one directive" >> {
+
+    // rule with ID rule1 defined in com/normation/rudder/MockServices.scala has name:
+    // 10. Global configuration for all nodes
+    // so: 10__Global_configuration_for_all_nodes
+    val fileName = "10__Clock_Configuration.json"
+
+    val archiveName = "archive-directive"
+    restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+
+    restTest.testGETResponse("/api/archives/export?directives=directive1&include=none") {
+      case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+        val zipFile = testDir/s"${archiveName}.zip"
+        val zipOut = new FileOutputStream(zipFile.toJava)
+        out(zipOut)
+        zipOut.close()
+        // unzip
+        ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+        (children(testDir/s"${archiveName}/directives") must containTheSameElementsAs(List(fileName))) and
+        (children(testDir/s"${archiveName}/groups").isEmpty must beTrue) and
+        (children(testDir/s"${archiveName}/rules").isEmpty must beTrue) and
+        (children(testDir/s"${archiveName}/techniques").isEmpty must beTrue)
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+  "correctly build an archive of one group" >> {
+
+    // group with ID 0000f5d3-8c61-4d20-88a7-bb947705ba8a defined in com/normation/rudder/MockServices.scala has name:
+    // Real nodes
+    // so: Real_nodes
+    val fileName = "Real_nodes.json"
+
+    val archiveName = "archive-group"
+    restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+
+    restTest.testGETResponse("/api/archives/export?groups=0000f5d3-8c61-4d20-88a7-bb947705ba8a&include=none") {
+      case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+        val zipFile = testDir/s"${archiveName}.zip"
+        val zipOut = new FileOutputStream(zipFile.toJava)
+        out(zipOut)
+        zipOut.close()
+        // unzip
+        ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+        (children(testDir/s"${archiveName}/groups") must containTheSameElementsAs(List(fileName)))
+        (children(testDir/s"${archiveName}/rules").isEmpty must beTrue) and
+        (children(testDir/s"${archiveName}/directives").isEmpty must beTrue) and
+        (children(testDir/s"${archiveName}/techniques").isEmpty must beTrue)
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+  "correctly build an archive of one technique" >> {
+    val archiveName = "archive-technique"
+    restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+    val techniqueId = "Create_file/1.0"
+    restTest.testGETResponse(s"/api/archives/export?techniques=${techniqueId}&include=none") {
+      case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+        val zipFile = testDir/s"${archiveName}.zip"
+        val zipOut = new FileOutputStream(zipFile.toJava)
+        out(zipOut)
+        zipOut.close()
+        // unzip
+        ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+        val techniqueFiles = List("Create_file.ps1", "expected_reports.csv", "metadata.xml", "rudder_reporting.st")
+
+        (children(testDir/s"${archiveName}/techniques/${techniqueId}") must containTheSameElementsAs(techniqueFiles))
+        (children(testDir/s"${archiveName}/groups").isEmpty must beTrue) and
+        (children(testDir/s"${archiveName}/directives").isEmpty must beTrue) and
+        (children(testDir/s"${archiveName}/rules").isEmpty must beTrue)
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+
+  "correctly build an archive with two rules and only group and directive" in {
+    val fileName1 = "10__Global_configuration_for_all_nodes.json"
+    val fileName2 = "60-rule-technique-std-lib.json"
+
+    val archiveName = "archive-two-rules-with-dep"
+    restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+
+    restTest.testGETResponse("/api/archives/export?rules=rule1,ff44fb97-b65e-43c4-b8c2-0df8d5e8549f&include=groups,directives") {
+      case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+        val zipFile = testDir/s"${archiveName}.zip"
+        val zipOut = new FileOutputStream(zipFile.toJava)
+        out(zipOut)
+        zipOut.close()
+        // unzip
+        ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+        (children(testDir/s"${archiveName}/rules") must containTheSameElementsAs(List(fileName1, fileName2))) and
+        // only system group => none exported
+        (children(testDir/s"${archiveName}/groups") must containTheSameElementsAs(Nil)) and
+        (children(testDir/s"${archiveName}/directives") must containTheSameElementsAs(List(
+            "10__Clock_Configuration.json"
+          , "directive_16617aa8-1f02-4e4a-87b6-d0bcdfb4019f.json"
+          , "directive_e9a1a909-2490-4fc9-95c3-9d0aa01717c9.json"
+          , "directive_ff44fb97-b65e-43c4-b8c2-0df8d5e8549f.json"
+        ))) and
+        (children(testDir/s"${archiveName}/techniques").isEmpty must beTrue)
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+
+  "correctly build an archive with past revision items" >> {
+    import zio.json._
+    import com.normation.rudder.apidata.implicits._
+
+    val initRev = {
+      val head = restTestSetUp.mockGitRepo.gitRepo.db.exactRef("refs/heads/master")
+      val walk = new RevWalk(restTestSetUp.mockGitRepo.gitRepo.db)
+      val commit = walk.parseCommit(head.getObjectId)
+      walk.dispose()
+      commit.name()
+    }
+
+    //update rule definition
+    val ruleId = "rule1"
+    val ruleFileName = "10__Global_configuration_for_all_nodes.json"
+    val newDesc = "new rule description"
+
+    (for {
+      r <- restTestSetUp.mockRules.ruleRepo.getOpt(RuleId(RuleUid(ruleId))).notOptional(s"missing ${ruleId} in test")
+      _ <- restTestSetUp.mockRules.ruleRepo.update(r.copy(shortDescription = newDesc), ModificationId("rule"), EventActor("test"), None)
+    } yield ()).runNow
+    // update technique
+    val techniqueId = "Create_file/1.0"
+    val relPath = s"techniques/ncf_techniques/${techniqueId}/newfile"
+    val f = restTestSetUp.mockGitRepo.configurationRepositoryRoot/relPath
+    f.write("hello world")
+    restTestSetUp.mockGitRepo.gitRepo.git.add().addFilepattern(relPath).call()
+    restTestSetUp.mockGitRepo.gitRepo.git.commit().setMessage(s"add file in ${techniqueId}").call()
+    restTestSetUp.mockTechniques.techniqueReader.readTechniques
+
+    val baseFiles = List("Create_file.ps1", "expected_reports.csv", "metadata.xml", "rudder_reporting.st")
+
+    {
+      val archiveName = "archive-technique-head"
+      restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+      restTest.testGETResponse(s"/api/archives/export?rules=${ruleId}&techniques=${techniqueId}") {
+        case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+          val zipFile = testDir/s"${archiveName}.zip"
+          val zipOut = new FileOutputStream(zipFile.toJava)
+          out(zipOut)
+          zipOut.close()
+          // unzip
+          ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+          val r = (testDir / s"${archiveName}/rules/${ruleFileName}").contentAsString.fromJson[JQRule].getOrElse(throw new IllegalArgumentException(s"error in rule deserialization"))
+
+          (r.shortDescription.getOrElse("") must beMatching(newDesc)) and
+          (children(testDir/s"${archiveName}/techniques/${techniqueId}") must containTheSameElementsAs("newfile" :: baseFiles))
+
+        case err => ko(s"I got an error in test: ${err}")
+      }
+    } and {
+      val archiveName = "archive-technique-init"
+      restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+      // TODO: rule are not serialized in test repos, we won't find it!
+      restTest.testGETResponse(s"/api/archives/export?rules=${ruleId}&techniques=${techniqueId}%2B${initRev}") {
+        case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+          val zipFile = testDir/s"${archiveName}.zip"
+          val zipOut = new FileOutputStream(zipFile.toJava)
+          out(zipOut)
+          zipOut.close()
+          // unzip
+          ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+          //val r = (testDir / s"${archiveName}/rules/${ruleFileName}").contentAsString.fromJson[JQRule].getOrElse(throw new IllegalArgumentException(s"error in rule deserialization"))
+          //(r.shortDescription.getOrElse("") must beMatching("global config for all nodes")) and
+          (children(testDir/s"${archiveName}/techniques/${techniqueId}") must containTheSameElementsAs(baseFiles))
+
+        case err => ko(s"I got an error in test: ${err}")
+      }
+    }
+  }
+
+
 }
+

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTests.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTests.scala
@@ -1,0 +1,112 @@
+/*
+*************************************************************************************
+* Copyright 2018 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.rest
+
+import com.normation.rudder.domain.appconfig.FeatureSwitch
+
+import better.files.File
+import net.liftweb.common.Full
+import net.liftweb.common.Loggable
+import net.liftweb.http.InMemoryResponse
+import org.apache.commons.io.FileUtils
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.AfterAll
+
+import java.nio.charset.StandardCharsets
+import com.normation.zio._
+
+@RunWith(classOf[JUnitRunner])
+class ArchiveApiTests extends Specification with AfterAll with Loggable {
+
+  val restTestSetUp = RestTestSetUp.newEnv
+  val restTest = new RestTest(restTestSetUp.liftRules)
+
+  val testDir = File("/tmp/response-content")
+  testDir.createDirectoryIfNotExists(true)
+
+  override def afterAll(): Unit = {
+    if (System.getProperty("tests.clean.tmp") != "false") {
+      logger.info("Cleanup rest env ")
+      restTestSetUp.cleanup()
+      logger.info("Deleting directory " + testDir.pathAsString)
+      FileUtils.deleteDirectory(testDir.toJava)
+    }
+  }
+
+  sequential
+
+  "when the feature switch is disabled, request" should {
+    "error in GET /archive/export" in {
+      restTest.testGETResponse("/api/archive/export") {
+        case Full(InMemoryResponse(json, _, _, 500)) => new String(json, StandardCharsets.UTF_8) must beMatching(".*This API is disabled.*")
+        case err                                     => ko(s"I got an error in test: ${err}")
+      }
+    }
+
+    "error in POST /archive/export" in {
+      restTest.testEmptyPostResponse("/api/archive/import") {
+        case Full(InMemoryResponse(json, _, _, 500)) => new String(json, StandardCharsets.UTF_8) must beMatching(".*This API is disabled.*")
+        case err                                     => ko(s"I got an error in test: ${err}")
+      }
+    }
+  }
+
+  "when the feature switch is enabled, request" should {
+
+
+    "error in GET /archive/export" in {
+      // feature switch change needs to be at that level and not under "should" directly,
+      // else it contaminated all tests, even with the sequential annotation
+      restTestSetUp.archiveAPIModule.featureSwitchState.set(FeatureSwitch.Enabled).runNow
+      restTest.testGETResponse("/api/archive/export") {
+        case Full(resp) => resp.toResponse.code must beEqualTo(200)
+        case err        => ko(s"I got an error in test: ${err}")
+      }
+    }
+
+    "error in POST /archive/export" in {
+      restTest.testEmptyPostResponse("/api/archive/import") {
+        case Full(resp) => resp.toResponse.code must beEqualTo(200)
+        case err        => ko(s"I got an error in test: ${err}")
+      }
+    }
+  }
+
+}

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestDataExtractorTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestDataExtractorTest.scala
@@ -45,6 +45,7 @@ import com.normation.rudder.MockTechniques
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.policies._
 import com.normation.utils.StringUuidGeneratorImpl
+
 import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
@@ -53,6 +54,7 @@ import com.normation.rudder.apidata.JsonQueryObjects._
 import com.normation.rudder.apidata.JsonResponseObjects._
 import com.normation.rudder.apidata.JsonResponseObjects.JRRuleTarget._
 import com.normation.rudder.apidata.implicits._
+import com.normation.rudder.domain.nodes.NodeGroupUid
 
 @RunWith(classOf[JUnitRunner])
 class RestDataExtractorTest extends Specification {
@@ -77,10 +79,10 @@ class RestDataExtractorTest extends Specification {
   "extract RuleTarget" >> {
     val tests = List(
       ("""group:3d5d1d6c-4ba5-4ffc-b5a4-12ce02336f52"""
-      , JRRuleTarget(GroupTarget(NodeGroupId("3d5d1d6c-4ba5-4ffc-b5a4-12ce02336f52")))
+      , JRRuleTarget(GroupTarget(NodeGroupId(NodeGroupUid("3d5d1d6c-4ba5-4ffc-b5a4-12ce02336f52"))))
       )
     , ("""group:hasPolicyServer-root"""
-      , JRRuleTarget(GroupTarget(NodeGroupId("hasPolicyServer-root")))
+      , JRRuleTarget(GroupTarget(NodeGroupId(NodeGroupUid("hasPolicyServer-root"))))
       )
     , ("""policyServer:root"""
       , JRRuleTarget(PolicyServerTarget(NodeId("root")))
@@ -89,7 +91,7 @@ class RestDataExtractorTest extends Specification {
       , JRRuleTarget(AllTarget)
       )
     , ("""{"include":{"or":["special:all"]},"exclude":{"or":["group:all-nodes-with-dsc-agent"]}}"""
-      , JRRuleTarget(TargetExclusion(TargetUnion(Set(AllTarget)), TargetUnion(Set(GroupTarget(NodeGroupId("all-nodes-with-dsc-agent"))))))
+      , JRRuleTarget(TargetExclusion(TargetUnion(Set(AllTarget)), TargetUnion(Set(GroupTarget(NodeGroupId(NodeGroupUid("all-nodes-with-dsc-agent")))))))
       )
     , ("""{"include":{"or":[]},"exclude":{"or":[]}}"""
       , JRRuleTarget(TargetExclusion(TargetUnion(Set()), TargetUnion(Set())))

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -616,6 +616,11 @@ class RestTestSetUp {
   val resourceFileService : ResourceFileService = null
   val settingsService = new MockSettings(workflowLevelService, new AsyncWorkflowInfo())
 
+  object archiveAPIModule {
+    val featureSwitchState = Ref.make[FeatureSwitch](FeatureSwitch.Disabled).runNow
+    val api = new ArchiveApi(featureSwitchState.get)
+  }
+
   val apiModules = List(
       systemApi
     , new ParameterApi(restExtractorService, zioJsonExtractor, parameterApiService2, parameterApiService14)
@@ -625,9 +630,10 @@ class RestTestSetUp {
     , new NodeApi(restExtractorService, restDataSerializer, nodeApiService2, nodeApiService4, nodeApiService6, nodeApiService8, nodeApiService12,  nodeApiService13, null, DeleteMode.Erase)
     , new GroupsApi(mockNodeGroups.groupsRepo, restExtractorService, zioJsonExtractor, uuidGen, groupService2, groupService6, groupService14, groupApiInheritedProperties)
     , new SettingsApi(restExtractorService, settingsService.configService, asyncDeploymentAgent, uuidGen, settingsService.policyServerManagementService, nodeInfo)
+    , archiveAPIModule.api
   )
 
-  val apiVersions = ApiVersion(13 , true) :: ApiVersion(14 , false) :: Nil
+  val apiVersions = ApiVersion(13 , true) :: ApiVersion(14 , false) :: ApiVersion(15 , false) :: Nil
   val (rudderApi, liftRules) = TraitTestApiFromYamlFiles.buildLiftRules(apiModules, apiVersions, Some(userService))
 
   liftRules.statelessDispatch.append(RestStatus)

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
@@ -60,7 +60,7 @@ class TestRestFromFileDef extends TraitTestApiFromYamlFiles with AfterAll {
   val tmpApiTemplate = restTestSetUp.baseTempDirectory / "apiTemplates"
   tmpApiTemplate.createDirectories()
 
-  // nodeXX appears at seleral places
+  // nodeXX appears at several places
 
 
   override def yamlSourceDirectory: String = "api"
@@ -93,8 +93,7 @@ class TestRestFromFileDef extends TraitTestApiFromYamlFiles with AfterAll {
 
   // you can pass a list of file to test exclusively if you don't want to test all .yml
   // files in src/test/resource/${yamlSourceDirectory}
-//  doTest(Nil)
-  doTest("api_groups.yml" :: Nil)
+  doTest(Nil)
 
 }
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
@@ -91,8 +91,10 @@ class TestRestFromFileDef extends TraitTestApiFromYamlFiles with AfterAll {
   org.slf4j.LoggerFactory.getLogger("com.normation.rudder.rest.RestUtils").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.OFF)
 
 
-  doTest()
-
+  // you can pass a list of file to test exclusively if you don't want to test all .yml
+  // files in src/test/resource/${yamlSourceDirectory}
+//  doTest(Nil)
+  doTest("api_groups.yml" :: Nil)
 
 }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1331,7 +1331,7 @@ object RudderConfig extends Loggable {
     ApiVersion(12 , true) :: // rudder 6.0, 6.1
     ApiVersion(13 , true) :: // rudder 6.2
     ApiVersion(14 , false) :: // rudder 7.0
-    ApiVersion(16 , false) :: // rudder 7.2
+    ApiVersion(15 , false) :: // rudder 7.1
     Nil
 
   val jsonPluginDefinition = new ReadPluginPackageInfo("/var/rudder/packages/index.json")
@@ -1359,6 +1359,7 @@ object RudderConfig extends Loggable {
       , new RecentChangesAPI(recentChangesService, restExtractorService)
       , new RulesInternalApi(restExtractorService, ruleInternalApiService)
       , new HookApi(hookApiService)
+      , new ArchiveApi(configService.rudder_featureSwitch_archiveApi())
       // info api must be resolved latter, because else it misses plugin apis !
     )
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -202,12 +202,12 @@ class NodeGroupForm(
       & "group-name" #> groupName.toForm_!
       & "group-rudderid" #> <div class="form-group row">
                       <label class="wbBaseFieldLabel">Rudder ID</label>
-                      <input readonly="" class="form-control" value={nodeGroup.id.value}/>
+                      <input readonly="" class="form-control" value={nodeGroup.id.serialize}/>
                     </div>
       & "group-cfeclasses" #> <div class="form-group row">
                           <label class="wbBaseFieldLabel toggle-cond cond-hidden" onclick="$(this).toggleClass('cond-hidden')"><span class="text-fit">Agent conditions</span><i class="fa fa-chevron-down"></i></label>
-                          <div class="well" id={s"cfe-${nodeGroup.id.value}"}>
-                            {RuleTarget.toCFEngineClassName(nodeGroup.id.value)}<br/>
+                          <div class="well" id={s"cfe-${nodeGroup.id.serialize}"}>
+                            {RuleTarget.toCFEngineClassName(nodeGroup.id.serialize)}<br/>
                             {RuleTarget.toCFEngineClassName(nodeGroup.name)}
                           </div>
                         </div>
@@ -271,7 +271,7 @@ class NodeGroupForm(
   def showGroupProperties(group: NodeGroup): NodeSeq = {
     import com.normation.rudder.AuthorizationType
 
-    val groupId = group.id.value
+    val groupId = group.id.serialize
     val userHasRights = CurrentUser.checkRights(AuthorizationType.Group.Edit)
 
     val intro = (<div class="info">
@@ -398,7 +398,7 @@ class NodeGroupForm(
           case Right(g)  => g._1
           case Left(err) =>
             formTracker.addFormError(Text("Error when saving group"))
-            logger.error(s"Error when looking for group with id '${ng.id.value}': ${err.fullMsg}")
+            logger.error(s"Error when looking for group with id '${ng.id.serialize}': ${err.fullMsg}")
             ng
         }
         if(ng.copy(properties = savedGroup.properties, serverList = savedGroup.serverList) != savedGroup) {
@@ -554,7 +554,7 @@ class NodeGroupForm(
   private[this] def showGroupSection(group: Either[NonGroupRuleTarget, NodeGroup], parentCategoryId: NodeGroupCategoryId) : JsCmd = {
     val js = group match {
       case Left(target) => s"'target':'${target.target}"
-      case Right(g)     => s"'groupId':'${g.id.value}'"
+      case Right(g)     => s"'groupId':'${g.id.serialize}'"
     }
     //update UI
     onSuccessCallback(Left((group, parentCategoryId)))&

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleEditForm.scala
@@ -51,10 +51,13 @@ import com.normation.rudder.web.model.WBTextAreaField
 import com.normation.rudder.web.model.WBTextField
 import com.normation.rudder.web.services.DisplayDirectiveTree
 import com.normation.rudder.web.services.DisplayNodeGroupTree
+
 import bootstrap.liftweb.RudderConfig
 import com.normation.GitVersion
 import com.normation.GitVersion.Revision
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
+
 import net.liftweb.common._
 import net.liftweb.http.DispatchSnippet
 import net.liftweb.http.S
@@ -71,6 +74,7 @@ import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.services.workflows.RuleChangeRequest
 import com.normation.rudder.services.workflows.RuleModAction
 import com.normation.rudder.web.ChooseTemplate
+
 import com.normation.box._
 
 object RuleEditForm {
@@ -254,7 +258,7 @@ class RuleEditForm(
       } yield {
         val checkLinkType =
           if(gt.target.startsWith("group:")){
-            linkUtil.groupLink(NodeGroupId(gt.target.replaceFirst("group:", "")))
+            linkUtil.groupLink(NodeGroupId(NodeGroupUid(gt.target.replaceFirst("group:", ""))))
           }else{
             linkUtil.targetLink(gt)
           }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
@@ -270,7 +270,7 @@ class CreateCategoryOrGroupPopup(
         val query = Some(groupGenerator.flatMap(_.query).getOrElse(NewQuery(NodeReturnType,And,ResultTransformation.Identity,List(defaultLine))))
         val isDynamic = piStatic.get match { case "dynamic" => true ; case _ => false }
         val srvList =  groupGenerator.map(_.serverList).getOrElse(Set[NodeId]())
-        val nodeId = NodeGroupId(uuidGen.newUuid)
+        val nodeId = NodeGroupId(NodeGroupUid(uuidGen.newUuid))
         val nodeGroup = NodeGroup(nodeId,piName.get,piDescription.get, Nil, query,isDynamic,srvList,true)
         woNodeGroupRepository.create(
             nodeGroup
@@ -281,7 +281,7 @@ class CreateCategoryOrGroupPopup(
         ).toBox match {
           case Full(x) =>
             closePopup() &
-            onSuccessCallback(x.group.id.value) & onSuccessGroup(Right(x.group), NodeGroupCategoryId(piContainer.get)) & OnLoad(JsRaw("""$("[href='#groupCriteriaTab']").click();"""))
+            onSuccessCallback(x.group.id.serialize) & onSuccessGroup(Right(x.group), NodeGroupCategoryId(piContainer.get)) & OnLoad(JsRaw("""$("[href='#groupCriteriaTab']").click();"""))
           case Empty =>
             logger.error("An error occurred while saving the group")
             formTracker.addFormError(error("An error occurred while saving the group"))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
@@ -119,7 +119,7 @@ class CreateCloneGroupPopup(
         val parentCategoryId = NodeGroupCategoryId(groupContainer.get)
         val isDynamic = isStatic.get match { case "dynamic" => true ; case _ => false }
         val srvList =  nodeGroup.map(x => x.serverList).getOrElse(Set[NodeId]())
-        val nodeId = NodeGroupId(uuidGen.newUuid)
+        val nodeId = NodeGroupId(NodeGroupUid(uuidGen.newUuid))
         val clone = NodeGroup(
             nodeId
           , groupName.get
@@ -140,7 +140,7 @@ class CreateCloneGroupPopup(
         ).toBox match {
           case Full(x) =>
             closePopup() &
-            onSuccessCallback(x.group.id.value) &
+            onSuccessCallback(x.group.id.serialize) &
             onSuccessGroup(Right(x.group), parentCategoryId)
           case Empty =>
             logger.error("An error occurred while saving the group")

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNodeGroupTree.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNodeGroupTree.scala
@@ -43,6 +43,7 @@ import com.normation.rudder.domain.policies.FullGroupTarget
 import com.normation.rudder.domain.policies.FullRuleTargetInfo
 import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.web.model.JsTreeNode
+
 import net.liftweb.common.Loggable
 import net.liftweb.http.SHtml
 import net.liftweb.http.js._
@@ -50,7 +51,9 @@ import net.liftweb.util.Helpers
 import com.normation.rudder.domain.policies.FullRuleTarget
 import com.normation.rudder.domain.policies.RuleTarget
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.nodes.NodeInfo
+
 import bootstrap.liftweb.RudderConfig
 
 /**
@@ -126,7 +129,7 @@ object DisplayNodeGroupTree extends Loggable {
       val groupId = {
         targetInfo.target match {
           case g:FullGroupTarget =>
-            g.nodeGroup.id.value
+            g.nodeGroup.id.serialize
           case o:FullRuleTarget =>
             o.target.target
         }
@@ -157,7 +160,7 @@ object DisplayNodeGroupTree extends Loggable {
             val tooltipId = Helpers.nextFuncName
             <span class="treeActions">
               <span class="fa fa-pencil" tooltipid={tooltipId} title=""
-                onclick={linkUtil.redirectToGroupLink(NodeGroupId(groupId)).toJsCmd}
+                onclick={linkUtil.redirectToGroupLink(NodeGroupId(NodeGroupUid(groupId))).toJsCmd}
               ></span>
               <div class="tooltipContent" id={tooltipId}><div>Configure this group.</div></div>
             </span>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/SearchNodes.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/SearchNodes.scala
@@ -44,9 +44,12 @@ import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.web.components.SearchNodeComponent
 import com.normation.rudder.web.components.popup.CreateCategoryOrGroupPopup
+
 import bootstrap.liftweb.RudderConfig
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.NonGroupRuleTarget
+
 import net.liftweb.common._
 import net.liftweb.http.LocalSnippet
 import net.liftweb.http.SHtml
@@ -56,6 +59,7 @@ import net.liftweb.http.js.JE.JsRaw
 import net.liftweb.http.js.JE.JsVar
 import net.liftweb.http.js.JsCmd
 import net.liftweb.http.js.JsCmds._
+
 import com.normation.box._
 import com.normation.rudder.domain.queries.NewQuery
 import com.normation.rudder.domain.queries.Query
@@ -126,7 +130,7 @@ class SearchNodes extends StatefulSnippet with Loggable {
       creationPopup.set(Full(new CreateCategoryOrGroupPopup(
           // create a totally invalid group
           Some(new NodeGroup(
-              NodeGroupId("temporary"),
+              NodeGroupId(NodeGroupUid("temporary")),
               null,
               null,
               Nil,

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
@@ -55,6 +55,7 @@ import com.normation.ldap.sdk.LDAPConnectionProvider
 import com.normation.ldap.sdk.RoLDAPConnection
 import com.normation.rudder.configuration.ActiveDirective
 import com.normation.rudder.configuration.ConfigurationRepository
+import com.normation.rudder.configuration.GroupAndCat
 import com.normation.rudder.domain.NodeDit
 
 import org.junit.runner._
@@ -62,6 +63,7 @@ import org.specs2.mutable._
 import org.specs2.runner._
 import com.normation.rudder.domain.RudderDit
 import com.normation.rudder.domain.nodes.Node
+import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.policies.ActiveTechnique
 import com.normation.rudder.domain.policies.ActiveTechniqueCategory
@@ -257,6 +259,7 @@ class TestMigrateSystemTechniques7_0 extends Specification {
     override def getDirectiveLibrary(ids: Set[DirectiveId]): IOResult[FullActiveTechniqueCategory] = ???
     override def getDirectiveRevision(uid: DirectiveUid): IOResult[List[GitVersion.RevisionInfo]] = ???
     override def getRule(id: RuleId): IOResult[Option[Rule]] = ???
+    override def getGroup(id: NodeGroupId): IOResult[Option[GroupAndCat]] = ???
   }
   private[this] lazy val roLdapDirectiveRepository = new RoLDAPDirectiveRepository(
         rudderDit, roLdap, ldapEntityMapper, testEnv.techniqueRepository, uptLibReadWriteMutex

--- a/webapp/sources/utils/src/main/scala/com/normation/ObjectVersionCommons.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/ObjectVersionCommons.scala
@@ -100,7 +100,7 @@ final object GitVersion {
       case id :: Nil        => Right((id, GitVersion.DEFAULT_REV))
       case id :: "" :: Nil  => Right((id, GitVersion.DEFAULT_REV))
       case id :: rev :: Nil => Right((id, Revision(rev)))
-      case _                => Left(s"Error when parsing '${s}' as a directive id. At most one '+' is authorized.")
+      case _                => Left(s"Error when parsing '${s}' as a rudder id. At most one '+' is authorized.")
     }
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/21247

Only the export part in that PR. 
The syntax for the API is: 
```
 Request format:
   ../archives/export/rules=rule_ids&directives=dir_ids&techniques=tech_ids&groups=group_ids&include=scope
 Where:
 - rule_ids = xxxx-xxxx-xxx-xxx[,other ids]
 - dir_ids = xxxx-xxxx-xxx-xxx[,other ids]
 - group_ids = xxxx-xxxx-xxx-xxx[,other ids]
 - tech_ids = techniqueName/1.0[,other tech ids]
- scope = all (default), none, directives, techniques (implies directive), groups
```
Ssytem items are filtered out, it seems that it would cause more pain an complication than the opposite (with in addition the case of special target to handle). 

Interesting parts:

- zip is an horrible format. 
- there is a feature switch to enable the feature in settings (`rudder_featureSwitch_archiveApi=enalbed,disabled`)
- we use item names and not UUID for file names (UUID is still of course in the serialized json), with a simple name mangling that replace non ascii chars to their ascii correspondance (as utf and java intended)
- revision works, you can ask for specific revision of items (but the `+` in url must be encoded as `%2B` because urls)

It needs https://github.com/Normation/rudder/pull/4343 to be merged before it