### PR TITLE
Fixes #7008: After deleting a node, the user should be redirected to nodes list page

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -44,6 +44,7 @@ import com.normation.cfclerk.domain.HashAlgoConstraint.SHA1
 import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain._
 import com.normation.rudder.batch.AutomaticStartDeployment
+import com.normation.rudder.domain.logger.NodeLoggerPure
 import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.nodes.NodeKind
 import com.normation.rudder.domain.policies.GlobalPolicyMode
@@ -56,6 +57,8 @@ import com.normation.rudder.services.reports.NoReportInInterval
 import com.normation.rudder.services.reports.Pending
 import com.normation.rudder.web.model.JsNodeId
 import com.normation.rudder.web.services.CurrentUser
+import com.normation.rudder.web.snippet.RegisterToasts
+import com.normation.rudder.web.snippet.ToastNotification
 import com.normation.utils.DateFormaterService
 import com.normation.zio._
 import net.liftweb.common._
@@ -412,7 +415,7 @@ object DisplayNode extends Loggable {
             if (!isRootNode(sm.node.main.id)) {
               <div>
                   <div class="col-xs-12">
-                    {showDeleteButton(sm.node.main.id)}
+                    {showDeleteButton(sm.node.main)}
                   </div>
                 </div>
             } else { NodeSeq.Empty }
@@ -1072,7 +1075,7 @@ object DisplayNode extends Loggable {
     }
   }
 
