### PR TITLE
Fixes #23683: When a technique scope variable is used in a component key in a method call, logger fails to define the noop conditions in not_applicable cases

### DIFF
--- a/policies/rudderc/src/backends/unix/ncf/method_call.rs
+++ b/policies/rudderc/src/backends/unix/ncf/method_call.rs
@@ -94,8 +94,8 @@ pub fn method_call(m: Method, condition: Condition) -> Result<(Promise, Bundle)>
             .collect(),
     );
     let na_condition = format!(
-        "canonify(\"${{class_prefix}}_{}_{}\")",
-        info.bundle_name, &report_parameter
+        "canonify(\"${{class_prefix}}_{}_${{c_key}}\")",
+        info.bundle_name
     );
 
     let mut promises = match (&condition, is_supported) {

--- a/policies/rudderc/tests/cases/general/escaping/technique.cf
+++ b/policies/rudderc/tests/cases/general/escaping/technique.cf
@@ -28,14 +28,11 @@ bundle agent call_a86ce2e5_d5b6_45cc_87e8_c11cca71d966(c_name, c_key, report_id,
     "a86ce2e5-d5b6-45cc-87e8-c11cca71d966_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "a86ce2e5-d5b6-45cc-87e8-c11cca71d966_${report_data.directive_id}" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}"),
                                              if => concat("",canonify("${my_cond}"),".debian|",canonify("${sys.${plouf}"),"}");
-    "a86ce2e5-d5b6-45cc-87e8-c11cca71d966_${report_data.directive_id}" usebundle => _classes_noop(canonify("${class_prefix}_package_present_${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3
-	")),
+    "a86ce2e5-d5b6-45cc-87e8-c11cca71d966_${report_data.directive_id}" usebundle => _classes_noop(canonify("${class_prefix}_package_present_${c_key}")),
                                          unless => concat("",canonify("${my_cond}"),".debian|",canonify("${sys.${plouf}"),"}");
     "a86ce2e5-d5b6-45cc-87e8-c11cca71d966_${report_data.directive_id}" usebundle => log_rudder("Skipping method 'Package present' with key parameter '${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3
 	' since condition '${my_cond}.debian|${sys.${plouf}}' is not reached", "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3
-	", canonify("${class_prefix}_package_present_${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3
-	"), canonify("${class_prefix}_package_present_${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3
-	"), @{args}),
+	", canonify("${class_prefix}_package_present_${c_key}"), canonify("${class_prefix}_package_present_${c_key}"), @{args}),
                                          unless => concat("",canonify("${my_cond}"),".debian|",canonify("${sys.${plouf}"),"}");
 
 }

--- a/policies/rudderc/tests/cases/general/form/technique.cf
+++ b/policies/rudderc/tests/cases/general/form/technique.cf
@@ -19,9 +19,9 @@ bundle agent call_d86ce2e5_d5b6_45cc_87e8_c11cca71d907(c_name, c_key, report_id,
     "d86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "d86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}"),
                                              if => "debian";
-    "d86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => _classes_noop(canonify("${class_prefix}_package_present_htop")),
+    "d86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => _classes_noop(canonify("${class_prefix}_package_present_${c_key}")),
                                          unless => "debian";
-    "d86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => log_rudder("Skipping method 'Package present' with key parameter 'htop' since condition 'debian' is not reached", "htop", canonify("${class_prefix}_package_present_htop"), canonify("${class_prefix}_package_present_htop"), @{args}),
+    "d86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => log_rudder("Skipping method 'Package present' with key parameter 'htop' since condition 'debian' is not reached", "htop", canonify("${class_prefix}_package_present_${c_key}"), canonify("${class_prefix}_package_present_${c_key}"), @{args}),
                                          unless => "debian";
 
 }

--- a/policies/rudderc/tests/cases/general/ntp/technique.cf
+++ b/policies/rudderc/tests/cases/general/ntp/technique.cf
@@ -21,8 +21,8 @@ bundle agent call_d86ce2e5_d5b6_45cc_87e8_c11cca71d907(c_name, c_key, report_id,
 
   methods:
     "d86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
-    "d86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => _classes_noop(canonify("${class_prefix}_package_present_htop"));
-    "d86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => log_rudder("Skipping method 'Package present' with key parameter 'htop' since condition 'false' is not reached", "htop", canonify("${class_prefix}_package_present_htop"), canonify("${class_prefix}_package_present_htop"), @{args});
+    "d86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => _classes_noop(canonify("${class_prefix}_package_present_${c_key}"));
+    "d86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => log_rudder("Skipping method 'Package present' with key parameter 'htop' since condition 'false' is not reached", "htop", canonify("${class_prefix}_package_present_${c_key}"), canonify("${class_prefix}_package_present_${c_key}"), @{args});
 
 }
 bundle agent call_cf06e919_02b7_41a7_a03f_4239592f3c12(c_name, c_key, report_id, args, class_prefix, name) {
@@ -31,9 +31,9 @@ bundle agent call_cf06e919_02b7_41a7_a03f_4239592f3c12(c_name, c_key, report_id,
     "cf06e919-02b7-41a7-a03f-4239592f3c12_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "cf06e919-02b7-41a7-a03f-4239592f3c12_${report_data.directive_id}" usebundle => package_install("${name}"),
                                              if => "linux.fedora";
-    "cf06e919-02b7-41a7-a03f-4239592f3c12_${report_data.directive_id}" usebundle => _classes_noop(canonify("${class_prefix}_package_install_/bin/true \"# ${node.inventory[os][fullName]}\"")),
+    "cf06e919-02b7-41a7-a03f-4239592f3c12_${report_data.directive_id}" usebundle => _classes_noop(canonify("${class_prefix}_package_install_${c_key}")),
                                          unless => "linux.fedora";
-    "cf06e919-02b7-41a7-a03f-4239592f3c12_${report_data.directive_id}" usebundle => log_rudder("Skipping method 'Package install' with key parameter '/bin/true \"# ${node.inventory[os][fullName]}\"' since condition 'linux.fedora' is not reached", "/bin/true \"# ${node.inventory[os][fullName]}\"", canonify("${class_prefix}_package_install_/bin/true \"# ${node.inventory[os][fullName]}\""), canonify("${class_prefix}_package_install_/bin/true \"# ${node.inventory[os][fullName]}\""), @{args}),
+    "cf06e919-02b7-41a7-a03f-4239592f3c12_${report_data.directive_id}" usebundle => log_rudder("Skipping method 'Package install' with key parameter '/bin/true \"# ${node.inventory[os][fullName]}\"' since condition 'linux.fedora' is not reached", "/bin/true \"# ${node.inventory[os][fullName]}\"", canonify("${class_prefix}_package_install_${c_key}"), canonify("${class_prefix}_package_install_${c_key}"), @{args}),
                                          unless => "linux.fedora";
 
 }

--- a/policies/rudderc/tests/cases/general/reporting/technique.cf
+++ b/policies/rudderc/tests/cases/general/reporting/technique.cf
@@ -40,9 +40,9 @@ bundle agent call_b86ce2e5_d5b6_45cc_87e8_c11cca71d907(c_name, c_key, report_id,
     "b86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "b86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}"),
                                              if => "debian";
-    "b86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => _classes_noop(canonify("${class_prefix}_package_present_htop")),
+    "b86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => _classes_noop(canonify("${class_prefix}_package_present_${c_key}")),
                                          unless => "debian";
-    "b86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => log_rudder("Skipping method 'Package present' with key parameter 'htop' since condition 'debian' is not reached", "htop", canonify("${class_prefix}_package_present_htop"), canonify("${class_prefix}_package_present_htop"), @{args}),
+    "b86ce2e5-d5b6-45cc-87e8-c11cca71d907_${report_data.directive_id}" usebundle => log_rudder("Skipping method 'Package present' with key parameter 'htop' since condition 'debian' is not reached", "htop", canonify("${class_prefix}_package_present_${c_key}"), canonify("${class_prefix}_package_present_${c_key}"), @{args}),
                                          unless => "debian";
 
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/23683