### PR TITLE
Fixes #23446: Change request on special:all_nodes_without_role lead to error

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
@@ -84,12 +84,14 @@ case object AllTarget extends NonGroupRuleTarget {
 
 case object AllTargetExceptPolicyServers extends NonGroupRuleTarget {
   override def target = "special:all_exceptPolicyServers"
-  def r               = "special:all_exceptPolicyServers".r
+  // for compat reason in event logs < Rudder 7.0, we must be able to parse also old format: `special:all_nodes_without_role`
+  def r               = "(?:special:all_exceptPolicyServers|special:all_nodes_without_role)".r
 }
 
 case object AllPolicyServers extends NonGroupRuleTarget {
   override def target = "special:all_policyServers"
-  def r               = "special:all_policyServers".r
+  // for compat reason in event logs < Rudder 7.0, we must be able to parse also old format: `special:all_servers_with_role`
+  def r               = "(?:special:all_policyServers|special:all_servers_with_role)".r
 }
 
 /**


### PR DESCRIPTION
https://issues.rudder.io/issues/23446

I think we don't want to modify event logs (as a general rule). We should perhaps be able to store old event logs in a "cold storage" (other table, or crypted file, or whatever) and wait for old format to disappear. 

In the meantime, we will just parse the old and new format (it's extermelly limited in that case, so almost without impact)