### PR TITLE
Fixes #8166: Add filters on compliance tables to hide some kind of compliance

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/JsonEncoder.elm
@@ -6,7 +6,6 @@ import Json.Decode exposing (decodeValue, decodeString)
 import NodeProperties.DataTypes exposing (..)
 import NodeProperties.JsonDecoder exposing (..)
 
-import Debug as D
 
 encodeProperty : Model -> List EditProperty -> String -> Json.Encode.Value
 encodeProperty model properties action =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
@@ -17,7 +17,6 @@ import Rules.Init exposing (init)
 import Rules.View exposing (view)
 import Rules.ViewUtils exposing (..)
 
-
 -- PORTS / SUBSCRIPTIONS
 port successNotification : String -> Cmd msg
 port errorNotification   : String -> Cmd msg
@@ -215,8 +214,6 @@ update msg model =
               (model, Cmd.none)
         Err err ->
           processApiError ("Getting compliance details of Rule "++ id.value) err model
-
-
 
     GetRepairedReportsResult id start end res ->
       case res of

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
@@ -17,7 +17,6 @@ type TabMenu
   | TechnicalLogs
   | Rules
 
-
 type alias Tag =
   { key   : String
   , value : String
@@ -46,7 +45,6 @@ type alias Rule =
   , tags             : List Tag
   }
 
