### PR TITLE
Fixes #23152: Conditions syntax broken on Windows

### DIFF
--- a/policies/Cargo.lock
+++ b/policies/Cargo.lock
@@ -232,7 +232,7 @@ checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
 dependencies = [
  "memchr",
  "once_cell",
- "regex-automata",
+ "regex-automata 0.1.10",
  "serde",
 ]
 
@@ -1285,13 +1285,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata 0.3.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -1301,6 +1302,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
+name = "regex-automata"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.4",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,9 +1320,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rudder-module-type-directory"

--- a/policies/rudderc/src/backends/windows.rs
+++ b/policies/rudderc/src/backends/windows.rs
@@ -249,3 +249,33 @@ impl Windows {
         technique.render().map_err(|e| e.into())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use crate::backends::windows::filters::canonify_condition;
+
+    #[test]
+    fn it_canonifies_conditions() {
+        let c = "debian";
+        let r = "\"debian\"";
+        let res = canonify_condition(c).unwrap();
+        assert_eq!(res, r);
+
+        let c = "debian|ubuntu";
+        let r = "\"debian|ubuntu\"";
+        let res = canonify_condition(c).unwrap();
+        assert_eq!(res, r);
+
+        let c = "${var}";
+        let r = "\"\" + ([Rudder.Condition]::canonify(${var})) + \"\"";
+        let res = canonify_condition(c).unwrap();
+        assert_eq!(res, r);
+
+        let c = "${my_cond}.debian|${sys.${plouf}}";
+        let r = r##""" + ([Rudder.Condition]::canonify(${my_cond})) + ".debian|" + ([Rudder.Condition]::canonify(${sys.${plouf})) + "}""##;
+        let res = canonify_condition(c).unwrap();
+        assert_eq!(res, r);
+    }
+}

--- a/policies/rudderc/src/ir/condition.rs
+++ b/policies/rudderc/src/ir/condition.rs
@@ -150,3 +150,16 @@ impl<'de> Deserialize<'de> for Condition {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::ir::condition::Condition;
+
+    #[test]
+    fn it_parses_conditions() {
+        let c = "${my_cond} . debian | ${sys.${plouf}}";
+        let reference = "${my_cond}.debian|${sys.${plouf}}";
+        let p: Condition = c.parse().unwrap();
+        assert_eq!(p, Condition::Expression(reference.to_string()));
+    }
+}

--- a/policies/rudderc/templates/technique.ps1.askama
+++ b/policies/rudderc/templates/technique.ps1.askama
@@ -39,7 +39,7 @@ function {{ id|dsc_case }} {
     }
     {% match m.condition %}
     {%- when Some with (cond) %}
-    $class = "{{ cond|canonify_condition }}"
+    $class = {{ cond|canonify_condition }}
     if ($localContext.Evaluate($class)) {
         $methodParams = @{
             {% for arg in m.args %}

--- a/policies/rudderc/tests/cases/general/escaping/technique.ps1
+++ b/policies/rudderc/tests/cases/general/escaping/technique.ps1
@@ -33,11 +33,11 @@
         TechniqueName = $techniqueName
     }
     
-    $class = """ + ("
+    $class = "" + ([Rudder.Condition]::canonify(${my_cond})) + ".debian|" + ([Rudder.Condition]::canonify(${sys.${plouf})) + "}"
     if ($localContext.Evaluate($class)) {
         $methodParams = @{
             Architecture = ""
-            Name = "${sys.host} . | / ${sys.${host}} ' '' ''' "
+            Name = "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ `" `"`" \ \\😋aà3"
             Provider = ""
             Version = @'
 

--- a/policies/rudderc/tests/cases/general/form/technique.ps1
+++ b/policies/rudderc/tests/cases/general/form/technique.ps1
@@ -72,7 +72,7 @@
         TechniqueName = $techniqueName
     }
     
-    $class = ""debian""
+    $class = "debian"
     if ($localContext.Evaluate($class)) {
         $methodParams = @{
             Architecture = ""

--- a/policies/rudderc/tests/cases/general/ntp/technique.ps1
+++ b/policies/rudderc/tests/cases/general/ntp/technique.ps1
@@ -35,7 +35,7 @@
         TechniqueName = $techniqueName
     }
     
-    $class = ""false""
+    $class = "false"
     if ($localContext.Evaluate($class)) {
         $methodParams = @{
             Architecture = ""
@@ -65,7 +65,7 @@
         TechniqueName = $techniqueName
     }
     
-    $class = ""linux.fedora""
+    $class = "linux.fedora"
     if ($localContext.Evaluate($class)) {
         $methodParams = @{
             Name = "ntp"

--- a/policies/rudderc/tests/cases/general/reporting/technique.ps1
+++ b/policies/rudderc/tests/cases/general/reporting/technique.ps1
@@ -54,7 +54,7 @@
         TechniqueName = $techniqueName
     }
     
-    $class = ""debian""
+    $class = "debian"
     if ($localContext.Evaluate($class)) {
         $methodParams = @{
             Architecture = ""

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
@@ -951,13 +951,6 @@ class DSCTechniqueWriter(
     def indentNextLines(spaces: Int) = s.linesIterator.mkString("\n" + " " * spaces)
   }
 
-  // we use the same class prefix construction as for CFEngine.
-  // If it's really the same thing, it should either be given by technique editor or common to both
-  def computeClassPrefix(gm: GenericMethod, classParameter: String): String = {
-    // the canonification must be done commonly with other canon
-    s"""[Rudder.Condition]::canonify("${gm.classPrefix}_" + ${classParameter})"""
-  }
-
   // WARNING: this is extremely likely false, it MUST be done in the technique editor or
   // via a full fledge parser of conditions
   def canonifyCondition(methodCall: MethodCall, parentBlocks: List[MethodBlock]) = {


### PR DESCRIPTION
* Fix double double-quotes around conditions
* Fix parser to allow `[]{}$` outside substitution contexts
* Fix parser to fail when non-complete
* Remove an confusing unused scala function