### PR TITLE
Fixes #23780: Implement missing commands

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,7 +154,7 @@ pipeline {
                                 sh script: 'typos', label: 'check webapp api doc typos'
                             }
                             dir('relay') {
-                                sh script: 'typos --exclude "*.asc" --exclude "*.pem" --exclude "*.cert" --exclude "*.priv" --exclude "*.pub" --exclude "*.signed" --exclude "*.log" --exclude "*.json"', label: 'check relayd typos'
+                                sh script: 'typos --exclude "*.license" --exclude "*.asc" --exclude "*.pem" --exclude "*.cert" --exclude "*.priv" --exclude "*.pub" --exclude "*.signed" --exclude "*.log" --exclude "*.json"', label: 'check relayd typos'
                             }
                         }
                     }

--- a/relay/sources/Makefile
+++ b/relay/sources/Makefile
@@ -118,9 +118,10 @@ install: build
 	# rudder-package new implementation
 	install -m 755 rudder-package/target/release/rudder-package $(DESTDIR)/opt/rudder/bin/rudder-package
 	install -m 755 rudder-package/tools/rudder_plugins_key.gpg $(DESTDIR)/opt/rudder/etc/rudder-pkg/rudder_plugins_key.gpg
+	install -m 755 rudder-package/tools/rudder-package.sh $(DESTDIR)/opt/rudder/share/commands/package
 	install -m 755 rudder-pkg/rudder-pkg.conf $(DESTDIR)/opt/rudder/etc/rudder-pkg/rudder-pkg.conf
 	# rudder-pkg kept as backup for now
-	install -m 755 rudder-pkg/rudder-pkg $(DESTDIR)/opt/rudder/share/commands/package
+	install -m 755 rudder-pkg/rudder-pkg $(DESTDIR)/opt/rudder/share/python/rudder-pkg/rudder-pkg
 	ln -ns ../share/commands/package $(DESTDIR)/opt/rudder/bin/rudder-pkg
 	install -m 755 rudder-pkg/rudder_plugins_key.pub $(DESTDIR)/opt/rudder/etc/rudder-pkg/rudder_plugins_key.pub
 	install -m 644 autocomplete/rudder-pkg.sh $(DESTDIR)/etc/bash_completion.d/

--- a/relay/sources/rudder-package/Cargo.lock
+++ b/relay/sources/rudder-package/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -222,6 +222,29 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "cli-table"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfbb116d9e2c4be7011360d0c0bee565712c11e969c9609b25b619366dc379d"
+dependencies = [
+ "cli-table-derive",
+ "csv",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "cli-table-derive"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af3bfb9da627b0a6c467624fb7963921433774ed435493b5c08a3053e829ad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "colorchoice"
@@ -286,6 +309,27 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -471,7 +515,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -839,7 +883,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1043,7 +1087,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.39",
  "unicode-ident",
 ]
 
