### PR TITLE
Fixes #23555: When migrating json technique to yaml, canonify parameter name

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -230,7 +230,7 @@ object JsonResponseObjects {
     def from(param: TechniqueParameter) = {
       JRTechniqueParameter(
         param.id.value,
-        param.name.value,
+        param.name,
         param.description,
         param.mayBeEmpty
       )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechnique.scala
@@ -56,7 +56,6 @@ import zio.json.jsonHint
 sealed trait NcfId {
   def value:        String
   def validDscName: String
-  def canonify: String = value.replaceAll("[^a-zA-Z0-9_]", "_")
 }
 final case class BundleName(value: String) extends NcfId {
   val validDscName: String = value.split("_").map(_.capitalize).mkString("-")
@@ -190,10 +189,11 @@ final case class MethodParameter(
     parameterType: ParameterType.ParameterType
 )
 final case class TechniqueParameter(
-    id:          ParameterId,
-    name:        ParameterId,
-    description: String,
-    mayBeEmpty:  Boolean
+    id:            ParameterId,
+    name:          String,
+    description:   String,
+    documentation: String,
+    mayBeEmpty:    Boolean
 )
 
 object ParameterType {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
@@ -628,8 +628,8 @@ class WebappTechniqueCompiler(
       //     name       |   description
       <INPUT>
         <NAME>{parameter.id.value.toUpperCase()}</NAME>
-        <DESCRIPTION>{parameter.name.value}</DESCRIPTION>
-        <LONGDESCRIPTION>{parameter.description}</LONGDESCRIPTION>
+        <DESCRIPTION>{parameter.description}</DESCRIPTION>
+        <LONGDESCRIPTION>{parameter.documentation}</LONGDESCRIPTION>
         <CONSTRAINT>
           <TYPE>textarea</TYPE>
           <MAYBEEMPTY>{parameter.mayBeEmpty}</MAYBEEMPTY>
@@ -744,7 +744,7 @@ class ClassicTechniqueWriter(
     var bundleIncrement = 0
 
     val bundleParams =
-      if (technique.parameters.nonEmpty) technique.parameters.map(_.name.canonify).mkString("(", ",", ")") else ""
+      if (technique.parameters.nonEmpty) technique.parameters.map(_.name).mkString("(", ",", ")") else ""
 
     // generate a bundle which encapsulate the method_reporting_context + the actual method call
     // and the method to call this bundle
@@ -875,7 +875,8 @@ class ClassicTechniqueWriter(
          |# @description ${technique.description.replaceAll("\\R", "\n# ")}
          |# @version ${technique.version.value}
          |${technique.parameters.map { p =>
-          val param = ("name" -> p.name.value) ~ ("id" -> p.id.value) ~ ("description" -> p.description.replaceAll("\\R", "£# "))
+          val param =
+            ("name" -> p.name) ~ ("id" -> p.id.value) ~ ("description" -> p.description.replaceAll("\\R", "£# "))
           // for historical reason, we want to have real \n in the string, and not the char \n (because of how liftweb print them)
           s"""# @parameter ${compactRender(param).replaceAll("£#", "\n#")}"""
         }.mkString("\n")}
@@ -910,8 +911,8 @@ class ClassicTechniqueWriter(
     } else {
 
       val bundleParams =
-        if (technique.parameters.nonEmpty) technique.parameters.map(_.name.canonify).mkString("(", ",", ")") else ""
-      val args         = technique.parameters.map(p => s"$${${p.name.canonify}}").mkString(", ")
+        if (technique.parameters.nonEmpty) technique.parameters.map(_.name).mkString("(", ",", ")") else ""
+      val args         = technique.parameters.map(p => s"$${${p.name}}").mkString(", ")
 
       def bundleMethodCall(parentBlocks: List[MethodBlock])(method: MethodElem): List[(String, String)] = {
         method match {
@@ -1211,11 +1212,12 @@ class DSCTechniqueWriter(
     val parameters = technique.parameters.map { p =>
       val mandatory = if (p.mayBeEmpty) "$false" else "$true"
       s"""      [parameter(Mandatory=${mandatory})]
-         |      [string]$$${p.name.value},"""
+         |      [string]$$${p.name},"""
     }.mkString("\n").stripMargin('|')
 
     val techniquePath       = getTechniqueRelativePath(technique) + "/technique.ps1"
-    val techniqueParameters = technique.parameters.map(p => s"""    "${p.name.value}" = $$${p.name.value}""").mkString("\n")
+    val techniqueParameters =
+      technique.parameters.map(p => s"""    "${p.name}" = $$${p.name}""").mkString("\n")
 
     for {
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/yaml/YamlTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/yaml/YamlTechnique.scala
@@ -88,10 +88,11 @@ case class Reporting(
 )
 
 case class TechniqueParameter(
-    id:          ParameterId,
-    name:        ParameterId,
-    description: Option[String],
-    constraints: Constraints
+    id:            ParameterId,
+    name:          String,
+    description:   String,
+    documentation: Option[String],
+    constraints:   Constraints
 )
 
 case class Constraints(
@@ -211,7 +212,8 @@ object YamlTechniqueSerializer {
     TechniqueParameter(
       techniqueParameter.id,
       techniqueParameter.name,
-      if (techniqueParameter.description.isEmpty) None else Some(techniqueParameter.description),
+      techniqueParameter.description,
+      if (techniqueParameter.documentation.isEmpty) None else Some(techniqueParameter.documentation),
       Constraints(allow_empty = Some(techniqueParameter.mayBeEmpty))
     )
   }
@@ -220,7 +222,8 @@ object YamlTechniqueSerializer {
     com.normation.rudder.ncf.TechniqueParameter(
       techniqueParameter.id,
       techniqueParameter.name,
-      techniqueParameter.description.getOrElse(""),
+      techniqueParameter.description,
+      techniqueParameter.documentation.getOrElse(""),
       techniqueParameter.constraints.allow_empty.getOrElse(false)
     )
   }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/testing_variables_in_conditions/1.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/testing_variables_in_conditions/1.0/metadata.xml
@@ -36,7 +36,7 @@
     <SECTION name="Technique parameters">
       <INPUT>
         <NAME>40E3A5AB-0812-4A60-96F3-251BE8CEDF43</NAME>
-        <DESCRIPTION>my_custom_condition</DESCRIPTION>
+        <DESCRIPTION>my custom condition</DESCRIPTION>
         <LONGDESCRIPTION></LONGDESCRIPTION>
         <CONSTRAINT>
           <TYPE>textarea</TYPE>

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/testing_variables_in_conditions/1.0/technique.cf
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/testing_variables_in_conditions/1.0/technique.cf
@@ -1,7 +1,7 @@
 # @name Testing variables in conditions
 # @description 
 # @version 1.0
-# @parameter {"name":"my_custom_condition","id":"40e3a5ab-0812-4a60-96f3-251be8cedf43","description":""}
+# @parameter {"name":"my_custom_condition","id":"40e3a5ab-0812-4a60-96f3-251be8cedf43","description":"my custom condition"}
 
 bundle agent testing_variables_in_conditions(my_custom_condition)
 {

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/testing_variables_in_conditions/1.0/technique.yml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/testing_variables_in_conditions/1.0/technique.yml
@@ -5,6 +5,7 @@ category: ncf_techniques
 params:
   - id: 40e3a5ab-0812-4a60-96f3-251be8cedf43
     name: my_custom_condition
+    description: my custom condition
     constraints:
       allow_empty: false
 items:

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/1.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/1.0/metadata.xml
@@ -32,7 +32,7 @@
     <SECTION name="Technique parameters">
       <INPUT>
         <NAME>PACKAGE_VERSION</NAME>
-        <DESCRIPTION>version</DESCRIPTION>
+        <DESCRIPTION>package version</DESCRIPTION>
         <LONGDESCRIPTION>Package version to install</LONGDESCRIPTION>
         <CONSTRAINT>
           <TYPE>textarea</TYPE>

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/1.0/technique.cf
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/1.0/technique.cf
@@ -1,7 +1,7 @@
 # @name Test Technique created through Rudder API
 # @description This Technique exists only to see if Rudder creates Technique correctly.
 # @version 1.0
-# @parameter {"name":"version","id":"package_version","description":"Package version to install"}
+# @parameter {"name":"version","id":"package_version","description":"package version"}
 
 bundle agent technique_any(version)
 {

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/1.0/technique.yml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/1.0/technique.yml
@@ -6,7 +6,8 @@ category: ncf_techniques
 params:
   - id: package_version
     name: version
-    description: Package version to install
+    description: package version
+    documentation: Package version to install
     constraints:
       allow_empty: false
 items:

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/2.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/2.0/metadata.xml
@@ -32,7 +32,7 @@
     <SECTION name="Technique parameters">
       <INPUT>
         <NAME>PACKAGE_VERSION</NAME>
-        <DESCRIPTION>version</DESCRIPTION>
+        <DESCRIPTION>package version</DESCRIPTION>
         <LONGDESCRIPTION>Package version to install</LONGDESCRIPTION>
         <CONSTRAINT>
           <TYPE>textarea</TYPE>

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/2.0/technique.cf
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/2.0/technique.cf
@@ -1,7 +1,7 @@
 # @name Test Technique created through Rudder API
 # @description This Technique exists only to see if Rudder creates Technique correctly.
 # @version 2.0
-# @parameter {"name":"version","id":"package_version","description":"Package version to install"}
+# @parameter {"name":"version","id":"package_version","description":"package version"}
 
 bundle agent technique_any(version)
 {

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/metadata.xml
@@ -58,7 +58,7 @@
     <SECTION name="Technique parameters">
       <INPUT>
         <NAME>1AAACD71-C2D5-482C-BCFF-5EEE6F8DA9C2</NAME>
-        <DESCRIPTION>technique_parameter</DESCRIPTION>
+        <DESCRIPTION>technique parameter</DESCRIPTION>
         <LONGDESCRIPTION> a long description, with line 
  break within</LONGDESCRIPTION>
         <CONSTRAINT>

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/technique.cf
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/technique.cf
@@ -1,8 +1,7 @@
 # @name Test Technique created through Rudder API
 # @description This Technique exists only to see if Rudder creates Technique correctly.
 # @version 1.0
-# @parameter {"name":"technique_parameter","id":"1aaacd71-c2d5-482c-bcff-5eee6f8da9c2","description":" a long description, with line 
-#  break within"}
+# @parameter {"name":"technique_parameter","id":"1aaacd71-c2d5-482c-bcff-5eee6f8da9c2","description":"technique parameter"}
 
 bundle agent technique_by_Rudder(technique_parameter)
 {

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/technique.yml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/technique.yml
@@ -6,7 +6,8 @@ category: ncf_techniques
 params:
   - id: 1aaacd71-c2d5-482c-bcff-5eee6f8da9c2
     name: technique_parameter
-    description: " a long description, with line \n break within"
+    description: technique parameter
+    documentation: " a long description, with line \n break within"
     constraints:
       allow_empty: true
 items:

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
@@ -499,7 +499,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
       "",
       TechniqueParameter(
         ParameterId("1aaacd71-c2d5-482c-bcff-5eee6f8da9c2"),
-        ParameterId("technique_parameter"),
+        "technique_parameter",
+        "technique parameter",
         " a long description, with line \n break within",
         // we must ensure that it will lead to: [parameter(Mandatory=$false)]
         true
@@ -644,7 +645,13 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
       ) :: Nil,
       "This Technique exists only to see if Rudder creates Technique correctly.",
       "",
-      TechniqueParameter(ParameterId("package_version"), ParameterId("version"), "Package version to install", false) :: Nil,
+      TechniqueParameter(
+        ParameterId("package_version"),
+        "version",
+        "package version",
+        "Package version to install",
+        false
+      ) :: Nil,
       Nil,
       Map(),
       None
@@ -730,7 +737,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
       "",
       TechniqueParameter(
         ParameterId("40e3a5ab-0812-4a60-96f3-251be8cedf43"),
-        ParameterId("my_custom_condition"),
+        "my_custom_condition",
+        "my custom condition",
         "",
         false
       ) :: Nil,

--- a/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/post-migration/ncf_techniques/technique_with_parameters/1.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/post-migration/ncf_techniques/technique_with_parameters/1.0/metadata.xml
@@ -1,0 +1,52 @@
+<TECHNIQUE name="Technique with parameters">
+  <POLICYGENERATION>separated-with-parameters</POLICYGENERATION>
+  <MULTIINSTANCE>true</MULTIINSTANCE>
+  <DESCRIPTION>A technique with some parameters</DESCRIPTION>
+  <USEMETHODREPORTING>true</USEMETHODREPORTING>
+  <AGENT type="cfengine-community,cfengine-nova">
+    <BUNDLES>
+      <NAME>technique_with_parameters</NAME>
+    </BUNDLES>
+    <FILES>
+      <FILE name="RUDDER_CONFIGURATION_REPOSITORY/techniques/ncf_techniques/technique_with_parameters/1.0/technique.cf">
+        <INCLUDED>true</INCLUDED>
+      </FILE>
+      <FILE name="RUDDER_CONFIGURATION_REPOSITORY/techniques/ncf_techniques/technique_with_parameters/1.0/resources/test_resources.txt">
+        <INCLUDED>false</INCLUDED>
+        <OUTPATH>technique_with_parameters/1.0/resources/test_resources.txt</OUTPATH>
+      </FILE>
+    </FILES>
+  </AGENT>
+  <AGENT type="dsc">
+    <BUNDLES>
+      <NAME>Technique-With-Parameters</NAME>
+    </BUNDLES>
+    <FILES>
+      <FILE name="RUDDER_CONFIGURATION_REPOSITORY/techniques/ncf_techniques/technique_with_parameters/1.0/technique.ps1">
+        <INCLUDED>true</INCLUDED>
+      </FILE>
+      <FILE name="RUDDER_CONFIGURATION_REPOSITORY/techniques/ncf_techniques/technique_with_parameters/1.0/resources/test_resources.txt">
+        <INCLUDED>false</INCLUDED>
+        <OUTPATH>technique_with_parameters/1.0/resources/test_resources.txt</OUTPATH>
+      </FILE>
+    </FILES>
+  </AGENT>
+  <SECTIONS>
+    <SECTION component="true" multivalued="true" id="66744459-5829-43e0-8b1c-5fece7c0df7f" name="Trivial command">
+      <REPORTKEYS>
+        <VALUE id="66744459-5829-43e0-8b1c-5fece7c0df7f">ls ${The_File_To_Check}</VALUE>
+      </REPORTKEYS>
+    </SECTION>
+    <SECTION name="Technique parameters">
+      <INPUT>
+        <NAME>345388B1-7F68-44BD-95BC-C8B66A5010E9</NAME>
+        <DESCRIPTION>The File To Check</DESCRIPTION>
+        <LONGDESCRIPTION></LONGDESCRIPTION>
+        <CONSTRAINT>
+          <TYPE>textarea</TYPE>
+          <MAYBEEMPTY>false</MAYBEEMPTY>
+        </CONSTRAINT>
+      </INPUT>
+    </SECTION>
+  </SECTIONS>
+</TECHNIQUE>

--- a/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/post-migration/ncf_techniques/technique_with_parameters/1.0/technique.cf
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/post-migration/ncf_techniques/technique_with_parameters/1.0/technique.cf
@@ -1,0 +1,1 @@
+regenerated

--- a/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/post-migration/ncf_techniques/technique_with_parameters/1.0/technique.ps1
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/post-migration/ncf_techniques/technique_with_parameters/1.0/technique.ps1
@@ -1,0 +1,1 @@
+regenerated

--- a/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/post-migration/ncf_techniques/technique_with_parameters/1.0/technique.yml
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/post-migration/ncf_techniques/technique_with_parameters/1.0/technique.yml
@@ -1,0 +1,17 @@
+id: technique_with_parameters
+name: Technique with parameters
+version: '1.0'
+description: A technique with some parameters
+category: ncf_techniques
+params:
+  - id: 345388b1-7f68-44bd-95bc-c8b66a5010e9
+    name: The_File_To_Check
+    description: The File To Check
+    constraints:
+      allow_empty: false
+items:
+  - id: 66744459-5829-43e0-8b1c-5fece7c0df7f
+    name: Trivial command
+    method: command_execution
+    params:
+      command: ls ${The_File_To_Check}

--- a/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/techniques/ncf_techniques/technique_with_parameters/1.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/techniques/ncf_techniques/technique_with_parameters/1.0/metadata.xml
@@ -1,0 +1,52 @@
+<TECHNIQUE name="Technique with parameters">
+  <POLICYGENERATION>separated-with-parameters</POLICYGENERATION>
+  <MULTIINSTANCE>true</MULTIINSTANCE>
+  <DESCRIPTION>A technique with some parameters</DESCRIPTION>
+  <USEMETHODREPORTING>true</USEMETHODREPORTING>
+  <AGENT type="cfengine-community,cfengine-nova">
+    <BUNDLES>
+      <NAME>technique_with_parameters</NAME>
+    </BUNDLES>
+    <FILES>
+      <FILE name="RUDDER_CONFIGURATION_REPOSITORY/techniques/ncf_techniques/technique_with_parameters/1.0/technique.cf">
+        <INCLUDED>true</INCLUDED>
+      </FILE>
+      <FILE name="RUDDER_CONFIGURATION_REPOSITORY/techniques/ncf_techniques/technique_with_parameters/1.0/resources/test_resources.txt">
+        <INCLUDED>false</INCLUDED>
+        <OUTPATH>technique_with_parameters/1.0/resources/test_resources.txt</OUTPATH>
+      </FILE>
+    </FILES>
+  </AGENT>
+  <AGENT type="dsc">
+    <BUNDLES>
+      <NAME>Technique-With-Parameters</NAME>
+    </BUNDLES>
+    <FILES>
+      <FILE name="RUDDER_CONFIGURATION_REPOSITORY/techniques/ncf_techniques/technique_with_parameters/1.0/technique.ps1">
+        <INCLUDED>true</INCLUDED>
+      </FILE>
+      <FILE name="RUDDER_CONFIGURATION_REPOSITORY/techniques/ncf_techniques/technique_with_parameters/1.0/resources/test_resources.txt">
+        <INCLUDED>false</INCLUDED>
+        <OUTPATH>technique_with_parameters/1.0/resources/test_resources.txt</OUTPATH>
+      </FILE>
+    </FILES>
+  </AGENT>
+  <SECTIONS>
+    <SECTION component="true" multivalued="true" id="66744459-5829-43e0-8b1c-5fece7c0df7f" name="Trivial command">
+      <REPORTKEYS>
+        <VALUE id="66744459-5829-43e0-8b1c-5fece7c0df7f">ls ${The_File_To_Check}</VALUE>
+      </REPORTKEYS>
+    </SECTION>
+    <SECTION name="Technique parameters">
+      <INPUT>
+        <NAME>345388B1-7F68-44BD-95BC-C8B66A5010E9</NAME>
+        <DESCRIPTION>The File To Check</DESCRIPTION>
+        <LONGDESCRIPTION></LONGDESCRIPTION>
+        <CONSTRAINT>
+          <TYPE>textarea</TYPE>
+          <MAYBEEMPTY>false</MAYBEEMPTY>
+        </CONSTRAINT>
+      </INPUT>
+    </SECTION>
+  </SECTIONS>
+</TECHNIQUE>

--- a/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/techniques/ncf_techniques/technique_with_parameters/1.0/rudder_reporting.cf
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/techniques/ncf_techniques/technique_with_parameters/1.0/rudder_reporting.cf
@@ -1,0 +1,3 @@
+This should be removed: it existed in Rudder 7.3 when the webapp was generating content, but
+with rudderc in 8.0, it is not used anymore.
+It should also be cleanly committed.

--- a/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/techniques/ncf_techniques/technique_with_parameters/1.0/technique.cf
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/techniques/ncf_techniques/technique_with_parameters/1.0/technique.cf
@@ -1,0 +1,24 @@
+# @name Technique with parameters
+# @description A technique with some parameters
+# @version 1.0
+# @parameter {"name":"The File To Check","id":"345388b1-7f68-44bd-95bc-c8b66a5010e9","description":""}
+
+bundle agent technique_with_parameters(The_File_To_Check)
+{
+  vars:
+    "resources_dir" string => "${this.promise_dirname}/resources";
+  classes:
+    "pass3" expression => "pass2";
+    "pass2" expression => "pass1";
+    "pass1" expression => "any";
+  methods:
+    "66744459-5829-43e0-8b1c-5fece7c0df7f_${report_data.directive_id}" usebundle => technique_with_parameters_gm_0("Trivial command", "ls ${The_File_To_Check}", "66744459-5829-43e0-8b1c-5fece7c0df7f", "ls ${The_File_To_Check}"),
+                                                                              if => concat("any");
+
+}
+
+bundle agent technique_with_parameters_gm_0(c_name, c_key, report_id, command) {
+  methods:
+    "66744459-5829-43e0-8b1c-5fece7c0df7f_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}","${c_key}","${report_id}");
+    "66744459-5829-43e0-8b1c-5fece7c0df7f_${report_data.directive_id}" usebundle => command_execution("${command}");
+}

--- a/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/techniques/ncf_techniques/technique_with_parameters/1.0/technique.json
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/techniques/ncf_techniques/technique_with_parameters/1.0/technique.json
@@ -1,0 +1,37 @@
+{
+  "id":"technique_with_parameters",
+  "version":"1.0",
+  "category":"ncf_techniques",
+  "description":"A technique with some parameters",
+  "name":"Technique with parameters",
+  "calls":[
+    {
+      "method":"command_execution",
+      "condition":"",
+      "disableReporting":false,
+      "component":"Trivial command",
+      "parameters":[
+        {
+          "name":"command",
+          "value":"ls ${The_File_To_Check}"
+        }
+      ],
+      "id":"66744459-5829-43e0-8b1c-5fece7c0df7f"
+    }
+  ],
+  "parameter":[
+    {
+      "id":"345388b1-7f68-44bd-95bc-c8b66a5010e9",
+      "name":"The File To Check",
+      "description":"",
+      "mayBeEmpty":false
+    }
+  ],
+  "resources":[
+    {
+      "name":"test_resources.txt",
+      "state":"untouched"
+    }
+  ],
+  "source":"editor"
+}

--- a/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/techniques/ncf_techniques/technique_with_parameters/1.0/technique.ps1
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/techniques/ncf_techniques/technique_with_parameters/1.0/technique.ps1
@@ -1,0 +1,36 @@
+﻿function Technique-With-Parameters {
+  [CmdletBinding()]
+  param (
+      [parameter(Mandatory=$true)]
+      [string]$reportId,
+      [parameter(Mandatory=$true)]
+      [string]$techniqueName,
+      [parameter(Mandatory=$true)]
+      [string]$The File To Check,
+      [Rudder.PolicyMode]$policyMode
+  )
+  $techniqueParams = @{
+    "The File To Check" = $The File To Check
+  }
+  BeginTechniqueCall -Name $techniqueName -Parameters $techniqueParams
+  $reportIdBase = $reportId.Substring(0,$reportId.Length-1)
+  $localContext = New-Object -TypeName "Rudder.Context" -ArgumentList @($techniqueName)
+  $localContext.Merge($system_classes)
+  $resources_dir = $PSScriptRoot + "\resources"
+
+  $reportId=$reportIdBase+"66744459-5829-43e0-8b1c-5fece7c0df7f"
+  $componentKey = "ls ${The_File_To_Check}"
+  $reportParams = @{
+    ClassPrefix = ([Rudder.Condition]::canonify(("command_execution_" + $componentKey)))
+    ComponentKey = $componentKey
+    ComponentName = "Trivial command"
+    PolicyMode = $policyMode
+    ReportId = $reportId
+    DisableReporting = $false
+    TechniqueName = $techniqueName
+  }
+  $call = Command-Execution -Command "ls ${The_File_To_Check}" -PolicyMode $policyMode
+  $methodContext = Compute-Method-Call @reportParams -MethodCall $call
+  $localContext.merge($methodContext)
+  EndTechniqueCall -Name $techniqueName
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/23555

Principal changes: 

- add a `variableName` in `EditorTechnique -> parameters`. This is the canonified version of the parameter, the one used in .cf and .ps1 files, 
- remove `canonify` from `NcfId` since we now have access to it in technique param directly
- when we read old technique, do the canonification of `name` for params, and put the result in `variableName`
- map yaml field `name` to editor `variableName`, and `description` to editor `name` 

I didn't touch `JResponseObject`, they will likely need to be updated to add `variableName` field etc