### PR TITLE
Fixes #23381: Allow to edit yaml in editor

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
@@ -212,14 +212,22 @@ type alias TechniqueUiInfo =
   , nameState        : ValidationState TechniqueNameError
   , idState          : ValidationState TechniqueIdError
   , enableDragDrop   : Maybe CallId
+
+  }
+
+type alias TechniqueEditInfo =
+  {  value : String
+  ,  open : Bool
+  ,  result : Result String ()
   }
 
 type MethodCallTab = CallParameters | CallConditions | Result | CallReporting
 type MethodBlockTab = BlockConditions | BlockReporting | Children
 type MethodCallMode = Opened | Closed
 type Tab = General | Parameters | Resources | Output | None
-type Mode = Introduction | TechniqueDetails Technique TechniqueState TechniqueUiInfo
+type Mode = Introduction | TechniqueDetails Technique TechniqueState TechniqueUiInfo TechniqueEditInfo
 
+type CheckMode = Import String | EditYaml String | CheckJson Technique
 
 
 -- all events in the event loop
@@ -233,10 +241,12 @@ type Msg =
   | GetTechniqueResources  (Result (Http.Detailed.Error String) ( Http.Metadata, List Resource ))
   | GetCategories (Result (Http.Detailed.Error String)  ( Http.Metadata, TechniqueCategory ))
   | GetMethods   (Result (Http.Detailed.Error String) ( Http.Metadata, (Dict String Method) ))
-  | CheckTechnique (Result (Http.Detailed.Error String) ( Http.Metadata, Technique ))
+  | CheckOutJson CheckMode (Result (Http.Detailed.Error String) ( Http.Metadata, Technique ))
+  | CheckOutYaml CheckMode (Result (Http.Detailed.Error String) ( Http.Metadata, String ))
   | UIMethodAction CallId MethodCallUiInfo
   | UIBlockAction CallId MethodBlockUiInfo
   | RemoveMethod CallId
+  | UpdateEdition TechniqueEditInfo
   | CloneElem  MethodElem CallId
   | MethodCallParameterModified MethodCall ParameterId String
   | MethodCallModified MethodElem

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewMethodsList.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewMethodsList.elm
@@ -163,7 +163,7 @@ showMethodsCategories : Model -> (String, List  Method) -> Element Msg
 showMethodsCategories model (category, methods) =
   let
     addIndex = case model.mode of
-      TechniqueDetails t _ _ -> List.length t.elems
+      TechniqueDetails t _ _ _ -> List.length t.elems
       _ -> 0
     header = element "h5"
              |> addAttribute ( id category )
@@ -201,7 +201,7 @@ showMethod ui method mode dnd =
     attributes = class ("method method-elmt " ++ (if docOpen then "doc-opened" else ""))::  id method.id.value :: []
     methodUi =
       case mode of
-        TechniqueDetails _ _ techUiInfo ->
+        TechniqueDetails _ _ techUiInfo _ ->
           Maybe.withDefault (MethodCallUiInfo Closed CallParameters Unchanged) (Dict.get method.id.value techUiInfo.callsUI)
         _  -> (MethodCallUiInfo Closed CallParameters Unchanged)
   in

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueList.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueList.elm
@@ -153,12 +153,12 @@ draftsItem: Model -> Draft -> Html Msg
 draftsItem model draft =
   let
     activeClass = case model.mode of
-                    TechniqueDetails _ (Clone _ id) _ ->
+                    TechniqueDetails _ (Clone _ id) _ _ ->
                       if id.value == draft.id then
                          "jstree-clicked"
                       else
                         ""
-                    TechniqueDetails _ (Creation id) _ ->
+                    TechniqueDetails _ (Creation id) _ _ ->
                       if id.value == draft.id then
                          "jstree-clicked"
                       else
@@ -189,7 +189,7 @@ techniqueItem model technique =
     techniqueMethods = List.concatMap allMethodCalls technique.elems
     unknownMethods = (List.filter (\c -> Maybe.Extra.isNothing (Dict.get c.methodName.value model.methods)) techniqueMethods)
     activeClass = case model.mode of
-                    TechniqueDetails t (Edit _) _ ->
+                    TechniqueDetails t (Edit _) _ _ ->
                       if t.id == technique.id then
                          "jstree-clicked"
                       else


### PR DESCRIPTION
https://issues.rudder.io/issues/23381

This pr adds a way to display and edit a Technique yaml directly instead of using the editor UI

This feature is based on the check api that was added when adding yaml import, this api allow to check wether a technique is valid or not, it used to only accept yaml as input and responded a json.

I added a parameter to determine input and output types, (yaml or json) that allow to send a yaml and get back a json (will be used when we make some changes in our yaml and modify the technique in UI by getting back a valid json) 
But also to send a json and get a yaml back, so that we can send a json that represents what is currently displayed withtin the inventory and get back our  yaml representing what is displaed in the UI

I added a TechniqueEditInfo, which contains data related to yaml edition (is it displayed, what is the value, is it valid (not displayed yet))

Added a CheckMode type, that is used to handle how we will make a request to check API, how to handle the response and what to with it

There is three cases to handle:
  Importing a technique (make a call yaml -> Json, create a new technique in UI
 Get Json from yaml (Make a call yaml -> Json, update current technique)
 Get Yaml From Json (Make a Json-> Yaml, getting current technique yaml (not what is saved, but what is actually displayed) 

[Screencast from 2023-09-04 17-12-13.webm](https://github.com/Normation/rudder/assets/1238978/90833711-d7e7-4542-980d-4d538e3248cc)