-  private[this] def showDeleteButton(nodeId: NodeId) = {
+  private[this] def showDeleteButton(node: NodeSummary) = {
     def toggleDeletion(): JsCmd = {
       JsRaw(""" $('#deleteButton').toggle(300); $('#confirmDeletion').toggle(300) """)
     }
@@ -1098,7 +1101,7 @@ object DisplayNode extends Loggable {
       SHtml.ajaxButton("Cancel", () => { toggleDeletion() }, ("class", "btn btn-default"))
     }
           {
-      SHtml.ajaxButton("Confirm", () => { removeNode(nodeId) }, ("class", "btn btn-danger"))
+      SHtml.ajaxButton("Confirm", () => { removeNode(node) }, ("class", "btn btn-danger"))
     }
         </span>
       </div>
@@ -1107,109 +1110,41 @@ object DisplayNode extends Loggable {
 </div>
   }
 
-  private[this] def removeNode(nodeId: NodeId): JsCmd = {
+  private[this] def removeNode(node: NodeSummary): JsCmd = {
     val modId = ModificationId(uuidGen.newUuid)
-    removeNodeService.removeNodePure(nodeId, RudderConfig.RUDDER_DEFAULT_DELETE_NODE_MODE, modId, CurrentUser.actor).toBox match {
+    removeNodeService
+      .removeNodePure(node.id, RudderConfig.RUDDER_DEFAULT_DELETE_NODE_MODE, modId, CurrentUser.actor)
+      .toBox match {
       case Full(_) =>
         asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.actor)
-        onSuccess
+        onSuccess(node)
       case eb: EmptyBox =>
-        val message = s"There was an error while deleting Node '${nodeId.value}'"
+        val message = s"There was an error while deleting Node '${node.hostname}' [${node.id.value}]"
         val e       = eb ?~! message
-        logger.error(e.messageChain)
-        onFailure(nodeId, message, e.messageChain, None)
+        NodeLoggerPure.Delete.logEffect.error(e.messageChain)
+        onFailure(node, message, e.messageChain, None)
     }
   }
 
   private[this] def onFailure(
-      nodeId:    NodeId,
+      node:      NodeSummary,
       message:   String,
       details:   String,
       hookError: Option[HookReturnCode.Error]
   ): JsCmd = {
-
-    val hookDetails = {
-      hookError match {
-        case Some(error) =>
-          {
-            if (error.stdout.size > 0) {
-              <b>stdout</b>
-            <pre>{error.stdout}</pre>
-            } else {
-              NodeSeq.Empty
-            }
-          } ++ {
-            if (error.stderr.size > 0) {
-              <b>stderr</b>
-            <pre>{error.stderr}</pre>
-            } else {
-              NodeSeq.Empty
-            }
-          }
-        case None        => NodeSeq.Empty
-      }
-    }
-
-    val popupHtml =
-      <div class="modal-backdrop fade in" style="height: 100%;"></div>
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <div class="close" data-dismiss="modal">
-                    <span aria-hidden="true">&times;</span>
-                    <span class="sr-only">Close</span>
-                </div>
-                <h4 class="modal-title">
-                    Error during Node deletion
-                </h4>
-            </div>
-            <div class="modal-body">
-                <h4>{message}</h4>
-                <p>{details}</p>
-                {hookDetails}
-            </div>
-            <div class="modal-footer">
-                <button class="btn btn-default" type="button" data-dismiss="modal">
-                    Close
-                </button>
-            </div>
-        </div>
-    </div>;
-    JsRaw("""$('#errorPopupHtmlId').bsModal('hide');""") &
-    SetHtml(errorPopupHtmlId, popupHtml) &
-    JsRaw(s""" callPopupWithTimeout(200,"${errorPopupHtmlId}")""")
+    RegisterToasts.register(
+      ToastNotification.Error(
+        s"An error happened when trying to delete node '${node.hostname}' [${node.id.value}]. " +
+        "Please contact your server admin to resolve the problem. " +
+        s"Error was: '${message}'"
+      )
+    )
+    RedirectTo("/secure/nodeManager/nodes")
   }
 
-  private[this] def onSuccess: JsCmd = {
-    val popupHtml = {
-      <div class="modal-backdrop fade in" style="height: 100%;"></div>
-        <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <div class="close" data-dismiss="modal">
-                    <span aria-hidden="true">&times;</span>
-                    <span class="sr-only">Close</span>
-                </div>
-                <h4 class="modal-title">
-                    Success
-                </h4>
-            </div>
-            <div class="modal-body">
-                <h4 class="text-center">The node has been successfully removed from Rudder.</h4>
-            </div>
-            <div class="modal-footer">
-                <button class="btn btn-default" type="button" data-dismiss="modal">
-                    Close
-                </button>
-            </div>
-        </div>
-    </div>
-    }
-    JsRaw(s"updateHashString('nodeId', undefined); forceParseHashtag()") &
-    SetHtml("serverDetails", NodeSeq.Empty) &
-    JsRaw("""$('#successPopupHtmlId').bsModal('hide');""") &
-    SetHtml(successPopupHtmlId, popupHtml) &
-    JsRaw(s""" callPopupWithTimeout(200,"${successPopupHtmlId}") """)
+  private[this] def onSuccess(node: NodeSummary): JsCmd = {
+    RegisterToasts.register(ToastNotification.Success(s"Node '${node.hostname}' [${node.id.value}] was correctly deleted"))
+    RedirectTo("/secure/nodeManager/nodes")
   }
 
   private[this] def isRootNode(n: NodeId): Boolean = {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/RegisterToasts.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/RegisterToasts.scala
@@ -1,0 +1,94 @@
+/*
+ *************************************************************************************
+ * Copyright 2023 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.web.snippet
+
+import bootstrap.liftweb.StaticResourceRewrite
+import net.liftweb.http._
+import net.liftweb.http.js.JE._
+import net.liftweb.http.js.JsCmd
+import net.liftweb.http.js.JsCmds._
+import scala.xml.NodeSeq
+import scala.xml.Utility
+
+sealed trait ToastNotification {
+  def in: String
+  def message: String = Utility.escape(in).replaceAll("""\n""", " ")
+}
+
+object ToastNotification {
+
+  final case class Success(in: String) extends ToastNotification
+  final case class Error(in: String)   extends ToastNotification
+}
+
+object UnpublishedToasts extends SessionVar[List[ToastNotification]](Nil)
+
+/**
+ * A simple class to display toasts (notifications for success/etc) after a
+ * redirect
+ */
+object RegisterToasts {
+
+  def register(toast: ToastNotification) = {
+    UnpublishedToasts(toast :: UnpublishedToasts.get)
+  }
+}
+
+class RegisterToasts {
+
+  def display: NodeSeq = {
+    val toasts = UnpublishedToasts.get
+    UnpublishedToasts.set(Nil)
+    toasts match {
+      case Nil  => NodeSeq.Empty
+      case list =>
+        Script(
+          OnLoad(
+            list
+              .map(t => {
+                t match {
+                  case x: ToastNotification.Error   => JsRaw(s"""createErrorNotification("${x.message}")""").cmd
+                  case x: ToastNotification.Success => JsRaw(s"""createSuccessNotification("${x.message}")""").cmd
+                }
+              })
+              .reduce[JsCmd](_ & _)
+          )
+        )
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/common-layout.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/common-layout.html
@@ -108,6 +108,7 @@
     });
     </script>
     <script data-lift="SetupRedirect.display" ></script>
+    <script data-lift="RegisterToasts.display"></script>
     <script type="text/javascript">
       // <![CDATA[
       $(document).ready(function() {


### PR DESCRIPTION
https://issues.rudder.io/issues/7008

The redirection part is trivial: it's just two `RedirectTo` for the `onSuccess/onFailure` case. Can't be simpler. 
Safe, we want a notification that the node was deleted (or that there was an error), and we can't do that in JS since we are doing a redirect. 
So I created a simple snippet with a session var (`UnpublishedToasts`) that display the list of toast when the comon layout is loaded (ie at each actual load of a rudder page). 
You can register toasts with `RegisterToasts .register` anywhere in Rudder where the HTML session is defined (so mostly lift snippet). Toast are cleaned when displayed. 
The are session-bound, so linked to an user, and cleaned-up on loggout in any case.