### PR TITLE
Fixes #22654: Button to add/remove more entries indirectives are inside entries

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/DirectiveEditor.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/DirectiveEditor.scala
@@ -471,16 +471,10 @@ final case class MultivaluedSectionField(
           <div  id={sectionId} class={classes}>
               <div class="section-title" onClick={methodName}>{"%s #%s".format(name, i + 1)}</div>
               {showFormEntry(section, i)}
-              { // showAddAnother under the last element
-            if ((i + 1) == size) {
-              showAddAnother()
-            } else {
-              NodeSeq.Empty
-            }
-          }
             </div> ++ Script(JsRaw(""" function %s { %s } """.format(methodName, changeVisibility.toJsCmd)))
       }
     }</div>
+      <div> {showAddAnother()} </div>
     </td> ++ Script(OnLoad(JsVar("""
           $("input").not("#treeSearch").keydown( function(event) {
             processKey(event , 'policyConfigurationSave')


### PR DESCRIPTION
https://issues.rudder.io/issues/22654
![add_another](https://github.com/Normation/rudder/assets/23410978/5517c145-855d-43a9-98f6-b602989686f1)
