### PR TITLE
Fixes #22983: Snake-yaml dependency in zio-json is subjected to CVE

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -549,7 +549,7 @@ limitations under the License.
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>
-	<artifactId>postgresql</artifactId>
+	      <artifactId>postgresql</artifactId>
         <version>${postgresql-version}</version>
       </dependency>
       <dependency>
@@ -858,6 +858,12 @@ limitations under the License.
       <groupId>dev.zio</groupId>
       <artifactId>zio-json-yaml_${scala-binary-version}</artifactId>
       <version>${zio-json-version}</version>
+    </dependency>
+    <!-- explicit snakeyaml dependency to override default zio-json-version -->
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>${snakeyaml-version}</version>
     </dependency>
     <dependency>
       <groupId>io.scalaland</groupId>

--- a/webapp/sources/rudder/rudder-rest/pom.xml
+++ b/webapp/sources/rudder/rudder-rest/pom.xml
@@ -155,13 +155,6 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-    <!-- YAML parser, for REST API test -->
-    <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-      <version>${snakeyaml-version}</version>
-      <scope>test</scope>
-    </dependency>
 
     <!-- the slf4j commons-logging replacement -->
     <dependency>


### PR DESCRIPTION
https://issues.rudder.io/issues/22983

Make `snake-yaml` dependency explicit at the point where `zio-json` is used. API seems compatible and nothing breaks. 

Also remove `snake-yaml` dep in sub projects since it's now useless.  

![image](https://github.com/Normation/rudder/assets/44649/2a88e101-4440-48ac-8d0d-0c23dfd863cf)
