### PR TITLE
Fixes #23856: Impact of RBAC node filtering on compliance

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleApplicationStatus.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleApplicationStatus.scala
@@ -37,8 +37,6 @@
 
 package com.normation.rudder.domain.policies
 
-import com.normation.rudder.domain.nodes.NodeInfo
-
 /**
  * Application status of a rule
  */
@@ -60,7 +58,7 @@ object ApplicationStatus {
       applicationStatus: ApplicationStatus,
       targets:           Set[RuleTargetInfo],
       directives:        Set[(ActiveTechnique, Directive)],
-      nodes:             Iterable[NodeInfo]
+      nodeIsEmpty:       Boolean
   ) = {
     applicationStatus match {
       case FullyApplied          => ("In application", None)
@@ -82,7 +80,7 @@ object ApplicationStatus {
             (rule.isEnabledStatus && !rule.isEnabled, "Rule unapplied"),
             (directives.isEmpty, "No policy defined"),
             (!isAllTargetsEnabled, "Group disabled"),
-            (nodes.isEmpty, "Empty groups")
+            (nodeIsEmpty, "Empty groups")
           ) ++
           directives.flatMap {
             case (activeTechnique, directive) =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
@@ -44,6 +44,7 @@ import com.normation.utils.Control.sequence
 import net.liftweb.common._
 import net.liftweb.json._
 import net.liftweb.json.JsonDSL._
+import scala.collection.MapView
 import zio.Chunk
 
 /**
@@ -233,7 +234,7 @@ object RuleTarget extends Loggable {
    */
   def getNodeIds(
       targets:          Set[RuleTarget],
-      allNodes:         Map[NodeId, Boolean /* isPolicyServer */ ],
+      allNodes:         MapView[NodeId, Boolean /* isPolicyServer */ ],
       groups:           Map[NodeGroupId, Set[NodeId]],
       allNodesAreThere: Boolean = true // if we are working on a subset of node, set to false
   ): Set[NodeId] = {
@@ -241,7 +242,7 @@ object RuleTarget extends Loggable {
     targets.foldLeft(Set[NodeId]()) {
       case (nodes, target) =>
         target match {
-          case AllTarget                    => return allNodes.keySet
+          case AllTarget                    => return allNodes.keySet.toSet
           case AllTargetExceptPolicyServers => nodes ++ allNodes.collect { case (k, isPolicyServer) if (!isPolicyServer) => k }
           case AllPolicyServers             => nodes ++ allNodes.collect { case (k, isPolicyServer) if (isPolicyServer) => k }
           case PolicyServerTarget(nodeId)   =>
@@ -292,7 +293,7 @@ object RuleTarget extends Loggable {
    */
   def getNodeIdsChunk(
       targets:          Set[RuleTarget],
-      allNodes:         Map[NodeId, Boolean /* isPolicyServer */ ],
+      allNodes:         MapView[NodeId, Boolean /* isPolicyServer */ ],
       groups:           Map[NodeGroupId, Chunk[NodeId]],
       allNodesAreThere: Boolean = true // if we are working on a subset of node, set to false
   ): Chunk[NodeId] = {
@@ -302,7 +303,7 @@ object RuleTarget extends Loggable {
 
   def getNodeIdsChunkRec(
       targets:          Chunk[RuleTarget],
-      allNodes:         Map[NodeId, Boolean /* isPolicyServer */ ],
+      allNodes:         MapView[NodeId, Boolean /* isPolicyServer */ ],
       groups:           Map[NodeGroupId, Chunk[NodeId]],
       allNodesAreThere: Boolean = true // if we are working on a subset of node, set to false
   ): Chunk[NodeId] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
@@ -122,7 +122,9 @@ final case class RudderSettings(
     policyMode:             Option[PolicyMode],
     policyServerId:         NodeId,
     security:               Option[SecurityTag] // optional for backward compat. None means "no tenant"
-)
+) {
+  def isPolicyServer: Boolean = kind != NodeKind.Node
+}
 
 final case class InputDevice(caption: String, description: String, @jsonField("type") tpe: String)
 final case class LocalGroup(id: Int, name: String, members: Chunk[String])

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
@@ -54,6 +54,8 @@ class RuleTargetTest extends Specification with Loggable {
     )
   }.toMap
 
+  val nodeArePolicyServers = nodes.map { case (id, n) => (id, n.isPolicyServer) }.view
+
   val g1 = NodeGroup(
     NodeGroupId(NodeGroupUid("1")),
     "Empty group",
@@ -174,25 +176,25 @@ class RuleTargetTest extends Specification with Loggable {
     "Be found correctly on simple rule targets" in {
       groupTargets.forall {
         case (gt, g) =>
-          fngc.getNodeIds(Set(gt), nodes) === g.serverList
+          fngc.getNodeIds(Set(gt), nodeArePolicyServers) === g.serverList
       }
     }
     "Be found correctly on group targets union" in {
       unionTargets.forall {
         case (gt, g) =>
-          fngc.getNodeIds(Set(gt), nodes) === g
+          fngc.getNodeIds(Set(gt), nodeArePolicyServers) === g
       }
     }
     "Be found correctly on group targets intersection" in {
       interTargets.forall {
         case (gt, g) =>
-          fngc.getNodeIds(Set(gt), nodes) === g
+          fngc.getNodeIds(Set(gt), nodeArePolicyServers) === g
       }
     }
     "Be found correctly on group targets exclusion " in {
       allTargetExclusions.forall {
         case (target, resultNodes) =>
-          fngc.getNodeIds(Set(target), nodes) === resultNodes
+          fngc.getNodeIds(Set(target), nodeArePolicyServers) === resultNodes
       }
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
@@ -59,6 +59,7 @@ import org.joda.time.DateTime
 import org.junit.runner._
 import org.specs2.mutable._
 import org.specs2.runner._
+import scala.collection.MapView
 import scala.collection.SortedMap
 
 /**
@@ -190,7 +191,7 @@ class RuleValServiceTest extends Specification {
   // Ok, now I can test
   "The RuleValService, with one directive, one Meta-technique " should {
 
-    val ruleVal = ruleValService.buildRuleVal(rule, fullActiveTechniqueCategory, NodeConfigData.groupLib, Map())
+    val ruleVal = ruleValService.buildRuleVal(rule, fullActiveTechniqueCategory, NodeConfigData.groupLib, MapView())
 
     "return a Full(RuleVal)" in {
       ruleVal.isDefined == true
@@ -230,7 +231,7 @@ class RuleValServiceTest extends Specification {
   }
 
   "The cardinality computed " should {
-    val ruleVal = ruleValService.buildRuleVal(rule, fullActiveTechniqueCategory, NodeConfigData.groupLib, Map())
+    val ruleVal = ruleValService.buildRuleVal(rule, fullActiveTechniqueCategory, NodeConfigData.groupLib, MapView())
     val draft   = ruleVal.openOrThrowException("Should have been full for test").parsedPolicyDrafts.head
     // false PolicyVars for that draft
     val vars    = PolicyVars(draft.id, draft.policyMode, draft.originalVariables, draft.originalVariables, draft.trackerVariable)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
@@ -170,7 +170,8 @@ class TestBuildNodeConfiguration extends Specification {
     for (i <- 0 until 10) {
       logger.trace("\n--------------------------------")
       val t1           = System.currentTimeMillis()
-      val ruleVal      = ruleValService.buildRuleVal(rule, directiveLib, groupLib, allNodes)
+      val ruleVal      =
+        ruleValService.buildRuleVal(rule, directiveLib, groupLib, allNodes.map { case (id, n) => (id, n.isPolicyServer) }.view)
       val ruleVals     = Seq(ruleVal.getOrElse(throw new RuntimeException("oups")))
       val t2           = System.currentTimeMillis()
       val nodeContexts = buildContext

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/UserService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/UserService.scala
@@ -40,6 +40,8 @@ package com.normation.rudder
 import com.normation.eventlog.EventActor
 import com.normation.rudder.api.ApiAccount
 import com.normation.rudder.api.ApiAuthorization
+import com.normation.rudder.facts.nodes.NodeSecurityContext
+import com.normation.rudder.facts.nodes.QueryContext
 
 /*
  * This file define data type around what is a User in Rudder,
@@ -65,6 +67,11 @@ trait User {
     case RudderAccount.User(login, _) => login
     case RudderAccount.Api(api)       => api.name.value
   })
+  def nodePerms: NodeSecurityContext
+
+  def queryContext: QueryContext = {
+    QueryContext(actor, nodePerms)
+  }
 }
 
 /**

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -320,7 +320,7 @@ class ArchiveApi(
             merge   <- parseMergePolicy(req)
             archive <- parseArchive(zip)
             _       <- checkArchiveService.check(archive)
-            _       <- saveArchiveService.save(archive, merge, authzToken.actor)
+            _       <- saveArchiveService.save(archive, merge, authzToken.qc.actor)
             _       <- ApplicationLoggerPure.Archive.info(s"Uploaded archive '${zip.fileName}' processed successfully")
           } yield JRArchiveImported(true)
       }).tapError(err => ApplicationLoggerPure.Archive.error(s"Error when processing uploaded archive: ${err.fullMsg}"))

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
@@ -197,7 +197,7 @@ class DirectiveApi(
         result
       }
 
-      actionResponse(response, req, "Could not create Directive", id.map(_.value), authzToken.actor)(action)
+      actionResponse(response, req, "Could not create Directive", id.map(_.value), authzToken.qc.actor)(action)
     }
   }
 
@@ -219,7 +219,7 @@ class DirectiveApi(
         s"Could not delete Directive '$id'",
         Some(id),
         s"Delete Directive '${id}' from API",
-        authzToken.actor
+        authzToken.qc.actor
       )
     }
   }
@@ -273,7 +273,7 @@ class DirectiveApi(
         s"Could not update Directive '${id}'",
         Some(id),
         s"Update Directive '${id}' from API",
-        authzToken.actor
+        authzToken.qc.actor
       )
     }
   }
@@ -339,7 +339,7 @@ class DirectiveApi(
                            restDirective.id.map(_.uid).getOrElse(DirectiveUid(uuidGen.newUuid)),
                            restDirective.source,
                            params,
-                           authzToken.actor
+                           authzToken.qc.actor
                          )
       } yield {
         val action = if (restDirective.source.nonEmpty) "cloneDirective" else schema.name
@@ -362,7 +362,7 @@ class DirectiveApi(
       (for {
         id            <- DirectiveId.parse(sid).toIO
         restDirective <- zioJsonExtractor.extractDirective(req).chainError(s"Could not extract a directive from request.").toIO
-        result        <- serviceV14.updateDirective(restDirective.copy(id = Some(id)), params, authzToken.actor)
+        result        <- serviceV14.updateDirective(restDirective.copy(id = Some(id)), params, authzToken.qc.actor)
       } yield {
         result
       }).toLiftResponseOne(params, schema, s => Some(s.id))
@@ -379,7 +379,7 @@ class DirectiveApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      serviceV14.deleteDirective(DirectiveUid(id), params, authzToken.actor).toLiftResponseOne(params, schema, s => Some(s.id))
+      serviceV14.deleteDirective(DirectiveUid(id), params, authzToken.qc.actor).toLiftResponseOne(params, schema, s => Some(s.id))
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -325,7 +325,7 @@ class GroupsApi(
         req,
         s"Could not delete Group category '${id}'",
         Some(id),
-        authzToken.actor
+        authzToken.qc.actor
       )
     }
   }
@@ -362,7 +362,7 @@ class GroupsApi(
         req,
         s"Could not update Group category '${id}'",
         Some(id),
-        authzToken.actor
+        authzToken.qc.actor
       )
     }
   }
@@ -393,7 +393,7 @@ class GroupsApi(
         req,
         s"Could not create group category",
         None,
-        authzToken.actor
+        authzToken.qc.actor
       )
     }
   }
@@ -474,7 +474,7 @@ class GroupsApi(
       NodeGroupId
         .parse(sid)
         .toIO
-        .flatMap(id => serviceV14.deleteGroup(id, params, authzToken.actor))
+        .flatMap(id => serviceV14.deleteGroup(id, params, authzToken.qc.actor))
         .toLiftResponseOne(params, schema, s => Some(s.id))
     }
   }
@@ -489,7 +489,7 @@ class GroupsApi(
                        restGroup.id.getOrElse(NodeGroupId(NodeGroupUid(uuidGen.newUuid))),
                        restGroup.source,
                        params,
-                       authzToken.actor
+                       authzToken.qc.actor
                      )
       } yield {
         val action = if (restGroup.source.nonEmpty) "cloneGroup" else schema.name
@@ -511,7 +511,7 @@ class GroupsApi(
       (for {
         restGroup <- zioJsonExtractor.extractGroup(req).chainError(s"Could not extract a group from request.").toIO
         id        <- NodeGroupId.parse(sid).toIO
-        res       <- serviceV14.updateGroup(restGroup.copy(id = Some(id)), params, authzToken.actor)
+        res       <- serviceV14.updateGroup(restGroup.copy(id = Some(id)), params, authzToken.qc.actor)
       } yield {
         res
       }).toLiftResponseOne(params, schema, s => Some(s.id))
@@ -529,7 +529,7 @@ class GroupsApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      serviceV14.reloadGroup(id, params, authzToken.actor).toLiftResponseOne(params, schema, s => Some(s.id))
+      serviceV14.reloadGroup(id, params, authzToken.qc.actor).toLiftResponseOne(params, schema, s => Some(s.id))
     }
   }
 
@@ -584,7 +584,7 @@ class GroupsApi(
         req,
         s"Could not delete Group category '${id}'",
         Some(id),
-        authzToken.actor
+        authzToken.qc.actor
       )
     }
   }
@@ -621,7 +621,7 @@ class GroupsApi(
         req,
         s"Could not update Group category '${id}'",
         Some(id),
-        authzToken.actor
+        authzToken.qc.actor
       )
     }
   }
@@ -652,7 +652,7 @@ class GroupsApi(
         req,
         s"Could not create group category",
         None,
-        authzToken.actor
+        authzToken.qc.actor
       )
     }
   }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
@@ -233,7 +233,7 @@ class ParameterApi(
       (for {
         restParam <-
           zioJsonExtractor.extractGlobalParam(req).chainError(s"Could not extract a global parameter from request").toIO
-        result    <- serviceV14.createParameter(restParam, params, authzToken.actor)
+        result    <- serviceV14.createParameter(restParam, params, authzToken.qc.actor)
       } yield {
         result
       }).toLiftResponseOne(params, schema, s => Some(s.id))
@@ -250,7 +250,7 @@ class ParameterApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      serviceV14.deleteParameter(id, params, authzToken.actor).toLiftResponseOne(params, schema, s => Some(s.id))
+      serviceV14.deleteParameter(id, params, authzToken.qc.actor).toLiftResponseOne(params, schema, s => Some(s.id))
     }
   }
 
@@ -266,7 +266,7 @@ class ParameterApi(
     ): LiftResponse = {
       (for {
         restParam <- zioJsonExtractor.extractGlobalParam(req).chainError(s"Could not extract parameter from request.").toIO
-        result    <- serviceV14.updateParameter(restParam.copy(id = Some(id)), params, authzToken.actor)
+        result    <- serviceV14.updateParameter(restParam.copy(id = Some(id)), params, authzToken.qc.actor)
       } yield {
         result
       }).toLiftResponseOne(params, schema, s => Some(s.id))

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -204,12 +204,12 @@ class SettingsApi(
       var generate = false
       val data     = for {
         setting <- allSettings(version)
-        value   <- setting.setFromRequestOpt(req, authzToken.actor)
+        value   <- setting.setFromRequestOpt(req, authzToken.qc.actor)
       } yield {
         if (value.isDefined) generate = generate || setting.startPolicyGeneration
         JField(setting.key, value)
       }
-      startNewPolicyGeneration(authzToken.actor)
+      startNewPolicyGeneration(authzToken.qc.actor)
       RestUtils.response(restExtractorService, "settings", None)(Full(data), req, s"Could not modfiy settings")("modifySettings")
     }
   }
@@ -250,7 +250,7 @@ class SettingsApi(
     ): LiftResponse = {
       val data: Box[JValue] = for {
         setting <- settingFromKey(key, allSettings(version))
-        value   <- setting.setFromRequest(req, authzToken.actor)
+        value   <- setting.setFromRequest(req, authzToken.qc.actor)
       } yield {
         (key -> value)
       }
@@ -911,7 +911,7 @@ class SettingsApi(
         }
       }
 
-      val actor          = authzToken.actor
+      val actor          = authzToken.qc.actor
       val modificationId = new ModificationId(uuidGen.newUuid)
       val nodeId         = NodeId(id)
       val result         = for {
@@ -994,7 +994,7 @@ class SettingsApi(
         }
       }
 
-      val actor          = authzToken.actor
+      val actor          = authzToken.qc.actor
       val modificationId = new ModificationId(uuidGen.newUuid)
       val nodeId         = NodeId(id)
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
@@ -232,7 +232,7 @@ class TechniqueApi(
       val content = {
         for {
           force <- restExtractorService.extractBoolean("force")(req)(identity) map (_.getOrElse(false))
-          _     <- techniqueWriter.deleteTechnique(techniqueInfo._1, techniqueInfo._2, force, modId, authzToken.actor).toBox
+          _     <- techniqueWriter.deleteTechnique(techniqueInfo._1, techniqueInfo._2, force, modId, authzToken.qc.actor).toBox
         } yield {
           import net.liftweb.json.JsonDSL._
           (("id"       -> techniqueInfo._1)
@@ -268,7 +268,7 @@ class TechniqueApi(
               case Full(bytes) => new String(bytes, charset).fromJson[EditorTechnique].toIO
             }
           methodMap        <- techniqueReader.getMethodsMetadata
-          updatedTechnique <- techniqueWriter.writeTechniqueAndUpdateLib(technique, modId, authzToken.actor)
+          updatedTechnique <- techniqueWriter.writeTechniqueAndUpdateLib(technique, modId, authzToken.qc.actor)
           json             <- serviceV14.getTechniqueJson(updatedTechnique)
         } yield {
           json
@@ -342,7 +342,7 @@ class TechniqueApi(
                                             s"An error occurred while reading techniques when updating them: ${errors.map(_.msg).mkString("\n ->", "\n ->", "")}"
                                           )
                                         }
-        _                            <- ZIO.foreach(techniques)(t => techniqueWriter.writeTechnique(t, modId, authzToken.actor))
+        _                            <- ZIO.foreach(techniques)(t => techniqueWriter.writeTechnique(t, modId, authzToken.qc.actor))
         json                         <- ZIO.foreach(techniques)(_.toJsonAST.toIO)
       } yield {
         json
@@ -451,7 +451,7 @@ class TechniqueApi(
 
           // If no internalId (used to manage temporary folder for resources), ignore resources, this can happen when importing techniques through the api
           resoucesMoved <- technique.internalId.map(internalId => moveRessources(technique, internalId)).getOrElse("Ok".succeed)
-          updatedTech   <- techniqueWriter.writeTechniqueAndUpdateLib(technique, modId, authzToken.actor)
+          updatedTech   <- techniqueWriter.writeTechniqueAndUpdateLib(technique, modId, authzToken.qc.actor)
           json          <- serviceV14.getTechniqueJson(updatedTech)
         } yield {
           json

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/CurrentUser.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/CurrentUser.scala
@@ -43,7 +43,6 @@ import com.normation.rudder.RudderAccount
 import com.normation.rudder.User
 import com.normation.rudder.api.ApiAuthorization
 import com.normation.rudder.facts.nodes.NodeSecurityContext
-import com.normation.rudder.facts.nodes.QueryContext
 import net.liftweb.http.RequestVar
 
 /**
@@ -93,9 +92,5 @@ object CurrentUser extends RequestVar[Option[RudderUserDetail]](None) with User 
   def nodePerms: NodeSecurityContext = this.get match {
     case Some(u) => u.nodePerms
     case None    => NodeSecurityContext.None
-  }
-
-  def queryContext: QueryContext = {
-    QueryContext(actor, nodePerms)
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
@@ -51,6 +51,7 @@ import com.normation.rudder.UserService
 import com.normation.rudder.api.ApiAuthorization
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.domain.logger.ApplicationLogger
+import com.normation.rudder.facts.nodes.NodeSecurityContext
 import com.normation.rudder.rest.lift.LiftApiModuleProvider
 import com.normation.rudder.rest.lift.LiftApiProcessingLogger
 import com.normation.rudder.rest.lift.LiftHandler
@@ -114,6 +115,7 @@ object TraitTestApiFromYamlFiles {
             val account                              = RudderAccount.User("test-user", "pass")
             def checkRights(auth: AuthorizationType) = true
             def getApiAuthz                          = ApiAuthorization.allAuthz
+            def nodePerms: NodeSecurityContext = NodeSecurityContext.All
           }
           val getCurrentUser = user
         }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -62,6 +62,7 @@ import com.normation.cfclerk.services.impl._
 import com.normation.cfclerk.xmlparsers._
 import com.normation.cfclerk.xmlwriters.SectionSpecWriter
 import com.normation.cfclerk.xmlwriters.SectionSpecWriterImpl
+import com.normation.errors._
 import com.normation.errors.IOResult
 import com.normation.errors.SystemError
 import com.normation.inventory.domain._
@@ -1630,7 +1631,7 @@ object RudderConfigInit {
         woRuleCategoryRepository,
         roDirectiveRepository,
         roNodeGroupRepository,
-        nodeFactInfoService,
+        nodeFactRepository,
         configService.rudder_global_policy_mode _,
         ruleApplicationStatus
       )
@@ -1795,11 +1796,11 @@ object RudderConfigInit {
 
     lazy val complianceAPIService = new ComplianceAPIService(
       roRuleRepository,
-      nodeFactInfoService,
+      nodeFactRepository,
       roNodeGroupRepository,
       reportingService,
       roDirectiveRepository,
-      () => globalComplianceModeService.getGlobalComplianceMode
+      globalComplianceModeService.getGlobalComplianceMode.toIO
     )
 
     lazy val techniqueArchiver = new TechniqueArchiverImpl(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -135,7 +135,7 @@ class NodeGroupForm(
       setIds = target match {
                  case Right(nodeGroup) => nodeGroup.serverList
                  case Left(target)     =>
-                   val allNodes = nodes.mapValues(_.rudderSettings.kind.isPolicyServer).toMap
+                   val allNodes = nodes.mapValues(_.rudderSettings.kind.isPolicyServer)
                    RuleTarget.getNodeIds(Set(target), allNodes, Map())
                }
     } yield {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ExpectedPolicyPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ExpectedPolicyPopup.scala
@@ -111,7 +111,7 @@ class ExpectedPolicyPopup(
       val pendingNode = Map((nodeSrv.id, nodeSrv.isPolicyServer))
       val groups      = groupTargets.map(x => (x, Set(nodeSrv.id))).toMap
 
-      rules.filter(r => RuleTarget.getNodeIds(r.targets, pendingNode, groups, false).nonEmpty)
+      rules.filter(r => RuleTarget.getNodeIds(r.targets, pendingNode.view, groups, false).nonEmpty)
     }
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/23856

So this PR brings several things: 
- (a port of https://github.com/Normation/rudder/pull/5267)
- make compliance computation aware of `QueryContext` 
- the last one is a technical change so that `QueryContext` are provided in API `authzToken` parameter, and so we are really able to start porting APIs. 

## Where is the compliance computation update to handle node tenants?

Well, there is none, because we did the things correctly: compliance computation takes a list of nodes and everything is node-centric. So we are just passing the correct list based on the user tenant, and most of the changes are just about "correctly weaving from web context to compliance computation the `QueryContext` to be able to have the list of node based on tenants".

The main change is in `RuleApplicationStatusService.isApplied` and `RuleValService.buildRuleVal` and in `ComplianceAPIService` (`reportingService.findDirectiveNodeStatusReports`) that now uses the restricted list of nodes.


## Evolving user authz availability in requests

That PR (finally) allows to have the user `node permissions` correctly threaded in all request contexts, be them in UI or in API. 
It needed mainly two things: 
- (yet another) change in `CurrentUser` so that we correctly set its value from spring security result in all context (normal session UI, comet/async case, stateless API requests)
- a change in what is the standard `authzToken` in API: in place of just getting the `actor`, it now holds a full `QueryContext` with also `NodeSecurityContext`.  The actual change is trivial and happens in webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala: we already had the user at end with correct info, so just use them. 

Most of the remaining changes are boring declaration of `implicit val qc: QueryContext = authzToken.qc` in all API that needs them. 

## Using `MapView` in more places

Our `CoreNodeFactRepository#getAll` was changed to use `MapView` in place of a new `Map` or something else in a previous commit to avoid a too big refactoring and help with performance. 

In that PR, we see that is seems to work very well: we have a lot of cases where we were filtering on `nodeInfoService.getAll` result to just map values to know the node's `isPolicyServer` or `policyMode`. 
By having the `MapView`, we avoid a lot of intermediary copies (which were not really needed). 
There was also a lot of places where `MapView` was used so we are just removing more collection creation. 

This is a rather impacting change, it touches a lot of place, but it is rather trivial : now that Scala clearly differentiate between `Map` and `MapView`, the compiler tells us where we need to concretize the view. 

## Switching from NodeInfoService to CoreNodeFact

This is rather easy a normalized. CoreNodeFact is a super-set of NodeInfo, so we don't miss any data. 
At several places, I was able to reduce the refactoring need by relaxing the parameter: we were asking for `Map[NodeId, NodeInfo]` but really using only `nodeInfo.isPolicyServer` for example. I think it used to be done like that to avoid more collection duplication/transformation. 
With the previous change about `MapView`, I was able to pass `MapView[NodeId, Boolean]` without new collection copy, and without the need to switch from `NodeInfo` to `CoreNodeFact` (but yes, I had to switch from `NodeInfo` to `Boolean` ;) )


