### PR TITLE
Fixes #22206: Allow user to define custom roles in rudder-user.xml

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
@@ -60,6 +60,9 @@ object ApplicationLoggerPure extends NamedZioLogger {
     def loggerName = parent.loggerName + ".plugin"
   }
 
+  object Authz extends NamedZioLogger {
+    def loggerName = parent.loggerName + ".authorization"
+  }
 }
 
 object ApiLogger extends Logger {

--- a/webapp/sources/rudder/rudder-web/src/main/resources/demo-rudder-users.xml
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/demo-rudder-users.xml
@@ -53,7 +53,7 @@
   (where you define the actual authorisations of the user). The "hash" field of
   "authentication" can be omitted.
 
-  The "role" tag must contain one or more of these values (comma separated), depending
+  The "roles" tag must contain one or more of these values (comma separated), depending
   on the what the user should be allowed to do:
     "administrator" (all rights), "administration_only" (administration tab), "user"
     (all nodes, configuration tab), "configuration" (configuration tab), "read_only"
@@ -65,7 +65,20 @@
     "directive", "parameter", "validator", "deployer",
     level: "read", "write", "edit", "all" (read, write, edit)
 
-  Example: "node_read" (can read nodes), "validator_all" (same as validator)
+  Example: "node_read" (can read nodes), "validator_all" (same as validator).
+
+  If the extended authorisations feature is enable, you can define custom roles. They are introduced by the `custom-roles`
+  tag and they allow to define new role name for set of roles or authorisations.
+  A custom role is defined with the `<role>` tag with the attribute "name" (case-insensitive name of the role) and
+  "roles" (same as for an user).
+  Ex:
+  <authentication>
+    <custom-roles>
+      <role name="role_a0" roles="node_read,node_write,configuration"/>
+      <role name="role_a1" roles="ROLE_A0,inventory"/>
+    </custom-roles>
+  <authentication>
+
 
   Please take a look at Rudder's documentation for additional details, either from the
   application itself (upper right corner) or on
@@ -78,6 +91,6 @@
 
 <authentication hash="bcrypt" case-sensitivity="true">
   <!--
-    <user name="NAME" password="REPLACE_BY_HASH" role="ROLE" />
+    <user name="NAME" password="REPLACE_BY_HASH" roles="ROLE" />
   -->
 </authentication>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1072,17 +1072,13 @@ object RudderConfig extends Loggable {
 
   // rudder user list
   lazy val rudderUserListProvider: FileUserDetailListProvider = {
-    (for {
-      resource <- UserFileProcessing.getUserResourceFile()
-    } yield {
-      resource
-    }) match {
-      case Right(resource)                           =>
+    UserFileProcessing.getUserResourceFile().either.runNow match {
+      case Right(resource) =>
         new FileUserDetailListProvider(roleApiMapping, userAuthorisationLevel, resource)
-      case Left(UserConfigFileError(msg, exception)) =>
-        ApplicationLogger.error(msg, Box(exception))
+      case Left(err)       =>
+        ApplicationLogger.error(err.fullMsg)
         // make the application not available
-        throw new javax.servlet.UnavailableException(s"Error when triyng to parse Rudder users file, aborting.")
+        throw new javax.servlet.UnavailableException(s"Error when trying to parse Rudder users file, aborting.")
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/Authz.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/Authz.scala
@@ -38,7 +38,6 @@
 package com.normation.rudder.web.snippet
 
 import com.normation.rudder.AuthorizationType
-import com.normation.rudder.RoleToRights
 import com.normation.rudder.web.services.CurrentUser
 import net.liftweb.common._
 import net.liftweb.http._
@@ -78,10 +77,13 @@ class Authz extends DispatchSnippet with Loggable {
 
   def testRight(xml: NodeSeq): NodeSeq = {
     S.attr("role") match {
-      case Full(role)
-          if (CurrentUser.checkRights(RoleToRights.parseAuthz(role).headOption.getOrElse(AuthorizationType.NoRights))) =>
-        xml
-      case x => NodeSeq.Empty
+      case Full(role) =>
+        AuthorizationType.parseAuthz(role) match {
+          case Left(err)    => NodeSeq.Empty
+          case Right(authz) =>
+            if (CurrentUser.checkRights(authz.headOption.getOrElse(AuthorizationType.NoRights))) xml else NodeSeq.Empty
+        }
+      case x          => NodeSeq.Empty
     }
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/22206

Introduce the possibility to have user-defined roles in the `rudder-users.xml` file. 

The main changes are:
- the user file parsing steps are not more cleanly separated, with the parsing first step that just check for the XML structure, extract data but doesn't do any consistancy check ; then we have a different step for custom role check and an other for user roles,
- for the parsing of users, both `role` (as before 7.3) and `roles` (7.3 normalization) tags are accepted,
- parsing authorisation (ie `node_read` etc) is moved to the `AuthorizationType` class,
- authorisation type (`read`, `write`, `edit`) are defined in a sealed class so that we can check that a custom role doesn't overlap an authorisation
- `RoleToAuthz` object is renamed `RudderRoles`. It's a *stateful* object and so should be a class+impl, but b/c of the existing object status everywhere in rudder/plugin, I wasn't sure it will be possible to change. With implementation insight, it seems that it can be done (perhaps during a latter phase).
- `RudderRoles` holds all known roles and is able to parse custom roles and register new ones. 
- `custom-roles` are case insensitive (because it was already the case for built-in roles, and we don't want to have two roles providing vastly different authorisations only diffing by case sensisitivity). No other restriction is put on role name legal characters, it may be a point to decide.
- a `custom-role` can't refere a non-existing role (the whole custom-role declaration will be ignored)
- order of custom-role definition does not matter
- the main difficulty is the cycle detection in custom role and so the `resolveCustomRoles` method. That method contains all the logic and relies on several sub-function for each step. The basic idea of the algo is the input/pending/done queues with callback for pending when a new role reaches done. Implemented with ZIO  `Ref`, it's ok-ish in clarity 
- some unit tests are added to check the different assumptions. In particular one try to use all the different edge cases (role with empty list of roles, overriding name, case insensitivity, several cycles detections)