### PR TITLE
Fixes #22378: Generate policies for campaigns before it starts officially, delete them after it stops (1 hour delay each)

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunHooks.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunHooks.scala
@@ -279,7 +279,7 @@ object RunHooks {
                          case Some(ok) =>
                            ok.succeed
                          case None     =>
-                           val msg = s"Hook ${cmdInfo} timed out after ${killTimeout.asJava.toString}"
+                           val msg = s"Hook ${cmdInfo} timed out after ${killTimeout.render}"
                            PureHooksLogger.LongExecLogger.error(msg) *> Unexpected(msg).fail
                        }
                        .untraced

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -3195,6 +3195,6 @@ class MockCampaign() {
     }
   }
 
-  val mainCampaignService = new MainCampaignService(dumbCampaignEventRepository, repo, new StringUuidGeneratorImpl())
+  val mainCampaignService = new MainCampaignService(dumbCampaignEventRepository, repo, new StringUuidGeneratorImpl(), 0, 0)
 
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2920,7 +2920,7 @@ object RudderConfig extends Loggable {
     .make(campaignSerializer, campaignPath, campaignEventRepo)
     .runOrDie(err => new RuntimeException(s"Error during initialization of campaign repository: " + err.fullMsg))
 
-  val mainCampaignService      = new MainCampaignService(campaignEventRepo, campaignRepo, uuidGen)
+  val mainCampaignService      = new MainCampaignService(campaignEventRepo, campaignRepo, uuidGen, 1, 1)
   lazy val jsonReportsAnalyzer = JSONReportsAnalyser(reportsRepository, propertyRepository)
 
   // todo: scheduler interval should be a property


### PR DESCRIPTION
https://issues.rudder.io/issues/22378