### PR TITLE
Fixes #23564: Always display generic method name

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewMethod.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewMethod.elm
@@ -522,7 +522,6 @@ callBody model ui techniqueUi call pid =
                                        [ element "div"
                                          |> addClass ("gm-label-name " ++ methodNameLabelClass)
                                          |> appendText method.name
-                                         |> addActionStopPropagation ("mouseover" , HoverMethod Nothing)
                                        , element "div"
                                          |> addClass "form-group"
                                          |> appendChildList
@@ -545,12 +544,11 @@ callBody model ui techniqueUi call pid =
                                   |> addActionStopPropagation ("click" , DisableDragDrop)
                                   |> addActionStopPropagation ("mouseover" , HoverMethod Nothing)
                                 )
-                             |> appendChildConditional
+                             |> appendChild
                                 ( element "div"
                                   |> addClass ("gm-label-name " ++ methodNameLabelClass)
                                   |> appendText method.name
                                 )
-                                ((not (String.isEmpty call.component)) && call.component /= method.name )
 
     methodNameId = case ui.mode of
                      Opened -> element "span" |> appendText method.name


### PR DESCRIPTION
https://issues.rudder.io/issues/23564
![metod_name](https://github.com/Normation/rudder/assets/23410978/ce9f94b6-899d-4d49-9c04-b98dc077da28)
