### PR TITLE
Fixes #23285: Change the display of the new filemanager to match the previous one

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Env.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Env.elm
@@ -1,22 +1,25 @@
 module FileManager.Env exposing (..)
 
-import FileManager.Action exposing (..)
 import Browser.Dom exposing (getElement)
 import List exposing (filter, indexedMap, map, member, reverse)
-import FileManager.Model exposing (..)
+import List.Extra exposing (takeWhile)
 import Platform.Cmd
-import FileManager.Port exposing (close)
 import String exposing (fromInt)
 import Task exposing (sequence)
 import Tuple exposing (first, second)
-import FileManager.Util exposing (..)
+import Dict exposing (Dict)
+
+import FileManager.Action exposing (..)
+import FileManager.Port exposing (close)
+import FileManager.Model exposing (..)
 import FileManager.Vec exposing (..)
+import FileManager.Util exposing (..)
 
 handleEnvMsg : EnvMsg -> Model -> (Model, Cmd Msg)
 handleEnvMsg msg model = case msg of
   Open () -> ({ model | open = True }, Cmd.none)
   Close -> ({ model | open = False, selected = [] }, close [])
-  Accept -> ({ model | open = False, selected = [] }, close <| reverse <| map ((++) model.dir << .name) model.selected)
+  Accept -> ({ model | open = False, selected = [] }, close <| reverse <| map ((++) (getDirPath model.dir) << .name) model.selected)
   MouseDown maybe pos1 ctrl ->
     ( { model
       | mouseDown = True
@@ -50,7 +53,7 @@ handleEnvMsg msg model = case msg of
         | mouseDown = False
         , drag = False
         , showContextMenu = case maybe of
-            Just file -> not <| model.dir == model.clipboardDir && member file model.clipboardFiles
+            Just file -> not <| (getDirPath model.dir) == model.clipboardDir && member file model.clipboardFiles
             Nothing -> True
         , selected = case maybe of
             Just _ -> model.selected
@@ -76,14 +79,50 @@ handleEnvMsg msg model = case msg of
         }
         , case maybe of
             Just file -> if model.drag && (file.type_ == "dir") && (not << member file) model.selected
-              then move model.api model.dir model.selected <| "/" ++ file.name ++ "/"
+              then move model.api (getDirPath model.dir) model.selected <| "/" ++ file.name ++ "/"
               else Cmd.none
             Nothing -> Cmd.none
-      )      
-  GetLs dir -> ({ model | dir = dir, files = [], load = True }, listDirectory model.api dir)
-  LsGotten result -> case result of
-    Ok files -> ({ model | files = files, selected = [], load = False }, Cmd.none)
+      )
+
+  GetLs dir ->
+    let
+      newDir = if List.member dir model.dir then takeWhile (\d -> d /= dir) model.dir else List.append model.dir [dir]
+    in
+      ({ model | dir = newDir, files = [], load = True }, listDirectory model.api newDir)
+
+  GetLsTree dir ->
+    ({ model | dir = dir, files = [], load = True }, listDirectory model.api dir)
+
+  LsGotten folder result -> case result of
+    Ok files ->
+      let
+        toItems : List FileMeta -> List String
+        toItems fs = fs
+          |> List.filter (\f -> f.type_ == "dir")
+          |> List.map .name
+          |> List.sort
+
+        childs = toItems files
+
+        newTree = case Dict.get folder model.tree of
+          Just ti -> Dict.insert folder (TreeItem folder ti.parents childs) model.tree
+          Nothing ->
+            let
+              values = Dict.values model.tree
+
+              parents = case List.Extra.find (\ti -> List.member folder ti.childs) values of
+                Just p  -> List.append [p.name] p.parents
+                Nothing -> []
+
+            in
+              Dict.insert folder (TreeItem folder parents childs) model.tree
+
+        filters = model.filters
+        newFilters = {filters | opened = folder :: filters.opened}
+      in
+        ({ model | files = files, selected = [], load = False, tree = newTree, filters = newFilters }, Cmd.none)
     Err _ -> (model, Cmd.none)
+
   Refresh result -> case result of
     Ok () -> (model, listDirectory model.api model.dir)
     Err _ -> (model, Cmd.none)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Model.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Model.elm
@@ -4,6 +4,7 @@ import Browser.Dom exposing (Element)
 import File exposing (File)
 import Http exposing (Error)
 import FileManager.Vec exposing (..)
+import Dict exposing (Dict)
 
 type alias Flags =
   { api: String
@@ -13,11 +14,24 @@ type alias Flags =
   , hasWriteRights : Bool
   }
 
