### PR TITLE
Fixes #23074: Generation not queued when one already started

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AsyncDeploymentActor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AsyncDeploymentActor.scala
@@ -269,6 +269,7 @@ final class AsyncDeploymentActor(
                 "Automatic policy generation request: queued - one policy " +
                 "generation already running"
               )
+              currentDeployerState = ProcessingAndPendingAuto(DateTime.now, p, actor, 0)
 
             case p: ProcessingAndPendingAuto => // drop message, one is already pending
               PolicyGenerationLogger.manager.debug(


### PR DESCRIPTION
https://issues.rudder.io/issues/23074

In PR https://github.com/Normation/rudder/pull/4832/files#diff-2bfd5f67b4c377de308d2c78906f3ecf1684b561fc7c22739dfd18aea93156afL275 we removed the actual queuing, not only the save of log event, which breaks the state machine. 