### PR TITLE
Fixes #23335: Tables in Rudder UI are sorted alphabetically but should also follow a numerical sort

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/directivecompliance/sources/ComplianceUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/directivecompliance/sources/ComplianceUtils.elm
@@ -12,6 +12,7 @@ import String exposing (fromFloat)
 import Tuple exposing (first, second)
 import ApiCalls exposing (..)
 
+
 getValueCompliance : Maybe Float -> Float
 getValueCompliance f =
   case f of

--- a/webapp/sources/rudder/rudder-web/src/main/elm/directivecompliance/sources/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/directivecompliance/sources/ViewUtils.elm
@@ -14,6 +14,7 @@ import ApiCalls exposing (..)
 import ComplianceUtils exposing (..)
 import Json.Decode as Decode
 import Tuple3
+import NaturalOrdering as N exposing (compare)
 
 onCustomClick : msg -> Html.Attribute msg
 onCustomClick msg =
@@ -67,9 +68,9 @@ valueCompliance =
   ItemFun
     (\ _ _ _ -> [])
     (\_ i -> i)
-    [ ("Value", .value >> text, (\d1 d2 -> compare d1.value  d2.value))
-    , ("Messages", .reports >> List.map (\r -> Maybe.withDefault "" r.message) >> List.foldl (++) "\n"  >> text, (\d1 d2 -> compare d1.value d2.value) )
-    , ( "Status", .reports >> buildComplianceReport, (\d1 d2 -> compare d1.value d2.value))
+    [ ("Value", .value >> text, (\d1 d2 -> N.compare d1.value  d2.value))
+    , ("Messages", .reports >> List.map (\r -> Maybe.withDefault "" r.message) >> List.foldl (++) "\n"  >> text, (\d1 d2 -> N.compare d1.value d2.value) )
+    , ( "Status", .reports >> buildComplianceReport, (\d1 d2 -> Basics.compare d1.value d2.value))
     ]
     .value
     Nothing
@@ -102,8 +103,8 @@ byComponentCompliance subFun =
              List.map Right (List.sortWith sortFunction c.values)
     )
     (\_ i -> i)
