### PR TITLE
Bug #23671 : Locale issue: date picker outputs date in wrong order 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
@@ -567,7 +567,7 @@ case object DateComparator extends LDAPCriterionType {
   val fmt                                = "dd/MM/yyyy"
   val frenchFmt                          = DateTimeFormat.forPattern(fmt).withLocale(Locale.FRANCE)
   def error(value: String, e: Exception) = Inconsistency(
-    s"Invalide date: '${value}', expected format is: '${fmt}'. Error was: ${e.getMessage}"
+    s"Invalid date: '${value}', expected format is: '${fmt}'. Error was: ${e.getMessage}"
   )
 
   override protected def validateSubCase(v: String, comparator: CriterionComparator) = try {
@@ -579,6 +579,7 @@ case object DateComparator extends LDAPCriterionType {
   // init a jquery datepicker
   override def initForm(formId: String): JsCmd = OnLoad(JsRaw("""var init = $.datepicker.regional['en'];
        init['showOn'] = 'focus';
+       init['dateFormat'] = 'dd/mm/yy';
        $('#%s').datepicker(init);
        """.format(formId)))
   override def destroyForm(formId: String): JsCmd = OnLoad(JsRaw("""$('#%s').datepicker( "destroy" );""".format(formId)))


### PR DESCRIPTION
https://issues.rudder.io/issues/23671

This is a simple fix, it only affects the JavaScript date picker module in group criteria that was not sync with the expected [defined format](https://github.com/Normation/rudder/pull/5201/files#diff-5192ead8ee6e8bbdfc1c1de061965986ff9d79c1e6216b2dc3ac06ba68e61582L567) in the backend to `dd/MM/yyyy`.

In this case, this bug affects the criteria `Last inventory date` in group criteria page. It appears that the format of inventory date is like `2023-08-17 14:31:49+0200` so to the format `yyyy/mm/dd`.

![image](https://github.com/Normation/rudder/assets/23410978/a65fb4cc-2f5a-4190-aecc-5b54fc4b7d4d)

I think the date picker should use the same format. Despite the fact that the date picker and the inventory date doesn't use the same format, this PR fix the problem and the filter seems to work

![datepicker](https://github.com/Normation/rudder/assets/23410978/2ff5dcfd-178a-44e7-9fbd-598625bd3a8d)

This is not an ideal solution since we use the format `yyyy/mm/dd` in general in the interface, but changing the format in the backend, means higher risk of breaking anything else, and we should consider refactoring this part and think about what standard we want to apply everywhere to be consistent.
Here there are some ideas about what can we do to change the format in backend: https://github.com/Normation/rudder/pull/5157