### PR TITLE
Fixes #23372: Add a way to set a message if "change audit logs" setting is enabled

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ApiCalls.elm
@@ -9,7 +9,7 @@ import Time.ZonedDateTime exposing (ZonedDateTime)
 import Url
 import Url.Builder exposing (QueryParameter, int, string)
 
-import ChangeRequest exposing (decodeGetChangeRequestSettings)
+import ChangeRequest exposing (changeRequestParameters, decodeGetChangeRequestSettings)
 
 --
 -- This files contains all API calls for the Rules UI
@@ -250,8 +250,8 @@ saveRuleDetails ruleDetails creation model =
       request
         { method  = method
         , headers = []
-        , url     = getUrl model url []
-        , body    = encodeRuleDetails ruleDetails model.ui.crSettings |> jsonBody
+        , url     = getUrl model url  (changeRequestParameters model.ui.crSettings)
+        , body    = encodeRuleDetails ruleDetails |> jsonBody
         , expect  = expectJson SaveRuleDetails decodeGetRuleDetails
         , timeout = Nothing
         , tracker = Nothing
@@ -267,8 +267,8 @@ saveDisableAction ruleDetails model =
       request
         { method  = "POST"
         , headers = []
-        , url     = getUrl model ["rules", ruleDetails.id.value ] []
-        , body    = encodeRuleDetails ruleDetails model.ui.crSettings |> jsonBody
+        , url     = getUrl model ["rules", ruleDetails.id.value ] (changeRequestParameters model.ui.crSettings)
+        , body    = encodeRuleDetails ruleDetails |> jsonBody
         , expect  = expectJson SaveDisableAction decodeGetRuleDetails
         , timeout = Nothing
         , tracker = Nothing

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ApiCalls.elm
@@ -9,6 +9,7 @@ import Time.ZonedDateTime exposing (ZonedDateTime)
 import Url
 import Url.Builder exposing (QueryParameter, int, string)
 
+import ChangeRequest exposing (decodeGetChangeRequestSettings)
 
 --
 -- This files contains all API calls for the Rules UI
@@ -93,6 +94,23 @@ getPolicyMode model =
         }
   in
     req
+
+getCrSettings : Model -> Cmd Msg
+getCrSettings model =
+  let
+    req =
+      request
+        { method  = "GET"
+        , headers = []
+        , url     = getUrl model [ "settings" ] []
+        , body    = emptyBody
+        , expect  = expectJson GetChangeRequestSettings decodeGetChangeRequestSettings
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+  in
+    req
+
 
 getGroupsTree : Model -> Cmd Msg
 getGroupsTree model =
@@ -233,7 +251,7 @@ saveRuleDetails ruleDetails creation model =
         { method  = method
         , headers = []
         , url     = getUrl model url []
-        , body    = encodeRuleDetails ruleDetails |> jsonBody
+        , body    = encodeRuleDetails ruleDetails model.ui.crSettings |> jsonBody
         , expect  = expectJson SaveRuleDetails decodeGetRuleDetails
         , timeout = Nothing
         , tracker = Nothing
@@ -244,12 +262,13 @@ saveRuleDetails ruleDetails creation model =
 saveDisableAction : Rule -> Model ->  Cmd Msg
 saveDisableAction ruleDetails model =
   let
+    changeAction = "Disable "
     req =
       request
         { method  = "POST"
         , headers = []
         , url     = getUrl model ["rules", ruleDetails.id.value ] []
-        , body    = encodeRuleDetails ruleDetails |> jsonBody
+        , body    = encodeRuleDetails ruleDetails model.ui.crSettings |> jsonBody
         , expect  = expectJson SaveDisableAction decodeGetRuleDetails
         , timeout = Nothing
         , tracker = Nothing

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ChangeRequest.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ChangeRequest.elm
@@ -1,0 +1,57 @@
+module ChangeRequest exposing (..)
+
+import Json.Encode exposing (..)
+import Json.Decode exposing (..)
+import Json.Decode.Pipeline exposing (..)
+import Json.Decode.Field exposing (..)
+
+--
+-- Module to handle change request settings
+--
+
+type alias ChangeRequestSettings =
+  { enableChangeMessage    : Bool
+  , mandatoryChangeMessage : Bool
+  , changeMessagePrompt    : String
+  , enableChangeRequest    : Bool
+  , changeRequestName      : String
+  , newMessagePrompt       : String
+  , displayMessagePrompt   : Bool
+  }
+
+decodeGetChangeRequestSettings : Decoder ChangeRequestSettings
+decodeGetChangeRequestSettings =
+  at ["data", "settings" ] decodeChangeRequestSettings
+
+decodeChangeRequestSettings : Decoder ChangeRequestSettings
+decodeChangeRequestSettings =
+  succeed ChangeRequestSettings
+    |> required "enable_change_message"    Json.Decode.bool
+    |> required "mandatory_change_message" Json.Decode.bool
+    |> required "change_message_prompt"    Json.Decode.string
+    |> required "enable_change_request"    Json.Decode.bool
+    |> hardcoded ""
+    |> hardcoded ""
+    |> hardcoded False
+
+encodeChangeRequestSettings: Maybe ChangeRequestSettings -> List (String, Json.Encode.Value)
+encodeChangeRequestSettings changeRequestSettings =
+  case changeRequestSettings of
+    Nothing -> []
+    Just settings ->
+      let
+        changeAuditParams =
+          if settings.enableChangeMessage then
+            [ ( "reason" , Json.Encode.string settings.newMessagePrompt ) ]
+          else
+            []
+
+        changeRequestParams =
+          if settings.enableChangeRequest then
+            [ ( "changeRequestName"        , Json.Encode.string settings.changeRequestName )
+            , ( "changeRequestDescription" , Json.Encode.string settings.newMessagePrompt  )
+            ]
+          else
+            []
+      in
+        List.append changeAuditParams changeRequestParams

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ChangeRequest.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ChangeRequest.elm
@@ -1,9 +1,8 @@
 module ChangeRequest exposing (..)
 
-import Json.Encode exposing (..)
 import Json.Decode exposing (..)
 import Json.Decode.Pipeline exposing (..)
-import Json.Decode.Field exposing (..)
+import Url.Builder
 
 --
 -- Module to handle change request settings
@@ -15,7 +14,7 @@ type alias ChangeRequestSettings =
   , changeMessagePrompt    : String
   , enableChangeRequest    : Bool
   , changeRequestName      : String
-  , newMessagePrompt       : String
+  , message                : String
   , displayMessagePrompt   : Bool
   }
 
@@ -34,22 +33,22 @@ decodeChangeRequestSettings =
     |> hardcoded ""
     |> hardcoded False
 
-encodeChangeRequestSettings: Maybe ChangeRequestSettings -> List (String, Json.Encode.Value)
-encodeChangeRequestSettings changeRequestSettings =
+changeRequestParameters: Maybe ChangeRequestSettings -> List Url.Builder.QueryParameter
+changeRequestParameters changeRequestSettings =
   case changeRequestSettings of
     Nothing -> []
     Just settings ->
       let
         changeAuditParams =
           if settings.enableChangeMessage then
-            [ ( "reason" , Json.Encode.string settings.newMessagePrompt ) ]
+            [ Url.Builder.string "reason" settings.message ]
           else
             []
 
         changeRequestParams =
           if settings.enableChangeRequest then
-            [ ( "changeRequestName"        , Json.Encode.string settings.changeRequestName )
-            , ( "changeRequestDescription" , Json.Encode.string settings.newMessagePrompt  )
+            [ Url.Builder.string  "changeRequestName" settings.changeRequestName
+            , Url.Builder.string "changeRequestDescription"  settings.message
             ]
           else
             []

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/DataTypes.elm
@@ -4,6 +4,7 @@ import Dict exposing (Dict)
 import Http exposing (Error)
 import Time.ZonedDateTime exposing (ZonedDateTime)
 
+import ChangeRequest exposing (ChangeRequestSettings)
 --
 -- All our data types
 --
@@ -22,7 +23,7 @@ type alias Tag =
   , value : String
   }
 
-type ModalState = NoModal | DeletionValidation Rule | DeactivationValidation Rule | DeletionValidationCat (Category Rule)
+type ModalState = NoModal | DeletionValidation Rule (Maybe ChangeRequestSettings) | DeactivationValidation Rule (Maybe ChangeRequestSettings) | DeletionValidationCat (Category Rule) | SaveAuditMsg Bool Rule (Maybe Rule) ChangeRequestSettings
 
 type RuleTarget = Composition RuleTarget RuleTarget | And (List RuleTarget) | Or (List RuleTarget) | NodeGroupId String | Special String | Node String
 
@@ -31,18 +32,18 @@ type alias DirectiveId = { value : String }
 type alias NodeId      = { value : String }
 
 type alias Rule =
-  { id                : RuleId
-  , name              : String
-  , categoryId        : String
-  , shortDescription  : String
-  , longDescription   : String
-  , enabled           : Bool
-  , isSystem          : Bool
-  , directives        : List DirectiveId
-  , targets           : List RuleTarget
-  , policyMode        : String
-  , status            : RuleStatus
-  , tags              : List Tag
+  { id               : RuleId
+  , name             : String
+  , categoryId       : String
+  , shortDescription : String
+  , longDescription  : String
+  , enabled          : Bool
+  , isSystem         : Bool
+  , directives       : List DirectiveId
+  , targets          : List RuleTarget
+  , policyMode       : String
+  , status           : RuleStatus
+  , tags             : List Tag
   }
 
 
@@ -276,6 +277,7 @@ type alias UI =
   , loadingRules     : Bool
   , isAllCatFold     : Bool
   , saving           : Bool
+  , crSettings       : Maybe ChangeRequestSettings
   }
 
 type alias  Changes =
@@ -316,6 +318,7 @@ type Msg
   | CallApi                  Bool (Model -> Cmd Msg)
   | GetRuleDetailsResult     (Result Error Rule)
   | GetPolicyModeResult      (Result Error String)
+  | GetChangeRequestSettings (Result Error ChangeRequestSettings)
   | GetCategoryDetailsResult (Result Error (Category Rule))
   | GetRulesComplianceResult (Result Error (List RuleComplianceGlobal))
   | GetRuleNodesDirectivesResult RuleId (Result Error RuleNodesDirectives)
@@ -336,6 +339,7 @@ type Msg
   | OpenDeletionPopup Rule
   | OpenDeletionPopupCat (Category Rule)
   | OpenDeactivationPopup Rule
+  | OpenSaveAuditMsgPopup Rule ChangeRequestSettings
   | ClosePopup Msg
   | Ignore
   | ToggleRow              String String
@@ -347,3 +351,4 @@ type Msg
   | FoldAllCategories      Filters
   | RefreshComplianceTable RuleId
   | RefreshReportsTable    RuleId
+  | UpdateCrSettings       ChangeRequestSettings

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/Init.elm
@@ -11,7 +11,7 @@ init flags =
 
     initCategory = Category "" "" "" (SubCategories []) []
     initFilters  = Filters (TableFilters Name Asc "" []) (TreeFilters "" [] (Tag "" "") [])
-    initUI       = UI initFilters initFilters initFilters NoModal flags.hasWriteRights True False False
+    initUI       = UI initFilters initFilters initFilters NoModal flags.hasWriteRights True False False Nothing
     initModel    = Model flags.contextPath Loading "" initCategory initCategory initCategory Dict.empty Dict.empty Dict.empty Dict.empty initUI
 
     listInitActions =
@@ -22,6 +22,7 @@ init flags =
       , getTechniquesTree  initModel
       , getRulesTree       initModel
       , getRuleChanges     initModel
+      , getCrSettings      initModel
       ]
 
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/JsonEncoder.elm
@@ -2,15 +2,14 @@ module  JsonEncoder exposing (..)
 
 import DataTypes exposing (..)
 import Json.Encode exposing (..)
-import ChangeRequest exposing (ChangeRequestSettings, encodeChangeRequestSettings)
+import ChangeRequest exposing (ChangeRequestSettings)
 
-encodeRuleDetails: Rule -> Maybe ChangeRequestSettings -> Value
-encodeRuleDetails ruleDetails crSettings =
+encodeRuleDetails: Rule -> Value
+encodeRuleDetails ruleDetails =
   let
     listTags = object(List.map (\t -> (t.key, string t.value)) ruleDetails.tags)
-    encodeCrSettings = encodeChangeRequestSettings crSettings
   in
-      object ( List.append
+   object
         [ ("id"               , string ruleDetails.id.value            )
         , ("displayName"      , string ruleDetails.name                )
         , ("category"         , string ruleDetails.categoryId          )
@@ -22,8 +21,6 @@ encodeRuleDetails ruleDetails crSettings =
         , ("targets"          , list encodeTargets ruleDetails.targets )
         , ("tags"             , list encodeTags ruleDetails.tags       )
         ]
-        encodeCrSettings
-      )
 
 encodeCategoryDetails: String -> (Category Rule) -> Value
 encodeCategoryDetails parentId category =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/JsonEncoder.elm
@@ -2,25 +2,28 @@ module  JsonEncoder exposing (..)
 
 import DataTypes exposing (..)
 import Json.Encode exposing (..)
+import ChangeRequest exposing (ChangeRequestSettings, encodeChangeRequestSettings)
 
-
-encodeRuleDetails: Rule -> Value
-encodeRuleDetails ruleDetails =
+encodeRuleDetails: Rule -> Maybe ChangeRequestSettings -> Value
+encodeRuleDetails ruleDetails crSettings =
   let
     listTags = object(List.map (\t -> (t.key, string t.value)) ruleDetails.tags)
+    encodeCrSettings = encodeChangeRequestSettings crSettings
   in
-      object [
-        ("id"               , string ruleDetails.id.value            )
-      , ("displayName"      , string ruleDetails.name                )
-      , ("category"         , string ruleDetails.categoryId          )
-      , ("shortDescription" , string ruleDetails.shortDescription    )
-      , ("longDescription"  , string ruleDetails.longDescription     )
-      , ("enabled"          , bool   ruleDetails.enabled             )
-      , ("system"           , bool   ruleDetails.isSystem            )
-      , ("directives"       , list string (List.map .value ruleDetails.directives) )
-      , ("targets"          , list encodeTargets ruleDetails.targets )
-      , ("tags"             , list encodeTags ruleDetails.tags       )
-      ]
+      object ( List.append
+        [ ("id"               , string ruleDetails.id.value            )
+        , ("displayName"      , string ruleDetails.name                )
+        , ("category"         , string ruleDetails.categoryId          )
+        , ("shortDescription" , string ruleDetails.shortDescription    )
+        , ("longDescription"  , string ruleDetails.longDescription     )
+        , ("enabled"          , bool   ruleDetails.enabled             )
+        , ("system"           , bool   ruleDetails.isSystem            )
+        , ("directives"       , list string (List.map .value ruleDetails.directives) )
+        , ("targets"          , list encodeTargets ruleDetails.targets )
+        , ("tags"             , list encodeTags ruleDetails.tags       )
+        ]
+        encodeCrSettings
+      )
 
 encodeCategoryDetails: String -> (Category Rule) -> Value
 encodeCategoryDetails parentId category =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/Rules.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/Rules.elm
@@ -310,7 +310,7 @@ update msg model =
             ui = details.ui
             modelUi = model.ui
             crSettings = case modelUi.crSettings of
-              Just cr -> Just { cr | newMessagePrompt = "" }
+              Just cr -> Just { cr | message = "" }
               Nothing -> modelUi.crSettings
             newModel = {model | mode = RuleForm {details | originRule = Just ruleDetails, rule = ruleDetails, ui = {ui | editDirectives = False, editGroups = False}}, ui = {modelUi | saving = False, crSettings = crSettings} }
           in
@@ -334,7 +334,7 @@ update msg model =
             txtDisable = if ruleDetails.enabled then "enabled" else "disabled"
             ui = model.ui
             crSettings = case ui.crSettings of
-              Just s  -> Just { s | newMessagePrompt = ""}
+              Just s  -> Just { s | message = ""}
               Nothing -> Nothing
           in
             ({model | mode = RuleForm {details | originRule = Just ruleDetails, rule = ruleDetails}, ui = { ui | crSettings = crSettings}}, (Cmd.batch [successNotification ("Rule '"++ ruleDetails.name ++"' successfully "++ txtDisable), (getRulesTree model)]))
@@ -368,7 +368,7 @@ update msg model =
             newMode  = if r.rule.id == ruleId then RuleTable else model.mode
             ui = model.ui
             crSettings = case ui.crSettings of
-              Just s  -> Just { s | newMessagePrompt = ""}
+              Just s  -> Just { s | message = ""}
               Nothing -> Nothing
 
             newModel = { model | mode = newMode, ui = { ui | crSettings = crSettings} }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/View.elm
@@ -146,7 +146,7 @@ view model =
             [ text "Change audit message"
             , text (if crSettings.mandatoryChangeMessage then " (required)" else "")
             ]
-            , textarea [class "form-control", placeholder crSettings.changeMessagePrompt, onInput (\s -> UpdateCrSettings {crSettings | newMessagePrompt = s}), value crSettings.newMessagePrompt ][]
+            , textarea [class "form-control", placeholder crSettings.changeMessagePrompt, onInput (\s -> UpdateCrSettings {crSettings | message = s}), value crSettings.message ][]
           ]
         ]
       else
