### PR TITLE
Fixes #23747: Using deprecated chart.js options generates errors in the console

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -187,18 +187,18 @@ function recentChangesGraph(changes, graphId, displayFullGraph) {
     , responsive: true
     , maintainAspectRatio: false
     , scales: {
-        xAxes: [{
+        x: {
             display: displayFullGraph
           , categoryPercentage:1
           , barPercentage:1
-        }]
-      , yAxes: [{
+        }
+      , y: {
           display: displayFullGraph
         , ticks: {
               beginAtZero: true
             , min : 0
           }
-        }]
+        }
       }
     , tooltips : {
           enabled: displayFullGraph


### PR DESCRIPTION
https://issues.rudder.io/issues/23747

This bug was introduced when we upgraded to version 3 of chart.js. We were still using the syntax from v2 of chart.js, but it has changed in v3.