### PR TITLE
Fixes #23357: Display compilation output  in technique details

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
@@ -232,7 +232,7 @@ update msg model =
     NewTechnique internalId ->
       let
         ui = TechniqueUiInfo General Dict.empty Dict.empty [] False Unchanged Unchanged Nothing
-        t = Technique (TechniqueId "") "1.0" "" "" "" "ncf_techniques" [] [] [] []
+        t = Technique (TechniqueId "") "1.0" "" "" "" "ncf_techniques" [] [] [] [] Nothing
         newModel =  { model | mode = TechniqueDetails t (Creation internalId) ui}
       in
         updatedStoreTechnique newModel

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
@@ -56,6 +56,15 @@ type alias Method =
   , rename         : Maybe String
   }
 
+type alias CompilationOutput =
+  { compiler:  String
+  , fallbacked: Bool
+  , resultCode: Int
+  , msg:        String
+  , stdout:     String
+  , stderr:     String
+  }
+
 type alias Technique =
   { id            : TechniqueId
   , version       : String
@@ -67,6 +76,7 @@ type alias Technique =
   , parameters    : List TechniqueParameter
   , resources     : List Resource
   , tags          : List (String,String)
+  , output        : Maybe CompilationOutput
   }
 
 type MethodElem = Call (Maybe CallId) MethodCall | Block (Maybe CallId) MethodBlock
@@ -207,7 +217,7 @@ type alias TechniqueUiInfo =
 type MethodCallTab = CallParameters | CallConditions | Result | CallReporting
 type MethodBlockTab = BlockConditions | BlockReporting | Children
 type MethodCallMode = Opened | Closed
-type Tab = General |  Parameters | Resources | None
+type Tab = General | Parameters | Resources | Output | None
 type Mode = Introduction | TechniqueDetails Technique TechniqueState TechniqueUiInfo
 
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/JsonDecoder.elm
@@ -110,6 +110,15 @@ decodeTechniqueMaybe =
          _ -> succeed Nothing
      )
 
+decodeOutput : Decoder CompilationOutput
+decodeOutput =
+  succeed CompilationOutput
+    |> required "compiler" string
+    |> required "fallbacked"  bool
+    |> required "resultCode"  int
+    |> required "msg"  string
+    |> required "stdout"  string
+    |> required "stderr"  string
 
 decodeTechnique : Decoder Technique
 decodeTechnique =
@@ -124,6 +133,7 @@ decodeTechnique =
     |> required "parameters" (list decodeTechniqueParameter)
     |> required "resources" (list decodeResource)
     |> required "tags" (keyValuePairs string)
+    |> optional "output" (decodeOutput |> map Just) Nothing
 
 decodeAgent : Decoder Agent
 decodeAgent =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
@@ -16,6 +16,7 @@ import Editor.ViewMethod exposing (..)
 import Editor.ViewMethodsList exposing (..)
 import Editor.ViewTechniqueTabs exposing (..)
 import Editor.ViewTechniqueList exposing (..)
+import Maybe.Extra
 
 
 --
@@ -326,6 +327,15 @@ showTechnique model technique origin ui =
               ]
             ]
           ]
+        , if (Maybe.Extra.isJust technique.output) then
+            li [ class (activeTabClass Output)  , onClick (SwitchTab Output)] [
+              a [] [
+                text "Compilation output "
+              , span [  class  ( "fa ") ] []
+              ]
+            ]
+            else
+              text ""
         ]
       ]
     , div [ class "main-details", id "details"]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueTabs.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueTabs.elm
@@ -6,6 +6,7 @@ import Html.Events exposing (..)
 
 import Editor.AgentValueParser exposing (..)
 import Editor.DataTypes exposing (..)
+import String.Extra
 
 
 --
@@ -279,3 +280,48 @@ techniqueTab model technique creation ui =
             ]
           ]
         ]
+    Output ->
+      case technique.output of
+        Nothing -> text ""
+        Just out ->
+         div [ class "tab tab-general" ] [
+           div [ class "row form-group" ] [
+             label [ class "col-xs-12 control-label" ] [ text "Compiled by"  ]
+           , div  [ class "col-sm-8" ] [
+               input [readonly True, type_ "text", class "form-control", value out.compiler ] []
+             ]
+           ]
+         , div [ class "row form-group" ] [
+             label [ class "col-xs-12 control-label" ] [ text "Result code"  ]
+           , div  [ class "col-sm-8" ] [
+               input [readonly True, type_ "text", class "form-control", value (String.fromInt out.resultCode) ] []
+             ]
+           ]
+         , if String.Extra.isBlank out.msg then
+             text ""
+           else
+             div [ class "row form-group" ] [
+               label [ class "col-xs-12 control-label" ] [ text "Message"  ]
+             ,  div  [ class "col-xs-12" ] [
+                  pre [class "command-output pre-scrollable"] [  text out.msg ]
+                ]
+             ]
+         , if String.Extra.isBlank out.stdout then
+             text ""
+           else
+             div [ class "row form-group" ] [
+               label [ class "col-xs-12 control-label" ] [ text "Standard out"  ]
+             , div  [ class "col-xs-12" ] [
+                 pre [class "command-output pre-scrollable"] [ text out.stdout ]
+               ]
+             ]
+         , if String.Extra.isBlank out.stderr then
+             text ""
+           else
+             div [ class "row form-group" ] [
+               label [ class "col-xs-12 control-label" ] [ text "Error out"  ]
+             , div  [ class "col-xs-12" ] [
+                 pre [class "command-output pre-scrollable"] [ text out.stderr ]
+               ]
+             ]
+         ]

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1639,8 +1639,8 @@ object RudderConfigInit {
         gitParseTechniqueLibrary,
         ncfTechniqueReader,
         techniqueSerializer,
-        yamlTechniqueSerializer,
-        restDataSerializer
+        restDataSerializer,
+        techniqueCompiler
       )
     }
 

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder.css
@@ -1508,3 +1508,7 @@ label span.text-fit{
 .cursorPointer {
   cursor:pointer;
 }
+
+pre.command-output{
+  white-space: break-spaces;
+}

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateJsonTechniquesToYaml.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateJsonTechniquesToYaml.scala
@@ -128,6 +128,10 @@ class TestMigrateJsonTechniquesToYaml extends Specification with ContentMatchers
       // this should not be called because we force rudderc via compilation config, so here we failed loudly if exec
       throw new IllegalArgumentException(s"Test is calling fallback compiler for technique: ${technique.path}")
     }
+
+    override def getCompilationOutputFile(technique: EditorTechnique): File = null
+
+    override def getCompilationConfigFile(technique: EditorTechnique): File = null
   }
 
   val techniqueCompiler = new TechniqueCompilerWithFallback(


### PR DESCRIPTION
https://issues.rudder.io/issues/23357

The PR adds compilation output to technique api, output entry is defined if there is a valid compilation-output.yml file

it also add the display of it in technique editor, tab is displayed only if there is an output  

data are displayed within the tab if this the valus is not empty (no stdout in the screen, but stderr is displayed

Maybe we could add interpretation of Result code in a next PR (with a check if code is equal to 0, a cross for error return codes)

![Screenshot from 2023-08-30 01-27-13](https://github.com/Normation/rudder/assets/1238978/f764398f-5c0b-499f-9163-c38371c6f72f)
