### PR TITLE
Fixes #23175: Build rust binaries with cargo auditable

### DIFF
--- a/ci/rust.sh
+++ b/ci/rust.sh
@@ -18,5 +18,6 @@ wget --quiet https://github.com/EmbarkStudios/cargo-deny/releases/download/$DENY
 tar -xf cargo-deny-$DENY_VER-x86_64-unknown-linux-musl.tar.gz
 mv cargo-deny-$DENY_VER-x86_64-unknown-linux-musl/cargo-deny /usr/local/bin/
 
-# cargo-vet
+# Build & check tools
 cargo install --locked cargo-vet@0.8.0
+cargo install --locked cargo-auditable@0.6.1

--- a/policies/Makefile
+++ b/policies/Makefile
@@ -19,7 +19,7 @@ test: libs
 	cargo run --quiet --bin rudderc -- --quiet lib -f json --stdout -l target/repos/ncf/tree/30_generic_methods/ -l target/repos/dsc/plugin/src/ncf/30_generic_methods/ >/dev/null
 
 static: libs version
-	cargo build --release --locked --features embedded-lib
+	cargo auditable build --release --locked --features embedded-lib
 
 %.cf: %.yml libs
 	cd $(shell dirname $@) && cargo run --quiet --bin rudderc -- --quiet build -l ../../../../target/repos/ncf/tree/30_generic_methods/

--- a/rust.makefile
+++ b/rust.makefile
@@ -17,7 +17,7 @@ version:
 # https://matklad.github.io/2021/09/04/fast-rust-builds.html#ci-workflow
 build: CARGO_INCREMENTAL=0
 build: version
-	cargo build --release --locked
+	cargo auditable build --release --locked
 
 dev-doc:
 	cargo doc --document-private-items --open


### PR DESCRIPTION
https://issues.rudder.io/issues/23175

* Build binaries with https://github.com/rust-secure-code/cargo-auditable
* Embeds dependencies list in binary
* Allows SBOM and vulnerability audit directly on produced artifacts