### PR TITLE
Fixes #23802: rudderc should export a technique with ids

### DIFF
--- a/policies/.gitignore
+++ b/policies/.gitignore
@@ -7,3 +7,4 @@
 /rudderc/docs/examples/*.cf
 /rudderc/docs/examples/*.ps1
 rudderc/src/methods.json
+/rudderc/tests/cases/general/*/technique.ids.yml

--- a/policies/rudderc/docs/src/usage.md
+++ b/policies/rudderc/docs/src/usage.md
@@ -115,7 +115,7 @@ To open the documentation in your browser after build, pass the `--open` option.
 You can export your current technique with:
 
 ```shell
-$ rudderc export
+$ rudderc build --export
      Writing ./target/ntp_technique-0.1.zip
 ```
 

--- a/policies/rudderc/src/cli.rs
+++ b/policies/rudderc/src/cli.rs
@@ -61,6 +61,10 @@ pub enum Command {
         #[arg(long)]
         standalone: bool,
 
+        /// Export as an archive for import into a Rudder server
+        #[arg(long)]
+        export: bool,
+
         /// Add ids to the source technique. This will also reformat the file.
         #[arg(long)]
         store_ids: bool,
@@ -86,15 +90,6 @@ pub enum Command {
         /// Verbose agent
         #[arg(long)]
         agent_verbose: bool,
-    },
-
-    /// Export as an archive for import into a Rudder server
-    Export {
-        /// Output file
-        ///
-        /// Defaults to the target directory.
-        #[arg(short, long)]
-        output: Option<PathBuf>,
     },
 
     /// Build the method documentation

--- a/policies/rudderc/src/lib.rs
+++ b/policies/rudderc/src/lib.rs
@@ -106,6 +106,7 @@ pub fn run(args: MainArgs) -> Result<()> {
             library,
             output,
             standalone,
+            export,
             store_ids,
         } => {
             let library = check_libraries(library)?;
@@ -115,8 +116,12 @@ pub fn run(args: MainArgs) -> Result<()> {
                 input,
                 actual_output.as_path(),
                 standalone,
-                store_ids,
-            )
+                store_ids || export,
+            )?;
+            if export {
+                action::export(&cwd, actual_output)?;
+            }
+            Ok(())
         }
         Command::Test {
             library,
@@ -136,7 +141,6 @@ pub fn run(args: MainArgs) -> Result<()> {
                 agent_verbose,
             )
         }
-        Command::Export { output } => action::export(&cwd, output),
         Command::Lib {
             library,
             output,
@@ -179,7 +183,7 @@ pub mod action {
         frontends::read_methods,
         ir::Technique,
         test::TestCase,
-        METADATA_FILE, RESOURCES_DIR, TARGET_DIR, TECHNIQUE, TECHNIQUE_SRC, TESTS_DIR,
+        METADATA_FILE, RESOURCES_DIR, TECHNIQUE, TECHNIQUE_SRC, TESTS_DIR,
     };
 
     /// Create a technique skeleton
@@ -463,31 +467,35 @@ pub mod action {
         Ok(())
     }
 
-    pub fn export(src: &Path, output: Option<PathBuf>) -> Result<()> {
+    pub fn export(src: &Path, dir: PathBuf) -> Result<()> {
         // We don't need to parse everything, let's just extract what we need
-        let technique_src = src.join(TECHNIQUE_SRC);
-        let yml: serde_yaml::Value = serde_yaml::from_str(&read_to_string(&technique_src)?)?;
+        // We use the technique with ids
+        let technique_src = src.join(TECHNIQUE_SRC).with_extension("ids.yml");
+        let yml: serde_yaml::Value =
+            serde_yaml::from_str(&read_to_string(&technique_src).context(format!(
+                "Could not read source technique {}",
+                technique_src.display()
+            ))?)?;
         let id = yml.get("id").unwrap().as_str().unwrap();
         let version = yml.get("version").unwrap().as_str().unwrap();
-        let actual_output = match output {
-            Some(p) => p,
-            None => {
-                let dir = src.join(TARGET_DIR);
-                create_dir_all(&dir)?;
-                dir.join(format!("{}-{}.zip", id, version))
-            }
-        };
+        create_dir_all(&dir).context(format!("Creating output directory {}", dir.display()))?;
+        let actual_output = dir.join(format!("{}-{}.zip", id, version));
 
-        let file = File::create(&actual_output)?;
+        let file = File::create(&actual_output).context(format!(
+            "Creating export output file {}",
+            &actual_output.display()
+        ))?;
         let options = zip::write::FileOptions::default();
         let mut zip = ZipWriter::new(file);
 
         let zip_dir = format!("archive/techniques/ncf_techniques/{id}/{version}");
-
         // Technique
         zip.start_file(format!("{}/{}", zip_dir, TECHNIQUE_SRC), options)?;
         let mut buffer = Vec::new();
-        let mut f = File::open(technique_src)?;
+        let mut f = File::open(&technique_src).context(format!(
+            "Opening technique source {}",
+            technique_src.display()
+        ))?;
         f.read_to_end(&mut buffer)?;
         zip.write_all(&buffer)?;
 

--- a/policies/rudderc/tests/compile.rs
+++ b/policies/rudderc/tests/compile.rs
@@ -31,7 +31,7 @@ pub fn init_logs() {
 const TEST_METHODS: &str = "tests/lib/common/30_generic_methods";
 
 /// Compiles all files in `cases/general`. Files ending in `.fail.yml` are expected to fail.
-#[test_resources("tests/cases/general/*/*.yml")]
+#[test_resources("tests/cases/general/*/technique.yml")]
 fn compile(filename: &str) {
     init_logs();
     let input = read_to_string(filename).unwrap();

--- a/policies/rudderc/tests/export.rs
+++ b/policies/rudderc/tests/export.rs
@@ -1,20 +1,32 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2019-2020 Normation SAS
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use test_generator::test_resources;
 
 use rudderc::action;
 
-#[test]
-fn test_export_resources() {
-    let technique_dir = Path::new("./tests/cases/general/ntp");
-    let res = action::export(technique_dir, None);
-    res.unwrap();
-}
-
-#[test]
-fn test_export_without_resources() {
-    let technique_dir = Path::new("./tests/cases/general/min");
-    let res = action::export(technique_dir, None);
+#[test_resources("tests/cases/general/*/technique.yml")]
+fn compile(filename: &str) {
+    // One example with resource, one example without
+    let technique_dir = Path::new(filename).parent().unwrap();
+    action::build(
+        &[PathBuf::from("tests/lib/common")],
+        &technique_dir.join("technique.yml"),
+        &technique_dir.join("target"),
+        false,
+        true,
+    )
+    .unwrap();
+    // Check that the generated technique is correct
+    action::build(
+        &[PathBuf::from("tests/lib/common")],
+        &technique_dir.join("technique.ids.yml"),
+        &technique_dir.join("target"),
+        false,
+        false,
+    )
+    .unwrap();
+    let res = action::export(technique_dir, technique_dir.join("target"));
     res.unwrap();
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/23802

* Remove the `export` subcommand as we now need to be able to build the techniques, hence identical parameters to `build`, so it becomes an option of the `build` command
* Fix condition serialization. For some reason the `false` condition was serialized to `null`.
* Run export test on all test techniques, and also check validity of the `technique.ids.yml` file by re-building it.