### PR TITLE
Fixes #23684: Migrate rudder-templates-cli package to zio-json

### DIFF
--- a/webapp/sources/rudder/rudder-templates-cli/src/main/scala/com/normation/templates/cli/TemplateCli.scala
+++ b/webapp/sources/rudder/rudder-templates-cli/src/main/scala/com/normation/templates/cli/TemplateCli.scala
@@ -45,7 +45,6 @@ import com.normation.zio._
 import java.io.File
 import java.nio.charset.StandardCharsets
 import net.liftweb.common._
-import net.liftweb.json._
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.IOUtils
 import scala.collection.immutable.ArraySeq


### PR DESCRIPTION
https://issues.rudder.io/issues/23684

The first one in the series of 'migration from lift-json to zio-json' :partying_face: 

A `Json.Obj` is just a `Chunk[(String, Json)]` as a collection of pair in zio-json