### PR TITLE
Fixes #14371: At least on windows, technique editor parameters can not handle "_" char

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
@@ -1120,7 +1120,7 @@ class DSCTechniqueWriter(
       case params =>
         params
           .map(p => s"""      [parameter(Mandatory=$$true)]
-             |      [string]$$${p.name.validDscName},""")
+             |      [string]$$${p.name.value},""")
           .mkString("\n", "\n", "")
           .stripMargin('|')
     }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/1.0/technique.ps1
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/1.0/technique.ps1
@@ -6,7 +6,7 @@
       [parameter(Mandatory=$true)]
       [string]$techniqueName,
       [parameter(Mandatory=$true)]
-      [string]$Version,
+      [string]$version,
       [switch]$auditOnly
   )
   $reportIdBase = $reportId.Substring(0,$reportId.Length-1)

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/2.0/technique.ps1
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/2.0/technique.ps1
@@ -6,7 +6,7 @@
       [parameter(Mandatory=$true)]
       [string]$techniqueName,
       [parameter(Mandatory=$true)]
-      [string]$Version,
+      [string]$version,
       [switch]$auditOnly
   )
   $reportIdBase = $reportId.Substring(0,$reportId.Length-1)

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/technique.ps1
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/technique.ps1
@@ -6,7 +6,7 @@
       [parameter(Mandatory=$true)]
       [string]$techniqueName,
       [parameter(Mandatory=$true)]
-      [string]$TechniqueParameter,
+      [string]$technique_parameter,
       [switch]$auditOnly
   )
   $reportIdBase = $reportId.Substring(0,$reportId.Length-1)


### PR DESCRIPTION
https://issues.rudder.io/issues/14371

So, the problem is that the parameter name of the technique is:
- "transformed" to be a valide power shell name in the list of parameters (ie the name of the parameter is changed to removed "_"), 
- not transformed when call with `${}`
The mismatch between declaration and call-site lead to the problem. 

Plus, it seems that we don't need a "power shell valid name" for the parameter name, and that "_" are ok. 