@@ -159,7 +159,7 @@ view model =
           (auditForm, btnDisabled) = case crSettings of
             Just s  ->
               ( changeAuditForm s
-              , (s.mandatoryChangeMessage && String.isEmpty s.newMessagePrompt)
+              , (s.mandatoryChangeMessage && String.isEmpty s.message)
               )
             Nothing ->
               ( text ""
@@ -194,7 +194,7 @@ view model =
           (auditForm, btnDisabled) = case crSettings of
             Just s  ->
               ( changeAuditForm s
-              , (s.mandatoryChangeMessage && String.isEmpty s.newMessagePrompt)
+              , (s.mandatoryChangeMessage && String.isEmpty s.message)
               )
             Nothing ->
               ( text ""
@@ -272,7 +272,7 @@ view model =
                   [ i [ class "fa fa-arrow-left space-right" ] []
                   , text "Cancel "
                   ]
-                , button [ class "btn btn-primary", onClick (ClosePopup (CallApi True (saveRuleDetails rule (isNothing originRule)))), disabled (crSettings.mandatoryChangeMessage && String.isEmpty crSettings.newMessagePrompt) ]
+                , button [ class "btn btn-primary", onClick (ClosePopup (CallApi True (saveRuleDetails rule (isNothing originRule)))), disabled (crSettings.mandatoryChangeMessage && String.isEmpty crSettings.message) ]
                   ( if crSettings.enableChangeRequest then
                     [ text "Create change request "
                     , i [ class "fa fa-plus" ] []

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewRuleDetails.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewRuleDetails.elm
@@ -145,10 +145,21 @@ editionTemplate model details =
       Nothing -> 0
 
     saveAction =
-      if String.isEmpty (String.trim rule.name) then
-        Ignore
-      else
-        (CallApi True (saveRuleDetails rule (Maybe.Extra.isNothing details.originRule)))
+      let
+        defaultAction = checkAction (CallApi True (saveRuleDetails rule (Maybe.Extra.isNothing details.originRule)))
+        checkAction action =
+          if String.isEmpty (String.trim rule.name) then
+            Ignore
+          else
+            action
+      in
+        case model.ui.crSettings of
+          Just cr ->
+            if cr.enableChangeMessage || cr.enableChangeRequest then
+              checkAction (OpenSaveAuditMsgPopup rule cr)
+            else
+              defaultAction
+          Nothing -> defaultAction
 
   in
     div [class "main-container"]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewUtils.elm
@@ -5,7 +5,7 @@ import Dict exposing (Dict)
 import Either exposing (Either(..))
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import Html.Events exposing (onClick, custom)
+import Html.Events exposing (onClick, custom, onInput)
 import List.Extra
 import List
 import Maybe.Extra
@@ -14,6 +14,7 @@ import ComplianceUtils exposing (..)
 import Json.Decode as Decode
 import Tuple3
 import NaturalOrdering as N exposing (compare)
+import ChangeRequest exposing (ChangeRequestSettings)
 
 onCustomClick : msg -> Html.Attribute msg
 onCustomClick msg =

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.css
@@ -277,6 +277,20 @@
   font-size: 0.8em;
   margin-left: 6px;
 }
+
+.header-buttons .dropdown-menu.dropdown-message {
+  padding: 10px;
+  background-color: #F8F9FC;
+  border: 1px solid #D6DEEF;
+  width: 450px;
+  font-size: 14px;
+}
+.header-buttons .dropdown-menu.dropdown-message textarea + .btn {
+  margin-left: 0;
+  margin-top: 10px;
+  min-width: 60px;
+}
+
 /* === BADGES === */
 .badge.badge-grey {
   font-weight: 600 !important;


### PR DESCRIPTION
https://issues.rudder.io/issues/23372

Putting back the change audit message / change request popup after it was removed when the rules interface was rewritten in version 7.0.

We want to control this popup in Elm, so we're rewriting an Elm module to handle change requests and change audit messages, which we're integrating into the Rules application.

The interface is almost identical to what existed before, the aim here is not to improve the user experience but to restore this functionality which had disappeared.