### PR TITLE
Fixes #23150: Sort bundles in CFEngine output

### DIFF
--- a/policies/rudderc/src/backends/unix/ncf/technique.rs
+++ b/policies/rudderc/src/backends/unix/ncf/technique.rs
@@ -74,10 +74,7 @@ impl fmt::Display for Technique {
         if self.description.is_some() {
             writeln!(f, "# @description {}", self.description.as_ref().unwrap())?;
         }
-
-        let mut sorted_bundles = self.bundles.clone();
-        sorted_bundles.sort_by(|a, b| b.name.cmp(&a.name));
-        for bundle in sorted_bundles {
+        for bundle in &self.bundles {
             write!(f, "\n{}", bundle)?;
         }
         writeln!(f)?;

--- a/policies/rudderc/tests/cases/general/reporting/technique.cf
+++ b/policies/rudderc/tests/cases/general/reporting/technique.cf
@@ -27,11 +27,23 @@ bundle agent reporting {
     "c76686bb-79ab-4ae5-b45f-108492ab4101_${report_data.directive_id}" usebundle => call_c76686bb_79ab_4ae5_b45f_108492ab4101("Disabled reporting", "ntp", "c76686bb-79ab-4ae5-b45f-108492ab4101", @{args}, "${class_prefix}", "ntp", "", "", "");
 
 }
-bundle agent call_df06e919_02b7_41a7_a03f_4239592f3c45(c_name, c_key, report_id, args, class_prefix, name, version, architecture, provider) {
+bundle agent call_a86ce2e5_d5b6_45cc_87e8_c11cca71d908(c_name, c_key, report_id, args, class_prefix, name, version, architecture, provider) {
 
   methods:
-    "df06e919-02b7-41a7-a03f-4239592f3c45_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
-    "df06e919-02b7-41a7-a03f-4239592f3c45_${report_data.directive_id}" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}");
+    "a86ce2e5-d5b6-45cc-87e8-c11cca71d908_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
+    "a86ce2e5-d5b6-45cc-87e8-c11cca71d908_${report_data.directive_id}" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}");
+
+}
+bundle agent call_b86ce2e5_d5b6_45cc_87e8_c11cca71d907(c_name, c_key, report_id, args, class_prefix, name, version, architecture, provider) {
+
+  methods:
+    "b86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
+    "b86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}"),
+                                             if => "debian";
+    "b86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => _classes_noop(canonify("${class_prefix}_package_present_htop")),
+                                         unless => "debian";
+    "b86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => log_rudder("Skipping method 'Package present' with key parameter 'htop' since condition 'debian' is not reached", "htop", canonify("${class_prefix}_package_present_htop"), canonify("${class_prefix}_package_present_htop"), @{args}),
+                                         unless => "debian";
 
 }
 bundle agent call_df06e919_02b7_41a7_a03f_4239592f3c12(c_name, c_key, report_id, args, class_prefix, name, version, architecture, provider) {
@@ -41,11 +53,11 @@ bundle agent call_df06e919_02b7_41a7_a03f_4239592f3c12(c_name, c_key, report_id,
     "df06e919-02b7-41a7-a03f-4239592f3c12_${report_data.directive_id}" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}");
 
 }
-bundle agent call_cf06e919_02b7_41a7_a03f_4239592f3c21(c_name, c_key, report_id, args, class_prefix, name, version, architecture, provider) {
+bundle agent call_df06e919_02b7_41a7_a03f_4239592f3c45(c_name, c_key, report_id, args, class_prefix, name, version, architecture, provider) {
 
   methods:
-    "cf06e919-02b7-41a7-a03f-4239592f3c21_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
-    "cf06e919-02b7-41a7-a03f-4239592f3c21_${report_data.directive_id}" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}");
+    "df06e919-02b7-41a7-a03f-4239592f3c45_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
+    "df06e919-02b7-41a7-a03f-4239592f3c45_${report_data.directive_id}" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}");
 
 }
 bundle agent call_cf06e919_02b7_41a7_a03f_4239592f3c14(c_name, c_key, report_id, args, class_prefix, name, version, architecture, provider) {
@@ -62,6 +74,13 @@ bundle agent call_cf06e919_02b7_41a7_a03f_4239592f3c13(c_name, c_key, report_id,
     "cf06e919-02b7-41a7-a03f-4239592f3c13_${report_data.directive_id}" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}");
 
 }
+bundle agent call_cf06e919_02b7_41a7_a03f_4239592f3c21(c_name, c_key, report_id, args, class_prefix, name, version, architecture, provider) {
+
+  methods:
+    "cf06e919-02b7-41a7-a03f-4239592f3c21_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
+    "cf06e919-02b7-41a7-a03f-4239592f3c21_${report_data.directive_id}" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}");
+
+}
 bundle agent call_c76686bb_79ab_4ae5_b45f_108492ab4101(c_name, c_key, report_id, args, class_prefix, name, version, architecture, provider) {
 
   methods:
@@ -69,24 +88,5 @@ bundle agent call_c76686bb_79ab_4ae5_b45f_108492ab4101(c_name, c_key, report_id,
     "c76686bb-79ab-4ae5-b45f-108492ab4101_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "c76686bb-79ab-4ae5-b45f-108492ab4101_${report_data.directive_id}" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}");
     "c76686bb-79ab-4ae5-b45f-108492ab4101_${report_data.directive_id}" usebundle => enable_reporting();
-
-}
-bundle agent call_b86ce2e5_d5b6_45cc_87e8_c11cca71d907(c_name, c_key, report_id, args, class_prefix, name, version, architecture, provider) {
-
-  methods:
-    "b86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
-    "b86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}"),
-                                             if => "debian";
-    "b86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => _classes_noop(canonify("${class_prefix}_package_present_htop")),
-                                         unless => "debian";
-    "b86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => log_rudder("Skipping method 'Package present' with key parameter 'htop' since condition 'debian' is not reached", "htop", canonify("${class_prefix}_package_present_htop"), canonify("${class_prefix}_package_present_htop"), @{args}),
-                                         unless => "debian";
-
-}
-bundle agent call_a86ce2e5_d5b6_45cc_87e8_c11cca71d908(c_name, c_key, report_id, args, class_prefix, name, version, architecture, provider) {
-
-  methods:
-    "a86ce2e5-d5b6-45cc-87e8-c11cca71d908_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
-    "a86ce2e5-d5b6-45cc-87e8-c11cca71d908_${report_data.directive_id}" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}");
 
 }


### PR DESCRIPTION
Bundle should be in the order they run, not alphanumeric order.