### PR TITLE
Fixes #23801: Content of warning tooltip for unknow method should not overflow

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewTechniqueList.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/editor/sources/ViewTechniqueList.elm
@@ -224,7 +224,7 @@ techniqueItem model technique =
             , if hasUnknownMethod  then
                 span [ class "cursor-help popover-bs", attribute "data-toggle"  "popover", attribute "data-trigger" "hover"
                      , attribute "data-container" "body", attribute  "data-placement" "right", attribute "data-title" technique.name
-                     , attribute "data-content" ("<div>This technique uses <b>unknown</b> generic methods: " ++ (String.join "," (List.map (\m -> m.methodName.value) unknownMethods)) ++ ".</br>These methods does not exists in provided library, you must provide it or it will break at run time</div>")
+                     , attribute "data-content" ("<div>This technique uses <b>unknown</b> generic methods: " ++ (String.join ", " (List.map (\m -> m.methodName.value) (List.Extra.unique unknownMethods))) ++ ".</br>These methods does not exists in provided library, you must provide it or it will break at run time</div>")
                      , attribute "data-html" "true" ] [ i [ class "fa fa-warning text-warning-rudder min-size-icon unknown-gm-icon" ] [] ]
               else
                 text ""


### PR DESCRIPTION
https://issues.rudder.io/issues/23801
Before : 
![image](https://github.com/Normation/rudder/assets/23410978/4ff9b0d1-dff3-4636-adfe-fd25df7c089b)
After: ![image](https://github.com/Normation/rudder/assets/23410978/6f443d7f-7da8-4b65-9acc-05f4a2891fa7)
