### PR TITLE
Fixes #22978: Cache most current Version number to save lots of memory

### DIFF
--- a/webapp/sources/utils/src/main/scala/com/normation/utils/Version.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/Version.scala
@@ -38,6 +38,7 @@
 package com.normation.utils
 
 import java.nio.charset.Charset
+import zio.Chunk
 
 /**
  * When comparing two version numbers, first the epoch of each are compared, then
@@ -141,15 +142,21 @@ object PartType {
   // snapshot < nightly < alpha < beta < milestone < rc < [0-9] < other
 
   // we keep original name in value
-  final case class Snapshot(value: String)  extends PartType { def index = 0; def toVersionString: String = value          }
-  final case class Nightly(value: String)   extends PartType { def index = 1; def toVersionString: String = value          }
-  final case class Alpha(value: String)     extends PartType { def index = 2; def toVersionString: String = value          }
-  final case class Beta(value: String)      extends PartType { def index = 3; def toVersionString: String = value          }
-  final case class Milestone(value: String) extends PartType { def index = 4; def toVersionString: String = value          }
-  final case class RC(value: String)        extends PartType { def index = 5; def toVersionString: String = value          }
-  final case class Numeric(value: Long)     extends PartType { def index = 6; def toVersionString: String = value.toString }
-  final case class Chars(value: String)     extends PartType { def index = 7; def toVersionString: String = value          }
+  final case class Snapshot(value: String)       extends PartType { def index = 0; def toVersionString: String = value          }
+  final case class Nightly(value: String)        extends PartType { def index = 1; def toVersionString: String = value          }
+  final case class Alpha(value: String)          extends PartType { def index = 2; def toVersionString: String = value          }
+  final case class Beta(value: String)           extends PartType { def index = 3; def toVersionString: String = value          }
+  final case class Milestone(value: String)      extends PartType { def index = 4; def toVersionString: String = value          }
+  final case class RC(value: String)             extends PartType { def index = 5; def toVersionString: String = value          }
+  final case class Numeric private (value: Long) extends PartType { def index = 6; def toVersionString: String = value.toString }
+  final case class Chars(value: String)          extends PartType { def index = 7; def toVersionString: String = value          }
 
+  object Numeric {
+    // with software in node, we have zillion of duplication of numeric of low ran, so we store them here:
+    val cacheSize = 100
+    val numCache  = Chunk.fromIterable((0 until cacheSize).map(i => new Numeric(i.toLong)))
+    def apply(n: Long): Numeric = if (n < cacheSize) numCache(n.toInt) else new Numeric(n)
+  }
   def compare(a: PartType, b: PartType): Int = {
     val d = a.index - b.index
     if (d == 0) {
@@ -246,7 +253,7 @@ object ParseVersion {
   def noSepPart1[A: P] = P(chars).map(c => VersionPart.After(Separator.None, c) :: Nil)
   def noSepPart2[A: P] = P(num).map(n => VersionPart.After(Separator.None, PartType.Numeric(n)) :: Nil)
 
-  def startNum[A: P] = P(num).map(PartType.Numeric)
+  def startNum[A: P] = P(num).map(i => PartType.Numeric(i))
 
   def version[A: P] = P(
     Start ~ epoch.? ~/ startNum ~/


### PR DESCRIPTION
https://issues.rudder.io/issues/22978

We have a parser for `Version` object which create instance of `Numeric`, `Chars` etc part for each segment of a version (each part separated by `.`, `~`, etc). 
So typically for version `1.2.3`, we get 3 new instances of `Numeric(1)`, `Numeric(2)`, `Numeric(3)`. When we have thousands of versions processed, that create a lot of churn. We also know that the low numeric values are over represented in version, so we can easily create a cache for values under 100 and have only one instance of these `Numeric` in RAM at any point. 100 `Numeric` consume almost nothing, it doesn't change memory requirements for rudder. 

The cache is implemented by making the `Numeric` constructor private and always using its factory, which was already the usage case since it's a case class. Then, we just look if the value to construct is lower than the max value in our cache and either use the cached value or create a new instance. 