### PR TITLE
Fixes #23837: Enforce change request and workflow table schema

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -51,6 +51,7 @@ import bootstrap.liftweb.checks.migration.CheckAddSpecialNodeGroupsDescription
 import bootstrap.liftweb.checks.migration.CheckAddSpecialTargetAllPolicyServers
 import bootstrap.liftweb.checks.migration.CheckMigratedSystemTechniques
 import bootstrap.liftweb.checks.migration.CheckRemoveRuddercSetting
+import bootstrap.liftweb.checks.migration.MigrateChangeValidationEnforceSchema
 import bootstrap.liftweb.checks.migration.MigrateEventLogEnforceSchema
 import bootstrap.liftweb.checks.onetimeinit.CheckInitUserTemplateLibrary
 import bootstrap.liftweb.checks.onetimeinit.CheckInitXmlExport
@@ -3204,6 +3205,7 @@ object RudderConfigInit {
     lazy val allBootstrapChecks = new SequentialImmediateBootStrapChecks(
       new CheckConnections(dataSourceProvider, rwLdap),
       new MigrateEventLogEnforceSchema(doobie),
+      new MigrateChangeValidationEnforceSchema(doobie),
       new CheckTechniqueLibraryReload(
         techniqueRepositoryImpl,
         uuidGen

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/DbCommonMigration.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/DbCommonMigration.scala
@@ -1,0 +1,21 @@
+package bootstrap.liftweb.checks.migration
+
+import doobie.ConnectionIO
+import doobie.syntax.string._
+
+/**
+ * Mixin that provides set of utils for SQL migration
+ */
+trait DbCommonMigration {
+
+  def isColumnNullable(tableName: String, columnName: String): ConnectionIO[Boolean] = {
+    sql"""
+      select count(*)
+      from information_schema.columns
+      where table_name = $tableName
+      and column_name = $columnName
+      and is_nullable = 'YES'
+    """.query[Int].unique.map(_ > 0)
+  }
+
+}

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/MigrateChangeValidationEnforceSchema.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/MigrateChangeValidationEnforceSchema.scala
@@ -1,0 +1,121 @@
+/*
+ *************************************************************************************
+ * Copyright 2023 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package bootstrap.liftweb.checks.migration
+
+import bootstrap.liftweb.BootstrapChecks
+import bootstrap.liftweb.BootstrapLogger
+import com.normation.errors.RudderError
+import com.normation.rudder.db.Doobie
+import com.normation.zio.UnsafeRun
+import doobie.Transactor
+import doobie.implicits._
+import doobie.util.fragment.Fragment
+import doobie.util.update.Update0
+import zio._
+import zio.interop.catz._
+
+/*
+ * Ths migration applies a change in the schema of the change requests and workflow table :
+ *  - add not null constraint to id, state columns in the workflow table
+ *  - add not null constraint to content column in the change requests table
+ */
+class MigrateChangeValidationEnforceSchema(
+    doobie: Doobie
+) extends BootstrapChecks with DbCommonMigration {
+
+  import doobie._
+
+  val msg: String = "change requests and workflow columns that should be not null (id, state, content)"
+
+  protected def changeRequestTableName: String   = "changerequest"
+  private def changeRequestTable:       Fragment = Fragment.const(changeRequestTableName)
+  protected def workflowTableName:      String   = "workflow"
+  private def workflowTable:            Fragment = Fragment.const(workflowTableName)
+
+  override def description: String =
+    "Check if changerequest(content), workflow(id, state) have a not null constraint, otherwise migrate these columns"
+
+  def alterTableStatement(table: Fragment, column: Fragment): Update0 = {
+    sql"alter table $table alter column $column set not null".update
+  }
+
+  // we need the table fragment to be the class method that can be overriden (e.g. for tests)
+  private def transactMigration(table: String, tableFragment: Fragment, column: String)(implicit
+      xa:                              Transactor[Task]
+  ): Task[Unit] = {
+    val columnFragment = Fragment.const(column)
+    for {
+      migrate <- isColumnNullable(table, column).transact(xa) // migrate when column is still nullable
+      _       <- if (migrate) alterTableStatement(tableFragment, columnFragment).run.transact(xa)
+                 else {
+                   BootstrapLogger.debug(
+                     s"No need to migrate: have already previously migrated table ${table} column ${column} (${msg})"
+                   )
+                 }
+
+    } yield ()
+  }
+
+  def migrationEffect(implicit xa: Transactor[Task]): Task[Unit] = {
+    val changeRequestContent = transactMigration(changeRequestTableName, changeRequestTable, "content")
+    val workflowId           = transactMigration(workflowTableName, workflowTable, "id")
+    val workflowState        = transactMigration(workflowTableName, workflowTable, "state")
+
+    changeRequestContent *> workflowId *> workflowState
+  }
+
+  val migrateAsync: URIO[Any, Fiber.Runtime[RudderError, Unit]] = {
+    transactIOResult(s"Error with 'EventLog' table migration")(
+      migrationEffect(_)
+        .foldZIO(
+          err =>
+            BootstrapLogger.error(
+              s"Non-fatal error when trying to migrate ${msg}." +
+              s"\nThis is a data check and it should not alter the behavior of Rudder." +
+              s"\nPlease contact the development team with the following information to help resolving the issue : ${err.getMessage}"
+            ),
+          _ => BootstrapLogger.info(s"Migrated ${msg}")
+        )
+    ).forkDaemon
+  }
+
+  override def checks(): Unit = {
+    migrateAsync.runNow
+  }
+
+}

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateChangeValidationEnforceSchema.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateChangeValidationEnforceSchema.scala
@@ -1,0 +1,181 @@
+/*
+ *************************************************************************************
+ * Copyright 2023 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package bootstrap.liftweb.checks.migration
+
+import com.normation.rudder.db.DBCommon
+import com.normation.rudder.db.Doobie
+import com.normation.zio.UnsafeRun
+import doobie.Transactor
+import doobie.specs2.analysisspec.IOChecker
+import doobie.syntax.all._
+import doobie.util.fragment
+import doobie.util.fragments.and
+import doobie.util.fragments.whereOr
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.core.Fragments
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+import zio._
+import zio.interop.catz._
+
+@RunWith(classOf[JUnitRunner])
+class TestMigrateChangeValidationEnforceSchema extends DBCommon with IOChecker {
+  import TestMigrateChangeValidationEnforceSchema._
+
+  private lazy val migrateChangeValidation = new MigrateChangeValidationEnforceSchemaTempTable(doobie)
+
+  override def transactor: Transactor[cats.effect.IO] = doobie.xaio
+
+  override def cleanDb(): Unit = {
+    doobie.transactRunEither(
+      sql"""
+        DROP TABLE IF EXISTS ${tempWorkflowTable};
+        DROP TABLE IF EXISTS ${tempCRTable};
+        DROP SEQUENCE IF EXISTS ChangeRequestId_temp;
+      """.update.run.transact(_)
+    ) match {
+      case Right(_) => ()
+      case Left(ex) => throw ex
+    }
+  }
+
+  // The previous schema, with the renamed table for this test
+  // We need to know for sure the initial state and the final state of the migrated table,
+  // so we define and use the previous schema without conflicting with the current one (with all values renamed)
+  private val previousSchemaDDL = sql"""
+    CREATE SEQUENCE IF NOT EXISTS ChangeRequestId_temp start 1;
+
+    CREATE TABLE ${tempCRTable} (
+      id             integer PRIMARY KEY DEFAULT nextval('ChangeRequestId_temp')
+    , name           text CHECK (name <> '')
+    , description    text
+    , creationTime   timestamp with time zone
+    , content        xml
+    , modificationId text
+    );
+    
+    CREATE TABLE ${tempWorkflowTable} (
+      id    integer REFERENCES ${tempCRTable} (id)
+    , state text
+    );
+  """
+
+  override def initDb(): Unit = {
+    super.initDb()
+    doobie.transactRunEither(previousSchemaDDL.update.run.transact(_)) match {
+      case Right(_) => ()
+      case Left(ex) => throw ex
+    }
+  }
+
+  sequential
+
+  "MigrateChangeValidationEnforceSchema" should {
+
+    "type-check queries" in {
+      if (doDatabaseConnection) {
+        check(migrateChangeValidation.alterTableStatement(tempCRTable, fr"content"))
+        check(migrateChangeValidation.alterTableStatement(tempWorkflowTable, fr"id"))
+        check(migrateChangeValidation.alterTableStatement(tempWorkflowTable, fr"state"))
+      } else Fragments.empty
+    }
+
+    "migrate all columns successfully" in {
+      migrateChangeValidation.migrateAsync.runNow.join.runNow
+
+      doobie.transactRunEither(
+        (sql"""
+          SELECT DISTINCT column_name, is_nullable
+          FROM INFORMATION_SCHEMA.COLUMNS
+        """ ++ whereOr(
+          and(fr"table_name = ${tempCRTableName}", fr"column_name = 'content'"),
+          and(fr"table_name = ${tempWorkflowTableName}", fr"column_name = 'id'"),
+          and(fr"table_name = ${tempWorkflowTableName}", fr"column_name = 'state'")
+        ))
+          .query[(String, String)]
+          .to[List]
+          .transact(_)
+      ) match {
+        case Right(res) =>
+          res must containTheSameElementsAs(
+            List(
+              ("content", "NO"),
+              ("id", "NO"),
+              ("state", "NO")
+            )
+          )
+        case Left(ex)   =>
+          ko(
+            s"The migration of 'ChangeRequest' and 'Workflow' tables does not add NOT NULL constraint to all columns with error : ${ex.getMessage}"
+          )
+      }
+    }
+
+    "catch all migration errors" in {
+      lazy val migrateChangeValidation =
+        new MigrateChangeValidationEnforceSchemaTempTable(doobie, Some(ZIO.fail(new Exception("some database error"))))
+
+      Try(migrateChangeValidation.migrateAsync.runNow.join.runNow) match {
+        case Failure(_)  => ko("The parent program should not fail even if the fiber failed")
+        case Success(()) => ok("The parent program continued to run despite the migration fiber error")
+      }
+
+    }
+  }
+}
+
+object TestMigrateChangeValidationEnforceSchema {
+  // the tables are setup and tear down for the lifetime of this test execution
+  private val tempCRTableName       = "changerequest_migratetest"
+  private val tempCRTable           = fragment.Fragment.const(tempCRTableName)
+  private val tempWorkflowTableName = "workflow_migratetest"
+  private val tempWorkflowTable     = fragment.Fragment.const(tempWorkflowTableName)
+
+  private class MigrateChangeValidationEnforceSchemaTempTable(doobie: Doobie, overrideEffect: Option[Task[Unit]] = None)
+      extends MigrateChangeValidationEnforceSchema(doobie) {
+    override def changeRequestTableName:                         String     = tempCRTableName
+    override def workflowTableName:                              String     = tempWorkflowTableName
+    override def migrationEffect(implicit xa: Transactor[Task]): Task[Unit] = {
+      val default = super.migrationEffect(xa)
+      overrideEffect.getOrElse(default)
+    }
+  }
+
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/23837

We need to add `NOT NULL` constraint to the change-validation plugin tables, in order to enforce the table schema  (until now there does not seem to be a `null` value that has been written in the table, in that case the migration would fail but the user would have a nice error log). I added database tests.

Note that this PR is very similar to https://github.com/Normation/rudder/pull/5232  