-    [ ("Component", name >> text,  (\d1 d2 -> compare (name d1) (name d2)))
-    , ("Compliance", \i -> buildComplianceBar (compliance i), (\d1 d2 -> compare (name d1) (name d2)) )
+    [ ("Component", name >> text,  (\d1 d2 -> N.compare (name d1) (name d2)))
+    , ("Compliance", \i -> buildComplianceBar (compliance i), (\d1 d2 -> Basics.compare (name d1) (name d2)) )
     ]
     name
     (Just ( \x ->
@@ -130,8 +131,8 @@ byNodeCompliance mod =
         List.sortWith sortFunction item.rules
     )
     (\m i -> i)
-    [ ("Node", (\nId -> span[][ (badgePolicyMode mod.policyMode nId.policyMode), text nId.name, goToBtn (getNodeLink mod.contextPath nId.nodeId.value)]),  (\n1 n2 -> compare n1.name n2.name))
-    , ("Compliance", .complianceDetails >> buildComplianceBar,  (\n1 n2 -> compare n1.compliance n2.compliance))
+    [ ("Node", (\nId -> span[][ (badgePolicyMode mod.policyMode nId.policyMode), text nId.name, goToBtn (getNodeLink mod.contextPath nId.nodeId.value)]),  (\n1 n2 -> N.compare n1.name n2.name))
+    , ("Compliance", .complianceDetails >> buildComplianceBar,  (\n1 n2 -> Basics.compare n1.compliance n2.compliance))
     ]
     (.nodeId >> .value)
     (Just (\b -> showComplianceDetails rule b))
@@ -151,8 +152,8 @@ byRuleCompliance model subFun =
       List.sortWith sortFunction item.components
     )
     (\m i ->  i )
-    [ ("Rule", \i  -> span [] [ (badgePolicyMode model.policyMode (Maybe.map .policyMode model.directiveCompliance|> Maybe.withDefault "default")), text i.name , goToBtn (getRuleLink contextPath i.ruleId) ],  (\r1 r2 -> compare r1.name r2.name ))
-    , ("Compliance", \i -> buildComplianceBar  i.complianceDetails,  (\(r1) (r2) -> compare r1.compliance r2.compliance ))
+    [ ("Rule", \i  -> span [] [ (badgePolicyMode model.policyMode (Maybe.map .policyMode model.directiveCompliance|> Maybe.withDefault "default")), text i.name , goToBtn (getRuleLink contextPath i.ruleId) ],  (\r1 r2 -> N.compare r1.name r2.name ))
+    , ("Compliance", \i -> buildComplianceBar  i.complianceDetails,  (\(r1) (r2) -> Basics.compare r1.compliance r2.compliance ))
     ]
     (.ruleId >> .value)
     (Just (\b -> showComplianceDetails (byComponentCompliance subFun) b))
@@ -168,8 +169,8 @@ nodeValueCompliance mod =
         List.sortWith sortFunction item.values
     )
     (\_ i -> i)
-    [ ("Node", (\nId -> span[][text nId.name, goToBtn (getNodeLink mod.contextPath nId.nodeId.value)]),  (\d1 d2 -> compare d1.name d2.name))
-    , ("Compliance", .complianceDetails >> buildComplianceBar ,  (\d1 d2 -> compare d1.compliance d2.compliance))
+    [ ("Node", (\nId -> span[][text nId.name, goToBtn (getNodeLink mod.contextPath nId.nodeId.value)]),  (\d1 d2 -> N.compare d1.name d2.name))
+    , ("Compliance", .complianceDetails >> buildComplianceBar ,  (\d1 d2 -> Basics.compare d1.compliance d2.compliance))
     ]
     (.nodeId >> .value)
     (Just (\item -> showComplianceDetails valueCompliance item))

--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/elm.json
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/elm.json
@@ -27,6 +27,7 @@
             "elm-community/maybe-extra": "5.3.0",
             "elm-community/string-extra": "4.0.1",
             "jzxhuang/http-extras": "2.1.0",
+            "mcordova47/elm-natural-ordering": "1.1.0",
             "pablohirafuji/elm-markdown": "2.0.5",
             "rtfeldman/elm-iso8601-date-strings": "1.1.4",
             "toastal/either": "3.6.3",
@@ -40,6 +41,7 @@
             "elm/bytes": "1.0.8",
             "elm/url": "1.0.0",
             "elm-community/basics-extra": "4.1.0",
+            "kuon/elm-string-normalize": "1.0.5",
             "rtfeldman/elm-hex": "1.0.0",
             "the-sett/elm-pretty-printer": "2.2.3"
         }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewTechniqueList.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewTechniqueList.elm
@@ -8,7 +8,7 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import List.Extra
 import Maybe.Extra
-
+import NaturalOrdering as N exposing (compare)
 --
 -- This file deals with the technique list UI
 -- (ie the part in the left of the UI)
@@ -60,8 +60,8 @@ techniqueList : Model -> List Technique -> Html Msg
 techniqueList model techniques =
   let
     strFilter = String.toLower (String.trim model.techniqueFilter.filter)
-    filteredTechniques = List.sortBy .name (List.filter (\t -> (String.contains strFilter (String.toLower t.name)) || (String.contains strFilter (String.toLower t.id.value)) ) techniques)
-    filteredDrafts = List.sortBy (.technique >> .name) (List.filter (\t -> (String.contains strFilter (String.toLower t.technique.name)) && Maybe.Extra.isNothing t.origin ) (Dict.values model.drafts))
+    filteredTechniques = List.sortWith (\t1 t2 -> N.compare t1.name t2.name) (List.filter (\t -> (String.contains strFilter (String.toLower t.name)) || (String.contains strFilter (String.toLower t.id.value)) ) techniques)
+    filteredDrafts = List.sortWith (\t1 t2 -> N.compare t1.technique.name t2.technique.name) (List.filter (\t -> (String.contains strFilter (String.toLower t.technique.name)) && Maybe.Extra.isNothing t.origin ) (Dict.values model.drafts))
     techniqueItems =
       if List.isEmpty techniques && Dict.isEmpty model.drafts then
          div [ class "empty"] [text "The techniques list is empty."]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/View.elm
@@ -7,6 +7,7 @@ import Html.Events exposing (onClick, onInput)
 import List
 import List.Extra
 import String
+import NaturalOrdering as N exposing (compare)
 import ApiCalls exposing (..)
 import ViewRulesTable exposing (..)
 import ViewRuleDetails exposing (..)
@@ -50,21 +51,21 @@ view model =
       let
         missingCat = getSubElems item
           |> List.filter (\c -> c.id == missingCategoryId)
-          |> List.sortBy .name
+          |> List.sortWith (\c1 c2 -> N.compare c1.name c2.name)
           |> List.filterMap ruleTreeCategory
 
         categories = getSubElems item
           |> List.filter (\c -> c.id /= missingCategoryId)
-          |> List.sortBy .name
+          |> List.sortWith (\c1 c2 -> N.compare c1.name c2.name)
           |> List.filterMap ruleTreeCategory
 
         rules = item.elems
           |> List.filter (\r -> filterSearch model.ui.ruleFilters.treeFilters.filter (searchFieldRules r model))
           |> List.filter (\r -> filterTags r.tags model.ui.ruleFilters.treeFilters.tags)
-          |> List.sortBy .name
+          |> List.sortWith (\r1 r2 -> N.compare r1.name r2.name)
           |> List.map ruleTreeElem
 
-        childsList  = ul[class "jstree-children"] (List.concat [categories, rules, missingCat] )
+        childsList  = ul[class "jstree-children"] (List.concat [categories, rules, missingCat])
 
         mainMissingCat =
           if(item.id == missingCategoryId) then

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewTabContent.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewTabContent.elm
@@ -10,7 +10,7 @@ import List.Extra
 import List
 import Maybe.Extra
 import Set
-import NaturalOrdering exposing (compareOn)
+import NaturalOrdering as N exposing (compareOn, compare)
 import ComplianceUtils exposing (..)
 import Tuple3
 import ViewRepairedReports
@@ -393,7 +393,7 @@ directivesTab model details =
         let
           filteredDirectives = ruleDirectives
             |> List.filter (\d -> d.enabled && (filterSearch model.ui.directiveFilters.tableFilters.filter (searchFieldDirectives d)))
-            |> List.sortBy .displayName
+            |> List.sortWith (\d1 d2 -> N.compare d1.displayName d2.displayName)
           sortedDirectives   = case tableFilters.sortOrder of
             Asc  -> filteredDirectives
             Desc -> List.reverse filteredDirectives
@@ -471,7 +471,7 @@ directivesTab model details =
           let
             directivesList = item.directives
               |> List.filter (\d -> (filterSearch model.ui.directiveFilters.treeFilters.filter (searchFieldDirectives d)))
-              |> List.sortBy .displayName
+              |> List.sortWith (\d1 d2 -> N.compare d1.displayName d2.displayName)
               |> List.map  (\d ->
                 let
                   selectedClass = if (List.member d.id rule.directives) then " item-selected" else ""
@@ -527,7 +527,7 @@ directivesTab model details =
         directiveTreeCategory item =
           let
             categories = getSubElems item
-              |> List.sortBy .name
+              |> List.sortWith (\c1 c2 -> N.compare c1.name c2.name)
               |> List.filterMap directiveTreeCategory
             techniques = item.elems
               |> List.filterMap directiveTreeElem
@@ -817,11 +817,11 @@ groupsTab model details =
         groupTreeCategory item =
           let
             categories = getSubElems item
-              |> List.sortBy .name
+              |> List.sortWith (\c1 c2 -> N.compare c1.name c2.name)
               |> List.filterMap groupTreeCategory
             groups = item.elems
               |> List.filter (\g -> (filterSearch model.ui.groupFilters.treeFilters.filter (searchFieldGroups g)))
-              |> List.sortBy .name
+              |> List.sortWith (\g1 g2 -> N.compare g1.name g2.name)
               |> List.map groupTreeElem
             children  = categories ++ groups
           in

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewUtils.elm
@@ -13,6 +13,7 @@ import String exposing (fromFloat)
 import ComplianceUtils exposing (..)
 import Json.Decode as Decode
 import Tuple3
+import NaturalOrdering as N exposing (compare)
 
 onCustomClick : msg -> Html.Attribute msg
 onCustomClick msg =
@@ -129,9 +130,9 @@ valueCompliance =
   ItemFun
     (\ _ _ _ -> [])
     (\_ i -> i)
-    [ ("Value", .value >> text, (\d1 d2 -> compare d1.value  d2.value))
-    , ("Message", .message >>  text, (\d1 d2 -> compare d1.message d2.message) )
-    , ("Status", \r -> td [class "report-compliance"] [ div[] [ span[class r.status][text ( buildComplianceReport r) ] ] ] , (\d1 d2 -> compare (reportStatusOrder d1) (reportStatusOrder d2)))
+    [ ("Value", .value >> text, (\d1 d2 -> N.compare d1.value  d2.value))
+    , ("Message", .message >>  text, (\d1 d2 -> N.compare d1.message d2.message) )
+    , ("Status", \r -> td [class "report-compliance"] [ div[] [ span[class r.status][text ( buildComplianceReport r) ] ] ] , (\d1 d2 -> Basics.compare (reportStatusOrder d1) (reportStatusOrder d2)))
     ]
     .value
     Nothing
@@ -147,8 +148,8 @@ nodeValueCompliance mod =
         List.sortWith sortFunction item.values
     )
     (\_ i -> i)
-    [ ("Node", .nodeId >> (\nId -> span[][text (getNodeHostname mod nId.value), goToBtn (getNodeLink mod.contextPath nId.value)]),  (\d1 d2 -> compare d1.name d2.name))
-    , ("Compliance", .complianceDetails >> buildComplianceBar ,  (\d1 d2 -> compare d1.compliance d2.compliance))
+    [ ("Node", .nodeId >> (\nId -> span[][text (getNodeHostname mod nId.value), goToBtn (getNodeLink mod.contextPath nId.value)]),  (\d1 d2 -> N.compare d1.name d2.name))
+    , ("Compliance", .complianceDetails >> buildComplianceBar ,  (\d1 d2 -> Basics.compare d1.compliance d2.compliance))
     ]
     (.nodeId >> .value)
     (Just (\item -> showComplianceDetails valueCompliance item))
@@ -185,8 +186,8 @@ byComponentCompliance subFun =
              List.map Right (List.sortWith sortFunction c.values)
     )
     (\_ i -> i)
-    [ ("Component", name >> text,  (\d1 d2 -> compare (name d1) (name d2)))
-    , ("Compliance", \i -> buildComplianceBar (compliance i), (\d1 d2 -> compare (complianceValue d1) (complianceValue d2)) )
+    [ ("Component", name >> text,  (\d1 d2 -> N.compare (name d1) (name d2)))
+    , ("Compliance", \i -> buildComplianceBar (compliance i), (\d1 d2 -> Basics.compare (complianceValue d1) (complianceValue d2)) )
     ]
     name
     (Just ( \x ->
@@ -214,8 +215,8 @@ byDirectiveCompliance mod subFun =
       List.sortWith sortFunction item.components
     )
     (\m i -> (Maybe.withDefault (Directive i.directiveId i.name "" "" "" False False "" []) (Dict.get i.directiveId.value m.directives), i ))
-    [ ("Directive", \(d,_)  -> span [] [ badgePolicyMode globalPolicy d.policyMode, text d.displayName, buildTagsTree d.tags, goToBtn (getDirectiveLink contextPath d.id) ],  (\(_,d1) (_,d2) -> compare d1.name d2.name ))
-    , ("Compliance", \(_,i) -> buildComplianceBar  i.complianceDetails,  (\(_,d1) (_,d2) -> compare d1.compliance d2.compliance ))
+    [ ("Directive", \(d,_)  -> span [] [ badgePolicyMode globalPolicy d.policyMode, text d.displayName, buildTagsTree d.tags, goToBtn (getDirectiveLink contextPath d.id) ],  (\(_,d1) (_,d2) -> N.compare d1.name d2.name ))
+    , ("Compliance", \(_,i) -> buildComplianceBar  i.complianceDetails,  (\(_,d1) (_,d2) -> Basics.compare d1.compliance d2.compliance ))
     ]
     (.directiveId >> .value)
     (Just (\b -> showComplianceDetails (byComponentCompliance subFun) b))
@@ -234,8 +235,8 @@ byNodeCompliance mod =
         List.sortWith sortFunction item.directives
     )
     (\_ i -> i)
-    [ ("Node", .nodeId >> (\nId -> span[][text (getNodeHostname mod nId.value), goToBtn (getNodeLink mod.contextPath nId.value)]),  (\d1 d2 -> compare d1.name d2.name))
-    , ("Compliance", .complianceDetails >> buildComplianceBar,  (\d1 d2 -> compare d1.compliance d2.compliance))
+    [ ("Node", .nodeId >> (\nId -> span[][text (getNodeHostname mod nId.value), goToBtn (getNodeLink mod.contextPath nId.value)]),  (\d1 d2 -> N.compare d1.name d2.name))
+    , ("Compliance", .complianceDetails >> buildComplianceBar,  (\d1 d2 -> Basics.compare d1.compliance d2.compliance))
     ]
     (.nodeId >> .value)
     (Just (\b -> showComplianceDetails directive b))


### PR DESCRIPTION
https://issues.rudder.io/issues/23335
Whenever we want to compare the name or value of an object in string form, we want to use a natural sort so that decimals in string form are correctly sorted, like :
`["1.2", "1.1", "1.10"] => ["1.1", "1.2", "1.10"]`

To do that we use the compare function from [mcordova47/elm-natural-ordering package](https://package.elm-lang.org/packages/mcordova47/elm-natural-ordering/latest/).