### PR TITLE
Fixes #23098: Plugin cannot add custom roles or it will be overwritten by boot custom roles 

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -653,7 +653,7 @@ class Boot extends Loggable {
     LiftRules.setSiteMapFunc(() => SiteMap(newSiteMap: _*))
 
     // load users from rudder-users.xml
-    RudderConfig.rudderUserListProvider.reload()
+    RudderConfig.rudderUserListProvider.reload(false)
 
     // start node count historization
     ZioRuntime.runNow(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
@@ -313,9 +313,9 @@ final class FileUserDetailListProvider(roleApiMapping: RoleApiMapping, authorisa
   /**
    * Reload the list of users. Only update the cache if there is no errors.
    */
-  def reloadPure(): IOResult[Unit] = {
+  def reloadPure(resetRoles: Boolean): IOResult[Unit] = {
     for {
-      config <- UserFileProcessing.parseUsers(roleApiMapping, file, authorisationLevel.userAuthEnabled, reload = true)
+      config <- UserFileProcessing.parseUsers(roleApiMapping, file, authorisationLevel.userAuthEnabled, resetRoles)
       _      <- cache.set(config)
       cbs    <- callbacks.get
       _      <- ZIO.foreach(cbs) { cb =>
@@ -327,8 +327,8 @@ final class FileUserDetailListProvider(roleApiMapping: RoleApiMapping, authorisa
     } yield ()
   }
 
-  def reload(): Unit = {
-    reloadPure()
+  def reload(resetRoles: Boolean): Unit = {
+    reloadPure(resetRoles)
       .catchAll(err =>
         ApplicationLoggerPure.error(s"Error when reloading users and roles authorisation configuration file: ${err.fullMsg}")
       )


### PR DESCRIPTION
https://issues.rudder.io/issues/23098

This pr allows plugin to declare custom roles, reload of users at webapp startup cleans custom roles without this