### PR TITLE
Fixes #22534: List Managed Nodes API with any of the fields listed in the "full" never answer

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/services/core/FullInventoryRepository.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/services/core/FullInventoryRepository.scala
@@ -109,6 +109,9 @@ trait ReadOnlyFullInventoryRepository {
 
   def getAllInventories(inventoryStatus: InventoryStatus): IOResult[Map[NodeId, FullInventory]]
 
+  // get inventories for a set of nodes
+  def getInventories(inventoryStatus: InventoryStatus, nodeIds: Set[NodeId]): IOResult[Map[NodeId, FullInventory]]
+
   def getAllNodeInventories(inventoryStatus: InventoryStatus): IOResult[Map[NodeId, NodeInventory]]
 }
 

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/FullInventoryRepositoryImpl.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/FullInventoryRepositoryImpl.scala
@@ -49,6 +49,7 @@ import com.normation.ldap.sdk.LDAPIOResult._
 import com.normation.utils.HostnameRegex
 import com.normation.utils.NodeIdRegex
 import com.unboundid.ldap.sdk.DN
+import com.unboundid.ldap.sdk.Filter
 import com.unboundid.ldap.sdk.Modification
 import com.unboundid.ldap.sdk.ModificationType
 import com.unboundid.ldif.LDIFChangeRecord
@@ -281,6 +282,35 @@ class FullInventoryRepositoryImpl(
     })
   }.chainError(s"Error when getting all node inventories")
 
