### PR TITLE
Fixes #23216: Update Rust compiler to 1.71.1 for security fix

### DIFF
--- a/policies/Dockerfile
+++ b/policies/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.66.1-bullseye
+FROM rust:1.71.1-bullseye
 LABEL ci=rudder/policies/Dockerfile
 
 ARG USER_ID=1000

--- a/policies/rudder-module-type/src/cfengine/protocol.rs
+++ b/policies/rudder-module-type/src/cfengine/protocol.rs
@@ -34,18 +34,13 @@ impl FromStr for Class {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy, Default)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum ActionPolicy {
     #[serde(alias = "nop")]
     Warn,
+    #[default]
     Fix,
-}
-
-impl Default for ActionPolicy {
-    fn default() -> Self {
-        ActionPolicy::Fix
-    }
 }
 
 impl From<ActionPolicy> for PolicyMode {

--- a/policies/rudderc/src/ir/technique.rs
+++ b/policies/rudderc/src/ir/technique.rs
@@ -211,7 +211,7 @@ impl fmt::Display for BlockReporting {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum BlockReportingMode {
     #[serde(rename = "worst-case-weighted-sum")]
     WorstCaseWeightedSum,
@@ -221,6 +221,7 @@ pub enum BlockReportingMode {
     Focus,
     #[serde(rename = "weighted")]
     #[serde(alias = "enabled")]
+    #[default]
     Weighted,
     #[serde(rename = "disabled")]
     Disabled,
@@ -242,22 +243,11 @@ impl fmt::Display for BlockReportingMode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum LeafReporting {
     #[serde(rename = "enabled")]
+    #[default]
     Enabled,
     #[serde(rename = "disabled")]
     Disabled,
-}
-
-impl Default for BlockReportingMode {
-    fn default() -> Self {
-        BlockReportingMode::Weighted
-    }
-}
-
-impl Default for LeafReporting {
-    fn default() -> Self {
-        LeafReporting::Enabled
-    }
 }

--- a/policies/rudderc/src/logs.rs
+++ b/policies/rudderc/src/logs.rs
@@ -11,7 +11,7 @@ use colored::Colorize;
 use env_logger::fmt::{Color, Formatter, Style, StyledValue};
 use log::{info, Level, LevelFilter, Record};
 
-fn colored_level<'a>(style: &'a mut Style, level: Level) -> StyledValue<'a, &'static str> {
+fn colored_level(style: &mut Style, level: Level) -> StyledValue<&'static str> {
     match level {
         Level::Warn => style
             .set_color(Color::Yellow)

--- a/policies/rust-toolchain.toml
+++ b/policies/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.66.1"
+channel = "1.71.1"

--- a/relay/sources/relayd/Dockerfile
+++ b/relay/sources/relayd/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.70.0-bullseye
+FROM rust:1.71.1-bullseye
 LABEL ci=rudder/relay/sources/relayd/Dockerfile
 
 ARG USER_ID=1000

--- a/relay/sources/relayd/rust-toolchain.toml
+++ b/relay/sources/relayd/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.71.1"
 


### PR DESCRIPTION
https://issues.rudder.io/issues/23216