@@ -1056,6 +1100,7 @@ dependencies = [
  "assert-json-diff",
  "base16ct",
  "clap",
+ "cli-table",
  "dir-diff",
  "env_logger",
  "flate2",
@@ -1174,7 +1219,7 @@ checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1262,6 +1307,17 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1442,6 +1498,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
 name = "url"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,7 +1584,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
@@ -1556,7 +1618,7 @@ checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/relay/sources/rudder-package/Cargo.lock
+++ b/relay/sources/rudder-package/Cargo.lock
@@ -786,6 +786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,6 +1122,7 @@ dependencies = [
  "serde_json",
  "serde_toml",
  "sha2",
+ "spinners",
  "tar",
  "tempfile",
  "which",
@@ -1148,6 +1155,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
@@ -1303,10 +1316,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinners"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ef947f358b9c238923f764c72a4a9d42f2d637c46e059dbd319d6e7cfb4f82"
+dependencies = [
+ "lazy_static",
+ "maplit",
+ "strum",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "syn"

--- a/relay/sources/rudder-package/Cargo.lock
+++ b/relay/sources/rudder-package/Cargo.lock
@@ -452,9 +452,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -566,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
@@ -701,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -862,9 +862,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.59"
+version = "0.10.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a257ad03cd8fb16ad4172fedf8094451e1af1c4b70097636ef2eac9a5f0cc33"
+checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -894,9 +894,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.95"
+version = "0.9.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a4130519a360279579c2053038317e40eff64d13fd3f004f9e1b72b8a6aaf9"
+checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
 dependencies = [
  "cc",
  "libc",
@@ -906,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
@@ -1204,18 +1204,18 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1505,9 +1505,9 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/relay/sources/rudder-package/Cargo.toml
+++ b/relay/sources/rudder-package/Cargo.toml
@@ -33,6 +33,7 @@ tar = "0.4.40"
 tempfile = "3.8.0"
 which = "5.0.0"
 flate2 = "1.0.28"
+cli-table = "0.4.7"
 
 [profile.dev]
 # Disabling debug info speeds up builds a bunch,

--- a/relay/sources/rudder-package/Cargo.toml
+++ b/relay/sources/rudder-package/Cargo.toml
@@ -34,6 +34,7 @@ tempfile = "3.8.0"
 which = "5.0.0"
 flate2 = "1.0.28"
 cli-table = "0.4.7"
+spinners = "4.1.1"
 
 [profile.dev]
 # Disabling debug info speeds up builds a bunch,

--- a/relay/sources/rudder-package/Dockerfile
+++ b/relay/sources/rudder-package/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.72.0-bullseye
+FROM rust:1.74.0-bullseye
 LABEL ci=rudder/relay/sources/rudder-package/Dockerfile
 
 ARG USER_ID=1000

--- a/relay/sources/rudder-package/rust-toolchain.toml
+++ b/relay/sources/rudder-package/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
-channel = "1.72.0"
-
+channel = "1.74.0"

--- a/relay/sources/rudder-package/src/archive.rs
+++ b/relay/sources/rudder-package/src/archive.rs
@@ -230,17 +230,12 @@ impl Rpkg {
         );
         Database::write(PACKAGES_DATABASE_PATH, db)?;
         // Run postinst if any
-        let install_or_upgrade: PackageScriptArg = PackageScriptArg::Install;
+        let install_or_upgrade = PackageScriptArg::Install;
         self.metadata
             .run_package_script(PackageScript::Postinst, install_or_upgrade)?;
         // Update the webapp xml file if the plugin contains one or more jar file
         debug!("Enabling the associated jars if any");
-        match self.metadata.jar_files.clone() {
-            None => (),
-            Some(jars) => {
-                webapp.enable_jars(&jars)?;
-            }
-        }
+        webapp.enable_jars(&self.metadata.jar_files)?;
         // Restarting webapp
         debug!("Install completed");
         Ok(())

--- a/relay/sources/rudder-package/src/archive.rs
+++ b/relay/sources/rudder-package/src/archive.rs
@@ -156,7 +156,8 @@ impl Rpkg {
     fn unpack_embedded_txz(&self, txz_name: &str, dst_path: PathBuf) -> Result<(), anyhow::Error> {
         debug!(
             "Extracting archive '{}' in folder '{}'",
-            txz_name, dst_path.display()
+            txz_name,
+            dst_path.display()
         );
         // Loop over ar archive files
         let mut archive = Archive::new(File::open(self.path.clone()).unwrap());
@@ -231,7 +232,10 @@ impl Rpkg {
         // Update the webapp xml file if the plugin contains one or more jar file
         debug!("Enabling the associated jars if any");
         webapp.enable_jars(&self.metadata.jar_files)?;
-        info!("Plugin {} was sucessfully installed", self.metadata.short_name());
+        info!(
+            "Plugin {} was successfully installed",
+            self.metadata.short_name()
+        );
         Ok(())
     }
 }

--- a/relay/sources/rudder-package/src/archive.rs
+++ b/relay/sources/rudder-package/src/archive.rs
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2023 Normation SAS
 
-use anyhow::{anyhow, bail, Context, Ok, Result};
-use ar::Archive;
 use core::fmt;
-use log::debug;
-use serde::{Deserialize, Serialize};
 use std::{
     fs::{self, *},
     io::{Cursor, Read},
     path::PathBuf,
 };
+
+use anyhow::{anyhow, bail, Context, Ok, Result};
+use ar::Archive;
+use log::debug;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     database::{Database, InstalledPlugin},

--- a/relay/sources/rudder-package/src/archive.rs
+++ b/relay/sources/rudder-package/src/archive.rs
@@ -10,7 +10,7 @@ use std::{
 
 use anyhow::{anyhow, bail, Context, Ok, Result};
 use ar::Archive;
-use log::debug;
+use log::{debug, info};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -187,7 +187,7 @@ impl Rpkg {
     }
 
     pub fn install(&self, force: bool, db: &mut Database, webapp: &mut Webapp) -> Result<()> {
-        debug!("Installing rpkg '{}'...", self.path.display());
+        info!("Installing rpkg '{}'...", self.path.display());
         // Verify webapp compatibility
         if !(force
             || self
@@ -231,8 +231,7 @@ impl Rpkg {
         // Update the webapp xml file if the plugin contains one or more jar file
         debug!("Enabling the associated jars if any");
         webapp.enable_jars(&self.metadata.jar_files)?;
-        // Restarting webapp
-        debug!("Install completed");
+        info!("Plugin {} was sucessfully installed", self.metadata.short_name());
         Ok(())
     }
 }

--- a/relay/sources/rudder-package/src/archive.rs
+++ b/relay/sources/rudder-package/src/archive.rs
@@ -155,8 +155,8 @@ impl Rpkg {
 
     fn unpack_embedded_txz(&self, txz_name: &str, dst_path: PathBuf) -> Result<(), anyhow::Error> {
         debug!(
-            "Extracting archive '{}' in folder '{:?}'",
-            txz_name, dst_path
+            "Extracting archive '{}' in folder '{}'",
+            txz_name, dst_path.display()
         );
         // Loop over ar archive files
         let mut archive = Archive::new(File::open(self.path.clone()).unwrap());

--- a/relay/sources/rudder-package/src/archive.rs
+++ b/relay/sources/rudder-package/src/archive.rs
@@ -207,7 +207,7 @@ impl Rpkg {
         // Extract package scripts
         self.unpack_embedded_txz("script.txz", PathBuf::from(PACKAGES_FOLDER))?;
         // Run preinst if any
-        let install_or_upgrade= PackageScriptArg::Install;
+        let install_or_upgrade = PackageScriptArg::Install;
         self.metadata
             .run_package_script(PackageScript::Preinst, install_or_upgrade)?;
         // Extract archive content

--- a/relay/sources/rudder-package/src/cli.rs
+++ b/relay/sources/rudder-package/src/cli.rs
@@ -54,6 +54,17 @@ pub enum Command {
         #[clap()]
         package: Vec<String>,
     },
+    /// Upgrade plugins
+    Upgrade {
+        #[clap(long, short, help = "Upgrade all installed plugins")]
+        all: bool,
+
+        #[clap(long, help = "Run all the postinstall scripts of installed plugins")]
+        all_postinstall: bool,
+
+        #[clap()]
+        package: Vec<String>,
+    },
     /// Uninstall plugins
     Uninstall {
         #[clap()]
@@ -98,8 +109,15 @@ pub enum Command {
         #[clap()]
         package: Vec<String>,
 
-        #[clap(long, short, help = "Enable all installed plugins")]
+        #[clap(long, short, help = "Disable all installed plugins")]
         all: bool,
+
+        #[clap(
+            long,
+            short,
+            help = "Disable all installed plugins incompatible with the Web application version"
+        )]
+        incompatible: bool,
     },
     /// Test connection to the plugin repository
     CheckConnection {},

--- a/relay/sources/rudder-package/src/cli.rs
+++ b/relay/sources/rudder-package/src/cli.rs
@@ -73,7 +73,7 @@ pub enum Command {
     /// Show detailed information about a plugin
     Show {
         #[clap()]
-        package: String,
+        package: Vec<String>,
     },
     /// Enable installed plugins
     Enable {

--- a/relay/sources/rudder-package/src/cli.rs
+++ b/relay/sources/rudder-package/src/cli.rs
@@ -5,15 +5,12 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::CONFIG_PATH;
 
-#[derive(ValueEnum)]
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(ValueEnum, Copy, Clone, Debug, Default)]
 pub enum Format {
     Json,
     #[default]
     Human,
 }
-
-
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -39,20 +36,27 @@ pub enum Command {
         #[clap()]
         package: Vec<String>,
     },
+    /// Show the plugin list
     List {
         #[clap(long, short, help = "Show all available plugins")]
         all: bool,
 
         #[clap(long, short, help = "Show enabled plugins")]
         enabled: bool,
-        
+
         #[clap(long, short, help = "Output format")]
         format: Format,
+    },
+    /// Show detailed information about a plugin
+    Show {
+        #[clap()]
+        package: String,
     },
     Uninstall {
         #[clap()]
         package: Vec<String>,
     },
+    /// Update package index and licenses
     Update {},
     Enable {
         #[clap()]
@@ -71,4 +75,12 @@ pub enum Command {
         )]
         restore: bool,
     },
+    Disable {
+        #[clap()]
+        package: Option<Vec<String>>,
+
+        #[clap(long, short, help = "Enable all installed plugins")]
+        all: bool,
+    },
+    CheckConnection {},
 }

--- a/relay/sources/rudder-package/src/cli.rs
+++ b/relay/sources/rudder-package/src/cli.rs
@@ -29,6 +29,9 @@ pub struct Args {
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
+    /// Update package index and licenses from the repository
+    Update {},
+    /// Install plugins, locally or from the repository
     Install {
         #[clap(long, short, help = "Force installation of given plugin")]
         force: bool,
@@ -36,7 +39,12 @@ pub enum Command {
         #[clap()]
         package: Vec<String>,
     },
-    /// Show the plugin list
+    /// Uninstall plugins
+    Uninstall {
+        #[clap()]
+        package: Vec<String>,
+    },
+    /// Display the plugins list
     List {
         #[clap(long, short, help = "Show all available plugins")]
         all: bool,
@@ -52,15 +60,10 @@ pub enum Command {
         #[clap()]
         package: String,
     },
-    Uninstall {
-        #[clap()]
-        package: Vec<String>,
-    },
-    /// Update package index and licenses
-    Update {},
+    /// Enable installed plugins
     Enable {
         #[clap()]
-        package: Option<Vec<String>>,
+        package: Vec<String>,
 
         #[clap(long, short, help = "Enable all installed plugins")]
         all: bool,
@@ -75,12 +78,14 @@ pub enum Command {
         )]
         restore: bool,
     },
+    /// Disable installed plugins
     Disable {
         #[clap()]
-        package: Option<Vec<String>>,
+        package: Vec<String>,
 
         #[clap(long, short, help = "Enable all installed plugins")]
         all: bool,
     },
+    /// Test connection to the plugin repository
     CheckConnection {},
 }

--- a/relay/sources/rudder-package/src/cli.rs
+++ b/relay/sources/rudder-package/src/cli.rs
@@ -1,9 +1,19 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2023 Normation SAS
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::CONFIG_PATH;
+
+#[derive(ValueEnum)]
+#[derive(Copy, Clone, Debug, Default)]
+pub enum Format {
+    Json,
+    #[default]
+    Human,
+}
+
+
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -23,13 +33,22 @@ pub struct Args {
 #[derive(Debug, Subcommand)]
 pub enum Command {
     Install {
-        #[clap(long, short = 'f', help = "Force installation of given plugin")]
+        #[clap(long, short, help = "Force installation of given plugin")]
         force: bool,
 
         #[clap()]
         package: Vec<String>,
     },
-    List {},
+    List {
+        #[clap(long, short, help = "Show all available plugins")]
+        all: bool,
+
+        #[clap(long, short, help = "Show enabled plugins")]
+        enabled: bool,
+        
+        #[clap(long, short, help = "Output format")]
+        format: Format,
+    },
     Uninstall {
         #[clap()]
         package: Vec<String>,

--- a/relay/sources/rudder-package/src/cli.rs
+++ b/relay/sources/rudder-package/src/cli.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2023 Normation SAS
 
+use std::fmt::Display;
+
 use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::CONFIG_PATH;
@@ -10,6 +12,16 @@ pub enum Format {
     Json,
     #[default]
     Human,
+}
+
+impl Display for Format {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f,"{}",
+        match self {
+            Self::Json => "json",
+            Self::Human => "human",
+        })
+    }
 }
 
 #[derive(Parser, Debug)]
@@ -52,7 +64,7 @@ pub enum Command {
         #[clap(long, short, help = "Show enabled plugins")]
         enabled: bool,
 
-        #[clap(long, short, help = "Output format")]
+        #[clap(long, short, help = "Output format", default_value_t = Format::Human)]
         format: Format,
     },
     /// Show detailed information about a plugin

--- a/relay/sources/rudder-package/src/cli.rs
+++ b/relay/sources/rudder-package/src/cli.rs
@@ -16,11 +16,14 @@ pub enum Format {
 
 impl Display for Format {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f,"{}",
-        match self {
-            Self::Json => "json",
-            Self::Human => "human",
-        })
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Json => "json",
+                Self::Human => "human",
+            }
+        )
     }
 }
 

--- a/relay/sources/rudder-package/src/config.rs
+++ b/relay/sources/rudder-package/src/config.rs
@@ -4,6 +4,7 @@
 use std::{fmt, fs::read_to_string, path::Path};
 
 use anyhow::Result;
+use log::info;
 use serde::{Deserialize, Serialize};
 
 const PUBLIC_REPO_URL: &str = "https://repository.rudder.io/plugins";
@@ -77,7 +78,15 @@ impl Configuration {
     }
 
     pub fn read(path: &Path) -> Result<Self> {
-        let c = read_to_string(path)?;
+        let c = if path.exists() {
+            read_to_string(path)?
+        } else {
+            info!(
+                "'{}' does not exist, using default configuration",
+                path.display()
+            );
+            "".to_string()
+        };
         Self::parse(&c)
     }
 }

--- a/relay/sources/rudder-package/src/database.rs
+++ b/relay/sources/rudder-package/src/database.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
+use log::debug;
 use serde::{Deserialize, Serialize};
 
 use super::archive::Rpkg;
@@ -18,7 +19,6 @@ use crate::{
     webapp::Webapp,
     PACKAGES_DATABASE_PATH, PACKAGES_FOLDER,
 };
-use log::debug;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Database {
@@ -50,10 +50,10 @@ impl Database {
     }
 
     /// Return the plugin containing a given jar
-    pub fn plugin_provides_jar(&self, jar: String) -> Option<&InstalledPlugin> {
+    pub fn plugin_provides_jar(&self, jar: &String) -> Option<&InstalledPlugin> {
         self.plugins
             .values()
-            .find(|p| p.metadata.jar_files.contains(&jar))
+            .find(|p| p.metadata.jar_files.contains(jar))
     }
 
     pub fn uninstall(&mut self, plugin_name: &str, webapp: &mut Webapp) -> Result<()> {

--- a/relay/sources/rudder-package/src/database.rs
+++ b/relay/sources/rudder-package/src/database.rs
@@ -51,19 +51,26 @@ impl Database {
     }
 
     pub fn insert(&mut self, k: String, v: InstalledPlugin) -> Result<()> {
-        self.plugins.insert(k,v);
+        self.plugins.insert(k, v);
         self.write()
     }
 
     pub fn write(&mut self) -> Result<()> {
-        debug!("Updating the installed plugin database in '{}'", self.path.display());
+        debug!(
+            "Updating the installed plugin database in '{}'",
+            self.path.display()
+        );
         let file = fs::OpenOptions::new()
-                .write(true)
-                .truncate(true)
-                .open(&self.path)?;
+            .write(true)
+            .truncate(true)
+            .open(&self.path)?;
         let mut writer = BufWriter::new(file);
-        serde_json::to_writer_pretty(&mut writer, &self)
-            .with_context(|| format!("Failed to update the installed plugins database {}", self.path.display()))?;
+        serde_json::to_writer_pretty(&mut writer, &self).with_context(|| {
+            format!(
+                "Failed to update the installed plugins database {}",
+                self.path.display()
+            )
+        })?;
         Ok(())
     }
 
@@ -262,7 +269,10 @@ mod tests {
     fn test_adding_a_plugin_to_db() {
         use crate::versions;
 
-        let mut a = Database::read(Path::new("./tests/database/plugin_database_update_sample.json")).unwrap();
+        let mut a = Database::read(Path::new(
+            "./tests/database/plugin_database_update_sample.json",
+        ))
+        .unwrap();
         let addon = InstalledPlugin {
             files: vec![String::from("/tmp/my_path")],
             metadata: plugin::Metadata {

--- a/relay/sources/rudder-package/src/database.rs
+++ b/relay/sources/rudder-package/src/database.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use anyhow::{anyhow, bail, Context, Result};
-use log::{debug, info, warn};
+use log::{debug, info};
 use serde::{Deserialize, Serialize};
 
 use super::archive::Rpkg;
@@ -176,7 +176,7 @@ impl Database {
         // Update the database
         self.plugins.remove(&plugin_name);
         self.write()?;
-        info!("Plugin {} sucessfully uninstalled", short_name);
+        info!("Plugin {} successfully uninstalled", short_name);
         Ok(())
     }
 

--- a/relay/sources/rudder-package/src/database.rs
+++ b/relay/sources/rudder-package/src/database.rs
@@ -224,7 +224,7 @@ pub struct InstalledPlugin {
 
 impl InstalledPlugin {
     pub fn disable(&self, webapp: &mut Webapp) -> Result<()> {
-        debug!("Disabling plugin {}", self.metadata.short_name());
+        info!("Disabling plugin {}", self.metadata.short_name());
         if self.metadata.jar_files.is_empty() {
             debug!("Plugin {} does not support the enable/disable feature, it will always be enabled if installed.", self.metadata.name);
             Ok(())
@@ -234,7 +234,7 @@ impl InstalledPlugin {
     }
 
     pub fn enable(&self, webapp: &mut Webapp) -> Result<()> {
-        debug!("Enabling plugin {}", self.metadata.short_name());
+        info!("Enabling plugin {}", self.metadata.short_name());
         if self.metadata.jar_files.is_empty() {
             debug!("Plugin {} does not support the enable/disable feature, it will always be enabled if installed.", self.metadata.name);
             Ok(())

--- a/relay/sources/rudder-package/src/database.rs
+++ b/relay/sources/rudder-package/src/database.rs
@@ -135,21 +135,15 @@ impl Database {
     }
 
     pub fn uninstall(&mut self, plugin_name: &str, webapp: &mut Webapp) -> Result<()> {
-        // Force to use plugin long qualified name
-        let plugin_name = if !plugin_name.starts_with("rudder-plugin-") {
-            format!("rudder-plugin-{plugin_name}")
-        } else {
-            plugin_name.to_owned()
-        };
         let short_name = plugin_name.strip_prefix("rudder-plugin-").unwrap();
         // Return Ok if not installed
-        if !self.plugins.contains_key(&plugin_name) {
+        if !self.plugins.contains_key(plugin_name) {
             info!("Plugin {} is not installed.", short_name);
             return Ok(());
         }
         debug!("Uninstalling plugin {}", short_name);
         // Disable the jar files if any
-        let installed_plugin = self.plugins.get(&plugin_name).ok_or(anyhow!(
+        let installed_plugin = self.plugins.get(plugin_name).ok_or(anyhow!(
             "Could not extract data for plugin {} in the database",
             short_name
         ))?;
@@ -174,7 +168,7 @@ impl Database {
             ))?;
         }
         // Update the database
-        self.plugins.remove(&plugin_name);
+        self.plugins.remove(plugin_name);
         self.write()?;
         info!("Plugin {} successfully uninstalled", short_name);
         Ok(())
@@ -218,7 +212,7 @@ pub struct InstalledPlugin {
 
 impl InstalledPlugin {
     pub fn disable(&self, webapp: &mut Webapp) -> Result<()> {
-        debug!("Disabling plugin {}", self.metadata.name);
+        debug!("Disabling plugin {}", self.metadata.short_name());
         if self.metadata.jar_files.is_empty() {
             debug!("Plugin {} does not support the enable/disable feature, it will always be enabled if installed.", self.metadata.name);
             Ok(())
@@ -228,9 +222,9 @@ impl InstalledPlugin {
     }
 
     pub fn enable(&self, webapp: &mut Webapp) -> Result<()> {
-        debug!("Enabling plugin {}", self.metadata.name);
+        debug!("Enabling plugin {}", self.metadata.short_name());
         if self.metadata.jar_files.is_empty() {
-            println!("Plugin {} does not support the enable/disable feature, it will always be enabled if installed.", self.metadata.name);
+            debug!("Plugin {} does not support the enable/disable feature, it will always be enabled if installed.", self.metadata.name);
             Ok(())
         } else {
             webapp.enable_jars(&self.metadata.jar_files)

--- a/relay/sources/rudder-package/src/database.rs
+++ b/relay/sources/rudder-package/src/database.rs
@@ -55,7 +55,7 @@ impl Database {
             p.metadata
                 .jar_files
                 .as_ref()
-                .map(|j| dbg!(j).contains(dbg!(&jar)))
+                .map(|j| j.contains(&jar))
                 .unwrap_or(false)
         })
     }

--- a/relay/sources/rudder-package/src/database.rs
+++ b/relay/sources/rudder-package/src/database.rs
@@ -160,7 +160,7 @@ mod tests {
             .expect("Unable to parse file './tests/pluginèdatabase_parsing.json'");
         let db: Database = serde_json::from_str(&data).unwrap();
         assert_eq!(
-            db.plugins["rudder-plugin-aix"].metadata.plugin_type,
+            db.plugins["rudder-plugin-aix"].metadata.package_type,
             archive::PackageType::Plugin
         );
     }
@@ -173,7 +173,7 @@ mod tests {
         let addon = InstalledPlugin {
             files: vec![String::from("/tmp/my_path")],
             metadata: plugin::Metadata {
-                plugin_type: archive::PackageType::Plugin,
+                package_type: archive::PackageType::Plugin,
                 name: String::from("my_name"),
                 version: versions::ArchiveVersion::from_str("0.0.0-0.0").unwrap(),
                 build_date: String::from("2023-10-13T10:03:34+00:00"),

--- a/relay/sources/rudder-package/src/database.rs
+++ b/relay/sources/rudder-package/src/database.rs
@@ -102,7 +102,7 @@ impl Database {
             package
         } else {
             // Find compatible plugin if any
-            let to_dl_and_install = match index.and_then(|i|i.get_compatible_plugin(&webapp.version, &package)) {
+            let to_dl_and_install = match index.and_then(|i|i.latest_compatible_plugin(&webapp.version, &package)) {
                     None => bail!("Could not find any compatible '{}' plugin with the current Rudder version in the configured repository.", package),
                     Some(p) => {
                         debug!("Found a compatible plugin in the repository:\n{:?}", p);

--- a/relay/sources/rudder-package/src/database.rs
+++ b/relay/sources/rudder-package/src/database.rs
@@ -49,6 +49,17 @@ impl Database {
         }
     }
 
+    /// Return the plugin containing a given jar
+    pub fn plugin_provides_jar(&self, jar: String) -> Option<&InstalledPlugin> {
+        self.plugins.values().find(|p| {
+            p.metadata
+                .jar_files
+                .as_ref()
+                .map(|j| dbg!(j).contains(dbg!(&jar)))
+                .unwrap_or(false)
+        })
+    }
+
     pub fn uninstall(&mut self, plugin_name: &str, webapp: &mut Webapp) -> Result<()> {
         // Force to use plugin long qualified name
         if !plugin_name.starts_with("rudder-plugin-") {

--- a/relay/sources/rudder-package/src/dependency.rs
+++ b/relay/sources/rudder-package/src/dependency.rs
@@ -3,7 +3,7 @@
 
 use std::{process::Command, str};
 
-use log::{debug, error};
+use log::{debug, warn};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use which::which;
@@ -66,7 +66,7 @@ pub trait IsInstalled {
 
 impl IsInstalled for PythonDependency {
     fn is_installed(&self) -> bool {
-        error!("Deprecated dependency type 'python' with value '{}'. It is up to you to make sure it is installed, ignoring.", self.0);
+        warn!("Deprecated dependency type 'python' with value '{}'. It is up to you to make sure it is installed, ignoring.", self.0);
         true
     }
 }
@@ -98,7 +98,7 @@ impl IsInstalled for AptDependency {
 impl IsInstalled for RpmDependency {
     fn is_installed(&self) -> bool {
         let mut binding = Command::new("rpm");
-        let cmd = binding.arg("-q").arg(self.0.clone());
+        let cmd = binding.arg("-q").arg("--").arg(&self.0);
         let result = match CmdOutput::new(cmd) {
             Ok(a) => a,
             Err(e) => {
@@ -117,7 +117,7 @@ impl IsInstalled for RpmDependency {
 
 impl IsInstalled for BinaryDependency {
     fn is_installed(&self) -> bool {
-        match which(self.0.clone()) {
+        match which(&self.0) {
             Ok(_) => {
                 debug!("'binary' base dependency '{}' found on the system", self.0);
                 true

--- a/relay/sources/rudder-package/src/lib.rs
+++ b/relay/sources/rudder-package/src/lib.rs
@@ -114,7 +114,10 @@ pub fn run() -> Result<()> {
                 )
             }
         }
-        Command::Update {} => repo.update(&webapp)?,
+        Command::Update {} => {
+            repo.update(&webapp)?;
+            info!("Index and licenses successfully updated")
+        }
         Command::Enable {
             package,
             all,
@@ -131,8 +134,10 @@ pub fn run() -> Result<()> {
                 let backup_path = Path::new(TMP_PLUGINS_FOLDER).join("plugins_status.backup");
                 if save {
                     db.enabled_plugins_save(&backup_path, &mut webapp)?;
+                    info!("Plugins status successfully saved");
                 } else if restore {
                     db.enabled_plugins_restore(&backup_path, &mut webapp)?;
+                    info!("Plugins status successfully restored");
                 } else {
                     bail!("No plugin provided");
                 }
@@ -141,8 +146,8 @@ pub fn run() -> Result<()> {
                     None => bail!("Plugin {} not installed", p),
                     Some(p) => p.enable(&mut webapp),
                 })?;
+                info!("Plugins successfully enabled");
             }
-            info!("Plugins successfully enabled");
         }
         Command::Disable { package, all } => {
             let to_disable: Vec<String> = if all {

--- a/relay/sources/rudder-package/src/lib.rs
+++ b/relay/sources/rudder-package/src/lib.rs
@@ -94,7 +94,7 @@ pub fn run() -> Result<()> {
     match args.command {
         Command::Install { force, package } => package
             .into_iter()
-            .try_for_each(|p| db.install(force, p, &repo,index.as_ref(), &mut webapp))?,
+            .try_for_each(|p| db.install(force, p, &repo, index.as_ref(), &mut webapp))?,
         Command::Uninstall { package: packages } => packages
             .into_iter()
             .try_for_each(|p| db.uninstall(&p, &mut webapp))?,

--- a/relay/sources/rudder-package/src/lib.rs
+++ b/relay/sources/rudder-package/src/lib.rs
@@ -89,7 +89,7 @@ pub fn run() -> Result<()> {
             enabled,
             format,
         } => {
-            action::list(all, enabled, format, &mut webapp)?;
+            action::list(all, enabled, format, &webapp)?;
         }
         _ => {
             error!("This command is not implemented");
@@ -107,6 +107,7 @@ pub mod action {
     use crate::archive::Rpkg;
     use crate::cli::Format;
     use crate::database::Database;
+    use crate::list::ListOutput;
     use crate::repo_index::RepoIndex;
     use crate::repository::Repository;
     use crate::versions::RudderVersion;
@@ -124,8 +125,9 @@ pub mod action {
         let db = Database::read(PACKAGES_DATABASE_PATH)?;
         // Available plugins
         let index = RepoIndex::from_path(REPOSITORY_INDEX_PATH)?;
-        // Enabled
-        list(all, enabled, format, webapp);
+
+        let out = ListOutput::new(all, enabled, &db, &index, webapp)?;
+        out.display(format)?;
         Ok(())
     }
 

--- a/relay/sources/rudder-package/src/lib.rs
+++ b/relay/sources/rudder-package/src/lib.rs
@@ -124,25 +124,26 @@ pub fn run() -> Result<()> {
                     }
                 }
                 info!("All postinstall scripts ran");
-            }
-            // Normal upgrades
-            let to_upgrade: Vec<String> = if all {
-                db.plugins.keys().cloned().collect()
             } else {
-                let packages = long_names(package);
-                for p in &packages {
-                    if db.plugins.get(p).is_none() {
-                        bail!(
-                            "Plugin {} is not installed, stopping upgrade",
-                            short_name(p)
-                        )
+                // Normal upgrades
+                let to_upgrade: Vec<String> = if all {
+                    db.plugins.keys().cloned().collect()
+                } else {
+                    let packages = long_names(package);
+                    for p in &packages {
+                        if db.plugins.get(p).is_none() {
+                            bail!(
+                                "Plugin {} is not installed, stopping upgrade",
+                                short_name(p)
+                            )
+                        }
                     }
-                }
-                packages
-            };
-            to_upgrade
-                .into_iter()
-                .try_for_each(|p| db.install(false, p, &repo, index.as_ref(), &mut webapp))?;
+                    packages
+                };
+                to_upgrade
+                    .into_iter()
+                    .try_for_each(|p| db.install(false, p, &repo, index.as_ref(), &mut webapp))?;
+            }
         }
         Command::List {
             all,

--- a/relay/sources/rudder-package/src/lib.rs
+++ b/relay/sources/rudder-package/src/lib.rs
@@ -9,6 +9,7 @@ mod cmd;
 mod config;
 mod database;
 mod dependency;
+mod license;
 mod list;
 mod plugin;
 mod repo_index;
@@ -30,6 +31,7 @@ use crate::{
     cli::Command,
     config::Configuration,
     database::Database,
+    license::Licenses,
     list::ListOutput,
     plugin::{long_names, short_name},
     repo_index::RepoIndex,
@@ -97,6 +99,7 @@ pub fn run() -> Result<()> {
     let mut webapp = Webapp::new(PathBuf::from(WEBAPP_XML_PATH), webapp_version);
     let mut db = Database::read(Path::new(PACKAGES_DATABASE_PATH))?;
     let index = RepoIndex::from_path(REPOSITORY_INDEX_PATH)?;
+    let licenses = Licenses::from_path(Path::new(LICENSES_FOLDER))?;
 
     match args.command {
         Command::Install { force, package } => {
@@ -186,7 +189,8 @@ pub fn run() -> Result<()> {
             all,
             enabled,
             format,
-        } => ListOutput::new(all, enabled, &db, index.as_ref(), &webapp)?.display(format)?,
+        } => ListOutput::new(all, enabled, &licenses, &db, index.as_ref(), &webapp)?
+            .display(format)?,
         Command::Show { package } => {
             for p in long_names(package) {
                 println!(

--- a/relay/sources/rudder-package/src/lib.rs
+++ b/relay/sources/rudder-package/src/lib.rs
@@ -142,7 +142,7 @@ pub fn run() -> Result<()> {
                     Some(p) => p.enable(&mut webapp),
                 })?;
             }
-            info!("Plugins sucessfully enabled");
+            info!("Plugins successfully enabled");
         }
         Command::Disable { package, all } => {
             let to_disable: Vec<String> = if all {
@@ -156,7 +156,7 @@ pub fn run() -> Result<()> {
                     None => bail!("Plugin {} not installed", p),
                     Some(p) => p.disable(&mut webapp),
                 })?;
-            info!("Plugins sucessfully disabled");
+            info!("Plugins successfully disabled");
         }
         Command::CheckConnection {} => repo.test_connection()?,
     }

--- a/relay/sources/rudder-package/src/lib.rs
+++ b/relay/sources/rudder-package/src/lib.rs
@@ -95,7 +95,9 @@ pub fn run() -> Result<()> {
             action::install(force, package, repo, &mut webapp)?;
         }
         Command::Uninstall { package: packages } => {
-            packages.iter().try_for_each(|p| db.uninstall(p, &mut webapp))?;
+            packages
+                .iter()
+                .try_for_each(|p| db.uninstall(p, &mut webapp))?;
         }
         Command::List {
             all,
@@ -104,8 +106,19 @@ pub fn run() -> Result<()> {
         } => {
             ListOutput::new(all, enabled, &db, &index, &webapp)?.display(format)?;
         }
-        _ => {
-            todo!("This command is not implemented yet");
+        Command::Show { package } => todo!(),
+        Command::Update {} => {
+            repo.update()?;
+        }
+        Command::Enable {
+            package,
+            all,
+            save,
+            restore,
+        } => todo!(),
+        Command::Disable { package, all } => todo!(),
+        Command::CheckConnection {} => {
+            repo.test_connection()?;
         }
     }
     Ok(())
@@ -203,11 +216,9 @@ pub mod action {
             let mut enabled_jars_from_plugins = Vec::<String>::new();
             let enabled_jar = w.jars()?;
             for (k, v) in db.plugins.clone() {
-                if let Some(j) = v.metadata.jar_files {
-                    if j.iter().any(|x| enabled_jar.contains(x)) {
+                    if v.metadata.jar_files.iter().any(|x| enabled_jar.contains(x)) {
                         enabled_jars_from_plugins.push(format!("enable {}", k))
                     }
-                }
             }
             fs::write(backup_path, enabled_jars_from_plugins.join("\n"))?;
             return Ok(());

--- a/relay/sources/rudder-package/src/lib.rs
+++ b/relay/sources/rudder-package/src/lib.rs
@@ -110,7 +110,7 @@ pub fn run() -> Result<()> {
                 .ok_or_else(|| anyhow!("Could not find plugin"))?
                 .metadata
         ),
-        Command::Update {} => repo.update()?,
+        Command::Update {} => repo.update(&webapp)?,
         Command::Enable {
             package,
             all,

--- a/relay/sources/rudder-package/src/license.rs
+++ b/relay/sources/rudder-package/src/license.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2023 Normation SAS
+
+use anyhow::{anyhow, Result};
+use serde::Serialize;
+use std::{collections::HashMap, fs, path::Path};
+
+/// Very simple signature file reader
+/// We mainly need to extract expiration date for each plugin
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize)]
+pub struct License {
+    pub start_date: String,
+    pub end_date: String,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Licenses {
+    pub inner: HashMap<String, License>,
+}
+
+impl Licenses {
+    pub fn from_path(path: &Path) -> Result<Self> {
+        fn find_key_value<'a>(key: &'a str, content: &'a str) -> Option<&'a str> {
+            content
+                .lines()
+                .find(|l| l.starts_with(&format!("{key}=")))
+                .and_then(|l| l.split('=').nth(1))
+        }
+
+        let mut res = HashMap::new();
+        if path.exists() {
+            for entry in fs::read_dir(path)? {
+                let entry = entry?;
+                let path = entry.path();
+                if path.extension().map(|e| e.to_string_lossy().into_owned())
+                    == Some("license".to_string())
+                {
+                    let s = fs::read_to_string(path)?;
+                    let plugin = find_key_value("softwareid", &s)
+                        .ok_or(anyhow!("Could not find software id in license"))?
+                        .to_owned();
+                    let start_date = find_key_value("startdate", &s)
+                        .ok_or(anyhow!("Could not find start date in license"))?
+                        .to_owned();
+                    let end_date = find_key_value("enddate", &s)
+                        .ok_or(anyhow!("Could not find end date in license"))?
+                        .to_owned();
+                    res.insert(
+                        plugin,
+                        License {
+                            start_date,
+                            end_date,
+                        },
+                    );
+                }
+            }
+        }
+        Ok(Self { inner: res })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_parses_license() {
+        let licenses = Licenses::from_path(Path::new("tests/licenses")).unwrap();
+        dbg!(licenses);
+    }
+}

--- a/relay/sources/rudder-package/src/list.rs
+++ b/relay/sources/rudder-package/src/list.rs
@@ -95,10 +95,7 @@ impl ListOutput {
 
         for p in db.plugins.values() {
             let name = p
-                .metadata
-                .name
-                .strip_prefix("rudder-plugin-")
-                .unwrap()
+                .metadata.short_name()
                 .to_string();
             let enabled = match p.metadata.plugin_type() {
                 PluginType::Standalone => true,

--- a/relay/sources/rudder-package/src/list.rs
+++ b/relay/sources/rudder-package/src/list.rs
@@ -143,11 +143,11 @@ impl ListOutput {
 mod tests {
     use std::path::PathBuf;
 
-    use crate::{cli::Format, database::Database, repo_index::RepoIndex, webapp::Webapp};
+    use crate::{cli::Format, database::Database, repo_index::RepoIndex, webapp::Webapp, versions::RudderVersion};
 
     #[test]
     fn it_lists_plugins() {
-        let w = Webapp::new(PathBuf::from("tests/webapp_xml/example.xml"));
+        let w = Webapp::new(PathBuf::from("tests/webapp_xml/example.xml"), RudderVersion::from_path("./tests/versions/rudder-server-version").unwrap());
         let r = RepoIndex::from_path("./tests/repo_index.json").unwrap();
         let d = Database::read("./tests/database/plugin_database_update_sample.json").unwrap();
 

--- a/relay/sources/rudder-package/src/list.rs
+++ b/relay/sources/rudder-package/src/list.rs
@@ -42,8 +42,13 @@ impl ListOutput {
             .map(|e| {
                 vec![
                     e.name.cell(),
-                    e.version.unwrap_or("".to_string()).cell(),
-                    e.latest_version.unwrap_or("".to_string()).cell(),
+                    e.version.as_ref().unwrap_or(&"".to_string()).cell(),
+                    if e.latest_version == e.version {
+                        "".to_string()
+                    } else {
+                        e.latest_version.unwrap_or("".to_string())
+                    }
+                    .cell(),
                     e.plugin_type.cell(),
                     match (e.installed, e.enabled, e.plugin_type) {
                         (false, _, _) => "",

--- a/relay/sources/rudder-package/src/list.rs
+++ b/relay/sources/rudder-package/src/list.rs
@@ -3,108 +3,142 @@
 
 use std::collections::HashSet;
 
+use crate::{
+    cli::Format, database::Database, plugin::PluginType, repo_index::RepoIndex, webapp::Webapp,
+};
 use anyhow::Result;
+use serde::Serialize;
 
-use crate::{cli::Format, database::Database, repo_index::RepoIndex, webapp::Webapp};
+pub struct ListOutput {
+    inner: Vec<ListEntry>,
+}
 
 /// Content we want to display about each plugin
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ListEntry {
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct ListEntry {
     /// Plugin name ("short")
     name: String,
     /// Full plugin version
     version: String,
     /// None means no higher version is available
-    available: Option<String>,
-    // None means plugin is not disableable
-    enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    latest_version: Option<String>,
+    enabled: bool,
+    #[serde(rename = "type")]
+    plugin_type: PluginType,
 }
 
-fn human_table(list: Vec<ListEntry>) {
-    use cli_table::{format::Justify, print_stdout, Cell, Style, Table};
+impl ListOutput {
+    fn human_table(self) -> Result<()> {
+        use cli_table::{format::Justify, print_stdout, Cell, Style, Table};
 
-    let table = list
-        .into_iter()
-        .map(|e| {
-            vec![
-                e.name.cell(),
-                e.version.cell().justify(Justify::Right),
-                "".cell(),
-                if e.enabled.is_some() { "web plugin"} else {"standalone plugin"}.cell(),
-                e.enabled
-                    .map(|s| if s {"enabled"} else {"disabled"})
-                    .unwrap_or("")
+        let table = self
+            .inner
+            .into_iter()
+            .map(|e| {
+                vec![
+                    e.name.cell(),
+                    e.version.cell().justify(Justify::Right),
+                    e.latest_version.unwrap_or("".to_string()).cell(),
+                    e.plugin_type.cell(),
+                    match e.plugin_type {
+                        PluginType::Web => {
+                            if e.enabled {
+                                "installed (enabled)"
+                            } else {
+                                "installed (disabled)"
+                            }
+                        }
+                        PluginType::Standalone => "installed",
+                    }
                     .cell(),
-            ]
-        })
-        .table()
-        .title(vec![
-            "Name".cell().bold(true),
-            "Installed".cell().bold(true),
-            "Latest".cell().bold(true),
-            "Type".cell().bold(true),
-            "Status".cell().bold(true),
-        ]);
-
-    assert!(print_stdout(table).is_ok());
-}
-
-pub fn list(
-    show_all: bool,
-    show_only_enabled: bool,
-    format: Format,
-    db: &Database,
-    index: &RepoIndex,
-    webapp: &Webapp,
-) -> Result<()> {
-    let mut plugins: Vec<ListEntry> = vec![];
-    // Principles:
-    //
-    // * By default, display installed plugins.
-    // * If an index is available and "all", also add available plugins.
-    // * If "enabled", display installed package minus disabled ones.
-    let jars = webapp.jars()?;
-    let enabled_plugins: HashSet<String> = jars
-        .into_iter()
-        .flat_map(|j| db.plugin_provides_jar(j))
-        .map(|p| p.metadata.name.clone())
-        .collect();
-
-    for p in db.plugins.values() {
-        let name = p
-            .metadata
-            .name
-            .strip_prefix("rudder-plugin-")
-            .unwrap()
-            .to_string();
-        let enabled = p
-            .metadata
-            .jar_files
-            .as_ref()
-            .map(|_| enabled_plugins.contains(&p.metadata.name));
-        let e = ListEntry {
-            name,
-            version: p.metadata.version.to_string(),
-            available: None,
-            enabled,
-        };
-        if !(show_only_enabled && enabled == Some(false)) {
-            plugins.push(e);
-        }
+                ]
+            })
+            .table()
+            .title(vec![
+                "Name".cell().bold(true),
+                "Installed".cell().bold(true),
+                "Latest".cell().bold(true),
+                "Type".cell().bold(true),
+                "Status".cell().bold(true),
+            ]);
+        print_stdout(table)?;
+        Ok(())
     }
 
-    if show_all {
-        for p in index.inner().iter() {
-            //dbg!(&p.metadata.name);
-            //dbg!(&p.metadata.version);
-        }
+    fn json(&self) -> Result<()> {
+        let out = serde_json::to_string(&self.inner)?;
+        println!("{}", out);
+        Ok(())
     }
-    dbg!(&plugins);
 
-    plugins.sort_by_key(|e| e.name.clone());
+    pub fn new(
+        show_all: bool,
+        show_only_enabled: bool,
+        db: &Database,
+        index: &RepoIndex,
+        webapp: &Webapp,
+    ) -> Result<Self> {
+        let mut plugins: Vec<ListEntry> = vec![];
+        // Principles:
+        //
+        // * By default, display installed plugins.
+        // * If an index is available and "all", also add available plugins.
+        // * If "enabled", display installed package minus disabled ones.
+        let jars = webapp.jars()?;
+        let enabled_plugins: HashSet<String> = jars
+            .into_iter()
+            .flat_map(|j| db.plugin_provides_jar(j))
+            .map(|p| p.metadata.name.clone())
+            .collect();
 
-    human_table(plugins);
-    Ok(())
+        for p in db.plugins.values() {
+            let name = p
+                .metadata
+                .name
+                .strip_prefix("rudder-plugin-")
+                .unwrap()
+                .to_string();
+            let enabled = p
+                .metadata
+                .jar_files
+                .as_ref()
+                .map(|_| enabled_plugins.contains(&p.metadata.name))
+                .unwrap_or(true);
+            let e = ListEntry {
+                name,
+                version: p.metadata.version.to_string(),
+                latest_version: None,
+                plugin_type: p.metadata.plugin_type(),
+                enabled,
+            };
+            if !show_only_enabled || enabled {
+                // Standalone plugins are always considered enabled
+                // (even if some might not be: disabled systemd service for notify, etc.)
+                plugins.push(e);
+            }
+        }
+
+        if show_all {
+            for p in index.inner().iter() {
+                //dbg!(&p.metadata.name);
+                //dbg!(&p.metadata.version);
+            }
+        }
+
+        // Sort by name alphabetical order
+        plugins.sort_by_key(|e| e.name.clone());
+
+        Ok(Self { inner: plugins })
+    }
+
+    pub fn display(self, format: Format) -> Result<()> {
+        match format {
+            Format::Json => self.json()?,
+            Format::Human => self.human_table()?,
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -119,6 +153,7 @@ mod tests {
         let r = RepoIndex::from_path("./tests/repo_index.json").unwrap();
         let d = Database::read("./tests/database/plugin_database_update_sample.json").unwrap();
 
-        super::list(true, false, Format::Json, &d, &r, &w).unwrap();
+        let out = super::ListOutput::new(true, false, &d, &r, &w).unwrap();
+        out.display(Format::Human).unwrap();
     }
 }

--- a/relay/sources/rudder-package/src/list.rs
+++ b/relay/sources/rudder-package/src/list.rs
@@ -94,9 +94,7 @@ impl ListOutput {
             .collect();
 
         for p in db.plugins.values() {
-            let name = p
-                .metadata.short_name()
-                .to_string();
+            let name = p.metadata.short_name().to_string();
             let enabled = match p.metadata.plugin_type() {
                 PluginType::Standalone => true,
                 PluginType::Web => enabled_plugins.contains(&p.metadata.name),
@@ -117,7 +115,7 @@ impl ListOutput {
 
         if show_all {
             if let Some(i) = index {
-                for p in i.inner().iter() {
+                for _p in i.inner().iter() {
                     //dbg!(&p.metadata.name);
                     //dbg!(&p.metadata.version);
                 }
@@ -143,12 +141,11 @@ impl ListOutput {
 mod tests {
     use std::path::{Path, PathBuf};
 
+    use super::ListOutput;
     use crate::{
         cli::Format, database::Database, repo_index::RepoIndex, versions::RudderVersion,
         webapp::Webapp,
     };
-
-    use super::ListOutput;
 
     #[test]
     fn it_lists_plugins() {

--- a/relay/sources/rudder-package/src/list.rs
+++ b/relay/sources/rudder-package/src/list.rs
@@ -113,6 +113,7 @@ impl ListOutput {
             }
         }
 
+        // FIXME: integrate latest version info
         if show_all {
             if let Some(i) = index {
                 for _p in i.inner().iter() {

--- a/relay/sources/rudder-package/src/list.rs
+++ b/relay/sources/rudder-package/src/list.rs
@@ -99,12 +99,10 @@ impl ListOutput {
                 .strip_prefix("rudder-plugin-")
                 .unwrap()
                 .to_string();
-            let enabled = p
-                .metadata
-                .jar_files
-                .as_ref()
-                .map(|_| enabled_plugins.contains(&p.metadata.name))
-                .unwrap_or(true);
+            let enabled = match p.metadata.plugin_type() {
+                PluginType::Standalone => true,
+                PluginType::Web => enabled_plugins.contains(&p.metadata.name),
+            };
             let e = ListEntry {
                 name,
                 version: p.metadata.version.to_string(),

--- a/relay/sources/rudder-package/src/list.rs
+++ b/relay/sources/rudder-package/src/list.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2023 Normation SAS
+
+use anyhow::Result;
+
+use crate::{cli::Format, database::Database, repo_index::RepoIndex, webapp::Webapp};
+
+/// Content we want to display about each plugin
+pub struct ListEntry<'a> {
+    name: &'a str,
+    version: &'a str,
+    available: Option<&'a str>,
+    enabled: bool,
+}
+
+pub fn list(
+    all: bool,
+    enabled: bool,
+    format: Format,
+    db: &Database,
+    index: &RepoIndex,
+    webapp: &Webapp,
+) -> Result<()> {
+
+    dbg!(index);
+
+    for p in index.inner().iter() {
+        dbg!(&p.metadata.name);
+        dbg!(&p.metadata.version.to_string());
+    }
+    
+
+    
+    //dbg!(db);
+    let enabled = webapp.jars()?;
+    //dbg!(enabled);
+
+
+    
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::{cli::Format, database::Database, repo_index::RepoIndex, webapp::Webapp};
+
+    #[test]
+    fn it_lists_plugins() {
+        let w = Webapp::new(PathBuf::from("tests/webapp_xml/example.xml"));
+        let r = RepoIndex::from_path("./tests/repo_index.json").unwrap();
+        let d = Database::read("./tests/database/plugin_database_update_sample.json").unwrap();
+
+        super::list(true, false, Format::Json, &d, &r, &w).unwrap();
+    }
+}

--- a/relay/sources/rudder-package/src/list.rs
+++ b/relay/sources/rudder-package/src/list.rs
@@ -77,7 +77,7 @@ impl ListOutput {
         show_all: bool,
         show_only_enabled: bool,
         db: &Database,
-        index: &RepoIndex,
+        index: Option<&RepoIndex>,
         webapp: &Webapp,
     ) -> Result<Self> {
         let mut plugins: Vec<ListEntry> = vec![];
@@ -119,9 +119,11 @@ impl ListOutput {
         }
 
         if show_all {
-            for p in index.inner().iter() {
-                //dbg!(&p.metadata.name);
-                //dbg!(&p.metadata.version);
+            if let Some(i) = index {
+                for p in i.inner().iter() {
+                    //dbg!(&p.metadata.name);
+                    //dbg!(&p.metadata.version);
+                }
             }
         }
 
@@ -142,12 +144,14 @@ impl ListOutput {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::{PathBuf, Path};
 
     use crate::{
         cli::Format, database::Database, repo_index::RepoIndex, versions::RudderVersion,
         webapp::Webapp,
     };
+
+    use super::ListOutput;
 
     #[test]
     fn it_lists_plugins() {
@@ -155,10 +159,12 @@ mod tests {
             PathBuf::from("tests/webapp_xml/example.xml"),
             RudderVersion::from_path("./tests/versions/rudder-server-version").unwrap(),
         );
-        let r = RepoIndex::from_path("./tests/repo_index.json").unwrap();
-        let d = Database::read("./tests/database/plugin_database_update_sample.json").unwrap();
-
-        let out = super::ListOutput::new(true, false, &d, &r, &w).unwrap();
+        let r =RepoIndex::from_path("./tests/repo_index.json").unwrap().unwrap();
+        let d = Database::read(Path::new(
+            "./tests/database/plugin_database_update_sample.json",
+        ))
+        .unwrap();
+        let out = ListOutput::new(true, false, &d, Some(&r), &w).unwrap();
         out.display(Format::Human).unwrap();
     }
 }

--- a/relay/sources/rudder-package/src/list.rs
+++ b/relay/sources/rudder-package/src/list.rs
@@ -3,11 +3,12 @@
 
 use std::collections::HashSet;
 
+use anyhow::Result;
+use serde::Serialize;
+
 use crate::{
     cli::Format, database::Database, plugin::PluginType, repo_index::RepoIndex, webapp::Webapp,
 };
-use anyhow::Result;
-use serde::Serialize;
 
 pub struct ListOutput {
     inner: Vec<ListEntry>,
@@ -88,7 +89,7 @@ impl ListOutput {
         let jars = webapp.jars()?;
         let enabled_plugins: HashSet<String> = jars
             .into_iter()
-            .flat_map(|j| db.plugin_provides_jar(j))
+            .flat_map(|j| db.plugin_provides_jar(&j))
             .map(|p| p.metadata.name.clone())
             .collect();
 
@@ -143,11 +144,17 @@ impl ListOutput {
 mod tests {
     use std::path::PathBuf;
 
-    use crate::{cli::Format, database::Database, repo_index::RepoIndex, webapp::Webapp, versions::RudderVersion};
+    use crate::{
+        cli::Format, database::Database, repo_index::RepoIndex, versions::RudderVersion,
+        webapp::Webapp,
+    };
 
     #[test]
     fn it_lists_plugins() {
-        let w = Webapp::new(PathBuf::from("tests/webapp_xml/example.xml"), RudderVersion::from_path("./tests/versions/rudder-server-version").unwrap());
+        let w = Webapp::new(
+            PathBuf::from("tests/webapp_xml/example.xml"),
+            RudderVersion::from_path("./tests/versions/rudder-server-version").unwrap(),
+        );
         let r = RepoIndex::from_path("./tests/repo_index.json").unwrap();
         let d = Database::read("./tests/database/plugin_database_update_sample.json").unwrap();
 

--- a/relay/sources/rudder-package/src/list.rs
+++ b/relay/sources/rudder-package/src/list.rs
@@ -144,7 +144,7 @@ impl ListOutput {
 
 #[cfg(test)]
 mod tests {
-    use std::path::{PathBuf, Path};
+    use std::path::{Path, PathBuf};
 
     use crate::{
         cli::Format, database::Database, repo_index::RepoIndex, versions::RudderVersion,
@@ -159,7 +159,9 @@ mod tests {
             PathBuf::from("tests/webapp_xml/example.xml"),
             RudderVersion::from_path("./tests/versions/rudder-server-version").unwrap(),
         );
-        let r =RepoIndex::from_path("./tests/repo_index.json").unwrap().unwrap();
+        let r = RepoIndex::from_path("./tests/repo_index.json")
+            .unwrap()
+            .unwrap();
         let d = Database::read(Path::new(
             "./tests/database/plugin_database_update_sample.json",
         ))

--- a/relay/sources/rudder-package/src/plugin.rs
+++ b/relay/sources/rudder-package/src/plugin.rs
@@ -58,11 +58,13 @@ impl Display for Metadata {
             "Name: {}
 Version: {}
 Description: {}
+Type: {} plugin
 Build-date: {}
 Build-commit: {}",
             self.name,
             self.version,
             self.description.as_ref().unwrap_or(&"".to_owned()),
+            self.plugin_type(),
             self.build_date,
             self.build_commit))?;
         f.write_str("\nJar files:")?;

--- a/relay/sources/rudder-package/src/plugin.rs
+++ b/relay/sources/rudder-package/src/plugin.rs
@@ -99,6 +99,10 @@ impl Metadata {
         }
     }
 
+    pub fn short_name(&self) -> &str {
+        self.name.strip_prefix("rudder-plugin-").unwrap()
+    }
+
     pub fn run_package_script(
         &self,
         script: PackageScript,
@@ -106,7 +110,7 @@ impl Metadata {
     ) -> Result<(), anyhow::Error> {
         debug!(
             "Running package script '{}' with args '{}' for plugin '{}' in version '{}-{}'...",
-            script, arg, self.name, self.version.rudder_version, self.version.plugin_version
+            script, arg, self.short_name(), self.version.rudder_version, self.version.plugin_version
         );
         let package_script_path = Path::new(PACKAGES_FOLDER)
             .join(self.name.clone())

--- a/relay/sources/rudder-package/src/plugin.rs
+++ b/relay/sources/rudder-package/src/plugin.rs
@@ -66,7 +66,8 @@ Build-commit: {}",
             self.description.as_ref().unwrap_or(&"".to_owned()),
             self.plugin_type(),
             self.build_date,
-            self.build_commit))?;
+            self.build_commit
+        ))?;
         f.write_str("\nJar files:")?;
         if self.jar_files.is_empty() {
             f.write_str(" none")?;
@@ -81,7 +82,7 @@ Build-commit: {}",
             writeln!(f, "  {}: {}", a, p)?;
         }
         Ok(())
-            }
+    }
 }
 
 impl Metadata {

--- a/relay/sources/rudder-package/src/plugin.rs
+++ b/relay/sources/rudder-package/src/plugin.rs
@@ -78,7 +78,7 @@ Description: {}
 Type: {} plugin
 Build-date: {}
 Build-commit: {}",
-            self.name,
+            self.short_name(),
             self.version,
             self.description.as_ref().unwrap_or(&"".to_owned()),
             self.plugin_type(),

--- a/relay/sources/rudder-package/src/plugin.rs
+++ b/relay/sources/rudder-package/src/plugin.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2023 Normation SAS
 
-use std::{collections::HashMap, path::Path, process::Command, fmt::Display};
+use std::{collections::HashMap, fmt::Display, path::Path, process::Command};
 
 use anyhow::bail;
 use log::debug;
@@ -15,21 +15,21 @@ use crate::{
 };
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
 pub struct Metadata {
     #[serde(rename = "type")]
     pub package_type: archive::PackageType,
     pub name: String,
     pub version: versions::ArchiveVersion,
-    #[serde(rename(serialize = "build-date", deserialize = "build-date"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     pub build_date: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub depends: Option<Dependencies>,
-    #[serde(rename(serialize = "build-commit", deserialize = "build-commit"))]
     pub build_commit: String,
     pub content: HashMap<String, String>,
-    #[serde(rename(serialize = "jar-files", deserialize = "jar-files"))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub jar_files: Option<Vec<String>>,
+    #[serde(default)]
+    pub jar_files: Vec<String>,
 }
 
 /// Not present in metdata but computed from them
@@ -42,13 +42,44 @@ pub enum PluginType {
     Standalone,
 }
 
-impl Display for PluginType{
+impl Display for PluginType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-       f.write_str(match self {
+        f.write_str(match self {
             Self::Web => "web",
             Self::Standalone => "standalone",
         })
     }
+}
+
+// Used by the "show" command
+impl Display for Metadata {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&format!(
+            "Name: {}
+Version: {}
+Description: {}
+Build-date: {}
+Build-commit: {}",
+            self.name,
+            self.version,
+            self.description.as_ref().unwrap_or(&"".to_owned()),
+            self.build_date,
+            self.build_commit))?;
+        f.write_str("\nJar files:")?;
+        if self.jar_files.is_empty() {
+            f.write_str(" none")?;
+        } else {
+            f.write_str("\n")?;
+            for j in self.jar_files.iter() {
+                write!(f, "  {}", j)?;
+            }
+        }
+        f.write_str("\nContents:\n")?;
+        for (a, p) in self.content.iter() {
+            writeln!(f, "  {}: {}", a, p)?;
+        }
+        Ok(())
+            }
 }
 
 impl Metadata {
@@ -57,10 +88,10 @@ impl Metadata {
     }
 
     pub fn plugin_type(&self) -> PluginType {
-        if self.jar_files.is_some() {
-            PluginType::Web
-        } else {
+        if self.jar_files.is_empty() {
             PluginType::Standalone
+        } else {
+            PluginType::Web
         }
     }
 

--- a/relay/sources/rudder-package/src/plugin.rs
+++ b/relay/sources/rudder-package/src/plugin.rs
@@ -11,7 +11,7 @@ use crate::{
     archive::{self, PackageScript, PackageScriptArg},
     cmd::CmdOutput,
     dependency::Dependencies,
-    versions, PACKAGES_FOLDER,
+    versions::{self, RudderVersion}, PACKAGES_FOLDER,
 };
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
@@ -86,7 +86,7 @@ Build-commit: {}",
 }
 
 impl Metadata {
-    pub fn is_compatible(&self, webapp_version: &str) -> bool {
+    pub fn is_compatible(&self, webapp_version: &RudderVersion) -> bool {
         self.version.rudder_version.is_compatible(webapp_version)
     }
 

--- a/relay/sources/rudder-package/src/plugin.rs
+++ b/relay/sources/rudder-package/src/plugin.rs
@@ -11,7 +11,8 @@ use crate::{
     archive::{self, PackageScript, PackageScriptArg},
     cmd::CmdOutput,
     dependency::Dependencies,
-    versions::{self, RudderVersion}, PACKAGES_FOLDER,
+    versions::{self, RudderVersion},
+    PACKAGES_FOLDER,
 };
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]

--- a/relay/sources/rudder-package/src/plugin.rs
+++ b/relay/sources/rudder-package/src/plugin.rs
@@ -27,6 +27,10 @@ pub fn long_names(l: Vec<String>) -> Vec<String> {
         .collect()
 }
 
+pub fn short_name(p: &str) -> &str {
+    p.strip_prefix("rudder-plugin-").unwrap_or(p)
+}
+
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct Metadata {
@@ -112,7 +116,7 @@ impl Metadata {
     }
 
     pub fn short_name(&self) -> &str {
-        self.name.strip_prefix("rudder-plugin-").unwrap()
+        short_name(&self.name)
     }
 
     pub fn run_package_script(

--- a/relay/sources/rudder-package/src/plugin.rs
+++ b/relay/sources/rudder-package/src/plugin.rs
@@ -33,7 +33,7 @@ pub struct Metadata {
     pub jar_files: Vec<String>,
 }
 
-/// Not present in metdata but computed from them
+/// Not present in metadata but computed from them
 ///
 /// Allows exposing to the user if the plugin will appear in the interface or not.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Copy, Clone)]
@@ -110,7 +110,11 @@ impl Metadata {
     ) -> Result<(), anyhow::Error> {
         debug!(
             "Running package script '{}' with args '{}' for plugin '{}' in version '{}-{}'...",
-            script, arg, self.short_name(), self.version.rudder_version, self.version.plugin_version
+            script,
+            arg,
+            self.short_name(),
+            self.version.rudder_version,
+            self.version.plugin_version
         );
         let package_script_path = Path::new(PACKAGES_FOLDER)
             .join(self.name.clone())

--- a/relay/sources/rudder-package/src/plugin.rs
+++ b/relay/sources/rudder-package/src/plugin.rs
@@ -15,6 +15,18 @@ use crate::{
     PACKAGES_FOLDER,
 };
 
+pub fn long_names(l: Vec<String>) -> Vec<String> {
+    l.into_iter()
+        .map(|p| {
+            if p.starts_with("rudder-plugin-") {
+                p
+            } else {
+                format!("rudder-plugin-{p}")
+            }
+        })
+        .collect()
+}
+
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct Metadata {

--- a/relay/sources/rudder-package/src/repo_index.rs
+++ b/relay/sources/rudder-package/src/repo_index.rs
@@ -71,7 +71,9 @@ mod tests {
 
     #[test]
     fn test_plugin_index_parsing() {
-        let index: RepoIndex = RepoIndex::from_path("./tests/repo_index.json").unwrap().unwrap();
+        let index: RepoIndex = RepoIndex::from_path("./tests/repo_index.json")
+            .unwrap()
+            .unwrap();
         let expected = RepoIndex(
       vec![
         Plugin {

--- a/relay/sources/rudder-package/src/repo_index.rs
+++ b/relay/sources/rudder-package/src/repo_index.rs
@@ -20,7 +20,7 @@ impl RepoIndex {
     pub fn inner(&self) -> &[Plugin] {
         self.0.as_slice()
     }
- 
+
     pub fn get_compatible_plugins(&self, webapp_version: RudderVersion) -> Vec<Plugin> {
         self.clone()
             .0
@@ -76,13 +76,14 @@ mod tests {
             package_type: archive::PackageType::Plugin,
             name: String::from("rudder-plugin-aix"),
             version: versions::ArchiveVersion::from_str("8.0.0~beta2-2.1").unwrap(),
+                        description: None,
             build_date: String::from("2023-09-14T14:31:35+00:00"),
             build_commit: String::from("2198ca7c0aa0a4e19f04e0ace099520371641f92"),
             content: HashMap::from([
               (String::from("files.txz"), String::from("/opt/rudder/share/plugins")),
             ]),
             depends: None,
-            jar_files: Some(vec![String::from("/opt/rudder/share/plugins/aix/aix.jar")]),
+            jar_files: vec![String::from("/opt/rudder/share/plugins/aix/aix.jar")],
           },
           path: String::from("./8.0/aix/release/rudder-plugin-aix-8.0.0~beta2-2.1.rpkg"),
         },
@@ -91,13 +92,14 @@ mod tests {
             package_type: archive::PackageType::Plugin,
             name: String::from("rudder-plugin-aix"),
             version: versions::ArchiveVersion::from_str("8.0.0~rc1-2.1").unwrap(),
+                        description: None,
             build_date: String::from("2023-10-13T09:44:54+00:00"),
             build_commit: String::from("cdcf8a4b01124b9b309903cafd95b3a161a9c35c"),
             content: HashMap::from([
               (String::from("files.txz"), String::from("/opt/rudder/share/plugins")),
             ]),
             depends: None,
-            jar_files: Some(vec![String::from("/opt/rudder/share/plugins/aix/aix.jar")]),
+            jar_files: vec![String::from("/opt/rudder/share/plugins/aix/aix.jar")],
           },
           path: String::from("./8.0/aix/rudder-plugin-aix-8.0.0~rc1-2.1.rpkg/release/rudder-plugin-aix-8.0.0~rc1-2.1.rpkg"),
         },
@@ -106,13 +108,14 @@ mod tests {
             package_type: archive::PackageType::Plugin,
             name: String::from("rudder-plugin-vault"),
             version: versions::ArchiveVersion::from_str("8.0.0~rc1-2.1-nightly").unwrap(),
+                        description: None,
             build_date: String::from("2023-10-07T20:38:18+00:00"),
             build_commit: String::from("747126d505b3cac0403014cf35a4caf3a3ec886f"),
             content: HashMap::from([
               (String::from("files.txz"), String::from("/opt/rudder/")),
             ]),
             depends: None,
-            jar_files: None,
+            jar_files: vec![],
           },
           path: String::from("./8.0/rudder-plugin-vault-8.0.0~rc1-2.1-nightly.rpkg/nightly/rudder-plugin-vault-8.0.0~rc1-2.1-nightly.rpkg"),
         },

--- a/relay/sources/rudder-package/src/repo_index.rs
+++ b/relay/sources/rudder-package/src/repo_index.rs
@@ -73,7 +73,7 @@ mod tests {
       vec![
         Plugin {
           metadata: plugin::Metadata {
-            plugin_type: archive::PackageType::Plugin,
+            package_type: archive::PackageType::Plugin,
             name: String::from("rudder-plugin-aix"),
             version: versions::ArchiveVersion::from_str("8.0.0~beta2-2.1").unwrap(),
             build_date: String::from("2023-09-14T14:31:35+00:00"),
@@ -88,7 +88,7 @@ mod tests {
         },
         Plugin {
           metadata: plugin::Metadata {
-            plugin_type: archive::PackageType::Plugin,
+            package_type: archive::PackageType::Plugin,
             name: String::from("rudder-plugin-aix"),
             version: versions::ArchiveVersion::from_str("8.0.0~rc1-2.1").unwrap(),
             build_date: String::from("2023-10-13T09:44:54+00:00"),
@@ -103,7 +103,7 @@ mod tests {
         },
         Plugin {
           metadata: plugin::Metadata {
-            plugin_type: archive::PackageType::Plugin,
+            package_type: archive::PackageType::Plugin,
             name: String::from("rudder-plugin-vault"),
             version: versions::ArchiveVersion::from_str("8.0.0~rc1-2.1-nightly").unwrap(),
             build_date: String::from("2023-10-07T20:38:18+00:00"),

--- a/relay/sources/rudder-package/src/repo_index.rs
+++ b/relay/sources/rudder-package/src/repo_index.rs
@@ -42,13 +42,8 @@ impl RepoIndex {
     ) -> Option<Plugin> {
         self.get_compatible_plugins(webapp_version)
             .into_iter()
-            .find(|x| {
-                [
-                    plugin_name.to_string(),
-                    format!("rudder-plugin-{}", plugin_name),
-                ]
-                .contains(&x.metadata.name)
-            })
+            // FIXME: could have several plugin version compatible, we need to select the latest
+            .find(|x| plugin_name == x.metadata.name)
     }
 }
 

--- a/relay/sources/rudder-package/src/repo_index.rs
+++ b/relay/sources/rudder-package/src/repo_index.rs
@@ -17,6 +17,10 @@ impl RepoIndex {
         Ok(index)
     }
 
+    pub fn inner(&self) -> &[Plugin] {
+        self.0.as_slice()
+    }
+ 
     pub fn get_compatible_plugins(&self, webapp_version: RudderVersion) -> Vec<Plugin> {
         self.clone()
             .0
@@ -50,7 +54,7 @@ pub struct Plugin {
     pub path: String,
 
     #[serde(flatten)]
-    metadata: plugin::Metadata,
+    pub metadata: plugin::Metadata,
 }
 
 #[cfg(test)]

--- a/relay/sources/rudder-package/src/repo_index.rs
+++ b/relay/sources/rudder-package/src/repo_index.rs
@@ -21,7 +21,7 @@ impl RepoIndex {
         self.0.as_slice()
     }
 
-    pub fn get_compatible_plugins(&self, webapp_version: RudderVersion) -> Vec<Plugin> {
+    pub fn get_compatible_plugins(&self, webapp_version: &RudderVersion) -> Vec<Plugin> {
         self.clone()
             .0
             .into_iter()
@@ -34,7 +34,7 @@ impl RepoIndex {
 
     pub fn get_compatible_plugin(
         &self,
-        webapp_version: RudderVersion,
+        webapp_version: &RudderVersion,
         plugin_name: &str,
     ) -> Option<Plugin> {
         self.get_compatible_plugins(webapp_version)

--- a/relay/sources/rudder-package/src/repository.rs
+++ b/relay/sources/rudder-package/src/repository.rs
@@ -6,9 +6,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use flate2::read::GzDecoder;
-use log::debug;
+use log::{debug, info};
 use reqwest::{
     blocking::{Client, Response},
     Proxy, StatusCode, Url,
@@ -133,7 +133,9 @@ impl Repository {
     }
 
     pub fn test_connection(&self) -> Result<()> {
-        self.get("")?;
+        self.get("")
+            .context(format!("Could not connect with {}", self.server))?;
+        info!("Connection with {}: OK", self.server);
         Ok(())
     }
 

--- a/relay/sources/rudder-package/src/repository.rs
+++ b/relay/sources/rudder-package/src/repository.rs
@@ -18,7 +18,9 @@ use tempfile::tempdir;
 
 use crate::{
     config::{Configuration, Credentials},
-    signature::{SignatureVerifier, VerificationSuccess}, versions::RudderVersion, RUDDER_VERSION_PATH, REPOSITORY_INDEX_PATH,
+    signature::{SignatureVerifier, VerificationSuccess},
+    versions::RudderVersion,
+    REPOSITORY_INDEX_PATH, RUDDER_VERSION_PATH,
 };
 
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
@@ -170,8 +172,6 @@ impl Repository {
         }
         Ok(())
     }
-
-
 }
 
 #[cfg(test)]

--- a/relay/sources/rudder-package/src/repository.rs
+++ b/relay/sources/rudder-package/src/repository.rs
@@ -20,7 +20,7 @@ use crate::{
     config::{Configuration, Credentials},
     signature::{SignatureVerifier, VerificationSuccess},
     webapp::Webapp,
-    REPOSITORY_INDEX_PATH,
+    LICENSES_FOLDER, REPOSITORY_INDEX_PATH,
 };
 
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
@@ -161,8 +161,7 @@ impl Repository {
         // Update the licenses
         if let Some(user) = self.get_username() {
             debug!("Updating licenses");
-            // FIXME: take as param, we need to be able to test this
-            let license_folder = PathBuf::from("/opt/rudder/etc/plugins/licenses");
+            let license_folder = PathBuf::from(LICENSES_FOLDER);
             let archive_name = format!("{}-license.tar.gz", user);
             let local_archive_path = &license_folder.clone().join(archive_name.clone());
             if let Err(e) = self.download_unsafe(

--- a/relay/sources/rudder-package/src/repository.rs
+++ b/relay/sources/rudder-package/src/repository.rs
@@ -37,6 +37,8 @@ impl Repository {
     pub fn new(config: &Configuration, verifier: SignatureVerifier) -> Result<Self> {
         let mut client = Client::builder()
             .use_native_tls()
+            // Enforce HTTPS at client level
+            .https_only(true)
             .user_agent(APP_USER_AGENT);
 
         if let Some(proxy_cfg) = &config.proxy {

--- a/relay/sources/rudder-package/src/repository.rs
+++ b/relay/sources/rudder-package/src/repository.rs
@@ -19,7 +19,8 @@ use tempfile::tempdir;
 use crate::{
     config::{Configuration, Credentials},
     signature::{SignatureVerifier, VerificationSuccess},
-    REPOSITORY_INDEX_PATH, RUDDER_VERSION_PATH, webapp::Webapp,
+    webapp::Webapp,
+    REPOSITORY_INDEX_PATH,
 };
 
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);

--- a/relay/sources/rudder-package/src/versions.rs
+++ b/relay/sources/rudder-package/src/versions.rs
@@ -140,7 +140,7 @@ impl RudderVersion {
             Some(c) => c,
         };
         debug!(
-            "Raw Rudder version read from '{}' file: '{}'.",
+            "Rudder version read from '{}' file: '{}'.",
             path, &caps["raw_rudder_version"]
         );
         RudderVersion::from_str(&caps["raw_rudder_version"])

--- a/relay/sources/rudder-package/src/versions.rs
+++ b/relay/sources/rudder-package/src/versions.rs
@@ -436,7 +436,9 @@ mod tests {
     ) {
         let m = ArchiveVersion::from_str(metadata_version).unwrap();
         assert_eq!(
-            m.rudder_version.clone().is_compatible(&RudderVersion::from_str(webapp_version).unwrap()),
+            m.rudder_version
+                .clone()
+                .is_compatible(&RudderVersion::from_str(webapp_version).unwrap()),
             is_compatible,
             "Unexpected compatibility checkfor webapp version '{}' and metadata version {:?}'",
             webapp_version,

--- a/relay/sources/rudder-package/src/versions.rs
+++ b/relay/sources/rudder-package/src/versions.rs
@@ -21,7 +21,6 @@ impl Display for ArchiveVersion {
     }
 }
 
-
 impl FromStr for ArchiveVersion {
     type Err = Error;
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {

--- a/relay/sources/rudder-package/src/versions.rs
+++ b/relay/sources/rudder-package/src/versions.rs
@@ -15,6 +15,13 @@ pub struct ArchiveVersion {
     pub plugin_version: PluginVersion,
 }
 
+impl Display for ArchiveVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}-{}", self.rudder_version, self.plugin_version)
+    }
+}
+
+
 impl FromStr for ArchiveVersion {
     type Err = Error;
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {

--- a/relay/sources/rudder-package/src/versions.rs
+++ b/relay/sources/rudder-package/src/versions.rs
@@ -125,11 +125,8 @@ pub struct RudderVersion {
 }
 
 impl RudderVersion {
-    pub fn is_compatible(&self, webapp_version: &str) -> bool {
-        match RudderVersion::from_str(webapp_version) {
-            Ok(w) => *self == w,
-            Err(_) => false,
-        }
+    pub fn is_compatible(&self, webapp_version: &RudderVersion) -> bool {
+        self == webapp_version
     }
 
     pub fn from_path(path: &str) -> Result<Self, Error> {
@@ -439,7 +436,7 @@ mod tests {
     ) {
         let m = ArchiveVersion::from_str(metadata_version).unwrap();
         assert_eq!(
-            m.rudder_version.clone().is_compatible(webapp_version),
+            m.rudder_version.clone().is_compatible(&RudderVersion::from_str(webapp_version).unwrap()),
             is_compatible,
             "Unexpected compatibility checkfor webapp version '{}' and metadata version {:?}'",
             webapp_version,

--- a/relay/sources/rudder-package/src/webapp.rs
+++ b/relay/sources/rudder-package/src/webapp.rs
@@ -183,7 +183,7 @@ mod tests {
         assert_eq!(
             jars,
             vec![
-                "/opt/rudder/share/plugins/auth-backends/auth-backends.jar",
+                "/opt/rudder/share/plugins/dsc/dsc.jar",
                 "/opt/rudder/share/plugins/api-authorizations/api-authorizations.jar"
             ]
         );

--- a/relay/sources/rudder-package/src/webapp.rs
+++ b/relay/sources/rudder-package/src/webapp.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2023 Normation SAS
 
-use spinners::{Spinner, Spinners};
 use std::{
     collections::HashSet,
     fs,
@@ -17,6 +16,7 @@ use quick_xml::{
     reader::Reader,
     Writer,
 };
+use spinners::{Spinner, Spinners};
 
 use crate::{cmd::CmdOutput, versions::RudderVersion};
 
@@ -174,7 +174,6 @@ impl Webapp {
     /// Synchronous restart of the web application
     pub fn apply_changes(&mut self) -> Result<()> {
         if self.pending_changes {
-            print!("  ");
             let mut sp = Spinner::new(
                 Spinners::Dots,
                 "Restarting the Web application to apply changes".into(),

--- a/relay/sources/rudder-package/src/webapp.rs
+++ b/relay/sources/rudder-package/src/webapp.rs
@@ -1,21 +1,23 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2023 Normation SAS
 
-use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
-use quick_xml::reader::Reader;
-use quick_xml::Writer;
-use std::collections::HashSet;
-use std::fs;
-use std::io::{Cursor, Write};
-use std::path::PathBuf;
-
-use std::process::Command;
+use std::{
+    collections::HashSet,
+    fs,
+    io::{Cursor, Write},
+    path::PathBuf,
+    process::Command,
+};
 
 use anyhow::Result;
 use log::debug;
+use quick_xml::{
+    events::{BytesEnd, BytesStart, BytesText, Event},
+    reader::Reader,
+    Writer,
+};
 
-use crate::cmd::CmdOutput;
-use crate::versions::RudderVersion;
+use crate::{cmd::CmdOutput, versions::RudderVersion};
 
 /// We want to write the file after each plugin to avoid half-installs
 pub struct Webapp {
@@ -181,7 +183,10 @@ mod tests {
 
     #[test]
     fn it_reads_jars() {
-        let w = Webapp::new(PathBuf::from("tests/webapp_xml/example.xml"), RudderVersion::from_path("./tests/versions/rudder-server-version").unwrap() );
+        let w = Webapp::new(
+            PathBuf::from("tests/webapp_xml/example.xml"),
+            RudderVersion::from_path("./tests/versions/rudder-server-version").unwrap(),
+        );
         let jars = w.jars().unwrap();
         assert_eq!(
             jars,
@@ -201,7 +206,10 @@ mod tests {
         let expected = path::Path::new(&sample).with_extension("xml.expected");
         let target = temp_dir.path().join(origin);
         fs::copy(sample, target.clone()).unwrap();
-        let mut x = Webapp::new(target.clone(), RudderVersion::from_path("./tests/versions/rudder-server-version").unwrap());
+        let mut x = Webapp::new(
+            target.clone(),
+            RudderVersion::from_path("./tests/versions/rudder-server-version").unwrap(),
+        );
         let _ = x.enable_jars(&[String::from(jar_name)]);
         assert_eq!(
             fs::read_to_string(target).unwrap(),
@@ -219,7 +227,10 @@ mod tests {
         let expected = path::Path::new(&sample).with_extension("xml.expected");
         let target = temp_dir.path().join(origin);
         fs::copy(sample, target.clone()).unwrap();
-        let mut x = Webapp::new(target.clone(), RudderVersion::from_path("./tests/versions/rudder-server-version").unwrap());
+        let mut x = Webapp::new(
+            target.clone(),
+            RudderVersion::from_path("./tests/versions/rudder-server-version").unwrap(),
+        );
         let _ = x.disable_jars(&[String::from(jar_name)]);
         assert_eq!(
             fs::read_to_string(target).unwrap(),

--- a/relay/sources/rudder-package/src/webapp.rs
+++ b/relay/sources/rudder-package/src/webapp.rs
@@ -15,18 +15,21 @@ use anyhow::Result;
 use log::debug;
 
 use crate::cmd::CmdOutput;
+use crate::versions::RudderVersion;
 
 /// We want to write the file after each plugin to avoid half-installs
 pub struct Webapp {
     pub path: PathBuf,
     pending_changes: bool,
+    pub version: RudderVersion,
 }
 
 impl Webapp {
-    pub fn new(path: PathBuf) -> Self {
+    pub fn new(path: PathBuf, version: RudderVersion) -> Self {
         Self {
             path,
             pending_changes: false,
+            version,
         }
     }
 
@@ -178,7 +181,7 @@ mod tests {
 
     #[test]
     fn it_reads_jars() {
-        let w = Webapp::new(PathBuf::from("tests/webapp_xml/example.xml"));
+        let w = Webapp::new(PathBuf::from("tests/webapp_xml/example.xml"), RudderVersion::from_path("./tests/versions/rudder-server-version").unwrap() );
         let jars = w.jars().unwrap();
         assert_eq!(
             jars,
@@ -198,7 +201,7 @@ mod tests {
         let expected = path::Path::new(&sample).with_extension("xml.expected");
         let target = temp_dir.path().join(origin);
         fs::copy(sample, target.clone()).unwrap();
-        let mut x = Webapp::new(target.clone());
+        let mut x = Webapp::new(target.clone(), RudderVersion::from_path("./tests/versions/rudder-server-version").unwrap());
         let _ = x.enable_jars(&[String::from(jar_name)]);
         assert_eq!(
             fs::read_to_string(target).unwrap(),
@@ -216,7 +219,7 @@ mod tests {
         let expected = path::Path::new(&sample).with_extension("xml.expected");
         let target = temp_dir.path().join(origin);
         fs::copy(sample, target.clone()).unwrap();
-        let mut x = Webapp::new(target.clone());
+        let mut x = Webapp::new(target.clone(), RudderVersion::from_path("./tests/versions/rudder-server-version").unwrap());
         let _ = x.disable_jars(&[String::from(jar_name)]);
         assert_eq!(
             fs::read_to_string(target).unwrap(),

--- a/relay/sources/rudder-package/src/webapp.rs
+++ b/relay/sources/rudder-package/src/webapp.rs
@@ -125,7 +125,7 @@ impl Webapp {
                     writer.write_event(Event::End(e))?;
                 }
                 Event::End(e) if e.name().as_ref() == b"Configure" => {
-                    // there is not extry at all
+                    // there is not entry at all
                     if !extra_classpath_found && !present.is_empty() {
                         // Create the element if needed
                         let mut start = BytesStart::new("Set");

--- a/relay/sources/rudder-package/tests/database/plugin_database_update_sample.json.expected
+++ b/relay/sources/rudder-package/tests/database/plugin_database_update_sample.json.expected
@@ -241,6 +241,7 @@
       "version": "8.0.0~rc2-2.2",
       "build-date": "2023-10-13T10:02:19+00:00",
       "build-commit": "45b05f29381170c7a61484a59dcffec550a9c531",
+      "jar-files": [],
       "depends": {
         "python": [
           "python3-requests"
@@ -286,6 +287,7 @@
       "version": "0.0.0-0.0",
       "build-date": "2023-10-13T10:03:34+00:00",
       "build-commit": "2abc53fb8b2d1c667a91b1a1da2f941a99872cdf",
+      "jar-files": [],
       "content": {
         "files.txz": "/opt/rudder/share/plugins"
       }

--- a/relay/sources/rudder-package/tests/licenses/example.license
+++ b/relay/sources/rudder-package/tests/licenses/example.license
@@ -1,0 +1,13 @@
+header=rudder-license-v1
+algorithm=SHA512WithRSA
+digest=b2bc7a49db69a1c39ac6fa0cad4230edf5e9b4eb0
+digestdate=2023-09-20T19:26:36+00:00
+keyid=2a5ba55f
+---- signed information about the license
+licensee=Normation
+softwareid=rudder-plugin-dsc
+minversion=0.0-0.0
+maxversion=99.99-99.99
+startdate=2020-03-31T00:00:00Z
+enddate=2024-09-28T12:00:00Z
+----

--- a/relay/sources/rudder-package/tests/webapp_xml/example.xml
+++ b/relay/sources/rudder-package/tests/webapp_xml/example.xml
@@ -6,7 +6,7 @@
 	<Set name="contextPath">/rudder</Set>
 	<Set name="war">/opt/rudder/share/webapps/rudder.war</Set>
 
-	<Set name="extraClasspath">/opt/rudder/share/plugins/auth-backends/auth-backends.jar,/opt/rudder/share/plugins/api-authorizations/api-authorizations.jar</Set>
+	<Set name="extraClasspath">/opt/rudder/share/plugins/dsc/dsc.jar,/opt/rudder/share/plugins/api-authorizations/api-authorizations.jar</Set>
 
   <Set name="tempDirectory">/var/rudder/tmp/jetty/jetty-rudder.war.dir</Set>
 

--- a/relay/sources/rudder-package/tools/rudder-package.sh
+++ b/relay/sources/rudder-package/tools/rudder-package.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Entry point for the "rudder package" command.
+
+if [ "${RUDDER_PKG_COMPAT}" = "1" ]; then
+  exec /opt/rudder/share/python/rudder-pkg/rudder-pkg "$@"
+else
+  exec /opt/rudder/bin/rudder-package "$@"
+fi


### PR DESCRIPTION
https://issues.rudder.io/issues/23780

* All data sources are now defined once and passed to the different modules
* Fixes a few commands, especially enable/disable.
* Index is now an `Option<RepoIndex>`
* `jar_files` is now a simple `Vec<>` instead of `Option<Vec<>>`, as there were no semantic differences between `Some(vec![])` and `None`.
* Latest version selection from index is fixed using version ordering.
* Added a `PluginType` and display it.

Update 28 nov.:
* Licenses parsing and display in list
* Fixed upgrade process
* Don't fail on first error but treat all passed packages in all commands
* Enforce HTTPS (to mitigate the risk of malicious index)

Added a few pieces:
* [x] list (array and json)
* [x] update-all
  * `upgrade --all` (and also allow `upgrade <package>`)
* [x] postupgrade: run all postinstall for installed plugins
  * `upgrade --all-postinst`
* [x] check-compatibility: disable incompatible plugins
  * `disable --incompatible`
* [x] script to replace the current python script and allow access to the fallback implementation thanks to en env var

Remaining tasks:
* Upgrade notes
* Architecture documentation in the repository
* Packaging scripts update and check from migration