### PR TITLE
Fixes #22518: Recent changes drop down cannot be read

### DIFF
--- a/webapp/sources/rudder/rudder-web/pom.xml
+++ b/webapp/sources/rudder/rudder-web/pom.xml
@@ -161,7 +161,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
             </configuration>
           </execution>
           <execution>
-            <id>elm-test</id>
+            <id>elm-test-editor</id>
             <phase>test</phase>
             <goals>
               <goal>exec</goal>
@@ -169,6 +169,18 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
             <configuration>
               <executable>npx</executable>
               <workingDirectory>src/main/elm/editor</workingDirectory>
+              <commandlineArgs>elm-test</commandlineArgs>
+            </configuration>
+          </execution>
+          <execution>
+            <id>elm-test-rules</id>
+            <phase>test</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>npx</executable>
+              <workingDirectory>src/main/elm/rules</workingDirectory>
               <commandlineArgs>elm-test</commandlineArgs>
             </configuration>
           </execution>

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/elm.json
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/elm.json
@@ -41,7 +41,9 @@
         }
     },
     "test-dependencies": {
-        "direct": {},
+        "direct": {
+            "elm-explorations/test": "2.1.2"
+        },
         "indirect": {}
     }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewRepairedReports.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/ViewRepairedReports.elm
@@ -6,6 +6,8 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Time.Iso8601
+import Time.ZonedDateTime as ZDT exposing (ZonedDateTime)
+import Time.TimeZone as TZ exposing (TimeZone)
 
 
 type alias TableColumn =
@@ -25,7 +27,7 @@ columns model =
 
 options: RuleId ->  Model -> List (Html Msg)
 options ruleId model =
-  List.reverse <| List.indexedMap (\id c -> option [value (String.fromInt id)] [text ("Between " ++ (Time.Iso8601.fromZonedDateTime c.start) ++  " and " ++ (Time.Iso8601.fromZonedDateTime c.end) ++ " ( " ++ (String.fromFloat c.changes) ++ " changes)") ] ) <| Maybe.withDefault [] (Dict.get ruleId.value model.changes )
+  List.reverse <| List.indexedMap (\id c -> option [value (String.fromInt id)] [text (showChanges c) ] ) <| Maybe.withDefault [] (Dict.get ruleId.value model.changes )
 
 showTab: Model -> RuleDetails -> Html Msg
 showTab model details =
@@ -65,3 +67,18 @@ showTab model details =
           ]
         ]
       ]
+
+showChanges: Changes -> String
+showChanges c =
+  let
+    formatYear = String.fromInt << ZDT.year
+    formatTwoDigitInt = String.padLeft 2 '0' << String.fromInt
+    formatMonth = formatTwoDigitInt << ZDT.month
+    formatDay = formatTwoDigitInt << ZDT.day
+    formatHour = formatTwoDigitInt << ZDT.hour
+    formatMinute = formatTwoDigitInt << ZDT.minute
+    formatTimeZone d = "UTC" ++ (String.left 3 <| TZ.offsetString (ZDT.toPosix d) (ZDT.timeZone d))
+    formatChangeDate d = (formatYear d) ++ "-" ++ (formatMonth d) ++ "-" ++ (formatDay d) ++ " " ++ (formatHour d) ++ ":" ++ (formatMinute d) ++ " " ++ (formatTimeZone d)
+    formatChangeCount n = (String.fromFloat n) ++ (if n > 1 then " changes" else " change")
+  in
+    ("Between " ++ (formatChangeDate c.start) ++  " and " ++ (formatChangeDate c.end) ++ " (" ++ formatChangeCount c.changes) ++ ")"

--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/tests/ViewRepairedReportsTest.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/tests/ViewRepairedReportsTest.elm
@@ -1,0 +1,42 @@
+module ViewRepairedReportsTest exposing (..)
+
+import DataTypes exposing (Changes)
+import Expect exposing (Expectation)
+import Time.DateTime exposing (epoch)
+import Time.ZonedDateTime exposing (fromDateTime, ZonedDateTime)
+import Time.Iso8601 exposing (toZonedDateTime)
+import Time.TimeZones exposing (utc, europe_paris)
+import Test exposing (..)
+
+import ViewRepairedReports exposing (showChanges)
+
+parseDate : String -> ZonedDateTime
+parseDate = Result.withDefault (fromDateTime utc epoch) << toZonedDateTime europe_paris
+
+changes : Float -> Changes
+changes n = {
+  start = parseDate "2023-10-12T02:00:00+00:00"
+  , end = parseDate "2023-10-13T20:00:00+00:00"
+  , changes = n }
+
+suite : Test
+suite =
+  describe "ViewRepairedReports module"
+    [ describe "showChange util"
+      [ test "should display 0 change" <|
+        \_ ->
+          changes 0
+            |> showChanges
+            |> Expect.equal "Between 2023-10-12 04:00 UTC+02 and 2023-10-13 22:00 UTC+02 (0 change)"
+      , test "should display 1 change" <|
+        \_ ->
+          changes 1
+            |> showChanges
+            |> Expect.equal "Between 2023-10-12 04:00 UTC+02 and 2023-10-13 22:00 UTC+02 (1 change)"
+      , test "should display multiple changes" <|
+        \_ ->
+          changes 10
+            |> showChanges
+            |> Expect.equal "Between 2023-10-12 04:00 UTC+02 and 2023-10-13 22:00 UTC+02 (10 changes)"
+    ]
+  ]


### PR DESCRIPTION
https://issues.rudder.io/issues/22518

I removed the seconds from the formatted date (see the unit tests for examples of what will be displayed)