### PR TITLE
Fixes #23042: There is a blank space above almost every Rudder page

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/common-layout.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/common-layout.html
@@ -10,6 +10,7 @@
 
     <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/libs/jquery-ui-timepicker-addon.min.css" media="screen" />
     <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/angular/angular-filemanager.min.css" media="screen" />
+
     <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/jstree/style.css" media="screen" />
     <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/fontawesome-5-15-1/css/all.min.css"/>
     <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/fontawesome-5-15-1/css/v4-shims.min.css"/>
@@ -426,27 +427,29 @@
     <img alt="" id="ajax-loader" class="ajaxloader svg-loader" data-lift="with-cached-resource" src="/images/ajax-loader.svg"/>
 
     <div class="content-wrapper">
-      <lift:Authz.whenhasrights>
-        <rudder-notifications></rudder-notifications>
-        <div id="content">
-        <!-- Here come the content bound by <lift:surround at="content"> -->
-        </div>
-      </lift:Authz.whenhasrights>
+      <div class="rudder_col">
+        <lift:Authz.whenhasrights>
+          <rudder-notifications></rudder-notifications>
+          <div id="content">
+          <!-- Here come the content bound by <lift:surround at="content"> -->
+          </div>
+        </lift:Authz.whenhasrights>
 
-      <lift:Authz.whennorights>
-        <div class="rudder-template one-col">
-          <div class="template-main">
-            <div class="jumbotron text-center">
-              <h2 style="color: #041922;margin-bottom: 30px;">
-                You don't have sufficient authorization rights to access this content.
-              </h2>
-              <h4>
-                Please contact your administrator to have more information.
-              </h4>
+        <lift:Authz.whennorights>
+          <div class="rudder-template one-col">
+            <div class="template-main">
+              <div class="jumbotron text-center">
+                <h2 style="color: #041922;margin-bottom: 30px;">
+                  You don't have sufficient authorization rights to access this content.
+                </h2>
+                <h4>
+                  Please contact your administrator to have more information.
+                </h4>
+              </div>
             </div>
           </div>
-        </div>
-      </lift:Authz.whennorights>
+        </lift:Authz.whennorights>
+      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
https://issues.rudder.io/issues/23042

While working on this issue : https://github.com/Normation/rudder/pull/4871 
I removed one too many html tags ( `.rudder_col` ), which broke some css rules