### PR TITLE
Fixes #23352: Import/Export yaml with technique editor

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -621,6 +621,12 @@ object TechniqueApi       extends ApiModuleProvider[TechniqueApi]               
     val description    = "reload methods metadata from file system"
     val (action, path) = POST / "methods" / "reload"
   }
+  final case object CheckTechnique         extends TechniqueApi with ZeroParam with StartsAtVersion16 with SortIndex {
+    val z              = implicitly[Line].value
+    val description    = "Check if a techniques is valid yaml, with rudderc compilation, with various output (json ? yaml ?)"
+    val (action, path) = POST / "techniques" / "check"
+  }
+
   def endpoints = ca.mrvisser.sealerate.values[TechniqueApi].toList.sortBy(_.z)
 }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestUtils.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestUtils.scala
@@ -81,6 +81,13 @@ case class JsonResponsePrettify(
  */
 object RestUtils extends Loggable {
 
+  def getCharset(req: Req) = {
+    // copied from `Req.forcedBodyAsJson`
+    def r  = """; *charset=(.*)""".r
+    def r2 = """[^=]*$""".r
+    req.contentType.flatMap(ct => r.findFirstIn(ct).flatMap(r2.findFirstIn)).getOrElse("UTF-8")
+  }
+
   def apiVersionFromRequest(req: Req)(implicit availableVersions: List[ApiVersion]): Box[ApiVersion] = {
 
     val latest = availableVersions.maxBy(_.value)

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -723,6 +723,7 @@ class RestTestSetUp {
     mockTechniques.techniqueRevisionRepo,
     null,
     null,
+    null,
     null
   )
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ApiCalls.elm
@@ -4,7 +4,7 @@ import Dict
 import Http exposing (..)
 import Http.Detailed as Detailed
 import Json.Decode exposing (list)
-import Maybe.Extra
+import Json.Encode exposing (object, string)
 
 import Editor.DataTypes exposing (..)
 import Editor.JsonDecoder exposing (..)
@@ -45,6 +45,38 @@ getTechniques  model =
   in
     req
 
+
+getTechniqueYaml :  Model -> Technique -> Cmd Msg
+getTechniqueYaml model technique =
+  let
+    req =
+      request
+        { method  = "GET"
+        , headers = []
+        , url     = getUrl model "techniques/"++technique.id.value++"/"++technique.version++"?format=yaml"
+        , body    = emptyBody
+        , expect  = Detailed.expectJson GetYaml ( Json.Decode.at ["data", "techniques" ] (headList  (Json.Decode.list (Json.Decode.at ["content"] Json.Decode.string))))
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+  in
+    req
+
+checkTechniqueYaml :  Model -> String -> Cmd Msg
+checkTechniqueYaml model content =
+  let
+    req =
+      request
+        { method  = "POST"
+        , headers = []
+        , url     = getUrl model "techniques/check"
+        , body    = jsonBody (object [( "content", string content)] )
+        , expect  = Detailed.expectJson CheckTechnique ( Json.Decode.at ["data", "techniques" ] (headList  (Json.Decode.list decodeTechnique)))
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+  in
+    req
 getTechniquesCategories : Model -> Cmd Msg
 getTechniquesCategories model =
   let

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
@@ -216,12 +216,14 @@ type Mode = Introduction | TechniqueDetails Technique TechniqueState TechniqueUi
 type Msg =
     SelectTechnique (Either Technique Draft)
   | GetTechniques   (Result (Http.Detailed.Error String) ( Http.Metadata, List Technique ))
+  | GetYaml         (Result (Http.Detailed.Error String) ( Http.Metadata, String ))
   | SaveTechnique   (Result (Http.Detailed.Error String) ( Http.Metadata, Technique ))
   | UpdateTechnique Technique
   | DeleteTechnique (Result (Http.Detailed.Error String) ( Http.Metadata, TechniqueId ))
   | GetTechniqueResources  (Result (Http.Detailed.Error String) ( Http.Metadata, List Resource ))
   | GetCategories (Result (Http.Detailed.Error String)  ( Http.Metadata, TechniqueCategory ))
   | GetMethods   (Result (Http.Detailed.Error String) ( Http.Metadata, (Dict String Method) ))
+  | CheckTechnique (Result (Http.Detailed.Error String) ( Http.Metadata, Technique ))
   | UIMethodAction CallId MethodCallUiInfo
   | UIBlockAction CallId MethodBlockUiInfo
   | RemoveMethod CallId
@@ -267,6 +269,7 @@ type Msg =
   | MoveCompleted DragElement DropElement
   -- Sometimes drag and drop event are blocked / catched, fire it manually
   | CompleteMove
+  | FinalizeImport String
   | SetMissingIds String
   | Notification (String -> Cmd Msg) String
   | DisableDragDrop

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1639,6 +1639,7 @@ object RudderConfigInit {
         gitParseTechniqueLibrary,
         ncfTechniqueReader,
         techniqueSerializer,
+        yamlTechniqueSerializer,
         restDataSerializer
       )
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/23352

Adds a new API to check whether a technique is valid or not (accepts a yaml, returns a json) to use to import a yaml technique

Modify getTechnique api to add a format parameter to return a yaml instead of a json to use to export a technique as yaml

modify the technique editor to use both new api/parameters 