### PR TITLE
Fixes #21869: Update scala-lib version due to CVE2022-36944

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryHistoryLogRepository.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryHistoryLogRepository.scala
@@ -69,10 +69,10 @@ class FullInventoryFileMarshalling(
           if(null != e) buf += e
         } while(null != e)
         buf
-      } mapError {
+      } mapError { x => (x: @unchecked) match {
         case e : LDIFException => InventoryError.System(e.getMessage)
         case e : FileNotFoundException => InventoryError.System((s"History file '${in.getAbsolutePath}' was not found. It was likelly deleted"))
-      }).flatMap { buf =>
+      }}).flatMap { buf =>
         fromLdapEntries.fromLdapEntries(buf.map(e => new LDAPEntry(e)).toSeq)
       }
     }

--- a/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestInventory.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestInventory.scala
@@ -42,6 +42,7 @@ import com.normation.inventory.domain._
 import com.normation.ldap.listener.InMemoryDsConnectionProvider
 import com.normation.ldap.sdk.RoLDAPConnection
 import com.normation.ldap.sdk.RwLDAPConnection
+
 import com.normation.zio.ZioRuntime
 import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.Modification
@@ -50,6 +51,7 @@ import org.junit.runner._
 import org.specs2.matcher.MatchResult
 import org.specs2.mutable._
 import org.specs2.runner._
+
 import zio._
 import com.normation.zio._
 

--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -182,7 +182,7 @@ limitations under the License.
             <arg>-Ywarn-unused:privates</arg>        <!-- Warn if a private member is unused. -->
             <arg>-Ywarn-unused:implicits</arg>       <!-- Warn if an implicit parameter is unused. -->
             <arg>-Ywarn-unused:privates</arg>        <!-- Warn if a private member is unused. -->
-            <arg>-Ybackend-parallelism</arg><arg>8</arg>         <!-- Enable paralellisation — change to desired number! -->
+            <arg>-Ybackend-parallelism</arg><arg>8</arg>         <!-- Enable parallelization — change to desired number! -->
             <arg>-Ycache-plugin-class-loader:last-modified</arg> <!-- Enables caching of classloaders for compiler plugins -->
             <arg>-Ycache-macro-class-loader:last-modified</arg>  <!-- and macro definitions. This can lead to performance improvements. -->
             <arg>-P:silencer:checkUnused</arg>
@@ -357,7 +357,7 @@ limitations under the License.
     <rudder-major-version>6.2</rudder-major-version>
     <rudder-version>6.2.20-SNAPSHOT</rudder-version>
 
-    <scala-version>2.13.3</scala-version>
+    <scala-version>2.13.9</scala-version>
     <scala-binary-version>2.13</scala-binary-version>
     <scala-xml-version>1.3.0</scala-xml-version>
     <lift-version>3.4.2</lift-version>
@@ -376,7 +376,7 @@ limitations under the License.
     <cglib-version>3.3.0</cglib-version>
     <asm-version>5.2</asm-version>
     <bcpkix-jdk15on-version>1.68</bcpkix-jdk15on-version>
-    <silencer-lib-version>1.7.1</silencer-lib-version>
+    <silencer-lib-version>1.7.11</silencer-lib-version>
     <better-files-version>3.9.1</better-files-version>
     <sourcecode-version>0.2.1</sourcecode-version>
     <quicklens-version>1.6.1</quicklens-version>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/TechniqueVersion.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/TechniqueVersion.scala
