### PR TITLE
Fixes #23474: Ensure yaml technique id and technique directory path agree

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechniqueReader.scala
@@ -86,6 +86,7 @@ class EditorTechniqueReaderImpl(
                             (for {
                               content    <- IOResult.attempt(s"Error when reading '${file.pathAsString}'")(file.contentAsString)
                               editorTech <- yamlTechniqueSerializer.yamlToEditorTechnique(file.contentAsString)
+                              _          <- EditorTechnique.checkTechniqueIdConsistency(file.parent, editorTech)
                             } yield editorTech)
                               .chainError(s"An Error occurred while extracting data from technique ${file.pathAsString}")
                               .either

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
@@ -81,14 +81,14 @@ import zio.syntax._
 trait TechniqueCompiler {
 
   /*
+   * Compile given technique based on editor descriptor.
+   *
    * Note: until we get ride of webapp generation, we must keep `EditorTechnique` as the main parameter of the
    * compilation service. This is because the likely main case where we will need to fallback to webapp generation
    * is for technique from editor, and in that case we have more chance to be able to fall back if we use
    * directly the data structure of the editor than if we follow a chain of translation from editor technique to yaml to
    * something back that the fallback compiler can understand.
    */
-
-  // compile given technique based on editor
   def compileTechnique(technique: EditorTechnique): IOResult[TechniqueCompilationOutput]
 
   // compile based on absolute path of techniqueId/1.0 directory. If the technique is not yaml, it's an error.
@@ -101,6 +101,7 @@ trait TechniqueCompiler {
                 yamlFile.contentAsString(StandardCharsets.UTF_8)
               }
       t    <- yaml.fromYaml[EditorTechnique].toIO
+      _    <- EditorTechnique.checkTechniqueIdConsistency(techniqueBaseDirectory, t)
       res  <- compileTechnique(t)
     } yield res
   }
@@ -375,8 +376,8 @@ class TechniqueCompilerWithFallback(
     gitDir / getTechniqueRelativePath(technique) / compilationConfigFilename
 
   /*
-   * This method read compilation file, compile accordingly, and write if need the new
-   * compilation file
+   * This method read compilation file, compile accordingly, and write if needed the new
+   * compilation file.
    */
   override def compileTechnique(technique: EditorTechnique): IOResult[TechniqueCompilationOutput] = {
     for {


### PR DESCRIPTION
https://issues.rudder.io/issues/23474

That was a bit more complicated than wished, because given the scenario (rudder loading, ncf techniquer regen, etc) we have several entry point where the code can read/load a technique and notice the user - and then, its on cache / not reparsed by technique lib, so the warning may not happen anymore. 

So the different entry point:
- `GitTechniqueReader`: for the case were user is compiling its yaml technique by hand, and then copying all the file into a bad path. We can only detect when the technique lib is reloaded that something is wrong
- `TechniqueCompiler`: that's the case where we are seing outdated generated files compared to `technique.yml` (at different point, notably on technique write) and call the compiler based on path
- `TechniqueReader`: that's the case where a recompilation of ncf technique is asked at boot for example. 

![image](https://github.com/Normation/rudder/assets/44649/681d262f-c82d-4b4e-8c8e-fcc6d34b2e97)

![image](https://github.com/Normation/rudder/assets/44649/f2cd24ef-da67-49e2-aa38-bb8c4d5a1369)

