### PR TITLE
Fixes #23000: When changes messages are mandatory and saving a technique we have an error message about missing info but technique is saved

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
@@ -65,7 +65,6 @@ import com.normation.rudder.repository.json.DataExtractor.OptionnalJson
 import com.normation.rudder.repository.xml.TechniqueRevisionRepository
 import com.normation.rudder.rest.{TechniqueApi => API, _}
 import com.normation.rudder.rest.RestUtils.ActionType
-import com.normation.rudder.rest.RestUtils.actionResponse2
 import com.normation.rudder.rest.RestUtils.response
 import com.normation.rudder.rest.implicits._
 import com.normation.utils.ParseVersion
@@ -109,7 +108,28 @@ class TechniqueApi(
   def actionResp(function: Box[ActionType], req: Req, errorMessage: String, actor: EventActor)(implicit
       action:              String
   ): LiftResponse = {
-    actionResponse2(restExtractorService, dataName, uuidGen, None)(function, req, errorMessage)(action, actor)
+    // implementation copied from RestUtils#actionResponse2
+    // but changed to never fail on reason message extraction
+    implicit val prettify = restExtractorService.extractPrettify(req.params)
+    import net.liftweb.json.JsonDSL._
+    import net.liftweb.common.EmptyBox
+
+    (
+      for {
+        reason <- restExtractorService.extractReason(req).or(Full(Some("Technique updated via technique editor API")))
+        modId   = ModificationId(uuidGen.newUuid)
+        result <- function.flatMap(_(actor, modId, reason))
+      } yield {
+        result
+      }
+    ) match {
+      case Full(result: JValue) =>
+        RestUtils.toJsonResponse(None, (dataName -> result))
+      case eb: EmptyBox =>
+        val message = (eb ?~! errorMessage).messageChain
+        RestUtils.toJsonError(None, message)
+    }
+
   }
 
   def getLiftEndpoints(): List[LiftApiModule] = {
@@ -226,18 +246,25 @@ class TechniqueApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      val modId    = ModificationId(uuidGen.newUuid)
-      val response = {
+      val modId = ModificationId(uuidGen.newUuid)
+      val wrapper: ActionType = (_, _, _) => {
         for {
           json             <- req.json ?~! "No JSON data sent"
           methodMap        <- techniqueReader.getMethodsMetadata.toBox
           technique        <- restExtractor.extractEditorTechnique(json, methodMap, false, false)
-          updatedTechnique <- techniqueWriter.writeTechniqueAndUpdateLib(technique, methodMap, modId, authzToken.actor).toBox
+          updatedTechnique <- techniqueWriter
+                                .writeTechniqueAndUpdateLib(
+                                  technique,
+                                  methodMap,
+                                  modId,
+                                  authzToken.actor
+                                )
+                                .toBox
         } yield {
           JObject(JField("technique", techniqueSerializer.serializeTechniqueMetadata(updatedTechnique, methodMap)))
         }
       }
-      val wrapper: ActionType = { case _ => response }
+
       actionResp(Full(wrapper), req, "Could not update ncf technique", authzToken.actor)("UpdateTechnique")
     }
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/23000

Since technique editor doesn't manage reason popup (need to be corrected, at least along with https://issues.rudder.io/issues/22895) we always provide one. We already had reimplemented part of `RestUtils` methods in technique editor API (not sure why), so it's just copying more code. Since it will be removed in 8.0, that's not too bad. 

The other part about `wrapper` is needed else we always evaluate response before wrapping in it: it's `Box`, not `ZIO`, so it's strict and not lazy. The consequence here was that even when the `extractReason` was returning an error, the `writeTechniqueAndUpdateLib` was already done which was false. 