### PR TITLE
Fixes #22388: Bad report maching when reportid are present

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
@@ -1543,12 +1543,8 @@ object ExecutionBatch extends Loggable {
 
             val (ok, unexpected) = matched.foldLeft((List.empty[ResultReports], List.empty[ResultReports])) {
               case ((ok, unexp), next) =>
-                val componentOk = next.component == expectedComponent.componentName || replaceCFEngineVars(
-                  expectedComponent.componentName
-                ).matcher(next.component).matches()
-                val valueOk     = next.keyValue == expectedValueId.value || replaceCFEngineVars(expectedValueId.value)
-                  .matcher(next.keyValue)
-                  .matches()
+                val componentOk = next.component.startsWith(expectedComponent.componentName.takeWhile(_ != '$'))
+                val valueOk     = next.keyValue.startsWith(expectedValueId.value.takeWhile(_ != '$'))
 
                 if (componentOk && valueOk) {
                   (next :: ok, unexp)


### PR DESCRIPTION
https://issues.rudder.io/issues/22388

- backport the tests change from https://github.com/Normation/rudder/pull/4897
- make the pattern check for component name and variable with `$` more lenient: now, we only compare that what is before the `$` is identical (ie whole string when no variable, nothing when the variable is at the begining, etc)