### PR TITLE
Fixes #23406: Clean-up acceptation inventory

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/resources/reportsSchema.sql
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/reportsSchema.sql
@@ -423,7 +423,8 @@ CREATE INDEX event_state_index ON CampaignEvents ((state->>'value'));
  */
 
 CREATE TABLE NodeFacts (
-  nodeId           text PRIMARY KEY
-, acceptRefuseDate timestamp with time zone
-, acceptRefuseFact jsonb
+  nodeId            text PRIMARY KEY
+, acceptRefuseEvent jsonb  -- { 'date': 'rfc3339 timestamp', 'actor': 'actor name', 'statue'; 'accepted or refused' }
+, acceptRefuseFact  jsonb  -- the big node fact data structure
+, deleteEvent       jsonb  -- { 'date': 'rfc3339 timestamp', 'actor': 'actor name' }
 );

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
@@ -51,7 +51,6 @@ import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.domain.properties.PropertyProvider
 import com.normation.rudder.domain.servers.Srv
 import com.normation.rudder.reports._
-import com.normation.utils.DateFormaterService
 import com.normation.utils.ParseVersion
 import com.normation.utils.Version
 import com.softwaremill.quicklens._
@@ -783,12 +782,10 @@ object NodeFactSerialisation {
   // Method too large: com/normation/rudder/facts/nodes/NodeFactSerialisation$.<clinit> ()V
 
   import com.normation.inventory.domain.JsonSerializers.implicits.{decoderDateTime => _, encoderDateTime => _, _}
+  import com.normation.utils.DateFormaterService.json._
 
   object SimpleCodec {
 
-    implicit val encoderDateTime:     JsonEncoder[DateTime]       = JsonEncoder.string.contramap(DateFormaterService.serialize)
-    implicit val decoderDateTime:     JsonDecoder[DateTime]       =
-      JsonDecoder.string.mapOrFail(d => DateFormaterService.parseDate(d).left.map(_.fullMsg))
     implicit val codecOptionDateTime: JsonCodec[Option[DateTime]] = DeriveJsonCodec.gen
     implicit val codecNodeId:         JsonCodec[NodeId]           = JsonCodec.string.transform[NodeId](NodeId(_), _.value)
     implicit val codecJsonOsDetails:  JsonCodec[JsonOsDetails]    = DeriveJsonCodec.gen

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/InventoryHistoryJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/InventoryHistoryJdbcRepository.scala
@@ -21,59 +21,95 @@
 package com.normation.rudder.services.nodes.history.impl
 
 import com.normation.errors._
+import com.normation.eventlog.EventActor
+import com.normation.inventory.domain.AcceptedInventory
+import com.normation.inventory.domain.InventoryStatus
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.db.Doobie
 import com.normation.rudder.facts.nodes.NodeFact
 import com.normation.rudder.services.nodes.history.HistoryLog
 import com.normation.rudder.services.nodes.history.HistoryLogRepository
+import com.normation.utils.DateFormaterService
+import com.normation.utils.DateFormaterService.json._
 import doobie.Meta
 import doobie.Read
 import doobie.Write
 import doobie.implicits._
-import doobie.implicits.javasql._
 import doobie.implicits.toSqlInterpolator
 import org.joda.time.DateTime
 import zio.interop.catz._
+import zio.json._
 
 /*
+ * Store inventory information about a node for when it is accepted/refused.
+ * This service is a bit convoluted b/c it was adapted from a time where we used LDAP LDIF.
+ * But it proved to be generic enough to adapt to postgres. Still, the types are a be complicated.
+ *
  * Storage of NodeFact into `NodeFacts` table which is:
  *
- *   nodeId           text PRIMARY KEY
- * , acceptRefuseDate timestamp with time zone
- * , acceptRefuseFact jsonb
- *
+ *   nodeId            text PRIMARY KEY
+ * , acceptRefuseEvent jsonb // { "date": "timestamp with timezone", "actor": "string", "status": "accepted/deleted" }
+ * , acceptRefuseFact  jsonb
+ * , deleteEvent       jsonb // { "date": "timestamp with timezone", "actor": "string" }
  *
  */
 
-final case class FactLog(id: NodeId, datetime: DateTime, data: NodeFact) extends HistoryLog[NodeId, DateTime, NodeFact] {
+final case class FactLogData(fact: NodeFact, actor: EventActor, status: InventoryStatus)
+
+final case class FactLog(id: NodeId, datetime: DateTime, data: FactLogData) extends HistoryLog[NodeId, DateTime, FactLogData] {
   override val historyType: String   = "nodefact"
   override def version:     DateTime = datetime
 }
 
+final case class NodeAcceptRefuseEvent(date: DateTime, actor: String, status: String)
+object NodeAcceptRefuseEvent {
+  implicit val codecFactLogAcceptRefuseEvent: JsonCodec[NodeAcceptRefuseEvent] = DeriveJsonCodec.gen
+}
+final case class NodeDeleteEvent(date: DateTime, actor: String)
+object NodeDeleteEvent       {
+  implicit val codecNodeDeleteEvent: JsonCodec[NodeDeleteEvent] = DeriveJsonCodec.gen
+}
+
+trait InventoryHistoryDelete {
+  // if the node doesn't have an acceptation line, ignore
+  def saveDeleteEvent(id: NodeId, date: DateTime, actor: EventActor): IOResult[Unit]
+
+  def getDeleteEvent(id: NodeId): IOResult[Option[NodeDeleteEvent]]
+
+  // delete a node facts
+  def delete(id: NodeId): IOResult[Unit]
+
+  def deleteFactIfDeleteEventBefore(date: DateTime): IOResult[Vector[NodeId]]
+
+  def deleteFactCreatedBefore(date: DateTime): IOResult[Vector[NodeId]]
+}
+
 class InventoryHistoryJdbcRepository(
     doobie: Doobie
-) extends HistoryLogRepository[NodeId, DateTime, NodeFact, FactLog] {
+) extends HistoryLogRepository[NodeId, DateTime, FactLogData, FactLog] with InventoryHistoryDelete {
 
   import com.normation.rudder.db.Doobie.DateTimeMeta
   import com.normation.rudder.db.json.implicits._
   import com.normation.rudder.facts.nodes.NodeFactSerialisation._
   import doobie._
 
-  implicit val nodeFactMeta: Meta[NodeFact] = new Meta(pgDecoderGet, pgEncoderPut)
+  implicit val nodeAcceptRefuseEventaMeta: Meta[NodeAcceptRefuseEvent] = new Meta(pgDecoderGet, pgEncoderPut)
+  implicit val nodeDeleteEventaMeta:       Meta[NodeDeleteEvent]       = new Meta(pgDecoderGet, pgEncoderPut)
+  implicit val nodeFactMeta:               Meta[NodeFact]              = new Meta(pgDecoderGet, pgEncoderPut)
 
   implicit val lotWrite: Write[FactLog] = {
-    Write[(String, DateTime, NodeFact)].contramap {
+    Write[(String, NodeAcceptRefuseEvent, NodeFact)].contramap {
       case log =>
-        (log.id.value, log.version, log.data)
+        (log.id.value, NodeAcceptRefuseEvent(log.version, log.data.actor.name, log.data.status.name), log.data.fact)
     }
   }
 
   implicit val logRead: Read[FactLog] = {
-    Read[(String, DateTime, NodeFact)].map { d: (String, DateTime, NodeFact) =>
+    Read[(String, NodeAcceptRefuseEvent, NodeFact)].map { d: (String, NodeAcceptRefuseEvent, NodeFact) =>
       FactLog(
         NodeId(d._1),
-        d._2,
-        d._3
+        d._2.date,
+        FactLogData(d._3, EventActor(d._2.actor), InventoryStatus.apply(d._2.status).getOrElse(AcceptedInventory))
       )
     }
   }
@@ -82,9 +118,10 @@ class InventoryHistoryJdbcRepository(
    * Save an inventory and return the ID of the saved inventory, and
    * its version
    */
-  override def save(id: NodeId, data: NodeFact, datetime: DateTime = DateTime.now): IOResult[FactLog] = {
-    val q = sql"""insert into nodefacts (nodeId, acceptRefuseDate, acceptRefuseFact) values (${id}, ${datetime}, ${data})
-                  on conflict (nodeId) do update set (acceptRefuseDate, acceptRefuseFact) = (EXCLUDED.acceptRefuseDate, EXCLUDED.acceptRefuseFact)"""
+  override def save(id: NodeId, data: FactLogData, datetime: DateTime = DateTime.now): IOResult[FactLog] = {
+    val event = NodeAcceptRefuseEvent(datetime, data.actor.name, data.status.name)
+    val q     = sql"""insert into nodefacts (nodeId, acceptRefuseEvent, acceptRefuseFact) values (${id}, ${event}, ${data.fact})
+                  on conflict (nodeId) do update set (acceptRefuseEvent, acceptRefuseFact) = (EXCLUDED.acceptRefuseEvent, EXCLUDED.acceptRefuseFact)"""
 
     transactIOResult(s"error when update node '${id.value}' accept/refuse fact")(xa => q.update.run.transact(xa)).map(_ =>
       FactLog(id, datetime, data)
@@ -105,8 +142,10 @@ class InventoryHistoryJdbcRepository(
    * Get the record for the given UUID and version.
    */
   override def get(id: NodeId, version: DateTime): IOResult[FactLog] = {
-    val q =
-      sql"select nodeId, acceptRefuseDate, acceptRefuseFact from nodefacts where nodeId = ${id.value} and acceptRefuseDate = ${new java.sql.Timestamp(version.getMillis)}"
+    val q = {
+      sql"select nodeId, acceptRefuseEvent, acceptRefuseFact from nodefacts where nodeId = ${id.value} and acceptRefuseEvent ->>'date' = ${DateFormaterService
+          .serialize(version)}"
+    }
 
     transactIOResult(s"error when getting node '${id.value}' accept/refuse fact")(xa => q.query[FactLog].unique.transact(xa))
   }
@@ -119,11 +158,58 @@ class InventoryHistoryJdbcRepository(
    */
   override def versions(id: NodeId): IOResult[Seq[DateTime]] = {
     val q =
-      sql"select acceptRefuseDate from nodefacts where nodeId = ${id.value}"
+      sql"select acceptRefuseEvent ->> 'date' from nodefacts where nodeId = ${id.value}"
 
     transactIOResult(s"error when getting node '${id.value}' accept/refuse fact date")(xa =>
       q.query[DateTime].option.transact(xa)
     ).map(_.toSeq)
   }
 
+  // save and get delete event
+
+  // if the node doesn't have an acceptation line, ignore
+  def saveDeleteEvent(id: NodeId, date: DateTime, actor: EventActor): IOResult[Unit] = {
+    val event = NodeDeleteEvent(date, actor.name)
+    val q     = sql"""update nodefacts set deleteEvent = ${event} where nodeid=${id}"""
+    transactIOResult(s"error when setting delete event for node '${id.value}'")(xa => q.update.run.transact(xa)).unit
+  }
+
+  def getDeleteEvent(id: NodeId): IOResult[Option[NodeDeleteEvent]] = {
+    val q = sql"""select deleteEvent from nodefacts where id=${id}"""
+    transactIOResult(s"error when getting node '${id.value}' delete event")(xa => q.query[NodeDeleteEvent].option.transact(xa))
+  }
+
+  // delete a node facts
+  def delete(id: NodeId): IOResult[Unit] = {
+    val q = sql"""delete from nodefacts where id=${id}"""
+    transactIOResult(s"error when deleting acceptation information for node '${id.value}'")(xa => q.update.run.transact(xa)).unit
+  }
+
+  // delete all facts which have a delete event older then given data
+  def deleteFactIfDeleteEventBefore(date: DateTime): IOResult[Vector[NodeId]] = {
+    val q = sql"""delete from nodefacts
+           where to_timestamp(deleteEvent->>'date', 'YYYY-MM-DDTHH:MI:SS.MS') < ${date}
+           returning nodeid"""
+
+    transactIOResult(
+      s"error when deleting acceptation information for deleted nodes older than '${DateFormaterService.getDisplayDate(date)}'"
+    )(xa => {
+      q.query[NodeId].to[Vector].transact(xa)
+    })
+  }
+
+  // delete all facts which were created before given data (whatever node current status)
+  // Postgresql has a "returning id" clause, but it does not seems to be supported by JDBC. It
+  // would have been good for logs
+  def deleteFactCreatedBefore(date: DateTime): IOResult[Vector[NodeId]] = {
+    val q = sql"""delete from nodefacts
+         where to_timestamp(acceptRefuseEvent->>'date', 'YYYY-MM-DDTHH:MI:SS.MS') < ${date}
+         returning nodeid"""
+
+    transactIOResult(
+      s"error when deleting acceptation information for node facts older than '${DateFormaterService.getDisplayDate(date)}'"
+    )(xa => {
+      q.query[NodeId].to[Vector].transact(xa)
+    })
+  }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/servers/TestRemoveNodeService.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/servers/TestRemoveNodeService.scala
@@ -37,6 +37,7 @@
 package com.normation.rudder.services.servers
 
 import better.files._
+import com.normation.eventlog.EventActor
 import com.normation.inventory.domain.NodeId
 import com.normation.zio._
 import org.joda.time.DateTime
@@ -96,7 +97,7 @@ class TestRemoveNodeService extends Specification with AfterAll {
    */
   "Policy directory should be cleaned" >> {
     startFS.foreach(_.createDirectories())
-    cleanUp.run(NodeId("nodeXX"), DeleteMode.Erase, None, Set()).runNow
+    cleanUp.run(NodeId("nodeXX"), DeleteMode.Erase, None, Set(), EventActor("test")).runNow
     val files = varRudderShare.collectChildren(_ => true).toList.map(_.pathAsString)
 
     files must containTheSameElementsAs(expected.map(_.pathAsString))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/NodeHistoryViewer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/NodeHistoryViewer.scala
@@ -39,7 +39,6 @@ package com.normation.rudder.web.snippet.node
 
 import bootstrap.liftweb.RudderConfig
 import com.normation.box._
-import com.normation.inventory.domain.AcceptedInventory
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.web.model.JsNodeId
 import com.normation.rudder.web.services.DisplayNode
@@ -80,8 +79,8 @@ class NodeHistoryViewer extends StatefulSnippet {
             case Empty            => <div class="error">No history was retrieved for the chosen date</div>
             case Full(sm)         =>
               <div id={hid}>{
-                DisplayNode.showPannedContent(None, sm.data.toFullInventory, AcceptedInventory, "hist") ++
-                Script(DisplayNode.jsInit(sm.id, sm.data.toFullInventory.node.softwareIds, "hist"))
+                DisplayNode.showPannedContent(None, sm.data.fact.toFullInventory, sm.data.status, "hist") ++
+                Script(DisplayNode.jsInit(sm.id, sm.data.fact.toFullInventory.node.softwareIds, "hist"))
               }</div>
           }
         }
@@ -121,8 +120,8 @@ class NodeHistoryViewer extends StatefulSnippet {
       case Failure(m, _, _) => Alert("Error while trying to display node history. Error message:" + m)
       case Empty            => Alert("No history was retrieved for the chosen date")
       case Full(sm)         =>
-        SetHtml(hid, DisplayNode.showPannedContent(None, sm.data.toFullInventory, AcceptedInventory, "hist")) &
-        DisplayNode.jsInit(sm.id, sm.data.toFullInventory.node.softwareIds, "hist")
+        SetHtml(hid, DisplayNode.showPannedContent(None, sm.data.fact.toFullInventory, sm.data.status, "hist")) &
+        DisplayNode.jsInit(sm.id, sm.data.fact.toFullInventory.node.softwareIds, "hist")
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/PendingHistoryGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/PendingHistoryGrid.scala
@@ -41,7 +41,6 @@ import bootstrap.liftweb.RudderConfig
 import com.normation.box._
 import com.normation.eventlog._
 import com.normation.inventory.domain.NodeId
-import com.normation.inventory.domain.RemovedInventory
 import com.normation.rudder.domain.eventlog._
 import com.normation.rudder.domain.eventlog.DeleteNodeEventLog
 import com.normation.rudder.web.services.DisplayNode
@@ -230,9 +229,9 @@ object PendingHistoryGrid extends Loggable {
                displayIfDeleted(id, version, deletedNodes)
              else
                NodeSeq.Empty) ++
-            DisplayNode.showPannedContent(None, sm.data.toFullInventory, RemovedInventory, "hist")
+            DisplayNode.showPannedContent(None, sm.data.fact.toFullInventory, sm.data.status, "hist")
           ) &
-          DisplayNode.jsInit(sm.id, sm.data.toFullInventory.node.softwareIds, "hist")
+          DisplayNode.jsInit(sm.id, sm.data.fact.toFullInventory.node.softwareIds, "hist")
       }
     }
   }

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/DateFormaterService.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/DateFormaterService.scala
@@ -48,6 +48,7 @@ import org.joda.time.format.DateTimeFormatterBuilder
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.format.PeriodFormatterBuilder
 import scala.util.control.NonFatal
+import zio.json._
 
 object DateFormaterService {
 
@@ -138,4 +139,11 @@ object DateFormaterService {
     .appendFractionOfSecond(3, 9)
     .toFormatter()
 
+  object json {
+    implicit val encoderDateTime: JsonEncoder[DateTime] = JsonEncoder.string.contramap(DateFormaterService.serialize)
+    implicit val decoderDateTime: JsonDecoder[DateTime] =
+      JsonDecoder.string.mapOrFail(d => DateFormaterService.parseDate(d).left.map(_.fullMsg))
+
+    implicit val codecDateTime: JsonCodec[DateTime] = new JsonCodec[DateTime](encoderDateTime, decoderDateTime)
+  }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/23406

- create a json codec for `DateTime` in `DateFormaterService` so that it's available everywhere (`zio.json` is available in `utils`)
- we had a problem with log handler for sql statements, it has also a dedicated bug: https://github.com/Normation/rudder/pull/5037
- Until now, we were relying on `eventlog` to know who/when accepted/refused/deleted a node, which can be quite costly for deletion. We want to store these information in the `NodeFact` table so that it is self contained for clean-up. The data will be cleaned-up with the node inventory expiration time. There is duplication, but for immutable log data, and it's rather small (date, actor). 
-  we want to use the same structure for deletion and for accept / refuse => this first commit is just to change format for accept/refuse and handle sql table migration at boot.
- there is two configurable duration for clean-up: 
    - `rudder.inventories.pendingChoiceHistoryCleanupLatency.deletedNode` is the inteval we keep the inventory log for a refused/deleted node (default to 30 days ; 0 means immediately)
    - `rudder.inventories.pendingChoiceHistoryCleanupLatency.acceptedNode` is the interval we keep the inventory log for an accepted (non deleted) node (default 0 mean "as long as node is not deleted")
- to avoid yet another daily cron for cleaning things, I added the clean-up logic to `PurgeOldInventoryFiles` which a new name: `PurgeOldInventoryData`
- I have the SQL for the new table in three places, it really doesn't seems optimal, but I don't know how to reduce that. We will need to carefully check they are the same. 