@@ -260,8 +260,8 @@ object ParseVersion {
   def versionChar(c: Char) = ascii.canEncode(c) && !(c.isDigit || c.isControl || c.isSpaceChar || separatorChar(c))
   def separatorChar(c: Char) = List('~', '+', ',', '-', '.').contains(c)
 
-  def num[_ :P] = P(CharIn("0-9").rep(1).!.map(_.toLong))
-  def chars[_ : P] = P( CharsWhile(versionChar).rep(1).! ).map { s =>
+  def num[A: P] = P(CharIn("0-9").rep(1).!.map(_.toLong))
+  def chars[A: P] = P( CharsWhile(versionChar).rep(1).! ).map { s =>
     import PartType._
     s.toLowerCase match {
       case "snapshot"  => Snapshot(s)
@@ -273,7 +273,7 @@ object ParseVersion {
       case _           => Chars(s)
   }}
 
-  def epoch[_:P] = P( num ~ ":")
+  def epoch[A: P] = P( num ~ ":")
   def toSeparator(c: Char) = { c match {
     case '~' => Separator.Tilde
     case '-' => Separator.Minus
@@ -281,7 +281,7 @@ object ParseVersion {
     case ',' => Separator.Comma
     case '.' => Separator.Dot
   }}
-  def separators[_:P] = P( CharsWhile(separatorChar).! ).map { (s: String) =>
+  def separators[A: P] = P( CharsWhile(separatorChar).! ).map { (s: String) =>
     s.toSeq.map(toSeparator)
   }
 
@@ -289,29 +289,29 @@ object ParseVersion {
     case Separator.Tilde => VersionPart.Before(Separator.Tilde, PartType.Chars(""))
     case sep             => VersionPart.After(sep, PartType.Chars(""))
   } }
-  def numPart[_:P]: P[List[VersionPart]] = P( separators ~ num).map { case (seq, n) => // seq is at least 1
+  def numPart[A: P]: P[List[VersionPart]] = P( separators ~ num).map { case (seq, n) => // seq is at least 1
     seq.last match {
       case Separator.Tilde => listOfSepToPart(seq.init.toList) ::: VersionPart.Before(Separator.Tilde, PartType.Numeric(n)) :: Nil
       case sep             => listOfSepToPart(seq.init.toList) ::: VersionPart.After (sep            , PartType.Numeric(n)) :: Nil
   }}
 
-  def charPart[_:P]: P[List[VersionPart]] = P( separators ~ chars).map { case (seq, n) => // seq is at least 1
+  def charPart[A: P]: P[List[VersionPart]] = P( separators ~ chars).map { case (seq, n) => // seq is at least 1
     (seq.last, n) match {
       case (Separator.Tilde, s)                => listOfSepToPart(seq.init.toList) ::: VersionPart.Before(Separator.Tilde, s) :: Nil
       case (sep            , c:PartType.Chars) => listOfSepToPart(seq.init.toList) ::: VersionPart.After(sep, c)              :: Nil
       case (sep            , prerelease      ) => listOfSepToPart(seq.init.toList) ::: VersionPart.Before(sep, prerelease)    :: Nil
   }}
 
-  def noSepPart1[_:P] = P( chars ).map { c =>
+  def noSepPart1[A: P] = P( chars ).map { c =>
       VersionPart.After(Separator.None, c) :: Nil
   }
-  def noSepPart2[_:P] = P( num ).map { n =>
+  def noSepPart2[A: P] = P( num ).map { n =>
       VersionPart.After(Separator.None, PartType.Numeric(n)) :: Nil
   }
 
-  def startNum[_:P] = P( num ).map(PartType.Numeric)
+  def startNum[A: P] = P( num ).map(PartType.Numeric)
 
-  def version[_ :P] = P( Start ~ epoch.? ~/ (startNum | chars) ~/
+  def version[A: P] = P( Start ~ epoch.? ~/ (startNum | chars) ~/
                          (numPart | charPart | noSepPart1 | noSepPart2).rep(0) ~ separators.? ~ End).map {
     case (e, head, list, opt) =>
       Version(e.getOrElse(0L), head, list.flatten.toList ::: listOfSepToPart(opt.toList.flatten))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitUtilsImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitUtilsImpl.scala
@@ -126,7 +126,7 @@ class SimpleGitRevisionProvider(refPath:String,repo:GitRepositoryProvider) exten
         "not start with 'refs/'. Are you sure you don't mistype something ?")
   }
 
-  private[this] var currentId = Ref.make[ObjectId](getAvailableRevTreeId.runNow).runNow
+  private[this] val currentId = Ref.make[ObjectId](getAvailableRevTreeId.runNow).runNow
 
   override def getAvailableRevTreeId : IOResult[ObjectId] = {
     IOResult.effect {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlwriters/SectionSpecWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlwriters/SectionSpecWriter.scala
@@ -76,6 +76,8 @@ class SectionSpecWriterImpl extends SectionSpecWriter {
             val label = valueLabel match {
               case select:SelectVariableSpec => SELECT
               case selectOne:SelectOneVariableSpec => SELECT1
+              case x => throw new IllegalArgumentException(s"We found '${x.getClass.getSimpleName}' when we were looking" +
+                                                           s" for SelectVariableSpec or SelectOneVariableSpec. Please report as a bug.'")
             }
 
             (label, valueLabel.valueslabels)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/eventlog/ArchiveEventLog.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/eventlog/ArchiveEventLog.scala
@@ -362,6 +362,8 @@ object Rollback extends EventLogFilter {
       </main>):_*
     ) ) )
 
+  val tagName = "rollback"
+
 }
 
 object ImportExportEventLogsFilter {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Properties.scala
@@ -452,6 +452,7 @@ object GenericProperty {
       case ConfigValueType.NULL    => JNothing
       case ConfigValueType.BOOLEAN => JBool(value.unwrapped().asInstanceOf[Boolean])
       case ConfigValueType.NUMBER  => value.unwrapped() match {
+        case f: java.lang.Float    => JDouble(f.doubleValue())
         case d: java.lang.Double   => JDouble(d)
         case i: java.lang.Integer  => JInt(BigInt(i))
         case l: java.lang.Long     => JInt(BigInt(l))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ReportsJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ReportsJdbcRepository.scala
@@ -426,6 +426,7 @@ class ReportsJdbcRepository(doobie: Doobie) extends ReportsRepository with Logga
               recDisctinct(a :: t)
             } else (a, b) match {
               //by default, take the one with a configId.
+              case (AgentRun(_, None, _, _), AgentRun(_, None, _, _))      => recDisctinct(a :: t)
               case (AgentRun(_, Some(idA), _, _), AgentRun(_, None, _, _)) => recDisctinct(a :: t)
               case (AgentRun(_, None, _, _), AgentRun(_, Some(idB), _, _)) => recDisctinct(b :: t)
               //this one, with two config id, should never happen, but still...

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
@@ -131,6 +131,7 @@ class LDAPDiffMapper(
                                   case None          => diff
                                   case Some(targets) => diff.map( _.copy(modTarget = Some(SimpleDiff(oldCr.targets, targets.toSet))))
                                 }
+                              case x => Left(Err.UnexpectedObject(s"Bad change record type for requested action 'update rule': ${mod.toString}"))
                             }
                           case A_DIRECTIVE_UUID =>
                             diff.map( _.copy(modDirectiveIds = Some(SimpleDiff(oldCr.directiveIds, mod.getValues.map( DirectiveId(_) ).toSet))))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/RudderPrettyPrinter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/RudderPrettyPrinter.scala
@@ -220,7 +220,7 @@ class RudderPrettyPrinter(width: Int, step: Int) {
     reset()
     traverse(n, pscope, 0)
     var cur = 0
-    for (b <- items.reverse) b match {
+    for (b <- items.reverse) (b: @unchecked) match {
       case Break =>
         if (!lastwasbreak) sb.append('\n')  // on windows: \r\n ?
         lastwasbreak = true

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
@@ -689,6 +689,7 @@ class EventLogDetailsServiceImpl(
       case x:ImportRulesArchive => getCommitInfo(xml, ImportRulesArchive.tagName)
       case x:ImportParametersArchive => getCommitInfo(xml, ImportParametersArchive.tagName)
       case x:ImportFullArchive => getCommitInfo(xml, ImportFullArchive.tagName)
+      case x: Rollback => getCommitInfo(xml, Rollback.tagName)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogServiceImpl.scala
@@ -54,7 +54,7 @@ class EventLogDeploymentService(
    */
   def getLastDeployement() : Box[CurrentDeploymentStatus] = {
     val query = "eventtype in ('" + SuccessfulDeploymentEventType.serialize +"', '"+FailedDeploymentEventType.serialize +"')"
-    repository.getEventLogByCriteria(Some(query), Some(1), Some("creationdate desc"), None ).toBox match {
+    (repository.getEventLogByCriteria(Some(query), Some(1), Some("creationdate desc"), None ).toBox: @unchecked) match {
       case Full(seq) if seq.size > 1 => Failure("Too many answer from last policy update")
       case Full(seq) if seq.size == 1 =>
         eventLogDetailsService.getDeploymentStatusDetails(seq.head.details)
@@ -68,7 +68,7 @@ class EventLogDeploymentService(
    */
   def getLastSuccessfulDeployement() : Box[EventLog] = {
     val query = "eventtype = '"+SuccessfulDeploymentEventType.serialize +"'"
-    repository.getEventLogByCriteria(Some(query), Some(1), Some("creationdate desc"), None ).toBox match {
+    (repository.getEventLogByCriteria(Some(query), Some(1), Some("creationdate desc"), None ).toBox: @unchecked) match {
       case Full(seq) if seq.size > 1 => Failure("Too many answer from last policy update")
       case Full(seq) if seq.size == 1 => Full(seq.head)
       case Full(seq) if seq.size == 0 => Empty

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/MergeNodeProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/MergeNodeProperties.scala
@@ -261,7 +261,7 @@ object MergeNodeProperties {
       val p = properties(k)
       val d = defaults(k)
       val mergedProp = NodeProperty(GenericProperty.mergeConfig(d.prop.config, p.config)).withProvider(OVERRIDE_PROVIDER)
-      val obj = p match {
+      val obj = (p: @unchecked) match {
         case x: NodeProperty    => ParentProperty.Node  ("this node" , NodeId(objectId)     , p.value)
         case x: GroupProperty   => ParentProperty.Group ("this group", NodeGroupId(objectId), p.value)
         case x: GlobalParameter => ParentProperty.Global(                                     p.value)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
@@ -1024,7 +1024,7 @@ class NodeInfoServiceCachedImpl(
                      (Task.effect(con.backed.search(searchRequest).getSearchEntries) catchAll {
                        case e:LDAPSearchException if(e.getResultCode == ResultCode.SIZE_LIMIT_EXCEEDED) =>
                          e.getSearchEntries().succeed
-                       case e:LDAPException =>
+                       case e: Throwable =>
                          SystemError("Error when searching node information", e).fail
                      }).foldM(
                        err =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/InterpolatedValueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/InterpolatedValueCompiler.scala
@@ -239,7 +239,7 @@ trait AnalyseInterpolation[T, I <: GenericInterpolationContext[T]] {
       case Property(tokens, opt) =>
         ((tokens foldLeft (Right(Nil): PureResult[List[String]])) {
           case (l @ Left(_), _) => l
-          case (Right(acc), t) => analyse(context,t).map(acc :+ )
+          case (Right(acc), t) => analyse(context,t).map(acc.appended)
         }).flatMap( path =>
         opt match {
           case None =>
@@ -446,7 +446,7 @@ object PropertyParser {
   import fastparse._, NoWhitespace._
 
   def parse(value: String): PureResult[List[Token]] = {
-    fastparse.parse(value, all(_)) match {
+    (fastparse.parse(value, all(_)): @unchecked) match {
       case Parsed.Success(value, index)    => Right(value)
       case Parsed.Failure(label, i, extra) => Left(Unexpected(
         s"""Error when parsing value (without ''): '${value}'. Error message is: ${extra.trace().aggregateMsg}""".stripMargin))
@@ -466,61 +466,61 @@ object PropertyParser {
   }
 
 
-  def all[_: P] : P[List[Token]] = P( Start ~ (token.rep(1) | empty )  ~ End).map(_.toList)
-  def token [_ : P] : P[Token] = noVariableStart | variable | ( "${" ~ noVariableEnd.map(_.prefix("${")))
+  def all[A: P] : P[List[Token]] = P( Start ~ (token.rep(1) | empty )  ~ End).map(_.toList)
+  def token [A: P] : P[Token] = noVariableStart | variable | ( "${" ~ noVariableEnd.map(_.prefix("${")))
   //empty string is a special case that must be look appart from plain string.
-  def empty[_ : P] = P("").map(_ => CharSeq("") :: Nil)
-  def space[_:P] = P(CharsWhile(_.isWhitespace, 0))
+  def empty[A: P] = P("").map(_ => CharSeq("") :: Nil)
+  def space[A: P] = P(CharsWhile(_.isWhitespace, 0))
   // plain string must not match our identifier, ${rudder.* and ${node.properties.*}
   // here we defined a function to build them
-  def noVariableStart[_: P] : P[CharSeq] = P( (!"${" ~ AnyChar).rep(1).! ).map { CharSeq(_) }
-  def noVariableEnd[_: P] : P[CharSeq] = P( (!"}" ~ AnyChar).rep(1).! ).map { CharSeq(_) }
+  def noVariableStart[A: P] : P[CharSeq] = P( (!"${" ~ AnyChar).rep(1).! ).map { CharSeq(_) }
+  def noVariableEnd[A: P] : P[CharSeq] = P( (!"}" ~ AnyChar).rep(1).! ).map { CharSeq(_) }
 
-  def variable[_: P] = P("${" ~ space ~ variableType ~ space ~ "}" )
+  def variable[A: P] = P("${" ~ space ~ variableType ~ space ~ "}" )
 
-  def variableType[_: P] = P( interpolatedVariable | otherVariable )
-  def variableId[_: P] : P[String] = P(CharIn("""\-_a-zA-Z0-9""").rep(1).!)
-  def propertyId[_: P] : P[String] = P(CharsWhile(validPropertyNameChar).!)
+  def variableType[A: P] = P( interpolatedVariable | otherVariable )
+  def variableId[A: P] : P[String] = P(CharIn("""\-_a-zA-Z0-9""").rep(1).!)
+  def propertyId[A: P] : P[String] = P(CharsWhile(validPropertyNameChar).!)
 
   // other cases of ${}: cfengine variables, etc
-  def otherVariable[_: P]: P[NonRudderVar] = P( (variableId ~ ".").rep(0) ~ variableId ).map { case (begin, end) =>  NonRudderVar((begin :+ end).mkString(".")) }
+  def otherVariable[A: P]: P[NonRudderVar] = P( (variableId ~ ".").rep(0) ~ variableId ).map { case (begin, end) =>  NonRudderVar((begin :+ end).mkString(".")) }
 
-  def interpolatedVariable [_: P]   : P[Interpolation] = P( rudderVariable | nodeProperty )
+  def interpolatedVariable [A: P]   : P[Interpolation] = P( rudderVariable | nodeProperty )
   //identifier for step in the path or param names
 
   //an interpolated variable looks like: ${rudder.XXX}, or ${RuDder.xXx}
   // after "${rudder." there is no backtracking to an "otherProp" or string possible.
-  def rudderVariable[_: P]  : P[Interpolation] = P( IgnoreCase("rudder") ~ space ~ "." ~ space ~/ (rudderNode | parameters | oldParameter) )
+  def rudderVariable[A: P]  : P[Interpolation] = P( IgnoreCase("rudder") ~ space ~ "." ~ space ~/ (rudderNode | parameters | oldParameter) )
 
   //a node path looks like: ${rudder.node.HERE.PATH}
-  def rudderNode[_: P]  : P[Interpolation] = P( IgnoreCase("node") ~/ space ~ "." ~ space ~/ variableId.rep(sep = space ~ "." ~ space) ).map { seq => NodeAccessor(seq.toList) }
+  def rudderNode[A: P]  : P[Interpolation] = P( IgnoreCase("node") ~/ space ~ "." ~ space ~/ variableId.rep(sep = space ~ "." ~ space) ).map { seq => NodeAccessor(seq.toList) }
 
   //a parameter old syntax looks like: ${rudder.param.PARAM_NAME}
-  def oldParameter[_: P]  : P[Interpolation] = P(IgnoreCase("param") ~ space ~ "." ~/ space ~/ variableId).map{ p => Param(p :: Nil) }
+  def oldParameter[A: P]  : P[Interpolation] = P(IgnoreCase("param") ~ space ~ "." ~/ space ~/ variableId).map{ p => Param(p :: Nil) }
 
   //a parameter new syntax looks like: ${rudder.parameters[PARAM_NAME][SUB_NAME]}
-  def parameters[_: P]  : P[Interpolation] = P(IgnoreCase("parameters") ~/ arrayNames ).map{ p => Param(p.toList) }
+  def parameters[A: P]  : P[Interpolation] = P(IgnoreCase("parameters") ~/ arrayNames ).map{ p => Param(p.toList) }
 
   //a node property looks like: ${node.properties[.... Cut after "properties".
-  def nodeProperty[_: P]    : P[Interpolation] =  (IgnoreCase("node") ~ space ~ "." ~ space ~ IgnoreCase("properties") ~/ propertyPath ~/
+  def nodeProperty[A: P]    : P[Interpolation] =  (IgnoreCase("node") ~ space ~ "." ~ space ~ IgnoreCase("properties") ~/ propertyPath ~/
                                                    nodePropertyOption.? ).map { case (path, opt) => Property(path.toList, opt) }
-  def propertyPath[_: P] : P[List[Token]] = P((space ~ "[" ~ space ~ propertyToken ~ space ~ "]" ).rep(1) ).map(_.toList)
+  def propertyPath[A: P] : P[List[Token]] = P((space ~ "[" ~ space ~ propertyToken ~ space ~ "]" ).rep(1) ).map(_.toList)
 
-  def propertyToken [_ : P] : P[Token] = propertyId.map(CharSeq) | variable | ( "${" ~ noVariableEnd.map(_.prefix("${")))
+  def propertyToken [A: P] : P[Token] = propertyId.map(CharSeq) | variable | ( "${" ~ noVariableEnd.map(_.prefix("${")))
   // parse an array of property names: `[name1][name2]..` (for parameter/node properties)
-  def arrayNames[_: P] : P[List[String]] = P((space ~ "[" ~ space ~ propertyId ~ space ~ "]" ).rep(1) ).map(_.toList)
+  def arrayNames[A: P] : P[List[String]] = P((space ~ "[" ~ space ~ propertyId ~ space ~ "]" ).rep(1) ).map(_.toList)
 
   //here, the number of " must be strictly decreasing - ie. triple quote before
-  def nodePropertyOption[_: P]  : P[PropertyOption] = P( space ~ "|" ~/ space ~ ( onNodeOption | defaultOption ) )
+  def nodePropertyOption[A: P]  : P[PropertyOption] = P( space ~ "|" ~/ space ~ ( onNodeOption | defaultOption ) )
 
-  def defaultOption[_: P]  : P[DefaultValue] = P( IgnoreCase("default") ~/ space ~ "=" ~/ space ~/ ( P( string("\"") |string("\"\"\"") | emptyString  | variable.map(_ :: Nil)) ) ).map(DefaultValue(_))
-  def onNodeOption[_: P]   : P[InterpreteOnNode.type] = P( IgnoreCase("node")).map(_ => InterpreteOnNode)
+  def defaultOption[A: P]  : P[DefaultValue] = P( IgnoreCase("default") ~/ space ~ "=" ~/ space ~/ ( P( string("\"") |string("\"\"\"") | emptyString  | variable.map(_ :: Nil)) ) ).map(DefaultValue(_))
+  def onNodeOption[A: P]   : P[InterpreteOnNode.type] = P( IgnoreCase("node")).map(_ => InterpreteOnNode)
 
-  def emptyString[_: P] : P[List[Token]] = P( "\"\"\"\"\"\"" | "\"\"").map { _ => CharSeq("")::Nil }
+  def emptyString[A: P] : P[List[Token]] = P( "\"\"\"\"\"\"" | "\"\"").map { _ => CharSeq("")::Nil }
 
   //string must be simple or triple quoted string
 
-  def string[_: P] (quote : String) : P[List[Token]]     = P( quote ~ ( noVariableStartString(quote) | variable | ( "${" ~ noVariableEndString(quote)).map(_.prefix("${"))   ).rep(1) ~ quote).map { case x => x.toList }
-  def noVariableStartString[_: P] (quote : String) : P[CharSeq] = P( (!"${" ~ (!quote ~ AnyChar)).rep(1).! ).map { CharSeq(_) }
-  def noVariableEndString[_: P] (quote : String) : P[CharSeq] = P( (!"}" ~ (!quote ~ AnyChar)).rep(1).! ).map { CharSeq(_) }
+  def string[A: P] (quote : String) : P[List[Token]]     = P( quote ~ ( noVariableStartString(quote) | variable | ( "${" ~ noVariableEndString(quote)).map(_.prefix("${"))   ).rep(1) ~ quote).map { case x => x.toList }
+  def noVariableStartString[A: P] (quote : String) : P[CharSeq] = P( (!"${" ~ (!quote ~ AnyChar)).rep(1).! ).map { CharSeq(_) }
+  def noVariableEndString[A: P] (quote : String) : P[CharSeq] = P( (!"}" ~ (!quote ~ AnyChar)).rep(1).! ).map { CharSeq(_) }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueAcceptationDatetimeUpdater.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueAcceptationDatetimeUpdater.scala
@@ -205,7 +205,7 @@ class TechniqueAcceptationUpdater(
           logPure.debug(s"Category '${cat.id.toString}' updated") *>
           roActiveTechniqueRepo.getActiveTechniqueCategory(toActiveCatId(cat.id)).flatMap { opt => opt match {
             case None          =>
-              cat.id match {
+              (cat.id: @unchecked) match {
                 case _:RootTechniqueCategoryId.type => UIO.unit
                 case i:SubTechniqueCategoryId =>
                   rwActiveTechniqueRepo.addActiveTechniqueCategory(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepository.scala
@@ -185,6 +185,7 @@ object NodeConfigurationHash {
           } catch {
             case ex: TechniqueVersionFormatException => Left((s"Technique version for policy '${ruleId}@@${directiveId}' was not recognized: ${techniqueVerion}", p))
           }
+        case x => Left((s"Error when parsing policy: a json array", x))
       }
     }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
@@ -781,7 +781,7 @@ class PolicyWriterServiceImpl(
         policy.technique.agentConfig.runHooks.nonEmpty ::
         policy.technique.id.name ::
         policy.technique.id.version ::
-        policy.technique.isSystem ::
+        policy.technique.isSystem.toString ::
         policy.directiveOrder.value ::
         Nil
       ).mkString("\"","\",\"","\"")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupService.scala
@@ -57,7 +57,6 @@ import com.unboundid.ldap.sdk.SearchRequest
 import com.normation.inventory.ldap.core.LDAPConstants._
 import com.normation.ldap.sdk.BuildFilter._
 import com.unboundid.ldap.sdk.Filter
-import com.unboundid.ldap.sdk.LDAPException
 import com.unboundid.ldap.sdk.LDAPSearchException
 import com.unboundid.ldap.sdk.ResultCode
 import org.joda.time.DateTime
@@ -185,7 +184,7 @@ class DynGroupServiceImpl(
                    (Task.effect(con.backed.search(searchRequest).getSearchEntries) catchAll {
                      case e:LDAPSearchException if(e.getResultCode == ResultCode.SIZE_LIMIT_EXCEEDED) =>
                        e.getSearchEntries().succeed
-                     case e:LDAPException =>
+                     case e:Throwable =>
                        SystemError("Error when searching dyngroup information", e).fail
                    }).foldM(
                      err =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchQueryParser.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchQueryParser.scala
@@ -76,7 +76,7 @@ object QSRegexQueryParser {
     if(value.trim.isEmpty()) {
       Left(Unexpected("You can't search with an empty or whitespace only query"))
     } else {
-      fastparse.parse(value, all(_)) match {
+      (fastparse.parse(value, all(_)): @unchecked) match {
         case Parsed.Success(parsed, index)   => interprete(parsed)
         case Parsed.Failure(label, i, extra) => Left(Unexpected(s"""Error when parsing query "${value}", error message is: ${label}"""))
       }
@@ -159,42 +159,42 @@ object QSRegexQueryParser {
   ///// this is the entry point /////
   /////
 
-  private[this] def all[_:P]          : P[QF] = P( Start ~ ( nominal | onlyFilters ) ~ End )
+  private[this] def all[A:P]          : P[QF] = P( Start ~ ( nominal | onlyFilters ) ~ End )
 
   /////
   ///// different structure of queries
   /////
 
   //degenerated case with only filters, no query string
-  private[this] def onlyFilters[_:P]  : P[QF] = P( filter.rep(1) )                      map { case f             => (EmptyQuery, f.toList) }
+  private[this] def onlyFilters[A:P]  : P[QF] = P( filter.rep(1) )                      map { case f             => (EmptyQuery, f.toList) }
 
   //nonimal case: zero of more filter, a query string, zero or more filter
-  private[this] def nominal[_:P]      : P[QF] = P( filter.rep(0) ~/ ( case0 | case1 ) ) map { case (f1, (q, f2)) => (check(q), f1.toList ::: f2.toList) }
+  private[this] def nominal[A:P]      : P[QF] = P( filter.rep(0) ~/ ( case0 | case1 ) ) map { case (f1, (q, f2)) => (check(q), f1.toList ::: f2.toList) }
 
   //need the two following rules so that so the parsing is correctly done for filter in the end
-  private[this] def case0[_:P]        : P[QF] = P( queryInMiddle ~ filter.rep(1) )      map { case (q, f)        => (check(q)  , f.toList) }
-  private[this] def case1[_:P]        : P[QF] = P( queryAtEnd                    )      map { case q             => (check(q)  , Nil     ) }
+  private[this] def case0[A:P]        : P[QF] = P( queryInMiddle ~ filter.rep(1) )      map { case (q, f)        => (check(q)  , f.toList) }
+  private[this] def case1[A:P]        : P[QF] = P( queryAtEnd                    )      map { case q             => (check(q)  , Nil     ) }
 
   /////
   ///// simple elements: filters
   /////
 
   // deal with filters: they all start with "in:"
-  private[this] def filter[_:P]       : P[Filter] = P( filterAttr | filterType )
-  private[this] def filterType[_:P]   : P[Filter] = P( IgnoreCase("is:") ~ filterKeys )  map { FilterType }
-  private[this] def filterAttr[_:P]   : P[Filter] = P( IgnoreCase("in:") ~ filterKeys )  map { FilterAttr }
+  private[this] def filter[A:P]       : P[Filter] = P( filterAttr | filterType )
+  private[this] def filterType[A:P]   : P[Filter] = P( IgnoreCase("is:") ~ filterKeys )  map { FilterType }
+  private[this] def filterAttr[A:P]   : P[Filter] = P( IgnoreCase("in:") ~ filterKeys )  map { FilterAttr }
 
   // the keys part
-  private[this] def filterKeys[_:P]   : P[Set[String]] = P( filterKey.rep(sep = ",") )   map { l => l.toSet }
-  private[this] def filterKey[_:P]    : P[String]      = P( CharsWhileIn("""\\-._a-zA-Z0-9""").! )
+  private[this] def filterKeys[A:P]   : P[Set[String]] = P( filterKey.rep(sep = ",") )   map { l => l.toSet }
+  private[this] def filterKey[A:P]    : P[String]      = P( CharsWhileIn("""\\-._a-zA-Z0-9""").! )
 
   /////
   ///// simple elements: query string
   /////
 
   // we need to case, because regex are bad to look-ahead and see if there is still filter after. .+? necessary to stop at first filter
-  private[this] def queryInMiddle[_:P]: P[QueryString] = P( (!("in:"|"is:") ~ AnyChar).rep(1).! ) map { x => CharSeq(x.trim) }
-  private[this] def queryAtEnd[_:P]   : P[QueryString] = P( AnyChar.rep(1).!                    ) map { x => CharSeq(x.trim) }
+  private[this] def queryInMiddle[A:P]: P[QueryString] = P( (!("in:"|"is:") ~ AnyChar).rep(1).! ) map { x => CharSeq(x.trim) }
+  private[this] def queryAtEnd[A:P]   : P[QueryString] = P( AnyChar.rep(1).!                    ) map { x => CharSeq(x.trim) }
 
   /////
   ///// utility methods

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/TechniqueTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/TechniqueTest.scala
@@ -46,6 +46,9 @@ import com.normation.cfclerk.xmlparsers._
 import scala.xml._
 import com.normation.cfclerk.services.impl.SystemVariableSpecServiceImpl
 
+import com.github.ghik.silencer.silent
+
+@silent("a type was inferred to be `\\w+`; this may indicate a programming error.")
 @RunWith(classOf[JUnitRunner])
 class TechniqueTest extends Specification {
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/RunNuCommandTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/RunNuCommandTest.scala
@@ -37,6 +37,8 @@
 
 package com.normation.rudder.hooks
 
+import com.github.ghik.silencer.silent
+
 import java.io.File
 
 import org.junit.runner.RunWith
@@ -55,6 +57,7 @@ import org.joda.time.format.ISODateTimeFormat
  * the process context (environment variable, file descriptors..)
  */
 
+@silent("a type was inferred to be `\\w+`; this may indicate a programming error.")
 @RunWith(classOf[JUnitRunner])
 class RunNuCommandTest() extends Specification {
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/inventory/TestCertificate.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/inventory/TestCertificate.scala
@@ -63,7 +63,9 @@ import com.normation.inventory.provisioning.fusion.FusionReportUnmarshaller
 import com.normation.zio._
 import zio._
 import zio.syntax._
+import com.github.ghik.silencer.silent
 
+@silent("a type was inferred to be `\\w+`; this may indicate a programming error.")
 @RunWith(classOf[JUnitRunner])
 class TestCertificate extends Specification with Loggable {
   Security.addProvider(new BouncyCastleProvider())

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/migration/TestDbMigration.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/migration/TestDbMigration.scala
@@ -50,6 +50,7 @@ import com.normation.rudder.db.DBCommon
 
 import com.normation.rudder.db.Doobie._
 
+import com.github.ghik.silencer.silent
 import doobie.implicits._
 import doobie.implicits.javasql._
 import zio.interop.catz._
@@ -113,6 +114,7 @@ final case class MigrationTestLog(
  * with parameters defined in src/test/resources/database.properties.
  * That database should be empty to avoid table name collision.
  */
+@silent("a type was inferred to be `\\w+`; this may indicate a programming error.")
 @RunWith(classOf[JUnitRunner])
 class TestDbMigration_5_6 extends DBCommon with XmlMatchers {
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/HistorizationRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/HistorizationRepositoryTest.scala
@@ -47,6 +47,7 @@ import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.services.eventlog.HistorizationServiceImpl
 import com.normation.rudder.services.policies.NodeConfigData
 
+import com.github.ghik.silencer.silent
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 
@@ -55,6 +56,7 @@ import org.specs2.runner.JUnitRunner
  * Test on database.
  *
  */
+@silent("a type was inferred to be `\\w+`; this may indicate a programming error.")
 @RunWith(classOf[JUnitRunner])
 class HistorizationRepositoryTest extends DBCommon with BoxSpecMatcher  {
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PolicyAgregationTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PolicyAgregationTest.scala
@@ -53,8 +53,9 @@ import com.normation.rudder.services.policies.NodeConfigData
 import com.normation.rudder.services.policies.BoundPolicyDraft
 import org.joda.time.DateTime
 import com.normation.inventory.domain.AgentType
+import com.github.ghik.silencer.silent
 
-
+@silent("a type was inferred to be `\\w+`; this may indicate a programming error.")
 @RunWith(classOf[JUnitRunner])
 class PolicyAgregationTest extends Specification {
   implicit def str2pId(id: String) = TechniqueId(TechniqueName(id), TechniqueVersion("1.0"))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
@@ -67,7 +67,6 @@ import com.normation.rudder.services.policies.ParameterForConfiguration
 import com.normation.rudder.services.policies.Policy
 import java.nio.charset.StandardCharsets
 
-import com.github.ghik.silencer.silent
 import com.normation.rudder.domain.logger.NodeConfigurationLoggerImpl
 import com.normation.rudder.domain.logger.PolicyGenerationLogger
 import com.normation.rudder.services.policies.MergePolicyService
@@ -292,7 +291,6 @@ class WriteSystemTechniquesTest extends TechniquesTest{
 
     "correctly write the expected policies files with defauls installation but `.new` files exists" in {
 
-      @silent("local val .* in method addCrap is never used")
       def addCrap(path: String): Unit = {
         better.files.File(path).append("some text that should be overwritten during generation").append(
           //this need to be longer than at least one file, else it's overwritten enterly without exposing the pb

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -55,8 +55,10 @@ import org.specs2.runner._
 import com.normation.rudder.reports.AgentRunInterval
 import com.normation.rudder.services.reports.ExecutionBatch.MergeInfo
 
+import com.github.ghik.silencer.silent
 
 
+@silent("a type was inferred to be `\\w+`; this may indicate a programming error.")
 @RunWith(classOf[JUnitRunner])
 class ExecutionBatchTest extends Specification {
   private implicit def str2directiveId(s:String) = DirectiveId(s)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -429,7 +429,7 @@ final case class RestExtractorService (
       case Disabled  => Full(None)
       case mode =>
         val reason = extractString("reason")(req)(Full(_))
-        mode match {
+        (mode: @unchecked) match {
           case Mandatory =>
             reason match {
               case Full(None) =>  Failure("Reason field is mandatory and should be at least 5 characters long")

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/UserPropertyService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/UserPropertyService.scala
@@ -39,7 +39,7 @@ import com.normation.box._
 import com.normation.errors._
 import zio.syntax._
 
-object ReasonBehavior extends Enumeration {
+final object ReasonBehavior extends Enumeration {
   type ReasonBehavior = Value
   val Disabled, Mandatory, Optionnal = Value
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SystemApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SystemApiTest.scala
@@ -42,6 +42,8 @@ import java.nio.file.Files
 import java.util.zip.ZipFile
 
 import com.normation.rudder.rest.RestUtils.toJsonResponse
+
+import com.github.ghik.silencer.silent
 import net.liftweb.common.{Full, Loggable}
 import net.liftweb.http.{InMemoryResponse, Req}
 import net.liftweb.json.JsonAST.{JArray, JField, JObject}
@@ -53,6 +55,7 @@ import org.specs2.runner.JUnitRunner
 import org.specs2.specification.AfterAll
 import net.liftweb.http.JsonResponse
 
+@silent("a type was inferred to be `\\w+`; this may indicate a programming error.")
 @RunWith(classOf[JUnitRunner])
 class SystemApiTests extends Specification with AfterAll with Loggable {
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/BootstrapChecks.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/BootstrapChecks.scala
@@ -69,7 +69,7 @@ object BootstrapLogger extends NamedZioLogger {
 
 class SequentialImmediateBootStrapChecks(_checkActions:BootstrapChecks*) extends BootstrapChecks {
 
-  private[this] var checkActions = collection.mutable.Buffer[BootstrapChecks](_checkActions:_*)
+  private[this] val checkActions = collection.mutable.Buffer[BootstrapChecks](_checkActions:_*)
 
   def appendBootstrapChecks(check: BootstrapChecks): Unit = {
     checkActions.append(check)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
@@ -249,7 +249,7 @@ class DirectiveEditForm(
        } &
        "#clone" #> SHtml.ajaxButton(
             { Text("Clone") },
-            { () =>  clone() },
+            { () =>  clonePopup() },
             {("class", "btn btn-default")},
             {("type", "button")}
        ) &
@@ -310,7 +310,7 @@ class DirectiveEditForm(
     )
   }
 
-  private[this] def clone(): JsCmd = {
+  private[this] def clonePopup(): JsCmd = {
     SetHtml("basePopup", newCreationPopup(technique, activeTechnique)) &
     JsRaw(s""" createPopup("basePopup"); """)
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueEditForm.scala
@@ -251,7 +251,7 @@ class TechniqueEditForm(
 
   private[this] val crReasons = {
     import com.normation.rudder.web.services.ReasonBehavior._
-    userPropertyService.reasonsFieldBehavior match {
+    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled => None
       case Mandatory => Some(buildReasonField(true, "subContainerReasonField"))
       case Optionnal => Some(buildReasonField(false, "subContainerReasonField"))
@@ -260,7 +260,7 @@ class TechniqueEditForm(
 
   private[this] val crReasonsRemovePopup = {
     import com.normation.rudder.web.services.ReasonBehavior._
-    userPropertyService.reasonsFieldBehavior match {
+    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled => None
       case Mandatory => Some(buildReasonField(true, "subContainerReasonField"))
       case Optionnal => Some(buildReasonField(false, "subContainerReasonField"))
@@ -269,7 +269,7 @@ class TechniqueEditForm(
 
   private[this] val crReasonsDisablePopup = {
     import com.normation.rudder.web.services.ReasonBehavior._
-    userPropertyService.reasonsFieldBehavior match {
+    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled => None
       case Mandatory => Some(buildReasonField(true, "subContainerReasonField"))
       case Optionnal => Some(buildReasonField(false, "subContainerReasonField"))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
@@ -297,7 +297,7 @@ class CreateCategoryOrGroupPopup(
 
   private[this] val piReasons = {
     import com.normation.rudder.web.services.ReasonBehavior._
-    userPropertyService.reasonsFieldBehavior match {
+    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled => None
       case Mandatory => Some(buildReasonField(true, "subContainerReasonField"))
       case Optionnal => Some(buildReasonField(false, "subContainerReasonField"))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneDirectivePopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneDirectivePopup.scala
@@ -126,7 +126,7 @@ class CreateCloneDirectivePopup(
 
   private[this] val reasons = {
     import com.normation.rudder.web.services.ReasonBehavior._
-    userPropertyService.reasonsFieldBehavior match {
+    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled => None
       case Mandatory => Some(buildReasonField(true, "subContainerReasonField"))
       case Optionnal => Some(buildReasonField(false, "subContainerReasonField"))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
@@ -176,7 +176,7 @@ class CreateCloneGroupPopup(
 
   private[this] val groupReasons = {
     import com.normation.rudder.web.services.ReasonBehavior._
-    userPropertyService.reasonsFieldBehavior match {
+    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled => None
       case Mandatory => Some(buildReasonField(true, "subContainerReasonField"))
       case Optionnal => Some(buildReasonField(false, "subContainerReasonField"))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
@@ -294,7 +294,7 @@ class CreateOrUpdateGlobalParameterPopup(
 
   private[this] val paramReasons = {
     import com.normation.rudder.web.services.ReasonBehavior._
-    userPropertyService.reasonsFieldBehavior match {
+    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled => None
       case Mandatory => Some(buildReasonField(true, "subContainerReasonField"))
       case Optionnal => Some(buildReasonField(false, "subContainerReasonField"))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateRulePopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateRulePopup.scala
@@ -124,7 +124,7 @@ class CreateOrCloneRulePopup(
 
   private[this] val reason = {
     import com.normation.rudder.web.services.ReasonBehavior._
-    userPropertyService.reasonsFieldBehavior match {
+    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled => None
       case Mandatory => Some(buildReasonField(true, "subContainerReasonField"))
       case Optionnal => Some(buildReasonField(false, "subContainerReasonField"))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/GiveReasonPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/GiveReasonPopup.scala
@@ -98,7 +98,7 @@ class GiveReasonPopup(
 
 ///////////// fields for category settings ///////////////////
   private[this] val crReasons = {
-    userPropertyService.reasonsFieldBehavior match {
+    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled => None
       case Mandatory => Some(buildReasonField(true, "subContainerReasonField"))
       case Optionnal => Some(buildReasonField(false, "subContainerReasonField"))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ModificationValidationPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ModificationValidationPopup.scala
@@ -256,7 +256,7 @@ class ModificationValidationPopup(
   //must be here because used in val popupWarningMessages
   private[this] val crReasons = {
     import com.normation.rudder.web.services.ReasonBehavior._
-    userPropertyService.reasonsFieldBehavior match {
+    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled => None
       case Mandatory => Some(buildReasonField(true, "subContainerReasonField"))
       case Optionnal => Some(buildReasonField(false, "subContainerReasonField"))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleModificationValidationPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleModificationValidationPopup.scala
@@ -161,7 +161,7 @@ class RuleModificationValidationPopup(
 
   private[this] val crReasons = {
     import com.normation.rudder.web.services.ReasonBehavior._
-    userPropertyService.reasonsFieldBehavior match {
+    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled => None
       case Mandatory => Some(buildReasonField(true, "subContainerReasonField"))
       case Optionnal => Some(buildReasonField(false, "subContainerReasonField"))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -592,7 +592,7 @@ class ReportDisplayer(
     * we could add more information at each level (directive name? rule name?)
     */
     for {
-      (_, directive) <- DirectiveStatusReport.merge(nodeStatusReports.reports.toIterable.flatMap(_.directives.values))
+      (_, directive) <- DirectiveStatusReport.merge(nodeStatusReports.reports.toList.flatMap(_.directives.values))
       value          <- directive.getValues(v => v.status == status)
     } yield {
       val (techName, techVersion) = directiveLib.allDirectives.get(value._1).map { case(tech,dir) =>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HealthcheckInfo.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HealthcheckInfo.scala
@@ -49,7 +49,7 @@ import net.liftweb.http.DispatchSnippet
 
 import scala.xml.NodeSeq
 
-trait NotificationLevel
+sealed trait NotificationLevel
 object NotificationLevel {
   final case object Info extends NotificationLevel
   final case object Warning extends NotificationLevel

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -168,7 +168,7 @@ class HomePage extends Loggable {
 
   def getAllCompliance: NodeSeq = {
 
-    trait ChartType
+sealed trait ChartType
 final case object PendingChartType extends ChartType
 final case object DisabledChartType extends ChartType
 final case class ColoredChartType(value: Double) extends ChartType

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/TechniqueLibraryManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/TechniqueLibraryManagement.scala
@@ -118,7 +118,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
   private[this] val rootCategoryId = roActiveTechniqueRepository.getActiveTechniqueLibrary.map( _.id ).toBox
 
   private[this] val currentTechniqueDetails = new LocalSnippet[TechniqueEditForm]
-  private[this] var currentTechniqueCategoryDetails = new LocalSnippet[TechniqueCategoryEditForm]
+  private[this] val currentTechniqueCategoryDetails = new LocalSnippet[TechniqueCategoryEditForm]
 
   private[this] val techniqueId: Box[String] = S.param("techniqueId")
 

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPConnection.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPConnection.scala
@@ -360,11 +360,11 @@ sealed class RoLDAPConnection(
         //build the tree
         LDAPTree(all.getSearchEntries.asScala.map(x => LDAPEntry(x))).map(Some(_))
       } else None.succeed
-    } catchAll {
+    } catchAll { x => (x: @unchecked) match {
       //a no such object error simply means that the required LDAP tree is not in the directory
       case e:LDAPSearchException if(NO_SUCH_OBJECT == e.getResultCode) => None.succeed
-      case e:LDAPException => LDAPRudderError.BackendException(s"Can not get tree '${dn}': ${e.getDiagnosticMessage}", e).fail
-    }
+      case e:LDAPException => LDAPRudderError.BackendException(s"Can not get tree '${dn.toString}': ${e.getDiagnosticMessage}", e).fail
+    } }
   }
 }
 
@@ -520,7 +520,7 @@ class RwLDAPConnection(
       } else {
         LDAPRudderError.FailureResult(s"Error when doing action '${modName}' with and LDIF change request: ${res.getDiagnosticMessage}", res).fail
       }
-    } catchAll {
+    } catchAll { x => (x: @unchecked) match {
       case ex:LDAPException =>
         if(onlyReportThat(ex.getResultCode)) {
           logIgnoredException(record.getDN, modName, ex)
@@ -530,7 +530,7 @@ class RwLDAPConnection(
         }
       // catchAll is still a lie, and we want to crash on an other exception
       case ex:Throwable => throw ex
-    }
+    } }
   }
 
 
@@ -690,7 +690,7 @@ class RwLDAPConnection(
     }
 
     for {
-      _   <- blocking(ldifFileLogger.tree(tree)) mapError (e => LDAPRudderError.BackendException(s"Error when loggin operation on LDAP tree: '${tree.parentDn}'", e))
+      _   <- blocking(ldifFileLogger.tree(tree)) mapError (e => LDAPRudderError.BackendException(s"Error when logging operation on LDAP tree: '${tree.parentDn.toString}'", e))
              //process mofications
       now <- getTree(tree.root.dn)
       res <- (now match {

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPTree.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPTree.scala
@@ -48,7 +48,7 @@ trait LDAPTree extends Tree[LDAPEntry] with ToLDIFRecords with ToLDIFString  {
 
   var _children = new HashMap[RDN,LDAPTree]()
 
-  override def children = Map() ++ _children
+  override def children: Map[RDN, LDAPTree] = Map() ++ _children
 
   def addChild(child:LDAPTree) : Unit = {
     require(root.optDn == child.root.parentDn,

--- a/webapp/sources/scala-ldap/src/test/scala/com/normation/ldap/sdk/LDAPTreeTest.scala
+++ b/webapp/sources/scala-ldap/src/test/scala/com/normation/ldap/sdk/LDAPTreeTest.scala
@@ -20,14 +20,18 @@
 
 package com.normation.ldap.sdk
 
-import com.unboundid.ldap.sdk.{RDN,DN}
+import com.unboundid.ldap.sdk.DN
+import com.unboundid.ldap.sdk.RDN
 import DN.NULL_DN
+import com.github.ghik.silencer.silent
+
 import com.normation.zio._
 import org.junit.runner.RunWith
 import org.specs2.mutable._
 import org.specs2.runner.JUnitRunner
 
 
+@silent("a type was inferred to be `\\w+`; this may indicate a programming error.")
 @RunWith(classOf[JUnitRunner])
 class LDAPTreeTest extends Specification {
 


### PR DESCRIPTION
https://issues.rudder.io/issues/21869

The only change that is new compared to branche 7.x is the use of 
```
import com.github.ghik.silencer.silent

@silent("a type was inferred to be `\\w+`; this may indicate a programming error.")
```

On some `specs2` test classes to avoid gazillion of said warning which is not interesting in a test class (yes, really, I'm OK to unify a `MatchResul[Int]` with a `MatchResult[String]`).

The backport strategy of other changes is mainly "compare with branch 7.2, copy what is there". 
It means that sometime, error messages or the code is a bit changed, but I didn't see any cases where it was for a worst thing. And almost all changes were already in 7.0/7.1, so well tested.
It worked in 99%. There was a couple of cases where type have changed, and in these cases, I only backported the warning correction in these case, not the whole change for the line.