### PR TITLE
Fixes #19986: On "Node search" page, we can click on "Create node group from this query" even if there were no query

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
@@ -74,7 +74,7 @@ class SearchNodeComponent(
 
     _query:           Option[NewQuery],
     _srvList:         Box[Seq[NodeInfo]],
-    onUpdateCallback: () => JsCmd = { () => Noop }, // this one is not used yet
+    onUpdateCallback: () => JsCmd = { () => Noop }, // on grid refresh
 
     onClickCallback: Option[(String, Boolean) => JsCmd] = None, // this callback is used when we click on an element in the grid
 
@@ -393,7 +393,7 @@ class SearchNodeComponent(
     srvList match {
       case Full(seq) =>
         val refresh = srvGrid.refreshData(() => Some(seq), onClickCallback, tableId)
-        JsRaw(s"""(${refresh.toJsCmd}());createTooltip();""")
+        JsRaw(s"""(${refresh.toJsCmd}());createTooltip();""") & onUpdateCallback()
 
       case Empty =>
         Noop

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/SearchNodes.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/SearchNodes.scala
@@ -164,7 +164,7 @@ class SearchNodes extends StatefulSnippet with Loggable {
       "htmlIdCategory",
       query,
       srvList,
-      () => Noop,
+      () => JsRaw("""$("#createGroupFromQueryButton").prop("disabled", false)"""),
       Some(showNodeDetails),
       onSearchCallback = updateQueryHash,
       groupPage = false
@@ -174,7 +174,13 @@ class SearchNodes extends StatefulSnippet with Loggable {
   }
 
   def createGroup(html: NodeSeq): NodeSeq = {
-    SHtml.ajaxButton("Create node group from this query", () => showPopup(), ("class", "btn btn-success new-icon space-top"))
+    SHtml.ajaxButton(
+      "Create node group from this query",
+      () => showPopup(),
+      ("id", "createGroupFromQueryButton"),
+      ("class", "btn btn-success new-icon space-top"),
+      ("disabled", "disabled")
+    )
   }
 
   def queryForm(sc: SearchNodeComponent) = {
@@ -227,7 +233,7 @@ class SearchNodes extends StatefulSnippet with Loggable {
         SetHtml("createGroupContainer", createPopup) &
         JsRaw(""" createPopup("createGroupPopup") """)
 
-      case eb: EmptyBox => Alert("Error when trying to retrieve the resquest, please try again")
+      case eb: EmptyBox => Alert("Error when trying to retrieve the request, please try again")
     }
   }
   private def updateQueryHash(button: Boolean, query: Option[NewQuery]): JsCmd = {


### PR DESCRIPTION
https://issues.rudder.io/issues/19986