### PR TITLE
Fixes #23492: Compliance filter is not clear enough when disabling a group of reports

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewUtils.elm
@@ -6,6 +6,7 @@ import Either exposing (Either(..))
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, custom, onInput)
+import Json.Encode
 import List.Extra
 import List
 import Maybe.Extra
@@ -25,7 +26,7 @@ onCustomClick msg =
     (Decode.succeed
       { message         = msg
       , stopPropagation = True
-      , preventDefault  = True
+      , preventDefault  = False
       }
     )
 
@@ -833,10 +834,12 @@ displayComplianceFilters filters updateAction =
         statusDropdown status substatus =
           let
             allSelected   = substatus |> List.all (\s -> List.member s selectedStatus)
+            anySelect = substatus |> List.any (\s -> List.member s selectedStatus)
+            indeterminate = property "indeterminate" (if not allSelected && anySelect then Json.Encode.string "true" else Json.Encode.null)
             newSelection  = if allSelected then selectedStatus |> List.filter (\s -> List.Extra.notMember s substatus) else List.Extra.unique (List.append selectedStatus substatus)
           in
             [ li [class "compliance-group", onCustomClick (updateAction {filters | tableFilters = {tableFilters | compliance = { complianceFilters | selectedStatus = newSelection }}})]
-              [ span[] [ input [type_ "checkbox", checked allSelected][] ]
+              [ span[] [ input [type_ "checkbox", checked allSelected, indeterminate][] ]
               , span[]
                 [ i[class ("compliance-badge badge-sm " ++ (String.toLower (String.replace " " "-" status)))][]
                 , text status


### PR DESCRIPTION
https://issues.rudder.io/issues/23492

Prevent default was making double click on checkbox keeping its status. 

Also add indeterminate status through property

[Screencast from 2023-09-28 14-29-00.webm](https://github.com/Normation/rudder/assets/1238978/0f114760-6a67-4c8d-8d11-641e81dd478e)


