### PR TITLE
Fixes #23610: The "Required/May be empy" button in the parameters of a technique is not intuitive enough

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewTechniqueTabs.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewTechniqueTabs.elm
@@ -49,25 +49,28 @@ techniqueParameter model technique param opened =
           ]
 
         ]
-    (beEmptyTitle, beEmptyClass) =
+    beEmptyTitle =
       if (param.mayBeEmpty) then
-        ( "Parameter value can be empty.\nWhen adding a parameter to an existing technique, policy will be generated with an empty value and automatically deployed to your nodes, so be careful when adding one"
-        , "btn-outline-primary"
-        )
+         "Parameter value can be empty.\nWhen adding a parameter to an existing technique, policy will be generated with an empty value and automatically deployed to your nodes, so be careful when adding one"
       else
-        ( "Parameter cannot be empty and needs a value.\nIf you add a parameter to an existing technique, policy generation will fail and you will need to update all directives with the new parameter value"
-        , "btn-info"
-        )
+         "Parameter cannot be empty and needs a value.\nIf you add a required parameter to an existing technique, policy generation will fail and you will need to update all directives with the new parameter value"
+    checkboxId = ("paramRequired-" ++ param.id.value)
   in
     li [] [
       span [ class "border" ] []
     , div [ class "param" ] [
         div [ class "input-group" ] [
           input [readonly (not model.hasWriteRights), type_ "text",  class "form-control", value param.name, placeholder "Parameter name", onInput (\s -> TechniqueParameterModified param.id {param | name = s }), required True] []
-        , div [ class "input-group-btn" ] [
-            button [ class ("btn btn-outline " ++ beEmptyClass), title beEmptyTitle, onClick (TechniqueParameterModified param.id {param | mayBeEmpty = not param.mayBeEmpty }) ] [
-              text ( if param.mayBeEmpty then "May be empty" else "Required" )
-            ]
+        , label [ class "input-group-addon", for checkboxId]
+          [ input[type_ "checkbox", id checkboxId, checked (not param.mayBeEmpty), onCheck (\c -> (TechniqueParameterModified param.id {param | mayBeEmpty = not c }))][]
+          , span [][text " Required "]
+          , span
+            [ class "cursor-help popover-bs", attribute "data-toggle" "popover"
+            , attribute "data-trigger" "hover", attribute "data-container" "body"
+            , attribute "data-placement" "bottom"
+            , attribute "data-content" beEmptyTitle
+            , attribute "data-html" "true"
+            ] [ i [ class "text-info fa fa-question-circle" ] []]
           ]
         , div [ class "input-group-btn" ] [
             button [ class "btn btn-outline-secondary clipboard", title "Copy to clipboard" , onClick (Copy ("${" ++ (canonifyHelper (Value param.name)) ++ "}")) ] [

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.css
@@ -662,6 +662,12 @@ ul.files-list.parameters > li > .param{
   padding: 10px 10px 10px 12px;
   flex: 1;
 }
+ul.files-list.parameters > li > .param .input-group > label.input-group-addon{
+  border-left: none;
+  border-color: #D6DEEF;
+  background: #F8F9FC;
+  cursor: pointer;
+}
 ul.files-list > li > .border{
   background-color: #ccc;
   opacity: .6;

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/techniqueEditor.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/techniqueEditor.html
@@ -129,7 +129,6 @@ $(document).ready(function(){
     }
     setTimeout(function(){
       $(".method textarea.form-control").on("input", autoResize).each(function(){
-        console.log($(this).clone(false));
         autoResize(this);
       });
     }, 10);


### PR DESCRIPTION
https://issues.rudder.io/issues/23610

The button has been replaced by a checkbox labelled 'Required'. If it's checked, it means it cannot be empty, it's as simple as that :
![Capture d’écran du 2023-10-26 17-34-32](https://github.com/Normation/rudder/assets/9928447/fe4beeee-cfa5-4f33-b8e2-7cdf13182dfb)
