### PR TITLE
Fixes #23466: Focus reporting is not working 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
@@ -141,7 +141,8 @@ sealed trait ComponentExpectedReport {
 final case class BlockExpectedReport(
     componentName:  String,
     reportingLogic: ReportingLogic,
-    subComponents:  List[ComponentExpectedReport]
+    subComponents:  List[ComponentExpectedReport],
+    id:             Option[String]
 ) extends ComponentExpectedReport
 
 final case class ValueExpectedReport(
@@ -376,7 +377,7 @@ object ExpectedReportsSerialisation {
         reportingLogic: ReportingLogic,
         subComponents:  List[JsonComponentExpectedReport7_0]
     ) extends JsonComponentExpectedReport7_0 {
-      def transform = BlockExpectedReport(componentName, reportingLogic, subComponents.map(_.transform))
+      def transform = BlockExpectedReport(componentName, reportingLogic, subComponents.map(_.transform), None)
     }
     implicit class _JsonBlockExpectedReport7_0(x: BlockExpectedReport)          {
       def transform = JsonBlockExpectedReport7_0(x.componentName, x.reportingLogic, x.subComponents.map(_.transform))
@@ -680,12 +681,16 @@ object ExpectedReportsSerialisation {
         }
       )
     }
-    final case class JsonBlockExpectedReport7_1(bid: String, rl: ReportingLogic, scs: List[JsonComponentExpectedReport7_1])
-        extends JsonComponentExpectedReport7_1                                   {
-      def transform = BlockExpectedReport(bid, rl, scs.map(_.transform))
+    final case class JsonBlockExpectedReport7_1(
+        bid: String,
+        rl:  ReportingLogic,
+        scs: List[JsonComponentExpectedReport7_1],
+        id:  Option[String]
+    ) extends JsonComponentExpectedReport7_1 {
+      def transform = BlockExpectedReport(bid, rl, scs.map(_.transform), id)
     }
     implicit class _JsonBlockExpectedReport7_1(x: BlockExpectedReport)           {
-      def transform = JsonBlockExpectedReport7_1(x.componentName, x.reportingLogic, x.subComponents.map(_.transform))
+      def transform = JsonBlockExpectedReport7_1(x.componentName, x.reportingLogic, x.subComponents.map(_.transform), x.id)
     }
 
     final case class JsonDirectiveExpectedReports7_1(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
@@ -294,7 +294,7 @@ class TechniqueWriterImpl(
           NodeSeq.Empty
         } else {
           val reportingLogic = block.reportingLogic.value
-          <SECTION component="true" multivalued="true" name={block.component} reporting={reportingLogic}>
+          <SECTION component="true" multivalued="true" name={block.component} reporting={reportingLogic} id={block.id}>
                 {childs}
               </SECTION>
         }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/metadata.xml
@@ -28,7 +28,7 @@
     </FILES>
   </AGENT>
   <SECTIONS>
-    <SECTION component="true" multivalued="true" name="block component" reporting="worst-case-weighted-sum">
+    <SECTION component="true" multivalued="true" name="block component" reporting="worst-case-weighted-sum" id="id_method">
       <SECTION component="true" multivalued="true" id="id1" name="Customized component">
         <REPORTKEYS>
           <VALUE id="id1">${node.properties[apache_package_name]}</VALUE>

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/ExpectedReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/ExpectedReportTest.scala
@@ -830,7 +830,8 @@ class ExpectedReportTest extends Specification {
                           ExpectedValueId("/tmp/${node.properties[filename]}", "87cad41f-ec88-4b32-a13c-136f15f7bf17")
                         )
                       )
-                    )
+                    ),
+                    None
                   )
                 )
               )

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -147,7 +147,7 @@ class ExecutionBatchTest extends Specification {
                 case ExpectedValueMatch(value, _) =>
                   ResultSuccessReport(now, ruleId, directiveId, nodeId, "report_id", componentName, value, now, "empty text")
               }