-
 type alias Directive =
   { id               : DirectiveId
   , displayName      : String
@@ -57,7 +55,7 @@ type alias Directive =
   , system           : Bool
   , policyMode       : String
   , tags             : List Tag
- }
+  }
 
 type alias Technique =
   { name       : String
@@ -160,12 +158,11 @@ type alias DirectiveCompliance value =
 
 type ComponentCompliance value = Block (BlockCompliance value) | Value (ComponentValueCompliance value)
 type alias BlockCompliance value =
-    { component         : String
-    , compliance        : Float
-    , complianceDetails : ComplianceDetails
-    , components        : List (ComponentCompliance value)
-    }
-
+  { component         : String
+  , compliance        : Float
+  , complianceDetails : ComplianceDetails
+  , components        : List (ComponentCompliance value)
+  }
 
 type alias ComponentValueCompliance value =
   { component         : String
@@ -185,7 +182,7 @@ type alias NodeValueCompliance =
   }
 
 type alias  ValueLine =
-  {  value   : String
+  { value   : String
   , message : String
   , status  : String
   }
@@ -250,10 +247,11 @@ type SortBy
 
 
 type alias TableFilters =
-  { sortBy    : SortBy
-  , sortOrder : SortOrder
-  , filter    : String
-  , unfolded  : List String
+  { sortBy     : SortBy
+  , sortOrder  : SortOrder
+  , filter     : String
+  , unfolded   : List String
+  , compliance : ComplianceFilters
   }
 
 type alias TreeFilters =
@@ -266,6 +264,12 @@ type alias TreeFilters =
 type alias Filters =
   { tableFilters : TableFilters
   , treeFilters  : TreeFilters
+  }
+
+type alias ComplianceFilters =
+  { showComplianceFilters : Bool
+  , showOnlyStatus        : Bool
+  , selectedStatus        : List String
   }
 
 type alias UI =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/Init.elm
@@ -6,13 +6,11 @@ import Rules.ApiCalls exposing (..)
 import Rules.DataTypes exposing (..)
 
 
--- PORTS
 init : { contextPath : String, hasWriteRights : Bool } -> ( Model, Cmd Msg )
 init flags =
   let
-
     initCategory = Category "" "" "" (SubCategories []) []
-    initFilters  = Filters (TableFilters Name Asc "" []) (TreeFilters "" [] (Tag "" "") [])
+    initFilters  = Filters (TableFilters Name Asc "" [] (ComplianceFilters False False [])) (TreeFilters "" [] (Tag "" "") [])
     initUI       = UI initFilters initFilters initFilters NoModal flags.hasWriteRights True False False Nothing
     initModel    = Model flags.contextPath Loading "" initCategory initCategory initCategory Dict.empty Dict.empty Dict.empty Dict.empty initUI
 
@@ -26,7 +24,6 @@ init flags =
       , getRuleChanges     initModel
       , getCrSettings      initModel
       ]
-
 
   in
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRulesTable.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRulesTable.elm
@@ -83,7 +83,7 @@ buildRulesTable model rules =
         compliance   =
           case getRuleCompliance model r.id of
             Just co ->
-              buildComplianceBar co.complianceDetails
+              buildComplianceBar (ComplianceFilters False False []) co.complianceDetails
             Nothing -> text "No report"
 
         changes = text (String.fromFloat (countRecentChanges r.id model.changes))

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.css
@@ -636,3 +636,25 @@ td.greyBackground, th.greyBackground {
 .pagination > li > a, .pagination > li > span {
   padding: 4px 8px;
 }
+
+/* HEADER */
+.rudder-template .table-header.extra-filters{
+  flex-direction: column;
+}
+.rudder-template .table-header .main-filters{
+  display: flex;
+  width: 100%;
+}
+.rudder-template .table-header .more-filters{
+  margin-top: 15px;
+}
+.rudder-template .table-header .more-filters .btn-group + .btn-group{
+  margin-left: 15px;
+}
+.rudder-template .table-header .main-filters .form-control + .btn,
+.rudder-template .table-header .main-filters .btn + .btn{
+  margin-left: 15px;
+}
+.rudder-template .table-header .btn-refresh{
+  margin-left: auto !important;
+}

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.css
@@ -3100,6 +3100,45 @@ table a > i.fa-pencil:hover{
   margin-bottom: 0;
 }
 
+/* DATATABLE FILTERS */
+.btn.btn-dropdown-compliance{
+  min-width: 250px;
+  display: inline-flex;
+  justify-content: start;
+  align-items: baseline;
+}
+.btn.btn-dropdown-compliance > i{
+  margin-left: auto;
+}
+.dropdown-menu.dropdown-compliance{
+  min-width: 250px;
+  padding-top: 0;
+  border-top: 1px solid #D6DEEF;
+  height: 400px;
+  overflow: auto;
+}
+ul.dropdown-menu.dropdown-compliance li {
+  border-bottom: 1px solid #D6DEEF;
+  display: flex;
+  width: 100%;
+  align-items: baseline;
+  cursor: pointer;
+}
+ul.dropdown-menu.dropdown-compliance li > span:first-child{
+  padding: 4px 4px 4px 10px;
+}
+ul.dropdown-menu.dropdown-compliance li > span:last-child {
+  padding: 4px 10px 4px 4px;
+}
+ul.dropdown-menu.dropdown-compliance li:not(.compliance-group) > span:first-child{
+  padding-left: 28px;
+}
+ul.dropdown-menu.dropdown-compliance > li {
+  background-color: #F8F9FC;
+}
+ul.dropdown-menu.dropdown-compliance > li > span:last-child {
+  font-weight: bold;
+}
 /* KEYFRAMES */
 @-webkit-keyframes text-radio-on {
   0%   {color: #646464;}

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-progress-bar.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-progress-bar.css
@@ -63,22 +63,28 @@
   border-top-right-radius: 4px;
   border-bottom-right-radius: 4px;
 }
-.content-wrapper .progress-bar-reportsdisabled {
+.content-wrapper .progress-bar-reportsdisabled,
+.compliance-badge.disabled {
   background-color: #72829D;
 }
-.content-wrapper .progress-bar-success {
+.content-wrapper .progress-bar-success,
+.compliance-badge.success {
   background-color: #13BEB7;
 }
-.content-wrapper .progress-bar-error {
+.content-wrapper .progress-bar-error,
+.compliance-badge.error {
   background-color: #DA291C
 }
-.content-wrapper .progress-bar-pending {
+.content-wrapper .progress-bar-pending,
+.compliance-badge.pending {
   background-color: #14C3DD;
 }
-.content-wrapper .progress-bar-no-report {
+.content-wrapper .progress-bar-no-report,
+.compliance-badge.no-report {
   background-color: #B1BBCB;
 }
-.content-wrapper .progress-bar-unknown {
+.content-wrapper .progress-bar-unknown,
+.compliance-badge.unexpected {
   background-color: #DA291C;
 }
 .content-wrapper .progress-bar-missing {
@@ -87,7 +93,8 @@
 .content-wrapper .progress-bar-audit-compliant {
   background-color: #13BEB7;
 }
-.content-wrapper .progress-bar-audit-noncompliant {
+.content-wrapper .progress-bar-audit-noncompliant,
+.compliance-badge.non-compliant {
   background-color: #EF9600;
 }
 .content-wrapper .progress-bar-audit-notapplicable {
@@ -97,3 +104,40 @@
   background-color: #DA291C
 }
 
+/* SMALL COMPLIANCE BADGE */
+.compliance-badge {
+  padding: 3px 8px;
+  display: inline-flex;
+  align-items: baseline;
+  border-radius: 10px;
+  margin-right: 10px;
+  font-size: .9em;
+  color: #fff;
+  margin-bottom: 10px;
+  font-weight: bold;
+  cursor: pointer;
+}
+.compliance-badge > .fa{
+  margin-left: 4px;
+}
+.compliance-badge.badge-sm {
+  padding: 0;
+  height: 12px;
+  width: 12px;
+  border-radius: 50%;
+  margin-right: 6px;
+  margin-bottom: 0;
+}
+
+.compliance-badge.unexpected,
+.compliance-badge.pending{
+  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+}
+.compliance-badge.badge-sm.unexpected,
+.compliance-badge.badge-sm.pending{
+  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.5) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.5) 50%, rgba(255, 255, 255, 0.5) 75%, transparent 75%, transparent);
+  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.5) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.5) 50%, rgba(255, 255, 255, 0.5) 75%, transparent 75%, transparent);
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.5) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.5) 50%, rgba(255, 255, 255, 0.5) 75%, transparent 75%, transparent);
+}

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.css
@@ -982,6 +982,7 @@
   border-top: 2px solid #d6deef;
   justify-content: space-between;
 }
+
 .list-container .list-heading{
   display: flex;
   justify-content: space-between;
@@ -998,6 +999,7 @@
 .tab-table-content .table-header .form-control{
   max-width: 420px;
 }
+
 .rudder-template .main-details .table-container{
   margin: 0 -15px -10px -15px;
 }

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/ruleManagement.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/ruleManagement.html
@@ -56,7 +56,6 @@
         }
       }
 
-
       // Initialize tooltips
       app.ports.initTooltips.subscribe(function(msg) {
         setTimeout(function(){
@@ -71,7 +70,6 @@
           event.preventDefault();
         });
       }, 950);
-
     });
   </script>
 


### PR DESCRIPTION
https://issues.rudder.io/issues/8166

Addition of a new filter based on compliance status. Users can now decide which statuses to hide or show.
 
![compliance-filter-1](https://github.com/Normation/rudder/assets/9928447/fb354d34-d106-4699-8ddc-e0ab28827c51)
![compliance-filter-2](https://github.com/Normation/rudder/assets/9928447/90b73916-3b94-40f6-9fcf-85cb97358a50)
