### PR TITLE
Fixes #23609: Assessments of several low impact CVE in current 7.3.x reported by contrastsecurity tool 

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -416,14 +416,14 @@ limitations under the License.
     <commons-codec-version>1.15</commons-codec-version>
     <commons-fileupload>1.5</commons-fileupload>
     <commons-csv-version>1.10.0</commons-csv-version>
-    <spring-version>5.3.29</spring-version>
-    <spring-security-version>5.7.10</spring-security-version>
-    <jgit-version>6.3.0.202209071007-r</jgit-version>
+    <jgit-version>6.7.0.202309050840-r</jgit-version>
+    <spring-version>5.3.30</spring-version>
+    <spring-security-version>5.7.11</spring-security-version>
     <cglib-version>3.3.0</cglib-version>
     <asm-version>9.4</asm-version>
     <!-- Level of Java compatibility, here 1.8+ -->
     <bouncycastle-compat>jdk18on</bouncycastle-compat>
-    <bouncycastle-version>1.72</bouncycastle-version>
+    <bouncycastle-version>1.76</bouncycastle-version>
     <better-files-version>3.9.1</better-files-version>
     <sourcecode-version>0.3.0</sourcecode-version>
     <quicklens-version>1.9.0</quicklens-version>
@@ -431,6 +431,7 @@ limitations under the License.
     <nuprocess-version>2.0.5</nuprocess-version>
     <postgresql-version>42.6.0</postgresql-version>
     <json-path-version>2.7.0</json-path-version>
+    <json-smart-version>2.4.11</json-smart-version>
     <scalaj-version>2.4.2</scalaj-version>
     <unboundid-version>6.0.6</unboundid-version>
     <fastparse-version>2.3.3</fastparse-version>
@@ -438,7 +439,7 @@ limitations under the License.
     <caffeine-version>3.1.1</caffeine-version>
     <jgrapht-version>1.5.1</jgrapht-version>
     <reflections-version>0.10.2</reflections-version>
-    <graalvm-version>22.3.0</graalvm-version>
+    <graalvm-version>22.3.4</graalvm-version>
     <chimney-version>0.6.2</chimney-version>
     <cron4s-version>0.6.1</cron4s-version>
     <ipaddress-version>5.3.4</ipaddress-version>

--- a/webapp/sources/rudder/rudder-core/pom.xml
+++ b/webapp/sources/rudder/rudder-core/pom.xml
@@ -210,6 +210,11 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <artifactId>json-path</artifactId>
       <version>${json-path-version}</version>
     </dependency>
+    <dependency>
+      <groupId>net.minidev</groupId>
+      <artifactId>json-smart</artifactId>
+      <version>${json-smart-version}</version>
+    </dependency>
 
     <!--
          @Nonnull annotation, avoid "Class javax.annotation.Nonnull not found

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/GitGC.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/GitGC.scala
@@ -79,6 +79,11 @@ class GitGC(
     }
 
     def isCancelled = false
+
+    // Added in recent jgit version (at least 6.5.0.202303070854-r)
+    // It can be used to display the duration of logs but we don't it just keep it
+    // If we really want to do it, then we would add a private var and use it in other methods
+    def showDuration(enabled: Boolean): Unit = ()
   }
 
   // must not fail, will be in a cron

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SharedFilesApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SharedFilesApiTest.scala
@@ -45,9 +45,7 @@ import org.joda.time.format.ISODateTimeFormat
 import org.junit.runner._
 import org.specs2.mutable._
 import org.specs2.runner._
-import scala.annotation.nowarn
 
-@nowarn("msg=a type was inferred to be `\\w+`; this may indicate a programming error.")
 @RunWith(classOf[JUnitRunner])
 class SharedFilesApiTest extends Specification {
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
@@ -42,7 +42,6 @@ import com.normation.errors.IOResult
 import com.normation.errors.PureResult
 import com.normation.errors.SystemError
 import com.normation.errors.Unexpected
-import com.normation.errors.effectUioUnit
 import com.normation.rudder._
 import com.normation.rudder.api._
 import com.normation.rudder.domain.logger.ApplicationLogger


### PR DESCRIPTION
https://issues.rudder.io/issues/23609

Update libraries to version without observable changes, or to version with changes already tested in Rudder 8.0 branches (jgit, graalvm). In the latest case, backport Rudder 8.0 changes.