### PR TITLE
Fixes #23227: 

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala
@@ -49,6 +49,11 @@ import com.normation.rudder.api.ApiAccount
 import com.normation.rudder.api.ApiAccountKind
 import com.normation.rudder.api.ApiAclElement
 import com.normation.rudder.api.HttpAction
+import com.normation.rudder.domain.logger.ApiLogger
+import com.normation.rudder.web.services.CurrentUser
+import net.liftweb.common._
+import net.liftweb.http.LiftResponse
+import net.liftweb.json.JsonDSL._
 
 /*
  * This trait allows to check for autorisation on a given boundedendpoint
@@ -265,4 +270,55 @@ object AclCheck {
     recMatches(aclPath.parts.toList, path.parts.toList)
   }
 
+}
+
+/*
+ * Check rights for old API. These API must be ported to the new scheme, but in the meantime,
+ * we must check rights by hand;
+ */
+object OldInternalApiAuthz {
+  import com.normation.rudder.AuthorizationType._
+  def fail(implicit action: String) = Failure(s"User '${CurrentUser.actor.name}' is not authorized to access API '${action}")
+
+  def withReadAdmin(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
+    if (CurrentUser.checkRights(Administration.Read)) resp
+    else {
+      ApiLogger.info(fail.messageChain)
+      RestUtils.toJsonError(None, fail.messageChain)
+    }
+  }
+
+  def withWriteAdmin(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
+    if (CurrentUser.checkRights(Administration.Write) || CurrentUser.checkRights(Administration.Edit)) resp
+    else {
+      ApiLogger.info(fail.messageChain)
+      RestUtils.toJsonError(None, fail.messageChain)
+    }
+  }
+
+  // this right is used for directive/rule tags completion, shared file/technique resource access, etc
+  def withReadConfig(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
+    if (CurrentUser.checkRights(Configuration.Read)) resp
+    else {
+      ApiLogger.info(fail.messageChain)
+      RestUtils.toJsonError(None, fail.messageChain)
+    }
+  }
+
+  // for quick search
+  def withReadUser(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
+    if (CurrentUser.checkRights(Configuration.Read) || CurrentUser.checkRights(Node.Read)) resp
+    else {
+      ApiLogger.info(fail.messageChain)
+      RestUtils.toJsonError(None, fail.messageChain)
+    }
+  }
+
+  def withWriteConfig(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
+    if (CurrentUser.checkRights(Configuration.Write) || CurrentUser.checkRights(Configuration.Edit)) resp
+    else {
+      ApiLogger.info(fail.messageChain)
+      RestUtils.toJsonError(None, fail.messageChain)
+    }
+  }
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala
@@ -280,45 +280,33 @@ object OldInternalApiAuthz {
   import com.normation.rudder.AuthorizationType._
   def fail(implicit action: String) = Failure(s"User '${CurrentUser.actor.name}' is not authorized to access API '${action}")
 
-  def withReadAdmin(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
-    if (CurrentUser.checkRights(Administration.Read)) resp
+  def withPerm(isAuthorized: Boolean, resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
+    if (isAuthorized) resp
     else {
-      ApiLogger.info(fail.messageChain)
+      ApiLogger.warn(fail.messageChain)
       RestUtils.toJsonError(None, fail.messageChain)
     }
   }
 
+  def withReadAdmin(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
+    withPerm(CurrentUser.checkRights(Administration.Read), resp)
+  }
+
   def withWriteAdmin(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
-    if (CurrentUser.checkRights(Administration.Write) || CurrentUser.checkRights(Administration.Edit)) resp
-    else {
-      ApiLogger.info(fail.messageChain)
-      RestUtils.toJsonError(None, fail.messageChain)
-    }
+    withPerm(CurrentUser.checkRights(Administration.Write) || CurrentUser.checkRights(Administration.Edit), resp)
   }
 
   // this right is used for directive/rule tags completion, shared file/technique resource access, etc
   def withReadConfig(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
-    if (CurrentUser.checkRights(Configuration.Read)) resp
-    else {
-      ApiLogger.info(fail.messageChain)
-      RestUtils.toJsonError(None, fail.messageChain)
-    }
+    withPerm(CurrentUser.checkRights(Configuration.Read), resp)
   }
 
   // for quick search
   def withReadUser(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
-    if (CurrentUser.checkRights(Configuration.Read) || CurrentUser.checkRights(Node.Read)) resp
-    else {
-      ApiLogger.info(fail.messageChain)
-      RestUtils.toJsonError(None, fail.messageChain)
-    }
+    withPerm(CurrentUser.checkRights(Configuration.Read) || CurrentUser.checkRights(Node.Read), resp)
   }
 
   def withWriteConfig(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
-    if (CurrentUser.checkRights(Configuration.Write) || CurrentUser.checkRights(Configuration.Edit)) resp
-    else {
-      ApiLogger.info(fail.messageChain)
-      RestUtils.toJsonError(None, fail.messageChain)
-    }
+    withPerm(CurrentUser.checkRights(Configuration.Write) || CurrentUser.checkRights(Configuration.Edit), resp)
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestApiAccounts.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestApiAccounts.scala
@@ -36,7 +36,15 @@ class RestApiAccounts(
 
   serve {
     case Get("secure" :: "apiaccounts" :: Nil, req) =>
-      readApi.getAllStandardAccounts.either.runNow match {
+      implicit val prettify = restExtractor
+        .extractBoolean("prettify")(req)(identity)
+        .getOrElse(Some(false))
+        .getOrElse(
+          false
+        )
+      implicit val action: String = "getAllAccounts"
+
+      OldInternalApiAuthz.withReadAdmin(readApi.getAllStandardAccounts.either.runNow match {
         case Right(accountSeq) =>
           val accounts = {
             (
@@ -44,16 +52,24 @@ class RestApiAccounts(
               ("accounts"         -> JArray(accountSeq.toList.map(_.toJson)))
             )
           }
-          toJsonResponse(None, accounts)("getAllAccounts", true)
+          toJsonResponse(None, accounts)
         case Left(err)         =>
           val msg = s"Could not get accounts cause : ${err.fullMsg}"
           logger.error(msg)
-          toJsonError(None, msg)("getAllAccounts", true)
+          toJsonError(None, msg)
 
-      }
+      })
 
     case "secure" :: "apiaccounts" :: Nil JsonPut body -> req =>
-      req.json match {
+      implicit val prettify = restExtractor
+        .extractBoolean("prettify")(req)(identity)
+        .getOrElse(Some(false))
+        .getOrElse(
+          false
+        )
+      implicit val action: String = "updateAccount"
+
+      OldInternalApiAuthz.withWriteAdmin(req.json match {
         case Full(json) =>
           restExtractor.extractApiAccountFromJSON(json) match {
             case Full(restApiAccount) =>
@@ -78,32 +94,40 @@ class RestApiAccounts(
                 writeApi.save(account, ModificationId(uuidGen.newUuid), userService.getCurrentUser.actor).either.runNow match {
                   case Right(_) =>
                     val accounts = ("accounts" -> JArray(List(account.toJson)))
-                    toJsonResponse(None, accounts)("updateAccount", true)
+                    toJsonResponse(None, accounts)
 
                   case Left(err) =>
                     val msg = s"Could not create account cause : ${err.fullMsg}"
                     logger.error(msg)
-                    toJsonError(None, msg)("updateAccount", true)
+                    toJsonError(None, msg)
                 }
               } else {
                 val msg = s"Could not create account cause : could not get account"
                 logger.error(msg)
-                toJsonError(None, msg)("updateAccount", true)
+                toJsonError(None, msg)
               }
 
             case eb: EmptyBox =>
               val msg = s"Could not create account cause : ${(eb ?~ "could not extract data from JSON").msg}"
               logger.error(msg)
-              toJsonError(None, msg)("updateAccount", true)
+              toJsonError(None, msg)
           }
         case eb: EmptyBox =>
           logger.error("No Json data sent")
-          toJsonError(None, "No Json data sent")("updateAccount", true)
-      }
+          toJsonError(None, "No Json data sent")
+      })
 
     case "secure" :: "apiaccounts" :: token :: Nil JsonPost body -> req =>
-      val apiToken = ApiToken(token)
-      req.json match {
+      val apiToken          = ApiToken(token)
+      implicit val prettify = restExtractor
+        .extractBoolean("prettify")(req)(identity)
+        .getOrElse(Some(false))
+        .getOrElse(
+          false
+        )
+      implicit val action: String = "updateAccount"
+
+      OldInternalApiAuthz.withWriteAdmin(req.json match {
         case Full(json) =>
           restExtractor.extractApiAccountFromJSON(json) match {
             case Full(restApiAccount) =>
@@ -115,43 +139,59 @@ class RestApiAccounts(
                 case Right(None) =>
                   val msg = s"Could not update account with token $token cause : could not get account"
                   logger.error(msg)
-                  toJsonError(None, msg)("updateAccount", true)
+                  toJsonError(None, msg)
                 case Left(err)   =>
                   val msg = s"Could not update account with token $token cause : ${err.fullMsg}"
                   logger.error(msg)
-                  toJsonError(None, msg)("updateAccount", true)
+                  toJsonError(None, msg)
               }
             case eb: EmptyBox =>
               val msg = s"Could not update account with token $token cause : ${(eb ?~ "could not extract data from JSON").msg}"
               logger.error(msg)
-              toJsonError(None, msg)("updateAccount", true)
+              toJsonError(None, msg)
           }
         case eb: EmptyBox =>
-          toJsonError(None, "No Json data sent")("updateAccount", true)
-      }
+          toJsonError(None, "No Json data sent")
+      })
 
     case Delete("secure" :: "apiaccounts" :: token :: Nil, req) =>
-      val apiToken = ApiToken(token)
-      readApi.getByToken(apiToken).either.runNow match {
+      val apiToken          = ApiToken(token)
+      implicit val prettify = restExtractor
+        .extractBoolean("prettify")(req)(identity)
+        .getOrElse(Some(false))
+        .getOrElse(
+          false
+        )
+      implicit val action: String = "deleteAccount"
+
+      OldInternalApiAuthz.withWriteAdmin(readApi.getByToken(apiToken).either.runNow match {
         case Right(Some(account)) =>
           writeApi.delete(account.id, ModificationId(uuidGen.newUuid), userService.getCurrentUser.actor).either.runNow match {
             case Right(_) =>
               val accounts = ("accounts" -> JArray(List(account.toJson)))
-              toJsonResponse(None, accounts)("deleteAccount", true)
+              toJsonResponse(None, accounts)
 
             case Left(err) =>
-              toJsonError(None, s"Could not delete account with token $token cause : ${err.fullMsg}")("deleteAccount", true)
+              toJsonError(None, s"Could not delete account with token $token cause : ${err.fullMsg}")
           }
 
         case Right(None) =>
-          toJsonError(None, s"Could not delete account with token $token cause : could not get account")("deleteAccount", true)
+          toJsonError(None, s"Could not delete account with token $token cause : could not get account")
         case Left(err)   =>
-          toJsonError(None, s"Could not delete account with token $token cause : ${err.fullMsg}")("deleteAccount", true)
-      }
+          toJsonError(None, s"Could not delete account with token $token cause : ${err.fullMsg}")
+      })
 
     case Post("secure" :: "apiaccounts" :: token :: "regenerate" :: Nil, req) =>
-      val apiToken = ApiToken(token)
-      readApi.getByToken(apiToken).either.runNow match {
+      val apiToken          = ApiToken(token)
+      implicit val prettify = restExtractor
+        .extractBoolean("prettify")(req)(identity)
+        .getOrElse(Some(false))
+        .getOrElse(
+          false
+        )
+      implicit val action: String = "regenerateAccount"
+
+      OldInternalApiAuthz.withWriteAdmin(readApi.getByToken(apiToken).either.runNow match {
         case Right(Some(account)) =>
           val newToken       = ApiToken(tokenGenerator.newToken(tokenSize))
           val generationDate = DateTime.now
@@ -165,7 +205,7 @@ class RestApiAccounts(
             .runNow match {
             case Right(account) =>
               val accounts = ("accounts" -> JArray(List(account.toJson)))
-              toJsonResponse(None, accounts)("regenerateAccount", true)
+              toJsonResponse(None, accounts)
 
             case Left(err) =>
               val msg = s"Could not regenerate account with token $token cause : ${err.fullMsg}"
@@ -179,23 +219,23 @@ class RestApiAccounts(
         case Right(None) =>
           val msg = s"Could not regenerate account with token $token cause could not get account"
           logger.error(msg)
-          toJsonError(None, msg)("regenerateAccount", true)
+          toJsonError(None, msg)
         case Left(err)   =>
           val msg = s"Could not regenerate account with token $token cause : ${err.fullMsg}"
           logger.error(msg)
-          toJsonError(None, msg)("regenerateAccount", true)
-      }
+          toJsonError(None, msg)
+      })
 
   }
 
-  def save(account: ApiAccount): LiftResponse = {
+  def save(account: ApiAccount)(implicit action: String, prettify: Boolean): LiftResponse = {
     writeApi.save(account, ModificationId(uuidGen.newUuid), userService.getCurrentUser.actor).either.runNow match {
       case Right(res) =>
         val accounts = ("accounts" -> JArray(List(res.toJson)))
-        toJsonResponse(None, accounts)("updateAccount", true)
+        toJsonResponse(None, accounts)
 
       case Left(err) =>
-        toJsonError(None, s"Could not update account '${account.name.value}' cause : ${err.fullMsg}")("updateAccount", true)
+        toJsonError(None, s"Could not update account '${account.name.value}' cause : ${err.fullMsg}")
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestApiAccounts.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestApiAccounts.scala
@@ -44,7 +44,9 @@ class RestApiAccounts(
         )
       implicit val action: String = "getAllAccounts"
 
-      OldInternalApiAuthz.withReadAdmin(readApi.getAllStandardAccounts.either.runNow match {
+      // here, 'write' and not 'read' because some tokens may have admin write access,
+      // and we want to avoid escalation
+      OldInternalApiAuthz.withWriteAdmin(readApi.getAllStandardAccounts.either.runNow match {
         case Right(accountSeq) =>
           val accounts = {
             (

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -66,7 +66,6 @@ import net.liftweb.http.js.JE.JsRaw
 import net.liftweb.http.js.JE.JsVar
 import net.liftweb.http.js.JE.Str
 import net.liftweb.http.js.JsCmds._
-import net.liftweb.json.JsonAST._
 import net.liftweb.json.JsonDSL._
 import net.liftweb.util._
 import net.liftweb.util.Helpers._


### PR DESCRIPTION
https://issues.rudder.io/issues/23227

Correct right checking for old APIs that don't take benefits of the framework with shema definition that manages that automatically. 
The idea is just to encapsulate each API endpoint logic with a `with[ActionType][ActionObject]` check that will do the correct check or else return an error.
For example for quicksearch:

```
....
    case Get("secure" :: "api" :: "quicksearch" :: Nil, req) => {
      OldInternalApiAuthz.withReadUser {
        ... the same code than before ...
     }
...
```

The error is logged two times: by hand at warn level for logger `api`, and automaticaly by the rest logger of the old API because it's an API error and they are always logger. Perhaps it's useless, but it seems strange that no logs are traced for `api`. The warn log can be removed by removing the line `ApiLogger.warn(fail.messageChain)`

Nothing else fancy, just be particulary careful when checking the PR that:
- only `GET` api has a `read` check, other have a `write` one, 
- the role of the check seems OK


Oh, and it shows that we must port all these old API to the new ones, checking by hand rights for each one is far too fragile.