### PR TITLE
Fixes #21394: Missing API documentation for import/export policies with dependencies

### DIFF
--- a/webapp/sources/api-doc/code_samples/curl/archives/export.sh
+++ b/webapp/sources/api-doc/code_samples/curl/archives/export.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" https://rudder.example.com/rudder/api/latest/archives/export/rules=8e522a3e-aa45-43cd-bf33-4e8d04a566f6&include=directives,groups

--- a/webapp/sources/api-doc/code_samples/curl/archives/import.sh
+++ b/webapp/sources/api-doc/code_samples/curl/archives/import.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" -X POST https://rudder.example.com/rudder/api/latest/archives/import --form "archive=@my-archive-file.zip"

--- a/webapp/sources/api-doc/openapi.src.yml
+++ b/webapp/sources/api-doc/openapi.src.yml
@@ -48,6 +48,8 @@ tags:
     description: Inventory processing service
   - name: Parameters
     description: Global parameters
+  - name: Archives
+    description: Import and export zip of policies
   - name: Settings
     description: Server configuration
   - name: System
@@ -141,6 +143,8 @@ paths:
     $ref: paths/compliance/nodes.yml
   "/compliance/nodes/{nodeId}":
     $ref: paths/compliance/node.yml
+  "/archives/export":
+    $ref: paths/archives/export.yml
   "/system/status":
     $ref: paths/system/status.yml
   "/system/info":

--- a/webapp/sources/api-doc/paths/archives/export.yml
+++ b/webapp/sources/api-doc/paths/archives/export.yml
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2022 Normation SAS
+get:
+  summary: Get a ZIP archive of the requested items and their dependencies
+  description: Get a ZIP archive or rules, directives, techniques and groups with optionally their dependencies
+  operationId: export
+  parameters:
+    - in: query
+      name: rules
+      schema:
+        type: array
+      description: IDs (optionally with revision, '+' need to be escaped as '%2B') of rules to include
+      style: form
+      explode: false
+      examples:
+        oneId:
+          summary: Example of a single ID
+          value: [a0573b59-e5bd-441b-9031-f307aa21a61e]   # ?rules=a0573b59-e5bd-441b-9031-f307aa21a61e
+        multipleIds:
+          summary: Example of multiple IDs, some with revisions
+          value: [a0573b59-e5bd-441b-9031-f307aa21a61e, 4cba6eee-3a43-4e17-a608-a4941b6d984f%2B35177d0823791a374de9e16a6ab27e6466fbc8c2]
+    - in: query
+      name: rules
+      schema:
+        type: array
+      description: IDs (optionally with revision, '+' need to be escaped as '%2B') of rules to include
+      style: form
+      explode: false
+      examples:
+        oneId:
+          summary: Example of a single ID
+          value: [a0573b59-e5bd-441b-9031-f307aa21a61e]   # ?rules=a0573b59-e5bd-441b-9031-f307aa21a61e
+        multipleIds:
+          summary: Example of multiple IDs, some with revisions
+          value: [a0573b59-e5bd-441b-9031-f307aa21a61e, 4cba6eee-3a43-4e17-a608-a4941b6d984f%2B35177d0823791a374de9e16a6ab27e6466fbc8c2]
+    - in: query
+      name: directives
+      schema:
+        type: array
+      description: IDs (optionally with revision, '+' need to be escaped as '%2B') of directives to include
+      style: form
+      explode: false
+      examples:
+        oneId:
+          summary: Example of a single ID
+          value: [a0573b59-e5bd-441b-9031-f307aa21a61e]   # ?directives=a0573b59-e5bd-441b-9031-f307aa21a61e
+        multipleIds:
+          summary: Example of multiple IDs, some with revisions
+          value: [a0573b59-e5bd-441b-9031-f307aa21a61e, 4cba6eee-3a43-4e17-a608-a4941b6d984f%2B35177d0823791a374de9e16a6ab27e6466fbc8c2]
+    - in: query
+      name: techniques
+      schema:
+        type: array
+      description: IDs, ie technique name/technique version (optionally with revision, '+' need to be escaped as '%2B') of techniques to include
+      style: form
+      explode: false
+      examples:
+        oneId:
+          summary: Example of a single ID
+          value: [fileContent/3.0] 
+        multipleIds:
+          summary: Example of multiple IDs, some with revisions
+          value: [userManagement/6.3, fileContent/3.0%2B35177d0823791a374de9e16a6ab27e6466fbc8c2]
+    - in: query
+      name: groups
+      schema:
+        type: array
+      description: IDs (optionally with revision, '+' need to be escaped as '%2B') of groups to include
+      style: form
+      explode: false
+      examples:
+        oneId:
+          summary: Example of a single ID
+          value: [a0573b59-e5bd-441b-9031-f307aa21a61e]   # ?groups=a0573b59-e5bd-441b-9031-f307aa21a61e
+        multipleIds:
+          summary: Example of multiple IDs, some with revisions
+          value: [a0573b59-e5bd-441b-9031-f307aa21a61e, 4cba6eee-3a43-4e17-a608-a4941b6d984f%2B35177d0823791a374de9e16a6ab27e6466fbc8c2]
+    - in: query
+      name: include
+      schema:
+        type: array
+        items: 
+          type: string
+          enum: 
+            - all (default)
+            - none 
+            - directives
+            - techniques
+            - groups
+      description: >-
+        Scope of dependencies to include in archive, where rule as directives and groups dependencies, directives have techniques dependencies,
+        and techniques and groups don't have dependencies. 'none' means no dependencies will be include, 'all' means that the whole tree will, 
+        'directives' and 'groups' means to include them specifically, 'techniques' means to include both directives and techniques.
+      style: form
+      explode: false
+      examples:
+        none:
+          summary: Do not include dependencies
+          value: [none] 
+        directivesAndGroups:
+          summary: Include directives and groups, but no techniques
+          value: [directives, groups]
+  responses:
+    "200":
+      description: A zip archive with the queried content.
+      content:
+        application/octet-stream:
+          schema:
+            type: string
+            format: binary
+  tags:
+    - Archives
+  x-code-samples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/archives/export.sh
+

