### PR TITLE
Fixes #20396: It's hard to understand what authentication backend failed when a fallback happens

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/DynamicRudderProviderManager.java
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/DynamicRudderProviderManager.java
@@ -51,5 +51,5 @@ interface DynamicRudderProviderManager {
     /*
      * Always return a non-null list of authentication provider
      */
-    public AuthenticationProvider[] getEnabledProviders();
+    public RudderAuthenticationProvider[] getEnabledProviders();
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/20396

Tested with file, ldap and OIDC backends. That's a lot of different case from springsecurity, whose API is just plan horrible. 
So nothing facny: 
- we need a new class `RudderAuthenticationProvider` that implements `AuthenticationProvider` else we don't have access to our provider identifier at login
- then, the hard part was trying to understand where in Spring we can put the log - it's in a finally, because control flow by exception is a thing in java
- then trying to understand all the things that can get null, and well anything can be null. 

![image](https://user-images.githubusercontent.com/44649/233402398-b4b1fcbe-8b31-4183-9b7d-0e51ba684df3.png)