+type ViewMode = ListView | GridView
+
+type SortBy = FileName | FileSize | FileDate | FileRights
+
+type SortOrder = Asc | Desc
+
+type alias Filters =
+  { filter : String
+  , sortBy : SortBy
+  , sortOrder : SortOrder
+  , opened : List String
+  }
+
 type alias Model =
   { api: String
   , thumbnailsUrl: String
   , downloadsUrl: String
-  , dir: String
+  , dir: List String
   , open: Bool
   , load: Bool
   , pos1: Vec2
@@ -41,6 +55,15 @@ type alias Model =
   , clipboardFiles: List FileMeta
   , uploadQueue: List File
   , hasWriteRights: Bool
+  , viewMode : ViewMode
+  , filters  : Filters
+  , tree     : Dict String TreeItem
+  }
+
+type alias TreeItem =
+  { name    : String
+  , parents : List String
+  , childs  : List String
   }
 
 type alias FileMeta =
@@ -70,6 +93,8 @@ type Msg
   | Delete
   | UpdateApiPath String
   | None
+  | ChangeViewMode ViewMode
+  | UpdateFilters Filters
 
 type EnvMsg
   = Open ()
@@ -80,7 +105,8 @@ type EnvMsg
   | MouseMove Vec2
   | MouseUp (Maybe FileMeta) Int
   | GetLs String
-  | LsGotten (Result Error (List FileMeta)) 
+  | GetLsTree (List String)
+  | LsGotten String (Result Error (List FileMeta))
   | Refresh (Result Error ())
   | GotContent (Result Error String)
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Util.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Util.elm
@@ -45,3 +45,7 @@ isJust maybe = case maybe of
 
 button : List (Attribute msg) -> List (Html msg) -> Html msg
 button atts childs = Html.button (type_ "button" :: atts) childs
+
+getDirPath : List String -> String
+getDirPath dir =
+  String.replace "//" "/" ((String.join "/" dir) ++ "/")

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-filemanager.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-filemanager.css
@@ -19,6 +19,10 @@
   cursor: pointer;
 }
 
+.fm-modal .fm-button{
+  min-width: 70px;
+}
+
 .fm-simple-screen {
   position: fixed;
   left: 0;
@@ -26,7 +30,6 @@
   width: 100%;
   height: 100%;
   z-index: 10000;
-  background-color: rgba(0, 0, 0, 0.75);
 }
 
 .fm-main {
@@ -39,12 +42,14 @@
   right: 100px;
   z-index: 1;
   font-family: var(--font-sans);
+  font-size: 14px;
 }
 
 .fm-bar {
   display: flex;
   align-items: center;
-  background-color: #0078D4;
+  background-color: #F8F9FC;
+  border-bottom: 1px solid #D6DEEF;
   padding: 0 12px;
 }
 
@@ -53,6 +58,11 @@
   border: none;
   background: none;
   cursor: pointer;
