### PR TITLE
Fixes #21321: Add API endpoint to import an archive of rules/etc

### DIFF
--- a/webapp/sources/api-doc/components/schemas/settings.yml
+++ b/webapp/sources/api-doc/components/schemas/settings.yml
@@ -164,14 +164,6 @@ settings:
       type: boolean
       default: true
       description: Recompute all dynamic groups at the start of policy generation
-    rudder_generation_rudderc_enabled_targets:
-      type: array
-      items:
-        type: string
-        enum:
-          - cfengine
-          - dsc
-      description: target agent languages for which rudderc will be tried first (with fallback to old generation method on error). Other targets will use fallback directly.
     rudder_compute_dyngroups_max_parallelism:
       type: string
       default: "1"

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/Technique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/Technique.scala
@@ -45,7 +45,7 @@ import com.normation.inventory.domain.AgentType
  * A name, used as an identifier, for a policy.
  * The name must be unique among all policies!
  *
- * TODO : check case sensivity and allowed chars.
+ * TODO : check case sensitivity and allowed chars.
  *
  */
 final case class TechniqueName(value: String) extends AnyVal with Ordered[TechniqueName] {
@@ -63,7 +63,7 @@ final case class TechniqueName(value: String) extends AnyVal with Ordered[Techni
  * among all policies, and a version for that policy.
  */
 final case class TechniqueId(name: TechniqueName, version: TechniqueVersion) extends Ordered[TechniqueId] {
-  // intented for debug/log, not serialization
+  // intended for debug/log, not serialization
   def debugString = serialize
   // a technique
   def serialize = name.value + "/" + version.serialize
@@ -79,6 +79,17 @@ final case class TechniqueId(name: TechniqueName, version: TechniqueVersion) ext
   @silent("method toString overrides concrete, non-deprecated symbol")
   @deprecated(s"Please use `debugString` or `serialize` in place of toString()", "7.0")
   override def toString: String = serialize
+}
+
+object TechniqueId {
+  def parse(s: String): Either[String, TechniqueId] = {
+    s.split("/").toList match {
+      case n :: v :: Nil =>
+        TechniqueVersion.parse(v).map(x => TechniqueId(TechniqueName(n), x))
+      case _ =>
+        Left(s"Error when parsing '${s}' as a technique id. It should have format 'techniqueName/version+rev' (with +rev optional)")
+    }
+  }
 }
 
 object RunHook {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/TechniqueRepository.scala
@@ -134,4 +134,5 @@ trait TechniqueRepository {
   }
 
   def getAllCategories: Map[TechniqueCategoryId, TechniqueCategory]
+
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
@@ -385,15 +385,12 @@ class GitTechniqueReader(
       }
     }
 
-    //has package id are unique among the whole tree, we are able to find a
-    //template only base on the techniqueId + name.
+    // since package id are unique among the whole tree, we are able to find a
+    // template only base on the techniqueId + name.
 
     val managed = Managed.make(
       for {
-        currentId <- rev match {
-                       case GitVersion.DEFAULT_REV => revisionProvider.currentRevTreeId
-                       case r                      => GitFindUtils.findRevTreeFromRevString(repo.db, r.value)
-                     }
+        currentId <- GitFindUtils.findRevTreeFromRevision(repo.db, rev, revisionProvider.currentRevTreeId)
         optStream <- IOResult.effect {
                        try {
                          //now, the treeWalk
@@ -505,7 +502,7 @@ class GitTechniqueReader(
       //ok, return the result in its immutable format
       TechniquesInfo(
           rootCategory       = techniqueInfos.rootCategory.get
-        , gitRev           = id.name()
+        , gitRev             = id.name()
         , techniquesCategory = techniqueInfos.techniquesCategory.toMap
         , techniques         = techniqueInfos.techniques.map { case(k,v) => (k, SortedMap.empty[TechniqueVersion,Technique] ++ v)}.toMap
         , subCategories      = Map[SubTechniqueCategoryId, SubTechniqueCategory]() ++ techniqueInfos.subCategories

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/eventlog/EventLog.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/eventlog/EventLog.scala
@@ -20,11 +20,33 @@
 
 package com.normation.eventlog
 
+import com.normation.utils.StringUuidGeneratorImpl
+
 import org.joda.time.DateTime
+
 import scala.xml._
 
 
 final case class EventActor(name:String) extends AnyVal
+
+/*
+ * Some data to hold common information about an event, and that will likely be used
+ * in (git) commit.
+ */
+final case class EventMetadata(
+    modId: ModificationId
+  , actor: EventActor
+  , msg  : Option[String]
+)
+
+object EventMetadata {
+  // this mainly use here. It removes the possibility to switch easily implementation,
+  // but it was never used in 10 y of rudder
+  val uuidGen = new StringUuidGeneratorImpl()
+  def withNewId(actor: EventActor, msg: Option[String] = None) = {
+    EventMetadata(ModificationId(uuidGen.newUuid), actor, msg)
+  }
+}
 
 /**
  * A type that describe on what category an event belongs to.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/eventlog/Modification.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/eventlog/Modification.scala
@@ -51,4 +51,6 @@ final case class ModificationId(value:String) extends AnyVal
 
 object ModificationId {
   val dummy = ModificationId("dummy-modification-id")
+
+
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -365,10 +365,7 @@ trait RudderJsonDecoders {
 
   // tags
   implicit val tagsDecoder: JsonDecoder[Tags] = JsonDecoder[List[Map[String, String]]].map { list =>
-    val res = list.flatMap { _.map {
-      case (k, v) => com.normation.rudder.domain.policies.Tag(TagName(k), TagValue(v))
-    } }
-    Tags(res.toSet)
+    Tags.fromMaps(list)
   }
   // PolicyMode
   implicit val policyModeDecoder: JsonDecoder[Option[PolicyMode]] = JsonDecoder[Option[String]].mapOrFail(opt => opt match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -37,18 +37,24 @@
 
 package com.normation.rudder.apidata
 
+import com.normation.GitVersion
 import com.normation.GitVersion.RevisionInfo
 import com.normation.rudder.apidata.JsonResponseObjects.JRPropertyHierarchy.JRPropertyHierarchyHtml
 import com.normation.rudder.apidata.JsonResponseObjects.JRPropertyHierarchy.JRPropertyHierarchyJson
 import com.normation.cfclerk.domain.Technique
+import com.normation.cfclerk.domain.TechniqueName
+import com.normation.cfclerk.domain.TechniqueVersion
+import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.policies._
 import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.rudder.rule.category.RuleCategory
+
 import zio.json.DeriveJsonEncoder
 import zio.json._
 import zio.json.internal.Write
 import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.repository.FullActiveTechnique
+
 import com.typesafe.config.ConfigRenderOptions
 import com.typesafe.config.ConfigValue
 import com.normation.rudder.domain.nodes.NodeGroup
@@ -61,6 +67,7 @@ import com.normation.rudder.domain.properties.NodePropertyHierarchy
 import com.normation.rudder.domain.properties.ParentProperty
 import com.normation.rudder.domain.properties.PropertyProvider
 import com.normation.rudder.domain.queries.CriterionLine
+import com.normation.rudder.domain.queries.QueryReturnType
 import com.normation.rudder.domain.queries.QueryTrait
 import com.normation.rudder.domain.queries.ResultTransformation
 import com.normation.rudder.ncf.BundleName
@@ -73,9 +80,18 @@ import com.normation.rudder.ncf.ResourceFile
 import com.normation.rudder.ncf.TechniqueParameter
 import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.utils.DateFormaterService
+
 import com.softwaremill.quicklens._
 import io.scalaland.chimney.dsl._
 import com.normation.rudder.hooks.Hooks
+import com.normation.rudder.rule.category.RuleCategoryId
+import com.normation.rudder.services.queries.CmdbQueryParser
+import com.normation.rudder.services.queries.StringCriterionLine
+import com.normation.rudder.services.queries.StringQuery
+
+import com.normation.errors._
+import zio.{Tag => _, _}
+import zio.syntax._
 
 /*
  * This class deals with everything serialisation related for API.
@@ -146,9 +162,29 @@ object JsonResponseObjects {
       // we have one more "section" indirection level between a section and its details:
       // { sections":[ { "section":{ "name": .... } }, { "section": { ... }} ]
     , sections: Option[List[Map[String, JRDirectiveSection]]]
-  )
+  ) {
+
+    // toMapVariable is just accumulating var by name in seq, see SectionVal.toMapVariables
+    def toMapVariables: Map[String,Seq[String]] = {
+      import scala.collection.mutable.{Map, Buffer}
+      val res = Map[String, Buffer[String]]()
+
+      def recToMap(sec : JRDirectiveSection) : Unit = {
+        sec.vars.foreach(_.foreach( _.foreach { case (_, sectionVar) =>
+          res.getOrElseUpdate(sectionVar.name, Buffer()).append(sectionVar.value)
+        }))
+        sec.sections.foreach(_.foreach(_.foreach { case (_, section) =>
+          recToMap( section )
+        }))
+      }
+      recToMap(this)
+      res.map { case (k,buf) => (k,buf.toSeq) }.toMap
+    }
+  }
+
+
   // we have one more level between a directive section and a section
-  final case class JRDirectiveSerctionHolder(
+  final case class JRDirectiveSectionHolder(
     section: JRDirectiveSection
   )
 
@@ -305,7 +341,33 @@ object JsonResponseObjects {
     , system           : Boolean
     , policyMode       : String
     , tags             : List[Map[String, String]]
-  )
+  ) {
+    def toDirective(): IOResult[(TechniqueName, Directive)] = {
+      for {
+        i <- DirectiveId.parse(id).toIO
+        v <- TechniqueVersion.parse(techniqueVersion).toIO
+          // the Map is just for "section" -> ...
+        s <- parameters.get("section").notOptional("Root section entry 'section' is missing for directive parameters")
+        m <- PolicyMode.parseDefault(policyMode).toIO
+      } yield {
+        ( TechniqueName(techniqueName)
+        , Directive(
+              i
+            , v
+            , s.toMapVariables
+            , displayName
+            , shortDescription
+            , m
+            , longDescription
+            , priority
+            , enabled
+            , system
+            , Tags.fromMaps(tags)
+          )
+        )
+      }
+    }
+  }
 
   object JRTechnique {
     def fromTechnique(technique : Technique, optEditorInfo : Option[EditorTechnique], methods: Map[BundleName, GenericMethod]) : JRTechnique = (
@@ -404,7 +466,25 @@ object JsonResponseObjects {
     , tags            : List[Map[String, String]]
     , policyMode      : Option[String]
     , status          : Option[JRApplicationStatus]
-  )
+  ) {
+    def toRule(): IOResult[Rule] = {
+      for {
+        i <- RuleId.parse(id).toIO
+        d <- ZIO.foreach(directives)(DirectiveId.parse(_).toIO)
+      } yield Rule(
+          i
+        , displayName
+        , RuleCategoryId(categoryId)
+        , targets.map(_.toRuleTarget).toSet
+        , d.toSet
+        , shortDescription
+        , longDescription
+        , enabled
+        , system
+        , Tags.fromMaps(tags)
+      )
+    }
+  }
 
   object JRRule {
     // create an empty json rule with just ID set
@@ -620,7 +700,9 @@ object JsonResponseObjects {
     , attribute : String
     , comparator: String
     , value     : String
-  )
+  ) {
+    def toStringCriterionLine = StringCriterionLine(objectType, attribute, comparator, Some(value))
+  }
 
   object JRCriterium {
     def fromCriterium(c: CriterionLine) = {
@@ -667,7 +749,37 @@ object JsonResponseObjects {
     , properties      : List[JRProperty]
     , target          : String
     , system          : Boolean
-  )
+  ) {
+    def toGroup(queryParser: CmdbQueryParser): IOResult[(NodeGroupCategoryId, NodeGroup)] = {
+      for {
+        i <- NodeGroupId.parse(id).toIO
+        q <- query match {
+               case None    => None.succeed
+               case Some(q) =>
+                 for {
+                   t <- QueryReturnType(q.select).toIO
+                   x <- queryParser.parse(StringQuery(t, Some(q.composition), q.transform, q.where.map(_.toStringCriterionLine) )).toIO
+                 } yield Some(x)
+             }
+      } yield {
+        ( NodeGroupCategoryId(category)
+        , NodeGroup(
+              i
+            , displayName
+            , description
+            , properties.map(p => GroupProperty(p.name, GitVersion.DEFAULT_REV, p.value, p.inheritMode, p.provider))
+            , q
+            , dynamic
+            , nodeIds.map(NodeId(_)).toSet
+            , enabled
+            , system
+          )
+        )
+      }
+    }
+  }
+
+
   object JRGroup {
     def empty(id: String) = JRGroup(None, id, "", "", "", None, Nil, false, false, Nil, Nil, "", false)
 
@@ -756,7 +868,7 @@ trait RudderJsonEncoders {
   implicit val rulesEncoder: JsonEncoder[JRRules] = DeriveJsonEncoder.gen
 
   implicit val directiveSectionVarEncoder: JsonEncoder[JRDirectiveSectionVar] = DeriveJsonEncoder.gen
-  implicit lazy val directiveSectionHolderEncoder: JsonEncoder[JRDirectiveSerctionHolder] = DeriveJsonEncoder.gen
+  implicit lazy val directiveSectionHolderEncoder: JsonEncoder[JRDirectiveSectionHolder] = DeriveJsonEncoder.gen
   implicit lazy val directiveSectionEncoder: JsonEncoder[JRDirectiveSection] = DeriveJsonEncoder.gen
   implicit val directiveEncoder: JsonEncoder[JRDirective] = DeriveJsonEncoder.gen
   implicit val directivesEncoder: JsonEncoder[JRDirectives] = DeriveJsonEncoder.gen
@@ -818,3 +930,28 @@ trait RudderJsonEncoders {
   implicit val revisionInfoEncoder: JsonEncoder[JRRevisionInfo] = DeriveJsonEncoder.gen
 }
 
+
+/*
+ * Decoders for JsonResponse object, when you need to read back something that they serialized.
+ */
+object JsonResponseObjectDecodes extends RudderJsonDecoders {
+  import JsonResponseObjects._
+
+  implicit lazy val decodeJRParentProperty: JsonDecoder[JRParentProperty] = DeriveJsonDecoder.gen
+  implicit lazy val decodeJRPropertyHierarchy: JsonDecoder[JRPropertyHierarchy] = DeriveJsonDecoder.gen
+  implicit lazy val decodePropertyProvider: JsonDecoder[PropertyProvider] = JsonDecoder.string.map(s =>
+    PropertyProvider(s)
+  )
+  implicit lazy val decodeJRProperty: JsonDecoder[JRProperty] = DeriveJsonDecoder.gen
+
+  implicit lazy val decodeJRCriterium: JsonDecoder[JRCriterium] = DeriveJsonDecoder.gen
+  implicit lazy val decodeJRDirectiveSectionVar: JsonDecoder[JRDirectiveSectionVar] = DeriveJsonDecoder.gen
+
+  implicit lazy val decodeJRApplicationStatus: JsonDecoder[JRApplicationStatus] = DeriveJsonDecoder.gen
+  implicit lazy val decodeJRQuery: JsonDecoder[JRQuery] = DeriveJsonDecoder.gen
+  implicit lazy val decodeJRDirectiveSection: JsonDecoder[JRDirectiveSection] = DeriveJsonDecoder.gen
+  implicit lazy val decodeJRRule: JsonDecoder[JRRule] = DeriveJsonDecoder.gen
+  implicit lazy val decodeJRGroup: JsonDecoder[JRGroup] = DeriveJsonDecoder.gen
+  implicit lazy val decodeJRDirective: JsonDecoder[JRDirective] = DeriveJsonDecoder.gen
+
+}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/configuration/ConfigurationRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/configuration/ConfigurationRepository.scala
@@ -41,8 +41,13 @@ import com.normation.GitVersion
 import com.normation.GitVersion.Revision
 import com.normation.GitVersion.RevisionInfo
 import com.normation.cfclerk.domain.Technique
+import com.normation.cfclerk.domain.TechniqueCategoryName
 import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.services.TechniqueRepository
+import com.normation.rudder.domain.nodes.NodeGroup
+import com.normation.rudder.domain.nodes.NodeGroupCategoryId
+import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
 
 import com.normation.errors.IOResult
 import com.normation.rudder.domain.policies.ActiveTechnique
@@ -54,6 +59,7 @@ import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.rudder.repository.RoDirectiveRepository
+import com.normation.rudder.repository.RoNodeGroupRepository
 import com.normation.rudder.repository.RoRuleRepository
 import com.normation.rudder.repository.xml.TechniqueRevisionRepository
 
@@ -64,6 +70,7 @@ import zio.syntax._
  * Easier te manage data
  */
 final case class ActiveDirective(activeTechnique: ActiveTechnique, directive: Directive)
+final case class GroupAndCat(group: NodeGroup, categoryId: NodeGroupCategoryId)
 
 /*
  * This class is in charge of loading and updating configuration objects in rudder.
@@ -81,8 +88,9 @@ trait RoConfigurationRepository {
    * Get a directive and its matching active technique for the given (id, version)
    */
   def getDirective(id: DirectiveId): IOResult[Option[ActiveDirective]]
-  def getTechnique(id: TechniqueId): IOResult[Option[Technique]]
+  def getTechnique(id: TechniqueId): IOResult[Option[(Chunk[TechniqueCategoryName], Technique)]]
   def getRule(id: RuleId): IOResult[Option[Rule]]
+  def getGroup(id: NodeGroupId): IOResult[Option[GroupAndCat]]
 
   def getDirectiveLibrary(ids: Set[DirectiveId]): IOResult[FullActiveTechniqueCategory]
 
@@ -104,15 +112,21 @@ trait RuleRevisionRepository {
   def getRuleRevision(uid: RuleUid, rev: Revision): IOResult[Option[Rule]]
 }
 
+trait GroupRevisionRepository {
+  def getGroupRevision(uid: NodeGroupUid, rev: Revision): IOResult[Option[GroupAndCat]]
+}
+
 /****************************************************************************************/
 
 class ConfigurationRepositoryImpl(
     roDirectiveRepository: RoDirectiveRepository
   , techniqueRepository  : TechniqueRepository
   , roRuleRepository     : RoRuleRepository
+  , roNodeGroupRepository: RoNodeGroupRepository
   , directiveRevisionRepo: DirectiveRevisionRepository
   , techniqueRevisionRepo: TechniqueRevisionRepository
   , ruleRevisionRepo     : RuleRevisionRepository
+  , groupRevisionRepo    : GroupRevisionRepository
 ) extends ConfigurationRepository {
 
   override def getDirective(id: DirectiveId): IOResult[Option[ActiveDirective]] = {
@@ -124,15 +138,17 @@ class ConfigurationRepositoryImpl(
     }).map( _.map{ case (at, d) => ActiveDirective(at, d)} )
   }
 
-  override def getTechnique(id: TechniqueId): IOResult[Option[Technique]] = {
+  override def getTechnique(id: TechniqueId): IOResult[Option[(Chunk[TechniqueCategoryName], Technique)]] = {
     id.version.rev match {
       case GitVersion.DEFAULT_REV =>
-        techniqueRepository.get(id).succeed
+        techniqueRepository.get(id) match {
+          case None    => None.succeed
+          case Some(t) => techniqueRepository.getTechniqueCategoriesBreadCrump(id).map(c => Some((Chunk.fromIterable(c.map(_.id.name)), t)))
+        }
       case r                      =>
         techniqueRevisionRepo.getTechnique(id.name, id.version.version, r)
     }
   }
-
 
   override def getRule(id: RuleId): IOResult[Option[Rule]] = {
     id.rev match {
@@ -140,6 +156,15 @@ class ConfigurationRepositoryImpl(
         roRuleRepository.getOpt(id)
       case r                      =>
         ruleRevisionRepo.getRuleRevision(id.uid, id.rev)
+    }
+  }
+
+  override def getGroup(id: NodeGroupId): IOResult[Option[GroupAndCat]] = {
+    id.rev match {
+      case GitVersion.DEFAULT_REV =>
+        roNodeGroupRepository.getNodeGroupOpt(id).map(_.map { case (g, c) => GroupAndCat(g, c)})
+      case r                      =>
+        groupRevisionRepo.getGroupRevision(id.uid, id.rev)
     }
   }
 
@@ -158,7 +183,8 @@ class ConfigurationRepositoryImpl(
       // now that we have all (and only) relevant techniques, find the one with version and retrieve them
       vTechIds  =  lib.allDirectives.collect { case (_, (fat, d)) if(nonDefaultRev(d.techniqueVersion.rev)) => TechniqueId(fat.techniqueName, d.techniqueVersion)}
       optTechs  <- ZIO.foreach(vTechIds)(getTechnique) // TODO: find a way to do that without N git treewalks
-      fullLib   =  lib.addTechniques(optTechs.flatten.toList)
+      // assume techniques don't change categories
+      fullLib   =  lib.addTechniques(optTechs.flatMap(_.map(_._2)).toList)
     } yield {
       fullLib
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
@@ -50,7 +50,14 @@ object ApplicationLogger extends Logger {
 
 object ApplicationLoggerPure extends NamedZioLogger {
   def loggerName = "application"
+
+  object Archive extends NamedZioLogger {
+    def loggerName = "application.archive"
+  }
+
 }
+
+
 
 object ApiLogger extends Logger {
   override protected def _logger = LoggerFactory.getLogger("api")
@@ -84,7 +91,7 @@ object ScheduledJobLoggerPure extends NamedZioLogger {
 }
 
 /**
- * A logger for new nodes informations
+ * A logger for new nodes information
  */
 object NodeLogger extends Logger {
   override protected def _logger = LoggerFactory.getLogger("nodes")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
@@ -208,6 +208,19 @@ final case class TargetExclusion(
 
 object RuleTarget extends Loggable {
 
+  // get only the node group from these target. Include all node group, be it
+  // included or excluded.
+  // All special target are ignored
+  def getNodeGroupIds(targets: Set[RuleTarget]): Chunk[NodeGroupId] = {
+    targets.foldLeft(Chunk[NodeGroupId]()) { case (groups , target) => target match {
+      case GroupTarget(groupId)        => groups :+ groupId
+      case TargetIntersection(targets) => groups ++ getNodeGroupIds(targets)
+      case TargetUnion(targets)        => groups ++ getNodeGroupIds(targets)
+      case TargetExclusion(x,y)        => groups ++ getNodeGroupIds(Set(x)) ++ getNodeGroupIds(Set(y))
+      case _                           => groups
+    } }
+  }
+
   /**
    * Return all node ids that match the set of target.
    * allNodes pair is: (nodeid, isPolicyServer)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Tags.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Tags.scala
@@ -63,6 +63,14 @@ final case class Tags(tags : Set[Tag]) extends AnyVal {
   }
 }
 
+object Tags {
+  // get tags from a list of key/value embodied by a Map with one elements (but
+  // also works with several elements in map)
+  def fromMaps(tags: List[Map[String, String]]) = {
+    Tags(tags.flatMap(_.map { case (k, v) => Tag(TagName(k), TagValue(v))}).toSet)
+  }
+}
+
 object JsonTagSerialisation {
 
   import net.liftweb.json._

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechnique.scala
@@ -93,6 +93,8 @@ object  ResourceFileState {
   }
 }
 
+// a resource file for technique. Be careful, sometime path is given relative to technique (should be always that)
+// be sometime relative to a sub-directory named "resources"
 case class ResourceFile(
     path  : String
   , state : ResourceFileState

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
@@ -39,10 +39,14 @@ package com.normation.rudder.repository.xml
 
 import com.normation.NamedZioLogger
 import com.normation.cfclerk.domain.SectionSpec
+import com.normation.cfclerk.domain.Technique
 import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.services.TechniqueRepository
+import com.normation.cfclerk.xmlparsers.TechniqueParser
+import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
+import com.normation.inventory.domain.AgentType
 import com.normation.rudder.domain.Constants.CONFIGURATION_RULES_ARCHIVE_TAG
 import com.normation.rudder.domain.Constants.GROUPS_ARCHIVE_TAG
 import com.normation.rudder.domain.Constants.PARAMETERS_ARCHIVE_TAG
@@ -58,8 +62,11 @@ import com.normation.rudder.git.GitArchiverFullCommitUtils
 import com.normation.rudder.git.GitConfigItemRepository
 import com.normation.rudder.git.GitPath
 import com.normation.rudder.git.GitRepositoryProvider
+import com.normation.rudder.ncf.ResourceFile
+import com.normation.rudder.ncf.ResourceFileState
 import com.normation.rudder.repository._
 import com.normation.rudder.services.marshalling._
+import com.normation.rudder.services.user.PersonIdentService
 
 import net.liftweb.common._
 import org.apache.commons.io.FileUtils
@@ -67,6 +74,8 @@ import org.eclipse.jgit.lib.PersonIdent
 
 import java.io.File
 import scala.collection.mutable.Buffer
+import scala.xml.Source
+import scala.xml.XML
 
 import zio._
 import zio.syntax._
@@ -169,9 +178,126 @@ trait BuildCategoryPathName[T] {
 }
 
 
+///////////////////////////////////////////////////////////////
+//////  Archive techniques (techniques, resources files  //////
+///////////////////////////////////////////////////////////////
+
+/*
+ * There is a low level API that works at "metadata.xml and files" level and only checks things like metadata.xml ok, overwriting ok,
+ * unicity, resources presents, agent file presents, etc
+ *
+ * This service is also in charge of low-level git related actions: delete files, commit, etc.
+ */
+trait TechniqueArchiver {
+  def deleteTechnique(techniqueId: TechniqueId, categories: Seq[String], modId: ModificationId, committer:  EventActor, msg: String) : IOResult[Unit]
+  def saveTechnique(techniqueId: TechniqueId, categories: Seq[String], resourcesStatus: Chunk[ResourceFile], modId: ModificationId, committer:  EventActor, msg: String) : IOResult[Unit]
+}
+
+/*
+ * List of files to add/delete in the commit.
+ * All path are given relative to git root, ie they can be used in
+ * a git command as they are.
+ */
+final case class TechniqueFilesToCommit(
+    add   : Chunk[String]
+  , delete: Chunk[String]
+)
+
+class TechniqueArchiverImpl (
+    override val gitRepo                   : GitRepositoryProvider
+  , override val xmlPrettyPrinter          : RudderPrettyPrinter
+  , override val gitModificationRepository : GitModificationRepository
+  , personIdentservice                     : PersonIdentService
+  , techniqueParser                        : TechniqueParser
+  , override val groupOwner                : String
+) extends GitConfigItemRepository with XmlArchiverUtils with TechniqueArchiver {
+
+  override val encoding : String = "UTF-8"
+
+  // we can't use "techniques" for relative path because of ncf and dsc files. This is an architecture smell, we need to clean it.
+  override val relativePath = "techniques"
+
+  def deleteTechnique(techniqueId: TechniqueId, categories: Seq[String],  modId: ModificationId, committer:  EventActor, msg: String) : IOResult[Unit] = {
+    (for {
+      ident   <- personIdentservice.getPersonIdentOrDefault(committer.name)
+      // construct the path to the technique. Root category is "/", so we filter out all / to be sure
+      categoryPath <- categories.filter(_ != "/").mkString("/").succeed
+      rm      <- IOResult.effect(gitRepo.git.rm.addFilepattern(s"${relativePath}/${categoryPath}/${techniqueId.serialize}").call())
+
+      commit  <- IOResult.effect(gitRepo.git.commit.setCommitter(ident).setMessage(msg).call())
+    } yield {
+      s"${relativePath}/${categoryPath}/${techniqueId.serialize}"
+    }).chainError(s"error when deleting and committing Technique '${techniqueId.serialize}").unit
+  }
+
+  /*
+   * Return the list of files to commit for the technique.
+   * For resources, we need to have an hint about the state because we can't guess for deleted files.
+   *
+   * TODO: resource files path and status should be deducted from the metadata.xml and the Resources ID.
+   *  It would insure that there is consistency between technique descriptor and actual content, and
+   * insure that the lower generation part has a clear and defined API, and that we can do whatever we want
+   * in the middle.
+   * All path are related to git repository root path (ie, the correct path to use in git command).
+   * gitTechniquePath is the path for the technique relative to that git root, without ending slash
+   */
+  def getFilesToCommit(technique: Technique, gitTechniquePath: String, resourcesStatus: Chunk[ResourceFile]): TechniqueFilesToCommit = {
+    // parse metadata.xml and find what files need to be added
+    val filesToAdd = (
+      "metadata.xml" +:           // standard technique API, used for policy generation pipeline
+      "technique.json" +:         // high-level API between technique editor and rudder. Will evolve to .yml
+      "technique.rd" +:           // deprecated in 7.2. Old rudder-lang input for rudderc, will be replace by yml file
+      (if(technique.agentConfigs.collectFirst(a => a.agentType == AgentType.CfeCommunity || a.agentType == AgentType.CfeEnterprise).nonEmpty) {
+        Chunk("rudder_reporting.cf", "technique.cf")
+      } else Chunk()) +:
+      (if(technique.agentConfigs.collectFirst(_.agentType == AgentType.Dsc).nonEmpty) {
+        Chunk("technique.ps1")
+      } else Chunk()) +:
+      resourcesStatus.collect {
+        case ResourceFile(path, action) if action == ResourceFileState.New | action == ResourceFileState.Modified => path
+      }
+    ).map(p => gitTechniquePath + "/" + p) // from path relative to technique to relative to git root
+
+
+    // apart resources, additional files to delete are for migration purpose.
+    val filesToDelete = (
+      s"ncf/50_techniques/${technique.id.name.value}" +:      // added in 5.1 for migration to 6.0
+      s"dsc/ncf/50_techniques/${technique.id.name.value}" +:  // added in 6.1
+      resourcesStatus.collect {
+        case ResourceFile(path, ResourceFileState.Deleted) => gitTechniquePath + "/" + path
+      }
+    )
+
+    TechniqueFilesToCommit(filesToAdd, filesToDelete)
+  }
+
+  override def saveTechnique(techniqueId: TechniqueId, categories: Seq[String], resourcesStatus: Chunk[ResourceFile], modId: ModificationId, committer:  EventActor, msg: String) : IOResult[Unit] = {
+
+    val categoryPath = categories.filter(_ != "/").mkString("/")
+    val techniqueGitPath = s"${relativePath}/${categoryPath}/${techniqueId.serialize}"
+
+    (for {
+      metadata <- IOResult.effect(XML.load(Source.fromFile((gitRepo.rootDirectory / techniqueGitPath / "metadata.xml").toJava)))
+      tech     <- techniqueParser.parseXml(metadata, techniqueId).toIO
+      files    =  getFilesToCommit(tech, techniqueGitPath, resourcesStatus)
+      ident    <- personIdentservice.getPersonIdentOrDefault(committer.name)
+      added    <- ZIO.foreach(files.add) { f =>
+                    IOResult.effect(gitRepo.git.add.addFilepattern(f).call())
+                  }
+      removed <- ZIO.foreach(files.delete) { f =>
+                   IOResult.effect(gitRepo.git.rm.addFilepattern(f).call())
+                 }
+      commit  <- IOResult.effect(gitRepo.git.commit.setCommitter(ident).setMessage(msg).call())
+    } yield ()).chainError(s"error when committing Technique '${techniqueId.serialize}'").unit
+  }
+
+}
+
+
 ///////////////////////////////////////////////////////////////////////////////////////////////
 //////  Archive the active technique library (categories, techniques, directives) //////
 ///////////////////////////////////////////////////////////////////////////////////////////////
+
 
 /**
  * A specific trait to create archive of an active technique category.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitParseRudderObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitParseRudderObjects.scala
@@ -41,13 +41,18 @@ import com.normation.GitVersion
 import com.normation.GitVersion.Revision
 import com.normation.GitVersion.RevisionInfo
 import com.normation.cfclerk.domain.Technique
+import com.normation.cfclerk.domain.TechniqueCategoryName
 import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.cfclerk.xmlparsers.TechniqueParser
 import com.normation.rudder.configuration.DirectiveRevisionRepository
+import com.normation.rudder.configuration.GroupAndCat
+import com.normation.rudder.configuration.GroupRevisionRepository
 import com.normation.rudder.configuration.RuleRevisionRepository
 import com.normation.rudder.domain.logger.ConfigurationLoggerPure
+import com.normation.rudder.domain.nodes.NodeGroupCategoryId
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.ActiveTechnique
 import com.normation.rudder.domain.policies.Directive
 import com.normation.rudder.domain.policies.DirectiveId
@@ -57,6 +62,7 @@ import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleTargetInfo
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.domain.properties.GlobalParameter
+import com.normation.rudder.git.FileTreeFilter
 import com.normation.rudder.git.GitCommitId
 import com.normation.rudder.git.GitFindUtils
 import com.normation.rudder.git.GitRepositoryProvider
@@ -78,11 +84,14 @@ import com.normation.utils.Version
 import com.softwaremill.quicklens._
 import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.lib.Repository
+import org.eclipse.jgit.treewalk.TreeWalk
 
+import java.io.InputStream
 import java.nio.file.Paths
 
 import zio._
 import zio.syntax._
+import com.normation.box.IOManaged
 import com.normation.errors._
 
 final case class GitRootCategory(
@@ -287,7 +296,9 @@ class GitParseGroupLibrary(
   , xmlMigration        : XmlEntityMigration
   , libRootDirectory    : String //relative name to git root file
   , categoryFileName    : String = "category.xml"
-) extends ParseGroupLibrary with GitParseCommon[NodeGroupCategoryContent] {
+) extends ParseGroupLibrary with GitParseCommon[NodeGroupCategoryContent] with GroupRevisionRepository {
+
+  val groupsDirectory: GitRootCategory = getGitDirectoryPath(libRootDirectory)
 
   def getArchiveForRevTreeId(revTreeId:ObjectId): IOResult[NodeGroupCategoryContent] = {
 
@@ -369,6 +380,38 @@ class GitParseGroupLibrary(
       res
     }
   }
+
+  override def getGroupRevision(uid: NodeGroupUid, rev: Revision): IOResult[Option[GroupAndCat]] = {
+    for {
+      treeId  <- GitFindUtils.findRevTreeFromRevString(repo.db, rev.value)
+      // nodegroups are any where in the subtree with parent directory name == uuid of the group category.
+      // So we need to find the group by name, and split path to get its category. Be careful, the name of root
+      // category is not "groups" but "GroupRoot"
+      groups <- GitFindUtils.listFiles(repo.db, treeId, List(groupsDirectory.directoryPath), uid.value + ".xml" :: Nil)
+      res    <- groups.toList match {
+        case Nil => None.succeed
+        case h :: Nil => for {
+                          xml      <- GitFindUtils.getFileContent(repo.db, treeId, h) { is =>
+                                         ParseXml(is, Some(h))
+                                       }
+                          groupXml <- xmlMigration.getUpToDateXml(xml).toIO
+                          group    <- groupUnserialiser.unserialise(groupXml).toIO
+                          // h is path relative to config-repo, so may contains only one "/" (rules/ruleId.xml)
+                          catId    = h.split('/').toList.reverse match {
+                            case Nil | _ :: Nil => // assume root category even if Nil
+                              NodeGroupCategoryId("GroupRoot")
+                            case group :: catId :: _ =>
+                              NodeGroupCategoryId(catId)
+                          }
+                          // we need to correct ID revision to the one we just looked-up.
+                          // (it's normal to not have it serialized, since it's given by git, it's not intrinsic)
+                        } yield Some(GroupAndCat(group.modify(_.id.rev).setTo(rev), catId))
+        case _ => Unexpected(s"Several groups with id '${uid.value}' found under '${groupsDirectory.directoryPath}' directory for revision '${rev.value}'").fail
+      }
+    } yield {
+      res
+    }
+  }
 }
 
 
@@ -377,12 +420,21 @@ trait TechniqueRevisionRepository {
    * Get the technique with given name, version and revision from history
    * (todo: what about head?)
    */
-  def getTechnique(name: TechniqueName, version: Version, rev: Revision): IOResult[Option[Technique]]
+  def getTechnique(name: TechniqueName, version: Version, rev: Revision): IOResult[Option[(Chunk[TechniqueCategoryName], Technique)]]
 
   /*
    * Get the list of valid revisions for given technique
    */
   def getTechniqueRevision(name: TechniqueName, version: Version): IOResult[List[RevisionInfo]]
+
+  /*
+   * Always use git, does not look at what is on the FS even when revision is default.
+   * Retrieve all files as input streams related to the technique.
+   * Path are relative to technique version directory, so that for ex,
+   * technique/1.0/metadata.xml has path "metadata.xml"
+   * Directories are added at the beginning
+   */
+  def getTechniqueFileContents(id: TechniqueId): IOResult[Option[Seq[(String, Option[IOManaged[InputStream]])]]]
 }
 
 
@@ -397,7 +449,7 @@ class GitParseTechniqueLibrary(
   /**
    * Get a technique for the specific given revision;
    */
-  def getTechnique(name: TechniqueName, version: Version, rev: Revision): IOResult[Option[Technique]] = {
+  override def getTechnique(name: TechniqueName, version: Version, rev: Revision): IOResult[Option[(Chunk[TechniqueCategoryName], Technique)]] = {
     val root = GitRootCategory.getGitDirectoryPath(libRootDirectory).root
     (for {
       v      <- TechniqueVersion(version, rev).left.map(Inconsistency).toIO
@@ -407,20 +459,20 @@ class GitParseTechniqueLibrary(
       _      <- ConfigurationLoggerPure.revision.trace(s"Git tree corresponding to revision: ${rev.value}: ${treeId.toString}")
       paths  <- GitFindUtils.listFiles(repo.db, treeId, List(root), List(s"${id.withDefaultRev.serialize}/${techniqueMetadata}"))
       _      <- ConfigurationLoggerPure.revision.trace(s"Found candidate paths: ${paths}")
-      tech   <- paths.size match {
+      tuple  <- paths.size match {
                   case 0 =>
-                    ConfigurationLoggerPure.debug(s"Technique ${id.debugString} not found") *>
+                    ConfigurationLoggerPure.revision.debug(s"Technique ${id.debugString} not found") *>
                     None.succeed
                   case 1 =>
                     val path = paths.head
-                    ConfigurationLoggerPure.trace(s"Technique ${id.debugString} found at path '${path}', loading it'") *>
+                    ConfigurationLoggerPure.revision.trace(s"Technique ${id.debugString} found at path '${path}', loading it'") *>
                     (for {
-                      t <- loadTechnique(repo.db, treeId, path, id)
-                      v <- TechniqueVersion(t.id.version.version, rev).toIO
+                      t <- loadTechnique(repo.db, treeId, path, id) // load correctly set technique revision
                     } yield {
-                      // we need to correct techniqueId revision to the one we just looked-up.
-                      // (it's normal to not have it serialized, since it's given by git, it's not intrinsic)
-                      Some(t.modify(_.id.version).using(_.withRevision(rev)))
+                      val endToRemove = "/" + name.value + "/" + version.toVersionString + "/metadata.xml"
+                      val relativePath = path.replaceFirst(root + "/", "").replaceAll(endToRemove, "")
+                      val cats = Chunk.fromIterable(relativePath.split('/')).map(TechniqueCategoryName(_))
+                      Some((cats, t))
                     }).tapError(err =>
                       ConfigurationLoggerPure.revision.debug(s"Impossible to find technique with id/revision: '${id.debugString}': ${err.fullMsg}.")
                     )
@@ -428,7 +480,7 @@ class GitParseTechniqueLibrary(
                     Unexpected(s"There is more than one technique with ID '${id}' in git: ${paths.mkString(",")}").fail
                  }
     } yield {
-      tech
+      tuple
     }).tapBoth(err => ConfigurationLoggerPure.error(err.fullMsg), {
       case None    => ConfigurationLoggerPure.revision.debug(s" -> not found")
       case Some(_) => ConfigurationLoggerPure.revision.debug(s" -> found it!")
@@ -455,8 +507,73 @@ class GitParseTechniqueLibrary(
     } yield {
       revs.toList
     }
+  }
+
+  /*
+   * Always use git, does not look at what is on the FS even when revision is default.
+   * Retrieve all files as input streams related to the technique.
+   * Path are relative to technique version directory, so that for ex,
+   * technique/1.0/metadata.xml has path "metadata.xml"
+   * Directories are added at the beginning
+   */
+  override def getTechniqueFileContents(id: TechniqueId): IOResult[Option[Seq[(String, Option[IOManaged[InputStream]])]]] = {
+    val root = GitRootCategory.getGitDirectoryPath(libRootDirectory).root
+
+    /*
+     * find the path of the technique version
+     */
+    def getFilePath(db: Repository, revTreeId: ObjectId, techniqueId: TechniqueId) = {
+      IOResult.effect {
+        //a first walk to find categories
+        val tw = new TreeWalk(db)
+        // there is no directory in git, only files
+        val filter = new FileTreeFilter(List(root + "/"), List(techniqueId.withDefaultRev.serialize + "/" + techniqueMetadata))
+        tw.setFilter(filter)
+        tw.setRecursive(true)
+        tw.reset(revTreeId)
+
+        var path = Option.empty[String]
+        while(tw.next && path.isEmpty) {
+          path = Some(tw.getPathString)
+          tw.close()
+        }
+        path.map(_.replaceAll("/" + techniqueMetadata, ""))
+      }
+    }
+
+    for {
+      _       <- ConfigurationLoggerPure.revision.debug(s"Looking for files for technique: ${id.debugString}")
+      treeId  <- GitFindUtils.findRevTreeFromRevision(repo.db, id.version.rev, revisionProvider.currentRevTreeId)
+      _       <- ConfigurationLoggerPure.revision.trace(s"Git tree corresponding to revision: ${id.version.rev.value}: ${treeId.toString}")
+      optPath <- getFilePath(repo.db, treeId, id)
+      _       <- ConfigurationLoggerPure.revision.trace(s"Found path for technique ${id.serialize}: ${optPath}")
+      all     <- optPath match {
+                   case None       => None.succeed
+                   case Some(path) =>
+                     for {
+                       all <- GitFindUtils.getStreamForFiles(repo.db, treeId, List(path))
+                       // we need to correct paths to be relative to path
+                       res <- (ZIO.foreach(all) { case (p, opt) =>
+                                val newPath = p.replaceAll("^"+path, "")
+                                newPath.strip() match {
+                                  case "" | "/" =>
+                                    None.succeed
+                                  case x =>
+                                    val relativePath = if(x.startsWith("/")) x.tail else x
+                                    ConfigurationLoggerPure.revision.trace(s"Add technique ${opt.fold("sub-directory")(_ =>"file")}: '${relativePath}'") *>
+                                    Some((relativePath, opt)).succeed
+                                }
+                              }).map(_.flatten)
+                     } yield {
+                       Some(res)
+                     }
+                 }
+    } yield {
+      all
+    }
 
   }
+
 
   def loadTechnique(db: Repository, revTreeId: ObjectId, gitPath: String, id: TechniqueId): IOResult[Technique] = {
     for {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
@@ -90,6 +90,7 @@ import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.DirectiveSaveDiff
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.repository.WoDirectiveRepository
+import com.normation.rudder.repository.xml.TechniqueArchiver
 import com.normation.rudder.services.nodes.PropertyEngineServiceImpl
 
 import org.specs2.matcher.ContentMatchers
@@ -97,7 +98,6 @@ import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
 import zio._
-import zio.syntax._
 import scala.collection.SortedMap
 import scala.collection.SortedSet
 import net.liftweb.common.Loggable
@@ -123,8 +123,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
 
   val expectedPath = "src/test/resources/configuration-repository"
   object TestTechniqueArchiver extends TechniqueArchiver {
-    def commitTechnique(technique : EditorTechnique, modId: ModificationId, commiter:  EventActor, msg : String) : IOResult[Unit] = UIO.unit
-    def deleteTechnique(techniqueName: String, techniqueVersion: String, categories : Seq[String], modId: ModificationId, commiter: EventActor, msg: String): IOResult[Unit] = UIO.unit
+    override def deleteTechnique(techniqueId: TechniqueId, categories: Seq[String], modId: ModificationId, committer: EventActor, msg: String): IOResult[Unit] = UIO.unit
+    override def saveTechnique(techniqueId: TechniqueId, categories: Seq[String], resourcesStatus: Chunk[ResourceFile], modId: ModificationId, committer: EventActor, msg: String): IOResult[Unit] = UIO.unit
   }
 
   object TestLibUpdater extends UpdateTechniqueLibrary {
@@ -229,7 +229,7 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
   val propertyEngineService = new PropertyEngineServiceImpl(List.empty)
   val valueCompiler = new InterpolatedValueCompilerImpl(propertyEngineService)
   val parameterTypeService : PlugableParameterTypeService = new PlugableParameterTypeService
-  val writer = new TechniqueWriter(
+  val writer = new TechniqueWriterImpl(
       TestTechniqueArchiver
     , TestLibUpdater
     , valueCompiler

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
@@ -191,6 +191,13 @@ trait ReadConfigService {
    */
   def rudder_featureSwitch_directiveScriptEngine(): IOResult[FeatureSwitch]
 
+
+  /**
+   * Should we activate import/export archive API
+   */
+  def rudder_featureSwitch_archiveApi(): IOResult[FeatureSwitch]
+
+
   /**
    * Default value for node properties after acceptation:
    * - policy mode
@@ -320,6 +327,11 @@ trait UpdateConfigService {
    */
   def set_rudder_featureSwitch_directiveScriptEngine(status: FeatureSwitch): IOResult[Unit]
 
+  /*
+   * Should we enable import/export archive API ?
+   */
+  def set_rudder_featureSwitch_archiveApi(status: FeatureSwitch): IOResult[Unit]
+
 /**
    * Set the compliance mode
    */
@@ -421,6 +433,7 @@ class GenericConfigService(
        rudder.policy.mode.name=${Enforce.name}
        rudder.policy.mode.overridable=true
        rudder.featureSwitch.directiveScriptEngine=enabled
+       rudder.featureSwitch.archiveApi=disabled
        rudder.node.onaccept.default.state=enabled
        rudder.node.onaccept.default.policyMode=default
        rudder.compliance.unexpectedReportUnboundedVarValues=true
@@ -704,6 +717,12 @@ class GenericConfigService(
    */
   def rudder_featureSwitch_directiveScriptEngine(): IOResult[FeatureSwitch] = get("rudder_featureSwitch_directiveScriptEngine")
   def set_rudder_featureSwitch_directiveScriptEngine(status: FeatureSwitch): IOResult[Unit] = save("rudder_featureSwitch_directiveScriptEngine", status)
+
+  /**
+   * Should we enable import/export archive API?
+   */
+  def rudder_featureSwitch_archiveApi(): IOResult[FeatureSwitch] = get("rudder_featureSwitch_archiveApi")
+  def set_rudder_featureSwitch_archiveApi(status: FeatureSwitch): IOResult[Unit] = save("rudder_featureSwitch_archiveApi", status)
 
   /**
    * Default value for node properties after acceptation:

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -889,6 +889,35 @@ object UserApi extends ApiModuleProvider[UserApi] {
 }
 
 /*
+ * An API for import & export of archives of objects with their dependencies
+ */
+sealed trait ArchiveApi extends EndpointSchema with GeneralApi with SortIndex {
+  override def dataContainer: Option[String] = None
+}
+object ArchiveApi extends ApiModuleProvider[ArchiveApi] {
+  /*
+   * Request format:
+   *   ../archives/export?rules=rule_ids&directives=dir_ids&techniques=tech_ids&groups=group_ids&include=scope
+   * Where:
+   * - rule_ids = xxxx-xxxx-xxx-xxx[,other ids]
+   * - dir_ids = xxxx-xxxx-xxx-xxx[,other ids]
+   * - group_ids = xxxx-xxxx-xxx-xxx[,other ids]
+   * - tech_ids = techniqueName/1.0[,other tech ids]
+   * - scope = all (default), none, directives, techniques (implies directive), groups
+   */
+  final case object ExportSimple extends ArchiveApi with ZeroParam with StartsAtVersion15 with SortIndex {val z = implicitly[Line].value
+    val description    = "Export the list of objects with their dependencies"
+    val (action, path) = GET / "archives" / "export"
+  }
+  final case object Import extends ArchiveApi with ZeroParam with StartsAtVersion15 with SortIndex {val z = implicitly[Line].value
+    val description    = "Import an archive"
+    val (action, path) = POST / "archives" / "import"
+  }
+
+  def endpoints = ca.mrvisser.sealerate.values[ArchiveApi].toList.sortBy( _.z )
+}
+
+/*
  * All API.
  */
 object AllApi {
@@ -903,6 +932,7 @@ object AllApi {
     TechniqueApi.endpoints :::
     RuleApi.endpoints :::
     InventoryApi.endpoints :::
+    ArchiveApi.endpoints :::
     InfoApi.endpoints :::
     HookApi.endpoints :::
     // UserApi is not declared here, it will be contributed by plugin

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonResponse.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonResponse.scala
@@ -48,7 +48,7 @@ import com.normation.rudder.rest.lift.DefaultParams
 
 /*
  * This class deals with everything serialisation related for API.
- * Change things with care! Everything must be versionned!
+ * Change things with care! Everything must be versioned!
  * Even changing a field name can lead to an API incompatible change and
  * so will need a new API version number (and be sure that old behavior is kept
  * for previous versions).
@@ -58,7 +58,7 @@ import com.normation.rudder.rest.lift.DefaultParams
 /*
  * Rudder standard response.
  * We normalize response format to look like what is detailed here: https://docs.rudder.io/api/v/13/#section/Introduction/Response-format
- * Data are always name-spaced, so that theorically an answer can mixe several type of data. For example, for node details:
+ * Data are always name-spaced, so that theoretically an answer can mixe several type of data. For example, for node details:
  *     "data": { "nodes": [ ... list of nodes ... ] }
  * And for globalCompliance:
  *     "data": { "globalCompliance": { ... } }
@@ -85,7 +85,7 @@ object RudderJsonResponse {
 
   //////////////////////////// Lift JSON response ////////////////////////////
 
-  final case class RudderJsonResponse[A](json: A, prettify: Boolean, code: Int)(implicit encoder: JsonEncoder[A]) extends LiftResponse {
+  final case class LiftJsonResponse[A](json: A, prettify: Boolean, code: Int)(implicit encoder: JsonEncoder[A]) extends LiftResponse {
     def toResponse = {
       val indent = if(prettify) Some(2) else None
       val bytes = encoder.encodeJson(json, indent).toString.getBytes("UTF-8")
@@ -109,10 +109,10 @@ object RudderJsonResponse {
 
   object generic {
     // generic response, not in rudder normalized format - use it if you want an ad-hoc json response.
-    def success[A]       (json: A)(implicit prettify: Boolean, encoder: JsonEncoder[A]) = RudderJsonResponse(json, prettify, 200)
-    def internalError[A] (json: A)(implicit prettify: Boolean, encoder: JsonEncoder[A]) = RudderJsonResponse(json, prettify, 500)
-    def notFoundError[A] (json: A)(implicit prettify: Boolean, encoder: JsonEncoder[A]) = RudderJsonResponse(json, prettify, 404)
-    def forbiddenError[A](json: A)(implicit prettify: Boolean, encoder: JsonEncoder[A]) = RudderJsonResponse(json, prettify, 404)
+    def success[A]       (json: A)(implicit prettify: Boolean, encoder: JsonEncoder[A]) = LiftJsonResponse(json, prettify, 200)
+    def internalError[A] (json: A)(implicit prettify: Boolean, encoder: JsonEncoder[A]) = LiftJsonResponse(json, prettify, 500)
+    def notFoundError[A] (json: A)(implicit prettify: Boolean, encoder: JsonEncoder[A]) = LiftJsonResponse(json, prettify, 404)
+    def forbiddenError[A](json: A)(implicit prettify: Boolean, encoder: JsonEncoder[A]) = LiftJsonResponse(json, prettify, 404)
   }
 
   trait DataContainer[A] {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -1,0 +1,944 @@
+/*
+*************************************************************************************
+* Copyright 2022 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.rest.lift
+
+import com.normation.cfclerk.domain.Technique
+import com.normation.cfclerk.domain.TechniqueCategoryName
+import com.normation.cfclerk.domain.TechniqueId
+import com.normation.cfclerk.domain.TechniqueName
+import com.normation.cfclerk.domain.TechniqueVersion
+import com.normation.cfclerk.services.TechniqueReader
+import com.normation.cfclerk.services.TechniqueRepository
+import com.normation.cfclerk.services.TechniquesInfo
+import com.normation.cfclerk.xmlparsers.TechniqueParser
+import com.normation.eventlog.EventActor
+import com.normation.eventlog.EventMetadata
+import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.apidata.JsonResponseObjects.JRDirective
+import com.normation.rudder.apidata.JsonResponseObjects.JRGroup
+import com.normation.rudder.apidata.JsonResponseObjects.JRRule
+import com.normation.rudder.apidata.implicits._
+import com.normation.rudder.configuration.ConfigurationRepository
+import com.normation.rudder.domain.appconfig.FeatureSwitch
+import com.normation.rudder.domain.logger.ApplicationLogger
+import com.normation.rudder.domain.logger.ApplicationLoggerPure
+import com.normation.rudder.domain.nodes.NodeGroup
+import com.normation.rudder.domain.nodes.NodeGroupCategoryId
+import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.policies.Directive
+import com.normation.rudder.domain.policies.DirectiveId
+import com.normation.rudder.domain.policies.Rule
+import com.normation.rudder.domain.policies.RuleId
+import com.normation.rudder.domain.policies.RuleTarget
+import com.normation.rudder.git.ZipUtils
+import com.normation.rudder.git.ZipUtils.Zippable
+import com.normation.rudder.ncf.ResourceFile
+import com.normation.rudder.ncf.ResourceFileState
+import com.normation.rudder.repository.RoDirectiveRepository
+import com.normation.rudder.repository.RoNodeGroupRepository
+import com.normation.rudder.repository.RoRuleRepository
+import com.normation.rudder.repository.WoDirectiveRepository
+import com.normation.rudder.repository.WoNodeGroupRepository
+import com.normation.rudder.repository.WoRuleRepository
+import com.normation.rudder.repository.xml.TechniqueArchiverImpl
+import com.normation.rudder.repository.xml.TechniqueRevisionRepository
+import com.normation.rudder.rest.ApiPath
+import com.normation.rudder.rest.AuthzToken
+import com.normation.rudder.rest.RudderJsonResponse
+import com.normation.rudder.rest.RudderJsonResponse.ResponseSchema
+import com.normation.rudder.rest.implicits._
+import com.normation.rudder.rest.lift.ImportAnswer._
+import com.normation.rudder.rest.{ArchiveApi => API}
+import com.normation.rudder.services.queries.CmdbQueryParser
+
+import better.files.File
+import cats.data.NonEmptyList
+import net.liftweb.http.FileParamHolder
+import net.liftweb.http.LiftResponse
+import net.liftweb.http.OutputStreamResponse
+import net.liftweb.http.Req
+
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.charset.StandardCharsets
+import java.text.Normalizer
+import java.util.zip.ZipEntry
+import scala.xml.XML
+
+import zio._
+import zio.json._
+import zio.syntax._
+import com.normation.errors._
+import com.normation.zio._
+
+/*
+ * Machinery to enable/disable the API given the value of the feature switch in config service.
+ * If disabled, always return an error with the info about how to enable it.
+ */
+final case class FeatureSwitch0[A <: LiftApiModule0](enable: A, disable: A)(featureSwitchState: IOResult[FeatureSwitch]) extends LiftApiModule0 {
+  override val schema = enable.schema
+  override def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    featureSwitchState.either.runNow match {
+      case Left(err) =>
+        ApplicationLogger.error(err.fullMsg)
+        RudderJsonResponse.internalError(ResponseSchema.fromSchema(schema), err.fullMsg)(params.prettify).toResponse
+      case Right(FeatureSwitch.Disabled) =>
+        disable.process0(version, path, req, params, authzToken)
+      case Right(FeatureSwitch.Enabled) =>
+        enable.process0(version, path, req, params, authzToken)
+    }
+  }
+}
+
+sealed trait ArchiveScope { def value: String }
+object ArchiveScope {
+
+  // using nodep/alldep to avoid confusion with "none" in scala code
+  final case object AllDep     extends ArchiveScope { val value = "all"        }
+  final case object NoDep      extends ArchiveScope { val value = "none"       }
+  final case object Directives extends ArchiveScope { val value = "directives" }
+  final case object Techniques extends ArchiveScope { val value = "techniques" }
+  final case object Groups     extends ArchiveScope { val value = "groups"     }
+
+  def values =  ca.mrvisser.sealerate.values[ArchiveScope].toList.sortBy( _.value )
+  def parse(s: String): Either[String, ArchiveScope] = {
+    values.find( _.value == s.toLowerCase.strip() ) match {
+      case None    => Left(s"Error: can not parse '${s}' as a scope for dependency resolution in archive. Accepted values are: ${values.mkString(", ")}")
+      case Some(x) => Right(x)
+    }
+  }
+}
+
+
+class ArchiveApi(
+    archiveBuilderService: ZipArchiveBuilderService
+  , featureSwitchState   : IOResult[FeatureSwitch]
+  , getArchiveName       : IOResult[String]
+  , zipArchiveReader     : ZipArchiveReader
+  , saveArchiveService   : SaveArchiveService
+) extends LiftApiModuleProvider[API] {
+
+
+  def schemas = API
+
+  def getLiftEndpoints(): List[LiftApiModule] = {
+    API.endpoints.map(e => e match {
+      case API.Import       => FeatureSwitch0(Import, ImportDisabled)(featureSwitchState)
+      case API.ExportSimple => FeatureSwitch0(ExportSimple, ExportSimpleDisabled)(featureSwitchState)
+    })
+  }
+
+  /*
+   * Default answer to use when the feature is disabled
+   */
+  trait ApiDisabled extends LiftApiModule0 {
+
+    override def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      RudderJsonResponse.internalError(
+          ResponseSchema.fromSchema(schema)
+        , """This API is disabled. It is in beta version and no compatibility is ensured. You can enable it with """ +
+          """the setting `rudder_featureSwitch_archiveApi` in settings API set to `{"value":"enabled"}`"""
+      )(params.prettify).toResponse
+    }
+  }
+
+  object ExportSimpleDisabled extends LiftApiModule0 with ApiDisabled { val schema = API.ExportSimple }
+
+  /*
+   * This API does not returns a standard JSON response, it returns a ZIP archive.
+   */
+  object ExportSimple extends LiftApiModule0 {
+    val schema = API.ExportSimple
+    /*
+     * Request format:
+     *   ../archives/export/rules=rule_ids&directives=dir_ids&techniques=tech_ids&groups=group_ids&include=scope
+     * Where:
+     * - rule_ids = xxxx-xxxx-xxx-xxx[,other ids]
+     * - dir_ids = xxxx-xxxx-xxx-xxx[,other ids]
+     * - group_ids = xxxx-xxxx-xxx-xxx[,other ids]
+     * - tech_ids = techniqueName/1.0[,other tech ids]
+     * - scope = all (default), none, directives, techniques (implies directive), groups
+     */
+    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+
+      // we use lots of comma separated arg, factor out the splitting logic
+      def splitArg(req: Req, name: String): List[String] = req.params.getOrElse(name, Nil).flatMap(seq => seq.split(',').toList.map(_.strip()))
+      def parseRuleIds(req: Req): IOResult[List[RuleId]] = {
+
+        ZIO.foreach(splitArg(req, "rules"))(RuleId.parse(_).toIO)
+      }
+      def parseDirectiveIds(req: Req): IOResult[List[DirectiveId]] = {
+        ZIO.foreach(splitArg(req, "directives"))(DirectiveId.parse(_).toIO)
+      }
+      def parseTechniqueIds(req: Req): IOResult[List[TechniqueId]] = {
+        ZIO.foreach(splitArg(req, "techniques"))(TechniqueId.parse(_).toIO)
+      }
+      def parseGroupIds(req: Req): IOResult[List[NodeGroupId]] = {
+        ZIO.foreach(splitArg(req, "groups"))(NodeGroupId.parse(_).toIO)
+      }
+      def parseScopes(req: Req): IOResult[List[ArchiveScope]] = {
+        splitArg(req, "include") match {
+          case Nil => List(ArchiveScope.AllDep).succeed
+          case seq => ZIO.foreach(seq)(ArchiveScope.parse(_).toIO)
+        }
+      }
+
+      // lift is not well suited for ZIO...
+      val rootDirName = getArchiveName.runNow
+
+      //do zip
+      val zippables = for {
+        _             <- ApplicationLoggerPure.Archive.debug(s"Building archive '${rootDirName}'")
+        ruleIds       <- parseRuleIds(req)
+        groupIds      <- parseGroupIds(req)
+        directiveIds  <- parseDirectiveIds(req)
+        techniquesIds <- parseTechniqueIds(req)
+        scopes        <- parseScopes(req)
+        _             <- ApplicationLoggerPure.Archive.debug(s"Archive requested for rules: [${ruleIds.map(_.serialize).mkString(", ")}], " +
+                                                             s"directives: [${directiveIds.map(_.serialize).mkString(", ")}], " +
+                                                             s"groups: [${groupIds.map(_.serialize).mkString(", ")}], " +
+                                                             s"techniques: [${techniquesIds.map(_.serialize).mkString(", ")}], " +
+                                                             s"scope: [${scopes.map(_.value).mkString(", ")}]")
+        zippables     <- archiveBuilderService.buildArchive(rootDirName, techniquesIds, directiveIds, groupIds, ruleIds, scopes.toSet)
+      } yield {
+        zippables
+      }
+
+      val headers = List(
+          ("Pragma", "public")
+        , ("Expires", "0")
+        , ("Cache-Control", "must-revalidate, post-check=0, pre-check=0")
+        , ("Cache-Control", "public")
+        , ("Content-Description", "File Transfer")
+        , ("Content-type", "application/octet-stream")
+        , ("Content-Disposition", s"""attachment; filename="${rootDirName}.zip"""")
+        , ("Content-Transfer-Encoding", "binary")
+      )
+      val send =  (os: OutputStream) => zippables.flatMap { z =>
+        ZipUtils.zip(os, z)
+      }.catchAll(err =>
+        ApplicationLoggerPure.Archive.error(s"Error when building zip archive: ${err.fullMsg}")
+      ).runNow
+      new OutputStreamResponse(send, -1, headers, Nil, 200)
+    }
+  }
+
+  object ImportDisabled extends LiftApiModule0 with ApiDisabled { override val schema = API.Import }
+
+  object Import extends LiftApiModule0 {
+    val schema = API.Import
+    // name of the form multipart that holds the archive binary content
+    val FILE = "archive"
+
+    /*
+     * We expect a binary file in multipart/form-data, not in application/x-www-form-urlencodedcontent
+     * You can get that in curl with:
+     * curl -k -X POST -H "X-API-TOKEN: ..." https://.../api/latest/archives/import --form "archive=@my-archive.zip"
+     */
+    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+
+      def parseArchive(archive: FileParamHolder): IOResult[PolicyArchive] = {
+        val originalFilename = archive.fileName
+
+        IOResult.effect(archive.fileStream).bracket(is => effectUioUnit(is.close())) {is =>
+          ZipUtils.getZipEntries(originalFilename, is)
+        }.flatMap(entries =>
+          zipArchiveReader.readPolicyItems(originalFilename, entries)
+        )
+      }
+
+      val prog = (req.uploadedFiles.find(_.name == FILE) match {
+        case None =>
+          Unexpected(s"Missing uploaded file with parameter name '${FILE}'").fail
+        case Some(zip) =>
+          for {
+            _       <- ApplicationLoggerPure.Archive.info(s"Received a new policy archive '${zip.fileName}', processing")
+            archive <- parseArchive(zip)
+            _       <- saveArchiveService.check(archive)
+            _       <- saveArchiveService.save(archive, authzToken.actor)
+            _       <- ApplicationLoggerPure.Archive.info(s"Uploaded archive '${zip.fileName}' processed successfully")
+          } yield JRArchiveImported(true)
+      }).tapError(
+        err => ApplicationLoggerPure.Archive.error(s"Error when processing uploaded archive: ${err.fullMsg}")
+      )
+
+      prog.toLiftResponseOne(params, schema, _ => None)
+    }
+  }
+}
+
+/*
+ * A dummy object waiting for implementation for import
+ */
+object ImportAnswer {
+
+  import zio.json._
+
+  case class JRArchiveImported(success: Boolean)
+
+  implicit lazy val encodeJRArchiveImported: JsonEncoder[JRArchiveImported] = DeriveJsonEncoder.gen
+
+}
+
+
+/**
+ * A service that is able to build a human readable file name from a string
+ */
+class FileArchiveNameService(
+  // zip has no max length, but winzip limit to 250 because of windows - https://kb.corel.com/en/125869
+  // So 240 for extension etc
+  maxSize: Int = 240
+) {
+  def toFileName(name: String): String = {
+    Normalizer.normalize(name, Normalizer.Form.NFKD)
+      .replaceAll("""[^\p{Alnum}-]""", "_").take(maxSize)
+  }
+
+}
+
+
+/**
+ * That class is in charge of building a archive of a set of rudder objects.
+ * It knows how to get objects from their ID, serialise them to the expected
+ * string representation, and check that file name are not overriding each others,
+ * but it does not know about how to get what objects need to be retrieved.
+ *
+ * For now, I don't see any way to not load rules/etc in memory (for ex for the case
+ * where they would already be in json somewhere) since we need name.
+ * That may be changed in the future, if config repo and archive converge toward
+ * and unique file format and convention, but it's not for now.
+ */
+class ZipArchiveBuilderService(
+    fileArchiveNameService: FileArchiveNameService
+  , configRepo            : ConfigurationRepository
+  , techniqueRevisionRepo : TechniqueRevisionRepository
+) {
+
+
+  // names of directories under the root directory of the archive
+  val RULES_DIR = "rules"
+  val GROUPS_DIR = "groups"
+  val DIRECTIVES_DIR = "directives"
+  val TECHNIQUES_DIR = "techniques"
+
+  /*
+   * get the content of the JSON string in the format expected by Zippable
+   */
+  def getJsonZippableContent(json: String): (InputStream => IOResult[Any]) => IOResult[Any] = {
+    (use: InputStream => IOResult[Any]) =>
+    IOResult.effect(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))).bracket(is => effectUioUnit(is.close)) { is =>
+      use(is)
+    }
+  }
+
+
+  /*
+   * function that will find the next available name from the given string,
+   * looking in pool to check for availability (and updating said pool).
+   * Extension is an extension that should not be normalized.
+   */
+  def findName(origName: String, extension: String, usedNames: Ref[Map[String, Set[String]]], category: String): IOResult[String] = {
+    def findRecName(s: Set[String], base: String, i: Int): String = {
+      val n = base+"_"+i
+      if(s.contains(n)) findRecName(s, base, i+1) else n
+    }
+    val name = fileArchiveNameService.toFileName(origName)+extension
+
+    // find a free name, avoiding overwriting a previous similar one
+    usedNames.modify(m => {
+      val realName = if( m(category).contains(name) ) {
+        findRecName(m(category), name, 1)
+      } else name
+      ( realName, m + ((category, m(category)+realName))  )
+    } )
+  }
+
+  /*
+   * Retrieve the technique using first the cache, then the config service, and update the
+   * cache accordingly
+   */
+  def getTechnique(techniqueId: TechniqueId, techniques: RefM[Map[TechniqueId, (Chunk[TechniqueCategoryName], Technique)]]): IOResult[(Chunk[TechniqueCategoryName], Technique)] = {
+    techniques.modify(cache => cache.get(techniqueId) match {
+     case None =>
+       for {
+         t <- configRepo.getTechnique(techniqueId).notOptional(s"Technique with id ${techniqueId.serialize} was not found in Rudder")
+         c =  cache + ((t._2.id, t))
+       } yield (t, c)
+     case Some(t) =>
+       (t, cache).succeed
+   })
+  }
+
+  /*
+   * Getting technique zippable is more complex than other items because we can have a lot of
+   * files. The strategy used is to always copy ALL files for the given technique
+   * TechniquesDir is the path where techniques are stored, ie for technique "user/1.0", we have:
+   * techniquesDir / user/1.0/ other techniques file
+   */
+  def getTechniqueZippable(archiveName:String, techniquesDir: String, cats: Chunk[TechniqueCategoryName], techniqueId: TechniqueId): IOResult[Seq[Zippable]] = {
+    for {
+      contents <- techniqueRevisionRepo.getTechniqueFileContents(techniqueId).notOptional(s"Technique with ID '${techniqueId.serialize}' was not found in repository. Please check name and revision.")
+      // we need to change root of zippable, we want techniques/myTechnique/1.0/[HERE] and we need to filter out root category
+      catDirs  =  cats.collect { case TechniqueCategoryName(value) if value != "/" => value }
+      basePath =  techniquesDir+"/" + catDirs.mkString("/") + "/" + techniqueId.withDefaultRev.serialize + "/"
+      // start by adding directories toward technique
+      zips     = catDirs.foldLeft(List[Zippable]()) { case (dirs, current) =>
+                 // each time, head is the last parent, revert at the end
+                 dirs.headOption match {
+                   case None          => Zippable(techniquesDir + "/" + current, None):: Nil
+                   case Some(parent)  => Zippable(parent.path + "/" + current, None) :: dirs
+                 }
+               }.reverse ++ contents.map { case (p, opt) => Zippable(basePath + p, opt.map(_.use))}
+      _       <- ApplicationLoggerPure.Archive.debug(s"Building archive '${archiveName}': adding technique zipables: ${zips.map(_.path).mkString(", ")}")
+    } yield {
+      zips
+    }
+  }
+
+  /*
+   * Prepare the archive.
+   * `rootDirName` is supposed to be normalized, no change will be done with it.
+   * Any missing object will lead to an error.
+   * For each element, an human readable name derived from the object name is used when possible.
+   *
+   * System elements are not archived
+   */
+  def buildArchive(
+      rootDirName: String
+    , techniqueIds: Seq[TechniqueId]
+    , directiveIds: Seq[DirectiveId]
+    , groupIds: Seq[NodeGroupId]
+    , ruleIds: Seq[RuleId]
+    , scopes: Set[ArchiveScope]
+  ): IOResult[Chunk[Zippable]] = {
+    // normalize to no slash at end
+    val root = rootDirName.strip().replaceAll("""/$""", "")
+    import ArchiveScope._
+    val includeDepTechniques = scopes.intersect(Set(AllDep, Techniques)).nonEmpty
+    // scope is transitive, techniques implies directives
+    val includeDepDirectives = includeDepTechniques || scopes.intersect(Set(AllDep, Directives)).nonEmpty
+    val includeDepGroups = scopes.intersect(Set(AllDep, Groups)).nonEmpty
+
+    // rule is easy and independent from other
+
+    for {
+      // for each kind, we need to keep trace of existing names to avoid overwriting
+      usedNames        <- Ref.make(Map.empty[String, Set[String]])
+      // dependency id to add at lower level
+      depDirectiveIds  <- Ref.make(List.empty[DirectiveId])
+      depGroupIds      <- Ref.make(List.empty[NodeGroupId])
+      _                <- ApplicationLoggerPure.Archive.debug(s"Building archive for rules: ${ruleIds.map(_.serialize).mkString(", ")}")
+      rootZip          <- Zippable(rootDirName, None).succeed
+      rulesDir         =  root + "/" + RULES_DIR
+      _                <- usedNames.update( _ + ((RULES_DIR, Set.empty[String])))
+      rulesDirZip      =  Zippable(rulesDir, None)
+      rulesZip         <- ZIO.foreach(ruleIds) { ruleId =>
+                            configRepo.getRule(ruleId).notOptional(s"Rule with id ${ruleId.serialize} was not found in Rudder").flatMap(rule =>
+                              if(rule.isSystem) None.succeed else {
+                                for {
+                                  _ <- depDirectiveIds.update(x => x ++ rule.directiveIds)
+                                  _ <- depGroupIds.update(x => x ++ RuleTarget.getNodeGroupIds(rule.targets))
+                                  json = JRRule.fromRule(rule, None, None, None).toJsonPretty
+                                  name <- findName(rule.name, ".json", usedNames, RULES_DIR)
+                                  path =  rulesDir + "/" + name
+                                  _    <- ApplicationLoggerPure.Archive.debug(s"Building archive '${rootDirName}': adding rule zipable: ${path}")
+                                } yield {
+                                  Some(Zippable(path, Some(getJsonZippableContent(json))))
+                                }
+                              }
+                            )
+                          }.map(_.flatten)
+      groupsDir        =  root + "/" + GROUPS_DIR
+      _                <- usedNames.update( _ + ((GROUPS_DIR, Set.empty[String])))
+      groupsDirZip     =  Zippable(groupsDir, None)
+      depGroups        <- if(includeDepGroups) depGroupIds.get else Nil.succeed
+      groupsZip        <- ZIO.foreach(groupIds ++ depGroups) { groupId =>
+                            configRepo.getGroup(groupId).notOptional(s"Group with id ${groupId.serialize} was not found in Rudder").flatMap(gc =>
+                              if(gc.group.isSystem) None.succeed else {
+                                val json =  JRGroup.fromGroup(gc.group, gc.categoryId, None).toJsonPretty
+                                for {
+                                  name <- findName(gc.group.name, ".json", usedNames, GROUPS_DIR)
+                                  path =  groupsDir + "/" + name
+                                  _    <- ApplicationLoggerPure.Archive.debug(s"Building archive '${rootDirName}': adding group zipable: ${path}")
+                                } yield Some(Zippable(path, Some(getJsonZippableContent(json))))
+                              }
+                            )
+                          }.map(_.flatten)
+      // directives need access to technique, but we don't want to look up several time the same one
+      techniques       <- RefM.make(Map.empty[TechniqueId, (Chunk[TechniqueCategoryName], Technique)])
+
+      directivesDir    =  root + "/" + DIRECTIVES_DIR
+      _                <- usedNames.update( _ + ((DIRECTIVES_DIR, Set.empty[String])))
+      directivesDirZip =  Zippable(directivesDir, None)
+      depDirectives    <- if(includeDepDirectives) depDirectiveIds.get else Nil.succeed
+      directivesZip    <- ZIO.foreach(directiveIds ++ depDirectives) { directiveId =>
+                            configRepo.getDirective(directiveId).notOptional(s"Directive with id ${directiveId.serialize} was not found in Rudder").flatMap(ad =>
+                              if(ad.directive.isSystem) None.succeed else {
+                                for {
+                                  tech <- getTechnique(TechniqueId(ad.activeTechnique.techniqueName, ad.directive.techniqueVersion), techniques)
+                                  json =  JRDirective.fromDirective(tech._2, ad.directive, None).toJsonPretty
+                                  name <- findName(ad.directive.name, ".json", usedNames, DIRECTIVES_DIR)
+                                  path =  directivesDir + "/" + name
+                                  _    <- ApplicationLoggerPure.Archive.debug(s"Building archive '${rootDirName}': adding directive zipable: ${path}")
+                                } yield Some(Zippable(path, Some(getJsonZippableContent(json))))
+                              }
+                            )
+                          }.map(_.flatten)
+      // Techniques don't need name normalization, their name is already normalized
+      techniquesDir    =  root + "/" + TECHNIQUES_DIR
+      techniquesDirZip =  Zippable(techniquesDir, None)
+      depTechniques    <- if(includeDepTechniques) techniques.get.map(_.keys) else Nil.succeed
+      allTech          <- ZIO.foreach(techniqueIds ++ depTechniques) { techniqueId => getTechnique(techniqueId, techniques) }
+      techniquesZip    <- ZIO.foreach(allTech.filter(_._2.isSystem == false)) { case (cats, technique) =>
+                            for {
+                              techZips  <- getTechniqueZippable(rootDirName, techniquesDir, cats, technique.id)
+                            } yield {
+                              // some directories may have been duplicated if several techniques are in the same category,
+                              // and zip does not like that
+                              techZips.distinctBy(_.path)
+                            }
+                          }
+    } yield {
+      Chunk(rootZip, rulesDirZip, groupsDirZip, directivesDirZip, techniquesDirZip) ++ rulesZip ++ techniquesZip.flatten ++ directivesZip ++ groupsZip
+    }
+  }
+
+}
+
+
+// metadata about policy archive, at least original file name
+final case class PolicyArchiveMetadata(
+  filename: String
+)
+
+case object PolicyArchiveMetadata {
+  def empty = PolicyArchiveMetadata("")
+}
+
+
+final case class TechniqueArchive(
+    technique: Technique
+  , category : Chunk[String]
+  , files    : Chunk[(String, Array[Byte])]
+)
+final case class DirectiveArchive(
+    technique: TechniqueName
+  , directive: Directive
+)
+final case class GroupArchive(
+    group   : NodeGroup
+  , category: NodeGroupCategoryId
+)
+
+/**
+ * An archive to be saved (~) atomically
+ * For techniques, we only parse metadata.xml, and we keep files as is
+ */
+final case class PolicyArchive(
+    metadata  : PolicyArchiveMetadata
+  , techniques: Chunk[TechniqueArchive]
+  , directives: Chunk[DirectiveArchive]
+  , groups    : Chunk[GroupArchive]
+  , rules     : Chunk[Rule]
+) {
+  def debugString: String = {
+    s"""Archive ${metadata.filename}:
+       | - techniques: ${techniques.map(_.technique.id.serialize).sorted.mkString(", ")}
+       | - directives: ${directives.map(d => s"'${d.directive.name}' [${d.directive.id.serialize}]").sorted.mkString(", ")}
+       | - groups    : ${groups.map(d => s"'${d.group.name}' [${d.group.id.serialize}]").sorted.mkString(", ")}
+       | - rules     : ${rules.map(d => s"'${d.name}' [${d.id.serialize}]").sorted.mkString(", ")}""".stripMargin
+  }
+}
+object PolicyArchive {
+  def empty = PolicyArchive(PolicyArchiveMetadata.empty, Chunk.empty, Chunk.empty, Chunk.empty, Chunk.empty)
+}
+
+final case class SortedEntries(
+    techniques: Chunk[(String, Array[Byte])]
+  , directives: Chunk[(String, Array[Byte])]
+  , groups    : Chunk[(String, Array[Byte])]
+  , rules     : Chunk[(String, Array[Byte])]
+)
+object SortedEntries {
+  def empty = SortedEntries(Chunk.empty, Chunk.empty, Chunk.empty, Chunk.empty)
+}
+
+final case class PolicyArchiveUnzip(
+    policies: PolicyArchive
+  , errors: Chunk[RudderError]
+)
+
+object PolicyArchiveUnzip {
+  def empty = PolicyArchiveUnzip(PolicyArchive.empty, Chunk.empty)
+}
+
+
+
+/**
+ * That class is in charge of reading a zip archive (as a sequence of ZipEntry items) and
+ * unflatten it into the corresponding Rudder policy items.
+ * We want to provide maximum information in one go for the user, so that if an archive
+ * can not be saved because some items override existing ones, then we want to list them
+ * all (and not stop at the first, then let the user iterate and stop again for the next file).
+ */
+trait ZipArchiveReader {
+  def readPolicyItems(archiveName: String, zipEntries: Seq[(ZipEntry, Option[Array[Byte]])]): IOResult[PolicyArchive]
+}
+class ZipArchiveReaderImpl(
+    cmdbQueryParser       : CmdbQueryParser
+  , techniqueParser       : TechniqueParser
+) extends ZipArchiveReader {
+    import com.softwaremill.quicklens._
+
+  val techniqueRegex = """.*techniques/(.+)""".r
+  val metadataRegex = """(.+)/metadata.xml""".r
+  val directiveRegex = """.*directives/(.+.json)""".r
+  val groupRegex = """.*groups/(.+.json)""".r
+  val ruleRegex = """.*rules/(.+.json)""".r
+
+  /*
+   * For technique, we are parsing metadata.xml.
+   * We also find technique name, version, and categories from base path.
+   * For file: we keep all, but we make their path relative to technique (ie we remove base path)
+   */
+  def parseTechnique(archiveName: String, basepath: String, files: Chunk[(String, Array[Byte])]): IOResult[TechniqueArchive] = {
+    // base path should look like "some/list/of/cats/techniqueName/techniqueVersion
+    def parseBasePath(p: String): IOResult[(TechniqueId, Chunk[String])] = {
+      p.split('/').toList.reverse match {
+        case version :: name :: cats =>
+          TechniqueVersion.parse(version).toIO.chainError(s"Error when extracting archive for technique at path ${basepath}") map(v =>
+            (TechniqueId(TechniqueName(name), v), Chunk.fromIterable(cats.reverse))
+          )
+        case _ => Unexpected(s"Error when extracting archive '${archiveName}': the path '${basepath}' contains a metadata.xml file but is not a valid " +
+                  s"technique path. Expected structure is categories/techniqueName/techniqueVersion/metadata.xml").fail
+      }
+    }
+
+    for {
+      path    <- parseBasePath(basepath)
+      (id, c) = path
+      optTech <- RefM.make(Option.empty[Technique])
+      // update path in files, and parse metadata when found
+      updated <- ZIO.foreach(files) { case (f, content) =>
+                   val name = f.replaceFirst(basepath + "/", "")
+                     ZIO.when(name.equalsIgnoreCase("metadata.xml")) {
+                       for {
+                         xml <- IOResult.effect(XML.load(new ByteArrayInputStream(content)))
+                         tech <- techniqueParser.parseXml(xml, id).toIO
+                         _ <- optTech.update {
+                           case None    => Some(tech).succeed
+                           case Some(_) => Unexpected(s"Error: archive contains several metadata.xml files for " +
+                                                      s"techniques '${basepath}', exactly one expected"
+                           ).fail
+                         }
+                       } yield ()
+                     } *>
+                     (name, content).succeed
+                   }
+      tech      <- optTech.get.notOptional(s"Error: archive does not contains a metadata.xml file for technique with id " +
+                                           s"'${basepath}', exactly one was expected")
+    } yield TechniqueArchive(tech, c, updated)
+  }
+  def parseDirective(name: String, content: Array[Byte])(implicit dec: JsonDecoder[JRDirective]): IOResult[DirectiveArchive] = {
+    (new String(content, StandardCharsets.UTF_8)).fromJson[JRDirective].toIO.flatMap(_.toDirective().map(t => DirectiveArchive(t._1, t._2)))
+  }
+  def parseGroup(name: String, content: Array[Byte])(implicit dec: JsonDecoder[JRGroup]): IOResult[GroupArchive] = {
+    (new String(content, StandardCharsets.UTF_8)).fromJson[JRGroup].toIO.flatMap(_.toGroup(cmdbQueryParser).map(d => GroupArchive(d._2, d._1)))
+  }
+  def parseRule(name: String, content: Array[Byte])(implicit dec: JsonDecoder[JRRule]): IOResult[Rule] = {
+    (new String(content, StandardCharsets.UTF_8)).fromJson[JRRule].toIO.flatMap(_.toRule())
+  }
+
+  /*
+   * Parse techniques.
+   * The map is [techniqueBasePath -> (metadata contant, list of all technique files, including metadata.xlm: (filename (including base path), content))
+   */
+  def parseTechniques(archiveName: String, arch: PolicyArchiveUnzip, techniques:  Map[String, Chunk[(String, Array[Byte])]]): IOResult[PolicyArchiveUnzip] = {
+    ZIO.foldLeft(techniques)(arch) { case (a, (basepath, files)) =>
+      parseTechnique(archiveName, basepath, files).either.map {
+        case Right(res) => a.modify(_.policies.techniques).using( _ :+ res)
+        case Left(err) => a.modify(_.errors).using( _ :+ err)
+      }
+    }
+  }
+  def parseSimpleFile[A](
+      arch    : PolicyArchiveUnzip
+    , elements: Chunk[(String, Array[Byte])]
+    , accessor: PathLazyModify[PolicyArchiveUnzip, Chunk[A]]
+    , parser  : (String, Array[Byte]) => IOResult[A]
+  ): IOResult[PolicyArchiveUnzip] = {
+    ZIO.foldLeft(elements)(arch) { case (a, t) =>
+      parser(t._1, t._2).either.map {
+        case Right(res) => accessor.using( _ :+ res)(a)
+        case Left(err) => a.modify(_.errors).using( _ :+ err)
+      }
+    }
+  }
+  def parseDirectives(arch: PolicyArchiveUnzip, directives: Chunk[(String, Array[Byte])])(implicit dec: JsonDecoder[JRDirective]): IOResult[PolicyArchiveUnzip] = {
+    parseSimpleFile(arch, directives, modifyLens[PolicyArchiveUnzip](_.policies.directives), parseDirective)
+  }
+  def parseGroups(arch: PolicyArchiveUnzip, groups: Chunk[(String, Array[Byte])])(implicit dec: JsonDecoder[JRGroup]): IOResult[PolicyArchiveUnzip] = {
+    parseSimpleFile(arch, groups, modifyLens[PolicyArchiveUnzip](_.policies.groups), parseGroup)
+  }
+  def parseRules(arch: PolicyArchiveUnzip, rules: Chunk[(String, Array[Byte])])(implicit dec: JsonDecoder[JRRule]): IOResult[PolicyArchiveUnzip] = {
+    parseSimpleFile(arch, rules, modifyLens[PolicyArchiveUnzip](_.policies.rules), parseRule)
+  }
+
+  def readPolicyItems(archiveName: String, zipEntries: Seq[(ZipEntry, Option[Array[Byte]])]): IOResult[PolicyArchive] = {
+
+    // sort files in rules, directives, groups, techniques
+    val sortedEntries = zipEntries.foldLeft(SortedEntries.empty) { case (arch, (e, optContent)) => (e.getName, optContent) match {
+      case (techniqueRegex(x), Some(content)) =>
+        ApplicationLoggerPure.Archive.logEffect.trace(s"Archive '${archiveName}': found technique file ${x}")
+        arch.modify(_.techniques).using( _ :+ (x, content))
+      case (directiveRegex(x), Some(content)) =>
+        ApplicationLoggerPure.Archive.logEffect.trace(s"Archive '${archiveName}': found directive file ${x}")
+        arch.modify(_.directives).using( _ :+ (x, content))
+      case (groupRegex(x), Some(content)) =>
+        ApplicationLoggerPure.Archive.logEffect.trace(s"Archive '${archiveName}': found group file ${x}")
+        arch.modify(_.groups).using( _ :+ (x, content))
+      case (ruleRegex(x), Some(content)) =>
+        ApplicationLoggerPure.Archive.logEffect.trace(s"Archive '${archiveName}': found rule file ${x}")
+        arch.modify(_.rules).using( _ :+ (x, content))
+      case (name, Some(_)) =>
+        ApplicationLoggerPure.Archive.logEffect.debug(s"Archive '${archiveName}': file does not matches a known category: ${name}")
+        arch
+      case (name, None) =>
+        ApplicationLoggerPure.Archive.logEffect.trace(s"Directory '${name}' in archive '${archiveName}': looking for entries")
+        arch
+    } }
+
+    // techniques are more complicated: they have several files and categories so we don't know where they are at first.
+    // We look for metadata.xml files, and from that we deduce a technique base path
+    // create a map of technique names -> list of (filename, content)
+    val metadatas = sortedEntries.techniques.collect { case (metadataRegex(basePath), c) => basePath }
+
+    // then, group by base path (cats/id/version) for technique ; then for each group, find from base path category
+    val techniqueUnzips = sortedEntries.techniques.groupBy { case (filename, _) => metadatas.find(base => filename.startsWith(base)) }.flatMap {
+      case (None, files) => //files that are not related to a metadata file: ignore (but log)
+        ApplicationLoggerPure.Archive.debug(s"Archive ${archiveName}: these were under 'techniques' directory but are not " +
+                                            s"linked to a metadata.xml file: ${files.map(_._1).mkString(" , ")}")
+        None
+      case (Some(base), files) =>
+        Some((base, files))
+    }
+
+    // now, parse everything and collect errors
+    import com.normation.rudder.apidata.JsonResponseObjectDecodes._
+    for {
+      _              <- ApplicationLoggerPure.Archive.debug(s"Processing archive '${archiveName}': techniques: '${techniqueUnzips.keys.mkString("', '")}'")
+      withTechniques <- parseTechniques(archiveName, PolicyArchiveUnzip.empty, techniqueUnzips)
+      _              <- ApplicationLoggerPure.Archive.debug(s"Processing archive '${archiveName}': directives: '${sortedEntries.directives.map(_._1).mkString("', '")}'")
+      withDirectives <- parseDirectives(withTechniques, sortedEntries.directives)
+      _              <- ApplicationLoggerPure.Archive.debug(s"Processing archive '${archiveName}': groups: '${sortedEntries.groups.map(_._1).mkString("', '")}'")
+      withGroups     <- parseGroups(withDirectives, sortedEntries.groups)
+      _              <- ApplicationLoggerPure.Archive.debug(s"Processing archive '${archiveName}': rules: '${sortedEntries.rules.map(_._1).mkString("', '")}'")
+      withRules      <- parseRules(withGroups, sortedEntries.rules)
+      // aggregate errors
+      policies       <- withRules.errors.toList match {
+                          case Nil       => withRules.policies.succeed
+                          case h :: tail => Accumulated(NonEmptyList.of(h, tail:_*)).fail
+                        }
+    } yield policies
+  }
+}
+
+
+trait SaveArchiveService {
+  /*
+   * Check if archive might be saved. The goal here is to provide as many insights as possible to
+   * user, and not only just the first one.
+   * Individual checks can be redo during the actual save, and other errors can happen at that moment.
+   * Here, it's for UX.
+   */
+  def check(archive: PolicyArchive): IOResult[Unit]
+
+  /*
+   * Save archive, as atomically as possible. We don't do revert on error, because import is not
+   * a system property, and we may have no human overlooking that no other changes are reverted.
+   * In case of error, provides as many insight as possible to user:
+   * - what was committed,
+   * - what was not
+   * - what may be partially
+   */
+  def save(archive: PolicyArchive, actor: EventActor): IOResult[Unit]
+}
+
+/*
+ * This implementation does not check for possible conflicts and just
+ * overwrite existing policies if updates are available in the archive.
+ */
+class SaveArchiveServiceImpl(
+    techniqueArchiver: TechniqueArchiverImpl
+  , techniqueReader  : TechniqueReader
+  , techniqueRepos   : TechniqueRepository
+  , roDirectiveRepos : RoDirectiveRepository
+  , woDirectiveRepos : WoDirectiveRepository
+  , roGroupRepos     : RoNodeGroupRepository
+  , woGroupRepos     : WoNodeGroupRepository
+  , roRuleRepos      : RoRuleRepository
+  , woRuleRepos      : WoRuleRepository
+) extends SaveArchiveService {
+
+
+  def checkTechnique(techInfo: TechniquesInfo, techArchive: TechniqueArchive): IOResult[Unit] = {
+
+    // check that the imported technique category is the same than the one already existing, if any
+    techInfo.techniquesCategory.collectFirst { case (TechniqueId(name, _), catId) if(name.value == techArchive.technique.name) => catId } match {
+      case None => // technique not present, ok
+        ZIO.unit
+      case Some(catId) =>
+        val existing = catId.getPathFromRoot.map(_.value).mkString("/")
+        val archive = techArchive.category.mkString("/")
+        if( existing == archive ) {
+          ZIO.unit
+        } else {
+          Inconsistency(s"Technique '${techArchive.technique.id.serialize}' from archive has category '${archive}' but a " +
+                        s"technique with that name already exists in category '${existing}': it must be imported in the " +
+                        s"same category, please update your archive.").fail
+        }
+    }
+  }
+  def checkItem[A](a: A): IOResult[Unit] = { // for now, nothing to check for directive, rule, group
+    ZIO.unit
+  }
+
+  // check if we can import archive.
+  def check(archive: PolicyArchive): IOResult[Unit] = {
+    val techInfo = techniqueRepos.getTechniquesInfo()
+    for {
+      tRes <- ZIO.foreach(archive.techniques)(t => checkTechnique(techInfo, t).either)
+      // TODO: check that all techniques (name and version) used by directive are known of rudder
+      dRes <- ZIO.foreach(archive.directives)(checkItem(_).either)
+      gRes <- ZIO.foreach(archive.groups)(checkItem(_).either)
+      rRes <- ZIO.foreach(archive.rules)(checkItem(_).either)
+      // collect all errors
+      _   <- (tRes ++ dRes ++ gRes ++ rRes).accumulateEitherDiscard.toIO
+    } yield ()
+  }
+
+
+  /*
+   * Saving a techniques:
+   * - override all files that are coming from archive
+   * - see if there's other file present - delete them
+   * - commit
+   */
+  def saveTechnique(eventMetadata: EventMetadata, t: TechniqueArchive): IOResult[Unit] = {
+    val techniqueDir = File(techniqueArchiver.gitRepo.rootDirectory.pathAsString + "/" + techniqueArchiver.relativePath + "/" + t.category.mkString("/") + "/" + t.technique.id.serialize)
+
+    for {
+      addedRef <- Ref.make(Chunk.fromIterable(t.files.map(_._1))) // path are relative to technique. Files we need to add as new in the end
+      diffRef  <- Ref.make(Chunk[ResourceFile]())
+      // get all file path (relative to technique dir)
+      existing <- IOResult.effect(if(techniqueDir.exists) {
+                    techniqueDir.collectChildren(_ => true).toList.map(_.pathAsString.replaceFirst(techniqueDir.pathAsString + "/", ""))
+                  } else { // technique or technique version does not exists
+                    Chunk.empty
+                  })
+      _        <- ZIO.foreach_(existing) { e =>
+                    for {
+                      keep <- addedRef.modify(a => if(a.contains(e)) { (true, a.filterNot(_ == e)) } else { (false, a) } )
+                      _    <- diffRef.update(_ :+ ResourceFile(e, if(keep) ResourceFileState.Modified else ResourceFileState.Deleted))
+                    } yield ()
+                  }
+      added   <- addedRef.get.map(_.map(ResourceFile(_, ResourceFileState.New)))
+      updated <- diffRef.get
+
+      // now, actually delete files marked so
+      _       <- ZIO.foreach_(updated) { u =>
+                   if(u.state == ResourceFileState.Deleted) {
+                     IOResult.effect(File(techniqueDir.pathAsString+ "/" + u.path).delete)
+                   } else ZIO.unit
+                 }
+      // now, write new/updated files
+      _       <- ZIO.foreach(t.files) { case (p, bytes) =>
+                   val f = File(techniqueDir.pathAsString+"/"+p)
+                   IOResult.effect{
+                     f.parent.createDirectoryIfNotExists(createParents = true) // for when the technique, or subdirectories for resources are not existing yet
+                     f.writeBytes(bytes.iterator)
+                   }
+                 }
+      // finally commit
+      _       <- techniqueArchiver.saveTechnique(t.technique.id, t.category, added++updated, eventMetadata.modId,
+                                                 eventMetadata.actor, eventMetadata.msg.getOrElse(s"Committing technique '${t.technique.id.serialize}' from archive"))
+    } yield ()
+  }
+
+  def saveDirective(eventMetadata: EventMetadata, d: DirectiveArchive): IOResult[Unit] = {
+    for {
+      at <- roDirectiveRepos.getActiveTechnique(d.technique).notOptional(s"Technique '${d.technique.value}' is used in imported directive ${d.directive.name} but is not in Rudder")
+      _  <- woDirectiveRepos.saveDirective(at.id, d.directive, eventMetadata.modId, eventMetadata.actor, eventMetadata.msg)
+    } yield ()
+  }
+  def saveGroup(eventMetadata: EventMetadata, g: GroupArchive): IOResult[Unit] = {
+    for {
+      x <- roGroupRepos.getNodeGroupOpt(g.group.id)
+      _ <- x match {
+        case Some(value) => woGroupRepos.update(g.group, eventMetadata.modId, eventMetadata.actor, eventMetadata.msg)
+        case None        => woGroupRepos.create(g.group, g.category, eventMetadata.modId, eventMetadata.actor, eventMetadata.msg)
+      }
+    } yield ()
+  }
+  def saveRule(eventMetadata: EventMetadata, r: Rule): IOResult[Unit] = {
+    for {
+      x <- roRuleRepos.getOpt(r.id)
+      _ <- x match {
+        case Some(value) => woRuleRepos.update(r, eventMetadata.modId, eventMetadata.actor, eventMetadata.msg)
+        case None        => woRuleRepos.create(r, eventMetadata.modId, eventMetadata.actor, eventMetadata.msg)
+      }
+    } yield ()
+  }
+
+  /*
+   * For rules/directives/groups, we build a change request & commit it.
+   * For techniques, we just write them in fs, commit, reload tech lib.
+   * Starts with techniques then other things.
+   */
+  override def save(archive: PolicyArchive, actor: EventActor): IOResult[Unit] = {
+    val eventMetadata = EventMetadata.withNewId(actor, Some(s"Importing archive '${archive.metadata.filename}'"))
+    for {
+      _ <- ZIO.foreach(archive.techniques) { saveTechnique(eventMetadata, _) }
+      _ <- IOResult.effect(techniqueReader.readTechniques)
+      _ <- ZIO.foreach(archive.directives) { saveDirective(eventMetadata, _) }
+      _ <- ZIO.foreach(archive.groups) { saveGroup(eventMetadata, _) }
+      _ <- ZIO.foreach(archive.rules) { saveRule(eventMetadata, _) }
+    } yield ()
+  }
+}

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
@@ -612,7 +612,7 @@ class DirectiveApiService14 (
           IOResult.effect(techniqueRepository.getLastTechniqueByName(techniqueName)).notOptional( s"Error while fetching last version of technique ${techniqueName.value}")
       case (Some(techniqueName), Some(version)) =>
         val id = TechniqueId(techniqueName, version)
-        configRepository.getTechnique(id).notOptional(s" Technique '${techniqueName.value}' version '${version.serialize}' is not a valid Technique")
+        configRepository.getTechnique(id).notOptional(s" Technique '${techniqueName.value}' version '${version.serialize}' is not a valid Technique").map(_._2)
     }
   }
 
@@ -650,7 +650,8 @@ class DirectiveApiService14 (
           // technique version: by default, directive one. It techniqueVersion is given, use that. If techniqueRevision is specified, use it.
           techVersion   =  restDirective.techniqueVersion.getOrElse(ad.directive.techniqueVersion)
           techId        =  TechniqueId(ad.activeTechnique.techniqueName, techVersion)
-          technique     <- configRepository.getTechnique(techId).notOptional(s"Technique with ID '${techId.debugString}' was not found")
+          tuple         <- configRepository.getTechnique(techId).notOptional(s"Technique with ID '${techId.debugString}' was not found")
+          (_,technique) =  tuple
           newDirective  =  restDirective.copy(enabled = Some(false), techniqueVersion = Some(techId.version))
           baseDirective =  ad.directive.modify(_.id.uid).setTo(directiveId)
           result        <- actualDirectiveCreation(newDirective, baseDirective, ad.activeTechnique, technique, params, actor)
@@ -724,7 +725,7 @@ class DirectiveApiService14 (
       tid = TechniqueId(at.activeTechnique.techniqueName, at.directive.techniqueVersion)
       t  <- configRepository.getTechnique(tid).notOptional(s"Technique with id '${tid.debugString}' was not found")
     } yield {
-      JRDirective.fromDirective(t, at.directive, None)
+      JRDirective.fromDirective(t._2, at.directive, None)
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -105,8 +105,6 @@ import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.services.policies.RuleApplicationStatusService
 import com.normation.rudder.web.services.ComputePolicyMode
 
-import scala.annotation.tailrec
-
 class RuleApi(
     restExtractorService: RestExtractorService
   , zioJsonExtractor    : ZioJsonExtractor

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -133,6 +133,7 @@ class SettingsApi(
       RestNodeAcceptDuplicatedHostname ::
       RestComputeDynGroupMaxParallelism ::
       RestSetupDone ::
+      ArchiveApiFeatureSwitch ::
       Nil
 
   val allSettings_v12 =   RestReportProtocolDefault :: allSettings_v10
@@ -596,7 +597,7 @@ final case object RestSendMetrics extends RestSetting[Option[SendMetrics]] {
   def set = configService.set_send_server_metrics _
 }
 
-final case object RestJSEngine extends RestSetting[FeatureSwitch] {
+  final case object RestJSEngine extends RestSetting[FeatureSwitch] {
     val startPolicyGeneration = true
     def toJson(value : FeatureSwitch) : JValue = value.name
     def parseJson(json: JValue) = {
@@ -613,7 +614,24 @@ final case object RestJSEngine extends RestSetting[FeatureSwitch] {
     def set = (value : FeatureSwitch, _, _) => configService.set_rudder_featureSwitch_directiveScriptEngine(value)
   }
 
-final case object RestOnAcceptPolicyMode extends RestSetting[Option[PolicyMode]] {
+  final case object ArchiveApiFeatureSwitch extends RestSetting[FeatureSwitch] {
+    val startPolicyGeneration = false
+    def toJson(value : FeatureSwitch) : JValue = value.name
+    def parseJson(json: JValue) = {
+      json match {
+        case JString(value) => FeatureSwitch.parse(value)
+        case x              => Failure("Invalid value "+x)
+      }
+    }
+    def parseParam(param : String) = {
+      FeatureSwitch.parse(param)
+    }
+    val key = "rudder_featureSwitch_archiveApi"
+    def get = configService.rudder_featureSwitch_archiveApi()
+    def set = (value : FeatureSwitch, _, _) => configService.set_rudder_featureSwitch_archiveApi(value)
+  }
+
+  final case object RestOnAcceptPolicyMode extends RestSetting[Option[PolicyMode]] {
     val startPolicyGeneration = false
     def parseParam(value: String): Box[Option[PolicyMode]] = {
       Full(PolicyMode.allModes.find( _.name == value))
@@ -629,7 +647,8 @@ final case object RestOnAcceptPolicyMode extends RestSetting[Option[PolicyMode]]
     def get = configService.rudder_node_onaccept_default_policy_mode()
     def set = (value : Option[PolicyMode], _, _) => configService.set_rudder_node_onaccept_default_policy_mode(value)
   }
-final case object RestOnAcceptNodeState extends RestSetting[NodeState] {
+
+  final case object RestOnAcceptNodeState extends RestSetting[NodeState] {
     val startPolicyGeneration = false
     def parseParam(value: String): Box[NodeState] = {
       Full(NodeState.values.find( _.name == value).getOrElse(NodeState.Enabled))

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/DirectiveEditorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/DirectiveEditorService.scala
@@ -100,9 +100,9 @@ class DirectiveEditorServiceImpl(
     for {
       //start by checking Directive existence
       pol <- techniqueRepository.getTechnique(techniqueId).notOptional(s"Error when looking for technique with ID '${techniqueId.debugString}'. Check technique name and version").toBox
-      allVars = pol.rootSection.copyWithoutSystemVars.getAllVariables
+      allVars = pol._2.rootSection.copyWithoutSystemVars.getAllVariables
       vars = getVars(allVars, withVarValues)
-      pe <- section2FieldService.initDirectiveEditor(pol, directiveId, vars)
+      pe <- section2FieldService.initDirectiveEditor(pol._2, directiveId, vars)
     } yield pe
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_directives.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_directives.yml
@@ -261,6 +261,22 @@ response:
             ]
           },
           {
+            "id":"99f4ef91-537b-4e03-97bc-e65b447514cc",
+            "displayName":"directive 99f4ef91-537b-4e03-97bc-e65b447514cc",
+            "shortDescription":"",
+            "longDescription":"",
+            "techniqueName":"fileTemplate",
+            "techniqueVersion":"1.0",
+            "parameters":{"section":{"name":"sections","sections":[{"section":{"name":"Apply template","sections":[{"section":{"name":"Load Template from a file or text input","vars":[{"var":{"name":"FILE_TEMPLATE_AGENT_DESTINATION_PATH","value":"/tmp/other-destination.txt"}},{"var":{"name":"FILE_TEMPLATE_RAW_OR_NOT","value":"Raw"}},{"var":{"name":"FILE_TEMPLATE_RAW_TEMPLATE","value":"some content"}},{"var":{"name":"FILE_TEMPLATE_TEMPLATE","value":""}}],"sections":[{"section":{"name":"Expand template"}},{"section":{"name":"Posthook","vars":[{"var":{"name":"FILE_TEMPLATE_TEMPLATE_POST_HOOK_COMMAND","value":"/bin/true"}}]}},{"section":{"name":"Put permissions"}},{"section":{"name":"Templates directory permissions"}},{"section":{"name":"Templates location"}},{"section":{"name":"UNIX specific options","vars":[{"var":{"name":"FILE_TEMPLATE_GROUP_OWNER","value":"root"}},{"var":{"name":"FILE_TEMPLATE_OWNER","value":"root"}},{"var":{"name":"FILE_TEMPLATE_PERMISSIONS","value":"777"}},{"var":{"name":"FILE_TEMPLATE_PERSISTENT_POST_HOOK","value":"true"}},{"var":{"name":"FILE_TEMPLATE_TEMPLATE_TYPE","value":"mustache"}}]}}]}}]}}]}},
+            "priority":5,
+            "enabled":true,
+            "system":false,
+            "policyMode":"default",
+            "tags":[
+
+            ]
+          },
+          {
             "id":"directive-copyGitFile",
             "displayName":"directive-copyGitFile",
             "shortDescription":"",
@@ -314,22 +330,6 @@ response:
             "techniqueName":"fileTemplate",
             "techniqueVersion":"1.0",
             "parameters":{"section":{"name":"sections","sections":[{"section":{"name":"Apply template","sections":[{"section":{"name":"Load Template from a file or text input","vars":[{"var":{"name":"FILE_TEMPLATE_AGENT_DESTINATION_PATH","value":"/tmp/destination.txt"}},{"var":{"name":"FILE_TEMPLATE_RAW_OR_NOT","value":"Raw"}},{"var":{"name":"FILE_TEMPLATE_RAW_TEMPLATE","value":"some content"}},{"var":{"name":"FILE_TEMPLATE_TEMPLATE","value":""}}],"sections":[{"section":{"name":"Expand template"}},{"section":{"name":"Posthook","vars":[{"var":{"name":"FILE_TEMPLATE_TEMPLATE_POST_HOOK_COMMAND","value":""}}]}},{"section":{"name":"Put permissions"}},{"section":{"name":"Templates directory permissions"}},{"section":{"name":"Templates location"}},{"section":{"name":"UNIX specific options","vars":[{"var":{"name":"FILE_TEMPLATE_GROUP_OWNER","value":"root"}},{"var":{"name":"FILE_TEMPLATE_OWNER","value":"root"}},{"var":{"name":"FILE_TEMPLATE_PERMISSIONS","value":"700"}},{"var":{"name":"FILE_TEMPLATE_PERSISTENT_POST_HOOK","value":"false"}},{"var":{"name":"FILE_TEMPLATE_TEMPLATE_TYPE","value":"mustache"}}]}}]}}]}}]}},
-            "priority":5,
-            "enabled":false,
-            "system":false,
-            "policyMode":"default",
-            "tags":[
-
-            ]
-          },
-          {
-            "id":"ff44fb97-b65e-43c4-b8c2-0df8d5e8549f",
-            "displayName":"directive ff44fb97-b65e-43c4-b8c2-0df8d5e8549f",
-            "shortDescription":"",
-            "longDescription":"",
-            "techniqueName":"fileTemplate",
-            "techniqueVersion":"1.0",
-            "parameters":{"section":{"name":"sections","sections":[{"section":{"name":"Apply template","sections":[{"section":{"name":"Load Template from a file or text input","vars":[{"var":{"name":"FILE_TEMPLATE_AGENT_DESTINATION_PATH","value":"/tmp/other-destination.txt"}},{"var":{"name":"FILE_TEMPLATE_RAW_OR_NOT","value":"Raw"}},{"var":{"name":"FILE_TEMPLATE_RAW_TEMPLATE","value":"some content"}},{"var":{"name":"FILE_TEMPLATE_TEMPLATE","value":""}}],"sections":[{"section":{"name":"Expand template"}},{"section":{"name":"Posthook","vars":[{"var":{"name":"FILE_TEMPLATE_TEMPLATE_POST_HOOK_COMMAND","value":"/bin/true"}}]}},{"section":{"name":"Put permissions"}},{"section":{"name":"Templates directory permissions"}},{"section":{"name":"Templates location"}},{"section":{"name":"UNIX specific options","vars":[{"var":{"name":"FILE_TEMPLATE_GROUP_OWNER","value":"root"}},{"var":{"name":"FILE_TEMPLATE_OWNER","value":"root"}},{"var":{"name":"FILE_TEMPLATE_PERMISSIONS","value":"777"}},{"var":{"name":"FILE_TEMPLATE_PERSISTENT_POST_HOOK","value":"true"}},{"var":{"name":"FILE_TEMPLATE_TEMPLATE_TYPE","value":"mustache"}}]}}]}}]}}]}},
             "priority":5,
             "enabled":false,
             "system":false,
@@ -1676,6 +1676,136 @@ response:
                     "name": "File content (from remote template)",
                     "directives": [
                       {
+                        "id": "99f4ef91-537b-4e03-97bc-e65b447514cc",
+                        "displayName": "directive 99f4ef91-537b-4e03-97bc-e65b447514cc",
+                        "shortDescription": "",
+                        "longDescription": "",
+                        "techniqueName": "fileTemplate",
+                        "techniqueVersion": "1.0",
+                        "parameters": {
+                          "section": {
+                            "name": "sections",
+                            "sections": [
+                              {
+                                "section": {
+                                  "name": "Apply template",
+                                  "sections": [
+                                    {
+                                      "section": {
+                                        "name": "Load Template from a file or text input",
+                                        "vars": [
+                                          {
+                                            "var": {
+                                              "name": "FILE_TEMPLATE_AGENT_DESTINATION_PATH",
+                                              "value": "/tmp/other-destination.txt"
+                                            }
+                                          },
+                                          {
+                                            "var": {
+                                              "name": "FILE_TEMPLATE_RAW_OR_NOT",
+                                              "value": "Raw"
+                                            }
+                                          },
+                                          {
+                                            "var": {
+                                              "name": "FILE_TEMPLATE_RAW_TEMPLATE",
+                                              "value": "some content"
+                                            }
+                                          },
+                                          {
+                                            "var": {
+                                              "name": "FILE_TEMPLATE_TEMPLATE",
+                                              "value": ""
+                                            }
+                                          }
+                                        ],
+                                        "sections": [
+                                          {
+                                            "section": {
+                                              "name": "Expand template"
+                                            }
+                                          },
+                                          {
+                                            "section": {
+                                              "name": "Posthook",
+                                              "vars": [
+                                                {
+                                                  "var": {
+                                                    "name": "FILE_TEMPLATE_TEMPLATE_POST_HOOK_COMMAND",
+                                                    "value": "/bin/true"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "section": {
+                                              "name": "Put permissions"
+                                            }
+                                          },
+                                          {
+                                            "section": {
+                                              "name": "Templates directory permissions"
+                                            }
+                                          },
+                                          {
+                                            "section": {
+                                              "name": "Templates location"
+                                            }
+                                          },
+                                          {
+                                            "section": {
+                                              "name": "UNIX specific options",
+                                              "vars": [
+                                                {
+                                                  "var": {
+                                                    "name": "FILE_TEMPLATE_GROUP_OWNER",
+                                                    "value": "root"
+                                                  }
+                                                },
+                                                {
+                                                  "var": {
+                                                    "name": "FILE_TEMPLATE_OWNER",
+                                                    "value": "root"
+                                                  }
+                                                },
+                                                {
+                                                  "var": {
+                                                    "name": "FILE_TEMPLATE_PERMISSIONS",
+                                                    "value": "777"
+                                                  }
+                                                },
+                                                {
+                                                  "var": {
+                                                    "name": "FILE_TEMPLATE_PERSISTENT_POST_HOOK",
+                                                    "value": "true"
+                                                  }
+                                                },
+                                                {
+                                                  "var": {
+                                                    "name": "FILE_TEMPLATE_TEMPLATE_TYPE",
+                                                    "value": "mustache"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        "priority": 5,
+                        "enabled": true,
+                        "system": false,
+                        "policyMode": "default",
+                        "tags": []
+                      },
+                      {
                         "id": "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "displayName": "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "shortDescription": "",
@@ -1779,136 +1909,6 @@ response:
                                                   "var": {
                                                     "name": "FILE_TEMPLATE_PERSISTENT_POST_HOOK",
                                                     "value": "false"
-                                                  }
-                                                },
-                                                {
-                                                  "var": {
-                                                    "name": "FILE_TEMPLATE_TEMPLATE_TYPE",
-                                                    "value": "mustache"
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  ]
-                                }
-                              }
-                            ]
-                          }
-                        },
-                        "priority": 5,
-                        "enabled": false,
-                        "system": false,
-                        "policyMode": "default",
-                        "tags": []
-                      },
-                      {
-                        "id": "ff44fb97-b65e-43c4-b8c2-0df8d5e8549f",
-                        "displayName": "directive ff44fb97-b65e-43c4-b8c2-0df8d5e8549f",
-                        "shortDescription": "",
-                        "longDescription": "",
-                        "techniqueName": "fileTemplate",
-                        "techniqueVersion": "1.0",
-                        "parameters": {
-                          "section": {
-                            "name": "sections",
-                            "sections": [
-                              {
-                                "section": {
-                                  "name": "Apply template",
-                                  "sections": [
-                                    {
-                                      "section": {
-                                        "name": "Load Template from a file or text input",
-                                        "vars": [
-                                          {
-                                            "var": {
-                                              "name": "FILE_TEMPLATE_AGENT_DESTINATION_PATH",
-                                              "value": "/tmp/other-destination.txt"
-                                            }
-                                          },
-                                          {
-                                            "var": {
-                                              "name": "FILE_TEMPLATE_RAW_OR_NOT",
-                                              "value": "Raw"
-                                            }
-                                          },
-                                          {
-                                            "var": {
-                                              "name": "FILE_TEMPLATE_RAW_TEMPLATE",
-                                              "value": "some content"
-                                            }
-                                          },
-                                          {
-                                            "var": {
-                                              "name": "FILE_TEMPLATE_TEMPLATE",
-                                              "value": ""
-                                            }
-                                          }
-                                        ],
-                                        "sections": [
-                                          {
-                                            "section": {
-                                              "name": "Expand template"
-                                            }
-                                          },
-                                          {
-                                            "section": {
-                                              "name": "Posthook",
-                                              "vars": [
-                                                {
-                                                  "var": {
-                                                    "name": "FILE_TEMPLATE_TEMPLATE_POST_HOOK_COMMAND",
-                                                    "value": "/bin/true"
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          },
-                                          {
-                                            "section": {
-                                              "name": "Put permissions"
-                                            }
-                                          },
-                                          {
-                                            "section": {
-                                              "name": "Templates directory permissions"
-                                            }
-                                          },
-                                          {
-                                            "section": {
-                                              "name": "Templates location"
-                                            }
-                                          },
-                                          {
-                                            "section": {
-                                              "name": "UNIX specific options",
-                                              "vars": [
-                                                {
-                                                  "var": {
-                                                    "name": "FILE_TEMPLATE_GROUP_OWNER",
-                                                    "value": "root"
-                                                  }
-                                                },
-                                                {
-                                                  "var": {
-                                                    "name": "FILE_TEMPLATE_OWNER",
-                                                    "value": "root"
-                                                  }
-                                                },
-                                                {
-                                                  "var": {
-                                                    "name": "FILE_TEMPLATE_PERMISSIONS",
-                                                    "value": "777"
-                                                  }
-                                                },
-                                                {
-                                                  "var": {
-                                                    "name": "FILE_TEMPLATE_PERSISTENT_POST_HOOK",
-                                                    "value": "true"
                                                   }
                                                 },
                                                 {

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
@@ -16,7 +16,31 @@ response:
             "displayName":"Real nodes",
             "description":"",
             "category":"GroupRoot",
-            "nodeIds":[
+            "query":{
+              "select":"nodeAndPolicyServer",
+              "composition":"or",
+              "where":[
+                {
+                  "objectType":"node",
+                  "attribute":"nodeId",
+                  "comparator":"eq",
+                  "value":"node1"
+                },
+                {
+                  "objectType":"node",
+                  "attribute":"nodeId",
+                  "comparator":"eq",
+                  "value":"node2"
+                },
+                {
+                  "objectType":"node",
+                  "attribute":"nodeId",
+                  "comparator":"eq",
+                  "value":"root"
+                }
+              ]
+            },
+           "nodeIds":[
               "node1",
               "node2",
               "root"
@@ -222,6 +246,30 @@ response:
             "displayName":"Real nodes",
             "description":"",
             "category":"GroupRoot",
+            "query":{
+              "select":"nodeAndPolicyServer",
+              "composition":"or",
+              "where":[
+                {
+                  "objectType":"node",
+                  "attribute":"nodeId",
+                  "comparator":"eq",
+                  "value":"node1"
+                },
+                {
+                  "objectType":"node",
+                  "attribute":"nodeId",
+                  "comparator":"eq",
+                  "value":"node2"
+                },
+                {
+                  "objectType":"node",
+                  "attribute":"nodeId",
+                  "comparator":"eq",
+                  "value":"root"
+                }
+              ]
+            },
             "nodeIds":["node1","node2","root"],
             "dynamic":false,
             "enabled":true,

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_settings.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_settings.yml
@@ -49,13 +49,13 @@ response:
           "require_time_synchronization":true,
           "rudder_compute_changes":true,
           "rudder_compute_dyngroups_max_parallelism":"1",
+          "rudder_featureSwitch_archiveApi":"disabled",
           "rudder_generation_compute_dyngroups":true,
           "rudder_generation_continue_on_error":false,
           "rudder_generation_delay":"0 seconds",
           "rudder_generation_js_timeout":30,
           "rudder_generation_max_parallelism":"x0.5",
           "rudder_generation_policy":"all",
-          "rudder_generation_rudderc_enabled_targets":[],
           "rudder_report_protocol_default":"HTTPS",
           "rudder_save_db_compliance_details":false,
           "rudder_save_db_compliance_levels":true,
@@ -65,27 +65,6 @@ response:
           "splay_time":4,
           "unexpected_unbound_var_values":true
         }
-      }
-    }
----
-description: Modify rudderc target
-method: POST
-url: /api/latest/settings/rudder_generation_rudderc_enabled_targets
-headers:
-  - "Content-Type: application/json"
-body: >-
-  {
-    "value": ["dsc"]
-  }
-response:
-  code: 200
-  content: >-
-    {
-      "action":"modifySetting",
-      "id":"rudder_generation_rudderc_enabled_targets",
-      "result":"success",
-      "data":{
-        "settings":{"rudder_generation_rudderc_enabled_targets":["dsc"]}
       }
     }
 ---

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTests.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTests.scala
@@ -1,0 +1,486 @@
+/*
+*************************************************************************************
+* Copyright 2018 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+package com.normation.rudder.rest
+
+import com.normation.cfclerk.domain.TechniqueId
+import com.normation.cfclerk.domain.TechniqueName
+import com.normation.cfclerk.domain.TechniqueVersion
+import com.normation.eventlog.EventActor
+import com.normation.eventlog.ModificationId
+import com.normation.rudder.apidata.JsonQueryObjects.JQRule
+import com.normation.rudder.domain.appconfig.FeatureSwitch
+import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
+import com.normation.rudder.domain.policies.DirectiveUid
+import com.normation.rudder.domain.policies.RuleId
+import com.normation.rudder.domain.policies.RuleUid
+import com.normation.rudder.git.ZipUtils
+import com.normation.rudder.rest.RudderJsonResponse.LiftJsonResponse
+import com.normation.utils.DateFormaterService
+
+import better.files.File
+import net.liftweb.common.Full
+import net.liftweb.common.Loggable
+import net.liftweb.http.InMemoryResponse
+import net.liftweb.http.OutputStreamResponse
+import org.apache.commons.io.FileUtils
+import org.eclipse.jgit.revwalk.RevWalk
+import org.joda.time.DateTime
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.AfterAll
+
+import java.io.FileOutputStream
+import java.nio.charset.StandardCharsets
+import java.util.zip.ZipFile
+
+import com.normation.errors.IOResult
+import com.normation.errors.effectUioUnit
+import com.normation.zio._
+
+@RunWith(classOf[JUnitRunner])
+class ArchiveApiTests extends Specification with AfterAll with Loggable {
+
+  val restTestSetUp = RestTestSetUp.newEnv
+  val restTest = new RestTest(restTestSetUp.liftRules)
+
+  val testDir = File(s"/tmp/test-rudder-response-content-${DateFormaterService.serialize(DateTime.now())}")
+  testDir.createDirectoryIfNotExists(true)
+
+  override def afterAll(): Unit = {
+    if (System.getProperty("tests.clean.tmp") != "false") {
+      logger.info("Cleanup rest env ")
+      restTestSetUp.cleanup()
+      logger.info("Deleting directory " + testDir.pathAsString)
+      FileUtils.deleteDirectory(testDir.toJava)
+    }
+  }
+
+  def children(f: File) = f.children.toList.map(_.name)
+
+  org.slf4j.LoggerFactory.getLogger("application.archive").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.TRACE)
+  org.slf4j.LoggerFactory.getLogger("configuration").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.TRACE)
+
+  sequential
+
+  "when the feature switch is disabled, request" should {
+    "error in GET /archives/export" in {
+      restTest.testGETResponse("/api/archives/export") {
+        case Full(InMemoryResponse(json, _, _, 500)) => new String(json, StandardCharsets.UTF_8) must beMatching(".*This API is disabled.*")
+        case err                                     => ko(s"I got an error in test: ${err}")
+      }
+    }
+
+    "error in POST /archives/export" in {
+      restTest.testEmptyPostResponse("/api/archives/import") {
+        case Full(InMemoryResponse(json, _, _, 500)) => new String(json, StandardCharsets.UTF_8) must beMatching(".*This API is disabled.*")
+        case err                                     => ko(s"I got an error in test: ${err}")
+      }
+    }
+  }
+
+  // FROM THERE, FEATURE IS ENABLED
+
+  "when the feature switch is enabled, request" should {
+    "succeed in GET /archives/export" in {
+      // feature switch change needs to be at that level and not under "should" directly,
+      // else it contaminated all tests, even with the sequential annotation
+      restTestSetUp.archiveAPIModule.featureSwitchState.set(FeatureSwitch.Enabled).runNow
+      restTest.testGETResponse("/api/archives/export") {
+        case Full(resp) => resp.toResponse.code must beEqualTo(200)
+        case err        => ko(s"I got an error in test: ${err}")
+      }
+    }
+  }
+
+  "correctly build an archive of one rule, no deps" >> {
+
+    // rule with ID rule1 defined in com/normation/rudder/MockServices.scala has name:
+    // 10. Global configuration for all nodes
+    // so: 10__Global_configuration_for_all_nodes
+    val fileName = "10__Global_configuration_for_all_nodes.json"
+
+    val archiveName = "archive-rule-no-dep"
+    restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+
+    restTest.testGETResponse("/api/archives/export?rules=rule1&include=none") {
+      case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+        val zipFile = testDir/s"${archiveName}.zip"
+        val zipOut = new FileOutputStream(zipFile.toJava)
+        out(zipOut)
+        zipOut.close()
+        // unzip
+        ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+        (children(testDir/s"${archiveName}/rules") must containTheSameElementsAs(List(fileName))) and
+        (children(testDir/s"${archiveName}/groups").isEmpty must beTrue) and
+        (children(testDir/s"${archiveName}/directives").isEmpty must beTrue) and
+        (children(testDir/s"${archiveName}/techniques").isEmpty must beTrue)
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+
+
+  "correctly build an archive with one rule, dep: group and technique (and implied directives)" in {
+    val fileName = "10__Global_configuration_for_all_nodes.json"
+
+    val archiveName = "archive-rule-with-dep"
+    restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+
+    restTest.testGETResponse("/api/archives/export?rules=rule1&include=groups,techniques") {
+      case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+        val zipFile = testDir/s"${archiveName}.zip"
+        val zipOut = new FileOutputStream(zipFile.toJava)
+        out(zipOut)
+        zipOut.close()
+        // unzip
+        ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+        (children(testDir/s"${archiveName}/rules") must containTheSameElementsAs(List(fileName))) and
+        // only system group => none exported
+        (children(testDir/s"${archiveName}/groups") must containTheSameElementsAs(Nil)) and
+        (children(testDir/s"${archiveName}/directives") must containTheSameElementsAs(List("10__Clock_Configuration.json"))) and
+        (children(testDir/s"${archiveName}/techniques/systemSettings/misc/clockConfiguration/3.0") must containTheSameElementsAs(List("changelog", "clockConfiguration.st", "metadata.xml")))
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+  "correctly build an archive of one directive" >> {
+
+    // rule with ID rule1 defined in com/normation/rudder/MockServices.scala has name:
+    // 10. Global configuration for all nodes
+    // so: 10__Global_configuration_for_all_nodes
+    val fileName = "10__Clock_Configuration.json"
+
+    val archiveName = "archive-directive"
+    restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+
+    restTest.testGETResponse("/api/archives/export?directives=directive1&include=none") {
+      case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+        val zipFile = testDir/s"${archiveName}.zip"
+        val zipOut = new FileOutputStream(zipFile.toJava)
+        out(zipOut)
+        zipOut.close()
+        // unzip
+        ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+        (children(testDir/s"${archiveName}/directives") must containTheSameElementsAs(List(fileName))) and
+        (children(testDir/s"${archiveName}/groups").isEmpty must beTrue) and
+        (children(testDir/s"${archiveName}/rules").isEmpty must beTrue) and
+        (children(testDir/s"${archiveName}/techniques").isEmpty must beTrue)
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+  "correctly build an archive of one group" >> {
+
+    // group with ID 0000f5d3-8c61-4d20-88a7-bb947705ba8a defined in com/normation/rudder/MockServices.scala has name:
+    // Real nodes
+    // so: Real_nodes
+    val fileName = "Real_nodes.json"
+
+    val archiveName = "archive-group"
+    restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+
+    restTest.testGETResponse("/api/archives/export?groups=0000f5d3-8c61-4d20-88a7-bb947705ba8a&include=none") {
+      case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+        val zipFile = testDir/s"${archiveName}.zip"
+        val zipOut = new FileOutputStream(zipFile.toJava)
+        out(zipOut)
+        zipOut.close()
+        // unzip
+        ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+        (children(testDir/s"${archiveName}/groups") must containTheSameElementsAs(List(fileName)))
+        (children(testDir/s"${archiveName}/rules").isEmpty must beTrue) and
+        (children(testDir/s"${archiveName}/directives").isEmpty must beTrue) and
+        (children(testDir/s"${archiveName}/techniques").isEmpty must beTrue)
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+  "correctly build an archive of one technique" >> {
+    val archiveName = "archive-technique"
+    restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+    val techniqueId = "Create_file/1.0"
+    restTest.testGETResponse(s"/api/archives/export?techniques=${techniqueId}&include=none") {
+      case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+        val zipFile = testDir/s"${archiveName}.zip"
+        val zipOut = new FileOutputStream(zipFile.toJava)
+        out(zipOut)
+        zipOut.close()
+        // unzip
+        ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+        val techniqueFiles = List("Create_file.ps1", "expected_reports.csv", "metadata.xml", "rudder_reporting.st")
+
+        (children(testDir/s"${archiveName}/techniques/ncf_techniques/${techniqueId}") must containTheSameElementsAs(techniqueFiles))
+        (children(testDir/s"${archiveName}/groups").isEmpty must beTrue) and
+        (children(testDir/s"${archiveName}/directives").isEmpty must beTrue) and
+        (children(testDir/s"${archiveName}/rules").isEmpty must beTrue)
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+
+  "correctly build an archive with two rules and only group and directive" in {
+    val fileName1 = "10__Global_configuration_for_all_nodes.json"
+    val fileName2 = "60-rule-technique-std-lib.json"
+
+    val archiveName = "archive-two-rules-with-dep"
+    restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+
+    restTest.testGETResponse("/api/archives/export?rules=rule1,ff44fb97-b65e-43c4-b8c2-0df8d5e8549f&include=groups,directives") {
+      case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+        val zipFile = testDir/s"${archiveName}.zip"
+        val zipOut = new FileOutputStream(zipFile.toJava)
+        out(zipOut)
+        zipOut.close()
+        // unzip
+        ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+        (children(testDir/s"${archiveName}/rules") must containTheSameElementsAs(List(fileName1, fileName2))) and
+        // only system group => none exported
+        (children(testDir/s"${archiveName}/groups") must containTheSameElementsAs(Nil)) and
+        (children(testDir/s"${archiveName}/directives") must containTheSameElementsAs(List(
+            "10__Clock_Configuration.json"
+          , "directive_16617aa8-1f02-4e4a-87b6-d0bcdfb4019f.json"
+          , "directive_e9a1a909-2490-4fc9-95c3-9d0aa01717c9.json"
+          , "directive_99f4ef91-537b-4e03-97bc-e65b447514cc.json"
+        ))) and
+        (children(testDir/s"${archiveName}/techniques").isEmpty must beTrue)
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+
+
+  "we should be able to unzip an archive with ZipInputStream" >> {
+    /*
+     * use one the previously downloaded archive, and unzip it into a new subdirectory, and compare content
+     */
+    val archiveDir = "archive-rule-with-dep"
+    val unzipped = testDir / archiveDir
+    val is = File(unzipped.pathAsString + ".zip").newInputStream
+    val entries = ZipUtils.getZipEntries("unzip-archive-with-input-stream", is).runNow
+    val dest = testDir / "unzip-with-input-stream"
+    dest.createDirectory()
+    entries.foreach { case (entry, bytes) =>
+      val d = dest / entry.getName
+      bytes match {
+        case None =>
+          d.createDirectoryIfNotExists(true)
+        case Some(b) =>
+          d.parent.createDirectoryIfNotExists()
+          d.writeBytes(b.iterator)
+      }
+    }
+
+    children(dest / archiveDir) must containTheSameElementsAs(children(unzipped))
+  }
+
+  "unzipping and reading an archive" >> {
+    /*
+     * use one the previously downloaded archive, and unzip it into a new subdirectory, and compare content
+     */
+    val archiveDir = "archive-rule-with-dep"
+    val unzipped = testDir / archiveDir
+    // read zip entries, load archive
+    val p = IOResult.effect(File(unzipped.pathAsString + ".zip").newInputStream).bracket(is => effectUioUnit(is.close)) { is =>
+      ZipUtils.getZipEntries(archiveDir + ".zip", is)
+    }.flatMap(entries =>
+      restTestSetUp.archiveAPIModule.zipArchiveReader.readPolicyItems(archiveDir + ".zip", entries)
+    ).runNow
+
+    val rule1 = restTestSetUp.mockRules.ruleRepo.getOpt(RuleId(RuleUid("rule1"))).notOptional(s"test").runNow
+    val dir1 = restTestSetUp.mockDirectives.directiveRepo.getDirective(DirectiveUid("directive1")).notOptional(s"test").runNow
+    val tech = restTestSetUp.mockTechniques.techniqueRepo.get(TechniqueId(TechniqueName("clockConfiguration"),
+      TechniqueVersion.parse("3.0").getOrElse(throw new IllegalArgumentException("test")) )
+    ).getOrElse(throw new IllegalArgumentException("test"))
+
+    (p.techniques(0).technique must beEqualTo(tech)) and
+    (p.directives(0).directive must beEqualTo(dir1)) and
+    (p.rules(0) must beEqualTo(rule1))
+  }
+
+  "uploading an archive" >> {
+    def sed(f: File, replace: String, by: String): Unit = {
+
+      val content = f.contentAsString.replaceAll(replace, by)
+      f.writeText(content)
+    }
+
+    /*
+     * Copy the content of a existing archive into an import directory, zip-it
+     */
+    val unzipped = testDir / "archive-rule-with-dep"
+
+    val dest = testDir / "import-rule-with-dep"
+    FileUtils.copyDirectory(unzipped.toJava, dest.toJava)
+    // add a group
+    (testDir / "archive-group" / "groups" / "Real_nodes.json").copyToDirectory(testDir / "import-rule-with-dep" / "groups")
+
+    val tech = restTestSetUp.mockTechniques.techniqueRepo.get(TechniqueId(TechniqueName("clockConfiguration"),
+      TechniqueVersion.parse("3.0").getOrElse(throw new IllegalArgumentException("test")) )
+    ).getOrElse(throw new IllegalArgumentException("test")).copy(name = "Time settings updated")
+    val dir1 = restTestSetUp.mockDirectives.directiveRepo.getDirective(DirectiveUid("directive1")).notOptional(s"test").runNow.
+      copy(shortDescription = "a new description")
+    val group = {
+      val (group, _) = restTestSetUp.mockNodeGroups.groupsRepo.getNodeGroup(NodeGroupId(NodeGroupUid("0000f5d3-8c61-4d20-88a7-bb947705ba8a"))).runNow
+      group.copy(description = "a new description")
+    }
+    val rule1 = restTestSetUp.mockRules.ruleRepo.getOpt(RuleId(RuleUid("rule1"))).notOptional(s"test").runNow.
+      copy(shortDescription = "a new description")
+
+    // change things
+    sed(dest / "techniques" / "systemSettings" / "misc" / "clockConfiguration" / "3.0"/ "metadata.xml"
+      , """<TECHNIQUE name="Time settings">""", s"""<TECHNIQUE name="${tech.name}">""")
+    sed(dest / "directives" / "10__Clock_Configuration.json"
+      , """"shortDescription" : """"", s""""shortDescription" : "${dir1.shortDescription}"""")
+    sed(dest / "groups" / "Real_nodes.json"
+      , """"description" : """"", s""""description" : "${group.description}"""")
+    sed(dest / "rules" / "10__Global_configuration_for_all_nodes.json"
+      , """global config for all nodes""", s"""${rule1.shortDescription}""")
+
+    // now zip it
+    val zip = File(dest.pathAsString+".zip")
+    dest.zipTo(zip)
+
+    restTest.testBinaryPOSTResponse(s"/api/archives/import", "archive", zip.name, zip.newInputStream.readAllBytes()) {
+      case Full(LiftJsonResponse(res, _, 200)) =>
+        restTestSetUp.archiveAPIModule.archiveSaver.base.get.runNow match {
+          case None    => ko(s"No policies were saved")
+          case Some(p) =>
+
+            (p.techniques(0).technique must beEqualTo(tech)) and
+            (p.directives(0).directive must beEqualTo(dir1)) and
+            (p.groups(0).group must beEqualTo(group))
+            (p.rules(0) must beEqualTo(rule1))
+        }
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+
+  /*
+   * This one change content of rule1, directive1 and group1, do it once you don't need original values
+   * anymore.
+   */
+  "correctly build an archive with past revision items" >> {
+    import zio.json._
+    import com.normation.rudder.apidata.implicits._
+
+    val initRev = {
+      val head = restTestSetUp.mockGitRepo.gitRepo.db.exactRef("refs/heads/master")
+      val walk = new RevWalk(restTestSetUp.mockGitRepo.gitRepo.db)
+      val commit = walk.parseCommit(head.getObjectId)
+      walk.dispose()
+      commit.name()
+    }
+
+    //update rule definition
+    val ruleId = "rule1"
+    val ruleFileName = "10__Global_configuration_for_all_nodes.json"
+    val newDesc = "new rule description"
+
+    (for {
+      r <- restTestSetUp.mockRules.ruleRepo.getOpt(RuleId(RuleUid(ruleId))).notOptional(s"missing ${ruleId} in test")
+      _ <- restTestSetUp.mockRules.ruleRepo.update(r.copy(shortDescription = newDesc), ModificationId("rule"), EventActor("test"), None)
+    } yield ()).runNow
+    // update technique
+    val techniqueId = "Create_file/1.0"
+    val relPath = s"techniques/ncf_techniques/${techniqueId}/newfile"
+    val f = restTestSetUp.mockGitRepo.configurationRepositoryRoot/relPath
+    f.write("hello world")
+    restTestSetUp.mockGitRepo.gitRepo.git.add().addFilepattern(relPath).call()
+    restTestSetUp.mockGitRepo.gitRepo.git.commit().setMessage(s"add file in ${techniqueId}").call()
+    restTestSetUp.mockTechniques.techniqueReader.readTechniques
+
+    val baseFiles = List("Create_file.ps1", "expected_reports.csv", "metadata.xml", "rudder_reporting.st")
+
+    {
+      val archiveName = "archive-technique-head"
+      restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+      restTest.testGETResponse(s"/api/archives/export?rules=${ruleId}&techniques=${techniqueId}") {
+        case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+          val zipFile = testDir/s"${archiveName}.zip"
+          val zipOut = new FileOutputStream(zipFile.toJava)
+          out(zipOut)
+          zipOut.close()
+          // unzip
+          ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+          val r = (testDir / s"${archiveName}/rules/${ruleFileName}").contentAsString.fromJson[JQRule].getOrElse(throw new IllegalArgumentException(s"error in rule deserialization"))
+
+          (r.shortDescription.getOrElse("") must beMatching(newDesc)) and
+          (children(testDir/s"${archiveName}/techniques/ncf_techniques/${techniqueId}") must containTheSameElementsAs("newfile" :: baseFiles))
+
+        case err => ko(s"I got an error in test: ${err}")
+      }
+    } and {
+      val archiveName = "archive-technique-init"
+      restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+      // TODO: rule are not serialized in test repos, we won't find it!
+      restTest.testGETResponse(s"/api/archives/export?rules=${ruleId}&techniques=${techniqueId}%2B${initRev}") {
+        case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+          val zipFile = testDir/s"${archiveName}.zip"
+          val zipOut = new FileOutputStream(zipFile.toJava)
+          out(zipOut)
+          zipOut.close()
+          // unzip
+          ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+          //val r = (testDir / s"${archiveName}/rules/${ruleFileName}").contentAsString.fromJson[JQRule].getOrElse(throw new IllegalArgumentException(s"error in rule deserialization"))
+          //(r.shortDescription.getOrElse("") must beMatching("global config for all nodes")) and
+          (children(testDir/s"${archiveName}/techniques/ncf_techniques/${techniqueId}") must containTheSameElementsAs(baseFiles))
+
+        case err => ko(s"I got an error in test: ${err}")
+      }
+    }
+  }
+}
+

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/NodeApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/NodeApiTest.scala
@@ -6,7 +6,6 @@ import com.normation.inventory.domain.PendingInventory
 
 import net.liftweb.common.Full
 import net.liftweb.common.Loggable
-import net.liftweb.http.InMemoryResponse
 import net.liftweb.json.JsonParser
 import net.liftweb.json.compactRender
 import org.junit.runner.RunWith

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -49,9 +49,6 @@ import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.FullInventory
 import com.normation.inventory.domain.NodeId
 import com.normation.inventory.domain.NodeInventory
-import com.normation.inventory.ldap.core.InventoryDit
-import com.normation.inventory.ldap.core.InventoryDitService
-import com.normation.inventory.ldap.core.InventoryDitServiceImpl
 import com.normation.rudder._
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.api.{ApiAuthorization => ApiAuthz}
@@ -59,8 +56,6 @@ import com.normation.rudder.apidata.RestDataSerializerImpl
 import com.normation.rudder.apidata.ZioJsonExtractor
 import com.normation.rudder.batch.PolicyGenerationTrigger.AllGeneration
 import com.normation.rudder.batch._
-import com.normation.rudder.domain.NodeDit
-import com.normation.rudder.domain.RudderDit
 import com.normation.rudder.domain.appconfig.FeatureSwitch
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
@@ -69,28 +64,19 @@ import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.GlobalPolicyMode
 import com.normation.rudder.domain.policies.PolicyMode.Audit
-import com.normation.rudder.domain.policies.PolicyMode.Enforce
 import com.normation.rudder.domain.policies.PolicyModeOverrides
-import com.normation.rudder.domain.policies.PolicyModeOverrides.Always
 import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleTarget
 import com.normation.rudder.domain.properties.GlobalParameter
-import com.normation.rudder.domain.queries.DitQueryData
-import com.normation.rudder.domain.queries.ObjectCriterion
 import com.normation.rudder.domain.reports.NodeConfigId
 import com.normation.rudder.domain.reports.NodeExpectedReports
 import com.normation.rudder.domain.reports.NodeModeConfig
-import com.normation.rudder.domain.secret.Secret
 import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.rudder.git.GitArchiveId
 import com.normation.rudder.git.GitCommitId
 import com.normation.rudder.git.GitPath
 import com.normation.rudder.hooks.HookEnvPairs
-import com.normation.rudder.ncf.ResourceFileService
-import com.normation.rudder.ncf.TechniqueReader
-import com.normation.rudder.ncf.TechniqueSerializer
-import com.normation.rudder.ncf.TechniqueWriter
 import com.normation.rudder.reports.AgentRunInterval
 import com.normation.rudder.reports.ComplianceMode
 import com.normation.rudder.reports.GlobalComplianceMode
@@ -121,14 +107,10 @@ import com.normation.rudder.services.policies.NodeConfiguration
 import com.normation.rudder.services.policies.NodeConfigurations
 import com.normation.rudder.services.policies.NodesContextResult
 import com.normation.rudder.services.policies.PromiseGenerationService
-import com.normation.rudder.services.policies.RuleApplicationStatusServiceImpl
 import com.normation.rudder.services.policies.RuleVal
 import com.normation.rudder.services.policies.nodeconfig.NodeConfigurationHash
-import com.normation.rudder.services.queries.CmdbQueryParser
-import com.normation.rudder.services.queries.DefaultStringQueryParser
 import com.normation.rudder.services.queries.DynGroupService
 import com.normation.rudder.services.queries.DynGroupUpdaterServiceImpl
-import com.normation.rudder.services.queries.JsonQueryLexer
 import com.normation.rudder.services.reports.CacheExpectedReportAction
 import com.normation.rudder.services.servers.DeleteMode
 import com.normation.rudder.services.system.DebugInfoScriptResult
@@ -146,8 +128,6 @@ import com.normation.rudder.web.services.StatelessUserPropertyService
 import com.normation.rudder.web.services.Translator
 import com.normation.utils.StringUuidGeneratorImpl
 
-import com.unboundid.ldap.sdk.DN
-import com.unboundid.ldap.sdk.RDN
 import net.liftweb.common.Box
 import net.liftweb.common.EmptyBox
 import net.liftweb.common.Full
@@ -176,6 +156,20 @@ import zio.duration._
 import zio.syntax._
 import com.normation.box._
 import com.normation.errors.IOResult
+import com.normation.rudder.domain.policies.PolicyMode.Enforce
+import com.normation.rudder.domain.policies.PolicyModeOverrides.Always
+import com.normation.rudder.domain.secret.Secret
+import com.normation.rudder.ncf.ResourceFileService
+import com.normation.rudder.ncf.TechniqueReader
+import com.normation.rudder.ncf.TechniqueSerializer
+import com.normation.rudder.ncf.TechniqueWriter
+import com.normation.rudder.services.policies.RuleApplicationStatusServiceImpl
+
+import org.apache.commons.httpclient.methods.multipart.ByteArrayPartSource
+import org.apache.commons.httpclient.methods.multipart.FilePart
+import org.apache.commons.httpclient.params.HttpMethodParams
+import org.apache.commons.io.output.ByteArrayOutputStream
+
 import com.normation.zio._
 
 /*
@@ -215,32 +209,17 @@ class RestTestSetUp {
     }
 
 
-  ///// query parsing ////
-  def DN(rdn: String, parent: DN) = new DN(new RDN(rdn),  parent)
-  val LDAP_BASEDN = new DN("cn=rudder-configuration")
-  val LDAP_INVENTORIES_BASEDN = DN("ou=Inventories", LDAP_BASEDN)
-  val LDAP_INVENTORIES_SOFTWARE_BASEDN = LDAP_INVENTORIES_BASEDN
-
-  val acceptedNodesDitImpl: InventoryDit = new InventoryDit(DN("ou=Accepted Inventories", LDAP_INVENTORIES_BASEDN), LDAP_INVENTORIES_SOFTWARE_BASEDN, "Accepted inventories")
-  val pendingNodesDitImpl: InventoryDit = new InventoryDit(DN("ou=Pending Inventories", LDAP_INVENTORIES_BASEDN), LDAP_INVENTORIES_SOFTWARE_BASEDN, "Pending inventories")
-  val removedNodesDitImpl = new InventoryDit(DN("ou=Removed Inventories", LDAP_INVENTORIES_BASEDN), LDAP_INVENTORIES_SOFTWARE_BASEDN,"Removed Servers")
-  val rudderDit = new RudderDit(DN("ou=Rudder", LDAP_BASEDN))
-  val nodeDit = new NodeDit(LDAP_BASEDN)
-  val inventoryDitService: InventoryDitService = new InventoryDitServiceImpl(pendingNodesDitImpl, acceptedNodesDitImpl, removedNodesDitImpl)
-  val ditQueryDataImpl = new DitQueryData(acceptedNodesDitImpl, nodeDit, rudderDit, () => Nil.succeed)
-  val queryParser = new CmdbQueryParser with DefaultStringQueryParser with JsonQueryLexer {
-    override val criterionObjects = Map[String, ObjectCriterion]() ++ ditQueryDataImpl.criteriaMap
-  }
 
   val mockGitRepo = new MockGitConfigRepo("")
   val mockTechniques = MockTechniques(mockGitRepo)
   val mockDirectives = new MockDirectives(mockTechniques)
   val mockRules = new MockRules()
-  val mockConfigRepo = new MockConfigRepo(mockTechniques, mockDirectives, mockRules)
   val mockNodes = new MockNodes()
   val mockParameters = new MockGlobalParam()
   val mockNodeGroups = new MockNodeGroups(mockNodes)
+  val mockLdapQueryParsing = new MockLdapQueryParsing(mockGitRepo, mockNodeGroups)
   val uuidGen = new StringUuidGeneratorImpl()
+  val mockConfigRepo = new MockConfigRepo(mockTechniques, mockDirectives, mockRules, mockNodeGroups, mockLdapQueryParsing)
 
   val dynGroupUpdaterService = new DynGroupUpdaterServiceImpl(mockNodeGroups.groupsRepo, mockNodeGroups.groupsRepo, mockNodes.queryProcessor)
 
@@ -355,14 +334,14 @@ class RestTestSetUp {
     , mockDirectives.directiveRepo
     , null //roNodeGroupRepository
     , mockTechniques.techniqueRepo
-    , queryParser //queryParser
+    , mockLdapQueryParsing.queryParser //queryParser
     , new StatelessUserPropertyService(() => false.succeed, () => false.succeed, () => "".succeed)
     , workflowLevelService
     , uuidGen
     , null
   )
 
-  val zioJsonExtractor = new ZioJsonExtractor(queryParser)
+  val zioJsonExtractor = new ZioJsonExtractor(mockLdapQueryParsing.queryParser)
 
   val restDataSerializer = RestDataSerializerImpl(
       mockTechniques.techniqueRepo
@@ -640,7 +619,7 @@ class RestTestSetUp {
 
   val groupService2  = new GroupApiService2( mockNodeGroups.groupsRepo, mockNodeGroups.groupsRepo, uuidGen, asyncDeploymentAgent, workflowLevelService, restExtractorService, mockNodes.queryProcessor, restDataSerializer)
   val groupService6  = new GroupApiService6( mockNodeGroups.groupsRepo, mockNodeGroups.groupsRepo, restDataSerializer)
-  val groupService14 = new GroupApiService14(mockNodeGroups.groupsRepo, mockNodeGroups.groupsRepo, mockParameters.paramsRepo, uuidGen, asyncDeploymentAgent, workflowLevelService, restExtractorService, queryParser, mockNodes.queryProcessor, restDataSerializer)
+  val groupService14 = new GroupApiService14(mockNodeGroups.groupsRepo, mockNodeGroups.groupsRepo, mockParameters.paramsRepo, uuidGen, asyncDeploymentAgent, workflowLevelService, restExtractorService, mockLdapQueryParsing.queryParser, mockNodes.queryProcessor, restDataSerializer)
   val groupApiInheritedProperties = new GroupApiInheritedProperties(mockNodeGroups.groupsRepo, mockParameters.paramsRepo)
   val ncfTechniqueWriter : TechniqueWriter = null
   val ncfTechniqueReader : TechniqueReader = null
@@ -648,6 +627,25 @@ class RestTestSetUp {
   val techniqueSerializer : TechniqueSerializer = null
   val resourceFileService : ResourceFileService = null
   val settingsService = new MockSettings(workflowLevelService, new AsyncWorkflowInfo())
+
+  object archiveAPIModule {
+    val archiveBuilderService = new ZipArchiveBuilderService(new FileArchiveNameService(), mockConfigRepo.configurationRepository, mockTechniques.techniqueRevisionRepo)
+    val featureSwitchState = Ref.make[FeatureSwitch](FeatureSwitch.Disabled).runNow
+    // archive name in a Ref to make it simple to change in tests
+    val rootDirName = Ref.make("archive").runNow
+    val zipArchiveReader = new ZipArchiveReaderImpl(mockLdapQueryParsing.queryParser, mockTechniques.techniqueParser)
+    // a mock save archive that stores result in a ref
+    object archiveSaver extends SaveArchiveService {
+      val base = Ref.make(Option.empty[PolicyArchive]).runNow
+
+      override def check(archive: PolicyArchive): IOResult[Unit] = ZIO.unit
+
+      override def save(archive: PolicyArchive, actor: EventActor): IOResult[Unit] = {
+        base.set(Some(archive)).unit
+      }
+    }
+    val api = new ArchiveApi(archiveBuilderService, featureSwitchState.get, rootDirName.get, zipArchiveReader, archiveSaver)
+  }
 
   val apiModules = List(
       systemApi
@@ -658,6 +656,7 @@ class RestTestSetUp {
     , new NodeApi(restExtractorService, restDataSerializer, nodeApiService2, nodeApiService4, nodeApiService6, nodeApiService8, nodeApiService12,  nodeApiService13, nodeApiService16, null, DeleteMode.Erase)
     , new GroupsApi(mockNodeGroups.groupsRepo, restExtractorService, zioJsonExtractor, uuidGen, groupService2, groupService6, groupService14, groupApiInheritedProperties)
     , new SettingsApi(restExtractorService, settingsService.configService, asyncDeploymentAgent, uuidGen, settingsService.policyServerManagementService, nodeInfo)
+    , archiveAPIModule.api
   )
 
   val apiVersions = ApiVersion(13 , true) :: ApiVersion(14 , false) :: ApiVersion(15 , false) :: Nil
@@ -779,6 +778,24 @@ class RestTest(liftRules: LiftRules) {
     mockJsonRequest(path,"POST", json)
   }
 
+  // url encode the data for param name
+  def binaryPOST(path: String, paramName: String, filename: String, data: Array[Byte]) = {
+    import org.apache.commons.httpclient.methods.multipart.MultipartRequestEntity
+    val mockReq = mockRequest(path, "POST")
+    val filePart = new FilePart(paramName, new ByteArrayPartSource(filename, data), null, StandardCharsets.UTF_8.name())
+    val parts = new MultipartRequestEntity(Array(filePart), new HttpMethodParams())
+    val out = new ByteArrayOutputStream()
+    parts.writeRequest(out)
+    // be careful, liftweb does not parse header, you need to put content type in the variable
+    mockReq.headers = Map(
+        "Content-Type" -> List(parts.getContentType)
+      , "Content-Length" -> List(parts.getContentLength.toString)
+    )
+    mockReq.contentType = parts.getContentType
+    mockReq.body = out.toByteArray
+    mockReq
+  }
+
   // high level methods. Directly manipulate response
   def testGETResponse[T](path: String)(tests: Box[LiftResponse] => MatchResult[T]) = {
     execRequestResponse(GET(path))(tests)
@@ -792,6 +809,9 @@ class RestTest(liftRules: LiftRules) {
   }
   def testPOSTResponse[T](path: String, json : JValue)(tests: Box[LiftResponse] => MatchResult[T]) = {
     execRequestResponse(jsonPOST(path, json))(tests)
+  }
+  def testBinaryPOSTResponse[T](path: String, paramName: String, filename: String, data: Array[Byte])(tests: Box[LiftResponse] => MatchResult[T]) = {
+    execRequestResponse(binaryPOST(path, paramName, filename, data))(tests)
   }
   def testEmptyPostResponse[T](path: String)(tests: Box[LiftResponse] => MatchResult[T]): MatchResult[T] = {
     execRequestResponse(POST(path))(tests)

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
@@ -60,7 +60,7 @@ class TestRestFromFileDef extends TraitTestApiFromYamlFiles with AfterAll {
   val tmpApiTemplate = restTestSetUp.baseTempDirectory / "apiTemplates"
   tmpApiTemplate.createDirectories()
 
-  // nodeXX appears at seleral places
+  // nodeXX appears at several places
 
 
   override def yamlSourceDirectory: String = "api"
@@ -93,8 +93,7 @@ class TestRestFromFileDef extends TraitTestApiFromYamlFiles with AfterAll {
 
   // you can pass a list of file to test exclusively if you don't want to test all .yml
   // files in src/test/resource/${yamlSourceDirectory}
-//  doTest(Nil)
-  doTest("api_groups.yml" :: Nil)
+  doTest(Nil)
 
 }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
@@ -578,7 +578,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
 
      configRepo.getTechnique(TechniqueId(activeTechnique.techniqueName, directive.techniqueVersion)).runNow match {
       case Some(technique) =>
-        val dirEditForm = createForm(directive, oldDirective, technique, None)
+        val dirEditForm = createForm(directive, oldDirective, technique._2, None)
         currentDirectiveSettingForm.set(Full(dirEditForm))
       case None =>
         // do we have at least one version for that technique ? We can then try to migrate towards it

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
@@ -40,6 +40,7 @@ package bootstrap.liftweb.checks.migration
 import com.normation.GitVersion
 import com.normation.cfclerk.domain.SectionSpec
 import com.normation.cfclerk.domain.Technique
+import com.normation.cfclerk.domain.TechniqueCategoryName
 import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.eventlog.EventActor
@@ -55,12 +56,14 @@ import com.normation.ldap.sdk.LDAPConnectionProvider
 import com.normation.ldap.sdk.RoLDAPConnection
 import com.normation.rudder.configuration.ActiveDirective
 import com.normation.rudder.configuration.ConfigurationRepository
+import com.normation.rudder.configuration.GroupAndCat
 import com.normation.rudder.domain.NodeDit
 import org.junit.runner._
 import org.specs2.mutable._
 import org.specs2.runner._
 import com.normation.rudder.domain.RudderDit
 import com.normation.rudder.domain.nodes.Node
+import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.policies.ActiveTechnique
 import com.normation.rudder.domain.policies.ActiveTechniqueCategory
@@ -251,11 +254,12 @@ class TestMigrateSystemTechniques7_0 extends Specification {
       , "metadata.xml"
     )
   lazy val configurationRepository = new ConfigurationRepository {
-    override def getTechnique(id: TechniqueId): IOResult[Option[Technique]] = testEnv.techniqueRepository.getLastTechniqueByName(id.name).succeed
+    override def getTechnique(id: TechniqueId): IOResult[Option[(Chunk[TechniqueCategoryName], Technique)]] = testEnv.techniqueRepository.getLastTechniqueByName(id.name).map((Chunk.empty, _)).succeed
     override def getDirective(id: DirectiveId): IOResult[Option[ActiveDirective]] = ???
     override def getDirectiveLibrary(ids: Set[DirectiveId]): IOResult[FullActiveTechniqueCategory] = ???
     override def getDirectiveRevision(uid: DirectiveUid): IOResult[List[GitVersion.RevisionInfo]] = ???
     override def getRule(id: RuleId): IOResult[Option[Rule]] = ???
+    override def getGroup(id: NodeGroupId): IOResult[Option[GroupAndCat]] = ???
   }
   private[this] lazy val roLdapDirectiveRepository = new RoLDAPDirectiveRepository(
         rudderDit, roLdap, ldapEntityMapper, testEnv.techniqueRepository, uptLibReadWriteMutex

--- a/webapp/sources/utils/src/main/scala/com/normation/ObjectVersionCommons.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/ObjectVersionCommons.scala
@@ -100,7 +100,7 @@ final object GitVersion {
       case id :: Nil        => Right((id, GitVersion.DEFAULT_REV))
       case id :: "" :: Nil  => Right((id, GitVersion.DEFAULT_REV))
       case id :: rev :: Nil => Right((id, Revision(rev)))
-      case _                => Left(s"Error when parsing '${s}' as a directive id. At most one '+' is authorized.")
+      case _                => Left(s"Error when parsing '${s}' as a rudder id. At most one '+' is authorized.")
     }
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/21247
 (before: https://issues.rudder.io/issues/21321)

This PR add the possiblity to export and import via upload zip archives to rudder. 

### Limitation are:

- we don't check much for now. Things that should be tested: technique and version used in directive, existence of provided group id for new groups, existence of groups/dierctives used in rule.
- the save is not even a bit atomic. We save technique, reload technique library, then directives, then groups, then rules. All that sould be done in one go, but we don't have underlying infrastructure yet. It might prove to be a showstopper that needs to be addressed before release (because here, we may start semi generation). An alternative would be to write everything in git, then "reload from master", but I have doubts making that the default behavior for archive upload, without someone to take care of the mess if something goes wrong (concurrent change for ex)

### Main arch change:
- created an `EventMetadata` to factor out `changeId, actor, option msg`. We should use it everywhere in the future, it's so much lighter. Perhaps find a shorter name
- some change in `ZioUtils#accumulate` to remove some dependencies on cats (I was needed some variation of what we had already)
- move the low level part of writting tehcniques (ie the commit part) in git archiver file, change a bit its signature
- update a lot of parts of mocking framework to make it usable with zip upload - also handle some cases were binary content were causing unhandled errors in our API


### For the export part in that PR
The syntax for the API is: 
```
 Request format:
   ../archives/export/rules=rule_ids&directives=dir_ids&techniques=tech_ids&groups=group_ids&include=scope
 Where:
 - rule_ids = xxxx-xxxx-xxx-xxx[,other ids]
 - dir_ids = xxxx-xxxx-xxx-xxx[,other ids]
 - group_ids = xxxx-xxxx-xxx-xxx[,other ids]
 - tech_ids = techniqueName/1.0[,other tech ids]
- scope = all (default), none, directives, techniques (implies directive), groups
```
Ssytem items are filtered out, it seems that it would cause more pain an complication than the opposite (with in addition the case of special target to handle). 

Interesting parts:

- zip is an horrible format. 
- there is a feature switch to enable the feature in settings (`rudder_featureSwitch_archiveApi=enalbed,disabled`)
- we use item names and not UUID for file names (UUID is still of course in the serialized json), with a simple name mangling that replace non ascii chars to their ascii correspondance (as utf and java intended)
- revision works, you can ask for specific revision of items (but the `+` in url must be encoded as `%2B` because urls)
