### PR TITLE
Fixes #23818:  Import archive for an existing technique delete the previous technique

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
@@ -534,7 +534,7 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
     webappCompiler,
     new RuddercService {
       override def compile(techniqueDir: File, options: RuddercOptions): IOResult[RuddercResult] = {
-        RuddercResult.Fail(42, "error:see implementation of test", "", "").succeed
+        RuddercResult.Fail(42, Chunk.empty, "error:see implementation of test", "", "").succeed
       }
     },
     TechniqueCompilerApp.Webapp,

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriterFallback.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriterFallback.scala
@@ -59,6 +59,7 @@ import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import org.specs2.specification.BeforeAfterAll
 import scala.annotation.nowarn
+import zio.Chunk
 import zio.syntax._
 
 /*
@@ -129,37 +130,37 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
             writeXML
             writeCFE
             writePS1
-            RuddercResult.Ok("ok", "stdout", "")
+            RuddercResult.Ok(Chunk.empty, "ok", "stdout", "")
           }
         case Content.techniqueNOK_user        =>
           IOResult.attempt {
-            RuddercResult.UserError(7, "nok:user", "stdout", "stderr")
+            RuddercResult.UserError(7, Chunk.empty, "nok:user", "stdout", "stderr")
           }
         case Content.techniqueNOK_empty_neg   =>
           IOResult.attempt {
-            RuddercResult.Fail(-42, "nok:empty", "stdout", "stderr")
+            RuddercResult.Fail(-42, Chunk.empty, "nok:empty", "stdout", "stderr")
           }
         case Content.techniqueNOK_empty_pos   =>
           IOResult.attempt {
-            RuddercResult.Fail(50, "nok:empty", "stdout", "stderr")
+            RuddercResult.Fail(50, Chunk.empty, "nok:empty", "stdout", "stderr")
           }
         case Content.techniqueNOK_xml         =>
           IOResult.attempt {
             writeXML
-            RuddercResult.Fail(60, "nok:xml", "stdout", "stderr")
+            RuddercResult.Fail(60, Chunk.empty, "nok:xml", "stdout", "stderr")
           }
         case Content.techniqueNOK_xml_cfe     =>
           IOResult.attempt {
             writeXML
             writeCFE
-            RuddercResult.Fail(70, "nok:cfe", "stdout", "stderr")
+            RuddercResult.Fail(70, Chunk.empty, "nok:cfe", "stdout", "stderr")
           }
         case Content.techniqueNOK_xml_cfe_ps1 =>
           IOResult.attempt {
             writeXML
             writeCFE
             writePS1
-            RuddercResult.Fail(80, "nok:ps1", "stdout", "stderr")
+            RuddercResult.Fail(80, Chunk.empty, "nok:ps1", "stdout", "stderr")
           }
         // other case must not exists in test, error.
         case other                            => Unexpected(s"Asking for technique with id '${other}' which is not a test case - go see TestRudderc").fail
@@ -296,7 +297,7 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
       initDirectories(compiler, technique)
       val res                = compiler.compileTechnique(technique).runNow
 
-      (res must beEqualTo(TechniqueCompilationOutput(Rudderc, false, 0, "ok", "stdout", ""))) and
+      (res must beEqualTo(TechniqueCompilationOutput(Rudderc, false, 0, Chunk.empty, "ok", "stdout", ""))) and
       (compilationConfigFile.exists must beFalse) and
       (compilationOutputFile.exists must beFalse) and
       checkXML(CreatedByRudderc) and
@@ -309,7 +310,7 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
       initDirectories(compiler, technique)
       val res                = compiler.compileTechnique(technique).runNow
 
-      (res must beEqualTo(TechniqueCompilationOutput(Rudderc, false, 7, "nok:user", "stdout", "stderr"))) and
+      (res must beEqualTo(TechniqueCompilationOutput(Rudderc, false, 7, Chunk.empty, "nok:user", "stdout", "stderr"))) and
       (compilationConfigFile.exists must beFalse) and
       (compilationOutputFile.exists must beTrue) and
       checkXML(Missing) and
@@ -322,7 +323,7 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
       initDirectories(compiler, technique)
       val res                = compiler.compileTechnique(technique).runNow
 
-      (res must beEqualTo(TechniqueCompilationOutput(Webapp, true, -42, "nok:empty", "stdout", "stderr"))) and
+      (res must beEqualTo(TechniqueCompilationOutput(Webapp, true, -42, Chunk.empty, "nok:empty", "stdout", "stderr"))) and
       (compilationConfigFile.exists must beFalse) and
       (compilationOutputFile.exists must beTrue) and
       checkXML(CreatedByWebapp) and
@@ -335,7 +336,7 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
       initDirectories(compiler, technique)
       val res                = compiler.compileTechnique(technique).runNow
 
-      (res must beEqualTo(TechniqueCompilationOutput(Webapp, true, 50, "nok:empty", "stdout", "stderr"))) and
+      (res must beEqualTo(TechniqueCompilationOutput(Webapp, true, 50, Chunk.empty, "nok:empty", "stdout", "stderr"))) and
       (compilationConfigFile.exists must beFalse) and
       (compilationOutputFile.exists must beTrue) and
       checkXML(CreatedByWebapp) and
@@ -348,7 +349,7 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
       initDirectories(compiler, technique)
       val res                = compiler.compileTechnique(technique).runNow
 
-      (res must beEqualTo(TechniqueCompilationOutput(Webapp, true, 60, "nok:xml", "stdout", "stderr"))) and
+      (res must beEqualTo(TechniqueCompilationOutput(Webapp, true, 60, Chunk.empty, "nok:xml", "stdout", "stderr"))) and
       (compilationConfigFile.exists must beFalse) and
       (compilationOutputFile.exists must beTrue) and
       checkXML(CreatedByWebapp) and
@@ -361,7 +362,7 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
       initDirectories(compiler, technique)
       val res                = compiler.compileTechnique(technique).runNow
 
-      (res must beEqualTo(TechniqueCompilationOutput(Webapp, true, 70, "nok:cfe", "stdout", "stderr"))) and
+      (res must beEqualTo(TechniqueCompilationOutput(Webapp, true, 70, Chunk.empty, "nok:cfe", "stdout", "stderr"))) and
       (compilationConfigFile.exists must beFalse) and
       (compilationOutputFile.exists must beTrue) and
       checkXML(CreatedByWebapp) and
@@ -374,7 +375,7 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
       initDirectories(compiler, technique)
       val res                = compiler.compileTechnique(technique).runNow
 
-      (res must beEqualTo(TechniqueCompilationOutput(Webapp, true, 80, "nok:ps1", "stdout", "stderr"))) and
+      (res must beEqualTo(TechniqueCompilationOutput(Webapp, true, 80, Chunk.empty, "nok:ps1", "stdout", "stderr"))) and
       (compilationConfigFile.exists must beFalse) and
       (compilationOutputFile.exists must beTrue) and
       checkXML(CreatedByWebapp) and
@@ -402,7 +403,24 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
       writeConfig
       val res                = compiler.compileTechnique(technique).runNow
 
-      (res must beEqualTo(TechniqueCompilationOutput(Webapp, false, 0, "Technique 'techniqueOK' written by webapp", "", ""))) and
+      import ResourceFileState.New
+
+      (res must beEqualTo(
+        TechniqueCompilationOutput(
+          Webapp,
+          false,
+          0,
+          Chunk(
+            ResourceFile("metadata.xml", New),
+            ResourceFile("rudder_reporting.cf", New),
+            ResourceFile("technique.cf", New),
+            ResourceFile("technique.ps1", New)
+          ),
+          "Technique 'techniqueOK' written by webapp",
+          "",
+          ""
+        )
+      )) and
       (compilationConfigFile.exists must beTrue) and
       (compilationOutputFile.exists must beFalse) and // it's not an override, there's no error: no output file
       checkXML(CreatedByWebapp) and

--- a/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/post-migration/ncf_techniques/technique_with_error/1.0/compilation-output.yml
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/configuration-repository-migrate-json-8_0/post-migration/ncf_techniques/technique_with_error/1.0/compilation-output.yml
@@ -1,6 +1,9 @@
 compiler: rudderc
 fallbacked: false
 resultCode: 42
+fileStatus:
+  - path: foo
+    state: deleted
 msg: error
 stdout: ''
 stderr: error stderr

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateJsonTechniquesToYaml.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateJsonTechniquesToYaml.scala
@@ -47,6 +47,8 @@ import com.normation.rudder.db.DB
 import com.normation.rudder.git.GitCommitId
 import com.normation.rudder.ncf.DeleteEditorTechnique
 import com.normation.rudder.ncf.EditorTechnique
+import com.normation.rudder.ncf.ResourceFile
+import com.normation.rudder.ncf.ResourceFileState
 import com.normation.rudder.ncf.RuddercOptions
 import com.normation.rudder.ncf.RuddercResult
 import com.normation.rudder.ncf.RuddercService
@@ -103,7 +105,7 @@ class TestMigrateJsonTechniquesToYaml extends Specification with ContentMatchers
     override def compile(techniqueDir: File, options: RuddercOptions): IOResult[RuddercResult] = {
       // test implementation that just create the files with the technique name in them safe for
       if (techniqueDir.parent.name == "technique_with_error") {
-        RuddercResult.Fail(42, "error", "", "error stderr").succeed
+        RuddercResult.Fail(42, Chunk(ResourceFile("foo", ResourceFileState.Deleted)), "error", "", "error stderr").succeed
       } else {
         // replace content to be sure we get there
         IOResult.attempt {
@@ -121,7 +123,7 @@ class TestMigrateJsonTechniquesToYaml extends Specification with ContentMatchers
           (TechniqueFiles.Generated.dsc ++ TechniqueFiles.Generated.cfengineRudderc).foreach { n =>
             (techniqueDir / n).write("regenerated")
           }
-          RuddercResult.Ok("", "", "")
+          RuddercResult.Ok(Chunk.empty, "", "", "")
         }
       }
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/23818

We didn't update the status of file in [GitArchivers.scala](https://github.com/Normation/rudder/pull/5224/files#diff-bb5734a3493073add0df1291f147ac6cd515b8a211f543610446796ed2374441) after the compilation was done, and we were basing our cleaning based on the "before compilation" status. 

So the main change is to track what files are produce by `rudderc` and weave that info up to the `GitArchiver` where we need it to compute the updated status. 

Appart that, add logs to better understand what is happening for a next time.