### PR TITLE
Fixes #23764: Change "Name" to something else in the technique editor

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewBlock.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewBlock.elm
@@ -401,12 +401,27 @@ blockBody model parentId block ui techniqueUi =
                      |> addActionStopPropagation ("mousedown" ,DisableDragDrop )
                   ]
     methodName = case ui.mode of
-                   Opened -> element "input"
-                             |> addAttributeList [ readonly (not model.hasWriteRights), onFocus DisableDragDrop , type_ "text"
-                                                 , name "component", class "form-control"
-                                                 , value block.component,  placeholder "Enter a component name" ]
-                             |> addActionStopPropagation ("mousedown" ,DisableDragDrop )
-                             |> addInputHandler  (\s -> MethodCallModified (Block parentId {block  | component = s }))
+                   Opened -> element "div"
+                             |> addClass "method-name"
+                             |> appendChild
+                                ( element "div"
+                                    |> addClass ("component-name-wrapper")
+                                    |> appendChild
+                                       ( element "div"
+                                         |> addClass "form-group"
+                                         |> appendChildList
+                                           [ element "div"
+                                             |> addClass "title-input-name"
+                                             |> appendText "Block name"
+                                           , element "input"
+                                             |> addAttributeList [ readonly (not model.hasWriteRights), onFocus DisableDragDrop , type_ "text"
+                                                                 , name "component", class "form-control"
+                                                                 , value block.component,  placeholder "Enter a friendly name for this component" ]
+                                             |> addActionStopPropagation ("mousedown" ,DisableDragDrop )
+                                             |> addInputHandler  (\s -> MethodCallModified (Block parentId {block  | component = s }))
+                                           ]
+                                       )
+                                )
                    Closed -> element "div"
                              |> addClass "method-name"
                              |> addStyleListConditional [ ("font-style", "italic"), ("opacity", "0.7") ]  (String.isEmpty block.component)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewMethod.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewMethod.elm
@@ -530,9 +530,9 @@ callBody model ui techniqueUi call pid =
                                          |> appendChildList
                                            [ element "div"
                                              |> addClass "title-input-name"
-                                             |> appendText "Name"
+                                             |> appendText "Method name"
                                            , element "input"
-                                             |> addAttributeList [ readonly (not model.hasWriteRights), stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True)), onFocus DisableDragDrop, type_ "text", name "component", style "width" "100%", class "form-control", value call.component,  placeholder "Enter a component name" ]
+                                             |> addAttributeList [ readonly (not model.hasWriteRights), stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True)), onFocus DisableDragDrop, type_ "text", name "component", style "width" "100%", class "form-control", value call.component,  placeholder "Enter a friendly name for this component" ]
                                              |> addInputHandler  (\s -> MethodCallModified (Call pid {call  | component = s }))
                                            ]
                                        ]

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.css
@@ -993,7 +993,7 @@ button.btn.clipboard:hover {
 }
 /* =====  BLOCK  ===== */
 .method-info .block-name-container{
-  padding: 15px 100px 0 15px;
+  padding: 10px 100px 0 0;
 }
 .method-info.closed .block-name-container{
   padding-left: 0;


### PR DESCRIPTION
https://issues.rudder.io/issues/23764

The view for the block had no labels for the "name" input : we add `Block name` and `Method name` respectively as labels for block and method components. I copied the same elements structure as for the methods to make the view of the block similar. 

Also, I renamed the placeholder of both inputs to "Enter a friendly name for this component"  : 

![image](https://github.com/Normation/rudder/assets/65616064/e51cf72d-70af-4537-ac94-8ff348a786ec)
