### PR TITLE
Fixes #23735: Exception when bad input for inventory duration config

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -186,6 +186,8 @@ rudder.batch.reportsCleaner.deleteLogReport.TTL=2x
 # you need ~65GB for a month back of data).
 # There is no archive state for compliance levels.
 #
+# Note that 0 (the default value) means that cleaning never occurs.
+#
 rudder.batch.reportscleaner.compliancelevels.delete.TTL=8
 
 #


### PR DESCRIPTION
https://issues.rudder.io/issues/23735

The only message that an `ExceptionInInitializerError` provides is `null`, so we do not want to show the message but the cause instead...

Also for config value errors, adopting a standard error format and catching errors could always be beneficial so I used that to improve the errors logs during boot when config errors should prevent the server from running...   

I also took into account the suggestions to add comments to the sample configuration file, and use the main value `rudder.batch.reportsCleaner.deleteLogReport.TTL` in the configuration in favor of `rudder.batch.reportsCleaner.deleteReportLog.TTL` (which we do not use in the code)