### PR TITLE
Fixes #23320: Quotes in group name generate JS errors when using GroupId criteria

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
@@ -494,13 +494,9 @@ object SearchNodeComponent {
         }
       case Nil    => ""
     }
+    val newForm      = comp.toForm(v_old, func, ("id" -> v_eltid), ("class" -> "queryInputValue form-control input-sm"))
     comp.destroyForm(v_eltid) &
-    JsRaw(
-      "jQuery('#%s').replaceWith('%s')".format(
-        v_eltid,
-        comp.toForm(v_old, func, ("id" -> v_eltid), ("class" -> "queryInputValue form-control input-sm"))
-      )
-    ) &
+    JsCmds.Replace(v_eltid, newForm) &
     comp.initForm(v_eltid) &
     JsCmds.ReplaceOptions(c_eltid, comparators, Full(selectedComp)) &
     setIsEnableFor(selectedComp, v_eltid) &


### PR DESCRIPTION
https://issues.rudder.io/issues/23320

form was added using a raw js script, doing a jquery.replace(id, 'content') where content was a the string containing the new form to insert. if this forms include a ' , the string is then broken.

Using List replace jscommand instead will sanitize your content correctly and escape the single quote