### PR TITLE
Fixes #23551: Broken handling of non-printable characters in techniques

### DIFF
--- a/policies/rudderc/docs/src/test.md
+++ b/policies/rudderc/docs/src/test.md
@@ -17,6 +17,9 @@ The format of the test case file is:
 params:
   param1: value1
   param2: true
+conditions:
+  - condition1
+  - condition2
 setup:
   - sh: "test command"
 check:
@@ -26,6 +29,7 @@ check:
 
 The setup and check sections contain a list of commands to run.
 These commands run in the test directory, and are passed to `/usr/bin/sh`.
+The `setup`,`params` and `conditions` entries are optional.
 
 The detailed test process is, for each `*.yml` file in the `tests` directory:
 
@@ -34,6 +38,7 @@ The detailed test process is, for each `*.yml` file in the `tests` directory:
 * Run an agent locally, which will:
     * Load all methods from the library
     * Read the parameters values from the YAML test case
+    * Define the conditions from the YAML test case
     * Run the technique with the given parameters
 * Run the check commands sequentially. The commands are called in the `/bin/sh` shell.
 

--- a/policies/rudderc/tests/cases/general/escaping/metadata.xml
+++ b/policies/rudderc/tests/cases/general/escaping/metadata.xml
@@ -1,5 +1,7 @@
-<TECHNIQUE name="Test various escaping cases ${sys.host} . | / ${sys.${host}} &apos; &apos;&apos; &apos;&apos;&apos; $ $$ &quot; &quot;&quot; \ \\😋aà3">
-  <DESCRIPTION>${sys.host} . | / ${sys.${host}} &apos; &apos;&apos; &apos;&apos;&apos; $ $$ &quot; &quot;&quot; \ \\😋aà3</DESCRIPTION>
+<TECHNIQUE name="Test various escaping cases ${sys.host} . | / ${sys.${host}} &apos; &apos;&apos; &apos;&apos;&apos; $ $$ &quot; &quot;&quot; \ \\😋aà3
+	">
+  <DESCRIPTION>${sys.host} . | / ${sys.${host}} &apos; &apos;&apos; &apos;&apos;&apos; $ $$ &quot; &quot;&quot; \ \\😋aà3
+	</DESCRIPTION>
   <USEMETHODREPORTING>true</USEMETHODREPORTING>
   <MULTIINSTANCE>true</MULTIINSTANCE>
   <POLICYGENERATION>separated-with-parameters</POLICYGENERATION>
@@ -28,16 +30,19 @@
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C27E</NAME>
         <DESCRIPTION>server</DESCRIPTION>
-        <LONGDESCRIPTION>${sys.host} . | / ${sys.${host}} &apos; &apos;&apos; &apos;&apos;&apos; $ $$ &quot; &quot;&quot; \ \\😋aà3</LONGDESCRIPTION>
+        <LONGDESCRIPTION>${sys.host} . | / ${sys.${host}} &apos; &apos;&apos; &apos;&apos;&apos; $ $$ &quot; &quot;&quot; \ \\😋aà3
+	</LONGDESCRIPTION>
         <CONSTRAINT>
           <TYPE>textarea</TYPE>
         </CONSTRAINT>
       </INPUT>
     </SECTION>
-    <SECTION name="${sys.host} . | / ${sys.${host}} &apos; &apos;&apos; &apos;&apos;&apos; $ $$ &quot; &quot;&quot; \ \\😋aà3" id="a86ce2e5-d5b6-45cc-87e8-c11cca71d966" component="true" multivalued="true">
+    <SECTION name="${sys.host} . | / ${sys.${host}} &apos; &apos;&apos; &apos;&apos;&apos; $ $$ &quot; &quot;&quot; \ \\😋aà3
+	" id="a86ce2e5-d5b6-45cc-87e8-c11cca71d966" component="true" multivalued="true">
       <REPORTKEYS>
         <VALUE id="a86ce2e5-d5b6-45cc-87e8-c11cca71d966">
           ${sys.host} . | / ${sys.${host}} &apos; &apos;&apos; &apos;&apos;&apos; $ $$ &quot; &quot;&quot; \ \\😋aà3
+	
         </VALUE>
       </REPORTKEYS>
     </SECTION>

--- a/policies/rudderc/tests/cases/general/escaping/technique.cf
+++ b/policies/rudderc/tests/cases/general/escaping/technique.cf
@@ -1,4 +1,5 @@
 # @name Test various escaping cases ${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ " "" \ \\😋aà3
