### PR TITLE
Fixes #22706: Ignore RUSTSEC-2023-0034 in relayd

### DIFF
--- a/relay/sources/relayd/deny.toml
+++ b/relay/sources/relayd/deny.toml
@@ -38,4 +38,6 @@ ignore = [
     "RUSTSEC-2023-0004",
     # Only used in tests
     "RUSTSEC-2023-0018",
+    # A DoS in h2
+    "RUSTSEC-2023-0034",
 ]


### PR DESCRIPTION
https://issues.rudder.io/issues/22706