### PR TITLE
Fixes #23639: Do not apply syntax highlighting to string properties

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ViewUtils.elm
@@ -172,12 +172,15 @@ displayNodePropertyRow model =
             , td [class "property-value"]
               [ div []
                 [ div [class ("value-container" ++ (if List.member p.name model.ui.showMore then " toggle" else "") ++ (if isTooLong p.value then " show-more" else "") ), onClick (ShowMore p.name) ]
-                  [ pre [class "json-beautify"]
-                    [ useTheme gitHub,
-                      json (displayJsonValue p.value)
+                  [ if (format == JsonFormat) then
+                      pre [class "json-beautify"]
+                      [ useTheme gitHub,
+                        json (displayJsonValue p.value)
                            |> Result.map toInlineHtml
                            |> Result.withDefault ( text (displayJsonValue p.value) )
-                    ]
+                      ]
+                    else
+                      pre [class "json-beautify"][text (displayJsonValue p.value)]
                   ]
                 , span [class "toggle-icon"][]
                 , button [class "btn btn-xs btn-default btn-clipboard", title "Copy to clipboard", onClick (Copy (displayJsonValue p.value))]


### PR DESCRIPTION
https://issues.rudder.io/issues/23639

![image](https://github.com/Normation/rudder/assets/329388/dc4374a7-b261-43bf-8809-142b7ba96646)
