### PR TITLE
Fixes #23045: Make commiting nodes to fact-repo optionnal

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
@@ -42,6 +42,7 @@ import com.normation.errors._
 import com.normation.errors.IOResult
 import com.normation.inventory.domain._
 import com.normation.rudder.apidata.FullDetailLevel
+import com.normation.rudder.domain.logger.NodeLogger
 import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.git.GitItemRepository
 import com.normation.rudder.git.GitRepositoryProvider
@@ -146,7 +147,8 @@ trait SerializeFacts[A, B] {
 
 class GitNodeFactRepository(
     override val gitRepo: GitRepositoryProvider,
-    groupOwner:           String
+    groupOwner:           String,
+    actuallyCommit:       Boolean
 ) extends NodeFactRepository with GitItemRepository
     with SerializeFacts[(NodeId, InventoryStatus), (NodeInfo, FullInventory, Seq[Software])] {
 
@@ -154,6 +156,14 @@ class GitNodeFactRepository(
   override val entity:     String = "node"
   override val fileFormat: String = "1"
   val commiter = new PersonIdent("rudder-fact", "email not set")
+
+  if (actuallyCommit) {
+    NodeLogger.info(s"Nodes changes will be historized in Git in ${gitRepo.rootDirectory.pathAsString}/nodes")
+  } else {
+    NodeLogger.info(
+      s"Nodes changes won't be historized in Git, only last state is stored in ${gitRepo.rootDirectory.pathAsString}/nodes"
+    )
+  }
 
   override def getEntityPath(id: (NodeId, InventoryStatus)): String = {
     s"${id._2.name}/${id._1.value}.json"
@@ -214,16 +224,17 @@ class GitNodeFactRepository(
 
   override def persist(nodeInfo: NodeInfo, inventory: FullInventory, software: Seq[Software]): IOResult[Unit] = {
     for {
-      json   <- toJson((nodeInfo, inventory, software))
-      file    = getFile(nodeInfo.id, inventory.node.main.status)
-      _      <- IOResult.effect(file.write(json))
-      _      <- IOResult.effect(file.setGroup(groupOwner))
-      gitPath = toGitPath(file.toJava)
-      saved  <- commitAddFile(
+      json <- toJson((nodeInfo, inventory, software))
+      file  = getFile(nodeInfo.id, inventory.node.main.status)
+      _    <- IOResult.effect(file.write(json))
+      _    <- IOResult.effect(file.setGroup(groupOwner))
+      _    <- ZIO.when(actuallyCommit) {
+                commitAddFile(
                   commiter,
-                  gitPath,
+                  toGitPath(file.toJava),
                   s"Save inventory facts for ${inventory.node.main.status.name} node '${nodeInfo.hostname}' (${nodeInfo.id.value})"
                 )
+              }
     } yield ()
   }
 
@@ -239,12 +250,14 @@ class GitNodeFactRepository(
         // however toFile exists, move, because if present it may be because a deletion didn't work and
         // we need to overwritte
         IOResult.effect(fromFile.moveTo(toFile)(File.CopyOptions(overwrite = true))) *>
-        commitMvDirectory(
-          commiter,
-          toGitPath(fromFile.toJava),
-          toGitPath(toFile.toJava),
-          s"Updating facts for node '${nodeId.value}': accepted"
-        ), // if source file does not exist, check if dest is present. If present, assume it's ok, else error
+        ZIO.when(actuallyCommit) {
+          commitMvDirectory(
+            commiter,
+            toGitPath(fromFile.toJava),
+            toGitPath(toFile.toJava),
+            s"Updating facts for node '${nodeId.value}': accepted"
+          )
+        }, // if source file does not exist, check if dest is present. If present, assume it's ok, else error
 
         ZIO.whenM(IOResult.effect(!toFile.exists)) {
           Inconsistency(
@@ -261,7 +274,11 @@ class GitNodeFactRepository(
       ZIO.foreach(List(PendingInventory, AcceptedInventory)) { s =>
         val file = getFile(nodeId, s)
         ZIO.whenM(IOResult.effect(file.exists)) {
-          commitRmFile(commiter, toGitPath(file.toJava), s"Updating facts for node '${nodeId.value}': deleted")
+          if (actuallyCommit) {
+            commitRmFile(commiter, toGitPath(file.toJava), s"Updating facts for node '${nodeId.value}': deleted")
+          } else {
+            IOResult.effect(file.delete())
+          }
         }
       } *> checkInit()
     }

--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -394,9 +394,9 @@ rudder.dir.dependencies=/var/rudder/tools
 #
 rudder.batch.techniqueLibrary.updateInterval=5
 
-##########################################################
-# Configuration repository, its update and Git properties ###########################
-##########################################################
+######################################################################
+# Configuration and fact repositories, its update and Git properties ###########################
+#####################################################################
 
 #
 # Configuration repository is the place where all Group/Directive/Rules
@@ -429,6 +429,21 @@ rudder.config.repo.new.file.group.owner=rudder
 # Default run at 3:42 every morning.
 #
 rudder.git.gc=0 42 3 * * ?
+
+
+#
+# The full path to the directory containing the
+# .git for facts: nodes
+#
+rudder.dir.gitRootFactRepo=/var/rudder/fact-repository
+
+#
+# By default, Rudder won"t make a commit for each inventory and
+# changes in node and it will only keep a non historized JSON
+# serialisation of the current state of the node. You can make
+# Rudder historize node changes with that option (boolean).
+#
+rudder.facts.repo.historizeNodeChange=false
 
 ###############################
 # Dynamic group configuration  ######################################################
@@ -577,7 +592,7 @@ rudder.auth.idle-timeout=30 minutes
 # This property contains the comma separated list of suffixes that will be checked
 # before running a hook under /opt/rudder/etc/hooks.d.
 # If an executable (+x) file has one of the following suffixes, it
-# will be IGNORED and the corresponding hook skipped. 
+# will be IGNORED and the corresponding hook skipped.
 # Non executable (-x) files are ALWAYS ignored, with or without any of these suffixes.
 #
 # Spaces are trimmed. Case is not relevant (both .disabled and .DISABLED will be ignored)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -574,6 +574,13 @@ object RudderConfig extends Loggable {
       case ex: Exception => "/var/rudder/fact-repository"
     }
   }
+  val RUDDER_GIT_FACT_COMMIT_NODES                 = {
+    try {
+      config.getBoolean("rudder.facts.repo.historizeNodeChange")
+    } catch {
+      case ex: Exception => false
+    }
+  }
   val RUDDER_DIR_TECHNIQUES                        = RUDDER_GIT_ROOT_CONFIG_REPO + "/techniques"
   val RUDDER_BATCH_DYNGROUP_UPDATEINTERVAL         = config.getInt("rudder.batch.dyngroup.updateInterval") // 60 //one hour
   val RUDDER_BATCH_TECHNIQUELIBRARY_UPDATEINTERVAL =
@@ -1572,7 +1579,7 @@ object RudderConfig extends Loggable {
     .runOrDie(err => new RuntimeException(s"Error when initializing git configuration repository: " + err.fullMsg))
   private[this] lazy val gitFactRepoGC = new GitGC(gitFactRepo, RUDDER_GIT_GC)
   gitFactRepoGC.start()
-  lazy val factRepo                    = new GitNodeFactRepository(gitFactRepo, RUDDER_GROUP_OWNER_CONFIG_REPO)
+  lazy val factRepo                    = new GitNodeFactRepository(gitFactRepo, RUDDER_GROUP_OWNER_CONFIG_REPO, RUDDER_GIT_FACT_COMMIT_NODES)
   factRepo.checkInit().runOrDie(err => new RuntimeException(s"Error when checking fact repository init: " + err.fullMsg))
 
   lazy val ldifInventoryLogger = new DefaultLDIFInventoryLogger(LDIF_TRACELOG_ROOT_DIR)


### PR DESCRIPTION
https://issues.rudder.io/issues/23045

The whole thing is about adding a boolean "actually do things with git" in `GitNodeFactRepository`. The parameter is taken from config file (default false if missing, ie in case of upgrade but also for new install). 

Then, it's just adding `ZIO.when(xxxx)` where needed, and compensate when the commit was doing more than just commit (deletion). 