### PR TITLE
Fixes #23184: Add a placeholder description for groups page like for techniques and directives

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
@@ -42,8 +42,14 @@
       </div>
   </div>
 
-  <div class="template-main" id="ajaxItemContainer" style="display:none;">
-      <span data-lift="node.Groups.initRightPanel"></span>
+  <div class="template-main" id="ajaxItemContainer">
+    <div class="jumbotron">
+      <h1>Groups</h1>
+      <p>A group is query over inventory data that defines a set of nodes, on which specific policies can then be applied.</p>
+      <p>Group categories are just there to visually organize groups and have no effect on the content of the groups or applied configuration.</p>
+      <p>There is a set of pre-defined groups (called system groups), that covers Rudder-related classification.</p>
+    </div>
+    <div data-lift="node.Groups.initRightPanel"></div>
   </div>
 
 </div>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
@@ -45,7 +45,7 @@
   <div class="template-main" id="ajaxItemContainer">
     <div class="jumbotron">
       <h1>Groups</h1>
-      <p>A group is query over inventory data that defines a set of nodes, on which specific policies can then be applied.</p>
+      <p>A group is based on a query over inventory data that defines a set of nodes, on which specific policies can then be applied.</p>
       <p>Group categories are just there to visually organize groups and have no effect on the content of the groups or applied configuration.</p>
       <p>There is a set of pre-defined groups (called system groups), that covers Rudder-related classification.</p>
     </div>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
@@ -46,7 +46,7 @@
     <div class="jumbotron">
       <h1>Groups</h1>
       <p>A group is based on a query over inventory data that defines a set of nodes, on which specific policies can then be applied.</p>
-      <p>Group categories are just there to visually organize groups and have no effect on the content of the groups or applied configuration.</p>
+      <p>Group categories are there to visually organize groups, and have no effect on the content of the groups or the applied configuration.</p>
       <p>There is a set of pre-defined groups (called system groups), that covers Rudder-related classification.</p>
     </div>
     <div data-lift="node.Groups.initRightPanel"></div>


### PR DESCRIPTION
https://issues.rudder.io/issues/23184

Added a jumbotron to match the technique and directive pages.

The text inside may need to be adjusted

![groups-jumbotron](https://github.com/Normation/rudder/assets/9928447/415d71e7-f6f5-4344-815a-d4cc54df0b8a)
