### PR TITLE
Fixes #23927: Migrate away from NodeInfoService

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -898,7 +898,7 @@ object JsonPropertySerialisation {
       buildHierarchy(list => list.reverse.map(_.toJson))
     }
 
-    def toApiJsonRenderParents = {
+    def toApiJsonRenderParents: JObject = {
       buildHierarchy(list => {
         list.reverse
           .map(p => {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
@@ -216,7 +216,7 @@ trait NodeInfoMatcher {
 }
 
 object NodeInfoMatcher {
-  // default builder: it will evaluated each time, sufficiant if all parts of the matcher uses NodeInfo
+  // default builder: it will evaluated each time, sufficient if all parts of the matcher uses NodeInfo
   def apply(s: String, f: NodeInfo => Boolean): NodeInfoMatcher = {
     new NodeInfoMatcher {
       override val debugString:             String  = s

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
@@ -306,6 +306,10 @@ trait GetNodesbySofwareName {
   def apply(softName: String): IOResult[List[(NodeId, Software)]]
 }
 
+object NoopGetNodesbySofwareName extends GetNodesbySofwareName {
+  override def apply(softName: String): IOResult[List[(NodeId, Software)]] = Nil.succeed
+}
+
 // default implementation is just a proxy on top of software dao
 class SoftDaoGetNodesbySofwareName(val softwareDao: ReadOnlySoftwareDAO) extends GetNodesbySofwareName {
   override def apply(softName: String): IOResult[List[(NodeId, Software)]] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
@@ -173,7 +173,7 @@ final case class FullNodeGroupCategory(
   /**
    * Given a nodeId, get all the groups where it belongs to.
    */
-  def getTarget(node: NodeInfo): Map[RuleTarget, FullRuleTargetInfo] = {
+  def getTarget(node: CoreNodeFact): Map[RuleTarget, FullRuleTargetInfo] = {
     allTargets.filter {
       case (t, info) =>
         info.target match {
@@ -183,12 +183,12 @@ final case class FullNodeGroupCategory(
             // here, we don't need all node info, just the current node
             // It's because we only do set analysis on node info, not things like "find all
             // the node with that policy server" in target.
-            getNodeIds(Set(t), MapView(node.id -> node.isPolicyServer)).contains(node.id)
+            getNodeIds(Set(t), MapView(node.id -> node.rudderSettings.isPolicyServer)).contains(node.id)
           case FullOtherTarget(t)             =>
             t match {
               case AllTarget                    => true
-              case AllTargetExceptPolicyServers => !node.isPolicyServer
-              case AllPolicyServers             => node.isPolicyServer
+              case AllTargetExceptPolicyServers => !node.rudderSettings.isPolicyServer
+              case AllPolicyServers             => node.rudderSettings.isPolicyServer
               case PolicyServerTarget(id)       => id == node.id
             }
         }
@@ -345,12 +345,11 @@ object RoNodeGroupRepository {
   }
 
   def getNodeIdsChunk(
-      allGroups:    Map[NodeGroupId, Chunk[NodeId]],
-      targets:      Set[RuleTarget],
-      allNodeInfos: Map[NodeId, NodeInfo]
+      allGroups:        Map[NodeGroupId, Chunk[NodeId]],
+      targets:          Set[RuleTarget],
+      arePolicyServers: MapView[NodeId, Boolean]
   ): Chunk[NodeId] = {
-    val allNodes = allNodeInfos.view.mapValues(x => (x.isPolicyServer))
-    RuleTarget.getNodeIdsChunk(targets, allNodes, allGroups)
+    RuleTarget.getNodeIdsChunk(targets, arePolicyServers, allGroups)
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/ClearCacheService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/ClearCacheService.scala
@@ -34,7 +34,6 @@ trait ClearCacheService {
    * - cachedAgentRunRepository
    * - recentChangesService
    * - reportingServiceImpl
-   * - nodeInfoServiceImpl
    */
   def action(actor: EventActor): Box[String]
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
@@ -272,7 +272,7 @@ final case class NodeConfiguration(
  * Unique identifier for the policy.
  * These is a general container that can be used to generate the different ID
  * used in rudder: the policyId as used in reports, the unique identifier
- * used to differenciate multi-version technique, etc.
+ * used to differentiate multi-version technique, etc.
  */
 final case class PolicyId(ruleId: RuleId, directiveId: DirectiveId, techniqueVersion: TechniqueVersion) {
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupService.scala
@@ -58,6 +58,7 @@ import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.queries.CriterionLine
 import com.normation.rudder.domain.queries.Equals
 import com.normation.rudder.domain.queries.Query
+import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.repository.ldap.LDAPEntityMapper
 import com.unboundid.ldap.sdk.DereferencePolicy
 import com.unboundid.ldap.sdk.Filter
@@ -346,7 +347,7 @@ class CheckPendingNodeInDynGroups(
         case (h :: tail, b, res) => // standard step: takes the group and deals with it
           NodeLogger.PendingNode.Policies.trace("==> process " + h.id.serialize)
           (queryChecker
-            .check(h.query, Some(h.testNodes.toSeq))
+            .check(h.query, Some(h.testNodes.toSeq))(QueryContext.systemQC) // dyn groups need access to all nodes
             .flatMap { nIds =>
               // node matching that group - also include the one from "include" coming from "or" dep
               val setNodeIds                       = nIds.toSet ++ h.includeNodes

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/NodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/NodeFactQueryProcessor.scala
@@ -123,8 +123,8 @@ class NodeFactQueryProcessor(
   def process(query: Query):       Box[Seq[NodeId]] = processPure(query).map(_.toList.map(_.id)).toBox
   def processOnlyId(query: Query): Box[Seq[NodeId]] = processPure(query).map(_.toList.map(_.id)).toBox
 
-  def check(query: Query, nodeIds: Option[Seq[NodeId]]): IOResult[Set[NodeId]]         = { ??? }
-  def processPure(query: Query):                         IOResult[Chunk[CoreNodeFact]] = {
+  def check(query: Query, nodeIds: Option[Seq[NodeId]])(implicit qc: QueryContext): IOResult[Set[NodeId]]         = { ??? }
+  def processPure(query: Query):                                                    IOResult[Chunk[CoreNodeFact]] = {
     def process(s: SelectNodeStatus) = {
       for {
         t0  <- currentTimeMillis

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/QueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/QueryProcessor.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.services.queries
 import com.normation.errors.IOResult
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.queries.Query
+import com.normation.rudder.facts.nodes.QueryContext
 import net.liftweb.common.Box
 
 trait QueryProcessor {
@@ -72,6 +73,6 @@ trait QueryChecker {
    *   Full(seq) with seq being the list of nodeId which verify
    *   query.
    */
-  def check(query: Query, nodeIds: Option[Seq[NodeId]]): IOResult[Set[NodeId]]
+  def check(query: Query, nodeIds: Option[Seq[NodeId]])(implicit qc: QueryContext): IOResult[Set[NodeId]]
 
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
@@ -44,6 +44,7 @@ import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.ComplianceLevel
 import com.normation.rudder.domain.reports.NodeStatusReport
+import com.normation.rudder.facts.nodes.QueryContext
 import net.liftweb.common.Box
 
 /**
@@ -57,11 +58,14 @@ trait ReportingService {
    * Optionally restrict the set to some rules if filterByRules is non empty (else,
    * find node status reports for all rules)
    */
-  def findRuleNodeStatusReports(nodeIds: Set[NodeId], filterByRules: Set[RuleId]): Box[Map[NodeId, NodeStatusReport]]
-  def findDirectiveNodeStatusReports(
-      nodeIds:                           Set[NodeId],
-      filterByDirectives:                Set[DirectiveId]
+  def findRuleNodeStatusReports(nodeIds: Set[NodeId], filterByRules: Set[RuleId])(implicit
+      qc:                                QueryContext
   ): Box[Map[NodeId, NodeStatusReport]]
+
+  def findDirectiveNodeStatusReports(
+      nodeIds:            Set[NodeId],
+      filterByDirectives: Set[DirectiveId]
+  )(implicit qc:          QueryContext): Box[Map[NodeId, NodeStatusReport]]
 
   def findUncomputedNodeStatusReports(): Box[Map[NodeId, NodeStatusReport]]
 
@@ -70,7 +74,9 @@ trait ReportingService {
    * Optionally restrict the set to some rules if filterByRules is non empty (else,
    * find node status reports for all rules)
    */
-  def findRuleNodeCompliance(nodeIds: Set[NodeId], filterByRules: Set[RuleId]): IOResult[Map[NodeId, ComplianceLevel]]
+  def findRuleNodeCompliance(nodeIds: Set[NodeId], filterByRules: Set[RuleId])(implicit
+      qc:                             QueryContext
+  ): IOResult[Map[NodeId, ComplianceLevel]]
 
   /**
    * Retrieve two sets of rule/node compliances level given the nodes Id.
@@ -81,41 +87,41 @@ trait ReportingService {
       nodeIds:             Set[NodeId],
       filterBySystemRules: Set[RuleId],
       filterByUserRules:   Set[RuleId]
-  ): IOResult[(Map[NodeId, ComplianceLevel], Map[NodeId, ComplianceLevel])]
+  )(implicit qc:           QueryContext): IOResult[(Map[NodeId, ComplianceLevel], Map[NodeId, ComplianceLevel])]
 
   /**
    * A specialised version of `findRuleNodeStatusReports` to find node status reports for a given rule.
    */
-  def findDirectiveRuleStatusReportsByRule(ruleId: RuleId): IOResult[Map[NodeId, NodeStatusReport]]
+  def findDirectiveRuleStatusReportsByRule(ruleId: RuleId)(implicit qc: QueryContext): IOResult[Map[NodeId, NodeStatusReport]]
 
   /**
     * find node status reports for a given node.
     */
-  def findNodeStatusReport(nodeId: NodeId): Box[NodeStatusReport]
+  def findNodeStatusReport(nodeId: NodeId)(implicit qc: QueryContext): Box[NodeStatusReport]
 
   /**
     * find node status reports for a given node.
     */
-  def findUserNodeStatusReport(nodeId: NodeId): Box[NodeStatusReport]
+  def findUserNodeStatusReport(nodeId: NodeId)(implicit qc: QueryContext): Box[NodeStatusReport]
 
   /**
     * find system node status reports for a given node.
     */
-  def findSystemNodeStatusReport(nodeId: NodeId): Box[NodeStatusReport]
+  def findSystemNodeStatusReport(nodeId: NodeId)(implicit qc: QueryContext): Box[NodeStatusReport]
 
   /**
    * find node status reports for *user* rules (all non system rules)
    */
-  def getUserNodeStatusReports(): Box[Map[NodeId, NodeStatusReport]]
+  def getUserNodeStatusReports()(implicit qc: QueryContext): Box[Map[NodeId, NodeStatusReport]]
 
-  def findStatusReportsForDirective(directiveId: DirectiveId): IOResult[Map[NodeId, NodeStatusReport]]
+  def findStatusReportsForDirective(directiveId: DirectiveId)(implicit qc: QueryContext): IOResult[Map[NodeId, NodeStatusReport]]
 
   /**
    * find node status reports for user and system rules but in a separated couple (system is first element, user second)
    */
   def getSystemAndUserCompliance(
       optNodeIds: Option[Set[NodeId]]
-  ): IOResult[(Map[NodeId, ComplianceLevel], Map[NodeId, ComplianceLevel])]
+  )(implicit qc:  QueryContext): IOResult[(Map[NodeId, ComplianceLevel], Map[NodeId, ComplianceLevel])]
 
   /**
    * * Get the global compliance for reports passed in parameters
@@ -131,9 +137,9 @@ trait ReportingService {
   * Also get an unique number which describe the global compliance value (without
   * taking into account pending reports).
   * It's what is displayed on Rudder home page.
-  * If all rules/directies are system one, returns none.
+  * If all rules/directives are system one, returns none.
   */
-  def getGlobalUserCompliance(): Box[Option[(ComplianceLevel, Long)]]
+  def getGlobalUserCompliance()(implicit qc: QueryContext): Box[Option[(ComplianceLevel, Long)]]
 
   // Utilitary method to filter reports by rules
   def filterReportsByRules(reports: Map[NodeId, NodeStatusReport], ruleIds: Set[RuleId]): Map[NodeId, NodeStatusReport] = {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -2281,7 +2281,7 @@ class MockNodes() {
 
     val list = new FactListNewNodes(nodeFactRepo)
 
-    override def listNewNodes: IOResult[Seq[CoreNodeFact]] = list.listNewNodes
+    override def listNewNodes()(implicit qc: QueryContext): IOResult[Seq[CoreNodeFact]] = list.listNewNodes()
 
     override def accept(id: NodeId)(implicit cc: ChangeContext): IOResult[CoreNodeFact] = {
       nodeFactRepo.changeStatus(id, AcceptedInventory) *>

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestPendingNodePolicies.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestPendingNodePolicies.scala
@@ -57,6 +57,7 @@ import com.normation.rudder.domain.queries.Or
 import com.normation.rudder.domain.queries.Query
 import com.normation.rudder.domain.queries.ResultTransformation._
 import com.normation.rudder.domain.queries.StringComparator
+import com.normation.rudder.facts.nodes.QueryContext
 import net.liftweb.common.Box
 import net.liftweb.common.EmptyBox
 import net.liftweb.common.Full
@@ -181,7 +182,7 @@ class TestPendingNodePolicies extends Specification {
 
   // a fake query checker
   val queryChecker = new QueryChecker {
-    override def check(query: Query, nodeIds: Option[Seq[NodeId]]): IOResult[Set[NodeId]] = {
+    override def check(query: Query, nodeIds: Option[Seq[NodeId]])(implicit qc: QueryContext): IOResult[Set[NodeId]] = {
       // make a 0 criteria request raise an error like LDAP would do,
       // see: https://www.rudder-project.org/redmine/issues/12338
       if (query.criteria.isEmpty) {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -402,6 +402,7 @@ class ComplianceApi(
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
       implicit val action   = schema.name
       implicit val prettify = params.prettify
+      implicit val qc: QueryContext = authzToken.qc
 
       (for {
         precision     <- restExtractor.extractPercentPrecision(req.params)
@@ -496,7 +497,7 @@ class ComplianceAPIService(
       _             <- TimingDebugLoggerPure.trace(s"getByDirectivesCompliance - getAllRules in ${t2 - t1} ms")
       nodeFacts     <- nodeFactRepos.getAll()
       t3            <- currentTimeMillis
-      _             <- TimingDebugLoggerPure.trace(s"getByDirectivesCompliance - nodeInfoService.getAll() in ${t3 - t2} ms")
+      _             <- TimingDebugLoggerPure.trace(s"getByDirectivesCompliance - nodeFactRepo.getAll() in ${t3 - t2} ms")
       compliance    <- getGlobalComplianceMode
       t4            <- currentTimeMillis
       _             <- TimingDebugLoggerPure.trace(s"getByDirectivesCompliance - getGlobalComplianceMode in ${t4 - t3} ms")
@@ -585,7 +586,7 @@ class ComplianceAPIService(
       _             <- TimingDebugLoggerPure.trace(s"getByRulesCompliance - getFullDirectiveLibrary in ${t3 - t2} ms")
       nodeFacts     <- nodeFactRepos.getAll()
       t4            <- currentTimeMillis
-      _             <- TimingDebugLoggerPure.trace(s"getByRulesCompliance - nodeInfoService.getAll() in ${t4 - t3} ms")
+      _             <- TimingDebugLoggerPure.trace(s"getByRulesCompliance - nodeFactRepo.getAll() in ${t4 - t3} ms")
       compliance    <- getGlobalComplianceMode
       t5            <- currentTimeMillis
       _             <- TimingDebugLoggerPure.trace(s"getByRulesCompliance - getGlobalComplianceMode in ${t5 - t4} ms")
@@ -850,7 +851,7 @@ class ComplianceAPIService(
     this.getByNodesCompliance(None, if (onlySystems) getSystemRules() else getAllUserRules()).toBox
   }
 
-  def getGlobalCompliance(): Box[Option[(ComplianceLevel, Long)]] = {
+  def getGlobalCompliance()(implicit qc: QueryContext): Box[Option[(ComplianceLevel, Long)]] = {
     this.reportingService.getGlobalUserCompliance()
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -291,7 +291,7 @@ class RestTestSetUp {
   }
   val policyGeneration              = new PromiseGenerationService {
     override def deploy():                                                                     Box[Set[NodeId]]                        = Full(Set())
-    override def getAllNodeInfos():                                                            Box[Map[NodeId, NodeInfo]]              = ???
+    override def getNodeFacts():                                                               Box[MapView[NodeId, CoreNodeFact]]      = ???
     override def getDirectiveLibrary(ids: Set[DirectiveId]):                                   Box[FullActiveTechniqueCategory]        = ???
     override def getGroupLibrary():                                                            Box[FullNodeGroupCategory]              = ???
     override def getAllGlobalParameters:                                                       Box[Seq[GlobalParameter]]               = ???
@@ -303,7 +303,7 @@ class RestTestSetUp {
     override def getMaxParallelism:                                                            () => Box[String]                       = ???
     override def getJsTimeout:                                                                 () => Box[Int]                          = ???
     override def getGenerationContinueOnError:                                                 () => Box[Boolean]                      = ???
-    override def writeCertificatesPem(allNodeInfos: Map[NodeId, NodeInfo]):                    Unit                                    = ???
+    override def writeCertificatesPem(allNodeInfos: MapView[NodeId, CoreNodeFact]):            Unit                                    = ???
     override def triggerNodeGroupUpdate():                                                     Box[Unit]                               = ???
     override def beforeDeploymentSync(generationTime: DateTime):                               Box[Unit]                               = ???
     override def HOOKS_D:                                                                      String                                  = ???
@@ -326,7 +326,7 @@ class RestTestSetUp {
     ): Box[Seq[RuleVal]] = ???
     override def getNodeContexts(
         nodeIds:              Set[NodeId],
-        allNodeInfos:         Map[NodeId, NodeInfo],
+        allNodeInfos:         MapView[NodeId, CoreNodeFact],
         allGroups:            FullNodeGroupCategory,
         globalParameters:     List[GlobalParameter],
         globalAgentRun:       AgentRunInterval,
@@ -611,7 +611,7 @@ class RestTestSetUp {
     List(
       CheckCoreNumber,
       CheckFreeSpace,
-      new CheckFileDescriptorLimit(mockNodes.nodeInfoService)
+      new CheckFileDescriptorLimit(mockNodes.nodeFactRepo)
     )
   )
   val fakeHcNotifService     = new HealthcheckNotificationService(fakeHealthcheckService, 5.minute)
@@ -748,7 +748,6 @@ class RestTestSetUp {
     null,
     null,
     null,
-    mockNodes.nodeInfoService,
     mockNodes.newNodeManager,
     null,
     restExtractorService,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeStateForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeStateForm.scala
@@ -37,8 +37,8 @@
 
 package com.normation.rudder.web.components
 
-import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.nodes.NodeState
+import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.web.ChooseTemplate
 import net.liftweb.common._
 import net.liftweb.http.DispatchSnippet
@@ -53,7 +53,7 @@ import scala.xml.NodeSeq
  * Component to display and configure the Agent Schedule
  */
 class NodeStateForm(
-    nodeInfo:      NodeInfo,
+    nodeFact:      CoreNodeFact,
     saveNodeState: NodeState => Box[NodeState] // and save it
 ) extends DispatchSnippet with Loggable {
 
@@ -76,7 +76,7 @@ class NodeStateForm(
   }.toList.sortBy(_._1).map(_._2)
 
   def nodeStateConfiguration: NodeSeq = {
-    var state = nodeInfo.state
+    var state = nodeFact.rudderSettings.state
 
     def process(): JsCmd = {
       saveNodeState(state) match {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNodeGroupTree.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNodeGroupTree.scala
@@ -40,11 +40,11 @@ package com.normation.rudder.web.services
 import bootstrap.liftweb.RudderConfig
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.nodes.NodeGroupUid
-import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.policies.FullGroupTarget
 import com.normation.rudder.domain.policies.FullRuleTarget
 import com.normation.rudder.domain.policies.FullRuleTargetInfo
 import com.normation.rudder.domain.policies.RuleTarget
+import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.web.model.JsTreeNode
 import net.liftweb.common.Loggable
@@ -225,7 +225,7 @@ object DisplayNodeGroupTree extends Loggable {
   // build the tree category, filtering only category with groups
   def buildTreeKeepingGroupWithNode(
       groupLib:        FullNodeGroupCategory,
-      nodeInfo:        NodeInfo,
+      nodeInfo:        CoreNodeFact,
       onClickCategory: Option[FullNodeGroupCategory => JsCmd] = None,
       onClickTarget:   Option[(FullNodeGroupCategory, FullRuleTargetInfo) => JsCmd] = None,
       targetActions:   Map[String, (FullRuleTargetInfo) => JsCmd] = Map()

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -211,7 +211,8 @@ class HomePage extends StatefulSnippet {
       n3                <- currentTimeMillis
       _                  = TimingDebugLogger.trace(s"Get rules: ${n3 - n2}ms")
       // reports contains the reports for user rules, used in the donut
-      reports           <- reportingService.findRuleNodeStatusReports(HomePage.nodeFacts.get.keys.toSet, userRules).toIO
+      reports           <-
+        reportingService.findRuleNodeStatusReports(HomePage.nodeFacts.get.keys.toSet, userRules)(CurrentUser.queryContext).toIO
       n4                <- currentTimeMillis
       _                  = TimingDebugLogger.trace(s"Compute Rule Node status reports for all nodes: ${n4 - n3}ms")
       // global compliance is a unique number, used in the top right hand size, based on

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
@@ -114,12 +114,16 @@ class AcceptNode extends Loggable {
 
   var errors: Option[String] = None
 
+  /*
+   * This is the main (and only) entry point of the snippet,
+   * drawing the pending nodes table.
+   */
   def list(html: NodeSeq): NodeSeq = {
 
-    newNodeManager.listNewNodes.toBox match {
+    newNodeManager.listNewNodes()(CurrentUser.queryContext).toBox match {
       case Empty                => <div>Error, no server found</div>
       case f @ Failure(_, _, _) => <div>Error while retrieving pending nodes list</div>
-      case Full(seq)            => display(html, seq)
+      case Full(seq)            => display(html, seq)(CurrentUser.queryContext)
     }
   }
 
@@ -216,7 +220,7 @@ class AcceptNode extends Loggable {
     if (serverList.isEmpty) {
       Alert("You didn't select any nodes")
     } else {
-      SetHtml("manageNewNode", listNode(serverList, template)) & OnLoad(
+      SetHtml("", listNode(serverList, template)) & OnLoad(
         JsRaw("""
           /* Set the table layout */
           $('#pendingNodeConfirm').dataTable({
@@ -317,7 +321,7 @@ class AcceptNode extends Loggable {
     OnLoad(JsRaw("""initBsModal("expectedPolicyPopup")"""))
   }
 
-  def display(html: NodeSeq, nodes: Seq[CoreNodeFact]): NodeSeq = {
+  def display(html: NodeSeq, nodes: Seq[CoreNodeFact])(implicit qc: QueryContext): NodeSeq = {
     val servers = {
       serverGrid.displayAndInit(
         nodes.map(_.toSrv),


### PR DESCRIPTION
https://issues.rudder.io/issues/23927

A not very exiting PR: mainly:
- replace `NodeInfoService` by `NodeFactRepository`
- change `NodeInfo` toward `CoreNodeFact` and adapt to the small attribute naming changes (add `.rudderSettings`, `fqdn` in place of `hostname`, and alway one agent and not a list)
- add lots of `implicit qr: QueryContext` and weave them upword until we find a direct interaction with a user page / API. 

So I tried to comment on all the things that are not trivials to make reviewable. 