### PR TITLE
Fixes #23591: Feature switch for archive API is still present

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
@@ -186,11 +186,6 @@ trait ReadConfigService {
   def rudder_featureSwitch_directiveScriptEngine(): IOResult[FeatureSwitch]
 
   /**
-   * Should we activate import/export archive API
-   */
-  def rudder_featureSwitch_archiveApi(): IOResult[FeatureSwitch]
-
-  /**
    * Default value for node properties after acceptation:
    * - policy mode
    * - node lifecycle state
@@ -314,11 +309,6 @@ trait UpdateConfigService {
    */
   def set_rudder_featureSwitch_directiveScriptEngine(status: FeatureSwitch): IOResult[Unit]
 
-  /*
-   * Should we enable import/export archive API ?
-   */
-  def set_rudder_featureSwitch_archiveApi(status: FeatureSwitch): IOResult[Unit]
-
   /**
    * Set the compliance mode
    */
@@ -414,7 +404,6 @@ class GenericConfigService(
        rudder.policy.mode.name=${Enforce.name}
        rudder.policy.mode.overridable=true
        rudder.featureSwitch.directiveScriptEngine=enabled
-       rudder.featureSwitch.archiveApi=disabled
        rudder.node.onaccept.default.state=enabled
        rudder.node.onaccept.default.policyMode=default
        rudder.compliance.unexpectedReportUnboundedVarValues=true
@@ -707,12 +696,6 @@ class GenericConfigService(
   def rudder_featureSwitch_directiveScriptEngine():                          IOResult[FeatureSwitch] = get("rudder_featureSwitch_directiveScriptEngine")
   def set_rudder_featureSwitch_directiveScriptEngine(status: FeatureSwitch): IOResult[Unit]          =
     save("rudder_featureSwitch_directiveScriptEngine", status)
-
-  /**
-   * Should we enable import/export archive API?
-   */
-  def rudder_featureSwitch_archiveApi():                          IOResult[FeatureSwitch] = get("rudder_featureSwitch_archiveApi")
-  def set_rudder_featureSwitch_archiveApi(status: FeatureSwitch): IOResult[Unit]          = save("rudder_featureSwitch_archiveApi", status)
 
   /**
    * Default value for node properties after acceptation:

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -130,7 +130,6 @@ class SettingsApi(
     RestNodeAcceptDuplicatedHostname ::
     RestComputeDynGroupMaxParallelism ::
     RestSetupDone ::
-    ArchiveApiFeatureSwitch ::
     Nil
   }
 
@@ -634,23 +633,6 @@ class SettingsApi(
     val key                       = "enable_javascript_directives"
     def get                       = configService.rudder_featureSwitch_directiveScriptEngine()
     def set                       = (value: FeatureSwitch, _, _) => configService.set_rudder_featureSwitch_directiveScriptEngine(value)
-  }
-
-  case object ArchiveApiFeatureSwitch extends RestSetting[FeatureSwitch] {
-    val startPolicyGeneration = false
-    def toJson(value: FeatureSwitch): JValue = value.name
-    def parseJson(json: JValue)   = {
-      json match {
-        case JString(value) => FeatureSwitch.parse(value)
-        case x              => Failure("Invalid value " + x)
-      }
-    }
-    def parseParam(param: String) = {
-      FeatureSwitch.parse(param)
-    }
-    val key                       = "rudder_featureSwitch_archiveApi"
-    def get                       = configService.rudder_featureSwitch_archiveApi()
-    def set                       = (value: FeatureSwitch, _, _) => configService.set_rudder_featureSwitch_archiveApi(value)
   }
 
   case object RestOnAcceptPolicyMode extends RestSetting[Option[PolicyMode]] {

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_settings.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_settings.yml
@@ -49,7 +49,6 @@ response:
           "require_time_synchronization":true,
           "rudder_compute_changes":true,
           "rudder_compute_dyngroups_max_parallelism":"1",
-          "rudder_featureSwitch_archiveApi":"disabled",
           "rudder_generation_compute_dyngroups":true,
           "rudder_generation_continue_on_error":false,
           "rudder_generation_delay":"0 seconds",

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
@@ -49,7 +49,6 @@ import com.normation.rudder.MockDirectives
 import com.normation.rudder.MockGitConfigRepo
 import com.normation.rudder.MockTechniques
 import com.normation.rudder.apidata.JsonQueryObjects.JQRule
-import com.normation.rudder.domain.appconfig.FeatureSwitch
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.DirectiveUid
@@ -65,11 +64,9 @@ import com.normation.rudder.rest.lift.TechniqueType
 import com.normation.utils.DateFormaterService
 import com.normation.zio._
 import java.io.FileOutputStream
-import java.nio.charset.StandardCharsets
 import java.util.zip.ZipFile
 import net.liftweb.common.Full
 import net.liftweb.common.Loggable
-import net.liftweb.http.InMemoryResponse
 import net.liftweb.http.OutputStreamResponse
 import org.apache.commons.io.FileUtils
 import org.eclipse.jgit.revwalk.RevWalk
@@ -113,30 +110,8 @@ class ArchiveApiTest extends Specification with AfterAll with Loggable {
 
   sequential
 
-  "when the feature switch is disabled, request" should {
-    "error in GET /archives/export" in {
-      restTest.testGETResponse("/api/latest/archives/export") {
-        case Full(InMemoryResponse(json, _, _, 500)) =>
-          new String(json, StandardCharsets.UTF_8) must beMatching(".*This API is disabled.*")
-        case err                                     => ko(s"I got an error in test: ${err}")
-      }
-    }
-
-    "error in POST /archives/export" in {
-      restTest.testEmptyPostResponse("/api/latest/archives/import") {
-        case Full(InMemoryResponse(json, _, _, 500)) =>
-          new String(json, StandardCharsets.UTF_8) must beMatching(".*This API is disabled.*")
-        case err                                     => ko(s"I got an error in test: ${err}")
-      }
-    }
-  }
-
-  // FROM THERE, FEATURE IS ENABLED
-  "when the feature switch is enabled, request" should {
+  "the archive feature is always enabled, and request" should {
     "succeed in GET /archives/export" in {
-      // feature switch change needs to be at that level and not under "should" directly,
-      // else it contaminated all tests, even with the sequential annotation
-      restTestSetUp.archiveAPIModule.featureSwitchState.set(FeatureSwitch.Enabled).runNow
       restTest.testGETResponse("/api/latest/archives/export") {
         case Full(resp) => resp.toResponse.code must beEqualTo(200)
         case err        => ko(s"I got an error in test: ${err}")

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -860,10 +860,10 @@ class RestTestSetUp {
       mockConfigRepo.configurationRepository,
       mockTechniques.techniqueRevisionRepo
     )
-    val featureSwitchState    = Ref.make[FeatureSwitch](FeatureSwitch.Disabled).runNow
+
     // archive name in a Ref to make it simple to change in tests
-    val rootDirName           = Ref.make("archive").runNow
-    val zipArchiveReader      = new ZipArchiveReaderImpl(mockLdapQueryParsing.queryParser, mockTechniques.techniqueParser)
+    val rootDirName      = Ref.make("archive").runNow
+    val zipArchiveReader = new ZipArchiveReaderImpl(mockLdapQueryParsing.queryParser, mockTechniques.techniqueParser)
     // a mock save archive that stores result in a ref
     object archiveSaver   extends SaveArchiveService  {
       val base = Ref.make(Option.empty[(PolicyArchive, MergePolicy)]).runNow
@@ -876,7 +876,6 @@ class RestTestSetUp {
     }
     val api = new ArchiveApi(
       archiveBuilderService,
-      featureSwitchState.get,
       rootDirName.get,
       zipArchiveReader,
       archiveSaver,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2033,7 +2033,6 @@ object RudderConfigInit {
       val rootDirName           = "archive".succeed
       new com.normation.rudder.rest.lift.ArchiveApi(
         archiveBuilderService,
-        configService.rudder_featureSwitch_archiveApi(),
         rootDirName,
         new ZipArchiveReaderImpl(queryParser, techniqueParser),
         new SaveArchiveServicebyRepo(


### PR DESCRIPTION
https://issues.rudder.io/issues/23591

Remove the Feature switch and related tests and settings. Nothing fancy, I hope I didn't missed anything. 
Nothing special to do for migration, it is not important to have old settings in LDAP. 