### PR TITLE
Fixes #23688: Import archive must refuse yaml technique with mismatch directory and id

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/a_simple_yaml_technique/1.0/resources/something.txt
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/a_simple_yaml_technique/1.0/resources/something.txt
@@ -1,0 +1,1 @@
+Some resource file.


### PR DESCRIPTION
https://issues.rudder.io/issues/23688


Add a check that Technique ID from path pattern matches technique from descriptor for YAML and JSON case after parsing the descriptor. We already have everything, just need to test at the correct place. 

The most part of the change is an unit test. 