### PR TITLE
Fixes #23217: Update embedded openssl to 1.1.1v - relayd

### DIFF
--- a/relay/sources/relayd/Cargo.lock
+++ b/relay/sources/relayd/Cargo.lock
@@ -1151,9 +1151,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.26.0+1.1.1u"
+version = "111.27.0+1.1.1v"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
+checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
https://issues.rudder.io/issues/23217