### PR TITLE
Fixes #23208: Add a warning in the logs when using local auth with non-bcrypt passwords

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckService.scala
@@ -1,6 +1,7 @@
 package com.normation.rudder.services.healthcheck
 
 import better.files.File.root
+import bootstrap.liftweb.AppConfigAuth
 import com.normation.errors.Inconsistency
 import com.normation.errors.IOResult
 import com.normation.rudder.domain.logger.{HealthcheckLoggerPure => logger}
@@ -166,6 +167,19 @@ final class CheckFileDescriptorLimit(val nodeInfoService: NodeInfoService) exten
         case _                              =>
           Ok(name, s"Maximum number of file descriptors is ${limit}")
       }
+    }
+  }
+}
+
+final class CheckLocalAccountHashMethod(val authConfigProvider: FileUserDetailListProvider) extends Check {
+  def name: CheckName                   = CheckName("Local users password hashes")
+  def run:  IOResult[HealthcheckResult] = for {
+    hash <- authConfigProvider.authConfig.encoder
+  } yield {
+    if (PasswordEncoder.safeEncoders.contains(hash)) {
+      Ok(name, s"${hash} password hash")
+    } else {
+      Warning(name, s"Unsafe password hash method ${hash}, you should switch to bcrypt")
     }
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -3267,7 +3267,8 @@ object RudderConfigInit {
       List(
         CheckCoreNumber,
         CheckFreeSpace,
-        new CheckFileDescriptorLimit(nodeInfoService)
+        new CheckFileDescriptorLimit(nodeInfoService),
+        new CheckLocalAccountHashMethod(rudderUserListProvider)
       )
     )
 


### PR DESCRIPTION
https://issues.rudder.io/issues/23208

* Remove the ability to use the fallback admin account with a clear text password in config
* Add a warn log when local users use an unsafe storage