### PR TITLE
Fixes #21825: Port code to ZIO2

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/DataTypes.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/DataTypes.scala
@@ -81,7 +81,7 @@ case object SecurityToken {
 
   def parseCertificate(cert: Certificate): IO[InventoryError, (java.security.PublicKey, List[(String, String)])] = {
     cert.cert.flatMap { ch =>
-      IO.effect {
+      ZIO.attempt {
         val c = new JcaX509CertificateConverter().getCertificate( ch )
         val dn = ch.getSubject.getRDNs.flatMap(_.getTypesAndValues.flatMap(tv => (tv.getType.toString, tv.getValue.toString) :: Nil)).toList
         (c.getPublicKey, dn)
@@ -100,7 +100,7 @@ case object SecurityToken {
       case None        => InventoryError.SecurityToken(s"Certificate subject doesn't contain node ID in 'UID' attribute: ${formatSubject(subject)}").fail
       case Some((k,v)) =>
         if(v.trim.equalsIgnoreCase(nodeId.value)) {
-          UIO.unit
+          ZIO.unit
         } else {
           InventoryError.SecurityToken(s"Certificate subject doesn't contain same node ID in 'UID' attribute as inventory node ID: ${formatSubject(subject)}").fail
         }
@@ -137,7 +137,7 @@ final case class PublicKey(value : String) extends SecurityToken {
     }
   }
   def publicKey : IOResult[java.security.PublicKey] = {
-    IO.effect {
+    ZIO.attempt {
       (new PEMParser(new StringReader(key))).readObject()
     }.mapError { ex =>
       InventoryError.CryptoEx(s"Key '${key}' cannot be parsed as a public key", ex)
@@ -165,12 +165,12 @@ final case class Certificate(value : String) extends SecurityToken {
   }
   def cert : IO[InventoryError, X509CertificateHolder] = {
     for {
-      reader <- IO.effect {
+      reader <- ZIO.attempt {
                   new PEMParser(new StringReader(key))
                 } mapError { e =>
                   InventoryError.CryptoEx(s"Key '${key}' cannot be parsed as a valid certificate", e)
                 }
-      obj    <- IO.effect(reader.readObject()).mapError { e =>
+      obj    <- ZIO.attempt(reader.readObject()).mapError { e =>
                   InventoryError.CryptoEx(s"Key '${key}' cannot be parsed as a valid certificate", e)
                 }
       res    <- obj match {

--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/services/provisioning/CheckInventoryDigest.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/services/provisioning/CheckInventoryDigest.scala
@@ -83,7 +83,7 @@ class ParseInventoryDigestFileV1 extends ParseInventoryDigestFile {
     val properties = new Properties()
 
     for {
-      loaded  <- Task.effect {
+      loaded  <- ZIO.attempt {
                    import scala.jdk.CollectionConverters._
                    properties.load(is)
                    properties.asInstanceOf[java.util.Map[String, String]].asScala.toMap
@@ -111,7 +111,7 @@ trait CheckInventoryDigest {
    * bouncy castle: https://www.bouncycastle.org/
    */
   def check(publicKey: PublicKey, digest: InventoryDigest, inventoryStream: InputStream): IOResult[Boolean] = {
-    Task.effect {
+    ZIO.attempt {
       val signature = Signature.getInstance("SHA512withRSA", "BC");
       signature.initVerify(publicKey);
       val data = IOUtils.toByteArray(inventoryStream)

--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/services/provisioning/InventoryParser.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/services/provisioning/InventoryParser.scala
@@ -87,7 +87,7 @@ trait InventoryParser {
 trait XmlInventoryParser extends InventoryParser {
 
   override def fromXml(inventoryName:String,is:InputStream) : IOResult[Inventory] = {
-    (Task.effect {
+    (ZIO.attempt {
       XML.load(is)
     } mapError { ex =>
       InventoryError.Deserialisation("Cannot parse uploaded file as an XML Fusion Inventory file", ex)

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionInventoryParser.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionInventoryParser.scala
@@ -426,7 +426,7 @@ class FusionInventoryParser(
       }
     }
 
-    checkNumberOfRudderTag.andThen(
+    checkNumberOfRudderTag *> (
       ( for {
         agents         <- agentList.map(_.flatten)
         agentOK        <- ZIO.when(agents.size < 1) {

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/PreInventoryParserCheckConsistency.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/PreInventoryParserCheckConsistency.scala
@@ -175,7 +175,7 @@ class PreInventoryParserCheckConsistency extends PreInventoryParser {
         case Right(x) => Right(x).succeed
         case Left(_)  => checkNodeSeq(inventory, "OPERATINGSYSTEM", false, Some(b)).either
       }
-    )).foldM(_ => error.fail, _=> inventory.succeed)
+    )).foldZIO(_ => error.fail, _=> inventory.succeed)
   }
 
   /**
@@ -192,10 +192,10 @@ class PreInventoryParserCheckConsistency extends PreInventoryParser {
 
     checkNodeSeq(inventory, "OPERATINGSYSTEM", false, Some("KERNEL_VERSION")).map(_ => inventory).catchAll  { _ =>
         //perhaps we are on AIX ?
-        checkNodeSeq(inventory, "OPERATINGSYSTEM", false, Some("KERNEL_NAME")) .foldM (
+        checkNodeSeq(inventory, "OPERATINGSYSTEM", false, Some("KERNEL_NAME")) .foldZIO (
             _ => failure
           , x =>  if(x.toLowerCase == "aix") { //ok, check for OSVERSION
-            checkNodeSeq(inventory, "HARDWARE", false, Some("OSVERSION")).foldM (
+            checkNodeSeq(inventory, "HARDWARE", false, Some("OSVERSION")).foldZIO (
                 _ => aixFailure
               , kernelVersion => //update the inventory to put it in the right place
                   (new scala.xml.transform.RuleTransformer(

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestPreParsing.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestPreParsing.scala
@@ -61,12 +61,12 @@ class TestPreParsing extends Specification {
   private[this] implicit class TestParser(pre: PreInventoryParser) {
 
     def fromXml(checkName:String,is:InputStream) : IOResult[NodeSeq] = {
-      Task.effect(XML.load(is)).mapError(SystemError("error in test", _))
+      ZIO.attempt(XML.load(is)).mapError(SystemError("error in test", _))
     }
 
     def check(checkRelativePath: String): Either[RudderError, NodeSeq] = {
-      (IO.bracket {
-        IOResult.effect {
+      (ZIO.acquireReleaseWith {
+        IOResult.attempt {
           val url = this.getClass.getClassLoader.getResource(checkRelativePath)
           if(null == url) throw new NullPointerException(s"Resource with relative path '${checkRelativePath}' is null (missing resource? Spelling? Permissions?)")
           url.openStream()

--- a/webapp/sources/ldap-inventory/inventory-provisioning-core/src/main/scala/com/normation/inventory/ldap/provisioning/LdifReportLogger.scala
+++ b/webapp/sources/ldap-inventory/inventory-provisioning-core/src/main/scala/com/normation/inventory/ldap/provisioning/LdifReportLogger.scala
@@ -71,8 +71,8 @@ trait LDIFInventoryLogger extends Any {
 
 object DefaultLDIFInventoryLogger {
   val logger = NamedZioLogger("trace.ldif.in.file")
-  val defaultLogDir = System.getProperty("java.io.tmpdir") +
-    System.getProperty("file.separator") + "LDIFLogReport"
+  val defaultLogDir = java.lang.System.getProperty("java.io.tmpdir") +
+    java.lang.System.getProperty("file.separator") + "LDIFLogReport"
 }
 
 import java.io.File
@@ -106,10 +106,10 @@ class DefaultLDIFInventoryLogger(val LDIFLogDir:String = DefaultLDIFInventoryLog
   ) : Task[String] = {
     val LDIFFile = fileFromName(inventoryName,tag)
     ZIO.when(logger.logEffect.isTraceEnabled) {
-      IO.bracket(IO.effect(new LDIFWriter(LDIFFile)))(writer =>  IO.effect(writer.close).catchAll(ex =>
+      ZIO.acquireReleaseWith(ZIO.attempt(new LDIFWriter(LDIFFile)))(writer => ZIO.attempt(writer.close).catchAll(ex =>
         logger.debug("LDIF log for inventory processing: " + LDIFFile.getAbsolutePath)
       )) { writer =>
-        Task.effect {
+        ZIO.attempt {
           val ldif = LDIFRecords //that's important, else we evaluate again and again LDIFRecords
 
           if(ldif.nonEmpty) { //don't check it if logger trace is not enabled
@@ -123,6 +123,6 @@ class DefaultLDIFInventoryLogger(val LDIFLogDir:String = DefaultLDIFInventoryLog
           }
         }
       }
-    } *> UIO.succeed(LDIFFile.getAbsolutePath)
+    } *> ZIO.succeed(LDIFFile.getAbsolutePath)
   }
 }

--- a/webapp/sources/ldap-inventory/inventory-provisioning-core/src/main/scala/com/normation/inventory/ldap/provisioning/UuidMergerPreCommit.scala
+++ b/webapp/sources/ldap-inventory/inventory-provisioning-core/src/main/scala/com/normation/inventory/ldap/provisioning/UuidMergerPreCommit.scala
@@ -130,7 +130,7 @@ class UuidMergerPreCommit(
      * if the nodeId is present to find the correct status.
      */
 
-    finalNodeMachine <- mergeNode(node).foldM(
+    finalNodeMachine <- mergeNode(node).foldZIO(
       err => InventoryProcessingLogger.error(s"Error when merging node inventory. Reported message: ${err.fullMsg}. Remove machine for saving") *> err.fail
       , optNode => optNode match {
           case None =>

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/FullInventoryRepositoryImpl.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/FullInventoryRepositoryImpl.scala
@@ -100,7 +100,7 @@ class FullInventoryRepositoryImpl(
    * find the first dn matching ID, starting with accepted, then pending, then deleted
    */
   private[this] def findDnForId[ID](con: RwLDAPConnection, id:ID, fdn:(ID, InventoryStatus) => DN): LDAPIOResult[Option[(DN, InventoryStatus)]] = {
-    IO.foldLeft(Seq(AcceptedInventory, PendingInventory, RemovedInventory))(Option.empty[(DN, InventoryStatus)]) { (current, inventory) =>
+    ZIO.foldLeft(Seq(AcceptedInventory, PendingInventory, RemovedInventory))(Option.empty[(DN, InventoryStatus)]) { (current, inventory) =>
       current match {
         case None     =>
           val testdn = fdn(id, inventory)
@@ -157,7 +157,7 @@ class FullInventoryRepositoryImpl(
 
     //only add keys for non empty node list
     for {
-      res <- IO.foreach(List(PendingInventory, AcceptedInventory, RemovedInventory)){ status =>
+      res <- ZIO.foreach(List(PendingInventory, AcceptedInventory, RemovedInventory)){ status =>
                machineForNodeStatus(con, status).map(r => (status, r))
              }
     } yield {
@@ -293,7 +293,7 @@ class FullInventoryRepositoryImpl(
                      }
       // we don't want that one error somewhere breaks everything
       nodes       <- ZIO.foreach(nodeTree.children.values) { tree =>
-                       mapper.nodeFromTree(tree).foldM(
+                       mapper.nodeFromTree(tree).foldZIO(
                          err => InventoryDataLogger.error(s"Error when mapping inventory data for entry '${tree.root.rdn.map(_.toString).getOrElse("")}': ${err.fullMsg}") *> None.succeed
                        , ok  => Some(ok).succeed
                        )
@@ -305,7 +305,7 @@ class FullInventoryRepositoryImpl(
                        case Some(tree) => tree.succeed
                      }
       machines    <- ZIO.foreach(machineTree.children.values){ tree =>
-                       mapper.machineFromTree(tree).foldM(
+                       mapper.machineFromTree(tree).foldZIO(
                          err => InventoryDataLogger.error(s"Error when mapping inventory data for entry '${tree.root.rdn.map(_.toString).getOrElse("")}': ${err.fullMsg}") *> None.succeed
                        , ok  => Some(ok).succeed
                        )
@@ -401,7 +401,7 @@ class FullInventoryRepositoryImpl(
                                      }
                            } yield {
                              res
-                           }).foldM(
+                           }).foldZIO(
                                 e => {
                                   InventoryProcessingLogger.warn(s"Error when trying to delete machine for server with id '${id.value}' and inventory status '${inventoryStatus.name}'. Message was: ${e.msg}") *>
                                   Seq().succeed
@@ -445,7 +445,7 @@ class FullInventoryRepositoryImpl(
                                       }
                       } yield {
                         moved
-                      }).foldM(
+                      }).foldZIO(
                         err => InventoryProcessingLogger.error(s"Error when updating the container value when moving nodes '${id.value}': ${err.msg}") *> Seq().succeed
                       , diff => diff.succeed
                       )

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryHistoryLogRepository.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryHistoryLogRepository.scala
@@ -60,8 +60,8 @@ class FullInventoryFileParser(
 
   def fromFile(in:File) : IOResult[FullInventory] = {
     import scala.collection.mutable.Buffer
-    IO.bracket(Task.effect(new LDIFReader(in)).mapError(e => InventoryError.System(e.getMessage)))(r => UIO(r.close)) { reader =>
-      (Task.effect {
+    ZIO.acquireReleaseWith(ZIO.attempt(new LDIFReader(in)).mapError(e => InventoryError.System(e.getMessage)))(r => effectUioUnit(r.close)) { reader =>
+      (ZIO.attempt {
         val buf = Buffer[Entry]()
         var e : Entry = null
         do {
@@ -80,8 +80,8 @@ class FullInventoryFileParser(
   }
 
   def toFile(out:File, data: FullInventory) : IOResult[FullInventory] = {
-    ZIO.bracket(Task.effect(new LDIFWriter(out)).mapError(e => InventoryError.System(e.getMessage)))(is => Task.effect(is.close).run) { printer =>
-      (Task.effect {
+    ZIO.acquireReleaseWith(ZIO.attempt(new LDIFWriter(out)).mapError(e => InventoryError.System(e.getMessage)))(is => effectUioUnit(is.close)) { printer =>
+      (ZIO.attempt {
         mapper.treeFromNode(data.node).toLDIFRecords.foreach { r => printer.writeLDIFRecord(r) }
         data.machine.foreach { m =>
           mapper.treeFromMachine(m).toLDIFRecords.foreach { r => printer.writeLDIFRecord(r) }

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/SoftwareService.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/SoftwareService.scala
@@ -47,12 +47,12 @@ class SoftwareServiceImpl(
                                   import better.files._
                                   import better.files.Dsl._
                                   (for {
-                                    f <- IOResult.effect {
+                                    f <- IOResult.attempt {
                                            val dir = File("/var/rudder/tmp/purgeSoftware")
                                            dir.createDirectories()
                                            File(dir, s"${DateFormaterService.serialize(DateTime.now())}-unreferenced-software-dns.txt")
                                          }
-                                    _ <- IOResult.effect {
+                                    _ <- IOResult.attempt {
                                            extraSoftware.foreach(x => (f  << softwareDIT.SOFTWARE.SOFT.dn(x).toString))
                                          }
                                     _ <- InventoryProcessingLogger.debug(s"[purge unreferenced software] List of unreferenced software DN available in file: ${f.pathAsString}")

--- a/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/history/impl/TestFileHistoryLogRepository.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/history/impl/TestFileHistoryLogRepository.scala
@@ -39,8 +39,8 @@ final case class SystemError(cause: Throwable) extends RudderError {
 
 object StringMarshaller extends FileMarshalling[String] {
   //simply read / write file content
-  override def fromFile(in:File) : IOResult[String] = IO.effect(FileUtils.readFileToString(in,"UTF-8")).mapError(SystemError)
-  override def toFile(out:File, data: String) : IOResult[String] = IO.effect {
+  override def fromFile(in:File) : IOResult[String] = ZIO.attempt(FileUtils.readFileToString(in,"UTF-8")).mapError(SystemError)
+  override def toFile(out:File, data: String) : IOResult[String] = ZIO.attempt {
     FileUtils.writeStringToFile(out,data, "UTF-8")
     data
   }.mapError(SystemError)
@@ -92,7 +92,7 @@ class TestFileHistoryLogRepository {
 }
 
 object TestFileHistoryLogRepository {
-  val rootDir = System.getProperty("java.io.tmpdir") + "/testFileHistoryLogRepo"
+  val rootDir = java.lang.System.getProperty("java.io.tmpdir") + "/testFileHistoryLogRepo"
 
   def clean: Unit = {
     FileUtils.deleteDirectory(new File(rootDir))

--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -408,7 +408,7 @@ limitations under the License.
     <ipaddress-version>5.3.3</ipaddress-version>
     <snakeyaml-version>1.30</snakeyaml-version>
 
-    <zhttp-version>1.0.0.0-RC27</zhttp-version> <!-- used in datasources -->
+    <zio-http-version>2.0.0-RC11</zio-http-version> <!-- used in datasources -->
 
     <!--
       These one must be updated to work together
@@ -422,9 +422,9 @@ limitations under the License.
     <fs2-version>3.2.4</fs2-version>
     <shapeless-version>2.3.7</shapeless-version>
     <cats-effect-version>3.3.4</cats-effect-version>
-    <dev-zio-version>1.0.10</dev-zio-version>
-    <zio-cats-version>3.2.9.1</zio-cats-version> <!-- gives fs2 3.1.6, but doobie 1.0.0-RC1 is in 3.0.3 -->
-    <zio-json-version>0.2.0-M4</zio-json-version>
+    <dev-zio-version>2.0.2</dev-zio-version>
+    <zio-cats-version>3.3.0</zio-cats-version> <!-- gives fs2 3.1.6, but doobie 1.0.0-RC1 is in 3.0.3 -->
+    <zio-json-version>0.3.0</zio-json-version>
 
     <!--
       Hack to make scalac jvm parameters like RAM configurable.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/PluginSettings.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/PluginSettings.scala
@@ -65,20 +65,20 @@ class FilePluginSettingsService  (
 
     val p = new Properties()
     for {
-      _ <- IOResult.effect(s"Reading properties from ${pluginConfFile.pathAsString}")(p.load(pluginConfFile.newInputStream))
+      _ <- IOResult.attempt(s"Reading properties from ${pluginConfFile.pathAsString}")(p.load(pluginConfFile.newInputStream))
 
-      url <- IOResult.effect(s"Getting plugin repository url in ${pluginConfFile.pathAsString}")(p.getProperty("url"))
-      userName <- IOResult.effect(s"Getting user name for plugin download in ${pluginConfFile.pathAsString}")(p.getProperty("username"))
-      pass <- IOResult.effect(s"Getting password for plugin download in ${pluginConfFile.pathAsString}")(p.getProperty("password"))
-      proxy <- IOResult.effect(s"Getting proxy for plugin download in ${pluginConfFile.pathAsString}") {
+      url <- IOResult.attempt(s"Getting plugin repository url in ${pluginConfFile.pathAsString}")(p.getProperty("url"))
+      userName <- IOResult.attempt(s"Getting user name for plugin download in ${pluginConfFile.pathAsString}")(p.getProperty("username"))
+      pass <- IOResult.attempt(s"Getting password for plugin download in ${pluginConfFile.pathAsString}")(p.getProperty("password"))
+      proxy <- IOResult.attempt(s"Getting proxy for plugin download in ${pluginConfFile.pathAsString}") {
         val res = p.getProperty("proxy_url", "")
         if (res == "") None else Some(res)
       }
-      proxy_user <- IOResult.effect(s"Getting proxy for plugin download in ${pluginConfFile.pathAsString}") {
+      proxy_user <- IOResult.attempt(s"Getting proxy for plugin download in ${pluginConfFile.pathAsString}") {
         val res = p.getProperty("proxy_user", "")
         if (res == "") None else Some(res)
       }
-      proxy_password <- IOResult.effect(s"Getting proxy for plugin download in ${pluginConfFile.pathAsString}") {
+      proxy_password <- IOResult.attempt(s"Getting proxy for plugin download in ${pluginConfFile.pathAsString}") {
         val res = p.getProperty("proxy_password", "")
         if (res == "") None else Some(res)
       }
@@ -88,7 +88,7 @@ class FilePluginSettingsService  (
   }
 
   def writePluginSettings(settings : PluginSettings): IOResult[Unit] = {
-    IOResult.effect({
+    IOResult.attempt({
       pluginConfFile.write(
         s"""[Rudder]
           |url = ${settings.url}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountRepository.scala
@@ -231,7 +231,7 @@ final class WoLDAPApiAccountRepository(
                                             case Some(diff) =>
                                               actionLogger.saveModifyApiAccount(modId, principal = actor, modifyDiff = diff, None).chainError("Error when logging modification of an API Account as an event")
                                             case None       =>
-                                              UIO.unit
+                                              ZIO.unit
                                           }
                               } yield {
                                 action

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeUnreferencedSoftwares.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeUnreferencedSoftwares.scala
@@ -41,7 +41,10 @@ package com.normation.rudder.batch
 import com.normation.rudder.domain.logger.ScheduledJobLogger
 import com.normation.inventory.ldap.core.SoftwareService
 
-import scala.concurrent.duration._
+import com.github.ghik.silencer.silent
+
+import scala.concurrent.duration.FiniteDuration
+
 import com.normation.zio._
 import zio._
 
@@ -55,13 +58,13 @@ class PurgeUnreferencedSoftwares(
 
   val logger = ScheduledJobLogger
 
-  if (updateInterval < 1.hour) {
+  if (updateInterval < 1.hour.asScala) {
     logger.info(s"[purge unreferenced software] Disable automatic purge of unreferenced softwares (update interval cannot be less than 1 hour)")
   } else {
     logger.debug(s"[purge unreferenced software] starting batch that purge unreferenced softwares, every ${updateInterval.toString()}")
     val prog = softwareService.deleteUnreferencedSoftware()
-    import zio.duration.Duration.{fromScala => zduration}
-    ZioRuntime.unsafeRun(prog.delay(zduration(1.hour)).repeat(Schedule.spaced(zduration(updateInterval))).provide(ZioRuntime.environment).forkDaemon)
+    import zio.Duration.{fromScala => zduration}
+    ZioRuntime.unsafeRun(prog.delay(1.hour).repeat(Schedule.spaced(zduration(updateInterval))).forkDaemon): @silent("a type was inferred to be `Any`")
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JSONReportsHandler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JSONReportsHandler.scala
@@ -43,7 +43,6 @@ import com.normation.rudder.repository.ReportsRepository
 import com.normation.rudder.repository.RudderPropertiesRepository
 
 import zio._
-import zio.duration.Duration
 import com.normation.errors._
 
 trait JSONReportsHandler {
@@ -76,7 +75,7 @@ case class JSONReportsAnalyser (reportsRepository: ReportsRepository, propRepo: 
       reports <- reportsRepository.getReportsByKindBetween(lowerId.getOrElse(0),None, 1000, List(Reports.REPORT_JSON)).toIO
 
       _       <- reports.maxByOption(_._1) match {
-                   case None    => UIO.unit
+                   case None    => ZIO.unit
                    case Some(r) =>
                      ZIO.foreach(reports)(r => handle(r._2)).catchAll(err => CampaignLogger.error(err.fullMsg)) *>
                      propRepo.updateReportHandlerLastId((r._1+1))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/MainCampaignService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/MainCampaignService.scala
@@ -38,20 +38,21 @@
 package com.normation.rudder.campaigns
 
 import cats.implicits._
+
 import com.normation.errors.IOResult
 import com.normation.errors.Inconsistency
 import com.normation.errors.RudderError
 import com.normation.utils.DateFormaterService
 import com.normation.utils.StringUuidGenerator
-import com.normation.zio.ZioRuntime
+
 import org.joda.time.DateTime
+
 import zio.Queue
 import zio.ZIO
-import zio.clock.Clock
-import zio.duration._
 import zio.syntax._
-
 import scala.annotation.nowarn
+
+import zio.Duration
 
 
 trait CampaignHandler{
@@ -92,7 +93,7 @@ class MainCampaignService(repo: CampaignEventRepository, campaignRepo: CampaignR
     }
   }
 
-  case class CampaignScheduler(main : MainCampaignService, queue:Queue[CampaignEventId], zclock: Clock) {
+  case class CampaignScheduler(main : MainCampaignService, queue:Queue[CampaignEventId]) {
 
     def queueCampaign(c: CampaignEvent) = {
       for {
@@ -207,7 +208,7 @@ class MainCampaignService(repo: CampaignEventRepository, campaignRepo: CampaignR
           }
       } yield {
         ()
-      }).provide(zclock).catchAll(failingLog)
+      }).catchAll(failingLog)
 
 
     }
@@ -224,7 +225,7 @@ class MainCampaignService(repo: CampaignEventRepository, campaignRepo: CampaignR
     def start() = loop().forever
   }
 
-  def nextDateFromDayTime(date : DateTime, start : DayTime) : DateTime = {
+  def nextDateFromDayTime(date : DateTime, start: DayTime) : DateTime = {
     (if ( date.getDayOfWeek > start.day.value
       || ( date.getDayOfWeek == start.day.value && date.getHourOfDay > start.realHour)
       || ( date.getDayOfWeek == start.day.value && date.getHourOfDay == start.realHour && date.getMinuteOfHour > start.realMinute)
@@ -351,7 +352,7 @@ class MainCampaignService(repo: CampaignEventRepository, campaignRepo: CampaignR
   }
 
   def start(initQueue: Queue[CampaignEventId]) = {
-    val s = CampaignScheduler(this, initQueue, ZioRuntime.environment)
+    val s = CampaignScheduler(this, initQueue)
     inner = Some(s)
     for {
       _ <- CampaignLogger.info("Starting campaign scheduler")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -400,7 +400,7 @@ object GenericProperty {
    * Parse a value that was correctly serialized to hocon (ie string are quoted, etc)
    */
   def parseSerialisedValue(value: String): PureResult[ConfigValue] = {
-    PureResult.effect(s"Error: value is not parsable as a property: ${value}") {
+    PureResult.attempt(s"Error: value is not parsable as a property: ${value}") {
       ConfigFactory.parseString(
         // it's necessary to put it on its own line to avoid pb with comments/multilines
         s"""{"x":
@@ -562,7 +562,7 @@ object GenericProperty {
    * Parse a string a hocon config object
    */
   def parseConfig(json: String): PureResult[Config] = {
-    PureResult.effectM(s"Error when parsing data as a property: ${json}") {
+    PureResult.attemptZIO(s"Error when parsing data as a property: ${json}") {
       val cfg = ConfigFactory.parseString(json)
       if(cfg.hasPath(NAME) && cfg.hasPath(VALUE)) Right(cfg)
       else Left(Inconsistency(s"Error when parsing data as a property: it misses required field 'name' or 'value': ${json}"))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitRepositoryProvider.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitRepositoryProvider.scala
@@ -98,12 +98,12 @@ object GitRepositoryProviderImpl {
      */
     def checkRootDirectory(dir: File): IOResult[Unit] = {
       if (!dir.exists) {
-        IOResult.effect(dir.createDirectories()).chainError(s"Directory '${dir.pathAsString}' was missing and we were " +
+        IOResult.attempt(dir.createDirectories()).chainError(s"Directory '${dir.pathAsString}' was missing and we were " +
                                                             s"unable to create it to init git repository").unit
       } else if (!dir.isOwnerWritable) {
         Inconsistency(s"Directory '${dir.pathAsString}' exists but it not writable and so it can't be use as a git repository root " +
                       s"directory. Please check that it's really a directory and that rights are correct").fail
-      } else UIO.unit
+      } else ZIO.unit
     }
 
     /**
@@ -111,7 +111,7 @@ object GitRepositoryProviderImpl {
      * If no git repos is found, create one.
      */
     def checkGitRepos(root:File) : IOResult[Repository] = {
-      IOResult.effect {
+      IOResult.attempt {
         val db = (new FileRepositoryBuilder().setWorkTree(root.toJava).build).asInstanceOf[FileRepository]
         if(!db.getConfig.getFile.exists) {
           GitRepositoryLogger.logEffect.info(s"Git directory was not initialised: create a new git repository into folder '${root.pathAsString}' and add all its content as initial release")
@@ -126,7 +126,7 @@ object GitRepositoryProviderImpl {
 
     val dir = File(gitRootPath)
     checkRootDirectory(dir) *>
-    checkGitRepos(dir).flatMap(db => IOResult.effect(new GitRepositoryProviderImpl(db, dir)))
+    checkGitRepos(dir).flatMap(db => IOResult.attempt(new GitRepositoryProviderImpl(db, dir)))
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitRevisionProvider.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitRevisionProvider.scala
@@ -106,7 +106,7 @@ class SimpleGitRevisionProvider(refPath:String,repo:GitRepositoryProvider) exten
   private[this] val currentId = Ref.make[ObjectId](getAvailableRevTreeId.runNow).runNow
 
   override def getAvailableRevTreeId : IOResult[ObjectId] = {
-    IOResult.effect {
+    IOResult.attempt {
       val treeId = repo.db.resolve(refPath)
 
       if(null == treeId) {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryFileWatcher.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryFileWatcher.scala
@@ -53,8 +53,6 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext
 
 import zio._
-import zio.clock.Clock
-import zio.duration._
 import zio.syntax._
 import com.normation.box.IOManaged
 import com.normation.errors.IOResult
@@ -100,7 +98,7 @@ object InventoryProcessingUtils {
   }
 
   def makeManagedStream(file: File, kind: String = "inventory") = IOManaged.makeM[InputStream] {
-    IOResult.effect(s"Error when trying to read ${kind} file '${file.name}'")(file.newInputStream)
+    IOResult.attempt(s"Error when trying to read ${kind} file '${file.name}'")(file.newInputStream)
   }(_.close())
   def makeFileExists(file: File) = IOManaged.make[Boolean](file.exists)(_ => ())
 }
@@ -132,7 +130,6 @@ class InventoryFileWatcher(
   val cronForMissed = new SchedulerMissedNotify(
       cleaner
     , collectOldInventoriesFrequency
-    , ZioRuntime.environment
   )
 
   def startGarbageCollection: Unit = {
@@ -144,10 +141,10 @@ class InventoryFileWatcher(
   }
 
   // That reference holds watcher instance to be able to stop them if asked
-  val ref = RefM.make(Option.empty[Watchers]).runNow
+  val ref = Ref.Synchronized.make(Option.empty[Watchers]).runNow
 
   def startWatcher() = semaphore.withPermit(
-    ref.update(opt =>
+    ref.updateZIO(opt =>
       opt match {
         case Some(_) => // does nothing
           InventoryProcessingLogger.info(s"Starting incoming inventory watcher ignored (already started).") *>
@@ -168,7 +165,7 @@ class InventoryFileWatcher(
   ).either.runNow
 
   def stopWatcher() = semaphore.withPermit(
-    ref.update(opt =>
+    ref.updateZIO(opt =>
       opt match {
         case None    => //ok
           InventoryProcessingLogger.info(s"Stopping incoming inventory watcher ignored (already stopped).")*>
@@ -197,7 +194,7 @@ class InventoryFileWatcher(
  */
 final class Watchers(incoming: FileMonitor, updates: FileMonitor) {
   def start(): IOResult[Unit] = {
-    IOResult.effect {
+    IOResult.attempt {
       // Execution context is not used here - binding to scala default global to satisfy scalac
       incoming.start()(scala.concurrent.ExecutionContext.global)
       updates.start()(scala.concurrent.ExecutionContext.global)
@@ -205,7 +202,7 @@ final class Watchers(incoming: FileMonitor, updates: FileMonitor) {
     }
   }
   def stop(): IOResult[Unit] = {
-    IOResult.effect {
+    IOResult.attempt {
       incoming.close()
       updates.close()
       Right(())
@@ -220,14 +217,14 @@ object Watchers {
         private var stopRequired = false
 
         // a one element queue to tempo overflow events
-        val tempoOverflow = ZioRuntime.unsafeRun(ZQueue.dropping[Unit](1))
+        val tempoOverflow = ZioRuntime.unsafeRun(Queue.dropping[Unit](1))
 
         // process overflow
         val overflowFiber = ZioRuntime.unsafeRun((for {
           _ <- tempoOverflow.take
           // if we are overflowing, we got at least a couple hundred inventories. Wait one minute before continuing
           _ <- InventoryProcessingLogger.info("Inotify watcher event overflow: waiting a minute before checking what inventories need to be processed")
-          _ <- UIO.unit.delay(1.minutes)
+          _ <- ZIO.unit.delay(1.minutes)
           // clean-up other overflow that happened during that time
           _ <- tempoOverflow.takeAll
           _ <- checkOld.checkFilesOlderThan(0.milli)
@@ -277,10 +274,10 @@ object Watchers {
         override def start()(implicit executionContext: ExecutionContext): Unit = {
           (
             (
-              IOResult.effect(this.watch(root, 0)) *>
+              IOResult.attempt(this.watch(root, 0)) *>
               (for {
-                k <- IOResult.effect(service.take())
-                _ <- IOResult.effect(process(k))
+                k <- IOResult.attempt(service.take())
+                _ <- IOResult.attempt(process(k))
               } yield ()).forever
             ).catchAll(err =>
               err.cause match {
@@ -350,14 +347,14 @@ class CheckExistingInventoryFilesImpl(
   }
 
   def addFiles(files: List[File]): UIO[Unit] = {
-    ZIO.foreach_(files)(file => fileProcessor.addFilePure(file).catchAll(err =>
+    ZIO.foreachDiscard(files)(file => fileProcessor.addFilePure(file).catchAll(err =>
       InventoryProcessingLogger.error(s"Error when processing old inventory file '${file.path}': ${err.fullMsg}")
     ))
   }
 
   def deleteFiles(files: List[ToClean]): UIO[Unit] = {
-    ZIO.foreach_(files) { f =>
-      (ZIO.effect(f.file.delete()) *> InventoryProcessingLogger.info(s"Deleting file '${f.file.name}': ${f.why}")).catchAll(err =>
+    ZIO.foreachDiscard(files) { f =>
+      (ZIO.attempt(f.file.delete()) *> InventoryProcessingLogger.info(s"Deleting file '${f.file.name}': ${f.why}")).catchAll(err =>
         InventoryProcessingLogger.error(s"Error when trying to delete inventory file '${f.file.name}' (${f.why}): ${err.getMessage}")
       )
     }
@@ -424,20 +421,20 @@ class CheckExistingInventoryFilesImpl(
     import scala.jdk.CollectionConverters._
     (for {
       // if that fails, just exit
-      ageLimit <- IOResult.effect(DateTime.now().minusMillis(d.toMillis.toInt))
+      ageLimit <- IOResult.attempt(DateTime.now().minusMillis(d.toMillis.toInt))
       filter   =  (f: File) => if (f.exists && InventoryProcessingUtils.hasValidInventoryExtension(f) && (f.isRegularFile && ageLimit.isAfter(f.lastModifiedTime.toEpochMilli))) Some(f) else None
       // if the listing fails, just exit
-      children <- ZIO.foreach(directories)(d => IOResult.effect(FileUtils.listFilesAndDirs(d.toJava, TrueFileFilter.TRUE, TrueFileFilter.TRUE).asScala))
+      children <- ZIO.foreach(directories)(d => IOResult.attempt(FileUtils.listFilesAndDirs(d.toJava, TrueFileFilter.TRUE, TrueFileFilter.TRUE).asScala))
       // filter file by file. In case of error, just skip it. Specifically ignore FileNotFound (davfs temp files disapear)
       filtered <- ZIO.foreach(children.flatten) { file =>
-                    IO.effect(filter(File(file.toPath))).catchAll {
+                    ZIO.attempt(filter(File(file.toPath))).catchAll {
                       case _: FileNotFoundException => // just ignore
                         InventoryProcessingLogger.trace(s"Ignoring file '${file.toString}' when processing old inventories: " +
                                                         s"FileNotFoundException (likely it disappeared between directory listing and filtering)"
-                        ) *> UIO.effectTotal(None)
+                        ) *> ZIO.succeed(None)
                       case ex: Throwable            => // log and switch to the next
                         InventoryProcessingLogger.warn(s"Error when processing file in old inventories: '${file.toString}': ${ex.getMessage}") *>
-                        UIO.effectTotal(None)
+                        ZIO.succeed(None)
                     }
                   }
       } yield (filtered.flatten)).catchAll(err =>
@@ -461,14 +458,14 @@ class CheckExistingInventoryFilesImpl(
 class SchedulerMissedNotify(
     checker: CheckExistingInventoryFiles
   , period : Duration
-  , zclock : Clock
 ){
   val schedule = {
     def loop(d: Duration) = for {
       _ <- checker.checkFilesOlderThan(d)
-      _ <- UIO.unit.delay(period)
+      _ <- ZIO.clockWith(_.sleep(period))
     } yield ()
-    (loop(Duration.Zero) *> loop(period).forever).forkDaemon.provide(zclock)
+
+    (loop(Duration.Zero) *> loop(period).forever).forkDaemon
   }
 }
 
@@ -522,7 +519,7 @@ class ProcessFile(
    * The task is configured to be processed after some delay.
    * We only modify that map as a result of a dequeue event.
    */
-  val toBeProcessed = ZioRuntime.unsafeRun(zio.RefM.make(Map.empty[File, Fiber[RudderError, Unit]]))
+  val toBeProcessed = ZioRuntime.unsafeRun(zio.Ref.Synchronized.make(Map.empty[File, Fiber[RudderError, Unit]]))
 
   /*
    * We need a queue of add file / file written even to delimit when a file should be
@@ -536,22 +533,22 @@ class ProcessFile(
   def processMessage(): UIO[Unit] = {
     watchEventQueue.take.flatMap {
       case WatchEvent.End(file) => // simple case: remove file from map
-        toBeProcessed.update[Any, Nothing](s =>
-          (s - file).succeed
+        toBeProcessed.update(s =>
+          (s - file)
         ).unit
 
       case WatchEvent.Mod(file) =>
         // look if the file is already here. If so, interrupt. In all case, create a new task.
 
-        (toBeProcessed.update { s =>
+        (toBeProcessed.updateZIO { s =>
           val newMap = {
             // the new task must :
             // - wait for 500 ms for interruption
             // - then execute on different IO scheduler
             // - if the map wasn't interrupted in the first 500 ms, it is not interruptible anymore
 
-            val effect = ZioRuntime.blocking(
-              UIO.unit.delay(fileWrittenThreshold).provide(ZioRuntime.environment)
+            val effect = (
+                 ZIO.unit.delay(fileWrittenThreshold)
               *> (watchEventQueue.offer(WatchEvent.End(file))
                  *> processFile(file).catchAll(err =>
                       InventoryProcessingLogger.error(s"Error when adding new inventory file '${file.path}' to processing: ${err.fullMsg}")
@@ -573,14 +570,14 @@ class ProcessFile(
   }
 
   //start the process
-  ZioRuntime.internal.unsafeRunSync(processMessage().forever.forkDaemon)
+  ZioRuntime.unsafeRun(processMessage().forever.forkDaemon)
 
   def addFilePure(file: File): IOResult[Unit] = {
     watchEventQueue.offer(WatchEvent.Mod(file)).unit
   }
 
   def addFile(file: File): Unit = {
-    ZioRuntime.internal.unsafeRunSync(addFilePure(file))
+    ZioRuntime.unsafeRun(addFilePure(file))
   }
 
   /*
@@ -596,7 +593,7 @@ class ProcessFile(
    * When queue is full, we prefer to drop old `SaveInventory` to new ones. In the worst case, they will be caught up
    * by the SchedulerMissedNotify and put again in the WatchEvent queue.
    */
-  protected val saveInventoryBuffer = ZQueue.sliding[InventoryPair](1024).runNow
+  protected val saveInventoryBuffer = Queue.sliding[InventoryPair](1024).runNow
 
   /*
    * The logic is:
@@ -617,7 +614,7 @@ class ProcessFile(
       _ <- if(file.name.endsWith(".gz")) {
              val dest = File(file.parent, file.nameWithoutExtension(includeAll = false))
              InventoryProcessingLogger.debug(s"Dealing with zip file '${file.name}'") *>
-             IOResult.effect {
+             IOResult.attempt {
                file.unGzipTo(dest)
                file.delete()
              }.unit
@@ -658,7 +655,7 @@ class ProcessFile(
       fst <- saveInventoryBuffer.take
       // deduplicate and prioritize file in 'incoming', which are new inventories. TakeAll is not blocking
       all <- saveInventoryBuffer.takeAll
-      inv =  (fst::all).find { _.inventory.parent == prioIncomingDir }.getOrElse(fst)
+      inv =  all.prepended(fst).find { _.inventory.parent == prioIncomingDir }.getOrElse(fst)
       // process
       _ <- InventoryProcessingLogger.info(s"Received new inventory file '${inv.inventory.name}' with signature available: process.")
       _ <- inventoryProcessor.saveInventoryBlocking(inv)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechnique.scala
@@ -508,7 +508,7 @@ class ResourceFileService( gitReposProvider    : GitRepositoryProvider) {
         s"Error when getting status of resource files of technique ${techniqueName}/${techniqueVersion}"
       )
       resourceDir =  File(gitReposProvider.db.getDirectory.getParent, resourcesPath)
-      allFiles    <- IOResult.effect(s"Error when getting all resource files of technique ${techniqueName}/${techniqueVersion} ") {
+      allFiles    <- IOResult.attempt(s"Error when getting all resource files of technique ${techniqueName}/${techniqueVersion} ") {
         getAllFiles(resourceDir)
       }
     } yield {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionRepository.scala
@@ -113,7 +113,7 @@ class CachedReportsExecutionRepository(
   private[this] var cache = Map[NodeId, Option[AgentRunWithNodeConfig]]()
 
 
-  override def clearCache(): Unit = semaphore.withPermit(IOResult.effect {
+  override def clearCache(): Unit = semaphore.withPermit(IOResult.attempt {
     cache = Map()
   }).runNow
 
@@ -138,7 +138,7 @@ class CachedReportsExecutionRepository(
   /**
    * Retrieve all runs that were not processed - for the moment, there are no limitation nor ordering/grouping
    */
-  def getNodesAndUncomputedCompliance(): IOResult[Map[NodeId, Option[AgentRunWithNodeConfig]]] = semaphore.withPermit(IOResult.effect {
+  def getNodesAndUncomputedCompliance(): IOResult[Map[NodeId, Option[AgentRunWithNodeConfig]]] = semaphore.withPermit(IOResult.attempt {
     for {
       runs  <- readBackend.getNodesAndUncomputedCompliance()
     } yield {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
@@ -185,7 +185,7 @@ class ComplianceJdbcRepository(
     transactIOResult("Error when saving node compliances:")(xa => (for {
       updated  <- saveComplianceDetails
       levels   <- saveComplianceLevels
-    } yield ()).transact(xa)).foldM(
+    } yield ()).transact(xa)).foldZIO(
       err => {
         // we need to filter out `ERROR: duplicate key value violates unique constraint "nodecompliancelevels_pkey"`
         // see https://issues.rudder.io/issues/18188 for details

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/EventLogJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/EventLogJdbcRepository.scala
@@ -88,13 +88,13 @@ class EventLogJdbcRepository(
                 )
         """.update.withUniqueGeneratedKeys[Int]("id").transact(xa))
 
-        (for {
+        for {
           id      <- boxId
           details =  eventLog.eventDetails.copy(id = Some(id), modificationId = Some(modId))
           saved   <- EventLogReportsMapper.mapEventLog(eventLog.eventType, details).toIO
         } yield {
           saved
-        }).blocking
+        }
 
       case _ => Inconsistency(s"Eventlog with type '${eventLog.eventType} has invalid XML for details (it must be a well formed document with only one root): ${eventLog.details}'").fail
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDirectiveRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDirectiveRepository.scala
@@ -663,7 +663,7 @@ class WoLDAPDirectiveRepository(
                              , oldRootSection
                            ).toIO.chainError("Error when processing saved modification to log them"))
       eventLogged <- (optDiff match {
-                       case None => UIO.unit
+                       case None => ZIO.unit
                        case Some(diff:AddDirectiveDiff) =>
                          actionLogger.saveAddDirective(
                              modId
@@ -944,7 +944,7 @@ class WoLDAPDirectiveRepository(
                                 con, techniqueName,
                                 { name => EQ(A_TECHNIQUE_UUID, name.value) },
                                 "1.1") flatMap {
-                                  case None => UIO.unit
+                                  case None => ZIO.unit
                                   case Some(uptEntry) => s"Can not add a technique with id '${techniqueName.value}' in user library. active technique '${uptEntry.dn}}' is already defined with such a reference technique.".fail
                               }
                             }
@@ -1013,7 +1013,7 @@ class WoLDAPDirectiveRepository(
                           s"Error when mapping technique '${uactiveTechniqueId.value}' update to an diff: ${saved}"
                          )
       loggedAction    <- optDiff match {
-                           case None       => UIO.unit
+                           case None       => ZIO.unit
                            case Some(diff) => actionLogger.saveModifyTechnique(modId, principal = actor, modifyDiff = diff, reason = reason)
                          }
       newactiveTechnique <- getActiveTechniqueByActiveTechnique(uactiveTechniqueId).notOptional(s"Technique with id '${uactiveTechniqueId.value}' can't be find back after status change")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -314,7 +314,7 @@ class LDAPEntityMapper(
                        }
       // custom properties mapped as NodeProperties
       properties    <- ZIO.foreach(inventoryEntry.valuesFor(A_CUSTOM_PROPERTY)) { json =>
-                         GenericProperty.parseConfig(json).toIO.foldM(
+                         GenericProperty.parseConfig(json).toIO.foldZIO(
                            err  =>
                              logPure.error(Chained(s"Error when trying to deserialize Node Custom Property, it will be ignored", err).fullMsg) *>
                              None.succeed

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapGroupLibrary.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapGroupLibrary.scala
@@ -218,7 +218,7 @@ class ImportGroupLibraryImpl(
                         system
                       }).catchAll { e =>
                         logPure.error("Error when trying to load archived active technique library. Rollbaching to previous one.") *>
-                        restoreArchive(con, rudderDit.GROUP.dn, targetArchiveDN).foldM(
+                        restoreArchive(con, rudderDit.GROUP.dn, targetArchiveDN).foldZIO(
                           _ => Chained("Error when trying to restore archive with ID '%s' for the active technique library".format(archiveId.value), e).fail
                         , _ => Chained("Error when trying to load archived active technique library. A rollback to previous state was executed", e).fail
                         )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapPolicyLibrary.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapPolicyLibrary.scala
@@ -155,7 +155,7 @@ class ImportTechniqueLibraryImpl(
                         system
                       }).catchAll { e =>
                              logPure.error("Error when trying to load archived active technique library. Rollbaching to previous one.") *>
-                             restoreArchive(con, rudderDit.ACTIVE_TECHNIQUES_LIB.dn, targetArchiveDN).foldM(
+                             restoreArchive(con, rudderDit.ACTIVE_TECHNIQUES_LIB.dn, targetArchiveDN).foldZIO(
                                _ => Chained("Error when trying to restore archive with ID '%s' for the active technique library".format(archiveId.value), e).fail
                              , _ => Chained("Error when trying to load archived active technique library. A rollback to previous state was executed", e).fail
                              )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitParseRudderObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitParseRudderObjects.scala
@@ -523,7 +523,7 @@ class GitParseTechniqueLibrary(
      * find the path of the technique version
      */
     def getFilePath(db: Repository, revTreeId: ObjectId, techniqueId: TechniqueId) = {
-      IOResult.effect {
+      IOResult.attempt {
         //a first walk to find categories
         val tw = new TreeWalk(db)
         // there is no directory in git, only files

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/ParseXml.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/ParseXml.scala
@@ -56,7 +56,7 @@ object ParseXml {
   def apply(is: InputStream, filePath : Option[String] = None) : IOResult[Elem] = {
     val name = filePath.getOrElse("[unknown]")
     for {
-      doc <- Task(XML.load(is)).catchAll {
+      doc <- ZIO.attempt(XML.load(is)).catchAll {
                case e: SAXParseException =>
                  SystemError(s"Unexpected issue with the XML file ${name}: ${e.getMessage}", e).fail
                case e: java.net.MalformedURLException =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/XmlArchiverUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/XmlArchiverUtils.scala
@@ -81,7 +81,7 @@ trait XmlArchiverUtils {
 
     // an utility that write text in a file and create file parents if needed
     // open file mode for create or overwrite mode
-    IOResult.effect {
+    IOResult.attempt {
       val file = fileName.toScala
       file.parent.createDirectoryIfNotExists(true).setPermissions(directoryPerms).setGroup(groupOwner)
       file.writeText(xmlPrettyPrinter.format(elem))(Seq(WRITE, TRUNCATE_EXISTING, CREATE), Charset.forName(encoding)).setPermissions(filePerms).setGroup(groupOwner)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/GitRuleCategoryArchiver.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/GitRuleCategoryArchiver.scala
@@ -167,7 +167,7 @@ class GitRuleCategoryArchiverImpl(
                      val commitMsg = s"Archive rule Category with ID '${category.id.value}' ${GET(reason)}"
                      commitAddFileWithModId(modId, commiter, gitPath, commitMsg)
                    case None =>
-                     UIO.unit
+                     ZIO.unit
                  }
     } yield {
       GitPath(gitPath)
@@ -191,14 +191,14 @@ class GitRuleCategoryArchiverImpl(
     val gitPath = toGitPath(ruleCategoryFile)
     if(ruleCategoryFile.exists) {
       for {
-        deleted  <- IOResult.effect(FileUtils.forceDelete(ruleCategoryFile))
+        deleted  <- IOResult.attempt(FileUtils.forceDelete(ruleCategoryFile))
         _        <- logPure.debug("Deleted archive of rule: " + ruleCategoryFile.getPath)
         commited <- doCommit match {
                       case Some((modId, commiter, reason)) =>
                         val commitMsg = s"Delete archive of rule with ID '${categoryId.value} ${GET(reason)}"
                         commitRmFileWithModId(modId, commiter, gitPath, commitMsg)
                       case None =>
-                        UIO.unit
+                        ZIO.unit
                     }
       } yield {
         GitPath(gitPath)
@@ -235,10 +235,10 @@ class GitRuleCategoryArchiverImpl(
                        ZIO.when(oldCategoryDir.isDirectory) {
                          //move content except category.xml
                          val filteredDir = oldCategoryDir.listFiles.toSeq.filter( f => f.getName != categoryFileName)
-                         ZIO.foreach(filteredDir) { f => IOResult.effect(FileUtils.moveToDirectory(f, newCategoryDir, false)) }
+                         ZIO.foreach(filteredDir) { f => IOResult.attempt(FileUtils.moveToDirectory(f, newCategoryDir, false)) }
                        } *>
                        //in all case, delete the file at the old directory path
-                       IOResult.effect(FileUtils.deleteQuietly(oldCategoryDir))
+                       IOResult.attempt(FileUtils.deleteQuietly(oldCategoryDir))
                      }
                    }
         commit  <- gitCommit match {
@@ -248,7 +248,7 @@ class GitRuleCategoryArchiverImpl(
                        val newPath = toGitPath(newCategoryDir)
                        commitMvDirectoryWithModId(modId, commiter, oldPath, newPath, commitMsg)
                      case None =>
-                       UIO.unit
+                       ZIO.unit
                    }
       } yield {
         GitPath(toGitPath(archive))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/ImportRuleCategoryLibrary.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/ImportRuleCategoryLibrary.scala
@@ -190,7 +190,7 @@ class ImportRuleCategoryLibraryImpl(
           } }
       }
 
-      IOResult.effect(recSanitizeCategory(rootCategory, rootCategory, true)).notOptional("Error when trying to sanitize serialised user library for consistency errors")
+      IOResult.attempt(recSanitizeCategory(rootCategory, rootCategory, true)).notOptional("Error when trying to sanitize serialised user library for consistency errors")
     }
 
     //all the logic for a library swap.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/LDAPRuleCategoryRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/LDAPRuleCategoryRepository.scala
@@ -278,7 +278,7 @@ class WoLDAPRuleCategoryRepository(
       result           <- con.save(categoryEntry, removeMissingAttributes = true)
       updated          <- get(category.id)
       autoArchive      <- (moved, result) match {
-                            case (_:LDIFNoopChangeRecord, _:LDIFNoopChangeRecord) => UIO.unit
+                            case (_:LDIFNoopChangeRecord, _:LDIFNoopChangeRecord) => ZIO.unit
                             case _ if(autoExportOnModify && !updated.isSystem) =>
                               (for {
                                 parents  <- getParents(updated.id)
@@ -287,7 +287,7 @@ class WoLDAPRuleCategoryRepository(
                               } yield {
                                 moved
                               }).chainError("Error when trying to  automaticallyarchive the category move or update")
-                            case _ => UIO.unit
+                            case _ => ZIO.unit
                           }
     } yield {
       updated

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckNotificationService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckNotificationService.scala
@@ -35,10 +35,11 @@
 */
 
 package com.normation.rudder.services.healthcheck
+import com.github.ghik.silencer.silent
+
 import com.normation.zio._
 import zio.Ref
 import zio._
-import zio.duration._
 
 
 class HealthcheckNotificationService(
@@ -75,6 +76,5 @@ class HealthcheckNotificationService(
   reloadCache(healthcheckCache)
     .repeat(Schedule.spaced(schedulerPeriod).forever)
     .forkDaemon
-    .provide(ZioRuntime.environment)
-    .runNow
+    .runNow : @silent("a type was inferred to be `Any`")
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/PropertyEngineService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/PropertyEngineService.scala
@@ -3,7 +3,6 @@ package com.normation.rudder.services.nodes
 import com.normation.errors._
 import com.normation.zio._
 import zio.Ref
-import zio.UIO
 
 final case class EngineOption(name: String, value: String)
 
@@ -16,7 +15,7 @@ trait RudderPropertyEngine {
 trait PropertyEngineService {
   def process(engineName: String, namespace: List[String], opt: Option[List[EngineOption]]): IOResult[String]
 
-  def addEngine(engine: RudderPropertyEngine): UIO[Unit]
+  def addEngine(engine: RudderPropertyEngine): zio.UIO[Unit]
 }
 
 class PropertyEngineServiceImpl(listOfEngine: List[RudderPropertyEngine]) extends PropertyEngineService {
@@ -36,7 +35,7 @@ class PropertyEngineServiceImpl(listOfEngine: List[RudderPropertyEngine]) extend
     }
   }
 
-  def addEngine(engine: RudderPropertyEngine): UIO[Unit] = {
+  def addEngine(engine: RudderPropertyEngine): zio.UIO[Unit] = {
     for {
       _ <- engines.update(_ + (engine.name.toLowerCase -> engine))
     } yield ()

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DependencyAndDeletionService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DependencyAndDeletionService.scala
@@ -242,7 +242,7 @@ class DependencyAndDeletionServiceImpl(
       ZIO.foreach(targets) { target =>
         for {
           targetInfo <- groupLib.allTargets.get(target).notOptional("target info must be defined")
-          _          <- if(targetInfo.isEnabled) UIO.unit
+          _          <- if(targetInfo.isEnabled) ZIO.unit
                         else Inconsistency(s"target is not enable: ${targetInfo.name}").fail
         } yield {
           rule

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
@@ -365,7 +365,7 @@ class SystemVariableServiceImpl(
         agent.securityToken match {
           // A certificat, we return it
           case cert:Certificate =>
-            // for the certificate part, we exec the IO. If we have failure, log it and return "None"
+            // for the certificate part, we exec the ZIO. If we have failure, log it and return "None"
             val parsedCert = cert.cert.either.runNow match {
               case Left(err) =>
                 logger.error(s"Error when parsing certificate for node '${node.hostname}' [${node.id.value}]: ${err.fullMsg}")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueAcceptationDatetimeUpdater.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueAcceptationDatetimeUpdater.scala
@@ -175,7 +175,7 @@ class TechniqueAcceptationUpdater(
             rwActiveTechniqueRepo.deleteCategory(toActiveCatId(cat.id), modId, actor, reason).map(_ => ())
           } else {
             logPure.info(s"Not deleting non empty category: '${cat.id.toString}'") *>
-            UIO.unit
+            ZIO.unit
           }) // do nothing
         case TechniqueCategoryModType.Added(cat, parentId) =>
           logPure.debug(s"Category '${cat.id.toString}' added into '${parentId.toString}'") *>
@@ -206,7 +206,7 @@ class TechniqueAcceptationUpdater(
           roActiveTechniqueRepo.getActiveTechniqueCategory(toActiveCatId(cat.id)).flatMap { opt => opt match {
             case None          =>
               (cat.id: @unchecked) match {
-                case _:RootTechniqueCategoryId.type => UIO.unit
+                case _:RootTechniqueCategoryId.type => ZIO.unit
                 case i:SubTechniqueCategoryId =>
                   rwActiveTechniqueRepo.addActiveTechniqueCategory(
                     ActiveTechniqueCategory(
@@ -237,7 +237,7 @@ class TechniqueAcceptationUpdater(
 
                               case (TechniqueDeleted(name, versions), None) =>
                                 //nothing to do
-                                UIO.unit
+                                ZIO.unit
 
                               case (TechniqueDeleted(name, versions), Some(activeTechnique)) =>
                                 // If an active technique, not system, still exists for that technique, disable it.
@@ -279,7 +279,7 @@ class TechniqueAcceptationUpdater(
                                  */
                                 mods.find(x => x._2 == VersionAdded || x._2 == VersionUpdated ) match {
                                   case None => //do nothing
-                                    UIO.unit
+                                    ZIO.unit
 
                                   case Some((version, mod)) =>
 
@@ -290,7 +290,7 @@ class TechniqueAcceptationUpdater(
                                       case None =>
                                         //hum, something changed on the repos since the update. Strange.
                                         //ignore ? => do nothing
-                                        UIO.unit
+                                        ZIO.unit
                                       case Some(t) =>
                                         val referenceId = t.head._2.id
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
@@ -100,7 +100,7 @@ import net.liftweb.common.Failure
 import net.liftweb.common.Full
 import org.joda.time.DateTime
 
-import zio._
+import zio.{System => _, _}
 import zio.syntax._
 import com.normation.box._
 
@@ -251,9 +251,9 @@ trait ListNewNode extends NewNodeManager {
     for {
       con  <- ldap
       seq  <- con.searchOne(pendingNodesDit.NODES.dn,ALL,Srv.ldapAttributes:_*)
-      srvs <- ZIO.foreach(seq) { e => serverSummaryService.makeSrv(e).foldM(
+      srvs <- ZIO.foreach(seq) { e => serverSummaryService.makeSrv(e).foldZIO(
                 err =>
-                  IOResult.effect(NodeLogger.PendingNode.debug(s"Error when mapping a pending node entry '${e.dn}' to a node object. Error was: ${err.fullMsg}")) *>
+                  IOResult.attempt(NodeLogger.PendingNode.debug(s"Error when mapping a pending node entry '${e.dn}' to a node object. Error was: ${err.fullMsg}")) *>
                   None.succeed
               , srv => Some(srv).succeed
               ) }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/PolicyServerManagementService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/PolicyServerManagementService.scala
@@ -279,7 +279,7 @@ object PolicyServerManagementService {
     //filter out bad networks
     def validNets(networks: List[AllowedNetwork]): IOResult[Unit] = {
       networks.accumulate(net =>
-        if(AllowedNetwork.isValid(net.inet)) UIO.unit
+        if(AllowedNetwork.isValid(net.inet)) ZIO.unit
         else Inconsistency(s"Allowed network '${net}' is not a valid network syntax").fail
       ).unit
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/system/DebugInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/system/DebugInfoService.scala
@@ -47,7 +47,6 @@ import com.normation.rudder.hooks._
 import scala.jdk.CollectionConverters._
 import com.normation.errors._
 import zio._
-import zio.duration._
 import zio.syntax._
 import com.normation.zio._
 
@@ -66,7 +65,7 @@ class DebugInfoServiceImpl extends DebugInfoService {
   val logger = NamedZioLogger(this.getClass.getName)
 
   private[this] def execScript() : IOResult[Promise[Nothing, CmdResult]] = {
-    val environment = System.getenv.asScala.toMap
+    val environment = java.lang.System.getenv.asScala.toMap
     val timeOut     = Duration(30, TimeUnit.SECONDS)
     val scriptPath  = "/opt/rudder/bin/rudder-debug-info"
     val cmd         = Cmd(scriptPath, Nil, environment)
@@ -80,7 +79,7 @@ class DebugInfoServiceImpl extends DebugInfoService {
   // In order for the API to build an InMemoryResponse
 
   private[this] def getScriptResult() : IOResult[DebugInfoScriptResult] = {
-    IOResult.effect(s"Could not get file debug info result file") {
+    IOResult.attempt(s"Could not get file debug info result file") {
       val resultPath = s"/var/rudder/debug/info/debug-info-latest.tar.gz"
       val result = Paths.get(resultPath).toRealPath()
       DebugInfoScriptResult(result.getFileName.toString, Files.readAllBytes(result))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/user/PersonIdentService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/user/PersonIdentService.scala
@@ -56,6 +56,6 @@ trait PersonIdentService {
 
 class TrivialPersonIdentService extends PersonIdentService {
   override def getPersonIdentOrDefault(username:String) : IOResult[PersonIdent] = {
-    zio.UIO(new PersonIdent(username, "email not set"))
+    zio.ZIO.succeed(new PersonIdent(username, "email not set"))
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/SomeTestNonUnit.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/SomeTestNonUnit.scala
@@ -27,7 +27,6 @@ package com.normation
 
 import java.io.File
 
-import _root_.zio.duration._
 import com.normation.box._
 import com.normation.errors.IOResult
 import com.normation.eventlog.EventActor
@@ -45,7 +44,7 @@ object TestAccumulate {
 
     val data = new TestNodeConfiguration("webapp/sources/rudder/rudder-core/")
 
-    def prog(s: String) = IOResult.effect{println(s); Thread.sleep(1*1000)}.forever.forkDaemon.unit
+    def prog(s: String) = IOResult.attempt{println(s); Thread.sleep(1*1000)}.forever.forkDaemon.unit
 
 
     val pid = new java.io.File("/proc/self").getCanonicalFile().getName()
@@ -57,7 +56,7 @@ object TestAccumulate {
     (1 to 10).foreach(i => prog(s"zio $i").runNow)
     // on Lift threadpool
     (1 to 18).foreach(i => LAScheduler.execute(() => prog (s"lift $i").toBox))
-    (1 to 5).foreach(i => IOResult.effect(prog(s"mixed $i").toBox).runNow)
+    (1 to 5).foreach(i => IOResult.attempt(prog(s"mixed $i").toBox).runNow)
 
 
     val wait = 40.seconds
@@ -73,7 +72,7 @@ object TestAccumulate {
 object ThatDoesNotBlock {
   def main(args: Array[String]): Unit = {
 
-    def prog(s: String) = IOResult.effect{println(s); Thread.sleep(2*1000)}.forever.forkDaemon.unit
+    def prog(s: String) = IOResult.attempt{println(s); Thread.sleep(2*1000)}.forever.forkDaemon.unit
 
     val pid = new java.io.File("/proc/self").getCanonicalFile().getName()
     println(s"Test starts with PID ${pid} on ${java.lang.Runtime.getRuntime().availableProcessors()} cores")
@@ -82,7 +81,7 @@ object ThatDoesNotBlock {
     (1 to 18).foreach(i => LAScheduler.execute(() => prog (s"lift $i").toBox))
    // on ZIO blocking threadpool
     (1 to 10).foreach(i => prog(s"zio $i").runNow)
-    (1 to 5).foreach(i => IOResult.effect(prog(s"mixed $i").toBox).runNow)
+    (1 to 5).foreach(i => IOResult.attempt(prog(s"mixed $i").toBox).runNow)
 
 
     val wait = 40.seconds
@@ -99,10 +98,10 @@ object SemaphoreReentrant {
 
     val sem = Semaphore.make(1).runNow
 
-    val prog1 = sem.withPermit(IOResult.effect(println("prog1")))
-    val prog2 = sem.withPermit(IOResult.effectM{
+    val prog1 = sem.withPermit(IOResult.attempt(println("prog1")))
+    val prog2 = sem.withPermit(IOResult.attemptZIO{
       for {
-        _ <- IOResult.effect(println("in prog2"))
+        _ <- IOResult.attempt(println("in prog2"))
         _ <- prog1
       } yield ()
     })

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitRepositoryTest.scala
@@ -51,6 +51,7 @@ import com.normation.rudder.repository.GitModificationRepository
 import com.normation.rudder.repository.xml.RudderPrettyPrinter
 import com.normation.rudder.repository.xml.XmlArchiverUtils
 
+import com.github.ghik.silencer.silent
 import org.apache.commons.io.FileUtils
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
@@ -74,6 +75,7 @@ import scala.util.Random
  * To see values for gitRoot, ptLib, etc, see at the end
  * of that file.
  */
+@silent("a type was inferred to be `\\w+`; this may indicate a programming error.")
 @RunWith(classOf[JUnitRunner])
 class JGitRepositoryTest extends Specification with Loggable with AfterAll {
 
@@ -87,7 +89,7 @@ class JGitRepositoryTest extends Specification with Loggable with AfterAll {
    * -Dtests.clean.tmp=false
    */
   override def afterAll() = {
-    if(System.getProperty("tests.clean.tmp") != "false") {
+    if(java.lang.System.getProperty("tests.clean.tmp") != "false") {
       logger.info("Deleting directory " + gitRoot.pathAsString)
       FileUtils.deleteDirectory(gitRoot.toJava)
     }
@@ -117,21 +119,21 @@ class JGitRepositoryTest extends Specification with Loggable with AfterAll {
     val ref = repository.findRef(commit)
 
     // a RevWalk allows to walk over commits based on some filtering that is defined
-    val walkM = ZManaged.make(IOResult.effect(new RevWalk(repository)))(x => effectUioUnit(x.close()))
-    val treeWalkM = ZManaged.make(IOResult.effect(new TreeWalk(repository)))(x => effectUioUnit(x.close()))
+    val walkM = ZIO.acquireRelease(IOResult.attempt(new RevWalk(repository)))(x => effectUioUnit(x.close()))
+    val treeWalkM = ZIO.acquireRelease(IOResult.attempt(new TreeWalk(repository)))(x => effectUioUnit(x.close()))
 
-    walkM.use(walk =>
+    ZIO.scoped[Any](walkM.flatMap(walk =>
       for {
-        commit <- IOResult.effect(walk.parseCommit(ref.getObjectId))
-        tree   <- IOResult.effect(commit.getTree)
-        res    <- treeWalkM.use{treeWalk =>
+        commit <- IOResult.attempt(walk.parseCommit(ref.getObjectId))
+        tree   <- IOResult.attempt(commit.getTree)
+        res    <- ZIO.scoped(treeWalkM.flatMap {treeWalk =>
                     treeWalk.setRecursive(true) // ok, can't throw exception
 
-                    IOResult.effect(treeWalk.addTree(tree)) *>
-                    ZIO.loop(treeWalk)(_.next, identity)(x => IOResult.effect(x.getPathString))
-                  }
+                    IOResult.attempt(treeWalk.addTree(tree)) *>
+                    ZIO.loop(treeWalk)(_.next, identity)(x => IOResult.attempt(x.getPathString))
+                  })
       } yield res
-    )
+    ))
   }
 
   "The test lib" should {
@@ -147,18 +149,18 @@ class JGitRepositoryTest extends Specification with Loggable with AfterAll {
       def getName(length: Int) = {
         if(length < 1) Inconsistency("Length must be positive").fail
         else {
-          IOResult.effect("")(Random.alphanumeric.take(length).toList.mkString(""))
+          IOResult.attempt("")(Random.alphanumeric.take(length).toList.mkString(""))
         }
       }
       def add(i: Int) = (for {
         name <- getName(8).map(s => i.toString + "_" + s)
         file =  gitRoot / name
-        f    <- IOResult.effect(file.write("something in " + name))
+        f    <- IOResult.attempt(file.write("something in " + name))
         _    <- archive.commitAddFileWithModId(ModificationId(name), actor, name, "add " + name)
       } yield (name))
 
       logger.debug(s"Commiting files in: " + gitRoot.pathAsString)
-      val files = ZIO.foreachParN(16)(1 to 50) { i => add(i) }.runNow
+      val files = ZIO.foreachPar(1 to 50) { i => add(i) }.withParallelism(16).runNow
 
       val created = readElementsAt(repo.db, "refs/heads/master").runNow
       created must containTheSameElementsAs(files)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/TechniqueRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/TechniqueRepositoryTest.scala
@@ -179,7 +179,7 @@ class TechniqueRepositoryTest extends Specification with Loggable with AfterAll 
    * -Dtests.clean.tmp=false
    */
   override def afterAll() = {
-    if(System.getProperty("tests.clean.tmp") != "false") {
+    if(java.lang.System.getProperty("tests.clean.tmp") != "false") {
       logger.info("Deleting directory " + setupRepos.abstractRoot.getAbsolutePath)
       FileUtils.deleteDirectory(setupRepos.abstractRoot)
     }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/DBCommon.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/DBCommon.scala
@@ -66,7 +66,7 @@ trait DBCommon extends Specification with Loggable with BeforeAfterAll {
 
   logger.info("""Set JAVA property 'test.postgres' to false to ignore that test, for example from maven with: mvn -DargLine="-Dtest.postgres=false" test""")
 
-  val doDatabaseConnection = System.getProperty("test.postgres", "").toLowerCase match {
+  val doDatabaseConnection = java.lang.System.getProperty("test.postgres", "").toLowerCase match {
     case "true" | "1" => true
     case _ => false
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/GenerateCompliance.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/GenerateCompliance.scala
@@ -50,7 +50,6 @@ import com.normation.rudder.domain.NodeDit
 import com.normation.rudder.domain.RudderDit
 import com.normation.rudder.domain.reports.ComplianceLevel
 import com.normation.rudder.repository.jdbc.RudderDatasourceProvider
-import com.normation.zio.ZioRuntime
 import com.normation.zio._
 import com.unboundid.ldap.sdk.DN
 import doobie._
@@ -107,7 +106,6 @@ object GenerateCompliance {
     , properties.getProperty("ldap.host")
     , properties.getProperty("ldap.port").toInt
     , poolSize = 2
-    , blockingModule = ZioRuntime.environment
   )
   lazy val rwLdap =
     new RWPooledSimpleAuthConnectionProvider(
@@ -116,7 +114,6 @@ object GenerateCompliance {
     , properties.getProperty("ldap.host")
     , properties.getProperty("ldap.port").toInt
     , poolSize = 2
-    , blockingModule = ZioRuntime.environment
     )
 
   lazy val rudderDit = new RudderDit(new DN(properties.getProperty("ldap.rudder.base")))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/ExpectedReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/ExpectedReportTest.scala
@@ -81,6 +81,26 @@ class ExpectedReportTest extends Specification {
   }
   sequential
 
+  "Just a block" >> {
+    import zio.json._
+    import ExpectedReportsSerialisation.Version7_1._
+    val jsonMin =
+      """
+      {
+        "vid": "Command execution",
+        "vs": [
+          [ "/bin/echo \"restore\"" ]
+         ]
+      }
+      """.stripMargin
+    val expected = ValueExpectedReport("Command execution", List(
+                  ExpectedValueMatch("/bin/echo \"restore\"","/bin/echo \"restore\"")
+               ))
+
+    (jsonMin.fromJson[JsonValueExpectedReport7_1].map(_.transform)) must beEqualTo(Right(expected))
+  }
+
+
   "Reading old expected reports" should {
 
     "correctly read node0" in {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/HooksTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/HooksTest.scala
@@ -44,7 +44,6 @@ import org.joda.time.format.ISODateTimeFormat
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-import zio.duration._
 import better.files._
 import com.normation.rudder.hooks.HookReturnCode.Ok
 import com.normation.rudder.hooks.HookReturnCode.ScriptError
@@ -53,6 +52,7 @@ import com.normation.rudder.hooks.HookReturnCode.Warning
 import org.specs2.specification.AfterAll
 
 import scala.jdk.CollectionConverters._
+import zio.{System => _, _}
 
 /**
  * Test properties about NuProcess command, especially about
@@ -136,7 +136,7 @@ class HooksTest() extends Specification with AfterAll {
 //
 //    val many = (ZIO.foreach(0 until 1000) { i =>
 //      runOne
-//    }).timed.provide(ZioRuntime.environment).map(_._1.toMillis)
+//    }).timed.map(_._1.toMillis)
 //
 //    /* Typical results in a dell xps 8 cores:
 //     *  2838 ms

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/RunNuCommandTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/RunNuCommandTest.scala
@@ -46,11 +46,11 @@ import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
 import scala.jdk.CollectionConverters._
-import zio.duration._
 import com.normation.zio._
 import com.normation.errors._
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
+import zio.{System => _, _}
 
 /**
  * Test properties about NuProcess command, especially about
@@ -76,7 +76,7 @@ class RunNuCommandTest() extends Specification {
           c.stderr
         }
 
-      prog.provide(ZioRuntime.environment).runNow must beMatching("return code=0\nPATH=.*\nfoo=bar\n".r)
+      prog.runNow must beMatching("return code=0\nPATH=.*\nfoo=bar\n".r)
     }
 
     "has only the 3 stdin, stdout, stderr file descriptors" in {
@@ -90,7 +90,7 @@ class RunNuCommandTest() extends Specification {
           (c.code, c.stdout.split("\n").size)
         }
 
-      prog.provide(ZioRuntime.environment).runNow must beEqualTo((0, 4))
+      prog.runNow must beEqualTo((0, 4))
     }
 
     "can actually modify the file system" in {
@@ -108,7 +108,7 @@ class RunNuCommandTest() extends Specification {
         }
 
       (file.exists() must beFalse) and
-      (prog.provide(ZioRuntime.environment).runNow must beEqualTo(0)) and
+      (prog.runNow must beEqualTo(0)) and
       (file.exists() must beTrue)
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/inventory/TestCertificate.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/inventory/TestCertificate.scala
@@ -92,7 +92,7 @@ class TestCertificate extends Specification with Loggable {
   // we need a callback after add to avoid flappy tests
   val reportSaver = new InventorySaver[Seq[LDIFChangeRecord]] {
     val postCommitCallback: Inventory => UIO[Unit] = callback
-    override def save(report: Inventory): IOResult[Seq[LDIFChangeRecord]] = IOResult.effect {
+    override def save(report: Inventory): IOResult[Seq[LDIFChangeRecord]] = IOResult.attempt {
       Thread.sleep(100) // false delay to be sure we match what is really inserted, not what is previously there
       repository += ((report.node.main.id, FullInventory(report.node, Some(report.machine))))
     }.map(_ => Nil).tap(_ => postCommitCallback(report))
@@ -108,7 +108,7 @@ class TestCertificate extends Specification with Loggable {
     override def get(id: NodeId): IOResult[Option[FullInventory]] = repository.get(id).succeed
 
     override def get(id: NodeId, inventoryStatus: InventoryStatus): IOResult[Option[FullInventory]] = get(id)
-    override def save(serverAndMachine: FullInventory): IOResult[Seq[LDIFChangeRecord]] = IOResult.effect(
+    override def save(serverAndMachine: FullInventory): IOResult[Seq[LDIFChangeRecord]] = IOResult.attempt(
       repository += ((serverAndMachine.node.main.id, serverAndMachine))
     ).map(_ => Nil)
 
@@ -127,7 +127,7 @@ class TestCertificate extends Specification with Loggable {
   , 2
   , fullInventoryRepo
   , new InventoryDigestServiceV1(fullInventoryRepo)
-  , () => UIO.unit
+  , () => ZIO.unit
   , new InventoryDit(new DN("cn=test"), new DN("cn=soft"),"Pending Servers")
   )
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/metrics/SchedulerTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/metrics/SchedulerTest.scala
@@ -38,14 +38,13 @@
 package com.normation.rudder.metrics
 
 import java.util.concurrent.TimeUnit
-
 import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
-import zio._
-import zio.clock._
-import zio.duration._
-import zio.test.environment._
+
+import zio.{Scheduler => _, _}
+import zio.test._
+import com.normation.zio.ZioRuntime
 
 
 @RunWith(classOf[JUnitRunner])
@@ -61,10 +60,9 @@ class SchedulerTest extends Specification {
  */
 
     "yield execution at the correct time" in  {
-      val prog = ZIO.accessM[Clock with TestClock] { testClock =>
-        // in RC18-2, we need to sleep as long as we adjusted
+      val prog = {
         def adjust(d: Duration) = {
-          testClock.get[TestClock.Service].adjust(d)
+          testClock.flatMap(_.adjust(d))
         }
         def take(q: Queue[Long], r: Ref[List[Long]]): UIO[Unit] = {
           for {
@@ -77,8 +75,8 @@ class SchedulerTest extends Specification {
 
           q <- Queue.unbounded[Long]
           r <- Ref.make(List.empty[Long])
-          c =  testClock.get[Clock.Service].currentTime(TimeUnit.MINUTES).flatMap(t => q.offer(t)).unit
-          s <- Scheduler.make[Unit](10.minutes, 20.minutes, Unit => c, UIO.unit, testClock)
+          c =  ZIO.clockWith(_.currentTime(TimeUnit.MINUTES)).flatMap(t => q.offer(t)).unit
+          s <- Scheduler.make[Unit](10.minutes, 20.minutes, Unit => c, ZIO.unit)
           // start prog and trigger event
           f <- s.start
           _ <- s.triggerSchedule(())
@@ -92,23 +90,21 @@ class SchedulerTest extends Specification {
           _ <- adjust( 1.minutes) // 20 min
           _ <- take(q,r) // 20 min
           _ <- adjust(12.minutes) *> s.triggerSchedule(()) // 32 min
-          // Due to https://github.com/zio/zio/issues/3395 this part is broken in `RC18-2`
-//          _ <- take(q,r) // 32 min
-//          _ <- adjust(20.minutes) // 52 min
-//          _ <- take(q,r) // 52 min
-//          _ <- s.triggerSchedule(()) // 52 min
-//          _ <- adjust(10.minutes) // 62 min
-//          _ <- take(q,r) // 62 min
-//          _ <- adjust(20.minutes) // 82 min
-//          _ <- take(q,r) // 82 min
-//          _ <- adjust(20.minutes) // 102 min
-//          _ <- take(q,r) // 102 min
+          _ <- take(q,r) // 32 min
+          _ <- adjust(20.minutes) // 52 min
+          _ <- take(q,r) // 52 min
+          _ <- s.triggerSchedule(()) // 52 min
+          _ <- adjust(10.minutes) // 62 min
+          _ <- take(q,r) // 62 min
+          _ <- adjust(20.minutes) // 82 min
+          _ <- take(q,r) // 82 min
+          _ <- adjust(20.minutes) // 102 min
+          _ <- take(q,r) // 102 min
           l <- r.get
         } yield l.reverse
-      }.provideLayer(testEnvironment)
-      val l = Runtime.default.unsafeRun(prog)
-//      l must containTheSameElementsAs(List(0L, 10L, 20L, 32L, 52L, 62L, 82L, 102L))
-      l must containTheSameElementsAs(List(0L, 10L, 20L))
+      }
+      val l = ZioRuntime.unsafeRun(prog.provideLayer(Scope.default >>> testEnvironment))
+      l must containTheSameElementsAs(List(0L, 10L, 20L, 32L, 52L, 62L, 82L, 102L))
     }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
@@ -111,15 +111,15 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
   }
 
   override def afterAll(): Unit = {
-    if(System.getProperty("tests.clean.tmp") != "false") {
+    if(java.lang.System.getProperty("tests.clean.tmp") != "false") {
       FileUtils.deleteDirectory(new File(basePath))
     }
   }
 
   val expectedPath = "src/test/resources/configuration-repository"
   object TestTechniqueArchiver extends TechniqueArchiver {
-    override def deleteTechnique(techniqueId: TechniqueId, categories: Seq[String], modId: ModificationId, committer: EventActor, msg: String): IOResult[Unit] = UIO.unit
-    override def saveTechnique(techniqueId: TechniqueId, categories: Seq[String], resourcesStatus: Chunk[ResourceFile], modId: ModificationId, committer: EventActor, msg: String): IOResult[Unit] = UIO.unit
+    override def deleteTechnique(techniqueId: TechniqueId, categories: Seq[String], modId: ModificationId, committer: EventActor, msg: String): IOResult[Unit] = ZIO.unit
+    override def saveTechnique(techniqueId: TechniqueId, categories: Seq[String], resourcesStatus: Chunk[ResourceFile], modId: ModificationId, committer: EventActor, msg: String): IOResult[Unit] = ZIO.unit
   }
 
   object TestLibUpdater extends UpdateTechniqueLibrary {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -41,6 +41,7 @@ import com.normation.BoxSpecMatcher
 import com.normation.GitVersion
 import com.normation.cfclerk.domain.Technique
 import com.normation.cfclerk.domain.TechniqueName
+
 import com.normation.errors._
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.db.DB
@@ -62,6 +63,7 @@ import com.normation.rudder.repository.{CategoryWithActiveTechniques, Compliance
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.services.policies.NodeConfigData
 import com.normation.rudder.services.reports.{CachedFindRuleNodeStatusReports, CachedNodeChangesServiceImpl, DefaultFindRuleNodeStatusReports, NodeChangesServiceImpl, NodeConfigurationService, NodeConfigurationServiceImpl, ReportingServiceImpl, UnexpectedReportInterpretation}
+
 import doobie.implicits._
 import net.liftweb.common.Box
 import net.liftweb.common.Empty
@@ -70,11 +72,12 @@ import org.joda.time.DateTime
 import org.joda.time.Duration
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
+
 import zio._
 import zio.syntax._
-
 import scala.collection.SortedMap
-import scala.concurrent.duration._
+import scala.concurrent.duration.FiniteDuration
+
 import zio.interop.catz._
 
 /**
@@ -194,7 +197,7 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
 
   lazy val dummyComplianceRepos = new ComplianceRepository() {
     override def saveRunCompliance(reports: List[NodeStatusReport]): IOResult[Unit] = {
-      UIO.unit
+      ZIO.unit
     }
   }
 
@@ -205,8 +208,8 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
       , dummyChangesCache
       , dummyComplianceCache
       , dummyComplianceRepos
-      , 1.hour
-      , 1.hour
+      , FiniteDuration(1, "hour")
+      , FiniteDuration(1, "hour")
     )
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/xml/TestGitFindUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/xml/TestGitFindUtils.scala
@@ -194,7 +194,7 @@ class TestGitFindUtils extends Specification with Loggable with AfterAll with Co
     unzip.mkdir()
 
     ZioRuntime.runNow(GitFindUtils.getZip(db, id).flatMap(bytes =>
-      IOResult.effect(FileUtils.writeByteArrayToFile(archive, bytes))
+      IOResult.attempt(FileUtils.writeByteArrayToFile(archive, bytes))
     ) *> ZipUtils.unzip(new ZipFile(archive), unzip))
 
     gitRoot must haveSameFilesAs(unzip).withFilter((file: File) => !file.getAbsolutePath.contains(".git"))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
@@ -171,8 +171,8 @@ class TestBuildNodeConfiguration extends Specification {
 //
 //  def main(args: Array[String]): Unit = {
 //
-//    def nano = UIO.effectTotal(System.nanoTime)
-//    def log(s: String, t1: Long, t2: Long) = UIO.effectTotal(logger.trace(s + s"${(t2-t1)/1000} µs"))
+//    def nano = ZIO.succeed(System.nanoTime)
+//    def log(s: String, t1: Long, t2: Long) = ZIO.succeed(logger.trace(s + s"${(t2-t1)/1000} µs"))
 //
 //    val count = 0 until 1
 //    val prog =
@@ -190,7 +190,7 @@ class TestBuildNodeConfiguration extends Specification {
 //                }
 //        t4   <- nano
 //        _    <- log(s"external $j : ", t1, t4)
-//        _    <- ref.get.flatMap(t => UIO.effectTotal(logger.trace(s"inner sum $j: ${t/1000} µs")))
+//        _    <- ref.get.flatMap(t => ZIO.succeed(logger.trace(s"inner sum $j: ${t/1000} µs")))
 //      } yield ()
 //    }
 //    ZioRuntime.unsafeRun(prog)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
@@ -74,7 +74,9 @@ import com.normation.rudder.domain.logger.NodeConfigurationLoggerImpl
 import com.normation.rudder.domain.logger.PolicyGenerationLogger
 import com.normation.rudder.services.policies.MergePolicyService
 import com.normation.rudder.services.policies.BoundPolicyDraft
+
 import org.apache.commons.io.FileUtils
+
 import zio.syntax._
 import com.normation.zio._
 import com.normation.rudder.services.policies.write.PolicyWriterServiceImpl.filepaths

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigRepository.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigRepository.scala
@@ -114,7 +114,7 @@ class LdapConfigRepository(
                   val modId = ModificationId(uuidGen.newUuid)
                   eventLogRepository.saveModifyGlobalProperty(modId, info.actor, oldProperty, property, info.eventLogType, info.reason)
                 case _ =>
-                  UIO.unit
+                  ZIO.unit
               }
           } yield {
             property

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
@@ -295,7 +295,7 @@ trait UpdateConfigService {
       _ <- set_rudder_compliance_mode_name(mode.name,actor, reason)
       u <- mode.name match {
              case ChangesOnly.name =>  set_rudder_compliance_heartbeatPeriod(mode.heartbeatPeriod, actor, reason)
-             case _ => UIO.unit
+             case _ => ZIO.unit
            }
     } yield {
       u
@@ -473,7 +473,7 @@ class GenericConfigService(
                     case Some(p) => p.succeed
                   }
       value    =  converter(param)
-      _        <- ZIO.whenM(needSave.get) {
+      _        <- ZIO.whenZIO(needSave.get) {
                     save(name, param)
                   }
     } yield {
@@ -602,7 +602,7 @@ class GenericConfigService(
   def set_rudder_workflow_enabled(value: Boolean): IOResult[Unit] = {
     if(workflowLevel.workflowLevelAllowsEnable) {
       save("rudder_workflow_enabled", value) <*
-      IOResult.effect(workflowUpdate ! WorkflowUpdate)
+      IOResult.attempt(workflowUpdate ! WorkflowUpdate)
     } else {
       Inconsistency("You can't change the change validation workflow type. Perhaps are you missing the 'changes validation' plugin?").fail
     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -659,7 +659,7 @@ final case class RestExtractorService (
   // for the key, we don't have type / agent here. We are just looking if the string is a valid PEM
   // and choose between certificate / public key
   def parseAgentKey(key: String): Box[SecurityToken] = {
-    IO.effect {
+    ZIO.attempt {
       (new PEMParser(new StringReader(key))).readObject()
     }.mapError { ex =>
       InventoryError.CryptoEx(s"Key '${key}' cannot be parsed as a public key", ex)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/CreateNodeData.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/CreateNodeData.scala
@@ -204,7 +204,7 @@ class NodeDetailsSerialize(
   }
 
   def parseAll(json: JValue): IOResult[List[Rest.NodeDetails]] = {
-    IOResult.effect(s"Error when deserializing a nodes for creation API")(json.extract[List[Rest.NodeDetails]])
+    IOResult.attempt(s"Error when deserializing a nodes for creation API")(json.extract[List[Rest.NodeDetails]])
   }
 }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/HookApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/HookApi.scala
@@ -44,7 +44,7 @@ class HookApiService(
 
   def listHooks(): IOResult[List[JRHooks]]  = {
     for {
-      hooksDirectories <- IOResult.effect(File(hooksDirectory).list.filter(_.isDirectory).toList)
+      hooksDirectories <- IOResult.attempt(File(hooksDirectory).list.filter(_.isDirectory).toList)
       hooks <- ZIO.foreach(hooksDirectories)(d => RunHooks.getHooksPure(s"$hooksDirectory/${d.name}", suffixIgnoreList))
       res = hooks.map(JRHooks.fromHook)
     } yield {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InventoryApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InventoryApi.scala
@@ -109,8 +109,8 @@ class InventoryApi (
     val sigExtension = ".sign"
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      def writeFile(item: FileParamHolder, file: File) = ZIO.bracket(IOResult.effect(item.fileStream))(is => effectUioUnit(is.close())) { is =>
-        IOResult.effect(file.outputStream.foreach(is.pipeTo(_)))
+      def writeFile(item: FileParamHolder, file: File) = ZIO.acquireReleaseWith(IOResult.attempt(item.fileStream))(is => effectUioUnit(is.close())) { is =>
+        IOResult.attempt(file.outputStream.foreach(is.pipeTo(_)))
       }
       def parseInventory(pretty: Boolean, inventoryFile: FileParamHolder, signatureFile: FileParamHolder): IOResult[String] = {
         // here, we are at the end of our world. Evaluate ZIO and see what happen.

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/PluginApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/PluginApi.scala
@@ -105,7 +105,7 @@ class PluginApi (
       val json=
         for {
         json <- req.json.toIO
-        conf <- IOResult.effect(Serialization.read[PluginSettings](net.liftweb.json.compactRender(json)))
+        conf <- IOResult.attempt(Serialization.read[PluginSettings](net.liftweb.json.compactRender(json)))
         _ <- pluginSettingsService.writePluginSettings(conf)
 
       } yield {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RecentChangesAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RecentChangesAPI.scala
@@ -132,13 +132,13 @@ class RecentChangesAPI (
       (for {
         startDate <- req.params.get("start") match {
           case Some(start :: Nil) =>
-            IOResult.effect(DateTime.parse(start))
+            IOResult.attempt(DateTime.parse(start))
           case _ =>
             Inconsistency("No start date defined").fail
         }
         endDate <- req.params.get("end") match {
           case Some(end :: Nil) =>
-            IOResult.effect(DateTime.parse(end))
+            IOResult.attempt(DateTime.parse(end))
           case _ =>
             Inconsistency("No end date defined").fail
         }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -846,7 +846,7 @@ final case object RestContinueGenerationOnError extends RestBooleanSetting {
         nodeInfo <- nodeInfoService.getNodeInfo(NodeId(id))
         isServer <- nodeInfo match {
           case Some(info) if info.isPolicyServer =>
-            UIO.unit
+            ZIO.unit
           case Some(_) =>
             Inconsistency(s"Can get allowed networks of node with '${id}' because it is node a policy server (root or relay)").fail
           case None =>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
@@ -84,7 +84,6 @@ import net.liftweb.common.Full
 import net.liftweb.json.JsonAST.JField
 import net.liftweb.json.JsonAST.JObject
 import net.liftweb.json.JsonAST.JString
-import zio.json.JsonCodec.apply
 
 import scala.collection.SortedMap
 
@@ -324,7 +323,7 @@ class TechniqueApi (
       val workspaceDir = File(s"/var/rudder/configuration-repository/${workspacePath}")
       val finalDir = File(s"/var/rudder/configuration-repository/${finalPath}")
 
-      IOResult.effect("Error when moving resource file from workspace to final destination") (
+      IOResult.attempt("Error when moving resource file from workspace to final destination") (
         if (workspaceDir.exists) {
           finalDir.createDirectoryIfNotExists(true)
           workspaceDir.moveTo(finalDir)(File.CopyOptions.apply(true))
@@ -545,7 +544,7 @@ class TechniqueAPIService6 (
               Inconsistency(s"Version '${version.serialize}' of Technique '${techniqueName.value}' does not exist").fail
             }
           }
-        case None => UIO.unit
+        case None => ZIO.unit
       }
     }
 
@@ -606,7 +605,7 @@ class TechniqueAPIService14 (
               Inconsistency(s"Version '${version.debugString}' of Technique '${techniqueName.value}' does not exist").fail
             }
           }
-        case None => UIO.unit
+        case None => ZIO.unit
       }
     }
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
@@ -71,6 +71,7 @@ import java.io.FileOutputStream
 import java.nio.charset.StandardCharsets
 import java.util.zip.ZipFile
 
+import zio.ZIO
 import com.normation.errors.IOResult
 import com.normation.errors.effectUioUnit
 import com.normation.zio._
@@ -331,7 +332,7 @@ class ArchiveApiTest extends Specification with AfterAll with Loggable {
     val archiveDir = "archive-rule-with-dep"
     val unzipped = testDir / archiveDir
     // read zip entries, load archive
-    val p = IOResult.effect(File(unzipped.pathAsString + ".zip").newInputStream).bracket(is => effectUioUnit(is.close)) { is =>
+    val p = ZIO.acquireReleaseWith(IOResult.attempt(File(unzipped.pathAsString + ".zip").newInputStream))(is => effectUioUnit(is.close)) { is =>
       ZipUtils.getZipEntries(archiveDir + ".zip", is)
     }.flatMap(entries =>
       restTestSetUp.archiveAPIModule.zipArchiveReader.readPolicyItems(archiveDir + ".zip", entries)

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -161,7 +161,6 @@ import org.eclipse.jgit.lib.PersonIdent
 import org.joda.time.DateTime
 import org.specs2.matcher.MatchResult
 import zio._
-import zio.duration._
 import zio.syntax._
 
 import java.nio.charset.StandardCharsets
@@ -585,7 +584,7 @@ class RestTestSetUp {
 
 
     override def saveRudderNode(id: NodeId, setup: NodeSetup): IO[Creation.CreationError, NodeId] = {
-      mockNodes.nodeInfoService.nodeBase.update { nodes =>
+      mockNodes.nodeInfoService.nodeBase.updateZIO { nodes =>
 
         nodes.get(id) match {
           case None    => CreationError.OnSaveNode(s"Can not merge node: missing").fail

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestPlusInPath.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestPlusInPath.scala
@@ -65,11 +65,11 @@ class TestRestPlusInPath extends Specification with BeforeAfterAll {
   override def beforeAll(): Unit = {
     val inventory = NodeInventory(NodeSummary(myNode.id, AcceptedInventory, "root", myNode.hostname, myNode.osDetails, myNode.policyServerId, myNode.keyStatus))
     val details = NodeDetails(myNode, inventory, None)
-    ZioRuntime.unsafeRun(env.mockNodes.nodeInfoService.nodeBase.update(nodes => (nodes+(myNode.id -> details)).succeed))
+    ZioRuntime.unsafeRun(env.mockNodes.nodeInfoService.nodeBase.updateZIO(nodes => (nodes+(myNode.id -> details)).succeed))
   }
 
   override def afterAll(): Unit = {
-    ZioRuntime.unsafeRun(env.mockNodes.nodeInfoService.nodeBase.update(nodes => (nodes-(myNode.id)).succeed))
+    ZioRuntime.unsafeRun(env.mockNodes.nodeInfoService.nodeBase.updateZIO(nodes => (nodes-(myNode.id)).succeed))
   }
 
   val test = new RestTest(env.liftRules)

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
@@ -50,9 +50,7 @@ import com.normation.rudder.rest.lift.LiftApiProcessingLogger
 import com.normation.rudder.rest.lift.LiftHandler
 
 import com.normation.errors.IOResult
-import com.normation.errors.RudderError
 import com.normation.errors.effectUioUnit
-
 import scala.jdk.CollectionConverters._
 import org.specs2.mutable._
 import org.specs2.specification.core.Fragment
@@ -78,6 +76,7 @@ import java.io.InputStream
 import java.nio.file.Path
 import java.nio.file.Paths
 
+import com.normation.box.IOManaged
 import com.normation.errors._
 
 /*
@@ -162,7 +161,7 @@ trait TraitTestApiFromYamlFiles extends Specification {
 
     // we accept that the resources is not there
     def listFilesUnder(dir: String, mandatory: Boolean): IOResult[List[String]] = {
-      IOResult.effectM(Resource.url(dir) match {
+      IOResult.attemptZIO(Resource.url(dir) match {
         case None if(mandatory)  => Unexpected(s"Missing required classpath resources: ${dir}").fail
         case None                => Nil.succeed
         case Some(_)             => Resource.getAsString(dir).linesIterator.toList.succeed
@@ -175,22 +174,22 @@ trait TraitTestApiFromYamlFiles extends Specification {
     }
 
     // file are copier directly into destDir
-    def copyTransform(orig: Path, destDir: File): IOResult[(String, Managed[RudderError, InputStream])] = {
+    def copyTransform(orig: Path, destDir: File): IOResult[(String, IOManaged[InputStream])] = {
       // for now, nothing more
       val name = orig.getFileName.toString
       val dest = destDir / name
       for {
-        f <- IOResult.effect(Resource.asString(orig.toString).map(s => dest.write(transform(name, s)))).notOptional(s"Missing source file: ${orig}")
+        f <- IOResult.attempt(Resource.asString(orig.toString).map(s => dest.write(transform(name, s)))).notOptional(s"Missing source file: ${orig}")
       } yield {
-        (name, Managed.make(IOResult.effect(f.newInputStream))(is => effectUioUnit(is.close())))
+        (name, ZIO.acquireRelease(IOResult.attempt(f.newInputStream))(is => effectUioUnit(is.close())))
       }
     }
 
     // the list anyref here is Yaml objects
-    def loadYamls(input: Managed[RudderError, InputStream]): IOResult[List[AnyRef]] = {
+    def loadYamls(input: IOManaged[InputStream]): IOResult[List[AnyRef]] = {
       for {
-        tool  <- IOResult.effect(new Yaml())
-        yamls <- input.use(x => IOResult.effect(tool.loadAll(x).asScala.toList))
+        tool  <- IOResult.attempt(new Yaml())
+        yamls <- ZIO.scoped(input.flatMap(x => IOResult.attempt(tool.loadAll(x).asScala.toList)))
       } yield {
         yamls
       }
@@ -199,7 +198,7 @@ trait TraitTestApiFromYamlFiles extends Specification {
     for {
       // base, directly from classpath
       baseFiles   <- listFilesUnder(baseDir, true).map(_.filter(only))
-      baseIs      =  baseFiles.map { name => (name, Managed.make(IOResult.effect(Resource.getAsStream(baseDir + "/" + name)))(is => effectUioUnit(is.close()))) }
+      baseIs      =  baseFiles.map { name => (name, ZIO.acquireRelease(IOResult.attempt(Resource.getAsStream(baseDir + "/" + name)))(is => effectUioUnit(is.close()))) }
       // templates: need copy to tmp file
       templates   <- listFilesUnder(templateDir, false).map(_.filter(only))
       copied      <- ZIO.foreach(templates) { t => copyTransform(Paths.get(templateDir, t), tmpDir) }

--- a/webapp/sources/rudder/rudder-templates-cli/src/test/scala/com/normation/templates/cli/TemplateCliTest.scala
+++ b/webapp/sources/rudder/rudder-templates-cli/src/test/scala/com/normation/templates/cli/TemplateCliTest.scala
@@ -64,7 +64,7 @@ class TemplateCliTest extends Specification with ContentMatchers with AfterAll {
 
   def dir(path: String) = (new File(testDir, path)).getAbsolutePath
 
-  "The main programm" should {
+  "The main program" should {
     "correctly replace variable in template" in {
 
       FileUtils.copyDirectory(new File("src/test/resources/templates1"), testDir)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/action/CheckNcfTechniqueUpdate.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/action/CheckNcfTechniqueUpdate.scala
@@ -116,7 +116,7 @@ class CheckNcfTechniqueUpdate(
                                                         // Update technique library once all technique are updated
         libUpdate   <- techLibUpdate.update(ModificationId(uuidGen.newUuid), EventActor(systemApiToken.name.value), Some(s"Update Technique library after updating all techniques at start up")).toIO.chainError( s"An error occured during techniques update after update of all techniques from the editor")
 
-        flagDeleted <- IOResult.effect( ncfTechniqueUpdateFlag.delete() )
+        flagDeleted <- IOResult.attempt( ncfTechniqueUpdateFlag.delete() )
       } yield {
          techniques
       }
@@ -124,7 +124,7 @@ class CheckNcfTechniqueUpdate(
 
     val prog = (for {
       _          <- techniqueReader.updateMethodsMetadataFile
-      flagExists <- IOResult.effect(s"An error occurred while accessing flag file '${ncfTechniqueUpdateFlag.pathAsString}'")(ncfTechniqueUpdateFlag.exists)
+      flagExists <- IOResult.attempt(s"An error occurred while accessing flag file '${ncfTechniqueUpdateFlag.pathAsString}'")(ncfTechniqueUpdateFlag.exists)
       _ <- if (flagExists) updateNcfTechniques else BootstrapLogger.info(s"Flag file '${ncfTechniqueUpdateFlag.pathAsString}' does not exist, do not regenerate ncf Techniques")
     } yield ())
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/CheckAddSpecialNodeGroupsDescription.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/CheckAddSpecialNodeGroupsDescription.scala
@@ -72,7 +72,7 @@ class CheckAddSpecialNodeGroupsDescription(
   override def description: String = "Check if system groups hasPolicyServer-root and all-nodes-with-cfengine-agent have the correct description and name"
 
   override def checks() : Unit = {
-    ZIO.whenM(checkMigrationNeeded())(
+    ZIO.whenZIO(checkMigrationNeeded())(
       createSpecialTarget()
     ).catchAll(err =>
       MigrationLoggerPure.error(s"Error when trying to modify name and description of groups hasPolicyServer-root and all-nodes-with-cfengine-agent")
@@ -89,7 +89,7 @@ class CheckAddSpecialNodeGroupsDescription(
       con                            <- ldap
       allLinux                       <- con.get(all_nodeGroupDN).chainError(s"Error when trying to get entry for ${all_nodeGroupDN} to modified name and description")
       allLinuxPolicyServerModified <- con.get(all_nodeGroupPolicyServerDN).chainError(s"Error when trying to get entry for ${all_nodeGroupPolicyServerDN} to modified name and description")
-      isAllLinuxModified             <- IOResult.effect(s"Error when trying to get attributes `${A_NAME}` and `${A_DESCRIPTION}` for ${all_nodeGroupDN.toString}") {
+      isAllLinuxModified             <- IOResult.attempt(s"Error when trying to get attributes `${A_NAME}` and `${A_DESCRIPTION}` for ${all_nodeGroupDN.toString}") {
                                           allLinux match {
                                             case Some(entry) =>
                                               entry.getAttribute(A_NAME).getValue == allNodeGroupNewName &&
@@ -97,7 +97,7 @@ class CheckAddSpecialNodeGroupsDescription(
                                             case None => false
                                           }
                                         }
-      isAllLinuxPolicyServerModified <- IOResult.effect(s"Error when trying to get attributes `${A_NAME}` and `${A_DESCRIPTION}` for ${all_nodeGroupPolicyServerDN.toString}") {
+      isAllLinuxPolicyServerModified <- IOResult.attempt(s"Error when trying to get attributes `${A_NAME}` and `${A_DESCRIPTION}` for ${all_nodeGroupPolicyServerDN.toString}") {
                                           allLinuxPolicyServerModified match {
                                             case Some(entry) =>
                                               entry.getAttribute(A_NAME).getValue == allNodeGroupPolicyServerNewName &&

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/CheckAddSpecialTargetAllPolicyServers.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/CheckAddSpecialTargetAllPolicyServers.scala
@@ -76,7 +76,7 @@ class CheckAddSpecialTargetAllPolicyServers(
   override def description: String = "Check if special target all_policyServers from Rudder 7.0 is present"
 
   override def checks() : Unit = {
-    ZIO.whenM(checkMigrationNeeded())(
+    ZIO.whenZIO(checkMigrationNeeded())(
       createSpecialTarget()
     ).catchAll(err =>
       MigrationLoggerPure.error(s"Error during addition of new special target 'all_policyServers'. You can restart Rudder to " +

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/onetimeinit/CheckInitXmlExport.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/onetimeinit/CheckInitXmlExport.scala
@@ -78,7 +78,7 @@ class CheckInitXmlExport(
                   itemArchiveManager.exportAll(ident, ModificationId(uuidGen.newUuid), RudderEventActor, Some("Initialising configuration-repository sub-system"), false)
                 } else {
                   BootstrapLogger.trace("At least a full archive of configuration items done, no need for further initialisation") *>
-                  UIO.unit
+                  ZIO.unit
                 }
 
     } yield {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/GiveReasonPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/GiveReasonPopup.scala
@@ -165,7 +165,7 @@ class GiveReasonPopup(
           }) match {
             case Full(res) =>
               val jsString = """setTimeout(function() { $("[activeTechniqueId=%s]")
-                .effect("highlight", {}, 2000)}, 100)"""
+                .attempt("highlight", {}, 2000)}, 100)"""
                 formTracker.clean
                 closePopup() &
                 onSuccessCallback(res.id) &

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/TechniqueLibraryManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/TechniqueLibraryManagement.scala
@@ -402,7 +402,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
             result
           }) match {
             case Full(res) =>
-              refreshTree() & JsRaw("""setTimeout(function() { $("[activeTechniqueId=%s]").effect("highlight", {}, 2000)}, 100)""".format(sourceactiveTechniqueId)) & refreshBottomPanel(res)
+              refreshTree() & JsRaw("""setTimeout(function() { $("[activeTechniqueId=%s]").attempt("highlight", {}, 2000)}, 100)""".format(sourceactiveTechniqueId)) & refreshBottomPanel(res)
             case f:Failure => Alert(f.messageChain + "\nPlease reload the page")
             case Empty => Alert("Error while trying to move Active Technique with requested id '%s' to category id '%s'\nPlease reload the page.".format(sourceactiveTechniqueId,destCatId))
           }
@@ -437,7 +437,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
           }) match {
             case Full(res) =>
               refreshTree() &
-              OnLoad(JsRaw("""setTimeout(function() { $("[catid=%s]").effect("highlight", {}, 2000);}, 100)"""
+              OnLoad(JsRaw("""setTimeout(function() { $("[catid=%s]").attempt("highlight", {}, 2000);}, 100)"""
                   .format(sourceCatId)))
             case f:Failure => Alert(f.messageChain + "\nPlease reload the page")
             case Empty => Alert("Error while trying to move category with requested id '%s' to category id '%s'\nPlease reload the page.".format(sourceCatId,destCatId))
@@ -485,7 +485,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
                 }) match {
                 case Full(res) =>
                   val jsString = """setTimeout(function() { $("[activeTechniqueId=%s]")
-                    .effect("highlight", {}, 2000)}, 100)"""
+                    .attempt("highlight", {}, 2000)}, 100)"""
                 refreshTree() & JsRaw(jsString
                     .format(sourceactiveTechniqueId)) &
                     refreshBottomPanel(res.id)
@@ -506,7 +506,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
 
   private[this] def onSuccessReasonPopup(id : ActiveTechniqueId) : JsCmd =  {
     val jsStr = """setTimeout(function() { $("[activeTechniqueId=%s]")
-      .effect("highlight", {}, 2000)}, 100)"""
+      .attempt("highlight", {}, 2000)}, 100)"""
     refreshTree() &
     JsRaw(jsStr) & refreshBottomPanel(id)
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
@@ -353,7 +353,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
               refreshGroupLib()
               (
                   refreshTree(htmlTreeNodeId(ng.id.serialize))
-                & JsRaw("""setTimeout(function() { $("[groupid=%s]").effect("highlight", {}, 2000)}, 100)""".format(sourceGroupId))
+                & JsRaw("""setTimeout(function() { $("[groupid=%s]").attempt("highlight", {}, 2000)}, 100)""".format(sourceGroupId))
                 & refreshRightPanel(GroupForm(Right(ng),cat))
               )
             case f:Failure => Alert(f.messageChain + "\nPlease reload the page")
@@ -393,7 +393,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
               refreshGroupLib()
               (
                   refreshTree(htmlTreeNodeId(id))
-                & OnLoad(JsRaw("""setTimeout(function() { $("[catid=%s]").effect("highlight", {}, 2000);}, 100)""".format(sourceCatId)))
+                & OnLoad(JsRaw("""setTimeout(function() { $("[catid=%s]").attempt("highlight", {}, 2000);}, 100)""".format(sourceCatId)))
                 & refreshRightPanel(CategoryForm(res))
               )
             case f:Failure => Alert(f.messageChain + "\nPlease reload the page")

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
@@ -189,7 +189,7 @@ class TestMigrateSystemTechniques7_0 extends Specification {
     override def getEventLogWithChangeRequest(id: Int): IOResult[Option[(EventLog, Option[ChangeRequestId])]] = ???
     override def getLastEventByChangeRequest(xpath: String, eventTypeFilter: List[EventLogFilter]): IOResult[Map[ChangeRequestId, EventLog]] = ???
 
-    // the following implementation likely means that these methods should return UIO.unit
+    // the following implementation likely means that these methods should return ZIO.unit
     override def saveAddDirective(modId: ModificationId, principal: EventActor, addDiff: AddDirectiveDiff, varsRootSectionSpec: SectionSpec, reason: Option[String]): IOResult[EventLog] = {
       ZIO.succeed(null)
     }

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/listener/InMemoryDsConnectionProvider.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/listener/InMemoryDsConnectionProvider.scala
@@ -25,7 +25,6 @@ import com.unboundid.ldap.sdk.schema.Schema
 import com.normation.ldap.ldif._
 import com.normation.ldap.sdk._
 import com.normation.ldap.sdk.syntax.UnboundidLDAPConnection
-import zio.blocking.Blocking
 import com.normation.zio._
 import zio._
 
@@ -41,7 +40,6 @@ class InMemoryDsConnectionProvider[CON <: RoLDAPConnection](
     //for example for bootstrap datas
   , bootstrapLDIFPaths : Seq[String] = Seq()
   , val ldifFileLogger:LDIFFileLogger = new DummyLDIFFileLogger()
-  , val blockingModule: Blocking
 ) extends LDAPConnectionProvider[CON] with OneConnectionProvider[CON] with UnboundidConnectionProvider {
 
   /**
@@ -61,7 +59,7 @@ class InMemoryDsConnectionProvider[CON <: RoLDAPConnection](
   override def newUnboundidConnection: UnboundidLDAPConnection = server.getConnection
 
   def newConnection: ZIO[Any, LDAPRudderError, CON] = {
-    LDAPIOResult.effectNonBlocking(new RwLDAPConnection(newUnboundidConnection,ldifFileLogger,blockingModule=blockingModule).asInstanceOf[CON])
+    LDAPIOResult.attempt(new RwLDAPConnection(newUnboundidConnection,ldifFileLogger).asInstanceOf[CON])
   }
 }
 
@@ -81,7 +79,7 @@ object InMemoryDsConnectionProvider {
     val schema = Schema.getSchema(schemaLDIFPaths:_*)
     val config = new InMemoryDirectoryServerConfig(baseDNs:_*)
     config.setSchema(schema)
-    new InMemoryDsConnectionProvider[CON](config,bootstrapLDIFPaths,ldifFileLogger, ZioRuntime.environment)
+    new InMemoryDsConnectionProvider[CON](config,bootstrapLDIFPaths,ldifFileLogger)
   }
 
 


### PR DESCRIPTION
https://issues.rudder.io/issues/21825

As explained in the ticket, we have a very useful migration from where you copy&past things: https://zio.dev/guides/migrate/zio-2.x-migration-guide/


Main anoying/unintersting changes: 
- there is a bug in zio-json (https://github.com/zio/zio-json/issues/622) that forces us to not use codec (see [ExpectedReports.scala](https://github.com/Normation/rudder/pull/4507/files#diff-223450414fa9cd87b265b4f5bc93a25dae3bd733e366c8008208e5360195a750))
- lots of renaming, the most pervasive being `.effect` to `.attempt`. Good to understand, bad for future merge. For consistency, I also renamed `IOResult.effect` into `IOResult.attemp`
- lots of others little renaming things like no more `UIO.unit` but `ZIO.unit`, `RefM` into `Ref.Synchronized`, all `.xxxM` methods into `.xxxZIO` methods, etc.
- A bit more involving, no more `Managed` but `ZIO.scope(...).flatMap(...)` and no more `bracket` but `ZIO.acquireReleaseWith` 
- `zio` package as a `System` object, so we need to `import zio.{System => _, _}` to avoid conflict with `java.lang.System`
- no more `zio.duration._` package, the implicits for `.seconds` etc are in `zio._`
- parallelism in traverse is not `.foreachParN(...)(N)` anymore but `.foreachPar(...).withParallelism(N)`
- queue method getAll etc returns `Chunk` so it's simpler to use chunk elsewhere around them

More interesting:

- `untraced` is not needed anymore: trace information are compile-time now and have almost not overhead at runtime
- no need to pass `clock` around, they are now part of `ZIO` based effects always here. It's also much more easier to access it for sleeping (see for ex [Scheduler.scala](https://github.com/Normation/rudder/pull/4507/files#diff-c618252426fbe1b029c1c9b066644a78efde2f0936a1d5aa24e7111d825b64d5)

The amazing

- they corrected https://github.com/zio/zio/issues/1275 which means that WE DON'T HAVE TO CARE ANYMORE IF THINGS BLOCK!
ZIO will try to do everything non-blocking and migrate the blocking effects in a dedicated threadpool. We can advise it, but it learn by itself what methods block and what don't! 
So we gain:
- no more deadlock due to blocking effects that we didn't know about (rare case now for us, since by default, we told that everything was blocking -see https://github.com/Normation/rudder/pull/4507/files#diff-d4590d1d8c70916376ea07260ff5f905f68f324e53b5298c5e9038fbe913fc15R95)
- no more special case for hotpoint, like [LDAPConnectionProvider.scala](https://github.com/Normation/rudder/pull/4507/files#diff-b9abdc511c6ce9db807dbbb8310bd3a91b65cbd6c62b083bf0ea7fc05d9e2e14)
- hopefully more consistant performance after a warm-up

And finally, the rewrite of [CronParser.scala](https://github.com/Normation/rudder/pull/4507/files#diff-a5d9d49bde6a00fd487a2447f2b62195b0649fbd5b7f15348ed0ca4211bdcc19) was kindly provided on ZIO chan.

We were lucky to not be using the IoC/`Has` framework which changed A LOT. Streams, too. All in all, the port is rather simple and for the hardest part, the community was extremelly helpfull.