### PR TITLE
Fixes #22126: Windows generic method parameters are always written "mandatory=true" even when "mayBeEmpty" 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
@@ -1118,9 +1118,11 @@ class DSCTechniqueWriter(
     val parameters = technique.parameters match {
       case Nil    => ""
       case params =>
-        params
-          .map(p => s"""      [parameter(Mandatory=$$true)]
-             |      [string]$$${p.name.value},""")
+        params.map { p =>
+          val mandatory = if (p.mayBeEmpty) "$false" else "$true"
+          s"""      [parameter(Mandatory=${mandatory})]
+             |      [string]$$${p.name.value},"""
+        }
           .mkString("\n", "\n", "")
           .stripMargin('|')
     }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/technique.ps1
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/technique.ps1
@@ -5,7 +5,7 @@
       [string]$reportId,
       [parameter(Mandatory=$true)]
       [string]$techniqueName,
-      [parameter(Mandatory=$true)]
+      [parameter(Mandatory=$false)]
       [string]$technique_parameter,
       [switch]$auditOnly
   )

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
@@ -498,6 +498,7 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         ParameterId("1aaacd71-c2d5-482c-bcff-5eee6f8da9c2"),
         ParameterId("technique_parameter"),
         " a long description, with line \n break within",
+        // we must ensure that it will lead to: [parameter(Mandatory=$false)]
         true
       ) :: Nil,
       Nil
@@ -526,9 +527,13 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
     }
 
     "Should generate expected dsc technique content for our technique" in {
-      val expectedDscFile = new File(s"${expectedPath}/${dscTechniquePath}")
-      val resultDscFile   = new File(s"${basePath}/${dscTechniquePath}")
-      resultDscFile must haveSameLinesAs(expectedDscFile)
+      val expectedDscFile        = new File(s"${expectedPath}/${dscTechniquePath}")
+      val resultDscFile          = new File(s"${basePath}/${dscTechniquePath}")
+      val mandatoryFalseRegex    = """.*\Q[parameter(Mandatory=$false)]\E.*""".r
+      val containsMandatoryFalse =
+        better.files.File(resultDscFile.getAbsolutePath).lines.collectFirst(l => mandatoryFalseRegex.matches(l))
+      (resultDscFile must haveSameLinesAs(expectedDscFile)) and
+      (containsMandatoryFalse.nonEmpty must beTrue)
     }
 
     "Should write classic technique files without problem" in {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeExpectedReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeExpectedReportTest.scala
@@ -53,7 +53,6 @@ import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
-import com.normation.rudder.domain.reports.ExpectedReportsSerialisation._
 import com.normation.rudder.domain.reports.ExpectedReportsSerialisation.Version7_0._
 import com.normation.rudder.domain.reports.RuleExpectedReports
 import org.joda.time.DateTime


### PR DESCRIPTION
https://issues.rudder.io/issues/22126