### PR TITLE
Fixes #23737: Update to chimney 0.8.2

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -443,7 +443,7 @@ limitations under the License.
     <jgrapht-version>1.5.2</jgrapht-version>
     <reflections-version>0.10.2</reflections-version>
     <graalvm-version>23.0.1</graalvm-version>
-    <chimney-version>0.7.5</chimney-version>
+    <chimney-version>0.8.2</chimney-version>
     <cron4s-version>0.6.1</cron4s-version>
     <ipaddress-version>5.4.0</ipaddress-version>
     <snakeyaml-version>2.2</snakeyaml-version>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -102,7 +102,10 @@ object JsonQueryObjects {
   ) {
 
     def update(ruleCategory: RuleCategory) = {
-      ruleCategory.using(this).ignoreRedundantPatcherFields.patch
+      ruleCategory.copy(
+        name = name.getOrElse(ruleCategory.name),
+        description = description.getOrElse(ruleCategory.description)
+      )
     }
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/23737

The new version of chimney warns about some deprecated API (that we do not use), and allows a better separation of concerns with implicit instances and derivation according to [the documentation](https://chimney.readthedocs.io/en/stable/cookbook/#automatic-semiautomatic-and-inlined-derivation) : `import io.scalaland.chimney.syntax._` can be used where there is already an implicit `Transformer` in scope, whereas the `import io.scalaland.chimney.dsl._` additionally `import io.scalaland.chimney.auto._` to generate automatic transformers :scream_cat:. 

Recommended usage would be : 
* not use automatic derivation, which is often the case by importing `dsl._`, so avoid using this import 
* import `syntax._`  when there are already instances declared with semi-automatic derivation : `Transformer.derive[A, B]` and derive instances. This is optimal when there are multiple places where mapping objects would occur (it would avoid in-place compilation of type-class implementations with automatic derivation). It is also the go-to import even if the instances are not derived but defined with `Transformer.define[A, B]` (see [this PR](https://github.com/Normation/rudder-plugins-private/pull/472/files#diff-b2073f32472a54acc3d383270bf032a81c6eabc8c54ac3e388e9ea8a6654497bR137-R145))  
* use the _inline_ mode which is cool if there are simple transformations that will not be made often, because it does not create and allocate type-class like with automatic derivation : `import io.scalaland.chimney.inline._`