### PR TITLE
Fixes #23218: Windows agent cannot get immediatly its policies right after being accepted

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/resources/hooks.d/policy-generation-finished/50-reload-policy-file-server
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/hooks.d/policy-generation-finished/50-reload-policy-file-server
@@ -12,6 +12,14 @@
 # Signal to cf-serverd that it shall look-up the new promises
 
 export PATH="/opt/rudder/bin:$PATH"
+
+# For windows agents
+# we need to reload the configuration on apache2, based on the policies
+# it must be done even if the hash didn't change, as cf-serverd doesn't have the lists of
+# windows agent in it, and it doesn't change on windows node addition/deletion
+rudder agent run -b system_rudder_apache_configuration,system_reload_rudder_services
+
+# for linux agents
 ACL_BACK="/var/rudder/tmp/cf-serverd.sha256"
 ACL_FILE="/var/rudder/cfengine-community/inputs/common/1.0/cf-serverd.cf"
 ACL_HASH=$(openssl sha256 -r "${ACL_FILE}" | cut -d' ' -f 1)


### PR DESCRIPTION
https://issues.rudder.io/issues/23218

Windows agent fetchs their policies with apache2, based on their certificate
This changes runs the part that is made to update the access rules, and reload apache2 if necessary, so that we can do a rudder agent update on window node once it's been accepted