### PR TITLE
Fixes #23155: Regenerate yaml technique and filter generated files in rule archives

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
@@ -331,7 +331,6 @@ class TechniqueCompilerWithFallback(
                 }
       app     = config.compiler.getOrElse(defaultCompiler)
       res    <- compileTechniqueInternal(technique, methods, app)
-      _      <- effectUioUnit(println(s"***** + $res}"))
       _      <- ZIO.when(res.fallbacked == true || res.resultCode != 0) {
                   writeCompilationOutputFile(technique, res)
                 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
@@ -103,12 +103,11 @@ trait TechniqueWriter {
  * to rudder dev.
  */
 class TechniqueWriterImpl(
-    archiver:            TechniqueArchiver,
-    techLibUpdate:       UpdateTechniqueLibrary,
-    deleteService:       DeleteEditorTechnique,
-    techniqueSerializer: YamlTechniqueSerializer,
-    compiler:            TechniqueCompiler,
-    baseConfigRepoPath:  String // root of config repos
+    archiver:           TechniqueArchiver,
+    techLibUpdate:      UpdateTechniqueLibrary,
+    deleteService:      DeleteEditorTechnique,
+    compiler:           TechniqueCompiler,
+    baseConfigRepoPath: String // root of config repos
 ) extends TechniqueWriter {
 
   def deleteTechnique(
@@ -182,10 +181,13 @@ class TechniqueWriterImpl(
   ///// utility methods /////
 
   def writeYaml(technique: EditorTechnique, methods: Map[BundleName, GenericMethod]): IOResult[String] = {
+    import YamlTechniqueSerializer._
+    import zio.yaml.YamlOps._
+
     val metadataPath = s"${technique.path}/technique.yml"
     val path         = s"${baseConfigRepoPath}/${metadataPath}"
     for {
-      content <- techniqueSerializer.toYml(technique).toIO
+      content <- technique.toYaml().toIO
       _       <- IOResult.attempt(s"An error occurred while creating yaml file for Technique '${technique.name}'") {
                    implicit val charSet = StandardCharsets.UTF_8
                    val file             = File(path).createFileIfNotExists(true)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/migration/MigrateOldTechniquesService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/migration/MigrateOldTechniquesService.scala
@@ -1,0 +1,178 @@
+/*
+ *************************************************************************************
+ * Copyright 2023 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.ncf.migration
+
+import com.normation.cfclerk.domain.ReportingLogic
+import com.normation.cfclerk.domain.ReportingLogic.WeightedReport
+import com.normation.errors._
+import com.normation.inventory.domain.Version
+import com.normation.rudder.ncf._
+import com.normation.rudder.ncf.yaml.YamlTechniqueSerializer
+import zio.json._
+
+/**
+ * An object able to migrate a (set of) old techniques with a
+ * JSON metadata file to one with Yaml.
+ *
+ * It understands the last available JSON file format in Rudder 7.3.
+ */
+object MigrateOldTechniquesService {
+
+  private object OldTechniqueSerializer {
+    case class JRTechniqueElem(
+        id:               String,
+        component:        String,
+        reportingLogic:   Option[JRReportingLogic],
+        condition:        String,
+        calls:            Option[List[JRTechniqueElem]],
+        method:           Option[String],
+        parameters:       Option[List[JRMethodCallValue]],
+        disableReporting: Option[Boolean]
+    )
+
+    case class JREditorTechnique(
+        name:        String,
+        version:     String,
+        id:          String,
+        category:    String,
+        calls:       List[JRTechniqueElem],
+        description: String,
+        parameter:   Seq[JRTechniqueParameter],
+        resources:   Seq[JRTechniqueResource]
+    )
+
+    case class JRTechniqueParameter(
+        id:          String,
+        name:        String,
+        description: String,
+        mayBeEmpty:  Boolean
+    )
+
+    case class JRTechniqueResource(
+        path:  String,
+        state: String
+    )
+
+    case class JRMethodCallValue(
+        name:  String,
+        value: String
+    )
+
+    case class JRReportingLogic(
+        name:  String,
+        value: Option[String]
+    )
+
+    implicit val oldResourceJsonDecoder:   JsonDecoder[JRTechniqueResource]  = DeriveJsonDecoder.gen
+    implicit val oldCallJsonDecoder:       JsonDecoder[JRMethodCallValue]    = DeriveJsonDecoder.gen
+    implicit val oldPReportingJsonDecoder: JsonDecoder[JRReportingLogic]     = DeriveJsonDecoder.gen
+    implicit val oldParamJsonDecoder:      JsonDecoder[JRTechniqueParameter] = DeriveJsonDecoder.gen
+    implicit lazy val oldElemJsonDecoder:  JsonDecoder[JRTechniqueElem]      = DeriveJsonDecoder.gen
+    implicit val oldJsonDecoder:           JsonDecoder[JREditorTechnique]    = DeriveJsonDecoder.gen
+    implicit val j:                        JsonDecoder[EditorTechnique]      = JsonDecoder[JREditorTechnique].map(toEditorTechnique)
+
+    private def toMethodElem(elem: JRTechniqueElem): MethodElem = {
+      val reportingLogic = elem.reportingLogic
+        .flatMap(r => ReportingLogic.parse(r.name ++ (r.value.map(v => s":$v")).getOrElse("")).toOption)
+        .getOrElse(WeightedReport)
+      elem.calls match {
+        case Some(calls) =>
+          MethodBlock(
+            elem.id,
+            elem.component,
+            reportingLogic,
+            elem.condition,
+            calls.map(toMethodElem)
+          )
+        case None        =>
+          MethodCall(
+            BundleName(elem.method.getOrElse("")),
+            elem.id,
+            elem.parameters.getOrElse(Nil).map(p => (ParameterId(p.name), p.value)).toMap,
+            elem.condition,
+            elem.component,
+            elem.disableReporting.getOrElse(false)
+          )
+      }
+    }
+
+    private def toEditorTechnique(oldTechnique: JREditorTechnique): EditorTechnique = {
+      val (desc, doc) =
+        if (oldTechnique.description.contains("\n")) ("", oldTechnique.description) else (oldTechnique.description, "")
+      EditorTechnique(
+        BundleName(oldTechnique.id),
+        new Version(oldTechnique.version),
+        oldTechnique.name,
+        oldTechnique.category,
+        oldTechnique.calls.map(toMethodElem),
+        desc,
+        doc,
+        oldTechnique.parameter.map(p => TechniqueParameter(ParameterId(p.id), ParameterId(p.name), p.description, p.mayBeEmpty)),
+        oldTechnique.resources.flatMap(s => ResourceFileState.parse(s.state).map(ResourceFile(s.path, _)).toSeq),
+        Map(),
+        None
+      )
+    }
+  }
+
+  /*
+   * Read a JSON string in old Rudder 7.3 metadata format as an Editor technique
+   */
+  def readFromOldJsonTechnique(json: String): PureResult[EditorTechnique] = {
+    import OldTechniqueSerializer._
+    json
+      .fromJson[EditorTechnique]
+      .left
+      .map(err => Inconsistency(s"Error when trying to read a technique with Rudder 7.3 JSON metadata descriptor: ${err}"))
+  }
+
+  /*
+   * transform a JSON string in old Rudder 7.3 format into a YAML string in 8.0 format
+   */
+  def toYaml(json: String): PureResult[String] = {
+    import YamlTechniqueSerializer._
+    import zio.yaml.YamlOps._
+
+    for {
+      technique <- readFromOldJsonTechnique(json).left.map(err =>
+                     Inconsistency(s"Error when trying to parse a technique.json in Rudder 7.3 format: ${err}")
+                   )
+      yaml      <- technique.toYaml().left.map(Inconsistency(_))
+    } yield yaml
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/yaml/YamlTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/yaml/YamlTechnique.scala
@@ -40,12 +40,13 @@ package com.normation.rudder.ncf.yaml
 import com.normation.cfclerk.domain.LoadTechniqueError.Consistancy
 import com.normation.cfclerk.domain.ReportingLogic
 import com.normation.cfclerk.domain.ReportingLogic.WeightedReport
+import com.normation.errors._
 import com.normation.errors.AccumulateErrors
+import com.normation.errors.Inconsistency
 import com.normation.errors.IOResult
 import com.normation.errors.PureResult
 import com.normation.inventory.domain.Version
 import com.normation.rudder.ncf._
-import com.normation.zio._
 import zio.json._
 import zio.json.yaml.DecoderYamlOps
 import zio.yaml.YamlOps._
@@ -98,7 +99,7 @@ case class Constraints(
     allow_empty: Option[Boolean]
 )
 
-class YamlTechniqueSerializer(resourceFileService: ResourceFileService) {
+object YamlTechniqueSerializer {
   implicit val encoderParameterId:        JsonEncoder[ParameterId]        = JsonEncoder[String].contramap(_.value)
   implicit val encoderFieldParameterId:   JsonFieldEncoder[ParameterId]   = JsonFieldEncoder[String].contramap(_.value)
   implicit val encoderBundleName:         JsonEncoder[BundleName]         = JsonEncoder[String].contramap(_.value)
@@ -108,6 +109,7 @@ class YamlTechniqueSerializer(resourceFileService: ResourceFileService) {
   implicit lazy val encoderMethodElem:    JsonEncoder[MethodItem]         = DeriveJsonEncoder.gen
   implicit val encoderTechniqueParameter: JsonEncoder[TechniqueParameter] = DeriveJsonEncoder.gen
   implicit val encoderTechnique:          JsonEncoder[Technique]          = DeriveJsonEncoder.gen
+  implicit val encoderEditorTechnique:    JsonEncoder[EditorTechnique]    = JsonEncoder[Technique].contramap(fromEditorTechnique(_))
 
   implicit val decoderBundleName:         JsonDecoder[BundleName]         = JsonDecoder[String].map(BundleName.apply)
   implicit val decoderParameterId:        JsonDecoder[ParameterId]        = JsonDecoder[String].map(ParameterId.apply)
@@ -118,115 +120,37 @@ class YamlTechniqueSerializer(resourceFileService: ResourceFileService) {
   implicit val decoderTechniqueParameter: JsonDecoder[TechniqueParameter] = DeriveJsonDecoder.gen
   implicit lazy val decoderMethodElem:    JsonDecoder[MethodItem]         = DeriveJsonDecoder.gen
   implicit val decoderTechnique:          JsonDecoder[Technique]          = DeriveJsonDecoder.gen
-  implicit val decoder:                   JsonDecoder[EditorTechnique]    =
-    JsonDecoder[Technique].mapOrFail(toJsonTechnique(_).either.runNow.left.map(_.msg))
 
-  def toYml(technique: Technique): Either[String, String] = technique.toYaml()
+  // be careful, the decoder derives values from yaml which does not know about Technique Resource - see companion class
+  implicit val decoderEditorTechnique: JsonDecoder[EditorTechnique] = JsonDecoder[Technique].mapOrFail(toEditorTechnique(_))
 
-  def toYml(technique: EditorTechnique): Either[String, String] = fromJsonTechnique(technique).toYaml()
+  // ell the following methods are utilities for `decoderEditorTechnique`
 
-  def fromYaml(yaml: String): Either[String, Technique] = yaml.fromYaml[Technique]
-
-  private def toJsonTechnique(technique: Technique): IOResult[EditorTechnique] = {
-    for {
-      items     <- technique.items.accumulatePure(toMethodElem).toIO
-      t          = EditorTechnique(
-                     technique.id,
-                     technique.version,
-                     technique.name,
-                     technique.category.getOrElse("ncf_techniques"),
-                     items,
-                     technique.description.getOrElse(""),
-                     technique.documentation.getOrElse(""),
-                     technique.params.getOrElse(Nil).map(toTechniqueParameter),
-                     Seq(),
-                     technique.tags.getOrElse(Map()),
-                     None
-                   )
-      resources <- resourceFileService.getResources(t)
+  private def toEditorTechnique(technique: Technique): Either[String, EditorTechnique] = {
+    (for {
+      items <- technique.items.accumulatePure(toMethodElem)
     } yield {
-      t.copy(resources = resources)
-    }
-  }
-
-  private def fromJsonTechnique(technique: EditorTechnique): Technique = {
-    Technique(
-      technique.id,
-      technique.name,
-      technique.version,
-      if (technique.description.isEmpty) {
+      EditorTechnique(
+        technique.id,
+        technique.version,
+        technique.name,
+        technique.category.getOrElse("ncf_techniques"),
+        items,
+        technique.description.getOrElse(""),
+        technique.documentation.getOrElse(""),
+        technique.params.getOrElse(Nil).map(toTechniqueParameter),
+        Seq(),
+        technique.tags.getOrElse(Map()),
         None
-      } else {
-        Some(technique.description)
-      },
-      technique.calls.map(fromJson).toList,
-      if (technique.documentation.isEmpty) None else Some(technique.documentation),
-      Some(technique.category),
-      if (technique.tags.isEmpty) None else Some(technique.tags),
-      if (technique.parameters.isEmpty) {
-        None
-      } else {
-        Some(technique.parameters.map(fromJson).toList)
-      }
-    )
+      )
+    }).left.map(acc => acc.fullMsg)
   }
 
-  def fromJson(techniqueParameter: com.normation.rudder.ncf.TechniqueParameter): TechniqueParameter = {
-    TechniqueParameter(
-      techniqueParameter.id,
-      techniqueParameter.name,
-      if (techniqueParameter.description.isEmpty) None else Some(techniqueParameter.description),
-      Constraints(allow_empty = Some(techniqueParameter.mayBeEmpty))
-    )
-  }
-
-  private def toTechniqueParameter(techniqueParameter: TechniqueParameter): com.normation.rudder.ncf.TechniqueParameter = {
-    com.normation.rudder.ncf.TechniqueParameter(
-      techniqueParameter.id,
-      techniqueParameter.name,
-      techniqueParameter.description.getOrElse(""),
-      techniqueParameter.constraints.allow_empty.getOrElse(false)
-    )
-  }
-
-  def toReporting(logic: ReportingLogic): Reporting  = {
-    import ReportingLogic._
-    logic match {
-      case FocusReport(component)                                           => Reporting(FocusReport.key, Some(component))
-      case WeightedReport | WorstReportWeightedOne | WorstReportWeightedSum => Reporting(logic.value, None)
+  private def toMethodElem(item: MethodItem): PureResult[MethodElem] = {
+    def toReportingLogic(reporting: Reporting): PureResult[ReportingLogic] = {
+      ReportingLogic.parse(reporting.mode ++ (reporting.id.map(":" ++ _).getOrElse("")))
     }
-  }
-  def fromJson(methodElem: MethodElem):   MethodItem = {
-    methodElem match {
-      case MethodBlock(id, name, reportingLogic, condition, items)               =>
-        MethodItem(
-          id,
-          name,
-          Some(toReporting(reportingLogic)),
-          if (condition.isEmpty) None else Some(condition),
-          None,
-          None,
-          None,
-          Some(items.map(fromJson))
-        )
-      case MethodCall(method, id, parameters, condition, name, disableReporting) =>
-        MethodItem(
-          id,
-          name,
-          if (disableReporting) Some(Reporting("disabled", None)) else None,
-          if (condition.isEmpty) None else Some(condition),
-          None,
-          Some(method.value),
-          Some(parameters),
-          None
-        )
-    }
-  }
 
-  def toReportingLogic(reporting: Reporting): PureResult[ReportingLogic] = {
-    ReportingLogic.parse(reporting.mode ++ (reporting.id.map(":" ++ _).getOrElse("")))
-  }
-  private def toMethodElem(item: MethodItem): PureResult[MethodElem]     = {
     item.items match {
       case Some(items) =>
         for {
@@ -260,4 +184,102 @@ class YamlTechniqueSerializer(resourceFileService: ResourceFileService) {
 
     }
   }
+
+  private def fromEditorTechnique(technique: EditorTechnique): Technique = {
+    Technique(
+      technique.id,
+      technique.name,
+      technique.version,
+      if (technique.description.isEmpty) {
+        None
+      } else {
+        Some(technique.description)
+      },
+      technique.calls.map(fromJsonMethodElem).toList,
+      if (technique.documentation.isEmpty) None else Some(technique.documentation),
+      Some(technique.category),
+      if (technique.tags.isEmpty) None else Some(technique.tags),
+      if (technique.parameters.isEmpty) {
+        None
+      } else {
+        Some(technique.parameters.map(fromJsonParam).toList)
+      }
+    )
+  }
+
+  private def fromJsonParam(techniqueParameter: com.normation.rudder.ncf.TechniqueParameter): TechniqueParameter = {
+    TechniqueParameter(
+      techniqueParameter.id,
+      techniqueParameter.name,
+      if (techniqueParameter.description.isEmpty) None else Some(techniqueParameter.description),
+      Constraints(allow_empty = Some(techniqueParameter.mayBeEmpty))
+    )
+  }
+
+  private def toTechniqueParameter(techniqueParameter: TechniqueParameter): com.normation.rudder.ncf.TechniqueParameter = {
+    com.normation.rudder.ncf.TechniqueParameter(
+      techniqueParameter.id,
+      techniqueParameter.name,
+      techniqueParameter.description.getOrElse(""),
+      techniqueParameter.constraints.allow_empty.getOrElse(false)
+    )
+  }
+
+  private def fromJsonMethodElem(methodElem: MethodElem): MethodItem = {
+    def toReporting(logic: ReportingLogic): Reporting = {
+      import ReportingLogic._
+      logic match {
+        case FocusReport(component)                                           =>
+          Reporting(
+            FocusReport.key,
+            Some(component)
+          )
+        case WeightedReport | WorstReportWeightedOne | WorstReportWeightedSum => Reporting(logic.value, None)
+      }
+    }
+
+    methodElem match {
+      case MethodBlock(id, name, reportingLogic, condition, items)               =>
+        MethodItem(
+          id,
+          name,
+          Some(toReporting(reportingLogic)),
+          if (condition.isEmpty) None else Some(condition),
+          None,
+          None,
+          None,
+          Some(items.map(fromJsonMethodElem))
+        )
+      case MethodCall(method, id, parameters, condition, name, disableReporting) =>
+        MethodItem(
+          id,
+          name,
+          if (disableReporting) Some(Reporting("disabled", None)) else None,
+          if (condition.isEmpty) None else Some(condition),
+          None,
+          Some(method.value),
+          Some(parameters),
+          None
+        )
+    }
+  }
+}
+
+class YamlTechniqueSerializer(resourceFileService: ResourceFileService) {
+  import YamlTechniqueSerializer._
+
+  // shortcut to avoid having to import yamlOps / toIO, but can be avoided
+  def toYml(technique: Technique): IOResult[String] = technique.toYaml().toIO
+
+  def toYml(technique: EditorTechnique): Either[String, String] = technique.toYaml()
+
+  def fromYml(yaml: String): Either[String, Technique] = yaml.fromYaml[Technique]
+
+  def yamlToEditorTechnique(yaml: String): IOResult[EditorTechnique] = {
+    for {
+      t         <- yaml.fromYaml[EditorTechnique].left.map(Inconsistency(_)).toIO
+      resources <- resourceFileService.getResources(t)
+    } yield t.copy(resources = resources)
+  }
+
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/a_simple_yaml_technique/1.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/a_simple_yaml_technique/1.0/metadata.xml
@@ -1,0 +1,35 @@
+<TECHNIQUE name="A simple yaml technique">
+  <DESCRIPTION>A simple yaml technique</DESCRIPTION>
+  <USEMETHODREPORTING>true</USEMETHODREPORTING>
+  <MULTIINSTANCE>false</MULTIINSTANCE>
+  <POLICYGENERATION>separated</POLICYGENERATION>
+  <AGENT type="cfengine-community">
+    <BUNDLES>
+      <NAME>a_simple_yaml_technique</NAME>
+    </BUNDLES>
+    <FILES>
+      <FILE name="technique.cf">
+        <INCLUDED>true</INCLUDED>
+      </FILE>
+    </FILES>
+  </AGENT>
+  <AGENT type="dsc">
+    <BUNDLES>
+      <NAME>A-Simple-Yaml-Technique</NAME>
+    </BUNDLES>
+    <FILES>
+      <FILE name="technique.ps1">
+        <INCLUDED>true</INCLUDED>
+      </FILE>
+    </FILES>
+  </AGENT>
+  <SECTIONS>
+    <SECTION name="File content" id="bfe1978f-b0e7-4da3-9544-06d53eb985fa" component="true" multivalued="true">
+      <REPORTKEYS>
+        <VALUE id="bfe1978f-b0e7-4da3-9544-06d53eb985fa">
+          /tmp/test-rudder.txt
+        </VALUE>
+      </REPORTKEYS>
+    </SECTION>
+  </SECTIONS>
+</TECHNIQUE>

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/a_simple_yaml_technique/1.0/technique.cf
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/a_simple_yaml_technique/1.0/technique.cf
@@ -1,0 +1,22 @@
+# @name A simple yaml technique
+# @version 1.0
+
+bundle agent a_simple_yaml_technique {
+
+  vars:
+    "args"              slist => {};
+    "report_param"      string => join("_", args);
+    "full_class_prefix" string => canonify("a_simple_yaml_technique_${report_param}");
+    "class_prefix"      string => string_head("${full_class_prefix}", "1000");
+
+  methods:
+    "bfe1978f-b0e7-4da3-9544-06d53eb985fa_${report_data.directive_id}" usebundle => call_bfe1978f_b0e7_4da3_9544_06d53eb985fa("File content", "/tmp/test-rudder.txt", "bfe1978f-b0e7-4da3-9544-06d53eb985fa", @{args}, "${class_prefix}", "/tmp/test-rudder.txt", "Hello World!", "true");
+
+}
+bundle agent call_bfe1978f_b0e7_4da3_9544_06d53eb985fa(c_name, c_key, report_id, args, class_prefix, path, lines, enforce) {
+
+  methods:
+    "bfe1978f-b0e7-4da3-9544-06d53eb985fa_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
+    "bfe1978f-b0e7-4da3-9544-06d53eb985fa_${report_data.directive_id}" usebundle => file_content("${path}", "${lines}", "${enforce}");
+
+}

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/a_simple_yaml_technique/1.0/technique.ps1
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/a_simple_yaml_technique/1.0/technique.ps1
@@ -1,0 +1,46 @@
+﻿function A-Simple-Yaml-Technique {
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $true)]
+        [string]$reportId,
+        [parameter(Mandatory = $true)]
+        [string]$techniqueName,
+
+        [Rudder.PolicyMode]$policyMode
+    )
+    $techniqueParams = @{
+
+    }
+    BeginTechniqueCall -Name $techniqueName -Parameters $techniqueParams
+    $reportIdBase = $reportId.Substring(0, $reportId.Length - 1)
+    $localContext = New-Object -TypeName "Rudder.Context" -ArgumentList @($techniqueName)
+    $localContext.Merge($system_classes)
+
+
+
+    $reportId=$reportIdBase + "bfe1978f-b0e7-4da3-9544-06d53eb985fa"
+    $componentKey = "/tmp/test-rudder.txt"
+    $reportParams = @{
+        ClassPrefix = ([Rudder.Condition]::canonify(("file_lines_present_" + $componentKey)))
+        ComponentKey = $componentKey
+        ComponentName = "File content"
+        PolicyMode = $policyMode
+        ReportId = $reportId
+        DisableReporting = $false
+        TechniqueName = $techniqueName
+    }
+    
+    $methodParams = @{
+        Enforce = "true"
+        Lines = "Hello World!"
+        Path = "/tmp/test-rudder.txt"
+        
+    }
+    $call = File-Content @methodParams -PolicyMode $policyMode
+    $methodContext = Compute-Method-Call @reportParams -MethodCall $call
+    $localContext.merge($methodContext)
+    
+
+
+    EndTechniqueCall -Name $techniqueName
+}

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/a_simple_yaml_technique/1.0/technique.yml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/a_simple_yaml_technique/1.0/technique.yml
@@ -1,0 +1,12 @@
+id: a_simple_yaml_technique
+name: A simple yaml technique
+version: '1.0'
+items:
+  - id: bfe1978f-b0e7-4da3-9544-06d53eb985fa
+    name: ''
+    method: file_content
+    params:
+      path: /tmp/test-rudder.txt
+      lines: Hello World!
+      enforce: 'true'
+category: ncf_techniques

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/test_import_export_archive/1.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/test_import_export_archive/1.0/metadata.xml
@@ -1,4 +1,4 @@
-<TECHNIQUE name="test_import_export_archive">
+<TECHNIQUE name="test import/export archive">
   <DESCRIPTION></DESCRIPTION>
   <USEMETHODREPORTING>true</USEMETHODREPORTING>
   <AGENT type="cfengine-community,cfengine-nova">

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
@@ -70,7 +70,6 @@ import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.domain.workflows.ChangeRequest
 import com.normation.rudder.ncf.ParameterType.PlugableParameterTypeService
-import com.normation.rudder.ncf.yaml.YamlTechniqueSerializer
 import com.normation.rudder.repository.CategoryWithActiveTechniques
 import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.rudder.repository.RoDirectiveRepository
@@ -352,16 +351,6 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         ZIO.unit
       }
     },
-    new YamlTechniqueSerializer(
-      new ResourceFileService() {
-        override def getResources(technique: EditorTechnique): IOResult[List[ResourceFile]] = Nil.succeed
-        override def getResourcesFromDir(
-            resourcesPath:    String,
-            techniqueName:    String,
-            techniqueVersion: String
-        ): IOResult[List[ResourceFile]] = Nil.succeed
-      }
-    ),
     compiler,
     basePath
   )

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/migration/TestMigrateOldTechniques.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/migration/TestMigrateOldTechniques.scala
@@ -1,0 +1,106 @@
+/*
+ *************************************************************************************
+ * Copyright 2023 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.ncf.migration
+
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+/*
+ * Test that the serialisation is correctly able to read ncf lib
+ */
+@RunWith(classOf[JUnitRunner])
+class TestMigrateOldTechniques extends Specification {
+
+  implicit class ForceGetEither[A, B](either: Either[A, B]) {
+    def forceGet: B = {
+      either match {
+        case Left(err) => throw new IllegalArgumentException(s"Test in error: ${err}")
+        case Right(v)  => v
+      }
+    }
+  }
+
+  s"We should be able to migrate a simple JSON techniques" >> {
+    val json = {
+      """
+        |{
+        |  "id":"test_import_export_archive",
+        |  "version":"1.0",
+        |  "category":"ncf_techniques",
+        |  "description":"",
+        |  "name":"test import/export archive",
+        |  "calls":[
+        |    {
+        |      "method":"command_execution",
+        |      "condition":"",
+        |      "disableReporting":false,
+        |      "component":"Command execution",
+        |      "parameters":[
+        |        {
+        |          "name":"command",
+        |          "value":"touch /tmp/toto"
+        |        }
+        |      ],
+        |      "id":"483b4b60-f940-4b65-834a-4d8ddd085c34"
+        |    }
+        |  ],
+        |  "parameter":[],
+        |  "resources":[],
+        |  "source":"editor"
+        |}""".stripMargin
+    }
+
+    val yaml = {
+      """id: test_import_export_archive
+        |name: test import/export archive
+        |version: '1.0'
+        |items:
+        |  - id: 483b4b60-f940-4b65-834a-4d8ddd085c34
+        |    name: Command execution
+        |    method: command_execution
+        |    params:
+        |      command: touch /tmp/toto
+        |category: ncf_techniques
+        |""".stripMargin
+    }
+
+    MigrateOldTechniquesService.toYaml(json).forceGet === yaml
+  }
+
+}

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -39,14 +39,12 @@ package com.normation.rudder.rest
 
 import com.normation.GitVersion
 import com.normation.box._
-import com.normation.cfclerk.domain.ReportingLogic
 import com.normation.cfclerk.domain.Technique
 import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.errors._
-import com.normation.inventory.domain.AgentType
 import com.normation.inventory.domain.Certificate
 import com.normation.inventory.domain.InventoryError
 import com.normation.inventory.domain.KeyStatus
@@ -78,18 +76,9 @@ import com.normation.rudder.domain.queries.Query
 import com.normation.rudder.domain.queries.QueryReturnType
 import com.normation.rudder.domain.reports.CompliancePrecision
 import com.normation.rudder.domain.workflows._
-import com.normation.rudder.ncf.BundleName
-import com.normation.rudder.ncf.Constraint._
-import com.normation.rudder.ncf.GenericMethod
-import com.normation.rudder.ncf.MethodParameter
-import com.normation.rudder.ncf.ParameterId
 import com.normation.rudder.ncf.ParameterType.ParameterTypeService
-import com.normation.rudder.ncf.ResourceFile
-import com.normation.rudder.ncf.ResourceFileState
-import com.normation.rudder.ncf.TechniqueParameter
 import com.normation.rudder.repository._
 import com.normation.rudder.repository.json.DataExtractor.CompleteJson
-import com.normation.rudder.repository.json.DataExtractor.OptionnalJson
 import com.normation.rudder.repository.ldap.NodeStateEncoder
 import com.normation.rudder.rest.data._
 import com.normation.rudder.rule.category.RuleCategoryId

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
@@ -76,7 +76,7 @@ class TechniqueApi(
     apiV6:                TechniqueAPIService6,
     serviceV14:           TechniqueAPIService14,
     techniqueWriter:      TechniqueWriter,
-    techniqueReader:      TechniqueReader,
+    techniqueReader:      EditorTechniqueReader,
     techniqueRepository:  TechniqueRepository,
     techniqueSerializer:  TechniqueSerializer,
     uuidGen:              StringUuidGenerator,
@@ -704,7 +704,7 @@ class TechniqueAPIService6(
 class TechniqueAPIService14(
     readDirective:       RoDirectiveRepository,
     techniqueRevisions:  TechniqueRevisionRepository,
-    techniqueReader:     TechniqueReader,
+    techniqueReader:     EditorTechniqueReader,
     techniqueSerializer: TechniqueSerializer,
     restDataSerializer:  RestDataSerializer
 ) {

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_directives.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_directives.yml
@@ -2031,6 +2031,11 @@ response:
                     ]
                   },
                   {
+                    "id":"a_simple_yaml_technique",
+                    "name":"A simple yaml technique",
+                    "directives":[]
+                  },
+                  {
                     "id": "technique_any",
                     "name": "TestTechnique created through Rudder API",
                     "directives": []
@@ -2047,7 +2052,7 @@ response:
                   },
                   {
                     "id": "test_import_export_archive",
-                    "name": "test_import_export_archive",
+                    "name": "test import/export archive",
                     "directives": [
                       {
                         "id": "test_import_export_archive_directive",

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_techniques.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_techniques.yml
@@ -11,12 +11,6 @@ response:
       "data":{
         "techniques":[
           {
-            "name":"rudder-service-postgresql",
-            "versions":[
-              "1.0"
-            ]
-          },
-          {
             "name":"inventory",
             "versions":[
               "1.0"
@@ -79,6 +73,18 @@ response:
           },
           {
             "name":"rudder-service-apache",
+            "versions":[
+              "1.0"
+            ]
+          },
+          {
+            "name":"a_simple_yaml_technique",
+            "versions":[
+              "1.0"
+            ]
+          },
+          {
+            "name":"rudder-service-postgresql",
             "versions":[
               "1.0"
             ]

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -83,8 +83,8 @@ import com.normation.rudder.git.GitArchiveId
 import com.normation.rudder.git.GitCommitId
 import com.normation.rudder.git.GitPath
 import com.normation.rudder.hooks.HookEnvPairs
+import com.normation.rudder.ncf.EditorTechniqueReader
 import com.normation.rudder.ncf.ResourceFileService
-import com.normation.rudder.ncf.TechniqueReader
 import com.normation.rudder.ncf.TechniqueSerializer
 import com.normation.rudder.ncf.TechniqueWriter
 import com.normation.rudder.reports.AgentRunInterval
@@ -846,11 +846,11 @@ class RestTestSetUp {
     restDataSerializer
   )
   val groupApiInheritedProperties = new GroupApiInheritedProperties(mockNodeGroups.groupsRepo, mockParameters.paramsRepo)
-  val ncfTechniqueWriter:  TechniqueWriter     = null
-  val ncfTechniqueReader:  TechniqueReader     = null
-  val techniqueRepository: TechniqueRepository = null
-  val techniqueSerializer: TechniqueSerializer = null
-  val resourceFileService: ResourceFileService = null
+  val ncfTechniqueWriter:  TechniqueWriter       = null
+  val ncfTechniqueReader:  EditorTechniqueReader = null
+  val techniqueRepository: TechniqueRepository   = null
+  val techniqueSerializer: TechniqueSerializer   = null
+  val resourceFileService: ResourceFileService   = null
   val settingsService = new MockSettings(workflowLevelService, new AsyncWorkflowInfo())
 
   object archiveAPIModule {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1133,7 +1133,7 @@ object RudderConfig extends Loggable {
   val linkUtil:                            LinkUtil                                   = rci.linkUtil
   val logDisplayer:                        LogDisplayer                               = rci.logDisplayer
   val mainCampaignService:                 MainCampaignService                        = rci.mainCampaignService
-  val ncfTechniqueReader:                  ncf.TechniqueReader                        = rci.ncfTechniqueReader
+  val ncfTechniqueReader:                  ncf.EditorTechniqueReader                  = rci.ncfTechniqueReader
   val newNodeManager:                      NewNodeManager                             = rci.newNodeManager
   val newNodeManagerHooks:                 NewNodeManagerHooks                        = rci.newNodeManagerHooks
   val nodeDit:                             NodeDit                                    = rci.nodeDit
@@ -1320,7 +1320,7 @@ case class RudderServiceApi(
     roRuleCategoryRepository:            RoRuleCategoryRepository,
     woRuleCategoryRepository:            WoRuleCategoryRepository,
     workflowLevelService:                DefaultWorkflowLevel,
-    ncfTechniqueReader:                  ncf.TechniqueReader,
+    ncfTechniqueReader:                  ncf.EditorTechniqueReader,
     recentChangesService:                NodeChangesService,
     ruleCategoryService:                 RuleCategoryService,
     restExtractorService:                RestExtractorService,
@@ -1511,7 +1511,7 @@ object RudderConfigInit {
       def getCurrentUser = CurrentUser
     }
 
-    lazy val ncfTechniqueReader: ncf.TechniqueReader = new ncf.TechniqueReader(
+    lazy val ncfTechniqueReader: ncf.EditorTechniqueReader = new ncf.EditorTechniqueReader(
       stringUuidGenerator,
       personIdentService,
       gitConfigRepo,
@@ -1835,7 +1835,6 @@ object RudderConfigInit {
         workflowLevelService,
         RUDDER_GIT_ROOT_CONFIG_REPO
       ),
-      yamlTechniqueSerializer,
       techniqueCompiler,
       RUDDER_GIT_ROOT_CONFIG_REPO
     )

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/action/CheckNcfTechniqueUpdate.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/action/CheckNcfTechniqueUpdate.scala
@@ -45,10 +45,10 @@ import com.normation.errors.RudderError
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
 import com.normation.rudder.api.ApiAccount
+import com.normation.rudder.ncf.EditorTechniqueReader
 import com.normation.rudder.ncf.ResourceFileService
 import com.normation.rudder.ncf.ResourceFileState
 import com.normation.rudder.ncf.ResourceFileState.Untouched
-import com.normation.rudder.ncf.TechniqueReader
 import com.normation.rudder.ncf.TechniqueWriter
 import com.normation.utils.StringUuidGenerator
 import com.normation.zio._
@@ -80,7 +80,7 @@ class CheckNcfTechniqueUpdate(
     systemApiToken:      ApiAccount,
     uuidGen:             StringUuidGenerator,
     techLibUpdate:       UpdateTechniqueLibrary,
-    techniqueReader:     TechniqueReader,
+    techniqueReader:     EditorTechniqueReader,
     resourceFileService: ResourceFileService
 ) extends BootstrapChecks {
 


### PR DESCRIPTION
https://issues.rudder.io/issues/23155

Archive adaptation to YAML technique. 

Missing: compilation of YAML techniques. This is harder than it seems (because we have a dozen different "Technique" and we need to rationnalize a bit access to things). 

What is done: 
- we filter out generated files when exporting YAML
- when importing a JSON technique, we migrate it

There is also some changes:

- I tried to remove string for path/file names/etc. For example, I added `TechniqueFiles` that keeps all common technique file names, like `TechniqueFiles.yaml` is `technique.yml`. 
- `MigrateOldTechniquesService` is now in indep object that is used in both bootstrap migration and archive import
- I refactored `YamlTechniqueSerialization` so that:
    - encode/decoder are pures (no I/O access) 
    - they are in an object and can be use anywhere
    
