### PR TITLE
Fixes #22249: Ignore RUSTSEC-2023-0001 in relayd

### DIFF
--- a/relay/sources/relayd/deny.toml
+++ b/relay/sources/relayd/deny.toml
@@ -23,6 +23,8 @@ ignore = [
     "RUSTSEC-2020-0071",
     # Same in chrono
     "RUSTSEC-2020-0159",
+    # Only affects windows
+    "RUSTSEC-2023-0001",
 ]
 
 # https://github.com/hsivonen/encoding_rs#licensing


### PR DESCRIPTION
https://issues.rudder.io/issues/22249