### PR TITLE
Fixes #23424: Make writing node state to fact repos optionnal

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
@@ -136,6 +136,11 @@ trait SerializeFacts[A, B] {
 
 }
 
+object NoopNodeFactRepository extends NodeFactRepository {
+  override def persist(nodeInfo: NodeInfo, inventory: FullInventory, software: Seq[Software]): IOResult[Unit] = ZIO.unit
+  override def changeStatus(nodeId: NodeId, status: InventoryStatus):                          IOResult[Unit] = ZIO.unit
+}
+
 /*
  * We have only one git for all fact repositories. This is the one managing semaphore, init, etc.
  * All fact repositories will be a subfolder on it:

--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -438,11 +438,15 @@ rudder.git.gc=0 42 3 * * ?
 rudder.dir.gitRootFactRepo=/var/rudder/fact-repository
 
 #
-# By default, Rudder won"t make a commit for each inventory and
-# changes in node and it will only keep a non historized JSON
-# serialisation of the current state of the node. You can make
-# Rudder historize node changes with that option (boolean).
-#
+# By default, Rudder won"t save anything about node on file
+# system. You can enable writing a JSON serialization of the
+# in node fact directory (/var/rudder/fact-repository/nodes) with
+# the following property set to true:
+rudder.facts.repo.writeNodeState=false
+
+# In addition to previous property, you can enable historization of
+# all node change in the fact-repository git by setting the following
+# property to true:
 rudder.facts.repo.historizeNodeChange=false
 
 ###############################

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -114,6 +114,8 @@ import com.normation.rudder.domain.logger.NodeConfigurationLoggerImpl
 import com.normation.rudder.domain.logger.ScheduledJobLoggerPure
 import com.normation.rudder.domain.queries._
 import com.normation.rudder.facts.nodes.GitNodeFactRepository
+import com.normation.rudder.facts.nodes.NodeFactRepository
+import com.normation.rudder.facts.nodes.NoopNodeFactRepository
 import com.normation.rudder.git.GitRepositoryProviderImpl
 import com.normation.rudder.git.GitRevisionProvider
 import com.normation.rudder.inventory.DefaultProcessInventoryService
@@ -566,21 +568,30 @@ object RudderConfig extends Loggable {
    * Root directory for git config-repo et fact-repo.
    * We should homogeneize naming here, ie s/rudder.dir.gitRoot/rudder.dir.gitRootConfigRepo/
    */
-  val RUDDER_GIT_ROOT_CONFIG_REPO                  = config.getString("rudder.dir.gitRoot")
-  val RUDDER_GIT_ROOT_FACT_REPO                    = {
+  val RUDDER_GIT_ROOT_CONFIG_REPO = config.getString("rudder.dir.gitRoot")
+  val RUDDER_GIT_ROOT_FACT_REPO   = {
     try {
       config.getString("rudder.dir.gitRootFactRepo")
     } catch {
       case ex: Exception => "/var/rudder/fact-repository"
     }
   }
-  val RUDDER_GIT_FACT_COMMIT_NODES                 = {
+
+  val RUDDER_GIT_FACT_WRITE_NODES  = {
+    try {
+      config.getBoolean("rudder.facts.repo.writeNodeState")
+    } catch {
+      case ex: Exception => false
+    }
+  }
+  val RUDDER_GIT_FACT_COMMIT_NODES = {
     try {
       config.getBoolean("rudder.facts.repo.historizeNodeChange")
     } catch {
       case ex: Exception => false
     }
   }
+
   val RUDDER_DIR_TECHNIQUES                        = RUDDER_GIT_ROOT_CONFIG_REPO + "/techniques"
   val RUDDER_BATCH_DYNGROUP_UPDATEINTERVAL         = config.getInt("rudder.batch.dyngroup.updateInterval") // 60 //one hour
   val RUDDER_BATCH_TECHNIQUELIBRARY_UPDATEINTERVAL =
@@ -1579,8 +1590,11 @@ object RudderConfig extends Loggable {
     .runOrDie(err => new RuntimeException(s"Error when initializing git configuration repository: " + err.fullMsg))
   private[this] lazy val gitFactRepoGC = new GitGC(gitFactRepo, RUDDER_GIT_GC)
   gitFactRepoGC.start()
-  lazy val factRepo                    = new GitNodeFactRepository(gitFactRepo, RUDDER_GROUP_OWNER_CONFIG_REPO, RUDDER_GIT_FACT_COMMIT_NODES)
-  factRepo.checkInit().runOrDie(err => new RuntimeException(s"Error when checking fact repository init: " + err.fullMsg))
+  lazy val factRepo: NodeFactRepository = if (RUDDER_GIT_FACT_WRITE_NODES) {
+    val r = new GitNodeFactRepository(gitFactRepo, RUDDER_GROUP_OWNER_CONFIG_REPO, RUDDER_GIT_FACT_COMMIT_NODES)
+    r.checkInit().runOrDie(err => new RuntimeException(s"Error when checking fact repository init: " + err.fullMsg))
+    r
+  } else NoopNodeFactRepository
 
   lazy val ldifInventoryLogger = new DefaultLDIFInventoryLogger(LDIF_TRACELOG_ROOT_DIR)
   lazy val inventorySaver      = new DefaultInventorySaver(


### PR DESCRIPTION
https://issues.rudder.io/issues/23424

Add a new rudder config property, `rudder.facts.repo.writeNodeState`, that when true totally disable node fact-repos (replaced by a no-op implementation). The property is false by default (in new install and migration, too).