-            case BlockExpectedReport(componentName, logic, sub)       =>
+            case BlockExpectedReport(componentName, logic, sub, _)    =>
               sub.map(mapComponent(_, directiveId)).flatten
           }
         }
@@ -816,7 +816,8 @@ class ExecutionBatchTest extends Specification {
       new ValueExpectedReport(
         "component",
         ExpectedValueMatch("foo", "foo") :: ExpectedValueMatch("bar", "bar") :: Nil
-      ) :: Nil
+      ) :: Nil,
+      None
     )
 
     val withGood = ExecutionBatch
@@ -937,7 +938,8 @@ class ExecutionBatchTest extends Specification {
       new ValueExpectedReport(
         "component",
         ExpectedValueMatch("foo", "foo") :: ExpectedValueMatch("bar", "bar") :: Nil
-      ) :: Nil
+      ) :: Nil,
+      None
     )
 
     val withGood = ExecutionBatch
@@ -1058,7 +1060,8 @@ class ExecutionBatchTest extends Specification {
       new ValueExpectedReport(
         "component",
         ExpectedValueMatch("foo", "foo") :: ExpectedValueMatch("bar", "bar") :: Nil
-      ) :: Nil
+      ) :: Nil,
+      None
     )
 
     val withGood = ExecutionBatch
@@ -1182,7 +1185,8 @@ class ExecutionBatchTest extends Specification {
       ) :: new ValueExpectedReport(
         "component1",
         ExpectedValueId("bar", "report_1") :: Nil
-      ) :: Nil
+      ) :: Nil,
+      None
     )
 
     val withGood = ExecutionBatch
@@ -1358,7 +1362,8 @@ class ExecutionBatchTest extends Specification {
         ) :: new ValueExpectedReport(
           "component2",
           ExpectedValueMatch("b1c2", "b1c2") :: Nil
-        ) :: Nil
+        ) :: Nil,
+        None
       ) :: BlockExpectedReport(
         "block2",
         ReportingLogic.WeightedReport,
@@ -1368,8 +1373,10 @@ class ExecutionBatchTest extends Specification {
         ) :: new ValueExpectedReport(
           "component2",
           ExpectedValueMatch("b2c2", "b2c2") :: Nil
-        ) :: Nil
-      ) :: Nil
+        ) :: Nil,
+        None
+      ) :: Nil,
+      None
     )
     val directiveExpectedReports =
       DirectiveExpectedReports(DirectiveId(DirectiveUid("policy")), None, false, expectedComponent :: Nil)
@@ -1527,7 +1534,8 @@ class ExecutionBatchTest extends Specification {
         ) :: new ValueExpectedReport(
           "component2",
           ExpectedValueMatch("b1c2", "b1c2") :: Nil
-        ) :: Nil
+        ) :: Nil,
+        None
       ) :: BlockExpectedReport(
         "block2",
         ReportingLogic.WeightedReport,
@@ -1537,8 +1545,10 @@ class ExecutionBatchTest extends Specification {
         ) :: new ValueExpectedReport(
           "component2",
           ExpectedValueMatch("${loop}", "${loop}") :: Nil
-        ) :: Nil
-      ) :: Nil
+        ) :: Nil,
+        None
+      ) :: Nil,
+      None
     )
     val directiveExpectedReports =
       DirectiveExpectedReports(DirectiveId(DirectiveUid("policy")), None, false, expectedComponent :: Nil)
@@ -1663,7 +1673,8 @@ class ExecutionBatchTest extends Specification {
         ) :: new ValueExpectedReport(
           "component",
           ExpectedValueId("keyvalue", "report_id_b1c2") :: Nil
-        ) :: Nil
+        ) :: Nil,
+        None
       ) :: BlockExpectedReport(
         "block2",
         ReportingLogic.WeightedReport,
@@ -1673,8 +1684,10 @@ class ExecutionBatchTest extends Specification {
         ) :: new ValueExpectedReport(
           "component",
           ExpectedValueId("${loop2}", "report_id_b2c2") :: Nil
-        ) :: Nil
-      ) :: Nil
+        ) :: Nil,
+        None
+      ) :: Nil,
+      None
     )
     val directiveExpectedReports =
       DirectiveExpectedReports(DirectiveId(DirectiveUid("policy")), None, false, expectedComponent :: Nil)
