### PR TITLE
Fixes #23326: Compile yaml technique on archive import

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechniqueReader.scala
@@ -31,8 +31,8 @@ import zio.syntax._
 
 trait EditorTechniqueReader {
   def readTechniquesMetadataFile: IOResult[(List[EditorTechnique], Map[BundleName, GenericMethod], List[RudderError])]
-  def getMethodsMetadata: IOResult[Map[BundleName, GenericMethod]]
-  
+  def getMethodsMetadata:         IOResult[Map[BundleName, GenericMethod]]
+
   // this one is an implementation detail of the cache-based version and should likely not be exposed here
   def updateMethodsMetadataFile: IOResult[CmdResult]
 }
@@ -76,7 +76,8 @@ class EditorTechniqueReaderImpl(
     }
   }
 
-  override def readTechniquesMetadataFile: IOResult[(List[EditorTechnique], Map[BundleName, GenericMethod], List[RudderError])] = {
+  override def readTechniquesMetadataFile
+      : IOResult[(List[EditorTechnique], Map[BundleName, GenericMethod], List[RudderError])] = {
     for {
       methods        <- getMethodsMetadata
       techniqueFiles <- getAllTechniqueFiles(configuration_repository / "techniques")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
@@ -42,7 +42,6 @@ import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.cfclerk.services.UpdateTechniqueLibrary
-
 import com.normation.errors._
 import com.normation.errors.IOResult
 import com.normation.eventlog.EventActor
@@ -52,10 +51,8 @@ import com.normation.rudder.domain.logger.TimingDebugLoggerPure
 import com.normation.rudder.ncf.yaml.YamlTechniqueSerializer
 import com.normation.rudder.repository.xml.TechniqueArchiver
 import com.normation.rudder.repository.xml.TechniqueFiles
-
 import com.normation.zio.currentTimeMillis
 import java.nio.charset.StandardCharsets
-
 import zio._
 
 /*

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
@@ -52,7 +52,6 @@ import com.normation.cfclerk.services.TechniquesInfo
 import com.normation.cfclerk.services.TechniquesLibraryUpdateNotification
 import com.normation.cfclerk.services.TechniquesLibraryUpdateType
 import com.normation.cfclerk.services.UpdateTechniqueLibrary
-
 import com.normation.errors._
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
@@ -86,7 +85,6 @@ import com.normation.rudder.services.workflows.NodeGroupChangeRequest
 import com.normation.rudder.services.workflows.RuleChangeRequest
 import com.normation.rudder.services.workflows.WorkflowLevelService
 import com.normation.rudder.services.workflows.WorkflowService
-
 import com.normation.zio._
 import java.io.{File => JFile}
 import java.io.InputStream
@@ -100,10 +98,8 @@ import org.specs2.matcher.ContentMatchers
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import org.specs2.specification.BeforeAfterAll
-
 import scala.collection.SortedMap
 import scala.collection.SortedSet
-
 import zio._
 import zio.syntax._
 
@@ -515,7 +511,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
   }
 
   val editorTechniqueReader = new EditorTechniqueReader() {
-    override def readTechniquesMetadataFile: IOResult[(List[EditorTechnique], Map[BundleName, GenericMethod], List[RudderError])] = {
+    override def readTechniquesMetadataFile
+        : IOResult[(List[EditorTechnique], Map[BundleName, GenericMethod], List[RudderError])] = {
       (List(technique), methods, Nil).succeed
     }
 
@@ -524,7 +521,7 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
     override def updateMethodsMetadataFile: IOResult[CmdResult] = ???
   }
 
-  val compiler = new TechniqueCompilerWithFallback(
+  val compiler      = new TechniqueCompilerWithFallback(
     valueCompiler,
     new RudderPrettyPrinter(Int.MaxValue, 2),
     parameterTypeService,
@@ -538,16 +535,16 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
     _.path,
     basePath
   )
-  val writer = new TechniqueWriterImpl(
+  val writer        = new TechniqueWriterImpl(
     TestTechniqueArchiver,
     TestLibUpdater,
     new DeleteEditorTechnique {
       override def deleteTechnique(
-        techniqueName   : String,
-        techniqueVersion: String,
-        deleteDirective : Boolean,
-        modId           : ModificationId,
-        committer       : EventActor
+          techniqueName:    String,
+          techniqueVersion: String,
+          deleteDirective:  Boolean,
+          modId:            ModificationId,
+          committer:        EventActor
       ): IOResult[Unit] = {
         ZIO.unit
       }
@@ -555,14 +552,13 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
     compiler,
     basePath
   )
-  val dscWriter = new DSCTechniqueWriter(
+  val dscWriter     = new DSCTechniqueWriter(
     basePath,
     valueCompiler,
     new ParameterType.PlugableParameterTypeService,
     _.path
   )
   val classicWriter = new ClassicTechniqueWriter(basePath, new ParameterType.PlugableParameterTypeService, _.path)
-
 
   val expectedMetadataPath = s"techniques/ncf_techniques/${technique.id.value}/${technique.version.value}/metadata.xml"
   val dscTechniquePath     = s"techniques/ncf_techniques/${technique.id.value}/${technique.version.value}/technique.ps1"

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -75,7 +75,6 @@ import com.normation.rudder.git.ZipUtils
 import com.normation.rudder.git.ZipUtils.Zippable
 import com.normation.rudder.ncf.ResourceFile
 import com.normation.rudder.ncf.ResourceFileState
-import com.normation.rudder.ncf.TechniqueCompiler
 import com.normation.rudder.ncf.migration.MigrateOldTechniquesService
 import com.normation.rudder.ncf.yaml.YamlTechniqueSerializer
 import com.normation.rudder.repository.RoDirectiveRepository

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -1089,7 +1089,6 @@ class SaveArchiveServicebyRepo(
     techniqueArchiver: TechniqueArchiverImpl,
     techniqueReader:   TechniqueReader,
     techniqueRepos:    TechniqueRepository,
-//    techniqueCompiler: TechniqueCompiler,
     roDirectiveRepos:  RoDirectiveRepository,
     woDirectiveRepos:  WoDirectiveRepository,
     roGroupRepos:      RoNodeGroupRepository,
@@ -1168,7 +1167,6 @@ class SaveArchiveServicebyRepo(
                  f.writeBytes(bytes.iterator)
                }
            }
-      // if the technique is a YAML file, we need in addition to regenerate files TODO
       // finally commit
       _ <- techniqueArchiver.saveTechnique(
              t.technique.id,

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
@@ -250,7 +250,7 @@ class TechniqueApi(
               case Full(bytes) => new String(bytes, charset).fromJson[EditorTechnique].toIO
             }
           methodMap        <- techniqueReader.getMethodsMetadata
-          updatedTechnique <- techniqueWriter.writeTechniqueAndUpdateLib(technique, methodMap, modId, authzToken.actor)
+          updatedTechnique <- techniqueWriter.writeTechniqueAndUpdateLib(technique, modId, authzToken.actor)
           json             <- updatedTechnique.toJsonAST.toIO
         } yield {
           json
@@ -322,7 +322,7 @@ class TechniqueApi(
                                             s"An error occurred while reading techniques when updating them: ${errors.map(_.msg).mkString("\n ->", "\n ->", "")}"
                                           )
                                         }
-        _                            <- ZIO.foreach(techniques)(t => techniqueWriter.writeTechnique(t, methods, modId, authzToken.actor))
+        _                            <- ZIO.foreach(techniques)(t => techniqueWriter.writeTechnique(t, modId, authzToken.actor))
         json                         <- ZIO.foreach(techniques)(_.toJsonAST.toIO)
       } yield {
         json
@@ -433,7 +433,7 @@ class TechniqueApi(
 
           // If no internalId (used to manage temporary folder for resources), ignore resources, this can happen when importing techniques through the api
           resoucesMoved <- technique.internalId.map(internalId => moveRessources(technique, internalId)).getOrElse("Ok".succeed)
-          updatedTech   <- techniqueWriter.writeTechniqueAndUpdateLib(technique, methodMap, modId, authzToken.actor)
+          updatedTech   <- techniqueWriter.writeTechniqueAndUpdateLib(technique, modId, authzToken.actor)
           json          <- updatedTech.toJsonAST.toIO
         } yield {
           json

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
@@ -387,7 +387,7 @@ class ArchiveApiTest extends Specification with AfterAll with Loggable {
   }
 
   "correctly build an archive of a YAML technique and filter generated files" >> {
-    val archiveName = "archive-technique"
+    val archiveName = "archive-technique-yaml"
     restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
     val techniqueId = "a_simple_yaml_technique/1.0"
     restTest.testGETResponse(s"/api/latest/archives/export?techniques=${techniqueId}&include=none") {

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SharedFilesApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SharedFilesApiTest.scala
@@ -45,9 +45,7 @@ import org.joda.time.format.ISODateTimeFormat
 import org.junit.runner._
 import org.specs2.mutable._
 import org.specs2.runner._
-import scala.annotation.nowarn
 
-@nowarn("msg=a type was inferred to be `\\w+`; this may indicate a programming error.")
 @RunWith(classOf[JUnitRunner])
 class SharedFilesApiTest extends Specification {
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -56,12 +56,14 @@ import bootstrap.liftweb.checks.migration.MigrateNodeAcceptationInventories
 import bootstrap.liftweb.checks.onetimeinit.CheckInitUserTemplateLibrary
 import bootstrap.liftweb.checks.onetimeinit.CheckInitXmlExport
 import com.normation.appconfig._
+
 import com.normation.box._
 import com.normation.cfclerk.services._
 import com.normation.cfclerk.services.impl._
 import com.normation.cfclerk.xmlparsers._
 import com.normation.cfclerk.xmlwriters.SectionSpecWriter
 import com.normation.cfclerk.xmlwriters.SectionSpecWriterImpl
+
 import com.normation.errors.IOResult
 import com.normation.errors.SystemError
 import com.normation.inventory.domain._
@@ -143,6 +145,8 @@ import com.normation.rudder.ncf.TechniqueSerializer
 import com.normation.rudder.ncf.TechniqueWriter
 import com.normation.rudder.ncf.TechniqueWriterImpl
 import com.normation.rudder.ncf.yaml.YamlTechniqueSerializer
+import com.normation.rudder.ncf.EditorTechniqueReader
+import com.normation.rudder.ncf.EditorTechniqueReaderImpl
 import com.normation.rudder.reports.AgentRunIntervalService
 import com.normation.rudder.reports.AgentRunIntervalServiceImpl
 import com.normation.rudder.reports.ComplianceModeService
@@ -197,6 +201,7 @@ import com.normation.templates.FillTemplatesService
 import com.normation.utils.CronParser._
 import com.normation.utils.StringUuidGenerator
 import com.normation.utils.StringUuidGeneratorImpl
+
 import com.normation.zio._
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigException
@@ -204,6 +209,7 @@ import com.typesafe.config.ConfigFactory
 import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.RDN
 import com.unboundid.ldif.LDIFChangeRecord
+
 import java.io.File
 import java.nio.file.attribute.PosixFilePermission
 import java.security.Security
@@ -213,8 +219,10 @@ import net.liftweb.common.Loggable
 import org.apache.commons.io.FileUtils
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.joda.time.DateTimeZone
+
 import scala.collection.mutable.Buffer
 import scala.concurrent.duration.FiniteDuration
+
 import zio.{Scheduler => _, System => _, _}
 import zio.syntax._
 
@@ -1320,7 +1328,7 @@ case class RudderServiceApi(
     roRuleCategoryRepository:            RoRuleCategoryRepository,
     woRuleCategoryRepository:            WoRuleCategoryRepository,
     workflowLevelService:                DefaultWorkflowLevel,
-    ncfTechniqueReader:                  ncf.EditorTechniqueReader,
+    ncfTechniqueReader:                  EditorTechniqueReader,
     recentChangesService:                NodeChangesService,
     ruleCategoryService:                 RuleCategoryService,
     restExtractorService:                RestExtractorService,
@@ -1511,7 +1519,7 @@ object RudderConfigInit {
       def getCurrentUser = CurrentUser
     }
 
-    lazy val ncfTechniqueReader: ncf.EditorTechniqueReader = new ncf.EditorTechniqueReader(
+    lazy val ncfTechniqueReader: EditorTechniqueReader = new EditorTechniqueReaderImpl(
       stringUuidGenerator,
       personIdentService,
       gitConfigRepo,
@@ -1820,6 +1828,7 @@ object RudderConfigInit {
       typeParameterService,
       new RuddercServiceImpl(RUDDERC_CMD, RUDDERC_FALLBACK_RETURN_CODE, 5.seconds),
       TECHNIQUE_COMPILER_APP,
+      ncfTechniqueReader,
       _.path,
       RUDDER_GIT_ROOT_CONFIG_REPO
     )

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -56,14 +56,12 @@ import bootstrap.liftweb.checks.migration.MigrateNodeAcceptationInventories
 import bootstrap.liftweb.checks.onetimeinit.CheckInitUserTemplateLibrary
 import bootstrap.liftweb.checks.onetimeinit.CheckInitXmlExport
 import com.normation.appconfig._
-
 import com.normation.box._
 import com.normation.cfclerk.services._
 import com.normation.cfclerk.services.impl._
 import com.normation.cfclerk.xmlparsers._
 import com.normation.cfclerk.xmlwriters.SectionSpecWriter
 import com.normation.cfclerk.xmlwriters.SectionSpecWriterImpl
-
 import com.normation.errors.IOResult
 import com.normation.errors.SystemError
 import com.normation.inventory.domain._
@@ -135,6 +133,8 @@ import com.normation.rudder.metrics._
 import com.normation.rudder.migration.DefaultXmlEventLogMigration
 import com.normation.rudder.ncf
 import com.normation.rudder.ncf.DeleteEditorTechniqueImpl
+import com.normation.rudder.ncf.EditorTechniqueReader
+import com.normation.rudder.ncf.EditorTechniqueReaderImpl
 import com.normation.rudder.ncf.GitResourceFileService
 import com.normation.rudder.ncf.ParameterType.PlugableParameterTypeService
 import com.normation.rudder.ncf.RuddercServiceImpl
@@ -145,8 +145,6 @@ import com.normation.rudder.ncf.TechniqueSerializer
 import com.normation.rudder.ncf.TechniqueWriter
 import com.normation.rudder.ncf.TechniqueWriterImpl
 import com.normation.rudder.ncf.yaml.YamlTechniqueSerializer
-import com.normation.rudder.ncf.EditorTechniqueReader
-import com.normation.rudder.ncf.EditorTechniqueReaderImpl
 import com.normation.rudder.reports.AgentRunIntervalService
 import com.normation.rudder.reports.AgentRunIntervalServiceImpl
 import com.normation.rudder.reports.ComplianceModeService
@@ -201,7 +199,6 @@ import com.normation.templates.FillTemplatesService
 import com.normation.utils.CronParser._
 import com.normation.utils.StringUuidGenerator
 import com.normation.utils.StringUuidGeneratorImpl
-
 import com.normation.zio._
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigException
@@ -209,7 +206,6 @@ import com.typesafe.config.ConfigFactory
 import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.RDN
 import com.unboundid.ldif.LDIFChangeRecord
-
 import java.io.File
 import java.nio.file.attribute.PosixFilePermission
 import java.security.Security
@@ -219,10 +215,8 @@ import net.liftweb.common.Loggable
 import org.apache.commons.io.FileUtils
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.joda.time.DateTimeZone
-
 import scala.collection.mutable.Buffer
 import scala.concurrent.duration.FiniteDuration
-
 import zio.{Scheduler => _, System => _, _}
 import zio.syntax._
 
@@ -1820,6 +1814,7 @@ object RudderConfigInit {
       gitModificationRepository,
       personIdentService,
       techniqueParser,
+      techniqueCompiler,
       RUDDER_GROUP_OWNER_CONFIG_REPO
     )
     lazy val techniqueCompiler:  TechniqueCompiler = new TechniqueCompilerWithFallback(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/action/CheckNcfTechniqueUpdate.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/action/CheckNcfTechniqueUpdate.scala
@@ -41,6 +41,7 @@ import better.files.File
 import bootstrap.liftweb.BootstrapChecks
 import bootstrap.liftweb.BootstrapLogger
 import com.normation.cfclerk.services.UpdateTechniqueLibrary
+
 import com.normation.errors.RudderError
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
@@ -51,6 +52,7 @@ import com.normation.rudder.ncf.ResourceFileState
 import com.normation.rudder.ncf.ResourceFileState.Untouched
 import com.normation.rudder.ncf.TechniqueWriter
 import com.normation.utils.StringUuidGenerator
+
 import com.normation.zio._
 import zio._
 import zio.syntax.ToZio
@@ -116,7 +118,7 @@ class CheckNcfTechniqueUpdate(
         // Actually write techniques
         written                 <- ZIO.foreach(techniquesWithResources) { t =>
                                      techniqueWrite
-                                       .writeTechnique(t, methods, ModificationId(uuidGen.newUuid), EventActor(systemApiToken.name.value))
+                                       .writeTechnique(t, ModificationId(uuidGen.newUuid), EventActor(systemApiToken.name.value))
                                        .chainError(s"An error occured while writing technique ${t.id.value}")
                                    }
         // Update technique library once all technique are updated

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/action/CheckNcfTechniqueUpdate.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/action/CheckNcfTechniqueUpdate.scala
@@ -41,7 +41,6 @@ import better.files.File
 import bootstrap.liftweb.BootstrapChecks
 import bootstrap.liftweb.BootstrapLogger
 import com.normation.cfclerk.services.UpdateTechniqueLibrary
-
 import com.normation.errors.RudderError
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
@@ -52,7 +51,6 @@ import com.normation.rudder.ncf.ResourceFileState
 import com.normation.rudder.ncf.ResourceFileState.Untouched
 import com.normation.rudder.ncf.TechniqueWriter
 import com.normation.utils.StringUuidGenerator
-
 import com.normation.zio._
 import zio._
 import zio.syntax.ToZio

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/action/MigrateOldTechniques.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/action/MigrateOldTechniques.scala
@@ -121,7 +121,7 @@ class MigrateOldTechniques(
         // Actually write techniques
         written   <- ZIO.foreach(techniques) { t =>
                        techniqueWrite
-                         .writeTechnique(t, methods, ModificationId(uuidGen.newUuid), EventActor(systemApiToken.name.value))
+                         .writeTechnique(t, ModificationId(uuidGen.newUuid), EventActor(systemApiToken.name.value))
                          .chainError(s"An error occurred while writing technique ${t.id.value}")
                      }
         // Actually write techniques


### PR DESCRIPTION
https://issues.rudder.io/issues/23326

This PR needs https://github.com/Normation/rudder/pull/4925 to be merged. :heavy_check_mark: 

The main added changes are: 

- `TechniqueCompiler` earn more compilation methods to ease the different cases we know: `compile an EditorTechnique` (always needed for the fallback case) or `we just know the base path of technique` (archive, migration...). 
- `TechniqueCompiler` also get a "migrate json and regenerate yaml if needed", which is basically "do what need to be done to have an up-to-date technique
- On the other hand, I removed methods parameter, since it's only needed for the fallback case, which should not be the  most used (and so it's ok to have on demand query of these info). This change is on a separated commit for now to ease the review.
- the `GitTechniqueArchive#saveTechnique` always check if migration/regen is needed before saving (since it reads `metadata.xml`). It seems to be a good place to have a "catch all" for doing that. 

The import yaml does not have unit test, I'm not sure how to set-up everything for that (note: it will be done in technique migration test and it need quite a lot of work)