+	
 # @version 0.1
 
 bundle agent escaping(server) {
@@ -10,7 +11,10 @@ bundle agent escaping(server) {
     "class_prefix"      string => string_head("${full_class_prefix}", "1000");
 
   methods:
-    "a86ce2e5-d5b6-45cc-87e8-c11cca71d966_${report_data.directive_id}" usebundle => call_a86ce2e5_d5b6_45cc_87e8_c11cca71d966("${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3", "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3", "a86ce2e5-d5b6-45cc-87e8-c11cca71d966", @{args}, "${class_prefix}", "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3", "", "", "");
+    "a86ce2e5-d5b6-45cc-87e8-c11cca71d966_${report_data.directive_id}" usebundle => call_a86ce2e5_d5b6_45cc_87e8_c11cca71d966("${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3
+	", "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3
+	", "a86ce2e5-d5b6-45cc-87e8-c11cca71d966", @{args}, "${class_prefix}", "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3
+	", "", "", "");
 
 }
 bundle agent call_a86ce2e5_d5b6_45cc_87e8_c11cca71d966(c_name, c_key, report_id, args, class_prefix, name, version, architecture, provider) {
@@ -19,9 +23,14 @@ bundle agent call_a86ce2e5_d5b6_45cc_87e8_c11cca71d966(c_name, c_key, report_id,
     "a86ce2e5-d5b6-45cc-87e8-c11cca71d966_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "a86ce2e5-d5b6-45cc-87e8-c11cca71d966_${report_data.directive_id}" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}"),
                                              if => concat("",canonify("${my_cond}"),".debian|",canonify("${sys.${plouf}"),"}");
-    "a86ce2e5-d5b6-45cc-87e8-c11cca71d966_${report_data.directive_id}" usebundle => _classes_noop(canonify("${class_prefix}_package_present_${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3")),
+    "a86ce2e5-d5b6-45cc-87e8-c11cca71d966_${report_data.directive_id}" usebundle => _classes_noop(canonify("${class_prefix}_package_present_${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3
+	")),
                                          unless => concat("",canonify("${my_cond}"),".debian|",canonify("${sys.${plouf}"),"}");
-    "a86ce2e5-d5b6-45cc-87e8-c11cca71d966_${report_data.directive_id}" usebundle => log_rudder("Skipping method 'Package present' with key parameter '${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3' since condition '${my_cond}.debian|${sys.${plouf}}' is not reached", "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3", canonify("${class_prefix}_package_present_${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3"), canonify("${class_prefix}_package_present_${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3"), @{args}),
+    "a86ce2e5-d5b6-45cc-87e8-c11cca71d966_${report_data.directive_id}" usebundle => log_rudder("Skipping method 'Package present' with key parameter '${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3
+	' since condition '${my_cond}.debian|${sys.${plouf}}' is not reached", "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3
+	", canonify("${class_prefix}_package_present_${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3
+	"), canonify("${class_prefix}_package_present_${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3
+	"), @{args}),
                                          unless => concat("",canonify("${my_cond}"),".debian|",canonify("${sys.${plouf}"),"}");
 
 }

--- a/policies/rudderc/tests/cases/general/escaping/technique.ps1
+++ b/policies/rudderc/tests/cases/general/escaping/technique.ps1
@@ -22,11 +22,13 @@
 
 
     $reportId=$reportIdBase + "a86ce2e5-d5b6-45cc-87e8-c11cca71d966"
-    $componentKey = "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ `" `"`" \ \\😋aà3"
+    $componentKey = "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ `" `"`" \ \\😋aà3
+	"
     $reportParams = @{
         ClassPrefix = ([Rudder.Condition]::canonify(("package_present_" + $componentKey)))
         ComponentKey = $componentKey
-        ComponentName = "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ `" `"`" \ \\😋aà3"
+        ComponentName = "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ `" `"`" \ \\😋aà3
+	"
         PolicyMode = $policyMode
         ReportId = $reportId
         DisableReporting = $false
@@ -37,7 +39,8 @@
     if ($localContext.Evaluate($class)) {
         $methodParams = @{
             Architecture = ""
-            Name = "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ `" `"`" \ \\😋aà3"
+            Name = "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ `" `"`" \ \\😋aà3
+	"
             Provider = ""
             Version = @'
 

--- a/policies/rudderc/tests/cases/general/escaping/technique.yml
+++ b/policies/rudderc/tests/cases/general/escaping/technique.yml
@@ -1,16 +1,16 @@
 ---
 id: escaping
-name: "Test various escaping cases ${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3"
-description: "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3"
+name: "Test various escaping cases ${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3\r\n\t"
+description: "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3\r\n\t"
 version: "0.1"
 params:
   - id: 3439bbb0-d8f1-4c43-95a9-0c56bfb8c27e
     name: "server"
-    description: "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3"
+    description: "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3\r\n\t"
 items:
-  - name: "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3"
+  - name: "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3\r\n\t"
     id: a86ce2e5-d5b6-45cc-87e8-c11cca71d966
     method: package_present
     condition: "${my_cond} . debian | ${sys.${plouf}}"
     params:
-      name: "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3"
+      name: "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3\r\n\t"


### PR DESCRIPTION
https://issues.rudder.io/issues/23551

This happens only when using double-quoted strings in YAML. In this case some special chars are escaped using a backslash. We end up with parameters containing unwanted chars (like backspace from `\b`). In addition `quick_xml` does not check its input for forbidden chars, and happily generates invalid XML.

This PR makes a first line of check at the end of the pipeline, to prevent writing broken files. We should find a better way to handle this (but it is tricky as using these escaped chars it is often not what users want...), and maybe make quick_xml properly escape these chars.