### PR TITLE
Fixes #15019: Tag are not displayed with a nice diff in eventLog 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/DirectiveDiff.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/DirectiveDiff.scala
@@ -75,19 +75,44 @@ final case class ModifyDirectiveDiff(
     id:            DirectiveId,
     name:          String, // keep the name around to be able to display it as it was at that time
 
-    modName:             Option[SimpleDiff[String]] = None,
-    modTechniqueVersion: Option[SimpleDiff[TechniqueVersion]] = None,
-    modParameters:       Option[SimpleDiff[SectionVal]] = None,
-    modShortDescription: Option[SimpleDiff[String]] = None,
-    modLongDescription:  Option[SimpleDiff[String]] = None,
-    modPriority:         Option[SimpleDiff[Int]] = None,
-    modIsActivated:      Option[SimpleDiff[Boolean]] = None,
-    modIsSystem:         Option[SimpleDiff[Boolean]] = None,
-    modPolicyMode:       Option[SimpleDiff[Option[PolicyMode]]] = None,
-    modTags:             Option[SimpleDiff[Set[Tag]]] = None
+    modName:             Option[SimpleDiff[String]],
+    modTechniqueVersion: Option[SimpleDiff[TechniqueVersion]],
+    modParameters:       Option[SimpleDiff[SectionVal]],
+    modShortDescription: Option[SimpleDiff[String]],
+    modLongDescription:  Option[SimpleDiff[String]],
+    modPriority:         Option[SimpleDiff[Int]],
+    modIsActivated:      Option[SimpleDiff[Boolean]],
+    modIsSystem:         Option[SimpleDiff[Boolean]],
+    modPolicyMode:       Option[SimpleDiff[Option[PolicyMode]]],
+    modTags:             Option[SimpleDiff[Tags]]
 ) extends DirectiveSaveDiff {
   def needDeployment: Boolean = {
     modTechniqueVersion.isDefined || modParameters.isDefined || modPriority.isDefined || modIsActivated.isDefined || modName.isDefined || modPolicyMode.isDefined
+  }
+}
+
+object ModifyDirectiveDiff {
+  // ModifyDirectiveDiff that has no modification
+  def emptyMod(
+      techniqueName: TechniqueName,
+      id:            DirectiveId,
+      name:          String
+  ): ModifyDirectiveDiff = {
+    ModifyDirectiveDiff(
+      techniqueName,
+      id,
+      name,
+      modName = None,
+      modTechniqueVersion = None,
+      modParameters = None,
+      modShortDescription = None,
+      modLongDescription = None,
+      modPriority = None,
+      modIsActivated = None,
+      modIsSystem = None,
+      modPolicyMode = None,
+      modTags = None
+    )
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/PolicyMode.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/PolicyMode.scala
@@ -41,6 +41,10 @@ import com.normation.errors._
 
 sealed trait PolicyMode { def name: String }
 object PolicyMode       {
+
+  // value which corresponds to a default policy mode, its value depending on context
+  val defaultValue: String = "default"
+
   final case object Audit   extends PolicyMode { val name = "audit"   }
   final case object Enforce extends PolicyMode { val name = "enforce" }
 
@@ -60,11 +64,11 @@ object PolicyMode       {
     }
   }
 
-  // get from string, with null, '' and 'default' will result in a None
+  // get from string, with null, '' and default value will result in a None
   def parseDefault(value: String): Either[RudderError, Option[PolicyMode]] = {
     value match {
-      case null | "" | "default" => Right(None)
-      case _                     => parse(value).map(Some(_))
+      case null | "" | `defaultValue` => Right(None)
+      case _                          => parse(value).map(Some(_))
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -544,9 +544,15 @@ class EventLogFactoryImpl(
           modifyDiff.modShortDescription.map(x => SimpleDiff.stringToXml(<shortDescription/>, x)) ++
           modifyDiff.modLongDescription.map(x => SimpleDiff.stringToXml(<longDescription/>, x)) ++
           modifyDiff.modPriority.map(x => SimpleDiff.intToXml(<priority/>, x)) ++
+          modifyDiff.modPolicyMode.map(x => {
+            SimpleDiff.toXml[Option[PolicyMode]](<policyMode/>, x) {
+              case None    => Text(PolicyMode.defaultValue)
+              case Some(y) => Text(y.name)
+            }
+          }) ++
           modifyDiff.modIsActivated.map(x => SimpleDiff.booleanToXml(<isEnabled/>, x)) ++
           modifyDiff.modIsSystem.map(x => SimpleDiff.booleanToXml(<isSystem/>, x)) ++
-          modifyDiff.modTags.map(x => SimpleDiff.toXml[Set[Tag]](<tags/>, x)(tags => TagsXml.toXml(Tags(tags))))
+          modifyDiff.modTags.map(x => SimpleDiff.toXml[Tags](<tags/>, x)(tags => TagsXml.toXml(tags)))
         }
         </directive>
       )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/modification/DiffService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/modification/DiffService.scala
@@ -110,6 +110,7 @@ class DiffServiceImpl extends DiffService {
     val diffSystem           = toDirectiveDiff(_.isSystem)
     val diffEnable           = toDirectiveDiff(_.isEnabled)
     val diffPolicyMode       = toDirectiveDiff(_.policyMode)
+    val diffTags             = toDirectiveDiff(_.tags)
     ModifyDirectiveDiff(
       techniqueName,
       reference.id,
@@ -122,7 +123,8 @@ class DiffServiceImpl extends DiffService {
       diffPriority,
       diffEnable,
       diffSystem,
-      diffPolicyMode
+      diffPolicyMode,
+      diffTags
     )
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -862,7 +862,7 @@ class MockDirectives(mockTechniques: MockTechniques) {
               diff(_.isEnabled),
               diff(_.isSystem),
               diff(_.policyMode),
-              diff(_.tags.tags)
+              diff(_.tags)
             )
           )
       }


### PR DESCRIPTION
https://issues.rudder.io/issues/15019

* Adding a `defaultValue` constant in `PolicyMode` that is used across many files to specify that the policy mode is inferred from the global context

* Add display of diffs for tags using 'simple lines diff' (the same that is used when displaying diffs on properties) :
 ![Screenshot from 2023-10-18 09-41-18](https://github.com/Normation/rudder/assets/65616064/cef08e9d-01d0-4a43-a272-c3e17b172d54)

* Add display of diffs also for the policy mode of a directive :  
![from-default-to-enforce](https://github.com/Normation/rudder/assets/65616064/bb96dab2-dc40-4e23-babe-521ac8902ae6)
