### PR TITLE
Fixes #21546: When editing a rule, the groups changes do not behave like the directives changes

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewUtils.elm
@@ -41,7 +41,7 @@ getRuleNbNodes ruleDetails =
 getRuleNbGroups : Maybe Rule -> Int
 getRuleNbGroups rule =
   case Maybe.Extra.unwrap [] .targets rule of
-    [Composition (Or i) (Or e)] -> List.length i
+    [Composition (Or i) (Or e)] -> List.length i + List.length e
     targets -> List.length targets
 
 


### PR DESCRIPTION
We also count excluded groups.
When we move a group from excluded to included (vice versa), we considere that there is a deletion and addition
https://issues.rudder.io/issues/21546
![swap-exluded-included](https://user-images.githubusercontent.com/23410978/187686131-f3aef3db-bb6c-47c6-8922-9391e679bb12.gif)


