### PR TITLE
Fixes #23707: Implement common zio-json utils for plugins in rudder 

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonRequest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonRequest.scala
@@ -1,0 +1,59 @@
+/*
+ *************************************************************************************
+ * Copyright 2023 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.rest
+
+import com.normation.errors.PureResult
+import com.normation.rudder.apidata.ZioJsonExtractor
+import net.liftweb.http.Req
+import zio.json._
+
+/**
+  * This class exposes utility methods regarding JSON requests.
+  * 
+  * @see RudderJsonResponse for the response counterpart.
+  */
+object RudderJsonRequest {
+
+  implicit class ReqToJson(req: Req) {
+
+    def fromJson[A](implicit decoder: JsonDecoder[A]): PureResult[A] = {
+      ZioJsonExtractor.parseJson(req)
+    }
+
+  }
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/23707

It is about moving code from [a plugin](https://github.com/Normation/rudder-plugins-private/pull/468/files#diff-53797078b2054da1a7e7aee8e315cd630043045f9e1ff19916e01a88a39c32e1L26), because it needs to be shared by many plugins and also probably in the API endpoints definitions when migrating lift-json to zio-json...