### PR TITLE
Fixes #19519: 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -641,7 +641,7 @@ class EventLogFactoryImpl(
         modifyDiff.modIsSystem.map(x => SimpleDiff.booleanToXml(<isSystem/>, x)) ++
         modifyDiff.modProperties.map(x => {
           SimpleDiff.toXml[List[GroupProperty]](<properties/>, x)(props =>
-            props.flatMap(p => <property><name>{p.name}</name><value>{Unparsed(p.valueAsString)}</value></property>)
+            props.flatMap(p => <property><name>{p.name}</name><value>{xml.Utility.escape(p.valueAsString)}</value></property>)
           )
         })
       }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
@@ -262,7 +262,7 @@ class NodeGroupSerialisationImpl(xmlVersion: String) extends NodeGroupSerialisat
           // value parsing of properties is a bit messy and semantically linked
           // to json, since value part can be a string or json object.
           // Parsing that back from xml would be tedious.
-          <property><name>{p.name}</name><value>{Unparsed(p.valueAsString)}</value></property>
+          <property><name>{p.name}</name><value>{xml.Utility.escape(p.valueAsString)}</value></property>
         }
       }</properties>
     )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -37,6 +37,7 @@
 
 package com.normation.rudder.services.marshalling
 
+import com.github.ghik.silencer.silent
 import com.normation.GitVersion
 import com.normation.GitVersion.ParseRev
 import com.normation.box._
@@ -86,6 +87,7 @@ import net.liftweb.common._
 import net.liftweb.common.Box._
 import net.liftweb.common.Failure
 import net.liftweb.util.Helpers.tryo
+import org.apache.commons.lang3.StringEscapeUtils
 import org.joda.time.format.ISODateTimeFormat
 import scala.util.{Failure => Catch}
 import scala.util.Success
@@ -276,7 +278,7 @@ class NodeGroupUnserialisationImpl(
                               .parse(
                                 (p \\ "name").text.trim,
                                 ParseRev((p \\ "revision").text.trim),
-                                (p \\ "value").text.trim,
+                                StringEscapeUtils.unescapeXml((p \\ "value").text.trim): @silent,
                                 (p \\ "inheritMode").headOption.flatMap(p => InheritMode.parseString(p.text.trim).toOption),
                                 (p \\ "provider").headOption.map(p => PropertyProvider(p.text.trim))
                               )

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
@@ -42,9 +42,6 @@ import com.normation.box._
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.NodeId
-import com.normation.rudder.domain.eventlog._
-import com.normation.rudder.domain.eventlog.AcceptNodeEventLog
-import com.normation.rudder.domain.eventlog.RefuseNodeEventLog
 import com.normation.rudder.domain.logger.TimingDebugLogger
 import com.normation.rudder.domain.servers.Srv
 import com.normation.rudder.web.ChooseTemplate


### PR DESCRIPTION
https://issues.rudder.io/issues/19519

Funny, we have an `xml.Utility.escape(...)` and an `xml.Utility.unescape()`, but they don't do the same thing at all. Really funny. 

I checked that restoring a node group archive is identity