### PR TITLE
Fixes #23443: After creating a change request, give the user a redirection link to its details

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/DataTypes.elm
@@ -44,6 +44,7 @@ type alias Rule =
   , policyMode       : String
   , status           : RuleStatus
   , tags             : List Tag
+  , changeRequestId  : Maybe String
   }
 
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/JsonDecoder.elm
@@ -85,6 +85,7 @@ decodeRule =
     |> required "policyMode"       string
     |> required "status"           decodeStatus
     |> required "tags"            (list (keyValuePairs string) |> andThen toTags)
+    |> optional "changeRequestId" (map Just string) Nothing
 
 toTags : List (List ( String, String )) -> Decoder (List Tag)
 toTags lst =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/View.elm
@@ -144,7 +144,7 @@ view model =
         , div[class "form-group"]
           [ label[]
             [ text "Change audit message"
-            , text (if crSettings.mandatoryChangeMessage then " (required)" else "")
+            , text (if crSettings.enableChangeMessage && crSettings.mandatoryChangeMessage then " (required)" else "")
             ]
             , textarea [class "form-control", placeholder crSettings.changeMessagePrompt, onInput (\s -> UpdateCrSettings {crSettings | message = s}), value crSettings.message ][]
           ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewCategoryDetails.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewCategoryDetails.elm
@@ -110,7 +110,7 @@ editionTemplateCat model details =
                 [ button [ class "btn btn-danger" , onClick (OpenDeletionPopupCat category)]
                   [ text "Delete", i [ class "fa fa-times-circle"][]]
                 ]
-              , btnSave model.ui.saving False (CallApi True (saveCategoryDetails category details.parentId (Maybe.Extra.isNothing details.originCategory)))
+              , btnSave model.ui.saving False (CallApi True (saveCategoryDetails category details.parentId (Maybe.Extra.isNothing details.originCategory))) False
               ]
             else
               []

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewRuleDetails.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewRuleDetails.elm
@@ -144,7 +144,7 @@ editionTemplate model details =
       Just oR -> Maybe.withDefault 0 details.numberOfDirectives
       Nothing -> 0
 
-    saveAction =
+    (saveAction, enabledCR) =
       let
         defaultAction = checkAction (CallApi True (saveRuleDetails rule (Maybe.Extra.isNothing details.originRule)))
         checkAction action =
@@ -156,10 +156,17 @@ editionTemplate model details =
         case model.ui.crSettings of
           Just cr ->
             if cr.enableChangeMessage || cr.enableChangeRequest then
-              checkAction (OpenSaveAuditMsgPopup rule cr)
+              ( checkAction (OpenSaveAuditMsgPopup rule cr)
+              , cr.enableChangeRequest
+              )
             else
-              defaultAction
-          Nothing -> defaultAction
+              ( defaultAction
+              , cr.enableChangeRequest
+              )
+          Nothing ->
+            ( defaultAction
+            , False
+            )
 
   in
     div [class "main-container"]
@@ -175,7 +182,7 @@ editionTemplate model details =
           :: (
             if model.ui.hasWriteRights then
               [ div [ class "btn-group" ]  topButtons
-              , btnSave model.ui.saving (String.isEmpty (String.trim rule.name)) saveAction
+              , btnSave model.ui.saving (String.isEmpty (String.trim rule.name)) saveAction enabledCR
               ]
             else
               []

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewUtils.elm
@@ -736,12 +736,20 @@ getGroupsNbResourcesBadge nbTargets nbInclude msg =
     , warningIcon
     ]
 
-btnSave : Bool -> Bool -> Msg -> Html Msg
-btnSave saving disable action =
+btnSave : Bool -> Bool -> Msg -> Bool -> Html Msg
+btnSave saving disable action crEnabled =
   let
-    icon = if saving then i [ class "fa fa-spinner fa-pulse"] [] else i [ class "fa fa-download"] []
+    icon =
+      if saving then
+        i [ class "fa fa-spinner fa-pulse"] []
+      else if crEnabled then
+        i [ class "fa fa-plus"] []
+      else
+        i [ class "fa fa-download"] []
+
+    btnClass = if crEnabled then "btn-cr" else "btn-save"
   in
-    button [class ("btn btn-success btn-save" ++ (if saving then " saving" else "")), type_ "button", disabled (saving || disable), onClick action]
+    button [class ("btn btn-success " ++ btnClass ++ (if saving then " saving" else "")), type_ "button", disabled (saving || disable), onClick action]
     [ icon ]
 
 rulesTableHeader : Filters -> Html Msg

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-elm.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-elm.js
@@ -12,6 +12,9 @@ $(document).ready(function(){
     var message = msg ? msg : "Your changes have been saved";
     appNotif.ports.successNotification.send(message);
   };
+  createLinkSuccessNotification = function (json){
+    appNotif.ports.linkSuccessNotification.send(json);
+  };
   createErrorNotification   = function (msg, code){
     appNotif.ports.errorNotification.send(msg, code);
   };

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.css
@@ -1607,7 +1607,11 @@ ul.applied-list > .add-target > .fa{
 .btn.btn-save:before{
   content: "Save";
 }
-.btn.btn-save.saving:before{
+.btn.btn-cr:before{
+  content: "Create change request";
+}
+.btn.btn-save.saving:before,
+.btn.btn-cr.saving:before{
   content: "Saving";
 }
 .btn.btn-save > .fa.fa-spin{

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/ruleManagement.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/ruleManagement.html
@@ -29,6 +29,9 @@
       app.ports.successNotification.subscribe(function(str) {
         createSuccessNotification(str)
       });
+      app.ports.linkSuccessNotification.subscribe(function(json) {
+        createLinkSuccessNotification(json)
+      });
       app.ports.errorNotification.subscribe(function(str) {
         createErrorNotification(str)
       });


### PR DESCRIPTION
https://issues.rudder.io/issues/23443

If change requests are enabled, the "Save" button is replaced by a "Create a change request" button.

Once a change request has been created, a success notification appears. This notification contains the link to the CR created, and only disappears if the user clicks on it :

![CR-notification](https://github.com/Normation/rudder/assets/9928447/b85406b2-7cf9-45ee-a16d-40b60396a09a)

