### PR TITLE
Fixes #23736: Implement common utils for compatibility of zio-json API response

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -128,7 +128,7 @@ final case class FeatureSwitch0[A <: LiftApiModule0](enable: A, disable: A)(feat
     featureSwitchState.either.runNow match {
       case Left(err)                     =>
         ApplicationLogger.error(err.fullMsg)
-        RudderJsonResponse.internalError(ResponseSchema.fromSchema(schema), err.fullMsg)(params.prettify).toResponse
+        RudderJsonResponse.internalError(None, ResponseSchema.fromSchema(schema), err.fullMsg)(params.prettify).toResponse
       case Right(FeatureSwitch.Disabled) =>
         disable.process0(version, path, req, params, authzToken)
       case Right(FeatureSwitch.Enabled)  =>


### PR DESCRIPTION
https://issues.rudder.io/issues/23736



When migrating from lift-json to zio-json, we do not currently have a way in our zio-json custom definitions to provide an `id` in the json response in case of error. We will need that in order to be compatible and have the same output when migrating.
