### PR TITLE
Fixes #23741: Testing json from API definitions in YAML should have a nice display

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/BoxSpecMatcher.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/BoxSpecMatcher.scala
@@ -42,14 +42,16 @@ import net.liftweb.common.Empty
 import net.liftweb.common.Failure
 import net.liftweb.common.Full
 import net.liftweb.common.Loggable
+import org.specs2.matcher.Matcher
 import org.specs2.matcher.MatchResult
+import org.specs2.matcher.NoShouldExpectations
 import org.specs2.mutable.Specification
 
 /**
  * Here we manage all the initialisation of services and database
  * state for the full example (after/before class).
  */
-trait BoxSpecMatcher extends Specification with Loggable {
+trait BoxSpecMatcher extends Specification with Loggable with NoShouldExpectations {
 
   /*
    * helpers for Box
@@ -82,6 +84,8 @@ trait BoxSpecMatcher extends Specification with Loggable {
     }
 
     def mustFullEq(res: T): MatchResult[Any] = matchRes((x: T) => x === res)
+
+    def mustMatch(m: Matcher[T], name: String): MatchResult[Any] = matchRes((x: T) => (x aka name) must m)
 
     def mustFull: MatchResult[Any] = matchRes((x: T) => ok(s"Got a ${x}"))
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/JsonSpecMatcher.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/JsonSpecMatcher.scala
@@ -1,0 +1,54 @@
+package com.normation
+
+import _root_.zio.json._
+import _root_.zio.json.ast.Json
+import org.specs2.matcher.Matcher
+import org.specs2.matcher.MustMatchers
+import org.specs2.mutable.Specification
+
+trait JsonSpecMatcher { self: MustMatchers with Specification =>
+
+  /**
+      * Tests for a non-strict equality of json, by comparing the string.
+      * Ignores any whitespace between words, non-words, and lines 
+      * i.e. additional whitespace in either side would still make the test pass.
+      * 
+      * Displays the actual and expected json in the error message in a pretty format.
+      */
+  def equalsJson(res: String):                 Matcher[String] = {
+    (
+      (s: String) => cleanParse(s) == cleanParse(res),
+      (s: String) => s"'${prettyPrint(s)}' did not equal '${prettyPrint(res)}'\neven when removing whitespaces"
+    )
+  }
+  // add the aka manually to the error message
+  def equalsJsonAka(res: String, aka: String): Matcher[String] = {
+    (
+      (s: String) => cleanParse(s) == cleanParse(res),
+      (s: String) => s"$aka: '${prettyPrint(s)}' did not equal '${prettyPrint(res)}'\neven when removing whitespaces"
+    )
+  }
+
+  def equalsJsonSemantic(res: String): Matcher[String] = {
+    (
+      (s: String) => s.fromJson[Json] == res.fromJson[Json],
+      (s: String) => s"'${prettyPrint(s)}' did not semantically equal '${prettyPrint(res)}'"
+    )
+  }
+
+  def equalsJsonSemanticAka(res: String, aka: String): Matcher[String] = {
+    (
+      (s: String) => s.fromJson[Json] == res.fromJson[Json],
+      (s: String) => s"$aka: '${prettyPrint(s)}' did not semantically equal '${prettyPrint(res)}'"
+    )
+  }
+
+  private def cleanParse(text: String) = {
+    val cleaned = text.replaceAll("(\\w)\\s+", "$1").replaceAll("(\\W)\\s+", "$1").replaceAll("\\s+$", "")
+    prettyPrint(cleaned)
+  }
+
+  private def prettyPrint(json: String) = {
+    json.fromJson[Json].map(_.toJsonPretty).getOrElse(json)
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -54,7 +54,6 @@ import com.normation.rudder.services.reports._
 import com.normation.rudder.web.ChooseTemplate
 import com.normation.rudder.web.model.JsNodeId
 import net.liftweb.common._
-import net.liftweb.http.S
 import net.liftweb.http.SHtml
 import net.liftweb.http.js.JE._
 import net.liftweb.http.js.JsCmd


### PR DESCRIPTION
https://issues.rudder.io/issues/23741

Now when testing for json equality (for instance in this test class [here](https://github.com/Normation/rudder/blob/e62443c97bbcd4f08516479fd974b658b5383438/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala#L93)), we can call `doTest(Nil, semanticJson = true)` that will check for semantic equality only (key-values in json object have no order).

We could as well do :

```scala
doTest(List("api_x.yaml")) // false by default
doTest(List("api_x.yaml", "api_y.yaml"), semanticJson = true)
```

!
