### PR TITLE
Fixes #23084: Remove constraint on component name pattern for matching reports

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -280,6 +280,10 @@ final case class DirectiveStatusReport(
                                |    ${components.sortBy(_.componentName).mkString("\n    ")}
                                |]"""
 
+  def getByReportId(reportId: String): List[ComponentValueStatusReport] = {
+    components.collect { case c => c.componentValues.collect { case cv if (cv.reportId == reportId) => cv } }.flatten
+  }
+
   def withFilteredElements(
       component: ComponentStatusReport => Boolean,
       values:    ComponentValueStatusReport => Boolean
@@ -448,6 +452,7 @@ object ComponentStatusReport extends Loggable {
 final case class ComponentValueStatusReport(
     componentValue:         String,
     expectedComponentValue: String,
+    reportId:               String,
     messages:               List[MessageStatusReport]
 ) extends StatusReport {
 
@@ -466,14 +471,17 @@ object ComponentValueStatusReport extends Loggable {
 
   /**
    * Merge a set of ComponentValueStatusReport, grouping
-   * them by component *unexpanded* value
+   * them by component reportId and then actual value and then expected value
    */
   def merge(values: Iterable[ComponentValueStatusReport]): List[ComponentValueStatusReport] = {
-    values.groupBy(_.componentValue).toList.flatMap {
-      case (component, values) =>
-        values.groupBy(_.expectedComponentValue).toList.map {
-          case (unexpanded, values) =>
-            ComponentValueStatusReport(component, unexpanded, values.toList.flatMap(_.messages))
+    values.groupBy(_.reportId).toList.flatMap {
+      case (id, groupedById) =>
+        groupedById.groupBy(_.componentValue).toList.flatMap {
+          case (component, groupedByActualValue) =>
+            groupedByActualValue.groupBy(_.expectedComponentValue).toList.map {
+              case (unexpanded, groupedByExpectedValue) =>
+                ComponentValueStatusReport(component, unexpanded, id, groupedByActualValue.toList.flatMap(_.messages))
+            }
         }
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
@@ -350,7 +350,7 @@ class StatusReportTest extends Specification {
         case (l, i) =>
           val parsed = l.split(",").map(_.trim).toList
           parsed match {
-            case n :: r :: _ :: d :: c :: v :: uv :: t :: m :: Nil =>
+            case n :: r :: id :: d :: c :: v :: uv :: t :: m :: Nil =>
               Some(
                 RuleNodeStatusReport(
                   n,
@@ -369,6 +369,7 @@ class StatusReportTest extends Specification {
                             ComponentValueStatusReport(
                               v,
                               uv,
+                              id,
                               List(
                                 MessageStatusReport(toRT(t), ?(m))
                               )
@@ -381,8 +382,8 @@ class StatusReportTest extends Specification {
                   DateTime.now.plusMinutes(5)
                 )
               )
-            case "" :: Nil | Nil                                   => None
-            case _                                                 => throw new IllegalArgumentException(s"Can not parse line ${i}: '${l}'")
+            case "" :: Nil | Nil                                    => None
+            case _                                                  => throw new IllegalArgumentException(s"Can not parse line ${i}: '${l}'")
           }
       }
       .flatten

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestDirectiveComplianceCsv.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestDirectiveComplianceCsv.scala
@@ -119,6 +119,7 @@ class TestDirectiveComplianceCsv extends Specification {
                         ComponentValueStatusReport(
                           "Disable-TlsCipherSuite -Name \"TLS_RSA_WITH_DES_CBC_SHA\" ",
                           "",
+                          "0",
                           List(
                             MessageStatusReport(
                               ReportType.AuditNotApplicable,
@@ -139,6 +140,7 @@ class TestDirectiveComplianceCsv extends Specification {
                         ComponentValueStatusReport(
                           "Disable-TlsCipherSuite -Name \"TLS_RSA_WITH_DES_CBC_SHA\" ",
                           "",
+                          "0",
                           List(
                             MessageStatusReport(
                               ReportType.AuditNotApplicable,
@@ -165,6 +167,7 @@ class TestDirectiveComplianceCsv extends Specification {
                         ComponentValueStatusReport(
                           "(Get-TlsCipherSuite -Name \"TLS_RSA_WITH_DES_CBC_SHA\").Count",
                           "",
+                          "0",
                           List(
                             MessageStatusReport(
                               ReportType.AuditNotApplicable,
@@ -185,6 +188,7 @@ class TestDirectiveComplianceCsv extends Specification {
                         ComponentValueStatusReport(
                           "(Get-TlsCipherSuite -Name \"TLS_RSA_WITH_DES_CBC_SHA\").Count",
                           "",
+                          "0",
                           List(
                             MessageStatusReport(
                               ReportType.AuditCompliant,


### PR DESCRIPTION
https://issues.rudder.io/issues/23084

Next step of https://github.com/Normation/rudder/pull/4897 and https://github.com/Normation/rudder/pull/4899

- we completely remove the pattern matching between expected component name & value and actual one for reports with a `reportId`
- we add a `reportId` field (default to `0` for case without a valid `reportId`) for `ComponentValueStatusReport` and addapt grouping in consequence, so that now, two report with same value but different report Id are splitted apart. 
    - the grouping is done `componentName` then `reportId` then  `keyValue` to minimize change (reportId first look like we should have something on top of `ComponentStatusReport` with Id, which doesn't match well the current reports structure where each report brings reportid)
- adpat tests to check all that