### PR TITLE
Fixes #23547: Remove technique.json and rudder_reporting.cf when migrating technique to new format

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
@@ -980,7 +980,7 @@ class ClassicTechniqueWriter(
 
       val reportingFile = File(
         basePath
-      ) / getTechniqueRelativePath(technique) / "rudder_reporting.cf"
+      ) / getTechniqueRelativePath(technique) / TechniqueFiles.Generated.cfengineReporting
       IOResult.attempt(
         s"Could not write na reporting Technique file '${technique.name}' in path ${reportingFile.path.toString}"
       ) {
@@ -1014,7 +1014,7 @@ class ClassicTechniqueWriter(
         {
       if (needReporting) {
         <FILE name={
-          s"RUDDER_CONFIGURATION_REPOSITORY/${getTechniqueRelativePath(technique)}/rudder_reporting.cf"
+          s"RUDDER_CONFIGURATION_REPOSITORY/${getTechniqueRelativePath(technique)}/${TechniqueFiles.Generated.cfengineReporting}"
         }>
             <INCLUDED>true</INCLUDED>
           </FILE>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
@@ -320,6 +320,8 @@ class TechniqueArchiverImpl(
       s"ncf/50_techniques/${technique.id.name.value}" +:       // added in 5.1 for migration to 6.0
         s"dsc/ncf/50_techniques/${technique.id.name.value}" +: // added in 6.1
         (gitTechniquePath + "/technique.rd") +:                // deprecated in 7.2. Old rudder-lang input for rudderc, will be replace by yml file
+        (gitTechniquePath + "/technique.json") +:              // deprecated 8.0. Old json format replaced by using technique.yml
+        (gitTechniquePath + "/rudder_reporting.cf") +:         // deprecated in 8.0. It was merged within technique.cf
         resourcesStatus.collect { case ResourceFile(path, ResourceFileState.Deleted) => gitTechniquePath + "/" + path }
     )
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
@@ -324,8 +324,6 @@ class TechniqueArchiverImpl(
       s"ncf/50_techniques/${technique.id.name.value}" +:       // added in 5.1 for migration to 6.0
         s"dsc/ncf/50_techniques/${technique.id.name.value}" +: // added in 6.1
         (gitTechniquePath + "/technique.rd") +:                // deprecated in 7.2. Old rudder-lang input for rudderc, will be replace by yml file
-        (gitTechniquePath + "/technique.json") +:              // deprecated 8.0. Old json format replaced by using technique.yml
-        (gitTechniquePath + "/rudder_reporting.cf") +:         // deprecated in 8.0. It was merged within technique.cf
         resourcesStatus.collect { case ResourceFile(path, ResourceFileState.Deleted) => gitTechniquePath + "/" + path }
     )
 

--- a/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/post-migration/ncf_techniques/technique_with_blocks/1.0/rudder_reporting.cf
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/post-migration/ncf_techniques/technique_with_blocks/1.0/rudder_reporting.cf
@@ -1,1 +1,0 @@
-regenerated

--- a/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/techniques/ncf_techniques/technique_with_blocks/1.0/rudder_reporting.cf
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/techniques/ncf_techniques/technique_with_blocks/1.0/rudder_reporting.cf
@@ -1,0 +1,3 @@
+This should be removed: it existed in Rudder 7.3 when the webapp was generating content, but
+with rudderc in 8.0, it is not used anymore.
+It should also be cleanly committed.

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateJsonTechniquesToYaml.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateJsonTechniquesToYaml.scala
@@ -114,7 +114,7 @@ class TestMigrateJsonTechniquesToYaml extends Specification with ContentMatchers
               .replace("<DESCRIPTION></DESCRIPTION>", "<DESCRIPTION>regenerated</DESCRIPTION>")
           )
           // we can replace other
-          (TechniqueFiles.Generated.dsc ++ TechniqueFiles.Generated.cfengine).foreach(n =>
+          (TechniqueFiles.Generated.dsc ++ TechniqueFiles.Generated.cfengineRudderc).foreach(n =>
             (techniqueDir / n).write("regenerated")
           )
           RuddercResult.Ok("", "", "")


### PR DESCRIPTION
https://issues.rudder.io/issues/23547