### PR TITLE
Fixes #21891: A namevirtualhost is mandatory when splitting vhost

### DIFF
--- a/relay/sources/apache/rudder-vhost.conf
+++ b/relay/sources/apache/rudder-vhost.conf
@@ -30,12 +30,12 @@
 </VirtualHost>
 
 # #############################################################################
-# # To use a different certificate/port/configuration for Web/API access and 
+# # To use a different certificate/port/configuration for Web/API access and
 # # and node communication, comment the default virtual host and uncomment and
 # # modify the following configuration.
 # #
 # # This is useful for:
-# # 
+# #
 # # * using a different certificate for the web UI/API
 # # * separating the network flows for security reasons
 # #
@@ -46,6 +46,9 @@
 # # If you change the port for one of the virtual hosts you will likely need to add
 # # Listen 8443
 #
+# # If you already have this you can remove it
+# NameVirtualHost *:443
+#
 # ########################
 # # Node communication
 # ########################
@@ -53,6 +56,7 @@
 # <VirtualHost *:443>
 #   ServerAdmin webmaster@localhost
 #
+#   # If your hostname == the ServerName of next vhost then you have to put a different name here
 #   # ServerName rudder.private.example.com
 #
 #   # # Uncomment to enable HSTS
@@ -66,7 +70,7 @@
 # </VirtualHost>
 #
 # ################
-# # Web/API 
+# # Web/API
 # ################
 #
 # <VirtualHost *:443>


### PR DESCRIPTION
https://issues.rudder.io/issues/21891