### PR TITLE
Fixes #23093: Warning for unused vars in 8.0 compilation

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -293,10 +293,6 @@ class NodeGroupForm(
   }
 
   def showGroupProperties(group: NodeGroup): NodeSeq = {
-    import com.normation.rudder.AuthorizationType
-
-    val groupId       = group.id.serialize
-    val userHasRights = CurrentUser.checkRights(AuthorizationType.Group.Edit)
 
     val intro = (<div class="info">
         <h4>Hierarchy of group and unicity of property name</h4>


### PR DESCRIPTION
https://issues.rudder.io/issues/23093

Rights were used in the angular app, now it's fully managed from elm side of the rewritten app, see: https://github.com/Normation/rudder/pull/4839