### PR TITLE
Fixes #23607: When a mandatory field in a technique is not defined, we can save a technique and we have a nasty error

### DIFF
--- a/policies/rudder-commons/src/lib.rs
+++ b/policies/rudder-commons/src/lib.rs
@@ -224,6 +224,7 @@ pub struct Select {
 #[serde(rename_all = "snake_case")]
 pub struct RegexConstraint {
     pub value: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
 }
 

--- a/webapp/sources/rudder/rudder-core/src/test/resources/ncf/generic_methods.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/ncf/generic_methods.json
@@ -1,154 +1,84 @@
 {
-  "monitoring_template": {
-    "name": "Monitoring template",
-    "bundle_name": "monitoring_template",
-    "bundle_args": [
-      "template"
-    ],
-    "description": "Add a monitoring template to a node (requires a monitoring plugin)",
-    "documentation": "This method assigns monitoring templates to a Rudder node. The Rudder plugin respective to\neach monitoring platform will apply those templates to the node.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "monitoring_template",
-    "class_parameter": "template",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/monitoring_template.cf",
-    "parameter": [
-      {
-        "name": "template",
-        "description": "Name of the monitoring template",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "registry_entry_absent": {
-    "name": "Registry entry absent",
-    "bundle_name": "registry_entry_absent",
-    "bundle_args": [
-      "key",
-      "entry"
-    ],
-    "description": "Ensure that a registry entry is absent from the given key.",
-    "documentation": "Ensure that a registry entry is absent from the given key.\n\n#### Examples\n\n```yaml\n-name: Make sure the Rudder reg does not define the unwantedEntry property\n method: registry_entry_absent\n   key: \"HKLM:\\SOFTWARE\\Rudder\"\n   entry: \"unwantedEntry\"\n```",
-    "agent_support": [
-      "dsc"
-    ],
-    "class_prefix": "registry_entry_absent",
-    "class_parameter": "entry",
-    "class_parameter_id": 2,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/registry_entry_absent.cf",
-    "parameter": [
-      {
-        "name": "key",
-        "description": "Registry key (ie, HKLM:\\Software\\Rudder)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "entry",
-        "description": "Registry entry name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "permissions_recurse": {
-    "name": "Permissions (recurse)",
-    "bundle_name": "permissions_recurse",
-    "bundle_args": [
-      "path",
-      "mode",
-      "owner",
-      "group"
-    ],
-    "description": "Verify if a file or directory has the right permissions recursively",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "permissions",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_recurse.cf",
-    "deprecated": "Use [permissions_recursive](#_permissions_recursive) instead.",
-    "rename": "permissions_recursive",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Path to the file / directory",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "mode",
-        "description": "Mode to enforce",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "owner",
-        "description": "Owner to enforce",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "group",
-        "description": "Group to enforce",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_from_template_type": {
-    "name": "File from template with type",
-    "bundle_name": "file_from_template_type",
+  "file_from_remote_template": {
+    "name": "File from remote template",
+    "bundle_name": "file_from_remote_template",
     "bundle_args": [
       "source_template",
-      "path",
+      "destination",
       "template_type"
     ],
-    "description": "Build a file from a template",
-    "documentation": "These methods write a file based on a provided template and the\ndata available to the agent.\n\n#### Usage\n\nTo use these methods (`file_from_template_*`), you need to have:\n\n* a template file\n* data to fill this template\n\nThe template file should be somewhere on the local file system, so\nif you want to use a file shared from the policy server, you need to copy \nit first (using [file_copy_from_remote_source](#_file_copy_from_remote_source)).\n\nIt is common to use a specific folder to store those templates after copy,\nfor example in `${sys.workdir}/tmp/templates/`.\n\nThe data that will be used while expanding the template is the data available in\nthe agent at the time of expansion. That means:\n\n* Agent's system variables (`${sys.*}`, ...) and conditions (`linux`, ...)\n* data defined during execution (result conditions of generic methods, ...)\n* conditions based on `condition_` generic methods\n* data defined in ncf using `variable_*` generic methods, which allow for example\n  to load data from local json or yaml files.\n\n#### Template types\n\nncf currently supports three templating languages:\n\n* *mustache* templates, which are documented in [file_from_template_mustache](#_file_from_template_mustache)\n* *jinja2* templates, which are documented in [file_from_template_jinja2](#_file_from_template_jinja2)\n* CFEngine templates, which are a legacy implementation that is here for compatibility,\nand should not be used for new templates.\n\n#### Example\n\nHere is a complete example of templating usage:\n\nThe (basic) template file, present on the server in `/PATH_TO_MY_FILE/ntp.conf.mustache`\n(for syntax reference, see [file_from_template_mustache](#_file_from_template_mustache)):\n\n```mustache\n{{#classes.linux}}\nserver {{{vars.configuration.ntp.hostname}}}\n{{/classes.linux}}\n{{^classes.linux}}\nserver hardcoded.server.example\n{{/classes.linux}}\n\n```\n\nAnd on your local node in `/tmp/ntp.json`, the following json file:\n\n```json\n{ \"hostname\": \"my.hostname.example\" }\n```\n\nAnd the following policy:\n\n```\n# Copy the file from the policy server\nfile_copy_from_remote_source(\"/PATH_TO_MY_FILE/ntp.conf.mustache\", \"${sys.workdir}/tmp/templates/ntp.conf.mustache\")\n# Define the `ntp` variable in the `configuration` prefix from the json file\nvariable_dict_from_file(\"configuration\", \"ntp\", \"/tmp/ntp.json\")\n# Expand yout template\nfile_from_template_type(\"${sys.workdir}/tmp/templates/ntp.conf.mustache\", \"/etc/ntp.conf\", \"mustache\")\n# or\n# file_from_template_mustache(\"${sys.workdir}/tmp/templates/ntp.conf.mustache\", \"/etc/ntp.conf\")\n```\n\nThe destination file will contain the expanded content, for example on a Linux node:\n\n```\nserver my.hostname.example\n```",
+    "description": "Build a file from a template on the Rudder server",
+    "documentation": "Write a file based on a template on the Rudder server and data available on the node\n\n#### Usage\n\nTo use this method, you need to have:\n\n* a template on the Rudder server shared folder\n* data to fill this template\n\nThe template needs to be located in the shared-files folder and can be accessed with:\n\n```\n/var/rudder/configuration-repository/shared-files/PATH_TO_YOUR_FILE\n```\n\nThe data that will be used while expanding the template is the data available in\nthe agent at the time of expansion. That means:\n\n* Agent's system variables (`${sys.*}`, ...) and conditions (`linux`, ...)\n* data defined during execution (result conditions of generic methods, ...)\n* conditions based on `condition_` generic methods\n* data defined using `variable_*` generic methods, which allow for example\n  to load data from local json or yaml files.\n\n#### Template types\n\nSupported templating languages:\n\n* *mustache* templates, which are documented in [file_from_template_mustache](#_file_from_template_mustache)\n* *jinja2* templates, which are documented in [file_from_template_jinja2](#_file_from_template_jinja2)\n\n#### Reporting\n\nThis method will provide extra `log_warning` message if the template was not updated, but the destination\nfile is modified.",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "file_from_template",
-    "class_parameter": "path",
+    "class_prefix": "file_from_remote_template",
+    "class_parameter": "destination",
     "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_template_type.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_remote_template.cf",
     "parameter": [
       {
         "name": "source_template",
-        "description": "Source file containing a template to be expanded (absolute path on the target node)",
+        "description": "Source file containing a template to be expanded (absolute path on the server)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "destination",
+        "description": "Destination file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "template_type",
+        "description": "Template type (jinja2 or mustache)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": "jinja2"
+            },
+            {
+              "value": "mustache"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_copy_from_remote_source": {
+    "name": "File copy from remote source",
+    "bundle_name": "file_copy_from_remote_source",
+    "bundle_args": [
+      "source",
+      "path"
+    ],
+    "description": "Ensure that a file or directory is copied from a policy server",
+    "documentation": "*Note*: This method uses the native agent copy protocol, and can only download files from\nthe policy server. To download a file from an external source, you can use\nHTTP with the [file_download](#_file_download) method.\n\nThis method requires that the policy server is configured to accept\ncopy of the source file from the agents it will be applied to.\n\nYou can download a file from the shared files with:\n\n```\n/var/rudder/configuration-repository/shared-files/PATH_TO_YOUR_FILE\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_copy_from_remote_source",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_copy_from_remote_source.cf",
+    "deprecated": "Use [file_from_remote_source](#_file_from_remote_source) instead.",
+    "rename": "file_from_remote_source",
+    "parameter": [
+      {
+        "name": "source",
+        "description": "Source file (absolute path on the policy server)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -165,10 +95,95 @@
           "max_length": 16384
         },
         "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
+      }
+    ]
+  },
+  "user_password_hash": {
+    "name": "User password hash",
+    "bundle_name": "user_password_hash",
+    "bundle_args": [
+      "login",
+      "password"
+    ],
+    "description": "Ensure a user's password. Password must respect `$id$salt$hashed` format\n as used in the UNIX /etc/shadow file.",
+    "documentation": "User must exists, password must be pre-hashed. Does not handle\n  empty password accounts. See UNIX /etc/shadow format.\n  entry example: `$1$jp5rCMS4$mhvf4utonDubW5M00z0Ow0`\n\n  An empty password will lead to an error and be notified.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "user_password_hash",
+    "class_parameter": "login",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/user_password_hash.cf",
+    "parameter": [
+      {
+        "name": "login",
+        "description": "User login",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
       },
       {
-        "name": "template_type",
-        "description": "Template type (cfengine, jinja2 or mustache)",
+        "name": "password",
+        "description": "User hashed password",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "condition_from_expression_persistent": {
+    "name": "Condition from expression persistent",
+    "bundle_name": "condition_from_expression_persistent",
+    "bundle_args": [
+      "condition",
+      "expression",
+      "duration"
+    ],
+    "description": "Create a new condition that persists across runs",
+    "documentation": "This method evaluates an expression (=condition combination), and produces a `${condition}_true`\nor a `${condition}_false` condition depending on the result on the expression,\nwhich will lasts for the **Duration** time:\n\n* This method always result with a *success* outcome status\n* If the expression evaluation results in a \"defined\" state, this will define a `${condition}_true` condition,\n* If the expression evaluation results in an \"undefined\" state, this will produce a `${condition}_false` condition.\n\n\nCalling this method with a condition expression transforms a complex expression into a single class condition.\n\nThe created condition is global to the agent and is persisted across runs.\nThe persistence duration is controlled using the parameter **Duration** which defines for how long the target\ncondition will be defined (in minutes). Note that there is no way to persist indefinitely.\n\n##### Example:\n\nIf you want to check if a condition evaluates to true, like checking that you\nare on Monday, 2am, on RedHat systems, and make it last one hour you can use the following policy\n\n```\ncondition_from_expression_persistent_(\"backup_time\", \"Monday.redhat.Hr02\", \"60\")\n```\nThe method will define:\n* In any case:\n    * `condition_from_expression_persistent_backup_time_kept`\n    * `condition_from_expression_persistent_backup_time_reached`\n* And:\n    * `backup_time_true` if the system is a RedHat like system, on Monday,\n     at 2am, and will persist for **Duration** minutes,\n    * `backup_time_false` if the system not a RedHat like system, or it's not Monday, or it's not 2am\n    * no extra condition if the expression is invalid (cannot be parsed)\n\n##### Notes:\n\nRudder will automatically \"canonify\" the given **Condition prefix** at execution time,\nwhich means that all non `[a-zA-Z0-9_]` characters will be replaced by an underscore.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "condition_from_expression_persistent",
+    "class_parameter": "condition",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/condition_from_expression_persistent.cf",
+    "parameter": [
+      {
+        "name": "condition",
+        "description": "The condition prefix",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "expression",
+        "description": "The expression evaluated to create the condition (use 'any' to always evaluate to true)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "duration",
+        "description": "The persistence suffix in minutes",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -179,29 +194,114 @@
     ],
     "parameter_rename": [
       {
-        "old": "destination",
+        "old": "condition_prefix",
+        "new": "condition"
+      },
+      {
+        "old": "condition_expression",
+        "new": "expression"
+      }
+    ]
+  },
+  "service_enabled": {
+    "name": "Service enabled at boot",
+    "bundle_name": "service_enabled",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Force a service to be started at boot",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "service_enabled",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_enabled.cf",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Service name (as recognized by systemd, init.d, Windows, SRC, SMF, etc...)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "service_name",
+        "new": "name"
+      }
+    ]
+  },
+  "directory_absent": {
+    "name": "Directory absent",
+    "bundle_name": "directory_absent",
+    "bundle_args": [
+      "path",
+      "recursive"
+    ],
+    "description": "Ensure a directory's absence",
+    "documentation": "If `recursive` is false, only an empty directory can be deleted.",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "directory_absent",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/directory_absent.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "Directory to remove",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "recursive",
+        "description": "Should deletion be recursive, \"true\" or \"false\" (defaults to \"false\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "target",
         "new": "path"
       }
     ]
   },
-  "file_block_present_in_section": {
-    "name": "File block in section",
-    "bundle_name": "file_block_present_in_section",
+  "file_key_value_present_option": {
+    "name": "File key-value present with option",
+    "bundle_name": "file_key_value_present_option",
     "bundle_args": [
       "path",
-      "section_start",
-      "section_end",
-      "block"
+      "key",
+      "value",
+      "separator",
+      "option"
     ],
-    "description": "Ensure that a section contains exactly a text block",
-    "documentation": "Ensure that a section contains exactly a text block.\nA section is delimited by a header and a footer.\n* If the section exists, its content will be replaced if needed\n* Otherwise it will be created at the end of the file",
+    "description": "Ensure that the file contains a pair of \"key separator value\", with options on the spacing around the separator",
+    "documentation": "Edit (or create) the file, and ensure it contains an entry key -> value with arbitrary separator between the key and its value.\nIf the key is already present, the method will change the value associated with this key.",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "file_block_present_in_section",
+    "class_prefix": "file_key_value_present",
     "class_parameter": "path",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_block_present_in_section.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_key_value_present_option.cf",
     "parameter": [
       {
         "name": "path",
@@ -214,8 +314,8 @@
         "type": "string"
       },
       {
-        "name": "section_start",
-        "description": "Start of the section",
+        "name": "key",
+        "description": "Key to define",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -224,8 +324,8 @@
         "type": "string"
       },
       {
-        "name": "section_end",
-        "description": "End of the section",
+        "name": "value",
+        "description": "Value to define",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -234,11 +334,29 @@
         "type": "string"
       },
       {
-        "name": "block",
-        "description": "Block representing the content of the section",
+        "name": "separator",
+        "description": "Separator between key and value, for example \"=\" or \" \" (without the quotes)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": true,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "option",
+        "description": "Option for the spacing around the separator: strict, which prevent spacing (space or tabs) around separators, or lax which accepts any number of spaces around separators",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": "strict"
+            },
+            {
+              "value": "lax"
+            }
+          ],
           "max_length": 16384
         },
         "type": "string"
@@ -251,25 +369,36 @@
       }
     ]
   },
-  "file_check_FIFO_pipe": {
-    "name": "File check is FIFO/Pipe",
-    "bundle_name": "file_check_FIFO_pipe",
+  "package_install_version": {
+    "name": "Package install version",
+    "bundle_name": "package_install_version",
     "bundle_args": [
-      "path"
+      "name",
+      "package_version"
     ],
-    "description": "Checks if a file exists and is a FIFO/Pipe",
-    "documentation": "This bundle will define a condition `file_check_FIFO_pipe_${path}_{ok, reached, kept}` if the\nfile is a FIFO, or `file_check_FIFO_pipe_${path}_{not_ok, reached, not_kept, failed}` if\nthe file is not a fifo or does not exist",
+    "description": "Install or update a package in a specific version",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "file_check_FIFO_pipe",
-    "class_parameter": "path",
+    "class_prefix": "package_install",
+    "class_parameter": "name",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_FIFO_pipe.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/package_install_version.cf",
+    "deprecated": "Use [package_present](#_package_present) instead.",
     "parameter": [
       {
-        "name": "path",
-        "description": "File name (absolute path on the target node)",
+        "name": "name",
+        "description": "Name of the package to install",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "package_version",
+        "description": "Version of the package to install (can be \"latest\" to install it in its latest version)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -280,33 +409,33 @@
     ],
     "parameter_rename": [
       {
-        "old": "file_name",
-        "new": "path"
+        "old": "package_name",
+        "new": "name"
       }
     ]
   },
-  "permissions_group_acl_present": {
-    "name": "Permissions group POSIX acl entry present",
-    "bundle_name": "permissions_group_acl_present",
+  "sharedfile_to_node": {
+    "name": "Sharedfile to node",
+    "bundle_name": "sharedfile_to_node",
     "bundle_args": [
-      "path",
-      "recursive",
-      "group",
-      "ace"
+      "remote_node",
+      "file_id",
+      "file_path",
+      "ttl"
     ],
-    "description": "Verify that an ace is present on a file or directory for a given group.\nThis method will make sure the given ace is present in the POSIX ACL of the target for the given group.",
-    "documentation": "The `permissions_*acl_*` manage the POSIX ACL on files and directories.\n\nPlease note that the mask will be automatically recalculated when editing ACLs.\n\n#### Parameters\n\n##### Path\n\nPath can be a regex with the following format:\n\n* `*` matches any filename or directory at one level, e.g. `*.cf` will match all files in one directory that end in .cf but it won't search across directories. `*/*.cf` on the other hand will look two levels deep.\n* `?` matches a single letter\n* `[a-z]` matches any letter from a to z\n* `{x,y,anything}` will match x or y or anything.\n\n##### Recursive\n\nCan be:\n\n* `true` to apply the given aces to folder and sub-folders and files.\n* or `false` to apply to the strict match of `Path`\n\nIf left blank, recursivity will automatically be set to `false`\n\n##### Group\n\n`Group` to enfoorce the ace, being the Linux account name.\nThis method can only handle one groupname.\n\n##### ACE\n\nThe operator can be:\n* `+` to add the given ACE to the current ones.\n* `-` to remove the given ACE to the current ones.\n* `=` to force the given ACE to the current ones.\n* `empty` if no operator is specified, it will be interpreted as `=`.\n\nACE must respect the classic:\n\n* `^[+-=]?(?=.*[rwx])r?w?x?$`\n\n#### Example\n\nGiven a file with the following getfacl output:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\ngroup::r--\ngroup:bob:rwx\nmask::rwx\nother::---\n\n~~~~\n\nApplying this method with the following parameters:\n\n* `path`: /tmp/myTestFile\n* `recursive`: false\n* `group`: bob\n* `ace`: -rw\n\nWill transform the previous ACLs in:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\ngroup::r--\ngroup:bob:--x\nmask::r-x\nother::---\n\n~~~~",
+    "description": "This method shares a file with another Rudder node",
+    "documentation": "This method shares a file with another Rudder node using a unique file identifier.\n\nRead the Rudder documentation for a [high level overview of file sharing between nodes](https://docs.rudder.io/reference/current/usage/advanced_configuration_management.html#_share_files_between_nodes).\n\nThe file will be kept on the policy server and transmitted to the destination node's policy server if it is different.\nIt will be kept on this server for the destination node to download as long as it is not replaced by a new\nfile with the same id or remove by expiration of the TTL.\n\n#### Parameters\n\nThis section describes the generic method parameters.\n\n#### remote_node\n\nThe node you want to share this file with. The uuid of a node\nis visible in the Nodes details (in the Web interface) or by entering\n`rudder agent info` on the target node.\n\n##### file_id\n\nThis is a name that will be used to identify the file in the target node. It should be unique\nand describe the file content.\n\n##### file_path\n\nThe local absolute path of the file to share.\n\n##### ttl\n\nThe TTL can be:\n\n* A simple integer, in this case it is assumed to be a number of *seconds*\n* A string including units indications, the possible units are:\n\n* *days*, *day* or *d*\n* *hours*, *hour*, or *h*\n* *minutes*, *minute*, or *m*\n* *seconds*, *second* or *s*\n\nThe ttl value can look like *1day 2hours 3minutes 4seconds* or can be abbreviated in the form *1d 2h 3m 4s*, or without spaces *1d2h3m4s* or any combination like *1day2h 3minute 4seconds*\nAny unit can be skipped, but the decreasing order needs to be respected.\n\n##### file_id\n\nThis is a name that will be used to identify the file once stored on the server. It should be unique\nand describe the file content.\n\n#### Example:\n\nWe have a node *A*, with uuid `2bf1afdc-6725-4d3d-96b8-9128d09d353c` which wants to share\nthe `/srv/db/application.properties` with node *B* with uuid `73570beb-2d4a-43d2-8ffc-f84a6817849c`.\n\nWe want this file to stay available for one year for node *B* on its policy server.\n\nThe node *B* wants to download it into `/opt/application/etc/application.properties`.\n\nThey have to agree (i.e. it has to be defined in the policies of both nodes) on the id of the file,\nthat will be used during the exchange, here it will be `application.properties`.\n\nTo share the file, node *A* will use:\n\n```\nsharedfile_to_node(\"73570beb-2d4a-43d2-8ffc-f84a6817849c\", \"application.properties\", \"/srv/db/application.properties\", \"356 days\")\n```\n\nTo download the file, node *B* will use [sharedfile_from_node](#_sharedfile_from_node) with:\n\n```\nsharedfile_from_node(\"2bf1afdc-6725-4d3d-96b8-9128d09d353c\", \"application.properties\", \"/opt/application/etc/application.properties\")\n```",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "permissions_group_acl_present",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_group_acl_present.cf",
+    "class_prefix": "sharedfile_to_node",
+    "class_parameter": "file_id",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/sharedfile_to_node.cf",
     "parameter": [
       {
-        "name": "path",
-        "description": "Path of the file or directory",
+        "name": "remote_node",
+        "description": "Which node to share the file with",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -315,23 +444,21 @@
         "type": "string"
       },
       {
-        "name": "recursive",
-        "description": "Recursive Should ACLs cleanup be recursive, \"true\" or \"false\" (defaults to \"false\")",
+        "name": "file_id",
+        "description": "Unique name that will be used to identify the file on the receiver",
         "constraints": {
-          "allow_empty_string": true,
+          "allow_empty_string": false,
           "allow_whitespace_string": false,
-          "select": [
-            "",
-            "true",
-            "false"
-          ],
+          "regex": {
+            "value": "^[A-z0-9._-]+$"
+          },
           "max_length": 16384
         },
         "type": "string"
       },
       {
-        "name": "group",
-        "description": "Group name",
+        "name": "file_path",
+        "description": "Path of the file to share",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -340,99 +467,23 @@
         "type": "string"
       },
       {
-        "name": "ace",
-        "description": "ACE to enforce for the given group.",
+        "name": "ttl",
+        "description": "Time to keep the file on the policy server in seconds or in human readable form (see long description)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
-          "regex": "^[+-=]?(?=.*[rwx])r?w?x?$",
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "permissions_other_acl_present": {
-    "name": "Permissions other POSIX acl entry present",
-    "bundle_name": "permissions_other_acl_present",
-    "bundle_args": [
-      "path",
-      "recursive",
-      "other"
-    ],
-    "description": "Verify that the other ace given is present on a file or directory.\nThis method will make sure the given other ace is present in the POSIX ACL of the target for.",
-    "documentation": "The `permissions_*acl_*` manage the POSIX ACL on files and directories.\n\nPlease note that the mask will be automatically recalculated when editing ACLs.\n\n#### Parameters\n\n##### Path\n\nPath can be a regex with the following format:\n\n* `*` matches any filename or directory at one level, e.g. `*.cf` will match all files in one directory that end in .cf but it won't search across directories. `*/*.cf` on the other hand will look two levels deep.\n* `?` matches a single letter\n* `[a-z]` matches any letter from a to z\n* `{x,y,anything}` will match x or y or anything.\n\n##### Recursive\n\nCan be:\n\n* `true` to apply the given aces to folder and sub-folders and files.\n* or `false` to apply to the strict match of `Path`\n\nIf left blank, recursivity will automatically be set to `false`\n\n##### Other_ACE\n\nThe operator can be:\n* `+` to add the given ACE to the current ones.\n* `-` to remove the given ACE to the current ones.\n* `=` to force the given ACE to the current ones.\n* `empty` if no operator is specified, it will be interpreted as `=`.\n\nACE must respect the classic:\n\n* `^[+-=]?(?=.*[rwx])r?w?x?$`\n\n#### Example\n\nGiven a file with the following getfacl output:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\nuser:bob:rwx\ngroup::r--\nmask::rwx\nother::r-x\n\n~~~~\n\nApplying this method with the following parameters:\n\n* `path`: /tmp/myTestFile\n* `recursive`: false\n* `other ace`: -rw\n\nWill transform the previous ACLs in:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\nuser:bob:rwx\ngroup::r--\nmask::rwx\nother::--x\n\n~~~~",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "permissions_other_acl_present",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_other_acl_present.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Path of the file or directory",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "recursive",
-        "description": "Recursive Should ACLs cleanup be recursive, \"true\" or \"false\" (defaults to \"false\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "true",
-            "false"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "other",
-        "description": "ACE to enforce for the given other.",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "regex": "^[+-=]?(?=.*[rwx])r?w?x?$",
+          "regex": {
+            "value": "^(\\d+\\s*(days?|d))?(\\d+\\s*(hours?|h))?(\\d+\\s*(minutes?|m))?(\\d+\\s*(seconds?|s))?$"
+          },
           "max_length": 16384
         },
         "type": "string"
       }
-    ]
-  },
-  "partition_check_mounted": {
-    "name": "Partition check mounted",
-    "bundle_name": "partition_check_mounted",
-    "bundle_args": [
-      "mount_point"
     ],
-    "description": "Checks if a given mount point exists",
-    "documentation": "This generic method check that a given path is a single mounted point\nthe partition doesn't exists or is not mounted.\n\nIt uses the command findmnt to check for mounted options, which should already be available on most Linux\ndistributions.\n\n\nThe method will report a `success`:\n\n* If the given path correspond to a single mount point\n\nAnd an `error`:\n\n* if the path given does is not a mount point\n* or if the command findmnt is not found in /mnt",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "mount_point",
-    "class_parameter": "mount_point",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/cis/partition_check_mounted.cf",
-    "parameter": [
+    "parameter_rename": [
       {
-        "name": "mount_point",
-        "description": "Mount point path (absolute mount path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
+        "old": "target_uuid",
+        "new": "remote_node"
       }
     ]
   },
@@ -563,926 +614,22 @@
       }
     ]
   },
-  "file_check_regular": {
-    "name": "File check if regular",
-    "bundle_name": "file_check_regular",
-    "bundle_args": [
-      "path"
-    ],
-    "description": "Checks if a file exists and is a regular file",
-    "documentation": "This bundle will define a condition `file_check_regular_${path}_{ok, reached, kept}` if the\nfile is a regular_file, or `file_check_regular_${path}_{not_ok, reached, not_kept, failed}` if\nthe file is not a regular file or does not exist",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_check_regular",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_regular.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file_name",
-        "new": "path"
-      }
-    ]
-  },
-  "user_create": {
-    "name": "User create",
-    "bundle_name": "user_create",
-    "bundle_args": [
-      "login",
-      "description",
-      "home",
-      "group",
-      "shell",
-      "locked"
-    ],
-    "description": "Create a user",
-    "documentation": "This method does not create the user's home directory.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "user_create",
-    "class_parameter": "login",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/user_create.cf",
-    "deprecated": "Please split into calls to other user_* methods:\n[user_present](#_user_present) [user_fullname](#_user_fullname) [user_home](#_user_home)\n[user_primary_group](#_user_primary_group) [user_shell](#_user_shell) and [user_locked](#_user_locked)",
-    "parameter": [
-      {
-        "name": "login",
-        "description": "User login",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "description",
-        "description": "User description",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "home",
-        "description": "User's home directory",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "group",
-        "description": "User's primary group",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "shell",
-        "description": "User's shell",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "locked",
-        "description": "Is the user locked ? true or false",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_from_string_mustache": {
-    "name": "File from a mustache string",
-    "bundle_name": "file_from_string_mustache",
-    "bundle_args": [
-      "template",
-      "path"
-    ],
-    "description": "Build a file from a mustache string",
-    "documentation": "Build a file from a mustache string.\nComplete mustache documentation is available in the *file\\_from\\_template\\_mustache* method documentation.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_from_string_mustache",
-    "class_parameter": "path",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_string_mustache.cf",
-    "parameter": [
-      {
-        "name": "template",
-        "description": "String containing a template to be expanded",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "Destination file (absolute path on the target node",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "destination",
-        "new": "path"
-      }
-    ]
-  },
-  "file_augeas_set": {
-    "name": "File Augeas set",
-    "bundle_name": "file_augeas_set",
-    "bundle_args": [
-      "path",
-      "value",
-      "lens",
-      "file"
-    ],
-    "description": "Use augeas commands and options to set a node label's value.",
-    "documentation": "Augeas is a tool that provides an abstraction layer for all the complexities that turn around editing files with regular expressions.\nIt's a tree based hierarchy tool, that handles system configuration files where you can securely modify your files and to do so you have to provide\nthe path to the node label's value.\n\nAugeas uses lenses which are like sort of modules that are in charge of identifying and converting files into tree and back.\n\nThis method uses `augtool` to force the value of an augeas node's label.\n\nActually there are two ways to use this method:\n\n* Either by providing the augeas **path** to the node's label and let **lens** and **file** empty.\n** this way augeas will load the common files and lens automatically\n* Or by using a given **file** path and a specific **lens**.\n** better performances since only one lens is loaded\n** support custom lens, custom paths (for instance to apply the Hosts lens to another file than `/etc/hosts`)\n* Either by simply providing an augeas **path** to the node's label\n\n*Warning*: When you don't specify the file and lens to use, no backup of the file will be made before\nediting it.\n\n#### Two uses cases examples:\n\nIn the first case, let's suppose that you want to set the value of the ip address of the first line in the `/etc/hosts` file to `192.168.1.5`,\nto do so you need to provide the augeas **path** and **value** parameters.\n\n```\nfile_augeas_set(\"/etc/hosts/1/ipaddr\", \"192.168.1.5\", \"\", \"\");\n```\n\nThe second case is more efficient, and forces the `Hosts` lens to parse the `/etc/hosts` file and set the value for the given **path** node:\n\n```\nfile_augeas_set(\"/etc/hosts/1/ipaddr\", \"192.168.1.5\", \"Hosts\", \"/etc/hosts\");\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_augeas_set",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_augeas_set.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "The path to the file and node label",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "value",
-        "description": "The value to set",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "lens",
-        "description": "Load a specific lens (optional)",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "file",
-        "description": "Load a specific file (optional)",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_check_block_device": {
-    "name": "File check if block device",
-    "bundle_name": "file_check_block_device",
-    "bundle_args": [
-      "path"
-    ],
-    "description": "Checks if a file exists and is a block device",
-    "documentation": "This bundle will define a condition `file_check_block_device_${path}_{ok, reached, kept}` if the\nfile is a block_device, or `file_check_block_device_${path}_{not_ok, reached, not_kept, failed}` if\nthe file is not a block device or does not exist",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_check_block_device",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_block_device.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file_name",
-        "new": "path"
-      }
-    ]
-  },
-  "variable_dict": {
-    "name": "Variable dict",
-    "bundle_name": "variable_dict",
-    "bundle_args": [
-      "prefix",
-      "name",
-      "value"
-    ],
-    "description": "Define a variable that contains key,value pairs (a dictionary)",
-    "documentation": "To use the generated variable, you must use the form `${prefix.name[key]}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \nPlease note that only global variables are available within templates.",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "variable_dict",
-    "class_parameter": "name",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/variable_dict.cf",
-    "parameter": [
-      {
-        "name": "prefix",
-        "description": "The prefix of the variable name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "name",
-        "description": "The variable to define, the full name will be prefix.name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "value",
-        "description": "The variable content in JSON format",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "variable_prefix",
-        "new": "prefix"
-      },
-      {
-        "old": "variable_name",
-        "new": "name"
-      }
-    ]
-  },
-  "file_key_value_present_in_ini_section": {
-    "name": "File key-value in INI section",
-    "bundle_name": "file_key_value_present_in_ini_section",
-    "bundle_args": [
-      "path",
-      "section",
-      "name",
-      "value"
-    ],
-    "description": "Ensure that a key-value pair is present in a section in a specific location. The objective of this method is to handle INI-style files.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_key_value_present_in_ini_section",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_key_value_present_in_ini_section.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "section",
-        "description": "Name of the INI-style section under which the line should be added or modified (not including the [] brackets)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "name",
-        "description": "Name of the key to add or edit",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "value",
-        "description": "Value of the key to add or edit",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file",
-        "new": "path"
-      }
-    ]
-  },
-  "file_keys_values_present": {
-    "name": "File keys-values present",
-    "bundle_name": "file_keys_values_present",
-    "bundle_args": [
-      "path",
-      "keys",
-      "separator"
-    ],
-    "description": "Ensure that the file contains all pairs of \"key separator value\", with arbitrary separator between each key and its value",
-    "documentation": "This method ensures key-value pairs are present in a file.\n\n#### Usage\n\nThis method will iterate over the key-value pairs in the dict, and:\n\n* If the key is not defined in the destination, add the *key* + *separator* + *value* line.\n* If the key is already present in the file, replace the *key* + *separator* + anything by *key* + *separator* + *value*\n\nThis method always ignores spaces and tabs when replacing (which means for example that `key = value` will match the `=` separator).\n\nKeys are considered unique (to allow replacing the value), so you should use [file_ensure_lines_present](#_file_ensure_lines_present)\nif you want to have multiple lines with the same key.\n\n#### Example\n\nIf you have an initial file (`/etc/myfile.conf`) containing:\n\n```\nkey1 = something\nkey3 = value3\n```\n\nTo define key-value pairs, use the [variable_dict](#_variable_dict) or\n[variable_dict_from_file](#_variable_dict_from_file) methods.\n\nFor example, if you use the following content (stored in `/tmp/data.json`):\n\n```json\n{\n   \"key1\": \"value1\",\n   \"key2\": \"value2\"\n}\n```\n\nWith the following policy:\n\n```\n# Define the `content` variable in the `configuration` prefix from the json file\nvariable_dict_from_file(\"configuration\", \"content\", \"/tmp/data.json\")\n# Enforce the presence of the key-value pairs\nfile_ensure_keys_values(\"/etc/myfile.conf\", \"configuration.content\", \" = \")\n\n```\n\nThe destination file (`/etc/myfile.conf`) will contain:\n\n```\nkey1 = value1\nkey3 = value3\nkey2 = value2\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_keys_values_present",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_keys_values_present.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "keys",
-        "description": "Name of the dict structure (without \"${}\") containing the keys (keys of the dict), and values to define (values of the dict)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "separator",
-        "description": "Separator between key and value, for example \"=\" or \" \" (without the quotes)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": true,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file",
-        "new": "path"
-      }
-    ]
-  },
-  "service_ensure_running_path": {
-    "name": "Service ensure running with service path",
-    "bundle_name": "service_ensure_running_path",
-    "bundle_args": [
-      "name",
-      "path"
-    ],
-    "description": "Ensure that a service is running using the appropriate method, specifying the path of the service in the ps output, or using Windows task manager",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "service_ensure_running",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_ensure_running_path.cf",
-    "deprecated": "Use [service_started_path](#_service_started_path) instead.",
-    "rename": "service_started_path",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Service name (as recognized by systemd, init.d, Windows, etc...)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "Service with its path, as in the output from 'ps'",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "service_name",
-        "new": "name"
-      },
-      {
-        "old": "service_path",
-        "new": "path"
-      }
-    ]
-  },
-  "variable_string_from_augeas": {
-    "name": "Variable string from Augeas",
-    "bundle_name": "variable_string_from_augeas",
-    "bundle_args": [
-      "prefix",
-      "name",
-      "path",
-      "lens",
-      "file"
-    ],
-    "description": "Use Augeas binaries to call Augtool commands and options to get a node label's value.",
-    "documentation": "Augeas is a tool that provides an abstraction layer for all the complexities that turn around editing files with regular expressions.\nIt's a tree based hierarchy tool, that handle system configuration files where you can securely modify your files. To do so you have to provide\nthe path to the node label's value.\n\nThis method aims to use `augtool` to extract a specific information from a configuration file into a rudder variable.\nIf Augeas is not installed on the agent, or if it fails to execute, it will produces an error.\n\n* **variable prefix**: target variable prefix\n* **variable name**: target variable name\n* **path**: augeas node path, use to describe the location of the target information we want to extract\n* **lens**: augeas lens to use, optional\n* **file**: absolute file path to target, optional\n\nActually there are two ways you can use this method:\n\n* Either by providing the augeas **path** to the node's label and let **lens** and **file** empty.\n** this way augeas will load the common files and lens automatically\n* Or by using a given **file** path and a specific **lens**.\n** better performances since only one lens is loaded\n** support custom lens, support custom paths\n\nThis mechanism is the same as in the `file_augeas_set` method.\n\n#### With autoload\n\nLet's consider that you want to obtain the value of the ip address of the first line in the `/etc/hosts`:\n\n(Note that the `label` and `value` parameters mentioned are naming examples of **variable prefix** and **variable name**, the augeas\n**path** `/etc/hosts/1/ipaddr`\nrepresents the `ipaddr` node label's value (in the augeas mean) in the first line of the file `/etc/hosts`).\n\n```\nvariable_string_from_augeas(\"label\",\"value\",\"/etc/hosts/1/ipaddr\", \"\", \"\");\n```\n\n#### Without autoload\n\nHere we want the same information as in the first example, but we will force the lens to avoid loading unnecessary files.\n\n```\nvariable_string_from_augeas(\"label\",\"value\",\"/etc/hosts/1/ipaddr\",\"Hosts\",\"/etc/hosts\");\n```\n\n#### Difference with `file augeas command`\n\nThis method is very similar to the `file augeas command` one, both execute an `augtool` command an dump its output in a rudder variable.\nBut their goal is really different:\n\n* This one will parse the output of the augeas `print` that we want to make it directly usable, but will be less flexible in its input.\n* The `file augeas command` offers much more possibilities to execute an augeas command to modify a file, but the output will be unparsed and most likely\n  unusable as a rudder variable, expect to dump an error or configuration somewhere.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "variable_string_from_augeas",
-    "class_parameter": "name",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/variable_string_from_augeas.cf",
-    "parameter": [
-      {
-        "name": "prefix",
-        "description": "The prefix of the variable name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "name",
-        "description": "The variable to define, the full name will be prefix.name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "The path to the file and node label",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "lens",
-        "description": "The lens specified by the user in case he wants to load a specified lens associated with its file",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "file",
-        "description": "The absolute path to the file specified by the user in case he wants to load a specified file associated with its lens",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "variable_prefix",
-        "new": "prefix"
-      },
-      {
-        "old": "variable_name",
-        "new": "name"
-      }
-    ]
-  },
-  "partition_check_options": {
-    "name": "Partition check options",
-    "bundle_name": "partition_check_options",
-    "bundle_args": [
-      "mount_point",
-      "options"
-    ],
-    "description": "Checks if a given mount point options are correct",
-    "documentation": "This generic method will check that correct options are applied on a\ngiven mount point.\nIt will never make modification to the node, it is only a `check` method.\n\nIt uses the command findmnt to check for mounted options, which should already be available on most Linux\ndistributions.\n\nThe method will report a `success`:\n\n* if the partition options are correct\n* which means that each options passed in parameters is included in the effective options.\n\nAnd an `error`:\n\n* If its options do not include the ones passed as parameters\n* if the partition is not mounted\n* or if the command findmnt is not found in /mnt\n\n####Example:\nIf we have a root partition mounted like this:\n```\nroot@server# findmnt -T /\nTARGET SOURCE                             FSTYPE OPTIONS\n/      /dev/mapper/debian--9--64--vg-root ext4   rw,relatime,errors=remount-ro,data=ordered\n```\nAnd we apply this generic method with the following parameters:\n\n* `mount_point` = /\n* `options` = relatime,rw, data=ordered\n\nIt will report a success.\n\nIf you only want to check that a partition is mounted, please use `partition_check_mounted` instead.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "mount_point",
-    "class_parameter": "mount_point",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/cis/partition_check_options.cf",
-    "parameter": [
-      {
-        "name": "mount_point",
-        "description": "Mount point path (absolute mount path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "options",
-        "description": "Comma separated list of the expected options (ex: rw,relatime)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "condition_from_command": {
-    "name": "Condition from command",
-    "bundle_name": "condition_from_command",
-    "bundle_args": [
-      "condition",
-      "command",
-      "true_codes",
-      "false_codes"
-    ],
-    "description": "Execute a command and create result conditions depending on its exit code",
-    "documentation": "This method executes a command, and defines a `${condition}_true` or a\n `${condition}_false` condition depending on the result of the command:\n\n* If the exit code **is in the \"True codes\"** list, this will produce a\n   kept outcome and a\n   `${condition}_true` condition,\n* If the exit code **is in the \"False codes\"** list, this will produce a\n   kept outcome and a\n   `${condition}_false` condition,\n* If the exit code **is not in \"True codes\" nor in \"False codes\"**, or if\n   the command can not be found, it will produce an\n   error outcome and\n   and no condition from `${condition}`\n\n\nThe created condition is global to the agent.\n\n##### Windows\n\nOn Windows nodes, the exit code is taken from the `LASTEXITCODE` which is defined either by:\n\n* The exit code of a binary execution (when the command a call to an exe)\n* The return code of a Powershell script\n\nDirect Powershell execution will almost always return 0 as `LASTEXITCODE` value, meaning that you have to execute either a binary or a Powershell\nscript to control the return code.\n\n##### Example:\n\nIf you run a command `/bin/check_network_status` that output code 0, 1 or 2 in\ncase of correct configuration, and 18 or 52 in case of invalid configuration,\nand you want to define a condition based on its execution result,\nyou can use:\n\n```\ncondition_from_command(\"network_correctly_defined\", \"/bin/check_network_status\", \"0,1,2\", \"18,52\")\n```\n\n* If the command exits with 0, 1 or 2, then it will define the conditions\n    * `network_correctly_defined_true`,\n    * `condition_from_command_network_correctly_defined_kept`,\n    * `condition_from_command_network_correctly_defined_reached`,\n\n* If the command exits 18, 52, then it will define the conditions\n    * `network_correctly_defined_false`,\n    * `condition_from_command_network_correctly_defined_kept`,\n    * `condition_from_command_network_correctly_defined_reached`\n\n* If the command exits any other code or is not found, then it will define the conditions\n    * `condition_from_command_network_correctly_defined_error`,\n    * `condition_from_command_network_correctly_defined_reached`\n\n##### Notes:\n\n* In audit mode, this method will still execute the command passed in parameter.\n  Which means that you should only pass non system-impacting commands to this method.\n\n* Rudder will automatically \"canonify\" the given **Condition prefix** at execution time,\n  which means that all non `[a-zA-Z0-9_]` characters will be replaced by an underscore.",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "condition_from_command",
-    "class_parameter": "condition",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/condition_from_command.cf",
-    "parameter": [
-      {
-        "name": "condition",
-        "description": "The condition name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "command",
-        "description": "The command to run",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "true_codes",
-        "description": "List of codes that produce a true status separated with commas (ex: 1,2,5)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "false_codes",
-        "description": "List of codes that produce a false status separated with commas (ex: 3,4,6)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "condition_prefix",
-        "new": "condition"
-      }
-    ]
-  },
-  "permissions_group_acl_absent": {
-    "name": "Permissions group POSIX acl entry absent",
-    "bundle_name": "permissions_group_acl_absent",
-    "bundle_args": [
-      "path",
-      "recursive",
-      "group"
-    ],
-    "description": "Verify that an ace is absent on a file or directory for a given group.\nThis method will make sure that no ace is present in the POSIX ACL of the target.",
-    "documentation": "The `permissions_*acl_*` manage the POSIX ACL on files and directories.\n\nPlease note that the mask will be automatically recalculated when editing ACLs.\n\n#### Parameters\n\n##### Path\n\nPath can be a regex with the following format:\n\n* `*` matches any filename or directory at one level, e.g. `*.cf` will match all files in one directory that end in .cf but it won't search across directories. `*/*.cf` on the other hand will look two levels deep.\n* `?` matches a single letter\n* `[a-z]` matches any letter from a to z\n* `{x,y,anything}` will match x or y or anything.\n\n##### Recursive\n\nCan be:\n\n* `true` to apply the given aces to folder and sub-folders and files.\n* or `false` to apply to the strict match of `Path`\n\nIf left blank, recursivity will automatically be set to `false`\n\n##### User\n\n`Username` to enforce the ace absence, being the Linux account name.\nThis method can only handle one groupname.\n\n#### Example\n\nGiven a file with the following getfacl output:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\ngroup::r--\ngroup:bob:rwx\nmask::rwx\nother::---\n\n~~~~\n\nApplying this method with the following parameters:\n\n* `path`: /tmp/myTestFile\n* `recursive`: false\n* `group`: bob\n\nWill transform the previous ACLs in:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\ngroup::r--\nmask::r--\nother::---\n\n~~~~",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "permissions_group_acl_absent",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_group_acl_absent.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Path of the file or directory",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "recursive",
-        "description": "Recursive Should ACLs cleanup be recursive, \"true\" or \"false\" (defaults to \"false\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "true",
-            "false"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "group",
-        "description": "Group name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "condition_from_variable_match": {
-    "name": "Condition from variable match",
-    "bundle_name": "condition_from_variable_match",
-    "bundle_args": [
-      "condition",
-      "variable_name",
-      "expected_match"
-    ],
-    "description": "Test the content of a string variable",
-    "documentation": "Test a string variable content and create conditions depending on its value:\n\n* If the variable **is found and its content matches** the given regex:\n    * a `${condition}_true` condition,\n    * and **kept outcome** status\n* If the variable **is found but its content does not match** the given regex:\n    * a `${condition}_false` condition,\n    * and a **kept outcome** status\n* If the variable **can not be found**:\n    * a `${condition}_false` condition\n    * and an **error outcome** status\n\nBe careful, we are using variable *name* not the value. For example if you want to match the property value \"foo\"\nyou will just need `node.properties[foo]` without `${...}` syntax\n\n/!\\ Regex for unix machine must be PCRE compatible and those for Windows agent must respect the .Net regex format.\n\n* If you want to test a technique parameter, use the `technique_id` of the technique\n  as variable prefix and the`parameter_name` as variable name.\n\nThe method only supports plain string type variables.",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "condition_from_variable_match",
-    "class_parameter": "condition",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/condition_from_variable_match.cf",
-    "parameter": [
-      {
-        "name": "condition",
-        "description": "Prefix of the class (condition) generated",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "variable_name",
-        "description": "Complete name of the variable being tested, like my_prefix.my_variable",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "expected_match",
-        "description": "Regex to use to test if the variable content is compliant",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "condition_prefix",
-        "new": "condition"
-      }
-    ]
-  },
-  "file_check_exists": {
-    "name": "File check exists",
-    "bundle_name": "file_check_exists",
-    "bundle_args": [
-      "path"
-    ],
-    "description": "Checks if a file exists",
-    "documentation": "This bundle will define a condition `file_check_exists_${path}_{ok, reached, kept}` if the\nfile exists, or `file_check_exists_${path}_{not_ok, reached, not_kept, failed}` if\nthe file doesn't exists",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_check_exists",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_exists.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file_name",
-        "new": "path"
-      }
-    ]
-  },
-  "rudder_inventory_trigger": {
-    "name": "Rudder inventory trigger",
-    "bundle_name": "rudder_inventory_trigger",
-    "bundle_args": [
-      "id"
-    ],
-    "description": "Trigger an inventory on the agent",
-    "documentation": "Trigger a Rudder inventory. This will not run the inventory\nimmediately but next time the agent runs.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "rudder_inventory_trigger",
-    "class_parameter": "id",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/rudder_inventory_trigger.cf",
-    "action": "",
-    "parameter": [
-      {
-        "name": "id",
-        "description": "Id of the reporting for this method (internal identifier, needs to be unique for each use of the method)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "condition_from_expression": {
-    "name": "Condition from expression",
-    "bundle_name": "condition_from_expression",
-    "bundle_args": [
-      "condition",
-      "expression"
-    ],
-    "description": "Create a new condition",
-    "documentation": "This method evaluates an expression, and produces a `${condition}_true`\nor a `${condition}_false` condition depending on the result of the\nexpression evaluation:\n\n* This method always result with a *success* outcome status\n* If the evaluation results in a \"defined\" state, this will define a\n   `${condition}_true` condition,\n* If the evaluation results in an \"undefined\" state, this will produce a\n   `${condition}_false` condition.\n\n\nCalling this method with a condition expression transforms a complex expression into a single condition.\n\nThe created condition is global to the agent.\n\n##### Example\n\nIf you want to check if a condition evaluates to true, like checking that you\nare on Monday, 2am, on RedHat systems, you can use the following policy\n\n```\ncondition_from_expression(\"backup_time\", \"Monday.redhat.Hr02\")\n```\n\nThe method will define:\n* In any case:\n     * `condition_from_expression_backup_time_kept`\n     * `condition_from_expression_backup_time_reached`\n* And:\n    * `backup_time_true` if the system is a RedHat like system, on Monday, at 2am.\n    * `backup_time_false` if the system not a RedHat like system, or it's not Monday, or it's not 2am\n    * no extra condition if the expression is invalid (cannot be parsed)\n\n##### Notes:\n\nRudder will automatically \"canonify\" the given **Condition prefix** at execution time,\nwhich means that all non `[a-zA-Z0-9_]` characters will be replaced by an underscore.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "condition_from_expression",
-    "class_parameter": "condition",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/condition_from_expression.cf",
-    "parameter": [
-      {
-        "name": "condition",
-        "description": "The condition prefix",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "expression",
-        "description": "The expression evaluated to create the condition (use 'any' to always evaluate to true)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "condition_prefix",
-        "new": "condition"
-      },
-      {
-        "old": "condition_expression",
-        "new": "expression"
-      }
-    ]
-  },
-  "service_stop": {
-    "name": "Service stop",
-    "bundle_name": "service_stop",
+  "service_start": {
+    "name": "Service start",
+    "bundle_name": "service_start",
     "bundle_args": [
       "name"
     ],
-    "description": "Stop a service using the appropriate method",
+    "description": "Start a service using the appropriate method",
     "documentation": "See [service_action](#_service_action) for documentation.",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "service_stop",
+    "class_prefix": "service_start",
     "class_parameter": "name",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_stop.cf",
-    "deprecated": "This is an action that should not be used in the general case.\nIf you really want to call the stop method, use [service_action](#_service_action).\nOtherwise, simply call [service_stopped](#_service_stopped)",
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_start.cf",
+    "deprecated": "This is an action that should not be used in the general case.\nIf you really want to call the start method, use [service_action](#_service_action).\nOtherwise, simply call [service_started](#_service_started)",
     "parameter": [
       {
         "name": "name",
@@ -1502,29 +649,147 @@
       }
     ]
   },
-  "file_key_value_present_option": {
-    "name": "File key-value present with option",
-    "bundle_name": "file_key_value_present_option",
+  "file_from_http_server": {
+    "name": "File from HTTP server",
+    "bundle_name": "file_from_http_server",
     "bundle_args": [
-      "path",
-      "key",
-      "value",
-      "separator",
-      "option"
+      "source",
+      "path"
     ],
-    "description": "Ensure that the file contains a pair of \"key separator value\", with options on the spacing around the separator",
-    "documentation": "Edit (or create) the file, and ensure it contains an entry key -> value with arbitrary separator between the key and its value.\nIf the key is already present, the method will change the value associated with this key.",
+    "description": "Download a file if it does not exist, using curl with a fallback on wget",
+    "documentation": "This method finds a HTTP command-line tool and downloads the given source\ninto the destination if it does not exist yet.\n\nThis method **will NOT update the file after the first download** until its removal.\n\nOn Linux based nodes it will tries `curl` first and fallback with `wget` if needed.\nOn Windows based nodes, only `curl` will be used.",
     "agent_support": [
-      "cfengine-community"
+      "cfengine-community",
+      "dsc"
     ],
-    "class_prefix": "file_key_value_present",
+    "class_prefix": "file_from_http_server",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_http_server.cf",
+    "parameter": [
+      {
+        "name": "source",
+        "description": "URL to download from",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "File destination (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
+      }
+    ]
+  },
+  "directory_create": {
+    "name": "Directory create",
+    "bundle_name": "directory_create",
+    "bundle_args": [
+      "path"
+    ],
+    "description": "Create a directory if it doesn't exist",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "directory_create",
     "class_parameter": "path",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_key_value_present_option.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/directory_create.cf",
+    "deprecated": "Use [directory_present](#_directory_present) instead.",
+    "rename": "directory_present",
     "parameter": [
       {
         "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
+        "description": "Full path of directory to create (trailing '/' is optional)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "target",
+        "new": "path"
+      }
+    ]
+  },
+  "service_ensure_disabled_at_boot": {
+    "name": "Service ensure disabled at boot",
+    "bundle_name": "service_ensure_disabled_at_boot",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Force a service not to be enabled at boot",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "service_ensure_disabled_at_boot",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_ensure_disabled_at_boot.cf",
+    "deprecated": "Use [service_disabled_at_boot](#_service_disabled_at_boot) instead.",
+    "rename": "service_disabled_at_boot",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Service name (as recognized by systemd, init.d, etc...)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "service_name",
+        "new": "name"
+      }
+    ]
+  },
+  "package_state": {
+    "name": "Package state",
+    "bundle_name": "package_state",
+    "bundle_args": [
+      "name",
+      "version",
+      "architecture",
+      "provider",
+      "state"
+    ],
+    "description": "Enforce the state of a package",
+    "documentation": "These methods manage packages using a package manager on the system.\n\n`package_present` and `package_absent` use a new package implementation, different from `package_install_*`,\n`package_remove_*` and `package_verify_*`. It should be more reliable, and handle upgrades better.\nIt is compatible though, and you can call generic methods from both implementations on the same host.\nThe only drawback is that the agent will have to maintain double caches for package lists, which\nmay cause a little unneeded overhead.\nThese methods will update the corresponding package if updates are available\nNew updates may not be detected even if there are some available,\nthis is due to the update cache that is refresh every 4 hours by default,\nyou can modify this behaviour called `updates_cache_expire` in `rudder` global parameter\n\n#### Package parameters\n\nThere is only one mandatory parameter, which is the package name to install.\nWhen it should be installed from a local package, you need to specify the full path to the package as name.\n\nThe version parameter allows specifying a version you want installed (not supported with snap).\nIt should be the complete versions string as used by the used package manager.\nThis parameter allows two special values:\n\n* *any* which is the default value, and is satisfied by any version of the given package\n* *latest* which will ensure, at each run, that the package is at the latest available version.\n\nThe last parameter is the provider, which is documented in the next section.\n\nYou can use [package_state_options](#_package_state_options) to pass options to the underlying package manager\n(currently only with *apt* package manager).\n\n#### Package providers\n\nThis method supports several package managers. You can specify the package manager\nyou want to use or let the method choose the default for the local system.\n\nThe package providers include a caching system for package information.\nThe package lists (installed, available and available updates) are only updated\nwhen the cache expires, or when an operation is made by the agent on packages.\n\n*Note*: The implementation of package operations is done in scripts called modules,\nwhich you can find in `${sys.workdir}/modules/packages/`.\n\n##### apt\n\nThis package provider uses *apt*/*dpkg* to manage packages on the system.\n*dpkg* will be used for all local actions, and *apt* is only needed to manage update and\ninstallation from a repository.\n\n##### rpm\n\nThis package provider uses *yum*/*rpm* to manage packages on the system. *rpm* will \nbe used for all local actions, and *yum* is only needed to manage update and\ninstallation from a repository.\n\nIt is able to downgrade packages when specifying an older version.\n\n##### zypper\n\nThis package provider uses *zypper*/*rpm* to manage packages on the system.\n*rpm* will be used for all local actions, and *zypper* is only needed to manage update and\ninstallation from a repository.\n\nNote: If the package version you want to install contains an epoch, you have to specify it\nin the version in the `epoch:version` form, like reported by `zypper info`.\n\n##### zypper_pattern\n\nThis package provider uses zypper with the `-t pattern` option to manage zypper patterns or\nmeta-packages on the system.\n\nSince a zypper pattern can be named differently than the rpm package name providing it, please\nalways use the exact pattern name (as listed in the output of `zypper patterns`)\nwhen using this provider.\n\nNote: When installing a pattern from a local rpm file, Rudder assumes that the pattern is built\nfollowing the \n[official zypper documentation](https://doc.opensuse.org/projects/libzypp/HEAD/zypp-pattern-packages.html).\n\nOlder implementations of zypper patterns may not be supported by this module.\n\nThis provider doesn't support installation from a file.\n\n##### slackpkg\n\nThis package provider uses Slackware's `installpkg` and `upgradepkg` tools to manage \npackages on the system\n\n##### pkg\n\nThis package provider uses FreeBSD's *pkg* to manage packages on the system.\nThis provider doesn't support installation from a file.\n\n#### ips\n\nThis package provider uses Solaris's pkg command to manage packages from IPS repositories on the system.\nThis provider doesn't support installation from a file.\n\n#### nimclient\n\nThis package provider uses AIX's nim client to manage packages from nim\nThis provider doesn't support installation from a file.\n\n#### snap\n\nThis package provider uses Ubuntu's *snap* to manage packages on the system\nThis provider doesn't support installation from a file.\n\n#### Examples\n\n```\n# To install postgresql in version 9.1 for x86_64 architecture\npackage_present(\"postgresql\", \"9.1\", \"x86_64\", \"\");\n# To ensure postgresql is always in the latest available version\npackage_present(\"postgresql\", \"latest\", \"\", \"\");\n# To ensure installing postgresql in any version\npackage_present(\"postgresql\", \"\", \"\", \"\");\n# To ensure installing postgresql in any version, forcing the yum provider\npackage_present(\"postgresql\", \"\", \"\", \"yum\");\n# To ensure installing postgresql from a local package\npackage_present(\"/tmp/postgresql-9.1-1.x86_64.rpm\", \"\", \"\", \"\");\n# To remove postgresql\npackage_absent(\"postgresql\", \"\", \"\", \"\");\n```\n\nSee also : [package_present](#_package_present), [package_absent](#_package_absent), [package_state_options](#_package_state_options)",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "package_state",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/package_state.cf",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Name of the package, or path to a local package if state is present",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -1533,81 +798,162 @@
         "type": "string"
       },
       {
-        "name": "key",
-        "description": "Key to define",
+        "name": "version",
+        "description": "Version of the package, can be \"latest\" for latest version or \"any\" for any version (defaults to \"any\")",
         "constraints": {
-          "allow_empty_string": false,
+          "allow_empty_string": true,
           "allow_whitespace_string": false,
           "max_length": 16384
         },
         "type": "string"
       },
       {
-        "name": "value",
-        "description": "Value to define",
+        "name": "architecture",
+        "description": "Architecture of the package, can be an architecture name  or \"default\" (defaults to \"default\")",
         "constraints": {
-          "allow_empty_string": false,
+          "allow_empty_string": true,
           "allow_whitespace_string": false,
           "max_length": 16384
         },
         "type": "string"
       },
       {
-        "name": "separator",
-        "description": "Separator between key and value, for example \"=\" or \" \" (without the quotes)",
+        "name": "provider",
+        "description": "Package provider to use, can be \"yum\", \"apt\", \"zypper\", \"zypper_pattern\", \"slackpkg\", \"pkg\", \"ips\", \"nimclient\", \"snap\" or \"default\" for system default package manager (defaults to \"default\")",
         "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": true,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "option",
-        "description": "Option for the spacing around the separator: strict, which prevent spacing (space or tabs) around separators, or lax which accepts any number of spaces around separators",
-        "constraints": {
-          "allow_empty_string": false,
+          "allow_empty_string": true,
           "allow_whitespace_string": false,
           "select": [
-            "strict",
-            "lax"
+            {
+              "value": ""
+            },
+            {
+              "value": "default"
+            },
+            {
+              "value": "yum"
+            },
+            {
+              "value": "apt"
+            },
+            {
+              "value": "zypper"
+            },
+            {
+              "value": "zypper_pattern"
+            },
+            {
+              "value": "slackpkg"
+            },
+            {
+              "value": "pkg"
+            },
+            {
+              "value": "ips"
+            },
+            {
+              "value": "nimclient"
+            },
+            {
+              "value": "snap"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "state",
+        "description": "State of the package, can be \"present\" or \"absent\" (defaults to \"present\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": ""
+            },
+            {
+              "value": "present"
+            },
+            {
+              "value": "absent"
+            }
           ],
           "max_length": 16384
         },
         "type": "string"
       }
+    ]
+  },
+  "file_report_content_tail": {
+    "name": "File report content tail",
+    "bundle_name": "file_report_content_tail",
+    "bundle_args": [
+      "path",
+      "limit"
+    ],
+    "description": "Report the tail of a file",
+    "documentation": "Report the tail of a file.\n\nThis method does nothing on the system, but only reports a partial content\nfrom a given file. This allows centralizing this information on the server, and avoid\nhaving to connect on each node to get this information.\n\nNOTE: This method only works in \"Full Compliance\" reporting mode.\n\n#### Parameters\n\n##### Target\n\nThis is the file you want to report content from. The method will return an error if it\ndoes not exist.\n\n##### Limit\n\nThe number of line to report.\n\n#### Examples\n\n```\n# To get the 3 first line of /etc/hosts\nfile_report_content(\"/etc/hosts\", \"3\");\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_report_content_tail",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_report_content_tail.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File to report content from",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "limit",
+        "description": "Number of lines to report (default is 10)",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "regex": {
+            "value": "^\\d*$"
+          },
+          "max_length": 16384
+        },
+        "type": "string"
+      }
     ],
     "parameter_rename": [
       {
-        "old": "file",
+        "old": "target",
         "new": "path"
       }
     ]
   },
-  "file_ensure_key_value": {
-    "name": "File ensure key -> value present",
-    "bundle_name": "file_ensure_key_value",
+  "permissions_dirs_recursive": {
+    "name": "Permissions dirs recursive",
+    "bundle_name": "permissions_dirs_recursive",
     "bundle_args": [
       "path",
-      "key",
-      "value",
-      "separator"
+      "mode",
+      "owner",
+      "group"
     ],
-    "description": "Ensure that the file contains a pair of \"key separator value\"",
-    "documentation": "Edit (or create) the file, and ensure it contains an entry key -> value with arbitrary separator between the key and its value.\nIf the key is already present, the method will change the value associated with this key.",
+    "description": "Verify if a directory and its content have the right permissions recursively",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "file_ensure_key_value",
+    "class_prefix": "permissions",
     "class_parameter": "path",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_key_value.cf",
-    "deprecated": "Use [file_key_value_present](#_file_key_value_present) instead.",
-    "rename": "file_key_value_present",
+    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_dirs_recursive.cf",
     "parameter": [
       {
         "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
+        "description": "Path to the directory",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -1616,8 +962,87 @@
         "type": "string"
       },
       {
-        "name": "key",
-        "description": "Key to define",
+        "name": "mode",
+        "description": "Mode to enforce",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "owner",
+        "description": "Owner to enforce",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "group",
+        "description": "Group to enforce",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "command_execution": {
+    "name": "Command execution",
+    "bundle_name": "command_execution",
+    "bundle_args": [
+      "command"
+    ],
+    "description": "Execute a command",
+    "documentation": "Execute the **Command** in shell.\n\nOn Unix based agents, the method status will report:\n\n* a **Repaired** if the return code is \"0\"\n* an **Error** if the return code is not \"0\"\n\nOn Windows based agents the command is executed through Powershell and its `&` operator.\nThe method status will report:\n\n* an **Error** in Audit mode as the command will not be executed\n* an **Error** in Enforce mode if the command did throw an exception\n* an **Error** in Enforce mode if the `LASTEXITCODE` of the execution was not 0. This can happen when calling '.exe' binaries for instance.\n* a **Repaired** in any other cases\n\nDo not use the \"exit\" command on Windows as the shell used is the same than the one running the agent!\n\n# Windows examples\n\n```\n# A simple command execution\nWrite-Output \"rudder test\" | Out-File \"C:\\test.txt\n\n# Another one with a statement, will report a Repaired if the folder exists,\n# and an error if it does not.\n{\n  if ( (Test-Path \"C:\\Program Files\\Rudder\" -PathType Container)) {\n    \"Rudder folder found!\"\n  } else {\n    throw \"Rudder folder does not exist!\"\n  }\n}\n\n```",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "command_execution",
+    "class_parameter": "command",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/command_execution.cf",
+    "action": "",
+    "parameter": [
+      {
+        "name": "command",
+        "description": "Command to run",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "user_shell": {
+    "name": "User shell",
+    "bundle_name": "user_shell",
+    "bundle_args": [
+      "login",
+      "shell"
+    ],
+    "description": "Define the shell of the user. User must already exist.",
+    "documentation": "This method does not create the user.\n  entry example: /bin/false",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "user_shell",
+    "class_parameter": "login",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/user_shell.cf",
+    "parameter": [
+      {
+        "name": "login",
+        "description": "User's login",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -1626,8 +1051,40 @@
         "type": "string"
       },
       {
-        "name": "value",
-        "description": "Value to define",
+        "name": "shell",
+        "description": "User's shell",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_template_expand": {
+    "name": "File template expand",
+    "bundle_name": "file_template_expand",
+    "bundle_args": [
+      "tml_file",
+      "path",
+      "mode",
+      "owner",
+      "group"
+    ],
+    "description": "This is a bundle to expand a template in a specific location",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_template_expand",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_template_expand.cf",
+    "deprecated": "This method uses CFEngine's templating which is deprecated and not portable across agents.\nPlease use [file_from_template_mustache](#_file_from_template_mustache) or [file_from_template_jinja2](#_file_from_template_jinja2) instead.",
+    "parameter": [
+      {
+        "name": "tml_file",
+        "description": "File name (with full path within the framework) of the template file",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -1636,11 +1093,41 @@
         "type": "string"
       },
       {
-        "name": "separator",
-        "description": "Separator between key and value, for example \"=\" or \" \" (without the quotes)",
+        "name": "path",
+        "description": "File name (with full path) where to expand the template",
         "constraints": {
           "allow_empty_string": false,
-          "allow_whitespace_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "mode",
+        "description": "Mode of destination file",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "owner",
+        "description": "Owner of destination file",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "group",
+        "description": "Group of destination file",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
           "max_length": 16384
         },
         "type": "string"
@@ -1648,7 +1135,7 @@
     ],
     "parameter_rename": [
       {
-        "old": "file",
+        "old": "target_file",
         "new": "path"
       }
     ]
@@ -1691,12 +1178,24 @@
           "allow_empty_string": false,
           "allow_whitespace_string": false,
           "select": [
-            "==",
-            "<=",
-            ">=",
-            "<",
-            ">",
-            "!="
+            {
+              "value": "=="
+            },
+            {
+              "value": "<="
+            },
+            {
+              "value": ">="
+            },
+            {
+              "value": "<"
+            },
+            {
+              "value": ">"
+            },
+            {
+              "value": "!="
+            }
           ],
           "max_length": 16384
         },
@@ -1740,60 +1239,24 @@
       }
     ]
   },
-  "package_check_installed": {
-    "name": "Package check installed",
-    "bundle_name": "package_check_installed",
+  "service_check_disabled_at_boot": {
+    "name": "Service check disabled at boot",
+    "bundle_name": "service_check_disabled_at_boot",
     "bundle_args": [
       "name"
     ],
-    "description": "Verify if a package is installed in any version",
-    "documentation": "This bundle will define a condition `package_check_installed_${file_name}_{ok, reached, kept}` if the\npackage is installed, or `package_check_installed_${file_name}_{not_ok, reached, not_kept, failed}` if\nthe package is not installed",
+    "description": "Check if a service is set to not start at boot using the appropriate method",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "package_check_installed",
+    "class_prefix": "service_check_disabled_at_boot",
     "class_parameter": "name",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/package_check_installed.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_check_disabled_at_boot.cf",
     "parameter": [
       {
         "name": "name",
-        "description": "Name of the package to check",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "package_name",
-        "new": "name"
-      }
-    ]
-  },
-  "service_start": {
-    "name": "Service start",
-    "bundle_name": "service_start",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Start a service using the appropriate method",
-    "documentation": "See [service_action](#_service_action) for documentation.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "service_start",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_start.cf",
-    "deprecated": "This is an action that should not be used in the general case.\nIf you really want to call the start method, use [service_action](#_service_action).\nOtherwise, simply call [service_started](#_service_started)",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Name of the service",
+        "description": "Service name (as recognized by systemd, init.d, etc...)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -1809,25 +1272,116 @@
       }
     ]
   },
-  "service_status": {
-    "name": "Service status",
-    "bundle_name": "service_status",
+  "user_locked": {
+    "name": "User locked",
+    "bundle_name": "user_locked",
     "bundle_args": [
-      "name",
-      "status"
+      "login"
     ],
-    "description": "This generic method defines if service should run or be stopped",
+    "description": "Ensure the user is locked. User must already exist.",
+    "documentation": "This method does not create the user. Note that locked accounts will\n  be marked with \"!\" in /etc/shadow, which is equivalent to \"*\".\n  To unlock a user, apply a user_password method.",
     "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "user_locked",
+    "class_parameter": "login",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/user_locked.cf",
+    "parameter": [
+      {
+        "name": "login",
+        "description": "User's login",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "user_absent": {
+    "name": "User absent",
+    "bundle_name": "user_absent",
+    "bundle_args": [
+      "login"
+    ],
+    "description": "Remove a user",
+    "documentation": "This method ensures that a user does not exist on the system.",
+    "agent_support": [
+      "cfengine-community",
       "dsc"
     ],
-    "class_prefix": "service_status",
+    "class_prefix": "user_absent",
+    "class_parameter": "login",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/user_absent.cf",
+    "parameter": [
+      {
+        "name": "login",
+        "description": "User login",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "group_present": {
+    "name": "Group present",
+    "bundle_name": "group_present",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Create a group",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "group_present",
     "class_parameter": "name",
     "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/service_status.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/group_present.cf",
     "parameter": [
       {
         "name": "name",
-        "description": "Service name",
+        "description": "Group name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "group",
+        "new": "name"
+      }
+    ]
+  },
+  "file_block_present": {
+    "name": "File block present",
+    "bundle_name": "file_block_present",
+    "bundle_args": [
+      "path",
+      "block"
+    ],
+    "description": "Ensure that a text block is present in a specific location",
+    "documentation": "Ensure that a text block is present in the target file.\nIf the block is not found, it will be added at the end of the file.\n\n#### Examples:\n\nGiven a file with the following content:\n```\napple\npear\nbanana\n```\nApplying the method with the block:\n```\npear\norange\n```\n\nWill result in the following content:\n```\napple\npear\nbanana\npear\norange\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_block_present",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_block_present.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -1836,42 +1390,8 @@
         "type": "string"
       },
       {
-        "name": "status",
-        "description": "Desired state for the user - can be 'Stopped' or 'Running'",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "select": [
-            "Stopped",
-            "Running"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "service_restart": {
-    "name": "Service restart",
-    "bundle_name": "service_restart",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Restart a service using the appropriate method",
-    "documentation": "See [service_action](#_service_action) for documentation.",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "service_restart",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_restart.cf",
-    "action": "",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Name of the service",
+        "name": "block",
+        "description": "Block(s) to add in the file",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -1882,31 +1402,43 @@
     ],
     "parameter_rename": [
       {
-        "old": "service_name",
-        "new": "name"
+        "old": "file",
+        "new": "path"
       }
     ]
   },
-  "monitoring_parameter": {
-    "name": "Monitoring parameter",
-    "bundle_name": "monitoring_parameter",
+  "variable_string": {
+    "name": "Variable string",
+    "bundle_name": "variable_string",
     "bundle_args": [
-      "key",
+      "prefix",
+      "name",
       "value"
     ],
-    "description": "Add a monitoring parameter to a node (requires a monitoring plugin)",
-    "documentation": "This method adds monitoring parameters to rudder nodes. The monitoring parameters are used to\npass configuration to the monitoring plugins running with Rudder. Expected keys and parameters\nare specific to each plugin and can be found in their respective documentation.",
+    "description": "Define a variable from a string parameter",
+    "documentation": "To use the generated variable, you must use the form `${prefix.name}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \nPlease note that only global variables are available within templates.",
     "agent_support": [
-      "cfengine-community"
+      "cfengine-community",
+      "dsc"
     ],
-    "class_prefix": "monitoring_parameter",
-    "class_parameter": "key",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/monitoring_parameter.cf",
+    "class_prefix": "variable_string",
+    "class_parameter": "name",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/variable_string.cf",
     "parameter": [
       {
-        "name": "key",
-        "description": "Name of the parameter",
+        "name": "prefix",
+        "description": "The prefix of the variable name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "name",
+        "description": "The variable to define, the full name will be prefix.name",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -1916,7 +1448,7 @@
       },
       {
         "name": "value",
-        "description": "Value of the parameter",
+        "description": "The variable content",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -1924,31 +1456,39 @@
         },
         "type": "string"
       }
+    ],
+    "parameter_rename": [
+      {
+        "old": "variable_prefix",
+        "new": "prefix"
+      },
+      {
+        "old": "variable_name",
+        "new": "name"
+      }
     ]
   },
-  "permissions_acl_entry": {
-    "name": "Permissions POSIX acl entry",
-    "bundle_name": "permissions_acl_entry",
+  "variable_dict_from_osquery": {
+    "name": "Variable dict from osquery",
+    "bundle_name": "variable_dict_from_osquery",
     "bundle_args": [
-      "path",
-      "recursive",
-      "user",
-      "group",
-      "other"
+      "prefix",
+      "name",
+      "query"
     ],
-    "description": "Verify that an ace is present on a file or directory.\nThis method will append the given aces to the current POSIX ACLs of\nthe target.",
-    "documentation": "The `permissions_*acl_*` manage the POSIX ACL on files and directories.\n\nPlease note that the mask will be automatically recalculated when editing ACLs.\n\n#### Parameters\n\n##### Path\n\nPath can be a regex with the following format:\n\n* `*` matches any filename or directory at one level, e.g. `*.cf` will match all files in one directory that end in .cf but it won't search across directories. `*/*.cf` on the other hand will look two levels deep.\n* `?` matches a single letter\n* `[a-z]` matches any letter from a to z\n* `{x,y,anything}` will match x or y or anything.\n\n##### Recursive\n\nCan be:\n\n* `true` to apply the given aces to folder and sub-folders and files.\n* or `false` to apply to the strict match of `Path`\n\nIf left blank, recursivity will automatically be set to `false`\n\n##### User and Group\n\nACE for user and group  can be left blank if they do not need any specification.\nIf fulfill, they must respect the format:\n\n`<username|groupname>:<operator><mode>`\n\nwith:\n\n* `username` being the Linux account name\n* `groupname` the Linux group name\n* Current `owner user` and `owner group` can be designed by the character `*`\n\nThe operator can be:\n* `+` to add the given ACE to the current ones.\n* `-` to remove the given ACE to the current ones.\n* `=` to force the given ACE to the current ones.\n\nYou can define multiple ACEs by separating them with commas.\n\n##### Other\n\nACE for other must respect the classic:\n\n* `[+-=]r?w?x?`\nIt can also be left blank to let the `Other` ACE unchanged.\n\n#### Example\n\nGiven a file with the following getfacl output:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile\ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\nuser:bob:rwx\ngroup::r--\nmask::rwx\nother::---\n\n~~~~\n\nApplying this method with the following parameters:\n\n* `path`: /tmp/myTestFile\n* `recursive`: false\n* `user`: *:-x, bob:\n* `group`: *:+rw\n* `other`: =r\n\nWill transform the previous ACLs in:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile\ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rw-\nuser:bob:---\ngroup::rw-\nmask::rw-\nother::r--\n\n~~~~\n\nThis method can not remove a given ACE, see here how the user bob ACE is handled.",
+    "description": "Define a variable that contains key,value pairs (a dictionary) from an osquery query",
+    "documentation": "To use the generated variable, you must use the form `${prefix.name[key]}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \nPlease note that only global variables are available within templates.\n\nThis method will define a dict variable from the output of an osquery query.\nThe query will be executed at every agent run, and its result will be usable as a standard\ndict variable.\n\n#### Setup\n\nThis method requires the presence of [osquery](https://osquery.io/) on the target nodes.\nIt won't install it automatically. Check the correct way of doing so for your OS.\n\n#### Building queries\n\nTo learn about the possible queries, read the [osquery schema](https://osquery.io/schema/) for your\nosquery version.\n\nYou can test the queries before using them with the `osqueryi` command, see the example below.\n\n#### Examples\n\n```\n# To get the number of cpus on the machine\nvariable_dict_from_osquery(\"prefix\", \"var1\", \"select cpu_logical_cores from system_info;\");\n```\n\nIt will produce the dict from the output of:\n\n```\nosqueryi --json \"select cpu_logical_cores from system_info;\"\n```\n\nHence something like:\n\n```json\n[\n {\"cpu_logical_cores\":\"8\"}\n]\n```\n\nTo access this value, use the `${prefix.var1[0][cpu_logical_cores]}` syntax.",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "permissions_acl_entry",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_acl_entry.cf",
+    "class_prefix": "variable_dict_from_osquery",
+    "class_parameter": "name",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/variable_dict_from_osquery.cf",
     "parameter": [
       {
-        "name": "path",
-        "description": "Path of the file or directory",
+        "name": "prefix",
+        "description": "The prefix of the variable name",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -1957,76 +1497,59 @@
         "type": "string"
       },
       {
-        "name": "recursive",
-        "description": "Recursive Should ACLs cleanup be recursive, \"true\" or \"false\" (defaults to \"false\")",
+        "name": "name",
+        "description": "The variable to define, the full name will be prefix.name",
         "constraints": {
-          "allow_empty_string": true,
+          "allow_empty_string": false,
           "allow_whitespace_string": false,
-          "select": [
-            "",
-            "true",
-            "false"
-          ],
           "max_length": 16384
         },
         "type": "string"
       },
       {
-        "name": "user",
-        "description": "User acls, comma separated, like: bob:+rwx, alice:-w",
+        "name": "query",
+        "description": "The query to execute (ending with a semicolon)",
         "constraints": {
-          "allow_empty_string": true,
+          "allow_empty_string": false,
           "allow_whitespace_string": false,
-          "regex": "^$|^(([A-z0-9._-]+|\\*):([+-=]r?w?x?)?,? *)+$",
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "group",
-        "description": "Group acls, comma separated, like: wheel:+wx, anon:-rwx",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "regex": "^$|^(([A-z0-9._-]+|\\*):([+-=]r?w?x?)?,? *)+$",
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "other",
-        "description": "Other acls, like -x",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "regex": "^$|^[+-=^]r?w?x?$",
           "max_length": 16384
         },
         "type": "string"
       }
+    ],
+    "parameter_rename": [
+      {
+        "old": "variable_prefix",
+        "new": "prefix"
+      },
+      {
+        "old": "variable_name",
+        "new": "name"
+      }
     ]
   },
-  "file_from_template_mustache": {
-    "name": "File from a mustache template",
-    "bundle_name": "file_from_template_mustache",
+  "file_copy_from_local_source": {
+    "name": "File copy from local source",
+    "bundle_name": "file_copy_from_local_source",
     "bundle_args": [
-      "source_template",
+      "source",
       "path"
     ],
-    "description": "Build a file from a mustache template",
-    "documentation": "See [file_from_template_type](#_file_from_template_type) for general documentation about\ntemplates usage.\n\n#### Syntax\n\nMustache is a logic-less templating language, available in a lot of languages, and\nused for file templating in Rudder.\nThe mustache syntax reference is [https://mustache.github.io/mustache.5.html](https://mustache.github.io/mustache.5.html).\nThe Windows implementation follows the standard, the Unix one is a bit richer as describe below.\n\nWe will here describe the way to get agent data into a template. Ass explained in the general templating\ndocumentation, we can access various data in a mustache template.\n\nThe main specificity compared to standard mustache syntax of prefixes in all expanded values:\n\n* `classes` to access conditions\n* `vars` to access all variables\n\n##### Classes\n\nHere is how to display content depending on conditions definition:\n\n```mustache\n{{#classes.my_condition}}\n   content when my_condition is defined\n{{/classes.my_condition}}\n\n{{^classes.my_condition}}\n   content when my_condition is *not* defined\n{{/classes.my_condition}}\n```\n\nNote: You cannot use condition expressions here.\n\n##### Scalar variable\n\nHere is how to display a scalar variable value (integer, string, ...),\nif you have defined `variable_string(\"variable_prefix\", \"my_variable\", \"my_value\")`:\n\n```\n{{{vars.variable_prefix.my_variable}}}\n```\n\nWe use the triple `{{{ }}}` to avoid escaping html entities.\n\n##### Iteration\n\nIteration is done using a syntax similar to scalar variables, but applied\non container variables.\n\n* Use `{{#vars.container}} content {{/vars.container}}` to iterate\n* Use `{{{.}}}` for the current element value in iteration\n* Use `{{{key}}}` for the `key` value in current element\n* Use `{{{.key}}}` for the `key` value in current element (Linux only)\n* Use `{{{@}}}` for the current element key in iteration (Linux only)\n\nTo iterate over a list, for example defined with:\n\n```\nvariable_iterator(\"variable_prefix\", \"iterator_name\", \"a,b,c\", \",\")\n```\n\nUse the following file:\n\n```mustache\n{{#vars.variable_prefix.iterator_name}}\n{{{.}}} is the current iterator_name value\n{{/vars.variable_prefix.iterator_name}}\n```\n\nWhich will be expanded as:\n\n```\na is the current iterator_name value\nb is the current iterator_name value\nc is the current iterator_name value\n```\n\nTo iterate over a container defined by the following json file, loaded with\n`variable_dict_from_file(\"variable_prefix\", \"dict_name\", \"path\")`:\n\n```json\n{\n   \"hosts\": [\n       \"host1\",\n       \"host2\"\n   ],\n   \"files\": [\n       {\"name\": \"file1\", \"path\": \"/path1\", \"users\": [ \"user1\", \"user11\" ] },\n       {\"name\": \"file2\", \"path\": \"/path2\", \"users\": [ \"user2\" ] }\n   ],\n   \"properties\": {\n       \"prop1\": \"value1\",\n       \"prop2\": \"value2\"\n   }\n}\n```\n\nUse the following template:\n\n```mustache\n{{#vars.variable_prefix.dict_name.hosts}}\n{{{.}}} is the current hosts value\n{{/vars.variable_prefix.dict_name.hosts}}\n\n# will display the name and path of the current file\n{{#vars.variable_prefix.dict_name.files}}\n{{{name}}}: {{{path}}}\n{{/vars.variable_prefix.dict_name.files}}\n# Lines below will only be properly rendered in unix Nodes\n# will display the users list of each file\n{{#vars.variable_prefix.dict_name.files}}\n{{{name}}}:{{#users}} {{{.}}}{{/users}}\n{{/vars.variable_prefix.dict_name.files}}\n\n\n# will display the current properties key/value pair\n{{#vars.variable_prefix.dict_name.properties}}\n{{{@}}} -> {{{.}}}\n{{/vars.variable_prefix.dict_name.properties}}\n\n```\n\nWhich will be expanded as:\n\n```\nhost1 is the current hosts value\nhost2 is the current hosts value\n\n# will display the name and path of the current file\nfile1: /path1\nfile2: /path2\n\n# Lines below will only be properly rendered in unix Nodes\n# will display the users list of each file\nfile1: user1 user11\nfile2: user2\n\n# will display the current properties key/value pair\nprop1 -> value1\nprop2 -> value2\n```\n\nNote: You can use `{{#-top-}} ... {{/-top-}}`\nto iterate over the top level container.\n\n##### System variables\n\nSome `sys` dict variables (like `sys.ipv4`) are also accessible as string, for example:\n\n* `${sys.ipv4}` gives `54.32.12.4`\n* `$[sys.ipv4[ethO]}` gives `54.32.12.4`\n* `$[sys.ipv4[eth1]}` gives `10.45.3.2`\n\nThese variables are not accessible as dict in the templating data, but are represented as\nstring:\n\n* `ipv4` is a string variable in the `sys` dict with value `54.32.12.4`\n* `ipv4[ethO]` is a string variable in the `sys` dict with value `54.32.12.4`\n* `ipv4` is not accessible as a dict in the template\n\nTo access these value, use the following syntax in your mustache templates:\n\n```\n{{{vars.sys.ipv4[eth0]}}}\n```",
+    "description": "Ensure that a file or directory is copied from a local source",
     "agent_support": [
       "cfengine-community",
       "dsc"
     ],
-    "class_prefix": "file_from_template",
+    "class_prefix": "file_copy_from_local_source",
     "class_parameter": "path",
     "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_template_mustache.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_copy_from_local_source.cf",
+    "deprecated": "Use [file_from_local_source](#_file_from_local_source) instead.",
+    "rename": "file_from_local_source",
     "parameter": [
       {
-        "name": "source_template",
-        "description": "Source file containing a template to be expanded (absolute path on the target node)",
+        "name": "source",
+        "description": "Source file (absolute path on the target node)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -2052,25 +1575,295 @@
       }
     ]
   },
-  "file_ensure_keys_values": {
-    "name": "File ensure keys -> values present",
-    "bundle_name": "file_ensure_keys_values",
+  "schedule_simple_catchup": {
+    "name": "Schedule Simple Catchup",
+    "bundle_name": "schedule_simple_catchup",
     "bundle_args": [
-      "path",
-      "keys",
-      "separator"
+      "job_id",
+      "agent_periodicity",
+      "max_execution_delay_minutes",
+      "max_execution_delay_hours",
+      "start_on_minutes",
+      "start_on_hours",
+      "start_on_day_of_week",
+      "periodicity_minutes",
+      "periodicity_hours",
+      "periodicity_days"
     ],
-    "description": "Ensure that the file contains all pairs of \"key separator value\", with arbitrary separator between each key and its value",
-    "documentation": "This method ensures key-value pairs are present in a file.\n\n#### Usage\n\nThis method will iterate over the key-value pairs in the dict, and:\n\n* If the key is not defined in the destination, add the *key* + *separator* + *value* line.\n* If the key is already present in the file, replace the *key* + *separator* + anything by *key* + *separator* + *value*\n\nThis method always ignores spaces and tabs when replacing (which means for example that `key = value` will match the `=` separator).\n\nKeys are considered unique (to allow replacing the value), so you should use [file_ensure_lines_present](#_file_ensure_lines_present)\nif you want to have multiple lines with the same key.\n\n#### Example\n\nIf you have an initial file (`/etc/myfile.conf`) containing:\n\n```\nkey1 = something\nkey3 = value3\n```\n\nTo define key-value pairs, use the [variable_dict](#_variable_dict) or\n[variable_dict_from_file](#_variable_dict_from_file) methods.\n\nFor example, if you use the following content (stored in `/tmp/data.json`):\n\n```json\n{\n   \"key1\": \"value1\",\n   \"key2\": \"value2\"\n}\n```\n\nWith the following policy:\n\n```\n# Define the `content` variable in the `configuration` prefix from the json file\nvariable_dict_from_file(\"configuration\", \"content\", \"/tmp/data.json\")\n# Enforce the presence of the key-value pairs\nfile_ensure_keys_values(\"/etc/myfile.conf\", \"configuration.content\", \" = \")\n\n```\n\nThe destination file (`/etc/myfile.conf`) will contain:\n\n```\nkey1 = value1\nkey3 = value3\nkey2 = value2\n```",
+    "description": "Trigger a repaired outcome when a job should be run (avoid losing a job)",
+    "documentation": "This bundle will define a condition `schedule_simple_${job_id}_{kept,repaired,not_ok,ok,reached}`\n\n * _ok or _kept for when there is nothing to do\n * _repaired if the job should run\n * _not_ok and _reached have their usual meaning\n\n If the agent run is skipped during the period, method tries to catchup the run on next agent run.\n If the agent run is skipped twice, only one run is caught up.\n If the agent is run twice (for example from a manual run), the job is run only once.",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "file_ensure_keys_values",
+    "class_prefix": "schedule_simple",
+    "class_parameter": "job_id",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/schedule_simple_catchup.cf",
+    "parameter": [
+      {
+        "name": "job_id",
+        "description": "A string to identify this job",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "agent_periodicity",
+        "description": "Agent run interval (in minutes)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "max_execution_delay_minutes",
+        "description": "On how many minutes you want to spread the job",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "max_execution_delay_hours",
+        "description": "On how many hours you want to spread the job",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "start_on_minutes",
+        "description": "At which minute should be the first run",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "start_on_hours",
+        "description": "At which hour should be the first run",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "start_on_day_of_week",
+        "description": "At which day of week should be the first run",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "periodicity_minutes",
+        "description": "Desired job run interval (in minutes)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "periodicity_hours",
+        "description": "Desired job run interval (in hours)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "periodicity_days",
+        "description": "Desired job run interval (in days)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_from_template_type": {
+    "name": "File from template with type",
+    "bundle_name": "file_from_template_type",
+    "bundle_args": [
+      "source_template",
+      "path",
+      "template_type"
+    ],
+    "description": "Build a file from a template",
+    "documentation": "These methods write a file based on a provided template and the\ndata available to the agent.\n\n#### Usage\n\nTo use these methods (`file_from_template_*`), you need to have:\n\n* a template file\n* data to fill this template\n\nThe template file should be somewhere on the local file system, so\nif you want to use a file shared from the policy server, you need to copy \nit first (using [file_copy_from_remote_source](#_file_copy_from_remote_source)).\n\nIt is common to use a specific folder to store those templates after copy,\nfor example in `${sys.workdir}/tmp/templates/`.\n\nThe data that will be used while expanding the template is the data available in\nthe agent at the time of expansion. That means:\n\n* Agent's system variables (`${sys.*}`, ...) and conditions (`linux`, ...)\n* data defined during execution (result conditions of generic methods, ...)\n* conditions based on `condition_` generic methods\n* data defined in ncf using `variable_*` generic methods, which allow for example\n  to load data from local json or yaml files.\n\n#### Template types\n\nncf currently supports three templating languages:\n\n* *mustache* templates, which are documented in [file_from_template_mustache](#_file_from_template_mustache)\n* *jinja2* templates, which are documented in [file_from_template_jinja2](#_file_from_template_jinja2)\n* CFEngine templates, which are a legacy implementation that is here for compatibility,\nand should not be used for new templates.\n\n#### Example\n\nHere is a complete example of templating usage:\n\nThe (basic) template file, present on the server in `/PATH_TO_MY_FILE/ntp.conf.mustache`\n(for syntax reference, see [file_from_template_mustache](#_file_from_template_mustache)):\n\n```mustache\n{{#classes.linux}}\nserver {{{vars.configuration.ntp.hostname}}}\n{{/classes.linux}}\n{{^classes.linux}}\nserver hardcoded.server.example\n{{/classes.linux}}\n\n```\n\nAnd on your local node in `/tmp/ntp.json`, the following json file:\n\n```json\n{ \"hostname\": \"my.hostname.example\" }\n```\n\nAnd the following policy:\n\n```\n# Copy the file from the policy server\nfile_copy_from_remote_source(\"/PATH_TO_MY_FILE/ntp.conf.mustache\", \"${sys.workdir}/tmp/templates/ntp.conf.mustache\")\n# Define the `ntp` variable in the `configuration` prefix from the json file\nvariable_dict_from_file(\"configuration\", \"ntp\", \"/tmp/ntp.json\")\n# Expand yout template\nfile_from_template_type(\"${sys.workdir}/tmp/templates/ntp.conf.mustache\", \"/etc/ntp.conf\", \"mustache\")\n# or\n# file_from_template_mustache(\"${sys.workdir}/tmp/templates/ntp.conf.mustache\", \"/etc/ntp.conf\")\n```\n\nThe destination file will contain the expanded content, for example on a Linux node:\n\n```\nserver my.hostname.example\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_from_template",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_template_type.cf",
+    "parameter": [
+      {
+        "name": "source_template",
+        "description": "Source file containing a template to be expanded (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "Destination file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "template_type",
+        "description": "Template type (cfengine, jinja2 or mustache)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
+      }
+    ]
+  },
+  "service_reload": {
+    "name": "Service reload",
+    "bundle_name": "service_reload",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Reload a service using the appropriate method",
+    "documentation": "See [service_action](#_service_action) for documentation.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "service_reload",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_reload.cf",
+    "action": "",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Name of the service",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "service_name",
+        "new": "name"
+      }
+    ]
+  },
+  "service_started_path": {
+    "name": "Service started with service path",
+    "bundle_name": "service_started_path",
+    "bundle_args": [
+      "name",
+      "path"
+    ],
+    "description": "Ensure that a service is running using the appropriate method, specifying the path of the service in the ps output, or using Windows task manager",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "service_started",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_started_path.cf",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Service name (as recognized by systemd, init.d, Windows, etc...)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "Service with its path, as in the output from 'ps'",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "service_name",
+        "new": "name"
+      },
+      {
+        "old": "service_path",
+        "new": "path"
+      }
+    ]
+  },
+  "file_ensure_key_value_parameter_not_in_list": {
+    "name": "File ensure key-value parameter not in list",
+    "bundle_name": "file_ensure_key_value_parameter_not_in_list",
+    "bundle_args": [
+      "path",
+      "key",
+      "key_value_separator",
+      "parameter_regex",
+      "parameter_separator",
+      "leading_char_separator",
+      "closing_char_separator"
+    ],
+    "description": "Ensure that a parameter doesn't exist in a list of parameters, on one single line, in the right hand side of a key->values line",
+    "documentation": "Edit the file, and ensure it does not contain the defined parameter in the list of values on the right hand side of a key->values line.\nIf the parameter is there, it will be removed. Please note that the parameter can be a regular expression. It will also remove any whitespace character between the `parameter` and `parameter_separator`\nOptionally, you can define leading and closing character to enclose the parameters\n\n#### Example\n\nIf you have an initial file (`/etc/default/grub`) containing\n\n```\nGRUB_CMDLINE_XEN=\"dom0_mem=16G dom0_max_vcpus=32\"\n```\n\nTo remove parameter `dom0_max_vcpus=32` in the right hand side of the line, you'll need the following policy\n\n```\nfile_ensure_key_value_parameter_not_in_list(\"/etc/default/grub\", \"GRUB_CMDLINE\", \"=\", \"dom0_max_vcpus=32\", \" \", \"\\\"\", \"\\\"\");\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_ensure_key_value_parameter_not_in_list",
     "class_parameter": "path",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_keys_values.cf",
-    "deprecated": "Use [file_keys_values_present](#_file_keys_values_present) instead.",
-    "rename": "file_keys_values_present",
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_key_value_parameter_not_in_list.cf",
+    "deprecated": "Use [file_key_value_parameter_absent_in_list](#_file_key_value_parameter_absent_in_list) instead.",
+    "rename": "file_key_value_parameter_absent_in_list",
     "parameter": [
       {
         "name": "path",
@@ -2083,8 +1876,8 @@
         "type": "string"
       },
       {
-        "name": "keys",
-        "description": "Name of the dict structure (without \"${}\") containing the keys (keys of the dict), and values to define (values of the dict)",
+        "name": "key",
+        "description": "Full key name",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -2093,45 +1886,18 @@
         "type": "string"
       },
       {
-        "name": "separator",
-        "description": "Separator between key and value, for example \"=\" or \" \" (without the quotes)",
+        "name": "key_value_separator",
+        "description": "character used to separate key and value in a key-value line",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": true,
           "max_length": 16384
         },
         "type": "string"
-      }
-    ],
-    "parameter_rename": [
+      },
       {
-        "old": "file",
-        "new": "path"
-      }
-    ]
-  },
-  "permissions_user_acl_present": {
-    "name": "Permissions user POSIX acl entry present",
-    "bundle_name": "permissions_user_acl_present",
-    "bundle_args": [
-      "path",
-      "recursive",
-      "user",
-      "ace"
-    ],
-    "description": "Verify that an ace is present on a file or directory for a given user.\nThis method will make sure the given ace is present in the POSIX ACL of the target.",
-    "documentation": "The `permissions_*acl_*` manage the POSIX ACL on files and directories.\n\nPlease note that the mask will be automatically recalculated when editing ACLs.\n\n#### Parameters\n\n##### Path\n\nPath can be globbing with the following format:\n\n* `*` matches any filename or directory at one level, e.g. `*.cf` will match all files in one directory that end in .cf but it won't search across directories. `*/*.cf` on the other hand will look two levels deep.\n* `?` matches a single letter\n* `[a-z]` matches any letter from a to z\n* `{x,y,anything}` will match x or y or anything.\n\n##### Recursive\n\nCan be:\n\n* `true` to apply the given aces to folder and sub-folders and files.\n* or `false` to apply to the strict match of `Path`\n\nIf left blank, recursivity will automatically be set to `false`\n\n##### User\n\n`Username` to enforce the ace, being the Linux account name.\nThis method can only handle one username.\n\n##### ACE\n\nThe operator can be:\n* `+` to add the given ACE to the current ones.\n* `-` to remove the given ACE to the current ones.\n* `=` to force the given ACE to the current ones.\n* `empty` if no operator is specified, it will be interpreted as `=`.\n\nACE must respect the classic:\n\n* `^[+-=]?(?=.*[rwx])r?w?x?$`\n\n#### Example\n\nGiven a file with the following getfacl output:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\nuser:bob:rwx\ngroup::r--\nmask::rwx\nother::---\n\n~~~~\n\nApplying this method with the following parameters:\n\n* `path`: /tmp/myTestFile\n* `recursive`: false\n* `user`: bob\n* `ace`: -rw\n\nWill transform the previous ACLs in:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\nuser:bob:--x\ngroup::r--\nmask::r-x\nother::---\n\n~~~~",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "permissions_user_acl_present",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_user_acl_present.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Path of the file or directory.",
+        "name": "parameter_regex",
+        "description": "Regular expression matching the sub-value to ensure is not present in the list of parameters that form the value part of that line",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -2140,146 +1906,30 @@
         "type": "string"
       },
       {
-        "name": "recursive",
-        "description": "Recursive Should ACLs cleanup be recursive, \"true\" or \"false\" (defaults to \"false\").",
+        "name": "parameter_separator",
+        "description": "Character used to separate parameters in the list",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": true,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "leading_char_separator",
+        "description": "leading character of the parameters",
         "constraints": {
           "allow_empty_string": true,
           "allow_whitespace_string": false,
-          "select": [
-            "",
-            "true",
-            "false"
-          ],
           "max_length": 16384
         },
         "type": "string"
       },
       {
-        "name": "user",
-        "description": "Username of the Linux account.",
+        "name": "closing_char_separator",
+        "description": "closing character of the parameters",
         "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "ace",
-        "description": "ACE to enforce for the given user.",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "regex": "^[+-=]?(?=.*[rwx])r?w?x?$",
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "variable_dict_from_file": {
-    "name": "Variable dict from JSON file",
-    "bundle_name": "variable_dict_from_file",
-    "bundle_args": [
-      "prefix",
-      "name",
-      "file_name"
-    ],
-    "description": "Define a variable that contains key,value pairs (a dictionary) from a JSON file",
-    "documentation": "To use the generated variable, you must use the form `${prefix.name[key]}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \nPlease note that only global variables are available within templates.\n\nSee [variable_dict_from_file_type](#_variable_dict_from_file_type) for complete documentation.",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "variable_dict_from_file",
-    "class_parameter": "name",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/variable_dict_from_file.cf",
-    "parameter": [
-      {
-        "name": "prefix",
-        "description": "The prefix of the variable name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "name",
-        "description": "The variable to define, the full name will be prefix.name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "file_name",
-        "description": "The absolute local file name with JSON content",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "variable_prefix",
-        "new": "prefix"
-      },
-      {
-        "old": "variable_name",
-        "new": "name"
-      }
-    ]
-  },
-  "file_line_present_in_xml_tag": {
-    "name": "File line in XML section",
-    "bundle_name": "file_line_present_in_xml_tag",
-    "bundle_args": [
-      "path",
-      "tag",
-      "line"
-    ],
-    "description": "Ensure that a line is present in a tag in a specific location. The objective of this method is to handle XML-style files. Note that if the tag is not present in the file, it won't be added, and the edition will fail.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_line_present_in_xml_tag",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_line_present_in_xml_tag.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "tag",
-        "description": "Name of the XML tag under which lines should be added (not including the <> brackets)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "line",
-        "description": "Line to ensure is present inside the section",
-        "constraints": {
-          "allow_empty_string": false,
+          "allow_empty_string": true,
           "allow_whitespace_string": false,
           "max_length": 16384
         },
@@ -2289,41 +1939,6 @@
     "parameter_rename": [
       {
         "old": "file",
-        "new": "path"
-      }
-    ]
-  },
-  "directory_present": {
-    "name": "Directory present",
-    "bundle_name": "directory_present",
-    "bundle_args": [
-      "path"
-    ],
-    "description": "Create a directory if it doesn't exist",
-    "documentation": "Create a directory if it doesn't exist.",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "directory_present",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/directory_present.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Full path of directory to create (trailing '/' is optional)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "target",
         "new": "path"
       }
     ]
@@ -2385,71 +2000,56 @@
       }
     ]
   },
-  "directory_absent": {
-    "name": "Directory absent",
-    "bundle_name": "directory_absent",
+  "condition_once": {
+    "name": "Condition once",
+    "bundle_name": "condition_once",
     "bundle_args": [
-      "path",
-      "recursive"
+      "condition"
     ],
-    "description": "Ensure a directory's absence",
-    "documentation": "If `recursive` is false, only an empty directory can be deleted.",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "directory_absent",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/directory_absent.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Directory to remove",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "recursive",
-        "description": "Should deletion be recursive, \"true\" or \"false\" (defaults to \"false\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "target",
-        "new": "path"
-      }
-    ]
-  },
-  "file_symlink_present_force": {
-    "name": "Symlink present (force overwrite)",
-    "bundle_name": "file_symlink_present_force",
-    "bundle_args": [
-      "source",
-      "path"
-    ],
-    "description": "Create a symlink at a destination path and pointing to a source target even if a file or directory already exists.",
+    "description": "Create a new condition only once",
+    "documentation": "This method define a condition named from the parameter **Condition** when it is\ncalled for the first time. Following agent execution will not define the\ncondition.\n\nThis allows executing actions only once on a given machine.\nThe created condition is global to the agent.\n\nIn case of reinstallation or factory-reset of the Rudder agent, this method \nwill no longer detect if the condition has already been defined.\n\n##### Example:\n\nIf you use:\n\n```\ncondition_once(\"my_condition\")\n```\n\nThe first agent run will have the condition `my_condition` defined, contrary to subsequent runs\nfor which no condition will be defined.\n\nSee also : [command\\_execution\\_once](#_command_execution_once)",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "file_symlink_present",
-    "class_parameter": "path",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_symlink_present_force.cf",
+    "class_prefix": "condition_once",
+    "class_parameter": "condition",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/condition_once.cf",
     "parameter": [
       {
-        "name": "source",
-        "description": "Source file (absolute path on the target node)",
+        "name": "condition",
+        "description": "The condition to define",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_replace_lines": {
+    "name": "File replace lines",
+    "bundle_name": "file_replace_lines",
+    "bundle_args": [
+      "path",
+      "line",
+      "replacement"
+    ],
+    "description": "Ensure that a line in a file is replaced by another one",
+    "documentation": "You can replace lines in a files, based on regular expression and captured pattern\n\n#### Syntax\n\nThe content to match in the file is a PCRE regular expression, unanchored\nthat you can replace with the content of replacement.\n\nContent can be captured in regular expression, and be reused with the notation `${match.1}` (for first matched\ncontent), `${match.2}` for second, etc, and the special captured group `${match.0}` for the whole text.\n\n#### Example\n\nHere is an example to remove enclosing specific tags\n\n```\nfile_replace_lines(\"/PATH_TO_MY_FILE/file\", \"<my>(.*)<pattern>\", \"my ${match.1} pattern\")\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_replace_lines",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_replace_lines.cf",
+    "action": "If the regex matches the replacement, then the line will be replaced every time",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -2458,8 +2058,18 @@
         "type": "string"
       },
       {
-        "name": "path",
-        "description": "Destination file (absolute path on the target node)",
+        "name": "line",
+        "description": "Line to match in the file",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "replacement",
+        "description": "Line to add in the file as a replacement",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -2470,7 +2080,7 @@
     ],
     "parameter_rename": [
       {
-        "old": "destination",
+        "old": "file",
         "new": "path"
       }
     ]
@@ -2511,26 +2121,26 @@
       }
     ]
   },
-  "file_from_remote_source": {
-    "name": "File from remote source",
-    "bundle_name": "file_from_remote_source",
+  "monitoring_parameter": {
+    "name": "Monitoring parameter",
+    "bundle_name": "monitoring_parameter",
     "bundle_args": [
-      "source",
-      "path"
+      "key",
+      "value"
     ],
-    "description": "Ensure that a file or directory is copied from a policy server",
-    "documentation": "*Note*: This method uses the agent native file copy protocol, and can only download files from\nthe policy server. To download a file from an external source, you can use\nHTTP with the [file_download](#_file_download) method.\n\nThis method requires that the policy server is configured to accept\ncopy of the source file from the agents it will be applied to.\n\nYou can download a file from the shared files with:\n```\n/var/rudder/configuration-repository/shared-files/PATH_TO_YOUR_FILE\n```",
+    "description": "Add a monitoring parameter to a node (requires a monitoring plugin)",
+    "documentation": "This method adds monitoring parameters to rudder nodes. The monitoring parameters are used to\npass configuration to the monitoring plugins running with Rudder. Expected keys and parameters\nare specific to each plugin and can be found in their respective documentation.",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "file_from_remote_source",
-    "class_parameter": "path",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_remote_source.cf",
+    "class_prefix": "monitoring_parameter",
+    "class_parameter": "key",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/monitoring_parameter.cf",
     "parameter": [
       {
-        "name": "source",
-        "description": "Source file (absolute path on the policy server)",
+        "name": "key",
+        "description": "Name of the parameter",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -2539,20 +2149,14 @@
         "type": "string"
       },
       {
-        "name": "path",
-        "description": "Destination file (absolute path on the target node)",
+        "name": "value",
+        "description": "Value of the parameter",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
           "max_length": 16384
         },
         "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "destination",
-        "new": "path"
       }
     ]
   },
@@ -2655,6 +2259,80 @@
       {
         "old": "file",
         "new": "path"
+      }
+    ]
+  },
+  "condition_from_variable_existence": {
+    "name": "Condition from variable existence",
+    "bundle_name": "condition_from_variable_existence",
+    "bundle_args": [
+      "condition",
+      "variable_name"
+    ],
+    "description": "Create a condition from the existence of a variable",
+    "documentation": "This method define a condition:\n* `{condition}_true` if the variable named from\n  the parameter **Variable name** is defined\n* `{condition}_false` if the variable named from\n  the parameter **Variable name** is not defined\n\nAlso, this method always result with a *success* outcome status.",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "condition_from_variable_existence",
+    "class_parameter": "condition",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/condition_from_variable_existence.cf",
+    "parameter": [
+      {
+        "name": "condition",
+        "description": "Prefix of the condition",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "variable_name",
+        "description": "Complete name of the variable being tested, like my_prefix.my_variable",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "condition_prefix",
+        "new": "condition"
+      }
+    ]
+  },
+  "monitoring_template": {
+    "name": "Monitoring template",
+    "bundle_name": "monitoring_template",
+    "bundle_args": [
+      "template"
+    ],
+    "description": "Add a monitoring template to a node (requires a monitoring plugin)",
+    "documentation": "This method assigns monitoring templates to a Rudder node. The Rudder plugin respective to\neach monitoring platform will apply those templates to the node.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "monitoring_template",
+    "class_parameter": "template",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/monitoring_template.cf",
+    "parameter": [
+      {
+        "name": "template",
+        "description": "Name of the monitoring template",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
       }
     ]
   },
@@ -2785,1162 +2463,6 @@
       }
     ]
   },
-  "file_template_expand": {
-    "name": "File template expand",
-    "bundle_name": "file_template_expand",
-    "bundle_args": [
-      "tml_file",
-      "path",
-      "mode",
-      "owner",
-      "group"
-    ],
-    "description": "This is a bundle to expand a template in a specific location",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_template_expand",
-    "class_parameter": "path",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_template_expand.cf",
-    "deprecated": "This method uses CFEngine's templating which is deprecated and not portable across agents.\nPlease use [file_from_template_mustache](#_file_from_template_mustache) or [file_from_template_jinja2](#_file_from_template_jinja2) instead.",
-    "parameter": [
-      {
-        "name": "tml_file",
-        "description": "File name (with full path within the framework) of the template file",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "File name (with full path) where to expand the template",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "mode",
-        "description": "Mode of destination file",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "owner",
-        "description": "Owner of destination file",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "group",
-        "description": "Group of destination file",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "target_file",
-        "new": "path"
-      }
-    ]
-  },
-  "service_ensure_disabled_at_boot": {
-    "name": "Service ensure disabled at boot",
-    "bundle_name": "service_ensure_disabled_at_boot",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Force a service not to be enabled at boot",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "service_ensure_disabled_at_boot",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_ensure_disabled_at_boot.cf",
-    "deprecated": "Use [service_disabled_at_boot](#_service_disabled_at_boot) instead.",
-    "rename": "service_disabled_at_boot",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Service name (as recognized by systemd, init.d, etc...)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "service_name",
-        "new": "name"
-      }
-    ]
-  },
-  "package_state_options": {
-    "name": "Package state with options",
-    "bundle_name": "package_state_options",
-    "bundle_args": [
-      "name",
-      "version",
-      "architecture",
-      "provider",
-      "state",
-      "options"
-    ],
-    "description": "Enforce the state of a package with options",
-    "documentation": "See [package_state](#_package_state) for documentation.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "package_state_options",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/package_state_options.cf",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Name of the package, or path to a local package if state is present",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "version",
-        "description": "Version of the package, can be \"latest\" for latest version or \"any\" for any version (defaults to \"any\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "architecture",
-        "description": "Architecture of the package, can be an architecture name  or \"default\" (defaults to \"default\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "provider",
-        "description": "Package provider to use, can be \"yum\", \"apt\", \"zypper\", \"zypper_pattern\", \"slackpkg\", \"pkg\", \"ips\", \"nimclient\", \"snap\" or \"default\" for system default package manager (defaults to \"default\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "default",
-            "yum",
-            "apt",
-            "zypper",
-            "zypper_pattern",
-            "slackpkg",
-            "pkg",
-            "ips",
-            "nimclient",
-            "snap"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "state",
-        "description": "State of the package, can be \"present\" or \"absent\" (defaults to \"present\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "present",
-            "absent"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "options",
-        "description": "Options no pass to the package manager (defaults to empty)",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "service_restart_if": {
-    "name": "Service restart at a condition",
-    "bundle_name": "service_restart_if",
-    "bundle_args": [
-      "name",
-      "expression"
-    ],
-    "description": "Restart a service using the appropriate method if the specified class is true, otherwise it is considered as not required and success classes are returned.",
-    "documentation": "See [service_action](#_service_action) for documentation.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "service_restart",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_restart_if.cf",
-    "deprecated": "Use [service_restart](#_service_restart) with a condition",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Name of the service",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "expression",
-        "description": "Condition expression which will trigger the restart of Service \"(package_service_installed|service_conf_changed)\" by example",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "service_name",
-        "new": "name"
-      },
-      {
-        "old": "trigger_class",
-        "new": "expression"
-      }
-    ]
-  },
-  "sharedfile_to_node": {
-    "name": "Sharedfile to node",
-    "bundle_name": "sharedfile_to_node",
-    "bundle_args": [
-      "remote_node",
-      "file_id",
-      "file_path",
-      "ttl"
-    ],
-    "description": "This method shares a file with another Rudder node",
-    "documentation": "This method shares a file with another Rudder node using a unique file identifier.\n\nRead the Rudder documentation for a [high level overview of file sharing between nodes](https://docs.rudder.io/reference/current/usage/advanced_configuration_management.html#_share_files_between_nodes).\n\nThe file will be kept on the policy server and transmitted to the destination node's policy server if it is different.\nIt will be kept on this server for the destination node to download as long as it is not replaced by a new\nfile with the same id or remove by expiration of the TTL.\n\n#### Parameters\n\nThis section describes the generic method parameters.\n\n#### remote_node\n\nThe node you want to share this file with. The uuid of a node\nis visible in the Nodes details (in the Web interface) or by entering\n`rudder agent info` on the target node.\n\n##### file_id\n\nThis is a name that will be used to identify the file in the target node. It should be unique\nand describe the file content.\n\n##### file_path\n\nThe local absolute path of the file to share.\n\n##### ttl\n\nThe TTL can be:\n\n* A simple integer, in this case it is assumed to be a number of *seconds*\n* A string including units indications, the possible units are:\n\n* *days*, *day* or *d*\n* *hours*, *hour*, or *h*\n* *minutes*, *minute*, or *m*\n* *seconds*, *second* or *s*\n\nThe ttl value can look like *1day 2hours 3minutes 4seconds* or can be abbreviated in the form *1d 2h 3m 4s*, or without spaces *1d2h3m4s* or any combination like *1day2h 3minute 4seconds*\nAny unit can be skipped, but the decreasing order needs to be respected.\n\n##### file_id\n\nThis is a name that will be used to identify the file once stored on the server. It should be unique\nand describe the file content.\n\n#### Example:\n\nWe have a node *A*, with uuid `2bf1afdc-6725-4d3d-96b8-9128d09d353c` which wants to share\nthe `/srv/db/application.properties` with node *B* with uuid `73570beb-2d4a-43d2-8ffc-f84a6817849c`.\n\nWe want this file to stay available for one year for node *B* on its policy server.\n\nThe node *B* wants to download it into `/opt/application/etc/application.properties`.\n\nThey have to agree (i.e. it has to be defined in the policies of both nodes) on the id of the file,\nthat will be used during the exchange, here it will be `application.properties`.\n\nTo share the file, node *A* will use:\n\n```\nsharedfile_to_node(\"73570beb-2d4a-43d2-8ffc-f84a6817849c\", \"application.properties\", \"/srv/db/application.properties\", \"356 days\")\n```\n\nTo download the file, node *B* will use [sharedfile_from_node](#_sharedfile_from_node) with:\n\n```\nsharedfile_from_node(\"2bf1afdc-6725-4d3d-96b8-9128d09d353c\", \"application.properties\", \"/opt/application/etc/application.properties\")\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "sharedfile_to_node",
-    "class_parameter": "file_id",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/sharedfile_to_node.cf",
-    "parameter": [
-      {
-        "name": "remote_node",
-        "description": "Which node to share the file with",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "file_id",
-        "description": "Unique name that will be used to identify the file on the receiver",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "regex": "^[A-z0-9._-]+$",
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "file_path",
-        "description": "Path of the file to share",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "ttl",
-        "description": "Time to keep the file on the policy server in seconds or in human readable form (see long description)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "regex": "^(\\d+\\s*(days?|d))?(\\d+\\s*(hours?|h))?(\\d+\\s*(minutes?|m))?(\\d+\\s*(seconds?|s))?$",
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "target_uuid",
-        "new": "remote_node"
-      }
-    ]
-  },
-  "service_ensure_stopped": {
-    "name": "Service ensure stopped",
-    "bundle_name": "service_ensure_stopped",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Ensure that a service is stopped using the appropriate method",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "service_ensure_stopped",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_ensure_stopped.cf",
-    "deprecated": "Use [service_stopped](#_service_stopped) instead.",
-    "rename": "service_stopped",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Service",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "service_name",
-        "new": "name"
-      }
-    ]
-  },
-  "variable_string_escaped": {
-    "name": "Variable string escaped",
-    "bundle_name": "variable_string_escaped",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Define a variable from another string variable and escape regular expression characters in it.",
-    "documentation": "To use the generated variable, you must use the form `${<name>_escaped}` where <name> is the composed complete name\nof the variable you want to escape.\n\nPlease note that the variable you want to escape must be defined before this method evaluation.\n\n#### Example:\n\nWith a variable defined by the generic method `variable_string`, named `my_prefix.my_variable` and valued to:\n\n````\n something like [] that\n````\n\nPassing `my_prefix.my_variable` as `name` parameter to this method will result in a\nvariable named `my_prefix.my_variable_escaped` and valued to:\n\n````\nsomething\\ like\\ \\[\\]\\ that\n````",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "variable_string_escaped",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/variable_string_escaped.cf",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "The variable to define, the full name will be prefix.name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "variable_name",
-        "new": "name"
-      }
-    ]
-  },
-  "file_copy_from_remote_source_recursion": {
-    "name": "File copy from remote source recurse",
-    "bundle_name": "file_copy_from_remote_source_recursion",
-    "bundle_args": [
-      "source",
-      "path",
-      "recursion"
-    ],
-    "description": "Ensure that a file or directory is copied from a policy server",
-    "documentation": "This method requires that the policy server is configured to accept\ncopy of the source file or directory from the agents it will be applied to.\n\nYou can download a file from the shared files with:\n\n```\n/var/rudder/configuration-repository/shared-files/PATH_TO_YOUR_DIRECTORY_OR_FILE\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_copy_from_remote_source",
-    "class_parameter": "path",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_copy_from_remote_source_recursion.cf",
-    "deprecated": "Use [file_from_remote_source_recursion](#_file_from_remote_source_recursion) instead.",
-    "rename": "file_from_remote_source_recursion",
-    "parameter": [
-      {
-        "name": "source",
-        "description": "Source file (absolute path on the policy server)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "Destination file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "recursion",
-        "description": "Recursion depth to enforce for this path (0, 1, 2, ..., inf)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "destination",
-        "new": "path"
-      }
-    ]
-  },
-  "service_check_running": {
-    "name": "Service check running",
-    "bundle_name": "service_check_running",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Check if a service is running using the appropriate method",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "service_check_running",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_check_running.cf",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Process name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "service_name",
-        "new": "name"
-      }
-    ]
-  },
-  "user_present": {
-    "name": "User present",
-    "bundle_name": "user_present",
-    "bundle_args": [
-      "login"
-    ],
-    "description": "Ensure a user exists on the system.",
-    "documentation": "This method does not create the user's home directory.\n Primary group will be created and set with default one, following the useradd default behavior.\n As in most UNIX system default behavior user creation will fail if a group with\n the user name already exists.",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "user_present",
-    "class_parameter": "login",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/user_present.cf",
-    "parameter": [
-      {
-        "name": "login",
-        "description": "User login",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "service_ensure_running": {
-    "name": "Service ensure running",
-    "bundle_name": "service_ensure_running",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Ensure that a service is running using the appropriate method",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "service_ensure_running",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_ensure_running.cf",
-    "deprecated": "Use [service_started](#_service_started) instead.",
-    "rename": "service_started",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Service name (as recognized by systemd, init.d, etc...)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "service_name",
-        "new": "name"
-      }
-    ]
-  },
-  "variable_string_from_math_expression": {
-    "name": "Variable string from math expression",
-    "bundle_name": "variable_string_from_math_expression",
-    "bundle_args": [
-      "prefix",
-      "name",
-      "expression",
-      "format"
-    ],
-    "description": "Define a variable from a mathematical expression",
-    "documentation": "To use the generated variable, you must use the form `${prefix.name}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \nPlease note that only global variables are available within templates.\n\n#### Usage\n\nThis function will evaluate a mathematical expression that may contain variables and format the result according to the provided format string.\n\nThe formatting string uses the standard POSIX printf format.\n\n#### Supported mathematical expressions\n\nAll the mathematical computations are done using floats.\n\nThe supported infix mathematical syntax, in order of precedence, is:\n\n- `(` and `)` parentheses for grouping expressions\n- `^` operator for exponentiation\n- `*` and `/` operators for multiplication and division\n- `%` operators for modulo operation\n- `+` and `-` operators for addition and subtraction\n- `==` \"close enough\" operator to tell if two expressions evaluate to the same number, with a tiny margin to tolerate floating point errors.  It returns 1 or 0.\n- `>=` \"greater or close enough\" operator with a tiny margin to tolerate floating point errors.  It returns 1 or 0.\n- `>` \"greater than\" operator.  It returns 1 or 0.\n- `<=` \"less than or close enough\" operator with a tiny margin to tolerate floating point errors.  It returns 1 or 0.\n- `<` \"less than\" operator.  It returns 1 or 0.\n\nThe numbers can be in any format acceptable to the C `scanf` function with the `%lf` format specifier, followed by the `k`, `m`, `g`, `t`, or `p` SI units.  So e.g. `-100` and `2.34m` are valid numbers.\n\nIn addition, the following constants are recognized:\n\n- `e`: 2.7182818284590452354\n- `log2e`: 1.4426950408889634074\n- `log10e`: 0.43429448190325182765\n- `ln2`: 0.69314718055994530942\n- `ln10`: 2.30258509299404568402\n- `pi`: 3.14159265358979323846\n- `pi_2`: 1.57079632679489661923 (pi over 2)\n- `pi_4`: 0.78539816339744830962 (pi over 4)\n- `1_pi`: 0.31830988618379067154 (1 over pi)\n- `2_pi`: 0.63661977236758134308 (2 over pi)\n- `2_sqrtpi`: 1.12837916709551257390 (2 over square root of pi)\n- `sqrt2`: 1.41421356237309504880 (square root of 2)\n- `sqrt1_2`: 0.70710678118654752440 (square root of 1/2)\n\nThe following functions can be used, with parentheses:\n\n- `ceil` and `floor`: the next highest or the previous highest integer\n- `log10`, `log2`, `log`\n- `sqrt`\n- `sin`, `cos`, `tan`, `asin`, `acos`, `atan`\n- `abs`: absolute value\n- `step`: 0 if the argument is negative, 1 otherwise\n\n#### Formatting options\n\nThe format field supports the following specifiers:\n\n* `%d` for decimal integer\n* `%x` for hexadecimal integer\n* `%o` for octal integer\n* `%f` for decimal floating point\n\nYou can use usual flags, width and precision syntax.\n\n#### Examples\n\nIf you use:\n\n```\nvariable_string(\"prefix\", \"var\", \"10\");\nvariable_string_from_math_expression(\"prefix\", \"sum\", \"2.0+3.0\", \"%d\");\nvariable_string_from_math_expression(\"prefix\", \"product\", \"3*${prefix.var}\", \"%d\");\n```\n\nThe `prefix.sum` string variable will contain `5` and `prefix.product` will contain `30`.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "variable_string_from_math_expression",
-    "class_parameter": "name",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/variable_string_from_math_expression.cf",
-    "parameter": [
-      {
-        "name": "prefix",
-        "description": "The prefix of the variable name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "name",
-        "description": "The variable to define, the full name will be prefix.name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "expression",
-        "description": "The mathematical expression to evaluate",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "format",
-        "description": "The format string to use",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "variable_prefix",
-        "new": "prefix"
-      },
-      {
-        "old": "variable_name",
-        "new": "name"
-      }
-    ]
-  },
-  "package_install_version_cmp": {
-    "name": "Package install version compare",
-    "bundle_name": "package_install_version_cmp",
-    "bundle_args": [
-      "name",
-      "version_comparator",
-      "package_version",
-      "action"
-    ],
-    "description": "Install a package or verify if it is installed in a specific version, or higher or lower version than a version specified",
-    "documentation": "*Example*:\n```\nmethods:\n    \"any\" usebundle => package_install_version_cmp(\"postgresql\", \">=\", \"9.1\", \"verify\");\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "package_install",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/package_install_version_cmp.cf",
-    "deprecated": "Use [package_present](#_package_present) instead.",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Name of the package to install or verify",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "version_comparator",
-        "description": "Comparator between installed version and defined version, can be ==,<=,>=,<,>,!=",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "select": [
-            "==",
-            "<=",
-            ">=",
-            "<",
-            ">",
-            "!="
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "package_version",
-        "description": "The version of the package to verify (can be \"latest\" for latest version)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "action",
-        "description": "Action to perform, can be add, verify (defaults to verify)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "package_name",
-        "new": "name"
-      }
-    ]
-  },
-  "variable_string_match": {
-    "name": "Variable string match",
-    "bundle_name": "variable_string_match",
-    "bundle_args": [
-      "name",
-      "expected_match"
-    ],
-    "description": "Test the content of a string variable",
-    "documentation": "Test a variable content and report a success if it matched, or an error if it does not or if the variable could not be found.\n Regex must respect PCRE format.\n Please note that this method is designed to only audit a variable state. If you want to use conditions resulting from this generic method,\n is it recommended to use instead condition_from_variable_match which is designed for it.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "variable_string_match",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/variable_string_match.cf",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Complete name of the variable being tested, like my_prefix.my_variable",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "expected_match",
-        "description": "Regex to use to test if the variable content is compliant",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "variable_name",
-        "new": "name"
-      }
-    ]
-  },
-  "service_action": {
-    "name": "Service action",
-    "bundle_name": "service_action",
-    "bundle_args": [
-      "name",
-      "action"
-    ],
-    "description": "Trigger an action on a service using the appropriate tool",
-    "documentation": "The `service_*` methods manage the services running on the system.\n\n#### Parameters\n\n##### Service name\n\nThe name of the service is the name understood by the service manager, except for the\n`is-active-process` action, where it is the regex to match against the running processes list.\n\n##### Action\n\nThe action is the name of an action to run on the given service.\nThe following actions can be used:\n\n* `start`\n* `stop`\n* `restart`\n* `reload` (or `refresh`)\n* `is-active` (or `status`)\n* `is-active-process` (in this case, the \"service\" parameter is the regex to match againt process list)\n* `enable`\n* `disable`\n* `is-enabled`\n\nOther actions may also be used, depending on the selected service manager.\n\n#### Implementation\n\nThese methods will detect the method to use according to the platform. You can run the methods with an `info`\nverbosity level to see which service manager will be used for a given action.\n\nWARNING: Due to compatibility issues when mixing calls to systemctl and service/init.d,\nwhen an init script exists, we will not use systemctl compatibility layer but directly service/init.d.\n\nThe supported service managers are:\n\n* systemd (any unknown action will be passed directly)\n* upstart\n* smf (for Solaris)\n* service command (for non-boot actions, any unknown action will be passed directly)\n* /etc/init.d scripts (for non-boot actions, any unknown action will be passed directly)\n* SRC (for AIX) (for non-boot actions)\n* chkconfig (for boot actions)\n* update-rc.d (for boot actions)\n* chitab (for boot actions)\n* links in /etc/rcX.d (for boot actions)\n* Windows services\n\n#### Examples\n\n```\n# To restart the apache2 service\nservice_action(\"apache2\", \"restart\");\nservice_restart(\"apache2\");\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "service_action",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_action.cf",
-    "action": "is-* commands are not actions, but all other commands are",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Name of the service",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "action",
-        "description": "Action to trigger on the service (start, stop, restart, reload, ...)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "service_name",
-        "new": "name"
-      }
-    ]
-  },
-  "file_check_symlink": {
-    "name": "File check if symlink",
-    "bundle_name": "file_check_symlink",
-    "bundle_args": [
-      "path"
-    ],
-    "description": "Checks if a file exists and is a symlink",
-    "documentation": "This bundle will define a condition `file_check_symlink_${path}_{ok, reached, kept}` if the\nfile is a symlink, or `file_check_symlink_${path}_{not_ok, reached, not_kept, failed}` if\nthe file is not a symlink or does not exist",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_check_symlink",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_symlink.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file_name",
-        "new": "path"
-      }
-    ]
-  },
-  "file_block_present": {
-    "name": "File block present",
-    "bundle_name": "file_block_present",
-    "bundle_args": [
-      "path",
-      "block"
-    ],
-    "description": "Ensure that a text block is present in a specific location",
-    "documentation": "Ensure that a text block is present in the target file.\nIf the block is not found, it will be added at the end of the file.\n\n#### Examples:\n\nGiven a file with the following content:\n```\napple\npear\nbanana\n```\nApplying the method with the block:\n```\npear\norange\n```\n\nWill result in the following content:\n```\napple\npear\nbanana\npear\norange\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_block_present",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_block_present.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "block",
-        "description": "Block(s) to add in the file",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file",
-        "new": "path"
-      }
-    ]
-  },
-  "file_ensure_line_present_in_xml_tag": {
-    "name": "File ensure line in XML section",
-    "bundle_name": "file_ensure_line_present_in_xml_tag",
-    "bundle_args": [
-      "path",
-      "tag",
-      "line"
-    ],
-    "description": "Ensure that a line is present in a tag in a specific location. The objective of this method is to handle XML-style files. Note that if the tag is not present in the file, it won't be added, and the edition will fail.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_ensure_line_present_in_xml_tag",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_line_present_in_xml_tag.cf",
-    "deprecated": "Use [file_line_present_in_xml_tag](#_file_line_present_in_xml_tag) instead.",
-    "rename": "file_line_present_in_xml_tag",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "tag",
-        "description": "Name of the XML tag under which lines should be added (not including the <> brackets)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "line",
-        "description": "Line to ensure is present inside the section",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file",
-        "new": "path"
-      }
-    ]
-  },
-  "package_install_version": {
-    "name": "Package install version",
-    "bundle_name": "package_install_version",
-    "bundle_args": [
-      "name",
-      "package_version"
-    ],
-    "description": "Install or update a package in a specific version",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "package_install",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/package_install_version.cf",
-    "deprecated": "Use [package_present](#_package_present) instead.",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Name of the package to install",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "package_version",
-        "description": "Version of the package to install (can be \"latest\" to install it in its latest version)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "package_name",
-        "new": "name"
-      }
-    ]
-  },
-  "kernel_module_loaded": {
-    "name": "Kernel module loaded",
-    "bundle_name": "kernel_module_loaded",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Ensure that a given kernel module is loaded on the system",
-    "documentation": "Ensure that a given kernel module is loaded on the system.\n  If the module is not loaded, it will try to load it via modprobe.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "kernel_module_loaded",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/kernel_module_loaded.cf",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Complete name of the kernel module, as seen by lsmod or listed in /proc/modules",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "module_name",
-        "new": "name"
-      }
-    ]
-  },
-  "file_copy_from_local_source": {
-    "name": "File copy from local source",
-    "bundle_name": "file_copy_from_local_source",
-    "bundle_args": [
-      "source",
-      "path"
-    ],
-    "description": "Ensure that a file or directory is copied from a local source",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "file_copy_from_local_source",
-    "class_parameter": "path",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_copy_from_local_source.cf",
-    "deprecated": "Use [file_from_local_source](#_file_from_local_source) instead.",
-    "rename": "file_from_local_source",
-    "parameter": [
-      {
-        "name": "source",
-        "description": "Source file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "Destination file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "destination",
-        "new": "path"
-      }
-    ]
-  },
-  "audit_from_command": {
-    "name": "Audit from command",
-    "bundle_name": "audit_from_command",
-    "bundle_args": [
-      "command",
-      "compliant_codes"
-    ],
-    "description": "Execute an audit only command and reports depending on exit code",
-    "documentation": "Execute an audit only command and reports depending on\nthe exit codes given in parameters.\nIf an exit code is not in the list it will lead to an error status.\nThe command is always executed and the report is adapted to work properly in\nenforce and in audit mode.\nIt is up to you to make sure the command doesn't modify the system status at all\nsince it is always executed, even in audit mode.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "audit_from_command",
-    "class_parameter": "command",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/audit_from_command.cf",
-    "parameter": [
-      {
-        "name": "command",
-        "description": "Command to run",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "compliant_codes",
-        "description": "List of codes that produce a compliant status separated with commas (ex: 1,2,5)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "condition_from_string_match": {
-    "name": "Condition from string match",
-    "bundle_name": "condition_from_string_match",
-    "bundle_args": [
-      "condition",
-      "value",
-      "regex"
-    ],
-    "description": "Test the content of a string variable",
-    "documentation": "Test a string against a regex pattern and create conditions depending on the match result:\n\n* `${condition}_true` condition is defined if the regex matches\n* `${condition}_false` condition is defined if the regex does not match the string\n\nThe regex is singleline, case sensitive, culture invariant and implicitly enclosed by the start/end of string\ndelimiters `^` and `$`.\nThis method's reporting status will always be \"success\".\n\n### Examples\n\n```yaml\n-name: Define is_matching_true\n method: condition_from_string_match\n params:\n   condition: is_matching\n   value: \"Some\\nmulti\\nline\\ntext\"\n   regex: \"Some.*text\"\n```",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "condition_from_string_match",
-    "class_parameter": "condition",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/condition_from_string_match.cf",
-    "parameter": [
-      {
-        "name": "condition",
-        "description": "Prefix of the class (condition) generated",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "value",
-        "description": "String typed value that will be tested against the regex",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "regex",
-        "description": "Pattern used to test if the value against",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "condition_prefix",
-        "new": "condition"
-      }
-    ]
-  },
   "permissions_recursive": {
     "name": "Permissions (recursive)",
     "bundle_name": "permissions_recursive",
@@ -4002,23 +2524,131 @@
       }
     ]
   },
-  "variable_from_vault": {
-    "name": "Variable from Vault",
-    "bundle_name": "variable_from_vault",
+  "file_augeas_set": {
+    "name": "File Augeas set",
+    "bundle_name": "file_augeas_set",
     "bundle_args": [
-      "prefix",
-      "name",
-      "path"
+      "path",
+      "value",
+      "lens",
+      "file"
     ],
-    "description": "Gets a key-value dictionary from Vault given the secret path",
-    "documentation": "To use the generated variable, you must use the form `${prefix.name}` with each name replaced with the parameters of this method.\n\nAccess to the vault has to be configured on each agent in /var/rudder/plugin-resources/vault.json. A sample config file is provided in /opt/rudder/share/plugins/vault/sample_vault.json\n\nThis generic method will report as performing a repair when it fetches a key, and an error when it fails to do so.",
+    "description": "Use augeas commands and options to set a node label's value.",
+    "documentation": "Augeas is a tool that provides an abstraction layer for all the complexities that turn around editing files with regular expressions.\nIt's a tree based hierarchy tool, that handles system configuration files where you can securely modify your files and to do so you have to provide\nthe path to the node label's value.\n\nAugeas uses lenses which are like sort of modules that are in charge of identifying and converting files into tree and back.\n\nThis method uses `augtool` to force the value of an augeas node's label.\n\nActually there are two ways to use this method:\n\n* Either by providing the augeas **path** to the node's label and let **lens** and **file** empty.\n** this way augeas will load the common files and lens automatically\n* Or by using a given **file** path and a specific **lens**.\n** better performances since only one lens is loaded\n** support custom lens, custom paths (for instance to apply the Hosts lens to another file than `/etc/hosts`)\n* Either by simply providing an augeas **path** to the node's label\n\n*Warning*: When you don't specify the file and lens to use, no backup of the file will be made before\nediting it.\n\n#### Two uses cases examples:\n\nIn the first case, let's suppose that you want to set the value of the ip address of the first line in the `/etc/hosts` file to `192.168.1.5`,\nto do so you need to provide the augeas **path** and **value** parameters.\n\n```\nfile_augeas_set(\"/etc/hosts/1/ipaddr\", \"192.168.1.5\", \"\", \"\");\n```\n\nThe second case is more efficient, and forces the `Hosts` lens to parse the `/etc/hosts` file and set the value for the given **path** node:\n\n```\nfile_augeas_set(\"/etc/hosts/1/ipaddr\", \"192.168.1.5\", \"Hosts\", \"/etc/hosts\");\n```",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "variable_from_vault",
+    "class_prefix": "file_augeas_set",
     "class_parameter": "path",
-    "class_parameter_id": 3,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/variable_from_vault.cf",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_augeas_set.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "The path to the file and node label",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "value",
+        "description": "The value to set",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "lens",
+        "description": "Load a specific lens (optional)",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "file",
+        "description": "Load a specific file (optional)",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "variable_string_match": {
+    "name": "Variable string match",
+    "bundle_name": "variable_string_match",
+    "bundle_args": [
+      "name",
+      "expected_match"
+    ],
+    "description": "Test the content of a string variable",
+    "documentation": "Test a variable content and report a success if it matched, or an error if it does not or if the variable could not be found.\n Regex must respect PCRE format.\n Please note that this method is designed to only audit a variable state. If you want to use conditions resulting from this generic method,\n is it recommended to use instead condition_from_variable_match which is designed for it.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "variable_string_match",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/variable_string_match.cf",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Complete name of the variable being tested, like my_prefix.my_variable",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "expected_match",
+        "description": "Regex to use to test if the variable content is compliant",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "variable_name",
+        "new": "name"
+      }
+    ]
+  },
+  "variable_string_from_augeas": {
+    "name": "Variable string from Augeas",
+    "bundle_name": "variable_string_from_augeas",
+    "bundle_args": [
+      "prefix",
+      "name",
+      "path",
+      "lens",
+      "file"
+    ],
+    "description": "Use Augeas binaries to call Augtool commands and options to get a node label's value.",
+    "documentation": "Augeas is a tool that provides an abstraction layer for all the complexities that turn around editing files with regular expressions.\nIt's a tree based hierarchy tool, that handle system configuration files where you can securely modify your files. To do so you have to provide\nthe path to the node label's value.\n\nThis method aims to use `augtool` to extract a specific information from a configuration file into a rudder variable.\nIf Augeas is not installed on the agent, or if it fails to execute, it will produces an error.\n\n* **variable prefix**: target variable prefix\n* **variable name**: target variable name\n* **path**: augeas node path, use to describe the location of the target information we want to extract\n* **lens**: augeas lens to use, optional\n* **file**: absolute file path to target, optional\n\nActually there are two ways you can use this method:\n\n* Either by providing the augeas **path** to the node's label and let **lens** and **file** empty.\n** this way augeas will load the common files and lens automatically\n* Or by using a given **file** path and a specific **lens**.\n** better performances since only one lens is loaded\n** support custom lens, support custom paths\n\nThis mechanism is the same as in the `file_augeas_set` method.\n\n#### With autoload\n\nLet's consider that you want to obtain the value of the ip address of the first line in the `/etc/hosts`:\n\n(Note that the `label` and `value` parameters mentioned are naming examples of **variable prefix** and **variable name**, the augeas\n**path** `/etc/hosts/1/ipaddr`\nrepresents the `ipaddr` node label's value (in the augeas mean) in the first line of the file `/etc/hosts`).\n\n```\nvariable_string_from_augeas(\"label\",\"value\",\"/etc/hosts/1/ipaddr\", \"\", \"\");\n```\n\n#### Without autoload\n\nHere we want the same information as in the first example, but we will force the lens to avoid loading unnecessary files.\n\n```\nvariable_string_from_augeas(\"label\",\"value\",\"/etc/hosts/1/ipaddr\",\"Hosts\",\"/etc/hosts\");\n```\n\n#### Difference with `file augeas command`\n\nThis method is very similar to the `file augeas command` one, both execute an `augtool` command an dump its output in a rudder variable.\nBut their goal is really different:\n\n* This one will parse the output of the augeas `print` that we want to make it directly usable, but will be less flexible in its input.\n* The `file augeas command` offers much more possibilities to execute an augeas command to modify a file, but the output will be unparsed and most likely\n  unusable as a rudder variable, expect to dump an error or configuration somewhere.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "variable_string_from_augeas",
+    "class_parameter": "name",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/variable_string_from_augeas.cf",
     "parameter": [
       {
         "name": "prefix",
@@ -4042,35 +2672,7 @@
       },
       {
         "name": "path",
-        "description": "Vault secret path",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "user_status": {
-    "name": "User status",
-    "bundle_name": "user_status",
-    "bundle_args": [
-      "user",
-      "status"
-    ],
-    "description": "This generic method defines if user is present or absent",
-    "agent_support": [
-      "dsc"
-    ],
-    "class_prefix": "user_status",
-    "class_parameter": "user",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/user_status.cf",
-    "parameter": [
-      {
-        "name": "user",
-        "description": "User name",
+        "description": "The path to the file and node label",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -4079,40 +2681,408 @@
         "type": "string"
       },
       {
-        "name": "status",
-        "description": "Desired state for the user - can be 'Present' or 'Absent'",
+        "name": "lens",
+        "description": "The lens specified by the user in case they want to load a specified lens associated with its file",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "file",
+        "description": "The absolute path to the file specified by the user in case they want to load a specified file associated with its lens",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "variable_prefix",
+        "new": "prefix"
+      },
+      {
+        "old": "variable_name",
+        "new": "name"
+      }
+    ]
+  },
+  "file_from_shared_folder": {
+    "name": "File copy from Rudder shared folder",
+    "bundle_name": "file_from_shared_folder",
+    "bundle_args": [
+      "source",
+      "path",
+      "hash_type"
+    ],
+    "description": "Ensure that a file or directory is copied from the Rudder shared folder.",
+    "documentation": "Ensure that a file or directory is copied from the Rudder shared folder.\nThe Rudder shared folder is located on the Rudder server under `/var/rudder/configuration-repository/shared-files`.\nEvery file/folder in the shared folder will be available for every managed node.\nThis method will download and update the destination file from a source taken from this shared folder.\nA file in the shared folder will be updated on the node side at agent run.",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "file_from_shared_folder",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_shared_folder.cf",
+    "parameter": [
+      {
+        "name": "source",
+        "description": "Source file (path, relative to /var/rudder/configuration-repository/shared-files)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "Destination file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "hash_type",
+        "description": "Hash algorithm used to check if file is updated (sha256, sha512). Only used on Windows, ignored on Unix. default is sha256",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
           "select": [
-            "Present",
-            "Absent"
+            {
+              "value": ""
+            },
+            {
+              "value": "sha256"
+            },
+            {
+              "value": "sha512"
+            },
+            {
+              "value": "md5"
+            },
+            {
+              "value": "sha1"
+            }
           ],
           "max_length": 16384
         },
         "type": "string"
       }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
+      }
     ]
   },
-  "package_install": {
-    "name": "Package install",
-    "bundle_name": "package_install",
+  "file_symlink_present_option": {
+    "name": "Symlink present (optional overwriting)",
+    "bundle_name": "file_symlink_present_option",
+    "bundle_args": [
+      "source",
+      "path",
+      "enforce"
+    ],
+    "description": "Create a symlink at a destination path and pointing to a source target. This is also possible to enforce its creation",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_symlink_present",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_symlink_present_option.cf",
+    "parameter": [
+      {
+        "name": "source",
+        "description": "Source file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "Destination file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "enforce",
+        "description": "Force symlink if file already exist (true or false)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
+      }
+    ]
+  },
+  "kernel_module_not_loaded": {
+    "name": "Kernel module not loaded",
+    "bundle_name": "kernel_module_not_loaded",
     "bundle_args": [
       "name"
     ],
-    "description": "Install or update a package in its latest version available",
+    "description": "Ensure that a given kernel module is not loaded on the system",
+    "documentation": "Ensure that a given kernel module is not loaded on the system.\n  If the module is loaded, it will try to unload it using modprobe.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "kernel_module_not_loaded",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/kernel_module_not_loaded.cf",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Complete name of the kernel module, as seen by lsmod or listed in /proc/modules",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "module_name",
+        "new": "name"
+      }
+    ]
+  },
+  "file_check_symlink": {
+    "name": "File check if symlink",
+    "bundle_name": "file_check_symlink",
+    "bundle_args": [
+      "path"
+    ],
+    "description": "Checks if a file exists and is a symlink",
+    "documentation": "This bundle will define a condition `file_check_symlink_${path}_{ok, reached, kept}` if the\nfile is a symlink, or `file_check_symlink_${path}_{not_ok, reached, not_kept, failed}` if\nthe file is not a symlink or does not exist",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_check_symlink",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_symlink.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file_name",
+        "new": "path"
+      }
+    ]
+  },
+  "file_create_symlink": {
+    "name": "Create symlink",
+    "bundle_name": "file_create_symlink",
+    "bundle_args": [
+      "source",
+      "path"
+    ],
+    "description": "Create a symlink at a destination path and pointing to a source target except if a file or directory already exists.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_create_symlink",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_create_symlink.cf",
+    "deprecated": "Use [file_symlink_present](#_file_symlink_present) instead.",
+    "rename": "file_symlink_present",
+    "parameter": [
+      {
+        "name": "source",
+        "description": "Source file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "Destination file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
+      }
+    ]
+  },
+  "file_line_present_in_ini_section": {
+    "name": "File line in INI section",
+    "bundle_name": "file_line_present_in_ini_section",
+    "bundle_args": [
+      "path",
+      "section",
+      "line"
+    ],
+    "description": "Ensure that a line is present in a section in a specific location. The objective of this method is to handle INI-style files.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_line_present_in_ini_section",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_line_present_in_ini_section.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "section",
+        "description": "Name of the INI-style section under which lines should be added (not including the [] brackets)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "line",
+        "description": "Line to ensure is present inside the section",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file",
+        "new": "path"
+      }
+    ]
+  },
+  "package_install_version_cmp": {
+    "name": "Package install version compare",
+    "bundle_name": "package_install_version_cmp",
+    "bundle_args": [
+      "name",
+      "version_comparator",
+      "package_version",
+      "action"
+    ],
+    "description": "Install a package or verify if it is installed in a specific version, or higher or lower version than a version specified",
+    "documentation": "*Example*:\n```\nmethods:\n    \"any\" usebundle => package_install_version_cmp(\"postgresql\", \">=\", \"9.1\", \"verify\");\n```",
     "agent_support": [
       "cfengine-community"
     ],
     "class_prefix": "package_install",
     "class_parameter": "name",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/package_install.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/package_install_version_cmp.cf",
     "deprecated": "Use [package_present](#_package_present) instead.",
     "parameter": [
       {
         "name": "name",
-        "description": "Name of the package to install",
+        "description": "Name of the package to install or verify",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "version_comparator",
+        "description": "Comparator between installed version and defined version, can be ==,<=,>=,<,>,!=",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": "=="
+            },
+            {
+              "value": "<="
+            },
+            {
+              "value": ">="
+            },
+            {
+              "value": "<"
+            },
+            {
+              "value": ">"
+            },
+            {
+              "value": "!="
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "package_version",
+        "description": "The version of the package to verify (can be \"latest\" for latest version)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "action",
+        "description": "Action to perform, can be add, verify (defaults to verify)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -4125,6 +3095,207 @@
       {
         "old": "package_name",
         "new": "name"
+      }
+    ]
+  },
+  "file_line_present_in_xml_tag": {
+    "name": "File line in XML section",
+    "bundle_name": "file_line_present_in_xml_tag",
+    "bundle_args": [
+      "path",
+      "tag",
+      "line"
+    ],
+    "description": "Ensure that a line is present in a tag in a specific location. The objective of this method is to handle XML-style files. Note that if the tag is not present in the file, it won't be added, and the edition will fail.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_line_present_in_xml_tag",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_line_present_in_xml_tag.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "tag",
+        "description": "Name of the XML tag under which lines should be added (not including the <> brackets)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "line",
+        "description": "Line to ensure is present inside the section",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file",
+        "new": "path"
+      }
+    ]
+  },
+  "file_keys_values_present": {
+    "name": "File keys-values present",
+    "bundle_name": "file_keys_values_present",
+    "bundle_args": [
+      "path",
+      "keys",
+      "separator"
+    ],
+    "description": "Ensure that the file contains all pairs of \"key separator value\", with arbitrary separator between each key and its value",
+    "documentation": "This method ensures key-value pairs are present in a file.\n\n#### Usage\n\nThis method will iterate over the key-value pairs in the dict, and:\n\n* If the key is not defined in the destination, add the *key* + *separator* + *value* line.\n* If the key is already present in the file, replace the *key* + *separator* + anything by *key* + *separator* + *value*\n\nThis method always ignores spaces and tabs when replacing (which means for example that `key = value` will match the `=` separator).\n\nKeys are considered unique (to allow replacing the value), so you should use [file_ensure_lines_present](#_file_ensure_lines_present)\nif you want to have multiple lines with the same key.\n\n#### Example\n\nIf you have an initial file (`/etc/myfile.conf`) containing:\n\n```\nkey1 = something\nkey3 = value3\n```\n\nTo define key-value pairs, use the [variable_dict](#_variable_dict) or\n[variable_dict_from_file](#_variable_dict_from_file) methods.\n\nFor example, if you use the following content (stored in `/tmp/data.json`):\n\n```json\n{\n   \"key1\": \"value1\",\n   \"key2\": \"value2\"\n}\n```\n\nWith the following policy:\n\n```\n# Define the `content` variable in the `configuration` prefix from the json file\nvariable_dict_from_file(\"configuration\", \"content\", \"/tmp/data.json\")\n# Enforce the presence of the key-value pairs\nfile_ensure_keys_values(\"/etc/myfile.conf\", \"configuration.content\", \" = \")\n\n```\n\nThe destination file (`/etc/myfile.conf`) will contain:\n\n```\nkey1 = value1\nkey3 = value3\nkey2 = value2\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_keys_values_present",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_keys_values_present.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "keys",
+        "description": "Name of the dict structure (without \"${}\") containing the keys (keys of the dict), and values to define (values of the dict)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "separator",
+        "description": "Separator between key and value, for example \"=\" or \" \" (without the quotes)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": true,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file",
+        "new": "path"
+      }
+    ]
+  },
+  "rudder_inventory_trigger": {
+    "name": "Rudder inventory trigger",
+    "bundle_name": "rudder_inventory_trigger",
+    "bundle_args": [
+      "id"
+    ],
+    "description": "Trigger an inventory on the agent",
+    "documentation": "Trigger a Rudder inventory. This will not run the inventory\nimmediately but next time the agent runs.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "rudder_inventory_trigger",
+    "class_parameter": "id",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/rudder_inventory_trigger.cf",
+    "action": "",
+    "parameter": [
+      {
+        "name": "id",
+        "description": "Id of the reporting for this method (internal identifier, needs to be unique for each use of the method)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "permissions_user_acl_absent": {
+    "name": "Permissions user POSIX acl entry absent",
+    "bundle_name": "permissions_user_acl_absent",
+    "bundle_args": [
+      "path",
+      "recursive",
+      "user"
+    ],
+    "description": "Verify that an ace is absent on a file or directory for a given user.\nThis method will make sure that no ace is present in the POSIX ACL of the target.",
+    "documentation": "The `permissions_*acl_*` manage the POSIX ACL on files and directories.\n\nPlease note that the mask will be automatically recalculated when editing ACLs.\n\n#### Parameters\n\n##### Path\n\nPath can be a regex with the following format:\n\n* `*` matches any filename or directory at one level, e.g. `*.cf` will match all files in one directory that end in .cf but it won't search across directories. `*/*.cf` on the other hand will look two levels deep.\n* `?` matches a single letter\n* `[a-z]` matches any letter from a to z\n* `{x,y,anything}` will match x or y or anything.\n\n##### Recursive\n\nCan be:\n\n* `true` to apply the given aces to folder and sub-folders and files.\n* or `false` to apply to the strict match of `Path`\n\nIf left blank, recursivity will automatically be set to `false`\n\n##### User\n\n`Username` to enforce the ace absence, being the Linux account name.\nThis method can only handle one username.\n\n#### Example\n\nGiven a file with the following getfacl output:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\nuser:bob:rwx\ngroup::r--\nmask::rwx\nother::---\n\n~~~~\n\nApplying this method with the following parameters:\n\n* `path`: /tmp/myTestFile\n* `recursive`: false\n* `user`: bob\n\nWill transform the previous ACLs in:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\ngroup::r--\nmask::r--\nother::---\n\n~~~~",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "permissions_user_acl_absent",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_user_acl_absent.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "Path of the file or directory",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "recursive",
+        "description": "Recursive Should ACLs cleanup be recursive, \"true\" or \"false\" (defaults to \"false\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": ""
+            },
+            {
+              "value": "true"
+            },
+            {
+              "value": "false"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "user",
+        "description": "Username of the Linux account.",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
       }
     ]
   },
@@ -4167,31 +3338,2212 @@
       }
     ]
   },
-  "windows_component_present": {
-    "name": "Windows component present",
-    "bundle_name": "windows_component_present",
+  "file_symlink_present_force": {
+    "name": "Symlink present (force overwrite)",
+    "bundle_name": "file_symlink_present_force",
     "bundle_args": [
-      "component"
+      "source",
+      "path"
     ],
-    "description": "Ensure that a specific windows component is present on the system.",
-    "documentation": "Ensure that a specific windows component is present on the system.",
+    "description": "Create a symlink at a destination path and pointing to a source target even if a file or directory already exists.",
     "agent_support": [
-      "dsc"
+      "cfengine-community"
     ],
-    "class_prefix": "windows_component_present",
-    "class_parameter": "component",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/windows_component_present.cf",
+    "class_prefix": "file_symlink_present",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_symlink_present_force.cf",
     "parameter": [
       {
-        "name": "component",
-        "description": "Windows component name",
+        "name": "source",
+        "description": "Source file (absolute path on the target node)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
           "max_length": 16384
         },
         "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "Destination file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
+      }
+    ]
+  },
+  "user_primary_group": {
+    "name": "User primary group",
+    "bundle_name": "user_primary_group",
+    "bundle_args": [
+      "login",
+      "primary_group"
+    ],
+    "description": "Define the primary group of the user. User must already exist.",
+    "documentation": "This method does not create the user.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "user_primary_group",
+    "class_parameter": "login",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/user_primary_group.cf",
+    "parameter": [
+      {
+        "name": "login",
+        "description": "User's login",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "primary_group",
+        "description": "User's primary group",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_content": {
+    "name": "File content",
+    "bundle_name": "file_content",
+    "bundle_args": [
+      "path",
+      "lines",
+      "enforce"
+    ],
+    "description": "Enforce the content of a file",
+    "documentation": "Enforce the content of a file.\nThe enforce parameter changes the edition method:\n\n* If *enforce* is set to *true* the file content will be forced\n* If *enforce* is set to *false* the file content will be forced line by line.\n  Which means that each line managed can not be duplicated and the order will\n  not be guaranteed.\n\nIn most cases, the *enforce* parameter should be set to *true*.\nWhen *enforce* is set to *false*, and the managed lines are:\n\n```\nBob\nAlice\nCharly\n```\n\nWill be compliant with the following file contents:\n\n```\nBob\nAlice\nCharly\n```\n\n```\nCharly\nBob\nAlice\nCharly\n```\n\n```\nBob\nCharly\nAlice\n```",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "file_lines_present",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_content.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "lines",
+        "description": "Line(s) to add in the file - if lines is a list, please use @{lines} to pass the iterator rather than iterating over each values",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "enforce",
+        "description": "Enforce the file to contain only line(s) defined (true or false)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file",
+        "new": "path"
+      }
+    ]
+  },
+  "file_create": {
+    "name": "File create",
+    "bundle_name": "file_create",
+    "bundle_args": [
+      "path"
+    ],
+    "description": "Create a file if it doesn't exist",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "file_create",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_create.cf",
+    "deprecated": "Use [file_present](#_file_present) instead.",
+    "rename": "file_present",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File to create (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "target",
+        "new": "path"
+      }
+    ]
+  },
+  "condition_from_variable_match": {
+    "name": "Condition from variable match",
+    "bundle_name": "condition_from_variable_match",
+    "bundle_args": [
+      "condition",
+      "variable_name",
+      "expected_match"
+    ],
+    "description": "Test the content of a string variable",
+    "documentation": "Test a string variable content and create conditions depending on its value:\n\n* If the variable **is found and its content matches** the given regex:\n    * a `${condition}_true` condition,\n    * and **kept outcome** status\n* If the variable **is found but its content does not match** the given regex:\n    * a `${condition}_false` condition,\n    * and a **kept outcome** status\n* If the variable **can not be found**:\n    * a `${condition}_false` condition\n    * and an **error outcome** status\n\nBe careful, we are using variable *name* not the value. For example if you want to match the property value \"foo\"\nyou will just need `node.properties[foo]` without `${...}` syntax\n\n/!\\ Regex for unix machine must be PCRE compatible and those for Windows agent must respect the .Net regex format.\n\n* If you want to test a technique parameter, use the `technique_id` of the technique\n  as variable prefix and the`parameter_name` as variable name.\n\nThe method only supports plain string type variables.",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "condition_from_variable_match",
+    "class_parameter": "condition",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/condition_from_variable_match.cf",
+    "parameter": [
+      {
+        "name": "condition",
+        "description": "Prefix of the class (condition) generated",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "variable_name",
+        "description": "Complete name of the variable being tested, like my_prefix.my_variable",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "expected_match",
+        "description": "Regex to use to test if the variable content is compliant",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "condition_prefix",
+        "new": "condition"
+      }
+    ]
+  },
+  "file_ensure_line_present_in_ini_section": {
+    "name": "File ensure line in INI section",
+    "bundle_name": "file_ensure_line_present_in_ini_section",
+    "bundle_args": [
+      "path",
+      "section",
+      "line"
+    ],
+    "description": "Ensure that a line is present in a section in a specific location. The objective of this method is to handle INI-style files.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_ensure_line_present_in_ini_section",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_line_present_in_ini_section.cf",
+    "deprecated": "Use [file_line_present_in_ini_section](#_file_line_present_in_ini_section) instead.",
+    "rename": "file_line_present_in_ini_section",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "section",
+        "description": "Name of the INI-style section under which lines should be added (not including the [] brackets)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "line",
+        "description": "Line to ensure is present inside the section",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file",
+        "new": "path"
+      }
+    ]
+  },
+  "http_request_content_headers": {
+    "name": "HTTP request sending content with headers",
+    "bundle_name": "http_request_content_headers",
+    "bundle_args": [
+      "method",
+      "url",
+      "content",
+      "headers"
+    ],
+    "description": "Make an HTTP request with a specific header",
+    "documentation": "Perform a HTTP request on the URL, method and headers provided\nand send the content provided. Will return an error if the request failed.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "http_request_content_headers",
+    "class_parameter": "url",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/http_request_content_headers.cf",
+    "action": "We don't know when HTTP methods cause side effect, this can be an action or not depending on your server behavior",
+    "parameter": [
+      {
+        "name": "method",
+        "description": "Method to call the URL (POST, PUT)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "url",
+        "description": "URL to send content to",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "content",
+        "description": "Content to send",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "headers",
+        "description": "Headers to include in the HTTP request",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "user_group": {
+    "name": "User group",
+    "bundle_name": "user_group",
+    "bundle_args": [
+      "login",
+      "group_name"
+    ],
+    "description": "Define secondary group for a user",
+    "documentation": "Ensure that a user is within a group\n\n#### Behavior\n\nEnsure that the user belongs in the given secondary group (non-exclusive)\n\n##### Parameters\n\n`login`      : the user login\n`group_name`: secondary group name the user should belong to (non-exclusive)\n\n#### Examples\n\nTo ensure that user `test` belongs in group `dev`\n\n```\n user_group(\"test\", \"dev\")\n```\nNote that it will make sure that user test is in group dev, but won't remove it\nfrom other groups it may belong to",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "user_group",
+    "class_parameter": "login",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/user_group.cf",
+    "parameter": [
+      {
+        "name": "login",
+        "description": "User login",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "group_name",
+        "description": "Secondary group name for the user",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "user",
+        "new": "login"
+      }
+    ]
+  },
+  "file_from_template_mustache": {
+    "name": "File from a mustache template",
+    "bundle_name": "file_from_template_mustache",
+    "bundle_args": [
+      "source_template",
+      "path"
+    ],
+    "description": "Build a file from a mustache template",
+    "documentation": "See [file_from_template_type](#_file_from_template_type) for general documentation about\ntemplates usage.\n\n#### Syntax\n\nMustache is a logic-less templating language, available in a lot of languages, and\nused for file templating in Rudder.\nThe mustache syntax reference is [https://mustache.github.io/mustache.5.html](https://mustache.github.io/mustache.5.html).\nThe Windows implementation follows the standard, the Unix one is a bit richer as describe below.\n\nWe will here describe the way to get agent data into a template. Ass explained in the general templating\ndocumentation, we can access various data in a mustache template.\n\nThe main specificity compared to standard mustache syntax of prefixes in all expanded values:\n\n* `classes` to access conditions\n* `vars` to access all variables\n\n##### Classes\n\nHere is how to display content depending on conditions definition:\n\n```mustache\n{{#classes.my_condition}}\n   content when my_condition is defined\n{{/classes.my_condition}}\n\n{{^classes.my_condition}}\n   content when my_condition is *not* defined\n{{/classes.my_condition}}\n```\n\nNote: You cannot use condition expressions here.\n\n##### Scalar variable\n\nHere is how to display a scalar variable value (integer, string, ...),\nif you have defined `variable_string(\"variable_prefix\", \"my_variable\", \"my_value\")`:\n\n```\n{{{vars.variable_prefix.my_variable}}}\n```\n\nWe use the triple `{{{ }}}` to avoid escaping html entities.\n\n##### Iteration\n\nIteration is done using a syntax similar to scalar variables, but applied\non container variables.\n\n* Use `{{#vars.container}} content {{/vars.container}}` to iterate\n* Use `{{{.}}}` for the current element value in iteration\n* Use `{{{key}}}` for the `key` value in current element\n* Use `{{{.key}}}` for the `key` value in current element (Linux only)\n* Use `{{{@}}}` for the current element key in iteration (Linux only)\n\nTo iterate over a list, for example defined with:\n\n```\nvariable_iterator(\"variable_prefix\", \"iterator_name\", \"a,b,c\", \",\")\n```\n\nUse the following file:\n\n```mustache\n{{#vars.variable_prefix.iterator_name}}\n{{{.}}} is the current iterator_name value\n{{/vars.variable_prefix.iterator_name}}\n```\n\nWhich will be expanded as:\n\n```\na is the current iterator_name value\nb is the current iterator_name value\nc is the current iterator_name value\n```\n\nTo iterate over a container defined by the following json file, loaded with\n`variable_dict_from_file(\"variable_prefix\", \"dict_name\", \"path\")`:\n\n```json\n{\n   \"hosts\": [\n       \"host1\",\n       \"host2\"\n   ],\n   \"files\": [\n       {\"name\": \"file1\", \"path\": \"/path1\", \"users\": [ \"user1\", \"user11\" ] },\n       {\"name\": \"file2\", \"path\": \"/path2\", \"users\": [ \"user2\" ] }\n   ],\n   \"properties\": {\n       \"prop1\": \"value1\",\n       \"prop2\": \"value2\"\n   }\n}\n```\n\nUse the following template:\n\n```mustache\n{{#vars.variable_prefix.dict_name.hosts}}\n{{{.}}} is the current hosts value\n{{/vars.variable_prefix.dict_name.hosts}}\n\n# will display the name and path of the current file\n{{#vars.variable_prefix.dict_name.files}}\n{{{name}}}: {{{path}}}\n{{/vars.variable_prefix.dict_name.files}}\n# Lines below will only be properly rendered in unix Nodes\n# will display the users list of each file\n{{#vars.variable_prefix.dict_name.files}}\n{{{name}}}:{{#users}} {{{.}}}{{/users}}\n{{/vars.variable_prefix.dict_name.files}}\n\n\n# will display the current properties key/value pair\n{{#vars.variable_prefix.dict_name.properties}}\n{{{@}}} -> {{{.}}}\n{{/vars.variable_prefix.dict_name.properties}}\n\n```\n\nWhich will be expanded as:\n\n```\nhost1 is the current hosts value\nhost2 is the current hosts value\n\n# will display the name and path of the current file\nfile1: /path1\nfile2: /path2\n\n# Lines below will only be properly rendered in unix Nodes\n# will display the users list of each file\nfile1: user1 user11\nfile2: user2\n\n# will display the current properties key/value pair\nprop1 -> value1\nprop2 -> value2\n```\n\nNote: You can use `{{#-top-}} ... {{/-top-}}`\nto iterate over the top level container.\n\n##### System variables\n\nSome `sys` dict variables (like `sys.ipv4`) are also accessible as string, for example:\n\n* `${sys.ipv4}` gives `54.32.12.4`\n* `$[sys.ipv4[ethO]}` gives `54.32.12.4`\n* `$[sys.ipv4[eth1]}` gives `10.45.3.2`\n\nThese variables are not accessible as dict in the templating data, but are represented as\nstring:\n\n* `ipv4` is a string variable in the `sys` dict with value `54.32.12.4`\n* `ipv4[ethO]` is a string variable in the `sys` dict with value `54.32.12.4`\n* `ipv4` is not accessible as a dict in the template\n\nTo access these value, use the following syntax in your mustache templates:\n\n```\n{{{vars.sys.ipv4[eth0]}}}\n```",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "file_from_template",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_template_mustache.cf",
+    "parameter": [
+      {
+        "name": "source_template",
+        "description": "Source file containing a template to be expanded (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "Destination file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
+      }
+    ]
+  },
+  "condition_from_command": {
+    "name": "Condition from command",
+    "bundle_name": "condition_from_command",
+    "bundle_args": [
+      "condition",
+      "command",
+      "true_codes",
+      "false_codes"
+    ],
+    "description": "Execute a command and create result conditions depending on its exit code",
+    "documentation": "This method executes a command, and defines a `${condition}_true` or a\n `${condition}_false` condition depending on the result of the command:\n\n* If the exit code **is in the \"True codes\"** list, this will produce a\n   kept outcome and a\n   `${condition}_true` condition,\n* If the exit code **is in the \"False codes\"** list, this will produce a\n   kept outcome and a\n   `${condition}_false` condition,\n* If the exit code **is not in \"True codes\" nor in \"False codes\"**, or if\n   the command can not be found, it will produce an\n   error outcome and\n   and no condition from `${condition}`\n\n\nThe created condition is global to the agent.\n\n##### Windows\n\nOn Windows nodes, the exit code is taken from the `LASTEXITCODE` which is defined either by:\n\n* The exit code of a binary execution (when the command a call to an exe)\n* The return code of a Powershell script\n\nDirect Powershell execution will almost always return 0 as `LASTEXITCODE` value, meaning that you have to execute either a binary or a Powershell\nscript to control the return code.\n\n##### Example:\n\nIf you run a command `/bin/check_network_status` that output code 0, 1 or 2 in\ncase of correct configuration, and 18 or 52 in case of invalid configuration,\nand you want to define a condition based on its execution result,\nyou can use:\n\n```\ncondition_from_command(\"network_correctly_defined\", \"/bin/check_network_status\", \"0,1,2\", \"18,52\")\n```\n\n* If the command exits with 0, 1 or 2, then it will define the conditions\n    * `network_correctly_defined_true`,\n    * `condition_from_command_network_correctly_defined_kept`,\n    * `condition_from_command_network_correctly_defined_reached`,\n\n* If the command exits 18, 52, then it will define the conditions\n    * `network_correctly_defined_false`,\n    * `condition_from_command_network_correctly_defined_kept`,\n    * `condition_from_command_network_correctly_defined_reached`\n\n* If the command exits any other code or is not found, then it will define the conditions\n    * `condition_from_command_network_correctly_defined_error`,\n    * `condition_from_command_network_correctly_defined_reached`\n\n##### Notes:\n\n* In audit mode, this method will still execute the command passed in parameter.\n  Which means that you should only pass non system-impacting commands to this method.\n\n* Rudder will automatically \"canonify\" the given **Condition prefix** at execution time,\n  which means that all non `[a-zA-Z0-9_]` characters will be replaced by an underscore.",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "condition_from_command",
+    "class_parameter": "condition",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/condition_from_command.cf",
+    "parameter": [
+      {
+        "name": "condition",
+        "description": "The condition name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "command",
+        "description": "The command to run",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "true_codes",
+        "description": "List of codes that produce a true status separated with commas (ex: 1,2,5)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "false_codes",
+        "description": "List of codes that produce a false status separated with commas (ex: 3,4,6)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "condition_prefix",
+        "new": "condition"
+      }
+    ]
+  },
+  "variable_string_escaped": {
+    "name": "Variable string escaped",
+    "bundle_name": "variable_string_escaped",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Define a variable from another string variable and escape regular expression characters in it.",
+    "documentation": "To use the generated variable, you must use the form `${<name>_escaped}` where <name> is the composed complete name\nof the variable you want to escape.\n\nPlease note that the variable you want to escape must be defined before this method evaluation.\n\n#### Example:\n\nWith a variable defined by the generic method `variable_string`, named `my_prefix.my_variable` and valued to:\n\n````\n something like [] that\n````\n\nPassing `my_prefix.my_variable` as `name` parameter to this method will result in a\nvariable named `my_prefix.my_variable_escaped` and valued to:\n\n````\nsomething\\ like\\ \\[\\]\\ that\n````",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "variable_string_escaped",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/variable_string_escaped.cf",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "The variable to define, the full name will be prefix.name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "variable_name",
+        "new": "name"
+      }
+    ]
+  },
+  "variable_string_default": {
+    "name": "Variable string with default",
+    "bundle_name": "variable_string_default",
+    "bundle_args": [
+      "prefix",
+      "name",
+      "source_variable",
+      "default_value"
+    ],
+    "description": "Define a variable from another variable name, with a default value if undefined",
+    "documentation": "To use the generated variable, you must use the form `${prefix.name}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \nPlease note that only global variables are available within templates.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "variable_string_default",
+    "class_parameter": "name",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/variable_string_default.cf",
+    "parameter": [
+      {
+        "name": "prefix",
+        "description": "The prefix of the variable name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "name",
+        "description": "The variable to define, the full name will be prefix.name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "source_variable",
+        "description": "The source variable name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "default_value",
+        "description": "The default value to use if source_variable is not defined",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "variable_prefix",
+        "new": "prefix"
+      },
+      {
+        "old": "variable_name",
+        "new": "name"
+      }
+    ]
+  },
+  "sharedfile_from_node": {
+    "name": "Sharedfile from node",
+    "bundle_name": "sharedfile_from_node",
+    "bundle_args": [
+      "remote_node",
+      "file_id",
+      "file_path"
+    ],
+    "description": "This method retrieves a file shared from another Rudder node",
+    "documentation": "This method retrieves a file shared from a Rudder node using a unique file identifier.\n\nThe file will be downloaded using native agent protocol and copied into a new file.\nThe destination path must be the complete absolute path of the destination file.\n\nSee [sharedfile_to_node](#_sharedfile_to_node) for a complete example.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "sharedfile_from_node",
+    "class_parameter": "file_id",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/sharedfile_from_node.cf",
+    "parameter": [
+      {
+        "name": "remote_node",
+        "description": "Which node to take the file from",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "file_id",
+        "description": "Unique name that was used to identify the file on the sender",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "regex": {
+            "value": "^[A-z0-9._-]+$"
+          },
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "file_path",
+        "description": "Where to put the file content",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "source_uuid",
+        "new": "remote_node"
+      }
+    ]
+  },
+  "file_check_hardlink": {
+    "name": "File check is hardlink",
+    "bundle_name": "file_check_hardlink",
+    "bundle_args": [
+      "path",
+      "path_2"
+    ],
+    "description": "Checks if two files are the same (hard links)",
+    "documentation": "This bundle will define a condition `file_check_hardlink_${path}_{ok, reached, kept}` if the\ntwo files `${path}` and `${path_2}` are hard links of each other, or `file_check_hardlink_${path}_{not_ok, reached, not_kept, failed}` if\nif the files are not hard links.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_check_hardlink",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_hardlink.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name #1 (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "path_2",
+        "description": "File name #2 (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file_name_1",
+        "new": "path"
+      },
+      {
+        "old": "file_name_2",
+        "new": "path_2"
+      }
+    ]
+  },
+  "command_execution_once": {
+    "name": "Command execution once",
+    "bundle_name": "command_execution_once",
+    "bundle_args": [
+      "command",
+      "ok_codes",
+      "until",
+      "unique_id"
+    ],
+    "description": "Execute a command only once on a node",
+    "documentation": "This method is useful for specific commands that should only be executed once per node.\n\nIf you can spot a condition for the command execution by testing the state of its target,\nit is better to use the `condition_from_command` method to test the state coupled with\nthe `command_execution_result` method to run the command if necessary.\n\nIn case of reinstallation or factory-reset of the Rudder agent, this method \nwill no longer detect if a command has already been executed.\n\n##### The method will:\n\n**Define** the `command_execution_once_${command}_kept` condition and do nothing if\na `command_execution_once` has already been executed on this machine with the same\n**Unique id**.\n\n**Execute** the command if it is the first occurrence and:\n* If the parameter **Until** is `*any*`, it will consider the command as executed on the machine and define\n  either:\n  * `command_execution_once_${command}_repaired` if the return code is in **ok_codes**,\n  * `command_execution_once_${command}_error` otherwise.\n* If the parameter **Until** is *ok* and:\n  * If the return code is in the **Ok codes** list, define the\n    `command_execution_once_${command}_repaired` condition\n  * If the return code is not in **Ok codes** it define the\n     `command_execution_once_${command}_error` condition and **retry at next agent run**.\n\nIf an exit code is not in the list it will lead to an error status.\nIf you want \"0\" to be a success you have to list it in the **Ok codes** list\n\n##### Example:\n\nIf you use:\n\n```\n    command_execution_once(\"command -a -t\", \"0\", \"ok\", \"my_program_setup\")\n```\n\nIt will retry to run `command -a -t` until it returns \"0\". Then it will\nnot execute it again.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "command_execution_once",
+    "class_parameter": "command",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/command_execution_once.cf",
+    "action": "",
+    "parameter": [
+      {
+        "name": "command",
+        "description": "Command to run",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "ok_codes",
+        "description": "List of codes that produce a repaired status separated with commas (ex: 1,2,5). Defaults to 0.",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "until",
+        "description": "Try to execute the command until a particular state: 'ok', 'any' (defaults to 'any')",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": ""
+            },
+            {
+              "value": "any"
+            },
+            {
+              "value": "ok"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "unique_id",
+        "description": "To identify the action without losing track if the command changes. Defaults to the command if you don't need it.",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "permissions_group_acl_present": {
+    "name": "Permissions group POSIX acl entry present",
+    "bundle_name": "permissions_group_acl_present",
+    "bundle_args": [
+      "path",
+      "recursive",
+      "group",
+      "ace"
+    ],
+    "description": "Verify that an ace is present on a file or directory for a given group.\nThis method will make sure the given ace is present in the POSIX ACL of the target for the given group.",
+    "documentation": "The `permissions_*acl_*` manage the POSIX ACL on files and directories.\n\nPlease note that the mask will be automatically recalculated when editing ACLs.\n\n#### Parameters\n\n##### Path\n\nPath can be a regex with the following format:\n\n* `*` matches any filename or directory at one level, e.g. `*.cf` will match all files in one directory that end in .cf but it won't search across directories. `*/*.cf` on the other hand will look two levels deep.\n* `?` matches a single letter\n* `[a-z]` matches any letter from a to z\n* `{x,y,anything}` will match x or y or anything.\n\n##### Recursive\n\nCan be:\n\n* `true` to apply the given aces to folder and sub-folders and files.\n* or `false` to apply to the strict match of `Path`\n\nIf left blank, recursivity will automatically be set to `false`\n\n##### Group\n\n`Group` to enfoorce the ace, being the Linux account name.\nThis method can only handle one groupname.\n\n##### ACE\n\nThe operator can be:\n* `+` to add the given ACE to the current ones.\n* `-` to remove the given ACE to the current ones.\n* `=` to force the given ACE to the current ones.\n* `empty` if no operator is specified, it will be interpreted as `=`.\n\nACE must respect the classic:\n\n* `^[+-=]?(?=.*[rwx])r?w?x?$`\n\n#### Example\n\nGiven a file with the following getfacl output:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\ngroup::r--\ngroup:bob:rwx\nmask::rwx\nother::---\n\n~~~~\n\nApplying this method with the following parameters:\n\n* `path`: /tmp/myTestFile\n* `recursive`: false\n* `group`: bob\n* `ace`: -rw\n\nWill transform the previous ACLs in:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\ngroup::r--\ngroup:bob:--x\nmask::r-x\nother::---\n\n~~~~",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "permissions_group_acl_present",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_group_acl_present.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "Path of the file or directory",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "recursive",
+        "description": "Recursive Should ACLs cleanup be recursive, \"true\" or \"false\" (defaults to \"false\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": ""
+            },
+            {
+              "value": "true"
+            },
+            {
+              "value": "false"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "group",
+        "description": "Group name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "ace",
+        "description": "ACE to enforce for the given group.",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "regex": {
+            "value": "^[+-=]?(?=.*[rwx])r?w?x?$"
+          },
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_lines_present": {
+    "name": "File lines present",
+    "bundle_name": "file_lines_present",
+    "bundle_args": [
+      "path",
+      "lines"
+    ],
+    "description": "Ensure that one or more lines are present in a file",
+    "documentation": "Edit the file, and ensure it contains the defined line(s). Regular expression can be used for the file name.",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "file_lines_present",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_lines_present.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "lines",
+        "description": "Line(s) to add in the file",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file",
+        "new": "path"
+      }
+    ]
+  },
+  "service_check_running_ps": {
+    "name": "Service check running ps",
+    "bundle_name": "service_check_running_ps",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Check if a service is running using ps",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "service_check_running",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_check_running_ps.cf",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Regular expression used to select a process in ps output",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "service_regex",
+        "new": "name"
+      }
+    ]
+  },
+  "group_absent": {
+    "name": "Group absent",
+    "bundle_name": "group_absent",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Make sure a group is absent",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "group_absent",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/group_absent.cf",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Group name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "group",
+        "new": "name"
+      }
+    ]
+  },
+  "service_restart_if": {
+    "name": "Service restart at a condition",
+    "bundle_name": "service_restart_if",
+    "bundle_args": [
+      "name",
+      "expression"
+    ],
+    "description": "Restart a service using the appropriate method if the specified class is true, otherwise it is considered as not required and success classes are returned.",
+    "documentation": "See [service_action](#_service_action) for documentation.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "service_restart",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_restart_if.cf",
+    "deprecated": "Use [service_restart](#_service_restart) with a condition",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Name of the service",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "expression",
+        "description": "Condition expression which will trigger the restart of Service \"(package_service_installed|service_conf_changed)\" by example",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "service_name",
+        "new": "name"
+      },
+      {
+        "old": "trigger_class",
+        "new": "expression"
+      }
+    ]
+  },
+  "variable_dict": {
+    "name": "Variable dict",
+    "bundle_name": "variable_dict",
+    "bundle_args": [
+      "prefix",
+      "name",
+      "value"
+    ],
+    "description": "Define a variable that contains key,value pairs (a dictionary)",
+    "documentation": "To use the generated variable, you must use the form `${prefix.name[key]}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \nPlease note that only global variables are available within templates.",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "variable_dict",
+    "class_parameter": "name",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/variable_dict.cf",
+    "parameter": [
+      {
+        "name": "prefix",
+        "description": "The prefix of the variable name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "name",
+        "description": "The variable to define, the full name will be prefix.name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "value",
+        "description": "The variable content in JSON format",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "variable_prefix",
+        "new": "prefix"
+      },
+      {
+        "old": "variable_name",
+        "new": "name"
+      }
+    ]
+  },
+  "variable_string_from_file": {
+    "name": "Variable string from file",
+    "bundle_name": "variable_string_from_file",
+    "bundle_args": [
+      "prefix",
+      "name",
+      "file_name"
+    ],
+    "description": "Define a variable from a file content",
+    "documentation": "To use the generated variable, you must use the form `${variable_prefix.variable_name}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \nPlease note that only global variables are available within templates.",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "variable_string_from_file",
+    "class_parameter": "name",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/variable_string_from_file.cf",
+    "parameter": [
+      {
+        "name": "prefix",
+        "description": "The prefix of the variable name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "name",
+        "description": "The variable to define, the full name will be variable_prefix.variable_name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "file_name",
+        "description": "The path of the file",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "variable_prefix",
+        "new": "prefix"
+      },
+      {
+        "old": "variable_name",
+        "new": "name"
+      }
+    ]
+  },
+  "http_request_check_status_headers": {
+    "name": "HTTP request check status with headers",
+    "bundle_name": "http_request_check_status_headers",
+    "bundle_args": [
+      "method",
+      "url",
+      "expected_status",
+      "headers"
+    ],
+    "description": "Checks status of an HTTP URL",
+    "documentation": "Perform a HTTP request on the URL, method and headers provided and check that the response has the expected status code (ie 200, 404, 503, etc)",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "http_request_check_status_headers",
+    "class_parameter": "url",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/http_request_check_status_headers.cf",
+    "action": "We don't know when HTTP methods cause side effect, this can be an action or not depending on your server behaviour",
+    "parameter": [
+      {
+        "name": "method",
+        "description": "Method to call the URL (GET, POST, PUT, DELETE)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "url",
+        "description": "URL to query",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "expected_status",
+        "description": "Expected status code of the HTTP response",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "headers",
+        "description": "Headers to include in the HTTP request (as a string, without ')",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_key_value_present_in_ini_section": {
+    "name": "File key-value in INI section",
+    "bundle_name": "file_key_value_present_in_ini_section",
+    "bundle_args": [
+      "path",
+      "section",
+      "name",
+      "value"
+    ],
+    "description": "Ensure that a key-value pair is present in a section in a specific location. The objective of this method is to handle INI-style files.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_key_value_present_in_ini_section",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_key_value_present_in_ini_section.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "section",
+        "description": "Name of the INI-style section under which the line should be added or modified (not including the [] brackets)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "name",
+        "description": "Name of the key to add or edit",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "value",
+        "description": "Value of the key to add or edit",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file",
+        "new": "path"
+      }
+    ]
+  },
+  "permissions_dirs_recurse": {
+    "name": "Permissions dirs recurse",
+    "bundle_name": "permissions_dirs_recurse",
+    "bundle_args": [
+      "path",
+      "mode",
+      "owner",
+      "group"
+    ],
+    "description": "Verify if a directory and its content have the right permissions recursively",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "permissions",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_dirs_recurse.cf",
+    "deprecated": "Use [permissions_dirs_recursive](#_permissions_dirs_recursive) instead.",
+    "rename": "permissions_dirs_recursive",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "Path to the directory",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "mode",
+        "description": "Mode to enforce",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "owner",
+        "description": "Owner to enforce",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "group",
+        "description": "Group to enforce",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_check_exists": {
+    "name": "File check exists",
+    "bundle_name": "file_check_exists",
+    "bundle_args": [
+      "path"
+    ],
+    "description": "Checks if a file exists",
+    "documentation": "This bundle will define a condition `file_check_exists_${path}_{ok, reached, kept}` if the\nfile exists, or `file_check_exists_${path}_{not_ok, reached, not_kept, failed}` if\nthe file doesn't exists",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_check_exists",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_exists.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file_name",
+        "new": "path"
+      }
+    ]
+  },
+  "file_create_symlink_force": {
+    "name": "Create symlink (force overwrite)",
+    "bundle_name": "file_create_symlink_force",
+    "bundle_args": [
+      "source",
+      "path"
+    ],
+    "description": "Create a symlink at a destination path and pointing to a source target even if a file or directory already exists.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_create_symlink",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_create_symlink_force.cf",
+    "deprecated": "Use [file_symlink_present_force](#_file_symlink_present_force) instead.",
+    "rename": "file_symlink_present_force",
+    "parameter": [
+      {
+        "name": "source",
+        "description": "Source file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "Destination file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
+      }
+    ]
+  },
+  "file_ensure_block_present": {
+    "name": "File ensure block present",
+    "bundle_name": "file_ensure_block_present",
+    "bundle_args": [
+      "path",
+      "block"
+    ],
+    "description": "Ensure that a text block is present in a specific location",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_ensure_block_present",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_block_present.cf",
+    "deprecated": "Use [file_block_present](#_file_block_present) instead.",
+    "rename": "file_block_present",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "block",
+        "description": "Block(s) to add in the file",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file",
+        "new": "path"
+      }
+    ]
+  },
+  "variable_dict_merge": {
+    "name": "Variable dict merge",
+    "bundle_name": "variable_dict_merge",
+    "bundle_args": [
+      "prefix",
+      "name",
+      "first_variable",
+      "second_variable"
+    ],
+    "description": "Define a variable resulting of the merge of two other variables",
+    "documentation": "To use the generated variable, you must use the form `${prefix.name[key]}` with each name replaced with the parameters of this method.\n\nThe resulting variable will be the merge of the two parameters, which means it is built by:\n\n* Taking the content of the first variable\n* Adding the content of the second variable, and replacing the keys that were already there\n\nIt is only a one-level merge, and the value of the first-level key will be completely replaced by the merge.\n\nThis method will fail if one of the variables is not defined. See [variable_dict_merge_tolerant](#_variable_dict_merge_tolerant)\nif you want to allow one of the variables not to be defined.\n\n### Usage\n\nIf you have a `prefix.variable1` variable defined by:\n\n```json\n{ \"key1\": \"value1\", \"key2\": \"value2\", \"key3\": { \"keyx\": \"valuex\" } }\n```\n\nAnd a `prefix.variable2` variable defined by:\n\n```json\n{ \"key1\": \"different\", \"key3\": \"value3\", \"key4\": \"value4\" }\n```\n\nAnd that you use:\n\n```\nvariablr_dict_merge(\"prefix\", \"variable3, \"prefix.variable1\", \"prefix.variable2\")\n```\n\nYou will get a `prefix.variable3` variable containing:\n\n```json\n{\n  \"key1\": \"different\",\n  \"key2\": \"value2\",\n  \"key3\": \"value3\",\n  \"key4\": \"value4\"\n}\n```",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "variable_dict_merge",
+    "class_parameter": "name",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/variable_dict_merge.cf",
+    "parameter": [
+      {
+        "name": "prefix",
+        "description": "The prefix of the variable name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "name",
+        "description": "The variable to define, the full name will be prefix.name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "first_variable",
+        "description": "The first variable, which content will be overridden in the resulting variable if necessary (written in the form prefix.name)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "second_variable",
+        "description": "The second variable, which content will override the first in the resulting variable if necessary (written in the form prefix.name)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "variable_prefix",
+        "new": "prefix"
+      },
+      {
+        "old": "variable_name",
+        "new": "name"
+      }
+    ]
+  },
+  "user_create": {
+    "name": "User create",
+    "bundle_name": "user_create",
+    "bundle_args": [
+      "login",
+      "description",
+      "home",
+      "group",
+      "shell",
+      "locked"
+    ],
+    "description": "Create a user",
+    "documentation": "This method does not create the user's home directory.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "user_create",
+    "class_parameter": "login",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/user_create.cf",
+    "deprecated": "Please split into calls to other user_* methods:\n[user_present](#_user_present) [user_fullname](#_user_fullname) [user_home](#_user_home)\n[user_primary_group](#_user_primary_group) [user_shell](#_user_shell) and [user_locked](#_user_locked)",
+    "parameter": [
+      {
+        "name": "login",
+        "description": "User login",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "description",
+        "description": "User description",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "home",
+        "description": "User's home directory",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "group",
+        "description": "User's primary group",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "shell",
+        "description": "User's shell",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "locked",
+        "description": "Is the user locked ? true or false",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_key_value_present": {
+    "name": "File key-value present",
+    "bundle_name": "file_key_value_present",
+    "bundle_args": [
+      "path",
+      "key",
+      "value",
+      "separator"
+    ],
+    "description": "Ensure that the file contains a pair of \"key separator value\"",
+    "documentation": "Edit (or create) the file, and ensure it contains an entry key -> value with arbitrary separator between the key and its value.\nIf the key is already present, the method will change the value associated with this key.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_key_value_present",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_key_value_present.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "key",
+        "description": "Key to define",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "value",
+        "description": "Value to define",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "separator",
+        "description": "Separator between key and value, for example \"=\" or \" \" (without the quotes)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": true,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file",
+        "new": "path"
+      }
+    ]
+  },
+  "file_check_character_device": {
+    "name": "File check if character device",
+    "bundle_name": "file_check_character_device",
+    "bundle_args": [
+      "path"
+    ],
+    "description": "Checks if a file exists and is a character device",
+    "documentation": "This bundle will define a condition `file_check_character_device_${path}_{ok, reached, kept}` if the\nfile is a character device, or `file_check_character_device_${path}_{not_ok, reached, not_kept, failed}` if\nthe file is not a character device or does not exist",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_check_character_device",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_character_device.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file_name",
+        "new": "path"
+      }
+    ]
+  },
+  "file_lines_absent": {
+    "name": "File lines absent",
+    "bundle_name": "file_lines_absent",
+    "bundle_args": [
+      "path",
+      "lines"
+    ],
+    "description": "Ensure that a line is absent in a specific location",
+    "documentation": "Edit the file, and ensure it does not contain the defined line. Regular expression can be used for both the file name and the lines absent.",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "file_lines_absent",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_lines_absent.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "lines",
+        "description": "Line(s) to remove in the file",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file",
+        "new": "path"
+      }
+    ]
+  },
+  "file_copy_from_local_source_with_check": {
+    "name": "File copy from local source with check",
+    "bundle_name": "file_copy_from_local_source_with_check",
+    "bundle_args": [
+      "source",
+      "path",
+      "check_command",
+      "rc_ok"
+    ],
+    "description": "Ensure that a file or directory is copied from a local source if a check command succeeds",
+    "documentation": "This method is a conditional file copy.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_copy_from_local_source_with_check",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_copy_from_local_source_with_check.cf",
+    "deprecated": "Use [file_from_local_source_with_check](#_file_from_local_source_with_check) instead.",
+    "rename": "file_from_local_source_with_check",
+    "parameter": [
+      {
+        "name": "source",
+        "description": "Source file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "Destination file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "check_command",
+        "description": "Command to run, it will get the source path as argument",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "rc_ok",
+        "description": "Return codes to be considered as valid, separated by a comma (default is 0)",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
+      }
+    ]
+  },
+  "file_absent": {
+    "name": "File absent",
+    "bundle_name": "file_absent",
+    "bundle_args": [
+      "path"
+    ],
+    "description": "Remove a file if it exists",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "file_absent",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_absent.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File to remove (absolute path on the path node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "target",
+        "new": "path"
+      }
+    ]
+  },
+  "variable_dict_from_file": {
+    "name": "Variable dict from JSON file",
+    "bundle_name": "variable_dict_from_file",
+    "bundle_args": [
+      "prefix",
+      "name",
+      "file_name"
+    ],
+    "description": "Define a variable that contains key,value pairs (a dictionary) from a JSON file",
+    "documentation": "To use the generated variable, you must use the form `${prefix.name[key]}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \nPlease note that only global variables are available within templates.\n\nSee [variable_dict_from_file_type](#_variable_dict_from_file_type) for complete documentation.",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "variable_dict_from_file",
+    "class_parameter": "name",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/variable_dict_from_file.cf",
+    "parameter": [
+      {
+        "name": "prefix",
+        "description": "The prefix of the variable name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "name",
+        "description": "The variable to define, the full name will be prefix.name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "file_name",
+        "description": "The absolute local file name with JSON content",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "variable_prefix",
+        "new": "prefix"
+      },
+      {
+        "old": "variable_name",
+        "new": "name"
+      }
+    ]
+  },
+  "package_remove": {
+    "name": "Package remove",
+    "bundle_name": "package_remove",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Remove a package",
+    "documentation": "*Example*:\n```\nmethods:\n    \"any\" usebundle => package_remove(\"htop\");\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "package_remove",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/package_remove.cf",
+    "deprecated": "Use [package_absent](#_package_absent) instead.",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Name of the package to remove",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "package_name",
+        "new": "name"
+      }
+    ]
+  },
+  "package_install": {
+    "name": "Package install",
+    "bundle_name": "package_install",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Install or update a package in its latest version available",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "package_install",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/package_install.cf",
+    "deprecated": "Use [package_present](#_package_present) instead.",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Name of the package to install",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "package_name",
+        "new": "name"
+      }
+    ]
+  },
+  "permissions_type_recursion": {
+    "name": "Permissions type recursion",
+    "bundle_name": "permissions_type_recursion",
+    "bundle_args": [
+      "path",
+      "mode",
+      "owner",
+      "group",
+      "type",
+      "recursion"
+    ],
+    "description": "Ensure that a file or directory is present and has the right mode/owner/group",
+    "documentation": "The method ensure that all files|directories|files and directories have\nthe correct owner, group owner and permissions.\n\nThe parameter *type* can be either: \"*all*\", \"*files*\" or \"*directories*\".\nThe parameter *recursion* can be either: \"*0,1,2,3,.... inf*\"\nThe level of recursion is the maximum depth of subfolder that will be managed by the method:\n\n* 0 being the current folder/file\n* 1 being the current folder/file and its subfolders\n* ..\n* inf being the file or the whole folder tree",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "permissions",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_type_recursion.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "Path to edit",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "mode",
+        "description": "Mode of the path to edit",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "owner",
+        "description": "Owner of the path to edit",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "group",
+        "description": "Group of the path to edit",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "type",
+        "description": "Type of the path to edit (all/files/directories)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "recursion",
+        "description": "Recursion depth to enforce for this path (0, 1, 2, ..., inf)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "service_ensure_running_path": {
+    "name": "Service ensure running with service path",
+    "bundle_name": "service_ensure_running_path",
+    "bundle_args": [
+      "name",
+      "path"
+    ],
+    "description": "Ensure that a service is running using the appropriate method, specifying the path of the service in the ps output, or using Windows task manager",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "service_ensure_running",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_ensure_running_path.cf",
+    "deprecated": "Use [service_started_path](#_service_started_path) instead.",
+    "rename": "service_started_path",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Service name (as recognized by systemd, init.d, Windows, etc...)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "Service with its path, as in the output from 'ps'",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "service_name",
+        "new": "name"
+      },
+      {
+        "old": "service_path",
+        "new": "path"
+      }
+    ]
+  },
+  "directory_check_exists": {
+    "name": "Directory check exists",
+    "bundle_name": "directory_check_exists",
+    "bundle_args": [
+      "path"
+    ],
+    "description": "Checks if a directory exists",
+    "documentation": "This bundle will define a condition `directory_check_exists_${path}_{ok, reached, kept}` if the\ndirectory exists, or `directory_check_exists_${path}_{not_ok, reached, not_kept, failed}` if\nthe directory doesn't exists",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "directory_check_exists",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/directory_check_exists.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "Full path of the directory to check",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "directory_name",
+        "new": "path"
+      }
+    ]
+  },
+  "file_check_block_device": {
+    "name": "File check if block device",
+    "bundle_name": "file_check_block_device",
+    "bundle_args": [
+      "path"
+    ],
+    "description": "Checks if a file exists and is a block device",
+    "documentation": "This bundle will define a condition `file_check_block_device_${path}_{ok, reached, kept}` if the\nfile is a block_device, or `file_check_block_device_${path}_{not_ok, reached, not_kept, failed}` if\nthe file is not a block device or does not exist",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_check_block_device",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_block_device.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file_name",
+        "new": "path"
       }
     ]
   },
@@ -4333,161 +5685,25 @@
       }
     ]
   },
-  "file_ensure_key_value_parameter_not_in_list": {
-    "name": "File ensure key-value parameter not in list",
-    "bundle_name": "file_ensure_key_value_parameter_not_in_list",
-    "bundle_args": [
-      "path",
-      "key",
-      "key_value_separator",
-      "parameter_regex",
-      "parameter_separator",
-      "leading_char_separator",
-      "closing_char_separator"
-    ],
-    "description": "Ensure that a parameter doesn't exist in a list of parameters, on one single line, in the right hand side of a key->values line",
-    "documentation": "Edit the file, and ensure it does not contain the defined parameter in the list of values on the right hand side of a key->values line.\nIf the parameter is there, it will be removed. Please note that the parameter can be a regular expression. It will also remove any whitespace character between the `parameter` and `parameter_separator`\nOptionally, you can define leading and closing character to enclose the parameters\n\n#### Example\n\nIf you have an initial file (`/etc/default/grub`) containing\n\n```\nGRUB_CMDLINE_XEN=\"dom0_mem=16G dom0_max_vcpus=32\"\n```\n\nTo remove parameter `dom0_max_vcpus=32` in the right hand side of the line, you'll need the following policy\n\n```\nfile_ensure_key_value_parameter_not_in_list(\"/etc/default/grub\", \"GRUB_CMDLINE\", \"=\", \"dom0_max_vcpus=32\", \" \", \"\\\"\", \"\\\"\");\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_ensure_key_value_parameter_not_in_list",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_key_value_parameter_not_in_list.cf",
-    "deprecated": "Use [file_key_value_parameter_absent_in_list](#_file_key_value_parameter_absent_in_list) instead.",
-    "rename": "file_key_value_parameter_absent_in_list",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "key",
-        "description": "Full key name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "key_value_separator",
-        "description": "character used to separate key and value in a key-value line",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": true,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "parameter_regex",
-        "description": "Regular expression matching the sub-value to ensure is not present in the list of parameters that form the value part of that line",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "parameter_separator",
-        "description": "Character used to separate parameters in the list",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": true,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "leading_char_separator",
-        "description": "leading character of the parameters",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "closing_char_separator",
-        "description": "closing character of the parameters",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file",
-        "new": "path"
-      }
-    ]
-  },
-  "file_present": {
-    "name": "File present",
-    "bundle_name": "file_present",
-    "bundle_args": [
-      "path"
-    ],
-    "description": "Create a file if it doesn't exist",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "file_present",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_present.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File to create (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "target",
-        "new": "path"
-      }
-    ]
-  },
-  "service_enabled": {
-    "name": "Service enabled at boot",
-    "bundle_name": "service_enabled",
+  "service_started": {
+    "name": "Service started",
+    "bundle_name": "service_started",
     "bundle_args": [
       "name"
     ],
-    "description": "Force a service to be started at boot",
+    "description": "Ensure that a service is running using the appropriate method",
     "agent_support": [
       "cfengine-community",
       "dsc"
     ],
-    "class_prefix": "service_enabled",
+    "class_prefix": "service_started",
     "class_parameter": "name",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_enabled.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_started.cf",
     "parameter": [
       {
         "name": "name",
-        "description": "Service name (as recognized by systemd, init.d, Windows, SRC, SMF, etc...)",
+        "description": "Service name (as recognized by systemd, init.d, etc...)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -4500,6 +5716,382 @@
       {
         "old": "service_name",
         "new": "name"
+      }
+    ]
+  },
+  "file_check_socket": {
+    "name": "File check if socket",
+    "bundle_name": "file_check_socket",
+    "bundle_args": [
+      "path"
+    ],
+    "description": "Checks if a file exists and is a socket",
+    "documentation": "This bundle will define a condition `file_check_socket_${path}_{ok, reached, kept}` if the\nfile is a socket, or `file_check_socket_${path}_{not_ok, reached, not_kept, failed}` if\nthe file is not a socket or does not exist",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_check_socket",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_socket.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file_name",
+        "new": "path"
+      }
+    ]
+  },
+  "service_ensure_running": {
+    "name": "Service ensure running",
+    "bundle_name": "service_ensure_running",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Ensure that a service is running using the appropriate method",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "service_ensure_running",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_ensure_running.cf",
+    "deprecated": "Use [service_started](#_service_started) instead.",
+    "rename": "service_started",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Service name (as recognized by systemd, init.d, etc...)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "service_name",
+        "new": "name"
+      }
+    ]
+  },
+  "file_check_regular": {
+    "name": "File check if regular",
+    "bundle_name": "file_check_regular",
+    "bundle_args": [
+      "path"
+    ],
+    "description": "Checks if a file exists and is a regular file",
+    "documentation": "This bundle will define a condition `file_check_regular_${path}_{ok, reached, kept}` if the\nfile is a regular_file, or `file_check_regular_${path}_{not_ok, reached, not_kept, failed}` if\nthe file is not a regular file or does not exist",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_check_regular",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_regular.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file_name",
+        "new": "path"
+      }
+    ]
+  },
+  "file_from_local_source_recursion": {
+    "name": "File from local source recursion",
+    "bundle_name": "file_from_local_source_recursion",
+    "bundle_args": [
+      "source",
+      "path",
+      "recursion"
+    ],
+    "description": "Ensure that a file or directory is copied from a local source",
+    "documentation": "Ensure that a file or directory is copied from a local source.\nIf the source is a directory, you can force a maximum level of copy recursion.\n\n* *0* being no recursion, which will only create an empty folder\n* *inf* being a complete recursive copy of the folder\n* *1,2,3,...* will force the maximal level of recursion to copy",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_from_local_source",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_local_source_recursion.cf",
+    "parameter": [
+      {
+        "name": "source",
+        "description": "Source file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "Destination file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "recursion",
+        "description": "Recursion depth to enforce for this path (0, 1, 2, ..., inf)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
+      }
+    ]
+  },
+  "user_home": {
+    "name": "User home",
+    "bundle_name": "user_home",
+    "bundle_args": [
+      "login",
+      "home"
+    ],
+    "description": "Define the home of the user. User must already exists.",
+    "documentation": "This method does not create the user, nor the home directory.\n    entry example: /home/myuser\n    The home given will be set, but not created.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "user_home",
+    "class_parameter": "login",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/user_home.cf",
+    "parameter": [
+      {
+        "name": "login",
+        "description": "User's login",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "home",
+        "description": "User's home",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "service_action": {
+    "name": "Service action",
+    "bundle_name": "service_action",
+    "bundle_args": [
+      "name",
+      "action"
+    ],
+    "description": "Trigger an action on a service using the appropriate tool",
+    "documentation": "The `service_*` methods manage the services running on the system.\n\n#### Parameters\n\n##### Service name\n\nThe name of the service is the name understood by the service manager, except for the\n`is-active-process` action, where it is the regex to match against the running processes list.\n\n##### Action\n\nThe action is the name of an action to run on the given service.\nThe following actions can be used:\n\n* `start`\n* `stop`\n* `restart`\n* `reload` (or `refresh`)\n* `is-active` (or `status`)\n* `is-active-process` (in this case, the \"service\" parameter is the regex to match against process list)\n* `enable`\n* `disable`\n* `is-enabled`\n\nOther actions may also be used, depending on the selected service manager.\n\n#### Implementation\n\nThese methods will detect the method to use according to the platform. You can run the methods with an `info`\nverbosity level to see which service manager will be used for a given action.\n\nWARNING: Due to compatibility issues when mixing calls to systemctl and service/init.d,\nwhen an init script exists, we will not use systemctl compatibility layer but directly service/init.d.\n\nThe supported service managers are:\n\n* systemd (any unknown action will be passed directly)\n* upstart\n* smf (for Solaris)\n* service command (for non-boot actions, any unknown action will be passed directly)\n* /etc/init.d scripts (for non-boot actions, any unknown action will be passed directly)\n* SRC (for AIX) (for non-boot actions)\n* chkconfig (for boot actions)\n* update-rc.d (for boot actions)\n* chitab (for boot actions)\n* links in /etc/rcX.d (for boot actions)\n* Windows services\n\n#### Examples\n\n```\n# To restart the apache2 service\nservice_action(\"apache2\", \"restart\");\nservice_restart(\"apache2\");\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "service_action",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_action.cf",
+    "action": "is-* commands are not actions, but all other commands are",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Name of the service",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "action",
+        "description": "Action to trigger on the service (start, stop, restart, reload, ...)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "service_name",
+        "new": "name"
+      }
+    ]
+  },
+  "kernel_module_configuration": {
+    "name": "Kernel module configuration",
+    "bundle_name": "kernel_module_configuration",
+    "bundle_args": [
+      "name",
+      "configuration"
+    ],
+    "description": "Ensure that the modprobe configuration of a given kernel module is correct",
+    "documentation": "Ensure that the modprobe configuration of a given kernel module is correct.\n Rudder will search for the module configuration in a per-module dedicated section in /etc/modprobe.d/managed\\_by\\_rudder.conf.\n\n * If the module configuration is not found or incorrect, Rudder will (re-)create its configuration.\n * If the module is configured but with a different option file than used by Rudder, it will add the\n expected one in /etc/modprobe.d/managed\\_by\\_rudder.conf but will leave intact the already present one.\n\n The configuration syntax must respect the one used by /etc/modprobe.d defined in the modprobe.d manual page.\n ```\n   # To pass a parameter to a module:\n   options module_name parameter_name=parameter_value\n   # To blacklist a module\n   blacklist modulename\n   # etc...\n ```\n\n#### Notes:\n If you want to force the module to be loaded at boot, use instead the method `kernel_module_enabled_at_boot` which\n uses other Rudder dedicated files.\n\n#### Example:\n\n To pass options to a broadcom module\n * `name` = b43\n * `configuration` = options b43 nohwcrypt=1 qos=0\n\n Will produce the resulting block in /etc/modprobe.d/managed\\_by\\_rudder.conf:\n ```\n ### b43 start section\n options b43 nohwcrypt=1 qos=0\n ### b43 end section\n ```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "kernel_module_configuration",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/kernel_module_configuration.cf",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Complete name of the kernel module, as seen by lsmod or listed in /proc/modules",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "configuration",
+        "description": "Complete configuration block to put in /etc/modprobe.d/",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "regex": {
+            "value": "^(alias|blacklist|install|options|remove|softdeps) +.*$"
+          },
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "module_name",
+        "new": "name"
+      }
+    ]
+  },
+  "package_check_installed": {
+    "name": "Package check installed",
+    "bundle_name": "package_check_installed",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Verify if a package is installed in any version",
+    "documentation": "This bundle will define a condition `package_check_installed_${file_name}_{ok, reached, kept}` if the\npackage is installed, or `package_check_installed_${file_name}_{not_ok, reached, not_kept, failed}` if\nthe package is not installed",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "package_check_installed",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/package_check_installed.cf",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Name of the package to check",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "package_name",
+        "new": "name"
+      }
+    ]
+  },
+  "package_verify_version": {
+    "name": "Package verify version",
+    "bundle_name": "package_verify_version",
+    "bundle_args": [
+      "name",
+      "version"
+    ],
+    "description": "Verify if a package is installed in a specific version",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "package_install",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/package_verify_version.cf",
+    "deprecated": "Use [package_present](#_package_present) in audit mode",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Name of the package to verify",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "version",
+        "description": "Version of the package to verify (can be \"latest\" for latest version)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "package_name",
+        "new": "name"
+      },
+      {
+        "old": "package_version",
+        "new": "version"
       }
     ]
   },
@@ -4537,238 +6129,156 @@
       }
     ]
   },
-  "package_state_windows": {
-    "name": "Package state windows",
-    "bundle_name": "package_state_windows",
+  "directory_present": {
+    "name": "Directory present",
+    "bundle_name": "directory_present",
     "bundle_args": [
-      "PackageName",
-      "Status",
-      "Provider",
-      "Params",
-      "Version",
-      "Source",
-      "ProviderParams",
-      "AutoUpgrade"
+      "path"
     ],
-    "description": "This method manage packages using a chocolatey on the system.",
-    "documentation": "Install a windows package using a given provider\n\n#### Parameters\n\nRequired args:\n\n* `PackageName` Name of target package\n* `Status` can be \"present\" or \"absent\"\n\nOptional args:\n\n* `Provider` Provider used to installed the package\n* `Params` Package parameters, passed to the installer\n* `Version` can be \"any\", \"latest\" or any exact specific version number\n* `Source` \"any\" or any specific arch\n* `ProviderParams` provider specific options\n* `AutoUpgrade` default set to false\n\n\n#### Providers\n\n##### choco\n\nThe method is a simple transcription of the cchoco `cChocoPaclageInstaller` DSC resource, adapted to Rudder.\nThe DSC module `cchoco` must be installed on your node before trying to use this method.\n\nYou can check the cchoco/chocolatey documentation to get more detailed information on the parameters.\nWARNING: If some exceptions are thrown about undefined env PATH variable after fresh cchoco lib in rudder,\nyou may need to reboot your machine or notify your system that the env variables have been changed.",
+    "description": "Create a directory if it doesn't exist",
+    "documentation": "Create a directory if it doesn't exist.",
     "agent_support": [
+      "cfengine-community",
       "dsc"
     ],
-    "class_prefix": "package_state_windows",
-    "class_parameter": "PackageName",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/package_state_windows.cf",
-    "parameter": [
-      {
-        "name": "PackageName",
-        "description": "Software name to install",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "Status",
-        "description": "'present' or 'absent', defaults to 'present'",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "present",
-            "absent"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "Provider",
-        "description": "default to choco",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "choco"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "Params",
-        "description": "params to pass to the package installation",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "Version",
-        "description": "version, default to latest",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "Source",
-        "description": "source",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "ProviderParams",
-        "description": "provider parameters, default to choco",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "AutoUpgrade",
-        "description": "autoUpgrade, default to false",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "true",
-            "false"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "registry_key_present": {
-    "name": "Registry key present",
-    "bundle_name": "registry_key_present",
-    "bundle_args": [
-      "key"
-    ],
-    "description": "Ensure that a Registry Key does exist.",
-    "documentation": "Create a Registry Key if it does not exist.\n  There are two different supported syntaxes to describe a Registry Key:\n\n  * with short drive name and \":\" like HKLM:\\SOFTWARE\\myKey\n  * with long drive name and without \":\" like HKEY_LOCAL_MACHINE:\\SOFTWARE\\myKey\n\n  Please, note that Rudder can not create new drive and new \"first-level\" Registry Keys.\n#### Examples\n\n```\n-name: Make sure the Rudder reg key is defined\n method: registry_entry_present\n   key: \"HKLM:\\SOFTWARE\\Rudder\"",
-    "agent_support": [
-      "dsc"
-    ],
-    "class_prefix": "registry_key_present",
-    "class_parameter": "key",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/registry_key_present.cf",
-    "parameter": [
-      {
-        "name": "key",
-        "description": "Registry key (ie, HKLM:\\Software\\Rudder)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "command_execution_once": {
-    "name": "Command execution once",
-    "bundle_name": "command_execution_once",
-    "bundle_args": [
-      "command",
-      "ok_codes",
-      "until",
-      "unique_id"
-    ],
-    "description": "Execute a command only once on a node",
-    "documentation": "This method is useful for specific commands that should only be executed once per node.\n\nIf you can spot a condition for the command execution by testing the state of its target,\nit is better to use the `condition_from_command` method to test the state coupled with\nthe `command_execution_result` method to run the command if necessary.\n\nIn case of reinstallation or factory-reset of the Rudder agent, this method \nwill no longer detect if a command has already been executed.\n\n##### The method will:\n\n**Define** the `command_execution_once_${command}_kept` condition and do nothing if\na `command_execution_once` has already been executed on this machine with the same\n**Unique id**.\n\n**Execute** the command if it is the first occurrence and:\n* If the parameter **Until** is `*any*`, it will consider the command as executed on the machine and define\n  either:\n  * `command_execution_once_${command}_repaired` if the return code is in **ok_codes**,\n  * `command_execution_once_${command}_error` otherwise.\n* If the parameter **Until** is *ok* and:\n  * If the return code is in the **Ok codes** list, define the\n    `command_execution_once_${command}_repaired` condition\n  * If the return code is not in **Ok codes** it define the\n     `command_execution_once_${command}_error` condition and **retry at next agent run**.\n\nIf an exit code is not in the list it will lead to an error status.\nIf you want \"0\" to be a success you have to list it in the **Ok codes** list\n\n##### Example:\n\nIf you use:\n\n```\n    command_execution_once(\"command -a -t\", \"0\", \"ok\", \"my_program_setup\")\n```\n\nIt will retry to run `command -a -t` until it returns \"0\". Then it will\nnot execute it again.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "command_execution_once",
-    "class_parameter": "command",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/command_execution_once.cf",
-    "action": "",
-    "parameter": [
-      {
-        "name": "command",
-        "description": "Command to run",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "ok_codes",
-        "description": "List of codes that produce a repaired status separated with commas (ex: 1,2,5). Defaults to 0.",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "until",
-        "description": "Try to execute the command until a particular state: 'ok', 'any' (defaults to 'any')",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "any",
-            "ok"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "unique_id",
-        "description": "To identify the action without losing track if the command changes. Defaults to the command if you don't need it.",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_replace_lines": {
-    "name": "File replace lines",
-    "bundle_name": "file_replace_lines",
-    "bundle_args": [
-      "path",
-      "line",
-      "replacement"
-    ],
-    "description": "Ensure that a line in a file is replaced by another one",
-    "documentation": "You can replace lines in a files, based on regular expression and captured pattern\n\n#### Syntax\n\nThe content to match in the file is a PCRE regular expression, unanchored\nthat you can replace with the content of replacement.\n\nContent can be captured in regular expression, and be reused with the notation `${match.1}` (for first matched\ncontent), `${match.2}` for second, etc, and the special captured group `${match.0}` for the whole text.\n\n#### Example\n\nHere is an example to remove enclosing specific tags\n\n```\nfile_replace_lines(\"/PATH_TO_MY_FILE/file\", \"<my>(.*)<pattern>\", \"my ${match.1} pattern\")\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_replace_lines",
+    "class_prefix": "directory_present",
     "class_parameter": "path",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_replace_lines.cf",
-    "action": "If the regex matches the replacement, then the line will be replaced every time",
+    "source": "/usr/share/ncf/tree/30_generic_methods/directory_present.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "Full path of directory to create (trailing '/' is optional)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "target",
+        "new": "path"
+      }
+    ]
+  },
+  "package_present": {
+    "name": "Package present",
+    "bundle_name": "package_present",
+    "bundle_args": [
+      "name",
+      "version",
+      "architecture",
+      "provider"
+    ],
+    "description": "Enforce the presence of a package",
+    "documentation": "See [package_state](#_package_state) for documentation.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "package_present",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/package_present.cf",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Name of the package, or path to a local package",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "version",
+        "description": "Version of the package, can be \"latest\" for latest version or \"any\" for any version (defaults to \"any\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "architecture",
+        "description": "Architecture of the package, can be an architecture name  or \"default\" (defaults to \"default\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "provider",
+        "description": "Package provider to use, can be \"yum\", \"apt\", \"zypper\", \"zypper_pattern\", \"slackpkg\", \"pkg\", \"ips\", \"nimclient\", \"snap\" or \"default\" for system default package manager (defaults to \"default\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": ""
+            },
+            {
+              "value": "default"
+            },
+            {
+              "value": "yum"
+            },
+            {
+              "value": "apt"
+            },
+            {
+              "value": "zypper"
+            },
+            {
+              "value": "zypper_pattern"
+            },
+            {
+              "value": "slackpkg"
+            },
+            {
+              "value": "pkg"
+            },
+            {
+              "value": "ips"
+            },
+            {
+              "value": "nimclient"
+            },
+            {
+              "value": "snap"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_ensure_keys_values": {
+    "name": "File ensure keys -> values present",
+    "bundle_name": "file_ensure_keys_values",
+    "bundle_args": [
+      "path",
+      "keys",
+      "separator"
+    ],
+    "description": "Ensure that the file contains all pairs of \"key separator value\", with arbitrary separator between each key and its value",
+    "documentation": "This method ensures key-value pairs are present in a file.\n\n#### Usage\n\nThis method will iterate over the key-value pairs in the dict, and:\n\n* If the key is not defined in the destination, add the *key* + *separator* + *value* line.\n* If the key is already present in the file, replace the *key* + *separator* + anything by *key* + *separator* + *value*\n\nThis method always ignores spaces and tabs when replacing (which means for example that `key = value` will match the `=` separator).\n\nKeys are considered unique (to allow replacing the value), so you should use [file_ensure_lines_present](#_file_ensure_lines_present)\nif you want to have multiple lines with the same key.\n\n#### Example\n\nIf you have an initial file (`/etc/myfile.conf`) containing:\n\n```\nkey1 = something\nkey3 = value3\n```\n\nTo define key-value pairs, use the [variable_dict](#_variable_dict) or\n[variable_dict_from_file](#_variable_dict_from_file) methods.\n\nFor example, if you use the following content (stored in `/tmp/data.json`):\n\n```json\n{\n   \"key1\": \"value1\",\n   \"key2\": \"value2\"\n}\n```\n\nWith the following policy:\n\n```\n# Define the `content` variable in the `configuration` prefix from the json file\nvariable_dict_from_file(\"configuration\", \"content\", \"/tmp/data.json\")\n# Enforce the presence of the key-value pairs\nfile_ensure_keys_values(\"/etc/myfile.conf\", \"configuration.content\", \" = \")\n\n```\n\nThe destination file (`/etc/myfile.conf`) will contain:\n\n```\nkey1 = value1\nkey3 = value3\nkey2 = value2\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_ensure_keys_values",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_keys_values.cf",
+    "deprecated": "Use [file_keys_values_present](#_file_keys_values_present) instead.",
+    "rename": "file_keys_values_present",
     "parameter": [
       {
         "name": "path",
@@ -4781,8 +6291,8 @@
         "type": "string"
       },
       {
-        "name": "line",
-        "description": "Line to match in the file",
+        "name": "keys",
+        "description": "Name of the dict structure (without \"${}\") containing the keys (keys of the dict), and values to define (values of the dict)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -4791,11 +6301,11 @@
         "type": "string"
       },
       {
-        "name": "replacement",
-        "description": "Line to add in the file as a replacement",
+        "name": "separator",
+        "description": "Separator between key and value, for example \"=\" or \" \" (without the quotes)",
         "constraints": {
           "allow_empty_string": false,
-          "allow_whitespace_string": false,
+          "allow_whitespace_string": true,
           "max_length": 16384
         },
         "type": "string"
@@ -4808,26 +6318,27 @@
       }
     ]
   },
-  "kernel_module_configuration": {
-    "name": "Kernel module configuration",
-    "bundle_name": "kernel_module_configuration",
+  "permissions_group_acl_absent": {
+    "name": "Permissions group POSIX acl entry absent",
+    "bundle_name": "permissions_group_acl_absent",
     "bundle_args": [
-      "name",
-      "configuration"
+      "path",
+      "recursive",
+      "group"
     ],
-    "description": "Ensure that the modprobe configuration of a given kernel module is correct",
-    "documentation": "Ensure that the modprobe configuration of a given kernel module is correct.\n Rudder will search for the module configuration in a per-module dedicated section in /etc/modprobe.d/managed\\_by\\_rudder.conf.\n\n * If the module configuration is not found or incorrect, Rudder will (re-)create its configuration.\n * If the module is configured but with a different option file than used by Rudder, it will add the\n expected one in /etc/modprobe.d/managed\\_by\\_rudder.conf but will leave intact the already present one.\n\n The configuration syntax must respect the one used by /etc/modprobe.d defined in the modprobe.d manual page.\n ```\n   # To pass a parameter to a module:\n   options module_name parameter_name=parameter_value\n   # To blacklist a module\n   blacklist modulename\n   # etc...\n ```\n\n#### Notes:\n If you want to force the module to be loaded at boot, use instead the method `kernel_module_enabled_at_boot` which\n uses other Rudder dedicated files.\n\n#### Example:\n\n To pass options to a broadcom module\n * `name` = b43\n * `configuration` = options b43 nohwcrypt=1 qos=0\n\n Will produce the resulting block in /etc/modprobe.d/managed\\_by\\_rudder.conf:\n ```\n ### b43 start section\n options b43 nohwcrypt=1 qos=0\n ### b43 end section\n ```",
+    "description": "Verify that an ace is absent on a file or directory for a given group.\nThis method will make sure that no ace is present in the POSIX ACL of the target.",
+    "documentation": "The `permissions_*acl_*` manage the POSIX ACL on files and directories.\n\nPlease note that the mask will be automatically recalculated when editing ACLs.\n\n#### Parameters\n\n##### Path\n\nPath can be a regex with the following format:\n\n* `*` matches any filename or directory at one level, e.g. `*.cf` will match all files in one directory that end in .cf but it won't search across directories. `*/*.cf` on the other hand will look two levels deep.\n* `?` matches a single letter\n* `[a-z]` matches any letter from a to z\n* `{x,y,anything}` will match x or y or anything.\n\n##### Recursive\n\nCan be:\n\n* `true` to apply the given aces to folder and sub-folders and files.\n* or `false` to apply to the strict match of `Path`\n\nIf left blank, recursivity will automatically be set to `false`\n\n##### User\n\n`Username` to enforce the ace absence, being the Linux account name.\nThis method can only handle one groupname.\n\n#### Example\n\nGiven a file with the following getfacl output:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\ngroup::r--\ngroup:bob:rwx\nmask::rwx\nother::---\n\n~~~~\n\nApplying this method with the following parameters:\n\n* `path`: /tmp/myTestFile\n* `recursive`: false\n* `group`: bob\n\nWill transform the previous ACLs in:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\ngroup::r--\nmask::r--\nother::---\n\n~~~~",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "kernel_module_configuration",
-    "class_parameter": "name",
+    "class_prefix": "permissions_group_acl_absent",
+    "class_parameter": "path",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/kernel_module_configuration.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_group_acl_absent.cf",
     "parameter": [
       {
-        "name": "name",
-        "description": "Complete name of the kernel module, as seen by lsmod or listed in /proc/modules",
+        "name": "path",
+        "description": "Path of the file or directory",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -4836,12 +6347,120 @@
         "type": "string"
       },
       {
-        "name": "configuration",
-        "description": "Complete configuration block to put in /etc/modprobe.d/",
+        "name": "recursive",
+        "description": "Recursive Should ACLs cleanup be recursive, \"true\" or \"false\" (defaults to \"false\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": ""
+            },
+            {
+              "value": "true"
+            },
+            {
+              "value": "false"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "group",
+        "description": "Group name",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
-          "regex": "^(alias|blacklist|install|options|remove|softdeps) +.*$",
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "sysctl_value": {
+    "name": "Sysctl value",
+    "bundle_name": "sysctl_value",
+    "bundle_args": [
+      "key",
+      "value",
+      "filename",
+      "option"
+    ],
+    "description": "Enforce a value in sysctl (optionally increase or decrease it)",
+    "documentation": "Enforce a value in sysctl\n\n#### Behaviors\n\nChecks for the current value defined for the given key\nIf it is not set, this method attempts to set it in the file defined as argument\nIf it is set, and corresponds to the desired value, it will success\nIf it is set, and does not correspond, the value will be set in the file defined, sysctl \nconfiguration is reloaded with `sysctl --system` and the \nresulting value is checked. \nIf it is not taken into account by sysctl because\nits overridden in another file or its an invalid key, the method returns an error\n\n#### Prerequisite\n\nThis method requires an /etc/sysctl.d folder, and the `sysctl --system` option.\nIt does not support Debian 6 or earlier, CentOS/RHEL 6 or earlier, SLES 11 or earlier,\nUbuntu 12_04 or earlier, AIX and Solaris.\n\n##### Parameters\n\n`key`   : the key to enforce/check\n`value` : the expected value for the key\n`filename` : filename (without extension) containing the key=value when need to be set, within /etc/sysctl.d.\n             This method adds the correct extension at the end of the filename\nOptional parameter:\n `min`: The value is the minimal value we request. the value is only changed if the current value is lower than `value`\n `max`: The value is the maximal value we request: the value is only changed if the current value is higher than `value`\n `default` (default value): The value is strictly enforced.\n\nComparison is numerical if possible, else alphanumerical\nSo 10 > 2, but Test10 < Test2\n\n#### Examples\n\nTo ensure that swappiness is disabled, and storing the configuration parameter in 99_rudder.conf\n\n```\n sysctl_value(\"vm.swappiness\", \"99_rudder\", \"0\", \"\")\n```\n\nTo ensure that the UDP buffer is at least 26214400\n\n```\n sysctl_value(\"net.core.rmem_max\", \"99_rudder\", \"26214400\", \"min\")\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "sysctl_value",
+    "class_parameter": "key",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/sysctl_value.cf",
+    "parameter": [
+      {
+        "name": "key",
+        "description": "The key to enforce",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "value",
+        "description": "The desired value",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "filename",
+        "description": "File name where to put the value in /etc/sysctl.d (without the .conf extension)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "option",
+        "description": "Optional modifier on value: Min, Max or Default (default value)",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "service_disabled": {
+    "name": "Service disabled at boot",
+    "bundle_name": "service_disabled",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Force a service not to be enabled at boot",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "service_disabled",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_disabled.cf",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Service name (as recognized by systemd, init.d, etc...)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
           "max_length": 16384
         },
         "type": "string"
@@ -4849,32 +6468,28 @@
     ],
     "parameter_rename": [
       {
-        "old": "module_name",
+        "old": "service_name",
         "new": "name"
       }
     ]
   },
-  "file_key_value_parameter_present_in_list": {
-    "name": "File key-value parameter in list",
-    "bundle_name": "file_key_value_parameter_present_in_list",
+  "file_ensure_lines_absent": {
+    "name": "File ensure lines absent",
+    "bundle_name": "file_ensure_lines_absent",
     "bundle_args": [
       "path",
-      "key",
-      "key_value_separator",
-      "parameter",
-      "parameter_separator",
-      "leading_char_separator",
-      "closing_char_separator"
+      "lines"
     ],
-    "description": "Ensure that one parameter exists in a list of parameters, on one single line, in the right hand side of a key->values line",
-    "documentation": "Edit the file, and ensure it contains the defined parameter in the list of values on the right hand side of a key->values line.\nIf the parameter is not there, it will be added at the end, separated by parameter_separator.\nOptionnaly, you can define leading and closing character to enclose the parameters\nIf the key does not exist in the file, it will be added in the file, along with the parameter\n\n#### Example\n\nIf you have an initial file (`/etc/default/grub`) containing\n\n```\nGRUB_CMDLINE_XEN=\"dom0_mem=16G\"\n```\n\nTo add parameter `dom0_max_vcpus=32` in the right hand side of the line, you'll need the following policy\n\n```\nfile_ensure_key_value_parameter_in_list(\"/etc/default/grub\", \"GRUB_CMDLINE\", \"=\", \"dom0_max_vcpus=32\", \" \", \"\\\"\", \"\\\"\");\n```",
+    "description": "Ensure that a line is absent in a specific location",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "file_key_value_parameter_present_in_list",
+    "class_prefix": "file_ensure_lines_absent",
     "class_parameter": "path",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_key_value_parameter_present_in_list.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_lines_absent.cf",
+    "deprecated": "Use [file_lines_absent](#_file_lines_absent) instead.",
+    "rename": "file_lines_absent",
     "parameter": [
       {
         "name": "path",
@@ -4887,60 +6502,10 @@
         "type": "string"
       },
       {
-        "name": "key",
-        "description": "Full key name",
+        "name": "lines",
+        "description": "Line(s) to remove in the file",
         "constraints": {
           "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "key_value_separator",
-        "description": "character used to separate key and value in a key-value line",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": true,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "parameter",
-        "description": "String representing the sub-value to ensure is present in the list of parameters that form the value part of that line",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "parameter_separator",
-        "description": "Character used to separate parameters in the list",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": true,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "leading_char_separator",
-        "description": "leading character of the parameters",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "closing_char_separator",
-        "description": "closing character of the parameters",
-        "constraints": {
-          "allow_empty_string": true,
           "allow_whitespace_string": false,
           "max_length": 16384
         },
@@ -4954,9 +6519,709 @@
       }
     ]
   },
-  "file_symlink_present_option": {
-    "name": "Symlink present (optional overwriting)",
-    "bundle_name": "file_symlink_present_option",
+  "variable_dict_from_file_type": {
+    "name": "Variable dict from file type",
+    "bundle_name": "variable_dict_from_file_type",
+    "bundle_args": [
+      "prefix",
+      "name",
+      "file_name",
+      "file_type"
+    ],
+    "description": "Define a variable that contains key,value pairs (a dictionary) from a JSON, CSV or YAML file",
+    "documentation": "To use the generated variable, you must use the form `${prefix.name[key]}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \n\nThis method will load data from various file formats (yaml, json, csv). \n\n#### CSV parsing\n\nThe input file must use CRLF as line delimiter\nto be readable (as stated in RFC 4180).\n\n#### Examples\n\n```\n# To read a json file with format auto detection \nvariable_dict_from_file_type(\"prefix\", \"var\", \"/tmp/file.json\", \"\");\n# To force yaml reading on a non file without yaml extension\nvariable_dict_from_file_type(\"prefix\", \"var\", \"/tmp/file\", \"YAML\");\n```\n\nIf `/tmp/file.json` contains:\n\n```json\n{\n  \"key1\": \"value1\"\n}\n```\n\nYou will be able to access the `value1` value with `${prefix.var[key1]}`.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "variable_dict_from_file_type",
+    "class_parameter": "name",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/variable_dict_from_file_type.cf",
+    "parameter": [
+      {
+        "name": "prefix",
+        "description": "The prefix of the variable name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "name",
+        "description": "The variable to define, the full name will be prefix.name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "file_name",
+        "description": "The file name to load data from",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "file_type",
+        "description": "The file type, can be \"JSON\", \"CSV\", \"YAML\" or \"auto\" for auto detection based on file extension, with a fallback to JSON (default is \"auto\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": ""
+            },
+            {
+              "value": "auto"
+            },
+            {
+              "value": "JSON"
+            },
+            {
+              "value": "YAML"
+            },
+            {
+              "value": "CSV"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "variable_prefix",
+        "new": "prefix"
+      },
+      {
+        "old": "variable_name",
+        "new": "name"
+      }
+    ]
+  },
+  "file_check_symlinkto": {
+    "name": "File check is symlink to",
+    "bundle_name": "file_check_symlinkto",
+    "bundle_args": [
+      "path",
+      "target"
+    ],
+    "description": "Checks if first file is symlink to second file",
+    "documentation": "This bundle will define a condition `file_check_symlinkto_${target}_{ok, reached, kept}` if the file `${path}`\nis a symbolic link to `${target}`, or `file_check_symlinkto_${target}_{not_ok, reached, not_kept, failed}` if\nif it is not a symbolic link, or any of the files does not exist. The symlink's path is resolved to the \nabsolute path and checked against the target file's path, which must also be an absolute path.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_check_symlinkto",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_symlinkto.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "Symbolic link (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "target",
+        "description": "Target file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "symlink",
+        "new": "path"
+      }
+    ]
+  },
+  "file_block_present_in_section": {
+    "name": "File block in section",
+    "bundle_name": "file_block_present_in_section",
+    "bundle_args": [
+      "path",
+      "section_start",
+      "section_end",
+      "block"
+    ],
+    "description": "Ensure that a section contains exactly a text block",
+    "documentation": "Ensure that a section contains exactly a text block.\nA section is delimited by a header and a footer.\n* If the section exists, its content will be replaced if needed\n* Otherwise it will be created at the end of the file",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_block_present_in_section",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_block_present_in_section.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "section_start",
+        "description": "Start of the section",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "section_end",
+        "description": "End of the section",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "block",
+        "description": "Block representing the content of the section",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file",
+        "new": "path"
+      }
+    ]
+  },
+  "permissions_posix_acls_absent": {
+    "name": "Permissions POSIX ACLs absent",
+    "bundle_name": "permissions_posix_acls_absent",
+    "bundle_args": [
+      "path",
+      "recursive"
+    ],
+    "description": "Ensure that files or directories has no ACLs set",
+    "documentation": "The `permissions_*acl_*` manage the POSIX ACL on files and directories.\n\n#### Parameters\n\n##### Path\n\nPath can be globbing with the following format:\n\n* * matches any filename or directory at one level, e.g. *.cf will match all files in one directory that end in .cf but it won't search across directories. */*.cf on the other hand will look two levels deep.\n* ? matches a single letter\n* [a-z] matches any letter from a to z\n* {x,y,anything} will match x or y or anything.\n\n##### Recursive\n\nCan be:\n\n* `true` to apply the given aces to folder and sub-folders and files.\n* or `false` to apply to the strict match of `Path`\n\nIf left blank, recursivity will automatically be set to `false`\n\n#### Example\nThe method has basically the same effect as `setfacl -b <path>`.\n\nGiven a file with the following getfacl output:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\nuser:vagrant:rwx\ngroup::r--\nmask::rwx\nother::---\n\n~~~~\n\nIt will remove all ACLs, and only let classic rights, here:\n\n~~~~\nroot@server# getfacl myTestFile \n# file: myTestFile\n# owner: root\n# group: root\nuser::rwx\ngroup::r--\nother::---\n\nroot@server# ls -l myTestFile\n-rwxr----- 1 root root 0 Mar 22 11:24 myTestFile\nroot@server# \n\n~~~~",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "permissions_posix_acls_absent",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_posix_acls_absent.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "Path of the file or directory",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "recursive",
+        "description": "Should ACLs cleanup be recursive, \"true\" or \"false\" (defaults to \"false\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": ""
+            },
+            {
+              "value": "true"
+            },
+            {
+              "value": "false"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "permissions_user_acl_present": {
+    "name": "Permissions user POSIX acl entry present",
+    "bundle_name": "permissions_user_acl_present",
+    "bundle_args": [
+      "path",
+      "recursive",
+      "user",
+      "ace"
+    ],
+    "description": "Verify that an ace is present on a file or directory for a given user.\nThis method will make sure the given ace is present in the POSIX ACL of the target.",
+    "documentation": "The `permissions_*acl_*` manage the POSIX ACL on files and directories.\n\nPlease note that the mask will be automatically recalculated when editing ACLs.\n\n#### Parameters\n\n##### Path\n\nPath can be globbing with the following format:\n\n* `*` matches any filename or directory at one level, e.g. `*.cf` will match all files in one directory that end in .cf but it won't search across directories. `*/*.cf` on the other hand will look two levels deep.\n* `?` matches a single letter\n* `[a-z]` matches any letter from a to z\n* `{x,y,anything}` will match x or y or anything.\n\n##### Recursive\n\nCan be:\n\n* `true` to apply the given aces to folder and sub-folders and files.\n* or `false` to apply to the strict match of `Path`\n\nIf left blank, recursivity will automatically be set to `false`\n\n##### User\n\n`Username` to enforce the ace, being the Linux account name.\nThis method can only handle one username.\n\n##### ACE\n\nThe operator can be:\n* `+` to add the given ACE to the current ones.\n* `-` to remove the given ACE to the current ones.\n* `=` to force the given ACE to the current ones.\n* `empty` if no operator is specified, it will be interpreted as `=`.\n\nACE must respect the classic:\n\n* `^[+-=]?(?=.*[rwx])r?w?x?$`\n\n#### Example\n\nGiven a file with the following getfacl output:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\nuser:bob:rwx\ngroup::r--\nmask::rwx\nother::---\n\n~~~~\n\nApplying this method with the following parameters:\n\n* `path`: /tmp/myTestFile\n* `recursive`: false\n* `user`: bob\n* `ace`: -rw\n\nWill transform the previous ACLs in:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\nuser:bob:--x\ngroup::r--\nmask::r-x\nother::---\n\n~~~~",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "permissions_user_acl_present",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_user_acl_present.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "Path of the file or directory.",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "recursive",
+        "description": "Recursive Should ACLs cleanup be recursive, \"true\" or \"false\" (defaults to \"false\").",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": ""
+            },
+            {
+              "value": "true"
+            },
+            {
+              "value": "false"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "user",
+        "description": "Username of the Linux account.",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "ace",
+        "description": "ACE to enforce for the given user.",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "regex": {
+            "value": "^[+-=]?(?=.*[rwx])r?w?x?$"
+          },
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "permissions_posix_acl_entry_parent": {
+    "name": "Permissions POSIX ACLs entry parent",
+    "bundle_name": "permissions_posix_acl_entry_parent",
+    "bundle_args": [
+      "path",
+      "recursive",
+      "user",
+      "group",
+      "other",
+      "parent_permissions_user",
+      "parent_permissions_group",
+      "parent_permissions_other"
+    ],
+    "description": "Ensure ACL on a file or folder and all its parent folders",
+    "documentation": "Ensure ACL on a file or folder and all its parent folders.\n\n\nForce the given ACL on the target `path` (supports globbing).\n\n* If `recursive` is set to `true`, the permissions will be applied to\n  every files and folder under the resolved `path` input.\n* If the `parent_permissions_*` inputs are not empty, they will be applied to every parent folders\n  to the resolved `path` input, excepting the root folder `/`.\n* ACL inputs are expected to be comma separated, and to follow this schema:\n  * `myuser:wx` to force the ACL entry\n  * `myuser:+wx` to edit the ACL without enforcing them all\n\nIf the `path` input resolves to `/this/is/my/path/mylogfile`, parent folders permissions will be applied to:\n```\n/this\n/this/is\n/this/is/my\n/this/is/my/path/\n```\n\n#### Examples:\n\n```yaml\n-name: Allows bob to write in its logfile\n method: permissions_posix_acl_entry_parent\n   path: /this/is/my/path/mylogfile\n   recursive: false\n   user: \"bob:rwx\"\n   parent_permissions_user: \"bob:rx\"\n\n```\n\n```yaml\n-name: Allows Bob and Alice to write in its logfile\n method: permissions_posix_acl_entry_parent\n   path: /this/is/my/path/mylogfile\n   recursive: false\n   user: \"bob:rwx,alice:+rwx\"\n   parent_permissions_user: \"bob:rx,alice:rx\"\n\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "permissions_posix_acl_entry_parent",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_posix_acl_entry_parent.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "Path of the file or directory",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "recursive",
+        "description": "Recursive Should ACLs cleanup be recursive, \"true\" or \"false\" (defaults to \"false\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": ""
+            },
+            {
+              "value": "true"
+            },
+            {
+              "value": "false"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "user",
+        "description": "User acls, comma separated, like: bob:+rwx, alice:-w",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "group",
+        "description": "Group acls, comma separated, like: wheel:+wx, anon:-rwx",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "other",
+        "description": "Other acls, like -x",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "parent_permissions_user",
+        "description": "User acls, comma separated, like: bob:+rwx, alice:-w",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "parent_permissions_group",
+        "description": "Group acls, comma separated, like: wheel:+wx, anon:-rwx",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "parent_permissions_other",
+        "description": "Other acls, like -x",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_from_string_mustache": {
+    "name": "File from a mustache string",
+    "bundle_name": "file_from_string_mustache",
+    "bundle_args": [
+      "template",
+      "path"
+    ],
+    "description": "Build a file from a mustache string",
+    "documentation": "Build a file from a mustache string.\nComplete mustache documentation is available in the *file\\_from\\_template\\_mustache* method documentation.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_from_string_mustache",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_string_mustache.cf",
+    "parameter": [
+      {
+        "name": "template",
+        "description": "String containing a template to be expanded",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "Destination file (absolute path on the target node",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
+      }
+    ]
+  },
+  "user_present": {
+    "name": "User present",
+    "bundle_name": "user_present",
+    "bundle_args": [
+      "login"
+    ],
+    "description": "Ensure a user exists on the system.",
+    "documentation": "This method does not create the user's home directory.\n Primary group will be created and set with default one, following the useradd default behavior.\n As in most UNIX system default behavior user creation will fail if a group with\n the user name already exists.",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "user_present",
+    "class_parameter": "login",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/user_present.cf",
+    "parameter": [
+      {
+        "name": "login",
+        "description": "User login",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_report_content": {
+    "name": "File report content",
+    "bundle_name": "file_report_content",
+    "bundle_args": [
+      "path",
+      "regex",
+      "context"
+    ],
+    "description": "Report the content of a file",
+    "documentation": "Report the content of a file.\n\nThis method does nothing on the system, but only reports a complete or partial content\nfrom a given file. This allows centralizing this information on the server, and avoid\nhaving to connect on each node to get this information.\n\nNOTE: This method only works in \"Full Compliance\" reporting mode.\n\n#### Parameters\n\n##### Target\n\nThis is the file you want to report content from. The method will return an error if it\ndoes not exist.\n\n##### Regex\n\nIf empty, the method will report the whole file content.\nIf set, the method will grep the file for the given regular expression, and\nreport the result.\n\n##### Context\n\nWhen specifying a regex, will add the number of lines of context around matches\n(default is 0, i.e. no context).\n\nWhen reporting the whole file, this parameter is ignored.\n\n#### Examples\n\n```\n# To get the whole /etc/hosts content\nfile_report_content(\"/etc/hosts\", \"\", \"\");\n# To get lines starting by \"nameserver\" in /etc/resolv.conf\nfile_report_content(\"/etc/resolv.conf\", \"^nameserver\", \"\");\n# To get lines containing \"rudder\" from /etc/hosts with 3 lines of context\nfile_report_content(\"/etc/hosts\", \"rudder\", \"3\");\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_report_content",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_report_content.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File to report content from",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "regex",
+        "description": "Regex to search in the file (empty for whole file)",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "context",
+        "description": "Number of context lines when matching regex (default is 0)",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "regex": {
+            "value": "^\\d*$"
+          },
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "target",
+        "new": "path"
+      }
+    ]
+  },
+  "file_check_FIFO_pipe": {
+    "name": "File check is FIFO/Pipe",
+    "bundle_name": "file_check_FIFO_pipe",
+    "bundle_args": [
+      "path"
+    ],
+    "description": "Checks if a file exists and is a FIFO/Pipe",
+    "documentation": "This bundle will define a condition `file_check_FIFO_pipe_${path}_{ok, reached, kept}` if the\nfile is a FIFO, or `file_check_FIFO_pipe_${path}_{not_ok, reached, not_kept, failed}` if\nthe file is not a fifo or does not exist",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_check_FIFO_pipe",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_FIFO_pipe.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file_name",
+        "new": "path"
+      }
+    ]
+  },
+  "permissions_acl_entry": {
+    "name": "Permissions POSIX acl entry",
+    "bundle_name": "permissions_acl_entry",
+    "bundle_args": [
+      "path",
+      "recursive",
+      "user",
+      "group",
+      "other"
+    ],
+    "description": "Verify that an ace is present on a file or directory.\nThis method will append the given aces to the current POSIX ACLs of\nthe target.",
+    "documentation": "The `permissions_*acl_*` manage the POSIX ACL on files and directories.\n\nPlease note that the mask will be automatically recalculated when editing ACLs.\n\n#### Parameters\n\n##### Path\n\nPath can be a regex with the following format:\n\n* `*` matches any filename or directory at one level, e.g. `*.cf` will match all files in one directory that end in .cf but it won't search across directories. `*/*.cf` on the other hand will look two levels deep.\n* `?` matches a single letter\n* `[a-z]` matches any letter from a to z\n* `{x,y,anything}` will match x or y or anything.\n\n##### Recursive\n\nCan be:\n\n* `true` to apply the given aces to folder and sub-folders and files.\n* or `false` to apply to the strict match of `Path`\n\nIf left blank, recursivity will automatically be set to `false`\n\n##### User and Group\n\nACE for user and group  can be left blank if they do not need any specification.\nIf fulfill, they must respect the format:\n\n`<username|groupname>:<operator><mode>`\n\nwith:\n\n* `username` being the Linux account name\n* `groupname` the Linux group name\n* Current `owner user` and `owner group` can be designed by the character `*`\n\nThe operator can be:\n* `+` to add the given ACE to the current ones.\n* `-` to remove the given ACE to the current ones.\n* `=` to force the given ACE to the current ones.\n\nYou can define multiple ACEs by separating them with commas.\n\n##### Other\n\nACE for other must respect the classic:\n\n* `[+-=]r?w?x?`\nIt can also be left blank to let the `Other` ACE unchanged.\n\n#### Example\n\nGiven a file with the following getfacl output:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile\ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\nuser:bob:rwx\ngroup::r--\nmask::rwx\nother::---\n\n~~~~\n\nApplying this method with the following parameters:\n\n* `path`: /tmp/myTestFile\n* `recursive`: false\n* `user`: *:-x, bob:\n* `group`: *:+rw\n* `other`: =r\n\nWill transform the previous ACLs in:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile\ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rw-\nuser:bob:---\ngroup::rw-\nmask::rw-\nother::r--\n\n~~~~\n\nThis method can not remove a given ACE, see here how the user bob ACE is handled.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "permissions_acl_entry",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_acl_entry.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "Path of the file or directory",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "recursive",
+        "description": "Recursive Should ACLs cleanup be recursive, \"true\" or \"false\" (defaults to \"false\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": ""
+            },
+            {
+              "value": "true"
+            },
+            {
+              "value": "false"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "user",
+        "description": "User acls, comma separated, like: bob:+rwx, alice:-w",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "regex": {
+            "value": "^$|^(([A-z0-9._-]+|\\*):([+-=]r?w?x?)?,? *)+$"
+          },
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "group",
+        "description": "Group acls, comma separated, like: wheel:+wx, anon:-rwx",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "regex": {
+            "value": "^$|^(([A-z0-9._-]+|\\*):([+-=]r?w?x?)?,? *)+$"
+          },
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "other",
+        "description": "Other acls, like -x",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "regex": {
+            "value": "^$|^[+-=^]r?w?x?$"
+          },
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_create_symlink_enforce": {
+    "name": "Create symlink (optional overwriting)",
+    "bundle_name": "file_create_symlink_enforce",
     "bundle_args": [
       "source",
       "path",
@@ -4966,10 +7231,12 @@
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "file_symlink_present",
+    "class_prefix": "file_create_symlink",
     "class_parameter": "path",
     "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_symlink_present_option.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_create_symlink_enforce.cf",
+    "deprecated": "Use [file_symlink_present_option](#_file_symlink_present_option) instead.",
+    "rename": "file_symlink_present_option",
     "parameter": [
       {
         "name": "source",
@@ -5005,52 +7272,6 @@
     "parameter_rename": [
       {
         "old": "destination",
-        "new": "path"
-      }
-    ]
-  },
-  "file_report_content_head": {
-    "name": "File report content head",
-    "bundle_name": "file_report_content_head",
-    "bundle_args": [
-      "path",
-      "limit"
-    ],
-    "description": "Report the head of a file",
-    "documentation": "Report the head of a file.\n\nThis method does nothing on the system, but only reports a partial content\nfrom a given file. This allows centralizing this information on the server, and avoid\nhaving to connect on each node to get this information.\n\nNOTE: This method only works in \"Full Compliance\" reporting mode.\n\n#### Parameters\n\n##### Target\n\nThis is the file you want to report content from. The method will return an error if it\ndoes not exist.\n\n##### Limit\n\nThe number of line to report.\n\n#### Examples\n\n```\n# To get the 3 first line of /etc/hosts\nfile_report_content(\"/etc/hosts\", \"3\");\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_report_content_head",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_report_content_head.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File to report content from",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "limit",
-        "description": "Number of lines to report (default is 10)",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "regex": "^\\d*$",
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "target",
         "new": "path"
       }
     ]
@@ -5137,1680 +7358,26 @@
       }
     ]
   },
-  "file_from_remote_source_recursion": {
-    "name": "File from remote source recursion",
-    "bundle_name": "file_from_remote_source_recursion",
+  "file_from_template_jinja2": {
+    "name": "File from a jinja2 template",
+    "bundle_name": "file_from_template_jinja2",
     "bundle_args": [
-      "source",
-      "path",
-      "recursion"
-    ],
-    "description": "Ensure that a file or directory is copied from a policy server",
-    "documentation": "This method requires that the policy server is configured to accept\ncopy of the source file or directory from the agents it will be applied to.\n\nYou can download a file from the shared files with:\n```\n/var/rudder/configuration-repository/shared-files/PATH_TO_YOUR_DIRECTORY_OR_FILE\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_from_remote_source",
-    "class_parameter": "path",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_remote_source_recursion.cf",
-    "parameter": [
-      {
-        "name": "source",
-        "description": "Source file (absolute path on the policy server)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "Destination file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "recursion",
-        "description": "Recursion depth to enforce for this path (0, 1, 2, ..., inf)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "destination",
-        "new": "path"
-      }
-    ]
-  },
-  "dsc_mof_file_apply": {
-    "name": "DSC MOF File Apply",
-    "bundle_name": "dsc_mof_file_apply",
-    "bundle_args": [
-      "MOFFile"
-    ],
-    "description": "Ensure that all MOF files under MOFFile are applied via DSC.",
-    "documentation": "Ensure that all MOF files contained under the target folder are applied via DSC\non the target node.",
-    "agent_support": [
-      "dsc"
-    ],
-    "class_prefix": "dsc_mof_file_apply",
-    "class_parameter": "MOFFile",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/dsc_mof_file_apply.cf",
-    "parameter": [
-      {
-        "name": "MOFFile",
-        "description": "Path to the mof that need to be applied",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_check_character_device": {
-    "name": "File check if character device",
-    "bundle_name": "file_check_character_device",
-    "bundle_args": [
+      "source_template",
       "path"
     ],
-    "description": "Checks if a file exists and is a character device",
-    "documentation": "This bundle will define a condition `file_check_character_device_${path}_{ok, reached, kept}` if the\nfile is a character device, or `file_check_character_device_${path}_{not_ok, reached, not_kept, failed}` if\nthe file is not a character device or does not exist",
+    "description": "Build a file from a jinja2 template",
+    "documentation": "See [file_from_template_type](#_file_from_template_type) for general documentation about\ntemplates usage.\n\nThis generic method will build a file from a jinja2 template\nusing data (conditions and variables) found in the execution context.\n\n\n#### Setup\n\nIt requires to have the jinja2 python module installed on the node, it can usually be done in ncf with\n`package_present(\"python-jinja2\", \"\", \"\", \"\")`.\n\nWARNING: If you are using a jinja2 version older than 2.7\n         trailing newlines will not be preserved in the destination file.\n\n#### Syntax\n\nJinja2 is a powerful templating language, running in Python.\nThe Jinja2 syntax reference documentation is [http://jinja.pocoo.org/docs/dev/templates/](http://jinja.pocoo.org/docs/dev/templates/)\nwhich will likely be useful, as Jinja2 is very rich and allows a lot more\nthat what is explained here.\n\nThis section presents some simple cases that cover what can be done with mustache templating,\nand the way the agent data is provided to the templating engine.\n\nThe main specificity of jinja2 templating is the use of two root containers:\n\n* `classes` to access currently defined conditions\n* `vars` to access all currently defined variables\n\nNote: You can add comments in the template, that will not be rendered in the output file with\n`{# ... #}`.\n\nYou can extend the Jinja2 templating engine by adding custom FILTERS and TESTS in the script\n`/var/rudder/configuration-repository/ncf/10_ncf_internals/modules/extensions/jinja2_custom.py`\n\nFor instance, to add a filter to uppercase a string and a test if a number is odd, you can create\nthe file `/var/rudder/configuration-repository/ncf/10_ncf_internals/modules/extensions/jinja2_custom.py`\non your Rudder server with the following content:\n\n```\ndef uppercase(input):\n    return input.upper()\n\ndef odd(value):\n    return True if (value % 2) else False\n\nFILTERS = {'uppercase': uppercase}\nTESTS = {'odd': odd}\n```\n\nThese filters and tests will be usable in your jinja2 templates automatically.\n\n##### Conditions\n\nTo display content based on conditions definition:\n\n```jinja2\n{% if classes.my_condition is defined  %}\n   display this if defined\n{% endif %}\n{% if not classes.my_condition is defined %}\n   display this if not defined\n{% endif %}\n```\n\nNote: You cannot use condition expressions here.\n\nYou can also use other tests, for example other built-in ones or\nthose defined in `jinja2_custom.py`:\n\n```jinja2\n{% if vars.variable_prefix.my_number is odd  %}\n   display if my_number is odd\n{% endif %}\n```\n\n##### Scalar variables\n\nHere is how to display a scalar variable value (integer, string, ...),\nif you have defined `variable_string(\"variable_prefix\", \"my_variable\", \"my_value\")`:\n\n```jinja2\n{{ vars.variable_prefix.my_variable }}\n```\n\nYou can also modify what is displayed by using filters. The built-in filters\ncan be extended in `jinja2_custom.py`:\n\n```jinja2\n{{ vars.variable_prefix.my_variable | uppercase }}\n```\n\nWill display the variable in uppercase.\n\n##### Iteration\n\nTo iterate over a list, for example defined with:\n\n```\nvariable_iterator(\"variable_prefix\", \"iterator_name\", \"a,b,c\", \",\")\n```\n\nUse the following file:\n\n```jinja2\n{% for item in vars.variable_prefix.iterator_name %}\n{{ item }} is the current iterator_name value\n{% endfor %}\n```\n\nWhich will be expanded as:\n\n```\na is the current iterator_name value\nb is the current iterator_name value\nc is the current iterator_name value\n```\n\nTo iterate over a container defined by the following json file, loaded with\n`variable_dict_from_file(\"variable_prefix\", \"dict_name\", \"path\")`:\n\n```json\n{\n   \"hosts\": [\n       \"host1\",\n       \"host2\"\n   ],\n   \"files\": [\n       {\"name\": \"file1\", \"path\": \"/path1\", \"users\": [ \"user1\", \"user11\" ] },\n       {\"name\": \"file2\", \"path\": \"/path2\", \"users\": [ \"user2\" ] }\n   ],\n   \"properties\": {\n       \"prop1\": \"value1\",\n       \"prop2\": \"value2\"\n   }\n}\n```\n\nUse the following template:\n\n```jinja2\n{% for item in vars.variable_prefix.dict_name.hosts %}\n{{ item }} is the current hosts value\n{% endfor %}\n\n# will display the name and path of the current file\n{% for file in vars.variable_prefix.dict_name.files %}\n{{ file.name }}: {{ file.path }}\n{% endfor %}\n\n# will display the users list of each file\n{% for file in vars.variable_prefix.dict_name.files %}\n{{ file.name }}: {{ file.users|join(' ') }}\n{% endfor %}\n\n\n# will display the current properties key/value pair\n{% for key, value in vars.variable_prefix.dict_name.properties.items() %}\n{{ key }} -> {{ value }}\n{% endfor %}\n\n```\n\nWhich will be expanded as:\n\n```\nhost1 is the current hosts value\nhost2 is the current hosts value\n\n# will display the name and path of the current file\nfile1: /path1\nfile2: /path2\n\n# will display the users list of each file\nfile1: user1 user11\nfile2: user2\n\n# will display the current properties key/value pair\nprop1 -> value1\nprop2 -> value2\n```\n\n##### System variables\n\nSome `sys` dict variables (like `sys.ipv4`) are also accessible as string, for example:\n\n* `${sys.ipv4}` gives `54.32.12.4`\n* `$[sys.ipv4[ethO]}` gives `54.32.12.4`\n* `$[sys.ipv4[eth1]}` gives `10.45.3.2`\n\nThese variables are not accessible as dict in the templating data, but are represented as\nstring:\n\n* `ipv4` is a string variable in the `sys` dict with value `54.32.12.4`\n* `ipv4[ethO]` is a string variable in the `sys` dict with value `54.32.12.4`\n* `ipv4` is not accessible as a dict in the template\n\nTo access these value, use the following syntax in your jinja2 templates:\n\n```\nvars.sys['ipv4[eth0]']\n```",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "file_check_character_device",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_character_device.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file_name",
-        "new": "path"
-      }
-    ]
-  },
-  "condition_once": {
-    "name": "Condition once",
-    "bundle_name": "condition_once",
-    "bundle_args": [
-      "condition"
-    ],
-    "description": "Create a new condition only once",
-    "documentation": "This method define a condition named from the parameter **Condition** when it is\ncalled for the first time. Following agent execution will not define the\ncondition.\n\nThis allows executing actions only once on a given machine.\nThe created condition is global to the agent.\n\nIn case of reinstallation or factory-reset of the Rudder agent, this method \nwill no longer detect if the condition has already been defined.\n\n##### Example:\n\nIf you use:\n\n```\ncondition_once(\"my_condition\")\n```\n\nThe first agent run will have the condition `my_condition` defined, contrary to subsequent runs\nfor which no condition will be defined.\n\nSee also : [command\\_execution\\_once](#_command_execution_once)",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "condition_once",
-    "class_parameter": "condition",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/condition_once.cf",
-    "parameter": [
-      {
-        "name": "condition",
-        "description": "The condition to define",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_ensure_lines_absent": {
-    "name": "File ensure lines absent",
-    "bundle_name": "file_ensure_lines_absent",
-    "bundle_args": [
-      "path",
-      "lines"
-    ],
-    "description": "Ensure that a line is absent in a specific location",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_ensure_lines_absent",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_lines_absent.cf",
-    "deprecated": "Use [file_lines_absent](#_file_lines_absent) instead.",
-    "rename": "file_lines_absent",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "lines",
-        "description": "Line(s) to remove in the file",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file",
-        "new": "path"
-      }
-    ]
-  },
-  "kernel_module_enabled_at_boot": {
-    "name": "Kernel module enabled at boot",
-    "bundle_name": "kernel_module_enabled_at_boot",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Ensure that a given kernel module will be loaded at system boot",
-    "documentation": "Ensure that a given kernel module is enabled at boot on the system.\n This method only works on systemd systems.\n Rudder will look for a line matching the module name in a given section in the file:\n\n * `/etc/modules-load.d/enabled_by_rudder.conf` on systemd systems\n\n If the module is already enabled by a different option file than used by Rudder, it will add\n an entry in the file managed by Rudder listed above, and leave intact the already present one.\n The modifications are persistent and made line per line, meaning that\n this Generic Method will never remove lines in the configuration file but only add it if needed.\n\n Please note that this method will not load the module nor configure it, it will only enable its loading at system boot.\n If you want to force the module to be loaded, use instead the method `kernel_module_loaded`.\n If you want to configure the module, use instead the method `kernel_module_configuration`.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "kernel_module_enabled_at_boot",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/kernel_module_enabled_at_boot.cf",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Complete name of the kernel module, as seen by lsmod or listed in /proc/modules",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "module_name",
-        "new": "name"
-      }
-    ]
-  },
-  "variable_iterator": {
-    "name": "Variable iterator",
-    "bundle_name": "variable_iterator",
-    "bundle_args": [
-      "prefix",
-      "name",
-      "value",
-      "separator"
-    ],
-    "description": "Define a variable that will be automatically iterated over",
-    "documentation": "The generated variable is a special variable that is automatically\niterated over. When you call a generic method with this variable as a parameter, n calls will be made,\none for each items of the variable.\nNote: there is a limit of 10000 items \n\nTo use the generated variable, you must use the form `${prefix.name}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \nPlease note that only global variables are available within templates.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "variable_iterator",
-    "class_parameter": "name",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/variable_iterator.cf",
-    "parameter": [
-      {
-        "name": "prefix",
-        "description": "The prefix of the variable name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "name",
-        "description": "The variable to define, the full name will be prefix.name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "value",
-        "description": "The variable content",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "separator",
-        "description": "Regular expression that is used to split the value into items ( usually: , )",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": true,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "variable_prefix",
-        "new": "prefix"
-      },
-      {
-        "old": "variable_name",
-        "new": "name"
-      }
-    ]
-  },
-  "user_shell": {
-    "name": "User shell",
-    "bundle_name": "user_shell",
-    "bundle_args": [
-      "login",
-      "shell"
-    ],
-    "description": "Define the shell of the user. User must already exist.",
-    "documentation": "This method does not create the user.\n  entry example: /bin/false",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "user_shell",
-    "class_parameter": "login",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/user_shell.cf",
-    "parameter": [
-      {
-        "name": "login",
-        "description": "User's login",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "shell",
-        "description": "User's shell",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_ensure_line_present_in_ini_section": {
-    "name": "File ensure line in INI section",
-    "bundle_name": "file_ensure_line_present_in_ini_section",
-    "bundle_args": [
-      "path",
-      "section",
-      "line"
-    ],
-    "description": "Ensure that a line is present in a section in a specific location. The objective of this method is to handle INI-style files.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_ensure_line_present_in_ini_section",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_line_present_in_ini_section.cf",
-    "deprecated": "Use [file_line_present_in_ini_section](#_file_line_present_in_ini_section) instead.",
-    "rename": "file_line_present_in_ini_section",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "section",
-        "description": "Name of the INI-style section under which lines should be added (not including the [] brackets)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "line",
-        "description": "Line to ensure is present inside the section",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file",
-        "new": "path"
-      }
-    ]
-  },
-  "http_request_check_status_headers": {
-    "name": "HTTP request check status with headers",
-    "bundle_name": "http_request_check_status_headers",
-    "bundle_args": [
-      "method",
-      "url",
-      "expected_status",
-      "headers"
-    ],
-    "description": "Checks status of an HTTP URL",
-    "documentation": "Perform a HTTP request on the URL, method and headers provided and check that the response has the expected status code (ie 200, 404, 503, etc)",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "http_request_check_status_headers",
-    "class_parameter": "url",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/http_request_check_status_headers.cf",
-    "action": "We don't know when HTTP methods cause side effect, this can be an action or not depending on your server behaviour",
-    "parameter": [
-      {
-        "name": "method",
-        "description": "Method to call the URL (GET, POST, PUT, DELETE)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "url",
-        "description": "URL to query",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "expected_status",
-        "description": "Expected status code of the HTTP response",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "headers",
-        "description": "Headers to include in the HTTP request (as a string, without ')",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_enforce_content": {
-    "name": "File enforce content",
-    "bundle_name": "file_enforce_content",
-    "bundle_args": [
-      "path",
-      "lines",
-      "enforce"
-    ],
-    "description": "Enforce the content of a file",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "file_ensure_lines_present",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_enforce_content.cf",
-    "deprecated": "Use [file_content](#_file_content) instead.",
-    "rename": "file_content",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "lines",
-        "description": "Line(s) to add in the file - if lines is a list, please use @{lines} to pass the iterator rather than iterating over each values",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "enforce",
-        "description": "Enforce the file to contain only line(s) defined (true or false)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file",
-        "new": "path"
-      }
-    ]
-  },
-  "user_home": {
-    "name": "User home",
-    "bundle_name": "user_home",
-    "bundle_args": [
-      "login",
-      "home"
-    ],
-    "description": "Define the home of the user. User must already exists.",
-    "documentation": "This method does not create the user, nor the home directory.\n    entry example: /home/myuser\n    The home given will be set, but not created.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "user_home",
-    "class_parameter": "login",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/user_home.cf",
-    "parameter": [
-      {
-        "name": "login",
-        "description": "User's login",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "home",
-        "description": "User's home",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_check_socket": {
-    "name": "File check if socket",
-    "bundle_name": "file_check_socket",
-    "bundle_args": [
-      "path"
-    ],
-    "description": "Checks if a file exists and is a socket",
-    "documentation": "This bundle will define a condition `file_check_socket_${path}_{ok, reached, kept}` if the\nfile is a socket, or `file_check_socket_${path}_{not_ok, reached, not_kept, failed}` if\nthe file is not a socket or does not exist",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_check_socket",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_socket.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file_name",
-        "new": "path"
-      }
-    ]
-  },
-  "package_verify_version": {
-    "name": "Package verify version",
-    "bundle_name": "package_verify_version",
-    "bundle_args": [
-      "name",
-      "version"
-    ],
-    "description": "Verify if a package is installed in a specific version",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "package_install",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/package_verify_version.cf",
-    "deprecated": "Use [package_present](#_package_present) in audit mode",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Name of the package to verify",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "version",
-        "description": "Version of the package to verify (can be \"latest\" for latest version)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "package_name",
-        "new": "name"
-      },
-      {
-        "old": "package_version",
-        "new": "version"
-      }
-    ]
-  },
-  "sysctl_value": {
-    "name": "Sysctl value",
-    "bundle_name": "sysctl_value",
-    "bundle_args": [
-      "key",
-      "value",
-      "filename",
-      "option"
-    ],
-    "description": "Enforce a value in sysctl (optionally increase or decrease it)",
-    "documentation": "Enforce a value in sysctl\n\n#### Behaviors\n\nChecks for the current value defined for the given key\nIf it is not set, this method attempts to set it in the file defined as argument\nIf it is set, and corresponds to the desired value, it will success\nIf it is set, and does not correspond, the value will be set in the file defined, sysctl \nconfiguration is reloaded with `sysctl --system` and the \nresulting value is checked. \nIf it is not taken into account by sysctl because\nits overridden in another file or its an invalid key, the method returns an error\n\n#### Prerequisite\n\nThis method requires an /etc/sysctl.d folder, and the `sysctl --system` option.\nIt does not support Debian 6 or earlier, CentOS/RHEL 6 or earlier, SLES 11 or earlier,\nUbuntu 12_04 or earlier, AIX and Solaris.\n\n##### Parameters\n\n`key`   : the key to enforce/check\n`value` : the expected value for the key\n`filename` : filename (without extension) containing the key=value when need to be set, within /etc/sysctl.d.\n             This method adds the correct extension at the end of the filename\nOptional parameter:\n `min`: The value is the minimal value we request. the value is only changed if the current value is lower than `value`\n `max`: The value is the maximal value we request: the value is only changed if the current value is higher than `value`\n `default` (default value): The value is strictly enforced.\n\nComparison is numerical if possible, else alphanumerical\nSo 10 > 2, but Test10 < Test2\n\n#### Examples\n\nTo ensure that swappiness is disabled, and storing the configuration parameter in 99_rudder.conf\n\n```\n sysctl_value(\"vm.swappiness\", \"99_rudder\", \"0\", \"\")\n```\n\nTo ensure that the UDP buffer is at least 26214400\n\n```\n sysctl_value(\"net.core.rmem_max\", \"99_rudder\", \"26214400\", \"min\")\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "sysctl_value",
-    "class_parameter": "key",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/sysctl_value.cf",
-    "parameter": [
-      {
-        "name": "key",
-        "description": "The key to enforce",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "value",
-        "description": "The desired value",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "filename",
-        "description": "File name where to put the value in /etc/sysctl.d (without the .conf extension)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "option",
-        "description": "Optional modifier on value: Min, Max or Default (default value)",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "http_request_content_headers": {
-    "name": "HTTP request sending content with headers",
-    "bundle_name": "http_request_content_headers",
-    "bundle_args": [
-      "method",
-      "url",
-      "content",
-      "headers"
-    ],
-    "description": "Make an HTTP request with a specific header",
-    "documentation": "Perform a HTTP request on the URL, method and headers provided\nand send the content provided. Will return an error if the request failed.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "http_request_content_headers",
-    "class_parameter": "url",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/http_request_content_headers.cf",
-    "action": "We don't know when HTTP methods cause side effect, this can be an action or not depending on your server behavior",
-    "parameter": [
-      {
-        "name": "method",
-        "description": "Method to call the URL (POST, PUT)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "url",
-        "description": "URL to send content to",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "content",
-        "description": "Content to send",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "headers",
-        "description": "Headers to include in the HTTP request",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "package_remove": {
-    "name": "Package remove",
-    "bundle_name": "package_remove",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Remove a package",
-    "documentation": "*Example*:\n```\nmethods:\n    \"any\" usebundle => package_remove(\"htop\");\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "package_remove",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/package_remove.cf",
-    "deprecated": "Use [package_absent](#_package_absent) instead.",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Name of the package to remove",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "package_name",
-        "new": "name"
-      }
-    ]
-  },
-  "permissions_posix_acls_absent": {
-    "name": "Permissions POSIX ACLs absent",
-    "bundle_name": "permissions_posix_acls_absent",
-    "bundle_args": [
-      "path",
-      "recursive"
-    ],
-    "description": "Ensure that files or directories has no ACLs set",
-    "documentation": "The `permissions_*acl_*` manage the POSIX ACL on files and directories.\n\n#### Parameters\n\n##### Path\n\nPath can be globbing with the following format:\n\n* * matches any filename or directory at one level, e.g. *.cf will match all files in one directory that end in .cf but it won't search across directories. */*.cf on the other hand will look two levels deep.\n* ? matches a single letter\n* [a-z] matches any letter from a to z\n* {x,y,anything} will match x or y or anything.\n\n##### Recursive\n\nCan be:\n\n* `true` to apply the given aces to folder and sub-folders and files.\n* or `false` to apply to the strict match of `Path`\n\nIf left blank, recursivity will automatically be set to `false`\n\n#### Example\nThe method has basically the same effect as `setfacl -b <path>`.\n\nGiven a file with the following getfacl output:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\nuser:vagrant:rwx\ngroup::r--\nmask::rwx\nother::---\n\n~~~~\n\nIt will remove all ACLs, and only let classic rights, here:\n\n~~~~\nroot@server# getfacl myTestFile \n# file: myTestFile\n# owner: root\n# group: root\nuser::rwx\ngroup::r--\nother::---\n\nroot@server# ls -l myTestFile\n-rwxr----- 1 root root 0 Mar 22 11:24 myTestFile\nroot@server# \n\n~~~~",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "permissions_posix_acls_absent",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_posix_acls_absent.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Path of the file or directory",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "recursive",
-        "description": "Should ACLs cleanup be recursive, \"true\" or \"false\" (defaults to \"false\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "true",
-            "false"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "permissions_user_acl_absent": {
-    "name": "Permissions user POSIX acl entry absent",
-    "bundle_name": "permissions_user_acl_absent",
-    "bundle_args": [
-      "path",
-      "recursive",
-      "user"
-    ],
-    "description": "Verify that an ace is absent on a file or directory for a given user.\nThis method will make sure that no ace is present in the POSIX ACL of the target.",
-    "documentation": "The `permissions_*acl_*` manage the POSIX ACL on files and directories.\n\nPlease note that the mask will be automatically recalculated when editing ACLs.\n\n#### Parameters\n\n##### Path\n\nPath can be a regex with the following format:\n\n* `*` matches any filename or directory at one level, e.g. `*.cf` will match all files in one directory that end in .cf but it won't search across directories. `*/*.cf` on the other hand will look two levels deep.\n* `?` matches a single letter\n* `[a-z]` matches any letter from a to z\n* `{x,y,anything}` will match x or y or anything.\n\n##### Recursive\n\nCan be:\n\n* `true` to apply the given aces to folder and sub-folders and files.\n* or `false` to apply to the strict match of `Path`\n\nIf left blank, recursivity will automatically be set to `false`\n\n##### User\n\n`Username` to enforce the ace absence, being the Linux account name.\nThis method can only handle one username.\n\n#### Example\n\nGiven a file with the following getfacl output:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\nuser:bob:rwx\ngroup::r--\nmask::rwx\nother::---\n\n~~~~\n\nApplying this method with the following parameters:\n\n* `path`: /tmp/myTestFile\n* `recursive`: false\n* `user`: bob\n\nWill transform the previous ACLs in:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\ngroup::r--\nmask::r--\nother::---\n\n~~~~",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "permissions_user_acl_absent",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_user_acl_absent.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Path of the file or directory",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "recursive",
-        "description": "Recursive Should ACLs cleanup be recursive, \"true\" or \"false\" (defaults to \"false\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "true",
-            "false"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "user",
-        "description": "Username of the Linux account.",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_report_content_tail": {
-    "name": "File report content tail",
-    "bundle_name": "file_report_content_tail",
-    "bundle_args": [
-      "path",
-      "limit"
-    ],
-    "description": "Report the tail of a file",
-    "documentation": "Report the tail of a file.\n\nThis method does nothing on the system, but only reports a partial content\nfrom a given file. This allows centralizing this information on the server, and avoid\nhaving to connect on each node to get this information.\n\nNOTE: This method only works in \"Full Compliance\" reporting mode.\n\n#### Parameters\n\n##### Target\n\nThis is the file you want to report content from. The method will return an error if it\ndoes not exist.\n\n##### Limit\n\nThe number of line to report.\n\n#### Examples\n\n```\n# To get the 3 first line of /etc/hosts\nfile_report_content(\"/etc/hosts\", \"3\");\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_report_content_tail",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_report_content_tail.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File to report content from",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "limit",
-        "description": "Number of lines to report (default is 10)",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "regex": "^\\d*$",
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "target",
-        "new": "path"
-      }
-    ]
-  },
-  "file_check_symlinkto": {
-    "name": "File check is symlink to",
-    "bundle_name": "file_check_symlinkto",
-    "bundle_args": [
-      "path",
-      "target"
-    ],
-    "description": "Checks if first file is symlink to second file",
-    "documentation": "This bundle will define a condition `file_check_symlinkto_${target}_{ok, reached, kept}` if the file `${path}`\nis a symbolic link to `${target}`, or `file_check_symlinkto_${target}_{not_ok, reached, not_kept, failed}` if\nif it is not a symbolic link, or any of the files does not exist. The symlink's path is resolved to the \nabsolute path and checked against the target file's path, which must also be an absolute path.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_check_symlinkto",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_symlinkto.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Symbolic link (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "target",
-        "description": "Target file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "symlink",
-        "new": "path"
-      }
-    ]
-  },
-  "variable_dict_from_osquery": {
-    "name": "Variable dict from osquery",
-    "bundle_name": "variable_dict_from_osquery",
-    "bundle_args": [
-      "prefix",
-      "name",
-      "query"
-    ],
-    "description": "Define a variable that contains key,value pairs (a dictionary) from an osquery query",
-    "documentation": "To use the generated variable, you must use the form `${prefix.name[key]}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \nPlease note that only global variables are available within templates.\n\nThis method will define a dict variable from the output of an osquery query.\nThe query will be executed at every agent run, and its result will be usable as a standard\ndict variable.\n\n#### Setup\n\nThis method requires the presence of [osquery](https://osquery.io/) on the target nodes.\nIt won't install it automatically. Check the correct way of doing so for your OS.\n\n#### Building queries\n\nTo learn about the possible queries, read the [osquery schema](https://osquery.io/schema/) for your\nosquery version.\n\nYou can test the queries before using them with the `osqueryi` command, see the example below.\n\n#### Examples\n\n```\n# To get the number of cpus on the machine\nvariable_dict_from_osquery(\"prefix\", \"var1\", \"select cpu_logical_cores from system_info;\");\n```\n\nIt will produce the dict from the output of:\n\n```\nosqueryi --json \"select cpu_logical_cores from system_info;\"\n```\n\nHence something like:\n\n```json\n[\n {\"cpu_logical_cores\":\"8\"}\n]\n```\n\nTo access this value, use the `${prefix.var1[0][cpu_logical_cores]}` syntax.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "variable_dict_from_osquery",
-    "class_parameter": "name",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/variable_dict_from_osquery.cf",
-    "parameter": [
-      {
-        "name": "prefix",
-        "description": "The prefix of the variable name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "name",
-        "description": "The variable to define, the full name will be prefix.name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "query",
-        "description": "The query to execute (ending with a semicolon)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "variable_prefix",
-        "new": "prefix"
-      },
-      {
-        "old": "variable_name",
-        "new": "name"
-      }
-    ]
-  },
-  "permissions_type_recursion": {
-    "name": "Permissions type recursion",
-    "bundle_name": "permissions_type_recursion",
-    "bundle_args": [
-      "path",
-      "mode",
-      "owner",
-      "group",
-      "type",
-      "recursion"
-    ],
-    "description": "Ensure that a file or directory is present and has the right mode/owner/group",
-    "documentation": "The method ensure that all files|directories|files and directories have\nthe correct owner, group owner and permissions.\n\nThe parameter *type* can be either: \"*all*\", \"*files*\" or \"*directories*\".\nThe parameter *recursion* can be either: \"*0,1,2,3,.... inf*\"\nThe level of recursion is the maximum depth of subfolder that will be managed by the method:\n\n* 0 being the current folder/file\n* 1 being the current folder/file and its subfolders\n* ..\n* inf being the file or the whole folder tree",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "permissions",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_type_recursion.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Path to edit",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "mode",
-        "description": "Mode of the path to edit",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "owner",
-        "description": "Owner of the path to edit",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "group",
-        "description": "Group of the path to edit",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "type",
-        "description": "Type of the path to edit (all/files/directories)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "recursion",
-        "description": "Recursion depth to enforce for this path (0, 1, 2, ..., inf)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "sharedfile_from_node": {
-    "name": "Sharedfile from node",
-    "bundle_name": "sharedfile_from_node",
-    "bundle_args": [
-      "remote_node",
-      "file_id",
-      "file_path"
-    ],
-    "description": "This method retrieves a file shared from another Rudder node",
-    "documentation": "This method retrieves a file shared from a Rudder node using a unique file identifier.\n\nThe file will be downloaded using native agent protocol and copied into a new file.\nThe destination path must be the complete absolute path of the destination file.\n\nSee [sharedfile_to_node](#_sharedfile_to_node) for a complete example.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "sharedfile_from_node",
-    "class_parameter": "file_id",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/sharedfile_from_node.cf",
-    "parameter": [
-      {
-        "name": "remote_node",
-        "description": "Which node to take the file from",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "file_id",
-        "description": "Unique name that was used to identify the file on the sender",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "regex": "^[A-z0-9._-]+$",
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "file_path",
-        "description": "Where to put the file content",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "source_uuid",
-        "new": "remote_node"
-      }
-    ]
-  },
-  "variable_dict_merge_tolerant": {
-    "name": "Variable dict merge tolerant",
-    "bundle_name": "variable_dict_merge_tolerant",
-    "bundle_args": [
-      "prefix",
-      "name",
-      "first_variable",
-      "second_variable"
-    ],
-    "description": "Define a variable resulting of the merge of two other variables, allowing merging undefined variables",
-    "documentation": "To use the generated variable, you must use the form `${prefix.name[key]}` with each name replaced with the parameters of this method.\n\nSee [variable_dict_merge](#_variable_dict_merge) for usage documentation. The only difference is that this method\nwill not fail if one of the variables do not exist, and will return the other one. If both are undefined, the method will still fail.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "variable_dict_merge_tolerant",
-    "class_parameter": "name",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/variable_dict_merge_tolerant.cf",
-    "parameter": [
-      {
-        "name": "prefix",
-        "description": "The prefix of the variable name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "name",
-        "description": "The variable to define, the full name will be prefix.name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "first_variable",
-        "description": "The first variable, which content will be overridden in the resulting variable if necessary (written in the form prefix.name)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "second_variable",
-        "description": "The second variable, which content will override the first in the resulting variable if necessary (written in the form prefix.name)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "variable_prefix",
-        "new": "prefix"
-      },
-      {
-        "old": "variable_name",
-        "new": "name"
-      }
-    ]
-  },
-  "permissions_ntfs": {
-    "name": "Permissions NTFS",
-    "bundle_name": "permissions_ntfs",
-    "bundle_args": [
-      "path",
-      "user",
-      "rights",
-      "accesstype",
-      "propagationpolicy"
-    ],
-    "description": "Ensure NTFS permissions on a file for a given user.",
-    "documentation": "Ensure that the correct NTFS permissions are applied on a file for a given user.\n\n Inheritance and propagation flags can also be managed. If left blank, no propagation will be set.\n\n To manage effective propagation or effective access, please disable the inheritance on the file before\n applying this generic method.\n\n Note: that the `Synchronize` permission may not work in some cases. This is a known bug.\n\n Right validate set:\n\n   None, ReadData, ListDirectory, WriteData, CreateFiles, AppendData, CreateDirectories, ReadExtendedAttributes,\n   WriteExtendedAttributes, ExecuteFile, Traverse, DeleteSubdirectoriesAndFiles, ReadAttributes, WriteAttributes, Write,\n   Delete, ReadPermissions, Read, ReadAndExecute, Modify, ChangePermissions, TakeOwnership, Synchronize, FullControl\n\n AccessType validate set:\n\n   Allow, Deny\n\n PropagationPolicy validate set:\n\n   ThisFolderOnly, ThisFolderSubfoldersAndFiles, ThisFolderAndSubfolders, ThisFolderAndFiles, SubfoldersAndFilesOnly,\n   SubfoldersOnly, FilesOnly",
-    "agent_support": [
-      "dsc"
-    ],
-    "class_prefix": "permissions_ntfs",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/permissions_ntfs.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File path",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "user",
-        "description": "DOMAIN\\Account",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "rights",
-        "description": "Comma separated right list",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "accesstype",
-        "description": "\"Allow\" or \"Deny\"",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "Allow",
-            "Deny",
-            ""
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "propagationpolicy",
-        "description": "Define the propagation policy of the access rule that Rudder is applying",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "ThisFolderOnly",
-            "ThisFolderSubfoldersAndFiles",
-            "ThisFolderAndSubfolders",
-            "ThisFolderAndFiles",
-            "SubfoldersAndFilesOnly",
-            "SubfoldersOnly",
-            "FilesOnly",
-            ""
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "kernel_module_not_loaded": {
-    "name": "Kernel module not loaded",
-    "bundle_name": "kernel_module_not_loaded",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Ensure that a given kernel module is not loaded on the system",
-    "documentation": "Ensure that a given kernel module is not loaded on the system.\n  If the module is loaded, it will try to unload it using modprobe.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "kernel_module_not_loaded",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/kernel_module_not_loaded.cf",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Complete name of the kernel module, as seen by lsmod or listed in /proc/modules",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "module_name",
-        "new": "name"
-      }
-    ]
-  },
-  "report_if_condition": {
-    "name": "Report if condition",
-    "bundle_name": "report_if_condition",
-    "bundle_args": [
-      "report_message",
-      "condition"
-    ],
-    "description": "Report a Rudder report based on a condition.",
-    "documentation": "This method will only send a Rudder report:\n\nIf the **condition** is met, it will report a compliant report, with the following message:\n`**<report_message>** was correct.`\n\nOtherwise, it will report an error, with the following message:\n`**report_message** was incorrect`\n\nThis method will never be in a repaired state.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "report_if_condition",
-    "class_parameter": "report_message",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/report_if_condition.cf",
-    "action": "",
-    "parameter": [
-      {
-        "name": "report_message",
-        "description": "Message subject, will be extended based on the report status",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "condition",
-        "description": "Condition to report a success",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "windows_component_absent": {
-    "name": "Windows component absent",
-    "bundle_name": "windows_component_absent",
-    "bundle_args": [
-      "component"
-    ],
-    "description": "Ensure that a specific windows component is absent from the system.",
-    "documentation": "Ensure that a specific windows component is absent from the system.",
-    "agent_support": [
-      "dsc"
-    ],
-    "class_prefix": "windows_component_absent",
-    "class_parameter": "component",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/windows_component_absent.cf",
-    "parameter": [
-      {
-        "name": "component",
-        "description": "Windows component name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "variable_string_from_file": {
-    "name": "Variable string from file",
-    "bundle_name": "variable_string_from_file",
-    "bundle_args": [
-      "prefix",
-      "name",
-      "file_name"
-    ],
-    "description": "Define a variable from a file content",
-    "documentation": "To use the generated variable, you must use the form `${variable_prefix.variable_name}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \nPlease note that only global variables are available within templates.",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "variable_string_from_file",
-    "class_parameter": "name",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/variable_string_from_file.cf",
-    "parameter": [
-      {
-        "name": "prefix",
-        "description": "The prefix of the variable name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "name",
-        "description": "The variable to define, the full name will be variable_prefix.variable_name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "file_name",
-        "description": "The path of the file",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "variable_prefix",
-        "new": "prefix"
-      },
-      {
-        "old": "variable_name",
-        "new": "name"
-      }
-    ]
-  },
-  "file_ensure_key_value_option": {
-    "name": "File ensure key -> value present with option",
-    "bundle_name": "file_ensure_key_value_option",
-    "bundle_args": [
-      "path",
-      "key",
-      "value",
-      "separator",
-      "option"
-    ],
-    "description": "Ensure that the file contains a pair of \"key separator value\", with options on the spacing around the separator",
-    "documentation": "Edit (or create) the file, and ensure it contains an entry key -> value with arbitrary separator between the key and its value.\nIf the key is already present, the method will change the value associated with this key.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_ensure_key_value",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_key_value_option.cf",
-    "deprecated": "Use [file_key_value_present_option](#_file_key_value_present_option) instead.",
-    "rename": "file_key_value_present_option",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "key",
-        "description": "Key to define",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "value",
-        "description": "Value to define",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "option",
-        "description": "Option for the spacing around the separator: strict, which prevent spacing (space or tabs) around separators, or lax which accepts any number of spaces around separators",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "select": [
-            "strict",
-            "lax"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "separator",
-        "description": "Separator between key and value, for example \"=\" or \" \" (without the quotes)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": true,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file",
-        "new": "path"
-      }
-    ]
-  },
-  "file_from_shared_folder": {
-    "name": "File copy from Rudder shared folder",
-    "bundle_name": "file_from_shared_folder",
-    "bundle_args": [
-      "source",
-      "path",
-      "hash_type"
-    ],
-    "description": "Ensure that a file or directory is copied from the Rudder shared folder.",
-    "documentation": "Ensure that a file or directory is copied from the Rudder shared folder.\nThe Rudder shared folder is located on the Rudder server under `/var/rudder/configuration-repository/shared-files`.\nEvery file/folder in the shared folder will be available for every managed node.\nThis method will download and update the destination file from a source taken from this shared folder.\nA file in the shared folder will be updated on the node side at agent run.",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "file_from_shared_folder",
+    "class_prefix": "file_from_template",
     "class_parameter": "path",
     "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_shared_folder.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_template_jinja2.cf",
     "parameter": [
       {
-        "name": "source",
-        "description": "Source file (path, relative to /var/rudder/configuration-repository/shared-files)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "Destination file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "hash_type",
-        "description": "Hash algorithm used to check if file is updated (sha256, sha512). Only used on Windows, ignored on Unix. default is sha256",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "sha256",
-            "sha512",
-            "md5",
-            "sha1"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "destination",
-        "new": "path"
-      }
-    ]
-  },
-  "file_copy_from_remote_source": {
-    "name": "File copy from remote source",
-    "bundle_name": "file_copy_from_remote_source",
-    "bundle_args": [
-      "source",
-      "path"
-    ],
-    "description": "Ensure that a file or directory is copied from a policy server",
-    "documentation": "*Note*: This method uses the native agent copy protocol, and can only download files from\nthe policy server. To download a file from an external source, you can use\nHTTP with the [file_download](#_file_download) method.\n\nThis method requires that the policy server is configured to accept\ncopy of the source file from the agents it will be applied to.\n\nYou can download a file from the shared files with:\n\n```\n/var/rudder/configuration-repository/shared-files/PATH_TO_YOUR_FILE\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_copy_from_remote_source",
-    "class_parameter": "path",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_copy_from_remote_source.cf",
-    "deprecated": "Use [file_from_remote_source](#_file_from_remote_source) instead.",
-    "rename": "file_from_remote_source",
-    "parameter": [
-      {
-        "name": "source",
-        "description": "Source file (absolute path on the policy server)",
+        "name": "source_template",
+        "description": "Source file containing a template to be expanded (absolute path on the target node)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -6836,36 +7403,27 @@
       }
     ]
   },
-  "file_lines_present": {
-    "name": "File lines present",
-    "bundle_name": "file_lines_present",
+  "service_ensure_started_at_boot": {
+    "name": "Service ensure started at boot",
+    "bundle_name": "service_ensure_started_at_boot",
     "bundle_args": [
-      "path",
-      "lines"
+      "name"
     ],
-    "description": "Ensure that one or more lines are present in a file",
+    "description": "Force a service to be started at boot",
     "agent_support": [
       "cfengine-community",
       "dsc"
     ],
-    "class_prefix": "file_lines_present",
-    "class_parameter": "path",
+    "class_prefix": "service_ensure_started_at_boot",
+    "class_parameter": "name",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_lines_present.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_ensure_started_at_boot.cf",
+    "deprecated": "Use [service_enabled](#_service_enabled) instead.",
+    "rename": "service_enabled",
     "parameter": [
       {
-        "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "lines",
-        "description": "Line(s) to add in the file",
+        "name": "name",
+        "description": "Service name (as recognized by systemd, init.d, Windows, SRC, SMF, etc...)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -6876,8 +7434,8 @@
     ],
     "parameter_rename": [
       {
-        "old": "file",
-        "new": "path"
+        "old": "service_name",
+        "new": "name"
       }
     ]
   },
@@ -6981,624 +7539,6 @@
       }
     ]
   },
-  "file_symlink_present": {
-    "name": "Symlink present",
-    "bundle_name": "file_symlink_present",
-    "bundle_args": [
-      "source",
-      "path"
-    ],
-    "description": "Create a symlink at a destination path and pointing to a source target except if a file or directory already exists.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_symlink_present",
-    "class_parameter": "path",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_symlink_present.cf",
-    "parameter": [
-      {
-        "name": "source",
-        "description": "Source file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "Destination file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "destination",
-        "new": "path"
-      }
-    ]
-  },
-  "file_from_http_server": {
-    "name": "File from HTTP server",
-    "bundle_name": "file_from_http_server",
-    "bundle_args": [
-      "source",
-      "path"
-    ],
-    "description": "Download a file if it does not exist, using curl with a fallback on wget",
-    "documentation": "This method finds a HTTP command-line tool and downloads the given source\ninto the destination if it does not exist yet.\n\nThis method **will NOT update the file after the first download** until its removal.\n\nOn Linux based nodes it will tries `curl` first and fallback with `wget` if needed.\nOn Windows based nodes, only `curl` will be used.",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "file_from_http_server",
-    "class_parameter": "path",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_http_server.cf",
-    "parameter": [
-      {
-        "name": "source",
-        "description": "URL to download from",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "File destination (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "destination",
-        "new": "path"
-      }
-    ]
-  },
-  "file_create_symlink_force": {
-    "name": "Create symlink (force overwrite)",
-    "bundle_name": "file_create_symlink_force",
-    "bundle_args": [
-      "source",
-      "path"
-    ],
-    "description": "Create a symlink at a destination path and pointing to a source target even if a file or directory already exists.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_create_symlink",
-    "class_parameter": "path",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_create_symlink_force.cf",
-    "deprecated": "Use [file_symlink_present_force](#_file_symlink_present_force) instead.",
-    "rename": "file_symlink_present_force",
-    "parameter": [
-      {
-        "name": "source",
-        "description": "Source file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "Destination file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "destination",
-        "new": "path"
-      }
-    ]
-  },
-  "permissions_posix_acl_entry_parent": {
-    "name": "Permissions POSIX ACLs entry parent",
-    "bundle_name": "permissions_posix_acl_entry_parent",
-    "bundle_args": [
-      "path",
-      "recursive",
-      "user",
-      "group",
-      "other",
-      "parent_permissions_user",
-      "parent_permissions_group",
-      "parent_permissions_other"
-    ],
-    "description": "Ensure ACL on a file or folder and all its parent folders",
-    "documentation": "Ensure ACL on a file or folder and all its parent folders.\n\n\nForce the given ACL on the target `path` (supports globbing).\n\n* If `recursive` is set to `true`, the permissions will be applied to\n  every files and folder under the resolved `path` input.\n* If the `parent_permissions_*` inputs are not empty, they will be applied to every parent folders\n  to the resolved `path` input, excepting the root folder `/`.\n* ACL inputs are expected to be comma separated, and to follow this schema:\n  * `myuser:wx` to force the ACL entry\n  * `myuser:+wx` to edit the ACL without enforcing them all\n\nIf the `path` input resolves to `/this/is/my/path/mylogfile`, parent folders permissions will be applied to:\n```\n/this\n/this/is\n/this/is/my\n/this/is/my/path/\n```\n\n#### Examples:\n\n```yaml\n-name: Allows bob to write in its logfile\n method: permissions_posix_acl_entry_parent\n   path: /this/is/my/path/mylogfile\n   recursive: false\n   user: \"bob:rwx\"\n   parent_permissions_user: \"bob:rx\"\n\n```\n\n```yaml\n-name: Allows Bob and Alice to write in its logfile\n method: permissions_posix_acl_entry_parent\n   path: /this/is/my/path/mylogfile\n   recursive: false\n   user: \"bob:rwx,alice:+rwx\"\n   parent_permissions_user: \"bob:rx,alice:rx\"\n\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "permissions_posix_acl_entry_parent",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_posix_acl_entry_parent.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Path of the file or directory",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "recursive",
-        "description": "Recursive Should ACLs cleanup be recursive, \"true\" or \"false\" (defaults to \"false\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "true",
-            "false"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "user",
-        "description": "User acls, comma separated, like: bob:+rwx, alice:-w",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "group",
-        "description": "Group acls, comma separated, like: wheel:+wx, anon:-rwx",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "other",
-        "description": "Other acls, like -x",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "parent_permissions_user",
-        "description": "User acls, comma separated, like: bob:+rwx, alice:-w",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "parent_permissions_group",
-        "description": "Group acls, comma separated, like: wheel:+wx, anon:-rwx",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "parent_permissions_other",
-        "description": "Other acls, like -x",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "audit_from_powershell_execution": {
-    "name": "Audit from Powershell execution",
-    "bundle_name": "audit_from_powershell_execution",
-    "bundle_args": [
-      "command",
-      "successRegex"
-    ],
-    "description": "Execute a Powershell command, script or binary (even in audit mode) and parse its output to report a succes or an error.",
-    "documentation": "Execute either a command, a script or a binary even in audit mode - it supports piping.\n \n \nIt will:\n\n* report a success if the execution succeeds and the output matches the given regex.\n* report an error otherwise.\n\nPowershell scripts exiting with non-zero return codes will be flagged as failed.\n \n\nNote: the command will be executed even in Audit mode, it is up to you to make sure it does not impact the system at all.\n\nNote: the regular expression/string to compare to the output are not anchored and are case insensitive.\n\nExamples:\n\nTo return success if process `explorer` is running, the `command` parameter needs to be\n\n```\nGet-Process | ForEach { ${const.dollar}_.ProcessName }\n```\n\nas the output of the command is a toString() on the generated objects, so you need to extract the relevant data. And the `successRegex` needs to be `explorer`.",
-    "agent_support": [
-      "dsc"
-    ],
-    "class_prefix": "audit_from_powershell_execution",
-    "class_parameter": "command",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/audit_from_powershell_execution.cf",
-    "parameter": [
-      {
-        "name": "command",
-        "description": "Command or script to execute",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "successRegex",
-        "description": "String or regular expression to compare the output with to define success",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_ensure_block_present": {
-    "name": "File ensure block present",
-    "bundle_name": "file_ensure_block_present",
-    "bundle_args": [
-      "path",
-      "block"
-    ],
-    "description": "Ensure that a text block is present in a specific location",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_ensure_block_present",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_block_present.cf",
-    "deprecated": "Use [file_block_present](#_file_block_present) instead.",
-    "rename": "file_block_present",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "block",
-        "description": "Block(s) to add in the file",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file",
-        "new": "path"
-      }
-    ]
-  },
-  "user_password_hash": {
-    "name": "User password hash",
-    "bundle_name": "user_password_hash",
-    "bundle_args": [
-      "login",
-      "password"
-    ],
-    "description": "Ensure a user's password. Password must respect `$id$salt$hashed` format\n as used in the UNIX /etc/shadow file.",
-    "documentation": "User must exists, password must be pre-hashed. Does not handle\n  empty password accounts. See UNIX /etc/shadow format.\n  entry example: `$1$jp5rCMS4$mhvf4utonDubW5M00z0Ow0`\n  \n  An empty password will lead to an error and be notified.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "user_password_hash",
-    "class_parameter": "login",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/user_password_hash.cf",
-    "parameter": [
-      {
-        "name": "login",
-        "description": "User login",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "password",
-        "description": "User hashed password",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "permissions_dirs_recursive": {
-    "name": "Permissions dirs recursive",
-    "bundle_name": "permissions_dirs_recursive",
-    "bundle_args": [
-      "path",
-      "mode",
-      "owner",
-      "group"
-    ],
-    "description": "Verify if a directory and its content have the right permissions recursively",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "permissions",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_dirs_recursive.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Path to the directory",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "mode",
-        "description": "Mode to enforce",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "owner",
-        "description": "Owner to enforce",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "group",
-        "description": "Group to enforce",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_from_template_jinja2": {
-    "name": "File from a jinja2 template",
-    "bundle_name": "file_from_template_jinja2",
-    "bundle_args": [
-      "source_template",
-      "path"
-    ],
-    "description": "Build a file from a jinja2 template",
-    "documentation": "See [file_from_template_type](#_file_from_template_type) for general documentation about\ntemplates usage.\n\nThis generic method will build a file from a jinja2 template\nusing data (conditions and variables) found in the execution context.\n\n\n#### Setup\n\nIt requires to have the jinja2 python module installed on the node, it can usually be done in ncf with\n`package_present(\"python-jinja2\", \"\", \"\", \"\")`.\n\nWARNING: If you are using a jinja2 version older than 2.7\n         trailing newlines will not be preserved in the destination file.\n\n#### Syntax\n\nJinja2 is a powerful templating language, running in Python.\nThe Jinja2 syntax reference documentation is [http://jinja.pocoo.org/docs/dev/templates/](http://jinja.pocoo.org/docs/dev/templates/)\nwhich will likely be useful, as Jinja2 is very rich and allows a lot more\nthat what is explained here.\n\nThis section presents some simple cases that cover what can be done with mustache templating,\nand the way the agent data is provided to the templating engine.\n\nThe main specificity of jinja2 templating is the use of two root containers:\n\n* `classes` to access currently defined conditions\n* `vars` to access all currently defined variables\n\nNote: You can add comments in the template, that will not be rendered in the output file with\n`{# ... #}`.\n\nYou can extend the Jinja2 templating engine by adding custom FILTERS and TESTS in the script\n`/var/rudder/configuration-repository/ncf/10_ncf_internals/modules/extensions/jinja2_custom.py`\n\nFor instance, to add a filter to uppercase a string and a test if a number is odd, you can create\nthe file `/var/rudder/configuration-repository/ncf/10_ncf_internals/modules/extensions/jinja2_custom.py`\non your Rudder server with the following content:\n\n```\ndef uppercase(input):\n    return input.upper()\n\ndef odd(value):\n    return True if (value % 2) else False\n\nFILTERS = {'uppercase': uppercase}\nTESTS = {'odd': odd}\n```\n\nThese filters and tests will be usable in your jinja2 templates automatically.\n\n##### Conditions\n\nTo display content based on conditions definition:\n\n```jinja2\n{% if classes.my_condition is defined  %}\n   display this if defined\n{% endif %}\n{% if not classes.my_condition is defined %}\n   display this if not defined\n{% endif %}\n```\n\nNote: You cannot use condition expressions here.\n\nYou can also use other tests, for example other built-in ones or\nthose defined in `jinja2_custom.py`:\n\n```jinja2\n{% if vars.variable_prefix.my_number is odd  %}\n   display if my_number is odd\n{% endif %}\n```\n\n##### Scalar variables\n\nHere is how to display a scalar variable value (integer, string, ...),\nif you have defined `variable_string(\"variable_prefix\", \"my_variable\", \"my_value\")`:\n\n```jinja2\n{{ vars.variable_prefix.my_variable }}\n```\n\nYou can also modify what is displayed by using filters. The built-in filters\ncan be extended in `jinja2_custom.py`:\n\n```jinja2\n{{ vars.variable_prefix.my_variable | uppercase }}\n```\n\nWill display the variable in uppercase.\n\n##### Iteration\n\nTo iterate over a list, for example defined with:\n\n```\nvariable_iterator(\"variable_prefix\", \"iterator_name\", \"a,b,c\", \",\")\n```\n\nUse the following file:\n\n```jinja2\n{% for item in vars.variable_prefix.iterator_name %}\n{{ item }} is the current iterator_name value\n{% endfor %}\n```\n\nWhich will be expanded as:\n\n```\na is the current iterator_name value\nb is the current iterator_name value\nc is the current iterator_name value\n```\n\nTo iterate over a container defined by the following json file, loaded with\n`variable_dict_from_file(\"variable_prefix\", \"dict_name\", \"path\")`:\n\n```json\n{\n   \"hosts\": [\n       \"host1\",\n       \"host2\"\n   ],\n   \"files\": [\n       {\"name\": \"file1\", \"path\": \"/path1\", \"users\": [ \"user1\", \"user11\" ] },\n       {\"name\": \"file2\", \"path\": \"/path2\", \"users\": [ \"user2\" ] }\n   ],\n   \"properties\": {\n       \"prop1\": \"value1\",\n       \"prop2\": \"value2\"\n   }\n}\n```\n\nUse the following template:\n\n```jinja2\n{% for item in vars.variable_prefix.dict_name.hosts %}\n{{ item }} is the current hosts value\n{% endfor %}\n\n# will display the name and path of the current file\n{% for file in vars.variable_prefix.dict_name.files %}\n{{ file.name }}: {{ file.path }}\n{% endfor %}\n\n# will display the users list of each file\n{% for file in vars.variable_prefix.dict_name.files %}\n{{ file.name }}: {{ file.users|join(' ') }}\n{% endfor %}\n\n\n# will display the current properties key/value pair\n{% for key, value in vars.variable_prefix.dict_name.properties.items() %}\n{{ key }} -> {{ value }}\n{% endfor %}\n\n```\n\nWhich will be expanded as:\n\n```\nhost1 is the current hosts value\nhost2 is the current hosts value\n\n# will display the name and path of the current file\nfile1: /path1\nfile2: /path2\n\n# will display the users list of each file\nfile1: user1 user11\nfile2: user2\n\n# will display the current properties key/value pair\nprop1 -> value1\nprop2 -> value2\n```\n\n##### System variables\n\nSome `sys` dict variables (like `sys.ipv4`) are also accessible as string, for example:\n\n* `${sys.ipv4}` gives `54.32.12.4`\n* `$[sys.ipv4[ethO]}` gives `54.32.12.4`\n* `$[sys.ipv4[eth1]}` gives `10.45.3.2`\n\nThese variables are not accessible as dict in the templating data, but are represented as\nstring:\n\n* `ipv4` is a string variable in the `sys` dict with value `54.32.12.4`\n* `ipv4[ethO]` is a string variable in the `sys` dict with value `54.32.12.4`\n* `ipv4` is not accessible as a dict in the template\n\nTo access these value, use the following syntax in your jinja2 templates:\n\n```\nvars.sys['ipv4[eth0]']\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_from_template",
-    "class_parameter": "path",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_template_jinja2.cf",
-    "parameter": [
-      {
-        "name": "source_template",
-        "description": "Source file containing a template to be expanded (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "Destination file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "destination",
-        "new": "path"
-      }
-    ]
-  },
-  "file_from_local_source_recursion": {
-    "name": "File from local source recursion",
-    "bundle_name": "file_from_local_source_recursion",
-    "bundle_args": [
-      "source",
-      "path",
-      "recursion"
-    ],
-    "description": "Ensure that a file or directory is copied from a local source",
-    "documentation": "Ensure that a file or directory is copied from a local source.\nIf the source is a directory, you can force a maximum level of copy recursion.\n\n* *0* being no recursion, which will only create an empty folder\n* *inf* being a complete recursive copy of the folder\n* *1,2,3,...* will force the maximal level of recursion to copy",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_from_local_source",
-    "class_parameter": "path",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_local_source_recursion.cf",
-    "parameter": [
-      {
-        "name": "source",
-        "description": "Source file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "Destination file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "recursion",
-        "description": "Recursion depth to enforce for this path (0, 1, 2, ..., inf)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "destination",
-        "new": "path"
-      }
-    ]
-  },
-  "service_started_path": {
-    "name": "Service started with service path",
-    "bundle_name": "service_started_path",
-    "bundle_args": [
-      "name",
-      "path"
-    ],
-    "description": "Ensure that a service is running using the appropriate method, specifying the path of the service in the ps output, or using Windows task manager",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "service_started",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_started_path.cf",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Service name (as recognized by systemd, init.d, Windows, etc...)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "Service with its path, as in the output from 'ps'",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "service_name",
-        "new": "name"
-      },
-      {
-        "old": "service_path",
-        "new": "path"
-      }
-    ]
-  },
-  "user_primary_group": {
-    "name": "User primary group",
-    "bundle_name": "user_primary_group",
-    "bundle_args": [
-      "login",
-      "primary_group"
-    ],
-    "description": "Define the primary group of the user. User must already exist.",
-    "documentation": "This method does not create the user.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "user_primary_group",
-    "class_parameter": "login",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/user_primary_group.cf",
-    "parameter": [
-      {
-        "name": "login",
-        "description": "User's login",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "primary_group",
-        "description": "User's primary group",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
   "variable_string_from_command": {
     "name": "Variable string from command",
     "bundle_name": "variable_string_from_command",
@@ -7660,27 +7600,26 @@
       }
     ]
   },
-  "registry_entry_present": {
-    "name": "Registry entry present",
-    "bundle_name": "registry_entry_present",
+  "condition_from_expression": {
+    "name": "Condition from expression",
+    "bundle_name": "condition_from_expression",
     "bundle_args": [
-      "key",
-      "entry",
-      "value",
-      "registryType"
+      "condition",
+      "expression"
     ],
-    "description": "Ensure the value of a registry entry is correct.\nIf the `key` and/or its `entry' does not exist yet, it will be created.\n\n#### Examples\n\n```\n-name: Rudder registry \"myEntry\" property must be set to 1\n method: registry_entry_present\n   key: \"HKLM:\\SOFTWARE\\Rudder\"\n   entry: \"myEntry\"\n   value: \"1\"\n   registryType: \"Dword\"\n```",
+    "description": "Create a new condition",
+    "documentation": "This method evaluates an expression, and produces a `${condition}_true`\nor a `${condition}_false` condition depending on the result of the\nexpression evaluation:\n\n* This method always result with a *success* outcome status\n* If the evaluation results in a \"defined\" state, this will define a\n   `${condition}_true` condition,\n* If the evaluation results in an \"undefined\" state, this will produce a\n   `${condition}_false` condition.\n\n\nCalling this method with a condition expression transforms a complex expression into a single condition.\n\nThe created condition is global to the agent.\n\n##### Example\n\nIf you want to check if a condition evaluates to true, like checking that you\nare on Monday, 2am, on RedHat systems, you can use the following policy\n\n```\ncondition_from_expression(\"backup_time\", \"Monday.redhat.Hr02\")\n```\n\nThe method will define:\n* In any case:\n     * `condition_from_expression_backup_time_kept`\n     * `condition_from_expression_backup_time_reached`\n* And:\n    * `backup_time_true` if the system is a RedHat like system, on Monday, at 2am.\n    * `backup_time_false` if the system not a RedHat like system, or it's not Monday, or it's not 2am\n    * no extra condition if the expression is invalid (cannot be parsed)\n\n##### Notes:\n\nRudder will automatically \"canonify\" the given **Condition prefix** at execution time,\nwhich means that all non `[a-zA-Z0-9_]` characters will be replaced by an underscore.",
     "agent_support": [
-      "dsc"
+      "cfengine-community"
     ],
-    "class_prefix": "registry_entry_present",
-    "class_parameter": "entry",
-    "class_parameter_id": 2,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/registry_entry_present.cf",
+    "class_prefix": "condition_from_expression",
+    "class_parameter": "condition",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/condition_from_expression.cf",
     "parameter": [
       {
-        "name": "key",
-        "description": "Registry key path (ie, HKLM:\\Software\\Rudder)",
+        "name": "condition",
+        "description": "The condition prefix",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -7689,40 +7628,58 @@
         "type": "string"
       },
       {
-        "name": "entry",
-        "description": "Registry entry name",
+        "name": "expression",
+        "description": "The expression evaluated to create the condition (use 'any' to always evaluate to true)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
           "max_length": 16384
         },
         "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "condition_prefix",
+        "new": "condition"
       },
       {
-        "name": "value",
-        "description": "Registry value",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
+        "old": "condition_expression",
+        "new": "expression"
+      }
+    ]
+  },
+  "file_present": {
+    "name": "File present",
+    "bundle_name": "file_present",
+    "bundle_args": [
+      "path"
+    ],
+    "description": "Create a file if it doesn't exist",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "file_present",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_present.cf",
+    "parameter": [
       {
-        "name": "registryType",
-        "description": "Registry value type (String, ExpandString, MultiString, Dword, Qword)",
+        "name": "path",
+        "description": "File to create (absolute path on the target node)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
-          "select": [
-            "String",
-            "ExpandString",
-            "MultiString",
-            "Dword"
-          ],
           "max_length": 16384
         },
         "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "target",
+        "new": "path"
       }
     ]
   },
@@ -7773,27 +7730,42 @@
       }
     ]
   },
-  "service_disabled": {
-    "name": "Service disabled at boot",
-    "bundle_name": "service_disabled",
+  "file_report_content_head": {
+    "name": "File report content head",
+    "bundle_name": "file_report_content_head",
     "bundle_args": [
-      "name"
+      "path",
+      "limit"
     ],
-    "description": "Force a service not to be enabled at boot",
+    "description": "Report the head of a file",
+    "documentation": "Report the head of a file.\n\nThis method does nothing on the system, but only reports a partial content\nfrom a given file. This allows centralizing this information on the server, and avoid\nhaving to connect on each node to get this information.\n\nNOTE: This method only works in \"Full Compliance\" reporting mode.\n\n#### Parameters\n\n##### Target\n\nThis is the file you want to report content from. The method will return an error if it\ndoes not exist.\n\n##### Limit\n\nThe number of line to report.\n\n#### Examples\n\n```\n# To get the 3 first line of /etc/hosts\nfile_report_content(\"/etc/hosts\", \"3\");\n```",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "service_disabled",
-    "class_parameter": "name",
+    "class_prefix": "file_report_content_head",
+    "class_parameter": "path",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_disabled.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_report_content_head.cf",
     "parameter": [
       {
-        "name": "name",
-        "description": "Service name (as recognized by systemd, init.d, etc...)",
+        "name": "path",
+        "description": "File to report content from",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "limit",
+        "description": "Number of lines to report (default is 10)",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "regex": {
+            "value": "^\\d*$"
+          },
           "max_length": 16384
         },
         "type": "string"
@@ -7801,32 +7773,31 @@
     ],
     "parameter_rename": [
       {
-        "old": "service_name",
-        "new": "name"
+        "old": "target",
+        "new": "path"
       }
     ]
   },
-  "file_from_local_source": {
-    "name": "File from local source",
-    "bundle_name": "file_from_local_source",
+  "file_from_remote_source": {
+    "name": "File from remote source",
+    "bundle_name": "file_from_remote_source",
     "bundle_args": [
       "source",
       "path"
     ],
-    "description": "Ensure that a file or directory is copied from a local source",
-    "documentation": "Ensure that a file or directory is copied from a local source on and from the target node.\nThe copy is not recursive if the target is a directory. To copy recursively a folder from a local\nsource, use the *File from local source recursion* method.",
+    "description": "Ensure that a file or directory is copied from a policy server",
+    "documentation": "*Note*: This method uses the agent native file copy protocol, and can only download files from\nthe policy server. To download a file from an external source, you can use\nHTTP with the [file_download](#_file_download) method.\n\nThis method requires that the policy server is configured to accept\ncopy of the source file from the agents it will be applied to.\n\nYou can download a file from the shared files with:\n```\n/var/rudder/configuration-repository/shared-files/PATH_TO_YOUR_FILE\n```",
     "agent_support": [
-      "cfengine-community",
-      "dsc"
+      "cfengine-community"
     ],
-    "class_prefix": "file_from_local_source",
+    "class_prefix": "file_from_remote_source",
     "class_parameter": "path",
     "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_local_source.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_remote_source.cf",
     "parameter": [
       {
         "name": "source",
-        "description": "Source file (absolute path on the target node)",
+        "description": "Source file (absolute path on the policy server)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -7848,6 +7819,111 @@
     "parameter_rename": [
       {
         "old": "destination",
+        "new": "path"
+      }
+    ]
+  },
+  "file_enforce_content": {
+    "name": "File enforce content",
+    "bundle_name": "file_enforce_content",
+    "bundle_args": [
+      "path",
+      "lines",
+      "enforce"
+    ],
+    "description": "Enforce the content of a file",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "file_ensure_lines_present",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_enforce_content.cf",
+    "deprecated": "Use [file_content](#_file_content) instead.",
+    "rename": "file_content",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "lines",
+        "description": "Line(s) to add in the file - if lines is a list, please use @{lines} to pass the iterator rather than iterating over each values",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "enforce",
+        "description": "Enforce the file to contain only line(s) defined (true or false)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file",
+        "new": "path"
+      }
+    ]
+  },
+  "file_ensure_lines_present": {
+    "name": "File ensure lines present",
+    "bundle_name": "file_ensure_lines_present",
+    "bundle_args": [
+      "path",
+      "lines"
+    ],
+    "description": "Ensure that one or more lines are present in a file",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "file_ensure_lines_present",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_lines_present.cf",
+    "deprecated": "Use [file_lines_present](#_file_lines_present) instead.",
+    "rename": "file_lines_present",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "lines",
+        "description": "Line(s) to add in the file",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file",
         "new": "path"
       }
     ]
@@ -7903,26 +7979,27 @@
       }
     ]
   },
-  "file_check_hardlink": {
-    "name": "File check is hardlink",
-    "bundle_name": "file_check_hardlink",
+  "report_if_condition": {
+    "name": "Report if condition",
+    "bundle_name": "report_if_condition",
     "bundle_args": [
-      "path",
-      "path_2"
+      "report_message",
+      "condition"
     ],
-    "description": "Checks if two files are the same (hard links)",
-    "documentation": "This bundle will define a condition `file_check_hardlink_${path}_{ok, reached, kept}` if the\ntwo files `${path}` and `${path_2}` are hard links of each other, or `file_check_hardlink_${path}_{not_ok, reached, not_kept, failed}` if\nif the files are not hard links.",
+    "description": "Report a Rudder report based on a condition.",
+    "documentation": "This method will only send a Rudder report:\n\nIf the **condition** is met, it will report a compliant report, with the following message:\n`**<report_message>** was correct.`\n\nOtherwise, it will report an error, with the following message:\n`**report_message** was incorrect`\n\nThis method will never be in a repaired state.",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "file_check_hardlink",
-    "class_parameter": "path",
+    "class_prefix": "report_if_condition",
+    "class_parameter": "report_message",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_check_hardlink.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/report_if_condition.cf",
+    "action": "",
     "parameter": [
       {
-        "name": "path",
-        "description": "File name #1 (absolute path on the target node)",
+        "name": "report_message",
+        "description": "Message subject, will be extended based on the report status",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -7931,303 +8008,10 @@
         "type": "string"
       },
       {
-        "name": "path_2",
-        "description": "File name #2 (absolute path on the target node)",
+        "name": "condition",
+        "description": "Condition to report a success",
         "constraints": {
           "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file_name_1",
-        "new": "path"
-      },
-      {
-        "old": "file_name_2",
-        "new": "path_2"
-      }
-    ]
-  },
-  "file_line_present_in_ini_section": {
-    "name": "File line in INI section",
-    "bundle_name": "file_line_present_in_ini_section",
-    "bundle_args": [
-      "path",
-      "section",
-      "line"
-    ],
-    "description": "Ensure that a line is present in a section in a specific location. The objective of this method is to handle INI-style files.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_line_present_in_ini_section",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_line_present_in_ini_section.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "section",
-        "description": "Name of the INI-style section under which lines should be added (not including the [] brackets)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "line",
-        "description": "Line to ensure is present inside the section",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file",
-        "new": "path"
-      }
-    ]
-  },
-  "package_state": {
-    "name": "Package state",
-    "bundle_name": "package_state",
-    "bundle_args": [
-      "name",
-      "version",
-      "architecture",
-      "provider",
-      "state"
-    ],
-    "description": "Enforce the state of a package",
-    "documentation": "These methods manage packages using a package manager on the system.\n\n`package_present` and `package_absent` use a new package implementation, different from `package_install_*`,\n`package_remove_*` and `package_verify_*`. It should be more reliable, and handle upgrades better.\nIt is compatible though, and you can call generic methods from both implementations on the same host.\nThe only drawback is that the agent will have to maintain double caches for package lists, which\nmay cause a little unneeded overhead.\nThese methods will update the corresponding package if updates are available\nNew updates may not be detected even if there are some available,\nthis is due to the update cache that is refresh every 4 hours by default,\nyou can modify this behaviour called `updates_cache_expire` in `rudder` global parameter\n\n#### Package parameters\n\nThere is only one mandatory parameter, which is the package name to install.\nWhen it should be installed from a local package, you need to specify the full path to the package as name.\n\nThe version parameter allows specifying a version you want installed (not supported with snap).\nIt should be the complete versions string as used by the used package manager.\nThis parameter allows two special values:\n\n* *any* which is the default value, and is satisfied by any version of the given package\n* *latest* which will ensure, at each run, that the package is at the latest available version.\n\nThe last parameter is the provider, which is documented in the next section.\n\nYou can use [package_state_options](#_package_state_options) to pass options to the underlying package manager\n(currently only with *apt* package manager).\n\n#### Package providers\n\nThis method supports several package managers. You can specify the package manager\nyou want to use or let the method choose the default for the local system.\n\nThe package providers include a caching system for package information.\nThe package lists (installed, available and available updates) are only updated\nwhen the cache expires, or when an operation is made by the agent on packages.\n\n*Note*: The implementation of package operations is done in scripts called modules,\nwhich you can find in `${sys.workdir}/modules/packages/`.\n\n##### apt\n\nThis package provider uses *apt*/*dpkg* to manage packages on the system.\n*dpkg* will be used for all local actions, and *apt* is only needed to manage update and\ninstallation from a repository.\n\n##### rpm\n\nThis package provider uses *yum*/*rpm* to manage packages on the system. *rpm* will \nbe used for all local actions, and *yum* is only needed to manage update and\ninstallation from a repository.\n\nIt is able to downgrade packages when specifying an older version.\n\n##### zypper\n\nThis package provider uses *zypper*/*rpm* to manage packages on the system.\n*rpm* will be used for all local actions, and *zypper* is only needed to manage update and\ninstallation from a repository.\n\nNote: If the package version you want to install contains an epoch, you have to specify it\nin the version in the `epoch:version` form, like reported by `zypper info`.\n\n##### zypper_pattern\n\nThis package provider uses zypper with the `-t pattern` option to manage zypper patterns or\nmeta-packages on the system.\n\nSince a zypper pattern can be named differently than the rpm package name providing it, please\nalways use the exact pattern name (as listed in the output of `zypper patterns`)\nwhen using this provider.\n\nNote: When installing a pattern from a local rpm file, Rudder assumes that the pattern is built\nfollowing the \n[official zypper documentation](https://doc.opensuse.org/projects/libzypp/HEAD/zypp-pattern-packages.html).\n\nOlder implementations of zypper patterns may not be supported by this module.\n\nThis provider doesn't support installation from a file.\n\n##### slackpkg\n\nThis package provider uses Slackware's `installpkg` and `upgradepkg` tools to manage \npackages on the system\n\n##### pkg\n\nThis package provider uses FreeBSD's *pkg* to manage packages on the system.\nThis provider doesn't support installation from a file.\n\n#### ips\n\nThis package provider uses Solaris's pkg command to manage packages from IPS repositories on the system.\nThis provider doesn't support installation from a file.\n\n#### nimclient\n\nThis package provider uses AIX's nim client to manage packages from nim\nThis provider doesn't support installation from a file.\n\n#### snap\n\nThis package provider uses Ubuntu's *snap* to manage packages on the system\nThis provider doesn't support installation from a file.\n\n#### Examples\n\n```\n# To install postgresql in version 9.1 for x86_64 architecture\npackage_present(\"postgresql\", \"9.1\", \"x86_64\", \"\");\n# To ensure postgresql is always in the latest available version\npackage_present(\"postgresql\", \"latest\", \"\", \"\");\n# To ensure installing postgresql in any version\npackage_present(\"postgresql\", \"\", \"\", \"\");\n# To ensure installing postgresql in any version, forcing the yum provider\npackage_present(\"postgresql\", \"\", \"\", \"yum\");\n# To ensure installing postgresql from a local package\npackage_present(\"/tmp/postgresql-9.1-1.x86_64.rpm\", \"\", \"\", \"\");\n# To remove postgresql\npackage_absent(\"postgresql\", \"\", \"\", \"\");\n```\n\nSee also : [package_present](#_package_present), [package_absent](#_package_absent), [package_state_options](#_package_state_options)",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "package_state",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/package_state.cf",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Name of the package, or path to a local package if state is present",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "version",
-        "description": "Version of the package, can be \"latest\" for latest version or \"any\" for any version (defaults to \"any\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "architecture",
-        "description": "Architecture of the package, can be an architecture name  or \"default\" (defaults to \"default\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "provider",
-        "description": "Package provider to use, can be \"yum\", \"apt\", \"zypper\", \"zypper_pattern\", \"slackpkg\", \"pkg\", \"ips\", \"nimclient\", \"snap\" or \"default\" for system default package manager (defaults to \"default\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "default",
-            "yum",
-            "apt",
-            "zypper",
-            "zypper_pattern",
-            "slackpkg",
-            "pkg",
-            "ips",
-            "nimclient",
-            "snap"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "state",
-        "description": "State of the package, can be \"present\" or \"absent\" (defaults to \"present\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "present",
-            "absent"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "variable_dict_from_file_type": {
-    "name": "Variable dict from file type",
-    "bundle_name": "variable_dict_from_file_type",
-    "bundle_args": [
-      "prefix",
-      "name",
-      "file_name",
-      "file_type"
-    ],
-    "description": "Define a variable that contains key,value pairs (a dictionary) from a JSON, CSV or YAML file",
-    "documentation": "To use the generated variable, you must use the form `${prefix.name[key]}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \n\nThis method will load data from various file formats (yaml, json, csv). \n\n#### CSV parsing\n\nThe input file must use CRLF as line delimiter\nto be readable (as stated in RFC 4180).\n\n#### Examples\n\n```\n# To read a json file with format auto detection \nvariable_dict_from_file_type(\"prefix\", \"var\", \"/tmp/file.json\", \"\");\n# To force yaml reading on a non file without yaml extension\nvariable_dict_from_file_type(\"prefix\", \"var\", \"/tmp/file\", \"YAML\");\n```\n\nIf `/tmp/file.json` contains:\n\n```json\n{\n  \"key1\": \"value1\"\n}\n```\n\nYou will be able to access the `value1` value with `${prefix.var[key1]}`.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "variable_dict_from_file_type",
-    "class_parameter": "name",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/variable_dict_from_file_type.cf",
-    "parameter": [
-      {
-        "name": "prefix",
-        "description": "The prefix of the variable name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "name",
-        "description": "The variable to define, the full name will be prefix.name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "file_name",
-        "description": "The file name to load data from",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "file_type",
-        "description": "The file type, can be \"JSON\", \"CSV\", \"YAML\" or \"auto\" for auto detection based on file extension, with a fallback to JSON (default is \"auto\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "auto",
-            "JSON",
-            "YAML",
-            "CSV"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "variable_prefix",
-        "new": "prefix"
-      },
-      {
-        "old": "variable_name",
-        "new": "name"
-      }
-    ]
-  },
-  "permissions_dirs": {
-    "name": "Permissions dirs",
-    "bundle_name": "permissions_dirs",
-    "bundle_args": [
-      "path",
-      "mode",
-      "owner",
-      "group"
-    ],
-    "description": "Verify if a directory has the right permissions non recursively",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "permissions",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_dirs.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Path of the directory",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "mode",
-        "description": "Mode to enforce",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "owner",
-        "description": "Owner to enforce",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "group",
-        "description": "Group to enforce",
-        "constraints": {
-          "allow_empty_string": true,
           "allow_whitespace_string": false,
           "max_length": 16384
         },
@@ -8235,24 +8019,27 @@
       }
     ]
   },
-  "file_key_value_present": {
-    "name": "File key-value present",
-    "bundle_name": "file_key_value_present",
+  "file_ensure_key_value_option": {
+    "name": "File ensure key -> value present with option",
+    "bundle_name": "file_ensure_key_value_option",
     "bundle_args": [
       "path",
       "key",
       "value",
-      "separator"
+      "separator",
+      "option"
     ],
-    "description": "Ensure that the file contains a pair of \"key separator value\"",
+    "description": "Ensure that the file contains a pair of \"key separator value\", with options on the spacing around the separator",
     "documentation": "Edit (or create) the file, and ensure it contains an entry key -> value with arbitrary separator between the key and its value.\nIf the key is already present, the method will change the value associated with this key.",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "file_key_value_present",
+    "class_prefix": "file_ensure_key_value",
     "class_parameter": "path",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_key_value_present.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_key_value_option.cf",
+    "deprecated": "Use [file_key_value_present_option](#_file_key_value_present_option) instead.",
+    "rename": "file_key_value_present_option",
     "parameter": [
       {
         "name": "path",
@@ -8285,6 +8072,24 @@
         "type": "string"
       },
       {
+        "name": "option",
+        "description": "Option for the spacing around the separator: strict, which prevent spacing (space or tabs) around separators, or lax which accepts any number of spaces around separators",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": "strict"
+            },
+            {
+              "value": "lax"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
         "name": "separator",
         "description": "Separator between key and value, for example \"=\" or \" \" (without the quotes)",
         "constraints": {
@@ -8302,57 +8107,27 @@
       }
     ]
   },
-  "command_execution": {
-    "name": "Command execution",
-    "bundle_name": "command_execution",
+  "audit_from_osquery": {
+    "name": "Audit from osquery",
+    "bundle_name": "audit_from_osquery",
     "bundle_args": [
-      "command"
+      "query",
+      "comparator",
+      "value"
     ],
-    "description": "Execute a command",
-    "documentation": "Execute the **Command** in shell.\n\nOn Unix based agents, the method status will report:\n\n* a **Repaired** if the return code is \"0\"\n* an **Error** if the return code is not \"0\"\n\nOn Windows based agents the command is executed through Powershell and its `&` operator.\nThe method status will report:\n\n* an **Error** in Audit mode as the command will not be executed\n* an **Error** in Enforce mode if the command did throw an exception\n* an **Error** in Enforce mode if the `LASTEXITCODE` of the execution was not 0. This can happend when calling '.exe' binaries for instance.\n* a **Repaired** in any other cases\n\nDo not use the \"exit\" command on Windows as the shell used is the same than the one running the agent!\n\n# Windows examples\n\n```\n# A simple command execution\nWrite-Output \"rudder test\" | Out-File \"C:\\test.txt\n\n# Another one with a statement, will report a Repaired if the folder exists,\n# and an error if it does not.\n{\n  if ( (Test-Path \"C:\\Program Files\\Rudder\" -PathType Container)) {\n    \"Rudder folder found!\"\n  } else {\n    throw \"Rudder folder does not exist!\"\n  }\n}\n\n```",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "command_execution",
-    "class_parameter": "command",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/command_execution.cf",
-    "action": "",
-    "parameter": [
-      {
-        "name": "command",
-        "description": "Command to run",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "user_secondary_groups": {
-    "name": "User secondary groups",
-    "bundle_name": "user_secondary_groups",
-    "bundle_args": [
-      "login",
-      "groups",
-      "force"
-    ],
-    "description": "Define secondary groups for a user",
-    "documentation": "Make sure that a user belong to the listed groups\n\n#### Behavior\n\nEnsure that the user belongs in the given secondary group, if `force` is set,\nthe user will be force to only be part of the listed `groups`.\n\n#### Examples\n\n```yaml\n-name: bob must be in the printers group\n method: user_secondary_groups\n params:\n   login: bob\n   groups: printers\n   force: false\n```\n\n```yaml\n-name: jenkins must only be part of jenkins and docker\n method: user_secondary_groups\n params:\n   login: jenkins\n   groups: jenkins,docker\n   force: true\n```",
+    "description": "Audit a system property through osquery",
+    "documentation": "This method uses osquery to fetch information about the system,\nand compares the value with the given one, using the provided comparator.\n\n#### Parameters\n\n* `query` is an osquery query returning exactly one result\n* `comparator` is the comparator to use: \"=\" for equality, \"!=\" for non-equality, \"~\" for regex comparison\n* `value` is the expected value, can be a string or a regex depending on the comparator\n\n#### Setup\n\nThis method requires the presence of [osquery](https://osquery.io/) on the target nodes.\nIt won't install it automatically. Check the correct way of doing so for your OS.\n\n#### Building queries\n\nTo learn about the possible queries, read the [osquery schema](https://osquery.io/schema/) for your\nosquery version.\n\nYou can test the queries before using them with the `osqueryi` command, see the example below.\n\n```\nosqueryi \"select cpu_logical_cores from system_info;\"\n```\n\nYou need to provide a query that returns exactly one value. If it's not the case, the method\nwill fail as it does not know what to check.\n\n#### Examples\n\n```\n# To check the number of cpus on the machine\naudit_from_osquery(\"select cpu_logical_cores from system_info;\", \"2\");\n```\n\nWill report a compliant report if the machine has 3 cores, and a non compliant one if not.",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "user_secondary_groups",
-    "class_parameter": "login",
+    "class_prefix": "audit_from_osquery",
+    "class_parameter": "query",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/user_secondary_group.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/audit_from_osquery.cf",
     "parameter": [
       {
-        "name": "login",
-        "description": "User login",
+        "name": "query",
+        "description": "The query to execute (ending with a semicolon)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -8361,112 +8136,32 @@
         "type": "string"
       },
       {
-        "name": "groups",
-        "description": "Comma separated secondary groups name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "force",
-        "description": "Remove user from non-listed groups, \"true\" or \"false\" (defaults to \"false\")",
+        "name": "comparator",
+        "description": "The comparator to use ('=', '!=' or '~', default is '=')",
         "constraints": {
           "allow_empty_string": true,
           "allow_whitespace_string": false,
           "select": [
-            "",
-            "true",
-            "false"
+            {
+              "value": ""
+            },
+            {
+              "value": "="
+            },
+            {
+              "value": "!="
+            },
+            {
+              "value": "~"
+            }
           ],
           "max_length": 16384
         },
         "type": "string"
-      }
-    ]
-  },
-  "powershell_execution": {
-    "name": "Powershell execution",
-    "bundle_name": "powershell_execution",
-    "bundle_args": [
-      "command",
-      "successRegex",
-      "repairedRegex"
-    ],
-    "description": "Execute a Powershell command, script or binary, and parse its output to define success, repair or error status",
-    "documentation": "Execute either a command, a script or a binary - it supports piping. If the execution succeed, it parses the output as a string. It the output contains the successRegex, it defines a success, else if the output contains the repairRegex, it defines a repair, else it defines an error.\nsuccessRegex and repairRegex are both optional, but at least one must be defined otherwise the method will always return an error.\n\nExamples:\n\nTo return success if process `explorer` is running, the `command` parameter needs to be\n\n```\nGet-Process | ForEach { ${const.dollar}_.ProcessName }\n```\nas the output of the command is a toString() on the generated objects, so you need to extract the relevant data. And the `successRegex` needs to be `explorer`.\n \nNote: the regular expression/string to compare to the output are case insensitive and not anchored.\n \nNote: powershell scripts exiting with a non-zero exit code will always result in an error\n \nNote: the $ need to be escaped, otherwise $_ is evaluated at runtime",
-    "agent_support": [
-      "dsc"
-    ],
-    "class_prefix": "powershell_execution",
-    "class_parameter": "command",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/powershell_execution.cf",
-    "parameter": [
-      {
-        "name": "command",
-        "description": "Command or script to execute",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
       },
       {
-        "name": "successRegex",
-        "description": "String or regular expression to compare the output with to define success",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "repairedRegex",
-        "description": "String or regular expression to compare the output with to define repair",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "dsc_from_configuration": {
-    "name": "DSC from configuration",
-    "bundle_name": "dsc_from_configuration",
-    "bundle_args": [
-      "tag",
-      "config_file"
-    ],
-    "description": "Compile and apply a given DSC configuration defined by a ps1 file",
-    "documentation": "Compile and apply a given DSC configuration.\nThe DSC configuration must be defined within a .ps1 file, and is expected to be\n\"self compilable\".\nA configuration data file (.psd1) containing variables can also be referenced by the ps1 script,\nby referring to it in the Configuration call.\n\nThe method will try to compile the configuration whenever the policies of the nodes are updated\nof if the previous compilation did not succeed.\n\nAll the Rudder variables are usable in your configuration.\n\nAlso the current method only allows DSC configurations to be run on the localhost target node,\nand when using a DSC push setup. Note that it may conflict with already existing DSC configurations\nnot handled by Rudder.\n\n### Example 1 - without external data\n\nHere is a configuration named `EnsureWebServer.ps1` with simple Windows feature management:\n\n```\nConfiguration EnsureWebServer {\n Node 'localhost' {\n   # Install the IIS role\n   WindowsFeature IIS {\n       Ensure       = 'Present'\n       Name         = 'Web-Server'\n   }\n\n   # Install the ASP .NET 4.5 role\n   WindowsFeature AspNet45 {\n       Ensure       = 'Present'\n       Name         = 'Web-Asp-Net45'\n   }\n }\n}\n\nEnsureWebServer\n```\n\n###  Example 2 with external data\n\nDsc configurations can be fed with external data, here is an example\nusing a datafile `Data.psd1` containing:\n\n```\n @{\n     AllNodes = @();\n     NonNodeData =\n     @{\n       ConfigFileContents = \"Hello World! This file is managed by Rudder\"\n     }\n }\n```\n\nUsed to feed the `HelloWorld.ps1` Contents key:\n\n```\nConfiguration HelloWorld {\n  Import-DscResource -ModuleName 'PSDesiredStateConfiguration'\n\n  Node 'localhost' {\n    File HelloWorld {\n        DestinationPath = \"${RudderBase}\\HelloWorld.txt\"\n        Ensure          = \"Present\"\n        Contents        = $ConfigurationData.NonNodeData.ConfigFileContents\n    }\n  }\n}\n\nHelloWorld -ConfigurationData /path/to/Data.psd1\n```\n\nPlease note that the reference to the data file is done inside the configuration file.",
-    "agent_support": [
-      "dsc"
-    ],
-    "class_prefix": "dsc_from_configuration",
-    "class_parameter": "tag",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/dsc_from_configuration.cf",
-    "parameter": [
-      {
-        "name": "tag",
-        "description": "Name of the configuration, for information purposes",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "config_file",
-        "description": "Absolute path of the .ps1 configuration file",
+        "name": "value",
+        "description": "The expected value",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -8476,311 +8171,27 @@
       }
     ]
   },
-  "file_report_content": {
-    "name": "File report content",
-    "bundle_name": "file_report_content",
+  "variable_iterator": {
+    "name": "Variable iterator",
+    "bundle_name": "variable_iterator",
     "bundle_args": [
-      "path",
-      "regex",
-      "context"
-    ],
-    "description": "Report the content of a file",
-    "documentation": "Report the content of a file.\n\nThis method does nothing on the system, but only reports a complete or partial content\nfrom a given file. This allows centralizing this information on the server, and avoid\nhaving to connect on each node to get this information.\n\nNOTE: This method only works in \"Full Compliance\" reporting mode.\n\n#### Parameters\n\n##### Target\n\nThis is the file you want to report content from. The method will return an error if it\ndoes not exist.\n\n##### Regex\n\nIf empty, the method will report the whole file content.\nIf set, the method will grep the file for the given regular expression, and\nreport the result.\n\n##### Context\n\nWhen specifying a regex, will add the number of lines of context around matches\n(default is 0, i.e. no context).\n\nWhen reporting the whole file, this parameter is ignored.\n\n#### Examples\n\n```\n# To get the whole /etc/hosts content\nfile_report_content(\"/etc/hosts\", \"\", \"\");\n# To get lines starting by \"nameserver\" in /etc/resolv.conf\nfile_report_content(\"/etc/resolv.conf\", \"^nameserver\", \"\");\n# To get lines containing \"rudder\" from /etc/hosts with 3 lines of context\nfile_report_content(\"/etc/hosts\", \"rudder\", \"3\");\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_report_content",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_report_content.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File to report content from",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "regex",
-        "description": "Regex to search in the file (empty for whole file)",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "context",
-        "description": "Number of context lines when matching regex (default is 0)",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "regex": "^\\d*$",
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "target",
-        "new": "path"
-      }
-    ]
-  },
-  "dsc_built_in_resource": {
-    "name": "DSC built-in resource",
-    "bundle_name": "dsc_built_in_resource",
-    "bundle_args": [
-      "tag",
-      "scriptBlock",
-      "resourceName"
-    ],
-    "description": "This generic method defines if service should run or be stopped",
-    "documentation": "Apply a given DSC resource to the node.\n\n#### Parameters\n\n* `tag` parameter is purely informative and has no impact on the resource.\n* `ResourceName` must be the explicit name of the DSC resource you wish to apply\n* `ScriptBlock` must be a powershell script in plain text, returning an Hashtable containing\n  the parameters to pass to the resource.\n\nNote that this method can only apply built-in Windows resources.\nIt will not be able to apply an external resource.\n\n#### Example\n\nIf we want to apply a [Registry resource](https://docs.microsoft.com/en-us/powershell/scripting/dsc/reference/resources/windows/registryresource?view=powershell-7).\nThe `resourceName` used will be `Registry`\nAnd a potential ScriptBlock could be:\n\n~~~\n $HKLM_SOFT=\"HKEY_LOCAL_MACHINE\\SOFTWARE\"\n $Ensure      = \"Present\"\n $Key         = $HKLM_SOFT + \"\\ExampleKey\"\n\n $table = @{}\n $table.Add(\"Ensure\", $Ensure)\n $table.Add(\"Key\", $Key)\n $table.Add(\"ValueName\", \"RudderTest\")\n $table.Add(\"ValueData\", \"TestData\")\n $table\n~~~\n\nNote that all the ScriptBlock will be readable on the Rudder logs or in the policy files.",
-    "agent_support": [
-      "dsc"
-    ],
-    "class_prefix": "dsc_built_in_resource",
-    "class_parameter": "tag",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/dsc_built_in_resource.cf",
-    "parameter": [
-      {
-        "name": "tag",
-        "description": "Informative name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "resourceName",
-        "description": "resourceName",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "scriptBlock",
-        "description": "Desired state for the resource",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "here-string"
-      }
-    ]
-  },
-  "package_absent": {
-    "name": "Package absent",
-    "bundle_name": "package_absent",
-    "bundle_args": [
+      "prefix",
       "name",
-      "version",
-      "architecture",
-      "provider"
+      "value",
+      "separator"
     ],
-    "description": "Enforce the absence of a package",
-    "documentation": "See [package_state](#_package_state) for documentation.",
+    "description": "Define a variable that will be automatically iterated over",
+    "documentation": "The generated variable is a special variable that is automatically\niterated over. When you call a generic method with this variable as a parameter, n calls will be made,\none for each items of the variable.\nNote: there is a limit of 10000 items \n\nTo use the generated variable, you must use the form `${prefix.name}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \nPlease note that only global variables are available within templates.",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "package_absent",
+    "class_prefix": "variable_iterator",
     "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/package_absent.cf",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Name of the package",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "version",
-        "description": "Version of the package or \"any\" for any version (defaults to \"any\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "architecture",
-        "description": "Architecture of the package, can be an architecture name  or \"default\" (defaults to \"default\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "provider",
-        "description": "Package provider to use, can be \"yum\", \"apt\", \"zypper\", \"zypper_pattern\", \"slackpkg\", \"pkg\", \"ips\", \"nimclient\", \"snap\" or \"default\" for system default package manager (defaults to \"default\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "default",
-            "yum",
-            "apt",
-            "zypper",
-            "zypper_pattern",
-            "slackpkg",
-            "pkg",
-            "ips",
-            "nimclient",
-            "snap"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "service_ensure_started_at_boot": {
-    "name": "Service ensure started at boot",
-    "bundle_name": "service_ensure_started_at_boot",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Force a service to be started at boot",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "service_ensure_started_at_boot",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_ensure_started_at_boot.cf",
-    "deprecated": "Use [service_enabled](#_service_enabled) instead.",
-    "rename": "service_enabled",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Service name (as recognized by systemd, init.d, Windows, SRC, SMF, etc...)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "service_name",
-        "new": "name"
-      }
-    ]
-  },
-  "file_from_local_source_with_check": {
-    "name": "File from local source with check",
-    "bundle_name": "file_from_local_source_with_check",
-    "bundle_args": [
-      "source",
-      "path",
-      "check_command",
-      "rc_ok"
-    ],
-    "description": "Ensure that a file or directory is copied from a local source if a check command succeeds",
-    "documentation": "This method is a conditional file copy.\n\nIt allows comparing the source and destination, and if they are different, call a command\nwith the source file path as argument, and only update the destination if the commands succeeds\n(i.e. returns a code included in rc_ok).\n\n#### Examples\n\n```\n# To copy a configuration file only if it passes a config test:\nfile_from_local_source_with_check(\"/tmp/program.conf\", \"/etc/program.conf\", \"program --config-test\", \"0\");\n```\n\nThis will:\n\n* Compare `/tmp/program.conf` and `/etc/program.conf`, and return `kept` if files are the same\n* If not, it will execute `program --config-test \"/tmp/program.conf\"` and check the return code\n* If it is one of the `rc_ok` codes, it will copy `/tmp/program.conf` into `/etc/program.conf` and return a repaired\n* If not, it will return an error",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_from_local_source_with_check",
-    "class_parameter": "path",
     "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_local_source_with_check.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/variable_iterator.cf",
     "parameter": [
       {
-        "name": "source",
-        "description": "Source file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "Destination file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "check_command",
-        "description": "Command to run, it will get the source path as argument",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "rc_ok",
-        "description": "Return codes to be considered as valid, separated by a comma (default is 0)",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "destination",
-        "new": "path"
-      }
-    ]
-  },
-  "file_augeas_commands": {
-    "name": "File Augeas commands",
-    "bundle_name": "file_augeas_commands",
-    "bundle_args": [
-      "variable_prefix",
-      "variable_name",
-      "commands",
-      "autoload"
-    ],
-    "description": "Use Augeas binaries to execute augtool commands and options directly on the agent.",
-    "documentation": "Augeas is a tool that provides an abstraction layer for all the complexities that turn around editing files with regular expressions.\n\nThis method defines a rudder variable from the output of a `augtool` command. The method has in total 4 parameters:\n\n* **variable_prefix**: target variable prefix\n* **variable_name**: target variable name\n* **commands**: augtool script to run\n* **autoload**: boolean to load or not the common augeas lens, default to `true`\n\nAugtool provides bunch of other commands and options that you can use in this generic method such as `match` to print the matches for a specific\npath expression, `span` to print position in input file corresponding to tree, `retrieve` to transform tree into text and `save` to save all pending changes.\nIf Augeas isn't installed on the agent, it will produces an error.\n\nThis method will execute the **commands** via `augtool`.\nThe particular thing you may want to do with this method is using it depending on you needs and in two cases.\n\n#### With autoload\n\nAugeas will accordingly load all files and lenses before executing the commands you have specified since **autoload** is active.\n\n```\nfile_augeas_commands(\"label\",\"value\",\"print /files/etc/hosts/*/ipaddr[../canonical=\"server.rudder.local\"]\",\"\")\n# The variable label.value will be defined as such:\n${label.value} -> /files/etc/hosts/2/ipaddr = \"192.168.2.2\"\n```\n\n```\nfile_augeas_commands(\"label\",\"value\",\"ls files/etc/ \\n print /files/etc/ssh/sshd_config\",\"true\")\n# Will define the variable label.value with the list of files availables in /etc and already parsable with augeas,\n# followed by the dump of the sshd_config file, parsed by augeas.\n```\n\n#### Without autoload\n\nThe second case is when you deactivate that option which means that you are specifying **autoload** to `false` and in this case you have to\nload manually your files and lenses in the **commands** parameter by using the `set` augeas command.\nBelow is a second example where the lens and file are explicitly set:\n\n```\nfile_augeas_commands(\"label\",\"value\",\"set /augeas/load/Sshd/lens \"Sshd.lns \\n set /augeas/load/Sshd/incl \"/etc/ssh/sshd_config\" \\n load \\n print /augeas/load/Sshd \\n print /augeas/load/Sshd \\n print /files/etc/ssh/sshd_config\",\"false\")\n```",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_augeas_commands",
-    "class_parameter": "variable_name",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_augeas_commands.cf",
-    "parameter": [
-      {
-        "name": "variable_prefix",
+        "name": "prefix",
         "description": "The prefix of the variable name",
         "constraints": {
           "allow_empty_string": false,
@@ -8790,91 +8201,8 @@
         "type": "string"
       },
       {
-        "name": "variable_name",
-        "description": "The variable to define, the full name will be variable_prefix.variable_name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "commands",
-        "description": "The augeas command(s)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "autoload",
-        "description": "Deactivate the `autoload` option if you don't want augeas to load all the files/lens, it's `true` by default.",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "true",
-            "false"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "user_absent": {
-    "name": "User absent",
-    "bundle_name": "user_absent",
-    "bundle_args": [
-      "login"
-    ],
-    "description": "Remove a user",
-    "documentation": "This method ensures that a user does not exist on the system.",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "user_absent",
-    "class_parameter": "login",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/user_absent.cf",
-    "parameter": [
-      {
-        "name": "login",
-        "description": "User login",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "environment_variable_present": {
-    "name": "Define environment variable",
-    "bundle_name": "environment_variable_present",
-    "bundle_args": [
-      "name",
-      "value"
-    ],
-    "description": "Enforce an environment variable value.",
-    "documentation": "Force the value of a shell environment variable.\nThe variable will be written in `/etc/environment`. A newly created environment variable\nwill not be usable by the agent until it is restarted.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "environment_variable_present",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/environment_variable.cf",
-    "parameter": [
-      {
         "name": "name",
-        "description": "Name of the environment variable",
+        "description": "The variable to define, the full name will be prefix.name",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -8884,36 +8212,7 @@
       },
       {
         "name": "value",
-        "description": "Value of the environment variable",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "user_uid": {
-    "name": "User uid",
-    "bundle_name": "user_uid",
-    "bundle_args": [
-      "login",
-      "uid"
-    ],
-    "description": "Define the uid of the user. User must already exists, uid must be non-allowed(unique).",
-    "documentation": "This method does not create the user.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "user_uid",
-    "class_parameter": "login",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/user_uid.cf",
-    "parameter": [
-      {
-        "name": "login",
-        "description": "User's login",
+        "description": "The variable content",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -8922,62 +8221,11 @@
         "type": "string"
       },
       {
-        "name": "uid",
-        "description": "User's uid",
+        "name": "separator",
+        "description": "Regular expression that is used to split the value into items ( usually: , )",
         "constraints": {
           "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_create_symlink_enforce": {
-    "name": "Create symlink (optional overwriting)",
-    "bundle_name": "file_create_symlink_enforce",
-    "bundle_args": [
-      "source",
-      "path",
-      "enforce"
-    ],
-    "description": "Create a symlink at a destination path and pointing to a source target. This is also possible to enforce its creation",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_create_symlink",
-    "class_parameter": "path",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_create_symlink_enforce.cf",
-    "deprecated": "Use [file_symlink_present_option](#_file_symlink_present_option) instead.",
-    "rename": "file_symlink_present_option",
-    "parameter": [
-      {
-        "name": "source",
-        "description": "Source file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "Destination file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "enforce",
-        "description": "Force symlink if file already exist (true or false)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
+          "allow_whitespace_string": true,
           "max_length": 16384
         },
         "type": "string"
@@ -8985,139 +8233,37 @@
     ],
     "parameter_rename": [
       {
-        "old": "destination",
-        "new": "path"
-      }
-    ]
-  },
-  "package_present": {
-    "name": "Package present",
-    "bundle_name": "package_present",
-    "bundle_args": [
-      "name",
-      "version",
-      "architecture",
-      "provider"
-    ],
-    "description": "Enforce the presence of a package",
-    "documentation": "See [package_state](#_package_state) for documentation.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "package_present",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/package_present.cf",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Name of the package, or path to a local package",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
+        "old": "variable_prefix",
+        "new": "prefix"
       },
       {
-        "name": "version",
-        "description": "Version of the package, can be \"latest\" for latest version or \"any\" for any version (defaults to \"any\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "architecture",
-        "description": "Architecture of the package, can be an architecture name  or \"default\" (defaults to \"default\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "provider",
-        "description": "Package provider to use, can be \"yum\", \"apt\", \"zypper\", \"zypper_pattern\", \"slackpkg\", \"pkg\", \"ips\", \"nimclient\", \"snap\" or \"default\" for system default package manager (defaults to \"default\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "select": [
-            "",
-            "default",
-            "yum",
-            "apt",
-            "zypper",
-            "zypper_pattern",
-            "slackpkg",
-            "pkg",
-            "ips",
-            "nimclient",
-            "snap"
-          ],
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "group_present": {
-    "name": "Group present",
-    "bundle_name": "group_present",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Create a group",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "group_present",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/group_present.cf",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Group name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "group",
+        "old": "variable_name",
         "new": "name"
       }
     ]
   },
-  "condition_from_variable_existence": {
-    "name": "Condition from variable existence",
-    "bundle_name": "condition_from_variable_existence",
+  "condition_from_string_match": {
+    "name": "Condition from string match",
+    "bundle_name": "condition_from_string_match",
     "bundle_args": [
       "condition",
-      "variable_name"
+      "value",
+      "regex"
     ],
-    "description": "Create a condition from the existence of a variable",
-    "documentation": "This method define a condition:\n* `{condition}_true` if the variable named from\n  the parameter **Variable name** is defined\n* `{condition}_false` if the variable named from\n  the parameter **Variable name** is not defined\n\nAlso, this method always result with a *success* outcome status.",
+    "description": "Test the content of a string variable",
+    "documentation": "Test a string against a regex pattern and create conditions depending on the match result:\n\n* `${condition}_true` condition is defined if the regex matches\n* `${condition}_false` condition is defined if the regex does not match the string\n\nThe regex is singleline, case sensitive, culture invariant and implicitly enclosed by the start/end of string\ndelimiters `^` and `$`.\nThis method's reporting status will always be \"success\".\n\n### Examples\n\n```yaml\n-name: Define is_matching_true\n method: condition_from_string_match\n params:\n   condition: is_matching\n   value: \"Some\\nmulti\\nline\\ntext\"\n   regex: \"Some.*text\"\n```",
     "agent_support": [
       "cfengine-community",
       "dsc"
     ],
-    "class_prefix": "condition_from_variable_existence",
+    "class_prefix": "condition_from_string_match",
     "class_parameter": "condition",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/condition_from_variable_existence.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/condition_from_string_match.cf",
     "parameter": [
       {
         "name": "condition",
-        "description": "Prefix of the condition",
+        "description": "Prefix of the class (condition) generated",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -9126,8 +8272,18 @@
         "type": "string"
       },
       {
-        "name": "variable_name",
-        "description": "Complete name of the variable being tested, like my_prefix.my_variable",
+        "name": "value",
+        "description": "String typed value that will be tested against the regex",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "regex",
+        "description": "Pattern used to test if the value against",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -9143,60 +8299,24 @@
       }
     ]
   },
-  "service_reload": {
-    "name": "Service reload",
-    "bundle_name": "service_reload",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Reload a service using the appropriate method",
-    "documentation": "See [service_action](#_service_action) for documentation.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "service_reload",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_reload.cf",
-    "action": "",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Name of the service",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "service_name",
-        "new": "name"
-      }
-    ]
-  },
-  "variable_dict_merge": {
-    "name": "Variable dict merge",
-    "bundle_name": "variable_dict_merge",
+  "variable_dict_merge_tolerant": {
+    "name": "Variable dict merge tolerant",
+    "bundle_name": "variable_dict_merge_tolerant",
     "bundle_args": [
       "prefix",
       "name",
       "first_variable",
       "second_variable"
     ],
-    "description": "Define a variable resulting of the merge of two other variables",
-    "documentation": "To use the generated variable, you must use the form `${prefix.name[key]}` with each name replaced with the parameters of this method.\n\nThe resulting variable will be the merge of the two parameters, which means it is built by:\n\n* Taking the content of the first variable\n* Adding the content of the second variable, and replacing the keys that were already there\n\nIt is only a one-level merge, and the value of the first-level key will be completely replaced by the merge.\n\nThis method will fail if one of the variables is not defined. See [variable_dict_merge_tolerant](#_variable_dict_merge_tolerant)\nif you want to allow one of the variables not to be defined.\n\n### Usage\n\nIf you have a `prefix.variable1` variable defined by:\n\n```json\n{ \"key1\": \"value1\", \"key2\": \"value2\", \"key3\": { \"keyx\": \"valuex\" } }\n```\n\nAnd a `prefix.variable2` variable defined by:\n\n```json\n{ \"key1\": \"different\", \"key3\": \"value3\", \"key4\": \"value4\" }\n```\n\nAnd that you use:\n\n```\nvariablr_dict_merge(\"prefix\", \"variable3, \"prefix.variable1\", \"prefix.variable2\")\n```\n\nYou will get a `prefix.variable3` variable containing:\n\n```json\n{\n  \"key1\": \"different\",\n  \"key2\": \"value2\",\n  \"key3\": \"value3\",\n  \"key4\": \"value4\"\n}\n```",
+    "description": "Define a variable resulting of the merge of two other variables, allowing merging undefined variables",
+    "documentation": "To use the generated variable, you must use the form `${prefix.name[key]}` with each name replaced with the parameters of this method.\n\nSee [variable_dict_merge](#_variable_dict_merge) for usage documentation. The only difference is that this method\nwill not fail if one of the variables do not exist, and will return the other one. If both are undefined, the method will still fail.",
     "agent_support": [
-      "cfengine-community",
-      "dsc"
+      "cfengine-community"
     ],
-    "class_prefix": "variable_dict_merge",
+    "class_prefix": "variable_dict_merge_tolerant",
     "class_parameter": "name",
     "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/variable_dict_merge.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/variable_dict_merge_tolerant.cf",
     "parameter": [
       {
         "name": "prefix",
@@ -9250,84 +8370,25 @@
       }
     ]
   },
-  "condition_from_expression_persistent": {
-    "name": "Condition from expression persistent",
-    "bundle_name": "condition_from_expression_persistent",
-    "bundle_args": [
-      "condition",
-      "expression",
-      "duration"
-    ],
-    "description": "Create a new condition that persists across runs",
-    "documentation": "This method evaluates an expression (=condition combination), and produces a `${condition}_true`\nor a `${condition}_false` condition depending on the result on the expression,\nwhich will lasts for the **Duration** time:\n\n* This method always result with a *success* outcome status\n* If the expression evaluation results in a \"defined\" state, this will define a `${condition}_true` condition,\n* If the expression evaluation results in an \"undefined\" state, this will produce a `${condition}_false` condition.\n\n\nCalling this method with a condition expression transforms a complex expression into a single class condition.\n\nThe created condition is global to the agent and is persisted across runs.\nThe persistence duration is controlled using the parameter **Duration** which defines for how long the target\ncondition will be defined (in minutes). Note that there is no way to persist indefinitely.\n\n##### Example:\n\nIf you want to check if a condition evaluates to true, like checking that you\nare on Monday, 2am, on RedHat systems, and make it last one hour you can use the following policy\n\n```\ncondition_from_expression_persistent_(\"backup_time\", \"Monday.redhat.Hr02\", \"60\")\n```\nThe method will define:\n* In any case:\n    * `condition_from_expression_persistent_backup_time_kept`\n    * `condition_from_expression_persistent_backup_time_reached`\n* And:\n    * `backup_time_true` if the system is a RedHat like system, on Monday,\n     at 2am, and will persist for **Duration** minutes,\n    * `backup_time_false` if the system not a RedHat like system, or it's not Monday, or it's not 2am\n    * no extra condition if the expression is invalid (cannot be parsed)\n\n##### Notes:\n\nRudder will automatically \"canonify\" the given **Condition prefix** at execution time,\nwhich means that all non `[a-zA-Z0-9_]` characters will be replaced by an underscore.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "condition_from_expression_persistent",
-    "class_parameter": "condition",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/condition_from_expression_persistent.cf",
-    "parameter": [
-      {
-        "name": "condition",
-        "description": "The condition prefix",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "expression",
-        "description": "The expression evaluated to create the condition (use 'any' to always evaluate to true)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "duration",
-        "description": "The persistence suffix in minutes",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "condition_prefix",
-        "new": "condition"
-      },
-      {
-        "old": "condition_expression",
-        "new": "expression"
-      }
-    ]
-  },
-  "group_absent": {
-    "name": "Group absent",
-    "bundle_name": "group_absent",
+  "kernel_module_enabled_at_boot": {
+    "name": "Kernel module enabled at boot",
+    "bundle_name": "kernel_module_enabled_at_boot",
     "bundle_args": [
       "name"
     ],
-    "description": "Make sure a group is absent",
+    "description": "Ensure that a given kernel module will be loaded at system boot",
+    "documentation": "Ensure that a given kernel module is enabled at boot on the system.\n This method only works on systemd systems.\n Rudder will look for a line matching the module name in a given section in the file:\n\n * `/etc/modules-load.d/enabled_by_rudder.conf` on systemd systems\n\n If the module is already enabled by a different option file than used by Rudder, it will add\n an entry in the file managed by Rudder listed above, and leave intact the already present one.\n The modifications are persistent and made line per line, meaning that\n this Generic Method will never remove lines in the configuration file but only add it if needed.\n\n Please note that this method will not load the module nor configure it, it will only enable its loading at system boot.\n If you want to force the module to be loaded, use instead the method `kernel_module_loaded`.\n If you want to configure the module, use instead the method `kernel_module_configuration`.",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "group_absent",
+    "class_prefix": "kernel_module_enabled_at_boot",
     "class_parameter": "name",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/group_absent.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/kernel_module_enabled_at_boot.cf",
     "parameter": [
       {
         "name": "name",
-        "description": "Group name",
+        "description": "Complete name of the kernel module, as seen by lsmod or listed in /proc/modules",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -9338,468 +8399,8 @@
     ],
     "parameter_rename": [
       {
-        "old": "group",
+        "old": "module_name",
         "new": "name"
-      }
-    ]
-  },
-  "file_content": {
-    "name": "File content",
-    "bundle_name": "file_content",
-    "bundle_args": [
-      "path",
-      "lines",
-      "enforce"
-    ],
-    "description": "Enforce the content of a file",
-    "documentation": "Enforce the content of a file.\nThe enforce parameter changes the edition method:\n\n* If *enforce* is set to *true* the file content will be forced\n* If *enforce* is set to *false* the file content will be forced line by line.\n  Which means that each line managed can not be duplicated and the order will\n  not be guaranteed.\n\nIn most cases, the *enforce* parameter should be set to *true*.\nWhen *enforce* is set to *false*, and the managed lines are:\n\n```\nBob\nAlice\nCharly\n```\n\nWill be compliant with the following file contents:\n\n```\nBob\nAlice\nCharly\n```\n\n```\nCharly\nBob\nAlice\nCharly\n```\n\n```\nBob\nCharly\nAlice\n```",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "file_lines_present",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_content.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "lines",
-        "description": "Line(s) to add in the file - if lines is a list, please use @{lines} to pass the iterator rather than iterating over each values",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "enforce",
-        "description": "Enforce the file to contain only line(s) defined (true or false)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file",
-        "new": "path"
-      }
-    ]
-  },
-  "user_locked": {
-    "name": "User locked",
-    "bundle_name": "user_locked",
-    "bundle_args": [
-      "login"
-    ],
-    "description": "Ensure the user is locked. User must already exist.",
-    "documentation": "This method does not create the user. Note that locked accounts will\n  be marked with \"!\" in /etc/shadow, which is equivalent to \"*\".\n  To unlock a user, apply a user_password method.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "user_locked",
-    "class_parameter": "login",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/user_locked.cf",
-    "parameter": [
-      {
-        "name": "login",
-        "description": "User's login",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "directory_check_exists": {
-    "name": "Directory check exists",
-    "bundle_name": "directory_check_exists",
-    "bundle_args": [
-      "path"
-    ],
-    "description": "Checks if a directory exists",
-    "documentation": "This bundle will define a condition `directory_check_exists_${path}_{ok, reached, kept}` if the\ndirectory exists, or `directory_check_exists_${path}_{not_ok, reached, not_kept, failed}` if\nthe directory doesn't exists",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "directory_check_exists",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/directory_check_exists.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Full path of the directory to check",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "directory_name",
-        "new": "path"
-      }
-    ]
-  },
-  "schedule_simple_catchup": {
-    "name": "Schedule Simple Catchup",
-    "bundle_name": "schedule_simple_catchup",
-    "bundle_args": [
-      "job_id",
-      "agent_periodicity",
-      "max_execution_delay_minutes",
-      "max_execution_delay_hours",
-      "start_on_minutes",
-      "start_on_hours",
-      "start_on_day_of_week",
-      "periodicity_minutes",
-      "periodicity_hours",
-      "periodicity_days"
-    ],
-    "description": "Trigger a repaired outcome when a job should be run (avoid losing a job)",
-    "documentation": "This bundle will define a condition `schedule_simple_${job_id}_{kept,repaired,not_ok,ok,reached}`\n\n * _ok or _kept for when there is nothing to do\n * _repaired if the job should run\n * _not_ok and _reached have their usual meaning\n\n If the agent run is skipped during the period, method tries to catchup the run on next agent run.\n If the agent run is skipped twice,, only one run is catched up.\n If the agent is run twice (for example from a manual run), the job is run only once.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "schedule_simple",
-    "class_parameter": "job_id",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/schedule_simple_catchup.cf",
-    "parameter": [
-      {
-        "name": "job_id",
-        "description": "A string to identify this job",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "agent_periodicity",
-        "description": "Agent run interval (in minutes)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "max_execution_delay_minutes",
-        "description": "On how many minutes you want to spread the job",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "max_execution_delay_hours",
-        "description": "On how many hours you want to spread the job",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "start_on_minutes",
-        "description": "At which minute should be the first run",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "start_on_hours",
-        "description": "At which hour should be the first run",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "start_on_day_of_week",
-        "description": "At which day of week should be the first run",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "periodicity_minutes",
-        "description": "Desired job run interval (in minutes)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "periodicity_hours",
-        "description": "Desired job run interval (in hours)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "periodicity_days",
-        "description": "Desired job run interval (in days)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_ensure_lines_present": {
-    "name": "File ensure lines present",
-    "bundle_name": "file_ensure_lines_present",
-    "bundle_args": [
-      "path",
-      "lines"
-    ],
-    "description": "Ensure that one or more lines are present in a file",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "file_ensure_lines_present",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_lines_present.cf",
-    "deprecated": "Use [file_lines_present](#_file_lines_present) instead.",
-    "rename": "file_lines_present",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "lines",
-        "description": "Line(s) to add in the file",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file",
-        "new": "path"
-      }
-    ]
-  },
-  "permissions_dirs_recurse": {
-    "name": "Permissions dirs recurse",
-    "bundle_name": "permissions_dirs_recurse",
-    "bundle_args": [
-      "path",
-      "mode",
-      "owner",
-      "group"
-    ],
-    "description": "Verify if a directory and its content have the right permissions recursively",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "permissions",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_dirs_recurse.cf",
-    "deprecated": "Use [permissions_dirs_recursive](#_permissions_dirs_recursive) instead.",
-    "rename": "permissions_dirs_recursive",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Path to the directory",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "mode",
-        "description": "Mode to enforce",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "owner",
-        "description": "Owner to enforce",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "group",
-        "description": "Group to enforce",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_create": {
-    "name": "File create",
-    "bundle_name": "file_create",
-    "bundle_args": [
-      "path"
-    ],
-    "description": "Create a file if it doesn't exist",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "file_create",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_create.cf",
-    "deprecated": "Use [file_present](#_file_present) instead.",
-    "rename": "file_present",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File to create (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "target",
-        "new": "path"
-      }
-    ]
-  },
-  "file_copy_from_local_source_with_check": {
-    "name": "File copy from local source with check",
-    "bundle_name": "file_copy_from_local_source_with_check",
-    "bundle_args": [
-      "source",
-      "path",
-      "check_command",
-      "rc_ok"
-    ],
-    "description": "Ensure that a file or directory is copied from a local source if a check command succeeds",
-    "documentation": "This method is a conditional file copy.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_copy_from_local_source_with_check",
-    "class_parameter": "path",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_copy_from_local_source_with_check.cf",
-    "deprecated": "Use [file_from_local_source_with_check](#_file_from_local_source_with_check) instead.",
-    "rename": "file_from_local_source_with_check",
-    "parameter": [
-      {
-        "name": "source",
-        "description": "Source file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "Destination file (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "check_command",
-        "description": "Command to run, it will get the source path as argument",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "rc_ok",
-        "description": "Return codes to be considered as valid, separated by a comma (default is 0)",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "destination",
-        "new": "path"
       }
     ]
   },
@@ -9871,6 +8472,535 @@
       }
     ]
   },
+  "package_verify": {
+    "name": "Package verify",
+    "bundle_name": "package_verify",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Verify if a package is installed in its latest version available",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "package_install",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/package_verify.cf",
+    "deprecated": "Use [package_present](#_package_present) in audit mode",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Name of the package to verify",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "package_name",
+        "new": "name"
+      }
+    ]
+  },
+  "file_from_local_source_with_check": {
+    "name": "File from local source with check",
+    "bundle_name": "file_from_local_source_with_check",
+    "bundle_args": [
+      "source",
+      "path",
+      "check_command",
+      "rc_ok"
+    ],
+    "description": "Ensure that a file or directory is copied from a local source if a check command succeeds",
+    "documentation": "This method is a conditional file copy.\n\nIt allows comparing the source and destination, and if they are different, call a command\nwith the source file path as argument, and only update the destination if the commands succeeds\n(i.e. returns a code included in rc_ok).\n\n#### Examples\n\n```\n# To copy a configuration file only if it passes a config test:\nfile_from_local_source_with_check(\"/tmp/program.conf\", \"/etc/program.conf\", \"program --config-test\", \"0\");\n```\n\nThis will:\n\n* Compare `/tmp/program.conf` and `/etc/program.conf`, and return `kept` if files are the same\n* If not, it will execute `program --config-test \"/tmp/program.conf\"` and check the return code\n* If it is one of the `rc_ok` codes, it will copy `/tmp/program.conf` into `/etc/program.conf` and return a repaired\n* If not, it will return an error",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_from_local_source_with_check",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_local_source_with_check.cf",
+    "parameter": [
+      {
+        "name": "source",
+        "description": "Source file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "Destination file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "check_command",
+        "description": "Command to run, it will get the source path as argument",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "rc_ok",
+        "description": "Return codes to be considered as valid, separated by a comma (default is 0)",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
+      }
+    ]
+  },
+  "package_state_options": {
+    "name": "Package state with options",
+    "bundle_name": "package_state_options",
+    "bundle_args": [
+      "name",
+      "version",
+      "architecture",
+      "provider",
+      "state",
+      "options"
+    ],
+    "description": "Enforce the state of a package with options",
+    "documentation": "See [package_state](#_package_state) for documentation.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "package_state_options",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/package_state_options.cf",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Name of the package, or path to a local package if state is present",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "version",
+        "description": "Version of the package, can be \"latest\" for latest version or \"any\" for any version (defaults to \"any\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "architecture",
+        "description": "Architecture of the package, can be an architecture name  or \"default\" (defaults to \"default\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "provider",
+        "description": "Package provider to use, can be \"yum\", \"apt\", \"zypper\", \"zypper_pattern\", \"slackpkg\", \"pkg\", \"ips\", \"nimclient\", \"snap\" or \"default\" for system default package manager (defaults to \"default\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": ""
+            },
+            {
+              "value": "default"
+            },
+            {
+              "value": "yum"
+            },
+            {
+              "value": "apt"
+            },
+            {
+              "value": "zypper"
+            },
+            {
+              "value": "zypper_pattern"
+            },
+            {
+              "value": "slackpkg"
+            },
+            {
+              "value": "pkg"
+            },
+            {
+              "value": "ips"
+            },
+            {
+              "value": "nimclient"
+            },
+            {
+              "value": "snap"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "state",
+        "description": "State of the package, can be \"present\" or \"absent\" (defaults to \"present\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": ""
+            },
+            {
+              "value": "present"
+            },
+            {
+              "value": "absent"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "options",
+        "description": "Options no pass to the package manager (defaults to empty)",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_ensure_line_present_in_xml_tag": {
+    "name": "File ensure line in XML section",
+    "bundle_name": "file_ensure_line_present_in_xml_tag",
+    "bundle_args": [
+      "path",
+      "tag",
+      "line"
+    ],
+    "description": "Ensure that a line is present in a tag in a specific location. The objective of this method is to handle XML-style files. Note that if the tag is not present in the file, it won't be added, and the edition will fail.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_ensure_line_present_in_xml_tag",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_line_present_in_xml_tag.cf",
+    "deprecated": "Use [file_line_present_in_xml_tag](#_file_line_present_in_xml_tag) instead.",
+    "rename": "file_line_present_in_xml_tag",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "tag",
+        "description": "Name of the XML tag under which lines should be added (not including the <> brackets)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "line",
+        "description": "Line to ensure is present inside the section",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file",
+        "new": "path"
+      }
+    ]
+  },
+  "permissions": {
+    "name": "Permissions (non recursive)",
+    "bundle_name": "permissions",
+    "bundle_args": [
+      "path",
+      "mode",
+      "owner",
+      "group"
+    ],
+    "description": "Set permissions on a file or directory (non recursively)",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "permissions",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/permissions.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "Path to the file/directory",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "mode",
+        "description": "Mode to enforce (like \"640\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "owner",
+        "description": "Owner to enforce (like \"root\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "group",
+        "description": "Group to enforce (like \"wheel\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_key_value_parameter_present_in_list": {
+    "name": "File key-value parameter in list",
+    "bundle_name": "file_key_value_parameter_present_in_list",
+    "bundle_args": [
+      "path",
+      "key",
+      "key_value_separator",
+      "parameter",
+      "parameter_separator",
+      "leading_char_separator",
+      "closing_char_separator"
+    ],
+    "description": "Ensure that one parameter exists in a list of parameters, on one single line, in the right hand side of a key->values line",
+    "documentation": "Edit the file, and ensure it contains the defined parameter in the list of values on the right hand side of a key->values line.\nIf the parameter is not there, it will be added at the end, separated by parameter_separator.\nOptionally, you can define leading and closing character to enclose the parameters\nIf the key does not exist in the file, it will be added in the file, along with the parameter\n\n#### Example\n\nIf you have an initial file (`/etc/default/grub`) containing\n\n```\nGRUB_CMDLINE_XEN=\"dom0_mem=16G\"\n```\n\nTo add parameter `dom0_max_vcpus=32` in the right hand side of the line, you'll need the following policy\n\n```\nfile_ensure_key_value_parameter_in_list(\"/etc/default/grub\", \"GRUB_CMDLINE\", \"=\", \"dom0_max_vcpus=32\", \" \", \"\\\"\", \"\\\"\");\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_key_value_parameter_present_in_list",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_key_value_parameter_present_in_list.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "key",
+        "description": "Full key name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "key_value_separator",
+        "description": "character used to separate key and value in a key-value line",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": true,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "parameter",
+        "description": "String representing the sub-value to ensure is present in the list of parameters that form the value part of that line",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "parameter_separator",
+        "description": "Character used to separate parameters in the list",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": true,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "leading_char_separator",
+        "description": "leading character of the parameters",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "closing_char_separator",
+        "description": "closing character of the parameters",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "file",
+        "new": "path"
+      }
+    ]
+  },
+  "file_from_local_source": {
+    "name": "File from local source",
+    "bundle_name": "file_from_local_source",
+    "bundle_args": [
+      "source",
+      "path"
+    ],
+    "description": "Ensure that a file or directory is copied from a local source",
+    "documentation": "Ensure that a file or directory is copied from a local source on and from the target node.\nThe copy is not recursive if the target is a directory. To copy recursively a folder from a local\nsource, use the *File from local source recursion* method.",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "file_from_local_source",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_local_source.cf",
+    "parameter": [
+      {
+        "name": "source",
+        "description": "Source file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "Destination file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
+      }
+    ]
+  },
+  "service_ensure_stopped": {
+    "name": "Service ensure stopped",
+    "bundle_name": "service_ensure_stopped",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Ensure that a service is stopped using the appropriate method",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "service_ensure_stopped",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_ensure_stopped.cf",
+    "deprecated": "Use [service_stopped](#_service_stopped) instead.",
+    "rename": "service_stopped",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Service",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "service_name",
+        "new": "name"
+      }
+    ]
+  },
   "service_check_started_at_boot": {
     "name": "Service check started at boot",
     "bundle_name": "service_check_started_at_boot",
@@ -9904,26 +9034,30 @@
       }
     ]
   },
-  "user_group": {
-    "name": "User group",
-    "bundle_name": "user_group",
+  "file_ensure_key_value": {
+    "name": "File ensure key -> value present",
+    "bundle_name": "file_ensure_key_value",
     "bundle_args": [
-      "login",
-      "group_name"
+      "path",
+      "key",
+      "value",
+      "separator"
     ],
-    "description": "Define secondary group for a user",
-    "documentation": "Ensure that a user is within a group\n\n#### Behavior\n\nEnsure that the user belongs in the given secondary group (non-exclusive)\n\n##### Parameters\n\n`login`      : the user login\n`group_name`: secondary group name the user should belong to (non-exclusive)\n\n#### Examples\n\nTo ensure that user `test` belongs in group `dev`\n\n```\n user_group(\"test\", \"dev\")\n```\nNote that it will make sure that user test is in group dev, but won't remove it\nfrom other groups it may belong to",
+    "description": "Ensure that the file contains a pair of \"key separator value\"",
+    "documentation": "Edit (or create) the file, and ensure it contains an entry key -> value with arbitrary separator between the key and its value.\nIf the key is already present, the method will change the value associated with this key.",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "user_group",
-    "class_parameter": "login",
+    "class_prefix": "file_ensure_key_value",
+    "class_parameter": "path",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/user_group.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_ensure_key_value.cf",
+    "deprecated": "Use [file_key_value_present](#_file_key_value_present) instead.",
+    "rename": "file_key_value_present",
     "parameter": [
       {
-        "name": "login",
-        "description": "User login",
+        "name": "path",
+        "description": "File name to edit (absolute path on the target node)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -9932,11 +9066,31 @@
         "type": "string"
       },
       {
-        "name": "group_name",
-        "description": "Secondary group name for the user",
+        "name": "key",
+        "description": "Key to define",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "value",
+        "description": "Value to define",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "separator",
+        "description": "Separator between key and value, for example \"=\" or \" \" (without the quotes)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": true,
           "max_length": 16384
         },
         "type": "string"
@@ -9944,64 +9098,68 @@
     ],
     "parameter_rename": [
       {
-        "old": "user",
-        "new": "login"
-      }
-    ]
-  },
-  "file_absent": {
-    "name": "File absent",
-    "bundle_name": "file_absent",
-    "bundle_args": [
-      "path"
-    ],
-    "description": "Remove a file if it exists",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "file_absent",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_absent.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File to remove (absolute path on the path node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "target",
+        "old": "file",
         "new": "path"
       }
     ]
   },
-  "service_started": {
-    "name": "Service started",
-    "bundle_name": "service_started",
+  "environment_variable_present": {
+    "name": "Define environment variable",
+    "bundle_name": "environment_variable_present",
     "bundle_args": [
-      "name"
+      "name",
+      "value"
     ],
-    "description": "Ensure that a service is running using the appropriate method",
+    "description": "Enforce an environment variable value.",
+    "documentation": "Force the value of a shell environment variable.\nThe variable will be written in `/etc/environment`. A newly created environment variable\nwill not be usable by the agent until it is restarted.",
     "agent_support": [
-      "cfengine-community",
-      "dsc"
+      "cfengine-community"
     ],
-    "class_prefix": "service_started",
+    "class_prefix": "environment_variable_present",
     "class_parameter": "name",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_started.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/environment_variable.cf",
     "parameter": [
       {
         "name": "name",
-        "description": "Service name (as recognized by systemd, init.d, etc...)",
+        "description": "Name of the environment variable",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "value",
+        "description": "Value of the environment variable",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "service_check_running": {
+    "name": "Service check running",
+    "bundle_name": "service_check_running",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Check if a service is running using the appropriate method",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "service_check_running",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_check_running.cf",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Process name",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -10017,27 +9175,27 @@
       }
     ]
   },
-  "audit_from_osquery": {
-    "name": "Audit from osquery",
-    "bundle_name": "audit_from_osquery",
+  "permissions_other_acl_present": {
+    "name": "Permissions other POSIX acl entry present",
+    "bundle_name": "permissions_other_acl_present",
     "bundle_args": [
-      "query",
-      "comparator",
-      "value"
+      "path",
+      "recursive",
+      "other"
     ],
-    "description": "Audit a system property through osquery",
-    "documentation": "This method uses osquery to fetch information about the system,\nand compares the value with the given one, using the provided comparator.\n\n#### Parameters\n\n* `query` is an osquery query returning exactly one result\n* `comparator` is the comparator to use: \"=\" for equality, \"!=\" for non-equality, \"~\" for regex comparison\n* `value` is the expected value, can be a string or a regex depending on the comparator\n\n#### Setup\n\nThis method requires the presence of [osquery](https://osquery.io/) on the target nodes.\nIt won't install it automatically. Check the correct way of doing so for your OS.\n\n#### Building queries\n\nTo learn about the possible queries, read the [osquery schema](https://osquery.io/schema/) for your\nosquery version.\n\nYou can test the queries before using them with the `osqueryi` command, see the example below.\n\n```\nosqueryi \"select cpu_logical_cores from system_info;\"\n```\n\nYou need to provide a query that returns exactly one value. If it's not the case, the method\nwill fail as it does not know what to check.\n\n#### Examples\n\n```\n# To check the number of cpus on the machine\naudit_from_osquery(\"select cpu_logical_cores from system_info;\", \"2\");\n```\n\nWill report a compliant report if the machine has 3 cores, and a non compliant one if not.",
+    "description": "Verify that the other ace given is present on a file or directory.\nThis method will make sure the given other ace is present in the POSIX ACL of the target for.",
+    "documentation": "The `permissions_*acl_*` manage the POSIX ACL on files and directories.\n\nPlease note that the mask will be automatically recalculated when editing ACLs.\n\n#### Parameters\n\n##### Path\n\nPath can be a regex with the following format:\n\n* `*` matches any filename or directory at one level, e.g. `*.cf` will match all files in one directory that end in .cf but it won't search across directories. `*/*.cf` on the other hand will look two levels deep.\n* `?` matches a single letter\n* `[a-z]` matches any letter from a to z\n* `{x,y,anything}` will match x or y or anything.\n\n##### Recursive\n\nCan be:\n\n* `true` to apply the given aces to folder and sub-folders and files.\n* or `false` to apply to the strict match of `Path`\n\nIf left blank, recursivity will automatically be set to `false`\n\n##### Other_ACE\n\nThe operator can be:\n* `+` to add the given ACE to the current ones.\n* `-` to remove the given ACE to the current ones.\n* `=` to force the given ACE to the current ones.\n* `empty` if no operator is specified, it will be interpreted as `=`.\n\nACE must respect the classic:\n\n* `^[+-=]?(?=.*[rwx])r?w?x?$`\n\n#### Example\n\nGiven a file with the following getfacl output:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\nuser:bob:rwx\ngroup::r--\nmask::rwx\nother::r-x\n\n~~~~\n\nApplying this method with the following parameters:\n\n* `path`: /tmp/myTestFile\n* `recursive`: false\n* `other ace`: -rw\n\nWill transform the previous ACLs in:\n\n~~~~\nroot@server# getfacl /tmp/myTestFile \ngetfacl: Removing leading '/' from absolute path names\n# file: tmp/myTestFile\n# owner: root\n# group: root\nuser::rwx\nuser:bob:rwx\ngroup::r--\nmask::rwx\nother::--x\n\n~~~~",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "audit_from_osquery",
-    "class_parameter": "query",
+    "class_prefix": "permissions_other_acl_present",
+    "class_parameter": "path",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/audit_from_osquery.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_other_acl_present.cf",
     "parameter": [
       {
-        "name": "query",
-        "description": "The query to execute (ending with a semicolon)",
+        "name": "path",
+        "description": "Path of the file or directory",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -10046,53 +9204,64 @@
         "type": "string"
       },
       {
-        "name": "comparator",
-        "description": "The comparator to use ('=', '!=' or '~', default is '=')",
+        "name": "recursive",
+        "description": "Recursive Should ACLs cleanup be recursive, \"true\" or \"false\" (defaults to \"false\")",
         "constraints": {
           "allow_empty_string": true,
           "allow_whitespace_string": false,
           "select": [
-            "",
-            "=",
-            "!=",
-            "~"
+            {
+              "value": ""
+            },
+            {
+              "value": "true"
+            },
+            {
+              "value": "false"
+            }
           ],
           "max_length": 16384
         },
         "type": "string"
       },
       {
-        "name": "value",
-        "description": "The expected value",
+        "name": "other",
+        "description": "ACE to enforce for the given other.",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
+          "regex": {
+            "value": "^[+-=]?(?=.*[rwx])r?w?x?$"
+          },
           "max_length": 16384
         },
         "type": "string"
       }
     ]
   },
-  "user_password_clear": {
-    "name": "User password clear",
-    "bundle_name": "user_password_clear",
+  "file_download": {
+    "name": "File download",
+    "bundle_name": "file_download",
     "bundle_args": [
-      "login",
-      "password"
+      "source",
+      "path"
     ],
-    "description": "Ensure a user's password.\n as used in the UNIX /etc/shadow file.",
-    "documentation": "User must exists, password will appear in clear text in code.\n  An empty password will lead to an error and be notified.",
+    "description": "Download a file if it does not exist, using curl with a fallback on wget",
+    "documentation": "This method finds a HTTP command-line tool and downloads the given source\ninto the destination.\n\nIt tries `curl` first, and `wget` as fallback.",
     "agent_support": [
+      "cfengine-community",
       "dsc"
     ],
-    "class_prefix": "user_password_clear",
-    "class_parameter": "login",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/user_password_clear.cf",
+    "class_prefix": "file_download",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_download.cf",
+    "deprecated": "Use [file_from_http_server](#_file_from_http_server) instead.",
+    "rename": "file_from_http_server",
     "parameter": [
       {
-        "name": "login",
-        "description": "User login",
+        "name": "source",
+        "description": "URL to download from",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -10101,8 +9270,8 @@
         "type": "string"
       },
       {
-        "name": "password",
-        "description": "User clear password",
+        "name": "path",
+        "description": "File destination (absolute path on the target node)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -10110,34 +9279,232 @@
         },
         "type": "string"
       }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
+      }
     ]
   },
-  "dsc_apply": {
-    "name": "DSC Apply",
-    "bundle_name": "dsc_apply",
+  "file_from_remote_source_recursion": {
+    "name": "File from remote source recursion",
+    "bundle_name": "file_from_remote_source_recursion",
     "bundle_args": [
-      "MOFFile"
+      "source",
+      "path",
+      "recursion"
     ],
-    "description": "Ensure that all MOF files under MOFFile are applied via DSC.",
-    "documentation": "Ensure that all MOF files contained under the target folder are applied via DSC\non the target node.",
+    "description": "Ensure that a file or directory is copied from a policy server",
+    "documentation": "This method requires that the policy server is configured to accept\ncopy of the source file or directory from the agents it will be applied to.\n\nYou can download a file from the shared files with:\n```\n/var/rudder/configuration-repository/shared-files/PATH_TO_YOUR_DIRECTORY_OR_FILE\n```",
     "agent_support": [
-      "dsc"
+      "cfengine-community"
     ],
-    "class_prefix": "dsc_apply",
-    "class_parameter": "MOFFile",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/dsc_apply.cf",
-    "rename": "dsc_mof_file_apply",
+    "class_prefix": "file_from_remote_source",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_remote_source_recursion.cf",
     "parameter": [
       {
-        "name": "MOFFile",
-        "description": "Path to the mof that need to be applied",
+        "name": "source",
+        "description": "Source file (absolute path on the policy server)",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
           "max_length": 16384
         },
         "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "Destination file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "recursion",
+        "description": "Recursion depth to enforce for this path (0, 1, 2, ..., inf)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
+      }
+    ]
+  },
+  "service_stop": {
+    "name": "Service stop",
+    "bundle_name": "service_stop",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Stop a service using the appropriate method",
+    "documentation": "See [service_action](#_service_action) for documentation.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "service_stop",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_stop.cf",
+    "deprecated": "This is an action that should not be used in the general case.\nIf you really want to call the stop method, use [service_action](#_service_action).\nOtherwise, simply call [service_stopped](#_service_stopped)",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Name of the service",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "service_name",
+        "new": "name"
+      }
+    ]
+  },
+  "file_augeas_commands": {
+    "name": "File Augeas commands",
+    "bundle_name": "file_augeas_commands",
+    "bundle_args": [
+      "variable_prefix",
+      "variable_name",
+      "commands",
+      "autoload"
+    ],
+    "description": "Use Augeas binaries to execute augtool commands and options directly on the agent.",
+    "documentation": "Augeas is a tool that provides an abstraction layer for all the complexities that turn around editing files with regular expressions.\n\nThis method defines a rudder variable from the output of a `augtool` command. The method has in total 4 parameters:\n\n* **variable_prefix**: target variable prefix\n* **variable_name**: target variable name\n* **commands**: augtool script to run\n* **autoload**: boolean to load or not the common augeas lens, default to `true`\n\nAugtool provides bunch of other commands and options that you can use in this generic method such as `match` to print the matches for a specific\npath expression, `span` to print position in input file corresponding to tree, `retrieve` to transform tree into text and `save` to save all pending changes.\nIf Augeas isn't installed on the agent, it will produces an error.\n\nThis method will execute the **commands** via `augtool`.\nThe particular thing you may want to do with this method is using it depending on you needs and in two cases.\n\n#### With autoload\n\nAugeas will accordingly load all files and lenses before executing the commands you have specified since **autoload** is active.\n\n```\nfile_augeas_commands(\"label\",\"value\",\"print /files/etc/hosts/*/ipaddr[../canonical=\"server.rudder.local\"]\",\"\")\n# The variable label.value will be defined as such:\n${label.value} -> /files/etc/hosts/2/ipaddr = \"192.168.2.2\"\n```\n\n```\nfile_augeas_commands(\"label\",\"value\",\"ls files/etc/ \\n print /files/etc/ssh/sshd_config\",\"true\")\n# Will define the variable label.value with the list of files availables in /etc and already parsable with augeas,\n# followed by the dump of the sshd_config file, parsed by augeas.\n```\n\n#### Without autoload\n\nThe second case is when you deactivate that option which means that you are specifying **autoload** to `false` and in this case you have to\nload manually your files and lenses in the **commands** parameter by using the `set` augeas command.\nBelow is a second example where the lens and file are explicitly set:\n\n```\nfile_augeas_commands(\"label\",\"value\",\"set /augeas/load/Sshd/lens \"Sshd.lns \\n set /augeas/load/Sshd/incl \"/etc/ssh/sshd_config\" \\n load \\n print /augeas/load/Sshd \\n print /augeas/load/Sshd \\n print /files/etc/ssh/sshd_config\",\"false\")\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_augeas_commands",
+    "class_parameter": "variable_name",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_augeas_commands.cf",
+    "parameter": [
+      {
+        "name": "variable_prefix",
+        "description": "The prefix of the variable name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "variable_name",
+        "description": "The variable to define, the full name will be variable_prefix.variable_name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "commands",
+        "description": "The augeas command(s)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "autoload",
+        "description": "Deactivate the `autoload` option if you don't want augeas to load all the files/lens, it's `true` by default.",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": ""
+            },
+            {
+              "value": "true"
+            },
+            {
+              "value": "false"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_copy_from_remote_source_recursion": {
+    "name": "File copy from remote source recurse",
+    "bundle_name": "file_copy_from_remote_source_recursion",
+    "bundle_args": [
+      "source",
+      "path",
+      "recursion"
+    ],
+    "description": "Ensure that a file or directory is copied from a policy server",
+    "documentation": "This method requires that the policy server is configured to accept\ncopy of the source file or directory from the agents it will be applied to.\n\nYou can download a file from the shared files with:\n\n```\n/var/rudder/configuration-repository/shared-files/PATH_TO_YOUR_DIRECTORY_OR_FILE\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "file_copy_from_remote_source",
+    "class_parameter": "path",
+    "class_parameter_id": 2,
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_copy_from_remote_source_recursion.cf",
+    "deprecated": "Use [file_from_remote_source_recursion](#_file_from_remote_source_recursion) instead.",
+    "rename": "file_from_remote_source_recursion",
+    "parameter": [
+      {
+        "name": "source",
+        "description": "Source file (absolute path on the policy server)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "path",
+        "description": "Destination file (absolute path on the target node)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "recursion",
+        "description": "Recursion depth to enforce for this path (0, 1, 2, ..., inf)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "destination",
+        "new": "path"
       }
     ]
   },
@@ -10209,163 +9576,28 @@
       }
     ]
   },
-  "registry_key_absent": {
-    "name": "Registry key absent",
-    "bundle_name": "registry_key_absent",
+  "package_absent": {
+    "name": "Package absent",
+    "bundle_name": "package_absent",
     "bundle_args": [
-      "key"
+      "name",
+      "version",
+      "architecture",
+      "provider"
     ],
-    "description": "Ensure that a registry key does not exist.",
-    "documentation": "Remove a Registry Key if it is present on the system.\n\nThere are two different supported syntaxes to describe a Registry Key:\n\n* with short drive name and \":\" like HKLM:\\SOFTWARE\\myKey\n* with long drive name and without \":\" like HKEY_LOCAL_MACHINE:\\SOFTWARE\\myKey\n\nPlease, note that Rudder can not remove drives and \"first-level\" Registry Keys.\n\n#### Examples\n\n```\n-name: Short name first-level key syntax\n method: registry_key_absent\n   key: \"HKLM:\\SOFTWARE\\Rudder\"\n\n-name: Long name first-level key syntax\n method: registry_key_absent\n   key: \"HKEY_LOCAL_MACHILE:\\SOFTWARE\\Rudder\"\n```",
-    "agent_support": [
-      "dsc"
-    ],
-    "class_prefix": "registry_key_absent",
-    "class_parameter": "key",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/registry_key_absent.cf",
-    "parameter": [
-      {
-        "name": "key",
-        "description": "Registry key (ie, HKLM:\\Software\\Rudder)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_download": {
-    "name": "File download",
-    "bundle_name": "file_download",
-    "bundle_args": [
-      "source",
-      "path"
-    ],
-    "description": "Download a file if it does not exist, using curl with a fallback on wget",
-    "documentation": "This method finds a HTTP command-line tool and downloads the given source\ninto the destination.\n\nIt tries `curl` first, and `wget` as fallback.",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "file_download",
-    "class_parameter": "path",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_download.cf",
-    "deprecated": "Use [file_from_http_server](#_file_from_http_server) instead.",
-    "rename": "file_from_http_server",
-    "parameter": [
-      {
-        "name": "source",
-        "description": "URL to download from",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "path",
-        "description": "File destination (absolute path on the target node)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "destination",
-        "new": "path"
-      }
-    ]
-  },
-  "service_check_disabled_at_boot": {
-    "name": "Service check disabled at boot",
-    "bundle_name": "service_check_disabled_at_boot",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Check if a service is set to not start at boot using the appropriate method",
+    "description": "Enforce the absence of a package",
+    "documentation": "See [package_state](#_package_state) for documentation.",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "service_check_disabled_at_boot",
+    "class_prefix": "package_absent",
     "class_parameter": "name",
     "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_check_disabled_at_boot.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/package_absent.cf",
     "parameter": [
       {
         "name": "name",
-        "description": "Service name (as recognized by systemd, init.d, etc...)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "service_name",
-        "new": "name"
-      }
-    ]
-  },
-  "windows_hotfix_absent": {
-    "name": "Windows hotfix absent",
-    "bundle_name": "windows_hotfix_absent",
-    "bundle_args": [
-      "hotfix"
-    ],
-    "description": "Ensure that a specific windows hotfix is absent from the system.",
-    "documentation": "Ensure that a specific windows hotfix is absent from the system.",
-    "agent_support": [
-      "dsc"
-    ],
-    "class_prefix": "windows_hotfix_absent",
-    "class_parameter": "hotfix",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/windows_hotfix_absent.cf",
-    "parameter": [
-      {
-        "name": "hotfix",
-        "description": "Windows hotfix name (ex: KB4033369)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "file_lines_absent": {
-    "name": "File lines absent",
-    "bundle_name": "file_lines_absent",
-    "bundle_args": [
-      "path",
-      "lines"
-    ],
-    "description": "Ensure that a line is absent in a specific location",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "file_lines_absent",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_lines_absent.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "File name to edit (absolute path on the target node)",
+        "description": "Name of the package",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -10374,70 +9606,65 @@
         "type": "string"
       },
       {
-        "name": "lines",
-        "description": "Line(s) to remove in the file",
+        "name": "version",
+        "description": "Version of the package or \"any\" for any version (defaults to \"any\")",
         "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "file",
-        "new": "path"
-      }
-    ]
-  },
-  "file_from_remote_template": {
-    "name": "File from remote template",
-    "bundle_name": "file_from_remote_template",
-    "bundle_args": [
-      "source_template",
-      "destination",
-      "template_type"
-    ],
-    "description": "Build a file from a template on the Rudder server",
-    "documentation": "Write a file based on a template on the Rudder server and data available on the node\n\n#### Usage\n\nTo use this method, you need to have:\n\n* a template on the Rudder server shared folder\n* data to fill this template\n\nThe template needs to be located in the shared-files folder and can be accessed with:\n\n```\n/var/rudder/configuration-repository/shared-files/PATH_TO_YOUR_FILE\n```\n\nThe data that will be used while expanding the template is the data available in\nthe agent at the time of expansion. That means:\n\n* Agent's system variables (`${sys.*}`, ...) and conditions (`linux`, ...)\n* data defined during execution (result conditions of generic methods, ...)\n* conditions based on `condition_` generic methods\n* data defined using `variable_*` generic methods, which allow for example\n  to load data from local json or yaml files.\n\n#### Template types\n\nSupported templating languages:\n\n* *mustache* templates, which are documented in [file_from_template_mustache](#_file_from_template_mustache)\n* *jinja2* templates, which are documented in [file_from_template_jinja2](#_file_from_template_jinja2)\n\n#### Reporting\n\nThis method will provide extra `log_warning` message if the template was not updated, but the destination\nfile is modified.",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "file_from_remote_template",
-    "class_parameter": "destination",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_from_remote_template.cf",
-    "parameter": [
-      {
-        "name": "source_template",
-        "description": "Source file containing a template to be expanded (absolute path on the server)",
-        "constraints": {
-          "allow_empty_string": false,
+          "allow_empty_string": true,
           "allow_whitespace_string": false,
           "max_length": 16384
         },
         "type": "string"
       },
       {
-        "name": "destination",
-        "description": "Destination file (absolute path on the target node)",
+        "name": "architecture",
+        "description": "Architecture of the package, can be an architecture name  or \"default\" (defaults to \"default\")",
         "constraints": {
-          "allow_empty_string": false,
+          "allow_empty_string": true,
           "allow_whitespace_string": false,
           "max_length": 16384
         },
         "type": "string"
       },
       {
-        "name": "template_type",
-        "description": "Template type (jinja2 or mustache)",
+        "name": "provider",
+        "description": "Package provider to use, can be \"yum\", \"apt\", \"zypper\", \"zypper_pattern\", \"slackpkg\", \"pkg\", \"ips\", \"nimclient\", \"snap\" or \"default\" for system default package manager (defaults to \"default\")",
         "constraints": {
-          "allow_empty_string": false,
+          "allow_empty_string": true,
           "allow_whitespace_string": false,
           "select": [
-            "jinja2",
-            "mustache"
+            {
+              "value": ""
+            },
+            {
+              "value": "default"
+            },
+            {
+              "value": "yum"
+            },
+            {
+              "value": "apt"
+            },
+            {
+              "value": "zypper"
+            },
+            {
+              "value": "zypper_pattern"
+            },
+            {
+              "value": "slackpkg"
+            },
+            {
+              "value": "pkg"
+            },
+            {
+              "value": "ips"
+            },
+            {
+              "value": "nimclient"
+            },
+            {
+              "value": "snap"
+            }
           ],
           "max_length": 16384
         },
@@ -10445,9 +9672,231 @@
       }
     ]
   },
-  "file_create_symlink": {
-    "name": "Create symlink",
-    "bundle_name": "file_create_symlink",
+  "user_secondary_groups": {
+    "name": "User secondary groups",
+    "bundle_name": "user_secondary_groups",
+    "bundle_args": [
+      "login",
+      "groups",
+      "force"
+    ],
+    "description": "Define secondary groups for a user",
+    "documentation": "Make sure that a user belong to the listed groups\n\n#### Behavior\n\nEnsure that the user belongs in the given secondary group, if `force` is set,\nthe user will be force to only be part of the listed `groups`.\n\n#### Examples\n\n```yaml\n-name: bob must be in the printers group\n method: user_secondary_groups\n params:\n   login: bob\n   groups: printers\n   force: false\n```\n\n```yaml\n-name: jenkins must only be part of jenkins and docker\n method: user_secondary_groups\n params:\n   login: jenkins\n   groups: jenkins,docker\n   force: true\n```",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "user_secondary_groups",
+    "class_parameter": "login",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/user_secondary_group.cf",
+    "parameter": [
+      {
+        "name": "login",
+        "description": "User login",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "groups",
+        "description": "Comma separated secondary groups name",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "force",
+        "description": "Remove user from non-listed groups, \"true\" or \"false\" (defaults to \"false\")",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "select": [
+            {
+              "value": ""
+            },
+            {
+              "value": "true"
+            },
+            {
+              "value": "false"
+            }
+          ],
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "permissions_recurse": {
+    "name": "Permissions (recurse)",
+    "bundle_name": "permissions_recurse",
+    "bundle_args": [
+      "path",
+      "mode",
+      "owner",
+      "group"
+    ],
+    "description": "Verify if a file or directory has the right permissions recursively",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "permissions",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_recurse.cf",
+    "deprecated": "Use [permissions_recursive](#_permissions_recursive) instead.",
+    "rename": "permissions_recursive",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "Path to the file / directory",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "mode",
+        "description": "Mode to enforce",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "owner",
+        "description": "Owner to enforce",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "group",
+        "description": "Group to enforce",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "user_uid": {
+    "name": "User uid",
+    "bundle_name": "user_uid",
+    "bundle_args": [
+      "login",
+      "uid"
+    ],
+    "description": "Define the uid of the user. User must already exists, uid must be non-allowed(unique).",
+    "documentation": "This method does not create the user.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "user_uid",
+    "class_parameter": "login",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/user_uid.cf",
+    "parameter": [
+      {
+        "name": "login",
+        "description": "User's login",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "uid",
+        "description": "User's uid",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "permissions_dirs": {
+    "name": "Permissions dirs",
+    "bundle_name": "permissions_dirs",
+    "bundle_args": [
+      "path",
+      "mode",
+      "owner",
+      "group"
+    ],
+    "description": "Verify if a directory has the right permissions non recursively",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "permissions",
+    "class_parameter": "path",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/permissions_dirs.cf",
+    "parameter": [
+      {
+        "name": "path",
+        "description": "Path of the directory",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "mode",
+        "description": "Mode to enforce",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "owner",
+        "description": "Owner to enforce",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "group",
+        "description": "Group to enforce",
+        "constraints": {
+          "allow_empty_string": true,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "file_symlink_present": {
+    "name": "Symlink present",
+    "bundle_name": "file_symlink_present",
     "bundle_args": [
       "source",
       "path"
@@ -10456,12 +9905,10 @@
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "file_create_symlink",
+    "class_prefix": "file_symlink_present",
     "class_parameter": "path",
     "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/file_create_symlink.cf",
-    "deprecated": "Use [file_symlink_present](#_file_symlink_present) instead.",
-    "rename": "file_symlink_present",
+    "source": "/usr/share/ncf/tree/30_generic_methods/file_symlink_present.cf",
     "parameter": [
       {
         "name": "source",
@@ -10491,24 +9938,133 @@
       }
     ]
   },
-  "variable_string_default": {
-    "name": "Variable string with default",
-    "bundle_name": "variable_string_default",
+  "service_restart": {
+    "name": "Service restart",
+    "bundle_name": "service_restart",
     "bundle_args": [
-      "prefix",
-      "name",
-      "source_variable",
-      "default_value"
+      "name"
     ],
-    "description": "Define a variable from another variable name, with a default value if undefined",
-    "documentation": "To use the generated variable, you must use the form `${prefix.name}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \nPlease note that only global variables are available within templates.",
+    "description": "Restart a service using the appropriate method",
+    "documentation": "See [service_action](#_service_action) for documentation.",
+    "agent_support": [
+      "cfengine-community",
+      "dsc"
+    ],
+    "class_prefix": "service_restart",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/service_restart.cf",
+    "action": "",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Name of the service",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "service_name",
+        "new": "name"
+      }
+    ]
+  },
+  "audit_from_command": {
+    "name": "Audit from command",
+    "bundle_name": "audit_from_command",
+    "bundle_args": [
+      "command",
+      "compliant_codes"
+    ],
+    "description": "Execute an audit only command and reports depending on exit code",
+    "documentation": "Execute an audit only command and reports depending on\nthe exit codes given in parameters.\nIf an exit code is not in the list it will lead to an error status.\nThe command is always executed and the report is adapted to work properly in\nenforce and in audit mode.\nIt is up to you to make sure the command doesn't modify the system status at all\nsince it is always executed, even in audit mode.",
     "agent_support": [
       "cfengine-community"
     ],
-    "class_prefix": "variable_string_default",
+    "class_prefix": "audit_from_command",
+    "class_parameter": "command",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/audit_from_command.cf",
+    "parameter": [
+      {
+        "name": "command",
+        "description": "Command to run",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      },
+      {
+        "name": "compliant_codes",
+        "description": "List of codes that produce a compliant status separated with commas (ex: 1,2,5)",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ]
+  },
+  "kernel_module_loaded": {
+    "name": "Kernel module loaded",
+    "bundle_name": "kernel_module_loaded",
+    "bundle_args": [
+      "name"
+    ],
+    "description": "Ensure that a given kernel module is loaded on the system",
+    "documentation": "Ensure that a given kernel module is loaded on the system.\n  If the module is not loaded, it will try to load it via modprobe.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "kernel_module_loaded",
+    "class_parameter": "name",
+    "class_parameter_id": 1,
+    "source": "/usr/share/ncf/tree/30_generic_methods/kernel_module_loaded.cf",
+    "parameter": [
+      {
+        "name": "name",
+        "description": "Complete name of the kernel module, as seen by lsmod or listed in /proc/modules",
+        "constraints": {
+          "allow_empty_string": false,
+          "allow_whitespace_string": false,
+          "max_length": 16384
+        },
+        "type": "string"
+      }
+    ],
+    "parameter_rename": [
+      {
+        "old": "module_name",
+        "new": "name"
+      }
+    ]
+  },
+  "variable_string_from_math_expression": {
+    "name": "Variable string from math expression",
+    "bundle_name": "variable_string_from_math_expression",
+    "bundle_args": [
+      "prefix",
+      "name",
+      "expression",
+      "format"
+    ],
+    "description": "Define a variable from a mathematical expression",
+    "documentation": "To use the generated variable, you must use the form `${prefix.name}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \nPlease note that only global variables are available within templates.\n\n#### Usage\n\nThis function will evaluate a mathematical expression that may contain variables and format the result according to the provided format string.\n\nThe formatting string uses the standard POSIX printf format.\n\n#### Supported mathematical expressions\n\nAll the mathematical computations are done using floats.\n\nThe supported infix mathematical syntax, in order of precedence, is:\n\n- `(` and `)` parentheses for grouping expressions\n- `^` operator for exponentiation\n- `*` and `/` operators for multiplication and division\n- `%` operators for modulo operation\n- `+` and `-` operators for addition and subtraction\n- `==` \"close enough\" operator to tell if two expressions evaluate to the same number, with a tiny margin to tolerate floating point errors.  It returns 1 or 0.\n- `>=` \"greater or close enough\" operator with a tiny margin to tolerate floating point errors.  It returns 1 or 0.\n- `>` \"greater than\" operator.  It returns 1 or 0.\n- `<=` \"less than or close enough\" operator with a tiny margin to tolerate floating point errors.  It returns 1 or 0.\n- `<` \"less than\" operator.  It returns 1 or 0.\n\nThe numbers can be in any format acceptable to the C `scanf` function with the `%lf` format specifier, followed by the `k`, `m`, `g`, `t`, or `p` SI units.  So e.g. `-100` and `2.34m` are valid numbers.\n\nIn addition, the following constants are recognized:\n\n- `e`: 2.7182818284590452354\n- `log2e`: 1.4426950408889634074\n- `log10e`: 0.43429448190325182765\n- `ln2`: 0.69314718055994530942\n- `ln10`: 2.30258509299404568402\n- `pi`: 3.14159265358979323846\n- `pi_2`: 1.57079632679489661923 (pi over 2)\n- `pi_4`: 0.78539816339744830962 (pi over 4)\n- `1_pi`: 0.31830988618379067154 (1 over pi)\n- `2_pi`: 0.63661977236758134308 (2 over pi)\n- `2_sqrtpi`: 1.12837916709551257390 (2 over square root of pi)\n- `sqrt2`: 1.41421356237309504880 (square root of 2)\n- `sqrt1_2`: 0.70710678118654752440 (square root of 1/2)\n\nThe following functions can be used, with parentheses:\n\n- `ceil` and `floor`: the next highest or the previous highest integer\n- `log10`, `log2`, `log`\n- `sqrt`\n- `sin`, `cos`, `tan`, `asin`, `acos`, `atan`\n- `abs`: absolute value\n- `step`: 0 if the argument is negative, 1 otherwise\n\n#### Formatting options\n\nThe format field supports the following specifiers:\n\n* `%d` for decimal integer\n* `%x` for hexadecimal integer\n* `%o` for octal integer\n* `%f` for decimal floating point\n\nYou can use usual flags, width and precision syntax.\n\n#### Examples\n\nIf you use:\n\n```\nvariable_string(\"prefix\", \"var\", \"10\");\nvariable_string_from_math_expression(\"prefix\", \"sum\", \"2.0+3.0\", \"%d\");\nvariable_string_from_math_expression(\"prefix\", \"product\", \"3*${prefix.var}\", \"%d\");\n```\n\nThe `prefix.sum` string variable will contain `5` and `prefix.product` will contain `30`.",
+    "agent_support": [
+      "cfengine-community"
+    ],
+    "class_prefix": "variable_string_from_math_expression",
     "class_parameter": "name",
     "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/variable_string_default.cf",
+    "source": "/usr/share/ncf/tree/30_generic_methods/variable_string_from_math_expression.cf",
     "parameter": [
       {
         "name": "prefix",
@@ -10531,8 +10087,8 @@
         "type": "string"
       },
       {
-        "name": "source_variable",
-        "description": "The source variable name",
+        "name": "expression",
+        "description": "The mathematical expression to evaluate",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -10541,8 +10097,8 @@
         "type": "string"
       },
       {
-        "name": "default_value",
-        "description": "The default value to use if source_variable is not defined",
+        "name": "format",
+        "description": "The format string to use",
         "constraints": {
           "allow_empty_string": false,
           "allow_whitespace_string": false,
@@ -10558,269 +10114,6 @@
       },
       {
         "old": "variable_name",
-        "new": "name"
-      }
-    ]
-  },
-  "windows_hotfix_present": {
-    "name": "Windows hotfix present",
-    "bundle_name": "windows_hotfix_present",
-    "bundle_args": [
-      "hotfix",
-      "package_path"
-    ],
-    "description": "Ensure that a specific windows hotfix is present from the system.",
-    "documentation": "Ensure that a specific windows hotfix is present from the system.",
-    "agent_support": [
-      "dsc"
-    ],
-    "class_prefix": "windows_hotfix_present",
-    "class_parameter": "hotfix",
-    "class_parameter_id": 1,
-    "source": "/var/rudder/configuration-repository/ncf/30_generic_methods/windows_hotfix_present.cf",
-    "parameter": [
-      {
-        "name": "hotfix",
-        "description": "Windows hotfix name (ex: KB4033369)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "package_path",
-        "description": "Windows hotfix package absolute path, can be a .msu archive or a .cab file",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "directory_create": {
-    "name": "Directory create",
-    "bundle_name": "directory_create",
-    "bundle_args": [
-      "path"
-    ],
-    "description": "Create a directory if it doesn't exist",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "directory_create",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/directory_create.cf",
-    "deprecated": "Use [directory_present](#_directory_present) instead.",
-    "rename": "directory_present",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Full path of directory to create (trailing '/' is optional)",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "target",
-        "new": "path"
-      }
-    ]
-  },
-  "variable_string": {
-    "name": "Variable string",
-    "bundle_name": "variable_string",
-    "bundle_args": [
-      "prefix",
-      "name",
-      "value"
-    ],
-    "description": "Define a variable from a string parameter",
-    "documentation": "To use the generated variable, you must use the form `${prefix.name}` with each name replaced with the parameters of this method.\n\nBe careful that using a global variable can lead to unpredictable content in case of multiple definition, which is implicitly the case when a technique has more than one instance (directive). \nPlease note that only global variables are available within templates.",
-    "agent_support": [
-      "cfengine-community",
-      "dsc"
-    ],
-    "class_prefix": "variable_string",
-    "class_parameter": "name",
-    "class_parameter_id": 2,
-    "source": "/usr/share/ncf/tree/30_generic_methods/variable_string.cf",
-    "parameter": [
-      {
-        "name": "prefix",
-        "description": "The prefix of the variable name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "name",
-        "description": "The variable to define, the full name will be prefix.name",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "value",
-        "description": "The variable content",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "variable_prefix",
-        "new": "prefix"
-      },
-      {
-        "old": "variable_name",
-        "new": "name"
-      }
-    ]
-  },
-  "permissions": {
-    "name": "Permissions (non recursive)",
-    "bundle_name": "permissions",
-    "bundle_args": [
-      "path",
-      "mode",
-      "owner",
-      "group"
-    ],
-    "description": "Set permissions on a file or directory (non recursively)",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "permissions",
-    "class_parameter": "path",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/permissions.cf",
-    "parameter": [
-      {
-        "name": "path",
-        "description": "Path to the file/directory",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "mode",
-        "description": "Mode to enforce (like \"640\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "owner",
-        "description": "Owner to enforce (like \"root\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      },
-      {
-        "name": "group",
-        "description": "Group to enforce (like \"wheel\")",
-        "constraints": {
-          "allow_empty_string": true,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ]
-  },
-  "package_verify": {
-    "name": "Package verify",
-    "bundle_name": "package_verify",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Verify if a package is installed in its latest version available",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "package_install",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/package_verify.cf",
-    "deprecated": "Use [package_present](#_package_present) in audit mode",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Name of the package to verify",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "package_name",
-        "new": "name"
-      }
-    ]
-  },
-  "service_check_running_ps": {
-    "name": "Service check running ps",
-    "bundle_name": "service_check_running_ps",
-    "bundle_args": [
-      "name"
-    ],
-    "description": "Check if a service is running using ps",
-    "agent_support": [
-      "cfengine-community"
-    ],
-    "class_prefix": "service_check_running",
-    "class_parameter": "name",
-    "class_parameter_id": 1,
-    "source": "/usr/share/ncf/tree/30_generic_methods/service_check_running_ps.cf",
-    "parameter": [
-      {
-        "name": "name",
-        "description": "Regular expression used to select a process in ps output",
-        "constraints": {
-          "allow_empty_string": false,
-          "allow_whitespace_string": false,
-          "max_length": 16384
-        },
-        "type": "string"
-      }
-    ],
-    "parameter_rename": [
-      {
-        "old": "service_regex",
         "new": "name"
       }
     ]


### PR DESCRIPTION
https://issues.rudder.io/issues/23607

In 8.0, rudderc has (inadvertently) changed the output format from a list of plain strings to a list of

```json
{
  "name": "optional",
  "value": "previous value"
}
```

And regex from a string to:

```json
{
  "error_message": "optional",
  "value": "previous value"
}
```

This change was not expected in the webapp, but the parser for this file was rewritten at the same time, with a typo on the constraint key name (`constraint` instead of `constraints`), which lead to totally ignoring constraints (and hide the error).

As the change in rudderc was made to improve consistency with select parameter type in techniques, this PR changes the expected format on the webapp side. We can do this as rudderc and the webapp come in the same package and are always in sync.

This PR fixes the checks on parameters in the editor:
![image](https://github.com/Normation/rudder/assets/329388/0e05ac0f-50eb-4f60-bdac-06177dc3c13b)

Also adding an annotation in rudderc to avoid the null `error_message` in regex:

```json
"regex": {
    "value": "^[A-z0-9._-]+$",
    "error_message": null
}
```