--- a/webapp/sources/api-doc/paths/archives/import.yml
+++ b/webapp/sources/api-doc/paths/archives/import.yml
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2022 Normation SAS
+post:
+  summary: Import a ZIP archive of policies into Rudder
+  description: Import a ZIP archive of techniques, directives, groups and rules in a saved in a normalized format into Rudder
+  operationId: import
+  requestBody:
+    content:
+      multipart/form-data:
+        schema:
+          type: object
+          properties:
+            archive:
+              type: string
+              format: binary
+              description: The ZIP archive file containing policies in a conventional layout and serialization format
+  responses:
+    "200":
+      description: Archive imported
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - import
+              data:
+                type: object
+                description: Details about archive import process
+                properties:
+                  archiveImported:
+                    type: boolean
+  tags:
+    - Archives
+  x-code-samples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/archives/import.sh

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
@@ -514,7 +514,7 @@ class ClassicTechniqueWriter(basePath : String, parameterTypeService: ParameterT
         case false =>
           val args = params.toList.zipWithIndex.map {
           case (_, id) =>
-            method.flatMap(_.parameters.get(id).map(_.id.value)).getOrElse("arg_" + id)
+            method.flatMap(_.parameters.get(id.toLong).map(_.id.value)).getOrElse("arg_" + id)
           }
           (args, s"""${call.methodId.value}(${convertArgsToBundleCall(args)});""")
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -906,11 +906,11 @@ object ArchiveApi extends ApiModuleProvider[ArchiveApi] {
    * - scope = all (default), none, directives, techniques (implies directive), groups
    */
   final case object ExportSimple extends ArchiveApi with ZeroParam with StartsAtVersion15 with SortIndex {val z = implicitly[Line].value
-    val description    = "Export the list of objects with their dependencies"
+    val description    = "Export the list of objects with their dependencies in a policy archive"
     val (action, path) = GET / "archives" / "export"
   }
   final case object Import extends ArchiveApi with ZeroParam with StartsAtVersion15 with SortIndex {val z = implicitly[Line].value
-    val description    = "Import an archive"
+    val description    = "Import policy archive"
     val (action, path) = POST / "archives" / "import"
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -637,14 +637,14 @@ class RestTestSetUp {
     // a mock save archive that stores result in a ref
     object archiveSaver extends SaveArchiveService {
       val base = Ref.make(Option.empty[PolicyArchive]).runNow
-
-      override def check(archive: PolicyArchive): IOResult[Unit] = ZIO.unit
-
       override def save(archive: PolicyArchive, actor: EventActor): IOResult[Unit] = {
         base.set(Some(archive)).unit
       }
     }
-    val api = new ArchiveApi(archiveBuilderService, featureSwitchState.get, rootDirName.get, zipArchiveReader, archiveSaver)
+    object archiveChecker extends CheckArchiveService {
+      override def check(archive: PolicyArchive): IOResult[Unit] = ZIO.unit
+    }
+    val api = new ArchiveApi(archiveBuilderService, featureSwitchState.get, rootDirName.get, zipArchiveReader, archiveSaver, archiveChecker)
   }
 
   val apiModules = List(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1426,8 +1426,9 @@ object RudderConfig extends Loggable {
       , configService.rudder_featureSwitch_archiveApi()
       , rootDirName
       , new ZipArchiveReaderImpl(queryParser, techniqueParser)
-      , new SaveArchiveServiceImpl(techniqueArchiver, techniqueReader, techniqueRepository, roDirectiveRepository, woDirectiveRepository
+      , new SaveArchiveServicebyRepo(techniqueArchiver, techniqueReader, techniqueRepository, roDirectiveRepository, woDirectiveRepository
                                    , roNodeGroupRepository, woNodeGroupRepository, roRuleRepository, woRuleRepository)
+      , new CheckArchiveServiceImpl(techniqueRepository)
     )
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/21394

Add missing API documentation for import/export. 
Also, split the checking archive part of "save archive service" so that it is easier to understand goals and to add checking point latter on. 