### PR TITLE
Fixes #23010: When we are logged out, the logout button doesn't work

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
@@ -35,6 +35,11 @@
 *************************************************************************************
 */
 
+
+/* Global variables */
+
+var isLoggedIn = true;
+
 /* Event handler function */
 
 var entityMap = {
@@ -944,4 +949,9 @@ function sidebarControl(a){
     }
     e.is(".treeview-menu") && a.preventDefault()
   })
+}
+
+function logout(cb){
+    if (isLoggedIn) cb();
+    else window.location.replace(contextPath);
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -390,9 +390,12 @@ class Boot extends Loggable {
     // Do nothing instead, as it allows to keep open tabs context until we get the new cookie
     // This does not affect security as it is only a redirection anyway and did not change
     // the session itself.
-    LiftRules.noCometSessionCmd.default.set(() =>
-      JsRaw(s"createErrorNotification('You have been signed out. Please reload the page to sign in again.')").cmd
-    )
+    // The global variable (rudder.js)
+    LiftRules.noCometSessionCmd.default.set(() => {
+      JsRaw(
+        s"isLoggedIn=false; createErrorNotification('You have been signed out. Please reload the page to sign in again.');"
+      ).cmd
+    })
 
     // Log CSP violations
     LiftRules.contentSecurityPolicyViolationReport = (r: ContentSecurityPolicyViolation) => {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/UserInformation.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/UserInformation.scala
@@ -80,6 +80,7 @@ class UserInformation extends DispatchSnippet with DefaultExtendableSnippet[User
   def logout = {
     "*" #> SHtml.ajaxButton(
       "Log out",
+      JE.Call("logout"),
       { () =>
         S.session match {
           case Full(session) => // we have a session, try to know who is login out


### PR DESCRIPTION
https://issues.rudder.io/issues/23010

The ajax button no longer works after logout because the session is already terminated and all ajax variables mapping are cleaned in Lift...
We need to know if user is already logged out, in that case we do simply redirect instead of making the ajax call.