### PR TITLE
Fixes #23606: Creating files with the file explorer fails when using invalid character

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Action.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Action.elm
@@ -13,7 +13,7 @@ import String exposing (dropLeft)
 import Url.Builder exposing (string, toQuery, QueryParameter)
 
 import FileManager.Model exposing (..)
-import FileManager.Util exposing (getDirPath)
+import FileManager.Util exposing (getDirPath, processApiError)
 
 get :  String -> Decoder a -> (Result Http.Error a -> msg) -> Cmd msg
 get url decoder handler =
@@ -93,7 +93,7 @@ move api srcDir files dstDir =
   api
   (Http.jsonBody body )
   (Decode.succeed ())
-  (EnvMsg << Refresh)
+  handleFileUpdate
 
 encodeFiles : List FileMeta -> List QueryParameter
 encodeFiles = map (string "files" << .name)
@@ -111,7 +111,7 @@ delete api dir files =
   api
   (Http.jsonBody body )
   (Decode.succeed ())
-  (EnvMsg << Refresh)
+  handleFileUpdate
 
 newFile : String  -> String -> String -> Cmd Msg
 newFile api dir name =
@@ -126,7 +126,7 @@ newFile api dir name =
   api
   (Http.jsonBody body )
   (Decode.succeed ())
-  (EnvMsg << Refresh)
+  handleFileUpdate
 
 headList : Decoder (List a) -> Decoder a
 headList decoder =
@@ -165,7 +165,7 @@ saveContent api dir name content =
   api
   (Http.jsonBody body )
   (Decode.succeed ())
-  (EnvMsg << Refresh)
+  handleFileUpdate
 
 
 newDir : String  -> String -> String -> Cmd Msg
@@ -181,7 +181,7 @@ newDir api dir name =
   api
   (Http.jsonBody body )
   (Decode.succeed ())
-  (EnvMsg << Refresh)
+  handleFileUpdate
 
 rename : String -> String -> String -> String -> Cmd Msg
 rename api dir oldName newName =
@@ -197,4 +197,10 @@ rename api dir oldName newName =
   api
   (Http.jsonBody body )
   (Decode.succeed ())
-  (EnvMsg << Refresh)
+  handleFileUpdate
+
+
+handleFileUpdate : Result Http.Error a -> Msg
+handleFileUpdate r = case r of
+  Ok _ -> EnvMsg (Refresh (Ok ()))
+  Err e -> FileUpdate (FileUpdateHttpError e)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Model.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Model.elm
@@ -86,6 +86,7 @@ type Msg
   | OpenNameDialog DialogAction
   | CloseNameDialog
   | ConfirmNameDialog
+  | FileUpdate FileUpdateError
   | Name String
   | Download
   | Cut
@@ -111,3 +112,4 @@ type EnvMsg
   | GotContent (Result Error String)
 
 type DialogAction = Rename FileMeta String | NewFile String | NewDir String | Edit String String | Closed
+type FileUpdateError = FileValidationError String | FileUpdateHttpError Http.Error

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Port.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Port.elm
@@ -1,5 +1,6 @@
 port module FileManager.Port exposing (..)
 
+port errorNotification : String -> Cmd msg
 port onOpen : (() -> msg) -> Sub msg
 port close : List String -> Cmd msg
 port updateApiPAth : (String -> msg) -> Sub msg

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Util.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Util.elm
@@ -1,8 +1,10 @@
 module FileManager.Util exposing (..)
 
+import FileManager.Port exposing (errorNotification)
 import Html exposing (Attribute, Html)
 import Html.Attributes exposing (type_)
 import Array exposing (Array, fromList, get, toList)
+import Http
 import List exposing (drop, indexedMap, map2, take)
 
 -- List
@@ -49,3 +51,26 @@ button atts childs = Html.button (type_ "button" :: atts) childs
 getDirPath : List String -> String
 getDirPath dir =
   String.replace "//" "/" ((String.join "/" dir) ++ "/")
+
+processApiError : String -> Http.Error -> Cmd msg
+processApiError apiName err =
+  let
+    message =
+      case err of
+        Http.BadUrl url ->
+            "The URL " ++ url ++ " was invalid"
+        Http.Timeout ->
+            "Unable to reach the server, try again"
+        Http.NetworkError ->
+            "Unable to reach the server, check your network connection"
+        Http.BadStatus 500 ->
+            "The server had a problem, try again later"
+        Http.BadStatus 400 ->
+            "Verify your information and try again"
+        Http.BadStatus _ ->
+            "Unknown error"
+        Http.BadBody errorMessage ->
+            errorMessage
+
+  in
+    errorNotification ("Error when " ++ apiName ++ ", details: \n" ++ message )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/wrapper.js
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/wrapper.js
@@ -1,7 +1,7 @@
 var FileManager = function () {
   return function (options) {
     var container;
-    
+
     if (!options.container) {
       container = document.createElement('div');
       document.body.appendChild(container);
@@ -27,6 +27,10 @@ var FileManager = function () {
 
       set onClose(callback) {
         fm.ports.close.subscribe(callback);
+      },
+
+      errorNotification: function (callback) {
+        fm.ports.createErrorNotification.subscribe(callback);
       }
     };
   };

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/techniqueEditor.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/techniqueEditor.html
@@ -83,6 +83,9 @@ $(document).ready(function(){
     app.ports.updateResources.send(null)
   });
 
+  fm.ports.errorNotification.subscribe(function(errorMessage) {
+    createErrorNotification(errorMessage);
+  });
 
 
   app.ports.pushUrl.subscribe(function(id) {

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/ComponentDirectiveEditForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/ComponentDirectiveEditForm.html
@@ -56,6 +56,10 @@
         hasWriteRights : hasWriteRights
       }
     });
+
+  fm.ports.errorNotification.subscribe(function(errorMessage) {
+    createErrorNotification(errorMessage);
+  });
   </script>
 
   <div id="editForm">


### PR DESCRIPTION
https://issues.rudder.io/issues/23606

We don't want the user to rename a file with invalid characters : we display a notification, and we can also avoid making an API request.

Also, when a API request fails, a generic error message will be displayed as notification  