### PR TITLE
Fixes #22645: Deadlock in rudder 7.3 (and perhaps 7.2)

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
@@ -39,6 +39,7 @@ package com.normation.rudder.domain.logger
 
 import com.normation.NamedZioLogger
 import net.liftweb.common.Logger
+import org.slf4j
 import org.slf4j.LoggerFactory
 
 /**
@@ -46,6 +47,10 @@ import org.slf4j.LoggerFactory
  */
 object ApplicationLogger extends Logger {
   override protected def _logger = LoggerFactory.getLogger("application")
+
+  object Properties extends Logger {
+    override protected def _logger: slf4j.Logger = LoggerFactory.getLogger("application.properties")
+  }
 }
 
 object ApplicationLoggerPure extends NamedZioLogger {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -96,6 +96,7 @@ import com.normation.plugins.SnippetExtensionRegister
 import com.normation.plugins.SnippetExtensionRegisterImpl
 import com.normation.rudder.UserService
 import com.normation.rudder.api._
+import com.normation.rudder.apidata.RestDataSerializer
 import com.normation.rudder.apidata.RestDataSerializerImpl
 import com.normation.rudder.apidata.ZioJsonExtractor
 import com.normation.rudder.batch._
@@ -104,6 +105,7 @@ import com.normation.rudder.campaigns.CampaignRepositoryImpl
 import com.normation.rudder.campaigns.CampaignSerializer
 import com.normation.rudder.campaigns.JSONReportsAnalyser
 import com.normation.rudder.campaigns.MainCampaignService
+import com.normation.rudder.configuration.ConfigurationRepository
 import com.normation.rudder.configuration.ConfigurationRepositoryImpl
 import com.normation.rudder.configuration.GroupRevisionRepository
 import com.normation.rudder.configuration.RuleRevisionRepository
@@ -368,18 +370,17 @@ object RudderProperties {
 
 }
 
-/**
- * Static initialization of Rudder services.
- * This is not a cake-pattern, just a plain object with load of lazy vals.
- */
-object RudderConfig extends Loggable {
+object RudderParsedProperties {
   import RudderProperties.config
 
-  private case class InitError(msg: String) extends Throwable(msg, null, false, false)
+  val logger = ApplicationLogger.Properties
 
   // set the file location that contains mime info
   java.lang.System
-    .setProperty("content.types.user.table", this.getClass.getClassLoader.getResource("content-types.properties").getPath)
+    .setProperty(
+      "content.types.user.table",
+      this.getClass.getClassLoader.getResource("content-types.properties").getPath
+    )
 
   //
   // Public properties
@@ -387,6 +388,26 @@ object RudderConfig extends Loggable {
   //
 
   private[this] val filteredPasswords = scala.collection.mutable.Buffer[String]()
+
+  def logRudderParsedProperties() = {
+    import scala.jdk.CollectionConverters._
+    val config = RudderProperties.config
+    if (ApplicationLogger.isInfoEnabled) {
+      // sort properties by key name
+      val properties = config.entrySet.asScala.toSeq.sortBy(_.getKey).flatMap { x =>
+        // the log line: registered property: property_name=property_value
+        if (hiddenRegisteredProperties.contains(x.getKey)) None
+        else {
+          Some(
+            s"registered property: ${x.getKey}=${if (filteredPasswords.contains(x.getKey)) "**********" else x.getValue.render}"
+          )
+        }
+      }
+      ApplicationLogger.info("List of registered properties:")
+      properties.foreach(p => ApplicationLogger.info(p))
+      ApplicationLogger.info("Plugin's license directory: '/opt/rudder/etc/plugins/licenses/'")
+    }
+  }
 
   // the LDAP password used for authentication is not used here, but should not appear nonetheless
   filteredPasswords += "rudder.auth.ldap.connection.bind.password"
@@ -412,13 +433,16 @@ object RudderConfig extends Loggable {
   val LDAP_HOST                         = config.getString("ldap.host")
   val LDAP_PORT                         = config.getInt("ldap.port")
   val LDAP_AUTHDN                       = config.getString("ldap.authdn")
-  val LDAP_AUTHPW                       = config.getString("ldap.authpw"); filteredPasswords += "ldap.authpw"
+  val LDAP_AUTHPW                       = config.getString("ldap.authpw");
+  filteredPasswords += "ldap.authpw"
   val LDAP_MAX_POOL_SIZE                = {
     try {
       config.getInt("ldap.maxPoolSize")
     } catch {
       case ex: ConfigException =>
-        ApplicationLogger.info("Property 'ldap.maxPoolSize' is missing or empty in rudder.configFile. Default to 2 connections.")
+        ApplicationLogger.info(
+          "Property 'ldap.maxPoolSize' is missing or empty in rudder.configFile. Default to 2 connections."
+        )
         2
     }
   }
@@ -454,7 +478,8 @@ object RudderConfig extends Loggable {
   val RUDDER_DIR_LOCK                   = config.getString("rudder.dir.lock") // TODO no more used ?
   val RUDDER_DIR_SHARED_FILES_FOLDER    = config.getString("rudder.dir.shared.files.folder")
   val RUDDER_WEBDAV_USER                = config.getString("rudder.webdav.user")
-  val RUDDER_WEBDAV_PASSWORD            = config.getString("rudder.webdav.password"); filteredPasswords += "rudder.webdav.password"
+  val RUDDER_WEBDAV_PASSWORD            = config.getString("rudder.webdav.password");
+  filteredPasswords += "rudder.webdav.password"
   val CFENGINE_POLICY_DISTRIBUTION_PORT = {
     try {
       config.getInt("rudder.policy.distribution.port.cfengine")
@@ -494,7 +519,8 @@ object RudderConfig extends Loggable {
   val RUDDER_JDBC_DRIVER        = config.getString("rudder.jdbc.driver")
   val RUDDER_JDBC_URL           = config.getString("rudder.jdbc.url")
   val RUDDER_JDBC_USERNAME      = config.getString("rudder.jdbc.username")
-  val RUDDER_JDBC_PASSWORD      = config.getString("rudder.jdbc.password"); filteredPasswords += "rudder.jdbc.password"
+  val RUDDER_JDBC_PASSWORD      = config.getString("rudder.jdbc.password");
+  filteredPasswords += "rudder.jdbc.password"
   val RUDDER_JDBC_MAX_POOL_SIZE = config.getInt("rudder.jdbc.maxPoolSize")
 
   val RUDDER_JDBC_BATCH_MAX_SIZE = {
@@ -516,16 +542,18 @@ object RudderConfig extends Loggable {
     }
   }
 
-  val RUDDER_GIT_GC = (try {
-    config.getString("rudder.git.gc")
-  } catch {
-    // missing key, perhaps due to migration, use default
-    case ex: Exception => {
-      val default = "0 42 3 * * ?"
-      logger.info(s"`rudder.git.gc` property is missing, using default schedule: ${default}")
-      default
+  val RUDDER_GIT_GC = (
+    try {
+      config.getString("rudder.git.gc")
+    } catch {
+      // missing key, perhaps due to migration, use default
+      case ex: Exception => {
+        val default = "0 42 3 * * ?"
+        logger.info(s"`rudder.git.gc` property is missing, using default schedule: ${default}")
+        default
+      }
     }
-  }).toOptCron match {
+  ).toOptCron match {
     case Left(err)  =>
       logger.error(s"Error when parsing cron for 'rudder.git.gc', it will be disabled: ${err.fullMsg}")
       None
@@ -648,7 +676,9 @@ object RudderConfig extends Loggable {
       config.getInt("rudder.bcrypt.cost")
     } catch {
       case ex: ConfigException =>
-        ApplicationLogger.debug("Property 'rudder.bcrypt.cost' is missing or empty in rudder.configFile. Default cost to 12.")
+        ApplicationLogger.debug(
+          "Property 'rudder.bcrypt.cost' is missing or empty in rudder.configFile. Default cost to 12."
+        )
         12
     }
   }
@@ -835,7 +865,13 @@ object RudderConfig extends Loggable {
 
   val WATCHER_GARBAGE_OLD_INVENTORIES_PERIOD = {
     try {
-      Duration.fromScala(scala.concurrent.duration.Duration.apply(config.getString("inventories.watcher.period.garbage.old")))
+      Duration.fromScala(
+        scala.concurrent.duration.Duration.apply(
+          config.getString(
+            "inventories.watcher.period.garbage.old"
+          )
+        )
+      )
     } catch {
       case ex: Exception => 5.minutes
     }
@@ -931,7 +967,30 @@ object RudderConfig extends Loggable {
     }
   }
 
-  ApplicationLogger.info(s"Starting Rudder ${rudderFullVersion} web application [build timestamp: ${builtTimestamp}]")
+}
+
+/**
+ * Static initialization of Rudder services.
+ * This is not a cake-pattern, just a plain object with load of lazy vals.
+ */
+object RudderConfig extends Loggable {
+
+  ApplicationLogger.info(
+    s"Starting Rudder ${RudderParsedProperties.rudderFullVersion} web application [build timestamp: ${RudderParsedProperties.builtTimestamp}]"
+  )
+
+  // For compatibility. We keep properties that we accessed by other services.
+  // They should be class parameters.
+  def rudderFullVersion                            = RudderParsedProperties.rudderFullVersion
+  def RUDDER_SERVER_HSTS                           = RudderParsedProperties.RUDDER_SERVER_HSTS
+  def RUDDER_SERVER_HSTS_SUBDOMAINS                = RudderParsedProperties.RUDDER_SERVER_HSTS_SUBDOMAINS
+  def AUTH_IDLE_TIMEOUT                            = RudderParsedProperties.AUTH_IDLE_TIMEOUT
+  def WATCHER_ENABLE                               = RudderParsedProperties.WATCHER_ENABLE
+  def RUDDER_DEFAULT_DELETE_NODE_MODE              = RudderParsedProperties.RUDDER_DEFAULT_DELETE_NODE_MODE
+  def RUDDER_BATCH_DYNGROUP_UPDATEINTERVAL         = RudderParsedProperties.RUDDER_BATCH_DYNGROUP_UPDATEINTERVAL
+  def RUDDER_GIT_ROOT_CONFIG_REPO                  = RudderParsedProperties.RUDDER_GIT_ROOT_CONFIG_REPO
+  def RUDDER_BCRYPT_COST                           = RudderParsedProperties.RUDDER_BCRYPT_COST
+  def RUDDER_BATCH_TECHNIQUELIBRARY_UPDATEINTERVAL = RudderParsedProperties.RUDDER_BATCH_TECHNIQUELIBRARY_UPDATEINTERVAL
 
   //
   // Theses services can be called from the outer world
@@ -941,883 +1000,127 @@ object RudderConfig extends Loggable {
 
   // we need that to be the first thing, and take care of Exception so that the error is
   // human understandable when the directory is not up
-
-  val roLDAPConnectionProvider: LDAPConnectionProvider[RoLDAPConnection] = roLdap
-  // test connection is up and try to make an human understandable error message.
-  ApplicationLogger.debug(s"Test if LDAP connection is active")
-  ZioRuntime
-    .unsafeRun((for {
-      con <- roLdap
-    } yield {
-      con.backed.getConnectionName
-    }).flip.option)
-    .foreach(err => throw new InitError("An error occurred when testing for LDAP connection, please check it: " + err.fullMsg))
-
-  val pendingNodesDit:               InventoryDit                  = pendingNodesDitImpl
-  val acceptedNodesDit:              InventoryDit                  = acceptedNodesDitImpl
-  val nodeDit:                       NodeDit                       = nodeDitImpl
-  val rudderDit:                     RudderDit                     = rudderDitImpl
-  val roRuleRepository:              RoRuleRepository              = roLdapRuleRepository
-  val woRuleRepository:              WoRuleRepository              = woLdapRuleRepository
-  val woNodeRepository:              WoNodeRepository              = woLdapNodeRepository
-  val roNodeGroupRepository:         RoNodeGroupRepository         = roLdapNodeGroupRepository
-  val woNodeGroupRepository:         WoNodeGroupRepository         = woLdapNodeGroupRepository
-  val techniqueRepository:           TechniqueRepository           = techniqueRepositoryImpl
-  val updateTechniqueLibrary:        UpdateTechniqueLibrary        = techniqueRepositoryImpl
-  val roDirectiveRepository:         RoDirectiveRepository         = roLdapDirectiveRepository
-  val woDirectiveRepository:         WoDirectiveRepository         = woLdapDirectiveRepository
-  val readOnlySoftwareDAO:           ReadOnlySoftwareDAO           = softwareInventoryDAO
-  val eventLogRepository:            EventLogRepository            = logRepository
-  val eventLogDetailsService:        EventLogDetailsService        = eventLogDetailsServiceImpl
-  val reportingService:              ReportingService              = reportingServiceImpl
-  lazy val asyncComplianceService:   AsyncComplianceService        = new AsyncComplianceService(reportingService)
-  val debugScript:                   DebugInfoService              = scriptLauncher
-  val stringUuidGenerator:           StringUuidGenerator           = uuidGen
-  val cmdbQueryParser:               CmdbQueryParser               = queryParser
-  val inventoryHistoryLogRepository: InventoryHistoryLogRepository = diffRepos
-  val inventoryEventLogService:      InventoryEventLogService      = inventoryLogEventServiceImpl
-  val ruleApplicationStatus:         RuleApplicationStatusService  = ruleApplicationStatusImpl
-  val propertyEngineService:         PropertyEngineService         = propertyEngineServiceImpl
-  val newNodeManager:                NewNodeManager                = newNodeManagerImpl
-  val nodeGrid:                      NodeGrid                      = nodeGridImpl
-  val nodeSummaryService:            NodeSummaryService            = nodeSummaryServiceImpl
-  val jsTreeUtilService:             JsTreeUtilService             = jsTreeUtilServiceImpl
-  val directiveEditorService:        DirectiveEditorService        = directiveEditorServiceImpl
-  val userPropertyService:           UserPropertyService           = userPropertyServiceImpl
-  val eventListDisplayer:            EventListDisplayer            = eventListDisplayerImpl
-  lazy val asyncDeploymentAgent:     AsyncDeploymentActor          = asyncDeploymentAgentImpl
-  val policyServerManagementService: PolicyServerManagementService = psMngtService
-  // val updateDynamicGroupsService : DynGroupUpdaterService = dynGroupUpdaterService
-  val updateDynamicGroups:           UpdateDynamicGroups           = dyngroupUpdaterBatch
-  val checkInventoryUpdate       = new CheckInventoryUpdate(
-    nodeInfoServiceImpl,
-    asyncDeploymentAgent,
-    stringUuidGenerator,
-    RUDDER_BATCH_CHECK_NODE_CACHE_INTERVAL
-  )
-  val purgeDeletedInventories    = new PurgeDeletedInventories(
-    removeNodeServiceImpl,
-    FiniteDuration(RUDDER_BATCH_PURGE_DELETED_INVENTORIES_INTERVAL.toLong, "hours"),
-    RUDDER_BATCH_PURGE_DELETED_INVENTORIES
-  )
-  val purgeUnreferencedSoftwares =
-    new PurgeUnreferencedSoftwares(softwareService, FiniteDuration(RUDDER_BATCH_DELETE_SOFTWARE_INTERVAL.toLong, "hours"))
-  val databaseManager:                   DatabaseManager              = databaseManagerImpl
-  val automaticReportsCleaning:          AutomaticReportsCleaning     = dbCleaner
-  val checkTechniqueLibrary:             CheckTechniqueLibrary        = techniqueLibraryUpdater
-  val automaticReportLogger:             AutomaticReportLogger        = autoReportLogger
-  val removeNodeService:                 RemoveNodeService            = removeNodeServiceImpl
-  val nodeInfoService:                   NodeInfoService              = nodeInfoServiceImpl
-  val reportDisplayer:                   ReportDisplayer              = reportDisplayerImpl
-  lazy val dependencyAndDeletionService: DependencyAndDeletionService = dependencyAndDeletionServiceImpl
-  val itemArchiveManager:                ItemArchiveManager           = itemArchiveManagerImpl
-  val personIdentService:                PersonIdentService           = personIdentServiceImpl
-  lazy val gitRevisionProvider:          GitRevisionProvider          = gitRevisionProviderImpl
-  val logDisplayer:                      LogDisplayer                 = logDisplayerImpl
-  val fullInventoryRepository:           LDAPFullInventoryRepository  = ldapFullInventoryRepository
-  val acceptedNodeQueryProcessor:        QueryProcessor               = queryProcessor
-  val categoryHierarchyDisplayer:        CategoryHierarchyDisplayer   = categoryHierarchyDisplayerImpl
-  val dynGroupService:                   DynGroupService              = dynGroupServiceImpl
-  val ditQueryData:                      DitQueryData                 = ditQueryDataImpl
-  val reportsRepository:                 ReportsRepository            = reportsRepositoryImpl
-  val eventLogDeploymentService:         EventLogDeploymentService    = eventLogDeploymentServiceImpl
-  lazy val srvGrid = new SrvGrid(roAgentRunsRepository, configService, roLdapRuleRepository, nodeInfoService)
-  val findExpectedReportRepository: FindExpectedReportRepository = findExpectedRepo
-  val roApiAccountRepository:       RoApiAccountRepository       = roLDAPApiAccountRepository
-  val woApiAccountRepository:       WoApiAccountRepository       = woLDAPApiAccountRepository
-
-  lazy val roAgentRunsRepository: RoReportsExecutionRepository = cachedAgentRunRepository
-
-  lazy val writeAllAgentSpecificFiles = new WriteAllAgentSpecificFiles(agentRegister)
-
-  // all cache that need to be cleared are stored here
-  lazy val clearableCache: Seq[CachedRepository] = Seq(
-    cachedAgentRunRepository,
-    recentChangesService,
-    reportingServiceImpl,
-    nodeInfoServiceImpl
-  )
-
-  val ldapInventoryMapper = inventoryMapper
-
-  val pluginSettingsService = new FilePluginSettingsService(root / "opt" / "rudder" / "etc" / "rudder-pkg" / "rudder-pkg.conf")
-  /////////////////////////////////////////////////
-  ////////// pluggable service providers //////////
-  /////////////////////////////////////////////////
-
-  /*
-   * Pluggable service:
-   * - Rudder Agent (agent type, agent os)
-   * - API ACL
-   * - Change Validation workflow
-   * - User authentication backends
-   * - User authorization capabilities
-   */
-  // Pluggable agent register
-  lazy val agentRegister = new AgentRegister()
-
-  // Plugin input interface to
-  lazy val apiAuthorizationLevelService = new DefaultApiAuthorizationLevel(LiftApiProcessingLogger)
-
-  // Plugin input interface for alternative workflow
-  lazy val workflowLevelService = new DefaultWorkflowLevel(
-    new NoWorkflowServiceImpl(
-      commitAndDeployChangeRequest
-    )
-  )
-
-  // Plugin input interface for alternative authentication providers
-  lazy val authenticationProviders = new AuthBackendProvidersManager()
-
-  // Plugin input interface for user management plugin
-  lazy val userAuthorisationLevel = new DefaultUserAuthorisationLevel()
-
-  // Plugin input interface for Authorization for API
-  lazy val authorizationApiMapping = new ExtensibleAuthorizationApiMapping(AuthorizationApiMapping.Core :: Nil)
-
-  ////////// end pluggable service providers //////////
-
-  lazy val roleApiMapping = new RoleApiMapping(authorizationApiMapping)
-
-  // rudder user list
-  lazy val rudderUserListProvider: FileUserDetailListProvider = {
-    UserFileProcessing.getUserResourceFile().either.runNow match {
-      case Right(resource) =>
-        new FileUserDetailListProvider(roleApiMapping, userAuthorisationLevel, resource)
-      case Left(err)       =>
-        ApplicationLogger.error(err.fullMsg)
-        // make the application not available
-        throw new javax.servlet.UnavailableException(s"Error when trying to parse Rudder users file, aborting.")
-    }
-  }
-
-  val roRuleCategoryRepository: RoRuleCategoryRepository = roLDAPRuleCategoryRepository
-  val ruleCategoryService:      RuleCategoryService      = new RuleCategoryService()
-  val woRuleCategoryRepository: WoRuleCategoryRepository = woLDAPRuleCategoryRepository
-
-  val changeRequestEventLogService: ChangeRequestEventLogService = new ChangeRequestEventLogServiceImpl(eventLogRepository)
-  val secretEventLogService:        SecretEventLogService        = new SecretEventLogServiceImpl(eventLogRepository)
-
-  lazy val xmlSerializer = XmlSerializerImpl(
-    ruleSerialisation,
-    directiveSerialisation,
-    nodeGroupSerialisation,
-    globalParameterSerialisation,
-    ruleCategorySerialisation
-  )
-
-  lazy val xmlUnserializer    = XmlUnserializerImpl(
-    ruleUnserialisation,
-    directiveUnserialisation,
-    nodeGroupUnserialisation,
-    globalParameterUnserialisation,
-    ruleCategoryUnserialisation
-  )
-  val workflowEventLogService = new WorkflowEventLogServiceImpl(eventLogRepository, uuidGen)
-  val diffService: DiffService = new DiffServiceImpl()
-  lazy val diffDisplayer = new DiffDisplayer(linkUtil)
-  lazy val commitAndDeployChangeRequest: CommitAndDeployChangeRequestService = {
-    new CommitAndDeployChangeRequestServiceImpl(
-      uuidGen,
-      roDirectiveRepository,
-      woDirectiveRepository,
-      roNodeGroupRepository,
-      woNodeGroupRepository,
-      roRuleRepository,
-      woRuleRepository,
-      roLDAPParameterRepository,
-      woLDAPParameterRepository,
-      asyncDeploymentAgent,
-      dependencyAndDeletionService,
-      configService.rudder_workflow_enabled _,
-      xmlSerializer,
-      xmlUnserializer,
-      sectionSpecParser,
-      dynGroupUpdaterService
-    )
-  }
-
-  val roParameterService: RoParameterService = roParameterServiceImpl
-  val woParameterService: WoParameterService = woParameterServiceImpl
-
-  //////////////////////////////////////////////////////////////////////////////////////////
-  ///////////////////////////////////////// REST ///////////////////////////////////////////
-  //////////////////////////////////////////////////////////////////////////////////////////
-
-  val restExtractorService = {
-    RestExtractorService(
-      roRuleRepository,
-      roDirectiveRepository,
-      roNodeGroupRepository,
-      techniqueRepository,
-      queryParser,
-      userPropertyService,
-      workflowLevelService,
-      stringUuidGenerator,
-      typeParameterService
-    )
-  }
-
-  val zioJsonExtractor = new ZioJsonExtractor(queryParser)
-
-  lazy val tokenGenerator = new TokenGeneratorImpl(32)
-
-  implicit val userService = new UserService {
-    def getCurrentUser = CurrentUser
-  }
-
-  val ncfTechniqueReader: ncf.TechniqueReader = new ncf.TechniqueReader(
-    restExtractorService,
-    stringUuidGenerator,
-    personIdentService,
-    gitConfigRepo,
-    prettyPrinter,
-    gitModificationRepository,
-    RUDDER_CHARSET.name,
-    RUDDER_GROUP_OWNER_CONFIG_REPO
-  )
-
-  val techniqueSerializer = new TechniqueSerializer(typeParameterService)
-
-  lazy val linkUtil      = new LinkUtil(roRuleRepository, roNodeGroupRepository, roDirectiveRepository, nodeInfoServiceImpl)
-  // REST API
-  val restApiAccounts    = new RestApiAccounts(
-    roApiAccountRepository,
-    woApiAccountRepository,
-    restExtractorService,
-    tokenGenerator,
-    uuidGen,
-    userService,
-    apiAuthorizationLevelService
-  )
-  val restDataSerializer = RestDataSerializerImpl(techniqueRepository, diffService)
-  val restQuicksearch    = new RestQuicksearch(
-    new FullQuickSearchService()(
-      roLDAPConnectionProvider,
-      nodeDit,
-      acceptedNodesDit,
-      rudderDit,
-      roDirectiveRepository,
-      nodeInfoService
-    ),
-    userService,
-    linkUtil
-  )
-  val restCompletion     = new RestCompletion(new RestCompletionService(roDirectiveRepository, roRuleRepository))
-
-  val ruleApiService2 = {
-    new RuleApiService2(
-      roRuleRepository,
-      woRuleRepository,
-      uuidGen,
-      asyncDeploymentAgent,
-      workflowLevelService,
-      restExtractorService,
-      restDataSerializer
-    )
-  }
-
-  val ruleApiService6  = {
-    new RuleApiService6(
-      roRuleCategoryRepository,
-      roRuleRepository,
-      woRuleCategoryRepository,
-      restDataSerializer
-    )
-  }
-  val ruleApiService13 = {
-    new RuleApiService14(
-      roRuleRepository,
-      woRuleRepository,
-      configurationRepository,
-      uuidGen,
-      asyncDeploymentAgent,
-      workflowLevelService,
-      roRuleCategoryRepository,
-      woRuleCategoryRepository,
-      roDirectiveRepository,
-      roNodeGroupRepository,
-      nodeInfoService,
-      configService.rudder_global_policy_mode _,
-      ruleApplicationStatus
-    )
-  }
-
-  val directiveApiService2 = {
-    new DirectiveApiService2(
-      roDirectiveRepository,
-      woDirectiveRepository,
-      uuidGen,
-      asyncDeploymentAgent,
-      workflowLevelService,
-      restExtractorService,
-      directiveEditorService,
-      restDataSerializer,
-      techniqueRepositoryImpl
-    )
-  }
-
-  val directiveApiService14 = {
-    new DirectiveApiService14(
-      roDirectiveRepository,
-      configurationRepository,
-      woDirectiveRepository,
-      uuidGen,
-      asyncDeploymentAgent,
-      workflowLevelService,
-      directiveEditorService,
-      restDataSerializer,
-      techniqueRepositoryImpl
-    )
-  }
-
-  val techniqueApiService6 = {
-    new TechniqueAPIService6(
-      roDirectiveRepository,
-      restDataSerializer
-    )
-  }
-
-  val techniqueApiService14 = {
-    new TechniqueAPIService14(
-      roDirectiveRepository,
-      gitParseTechniqueLibrary,
-      ncfTechniqueReader,
-      techniqueSerializer,
-      restDataSerializer
-    )
-  }
-
-  val groupApiService2 = {
-    new GroupApiService2(
-      roNodeGroupRepository,
-      woNodeGroupRepository,
-      uuidGen,
-      asyncDeploymentAgent,
-      workflowLevelService,
-      restExtractorService,
-      queryProcessor,
-      restDataSerializer
-    )
-  }
-
-  val groupApiService6 = {
-    new GroupApiService6(
-      roNodeGroupRepository,
-      woNodeGroupRepository,
-      restDataSerializer
-    )
-  }
-
-  val groupApiService14 = {
-    new GroupApiService14(
-      roNodeGroupRepository,
-      woNodeGroupRepository,
-      roLDAPParameterRepository,
-      uuidGen,
-      asyncDeploymentAgent,
-      workflowLevelService,
-      restExtractorService,
-      queryParser,
-      queryProcessor,
-      restDataSerializer
-    )
-  }
-
-  val nodeApiService2 = new NodeApiService2(
-    newNodeManager,
-    nodeInfoService,
-    removeNodeService,
-    uuidGen,
-    restExtractorService,
-    restDataSerializer
-  )
-
-  val nodeApiService4 = new NodeApiService4(
-    fullInventoryRepository,
-    nodeInfoService,
-    softwareInventoryDAO,
-    uuidGen,
-    restExtractorService,
-    restDataSerializer,
-    roAgentRunsRepository
-  )
-
-  val nodeApiService8 = {
-    new NodeApiService8(
-      woNodeRepository,
-      nodeInfoService,
-      uuidGen,
-      asyncDeploymentAgent,
-      RUDDER_RELAY_API,
-      userService
-    )
-  }
-
-  val nodeApiService12 = new NodeApiService12(
-    removeNodeService,
-    uuidGen,
-    restDataSerializer
-  )
-
-  val nodeApiService6 = new NodeApiService6(
-    nodeInfoService,
-    fullInventoryRepository,
-    softwareInventoryDAO,
-    restExtractorService,
-    restDataSerializer,
-    queryProcessor,
-    inventoryQueryChecker,
-    roAgentRunsRepository
-  )
-
-  val nodeApiService13 = new NodeApiService13(
-    nodeInfoService,
-    cachedAgentRunRepository,
-    readOnlySoftwareDAO,
-    restExtractorService,
-    () => configService.rudder_global_policy_mode().toBox,
-    reportingServiceImpl,
-    roNodeGroupRepository,
-    roLDAPParameterRepository
-  )
-
-  val nodeApiService16 = new NodeApiService15(
-    fullInventoryRepository,
-    rwLdap,
-    ldapEntityMapper,
-    newNodeManager,
-    stringUuidGenerator,
-    nodeDit,
-    pendingNodesDit,
-    acceptedNodesDit
-  )
-
-  val parameterApiService2  = {
-    new ParameterApiService2(
-      roLDAPParameterRepository,
-      woLDAPParameterRepository,
-      uuidGen,
-      workflowLevelService,
-      restExtractorService,
-      restDataSerializer
-    )
-  }
-  val parameterApiService14 = {
-    new ParameterApiService14(
-      roLDAPParameterRepository,
-      woLDAPParameterRepository,
-      uuidGen,
-      workflowLevelService
-    )
-  }
-
-  // System API
-
-  val clearCacheService = new ClearCacheServiceImpl(
-    nodeConfigurationHashRepo,
-    asyncDeploymentAgent,
-    eventLogRepository,
-    uuidGen,
-    clearableCache
-  )
-
-  val hookApiService = new HookApiService(HOOKS_D, HOOKS_IGNORE_SUFFIXES)
-
-  val systemApiService11 = new SystemApiService11(
-    updateTechniqueLibrary,
-    debugScript,
-    clearCacheService,
-    asyncDeploymentAgent,
-    uuidGen,
-    updateDynamicGroups,
-    itemArchiveManager,
-    personIdentService,
-    gitConfigRepo
-  )
-
-  val systemApiService13 = new SystemApiService13(
-    healthcheckService,
-    healthcheckNotificationService,
-    restDataSerializer,
-    softwareService
-  )
-
-  val ruleInternalApiService = new RuleInternalApiService(roRuleRepository, roNodeGroupRepository, nodeInfoService)
-
-  private[this] val complianceAPIService = new ComplianceAPIService(
-    roRuleRepository,
-    nodeInfoService,
-    roNodeGroupRepository,
-    reportingService,
-    roDirectiveRepository,
-    () => globalComplianceModeService.getGlobalComplianceMode
-  )
-
-  val techniqueArchiver = new TechniqueArchiverImpl(
-    gitConfigRepo,
-    prettyPrinter,
-    gitModificationRepository,
-    personIdentService,
-    techniqueParser,
-    RUDDER_GROUP_OWNER_CONFIG_REPO
-  )
-  val ncfTechniqueWriter: TechniqueWriter = new TechniqueWriterImpl(
-    techniqueArchiver,
-    updateTechniqueLibrary,
-    interpolationCompiler,
-    roDirectiveRepository,
-    woDirectiveRepository,
-    techniqueRepository,
-    workflowLevelService,
-    prettyPrinter,
-    RUDDER_GIT_ROOT_CONFIG_REPO,
-    typeParameterService,
-    techniqueSerializer
-  )
-
-  lazy val pipelinedInventoryParser: InventoryParser = {
-    val fusionReportParser = {
-      new FusionInventoryParser(
-        uuidGen,
-        rootParsingExtensions = Nil,
-        contentParsingExtensions = Nil,
-        ignoreProcesses = INVENTORIES_IGNORE_PROCESSES
-      )
-    }
-
-    new DefaultInventoryParser(
-      fusionReportParser,
-      Seq(
-        new PreInventoryParserCheckConsistency
-      )
-    )
-  }
-
-  lazy val automaticMerger: PreCommit = new UuidMergerPreCommit(
-    uuidGen,
-    acceptedNodesDit,
-    new NodeInventoryDNFinderService(
-      Seq(
-        // start by trying to use an already given UUID
-        NamedNodeInventoryDNFinderAction(
-          "use_existing_id",
-          new UseExistingNodeIdFinder(inventoryDitService, roLdap, acceptedNodesDit.BASE_DN.getParent)
-        )
-      )
-    ),
-    new MachineDNFinderService(
-      Seq(
-        // start by trying to use an already given UUID
-        NamedMachineDNFinderAction(
-          "use_existing_id",
-          new UseExistingMachineIdFinder(inventoryDitService, roLdap, acceptedNodesDit.BASE_DN.getParent)
-        ), // look if it's in the accepted inventories
-
-        NamedMachineDNFinderAction(
-          "check_mother_board_uuid_accepted",
-          new FromMotherBoardUuidIdFinder(roLdap, acceptedNodesDit, inventoryDitService)
-        ), // see if it's in the "pending" branch
-
-        NamedMachineDNFinderAction(
-          "check_mother_board_uuid_pending",
-          new FromMotherBoardUuidIdFinder(roLdap, pendingNodesDit, inventoryDitService)
-        ), // see if it's in the "removed" branch
-
-        NamedMachineDNFinderAction(
-          "check_mother_board_uuid_removed",
-          new FromMotherBoardUuidIdFinder(roLdap, removedNodesDitImpl, inventoryDitService)
-        )
-      )
-    ),
-    new NameAndVersionIdFinder(
-      "check_name_and_version",
-      roLdap,
-      inventoryMapper,
-      acceptedNodesDit
-    )
-  )
-
-  lazy val gitFactRepo                 = GitRepositoryProviderImpl
-    .make(RUDDER_GIT_ROOT_FACT_REPO)
-    .runOrDie(err => new RuntimeException(s"Error when initializing git configuration repository: " + err.fullMsg))
-  private[this] lazy val gitFactRepoGC = new GitGC(gitFactRepo, RUDDER_GIT_GC)
-  gitFactRepoGC.start()
-  lazy val factRepo                    = new GitNodeFactRepository(gitFactRepo, RUDDER_GROUP_OWNER_CONFIG_REPO)
-  factRepo.checkInit().runOrDie(err => new RuntimeException(s"Error when checking fact repository init: " + err.fullMsg))
-
-  lazy val ldifInventoryLogger = new DefaultLDIFInventoryLogger(LDIF_TRACELOG_ROOT_DIR)
-  lazy val inventorySaver      = new DefaultInventorySaver(
-    rwLdap,
-    acceptedNodesDit,
-    inventoryMapper,
-    (
-      CheckOsType
-      :: automaticMerger
-      :: CheckMachineName
-      :: new LastInventoryDate()
-      :: AddIpValues
-      :: new LogInventoryPreCommit(inventoryMapper, ldifInventoryLogger)
-      :: Nil
-    ),
-    (
-      new PendingNodeIfNodeWasRemoved(fullInventoryRepository)
-      :: new FactRepositoryPostCommit(factRepo, nodeInfoService)
-      :: new PostCommitLogger(ldifInventoryLogger)
-      :: new PostCommitInventoryHooks(HOOKS_D, HOOKS_IGNORE_SUFFIXES)
-      :: Nil
-    )
-  )
-
-  lazy val inventoryProcessorInternal = {
-    val checkLdapAlive: () => IOResult[Unit] = { () =>
-      for {
-        con <- rwLdap
-        res <- con.get(pendingNodesDit.NODES.dn, "1.1")
-      } yield {
-        ()
-      }
-    }
-    val maxParallel = {
-      try {
-        val user = if (MAX_PARSE_PARALLEL.endsWith("x")) {
-          val xx = MAX_PARSE_PARALLEL.substring(0, MAX_PARSE_PARALLEL.size - 1)
-          java.lang.Double.parseDouble(xx) * java.lang.Runtime.getRuntime.availableProcessors()
-        } else {
-          java.lang.Double.parseDouble(MAX_PARSE_PARALLEL)
-        }
-        Math.max(1, user).toLong
-      } catch {
-        case ex: Exception =>
-          // logs are not available here
-          println(
-            s"ERROR Error when parsing configuration properties for the parallelization of inventory processing. " +
-            s"Expecting a positive integer or number of time the available processors. Default to '0.5x': " +
-            s"inventory.parse.parallelization=${MAX_PARSE_PARALLEL}"
-          )
-          Math.max(1, Math.ceil(java.lang.Runtime.getRuntime.availableProcessors().toDouble / 2).toLong)
-      }
-    }
-    new InventoryProcessor(
-      pipelinedInventoryParser,
-      inventorySaver,
-      maxParallel,
-      fullInventoryRepository,
-      new InventoryDigestServiceV1(fullInventoryRepository),
-      checkLdapAlive,
-      pendingNodesDit
-    )
-  }
-
-  lazy val inventoryProcessor = {
-    val mover = new InventoryMover(
-      INVENTORY_DIR_RECEIVED,
-      INVENTORY_DIR_FAILED,
-      new InventoryFailedHook(
-        HOOKS_D,
-        HOOKS_IGNORE_SUFFIXES
-      )
-    )
-    new DefaultProcessInventoryService(inventoryProcessorInternal, mover)
-  }
-
-  lazy val inventoryWatcher = {
-    val fileProcessor = new ProcessFile(inventoryProcessor, INVENTORY_DIR_INCOMING)
-
-    new InventoryFileWatcher(
-      fileProcessor,
-      INVENTORY_DIR_INCOMING,
-      INVENTORY_DIR_UPDATE,
-      WATCHER_DELETE_OLD_INVENTORIES_AGE,
-      WATCHER_GARBAGE_OLD_INVENTORIES_PERIOD
-    )
-  }
-
-  lazy val cleanOldInventoryBatch = {
-    new PurgeOldInventoryFiles(
-      RUDDER_INVENTORIES_CLEAN_CRON,
-      RUDDER_INVENTORIES_CLEAN_AGE,
-      List(better.files.File(INVENTORY_DIR_FAILED), better.files.File(INVENTORY_DIR_RECEIVED))
-    )
-  }
-  cleanOldInventoryBatch.start()
-
-  val archiveApi = {
-    val archiveBuilderService =
-      new ZipArchiveBuilderService(new FileArchiveNameService(), configurationRepository, gitParseTechniqueLibrary)
-    // fixe archive name to make it simple to test
-    val rootDirName           = "archive".succeed
-    new com.normation.rudder.rest.lift.ArchiveApi(
-      archiveBuilderService,
-      configService.rudder_featureSwitch_archiveApi(),
-      rootDirName,
-      new ZipArchiveReaderImpl(queryParser, techniqueParser),
-      new SaveArchiveServicebyRepo(
-        techniqueArchiver,
-        techniqueReader,
-        techniqueRepository,
-        roDirectiveRepository,
-        woDirectiveRepository,
-        roNodeGroupRepository,
-        woNodeGroupRepository,
-        roRuleRepository,
-        woRuleRepository,
-        updateTechniqueLibrary,
-        asyncDeploymentAgent
-      ),
-      new CheckArchiveServiceImpl(techniqueRepository)
-    )
-  }
-
-  /*
-   * API versions are incremented each time incompatible changes are made (like adding or deleting endpoints - modification
-   * of an existing endpoint, if done in a purely compatible way, don't change api version).
-   * It may happen that some rudder branches don't have a version bump, and other have several (in case of
-   * horrible breaking bugs). We avoid the case where a previous release need a version bump.
-   * For ex:
-   * - 5.0: 14
-   * - 5.1: 14 (no change)
-   * - 5.2[.0~.4]: 15
-   * - 5.2.5: 16
-   */
-  val ApiVersions = {
-    ApiVersion(12, true) ::  // rudder 6.0, 6.1
-    ApiVersion(13, true) ::  // rudder 6.2
-    ApiVersion(14, false) :: // rudder 7.0
-    ApiVersion(15, false) :: // rudder 7.1 - system update on node details
-    ApiVersion(16, false) :: // rudder 7.2 - create node api, import/export archive, hooks & campaigns internal API
-    ApiVersion(17, false) :: // rudder 7.3 - directive compliance, campaign API is public
-    Nil
-  }
-
-  val jsonPluginDefinition = new ReadPluginPackageInfo("/var/rudder/packages/index.json")
-
-  val resourceFileService = new ResourceFileService(gitConfigRepo)
-  lazy val apiDispatcher  = new RudderEndpointDispatcher(LiftApiProcessingLogger)
-  lazy val rudderApi      = {
-    import com.normation.rudder.rest.lift._
-
-    val nodeInheritedProperties  =
-      new NodeApiInheritedProperties(nodeInfoService, roNodeGroupRepository, roLDAPParameterRepository)
-    val groupInheritedProperties = new GroupApiInheritedProperties(roNodeGroupRepository, roLDAPParameterRepository)
-
-    val campaignApi = new lift.CampaignApi(
-      campaignRepo,
-      campaignSerializer,
-      campaignEventRepo,
-      mainCampaignService,
-      restExtractorService,
-      stringUuidGenerator
-    )
-    val modules     = List(
-      new ComplianceApi(restExtractorService, complianceAPIService, roDirectiveRepository),
-      new GroupsApi(
-        roLdapNodeGroupRepository,
-        restExtractorService,
-        zioJsonExtractor,
-        stringUuidGenerator,
-        groupApiService2,
-        groupApiService6,
-        groupApiService14,
-        groupInheritedProperties
-      ),
-      new DirectiveApi(
-        roDirectiveRepository,
-        restExtractorService,
-        zioJsonExtractor,
-        stringUuidGenerator,
-        directiveApiService2,
-        directiveApiService14
-      ),
-      new NodeApi(
-        restExtractorService,
-        restDataSerializer,
-        nodeApiService2,
-        nodeApiService4,
-        nodeApiService6,
-        nodeApiService8,
-        nodeApiService12,
-        nodeApiService13,
-        nodeApiService16,
-        nodeInheritedProperties,
-        RUDDER_DEFAULT_DELETE_NODE_MODE
-      ),
-      new ParameterApi(restExtractorService, zioJsonExtractor, parameterApiService2, parameterApiService14),
-      new SettingsApi(
-        restExtractorService,
-        configService,
-        asyncDeploymentAgent,
-        stringUuidGenerator,
-        policyServerManagementService,
-        nodeInfoService
-      ),
-      new TechniqueApi(
-        restExtractorService,
-        techniqueApiService6,
-        techniqueApiService14,
-        ncfTechniqueWriter,
-        ncfTechniqueReader,
-        techniqueRepository,
-        techniqueSerializer,
-        stringUuidGenerator,
-        resourceFileService
-      ),
-      new RuleApi(
-        restExtractorService,
-        zioJsonExtractor,
-        ruleApiService2,
-        ruleApiService6,
-        ruleApiService13,
-        stringUuidGenerator
-      ),
-      new SystemApi(
-        restExtractorService,
-        systemApiService11,
-        systemApiService13,
-        rudderMajorVersion,
-        rudderFullVersion,
-        builtTimestamp
-      ),
-      new InventoryApi(restExtractorService, inventoryWatcher, better.files.File(INVENTORY_DIR_INCOMING)),
-      new PluginApi(restExtractorService, pluginSettingsService),
-      new RecentChangesAPI(recentChangesService, restExtractorService),
-      new RulesInternalApi(restExtractorService, ruleInternalApiService),
-      campaignApi,
-      new HookApi(hookApiService),
-      archiveApi
-      // info api must be resolved latter, because else it misses plugin apis !
-    )
-
-    val api = new LiftHandler(
-      apiDispatcher,
-      ApiVersions,
-      new AclApiAuthorization(LiftApiProcessingLogger, userService, () => apiAuthorizationLevelService.aclEnabled),
-      None
-    )
-    modules.foreach(module => api.addModules(module.getLiftEndpoints()))
-    api
-  }
-
-  // Internal APIs
-  val sharedFileApi          = new SharedFilesAPI(restExtractorService, RUDDER_DIR_SHARED_FILES_FOLDER)
-  val eventLogApi            = new EventLogAPI(eventLogRepository, restExtractorService, eventLogDetailsGenerator, personIdentService)
-  lazy val asyncWorkflowInfo = new AsyncWorkflowInfo
-  lazy val configService: ReadConfigService with UpdateConfigService = {
-    new GenericConfigService(
-      config,
-      new LdapConfigRepository(rudderDit, rwLdap, ldapEntityMapper, eventLogRepository, stringUuidGenerator),
-      asyncWorkflowInfo,
-      workflowLevelService
-    )
-  }
-
-  lazy val recentChangesService = new CachedNodeChangesServiceImpl(
-    new NodeChangesServiceImpl(reportsRepository),
-    () => configService.rudder_compute_changes().toBox
-  )
-
-  //////////////////////////////////////////////////////////////////////////////////////////
-  //////////////////////////////////////////////////////////////////////////////////////////
+  val rci = RudderConfigInit.init()
+
+  val ApiVersions:                         List[ApiVersion]                           = rci.apiVersions
+  val acceptedNodeQueryProcessor:          QueryProcessor                             = rci.acceptedNodeQueryProcessor
+  val acceptedNodesDit:                    InventoryDit                               = rci.acceptedNodesDit
+  val agentRegister:                       AgentRegister                              = rci.agentRegister
+  val apiAuthorizationLevelService:        DefaultApiAuthorizationLevel               = rci.apiAuthorizationLevelService
+  val apiDispatcher:                       RudderEndpointDispatcher                   = rci.apiDispatcher
+  val asyncComplianceService:              AsyncComplianceService                     = rci.asyncComplianceService
+  val asyncDeploymentAgent:                AsyncDeploymentActor                       = rci.asyncDeploymentAgent
+  val asyncWorkflowInfo:                   AsyncWorkflowInfo                          = rci.asyncWorkflowInfo
+  val authenticationProviders:             AuthBackendProvidersManager                = rci.authenticationProviders
+  val authorizationApiMapping:             ExtensibleAuthorizationApiMapping          = rci.authorizationApiMapping
+  val automaticReportLogger:               AutomaticReportLogger                      = rci.automaticReportLogger
+  val automaticReportsCleaning:            AutomaticReportsCleaning                   = rci.automaticReportsCleaning
+  val campaignEventRepo:                   CampaignEventRepositoryImpl                = rci.campaignEventRepo
+  val campaignSerializer:                  CampaignSerializer                         = rci.campaignSerializer
+  val categoryHierarchyDisplayer:          CategoryHierarchyDisplayer                 = rci.categoryHierarchyDisplayer
+  val changeRequestChangesUnserialisation: ChangeRequestChangesUnserialisation        = rci.changeRequestChangesUnserialisation
+  val changeRequestEventLogService:        ChangeRequestEventLogService               = rci.changeRequestEventLogService
+  val checkInventoryUpdate:                CheckInventoryUpdate                       = rci.checkInventoryUpdate
+  val checkTechniqueLibrary:               CheckTechniqueLibrary                      = rci.checkTechniqueLibrary
+  val clearCacheService:                   ClearCacheService                          = rci.clearCacheService
+  val cmdbQueryParser:                     CmdbQueryParser                            = rci.cmdbQueryParser
+  val commitAndDeployChangeRequest:        CommitAndDeployChangeRequestService        = rci.commitAndDeployChangeRequest
+  val configService:                       ReadConfigService with UpdateConfigService = rci.configService
+  val configurationRepository:             ConfigurationRepository                    = rci.configurationRepository
+  val databaseManager:                     DatabaseManager                            = rci.databaseManager
+  val debugScript:                         DebugInfoService                           = rci.debugScript
+  val dependencyAndDeletionService:        DependencyAndDeletionService               = rci.dependencyAndDeletionService
+  val deploymentService:                   PromiseGeneration_Hooks                    = rci.deploymentService
+  val diffDisplayer:                       DiffDisplayer                              = rci.diffDisplayer
+  val diffService:                         DiffService                                = rci.diffService
+  val directiveEditorService:              DirectiveEditorService                     = rci.directiveEditorService
+  val ditQueryData:                        DitQueryData                               = rci.ditQueryData
+  val doobie:                              Doobie                                     = rci.doobie
+  val dynGroupService:                     DynGroupService                            = rci.dynGroupService
+  val eventListDisplayer:                  EventListDisplayer                         = rci.eventListDisplayer
+  val eventLogApi:                         EventLogAPI                                = rci.eventLogApi
+  val eventLogDeploymentService:           EventLogDeploymentService                  = rci.eventLogDeploymentService
+  val eventLogDetailsService:              EventLogDetailsService                     = rci.eventLogDetailsService
+  val eventLogRepository:                  EventLogRepository                         = rci.eventLogRepository
+  val findExpectedReportRepository:        FindExpectedReportRepository               = rci.findExpectedReportRepository
+  val fullInventoryRepository:             LDAPFullInventoryRepository                = rci.fullInventoryRepository
+  val gitRevisionProvider:                 GitRevisionProvider                        = rci.gitRevisionProvider
+  val healthcheckNotificationService:      HealthcheckNotificationService             = rci.healthcheckNotificationService
+  val historizeNodeCountBatch:             IOResult[Unit]                             = rci.historizeNodeCountBatch
+  val interpolationCompiler:               InterpolatedValueCompilerImpl              = rci.interpolationCompiler
+  val inventoryEventLogService:            InventoryEventLogService                   = rci.inventoryEventLogService
+  val inventoryHistoryLogRepository:       InventoryHistoryLogRepository              = rci.inventoryHistoryLogRepository
+  val inventoryWatcher:                    InventoryFileWatcher                       = rci.inventoryWatcher
+  val itemArchiveManager:                  ItemArchiveManager                         = rci.itemArchiveManager
+  val jsTreeUtilService:                   JsTreeUtilService                          = rci.jsTreeUtilService
+  val jsonPluginDefinition:                ReadPluginPackageInfo                      = rci.jsonPluginDefinition
+  val jsonReportsAnalyzer:                 JSONReportsAnalyser                        = rci.jsonReportsAnalyzer
+  val linkUtil:                            LinkUtil                                   = rci.linkUtil
+  val logDisplayer:                        LogDisplayer                               = rci.logDisplayer
+  val mainCampaignService:                 MainCampaignService                        = rci.mainCampaignService
+  val ncfTechniqueReader:                  ncf.TechniqueReader                        = rci.ncfTechniqueReader
+  val newNodeManager:                      NewNodeManager                             = rci.newNodeManager
+  val nodeDit:                             NodeDit                                    = rci.nodeDit
+  val nodeGrid:                            NodeGrid                                   = rci.nodeGrid
+  val nodeInfoService:                     NodeInfoService                            = rci.nodeInfoService
+  val nodeSummaryService:                  NodeSummaryService                         = rci.nodeSummaryService
+  val pendingNodeCheckGroup:               CheckPendingNodeInDynGroups                = rci.pendingNodeCheckGroup
+  val pendingNodesDit:                     InventoryDit                               = rci.pendingNodesDit
+  val personIdentService:                  PersonIdentService                         = rci.personIdentService
+  val policyGenerationBootGuard:           zio.Promise[Nothing, Unit]                 = rci.policyGenerationBootGuard
+  val policyServerManagementService:       PolicyServerManagementService              = rci.policyServerManagementService
+  val propertyEngineService:               PropertyEngineService                      = rci.propertyEngineService
+  val purgeDeletedInventories:             PurgeDeletedInventories                    = rci.purgeDeletedInventories
+  val purgeUnreferencedSoftwares:          PurgeUnreferencedSoftwares                 = rci.purgeUnreferencedSoftwares
+  val readOnlySoftwareDAO:                 ReadOnlySoftwareDAO                        = rci.readOnlySoftwareDAO
+  val recentChangesService:                NodeChangesService                         = rci.recentChangesService
+  val removeNodeService:                   RemoveNodeService                          = rci.removeNodeService
+  val reportDisplayer:                     ReportDisplayer                            = rci.reportDisplayer
+  val reportingService:                    ReportingService                           = rci.reportingService
+  val reportsRepository:                   ReportsRepository                          = rci.reportsRepository
+  val restApiAccounts:                     RestApiAccounts                            = rci.restApiAccounts
+  val restCompletion:                      RestCompletion                             = rci.restCompletion
+  val restDataSerializer:                  RestDataSerializer                         = rci.restDataSerializer
+  val restExtractorService:                RestExtractorService                       = rci.restExtractorService
+  val restQuicksearch:                     RestQuicksearch                            = rci.restQuicksearch
+  val roAgentRunsRepository:               RoReportsExecutionRepository               = rci.roAgentRunsRepository
+  val roApiAccountRepository:              RoApiAccountRepository                     = rci.roApiAccountRepository
+  val roDirectiveRepository:               RoDirectiveRepository                      = rci.roDirectiveRepository
+  val roLDAPConnectionProvider:            LDAPConnectionProvider[RoLDAPConnection]   = rci.roLDAPConnectionProvider
+  val roLDAPParameterRepository:           RoLDAPParameterRepository                  = rci.roLDAPParameterRepository
+  val roNodeGroupRepository:               RoNodeGroupRepository                      = rci.roNodeGroupRepository
+  val roParameterService:                  RoParameterService                         = rci.roParameterService
+  val roRuleCategoryRepository:            RoRuleCategoryRepository                   = rci.roRuleCategoryRepository
+  val roRuleRepository:                    RoRuleRepository                           = rci.roRuleRepository
+  val rudderApi:                           LiftHandler                                = rci.rudderApi
+  val rudderDit:                           RudderDit                                  = rci.rudderDit
+  val rudderUserListProvider:              FileUserDetailListProvider                 = rci.rudderUserListProvider
+  val ruleApplicationStatus:               RuleApplicationStatusService               = rci.ruleApplicationStatus
+  val ruleCategoryService:                 RuleCategoryService                        = rci.ruleCategoryService
+  val rwLdap:                              LDAPConnectionProvider[RwLDAPConnection]   = rci.rwLdap
+  val sharedFileApi:                       SharedFilesAPI                             = rci.sharedFileApi
+  val snippetExtensionRegister:            SnippetExtensionRegister                   = rci.snippetExtensionRegister
+  val srvGrid:                             SrvGrid                                    = rci.srvGrid
+  val stringUuidGenerator:                 StringUuidGenerator                        = rci.stringUuidGenerator
+  val techniqueRepository:                 TechniqueRepository                        = rci.techniqueRepository
+  val tokenGenerator:                      TokenGeneratorImpl                         = rci.tokenGenerator
+  val updateDynamicGroups:                 UpdateDynamicGroups                        = rci.updateDynamicGroups
+  val updateDynamicGroupsService:          DynGroupUpdaterService                     = rci.updateDynamicGroupsService
+  val updateTechniqueLibrary:              UpdateTechniqueLibrary                     = rci.updateTechniqueLibrary
+  val userAuthorisationLevel:              DefaultUserAuthorisationLevel              = rci.userAuthorisationLevel
+  val userPropertyService:                 UserPropertyService                        = rci.userPropertyService
+  val userService:                         UserService                                = rci.userService
+  val woApiAccountRepository:              WoApiAccountRepository                     = rci.woApiAccountRepository
+  val woDirectiveRepository:               WoDirectiveRepository                      = rci.woDirectiveRepository
+  val woNodeGroupRepository:               WoNodeGroupRepository                      = rci.woNodeGroupRepository
+  val woNodeRepository:                    WoNodeRepository                           = rci.woNodeRepository
+  val woRuleCategoryRepository:            WoRuleCategoryRepository                   = rci.woRuleCategoryRepository
+  val woRuleRepository:                    WoRuleRepository                           = rci.woRuleRepository
+  val workflowEventLogService:             WorkflowEventLogService                    = rci.workflowEventLogService
+  val workflowLevelService:                WorkflowLevelService                       = rci.workflowLevelService
+  val aggregateReportScheduler:            FindNewReportsExecution                    = rci.aggregateReportScheduler
+  val secretEventLogService:               SecretEventLogService                      = rci.secretEventLogService
+  val changeRequestChangesSerialisation:   ChangeRequestChangesSerialisation          = rci.changeRequestChangesSerialisation
 
   /**
    * A method to call to force initialisation of all object and services.
@@ -1831,1313 +1134,2434 @@ object RudderConfig extends Loggable {
   def init(): IO[SystemError, Unit] = {
 
     IOResult.attempt {
-      import scala.jdk.CollectionConverters._
-      val config = RudderProperties.config
-      if (ApplicationLogger.isInfoEnabled) {
-        // sort properties by key name
-        val properties = config.entrySet.asScala.toSeq.sortBy(_.getKey).flatMap { x =>
-          // the log line: registered property: property_name=property_value
-          if (hiddenRegisteredProperties.contains(x.getKey)) None
-          else {
-            Some(
-              s"registered property: ${x.getKey}=${if (filteredPasswords.contains(x.getKey)) "**********" else x.getValue.render}"
-            )
-          }
-        }
-        ApplicationLogger.info("List of registered properties:")
-        properties.foreach(p => ApplicationLogger.info(p))
-        ApplicationLogger.info("Plugin's license directory: '/opt/rudder/etc/plugins/licenses/'")
-      }
 
+      RudderParsedProperties.logRudderParsedProperties()
       ////////// bootstraps checks //////////
       // they must be out of Lift boot() because that method
       // is encapsulated in a try/catch ( see net.liftweb.http.provider.HTTPProvider.bootLift )
-      val checks = RudderConfig.allBootstrapChecks
-      checks.checks()
+      rci.allBootstrapChecks.checks()
+
     }
   }
 
-  //
-  // Concrete implementation.
-  // They are private to that object, and they can refer to other
-  // private implementation as long as they conform to interface.
-  //
+}
 
-  lazy val gitParseTechniqueLibrary = new GitParseTechniqueLibrary(
-    techniqueParser,
-    gitConfigRepo,
-    gitRevisionProvider,
-    "techniques",
-    "metadata.xml"
-  )
-  lazy val configurationRepository  = new ConfigurationRepositoryImpl(
-    roLdapDirectiveRepository,
-    techniqueRepository,
-    roLdapRuleRepository,
-    roNodeGroupRepository,
-    parseActiveTechniqueLibrary,
-    gitParseTechniqueLibrary,
-    parseRules,
-    parseGroupLibrary
-  )
+/*
+ * A case class holder used to transfer services from the init method in RudderConfigInit
+ * to RudderConfig
+ */
+case class RudderServiceApi(
+    roLDAPConnectionProvider:            LDAPConnectionProvider[RoLDAPConnection],
+    pendingNodesDit:                     InventoryDit,
+    acceptedNodesDit:                    InventoryDit,
+    nodeDit:                             NodeDit,
+    rudderDit:                           RudderDit,
+    roRuleRepository:                    RoRuleRepository,
+    woRuleRepository:                    WoRuleRepository,
+    woNodeRepository:                    WoNodeRepository,
+    roNodeGroupRepository:               RoNodeGroupRepository,
+    woNodeGroupRepository:               WoNodeGroupRepository,
+    techniqueRepository:                 TechniqueRepository,
+    updateTechniqueLibrary:              UpdateTechniqueLibrary,
+    roDirectiveRepository:               RoDirectiveRepository,
+    woDirectiveRepository:               WoDirectiveRepository,
+    readOnlySoftwareDAO:                 ReadOnlySoftwareDAO,
+    eventLogRepository:                  EventLogRepository,
+    eventLogDetailsService:              EventLogDetailsService,
+    reportingService:                    ReportingService,
+    asyncComplianceService:              AsyncComplianceService,
+    debugScript:                         DebugInfoService,
+    cmdbQueryParser:                     CmdbQueryParser,
+    inventoryHistoryLogRepository:       InventoryHistoryLogRepository,
+    inventoryEventLogService:            InventoryEventLogService,
+    ruleApplicationStatus:               RuleApplicationStatusService,
+    propertyEngineService:               PropertyEngineService,
+    newNodeManager:                      NewNodeManager,
+    nodeGrid:                            NodeGrid,
+    nodeSummaryService:                  NodeSummaryService,
+    jsTreeUtilService:                   JsTreeUtilService,
+    directiveEditorService:              DirectiveEditorService,
+    userPropertyService:                 UserPropertyService,
+    eventListDisplayer:                  EventListDisplayer,
+    asyncDeploymentAgent:                AsyncDeploymentActor,
+    policyServerManagementService:       PolicyServerManagementService,
+    updateDynamicGroupsService:          DynGroupUpdaterService,
+    updateDynamicGroups:                 UpdateDynamicGroups,
+    checkInventoryUpdate:                CheckInventoryUpdate,
+    purgeDeletedInventories:             PurgeDeletedInventories,
+    purgeUnreferencedSoftwares:          PurgeUnreferencedSoftwares,
+    databaseManager:                     DatabaseManager,
+    automaticReportsCleaning:            AutomaticReportsCleaning,
+    checkTechniqueLibrary:               CheckTechniqueLibrary,
+    automaticReportLogger:               AutomaticReportLogger,
+    removeNodeService:                   RemoveNodeService,
+    nodeInfoService:                     NodeInfoService,
+    reportDisplayer:                     ReportDisplayer,
+    dependencyAndDeletionService:        DependencyAndDeletionService,
+    itemArchiveManager:                  ItemArchiveManager,
+    personIdentService:                  PersonIdentService,
+    gitRevisionProvider:                 GitRevisionProvider,
+    logDisplayer:                        LogDisplayer,
+    fullInventoryRepository:             LDAPFullInventoryRepository,
+    acceptedNodeQueryProcessor:          QueryProcessor,
+    categoryHierarchyDisplayer:          CategoryHierarchyDisplayer,
+    dynGroupService:                     DynGroupService,
+    ditQueryData:                        DitQueryData,
+    reportsRepository:                   ReportsRepository,
+    eventLogDeploymentService:           EventLogDeploymentService,
+    srvGrid:                             SrvGrid,
+    findExpectedReportRepository:        FindExpectedReportRepository,
+    roApiAccountRepository:              RoApiAccountRepository,
+    woApiAccountRepository:              WoApiAccountRepository,
+    roAgentRunsRepository:               RoReportsExecutionRepository,
+    pendingNodeCheckGroup:               CheckPendingNodeInDynGroups,
+    allBootstrapChecks:                  BootstrapChecks,
+    authenticationProviders:             AuthBackendProvidersManager,
+    rudderUserListProvider:              FileUserDetailListProvider,
+    restApiAccounts:                     RestApiAccounts,
+    restQuicksearch:                     RestQuicksearch,
+    restCompletion:                      RestCompletion,
+    sharedFileApi:                       SharedFilesAPI,
+    eventLogApi:                         EventLogAPI,
+    stringUuidGenerator:                 StringUuidGenerator,
+    inventoryWatcher:                    InventoryFileWatcher,
+    configService:                       ReadConfigService with UpdateConfigService,
+    historizeNodeCountBatch:             IOResult[Unit],
+    policyGenerationBootGuard:           zio.Promise[Nothing, Unit],
+    healthcheckNotificationService:      HealthcheckNotificationService,
+    jsonPluginDefinition:                ReadPluginPackageInfo,
+    rudderApi:                           LiftHandler,
+    authorizationApiMapping:             ExtensibleAuthorizationApiMapping,
+    roRuleCategoryRepository:            RoRuleCategoryRepository,
+    woRuleCategoryRepository:            WoRuleCategoryRepository,
+    workflowLevelService:                WorkflowLevelService,
+    ncfTechniqueReader:                  ncf.TechniqueReader,
+    recentChangesService:                NodeChangesService,
+    ruleCategoryService:                 RuleCategoryService,
+    restExtractorService:                RestExtractorService,
+    snippetExtensionRegister:            SnippetExtensionRegister,
+    clearCacheService:                   ClearCacheService,
+    linkUtil:                            LinkUtil,
+    userService:                         UserService,
+    apiVersions:                         List[ApiVersion],
+    apiDispatcher:                       RudderEndpointDispatcher,
+    configurationRepository:             ConfigurationRepository,
+    roParameterService:                  RoParameterService,
+    userAuthorisationLevel:              DefaultUserAuthorisationLevel,
+    agentRegister:                       AgentRegister,
+    asyncWorkflowInfo:                   AsyncWorkflowInfo,
+    commitAndDeployChangeRequest:        CommitAndDeployChangeRequestService,
+    doobie:                              Doobie,
+    restDataSerializer:                  RestDataSerializer,
+    workflowEventLogService:             WorkflowEventLogService,
+    changeRequestEventLogService:        ChangeRequestEventLogService,
+    changeRequestChangesUnserialisation: ChangeRequestChangesUnserialisation,
+    diffService:                         DiffService,
+    diffDisplayer:                       DiffDisplayer,
+    rwLdap:                              LDAPConnectionProvider[RwLDAPConnection],
+    apiAuthorizationLevelService:        DefaultApiAuthorizationLevel,
+    tokenGenerator:                      TokenGeneratorImpl,
+    roLDAPParameterRepository:           RoLDAPParameterRepository,
+    interpolationCompiler:               InterpolatedValueCompilerImpl,
+    deploymentService:                   PromiseGeneration_Hooks,
+    campaignEventRepo:                   CampaignEventRepositoryImpl,
+    mainCampaignService:                 MainCampaignService,
+    campaignSerializer:                  CampaignSerializer,
+    jsonReportsAnalyzer:                 JSONReportsAnalyser,
+    aggregateReportScheduler:            FindNewReportsExecution,
+    secretEventLogService:               SecretEventLogService,
+    changeRequestChangesSerialisation:   ChangeRequestChangesSerialisation
+)
 
-  private[this] lazy val roLDAPApiAccountRepository = new RoLDAPApiAccountRepository(
-    rudderDitImpl,
-    roLdap,
-    ldapEntityMapper,
-    tokenGenerator,
-    ApiAuthorization.allAuthz.acl // for system token
-  )
+/*
+ * This object is in charge of class instantiation in a method to avoid dead lock.
+ * See: https://issues.rudder.io/issues/22645
+ */
+object RudderConfigInit {
+  private case class InitError(msg: String) extends Throwable(msg, null, false, false)
 
-  private[this] lazy val woLDAPApiAccountRepository = new WoLDAPApiAccountRepository(
-    rudderDitImpl,
-    rwLdap,
-    ldapEntityMapper,
-    ldapDiffMapper,
-    logRepository,
-    personIdentServiceImpl
-  )
+  import RudderParsedProperties._
 
-  private[this] lazy val ruleApplicationStatusImpl: RuleApplicationStatusService = new RuleApplicationStatusServiceImpl()
-  private[this] lazy val propertyEngineServiceImpl: PropertyEngineService        = new PropertyEngineServiceImpl(
-    List.empty
-  )
+  def init(): RudderServiceApi = {
 
-  def DN(rdn: String, parent: DN)                         = new DN(new RDN(rdn), parent)
-  private[this] lazy val LDAP_BASEDN                      = new DN("cn=rudder-configuration")
-  private[this] lazy val LDAP_INVENTORIES_BASEDN          = DN("ou=Inventories", LDAP_BASEDN)
-  private[this] lazy val LDAP_INVENTORIES_SOFTWARE_BASEDN = LDAP_INVENTORIES_BASEDN
+    // test connection is up and try to make an human understandable error message.
+    ApplicationLogger.debug(s"Test if LDAP connection is active")
 
-  private[this] lazy val acceptedNodesDitImpl: InventoryDit = new InventoryDit(
-    DN("ou=Accepted Inventories", LDAP_INVENTORIES_BASEDN),
-    LDAP_INVENTORIES_SOFTWARE_BASEDN,
-    "Accepted inventories"
-  )
-  private[this] lazy val pendingNodesDitImpl:  InventoryDit = new InventoryDit(
-    DN("ou=Pending Inventories", LDAP_INVENTORIES_BASEDN),
-    LDAP_INVENTORIES_SOFTWARE_BASEDN,
-    "Pending inventories"
-  )
-  private[this] lazy val removedNodesDitImpl =
-    new InventoryDit(DN("ou=Removed Inventories", LDAP_INVENTORIES_BASEDN), LDAP_INVENTORIES_SOFTWARE_BASEDN, "Removed Servers")
-  private[this] lazy val rudderDitImpl:       RudderDit           = new RudderDit(DN("ou=Rudder", LDAP_BASEDN))
-  private[this] lazy val nodeDitImpl:         NodeDit             = new NodeDit(LDAP_BASEDN)
-  private[this] lazy val inventoryDitService: InventoryDitService =
-    new InventoryDitServiceImpl(pendingNodesDitImpl, acceptedNodesDitImpl, removedNodesDitImpl)
-  private[this] lazy val uuidGen:             StringUuidGenerator = new StringUuidGeneratorImpl
-  private[this] lazy val systemVariableSpecService = new SystemVariableSpecServiceImpl()
-  private[this] lazy val ldapEntityMapper: LDAPEntityMapper =
-    new LDAPEntityMapper(rudderDitImpl, nodeDitImpl, acceptedNodesDitImpl, queryParser, inventoryMapper)
+    lazy val writeAllAgentSpecificFiles = new WriteAllAgentSpecificFiles(agentRegister)
 
-  ///// items serializer - service that transforms items to XML /////
-  private[this] lazy val ruleSerialisation:                    RuleSerialisation                    = new RuleSerialisationImpl(
-    Constants.XML_CURRENT_FILE_FORMAT.toString
-  )
-  private[this] lazy val ruleCategorySerialisation:            RuleCategorySerialisation            = new RuleCategorySerialisationImpl(
-    Constants.XML_CURRENT_FILE_FORMAT.toString
-  )
-  private[this] lazy val rootSectionSerialisation:             SectionSpecWriter                    = new SectionSpecWriterImpl()
-  private[this] lazy val activeTechniqueCategorySerialisation: ActiveTechniqueCategorySerialisation =
-    new ActiveTechniqueCategorySerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
-  private[this] lazy val activeTechniqueSerialisation:         ActiveTechniqueSerialisation         =
-    new ActiveTechniqueSerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
-  private[this] lazy val directiveSerialisation:               DirectiveSerialisation               =
-    new DirectiveSerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
-  private[this] lazy val nodeGroupCategorySerialisation:       NodeGroupCategorySerialisation       =
-    new NodeGroupCategorySerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
-  private[this] lazy val nodeGroupSerialisation:               NodeGroupSerialisation               =
-    new NodeGroupSerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
-  private[this] lazy val deploymentStatusSerialisation:        DeploymentStatusSerialisation        =
-    new DeploymentStatusSerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
-  private[this] lazy val globalParameterSerialisation:         GlobalParameterSerialisation         =
-    new GlobalParameterSerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
-  private[this] lazy val apiAccountSerialisation:              APIAccountSerialisation              =
-    new APIAccountSerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
-  private[this] lazy val propertySerialization:                GlobalPropertySerialisation          =
-    new GlobalPropertySerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
-  lazy val changeRequestChangesSerialisation:                  ChangeRequestChangesSerialisation    = {
-    new ChangeRequestChangesSerialisationImpl(
-      Constants.XML_CURRENT_FILE_FORMAT.toString,
-      nodeGroupSerialisation,
-      directiveSerialisation,
+    // all cache that need to be cleared are stored here
+    lazy val clearableCache: Seq[CachedRepository] = Seq(
+      cachedAgentRunRepository,
+      recentChangesService,
+      reportingServiceImpl,
+      nodeInfoServiceImpl
+    )
+
+    lazy val pluginSettingsService = new FilePluginSettingsService(
+      root / "opt" / "rudder" / "etc" / "rudder-pkg" / "rudder-pkg.conf"
+    )
+    /////////////////////////////////////////////////
+    ////////// pluggable service providers //////////
+    /////////////////////////////////////////////////
+
+    /*
+     * Pluggable service:
+     * - Rudder Agent (agent type, agent os)
+     * - API ACL
+     * - Change Validation workflow
+     * - User authentication backends
+     * - User authorization capabilities
+     */
+    // Pluggable agent register
+    lazy val agentRegister = new AgentRegister()
+
+    // Plugin input interface to
+    lazy val apiAuthorizationLevelService = new DefaultApiAuthorizationLevel(LiftApiProcessingLogger)
+
+    // Plugin input interface for alternative workflow
+    lazy val workflowLevelService = new DefaultWorkflowLevel(
+      new NoWorkflowServiceImpl(
+        commitAndDeployChangeRequest
+      )
+    )
+
+    // Plugin input interface for alternative authentication providers
+    lazy val authenticationProviders = new AuthBackendProvidersManager()
+
+    // Plugin input interface for user management plugin
+    lazy val userAuthorisationLevel = new DefaultUserAuthorisationLevel()
+
+    // Plugin input interface for Authorization for API
+    lazy val authorizationApiMapping = new ExtensibleAuthorizationApiMapping(AuthorizationApiMapping.Core :: Nil)
+
+    ////////// end pluggable service providers //////////
+
+    lazy val roleApiMapping = new RoleApiMapping(authorizationApiMapping)
+
+    // rudder user list
+    lazy val rudderUserListProvider: FileUserDetailListProvider = {
+      UserFileProcessing.getUserResourceFile().either.runNow match {
+        case Right(resource) =>
+          new FileUserDetailListProvider(roleApiMapping, userAuthorisationLevel, resource)
+        case Left(err)       =>
+          ApplicationLogger.error(err.fullMsg)
+          // make the application not available
+          throw new javax.servlet.UnavailableException(s"Error when trying to parse Rudder users file, aborting.")
+      }
+    }
+
+    lazy val roRuleCategoryRepository: RoRuleCategoryRepository = roLDAPRuleCategoryRepository
+    lazy val ruleCategoryService:      RuleCategoryService      = new RuleCategoryService()
+    lazy val woRuleCategoryRepository: WoRuleCategoryRepository = woLDAPRuleCategoryRepository
+
+    lazy val changeRequestEventLogService: ChangeRequestEventLogService = new ChangeRequestEventLogServiceImpl(eventLogRepository)
+    lazy val secretEventLogService:        SecretEventLogService        = new SecretEventLogServiceImpl(eventLogRepository)
+
+    lazy val xmlSerializer = XmlSerializerImpl(
       ruleSerialisation,
+      directiveSerialisation,
+      nodeGroupSerialisation,
       globalParameterSerialisation,
-      techniqueRepositoryImpl,
-      rootSectionSerialisation
+      ruleCategorySerialisation
     )
-  }
-  lazy val secretSerialisation:                                SecretSerialisation                  =
-    new SecretSerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
-  private[this] lazy val eventLogFactory = new EventLogFactoryImpl(
-    ruleSerialisation,
-    directiveSerialisation,
-    nodeGroupSerialisation,
-    activeTechniqueSerialisation,
-    globalParameterSerialisation,
-    apiAccountSerialisation,
-    propertySerialization,
-    secretSerialisation
-  )
-  private[this] lazy val pathComputer    = new PathComputerImpl(
-    Constants.NODE_PROMISES_PARENT_DIR_BASE,
-    Constants.NODE_PROMISES_PARENT_DIR,
-    RUDDER_DIR_BACKUP,
-    Constants.CFENGINE_COMMUNITY_PROMISES_PATH,
-    Constants.CFENGINE_NOVA_PROMISES_PATH
-  )
 
-  /*
-   * For now, we don't want to query server other
-   * than the accepted ones.
-   */
-  private[this] lazy val getSubGroupChoices = () =>
-    roLdapNodeGroupRepository.getAll().map(seq => seq.map(g => SubGroupChoice(g.id, g.name)))
-  private[this] lazy val ditQueryDataImpl   = new DitQueryData(acceptedNodesDitImpl, nodeDit, rudderDit, getSubGroupChoices)
-  private[this] lazy val queryParser        = new CmdbQueryParser with DefaultStringQueryParser with JsonQueryLexer {
-    override val criterionObjects = Map[String, ObjectCriterion]() ++ ditQueryDataImpl.criteriaMap
-  }
-  private[this] lazy val inventoryMapper: InventoryMapper =
-    new InventoryMapper(inventoryDitService, pendingNodesDitImpl, acceptedNodesDitImpl, removedNodesDitImpl)
-  private[this] lazy val fullInventoryFromLdapEntries: FullInventoryFromLdapEntries =
-    new FullInventoryFromLdapEntriesImpl(inventoryDitService, inventoryMapper)
-  private[this] lazy val ldapDiffMapper = new LDAPDiffMapper(ldapEntityMapper, queryParser)
-
-  private[this] lazy val activeTechniqueCategoryUnserialisation = new ActiveTechniqueCategoryUnserialisationImpl
-  private[this] lazy val activeTechniqueUnserialisation         = new ActiveTechniqueUnserialisationImpl
-  private[this] lazy val directiveUnserialisation               = new DirectiveUnserialisationImpl
-  private[this] lazy val nodeGroupCategoryUnserialisation       = new NodeGroupCategoryUnserialisationImpl
-  private[this] lazy val nodeGroupUnserialisation               = new NodeGroupUnserialisationImpl(queryParser)
-  private[this] lazy val ruleUnserialisation                    = new RuleUnserialisationImpl
-  private[this] lazy val ruleCategoryUnserialisation            = new RuleCategoryUnserialisationImpl
-  private[this] lazy val globalParameterUnserialisation         = new GlobalParameterUnserialisationImpl
-  lazy val changeRequestChangesUnserialisation                  = new ChangeRequestChangesUnserialisationImpl(
-    nodeGroupUnserialisation,
-    directiveUnserialisation,
-    ruleUnserialisation,
-    globalParameterUnserialisation,
-    techniqueRepository,
-    sectionSpecParser
-  )
-  private[this] lazy val entityMigration                        = DefaultXmlEventLogMigration
-
-  private[this] lazy val eventLogDetailsServiceImpl = new EventLogDetailsServiceImpl(
-    queryParser,
-    new DirectiveUnserialisationImpl,
-    new NodeGroupUnserialisationImpl(queryParser),
-    new RuleUnserialisationImpl,
-    new ActiveTechniqueUnserialisationImpl,
-    new DeploymentStatusUnserialisationImpl,
-    new GlobalParameterUnserialisationImpl,
-    new ApiAccountUnserialisationImpl,
-    new SecretUnserialisationImpl
-  )
-
-  //////////////////////////////////////////////////////////
-  //  non success services that could perhaps be
-  //////////////////////////////////////////////////////////
-
-  // => rwLdap is only used to repair an error, that could be repaired elsewhere.
-
-  // => because of systemVariableSpecService
-  // metadata.xml parser
-
-  private[this] lazy val variableSpecParser = new VariableSpecParser
-  private[this] lazy val sectionSpecParser  = new SectionSpecParser(variableSpecParser)
-  private[this] lazy val techniqueParser    = {
-    new TechniqueParser(variableSpecParser, sectionSpecParser, systemVariableSpecService)
-  }
-
-  private[this] lazy val userPropertyServiceImpl = new StatelessUserPropertyService(
-    configService.rudder_ui_changeMessage_enabled _,
-    configService.rudder_ui_changeMessage_mandatory _,
-    configService.rudder_ui_changeMessage_explanation _
-  )
-
-  ////////////////////////////////////
-  //  non success services
-  ////////////////////////////////////
-
-  ///// end /////
-
-  private[this] lazy val logRepository                = {
-    val eventLogRepo = new EventLogJdbcRepository(doobie, eventLogFactory)
-    techniqueRepositoryImpl.registerCallback(
-      new LogEventOnTechniqueReloadCallback(
-        "LogEventTechnique",
-        100, // must be before most of other
-
-        eventLogRepo
-      )
+    lazy val xmlUnserializer         = XmlUnserializerImpl(
+      ruleUnserialisation,
+      directiveUnserialisation,
+      nodeGroupUnserialisation,
+      globalParameterUnserialisation,
+      ruleCategoryUnserialisation
     )
-    eventLogRepo
-  }
-  private[this] lazy val inventoryLogEventServiceImpl = new InventoryEventLogServiceImpl(logRepository)
-  private[this] lazy val gitConfigRepo                = GitRepositoryProviderImpl
-    .make(RUDDER_GIT_ROOT_CONFIG_REPO)
-    .runOrDie(err => new RuntimeException(s"Error when creating git configuration repository: " + err.fullMsg))
-  private[this] lazy val gitConfigRepoGC              = new GitGC(gitConfigRepo, RUDDER_GIT_GC)
-  gitConfigRepoGC.start()
-  private[this] lazy val gitRevisionProviderImpl      =
-    new LDAPGitRevisionProvider(rwLdap, rudderDitImpl, gitConfigRepo, RUDDER_TECHNIQUELIBRARY_GIT_REFS_PATH)
-  private[this] lazy val techniqueReader: TechniqueReader = {
-    // find the relative path from gitConfigRepo to the ptlib root
-    val gitSlash = new File(RUDDER_GIT_ROOT_CONFIG_REPO).getPath + "/"
-    if (!RUDDER_DIR_TECHNIQUES.startsWith(gitSlash)) {
-      ApplicationLogger.error(
-        "The Technique library root directory must be a sub-directory of '%s', but it is configured to be: '%s'".format(
-          RUDDER_GIT_ROOT_CONFIG_REPO,
-          RUDDER_DIR_TECHNIQUES
-        )
-      )
-      throw new RuntimeException(
-        "The Technique library root directory must be a sub-directory of '%s', but it is configured to be: '%s'".format(
-          RUDDER_GIT_ROOT_CONFIG_REPO,
-          RUDDER_DIR_TECHNIQUES
-        )
+    lazy val workflowEventLogService = new WorkflowEventLogServiceImpl(eventLogRepository, uuidGen)
+    lazy val diffService: DiffService = new DiffServiceImpl()
+    lazy val diffDisplayer = new DiffDisplayer(linkUtil)
+    lazy val commitAndDeployChangeRequest: CommitAndDeployChangeRequestService = {
+      new CommitAndDeployChangeRequestServiceImpl(
+        uuidGen,
+        roDirectiveRepository,
+        woDirectiveRepository,
+        roNodeGroupRepository,
+        woNodeGroupRepository,
+        roRuleRepository,
+        woRuleRepository,
+        roLDAPParameterRepository,
+        woLDAPParameterRepository,
+        asyncDeploymentAgent,
+        dependencyAndDeletionService,
+        configService.rudder_workflow_enabled _,
+        xmlSerializer,
+        xmlUnserializer,
+        sectionSpecParser,
+        dynGroupUpdaterService
       )
     }
 
-    // create a demo default-directive-names.conf if none exists
-    val defaultDirectiveNames = new File(RUDDER_DIR_TECHNIQUES, "default-directive-names.conf")
-    if (!defaultDirectiveNames.exists) {
-      FileUtils.writeStringToFile(
-        defaultDirectiveNames,
-        """
-          |#
-          |# This file contains the default name that a directive gets in Rudder UI creation pop-up.
-          |# The file format is a simple key=value file, with key being the techniqueName
-          |# or techniqueName/version and the value being the name to use.
-          |# An empty value will lead to an empty default name.
-          |# For a new Directive, we will try to lookup "TechniqueName/version" and if not
-          |# available "TechniqueName" from this file. If neither key is available, the
-          |# pop-up will use the actual Technique name as default.
-          |# Don't forget to commit the file to have modifications seen by Rudder.
-          |#
-          |
-          |# Default pattern for new directive from "userManagement" technique:
-          |userManagement=User: <name> Login: <login>
-          |# For userManagement version 2.0, prefer that pattern in new Directives:
-          |userManagement/2.0: User 2.0 [LOGIN]
-          |""".stripMargin,
-        RUDDER_CHARSET.value
+    lazy val roParameterService: RoParameterService = roParameterServiceImpl
+
+    //////////////////////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////// REST ///////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////////////////
+
+    lazy val restExtractorService = {
+      RestExtractorService(
+        roRuleRepository,
+        roDirectiveRepository,
+        roNodeGroupRepository,
+        techniqueRepository,
+        queryParser,
+        userPropertyService,
+        workflowLevelService,
+        stringUuidGenerator,
+        typeParameterService
       )
     }
 
-    val relativePath = RUDDER_DIR_TECHNIQUES.substring(gitSlash.size, RUDDER_DIR_TECHNIQUES.size)
-    new GitTechniqueReader(
-      techniqueParser,
-      gitRevisionProviderImpl,
+    lazy val zioJsonExtractor = new ZioJsonExtractor(queryParser)
+
+    lazy val tokenGenerator = new TokenGeneratorImpl(32)
+
+    implicit lazy val userService = new UserService {
+      def getCurrentUser = CurrentUser
+    }
+
+    lazy val ncfTechniqueReader: ncf.TechniqueReader = new ncf.TechniqueReader(
+      restExtractorService,
+      stringUuidGenerator,
+      personIdentService,
       gitConfigRepo,
-      "metadata.xml",
-      "category.xml",
-      Some(relativePath),
-      "default-directive-names.conf"
+      prettyPrinter,
+      gitModificationRepository,
+      RUDDER_CHARSET.name,
+      RUDDER_GROUP_OWNER_CONFIG_REPO
     )
-  }
 
-  private[this] lazy val roLdap = {
-    new ROPooledSimpleAuthConnectionProvider(
-      host = LDAP_HOST,
-      port = LDAP_PORT,
-      authDn = LDAP_AUTHDN,
-      authPw = LDAP_AUTHPW,
-      poolSize = LDAP_MAX_POOL_SIZE
+    lazy val techniqueSerializer = new TechniqueSerializer(typeParameterService)
+
+    lazy val linkUtil           = new LinkUtil(roRuleRepository, roNodeGroupRepository, roDirectiveRepository, nodeInfoServiceImpl)
+    // REST API
+    lazy val restApiAccounts    = new RestApiAccounts(
+      roApiAccountRepository,
+      woApiAccountRepository,
+      restExtractorService,
+      tokenGenerator,
+      uuidGen,
+      userService,
+      apiAuthorizationLevelService
     )
-  }
-  lazy val rwLdap               = {
-    new RWPooledSimpleAuthConnectionProvider(
-      host = LDAP_HOST,
-      port = LDAP_PORT,
-      authDn = LDAP_AUTHDN,
-      authPw = LDAP_AUTHPW,
-      poolSize = LDAP_MAX_POOL_SIZE
+    lazy val restDataSerializer = RestDataSerializerImpl(techniqueRepository, diffService)
+
+    lazy val restQuicksearch = new RestQuicksearch(
+      new FullQuickSearchService()(
+        roLDAPConnectionProvider,
+        nodeDit,
+        acceptedNodesDit,
+        rudderDit,
+        roDirectiveRepository,
+        nodeInfoService
+      ),
+      userService,
+      linkUtil
     )
-  }
+    lazy val restCompletion  = new RestCompletion(new RestCompletionService(roDirectiveRepository, roRuleRepository))
 
-  // query processor for accepted nodes
-  private[this] lazy val queryProcessor = new AcceptedNodesLDAPQueryProcessor(
-    nodeDitImpl,
-    acceptedNodesDitImpl,
-    new InternalLDAPQueryProcessor(roLdap, acceptedNodesDitImpl, nodeDit, ditQueryDataImpl, ldapEntityMapper),
-    nodeInfoServiceImpl
-  )
+    lazy val ruleApiService2 = {
+      new RuleApiService2(
+        roRuleRepository,
+        woRuleRepository,
+        uuidGen,
+        asyncDeploymentAgent,
+        workflowLevelService,
+        restExtractorService,
+        restDataSerializer
+      )
+    }
 
-  // we need a roLdap query checker for nodes in pending
-  private[this] lazy val inventoryQueryChecker = new PendingNodesLDAPQueryChecker(
-    new InternalLDAPQueryProcessor(
-      roLdap,
-      pendingNodesDitImpl,
-      nodeDit, // here, we don't want to look for subgroups to show them in the form => always return an empty list
+    lazy val ruleApiService6  = {
+      new RuleApiService6(
+        roRuleCategoryRepository,
+        roRuleRepository,
+        woRuleCategoryRepository,
+        restDataSerializer
+      )
+    }
+    lazy val ruleApiService13 = {
+      new RuleApiService14(
+        roRuleRepository,
+        woRuleRepository,
+        configurationRepository,
+        uuidGen,
+        asyncDeploymentAgent,
+        workflowLevelService,
+        roRuleCategoryRepository,
+        woRuleCategoryRepository,
+        roDirectiveRepository,
+        roNodeGroupRepository,
+        nodeInfoService,
+        configService.rudder_global_policy_mode _,
+        ruleApplicationStatus
+      )
+    }
 
-      new DitQueryData(pendingNodesDitImpl, nodeDit, rudderDit, () => Nil.succeed),
-      ldapEntityMapper
-    ),
-    nodeInfoServiceImpl
-  )
-  private[this] lazy val dynGroupServiceImpl   = new DynGroupServiceImpl(rudderDitImpl, roLdap, ldapEntityMapper)
+    lazy val directiveApiService2 = {
+      new DirectiveApiService2(
+        roDirectiveRepository,
+        woDirectiveRepository,
+        uuidGen,
+        asyncDeploymentAgent,
+        workflowLevelService,
+        restExtractorService,
+        directiveEditorService,
+        restDataSerializer,
+        techniqueRepositoryImpl
+      )
+    }
 
-  lazy val pendingNodeCheckGroup = new CheckPendingNodeInDynGroups(inventoryQueryChecker)
+    lazy val directiveApiService14 = {
+      new DirectiveApiService14(
+        roDirectiveRepository,
+        configurationRepository,
+        woDirectiveRepository,
+        uuidGen,
+        asyncDeploymentAgent,
+        workflowLevelService,
+        directiveEditorService,
+        restDataSerializer,
+        techniqueRepositoryImpl
+      )
+    }
 
-  private[this] lazy val ldapFullInventoryRepository =
-    new FullInventoryRepositoryImpl(inventoryDitService, inventoryMapper, rwLdap)
-  private[this] lazy val unitRefuseGroup:              UnitRefuseInventory                          =
-    new RefuseGroups("refuse_node:delete_id_in_groups", roLdapNodeGroupRepository, woLdapNodeGroupRepository)
-  private[this] lazy val acceptInventory:              UnitAcceptInventory with UnitRefuseInventory =
-    new AcceptInventory("accept_new_server:inventory", pendingNodesDitImpl, acceptedNodesDitImpl, ldapFullInventoryRepository)
-  private[this] lazy val acceptNodeAndMachineInNodeOu: UnitAcceptInventory with UnitRefuseInventory = {
-    new AcceptFullInventoryInNodeOu(
-      "accept_new_server:ou=node",
-      nodeDitImpl,
+    lazy val techniqueApiService6 = {
+      new TechniqueAPIService6(
+        roDirectiveRepository,
+        restDataSerializer
+      )
+    }
+
+    lazy val techniqueApiService14 = {
+      new TechniqueAPIService14(
+        roDirectiveRepository,
+        gitParseTechniqueLibrary,
+        ncfTechniqueReader,
+        techniqueSerializer,
+        restDataSerializer
+      )
+    }
+
+    lazy val groupApiService2 = {
+      new GroupApiService2(
+        roNodeGroupRepository,
+        woNodeGroupRepository,
+        uuidGen,
+        asyncDeploymentAgent,
+        workflowLevelService,
+        restExtractorService,
+        queryProcessor,
+        restDataSerializer
+      )
+    }
+
+    lazy val groupApiService6 = {
+      new GroupApiService6(
+        roNodeGroupRepository,
+        woNodeGroupRepository,
+        restDataSerializer
+      )
+    }
+
+    lazy val groupApiService14 = {
+      new GroupApiService14(
+        roNodeGroupRepository,
+        woNodeGroupRepository,
+        roLDAPParameterRepository,
+        uuidGen,
+        asyncDeploymentAgent,
+        workflowLevelService,
+        restExtractorService,
+        queryParser,
+        queryProcessor,
+        restDataSerializer
+      )
+    }
+
+    lazy val nodeApiService2 = new NodeApiService2(
+      newNodeManager,
+      nodeInfoService,
+      removeNodeService,
+      uuidGen,
+      restExtractorService,
+      restDataSerializer
+    )
+
+    lazy val nodeApiService4 = new NodeApiService4(
+      fullInventoryRepository,
+      nodeInfoService,
+      softwareInventoryDAO,
+      uuidGen,
+      restExtractorService,
+      restDataSerializer,
+      roAgentRunsRepository
+    )
+
+    lazy val nodeApiService8 = {
+      new NodeApiService8(
+        woNodeRepository,
+        nodeInfoService,
+        uuidGen,
+        asyncDeploymentAgent,
+        RUDDER_RELAY_API,
+        userService
+      )
+    }
+
+    lazy val nodeApiService12 = new NodeApiService12(
+      removeNodeService,
+      uuidGen,
+      restDataSerializer
+    )
+
+    lazy val nodeApiService6 = new NodeApiService6(
+      nodeInfoService,
+      fullInventoryRepository,
+      softwareInventoryDAO,
+      restExtractorService,
+      restDataSerializer,
+      queryProcessor,
+      inventoryQueryChecker,
+      roAgentRunsRepository
+    )
+
+    lazy val nodeApiService13 = new NodeApiService13(
+      nodeInfoService,
+      cachedAgentRunRepository,
+      readOnlySoftwareDAO,
+      restExtractorService,
+      () => configService.rudder_global_policy_mode().toBox,
+      reportingServiceImpl,
+      roNodeGroupRepository,
+      roLDAPParameterRepository
+    )
+
+    lazy val nodeApiService16 = new NodeApiService15(
+      fullInventoryRepository,
       rwLdap,
       ldapEntityMapper,
-      PendingInventory,
-      () => configService.rudder_node_onaccept_default_policy_mode().toBox,
-      () => configService.rudder_node_onaccept_default_state().toBox
+      newNodeManager,
+      stringUuidGenerator,
+      nodeDit,
+      pendingNodesDit,
+      acceptedNodesDit
     )
-  }
 
-  private[this] lazy val acceptHostnameAndIp: UnitAcceptInventory = new AcceptHostnameAndIp(
-    "accept_new_server:check_hostname_unicity",
-    AcceptedInventory,
-    queryProcessor,
-    ditQueryDataImpl,
-    psMngtService,
-    nodeInfoServiceImpl,
-    configService.node_accept_duplicated_hostname()
-  )
+    lazy val parameterApiService2  = {
+      new ParameterApiService2(
+        roLDAPParameterRepository,
+        woLDAPParameterRepository,
+        uuidGen,
+        workflowLevelService,
+        restExtractorService,
+        restDataSerializer
+      )
+    }
+    lazy val parameterApiService14 = {
+      new ParameterApiService14(
+        roLDAPParameterRepository,
+        woLDAPParameterRepository,
+        uuidGen,
+        workflowLevelService
+      )
+    }
 
-  private[this] lazy val historizeNodeStateOnChoice: UnitAcceptInventory with UnitRefuseInventory = {
-    new HistorizeNodeStateOnChoice(
-      "accept_or_refuse_new_node:historize_inventory",
-      ldapFullInventoryRepository,
-      diffRepos,
-      PendingInventory
+    // System API
+
+    lazy val clearCacheService = new ClearCacheServiceImpl(
+      nodeConfigurationHashRepo,
+      asyncDeploymentAgent,
+      eventLogRepository,
+      uuidGen,
+      clearableCache
     )
-  }
-  private[this] lazy val updateFactRepoOnChoice:     UnitAcceptInventory with UnitRefuseInventory = new UpdateFactRepoOnChoice(
-    "accept_or_refuse_new_node:update_fact_repo",
-    PendingInventory,
-    factRepo
-  )
 
-  private[this] lazy val nodeGridImpl = new NodeGrid(ldapFullInventoryRepository, nodeInfoServiceImpl, configService)
+    lazy val hookApiService = new HookApiService(HOOKS_D, HOOKS_IGNORE_SUFFIXES)
 
-  private[this] lazy val modificationService      =
-    new ModificationService(logRepository, gitModificationRepository, itemArchiveManagerImpl, uuidGen)
-  private[this] lazy val eventListDisplayerImpl   = new EventListDisplayer(logRepository)
-  private[this] lazy val eventLogDetailsGenerator = new EventLogDetailsGenerator(
-    eventLogDetailsServiceImpl,
-    logRepository,
-    roLdapNodeGroupRepository,
-    roLdapDirectiveRepository,
-    nodeInfoServiceImpl,
-    roLDAPRuleCategoryRepository,
-    modificationService,
-    personIdentServiceImpl,
-    linkUtil,
-    diffDisplayer
-  )
-  private[this] lazy val databaseManagerImpl      = new DatabaseManagerImpl(reportsRepositoryImpl, updateExpectedRepo)
-  private[this] lazy val softwareInventoryDAO:   ReadOnlySoftwareDAO  =
-    new ReadOnlySoftwareDAOImpl(inventoryDitService, roLdap, inventoryMapper)
-  private[this] lazy val softwareInventoryRWDAO: WriteOnlySoftwareDAO = new WriteOnlySoftwareDAOImpl(acceptedNodesDitImpl, rwLdap)
-  private[this] lazy val softwareService:        SoftwareService      =
-    new SoftwareServiceImpl(softwareInventoryDAO, softwareInventoryRWDAO, acceptedNodesDit)
-
-  private[this] lazy val nodeSummaryServiceImpl = new NodeSummaryServiceImpl(inventoryDitService, inventoryMapper, roLdap)
-  private[this] lazy val diffRepos: InventoryHistoryLogRepository = {
-    new InventoryHistoryLogRepository(
-      HISTORY_INVENTORIES_ROOTDIR,
-      new FullInventoryFileParser(fullInventoryFromLdapEntries, inventoryMapper)
+    lazy val systemApiService11 = new SystemApiService11(
+      updateTechniqueLibrary,
+      debugScript,
+      clearCacheService,
+      asyncDeploymentAgent,
+      uuidGen,
+      updateDynamicGroups,
+      itemArchiveManager,
+      personIdentService,
+      gitConfigRepo
     )
-  }
 
-  private[this] lazy val personIdentServiceImpl = new TrivialPersonIdentService
+    lazy val systemApiService13 = new SystemApiService13(
+      healthcheckService,
+      healthcheckNotificationService,
+      restDataSerializer,
+      softwareService
+    )
 
-  private[this] lazy val roParameterServiceImpl = new RoParameterServiceImpl(roLDAPParameterRepository)
-  private[this] lazy val woParameterServiceImpl =
-    new WoParameterServiceImpl(roParameterServiceImpl, woLDAPParameterRepository, asyncDeploymentAgentImpl)
+    lazy val ruleInternalApiService = new RuleInternalApiService(roRuleRepository, roNodeGroupRepository, nodeInfoService)
 
-  ///// items archivers - services that allows to transform items to XML and save then on a Git FS /////
-  private[this] lazy val gitModificationRepository = new GitModificationRepositoryImpl(doobie)
-  private[this] lazy val gitRuleArchiver:                    GitRuleArchiver                    = new GitRuleArchiverImpl(
-    gitConfigRepo,
-    ruleSerialisation,
-    rulesDirectoryName,
-    prettyPrinter,
-    gitModificationRepository,
-    RUDDER_CHARSET.name,
-    RUDDER_GROUP_OWNER_CONFIG_REPO
-  )
-  private[this] lazy val gitRuleCategoryArchiver:            GitRuleCategoryArchiver            = new GitRuleCategoryArchiverImpl(
-    gitConfigRepo,
-    ruleCategorySerialisation,
-    ruleCategoriesDirectoryName,
-    prettyPrinter,
-    gitModificationRepository,
-    RUDDER_CHARSET.name,
-    "category.xml",
-    RUDDER_GROUP_OWNER_CONFIG_REPO
-  )
-  private[this] lazy val gitActiveTechniqueCategoryArchiver: GitActiveTechniqueCategoryArchiver = {
-    new GitActiveTechniqueCategoryArchiverImpl(
+    lazy val complianceAPIService = new ComplianceAPIService(
+      roRuleRepository,
+      nodeInfoService,
+      roNodeGroupRepository,
+      reportingService,
+      roDirectiveRepository,
+      () => globalComplianceModeService.getGlobalComplianceMode
+    )
+
+    lazy val techniqueArchiver = new TechniqueArchiverImpl(
       gitConfigRepo,
-      activeTechniqueCategorySerialisation,
-      userLibraryDirectoryName,
+      prettyPrinter,
+      gitModificationRepository,
+      personIdentService,
+      techniqueParser,
+      RUDDER_GROUP_OWNER_CONFIG_REPO
+    )
+    lazy val ncfTechniqueWriter: TechniqueWriter = new TechniqueWriterImpl(
+      techniqueArchiver,
+      updateTechniqueLibrary,
+      interpolationCompiler,
+      roDirectiveRepository,
+      woDirectiveRepository,
+      techniqueRepository,
+      workflowLevelService,
+      prettyPrinter,
+      RUDDER_GIT_ROOT_CONFIG_REPO,
+      typeParameterService,
+      techniqueSerializer
+    )
+
+    lazy val pipelinedInventoryParser: InventoryParser = {
+      val fusionReportParser = {
+        new FusionInventoryParser(
+          uuidGen,
+          rootParsingExtensions = Nil,
+          contentParsingExtensions = Nil,
+          ignoreProcesses = INVENTORIES_IGNORE_PROCESSES
+        )
+      }
+
+      new DefaultInventoryParser(
+        fusionReportParser,
+        Seq(
+          new PreInventoryParserCheckConsistency
+        )
+      )
+    }
+
+    lazy val automaticMerger: PreCommit = new UuidMergerPreCommit(
+      uuidGen,
+      acceptedNodesDit,
+      new NodeInventoryDNFinderService(
+        Seq(
+          // start by trying to use an already given UUID
+          NamedNodeInventoryDNFinderAction(
+            "use_existing_id",
+            new UseExistingNodeIdFinder(inventoryDitService, roLdap, acceptedNodesDit.BASE_DN.getParent)
+          )
+        )
+      ),
+      new MachineDNFinderService(
+        Seq(
+          // start by trying to use an already given UUID
+          NamedMachineDNFinderAction(
+            "use_existing_id",
+            new UseExistingMachineIdFinder(inventoryDitService, roLdap, acceptedNodesDit.BASE_DN.getParent)
+          ), // look if it's in the accepted inventories
+
+          NamedMachineDNFinderAction(
+            "check_mother_board_uuid_accepted",
+            new FromMotherBoardUuidIdFinder(roLdap, acceptedNodesDit, inventoryDitService)
+          ), // see if it's in the "pending" branch
+
+          NamedMachineDNFinderAction(
+            "check_mother_board_uuid_pending",
+            new FromMotherBoardUuidIdFinder(roLdap, pendingNodesDit, inventoryDitService)
+          ), // see if it's in the "removed" branch
+
+          NamedMachineDNFinderAction(
+            "check_mother_board_uuid_removed",
+            new FromMotherBoardUuidIdFinder(roLdap, removedNodesDitImpl, inventoryDitService)
+          )
+        )
+      ),
+      new NameAndVersionIdFinder(
+        "check_name_and_version",
+        roLdap,
+        inventoryMapper,
+        acceptedNodesDit
+      )
+    )
+
+    lazy val gitFactRepo   = GitRepositoryProviderImpl
+      .make(RUDDER_GIT_ROOT_FACT_REPO)
+      .runOrDie(err => new RuntimeException(s"Error when initializing git configuration repository: " + err.fullMsg))
+    lazy val gitFactRepoGC = new GitGC(gitFactRepo, RUDDER_GIT_GC)
+    lazy val factRepo      = new GitNodeFactRepository(gitFactRepo, RUDDER_GROUP_OWNER_CONFIG_REPO)
+    factRepo.checkInit().runOrDie(err => new RuntimeException(s"Error when checking fact repository init: " + err.fullMsg))
+
+    lazy val ldifInventoryLogger = new DefaultLDIFInventoryLogger(LDIF_TRACELOG_ROOT_DIR)
+    lazy val inventorySaver      = new DefaultInventorySaver(
+      rwLdap,
+      acceptedNodesDit,
+      inventoryMapper,
+      (
+        CheckOsType
+        :: automaticMerger
+        :: CheckMachineName
+        :: new LastInventoryDate()
+        :: AddIpValues
+        :: new LogInventoryPreCommit(inventoryMapper, ldifInventoryLogger)
+        :: Nil
+      ),
+      (
+        new PendingNodeIfNodeWasRemoved(fullInventoryRepository)
+        :: new FactRepositoryPostCommit(factRepo, nodeInfoService)
+        :: new PostCommitLogger(ldifInventoryLogger)
+        :: new PostCommitInventoryHooks(HOOKS_D, HOOKS_IGNORE_SUFFIXES)
+        :: Nil
+      )
+    )
+
+    lazy val inventoryProcessorInternal = {
+      val checkLdapAlive: () => IOResult[Unit] = { () =>
+        for {
+          con <- rwLdap
+          res <- con.get(pendingNodesDit.NODES.dn, "1.1")
+        } yield {
+          ()
+        }
+      }
+      val maxParallel = {
+        try {
+          val user = if (MAX_PARSE_PARALLEL.endsWith("x")) {
+            val xx = MAX_PARSE_PARALLEL.substring(0, MAX_PARSE_PARALLEL.size - 1)
+            java.lang.Double.parseDouble(xx) * java.lang.Runtime.getRuntime.availableProcessors()
+          } else {
+            java.lang.Double.parseDouble(MAX_PARSE_PARALLEL)
+          }
+          Math.max(1, user).toLong
+        } catch {
+          case ex: Exception =>
+            // logs are not available here
+            println(
+              s"ERROR Error when parsing configuration properties for the parallelization of inventory processing. " +
+              s"Expecting a positive integer or number of time the available processors. Default to '0.5x': " +
+              s"inventory.parse.parallelization=${MAX_PARSE_PARALLEL}"
+            )
+            Math.max(1, Math.ceil(java.lang.Runtime.getRuntime.availableProcessors().toDouble / 2).toLong)
+        }
+      }
+      new InventoryProcessor(
+        pipelinedInventoryParser,
+        inventorySaver,
+        maxParallel,
+        fullInventoryRepository,
+        new InventoryDigestServiceV1(fullInventoryRepository),
+        checkLdapAlive,
+        pendingNodesDit
+      )
+    }
+
+    lazy val inventoryProcessor = {
+      val mover = new InventoryMover(
+        INVENTORY_DIR_RECEIVED,
+        INVENTORY_DIR_FAILED,
+        new InventoryFailedHook(
+          HOOKS_D,
+          HOOKS_IGNORE_SUFFIXES
+        )
+      )
+      new DefaultProcessInventoryService(inventoryProcessorInternal, mover)
+    }
+
+    lazy val inventoryWatcher = {
+      val fileProcessor = new ProcessFile(inventoryProcessor, INVENTORY_DIR_INCOMING)
+
+      new InventoryFileWatcher(
+        fileProcessor,
+        INVENTORY_DIR_INCOMING,
+        INVENTORY_DIR_UPDATE,
+        WATCHER_DELETE_OLD_INVENTORIES_AGE,
+        WATCHER_GARBAGE_OLD_INVENTORIES_PERIOD
+      )
+    }
+
+    lazy val cleanOldInventoryBatch = {
+      new PurgeOldInventoryFiles(
+        RUDDER_INVENTORIES_CLEAN_CRON,
+        RUDDER_INVENTORIES_CLEAN_AGE,
+        List(better.files.File(INVENTORY_DIR_FAILED), better.files.File(INVENTORY_DIR_RECEIVED))
+      )
+    }
+
+    lazy val archiveApi = {
+      val archiveBuilderService =
+        new ZipArchiveBuilderService(new FileArchiveNameService(), configurationRepository, gitParseTechniqueLibrary)
+      // fixe archive name to make it simple to test
+      val rootDirName           = "archive".succeed
+      new com.normation.rudder.rest.lift.ArchiveApi(
+        archiveBuilderService,
+        configService.rudder_featureSwitch_archiveApi(),
+        rootDirName,
+        new ZipArchiveReaderImpl(queryParser, techniqueParser),
+        new SaveArchiveServicebyRepo(
+          techniqueArchiver,
+          techniqueReader,
+          techniqueRepository,
+          roDirectiveRepository,
+          woDirectiveRepository,
+          roNodeGroupRepository,
+          woNodeGroupRepository,
+          roRuleRepository,
+          woRuleRepository,
+          updateTechniqueLibrary,
+          asyncDeploymentAgent
+        ),
+        new CheckArchiveServiceImpl(techniqueRepository)
+      )
+    }
+
+    /*
+     * API versions are incremented each time incompatible changes are made (like adding or deleting endpoints - modification
+     * of an existing endpoint, if done in a purely compatible way, don't change api version).
+     * It may happen that some rudder branches don't have a version bump, and other have several (in case of
+     * horrible breaking bugs). We avoid the case where a previous release need a version bump.
+     * For ex:
+     * - 5.0: 14
+     * - 5.1: 14 (no change)
+     * - 5.2[.0~.4]: 15
+     * - 5.2.5: 16
+     */
+    lazy val ApiVersions: List[ApiVersion] = {
+      ApiVersion(12, true) ::  // rudder 6.0, 6.1
+      ApiVersion(13, true) ::  // rudder 6.2
+      ApiVersion(14, false) :: // rudder 7.0
+      ApiVersion(15, false) :: // rudder 7.1 - system update on node details
+      ApiVersion(16, false) :: // rudder 7.2 - create node api, import/export archive, hooks & campaigns internal API
+      ApiVersion(17, false) :: // rudder 7.3 - directive compliance, campaign API is public
+      Nil
+    }
+
+    lazy val jsonPluginDefinition = new ReadPluginPackageInfo("/var/rudder/packages/index.json")
+
+    lazy val resourceFileService = new ResourceFileService(gitConfigRepo)
+    lazy val apiDispatcher       = new RudderEndpointDispatcher(LiftApiProcessingLogger)
+    lazy val rudderApi           = {
+      import com.normation.rudder.rest.lift._
+
+      val nodeInheritedProperties  =
+        new NodeApiInheritedProperties(nodeInfoService, roNodeGroupRepository, roLDAPParameterRepository)
+      val groupInheritedProperties = new GroupApiInheritedProperties(roNodeGroupRepository, roLDAPParameterRepository)
+
+      val campaignApi = new lift.CampaignApi(
+        campaignRepo,
+        campaignSerializer,
+        campaignEventRepo,
+        mainCampaignService,
+        restExtractorService,
+        stringUuidGenerator
+      )
+      val modules     = List(
+        new ComplianceApi(restExtractorService, complianceAPIService, roDirectiveRepository),
+        new GroupsApi(
+          roLdapNodeGroupRepository,
+          restExtractorService,
+          zioJsonExtractor,
+          stringUuidGenerator,
+          groupApiService2,
+          groupApiService6,
+          groupApiService14,
+          groupInheritedProperties
+        ),
+        new DirectiveApi(
+          roDirectiveRepository,
+          restExtractorService,
+          zioJsonExtractor,
+          stringUuidGenerator,
+          directiveApiService2,
+          directiveApiService14
+        ),
+        new NodeApi(
+          restExtractorService,
+          restDataSerializer,
+          nodeApiService2,
+          nodeApiService4,
+          nodeApiService6,
+          nodeApiService8,
+          nodeApiService12,
+          nodeApiService13,
+          nodeApiService16,
+          nodeInheritedProperties,
+          RUDDER_DEFAULT_DELETE_NODE_MODE
+        ),
+        new ParameterApi(restExtractorService, zioJsonExtractor, parameterApiService2, parameterApiService14),
+        new SettingsApi(
+          restExtractorService,
+          configService,
+          asyncDeploymentAgent,
+          stringUuidGenerator,
+          policyServerManagementService,
+          nodeInfoService
+        ),
+        new TechniqueApi(
+          restExtractorService,
+          techniqueApiService6,
+          techniqueApiService14,
+          ncfTechniqueWriter,
+          ncfTechniqueReader,
+          techniqueRepository,
+          techniqueSerializer,
+          stringUuidGenerator,
+          resourceFileService
+        ),
+        new RuleApi(
+          restExtractorService,
+          zioJsonExtractor,
+          ruleApiService2,
+          ruleApiService6,
+          ruleApiService13,
+          stringUuidGenerator
+        ),
+        new SystemApi(
+          restExtractorService,
+          systemApiService11,
+          systemApiService13,
+          rudderMajorVersion,
+          rudderFullVersion,
+          builtTimestamp
+        ),
+        new InventoryApi(restExtractorService, inventoryWatcher, better.files.File(INVENTORY_DIR_INCOMING)),
+        new PluginApi(restExtractorService, pluginSettingsService),
+        new RecentChangesAPI(recentChangesService, restExtractorService),
+        new RulesInternalApi(restExtractorService, ruleInternalApiService),
+        campaignApi,
+        new HookApi(hookApiService),
+        archiveApi
+        // info api must be resolved latter, because else it misses plugin apis !
+      )
+
+      val api = new LiftHandler(
+        apiDispatcher,
+        ApiVersions,
+        new AclApiAuthorization(LiftApiProcessingLogger, userService, () => apiAuthorizationLevelService.aclEnabled),
+        None
+      )
+      modules.foreach(module => api.addModules(module.getLiftEndpoints()))
+      api
+    }
+
+    // Internal APIs
+    lazy val sharedFileApi     = new SharedFilesAPI(restExtractorService, RUDDER_DIR_SHARED_FILES_FOLDER)
+    lazy val eventLogApi       = new EventLogAPI(eventLogRepository, restExtractorService, eventLogDetailsGenerator, personIdentService)
+    lazy val asyncWorkflowInfo = new AsyncWorkflowInfo
+    lazy val configService: ReadConfigService with UpdateConfigService = {
+      new GenericConfigService(
+        RudderProperties.config,
+        new LdapConfigRepository(rudderDit, rwLdap, ldapEntityMapper, eventLogRepository, stringUuidGenerator),
+        asyncWorkflowInfo,
+        workflowLevelService
+      )
+    }
+
+    lazy val recentChangesService = new CachedNodeChangesServiceImpl(
+      new NodeChangesServiceImpl(reportsRepository),
+      () => configService.rudder_compute_changes().toBox
+    )
+
+    //////////////////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////////////////
+
+    //
+    // Concrete implementation.
+    // They are private to that object, and they can refer to other
+    // private implementation as long as they conform to interface.
+    //
+
+    lazy val gitParseTechniqueLibrary = new GitParseTechniqueLibrary(
+      techniqueParser,
+      gitConfigRepo,
+      gitRevisionProvider,
+      "techniques",
+      "metadata.xml"
+    )
+    lazy val configurationRepository  = new ConfigurationRepositoryImpl(
+      roLdapDirectiveRepository,
+      techniqueRepository,
+      roLdapRuleRepository,
+      roNodeGroupRepository,
+      parseActiveTechniqueLibrary,
+      gitParseTechniqueLibrary,
+      parseRules,
+      parseGroupLibrary
+    )
+
+    /////////////////////////////////////////////////////////////////////
+    //// everything was private[this]
+    ////////////////////////////////////////////////////////////////////
+
+    lazy val roLDAPApiAccountRepository = new RoLDAPApiAccountRepository(
+      rudderDitImpl,
+      roLdap,
+      ldapEntityMapper,
+      tokenGenerator,
+      ApiAuthorization.allAuthz.acl // for system token
+    )
+    lazy val roApiAccountRepository: RoApiAccountRepository = roLDAPApiAccountRepository
+
+    lazy val woLDAPApiAccountRepository = new WoLDAPApiAccountRepository(
+      rudderDitImpl,
+      rwLdap,
+      ldapEntityMapper,
+      ldapDiffMapper,
+      logRepository,
+      personIdentServiceImpl
+    )
+    lazy val woApiAccountRepository: WoApiAccountRepository = woLDAPApiAccountRepository
+
+    lazy val ruleApplicationStatusImpl: RuleApplicationStatusService = new RuleApplicationStatusServiceImpl()
+    lazy val ruleApplicationStatus = ruleApplicationStatusImpl
+    lazy val propertyEngineServiceImpl: PropertyEngineService = new PropertyEngineServiceImpl(
+      List.empty
+    )
+    lazy val propertyEngineService = propertyEngineServiceImpl
+
+    def DN(rdn: String, parent: DN)           = new DN(new RDN(rdn), parent)
+    lazy val LDAP_BASEDN                      = new DN("cn=rudder-configuration")
+    lazy val LDAP_INVENTORIES_BASEDN          = DN("ou=Inventories", LDAP_BASEDN)
+    lazy val LDAP_INVENTORIES_SOFTWARE_BASEDN = LDAP_INVENTORIES_BASEDN
+
+    lazy val acceptedNodesDitImpl: InventoryDit = new InventoryDit(
+      DN("ou=Accepted Inventories", LDAP_INVENTORIES_BASEDN),
+      LDAP_INVENTORIES_SOFTWARE_BASEDN,
+      "Accepted inventories"
+    )
+    lazy val acceptedNodesDit = acceptedNodesDitImpl
+    lazy val pendingNodesDitImpl: InventoryDit = new InventoryDit(
+      DN("ou=Pending Inventories", LDAP_INVENTORIES_BASEDN),
+      LDAP_INVENTORIES_SOFTWARE_BASEDN,
+      "Pending inventories"
+    )
+    lazy val pendingNodesDit     = pendingNodesDitImpl
+    lazy val removedNodesDitImpl =
+      new InventoryDit(DN("ou=Removed Inventories", LDAP_INVENTORIES_BASEDN), LDAP_INVENTORIES_SOFTWARE_BASEDN, "Removed Servers")
+    lazy val rudderDitImpl: RudderDit = new RudderDit(DN("ou=Rudder", LDAP_BASEDN))
+    lazy val rudderDit = rudderDitImpl
+    lazy val nodeDitImpl: NodeDit = new NodeDit(LDAP_BASEDN)
+    lazy val nodeDit = nodeDitImpl
+    lazy val inventoryDitService: InventoryDitService =
+      new InventoryDitServiceImpl(pendingNodesDitImpl, acceptedNodesDitImpl, removedNodesDitImpl)
+    lazy val stringUuidGenerator: StringUuidGenerator = new StringUuidGeneratorImpl
+    lazy val uuidGen                   = stringUuidGenerator
+    lazy val systemVariableSpecService = new SystemVariableSpecServiceImpl()
+    lazy val ldapEntityMapper: LDAPEntityMapper =
+      new LDAPEntityMapper(rudderDitImpl, nodeDitImpl, acceptedNodesDitImpl, queryParser, inventoryMapper)
+
+    ///// items serializer - service that transforms items to XML /////
+    lazy val ruleSerialisation:                    RuleSerialisation                    = new RuleSerialisationImpl(
+      Constants.XML_CURRENT_FILE_FORMAT.toString
+    )
+    lazy val ruleCategorySerialisation:            RuleCategorySerialisation            = new RuleCategorySerialisationImpl(
+      Constants.XML_CURRENT_FILE_FORMAT.toString
+    )
+    lazy val rootSectionSerialisation:             SectionSpecWriter                    = new SectionSpecWriterImpl()
+    lazy val activeTechniqueCategorySerialisation: ActiveTechniqueCategorySerialisation =
+      new ActiveTechniqueCategorySerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
+    lazy val activeTechniqueSerialisation:         ActiveTechniqueSerialisation         =
+      new ActiveTechniqueSerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
+    lazy val directiveSerialisation:               DirectiveSerialisation               =
+      new DirectiveSerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
+    lazy val nodeGroupCategorySerialisation:       NodeGroupCategorySerialisation       =
+      new NodeGroupCategorySerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
+    lazy val nodeGroupSerialisation:               NodeGroupSerialisation               =
+      new NodeGroupSerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
+    lazy val deploymentStatusSerialisation:        DeploymentStatusSerialisation        =
+      new DeploymentStatusSerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
+    lazy val globalParameterSerialisation:         GlobalParameterSerialisation         =
+      new GlobalParameterSerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
+    lazy val apiAccountSerialisation:              APIAccountSerialisation              =
+      new APIAccountSerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
+    lazy val propertySerialization:                GlobalPropertySerialisation          =
+      new GlobalPropertySerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
+    lazy val changeRequestChangesSerialisation:    ChangeRequestChangesSerialisation    = {
+      new ChangeRequestChangesSerialisationImpl(
+        Constants.XML_CURRENT_FILE_FORMAT.toString,
+        nodeGroupSerialisation,
+        directiveSerialisation,
+        ruleSerialisation,
+        globalParameterSerialisation,
+        techniqueRepositoryImpl,
+        rootSectionSerialisation
+      )
+    }
+
+    lazy val eventLogFactory = new EventLogFactoryImpl(
+      ruleSerialisation,
+      directiveSerialisation,
+      nodeGroupSerialisation,
+      activeTechniqueSerialisation,
+      globalParameterSerialisation,
+      apiAccountSerialisation,
+      propertySerialization,
+      new SecretSerialisationImpl(Constants.XML_CURRENT_FILE_FORMAT.toString)
+    )
+    lazy val pathComputer    = new PathComputerImpl(
+      Constants.NODE_PROMISES_PARENT_DIR_BASE,
+      Constants.NODE_PROMISES_PARENT_DIR,
+      RUDDER_DIR_BACKUP,
+      Constants.CFENGINE_COMMUNITY_PROMISES_PATH,
+      Constants.CFENGINE_NOVA_PROMISES_PATH
+    )
+
+    /*
+     * For now, we don't want to query server other
+     * than the accepted ones.
+     */
+    lazy val getSubGroupChoices = () => roLdapNodeGroupRepository.getAll().map(seq => seq.map(g => SubGroupChoice(g.id, g.name)))
+    lazy val ditQueryDataImpl   = new DitQueryData(acceptedNodesDitImpl, nodeDit, rudderDit, getSubGroupChoices)
+    lazy val queryParser        = new CmdbQueryParser with DefaultStringQueryParser with JsonQueryLexer {
+      override val criterionObjects = Map[String, ObjectCriterion]() ++ ditQueryDataImpl.criteriaMap
+    }
+    lazy val inventoryMapper: InventoryMapper =
+      new InventoryMapper(inventoryDitService, pendingNodesDitImpl, acceptedNodesDitImpl, removedNodesDitImpl)
+    lazy val fullInventoryFromLdapEntries: FullInventoryFromLdapEntries =
+      new FullInventoryFromLdapEntriesImpl(inventoryDitService, inventoryMapper)
+    lazy val ldapDiffMapper = new LDAPDiffMapper(ldapEntityMapper, queryParser)
+
+    lazy val activeTechniqueCategoryUnserialisation = new ActiveTechniqueCategoryUnserialisationImpl
+    lazy val activeTechniqueUnserialisation         = new ActiveTechniqueUnserialisationImpl
+    lazy val directiveUnserialisation               = new DirectiveUnserialisationImpl
+    lazy val nodeGroupCategoryUnserialisation       = new NodeGroupCategoryUnserialisationImpl
+    lazy val nodeGroupUnserialisation               = new NodeGroupUnserialisationImpl(queryParser)
+    lazy val ruleUnserialisation                    = new RuleUnserialisationImpl
+    lazy val ruleCategoryUnserialisation            = new RuleCategoryUnserialisationImpl
+    lazy val globalParameterUnserialisation         = new GlobalParameterUnserialisationImpl
+    lazy val changeRequestChangesUnserialisation    = new ChangeRequestChangesUnserialisationImpl(
+      nodeGroupUnserialisation,
+      directiveUnserialisation,
+      ruleUnserialisation,
+      globalParameterUnserialisation,
+      techniqueRepository,
+      sectionSpecParser
+    )
+    lazy val entityMigration                        = DefaultXmlEventLogMigration
+
+    lazy val eventLogDetailsServiceImpl = new EventLogDetailsServiceImpl(
+      queryParser,
+      new DirectiveUnserialisationImpl,
+      new NodeGroupUnserialisationImpl(queryParser),
+      new RuleUnserialisationImpl,
+      new ActiveTechniqueUnserialisationImpl,
+      new DeploymentStatusUnserialisationImpl,
+      new GlobalParameterUnserialisationImpl,
+      new ApiAccountUnserialisationImpl,
+      new SecretUnserialisationImpl
+    )
+
+    //////////////////////////////////////////////////////////
+    //  non success services that could perhaps be
+    //////////////////////////////////////////////////////////
+
+    // => rwLdap is only used to repair an error, that could be repaired elsewhere.
+
+    // => because of systemVariableSpecService
+    // metadata.xml parser
+
+    lazy val variableSpecParser = new VariableSpecParser
+    lazy val sectionSpecParser  = new SectionSpecParser(variableSpecParser)
+    lazy val techniqueParser    = {
+      new TechniqueParser(variableSpecParser, sectionSpecParser, systemVariableSpecService)
+    }
+
+    lazy val userPropertyServiceImpl = new StatelessUserPropertyService(
+      configService.rudder_ui_changeMessage_enabled _,
+      configService.rudder_ui_changeMessage_mandatory _,
+      configService.rudder_ui_changeMessage_explanation _
+    )
+    lazy val userPropertyService     = userPropertyServiceImpl
+
+    ////////////////////////////////////
+    //  non success services
+    ////////////////////////////////////
+
+    ///// end /////
+
+    lazy val logRepository                = {
+      val eventLogRepo = new EventLogJdbcRepository(doobie, eventLogFactory)
+      techniqueRepositoryImpl.registerCallback(
+        new LogEventOnTechniqueReloadCallback(
+          "LogEventTechnique",
+          100, // must be before most of other
+
+          eventLogRepo
+        )
+      )
+      eventLogRepo
+    }
+    lazy val eventLogRepository           = logRepository
+    lazy val inventoryLogEventServiceImpl = new InventoryEventLogServiceImpl(logRepository)
+    lazy val gitConfigRepo                = GitRepositoryProviderImpl
+      .make(RUDDER_GIT_ROOT_CONFIG_REPO)
+      .runOrDie(err => new RuntimeException(s"Error when creating git configuration repository: " + err.fullMsg))
+    lazy val gitConfigRepoGC              = new GitGC(gitConfigRepo, RUDDER_GIT_GC)
+    lazy val gitRevisionProviderImpl      = {
+      new LDAPGitRevisionProvider(rwLdap, rudderDitImpl, gitConfigRepo, RUDDER_TECHNIQUELIBRARY_GIT_REFS_PATH)
+    }
+    lazy val gitRevisionProvider: GitRevisionProvider = gitRevisionProviderImpl
+
+    lazy val techniqueReader: TechniqueReader = {
+      // find the relative path from gitConfigRepo to the ptlib root
+      val gitSlash = new File(RUDDER_GIT_ROOT_CONFIG_REPO).getPath + "/"
+      if (!RUDDER_DIR_TECHNIQUES.startsWith(gitSlash)) {
+        ApplicationLogger.error(
+          "The Technique library root directory must be a sub-directory of '%s', but it is configured to be: '%s'".format(
+            RUDDER_GIT_ROOT_CONFIG_REPO,
+            RUDDER_DIR_TECHNIQUES
+          )
+        )
+        throw new RuntimeException(
+          "The Technique library root directory must be a sub-directory of '%s', but it is configured to be: '%s'".format(
+            RUDDER_GIT_ROOT_CONFIG_REPO,
+            RUDDER_DIR_TECHNIQUES
+          )
+        )
+      }
+
+      // create a demo default-directive-names.conf if none exists
+      val defaultDirectiveNames = new File(RUDDER_DIR_TECHNIQUES, "default-directive-names.conf")
+      if (!defaultDirectiveNames.exists) {
+        FileUtils.writeStringToFile(
+          defaultDirectiveNames,
+          """
+            |#
+            |# This file contains the default name that a directive gets in Rudder UI creation pop-up.
+            |# The file format is a simple key=value file, with key being the techniqueName
+            |# or techniqueName/version and the value being the name to use.
+            |# An empty value will lead to an empty default name.
+            |# For a new Directive, we will try to lookup "TechniqueName/version" and if not
+            |# available "TechniqueName" from this file. If neither key is available, the
+            |# pop-up will use the actual Technique name as default.
+            |# Don't forget to commit the file to have modifications seen by Rudder.
+            |#
+            |
+            |# Default pattern for new directive from "userManagement" technique:
+            |userManagement=User: <name> Login: <login>
+            |# For userManagement version 2.0, prefer that pattern in new Directives:
+            |userManagement/2.0: User 2.0 [LOGIN]
+            |""".stripMargin,
+          RUDDER_CHARSET.value
+        )
+      }
+
+      val relativePath = RUDDER_DIR_TECHNIQUES.substring(gitSlash.size, RUDDER_DIR_TECHNIQUES.size)
+      new GitTechniqueReader(
+        techniqueParser,
+        gitRevisionProviderImpl,
+        gitConfigRepo,
+        "metadata.xml",
+        "category.xml",
+        Some(relativePath),
+        "default-directive-names.conf"
+      )
+    }
+
+    lazy val roLdap                   = {
+      new ROPooledSimpleAuthConnectionProvider(
+        host = LDAP_HOST,
+        port = LDAP_PORT,
+        authDn = LDAP_AUTHDN,
+        authPw = LDAP_AUTHPW,
+        poolSize = LDAP_MAX_POOL_SIZE
+      )
+    }
+    lazy val roLDAPConnectionProvider = roLdap
+    lazy val rwLdap                   = {
+      new RWPooledSimpleAuthConnectionProvider(
+        host = LDAP_HOST,
+        port = LDAP_PORT,
+        authDn = LDAP_AUTHDN,
+        authPw = LDAP_AUTHPW,
+        poolSize = LDAP_MAX_POOL_SIZE
+      )
+    }
+
+    // query processor for accepted nodes
+    lazy val queryProcessor = new AcceptedNodesLDAPQueryProcessor(
+      nodeDitImpl,
+      acceptedNodesDitImpl,
+      new InternalLDAPQueryProcessor(roLdap, acceptedNodesDitImpl, nodeDit, ditQueryDataImpl, ldapEntityMapper),
+      nodeInfoServiceImpl
+    )
+
+    // we need a roLdap query checker for nodes in pending
+    lazy val inventoryQueryChecker = new PendingNodesLDAPQueryChecker(
+      new InternalLDAPQueryProcessor(
+        roLdap,
+        pendingNodesDitImpl,
+        nodeDit, // here, we don't want to look for subgroups to show them in the form => always return an empty list
+
+        new DitQueryData(pendingNodesDitImpl, nodeDit, rudderDit, () => Nil.succeed),
+        ldapEntityMapper
+      ),
+      nodeInfoServiceImpl
+    )
+    lazy val dynGroupServiceImpl   = new DynGroupServiceImpl(rudderDitImpl, roLdap, ldapEntityMapper)
+
+    lazy val pendingNodeCheckGroup = new CheckPendingNodeInDynGroups(inventoryQueryChecker)
+
+    lazy val ldapFullInventoryRepository =
+      new FullInventoryRepositoryImpl(inventoryDitService, inventoryMapper, rwLdap)
+    lazy val fullInventoryRepository     = ldapFullInventoryRepository
+    lazy val unitRefuseGroup:              UnitRefuseInventory                          =
+      new RefuseGroups("refuse_node:delete_id_in_groups", roLdapNodeGroupRepository, woLdapNodeGroupRepository)
+    lazy val acceptInventory:              UnitAcceptInventory with UnitRefuseInventory =
+      new AcceptInventory("accept_new_server:inventory", pendingNodesDitImpl, acceptedNodesDitImpl, ldapFullInventoryRepository)
+    lazy val acceptNodeAndMachineInNodeOu: UnitAcceptInventory with UnitRefuseInventory = {
+      new AcceptFullInventoryInNodeOu(
+        "accept_new_server:ou=node",
+        nodeDitImpl,
+        rwLdap,
+        ldapEntityMapper,
+        PendingInventory,
+        () => configService.rudder_node_onaccept_default_policy_mode().toBox,
+        () => configService.rudder_node_onaccept_default_state().toBox
+      )
+    }
+
+    lazy val acceptHostnameAndIp: UnitAcceptInventory = new AcceptHostnameAndIp(
+      "accept_new_server:check_hostname_unicity",
+      AcceptedInventory,
+      queryProcessor,
+      ditQueryDataImpl,
+      psMngtService,
+      nodeInfoServiceImpl,
+      configService.node_accept_duplicated_hostname()
+    )
+
+    lazy val historizeNodeStateOnChoice: UnitAcceptInventory with UnitRefuseInventory = {
+      new HistorizeNodeStateOnChoice(
+        "accept_or_refuse_new_node:historize_inventory",
+        ldapFullInventoryRepository,
+        diffRepos,
+        PendingInventory
+      )
+    }
+    lazy val updateFactRepoOnChoice:     UnitAcceptInventory with UnitRefuseInventory = new UpdateFactRepoOnChoice(
+      "accept_or_refuse_new_node:update_fact_repo",
+      PendingInventory,
+      factRepo
+    )
+
+    lazy val nodeGridImpl = new NodeGrid(ldapFullInventoryRepository, nodeInfoServiceImpl, configService)
+
+    lazy val modificationService      =
+      new ModificationService(logRepository, gitModificationRepository, itemArchiveManagerImpl, uuidGen)
+    lazy val eventListDisplayerImpl   = new EventListDisplayer(logRepository)
+    lazy val eventLogDetailsGenerator = new EventLogDetailsGenerator(
+      eventLogDetailsServiceImpl,
+      logRepository,
+      roLdapNodeGroupRepository,
+      roLdapDirectiveRepository,
+      nodeInfoServiceImpl,
+      roLDAPRuleCategoryRepository,
+      modificationService,
+      personIdentServiceImpl,
+      linkUtil,
+      diffDisplayer
+    )
+    lazy val databaseManagerImpl      = new DatabaseManagerImpl(reportsRepositoryImpl, updateExpectedRepo)
+    lazy val softwareInventoryDAO: ReadOnlySoftwareDAO =
+      new ReadOnlySoftwareDAOImpl(inventoryDitService, roLdap, inventoryMapper)
+    lazy val readOnlySoftwareDAO = softwareInventoryDAO
+    lazy val softwareInventoryRWDAO: WriteOnlySoftwareDAO = new WriteOnlySoftwareDAOImpl(acceptedNodesDitImpl, rwLdap)
+    lazy val softwareService:        SoftwareService      =
+      new SoftwareServiceImpl(softwareInventoryDAO, softwareInventoryRWDAO, acceptedNodesDit)
+
+    lazy val nodeSummaryServiceImpl = new NodeSummaryServiceImpl(inventoryDitService, inventoryMapper, roLdap)
+    lazy val diffRepos: InventoryHistoryLogRepository = {
+      new InventoryHistoryLogRepository(
+        HISTORY_INVENTORIES_ROOTDIR,
+        new FullInventoryFileParser(fullInventoryFromLdapEntries, inventoryMapper)
+      )
+    }
+    lazy val inventoryHistoryLogRepository = diffRepos
+
+    lazy val personIdentServiceImpl: PersonIdentService = new TrivialPersonIdentService
+    lazy val personIdentService = personIdentServiceImpl
+
+    lazy val roParameterServiceImpl = new RoParameterServiceImpl(roLDAPParameterRepository)
+
+    ///// items archivers - services that allows to transform items to XML and save then on a Git FS /////
+    lazy val gitModificationRepository = new GitModificationRepositoryImpl(doobie)
+    lazy val gitRuleArchiver:                    GitRuleArchiver                    = new GitRuleArchiverImpl(
+      gitConfigRepo,
+      ruleSerialisation,
+      rulesDirectoryName,
+      prettyPrinter,
+      gitModificationRepository,
+      RUDDER_CHARSET.name,
+      RUDDER_GROUP_OWNER_CONFIG_REPO
+    )
+    lazy val gitRuleCategoryArchiver:            GitRuleCategoryArchiver            = new GitRuleCategoryArchiverImpl(
+      gitConfigRepo,
+      ruleCategorySerialisation,
+      ruleCategoriesDirectoryName,
       prettyPrinter,
       gitModificationRepository,
       RUDDER_CHARSET.name,
       "category.xml",
       RUDDER_GROUP_OWNER_CONFIG_REPO
     )
-  }
-  private[this] lazy val gitActiveTechniqueArchiver:         GitActiveTechniqueArchiverImpl     = new GitActiveTechniqueArchiverImpl(
-    gitConfigRepo,
-    activeTechniqueSerialisation,
-    userLibraryDirectoryName,
-    prettyPrinter,
-    gitModificationRepository,
-    Buffer(),
-    RUDDER_CHARSET.name,
-    "activeTechniqueSettings.xml",
-    RUDDER_GROUP_OWNER_CONFIG_REPO
-  )
-  private[this] lazy val gitDirectiveArchiver:               GitDirectiveArchiver               = new GitDirectiveArchiverImpl(
-    gitConfigRepo,
-    directiveSerialisation,
-    userLibraryDirectoryName,
-    prettyPrinter,
-    gitModificationRepository,
-    RUDDER_CHARSET.name,
-    RUDDER_GROUP_OWNER_CONFIG_REPO
-  )
-  private[this] lazy val gitNodeGroupArchiver:               GitNodeGroupArchiver               = new GitNodeGroupArchiverImpl(
-    gitConfigRepo,
-    nodeGroupSerialisation,
-    nodeGroupCategorySerialisation,
-    groupLibraryDirectoryName,
-    prettyPrinter,
-    gitModificationRepository,
-    RUDDER_CHARSET.name,
-    "category.xml",
-    RUDDER_GROUP_OWNER_CONFIG_REPO
-  )
-  private[this] lazy val gitParameterArchiver:               GitParameterArchiver               = new GitParameterArchiverImpl(
-    gitConfigRepo,
-    globalParameterSerialisation,
-    parametersDirectoryName,
-    prettyPrinter,
-    gitModificationRepository,
-    RUDDER_CHARSET.name,
-    RUDDER_GROUP_OWNER_CONFIG_REPO
-  )
-  ////////////// MUTEX FOR rwLdap REPOS //////////////
+    lazy val gitActiveTechniqueCategoryArchiver: GitActiveTechniqueCategoryArchiver = {
+      new GitActiveTechniqueCategoryArchiverImpl(
+        gitConfigRepo,
+        activeTechniqueCategorySerialisation,
+        userLibraryDirectoryName,
+        prettyPrinter,
+        gitModificationRepository,
+        RUDDER_CHARSET.name,
+        "category.xml",
+        RUDDER_GROUP_OWNER_CONFIG_REPO
+      )
+    }
+    lazy val gitActiveTechniqueArchiver:         GitActiveTechniqueArchiverImpl     = new GitActiveTechniqueArchiverImpl(
+      gitConfigRepo,
+      activeTechniqueSerialisation,
+      userLibraryDirectoryName,
+      prettyPrinter,
+      gitModificationRepository,
+      Buffer(),
+      RUDDER_CHARSET.name,
+      "activeTechniqueSettings.xml",
+      RUDDER_GROUP_OWNER_CONFIG_REPO
+    )
+    lazy val gitDirectiveArchiver:               GitDirectiveArchiver               = new GitDirectiveArchiverImpl(
+      gitConfigRepo,
+      directiveSerialisation,
+      userLibraryDirectoryName,
+      prettyPrinter,
+      gitModificationRepository,
+      RUDDER_CHARSET.name,
+      RUDDER_GROUP_OWNER_CONFIG_REPO
+    )
+    lazy val gitNodeGroupArchiver:               GitNodeGroupArchiver               = new GitNodeGroupArchiverImpl(
+      gitConfigRepo,
+      nodeGroupSerialisation,
+      nodeGroupCategorySerialisation,
+      groupLibraryDirectoryName,
+      prettyPrinter,
+      gitModificationRepository,
+      RUDDER_CHARSET.name,
+      "category.xml",
+      RUDDER_GROUP_OWNER_CONFIG_REPO
+    )
+    lazy val gitParameterArchiver:               GitParameterArchiver               = new GitParameterArchiverImpl(
+      gitConfigRepo,
+      globalParameterSerialisation,
+      parametersDirectoryName,
+      prettyPrinter,
+      gitModificationRepository,
+      RUDDER_CHARSET.name,
+      RUDDER_GROUP_OWNER_CONFIG_REPO
+    )
+    ////////////// MUTEX FOR rwLdap REPOS //////////////
 
-  private[this] lazy val uptLibReadWriteMutex    = new ZioTReentrantLock("directive-lock")
-  private[this] lazy val groupLibReadWriteMutex  = new ZioTReentrantLock("group-lock")
-  private[this] lazy val nodeReadWriteMutex      = new ZioTReentrantLock("node-lock")
-  private[this] lazy val parameterReadWriteMutex = new ZioTReentrantLock("parameter-lock")
-  private[this] lazy val ruleReadWriteMutex      = new ZioTReentrantLock("rule-lock")
-  private[this] lazy val ruleCatReadWriteMutex   = new ZioTReentrantLock("rule-cat-lock")
+    lazy val uptLibReadWriteMutex    = new ZioTReentrantLock("directive-lock")
+    lazy val groupLibReadWriteMutex  = new ZioTReentrantLock("group-lock")
+    lazy val nodeReadWriteMutex      = new ZioTReentrantLock("node-lock")
+    lazy val parameterReadWriteMutex = new ZioTReentrantLock("parameter-lock")
+    lazy val ruleReadWriteMutex      = new ZioTReentrantLock("rule-lock")
+    lazy val ruleCatReadWriteMutex   = new ZioTReentrantLock("rule-cat-lock")
 
-  private[this] lazy val roLdapDirectiveRepository =
-    new RoLDAPDirectiveRepository(rudderDitImpl, roLdap, ldapEntityMapper, techniqueRepositoryImpl, uptLibReadWriteMutex)
-  private[this] lazy val woLdapDirectiveRepository = {
-    val repo = new WoLDAPDirectiveRepository(
-      roLdapDirectiveRepository,
+    lazy val roLdapDirectiveRepository =
+      new RoLDAPDirectiveRepository(rudderDitImpl, roLdap, ldapEntityMapper, techniqueRepositoryImpl, uptLibReadWriteMutex)
+    lazy val roDirectiveRepository: RoDirectiveRepository = roLdapDirectiveRepository
+    lazy val woLdapDirectiveRepository = {
+      val repo = new WoLDAPDirectiveRepository(
+        roLdapDirectiveRepository,
+        rwLdap,
+        ldapDiffMapper,
+        logRepository,
+        uuidGen,
+        gitDirectiveArchiver,
+        gitActiveTechniqueArchiver,
+        gitActiveTechniqueCategoryArchiver,
+        personIdentServiceImpl,
+        RUDDER_AUTOARCHIVEITEMS
+      )
+
+      gitActiveTechniqueArchiver.uptModificationCallback += new UpdatePiOnActiveTechniqueEvent(
+        gitDirectiveArchiver,
+        techniqueRepositoryImpl,
+        roLdapDirectiveRepository
+      )
+
+      techniqueRepositoryImpl.registerCallback(
+        new SaveDirectivesOnTechniqueCallback(
+          "SaveDirectivesOnTechniqueCallback",
+          100,
+          directiveEditorServiceImpl,
+          roLdapDirectiveRepository,
+          repo
+        )
+      )
+
+      repo
+    }
+    lazy val woDirectiveRepository: WoDirectiveRepository = woLdapDirectiveRepository
+
+    lazy val roLdapRuleRepository =
+      new RoLDAPRuleRepository(rudderDitImpl, roLdap, ldapEntityMapper, ruleReadWriteMutex)
+    lazy val roRuleRepository: RoRuleRepository = roLdapRuleRepository
+
+    lazy val woLdapRuleRepository: WoRuleRepository = new WoLDAPRuleRepository(
+      roLdapRuleRepository,
       rwLdap,
       ldapDiffMapper,
+      roLdapNodeGroupRepository,
       logRepository,
-      uuidGen,
-      gitDirectiveArchiver,
-      gitActiveTechniqueArchiver,
-      gitActiveTechniqueCategoryArchiver,
+      gitRuleArchiver,
       personIdentServiceImpl,
       RUDDER_AUTOARCHIVEITEMS
     )
+    lazy val woRuleRepository = woLdapRuleRepository
 
-    gitActiveTechniqueArchiver.uptModificationCallback += new UpdatePiOnActiveTechniqueEvent(
-      gitDirectiveArchiver,
-      techniqueRepositoryImpl,
-      roLdapDirectiveRepository
+    lazy val woLdapNodeRepository: WoNodeRepository = new WoLDAPNodeRepository(
+      nodeDitImpl,
+      acceptedNodesDit,
+      ldapEntityMapper,
+      rwLdap,
+      logRepository,
+      nodeReadWriteMutex,
+      cachedNodeConfigurationService,
+      reportingServiceImpl
     )
+    lazy val woNodeRepository = woLdapNodeRepository
 
-    techniqueRepositoryImpl.registerCallback(
-      new SaveDirectivesOnTechniqueCallback(
-        "SaveDirectivesOnTechniqueCallback",
-        100,
-        directiveEditorServiceImpl,
-        roLdapDirectiveRepository,
-        repo
-      )
-    )
-
-    repo
-  }
-  private[this] lazy val roLdapRuleRepository      =
-    new RoLDAPRuleRepository(rudderDitImpl, roLdap, ldapEntityMapper, ruleReadWriteMutex)
-
-  private[this] lazy val woLdapRuleRepository: WoRuleRepository = new WoLDAPRuleRepository(
-    roLdapRuleRepository,
-    rwLdap,
-    ldapDiffMapper,
-    roLdapNodeGroupRepository,
-    logRepository,
-    gitRuleArchiver,
-    personIdentServiceImpl,
-    RUDDER_AUTOARCHIVEITEMS
-  )
-
-  private[this] lazy val woLdapNodeRepository: WoNodeRepository = new WoLDAPNodeRepository(
-    nodeDitImpl,
-    acceptedNodesDit,
-    ldapEntityMapper,
-    rwLdap,
-    logRepository,
-    nodeReadWriteMutex,
-    cachedNodeConfigurationService,
-    reportingServiceImpl
-  )
-
-  private[this] lazy val roLdapNodeGroupRepository = new RoLDAPNodeGroupRepository(
-    rudderDitImpl,
-    roLdap,
-    ldapEntityMapper,
-    groupLibReadWriteMutex
-  )
-  private[this] lazy val woLdapNodeGroupRepository = new WoLDAPNodeGroupRepository(
-    roLdapNodeGroupRepository,
-    rwLdap,
-    ldapDiffMapper,
-    uuidGen,
-    logRepository,
-    gitNodeGroupArchiver,
-    personIdentServiceImpl,
-    RUDDER_AUTOARCHIVEITEMS
-  )
-
-  private[this] lazy val roLDAPRuleCategoryRepository = {
-    new RoLDAPRuleCategoryRepository(
+    lazy val roLdapNodeGroupRepository = new RoLDAPNodeGroupRepository(
       rudderDitImpl,
       roLdap,
       ldapEntityMapper,
-      ruleCatReadWriteMutex
+      groupLibReadWriteMutex
     )
-  }
-  private[this] lazy val woLDAPRuleCategoryRepository = {
-    new WoLDAPRuleCategoryRepository(
-      roLDAPRuleCategoryRepository,
+    lazy val roNodeGroupRepository: RoNodeGroupRepository = roLdapNodeGroupRepository
+
+    lazy val woLdapNodeGroupRepository = new WoLDAPNodeGroupRepository(
+      roLdapNodeGroupRepository,
       rwLdap,
+      ldapDiffMapper,
       uuidGen,
-      gitRuleCategoryArchiver,
+      logRepository,
+      gitNodeGroupArchiver,
       personIdentServiceImpl,
       RUDDER_AUTOARCHIVEITEMS
     )
-  }
+    lazy val woNodeGroupRepository: WoNodeGroupRepository = woLdapNodeGroupRepository
 
-  lazy val roLDAPParameterRepository               = new RoLDAPParameterRepository(
-    rudderDitImpl,
-    roLdap,
-    ldapEntityMapper,
-    parameterReadWriteMutex
-  )
-  private[this] lazy val woLDAPParameterRepository = new WoLDAPParameterRepository(
-    roLDAPParameterRepository,
-    rwLdap,
-    ldapDiffMapper,
-    logRepository,
-    gitParameterArchiver,
-    personIdentServiceImpl,
-    RUDDER_AUTOARCHIVEITEMS
-  )
+    lazy val roLDAPRuleCategoryRepository = {
+      new RoLDAPRuleCategoryRepository(
+        rudderDitImpl,
+        roLdap,
+        ldapEntityMapper,
+        ruleCatReadWriteMutex
+      )
+    }
 
-  private[this] lazy val itemArchiveManagerImpl = new ItemArchiveManagerImpl(
-    roLdapRuleRepository,
-    woLdapRuleRepository,
-    roLDAPRuleCategoryRepository,
-    roLdapDirectiveRepository,
-    roLdapNodeGroupRepository,
-    roLDAPParameterRepository,
-    woLDAPParameterRepository,
-    gitConfigRepo,
-    gitRevisionProviderImpl,
-    gitRuleArchiver,
-    gitRuleCategoryArchiver,
-    gitActiveTechniqueCategoryArchiver,
-    gitActiveTechniqueArchiver,
-    gitNodeGroupArchiver,
-    gitParameterArchiver,
-    parseRules,
-    parseActiveTechniqueLibrary,
-    parseGlobalParameter,
-    parseRuleCategories,
-    importTechniqueLibrary,
-    parseGroupLibrary,
-    importGroupLibrary,
-    importRuleCategoryLibrary,
-    logRepository,
-    asyncDeploymentAgentImpl,
-    gitModificationRepository,
-    dynGroupUpdaterService
-  )
+    lazy val woLDAPRuleCategoryRepository = {
+      new WoLDAPRuleCategoryRepository(
+        roLDAPRuleCategoryRepository,
+        rwLdap,
+        uuidGen,
+        gitRuleCategoryArchiver,
+        personIdentServiceImpl,
+        RUDDER_AUTOARCHIVEITEMS
+      )
+    }
 
-  private[this] lazy val globalComplianceModeService: ComplianceModeService   = {
-    new ComplianceModeServiceImpl(
-      () => configService.rudder_compliance_mode_name().toBox,
-      () => configService.rudder_compliance_heartbeatPeriod().toBox
+    lazy val roLDAPParameterRepository = new RoLDAPParameterRepository(
+      rudderDitImpl,
+      roLdap,
+      ldapEntityMapper,
+      parameterReadWriteMutex
     )
-  }
-  private[this] lazy val globalAgentRunService:       AgentRunIntervalService = {
-    new AgentRunIntervalServiceImpl(
-      nodeInfoServiceImpl,
-      () => configService.agent_run_interval().toBox,
-      () => configService.agent_run_start_hour().toBox,
-      () => configService.agent_run_start_minute().toBox,
-      () => configService.agent_run_splaytime().toBox,
-      () => configService.rudder_compliance_heartbeatPeriod().toBox
+
+    lazy val woLDAPParameterRepository = new WoLDAPParameterRepository(
+      roLDAPParameterRepository,
+      rwLdap,
+      ldapDiffMapper,
+      logRepository,
+      gitParameterArchiver,
+      personIdentServiceImpl,
+      RUDDER_AUTOARCHIVEITEMS
     )
-  }
 
-  private[this] lazy val systemVariableService: SystemVariableService = new SystemVariableServiceImpl(
-    systemVariableSpecService,
-    psMngtService,
-    RUDDER_DIR_DEPENDENCIES,
-    CFENGINE_POLICY_DISTRIBUTION_PORT,
-    HTTPS_POLICY_DISTRIBUTION_PORT,
-    RUDDER_DIR_SHARED_FILES_FOLDER,
-    RUDDER_WEBDAV_USER,
-    RUDDER_WEBDAV_PASSWORD,
-    RUDDER_JDBC_URL,
-    RUDDER_JDBC_USERNAME,
-    RUDDER_JDBC_PASSWORD,
-    RUDDER_GIT_ROOT_CONFIG_REPO,
-    rudderFullVersion,
-    () => configService.cfengine_server_denybadclocks().toBox,
-    () => configService.relay_server_sync_method().toBox,
-    () => configService.relay_server_syncpromises().toBox,
-    () => configService.relay_server_syncsharedfiles().toBox,
-    () => configService.cfengine_modified_files_ttl().toBox,
-    () => configService.cfengine_outputs_ttl().toBox,
-    () => configService.send_server_metrics().toBox,
-    () => configService.rudder_report_protocol_default().toBox,
-    () => configService.rudder_verify_certificates().toBox
-  )
-  private[this] lazy val rudderCf3PromisesFileWriterService = new PolicyWriterServiceImpl(
-    techniqueRepositoryImpl,
-    pathComputer,
-    new NodeConfigurationLoggerImpl(RUDDER_DEBUG_NODE_CONFIGURATION_PATH),
-    new PrepareTemplateVariablesImpl(
-      techniqueRepositoryImpl,
-      systemVariableSpecService,
-      new BuildBundleSequence(systemVariableSpecService, writeAllAgentSpecificFiles),
-      agentRegister
-    ),
-    new FillTemplatesService(),
-    writeAllAgentSpecificFiles,
-    HOOKS_D,
-    HOOKS_IGNORE_SUFFIXES,
-    RUDDER_CHARSET.value,
-    Some(RUDDER_GROUP_OWNER_GENERATED_POLICIES)
-  )
-
-  // must be here because of circular dependency if in techniqueRepository
-  techniqueRepositoryImpl.registerCallback(
-    new TechniqueAcceptationUpdater(
-      "UpdatePTAcceptationDatetime",
-      50,
-      roLdapDirectiveRepository,
-      woLdapDirectiveRepository,
-      techniqueRepository,
-      uuidGen
-    )
-  )
-
-  private[this] lazy val techniqueRepositoryImpl = {
-    val service = new TechniqueRepositoryImpl(
-      techniqueReader,
-      Seq(),
-      uuidGen
-    )
-    service
-  }
-  lazy val interpolationCompiler                 = new InterpolatedValueCompilerImpl(propertyEngineService)
-  lazy val typeParameterService:         PlugableParameterTypeService = new PlugableParameterTypeService()
-  private[this] lazy val ruleValService: RuleValService               = new RuleValServiceImpl(interpolationCompiler)
-
-  private[this] lazy val psMngtService: PolicyServerManagementService = new PolicyServerManagementServiceImpl(
-    rwLdap,
-    rudderDit,
-    eventLogRepository
-  )
-
-  lazy val deploymentService = {
-    new PromiseGenerationServiceImpl(
+    lazy val itemArchiveManagerImpl = new ItemArchiveManagerImpl(
       roLdapRuleRepository,
       woLdapRuleRepository,
-      ruleValService,
-      systemVariableService,
-      nodeConfigurationHashRepo,
-      nodeInfoServiceImpl,
-      updateExpectedRepo,
-      roNodeGroupRepository,
-      roDirectiveRepository,
-      configurationRepository,
-      ruleApplicationStatusImpl,
-      roParameterServiceImpl,
-      interpolationCompiler,
-      ldapFullInventoryRepository,
-      globalComplianceModeService,
-      globalAgentRunService,
-      reportingServiceImpl,
-      rudderCf3PromisesFileWriterService,
-      new WriteNodeCertificatesPemImpl(Some(RUDDER_RELAY_RELOAD)),
-      cachedNodeConfigurationService,
-      () => configService.rudder_featureSwitch_directiveScriptEngine().toBox,
-      () => configService.rudder_global_policy_mode().toBox,
-      () => configService.rudder_generation_compute_dyngroups().toBox,
-      () => configService.rudder_generation_max_parallelism().toBox,
-      () => configService.rudder_generation_js_timeout().toBox,
-      () => configService.rudder_generation_continue_on_error().toBox,
+      roLDAPRuleCategoryRepository,
+      roLdapDirectiveRepository,
+      roLdapNodeGroupRepository,
+      roLDAPParameterRepository,
+      woLDAPParameterRepository,
+      gitConfigRepo,
+      gitRevisionProviderImpl,
+      gitRuleArchiver,
+      gitRuleCategoryArchiver,
+      gitActiveTechniqueCategoryArchiver,
+      gitActiveTechniqueArchiver,
+      gitNodeGroupArchiver,
+      gitParameterArchiver,
+      parseRules,
+      parseActiveTechniqueLibrary,
+      parseGlobalParameter,
+      parseRuleCategories,
+      importTechniqueLibrary,
+      parseGroupLibrary,
+      importGroupLibrary,
+      importRuleCategoryLibrary,
+      logRepository,
+      asyncDeploymentAgentImpl,
+      gitModificationRepository,
+      dynGroupUpdaterService
+    )
+    lazy val itemArchiveManager: ItemArchiveManager = itemArchiveManagerImpl
+
+    lazy val globalComplianceModeService: ComplianceModeService   = {
+      new ComplianceModeServiceImpl(
+        () => configService.rudder_compliance_mode_name().toBox,
+        () => configService.rudder_compliance_heartbeatPeriod().toBox
+      )
+    }
+    lazy val globalAgentRunService:       AgentRunIntervalService = {
+      new AgentRunIntervalServiceImpl(
+        nodeInfoServiceImpl,
+        () => configService.agent_run_interval().toBox,
+        () => configService.agent_run_start_hour().toBox,
+        () => configService.agent_run_start_minute().toBox,
+        () => configService.agent_run_splaytime().toBox,
+        () => configService.rudder_compliance_heartbeatPeriod().toBox
+      )
+    }
+
+    lazy val systemVariableService: SystemVariableService = new SystemVariableServiceImpl(
+      systemVariableSpecService,
+      psMngtService,
+      RUDDER_DIR_DEPENDENCIES,
+      CFENGINE_POLICY_DISTRIBUTION_PORT,
+      HTTPS_POLICY_DISTRIBUTION_PORT,
+      RUDDER_DIR_SHARED_FILES_FOLDER,
+      RUDDER_WEBDAV_USER,
+      RUDDER_WEBDAV_PASSWORD,
+      RUDDER_JDBC_URL,
+      RUDDER_JDBC_USERNAME,
+      RUDDER_JDBC_PASSWORD,
+      RUDDER_GIT_ROOT_CONFIG_REPO,
+      rudderFullVersion,
+      () => configService.cfengine_server_denybadclocks().toBox,
+      () => configService.relay_server_sync_method().toBox,
+      () => configService.relay_server_syncpromises().toBox,
+      () => configService.relay_server_syncsharedfiles().toBox,
+      () => configService.cfengine_modified_files_ttl().toBox,
+      () => configService.cfengine_outputs_ttl().toBox,
+      () => configService.send_server_metrics().toBox,
+      () => configService.rudder_report_protocol_default().toBox,
+      () => configService.rudder_verify_certificates().toBox
+    )
+    lazy val rudderCf3PromisesFileWriterService = new PolicyWriterServiceImpl(
+      techniqueRepositoryImpl,
+      pathComputer,
+      new NodeConfigurationLoggerImpl(RUDDER_DEBUG_NODE_CONFIGURATION_PATH),
+      new PrepareTemplateVariablesImpl(
+        techniqueRepositoryImpl,
+        systemVariableSpecService,
+        new BuildBundleSequence(systemVariableSpecService, writeAllAgentSpecificFiles),
+        agentRegister
+      ),
+      new FillTemplatesService(),
+      writeAllAgentSpecificFiles,
       HOOKS_D,
       HOOKS_IGNORE_SUFFIXES,
-      UPDATED_NODE_IDS_PATH,
-      UPDATED_NODE_IDS_COMPABILITY,
-      GENERATION_FAILURE_MSG_PATH,
-      allNodeCertificatesPemFile = better.files.File("/var/rudder/lib/ssl/allnodescerts.pem"),
-      POSTGRESQL_IS_LOCAL
+      RUDDER_CHARSET.value,
+      Some(RUDDER_GROUP_OWNER_GENERATED_POLICIES)
     )
-  }
 
-  lazy val policyGenerationBootGuard = zio.Promise.make[Nothing, Unit].runNow
-
-  private[this] lazy val asyncDeploymentAgentImpl: AsyncDeploymentActor = {
-    val agent = new AsyncDeploymentActor(
-      deploymentService,
-      eventLogDeploymentServiceImpl,
-      deploymentStatusSerialisation,
-      () => configService.rudder_generation_delay(),
-      () => configService.rudder_generation_trigger(),
-      policyGenerationBootGuard
-    )
+    // must be here because of circular dependency if in techniqueRepository
     techniqueRepositoryImpl.registerCallback(
-      new DeployOnTechniqueCallback("DeployOnPTLibUpdate", 1000, agent)
+      new TechniqueAcceptationUpdater(
+        "UpdatePTAcceptationDatetime",
+        50,
+        roLdapDirectiveRepository,
+        woLdapDirectiveRepository,
+        techniqueRepository,
+        uuidGen
+      )
     )
-    agent
-  }
 
-  private[this] lazy val newNodeManagerImpl = {
-    // the sequence of unit process to accept a new inventory
-    val unitAcceptors = {
-      historizeNodeStateOnChoice ::
-      updateFactRepoOnChoice ::
-      acceptNodeAndMachineInNodeOu ::
-      acceptInventory ::
-      acceptHostnameAndIp ::
-      Nil
+    lazy val techniqueRepositoryImpl = {
+      val service = new TechniqueRepositoryImpl(
+        techniqueReader,
+        Seq(),
+        uuidGen
+      )
+      service
+    }
+    lazy val techniqueRepository: TechniqueRepository = techniqueRepositoryImpl
+    lazy val updateTechniqueLibrary: UpdateTechniqueLibrary = techniqueRepositoryImpl
+    lazy val interpolationCompiler = new InterpolatedValueCompilerImpl(propertyEngineService)
+    lazy val typeParameterService: PlugableParameterTypeService = new PlugableParameterTypeService()
+    lazy val ruleValService:       RuleValService               = new RuleValServiceImpl(interpolationCompiler)
+
+    lazy val psMngtService: PolicyServerManagementService = new PolicyServerManagementServiceImpl(
+      rwLdap,
+      rudderDit,
+      eventLogRepository
+    )
+    lazy val policyServerManagementService = psMngtService
+
+    lazy val deploymentService = {
+      new PromiseGenerationServiceImpl(
+        roLdapRuleRepository,
+        woLdapRuleRepository,
+        ruleValService,
+        systemVariableService,
+        nodeConfigurationHashRepo,
+        nodeInfoServiceImpl,
+        updateExpectedRepo,
+        roNodeGroupRepository,
+        roDirectiveRepository,
+        configurationRepository,
+        ruleApplicationStatusImpl,
+        roParameterServiceImpl,
+        interpolationCompiler,
+        ldapFullInventoryRepository,
+        globalComplianceModeService,
+        globalAgentRunService,
+        reportingServiceImpl,
+        rudderCf3PromisesFileWriterService,
+        new WriteNodeCertificatesPemImpl(Some(RUDDER_RELAY_RELOAD)),
+        cachedNodeConfigurationService,
+        () => configService.rudder_featureSwitch_directiveScriptEngine().toBox,
+        () => configService.rudder_global_policy_mode().toBox,
+        () => configService.rudder_generation_compute_dyngroups().toBox,
+        () => configService.rudder_generation_max_parallelism().toBox,
+        () => configService.rudder_generation_js_timeout().toBox,
+        () => configService.rudder_generation_continue_on_error().toBox,
+        HOOKS_D,
+        HOOKS_IGNORE_SUFFIXES,
+        UPDATED_NODE_IDS_PATH,
+        UPDATED_NODE_IDS_COMPABILITY,
+        GENERATION_FAILURE_MSG_PATH,
+        allNodeCertificatesPemFile = better.files.File("/var/rudder/lib/ssl/allnodescerts.pem"),
+        POSTGRESQL_IS_LOCAL
+      )
     }
 
-    // the sequence of unit process to refuse a new inventory
-    val unitRefusors = {
-      historizeNodeStateOnChoice ::
-      updateFactRepoOnChoice ::
-      unitRefuseGroup ::
-      acceptInventory ::
-      Nil
+    lazy val policyGenerationBootGuard = zio.Promise.make[Nothing, Unit].runNow
+
+    lazy val asyncDeploymentAgentImpl: AsyncDeploymentActor = {
+      val agent = new AsyncDeploymentActor(
+        deploymentService,
+        eventLogDeploymentServiceImpl,
+        deploymentStatusSerialisation,
+        () => configService.rudder_generation_delay(),
+        () => configService.rudder_generation_trigger(),
+        policyGenerationBootGuard
+      )
+      techniqueRepositoryImpl.registerCallback(
+        new DeployOnTechniqueCallback("DeployOnPTLibUpdate", 1000, agent)
+      )
+      agent
+    }
+    lazy val asyncDeploymentAgent = asyncDeploymentAgentImpl
+
+    lazy val newNodeManagerImpl = {
+      // the sequence of unit process to accept a new inventory
+      val unitAcceptors = {
+        historizeNodeStateOnChoice ::
+        updateFactRepoOnChoice ::
+        acceptNodeAndMachineInNodeOu ::
+        acceptInventory ::
+        acceptHostnameAndIp ::
+        Nil
+      }
+
+      // the sequence of unit process to refuse a new inventory
+      val unitRefusors = {
+        historizeNodeStateOnChoice ::
+        updateFactRepoOnChoice ::
+        unitRefuseGroup ::
+        acceptInventory ::
+        Nil
+      }
+
+      new NewNodeManagerImpl(
+        roLdap,
+        pendingNodesDitImpl,
+        acceptedNodesDitImpl,
+        nodeSummaryServiceImpl,
+        ldapFullInventoryRepository,
+        unitAcceptors,
+        unitRefusors,
+        inventoryHistoryLogRepository,
+        eventLogRepository,
+        dyngroupUpdaterBatch,
+        List(nodeInfoServiceImpl),
+        cachedNodeConfigurationService,
+        reportingServiceImpl,
+        nodeInfoServiceImpl,
+        HOOKS_D,
+        HOOKS_IGNORE_SUFFIXES
+      )
+    }
+    lazy val newNodeManager: NewNodeManager = newNodeManagerImpl
+
+    lazy val nodeConfigurationHashRepo: NodeConfigurationHashRepository = {
+      val x = new FileBasedNodeConfigurationHashRepository(FileBasedNodeConfigurationHashRepository.defaultHashesPath)
+      x.init
+      x
     }
 
-    new NewNodeManagerImpl(
+    lazy val reportingServiceImpl = {
+      val reportingServiceImpl = new CachedReportingServiceImpl(
+        new ReportingServiceImpl(
+          findExpectedRepo,
+          reportsRepositoryImpl,
+          roAgentRunsRepository,
+          globalAgentRunService,
+          nodeInfoServiceImpl,
+          roLdapDirectiveRepository,
+          roRuleRepository,
+          cachedNodeConfigurationService,
+          () => globalComplianceModeService.getGlobalComplianceMode,
+          configService.rudder_global_policy_mode _,
+          () => configService.rudder_compliance_unexpected_report_interpretation().toBox,
+          RUDDER_JDBC_BATCH_MAX_SIZE
+        ),
+        nodeInfoServiceImpl,
+        RUDDER_JDBC_BATCH_MAX_SIZE, // use same size as for SQL requests
+
+        complianceRepositoryImpl
+      )
+      // to avoid a StackOverflowError, we set the compliance cache once it'z ready,
+      // and can construct the nodeconfigurationservice without the comlpince cache
+      cachedNodeConfigurationService.addHook(reportingServiceImpl)
+      reportingServiceImpl
+    }
+    lazy val reportingService: ReportingService = reportingServiceImpl
+
+    lazy val pgIn                     = new PostgresqlInClause(70)
+    lazy val findExpectedRepo         = new FindExpectedReportsJdbcRepository(doobie, pgIn, RUDDER_JDBC_BATCH_MAX_SIZE)
+    lazy val updateExpectedRepo       = new UpdateExpectedReportsJdbcRepository(doobie, pgIn, RUDDER_JDBC_BATCH_MAX_SIZE)
+    lazy val reportsRepositoryImpl    = new ReportsJdbcRepository(doobie)
+    lazy val reportsRepository        = reportsRepositoryImpl
+    lazy val complianceRepositoryImpl = new ComplianceJdbcRepository(
+      doobie,
+      () => configService.rudder_save_db_compliance_details().toBox,
+      () => configService.rudder_save_db_compliance_levels().toBox
+    )
+    lazy val dataSourceProvider       = new RudderDatasourceProvider(
+      RUDDER_JDBC_DRIVER,
+      RUDDER_JDBC_URL,
+      RUDDER_JDBC_USERNAME,
+      RUDDER_JDBC_PASSWORD,
+      RUDDER_JDBC_MAX_POOL_SIZE
+    )
+    lazy val doobie                   = new Doobie(dataSourceProvider.datasource)
+
+    lazy val parseRules:                  ParseRules with RuleRevisionRepository         = new GitParseRules(
+      ruleUnserialisation,
+      gitConfigRepo,
+      entityMigration,
+      rulesDirectoryName
+    )
+    lazy val parseActiveTechniqueLibrary: GitParseActiveTechniqueLibrary                 = new GitParseActiveTechniqueLibrary(
+      activeTechniqueCategoryUnserialisation,
+      activeTechniqueUnserialisation,
+      directiveUnserialisation,
+      gitConfigRepo,
+      gitRevisionProvider,
+      entityMigration,
+      userLibraryDirectoryName
+    )
+    lazy val importTechniqueLibrary:      ImportTechniqueLibrary                         = new ImportTechniqueLibraryImpl(
+      rudderDitImpl,
+      rwLdap,
+      ldapEntityMapper,
+      uptLibReadWriteMutex
+    )
+    lazy val parseGroupLibrary:           ParseGroupLibrary with GroupRevisionRepository = new GitParseGroupLibrary(
+      nodeGroupCategoryUnserialisation,
+      nodeGroupUnserialisation,
+      gitConfigRepo,
+      entityMigration,
+      groupLibraryDirectoryName
+    )
+    lazy val parseGlobalParameter:        ParseGlobalParameters                          = new GitParseGlobalParameters(
+      globalParameterUnserialisation,
+      gitConfigRepo,
+      entityMigration,
+      parametersDirectoryName
+    )
+    lazy val parseRuleCategories:         ParseRuleCategories                            = new GitParseRuleCategories(
+      ruleCategoryUnserialisation,
+      gitConfigRepo,
+      entityMigration,
+      ruleCategoriesDirectoryName
+    )
+    lazy val importGroupLibrary:          ImportGroupLibrary                             = new ImportGroupLibraryImpl(
+      rudderDitImpl,
+      rwLdap,
+      ldapEntityMapper,
+      groupLibReadWriteMutex
+    )
+    lazy val importRuleCategoryLibrary:   ImportRuleCategoryLibrary                      = new ImportRuleCategoryLibraryImpl(
+      rudderDitImpl,
+      rwLdap,
+      ldapEntityMapper,
+      ruleCatReadWriteMutex
+    )
+    lazy val eventLogDeploymentServiceImpl = new EventLogDeploymentService(logRepository, eventLogDetailsServiceImpl)
+    lazy val nodeInfoServiceImpl           = new NodeInfoServiceCachedImpl(
       roLdap,
+      nodeDitImpl,
+      acceptedNodesDitImpl,
+      removedNodesDitImpl,
+      pendingNodesDitImpl,
+      ldapEntityMapper,
+      inventoryMapper,
+      FiniteDuration(LDAP_CACHE_NODE_INFO_MIN_INTERVAL.toMillis, "millis")
+    )
+    lazy val nodeInfoService:              NodeInfoService              = nodeInfoServiceImpl
+    lazy val dependencyAndDeletionService: DependencyAndDeletionService = new DependencyAndDeletionServiceImpl(
+      new FindDependenciesImpl(roLdap, rudderDitImpl, ldapEntityMapper),
+      roLdapDirectiveRepository,
+      woLdapDirectiveRepository,
+      woLdapRuleRepository,
+      woLdapNodeGroupRepository
+    )
+
+    lazy val logDisplayerImpl:               LogDisplayer               =
+      new LogDisplayer(reportsRepositoryImpl, configurationRepository, roLdapRuleRepository)
+    lazy val categoryHierarchyDisplayerImpl: CategoryHierarchyDisplayer = new CategoryHierarchyDisplayer()
+    lazy val dyngroupUpdaterBatch:           UpdateDynamicGroups        = new UpdateDynamicGroups(
+      dynGroupServiceImpl,
+      dynGroupUpdaterService,
+      asyncDeploymentAgentImpl,
+      uuidGen,
+      RUDDER_BATCH_DYNGROUP_UPDATEINTERVAL,
+      () => configService.rudder_compute_dyngroups_max_parallelism().toBox
+    )
+    lazy val updateDynamicGroups = dyngroupUpdaterBatch
+
+    lazy val dynGroupUpdaterService =
+      new DynGroupUpdaterServiceImpl(roLdapNodeGroupRepository, woLdapNodeGroupRepository, queryProcessor)
+
+    lazy val dbCleaner: AutomaticReportsCleaning = {
+      val cleanFrequency = AutomaticReportsCleaning.buildFrequency(
+        RUDDER_BATCH_REPORTSCLEANER_FREQUENCY,
+        RUDDER_BATCH_DATABASECLEANER_RUNTIME_MINUTE,
+        RUDDER_BATCH_DATABASECLEANER_RUNTIME_HOUR,
+        RUDDER_BATCH_DATABASECLEANER_RUNTIME_DAY
+      ) match {
+        case Full(freq) => freq
+        case eb: EmptyBox =>
+          val fail         = eb ?~! "automatic reports cleaner is not correct"
+          val exceptionMsg =
+            "configuration file (/opt/rudder/etc/rudder-webapp.conf) is not correctly set, cause is %s".format(fail.msg)
+          throw new RuntimeException(exceptionMsg)
+      }
+
+      new AutomaticReportsCleaning(
+        databaseManagerImpl,
+        roLDAPConnectionProvider,
+        RUDDER_BATCH_REPORTSCLEANER_DELETE_TTL,
+        RUDDER_BATCH_REPORTSCLEANER_ARCHIVE_TTL,
+        RUDDER_BATCH_REPORTSCLEANER_COMPLIANCE_DELETE_TTL,
+        RUDDER_BATCH_REPORTSCLEANER_LOG_DELETE_TTL,
+        cleanFrequency
+      )
+    }
+
+    lazy val techniqueLibraryUpdater = new CheckTechniqueLibrary(
+      techniqueRepositoryImpl,
+      asyncDeploymentAgent,
+      uuidGen,
+      RUDDER_BATCH_TECHNIQUELIBRARY_UPDATEINTERVAL
+    )
+
+    lazy val jsTreeUtilServiceImpl = new JsTreeUtilService(roLdapDirectiveRepository, techniqueRepositoryImpl)
+
+    /*
+     * Cleaning action are run for the case where the node was accepted, deleted, and unknown
+     * (ie: we want to be able to run cleaning actions even on a node that was deleted in the past, but
+     * for some reason the user discover that theres remaining things, and he wants to get rid of them
+     * without knowing rudder internal place to look for all possible garbages)
+     */
+
+    /*
+     * The list of post deletion action to execute in a shared reference, created at class instanciation.
+     * External services can update it from removeNodeServiceImpl.
+     */
+    lazy val postNodeDeleteActions = Ref
+      .make(
+        new RemoveNodeInfoFromCache(nodeInfoServiceImpl)
+        :: new CloseNodeConfiguration(updateExpectedRepo)
+        :: new RemoveNodeFromComplianceCache(cachedNodeConfigurationService, reportingServiceImpl)
+        :: new DeletePolicyServerPolicies(policyServerManagementService)
+        :: new ResetKeyStatus(rwLdap, removedNodesDitImpl)
+        :: new CleanUpCFKeys()
+        :: new CleanUpNodePolicyFiles("/var/rudder/share")
+        :: new DeleteNodeFact(factRepo)
+        :: Nil
+      )
+      .runNow
+
+    lazy val removeNodeServiceImpl = new RemoveNodeServiceImpl(
+      nodeDitImpl,
+      rudderDitImpl,
       pendingNodesDitImpl,
       acceptedNodesDitImpl,
-      nodeSummaryServiceImpl,
-      ldapFullInventoryRepository,
-      unitAcceptors,
-      unitRefusors,
-      inventoryHistoryLogRepository,
-      eventLogRepository,
-      dyngroupUpdaterBatch,
-      List(nodeInfoServiceImpl),
-      cachedNodeConfigurationService,
-      reportingServiceImpl,
+      removedNodesDitImpl,
+      rwLdap,
+      ldapEntityMapper,
+      roLdapNodeGroupRepository,
+      woLdapNodeGroupRepository,
       nodeInfoServiceImpl,
+      ldapFullInventoryRepository,
+      logRepository,
+      nodeReadWriteMutex,
+      pathComputer,
+      newNodeManager,
+      postNodeDeleteActions,
       HOOKS_D,
       HOOKS_IGNORE_SUFFIXES
     )
-  }
+    lazy val removeNodeService: RemoveNodeService = removeNodeServiceImpl
 
-  lazy val nodeConfigurationHashRepo: NodeConfigurationHashRepository = {
-    val x = new FileBasedNodeConfigurationHashRepository(FileBasedNodeConfigurationHashRepository.defaultHashesPath)
-    x.init
-    x
-  }
-
-  private[this] lazy val reportingServiceImpl = {
-    val reportingServiceImpl = new CachedReportingServiceImpl(
-      new ReportingServiceImpl(
-        findExpectedRepo,
-        reportsRepositoryImpl,
-        roAgentRunsRepository,
-        globalAgentRunService,
-        nodeInfoServiceImpl,
-        roLdapDirectiveRepository,
-        roRuleRepository,
-        cachedNodeConfigurationService,
-        () => globalComplianceModeService.getGlobalComplianceMode,
-        configService.rudder_global_policy_mode _,
-        () => configService.rudder_compliance_unexpected_report_interpretation().toBox,
-        RUDDER_JDBC_BATCH_MAX_SIZE
-      ),
-      nodeInfoServiceImpl,
-      RUDDER_JDBC_BATCH_MAX_SIZE, // use same size as for SQL requests
-
-      complianceRepositoryImpl
+    lazy val healthcheckService = new HealthcheckService(
+      List(
+        CheckCoreNumber,
+        CheckFreeSpace,
+        new CheckFileDescriptorLimit(nodeInfoService)
+      )
     )
-    // to avoid a StackOverflowError, we set the compliance cache once it'z ready,
-    // and can construct the nodeconfigurationservice without the comlpince cache
-    cachedNodeConfigurationService.addHook(reportingServiceImpl)
-    reportingServiceImpl
-  }
 
-  private[this] lazy val pgIn                     = new PostgresqlInClause(70)
-  private[this] lazy val findExpectedRepo         = new FindExpectedReportsJdbcRepository(doobie, pgIn, RUDDER_JDBC_BATCH_MAX_SIZE)
-  private[this] lazy val updateExpectedRepo       = new UpdateExpectedReportsJdbcRepository(doobie, pgIn, RUDDER_JDBC_BATCH_MAX_SIZE)
-  private[this] lazy val reportsRepositoryImpl    = new ReportsJdbcRepository(doobie)
-  private[this] lazy val complianceRepositoryImpl = new ComplianceJdbcRepository(
-    doobie,
-    () => configService.rudder_save_db_compliance_details().toBox,
-    () => configService.rudder_save_db_compliance_levels().toBox
-  )
-  private[this] lazy val dataSourceProvider       = new RudderDatasourceProvider(
-    RUDDER_JDBC_DRIVER,
-    RUDDER_JDBC_URL,
-    RUDDER_JDBC_USERNAME,
-    RUDDER_JDBC_PASSWORD,
-    RUDDER_JDBC_MAX_POOL_SIZE
-  )
-  lazy val doobie                                 = new Doobie(dataSourceProvider.datasource)
+    lazy val healthcheckNotificationService = new HealthcheckNotificationService(healthcheckService, RUDDER_HEALTHCHECK_PERIOD)
+    lazy val campaignSerializer             = new CampaignSerializer()
+    lazy val campaignEventRepo              = new CampaignEventRepositoryImpl(doobie, campaignSerializer)
+    lazy val campaignPath                   = root / "var" / "rudder" / "configuration-repository" / "campaigns"
 
-  private[this] lazy val parseRules:                ParseRules with RuleRevisionRepository         = new GitParseRules(
-    ruleUnserialisation,
-    gitConfigRepo,
-    entityMigration,
-    rulesDirectoryName
-  )
-  lazy val parseActiveTechniqueLibrary:             GitParseActiveTechniqueLibrary                 = new GitParseActiveTechniqueLibrary(
-    activeTechniqueCategoryUnserialisation,
-    activeTechniqueUnserialisation,
-    directiveUnserialisation,
-    gitConfigRepo,
-    gitRevisionProvider,
-    entityMigration,
-    userLibraryDirectoryName
-  )
-  private[this] lazy val importTechniqueLibrary:    ImportTechniqueLibrary                         = new ImportTechniqueLibraryImpl(
-    rudderDitImpl,
-    rwLdap,
-    ldapEntityMapper,
-    uptLibReadWriteMutex
-  )
-  private[this] lazy val parseGroupLibrary:         ParseGroupLibrary with GroupRevisionRepository = new GitParseGroupLibrary(
-    nodeGroupCategoryUnserialisation,
-    nodeGroupUnserialisation,
-    gitConfigRepo,
-    entityMigration,
-    groupLibraryDirectoryName
-  )
-  private[this] lazy val parseGlobalParameter:      ParseGlobalParameters                          = new GitParseGlobalParameters(
-    globalParameterUnserialisation,
-    gitConfigRepo,
-    entityMigration,
-    parametersDirectoryName
-  )
-  private[this] lazy val parseRuleCategories:       ParseRuleCategories                            = new GitParseRuleCategories(
-    ruleCategoryUnserialisation,
-    gitConfigRepo,
-    entityMigration,
-    ruleCategoriesDirectoryName
-  )
-  private[this] lazy val importGroupLibrary:        ImportGroupLibrary                             = new ImportGroupLibraryImpl(
-    rudderDitImpl,
-    rwLdap,
-    ldapEntityMapper,
-    groupLibReadWriteMutex
-  )
-  private[this] lazy val importRuleCategoryLibrary: ImportRuleCategoryLibrary                      = new ImportRuleCategoryLibraryImpl(
-    rudderDitImpl,
-    rwLdap,
-    ldapEntityMapper,
-    ruleCatReadWriteMutex
-  )
-  private[this] lazy val eventLogDeploymentServiceImpl = new EventLogDeploymentService(logRepository, eventLogDetailsServiceImpl)
-  private[this] lazy val nodeInfoServiceImpl           = new NodeInfoServiceCachedImpl(
-    roLdap,
-    nodeDitImpl,
-    acceptedNodesDitImpl,
-    removedNodesDitImpl,
-    pendingNodesDitImpl,
-    ldapEntityMapper,
-    inventoryMapper,
-    FiniteDuration(LDAP_CACHE_NODE_INFO_MIN_INTERVAL.toMillis, "millis")
-  )
-  private[this] lazy val dependencyAndDeletionServiceImpl: DependencyAndDeletionService = new DependencyAndDeletionServiceImpl(
-    new FindDependenciesImpl(roLdap, rudderDitImpl, ldapEntityMapper),
-    roLdapDirectiveRepository,
-    woLdapDirectiveRepository,
-    woLdapRuleRepository,
-    woLdapNodeGroupRepository
-  )
+    lazy val campaignRepo = CampaignRepositoryImpl
+      .make(campaignSerializer, campaignPath, campaignEventRepo)
+      .runOrDie(err => new RuntimeException(s"Error during initialization of campaign repository: " + err.fullMsg))
 
-  private[this] lazy val logDisplayerImpl:               LogDisplayer               =
-    new LogDisplayer(reportsRepositoryImpl, configurationRepository, roLdapRuleRepository)
-  private[this] lazy val categoryHierarchyDisplayerImpl: CategoryHierarchyDisplayer = new CategoryHierarchyDisplayer()
-  private[this] lazy val dyngroupUpdaterBatch:           UpdateDynamicGroups        = new UpdateDynamicGroups(
-    dynGroupServiceImpl,
-    dynGroupUpdaterService,
-    asyncDeploymentAgentImpl,
-    uuidGen,
-    RUDDER_BATCH_DYNGROUP_UPDATEINTERVAL,
-    () => configService.rudder_compute_dyngroups_max_parallelism().toBox
-  )
+    lazy val mainCampaignService = new MainCampaignService(campaignEventRepo, campaignRepo, uuidGen, 1, 1)
+    lazy val jsonReportsAnalyzer = JSONReportsAnalyser(reportsRepository, propertyRepository)
 
-  private[this] lazy val dynGroupUpdaterService =
-    new DynGroupUpdaterServiceImpl(roLdapNodeGroupRepository, woLdapNodeGroupRepository, queryProcessor)
+    // todo: scheduler interval should be a property
+    ZioRuntime.unsafeRun(jsonReportsAnalyzer.start(5.seconds).forkDaemon.provideLayer(ZioRuntime.layers))
 
-  private[this] lazy val dbCleaner: AutomaticReportsCleaning = {
-    val cleanFrequency = AutomaticReportsCleaning.buildFrequency(
-      RUDDER_BATCH_REPORTSCLEANER_FREQUENCY,
-      RUDDER_BATCH_DATABASECLEANER_RUNTIME_MINUTE,
-      RUDDER_BATCH_DATABASECLEANER_RUNTIME_HOUR,
-      RUDDER_BATCH_DATABASECLEANER_RUNTIME_DAY
-    ) match {
-      case Full(freq) => freq
-      case eb: EmptyBox =>
-        val fail         = eb ?~! "automatic reports cleaner is not correct"
-        val exceptionMsg =
-          "configuration file (/opt/rudder/etc/rudder-webapp.conf) is not correctly set, cause is %s".format(fail.msg)
-        throw new RuntimeException(exceptionMsg)
-    }
+    ZioRuntime.unsafeRun(MainCampaignService.start(mainCampaignService))
 
-    new AutomaticReportsCleaning(
-      databaseManagerImpl,
-      roLDAPConnectionProvider,
-      RUDDER_BATCH_REPORTSCLEANER_DELETE_TTL,
-      RUDDER_BATCH_REPORTSCLEANER_ARCHIVE_TTL,
-      RUDDER_BATCH_REPORTSCLEANER_COMPLIANCE_DELETE_TTL,
-      RUDDER_BATCH_REPORTSCLEANER_LOG_DELETE_TTL,
-      cleanFrequency
-    )
-  }
-
-  private[this] lazy val techniqueLibraryUpdater = new CheckTechniqueLibrary(
-    techniqueRepositoryImpl,
-    asyncDeploymentAgent,
-    uuidGen,
-    RUDDER_BATCH_TECHNIQUELIBRARY_UPDATEINTERVAL
-  )
-
-  private[this] lazy val jsTreeUtilServiceImpl = new JsTreeUtilService(roLdapDirectiveRepository, techniqueRepositoryImpl)
-
-  /*
-   * Cleaning action are run for the case where the node was accepted, deleted, and unknown
-   * (ie: we want to be able to run cleaning actions even on a node that was deleted in the past, but
-   * for some reason the user discover that theres remaining things, and he wants to get rid of them
-   * without knowing rudder internal place to look for all possible garbages)
-   */
-
-  /*
-   * The list of post deletion action to execute in a shared reference, created at class instanciation.
-   * External services can update it from removeNodeServiceImpl.
-   */
-  private[this] lazy val postNodeDeleteActions = Ref
-    .make(
-      new RemoveNodeInfoFromCache(nodeInfoServiceImpl)
-      :: new CloseNodeConfiguration(updateExpectedRepo)
-      :: new RemoveNodeFromComplianceCache(cachedNodeConfigurationService, reportingServiceImpl)
-      :: new DeletePolicyServerPolicies(policyServerManagementService)
-      :: new ResetKeyStatus(rwLdap, removedNodesDitImpl)
-      :: new CleanUpCFKeys()
-      :: new CleanUpNodePolicyFiles("/var/rudder/share")
-      :: new DeleteNodeFact(factRepo)
-      :: Nil
-    )
-    .runNow
-
-  private[this] lazy val removeNodeServiceImpl = new RemoveNodeServiceImpl(
-    nodeDitImpl,
-    rudderDitImpl,
-    pendingNodesDitImpl,
-    acceptedNodesDitImpl,
-    removedNodesDitImpl,
-    rwLdap,
-    ldapEntityMapper,
-    roLdapNodeGroupRepository,
-    woLdapNodeGroupRepository,
-    nodeInfoServiceImpl,
-    ldapFullInventoryRepository,
-    logRepository,
-    nodeReadWriteMutex,
-    pathComputer,
-    newNodeManager,
-    postNodeDeleteActions,
-    HOOKS_D,
-    HOOKS_IGNORE_SUFFIXES
-  )
-
-  private[this] lazy val healthcheckService = new HealthcheckService(
-    List(
-      CheckCoreNumber,
-      CheckFreeSpace,
-      new CheckFileDescriptorLimit(nodeInfoService)
-    )
-  )
-
-  lazy val healthcheckNotificationService = new HealthcheckNotificationService(healthcheckService, RUDDER_HEALTHCHECK_PERIOD)
-  lazy val campaignSerializer             = new CampaignSerializer()
-  lazy val campaignEventRepo              = new CampaignEventRepositoryImpl(doobie, campaignSerializer)
-  val campaignPath                        = root / "var" / "rudder" / "configuration-repository" / "campaigns"
-
-  lazy val campaignRepo = CampaignRepositoryImpl
-    .make(campaignSerializer, campaignPath, campaignEventRepo)
-    .runOrDie(err => new RuntimeException(s"Error during initialization of campaign repository: " + err.fullMsg))
-
-  val mainCampaignService      = new MainCampaignService(campaignEventRepo, campaignRepo, uuidGen, 1, 1)
-  lazy val jsonReportsAnalyzer = JSONReportsAnalyser(reportsRepository, propertyRepository)
-
-  // todo: scheduler interval should be a property
-  ZioRuntime.unsafeRun(jsonReportsAnalyzer.start(5.seconds).forkDaemon.provideLayer(ZioRuntime.layers))
-
-  ZioRuntime.unsafeRun(MainCampaignService.start(mainCampaignService))
-
-  /**
+    /**
    * *************************************************
    * Bootstrap check actions
    * **************************************************
    */
 
-  lazy val allBootstrapChecks = new SequentialImmediateBootStrapChecks(
-    new CheckConnections(dataSourceProvider, rwLdap),
-    new CheckTechniqueLibraryReload(
+    lazy val allBootstrapChecks = new SequentialImmediateBootStrapChecks(
+      new CheckConnections(dataSourceProvider, rwLdap),
+      new CheckTechniqueLibraryReload(
+        techniqueRepositoryImpl,
+        uuidGen
+      ),
+      new CheckAddSpecialTargetAllPolicyServers(rwLdap),
+      new CheckAddSpecialNodeGroupsDescription(rwLdap),
+      new CheckMigratedSystemTechniques(
+        policyServerManagementService,
+        gitConfigRepo,
+        nodeInfoService,
+        rwLdap,
+        techniqueRepository,
+        techniqueRepositoryImpl,
+        uuidGen,
+        woDirectiveRepository,
+        woRuleRepository
+      ),
+      new CheckRemoveRuddercSetting(rwLdap),
+      new CheckDIT(pendingNodesDitImpl, acceptedNodesDitImpl, removedNodesDitImpl, rudderDitImpl, rwLdap),
+      new CheckInitUserTemplateLibrary(
+        rudderDitImpl,
+        rwLdap,
+        techniqueRepositoryImpl,
+        roLdapDirectiveRepository,
+        woLdapDirectiveRepository,
+        uuidGen,
+        asyncDeploymentAgentImpl
+      ), // new CheckDirectiveBusinessRules()
+
+      new CheckRudderGlobalParameter(roLDAPParameterRepository, woLDAPParameterRepository, uuidGen),
+      new CheckInitXmlExport(itemArchiveManagerImpl, personIdentServiceImpl, uuidGen),
+      new CheckNcfTechniqueUpdate(
+        restExtractorService,
+        ncfTechniqueWriter,
+        roLDAPApiAccountRepository.systemAPIAccount,
+        uuidGen,
+        updateTechniqueLibrary,
+        ncfTechniqueReader,
+        resourceFileService
+      ),
+      new TriggerPolicyUpdate(
+        asyncDeploymentAgent,
+        uuidGen
+      ),
+      new RemoveFaultyLdapEntries(
+        woDirectiveRepository,
+        uuidGen
+      ),
+      new CreateSystemToken(roLDAPApiAccountRepository.systemAPIAccount),
+      new LoadNodeComplianceCache(nodeInfoService, reportingServiceImpl)
+    )
+
+    //////////////////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////// Directive Editor and web fields //////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////////////////
+
+    import com.normation.cfclerk.domain._
+
+    object FieldFactoryImpl extends DirectiveFieldFactory {
+      // only one field
+
+      override def forType(v: VariableSpec, id: String): DirectiveField = {
+        val prefixSize = "size-"
+        v match {
+          case selectOne:       SelectOneVariableSpec        => new SelectOneField(id, selectOne.valueslabels)
+          case select:          SelectVariableSpec           => new SelectField(id, select.valueslabels)
+          case input:           InputVariableSpec            =>
+            v.constraint.typeName match {
+              case str: SizeVType =>
+                new InputSizeField(
+                  id,
+                  () => configService.rudder_featureSwitch_directiveScriptEngine().toBox,
+                  str.name.substring(prefixSize.size)
+                )
+              case SharedFileVType            => new FileField(id)
+              case DestinationPathVType       => default(id)
+              case DateVType(r)               => new DateField(Translator.isoDateFormatter)(id)
+              case TimeVType(r)               => new TimeField(Translator.isoTimeFormatter)(id)
+              case PermVType                  => new FilePermsField(id)
+              case BooleanVType               => new CheckboxField(id)
+              case TextareaVType(r)           =>
+                new TextareaField(id, () => configService.rudder_featureSwitch_directiveScriptEngine().toBox)
+              // Same field type for password and MasterPassword, difference is that master will have slave/used derived passwords, and password will not have any slave/used field
+              case PasswordVType(algos)       =>
+                new PasswordField(
+                  id,
+                  algos,
+                  input.constraint.mayBeEmpty,
+                  () => configService.rudder_featureSwitch_directiveScriptEngine().toBox
+                )
+              case MasterPasswordVType(algos) =>
+                new PasswordField(
+                  id,
+                  algos,
+                  input.constraint.mayBeEmpty,
+                  () => configService.rudder_featureSwitch_directiveScriptEngine().toBox
+                )
+              case AixDerivedPasswordVType    => new DerivedPasswordField(id, HashAlgoConstraint.DerivedPasswordType.AIX)
+              case LinuxDerivedPasswordVType  => new DerivedPasswordField(id, HashAlgoConstraint.DerivedPasswordType.Linux)
+              case _                          => default(id)
+            }
+          case predefinedField: PredefinedValuesVariableSpec => new ReadOnlyTextField(id)
+
+          case _ =>
+            logger.error(
+              "Unexpected case : variable %s should not be displayed. Only select1, select or input can be displayed.".format(
+                v.name
+              )
+            )
+            default(id)
+        }
+      }
+
+      override def default(id: String) = new TextField(id, () => configService.rudder_featureSwitch_directiveScriptEngine().toBox)
+    }
+
+    lazy val section2FieldService:       Section2FieldService   = {
+      new Section2FieldService(FieldFactoryImpl, Translator.defaultTranslators)
+    }
+    lazy val directiveEditorServiceImpl: DirectiveEditorService =
+      new DirectiveEditorServiceImpl(configurationRepository, section2FieldService)
+    lazy val directiveEditorService = directiveEditorServiceImpl
+
+    lazy val reportDisplayerImpl = new ReportDisplayer(
+      roLdapRuleRepository,
+      roLdapDirectiveRepository,
       techniqueRepositoryImpl,
-      uuidGen
-    ),
-    new CheckAddSpecialTargetAllPolicyServers(rwLdap),
-    new CheckAddSpecialNodeGroupsDescription(rwLdap),
-    new CheckMigratedSystemTechniques(
-      policyServerManagementService,
-      gitConfigRepo,
-      nodeInfoService,
-      rwLdap,
-      techniqueRepository,
-      techniqueRepositoryImpl,
+      configService,
+      logDisplayerImpl
+    )
+    lazy val propertyRepository  = new RudderPropertiesRepositoryImpl(doobie)
+    lazy val autoReportLogger    = new AutomaticReportLogger(
+      propertyRepository,
+      reportsRepositoryImpl,
+      roLdapRuleRepository,
+      roLdapDirectiveRepository,
+      nodeInfoServiceImpl,
+      RUDDER_BATCH_REPORTS_LOGINTERVAL
+    )
+
+    lazy val scriptLauncher = new DebugInfoServiceImpl
+    lazy val debugScript    = scriptLauncher
+
+    ////////////////////// Snippet plugins & extension register //////////////////////
+    lazy val snippetExtensionRegister: SnippetExtensionRegister = new SnippetExtensionRegisterImpl()
+
+    lazy val cachedNodeConfigurationService: CachedNodeConfigurationService = {
+      val cached = new CachedNodeConfigurationService(findExpectedRepo, nodeInfoServiceImpl)
+      cached.init().runOrDie(err => new RuntimeException(s"Error when initializing node configuration cache: " + err))
+      cached
+    }
+
+    /*
+     * Agent runs: we use a cache for them.
+     */
+    lazy val cachedAgentRunRepository = {
+      val roRepo = new RoReportsExecutionRepositoryImpl(
+        doobie,
+        new WoReportsExecutionRepositoryImpl(doobie),
+        cachedNodeConfigurationService,
+        pgIn,
+        RUDDER_JDBC_BATCH_MAX_SIZE
+      )
+      new CachedReportsExecutionRepository(
+        roRepo
+      )
+    }
+    lazy val roAgentRunsRepository: RoReportsExecutionRepository = cachedAgentRunRepository
+
+    lazy val updatesEntryJdbcRepository = new LastProcessedReportRepositoryImpl(doobie)
+
+    lazy val executionService = {
+      val maxCatchupTime  = {
+        val temp = FiniteDuration(RUDDER_REPORTS_EXECUTION_MAX_DAYS.toLong, "day") + FiniteDuration(
+          RUDDER_REPORTS_EXECUTION_MAX_MINUTES.toLong,
+          "minutes"
+        )
+        if (temp.toMillis == 0) {
+          logger.error(
+            "'rudder.aggregateReports.maxDays' and 'rudder.aggregateReports.maxMinutes' properties are both 0 or empty. Set using 30 minutes as default value, please check /opt/rudder/etc/rudder-web.properties"
+          )
+          FiniteDuration(30, "minutes")
+        } else {
+          temp
+        }
+      }
+      val maxCatchupBatch = FiniteDuration(RUDDER_REPORTS_EXECUTION_MAX_SIZE.toLong, "minutes")
+
+      new ReportsExecutionService(
+        reportsRepository,
+        updatesEntryJdbcRepository,
+        recentChangesService,
+        reportingServiceImpl,
+        complianceRepositoryImpl,
+        maxCatchupTime,
+        maxCatchupBatch
+      )
+    }
+
+    lazy val aggregateReportScheduler = new FindNewReportsExecution(executionService, RUDDER_REPORTS_EXECUTION_INTERVAL)
+
+    // This needs to be done at the end, to be sure that all is initialized
+    deploymentService.setDynamicsGroupsService(dyngroupUpdaterBatch)
+
+    // aggregate information about node count
+    // don't forget to start-it once out of the zone which lead to dead-lock (ie: in Lift boot)
+    lazy val historizeNodeCountBatch = for {
+      gitLogger <- CommitLogServiceImpl.make(METRICS_NODES_DIRECTORY_GIT_ROOT)
+      writer    <- WriteNodeCSV.make(METRICS_NODES_DIRECTORY_GIT_ROOT, ";", "yyyy-MM")
+      service    = new HistorizeNodeCountService(
+                     new FetchDataServiceImpl(RudderConfig.nodeInfoService, RudderConfig.reportingService),
+                     writer,
+                     gitLogger,
+                     DateTimeZone.UTC // never change log line
+                   )
+      cron      <- Scheduler.make(
+                     METRICS_NODES_MIN_PERIOD,
+                     METRICS_NODES_MAX_PERIOD,
+                     s => service.scheduledLog(s),
+                     "Automatic recording of active nodes".succeed
+                   )
+      _         <-
+        ScheduledJobLoggerPure.metrics.info(
+          s"Starting node count historization batch (min:${METRICS_NODES_MIN_PERIOD.render}; max:${METRICS_NODES_MAX_PERIOD.render})"
+        )
+      _         <- cron.start
+    } yield ()
+
+    lazy val checkInventoryUpdate       = new CheckInventoryUpdate(
+      nodeInfoServiceImpl,
+      asyncDeploymentAgent,
       uuidGen,
-      woDirectiveRepository,
-      woRuleRepository
-    ),
-    new CheckRemoveRuddercSetting(rwLdap),
-    new CheckDIT(pendingNodesDitImpl, acceptedNodesDitImpl, removedNodesDitImpl, rudderDitImpl, rwLdap),
-    new CheckInitUserTemplateLibrary(
-      rudderDitImpl,
-      rwLdap,
+      RUDDER_BATCH_CHECK_NODE_CACHE_INTERVAL
+    )
+    lazy val purgeDeletedInventories    = new PurgeDeletedInventories(
+      removeNodeServiceImpl,
+      FiniteDuration(RUDDER_BATCH_PURGE_DELETED_INVENTORIES_INTERVAL.toLong, "hours"),
+      RUDDER_BATCH_PURGE_DELETED_INVENTORIES
+    )
+    lazy val purgeUnreferencedSoftwares = {
+      new PurgeUnreferencedSoftwares(
+        softwareService,
+        FiniteDuration(RUDDER_BATCH_DELETE_SOFTWARE_INTERVAL.toLong, "hours")
+      )
+    }
+    lazy val asynComplianceService      = new AsyncComplianceService(reportingService)
+
+    // reference services part of the API
+    val rci = RudderServiceApi(
+      roLdap,
+      pendingNodesDitImpl,
+      acceptedNodesDitImpl,
+      nodeDitImpl,
+      rudderDit,
+      roLdapRuleRepository,
+      woRuleRepository,
+      woNodeRepository,
+      roLdapNodeGroupRepository,
+      woLdapNodeGroupRepository,
+      techniqueRepositoryImpl,
       techniqueRepositoryImpl,
       roLdapDirectiveRepository,
       woLdapDirectiveRepository,
-      uuidGen,
-      asyncDeploymentAgentImpl
-    ), // new CheckDirectiveBusinessRules()
-
-    new CheckRudderGlobalParameter(roLDAPParameterRepository, woLDAPParameterRepository, uuidGen),
-    new CheckInitXmlExport(itemArchiveManagerImpl, personIdentServiceImpl, uuidGen),
-    new CheckNcfTechniqueUpdate(
-      restExtractorService,
-      ncfTechniqueWriter,
-      roLDAPApiAccountRepository.systemAPIAccount,
-      uuidGen,
-      updateTechniqueLibrary,
-      ncfTechniqueReader,
-      resourceFileService
-    ),
-    new TriggerPolicyUpdate(
-      asyncDeploymentAgent,
-      uuidGen
-    ),
-    new RemoveFaultyLdapEntries(
-      woDirectiveRepository,
-      uuidGen
-    ),
-    new CreateSystemToken(roLDAPApiAccountRepository.systemAPIAccount),
-    new LoadNodeComplianceCache(nodeInfoService, reportingServiceImpl)
-  )
-
-  //////////////////////////////////////////////////////////////////////////////////////////
-  ////////////////////////////// Directive Editor and web fields //////////////////////////////
-  //////////////////////////////////////////////////////////////////////////////////////////
-
-  import com.normation.cfclerk.domain._
-
-  object FieldFactoryImpl extends DirectiveFieldFactory {
-    // only one field
-
-    override def forType(v: VariableSpec, id: String): DirectiveField = {
-      val prefixSize = "size-"
-      v match {
-        case selectOne:       SelectOneVariableSpec        => new SelectOneField(id, selectOne.valueslabels)
-        case select:          SelectVariableSpec           => new SelectField(id, select.valueslabels)
-        case input:           InputVariableSpec            =>
-          v.constraint.typeName match {
-            case str: SizeVType =>
-              new InputSizeField(
-                id,
-                () => configService.rudder_featureSwitch_directiveScriptEngine().toBox,
-                str.name.substring(prefixSize.size)
-              )
-            case SharedFileVType            => new FileField(id)
-            case DestinationPathVType       => default(id)
-            case DateVType(r)               => new DateField(Translator.isoDateFormatter)(id)
-            case TimeVType(r)               => new TimeField(Translator.isoTimeFormatter)(id)
-            case PermVType                  => new FilePermsField(id)
-            case BooleanVType               => new CheckboxField(id)
-            case TextareaVType(r)           => new TextareaField(id, () => configService.rudder_featureSwitch_directiveScriptEngine().toBox)
-            // Same field type for password and MasterPassword, difference is that master will have slave/used derived passwords, and password will not have any slave/used field
-            case PasswordVType(algos)       =>
-              new PasswordField(
-                id,
-                algos,
-                input.constraint.mayBeEmpty,
-                () => configService.rudder_featureSwitch_directiveScriptEngine().toBox
-              )
-            case MasterPasswordVType(algos) =>
-              new PasswordField(
-                id,
-                algos,
-                input.constraint.mayBeEmpty,
-                () => configService.rudder_featureSwitch_directiveScriptEngine().toBox
-              )
-            case AixDerivedPasswordVType    => new DerivedPasswordField(id, HashAlgoConstraint.DerivedPasswordType.AIX)
-            case LinuxDerivedPasswordVType  => new DerivedPasswordField(id, HashAlgoConstraint.DerivedPasswordType.Linux)
-            case _                          => default(id)
-          }
-        case predefinedField: PredefinedValuesVariableSpec => new ReadOnlyTextField(id)
-
-        case _ =>
-          logger.error(
-            "Unexpected case : variable %s should not be displayed. Only select1, select or input can be displayed.".format(
-              v.name
-            )
-          )
-          default(id)
-      }
-    }
-
-    override def default(id: String) = new TextField(id, () => configService.rudder_featureSwitch_directiveScriptEngine().toBox)
-  }
-
-  private[this] lazy val section2FieldService:       Section2FieldService   = {
-    new Section2FieldService(FieldFactoryImpl, Translator.defaultTranslators)
-  }
-  private[this] lazy val directiveEditorServiceImpl: DirectiveEditorService =
-    new DirectiveEditorServiceImpl(configurationRepository, section2FieldService)
-
-  private[this] lazy val reportDisplayerImpl = new ReportDisplayer(
-    roLdapRuleRepository,
-    roLdapDirectiveRepository,
-    techniqueRepositoryImpl,
-    configService,
-    logDisplayerImpl
-  )
-  private[this] lazy val propertyRepository  = new RudderPropertiesRepositoryImpl(doobie)
-  private[this] lazy val autoReportLogger    = new AutomaticReportLogger(
-    propertyRepository,
-    reportsRepositoryImpl,
-    roLdapRuleRepository,
-    roLdapDirectiveRepository,
-    nodeInfoServiceImpl,
-    RUDDER_BATCH_REPORTS_LOGINTERVAL
-  )
-
-  private[this] lazy val scriptLauncher = new DebugInfoServiceImpl
-
-  ////////////////////// Snippet plugins & extension register //////////////////////
-  lazy val snippetExtensionRegister: SnippetExtensionRegister = new SnippetExtensionRegisterImpl()
-
-  private[this] lazy val cachedNodeConfigurationService: CachedNodeConfigurationService = {
-    val cached = new CachedNodeConfigurationService(findExpectedRepo, nodeInfoServiceImpl)
-    cached.init().runOrDie(err => new RuntimeException(s"Error when initializing node configuration cache: " + err))
-    cached
-  }
-
-  /*
-   * Agent runs: we use a cache for them.
-   */
-  private[this] lazy val cachedAgentRunRepository = {
-    val roRepo = new RoReportsExecutionRepositoryImpl(
-      doobie,
-      new WoReportsExecutionRepositoryImpl(doobie),
-      cachedNodeConfigurationService,
-      pgIn,
-      RUDDER_JDBC_BATCH_MAX_SIZE
-    )
-    new CachedReportsExecutionRepository(
-      roRepo
-    )
-  }
-
-  val updatesEntryJdbcRepository = new LastProcessedReportRepositoryImpl(doobie)
-
-  val executionService = {
-    val maxCatchupTime  = {
-      val temp = FiniteDuration(RUDDER_REPORTS_EXECUTION_MAX_DAYS.toLong, "day") + FiniteDuration(
-        RUDDER_REPORTS_EXECUTION_MAX_MINUTES.toLong,
-        "minutes"
-      )
-      if (temp.toMillis == 0) {
-        logger.error(
-          "'rudder.aggregateReports.maxDays' and 'rudder.aggregateReports.maxMinutes' properties are both 0 or empty. Set using 30 minutes as default value, please check /opt/rudder/etc/rudder-web.properties"
-        )
-        FiniteDuration(30, "minutes")
-      } else {
-        temp
-      }
-    }
-    val maxCatchupBatch = FiniteDuration(RUDDER_REPORTS_EXECUTION_MAX_SIZE.toLong, "minutes")
-
-    new ReportsExecutionService(
-      reportsRepository,
-      updatesEntryJdbcRepository,
-      recentChangesService,
+      softwareInventoryDAO,
+      eventLogRepository,
+      eventLogDetailsServiceImpl,
       reportingServiceImpl,
-      complianceRepositoryImpl,
-      maxCatchupTime,
-      maxCatchupBatch
+      asynComplianceService,
+      scriptLauncher,
+      queryParser,
+      inventoryHistoryLogRepository,
+      inventoryLogEventServiceImpl,
+      ruleApplicationStatusImpl,
+      propertyEngineService,
+      newNodeManagerImpl,
+      nodeGridImpl,
+      nodeSummaryServiceImpl,
+      jsTreeUtilServiceImpl,
+      directiveEditorService,
+      userPropertyService,
+      eventListDisplayerImpl,
+      asyncDeploymentAgent,
+      policyServerManagementService,
+      dynGroupUpdaterService,
+      dyngroupUpdaterBatch,
+      checkInventoryUpdate,
+      purgeDeletedInventories,
+      purgeUnreferencedSoftwares,
+      databaseManagerImpl,
+      dbCleaner,
+      techniqueLibraryUpdater,
+      autoReportLogger,
+      removeNodeServiceImpl,
+      nodeInfoServiceImpl,
+      reportDisplayerImpl,
+      dependencyAndDeletionService,
+      itemArchiveManagerImpl,
+      personIdentServiceImpl,
+      gitRevisionProviderImpl,
+      logDisplayerImpl,
+      ldapFullInventoryRepository,
+      queryProcessor,
+      categoryHierarchyDisplayerImpl,
+      dynGroupServiceImpl,
+      ditQueryDataImpl,
+      reportsRepository,
+      eventLogDeploymentServiceImpl,
+      new SrvGrid(roAgentRunsRepository, configService, roLdapRuleRepository, nodeInfoService),
+      findExpectedRepo,
+      roLDAPApiAccountRepository,
+      woLDAPApiAccountRepository,
+      cachedAgentRunRepository,
+      pendingNodeCheckGroup,
+      allBootstrapChecks,
+      authenticationProviders,
+      rudderUserListProvider,
+      restApiAccounts,
+      restQuicksearch,
+      restCompletion,
+      sharedFileApi,
+      eventLogApi,
+      uuidGen,
+      inventoryWatcher,
+      configService,
+      historizeNodeCountBatch,
+      policyGenerationBootGuard,
+      healthcheckNotificationService,
+      jsonPluginDefinition,
+      rudderApi,
+      authorizationApiMapping,
+      roRuleCategoryRepository,
+      woRuleCategoryRepository,
+      workflowLevelService,
+      ncfTechniqueReader,
+      recentChangesService,
+      ruleCategoryService,
+      restExtractorService,
+      snippetExtensionRegister,
+      clearCacheService,
+      linkUtil,
+      userService,
+      ApiVersions,
+      apiDispatcher,
+      configurationRepository,
+      roParameterService,
+      userAuthorisationLevel,
+      agentRegister,
+      asyncWorkflowInfo,
+      commitAndDeployChangeRequest,
+      doobie,
+      restDataSerializer,
+      workflowEventLogService,
+      changeRequestEventLogService,
+      changeRequestChangesUnserialisation,
+      diffService,
+      diffDisplayer,
+      rwLdap,
+      apiAuthorizationLevelService,
+      tokenGenerator,
+      roLDAPParameterRepository,
+      interpolationCompiler,
+      deploymentService,
+      campaignEventRepo,
+      mainCampaignService,
+      campaignSerializer,
+      jsonReportsAnalyzer,
+      aggregateReportScheduler,
+      secretEventLogService,
+      changeRequestChangesSerialisation
     )
+
+    // we need to reference batches not part of the API to start them since
+    // they are lazy val
+    cleanOldInventoryBatch.start()
+    gitFactRepoGC.start()
+    gitConfigRepoGC.start()
+    // UpdateDynamicGroups is part of rci
+    // reportingServiceImpl part of rci
+    // checkInventoryUpdate part of rci
+    // purgeDeletedInventories paat of rci
+    // purgeUnreferencedSoftwares part of rci
+    // AutomaticReportLogger part of rci
+    // AutomaticReportsCleaning part of rci
+    // CheckTechniqueLibrary part of rci
+    // AutomaticReportsCleaning part of rci
+
+    // return services part of the API
+    rci
   }
-
-  val aggregateReportScheduler = new FindNewReportsExecution(executionService, RUDDER_REPORTS_EXECUTION_INTERVAL)
-
-  // This needs to be done at the end, to be sure that all is initialized
-  deploymentService.setDynamicsGroupsService(dyngroupUpdaterBatch)
-
-  // aggregate information about node count
-  // don't forget to start-it once out of the zone which lead to dead-lock (ie: in Lift boot)
-  val historizeNodeCountBatch = for {
-    gitLogger <- CommitLogServiceImpl.make(METRICS_NODES_DIRECTORY_GIT_ROOT)
-    writer    <- WriteNodeCSV.make(METRICS_NODES_DIRECTORY_GIT_ROOT, ";", "yyyy-MM")
-    service    = new HistorizeNodeCountService(
-                   new FetchDataServiceImpl(RudderConfig.nodeInfoService, RudderConfig.reportingService),
-                   writer,
-                   gitLogger,
-                   DateTimeZone.UTC // never change log line
-                 )
-    cron      <- Scheduler.make(
-                   METRICS_NODES_MIN_PERIOD,
-                   METRICS_NODES_MAX_PERIOD,
-                   s => service.scheduledLog(s),
-                   "Automatic recording of active nodes".succeed
-                 )
-    _         <-
-      ScheduledJobLoggerPure.metrics.info(
-        s"Starting node count historization batch (min:${METRICS_NODES_MIN_PERIOD.render}; max:${METRICS_NODES_MAX_PERIOD.render})"
-      )
-    _         <- cron.start
-  } yield ()
-
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
@@ -87,8 +87,10 @@ object PasswordEncoder {
 
   val random = new SecureRandom()
 
-  def randomHexa(byteLength: Int) = {
-    val token = new Array[Byte](byteLength)
+  // see https://stackoverflow.com/a/44227131
+  // produce a random hexa string of 32 chars
+  def randomHexa32: String = {
+    val token = new Array[Byte](16)
     random.nextBytes(token)
     new java.math.BigInteger(1, token).toString(16)
   }
@@ -568,7 +570,7 @@ object UserFileProcessing {
                 // If the attribute is defined several times, use the first occurrence.
                 val p = pwd match {
                   case Some(p :: _) if (p.strip().size > 0) => p
-                  case _                                    => PasswordEncoder.randomHexa(10).mkString("")
+                  case _                                    => PasswordEncoder.randomHexa32
                 }
                 Some(ParsedUser(name, p, permissions)).succeed
 

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
@@ -109,10 +109,10 @@ class RudderUserDetailsTest extends Specification {
     (userDetailList.users.size must beEqualTo(0))
   }
 
-  "an account without password field get a random 20 char pass" >> {
+  "an account without password field get a random 32 chars pass" >> {
     val userDetailList = getUserDetailList(userXML_empty, "userXML_empty")
 
-    (userDetailList.users.size must beEqualTo(1)) and (userDetailList.users("admin").getPassword.size must beEqualTo(20))
+    (userDetailList.users.size must beEqualTo(1)) and (userDetailList.users("admin").getPassword.size must beEqualTo(32))
   }
 
   val userXML_3 = <authentication>


### PR DESCRIPTION
https://issues.rudder.io/issues/22645

(you should look at that PR without spaces change: https://github.com/Normation/rudder/pull/4760/files?w=1)

I found a way to keep compat and implement something that both make locks on init object a non existing problem and make rudder starts much faster (30~50%, I sometime get to "webapp started" log under 10s and it is now really CPU bounded, ie switching to "low energy" CPU policy increase boot time, max speed decrease it, etc)

So, the strategy is: 
- add a `RudderConfigInit`, with nothing in its constructor so that it returns immediately and a massive `init()` method that does all what RudderConfig used to be
- everything is a `lazy val` in that `init()` method. It allows JVM to sort instanciations and ensure there is no deadlock (scala compiler has some guards if everything is `lazy val`) 
- to have access to parsed properties, create a `RudderParsedProperties` that contains all parsed variable definitions and import it in `RudderConfigInit`. It would have been better to define a set of case classes for the parsed, typed properties and pass it around(also betterfor unit tests etc), but it would break a lot of APIs.
- for the rare properties that are referenced directly in classes and not through constructors, add proxies definition in `RudderConfig`. That's not a deadlock problem, since properties were resolved in the `RudderParserProperties` that is fully instanciated at that point. 
- group "init" code of service toward the end, so that it doesn't go in the way of effecient class instanciation/sorting 
- have a big case class (`RudderServiceApi`) that is returned at end of init method with all the services that were in RudderConfig and used elsewhere. This also ensure that `lazy val` are referenced that their RHS is actually executed. 
- RudderConfig is now just `val rci = RudderConfigInit.init()` + a big list of `val myService: ServiceInterface = rci.myService` 

Important notice: all terminal services, especially batches that aren't refered by anything strict (`val`, `start()` methods, etc), must be at least reference one time, either in `RudderServiceApi` or by calling a `start` method, else they won't be run at all.

It looks like it solves the case I found, and it should solve all cases of early init since `RudderConfigInit` object instanciation can't fail (everything is in init method), and then `RudderConfig` call init (which can fail but don't have lock to other parts). 

I also tried to minimize the change so that:
- futur upmerge are still doable without (too much) pain
- existing plugins and rudder API is not impacted. I hope I didn't miss any reference to `RudderConfig` but if it's the case, we just need to add the corresponding `val missingService = rci.theService` declaration in `RudderConfig` (and add more things in `RudderServiceApi` if needed)
