### PR TITLE
Fixes #23869: Cannot add properties to a group

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -321,8 +321,8 @@ class NodeGroupForm(
             var main = document.getElementById("nodeproperties-app")
                                                      |var initValues = {
                                                      |    contextPath    : "${S.contextPath}"
-                                                     |  , hasWriteRights : hasWriteRights
-                                                     |  , hasReadRights  : hasReadRights
+                                                     |  , hasNodeWrite   : CanWriteNode
+                                                     |  , hasNodeRead    : CanReadNode
                                                      |  , nodeId         : "${group.id.uid.value}"
                                                      |  , objectType     : 'group'
                                                      |};


### PR DESCRIPTION
https://issues.rudder.io/issues/23869
This bug was introduced by https://github.com/Normation/rudder/pull/5236
Since the property module is shared between the node property page and the group property page, we should reflect changes

In #5236  we have renamed the `hasWriteRights` because some other module was using the same naming (for AgentSchedule) and was interfering with the write rights for the properties