### PR TITLE
Fixes #23325: Simplify YAML encoding workaround

### DIFF
--- a/webapp/sources/utils/src/test/scala/zio/yaml/ZioYamlTest.scala
+++ b/webapp/sources/utils/src/test/scala/zio/yaml/ZioYamlTest.scala
@@ -1,0 +1,80 @@
+/*
+ *************************************************************************************
+ * Copyright 2019 Normation SAS
+ *************************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *************************************************************************************
+ */
+
+/*
+ * This class provides common usage for Zio
+ */
+
+package zio.yaml
+
+import org.junit.runner.RunWith
+import org.specs2.mutable._
+import org.specs2.runner.JUnitRunner
+import zio.json._
+
+@RunWith(classOf[JUnitRunner])
+class ZioYamlTest extends Specification {
+
+  final case class Param(
+      id:        String,
+      mandatory: Boolean
+  )
+
+  final case class Container(
+      id:      String,
+      version: Int,
+      params:  Seq[Param]
+  )
+
+  implicit val codecParam:           JsonCodec[Param]     = DeriveJsonCodec.gen
+  implicit val codecSimpleContainer: JsonCodec[Container] = DeriveJsonCodec.gen
+
+  val c = Container("foo", 42, List(Param("p1", true)))
+
+  "demonstrating yaml bad encoding with default ZIO Yaml" >> {
+    import zio.json.yaml._
+
+    // see the line break after `-`
+    c.toYaml() must beEqualTo(Right("""id: foo
+                                      |version: 42
+                                      |params:
+                                      |  -
+                                      |  id: p1
+                                      |  mandatory: true
+                                      |""".stripMargin))
+
+  }
+
+  "demonstrating correct encoding with our ZIO Yaml" >> {
+    import zio.yaml.YamlOps._
+
+    c.toYaml() must beEqualTo(
+      Right(
+        """id: foo
+          |version: 42
+          |params:
+          |  - id: p1
+          |    mandatory: true
+          |""".stripMargin
+      )
+    )
+
+  }
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/23325

As far as I saw, the only change was the addition of `dumperOptions.setIndentWithIndicator(true)`, so I removed everything else that was possible to rely on what the lib provide and avoid duplicating code. 
I also reodered code so that it follows the original one and make comparison easier. 

I've added a test so that we are informed if at some point, the base lib bug is corrected (and that our encoder works). 

Alse change licence header (that's not our copyright, we copied it, so it must be said, even if the original license allows that). 