### PR TITLE
Fixes #23462: Undocomment/remove parameter rudder.nodes.delete.defaultMode

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -495,17 +495,6 @@ rudder.batch.dyngroup.updateInterval=5
 history.inventories.rootdir=/var/rudder/inventories/historical
 
 #
-# Rudder used to store deleted node inventories in a dedicated LDAP branch:
-# ou=Nodes,ou=Removed Inventories,ou=Inventories,cn=rudder-configuration
-# As of Rudder 7.2, this feature is deprecated and node inventories are totally erased
-# when a node is deleted, either by API or UI.
-# Until Rudder 8.0, you can override that behaviour:
-# - locally for API deletion with the corresponding parameter, see
-#   https://docs.rudder.io/api/v/15/#tag/Nodes/operation/deleteNode
-# - globally by changing the parameter of the following property from `erase` to `move`
-rudder.nodes.delete.defaultMode = erase
-
-#
 # Periodically delete inventories under `/var/rudder/inventories/{received, failed}` directories.
 # File in these two directories are purged independently from files under {incoming, accepted-nodes-updates}
 # which are purged by the new inventory processor.  There is cron to configure when to delete them, and

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -115,7 +115,8 @@ import com.normation.rudder.domain.logger.ApplicationLogger
 import com.normation.rudder.domain.logger.NodeConfigurationLoggerImpl
 import com.normation.rudder.domain.logger.ScheduledJobLoggerPure
 import com.normation.rudder.domain.queries._
-import com.normation.rudder.facts.nodes.{GitNodeFactRepositoryImpl, NoopFactStorage}
+import com.normation.rudder.facts.nodes.GitNodeFactRepositoryImpl
+import com.normation.rudder.facts.nodes.NoopFactStorage
 import com.normation.rudder.git.GitRepositoryProvider
 import com.normation.rudder.git.GitRepositoryProviderImpl
 import com.normation.rudder.git.GitRevisionProvider
@@ -205,7 +206,6 @@ import com.typesafe.config.ConfigFactory
 import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.RDN
 import com.unboundid.ldif.LDIFChangeRecord
-
 import java.io.File
 import java.nio.file.attribute.PosixFilePermission
 import java.security.Security
@@ -215,7 +215,6 @@ import net.liftweb.common.Loggable
 import org.apache.commons.io.FileUtils
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.joda.time.DateTimeZone
-
 import scala.collection.mutable.Buffer
 import scala.concurrent.duration.FiniteDuration
 import zio.{Scheduler => _, System => _, _}
@@ -971,20 +970,6 @@ object RudderParsedProperties {
     }
   }
 
-  val RUDDER_DEFAULT_DELETE_NODE_MODE = {
-    val default = DeleteMode.Erase
-    val mode    = {
-      try {
-        config.getString("rudder.nodes.delete.defaultMode")
-      } catch {
-        case ex: ConfigException => default.name
-      }
-    }
-    val cfg     = DeleteMode.all.find(_.name == mode).getOrElse(default)
-    ApplicationLogger.info(s"Using '${cfg.name}' behavior when a node is deleted")
-    cfg
-  }
-
   // Store it an a Box as it's only used in Lift
   val AUTH_IDLE_TIMEOUT = {
     try {
@@ -1097,7 +1082,6 @@ object RudderConfig extends Loggable {
   def RUDDER_SERVER_HSTS_SUBDOMAINS                = RudderParsedProperties.RUDDER_SERVER_HSTS_SUBDOMAINS
   def AUTH_IDLE_TIMEOUT                            = RudderParsedProperties.AUTH_IDLE_TIMEOUT
   def WATCHER_ENABLE                               = RudderParsedProperties.WATCHER_ENABLE
-  def RUDDER_DEFAULT_DELETE_NODE_MODE              = RudderParsedProperties.RUDDER_DEFAULT_DELETE_NODE_MODE
   def RUDDER_BATCH_DYNGROUP_UPDATEINTERVAL         = RudderParsedProperties.RUDDER_BATCH_DYNGROUP_UPDATEINTERVAL
   def RUDDER_GIT_ROOT_CONFIG_REPO                  = RudderParsedProperties.RUDDER_GIT_ROOT_CONFIG_REPO
   def RUDDER_BCRYPT_COST                           = RudderParsedProperties.RUDDER_BCRYPT_COST
@@ -2147,7 +2131,7 @@ object RudderConfigInit {
           nodeApiService13,
           nodeApiService16,
           nodeInheritedProperties,
-          RUDDER_DEFAULT_DELETE_NODE_MODE
+          DeleteMode.Erase // only supported mode for Rudder 8.0
         ),
         new ParameterApi(restExtractorService, zioJsonExtractor, parameterApiService2, parameterApiService14),
         new SettingsApi(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -55,6 +55,7 @@ import com.normation.rudder.domain.reports.NodeStatusReport
 import com.normation.rudder.hooks.HookReturnCode
 import com.normation.rudder.services.reports.NoReportInInterval
 import com.normation.rudder.services.reports.Pending
+import com.normation.rudder.services.servers.DeleteMode
 import com.normation.rudder.web.model.JsNodeId
 import com.normation.rudder.web.services.CurrentUser
 import com.normation.rudder.web.snippet.RegisterToasts
@@ -1149,7 +1150,7 @@ object DisplayNode extends Loggable {
   private[this] def removeNode(node: NodeSummary): JsCmd = {
     val modId = ModificationId(uuidGen.newUuid)
     removeNodeService
-      .removeNodePure(node.id, RudderConfig.RUDDER_DEFAULT_DELETE_NODE_MODE, modId, CurrentUser.actor)
+      .removeNodePure(node.id, DeleteMode.Erase, modId, CurrentUser.actor) // only erase for Rudder 8.0
       .toBox match {
       case Full(_) =>
         asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.actor)


### PR DESCRIPTION
https://issues.rudder.io/issues/23462

We forgot the clean-up the old "move to LDAP removed node branch" delete mode that was deprecated in Rudder 7.3. 
So limit risk, we just hard code choice to `DeleteMode.Erase` and delete the parameter from config file.

I don't thing a migration script/warn is needed, but a update note will be