### PR TITLE
Fixes #23148: Temporary workaround for tag creation in rudder 8.0 alpha

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TagsEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TagsEditForm.scala
@@ -25,7 +25,13 @@ class TagsEditForm(tags: Tags, objectId: String) extends Loggable {
 
   def tagsForm(controllerId: String, appId: String, update: Box[Tags] => Unit, isRule: Boolean): NodeSeq = {
 
-    val valueInput = SHtml.textarea("", s => update(parseResult(s)), ("ng-model", "result"), ("ng-hide", "true"))
+    // TODO: THIS MUST BE CHANGE WHEN TAGS APP IS REWRITTEN
+    val valueInput = SHtml.textarea(
+      "",
+      s => update(parseResult("""[{"key":"TODO-CHANGE-CODE", "value":"in TagsEditForm"}]""")),
+      ("ng-model", "result"),
+      ("ng-hide", "true")
+    )
     val css: CssSel = {
       s"#${controllerId} *+" #> valueInput &
       s"#${controllerId} #tagForm" #> editTagsTemplate


### PR DESCRIPTION
https://issues.rudder.io/issues/23148

Workaround the tag limitation by providing a hard coded value that is clearly not something that we want to keep. 
Note: it will put that value in directive tags, so it must not outlive alpha cycle. 