### PR TITLE
Fixes #23305: When custom role permission list is empty, reload lead to stack trace

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
@@ -237,7 +237,7 @@ class RoleApiMapping(mapper: AuthorizationApiMapping) {
   }
 
   def getApiAclFromRoles(roles: Seq[Role]): List[ApiAclElement] = {
-    getApiAclFromRights(new Rights(roles.flatMap(_.rights.authorizationTypes): _*))
+    getApiAclFromRights(Rights(roles.flatMap(_.rights.authorizationTypes)))
   }
 
   // a merge function that groups action for identical path

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/CurrentUser.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/CurrentUser.scala
@@ -64,7 +64,7 @@ object CurrentUser extends SessionVar[Option[RudderUserDetail]]({
 
   def getRights: Rights = this.get match {
     case Some(u) => u.authz
-    case None    => new Rights(AuthorizationType.NoRights)
+    case None    => Rights.forAuthzs(AuthorizationType.NoRights)
   }
 
   def account: RudderAccount = this.get match {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/RudderUserDetails.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/RudderUserDetails.scala
@@ -36,7 +36,6 @@
  */
 package com.normation.rudder.web.services
 
-import com.normation.rudder.AuthorizationType
 import com.normation.rudder.Rights
 import com.normation.rudder.Role
 import com.normation.rudder.RudderAccount
@@ -74,7 +73,7 @@ object RudderAuthType {
   case object Api  extends RudderAuthType {
     override val grantedAuthorities = buildAuthority("ROLE_REMOTE")
 
-    val apiRudderRights = new Rights(AuthorizationType.NoRights)
+    val apiRudderRights = Rights.NoRights
     val apiRudderRole: Set[Role] = Set(Role.NoRights)
   }
 }
@@ -91,9 +90,8 @@ case class RudderUserDetail(
     apiAuthz: ApiAuthorization
 ) extends UserDetails {
   // merge roles rights
-  val authz                                               = new Rights(
-    (if (roles.nonEmpty) roles.flatMap(_.rights.authorizationTypes).toSeq else Seq(AuthorizationType.NoRights)): _*
-  )
+  val authz = Rights(roles.flatMap(_.rights.authorizationTypes))
+
   override val (getUsername, getPassword, getAuthorities) = account match {
     case RudderAccount.User(login, password) => (login, password, RudderAuthType.User.grantedAuthorities)
     case RudderAccount.Api(api)              => (api.name.value, api.token.value, RudderAuthType.Api.grantedAuthorities)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
@@ -370,7 +370,7 @@ object RudderAuthType {
   case object Api  extends RudderAuthType {
     override val grantedAuthorities = buildAuthority("ROLE_REMOTE")
 
-    val apiRudderRights = new Rights(AuthorizationType.NoRights)
+    val apiRudderRights = Rights.NoRights
     val apiRudderRole: Set[Role] = Set(Role.NoRights)
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/RegisterToasts.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/RegisterToasts.scala
@@ -37,7 +37,6 @@
 
 package com.normation.rudder.web.snippet
 
-import bootstrap.liftweb.StaticResourceRewrite
 import net.liftweb.http._
 import net.liftweb.http.js.JE._
 import net.liftweb.http.js.JsCmd

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
@@ -167,7 +167,8 @@ class RudderUserDetailsTest extends Specification {
     (userDetailList.isCaseSensitive must beTrue) and
     (userDetailList.users.size must beEqualTo(3)) and
     (userDetailList.customRoles must containTheSameElementsAs(parsedRoles)) and
-    (userDetailList.users("user_a1").roles must containTheSameElementsAs(List(roleA1)))
+    (userDetailList.users("user_a1").roles must containTheSameElementsAs(List(roleA1))) and
+    (roleC2.rights must beEqualTo(Role.NoRights.rights))
   }
 
   /// role specific  unit tests


### PR DESCRIPTION
https://issues.rudder.io/issues/23305

We used to forbid creation of a rights without any `Authorization` - which is good ! But the correct way to forbid it is by making creation impossible, not throwing a runtime error. 

This PR change the `Rights` class to a case class but with a private constructor to force the use of its object factory which does the correct checking and succeed in all case, returning the `NoRights` special value if needed. 

Remaining part of the PR are change to accomodate the use of the factory in place of `new`.

All over, it's a nice simplification.

PR https://github.com/Normation/rudder-plugins/pull/593 needs that one before being merged.