### PR TITLE
Fixes #23724: 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/EventLogRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/EventLogRepository.scala
@@ -70,6 +70,7 @@ import com.normation.rudder.domain.secret.Secret
 import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.rudder.domain.workflows.WorkflowStepChange
 import com.normation.rudder.services.eventlog.EventLogFactory
+import doobie._
 
 trait EventLogRepository {
   def eventLogFactory: EventLogFactory
@@ -483,15 +484,15 @@ trait EventLogRepository {
    * For the moment it only a string, it should be something else in the future
    */
   def getEventLogByCriteria(
-      criteria:       Option[String],
+      criteria:       Option[Fragment],
       limit:          Option[Int] = None,
-      orderBy:        Option[String] = None,
-      extendedFilter: Option[String] = None
+      orderBy:        List[Fragment] = Nil,
+      extendedFilter: Option[Fragment] = None
   ): IOResult[Seq[EventLog]]
 
   def getEventLogById(id: Long): IOResult[EventLog]
 
-  def getEventLogCount(criteria: Option[String], extendedFilter: Option[String] = None): IOResult[Long]
+  def getEventLogCount(criteria: Option[Fragment], extendedFilter: Option[Fragment] = None): IOResult[Long]
 
   def getEventLogByChangeRequest(
       changeRequest:   ChangeRequestId,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/InventoryEventLogServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/InventoryEventLogServiceImpl.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.services.eventlog
 import com.normation.box._
 import com.normation.rudder.domain.eventlog.InventoryEventLog
 import com.normation.rudder.repository.EventLogRepository
+import doobie._
 import net.liftweb.common._
 
 class InventoryEventLogServiceImpl(
@@ -51,7 +52,9 @@ class InventoryEventLogServiceImpl(
    * @return
    */
   def getInventoryEventLogs(): Box[Seq[InventoryEventLog]] = {
-    repository.getEventLogByCriteria(Some(" eventType in ('AcceptNode', 'RefuseNode', 'DeleteNode')")).toBox match {
+    repository
+      .getEventLogByCriteria(Some(Fragment.const(" eventType in ('AcceptNode', 'RefuseNode', 'DeleteNode') ")))
+      .toBox match {
       case Full(seq) =>
         val result = scala.collection.mutable.Buffer[InventoryEventLog]()
         for (log <- seq) {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -72,10 +72,8 @@ import net.liftweb.http.S
 import net.liftweb.http.SHtml
 import net.liftweb.http.js.JE._
 import net.liftweb.http.js.JsCmds._
-import net.liftweb.json.JArray
 import net.liftweb.json.JsonAST.JObject
 import net.liftweb.json.JsonAST.JValue
-import net.liftweb.json.JString
 import net.liftweb.util.Helpers._
 import org.eclipse.jgit.lib.PersonIdent
 import org.joda.time.DateTime

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -139,6 +139,7 @@ import com.normation.rudder.web.services.StatelessUserPropertyService
 import com.normation.rudder.web.services.Translator
 import com.normation.utils.StringUuidGeneratorImpl
 import com.normation.zio._
+import doobie._
 import java.nio.charset.StandardCharsets
 import net.liftweb.common.Box
 import net.liftweb.common.EmptyBox
@@ -236,15 +237,15 @@ class RestTestSetUp {
   val eventLogRepo                  = new EventLogRepository {
     override def saveEventLog(modId: ModificationId, eventLog: EventLog): IOResult[EventLog] = eventLog.succeed
 
-    override def eventLogFactory:                                                            EventLogFactory                                       = ???
+    override def eventLogFactory:                                                                EventLogFactory                                       = ???
     override def getEventLogByCriteria(
-        criteria:       Option[String],
+        criteria:       Option[Fragment],
         limit:          Option[Int],
-        orderBy:        Option[String],
-        extendedFilter: Option[String]
+        orderBy:        List[Fragment],
+        extendedFilter: Option[Fragment]
     ): IOResult[Seq[EventLog]] = ???
-    override def getEventLogById(id: Long):                                                  IOResult[EventLog]                                    = ???
-    override def getEventLogCount(criteria: Option[String], extendedFilter: Option[String]): IOResult[Long]                                        = ???
+    override def getEventLogById(id: Long):                                                      IOResult[EventLog]                                    = ???
+    override def getEventLogCount(criteria: Option[Fragment], extendedFilter: Option[Fragment]): IOResult[Long]                                        = ???
     override def getEventLogByChangeRequest(
         changeRequest:   ChangeRequestId,
         xpath:           String,
@@ -252,7 +253,7 @@ class RestTestSetUp {
         orderBy:         Option[String],
         eventTypeFilter: List[EventLogFilter]
     ): IOResult[Vector[EventLog]] = ???
-    override def getEventLogWithChangeRequest(id: Int):                                      IOResult[Option[(EventLog, Option[ChangeRequestId])]] = ???
+    override def getEventLogWithChangeRequest(id: Int):                                          IOResult[Option[(EventLog, Option[ChangeRequestId])]] = ???
     override def getLastEventByChangeRequest(
         xpath:           String,
         eventTypeFilter: List[EventLogFilter]

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/LogDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/LogDisplayer.scala
@@ -125,7 +125,9 @@ class LogDisplayer(
         case eb: EmptyBox =>
           val fail = eb ?~! "Could not get latest event logs"
           logger.error(fail.messageChain)
-          val xml  = <div class="error">Error when trying to get last event logs. Error message was: {fail.messageChain}</div>
+          val xml  = <div class="error">Error when trying to get last event logs. Error message was: {
+            fail.msg
+          }</div> // we don't want to let the user know about SQL error
           SetHtml("eventLogsError", xml)
       }
     }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/EventLogsViewer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/EventLogsViewer.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.web.snippet.administration
 import bootstrap.liftweb.RudderConfig
 import com.normation.box._
 import com.normation.eventlog.EventLog
+import doobie._
 import net.liftweb.common._
 import net.liftweb.http.DispatchSnippet
 
@@ -48,7 +49,7 @@ class EventLogsViewer extends DispatchSnippet with Loggable {
   private[this] val eventList = RudderConfig.eventListDisplayer
 
   def getLastEvents: Box[Seq[EventLog]] = {
-    repos.getEventLogByCriteria(None, Some(1000), Some("id DESC")).toBox
+    repos.getEventLogByCriteria(None, Some(1000), List(Fragment.const("id DESC"))).toBox
   }
 
   def dispatch = { case "display" => _ => eventList.display(() => getLastEvents) }

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateSystemTechnique7_0.scala
@@ -113,6 +113,7 @@ import com.normation.zio._
 import com.softwaremill.quicklens._
 import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.RDN
+import doobie._
 import java.io.File
 import org.apache.commons.io.FileUtils
 import org.eclipse.jgit.lib.PersonIdent
@@ -181,16 +182,16 @@ class TestMigrateSystemTechniques7_0 extends Specification {
   val rudderDit = new RudderDit(new DN("ou=Rudder,cn=rudder-configuration"))
 
   val eventLogRepos = new EventLogRepository {
-    override def saveEventLog(modId: ModificationId, eventLog: EventLog):                    IOResult[EventLog]                                    = eventLog.succeed
-    override def eventLogFactory:                                                            EventLogFactory                                       = ???
+    override def saveEventLog(modId: ModificationId, eventLog: EventLog):                        IOResult[EventLog]                                    = eventLog.succeed
+    override def eventLogFactory:                                                                EventLogFactory                                       = ???
     override def getEventLogByCriteria(
-        criteria:       Option[String],
+        criteria:       Option[Fragment],
         limit:          Option[Int],
-        orderBy:        Option[String],
-        extendedFilter: Option[String]
+        orderBy:        List[Fragment],
+        extendedFilter: Option[Fragment]
     ): IOResult[Seq[EventLog]] = ???
-    override def getEventLogById(id: Long):                                                  IOResult[EventLog]                                    = ???
-    override def getEventLogCount(criteria: Option[String], extendedFilter: Option[String]): IOResult[Long]                                        = ???
+    override def getEventLogById(id: Long):                                                      IOResult[EventLog]                                    = ???
+    override def getEventLogCount(criteria: Option[Fragment], extendedFilter: Option[Fragment]): IOResult[Long]                                        = ???
     override def getEventLogByChangeRequest(
         changeRequest:   ChangeRequestId,
         xpath:           String,
@@ -198,7 +199,7 @@ class TestMigrateSystemTechniques7_0 extends Specification {
         orderBy:         Option[String],
         eventTypeFilter: List[EventLogFilter]
     ): IOResult[Vector[EventLog]] = ???
-    override def getEventLogWithChangeRequest(id: Int):                                      IOResult[Option[(EventLog, Option[ChangeRequestId])]] = ???
+    override def getEventLogWithChangeRequest(id: Int):                                          IOResult[Option[(EventLog, Option[ChangeRequestId])]] = ???
     override def getLastEventByChangeRequest(
         xpath:           String,
         eventTypeFilter: List[EventLogFilter]


### PR DESCRIPTION
https://issues.rudder.io/issues/23724

So, most of the PR is about changing string to `doobie.Fragment` which leads to correctly escaped prepared statement (ie `?` + parameter). 
I also cut down information going back to UI, and kept the SQL errors for people able to see webapp logs.

Some subtilities:
- we need to parse `asc` `desc` because they are SQL keyword, so can't be passed with fragment (it seems)
- we need to use correct types for fragments, so for example we need `java.sql.Timestamp` in place of strings
- `Fragment.const` is necessary only for case where we want to avoid to interpolate (in the SQL prepared statement way) a variable but interpolate it as a string. I chose to use it for anything without SQL variable, included constant strings


There does not seems to have a lot of tests on event logs appart `EventLogJdbcRepositoryTest` which is ok, so I tested by hand:
- the fact that last generation time is correctly found, 
- in event log admin page, `filter` field with sql chars,
- dates (no start, no end, none (it's long), both), changing number of events by page

No plugin seems to be impacted, even `change-validation` (while it uses eventLog, but not the problematic  methods)