### PR TITLE
Fixes #22375: Nodes not answering are seen in "missing" rather than in "no reports"

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/DebugComplianceLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/DebugComplianceLogger.scala
@@ -121,7 +121,7 @@ object ComplianceDebugLogger extends Logger {
         s" last run: nodeConfigInfo: ${lastRunConfigInfo.toLog} received at ${lastRunDateTime.toIsoStringNoMillis} |" +
         s" expired at ${lastRunExpiration.toIsoStringNoMillis}"
 
-      case UnexpectedUnknowVersion(lastRunDateTime, lastRunConfigId, expectedConfig, expectedExpiration, _) =>
+      case UnexpectedUnknownVersion(lastRunDateTime, lastRunConfigId, expectedConfig, expectedExpiration, _) =>
         s"expected NodeConfigId: ${expectedConfig.toLog} |" +
         s" last run: nodeConfigId: ${lastRunConfigId.value} received at ${lastRunDateTime.toIsoStringNoMillis} |" +
         s" expired at ${expectedExpiration.toIsoStringNoMillis}"
@@ -149,7 +149,7 @@ object ComplianceDebugLogger extends Logger {
       case _: NoReportInInterval        => "NoReportInInterval"
       case _: UnexpectedVersion         => "UnexpectedVersion"
       case _: UnexpectedNoVersion       => "UnexpectedNoVersion"
-      case _: UnexpectedUnknowVersion   => "UnexpectedUnknowVersion"
+      case _: UnexpectedUnknownVersion  => "UnexpectedUnknowVersion"
       case _: ReportsDisabledInInterval => "ReportsDisabledInInterval"
       case _: Pending                   => "Pending"
       case _: ComputeCompliance         => "ComputeCompliance"

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -493,38 +493,38 @@ object NodeStatusReportSerialization {
   def jsonRunInfo(runInfo: RunAndConfigInfo): JValue = {
 
     runInfo match {
-      case NoRunNoExpectedReport                   =>
+      case NoRunNoExpectedReport                    =>
         ("type" -> "NoRunNoExpectedReport")
-      case NoExpectedReport(t, id)                 =>
+      case NoExpectedReport(t, id)                  =>
         (("type"             -> "NoExpectedReport")
         ~ ("lastRunConfigId" -> id.map(_.value)))
-      case NoReportInInterval(e, _)                =>
+      case NoReportInInterval(e, _)                 =>
         (("type"              -> "NoReportInInterval")
         ~ ("expectedConfigId" -> e.nodeConfigId.value))
-      case ReportsDisabledInInterval(e, _)         =>
+      case ReportsDisabledInInterval(e, _)          =>
         (("type"              -> "ReportsDisabled")
         ~ ("expectedConfigId" -> e.nodeConfigId.value))
-      case UnexpectedVersion(t, id, _, e, _, _)    =>
+      case UnexpectedVersion(t, id, _, e, _, _)     =>
         (("type"              -> "UnexpectedVersion")
         ~ ("expectedConfigId" -> e.nodeConfigId.value)
         ~ ("runConfigId"      -> id.get.nodeConfigId.value))
-      case UnexpectedNoVersion(_, id, _, e, _, _)  =>
+      case UnexpectedNoVersion(_, id, _, e, _, _)   =>
         (("type"              -> "UnexpectedNoVersion")
         ~ ("expectedConfigId" -> e.nodeConfigId.value)
         ~ ("runConfigId"      -> id.value))
-      case UnexpectedUnknowVersion(_, id, e, _, _) =>
+      case UnexpectedUnknownVersion(_, id, e, _, _) =>
         (("type"              -> "UnexpectedUnknownVersion")
         ~ ("expectedConfigId" -> e.nodeConfigId.value)
         ~ ("runConfigId"      -> id.value))
-      case Pending(e, r, _)                        =>
+      case Pending(e, r, _)                         =>
         (("type"              -> "Pending")
         ~ ("expectedConfigId" -> e.nodeConfigId.value)
         ~ ("runConfigId"      -> r.map(_._2.nodeConfigId.value)))
-      case ComputeCompliance(_, e, _)              =>
+      case ComputeCompliance(_, e, _)               =>
         (("type"              -> "ComputeCompliance")
         ~ ("expectedConfigId" -> e.nodeConfigId.value)
         ~ ("runConfigId"      -> e.nodeConfigId.value))
-      case NoUserRulesDefined(_, e, _, _, _)       =>
+      case NoUserRulesDefined(_, e, _, _, _)        =>
         (("type"              -> "NoUserRulesDefined")
         ~ ("expectedConfigId" -> e.nodeConfigId.value)
         ~ ("runConfigId"      -> e.nodeConfigId.value))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
@@ -146,21 +146,21 @@ class ComplianceJdbcRepository(
                 Some(RunCompliance.from(runTime, x.expirationDateTime, r))
             }
 
-          case x: NoExpectedReport        =>
+          case x: NoExpectedReport         =>
             // here, the expiration date has not much meaning, since we don't have
             // information on that node configuration (and so the node has most likelly no
             // idea whatsoever of any config, even global). Take default values,
             // ie 5min for run + 5min for grace
             Some(RunCompliance.from(x.lastRunDateTime, x.lastRunDateTime.plusMinutes(10), r))
-          case x: UnexpectedVersion       =>
+          case x: UnexpectedVersion        =>
             Some(RunCompliance.from(x.lastRunDateTime, x.lastRunExpiration, r))
-          case x: UnexpectedNoVersion     =>
+          case x: UnexpectedNoVersion      =>
             Some(RunCompliance.from(x.lastRunDateTime, x.lastRunExpiration, r))
-          case x: UnexpectedUnknowVersion =>
+          case x: UnexpectedUnknownVersion =>
             // same has for NoExpectedReport, we can't now what the node
             // thing its configuration is.
             Some(RunCompliance.from(x.lastRunDateTime, x.lastRunDateTime.plusMinutes(10), r))
-          case x: ComputeCompliance       =>
+          case x: ComputeCompliance        =>
             Some(RunCompliance.from(x.lastRunDateTime, x.expirationDateTime, r))
 
         }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -118,8 +118,8 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
     ),
     (
       buildNode("n7"),
-      run("n7", UnexpectedUnknowVersion(null, NodeConfigId("x"), null, expired, expired)),
-      run("n7", UnexpectedUnknowVersion(null, NodeConfigId("x"), null, stillOk, stillOk))
+      run("n7", UnexpectedUnknownVersion(null, NodeConfigId("x"), null, expired, expired)),
+      run("n7", UnexpectedUnknownVersion(null, NodeConfigId("x"), null, stillOk, stillOk))
     ),
     (
       buildNode("n8"),

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -257,7 +257,7 @@ class ReportDisplayer(
             <p>{currentConfigId(expectedConfigId)} and reports are disabled for that node.</p>
           )
 
-        case UnexpectedUnknowVersion(lastRunDateTime, lastRunConfigId, expectedConfig, expectedExpiration, _) =>
+        case UnexpectedUnknownVersion(lastRunDateTime, lastRunConfigId, expectedConfig, expectedExpiration, _) =>
           (
             <p>This node is sending reports from an unknown configuration policy (with configuration ID '{lastRunConfigId.value}'
                that is unknown to Rudder, run started at {lastRunDateTime.toString(dateFormat)}).
@@ -275,7 +275,7 @@ class ReportDisplayer(
      */
     val (background, lookReportsMessage) = report.runInfo match {
       case NoRunNoExpectedReport | _: NoExpectedReport | _: UnexpectedVersion | _: UnexpectedNoVersion |
-          _: UnexpectedUnknowVersion | _: NoReportInInterval =>
+          _: UnexpectedUnknownVersion | _: NoReportInInterval =>
         ("alert alert-danger", NodeSeq.Empty)
 
       case _: ReportsDisabledInInterval =>
@@ -438,7 +438,7 @@ class ReportDisplayer(
                             & "lastreportgrid-unexpected" #> NodeSeq.Empty
                           )(reportByNodeTemplate)
 
-                        case _: UnexpectedVersion | _: UnexpectedNoVersion | _: UnexpectedUnknowVersion | _: NoReportInInterval |
+                        case _: UnexpectedVersion | _: UnexpectedNoVersion | _: UnexpectedUnknownVersion | _: NoReportInInterval |
                             _: ReportsDisabledInInterval | _: NoUserRulesDefined =>
                           /*
                            * In these case, filter out "unexpected" reports to only


### PR DESCRIPTION
https://issues.rudder.io/issues/22375

So, the reason was that in the case were we had a valid old run, with a config id, but the expected report for that config id were missing (because they were old and so they got deleted since then), THEN we were going into a `UnexpectedUnknownVersion` in place of a `NoReportInInterval`. 
So now, we first check the date of the old run, and if the run is expired, we return `NoReturnInInterval`, else we return `UnexpectedUnknownVersion` (because in that case, we should really have the config id in base)