### PR TITLE
Fixes #23874: Remove the "Create with latest version" button from the version selection

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/directiveManagement.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/directiveManagement.html
@@ -195,11 +195,6 @@
                 <input id="displayDeprecation" type="checkbox" ng-model="displayDeprecated"/>
                 <label for="displayDeprecation">Display deprecated Technique versions</label>
               </div>
-              <lift:authz role="directive_write">
-                <div class="space-top">
-                  <button type="button" id="addButton" ng-click="techniques[techniques.length-1].action()" class="btn btn-success new-icon">Create with latest version</button>
-                </div>
-              </lift:authz>
             </div>
           </div>
         </div>


### PR DESCRIPTION
https://issues.rudder.io/issues/23874
15/12/2023 : [Discussion in progress](https://rudderio.slack.com/archives/C3X0V8ZL6/p1702637432816409) to decide what to do with the button. No clear decision has yet been taken.