### PR TITLE
Fixes #23798: rudderc method parsing breaks when method contains several bundles

### DIFF
--- a/policies/rudderc/src/frontends/methods/method.rs
+++ b/policies/rudderc/src/frontends/methods/method.rs
@@ -267,7 +267,8 @@ impl FromStr for MethodInfo {
         }
 
         // Bundle signature
-        let bundle_re = regex!(r"[^#]*bundle\s+agent\s+(\w+)\s*(\(([^)]*)\))?\s*\{?\s*");
+        let bundle_re = regex!(r"[^#{]*bundle\s+agent\s+(\w+)\s*(\(([^)]*)\))?\s*\{?\s*");
+        // Select the first bundle, which is by convention the main one
         if let Some(caps) = bundle_re.captures(s) {
             method.bundle_name = (caps[1]).to_string();
             method.bundle_args = match &caps.get(3) {

--- a/policies/rudderc/tests/methods/package_install.cf
+++ b/policies/rudderc/tests/methods/package_install.cf
@@ -57,3 +57,9 @@ bundle agent package_install(name)
 
       "report"             usebundle => _log_v3("Install package ${name}", "${name}", "${old_class_prefix}", "${class_prefix}", @{args});
 }
+
+bundle agent another_bundle(param)
+{
+  reports:
+      "dummy";
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/23798

Modify the regex to prevent capturing previous bundle calls in the match, so we're matching each bundle, and get back on the previous "first bundle is the main bundle" convention.

Before 
![image](https://github.com/Normation/rudder/assets/329388/b046aed1-4ba1-470d-8ade-4a4aac924fd7)

After
![image](https://github.com/Normation/rudder/assets/329388/389f5064-8652-4046-8da5-062e6e88ddec)
