### PR TITLE
Fixes #21322: Using '{' in node property lead to error

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestDataSerializer.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestDataSerializer.scala
@@ -128,7 +128,7 @@ final case class RestDataSerializerImpl (
 
   def serializeNode(node : Node) : JValue = {
     (   ("id"         -> node.id.value)
-      ~ ("properties" -> node.properties.toApiJson)
+      ~ ("properties" -> node.properties.sortBy(_.name).toApiJson)
       ~ ("policyMode" -> node.policyMode.map(_.name).getOrElse("default"))
       ~ ("state"      -> node.state.name)
     )
@@ -226,7 +226,7 @@ final case class RestDataSerializerImpl (
       ~ ("dynamic"         -> group.isDynamic)
       ~ ("enabled"         -> group.isEnabled )
       ~ ("groupClass"      -> List(group.id.value, group.name).map(RuleTarget.toCFEngineClassName _).sorted)
-      ~ ("properties"      -> group.properties.toApiJson)
+      ~ ("properties"      -> group.properties.sortBy(_.name).toApiJson)
     )
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -694,9 +694,8 @@ final case class RestExtractorService (
         }
         (for {
           _ <- PropertyParser.validPropertyName(nameValue)
-          p <- NodeProperty.parse(nameValue, GenericProperty.serializeJson(value), inheritMode, provider)
         } yield {
-          p
+          NodeProperty(nameValue, GenericProperty.fromJsonValue(value), inheritMode, provider)
         }).toBox
 
       case (a, b)  =>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/NodeDetailLevel.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/NodeDetailLevel.scala
@@ -184,7 +184,7 @@ object NodeDetailLevel {
     val runDate      : INFO => JValue = (info:INFO) => info._2.map(d => JString(serializeDate(info._3, d))).getOrElse(JNothing)
     // this date should have had a timezone in it
     val inventoryDate: INFO => JValue = (info:INFO) => serializeDate(info._3, info._1.inventoryDate)
-    val properties   : INFO => JValue = (info:INFO) => info._1.properties.toApiJson
+    val properties   : INFO => JValue = (info:INFO) => info._1.properties.sortBy(_.name).toApiJson
     val policyMode   : INFO => JValue = (info:INFO) => info._1.policyMode.map(_.name).getOrElse[String]("default")
     val timezone     : INFO => JValue = (info:INFO) => info._1.timezone.map( t => ("name" -> t.name) ~ ("offset" -> t.offset) )
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -74,6 +74,7 @@ import com.normation.rudder.services.servers.NewNodeManager
 import com.normation.rudder.services.servers.RemoveNodeService
 import com.normation.utils.Control._
 import com.normation.utils.StringUuidGenerator
+
 import net.liftweb.common.Box
 import net.liftweb.common.EmptyBox
 import net.liftweb.common.Failure
@@ -90,6 +91,7 @@ import net.liftweb.json.JsonDSL.string2jvalue
 import scalaj.http.Http
 import scalaj.http.HttpOptions
 import com.normation.rudder.domain.nodes.NodeProperty
+
 import com.normation.box._
 import com.normation.zio._
 import com.normation.errors._
@@ -114,6 +116,7 @@ import com.normation.rudder.services.nodes.MergeNodeProperties
 import com.normation.rudder.services.servers.DeleteMode
 import com.normation.rudder.services.reports.ReportingService
 import com.normation.utils.DateFormaterService
+
 import net.liftweb.http.JsonResponse
 import net.liftweb.http.js.JsExp
 import net.liftweb.json.JsonAST.JDouble
@@ -121,6 +124,7 @@ import net.liftweb.json.JsonAST.JField
 import net.liftweb.json.JsonAST.JInt
 import net.liftweb.json.JsonAST.JObject
 import net.liftweb.json.JsonAST.JString
+
 import zio.ZIO
 import zio.duration._
 
@@ -254,7 +258,8 @@ class NodeApi (
 
       (for {
         restNode <- if(req.json_?) {
-                      req.json.flatMap(body => restExtractor.extractNodeFromJSON(body))
+                      req.json.flatMap{ body =>
+                        restExtractor.extractNodeFromJSON(body)}
                     } else {
                       restExtractor.extractNode(req.params)
                     }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes_properties.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes_properties.yml
@@ -1,0 +1,132 @@
+---
+description: Get node (minimal)
+method: GET
+url: /api/latest/nodes/node1?include=minimal,properties
+response:
+  code: 200
+  content: >-
+    {
+      "action":"nodeDetails",
+      "id":"node1",
+      "result":"success",
+      "data":{
+        "nodes":[
+          {
+            "id":"node1",
+            "hostname":"node1.localhost",
+            "status":"accepted",
+            "properties":[]
+          }
+        ]
+      }
+    }
+---
+description: Add Json property
+method: POST
+url: /api/latest/nodes/node1
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "properties": [
+      { "name":"jsonArray"            , "value": [ "one", 2, true]   },
+      { "name":"jsonProp"             , "value": {"jsonObject":"ok"} },
+      { "name":"stringArray"          , "value": "[array]"           },
+      { "name":"stringNonMatching"    , "value": "{paren]"           },
+      { "name":"stringParen"          , "value": "{paren}"           },
+      { "name":"stringParenEscaped2"  , "value": "\\{paren\\}"       },
+      { "name":"stringParenIncomplete", "value": "{paren"            },
+      { "name":"stringQuoted"         , "value": "\"quotedString\""  },
+      { "name":"stringSimple"         , "value": "simple string"     }
+    ]
+  }
+response:
+  code: 200
+  note: >-
+    One backslash has not a very defined behavior in front of anything but " and \. The rule: if you want a \, you escape it.
+  content: >-
+    {
+      "action":"updateNode",
+      "id":"node1",
+      "result":"success",
+      "data":{
+        "id":"node1",
+        "properties":[
+          { "name":"jsonArray"            , "value": [ "one", 2, true]   },
+          { "name":"jsonProp"             , "value": {"jsonObject":"ok"} },
+          { "name":"stringArray"          , "value": "[array]"           },
+          { "name":"stringNonMatching"    , "value": "{paren]"           },
+          { "name":"stringParen"          , "value": "{paren}"           },
+          { "name":"stringParenEscaped2"  , "value": "\\{paren\\}"       },
+          { "name":"stringParenIncomplete", "value": "{paren"            },
+          { "name":"stringQuoted"         , "value": "\"quotedString\""  },
+          { "name":"stringSimple"         , "value": "simple string"     }
+        ],
+        "policyMode":"default","state":"enabled"
+      }
+    }
+---
+description: Get node (minimal)
+method: GET
+url: /api/latest/nodes/node1?include=minimal,properties
+response:
+  code: 200
+  content: >-
+    {
+      "action":"nodeDetails",
+      "id":"node1",
+      "result":"success",
+      "data":{
+        "nodes":[
+          {
+            "id":"node1",
+            "hostname":"node1.localhost",
+            "status":"accepted",
+            "properties":[
+              { "name":"jsonArray"            , "value": [ "one", 2, true]   },
+              { "name":"jsonProp"             , "value": {"jsonObject":"ok"} },
+              { "name":"stringArray"          , "value": "[array]"           },
+              { "name":"stringNonMatching"    , "value": "{paren]"           },
+              { "name":"stringParen"          , "value": "{paren}"           },
+              { "name":"stringParenEscaped2"  , "value": "\\{paren\\}"       },
+              { "name":"stringParenIncomplete", "value": "{paren"            },
+              { "name":"stringQuoted"         , "value": "\"quotedString\""  },
+              { "name":"stringSimple"         , "value": "simple string"     }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Delete Json property
+method: POST
+url: /api/latest/nodes/node1
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "properties": [
+          { "name":"jsonArray"            , "value": "" },
+          { "name":"jsonProp"             , "value": "" },
+          { "name":"stringArray"          , "value": "" },
+          { "name":"stringNonMatching"    , "value": "" },
+          { "name":"stringParen"          , "value": "" },
+          { "name":"stringParenEscaped2"  , "value": "" },
+          { "name":"stringParenIncomplete", "value": "" },
+          { "name":"stringQuoted"         , "value": "" },
+          { "name":"stringSimple"         , "value": "" }
+    ]
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action":"updateNode",
+      "id":"node1",
+      "result":"success",
+      "data":{
+        "id":"node1",
+        "properties":[],
+        "policyMode":"default","state":"enabled"
+      }
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -1373,7 +1373,7 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
 
   val allNodesInfo = Map( rootId -> root, node1.id -> node1, node2.id -> node2)
   // both nodeInfoService and repo, since we deal with the same underlying node objects
-  object nodeInfoService extends NodeInfoService with LDAPFullInventoryRepository {
+  object nodeInfoService extends NodeInfoService with LDAPFullInventoryRepository with WoNodeRepository {
 
     // node status is in inventory.main.
     val nodeBase = RefM.make(Map(
@@ -1432,6 +1432,24 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     override def delete(id: NodeId, inventoryStatus: InventoryStatus): IOResult[Seq[LDIFChangeRecord]] = ???
     override def move(id: NodeId, from: InventoryStatus, into: InventoryStatus): IOResult[Seq[LDIFChangeRecord]] = ???
     override def moveNode(id: NodeId, from: InventoryStatus, into: InventoryStatus): IOResult[Seq[LDIFChangeRecord]] = ???
+
+    override def updateNode(node: Node, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Node] = {
+      nodeBase.modify { nodes =>
+        nodes.get(node.id) match {
+          case None    => Inconsistency(s"Node ${node.id.value} does not exists").fail
+          case Some(n) =>
+            import com.softwaremill.quicklens._
+            val newN = n.modify(_.info.node).setTo(node)
+            (node, (nodes + ((node.id, newN)))).succeed
+        }
+      }
+    }
+
+    override def createNode(node: Node, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Node] = ???
+
+    override def deleteNode(node: Node, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Node] = ???
+
+    override def updateNodeKeyInfo(nodeId: NodeId, agentKey: Option[SecurityToken], agentKeyStatus: Option[KeyStatus], modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Unit] = ???
   }
 
   val defaultModesConfig = NodeModeConfig(

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -508,7 +508,7 @@ object RestTestSetUp {
   val nodeApiService2  = new NodeApiService2(null, nodeInfo, null, uuidGen, restExtractorService, restDataSerializer)
   val nodeApiService4  = new NodeApiService4(nodeInfo, nodeInfo, softDao, uuidGen, restExtractorService, restDataSerializer, roReportsExecutionRepository)
   val nodeApiService6  = new NodeApiService6(nodeInfo, nodeInfo, softDao, restExtractorService, restDataSerializer, mockNodes.queryProcessor, null, roReportsExecutionRepository)
-  val nodeApiService8  = new NodeApiService8(null, nodeInfo, uuidGen, asyncDeploymentAgent, "relay", null)
+  val nodeApiService8  = new NodeApiService8(nodeInfo, nodeInfo, uuidGen, asyncDeploymentAgent, "relay", userService)
   val nodeApiService12 = new NodeApiService12(null, uuidGen, restDataSerializer)
   val nodeApiService13 = new NodeApiService13(nodeInfo, roReportsExecutionRepository, softDao,restExtractorService, () => Full(GlobalPolicyMode(Audit, PolicyModeOverrides.Always)),null, null, null )
 


### PR DESCRIPTION
https://issues.rudder.io/issues/21322

Sorting properties in returned JSON request is to ease tests and be consistent with what we do in 7.0 and latter.

The real change is just not serializing then parsing again the property when it's already a JValue.

Other changes are just for test infra.