### PR TITLE
Fixes #22294: Workaround for CVE-2022-46176 in cargo

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[net]
+git-fetch-with-cli = true


### PR DESCRIPTION
https://issues.rudder.io/issues/22294