+  display: inline-flex;
+}
+
+.fm-arrow > svg > path:last-child{
+  fill: #738195;
 }
 
 .fm-arrow:focus {
@@ -62,7 +72,8 @@
 .fm-text {
   flex-grow: 1;
   margin-left: 10px;
-  color: #FFFFFF;
+  color: #738195;
+  font-weight: 500;
 }
 
 .fm-bar circle {
@@ -93,6 +104,7 @@
   border-bottom: 1px solid #FFFFFF;
   background-color: #FFFFFF;
   overflow: hidden;
+  flex: 1;
 }
 
 .fm-wrap {
@@ -127,11 +139,11 @@
 }
 
 .fm-file:hover {
-  background-color: #DEECF9;
+  background-color: #eef1f9;
 }
 
 .fm-selected {
-  background-color: #C7E0F4;
+  background-color: #C7E0F4 !important;
 }
 
 .fm-drag .fm-selected, .fm-cut {
@@ -143,7 +155,7 @@
   justify-content: center;
   align-items: center;
   width: 100px;
-  height: 100px;
+  height: 60px;
 }
 
 .fm-upload .fm-thumb {
@@ -166,9 +178,7 @@
 
 .fm-name {
   width: 100px;
-  margin-top: 10px;
   overflow: hidden;
-  font-size: 0.8em;
   text-align: center;
 }
 
@@ -177,17 +187,18 @@
   justify-content: flex-end;
   align-items: center;
   padding: 0 12px;
-  background-color: #0078D4;
+  background-color: #F8F9FC;
+  border-top: 1px solid #D6DEEF;
 }
 
 .fm-control button {
     margin-left: 7px;
     padding: 5px 10px;
-    border: none;
-    border-radius: 5px;
-    color: #0078D4;
+    border-radius: 4px;
+    color: #041922;
     background-color: #FFFFFF;
-    cursor: pointer;    
+    cursor: pointer;
+    border: 1px solid #D6DEEF;
 }
 
 .fm-helper {
@@ -215,8 +226,9 @@
   position: fixed;
   width: 150px;
   padding: 5px 0;
-  border: 1px solid #D0D0D0;
+  border: 1px solid #D6DEEF;
   background-color: #FFFFFF;
+  border-radius: 4px;
 }
 
 .fm-context-menu button {
@@ -230,7 +242,7 @@
 }
 
 .fm-context-menu button:hover {
-  background-color: #D0D0D0;
+  background-color: #eef1f9;
 }
 
 .fm-context-menu .disabled {
@@ -270,17 +282,23 @@
   z-index: 1;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.75);
+  background-color: #041922AA;
 }
 
 .fm-modal {
   padding: 20px;
   background-color: #FFFFFF;
+  border-radius: 4px;
 }
 
 .fm-modal label {
   display: block;
-  margin-bottom: 10px;
+  margin-bottom: 14px;
+  min-width: 400px;
+}
+
+.fm-modal label > strong{
+  margin-bottom: 6px;
 }
 
 .fm-modal > h1 {
@@ -300,4 +318,104 @@
 .fm-modal textarea {
   width: 50vw;
   height: 50vh;
+}
+
+/* BAR BUTTONS */
+.fm-bar-actions > .btn,
+.fm-bar-actions > .btn-group{
+  margin-left: 6px;
+}
+
+.fm-bar-actions .btn{
+  font-size: 16px;
+  background-color: transparent !important;
+  color: #738195;
+}
+
+/* SEARCH FILTER */
+.dropdown-menu.search-dropdown{
+  padding: 10px;
+  background-color: #F8F9FC;
+  width: 250px;
+}
+
+/* FILES TREE */
+.files-container {
+  background-color: #fff;
+  display: flex;
+  flex-direction: row;
+}
+
+.fm-filetree {
+  width: 320px;
+  height: 100%;
+  background-color: #fafafa;
+  border-right: 1px solid #D6DEEF;
+}
+
+.fm-filetree ul{
+  padding-left: 24px;
+  position: relative;
+}
+
+.fm-filetree > ul{
+  padding-left: 15px;
+}
+
+.fm-filetree ul li a{
+  display: flex;
+  align-items: center;
+  padding: 6px 0;
+  cursor: pointer;
+  color: #738195;
+  position: relative;
+  padding-left: 24px;
+}
+
+.fm-filetree ul li a:hover{
+  background-color: #eef1f9;
+  color: #041922;
+}
+.fm-filetree ul li a:before,
+.fm-filetree ul ul:before{
+  content: "";
+  border-left: 2px solid #D6DEEF;
+  display: block;
+  position: absolute;
+  height: 100%;
+  left: 10px;
+  top: 0;
+}
+.fm-filetree ul > li:last-child a:before {
+  height: 50%;
+}
+.fm-filetree ul > li:last-child ul:before {
+  content: initial;
+}
+.fm-filetree ul li svg{
+  position: absolute;
+  left: 0;
+}
+
+.fm-files-list{
+  width: 100%;
+}
+.fm-files-list > .dataTable {
+  border: none;
+}
+
+tr.fm-file-list > td > div {
+  display: flex;
+  align-items: center;
+}
+
+tr.fm-file-list .fm-thumb {
+  width: 30px;
+  height: 30px;
+  margin-right: 4px;
+}
+
+tr.fm-file-list .fm-name {
+  margin-left: 4px;
+  width: initial;
 }

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.css
@@ -193,6 +193,7 @@ body > .modal-backdrop.fade.in{
   border: 1px solid #d6deef;
   -webkit-box-shadow: none;
   box-shadow: none;
+  font-weight: normal;
 }
 .content-wrapper .form-control:active:focus {
   border-color: #d6deef;

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.css
@@ -63,7 +63,7 @@
   max-height: 250px;
   overflow: auto;
 }
-ul.dropdown-menu:not(.dropdown-search) {
+ul.dropdown-menu:not(.search-dropdown) {
   padding: 0;
   min-width: 170px;
   margin-left: -75px;

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.css
@@ -725,10 +725,12 @@
 .rudder-template .template-main .dataTable tr.details td.details{
   padding-left: 0;
 }
-.rudder-template .dataTable > tbody > tr:nth-child(even){
+.rudder-template .dataTable > tbody > tr:nth-child(even),
+.filemanager-container .dataTable > tbody > tr:nth-child(even){
   background-color: #F8F9FC;
 }
-.rudder-template .dataTable > tbody > tr:nth-child(even):hover{
+.rudder-template .dataTable > tbody > tr:nth-child(even):hover,
+.filemanager-container .dataTable > tbody > tr:nth-child(even):hover{
   background-color: #eef1f9;
 }
 .rudder-template .template-main .main-table > .table-container > .dataTable > tbody > tr.is-expired {


### PR DESCRIPTION
https://issues.rudder.io/issues/23285

The aim of this PR is to restore the look and functionality of the previous filemanager to the new one. The new features are :

- the ability to switch the display to a table/grid format
- a search bar
- a sorting system
- a file tree

![filemanager-1](https://github.com/Normation/rudder/assets/9928447/823278b7-d3c0-4958-b610-5969348f393d)
![filemanager-2](https://github.com/Normation/rudder/assets/9928447/741446fe-131d-4d07-abf5-29b7f3650d46)
