### PR TITLE
Fixes #23303: When drag'n drop, the selected method and the targeted drop zone should be more highlighted

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewBlock.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewBlock.elm
@@ -496,13 +496,13 @@ showChildren model block ui techniqueUi parentId =
              ]
 
           |> DragDrop.makeDroppable model.dnd (InBlock block) dragDropMessages
-          |> addStyle ("opacity", (if (DragDrop.isCurrentDropTarget model.dnd (InBlock block)) then "1" else  "0.4"))
+          |> addClass (if (DragDrop.isCurrentDropTarget model.dnd (InBlock block)) then " drop-target" else  "")
         ) (List.isEmpty block.calls)
      |> appendChildConditional
         ( element "li"
           |> addAttribute (id "no-methods")
           |> addStyle ("text-align", "center")
-          |> addStyle ("opacity", (if (DragDrop.isCurrentDropTarget model.dnd (InBlock block)) then "1" else  "0.4"))
+          |> addClass (if (DragDrop.isCurrentDropTarget model.dnd (InBlock block)) then " drop-target" else  "")
           |> appendChild
              ( element "i"
                |> addClass "fas fa-sign-in-alt"
@@ -510,10 +510,11 @@ showChildren model block ui techniqueUi parentId =
              )
           |> addStyle ("padding", "3px 15px")
           |> DragDrop.makeDroppable model.dnd (InBlock block) dragDropMessages
-        ) ( case DragDrop.currentlyDraggedObject model.dnd of
-            Nothing -> False
-            Just (Move x) ->Maybe.withDefault True (Maybe.map (\c->  (getId x) /= (getId c)) (List.head block.calls))
-            Just _ -> not (List.isEmpty block.calls)
+        ) ( case (List.isEmpty block.calls , DragDrop.currentlyDraggedObject model.dnd) of
+            ( True , _    ) -> False
+            ( _ , Nothing ) -> False
+            ( _ , Just (Move x) ) -> Maybe.withDefault True (Maybe.map (\c->  (getId x) /= (getId c)) (List.head block.calls))
+            ( _ , Just _        ) -> not (List.isEmpty block.calls)
         )
      |> appendChildList
           ( List.concatMap ( \ call ->
@@ -528,9 +529,10 @@ showChildren model block ui techniqueUi parentId =
                   base =     [ showMethodCall model methodUi techniqueUi (Just block.id) c ]
                   dropElem = AfterElem (Just block.id) (Call parentId c)
                   dropTarget =  element "li"
-                                |> addAttribute (id "no-methods") |> addStyle ("padding", "3px 15px")
+                                |> addAttribute (id "no-methods")
+                                |> addStyle ("padding", "3px 15px")
                                 |> addStyle ("text-align", "center")
-                                |> addStyle ("opacity", (if (DragDrop.isCurrentDropTarget model.dnd dropElem) then "1" else  "0.4"))
+                                |> addClass (if (DragDrop.isCurrentDropTarget model.dnd dropElem) then " drop-target" else  "")
                                 |> DragDrop.makeDroppable model.dnd dropElem dragDropMessages
                                 |> addAttribute (hidden currentDragChild)
                                 |> appendChild

--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewTechnique.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewTechnique.elm
@@ -213,7 +213,7 @@ showTechnique model technique origin ui =
            ( element "li"
              |> addAttribute (id "no-methods")
              |> addStyle ("text-align", "center")
-             |> addStyle ("opacity", (if (DragDrop.isCurrentDropTarget model.dnd StartList) then "1" else  "0.4"))
+             |> addClass (if (DragDrop.isCurrentDropTarget model.dnd StartList) then " drop-target" else "")
              |> appendChild
                 ( element "i"
                   |> addClass "fas fa-sign-in-alt"
@@ -236,9 +236,10 @@ showTechnique model technique origin ui =
                                                        Just _ -> False
                   dropElem = AfterElem Nothing call
                   dropTarget =  element "li"
-                                   |> addAttribute (id "no-methods") |> addStyle ("padding", "3px 15px")
+                                   |> addAttribute (id "no-methods")
+                                   |> addStyle ("padding", "3px 15px")
                                    |> addStyle ("text-align", "center")
-                                   |> addStyle ("opacity", (if (DragDrop.isCurrentDropTarget model.dnd dropElem) then "1" else  "0.4"))
+                                   |> addClass (if (DragDrop.isCurrentDropTarget model.dnd dropElem) then " drop-target" else  "")
                                    |> DragDrop.makeDroppable model.dnd dropElem dragDropMessages
                                    |> appendChild
                                       ( element "i"

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/style/rudder/rudder-technique-editor.css
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/style/rudder/rudder-technique-editor.css
@@ -459,9 +459,16 @@ ul.tabs-list > li > .badge.empty{
   color: #0519258c;
   background-color: #f3f8ff;
   cursor: pointer;
-  transition-property: opacity;
+  transition-property: opacity, border-color, box-shadow;
   transition-duration: .5s;
-  text-align:center
+  text-align:center;
+  opacity: .6;
+}
+
+.drop-target{
+  border-color: #1295c2 !important;
+  opacity:1 !important;
+  box-shadow: 0 0px 12px #1295c236;
 }
 
 /* FILEMANAGER */


### PR DESCRIPTION
https://issues.rudder.io/issues/23303

To improve feedback during drag'n drop, I've added an animation of the border colour and box-shadow of the targeted drop zone :
![highlighted-drop-zone](https://github.com/Normation/rudder/assets/9928447/4a43612e-7f7a-4f11-b389-12362f20461e)

However, I couldn't do anything to highlight the selected method - no css can be applied to the moving element during drag'n drop.

I took the opportunity to fix a bug with empty blocks: 2 drop zones would appear when a method was dragged over them :
![bug-block-no-method](https://github.com/Normation/rudder/assets/9928447/b9decf28-53fc-4961-b0ec-a74978fcda78)
