### PR TITLE
Fixes #23847: For technique parameter, name, id and doc are mixed up

### DIFF
--- a/policies/rudderc/src/backends/metadata.rs
+++ b/policies/rudderc/src/backends/metadata.rs
@@ -96,8 +96,8 @@ impl From<Parameter> for Input {
 
         Self {
             name: p.id.to_string().to_uppercase(),
-            description: p.name,
-            long_description: p.description,
+            description: p.description.unwrap_or(p.name),
+            long_description: p.documentation,
             constraint: Constraint {
                 _type: type_constraint.to_string(),
                 may_be_empty: if p.constraints.allow_empty {

--- a/policies/rudderc/tests/cases/general/escaping/technique.yml
+++ b/policies/rudderc/tests/cases/general/escaping/technique.yml
@@ -6,7 +6,7 @@ version: "0.1"
 params:
   - id: 3439bbb0-d8f1-4c43-95a9-0c56bfb8c27e
     name: "server"
-    description: "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3\r\n\t"
+    documentation: "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3\r\n\t"
 items:
   - name: "${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3\r\n\t"
     id: a86ce2e5-d5b6-45cc-87e8-c11cca71d966

--- a/policies/rudderc/tests/cases/general/form/metadata.xml
+++ b/policies/rudderc/tests/cases/general/form/metadata.xml
@@ -27,16 +27,15 @@
     <SECTION name="Technique parameters">
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C27A</NAME>
-        <DESCRIPTION>server_a</DESCRIPTION>
-        <LONGDESCRIPTION>description</LONGDESCRIPTION>
+        <DESCRIPTION>description</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>textarea</TYPE>
         </CONSTRAINT>
       </INPUT>
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C27B</NAME>
-        <DESCRIPTION>server_b</DESCRIPTION>
-        <LONGDESCRIPTION>The server hostname</LONGDESCRIPTION>
+        <DESCRIPTION>The server hostname</DESCRIPTION>
+        <LONGDESCRIPTION>This is markdown</LONGDESCRIPTION>
         <CONSTRAINT>
           <TYPE>textarea</TYPE>
           <MAYBEEMPTY>true</MAYBEEMPTY>

--- a/policies/rudderc/tests/cases/general/ntp/metadata.xml
+++ b/policies/rudderc/tests/cases/general/ntp/metadata.xml
@@ -44,8 +44,7 @@
     <SECTION name="Technique parameters">
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C27E</NAME>
-        <DESCRIPTION>server</DESCRIPTION>
-        <LONGDESCRIPTION>The server hostname</LONGDESCRIPTION>
+        <DESCRIPTION>The server hostname</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>textarea</TYPE>
         </CONSTRAINT>


### PR DESCRIPTION
https://issues.rudder.io/issues/23847

do the same as select one https://github.com/Normation/rudder/pull/5238/files#diff-9cccbc1bdfe2c43e82d1ceaafe377789de820f127ed601aae82b0ea883225653L139 than classic input

name in metadata.xml is the description of the parameter, long_description the documentation