@@ -1855,7 +1868,8 @@ class ExecutionBatchTest extends Specification {
         ) :: new ValueExpectedReport(
           "component2",
           ExpectedValueMatch("b1c2", "b1c2") :: Nil
-        ) :: Nil
+        ) :: Nil,
+        None
       ) :: BlockExpectedReport(
         "block2",
         ReportingLogic.FocusReport("component1"),
@@ -1865,8 +1879,10 @@ class ExecutionBatchTest extends Specification {
         ) :: new ValueExpectedReport(
           "component2",
           ExpectedValueMatch("b2c2", "b2c2") :: Nil
-        ) :: Nil
-      ) :: Nil
+        ) :: Nil,
+        None
+      ) :: Nil,
+      None
     )
     val directiveExpectedReports =
       DirectiveExpectedReports(DirectiveId(DirectiveUid("policy")), None, false, expectedComponent :: Nil)
@@ -2060,7 +2076,8 @@ class ExecutionBatchTest extends Specification {
         ) :: new ValueExpectedReport(
           "component2",
           ExpectedValueMatch("b1c2", "b1c2") :: Nil
-        ) :: Nil
+        ) :: Nil,
+        None
       ) :: BlockExpectedReport(
         "block2",
         ReportingLogic.WeightedReport,
@@ -2070,8 +2087,10 @@ class ExecutionBatchTest extends Specification {
         ) :: new ValueExpectedReport(
           "component2",
           ExpectedValueMatch("b2c2", "b2c2") :: Nil
-        ) :: Nil
-      ) :: Nil
+        ) :: Nil,
+        None
+      ) :: Nil,
+      None
     )
     val directiveExpectedReports =
       DirectiveExpectedReports(DirectiveId(DirectiveUid("policy")), None, false, expectedComponent :: Nil)
@@ -2214,7 +2233,8 @@ class ExecutionBatchTest extends Specification {
       new ValueExpectedReport(
         "component",
         ExpectedValueMatch("foo", "foo") :: ExpectedValueMatch("bar", "bar") :: Nil
-      ) :: Nil
+      ) :: Nil,
+      None
     )
 
     val withGood = ExecutionBatch
@@ -2535,7 +2555,8 @@ class ExecutionBatchTest extends Specification {
       ) :: new ValueExpectedReport(
         "Check right OK for ${user} and what follows '$' does not matter in pattern matching",
         ExpectedValueId("/bin/checkRightsOK ${user}", "report_1") :: Nil
-      ) :: Nil
+      ) :: Nil,
+      None
     )
 
     val reports = Seq[ResultReports](
@@ -2751,7 +2772,8 @@ class ExecutionBatchTest extends Specification {
           List(
             ValueExpectedReport("gm1", List(ExpectedValueId("value1", "reportid1"))),
             ValueExpectedReport("gm2", List(ExpectedValueId("value2", "reportid2")))
-          )
+          ),
+          None
         ),
         ValueExpectedReport("gm3", List(ExpectedValueId("value3", "reportid3"))),
         ValueExpectedReport("gm4", List(ExpectedValueId("value4", "reportid4")))


### PR DESCRIPTION
https://issues.rudder.io/issues/23466

Focus Reporting logic, which is created to focus a "reportId", matches on component name in later parts of compliance check and not on Id (that we don't have yet, but in 8.0 yes) to fix this in 7.3 i need to translate ids when defining expected reports to a valid component to match.

I also added an id on each block in metadata.xml for techniques in technique editor (which was already defined, but disappeared in metadatra.xl) so that we can match on block children and not just on methods

This adds an id to some expectedBlocks, but since it is optionnal it won't break our serialisation