### PR TITLE
Fixes #20071: Compliance incorrectly computed when two components have the same name and cfe vars are involved

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
@@ -350,7 +350,7 @@ class StatusReportTest extends Specification {
         case (l, i) =>
           val parsed = l.split(",").map(_.trim).toList
           parsed match {
-            case n :: r :: _ :: d :: c :: v :: uv :: t :: m :: Nil =>
+            case n :: r :: id :: d :: c :: v :: uv :: t :: m :: Nil =>
               Some(
                 RuleNodeStatusReport(
                   n,
@@ -369,6 +369,7 @@ class StatusReportTest extends Specification {
                             ComponentValueStatusReport(
                               v,
                               uv,
+                              id,
                               List(
                                 MessageStatusReport(toRT(t), ?(m))
                               )
@@ -381,8 +382,8 @@ class StatusReportTest extends Specification {
                   DateTime.now.plusMinutes(5)
                 )
               )
-            case "" :: Nil | Nil                                   => None
-            case _                                                 => throw new IllegalArgumentException(s"Can not parse line ${i}: '${l}'")
+            case "" :: Nil | Nil                                    => None
+            case _                                                  => throw new IllegalArgumentException(s"Can not parse line ${i}: '${l}'")
           }
       }
       .flatten


### PR DESCRIPTION
https://issues.rudder.io/issues/20071

Add tests to validate the current assumption on reporting:
- we check that when reports have report ID, everything is simpler: we can correctly split similar reports for different component. Merge works as expected
    - I added a `reportId` in `ComponentValueStatusReport` because it was extremelly hard to follow tests without it, and it was almost free to add, and actually it's quite strange it was not already there. Also added a method to find `ComponentValueStatusReport` in a block based on `reportId`
 - corrected the description of a test that was saying the opposite of what it was testing: we DO check that a component name matches the expected component name pattern when checking for reports. 