### PR TITLE
Fixes #22106: Creating a global parameter doesn't trigger a policy generation in Rudder 6.2, 7.1 and 7.2

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/parameters/ParameterDiff.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/parameters/ParameterDiff.scala
@@ -51,7 +51,7 @@ sealed trait ChangeRequestGlobalParameterDiff {
 }
 
 final case class AddGlobalParameterDiff(parameter:GlobalParameter) extends ParameterDiff with ChangeRequestGlobalParameterDiff {
-  def needDeployment : Boolean = false
+  def needDeployment : Boolean = true
 }
 
 final case class DeleteGlobalParameterDiff(parameter:GlobalParameter) extends ParameterDiff with ChangeRequestGlobalParameterDiff {


### PR DESCRIPTION
https://issues.rudder.io/issues/22106