+  // utility methods to get node/machine from ldap entries from the base dn
+  private[core] def machinesFromOuMachines(machinesTree: LDAPTree): IOResult[Iterable[Option[MachineInventory]]] = {
+    ZIO.foreach(machinesTree.children.values) { tree =>
+      mapper
+        .machineFromTree(tree)
+        .foldM(
+          err =>
+            InventoryDataLogger.error(
+              s"Error when mapping inventory data for entry '${tree.root.rdn.map(_.toString).getOrElse("")}': ${err.fullMsg}"
+            ) *> None.succeed,
+          ok => Some(ok).succeed
+        )
+    }
+  }
+
+  private[core] def nodesFromOuNodes(nodesTree: LDAPTree): IOResult[Iterable[Option[NodeInventory]]] = {
+    ZIO.foreach(nodesTree.children.values) { tree =>
+      mapper
+        .nodeFromTree(tree)
+        .foldM(
+          err =>
+            InventoryDataLogger.error(
+              s"Error when mapping inventory data for entry '${tree.root.rdn.map(_.toString).getOrElse("")}': ${err.fullMsg}"
+            ) *> None.succeed,
+          ok => Some(ok).succeed
+        )
+    }
+  }
+
   override def getAllInventories(inventoryStatus: InventoryStatus): IOResult[Map[NodeId, FullInventory]] = {
 
     for {
@@ -290,40 +320,20 @@ class FullInventoryRepositoryImpl(
       tree <- con.getTree(dit.BASE_DN)
 
       // Get into Nodes subtree
-      nodeTree    <- tree.flatMap(_.children.get(dit.NODES.rdn)) match {
-                       case None       => LDAPRudderError.Consistancy(s"Could not find node inventories in ${dit.BASE_DN.toString}").fail
-                       case Some(tree) => tree.succeed
-                     }
+      nodesTree <- tree.flatMap(_.children.get(dit.NODES.rdn)) match {
+                     case None       => LDAPRudderError.Consistancy(s"Could not find node inventories in ${dit.BASE_DN.toString}").fail
+                     case Some(tree) => tree.succeed
+                   }
       // we don't want that one error somewhere breaks everything
-      nodes       <- ZIO.foreach(nodeTree.children.values) { tree =>
-                       mapper
-                         .nodeFromTree(tree)
-                         .foldM(
-                           err =>
-                             InventoryDataLogger.error(
-                               s"Error when mapping inventory data for entry '${tree.root.rdn.map(_.toString).getOrElse("")}': ${err.fullMsg}"
-                             ) *> None.succeed,
-                           ok => Some(ok).succeed
-                         )
-                     }
+      nodes     <- nodesFromOuNodes(nodesTree)
 
       // Get into Machines subtree
-      machineTree <- tree.flatMap(_.children.get(dit.MACHINES.rdn)) match {
-                       case None       =>
-                         LDAPRudderError.Consistancy(s"Could not find machine inventories in ${dit.BASE_DN.toString}").fail
-                       case Some(tree) => tree.succeed
-                     }
-      machines    <- ZIO.foreach(machineTree.children.values) { tree =>
-                       mapper
-                         .machineFromTree(tree)
-                         .foldM(
-                           err =>
-                             InventoryDataLogger.error(
-                               s"Error when mapping inventory data for entry '${tree.root.rdn.map(_.toString).getOrElse("")}': ${err.fullMsg}"
-                             ) *> None.succeed,
-                           ok => Some(ok).succeed
-                         )
-                     }
+      machinesTree <- tree.flatMap(_.children.get(dit.MACHINES.rdn)) match {
+                        case None       =>
+                          LDAPRudderError.Consistancy(s"Could not find machine inventories in ${dit.BASE_DN.toString}").fail
+                        case Some(tree) => tree.succeed
+                      }
+      machines     <- machinesFromOuMachines(machinesTree)
 
     } yield {
       val machineMap = machines.flatten.map(m => (m.id, m)).toMap
@@ -336,6 +346,57 @@ class FullInventoryRepositoryImpl(
         .toMap
     }
   }.chainError(s"Error when getting all node inventories for status '${inventoryStatus.name}'")
+
+  override def getInventories(inventoryStatus: InventoryStatus, nodeIds: Set[NodeId]): IOResult[Map[NodeId, FullInventory]] = {
+    /*
+     * We need to only get back the tree for nodes that we are looking for, we need to build filter like:
+     * "(entryDN:dnSubtreeMatch:=cn=group_a,dc=abc,dc=xyz)"
+     */
+    def buildSubTreeFilter[A](base: DN, ids: List[A], dnToString: A => String): Filter = {
+      val dnFilters = Filter.create(s"entryDN=${base.toString()}") :: ids
+        .map(dnToString)
+        .sorted
+        .map(a => Filter.create(s"entryDN:dnSubtreeMatch:=${a}"))
+      BuildFilter.OR(dnFilters: _*)
+    }
+
+    for {
+      con       <- ldap
+      dit        = inventoryDitService.getDit(inventoryStatus)
+      // Get base tree, we will go into each subtree after
+      nodesTree <- con
+                     .getTreeFilter(
+                       dit.NODES.dn,
+                       buildSubTreeFilter[NodeId](dit.NODES.dn, nodeIds.toList, id => dit.NODES.NODE.dn(id).toString)
+                     )
+                     .notOptional(s"Missing node root tree")
+
+      // we don't want that one error somewhere breaks everything
+      nodes     <- nodesFromOuNodes(nodesTree).map(_.flatten)
+
+      machineUuids = nodes.flatMap(_.machineId.map(_._1))
+
+      // Get into Machines subtree
+      machinesTree <-
+        con
+          .getTreeFilter(
+            dit.MACHINES.dn,
+            buildSubTreeFilter[MachineUuid](dit.MACHINES.dn, machineUuids.toList, id => dit.MACHINES.MACHINE.dn(id).toString)
+          )
+          .notOptional(s"Missing machine root tree")
+
+      machines <- machinesFromOuMachines(machinesTree)
+    } yield {
+      val machineMap = machines.flatten.map(m => (m.id, m)).toMap
+      nodes
+        .map(node => {
+          val machine   = node.machineId.flatMap(mid => machineMap.get(mid._1))
+          val inventory = FullInventory(node, machine)
+          node.main.id -> inventory
+        })
+        .toMap
+    }
+  }
 
   override def get(id: NodeId, inventoryStatus: InventoryStatus): IOResult[Option[FullInventory]] = {
     for {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
@@ -67,7 +67,11 @@ object ApiLogger extends Logger {
 }
 
 object ApiLoggerPure extends NamedZioLogger {
-  def loggerName = "api"
+  def loggerName = "api-processing"
+
+  object Metrics extends NamedZioLogger {
+    def loggerName = "api-processing.metrics"
+  }
 }
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/inventory/TestCertificate.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/inventory/TestCertificate.scala
@@ -113,13 +113,15 @@ class TestCertificate extends Specification with Loggable {
       )
       .map(_ => Nil)
 
-    override def getMachineId(id: NodeId, inventoryStatus: InventoryStatus):         IOResult[Option[(MachineUuid, InventoryStatus)]] =
+    override def getMachineId(id: NodeId, inventoryStatus: InventoryStatus):             IOResult[Option[(MachineUuid, InventoryStatus)]] =
       ???
-    override def getAllInventories(inventoryStatus: InventoryStatus):                IOResult[Map[NodeId, FullInventory]]             = ???
-    override def getAllNodeInventories(inventoryStatus: InventoryStatus):            IOResult[Map[NodeId, NodeInventory]]             = ???
-    override def delete(id: NodeId, inventoryStatus: InventoryStatus):               IOResult[Seq[LDIFChangeRecord]]                  = ???
-    override def move(id: NodeId, from: InventoryStatus, into: InventoryStatus):     IOResult[Seq[LDIFChangeRecord]]                  = ???
-    override def moveNode(id: NodeId, from: InventoryStatus, into: InventoryStatus): IOResult[Seq[LDIFChangeRecord]]                  = ???
+    override def getAllInventories(inventoryStatus: InventoryStatus):                    IOResult[Map[NodeId, FullInventory]]             = ???
+    override def getInventories(inventoryStatus: InventoryStatus, nodeIds: Set[NodeId]): IOResult[Map[NodeId, FullInventory]]             =
+      ???
+    override def getAllNodeInventories(inventoryStatus: InventoryStatus):                IOResult[Map[NodeId, NodeInventory]]             = ???
+    override def delete(id: NodeId, inventoryStatus: InventoryStatus):                   IOResult[Seq[LDIFChangeRecord]]                  = ???
+    override def move(id: NodeId, from: InventoryStatus, into: InventoryStatus):         IOResult[Seq[LDIFChangeRecord]]                  = ???
+    override def moveNode(id: NodeId, from: InventoryStatus, into: InventoryStatus):     IOResult[Seq[LDIFChangeRecord]]                  = ???
   }
 
   val processor = new InventoryProcessor(

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
@@ -501,7 +501,7 @@ class RudderEndpointDispatcher(logger: Log) extends ConnectEndpoint {
  * P: extracted parameters from request
  */
 trait BuildHandler[REQ, RESP, T, P] {
-  // external service nneeded
+  // external service needed
   def authz:             ApiAuthorization[T]
   def connectEndpoint:   ConnectEndpoint
   def supportedVersions: List[ApiVersion]

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/LiftApiDispatcher.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/LiftApiDispatcher.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.rest.lift
 import cats.data._
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.api.HttpAction
+import com.normation.rudder.domain.logger.ApiLogger
 import com.normation.rudder.rest._
 import net.liftweb.common._
 import net.liftweb.http._
@@ -149,12 +150,12 @@ trait LiftApiModuleProvider[A <: EndpointSchema] {
 }
 
 object LiftApiProcessingLogger extends Log {
-  protected def _logger = LoggerFactory.getLogger("api-processing")
-  def trace(msg: => String): Unit = _logger.trace(msg)
-  def debug(msg: => String): Unit = _logger.debug(msg)
-  def info(msg: => String):  Unit = _logger.info(msg)
-  def warn(msg: => String):  Unit = _logger.warn(msg)
-  def error(msg: => String): Unit = _logger.error(msg)
+  protected def _logger:     Logger = ApiLogger
+  def trace(msg: => String): Unit   = _logger.trace(msg)
+  def debug(msg: => String): Unit   = _logger.debug(msg)
+  def info(msg: => String):  Unit   = _logger.info(msg)
+  def warn(msg: => String):  Unit   = _logger.warn(msg)
+  def error(msg: => String): Unit   = _logger.error(msg)
 }
 
 class LiftHandler(

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -59,6 +59,7 @@ import com.normation.rudder.apidata.RestDataSerializer
 import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.domain.NodeDit
+import com.normation.rudder.domain.logger.ApiLoggerPure
 import com.normation.rudder.domain.logger.NodeLogger
 import com.normation.rudder.domain.logger.NodeLoggerPure
 import com.normation.rudder.domain.logger.TimingDebugLoggerPure
@@ -1388,23 +1389,52 @@ class NodeApiService6(
       nodeIds      = nodeFilter.getOrElse(nodeInfos.keySet).toSet
       runs        <- roAgentRunsRepository.getNodesLastRun(nodeIds)
       inventories <- if (detailLevel.needFullInventory()) {
-                       inventoryRepository.getAllInventories(state).chainError("Error when looking for node inventories")
+                       for {
+                         d1  <- currentTimeMillis
+                         // the request with filter if quite complex, and just sending all the node DN for it to LDAP produces
+                         // a lot of data transfer. So a some point, it's better to just get everything back and filter out
+                         // data below, trading ram for LDAP processing. No idea what a good heuristic would be, setting
+                         // it to 2/3
+                         res <- (if (nodeIds.size < nodeInfos.size * 2 / 3) {
+                                   inventoryRepository.getInventories(state, nodeIds)
+                                 } else {
+                                   inventoryRepository.getAllInventories(state)
+                                 }).chainError("Error when looking for node inventories")
+                         d2  <- currentTimeMillis
+                         _   <- ApiLoggerPure.Metrics.debug(s"[${d2 - d1} ms] Getting inventories for level '${detailLevel}' ")
+                       } yield res
                      } else {
                        Map[NodeId, FullInventory]().succeed
                      }
       software    <- if (detailLevel.needSoftware()) {
-                       softwareRepository.getSoftwareByNode(nodeIds, state)
+                       for {
+                         d1  <- currentTimeMillis
+                         res <- softwareRepository.getSoftwareByNode(nodeIds, state)
+                         d2  <- currentTimeMillis
+                         _   <- ApiLoggerPure.Metrics.debug(s"[${d2 - d1} ms] Getting software for level '${detailLevel}'")
+                       } yield res
                      } else {
                        Map[NodeId, Seq[Software]]().succeed
                      }
+      d1          <- currentTimeMillis
+      jsons        = nodeIds.flatMap { id =>
+                       nodeInfos
+                         .get(id)
+                         .map { nodeInfo =>
+                           serializeInventory(
+                             nodeInfo,
+                             state,
+                             runs.get(id).flatMap(_.map(_.agentRunId.date)),
+                             inventories.get(id),
+                             software.getOrElse(id, Seq()),
+                             detailLevel
+                           )
+                         }
+                     }
+      d2          <- currentTimeMillis
+      _           <- ApiLoggerPure.Metrics.debug(s"[${d2 - d1} ms] Serializing nodes to json values")
     } yield {
-      for {
-        nodeId   <- nodeIds
-        nodeInfo <- nodeInfos.get(nodeId)
-      } yield {
-        val runDate = runs.get(nodeId).flatMap(_.map(_.agentRunId.date))
-        serializeInventory(nodeInfo, state, runDate, inventories.get(nodeId), software.getOrElse(nodeId, Seq()), detailLevel)
-      }
+      jsons
     }).either.runNow match {
       case Right(nodes) => {
         toJsonResponse(None, ("nodes" -> JArray(nodes.toList)))

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -1996,8 +1996,12 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
       getGenericOne(id, inventoryStatus, n => n.mInv.map(x => (x.id, x.status)))
     }
 
-    override def getAllInventories(inventoryStatus: InventoryStatus):     IOResult[Map[NodeId, FullInventory]] =
+    override def getAllInventories(inventoryStatus: InventoryStatus): IOResult[Map[NodeId, FullInventory]] =
       getGenericAll(inventoryStatus, _fullInventory)
+
+    override def getInventories(inventoryStatus: InventoryStatus, nodeIds: Set[NodeId]): IOResult[Map[NodeId, FullInventory]] =
+      getAllInventories(inventoryStatus).map(_.filter(x => nodeIds.contains(x._1)))
+
     override def getAllNodeInventories(inventoryStatus: InventoryStatus): IOResult[Map[NodeId, NodeInventory]] =
       getGenericAll(inventoryStatus, _fullInventory(_).map(_.node))
 

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPConnection.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPConnection.scala
@@ -250,6 +250,13 @@ trait ReadOnlyTreeLDAPConnection {
    *   Failure(message) if something goes wrong.
    */
   def getTree(dn: DN): LDAPIOResult[Option[LDAPTree]]
+
+  /*
+   * Get a tree with a filter.
+   * Be very careful with the filter, you need to have something compatible with subtree lookup,
+   * so something likely base on: "(entryDN:dnSubtreeMatch:=cn=group_a,dc=abc,dc=xyz)"
+   */
+  def getTreeFilter(dn: DN, filter: Filter): LDAPIOResult[Option[LDAPTree]]
 }
 
 trait WriteOnlyTreeLDAPConnection {
@@ -363,8 +370,12 @@ sealed class RoLDAPConnection(
    */
 
   override def getTree(dn: DN): LDAPIOResult[Option[LDAPTree]] = {
+    getTreeFilter(dn, BuildFilter.ALL)
+  }
+
+  override def getTreeFilter(dn: DN, filter: Filter): LDAPIOResult[Option[LDAPTree]] = {
     blocking {
-      backed.search(dn.toString, Sub.toUnboundid, BuildFilter.ALL)
+      backed.search(dn.toString, Sub.toUnboundid, filter)
     } flatMap { all =>
       if (all.getEntryCount() > 0) {
         // build the tree
@@ -379,6 +390,7 @@ sealed class RoLDAPConnection(
       }
     }
   }
+
 }
 
 object RwLDAPConnection {

--- a/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
@@ -564,7 +564,7 @@ trait ZioLogger {
 trait NamedZioLogger extends ZioLogger {
   import org.slf4j.LoggerFactory
 
-  // ensure that children use def or lazy val - val leads to UnitializedFieldError.
+  // ensure that children use def or lazy val - val leads to UninitializedFieldError.
   def loggerName: String
 
   final val logEffect = LoggerFactory.getLogger(loggerName)


### PR DESCRIPTION
https://issues.rudder.io/issues/22534

Add a methode to be able to filter out entries in a subtree research. 
Then use it in the LDAP "get inventories" to limit the subtrees to the one of the looked for nodes. 
We need a second request to get relevant machine (which use the same id of only requesting machines actually linked to nodes by filtering out the tree)