### PR TITLE
Fixes #23935: API for node group compliance

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
@@ -208,6 +208,13 @@ final case class TargetExclusion(
     copy(includedTarget, newExcluded)
   }
 
+  /**
+   * Check if a target is included in this target. Also check if the target is not in the excluded target if strict argument is true (default)
+   */
+  def includes(target: RuleTarget, strict: Boolean = true): Boolean = {
+    includedTarget.targets.contains(target) && (!strict || !excludedTarget.targets.contains(target))
+  }
+
 }
 
 object RuleTarget extends Loggable {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -186,6 +186,22 @@ object ComplianceApi       extends ApiModuleProvider[ComplianceApi] {
     val dataContainer  = Some("directivesCompliance")
   }
 
+  final case object GetNodeGroupComplianceId
+      extends ComplianceApi with GeneralApi with OneParam with StartsAtVersion17 with SortIndex {
+    val z              = implicitly[Line].value
+    val description    = "Get a node group's global compliance"
+    val (action, path) = GET / "compliance" / "groups" / "{id}"
+    val dataContainer  = Some("groupCompliance")
+  }
+
+  final case object GetNodeGroupComplianceTargetId
+      extends ComplianceApi with GeneralApi with OneParam with StartsAtVersion17 with SortIndex {
+    val z              = implicitly[Line].value
+    val description    = "Get a node group's targeted compliance"
+    val (action, path) = GET / "compliance" / "groups" / "{id}" / "target"
+    val dataContainer  = Some("groupCompliance")
+  }
+
   def endpoints = ca.mrvisser.sealerate.values[ComplianceApi].toList.sortBy(_.z)
 }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
@@ -132,7 +132,7 @@ object AuthorizationApiMapping {
           ComplianceApi.GetGlobalCompliance.x :: ComplianceApi.GetRulesCompliance.x :: ComplianceApi.GetRulesComplianceId.x ::
           ComplianceApi.GetNodesCompliance.x :: ComplianceApi.GetNodeComplianceId.x :: ChangesApi.GetRuleRepairedReports.x ::
           ChangesApi.GetRecentChanges.x :: ComplianceApi.GetDirectiveComplianceId.x ::
-          ComplianceApi.GetDirectivesCompliance.x :: Nil
+          ComplianceApi.GetDirectivesCompliance.x :: ComplianceApi.GetNodeGroupComplianceId.x :: ComplianceApi.GetNodeGroupComplianceTargetId.x :: Nil
         case Compliance.Write => Nil
         case Compliance.Edit  => Nil
 

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_compliance.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_compliance.yml
@@ -1,0 +1,2198 @@
+description: Get a node group's global compliance for group G1 (simple example)
+method: GET
+url: /secure/api/compliance/groups/g1
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getNodeGroupComplianceId",
+      "result" : "success",
+      "data" : {
+        "nodeGroups" : [
+          {
+            "id" : "g1",
+            "name" : "G1",
+            "compliance" : 60.0,
+            "mode" : "full-compliance",
+            "complianceDetails" : {
+              "successAlreadyOK" : 40.0,
+              "error" : 40.0,
+              "successRepaired" : 20.0
+            },
+            "rules" : [
+              {
+                "id" : "r1",
+                "name" : "R1",
+                "compliance" : 100.0,
+                "complianceDetails" : {
+                  "successAlreadyOK" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n2",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n2",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n2",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n1",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n1",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "r3",
+                "name" : "R3",
+                "compliance" : 0.0,
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "directive2",
+                    "name" : "directive2",
+                    "compliance" : 0.0,
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "directive2-component-r3-n1",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n1",
+                            "name" : "node1.localhost",
+                            "compliance" : 0.0,
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-r3-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name" : "directive2-component-r3-n2",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n2",
+                            "name" : "node1.localhost",
+                            "compliance" : 0.0,
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-r3-n2",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "r2",
+                "name" : "R2",
+                "compliance" : 100.0,
+                "complianceDetails" : {
+                  "successRepaired" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
+                    "name" : "directive 99f4ef91-537b-4e03-97bc-e65b447514cc",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successRepaired" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-r2-n1",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successRepaired" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n1",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successRepaired" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-r2-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successRepaired"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "nodes" : [
+              
+              {
+                "id" : "n2",
+                "name" : "node1.localhost",
+                "compliance" : 50.0,
+                "mode" : "full-compliance",
+                "complianceDetails" : {
+                  "successAlreadyOK" : 50.0,
+                  "error" : 50.0
+                },
+                "rules" : [
+                  {
+                    "id" : "r1",
+                    "name" : "R1",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n2",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n2",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id" : "r3",
+                    "name" : "R3",
+                    "compliance" : 0.0,
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "directive2",
+                        "name" : "directive2",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "directive2-component-r3-n2",
+                            "compliance" : 0.0,
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-r3-n2",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "n1",
+                "name" : "node1.localhost",
+                "compliance" : 66.66,
+                "mode" : "full-compliance",
+                "complianceDetails" : {
+                  "successAlreadyOK" : 33.33,
+                  "error" : 33.34,
+                  "successRepaired" : 33.33
+                },
+                "rules" : [
+                  {
+                    "id" : "r1",
+                    "name" : "R1",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n1",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id" : "r2",
+                    "name" : "R2",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successRepaired" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
+                        "name" : "directive 99f4ef91-537b-4e03-97bc-e65b447514cc",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successRepaired" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-r2-n1",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successRepaired" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-r2-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successRepaired"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id" : "r3",
+                    "name" : "R3",
+                    "compliance" : 0.0,
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "directive2",
+                        "name" : "directive2",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "directive2-component-r3-n1",
+                            "compliance" : 0.0,
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-r3-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Get a node group's targeted compliance for group G1 (simple example)
+method: GET
+url: /secure/api/compliance/groups/g1/target
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getNodeGroupComplianceTargetId",
+      "result" : "success",
+      "data" : {
+        "nodeGroups" : [
+          {
+            "id" : "g1",
+            "name" : "G1",
+            "compliance" : 100.0,
+            "mode" : "full-compliance",
+            "complianceDetails" : {
+              "successAlreadyOK" : 66.67,
+              "successRepaired" : 33.33
+            },
+            "rules" : [
+              {
+                "id" : "r1",
+                "name" : "R1",
+                "compliance" : 100.0,
+                "complianceDetails" : {
+                  "successAlreadyOK" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n2",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n2",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n2",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n1",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n1",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "r2",
+                "name" : "R2",
+                "compliance" : 100.0,
+                "complianceDetails" : {
+                  "successRepaired" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
+                    "name" : "directive99f4ef91-537b-4e03-97bc-e65b447514cc",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successRepaired" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-r2-n1",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successRepaired" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n1",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successRepaired" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-r2-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successRepaired"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "nodes" : [
+              {
+                "id" : "n2",
+                "name" : "node1.localhost",
+                "compliance" : 100.0,
+                "mode" : "full-compliance",
+                "complianceDetails" : {
+                  "successAlreadyOK" : 100.0
+                },
+                "rules" : [
+                  {
+                    "id" : "r1",
+                    "name" : "R1",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n2",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n2",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "n1",
+                "name" : "node1.localhost",
+                "compliance" : 100.0,
+                "mode" : "full-compliance",
+                "complianceDetails" : {
+                  "successAlreadyOK" : 50.0,
+                  "successRepaired" : 50.0
+                },
+                "rules" : [
+                  {
+                    "id" : "r1",
+                    "name" : "R1",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n1",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id" : "r2",
+                    "name" : "R2",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successRepaired" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
+                        "name" : "directive99f4ef91-537b-4e03-97bc-e65b447514cc",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successRepaired" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-r2-n1",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successRepaired" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-r2-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successRepaired"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Get a node group's global compliance for group G3 (simple example)
+method: GET
+url: /secure/api/compliance/groups/g3
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getNodeGroupComplianceId",
+      "result" : "success",
+      "data" : {
+        "nodeGroups" : [
+          {
+            "id" : "g3",
+            "name" : "G3",
+            "compliance" : 66.66,
+            "mode" : "full-compliance",
+            "complianceDetails" : {
+              "successAlreadyOK" : 33.33,
+              "error" : 33.34,
+              "successRepaired" : 33.33
+            },
+            "rules" : [
+              {
+                "id" : "r1",
+                "name" : "R1",
+                "compliance" : 100.0,
+                "complianceDetails" : {
+                  "successAlreadyOK" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n1",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n1",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "r3",
+                "name" : "R3",
+                "compliance" : 0.0,
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "directive2",
+                    "name" : "directive2",
+                    "compliance" : 0.0,
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "directive2-component-r3-n1",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n1",
+                            "name" : "node1.localhost",
+                            "compliance" : 0.0,
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-r3-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "r2",
+                "name" : "R2",
+                "compliance" : 100.0,
+                "complianceDetails" : {
+                  "successRepaired" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
+                    "name" : "directive99f4ef91-537b-4e03-97bc-e65b447514cc",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successRepaired" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-r2-n1",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successRepaired" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n1",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successRepaired" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-r2-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successRepaired"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "nodes" : [
+              {
+                "id" : "n1",
+                "name" : "node1.localhost",
+                "compliance" : 66.66,
+                "mode" : "full-compliance",
+                "complianceDetails" : {
+                  "successAlreadyOK" : 33.33,
+                  "error" : 33.34,
+                  "successRepaired" : 33.33
+                },
+                "rules" : [
+                  {
+                    "id" : "r1",
+                    "name" : "R1",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n1",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id" : "r2",
+                    "name" : "R2",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successRepaired" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
+                        "name" : "directive99f4ef91-537b-4e03-97bc-e65b447514cc",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successRepaired" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-r2-n1",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successRepaired" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-r2-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successRepaired"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id" : "r3",
+                    "name" : "R3",
+                    "compliance" : 0.0,
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "directive2",
+                        "name" : "directive2",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "directive2-component-r3-n1",
+                            "compliance" : 0.0,
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-r3-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Get a node group's targeted compliance for group G3 (simple example)
+method: GET
+url: /secure/api/compliance/groups/g3/target
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getNodeGroupComplianceTargetId",
+      "result" : "success",
+      "data" : {
+        "nodeGroups" : [
+          {
+            "id" : "g3",
+            "name" : "G3",
+            "compliance" : 0.0,
+            "mode" : "full-compliance",
+            "complianceDetails" : {
+              "error" : 100.0
+            },
+            "rules" : [
+              {
+                "id" : "r3",
+                "name" : "R3",
+                "compliance" : 0.0,
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "directive2",
+                    "name" : "directive2",
+                    "compliance" : 0.0,
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "directive2-component-r3-n1",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n1",
+                            "name" : "node1.localhost",
+                            "compliance" : 0.0,
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-r3-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "nodes" : [
+              {
+                "id" : "n1",
+                "name" : "node1.localhost",
+                "compliance" : 0.0,
+                "mode" : "full-compliance",
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "rules" : [
+                  {
+                    "id" : "r3",
+                    "name" : "R3",
+                    "compliance" : 0.0,
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "directive2",
+                        "name" : "directive2",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "directive2-component-r3-n1",
+                            "compliance" : 0.0,
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-r3-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Get a node group's global compliance for group BG1 (complex example)
+method: GET
+url: /secure/api/compliance/groups/bg1
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getNodeGroupComplianceId",
+      "result" : "success",
+      "data" : {
+        "nodeGroups" : [
+          {
+            "id" : "bg1",
+            "name" : "G1",
+            "compliance" : 66.67,
+            "mode" : "full-compliance",
+            "complianceDetails" : {
+              "successAlreadyOK" : 50.01,
+              "error" : 33.33,
+              "successRepaired" : 16.66
+            },
+            "rules" : [
+              {
+                "id" : "br1",
+                "name" : "R1",
+                "compliance" : 100.0,
+                "complianceDetails" : {
+                  "successAlreadyOK" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-br1-bn1",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "bn1",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-br1-bn1",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-br1-bn2",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "bn2",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-br1-bn2",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "br3",
+                "name" : "R3",
+                "compliance" : 0.0,
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "directive2",
+                    "name" : "directive2",
+                    "compliance" : 0.0,
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "directive2-component-br3-bn1",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "bn1",
+                            "name" : "node1.localhost",
+                            "compliance" : 0.0,
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-br3-bn1",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name" : "directive2-component-br3-bn2",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "bn2",
+                            "name" : "node1.localhost",
+                            "compliance" : 0.0,
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-br3-bn2",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "br4",
+                "name" : "R4",
+                "compliance" : 100.0,
+                "complianceDetails" : {
+                  "successAlreadyOK" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-br4-bn2",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "bn2",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-br4-bn2",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "br2",
+                "name" : "R2",
+                "compliance" : 100.0,
+                "complianceDetails" : {
+                  "successRepaired" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
+                    "name" : "directive99f4ef91-537b-4e03-97bc-e65b447514cc",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successRepaired" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-br2-bn1",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successRepaired" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "bn1",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successRepaired" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-br2-bn1",
+                                "reports" : [
+                                  {
+                                    "status" : "successRepaired"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "nodes" : [
+              {
+                "id" : "bn2",
+                "name" : "node1.localhost",
+                "compliance" : 66.67,
+                "mode" : "full-compliance",
+                "complianceDetails" : {
+                  "successAlreadyOK" : 66.67,
+                  "error" : 33.33
+                },
+                "rules" : [
+                  {
+                    "id" : "br1",
+                    "name" : "R1",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-br1-bn2",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-br1-bn2",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id" : "br3",
+                    "name" : "R3",
+                    "compliance" : 0.0,
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "directive2",
+                        "name" : "directive2",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "directive2-component-br3-bn2",
+                            "compliance" : 0.0,
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-br3-bn2",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id" : "br4",
+                    "name" : "R4",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-br4-bn2",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-br4-bn2",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "bn1",
+                "name" : "node1.localhost",
+                "compliance" : 66.66,
+                "mode" : "full-compliance",
+                "complianceDetails" : {
+                  "successAlreadyOK" : 33.33,
+                  "error" : 33.34,
+                  "successRepaired" : 33.33
+                },
+                "rules" : [
+                  {
+                    "id" : "br1",
+                    "name" : "R1",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-br1-bn1",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-br1-bn1",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id" : "br2",
+                    "name" : "R2",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successRepaired" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
+                        "name" : "directive99f4ef91-537b-4e03-97bc-e65b447514cc",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successRepaired" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-br2-bn1",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successRepaired" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-br2-bn1",
+                                "reports" : [
+                                  {
+                                    "status" : "successRepaired"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id" : "br3",
+                    "name" : "R3",
+                    "compliance" : 0.0,
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "directive2",
+                        "name" : "directive2",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "directive2-component-br3-bn1",
+                            "compliance" : 0.0,
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-br3-bn1",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Get a node group's targeted compliance for group G1 (complex example)
+method: GET
+url: /secure/api/compliance/groups/bg1/target
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getNodeGroupComplianceTargetId",
+      "result" : "success",
+      "data" : {
+        "nodeGroups" : [
+          {
+            "id" : "bg1",
+            "name" : "G1",
+            "compliance" : 100.0,
+            "mode" : "full-compliance",
+            "complianceDetails" : {
+              "successAlreadyOK" : 66.67,
+              "successRepaired" : 33.33
+            },
+            "rules" : [
+              {
+                "id" : "br2",
+                "name" : "R2",
+                "compliance" : 100.0,
+                "complianceDetails" : {
+                  "successRepaired" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
+                    "name" : "directive99f4ef91-537b-4e03-97bc-e65b447514cc",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successRepaired" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-br2-bn1",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successRepaired" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "bn1",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successRepaired" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-br2-bn1",
+                                "reports" : [
+                                  {
+                                    "status" : "successRepaired"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "br1",
+                "name" : "R1",
+                "compliance" : 100.0,
+                "complianceDetails" : {
+                  "successAlreadyOK" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-br1-bn1",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "bn1",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-br1-bn1",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-br1-bn2",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "bn2",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-br1-bn2",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "nodes" : [
+              {
+                "id" : "bn2",
+                "name" : "node1.localhost",
+                "compliance" : 100.0,
+                "mode" : "full-compliance",
+                "complianceDetails" : {
+                  "successAlreadyOK" : 100.0
+                },
+                "rules" : [
+                  {
+                    "id" : "br1",
+                    "name" : "R1",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-br1-bn2",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-br1-bn2",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "bn1",
+                "name" : "node1.localhost",
+                "compliance" : 100.0,
+                "mode" : "full-compliance",
+                "complianceDetails" : {
+                  "successAlreadyOK" : 50.0,
+                  "successRepaired" : 50.0
+                },
+                "rules" : [
+                  {
+                    "id" : "br1",
+                    "name" : "R1",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-br1-bn1",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-br1-bn1",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id" : "br2",
+                    "name" : "R2",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successRepaired" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
+                        "name" : "directive99f4ef91-537b-4e03-97bc-e65b447514cc",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successRepaired" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-br2-bn1",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successRepaired" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-br2-bn1",
+                                "reports" : [
+                                  {
+                                    "status" : "successRepaired"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Get a node group's global compliance for group BG6 (complex example)
+method: GET
+url: /secure/api/compliance/groups/bg6
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getNodeGroupComplianceId",
+      "result" : "success",
+      "data" : {
+        "nodeGroups" : [
+          {
+            "id" : "bg6",
+            "name" : "G6",
+            "compliance" : 100.0,
+            "mode" : "full-compliance",
+            "complianceDetails" : {
+              "successAlreadyOK" : 100.0
+            },
+            "rules" : [
+              {
+                "id" : "br4",
+                "name" : "R4",
+                "compliance" : 100.0,
+                "complianceDetails" : {
+                  "successAlreadyOK" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-br4-bn5",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "bn5",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-br4-bn5",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-br4-bn4",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "bn4",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-br4-bn4",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "br6",
+                "name" : "R6",
+                "compliance" : 0.0,
+                "complianceDetails" : {
+                  "noReport" : 100.0
+                },
+                "directives" : []
+              }
+            ],
+            "nodes" : [
+              {
+                "id" : "bn5",
+                "name" : "node1.localhost",
+                "compliance" : 100.0,
+                "mode" : "full-compliance",
+                "complianceDetails" : {
+                  "successAlreadyOK" : 100.0
+                },
+                "rules" : [
+                  {
+                    "id" : "br4",
+                    "name" : "R4",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-br4-bn5",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-br4-bn5",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id" : "bn4",
+                "name" : "node1.localhost",
+                "compliance" : 100.0,
+                "mode" : "full-compliance",
+                "complianceDetails" : {
+                  "successAlreadyOK" : 100.0
+                },
+                "rules" : [
+                  {
+                    "id" : "br4",
+                    "name" : "R4",
+                    "compliance" : 100.0,
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-br4-bn4",
+                            "compliance" : 100.0,
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-br4-bn4",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Get a node group's targeted compliance for group BG6 (complex example)
+method: GET
+url: /secure/api/compliance/groups/bg6/target
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getNodeGroupComplianceTargetId",
+      "result" : "success",
+      "data" : {
+        "nodeGroups" : [
+          {
+            "id" : "bg6",
+            "name" : "G6",
+            "compliance" : 0.0,
+            "mode" : "full-compliance",
+            "complianceDetails" : {},
+            "rules" : [
+              {
+                "id" : "br6",
+                "name" : "R6",
+                "compliance" : 0.0,
+                "complianceDetails" : {
+                  "noReport" : 100.0
+                },
+                "directives" : []
+              }
+            ],
+            "nodes" : [
+              {
+                "id" : "bn5",
+                "name" : "node1.localhost",
+                "compliance" : 0.0,
+                "mode" : "full-compliance",
+                "complianceDetails" : {},
+                "rules" : []
+              },
+              {
+                "id" : "bn4",
+                "name" : "node1.localhost",
+                "compliance" : 0.0,
+                "mode" : "full-compliance",
+                "complianceDetails" : {},
+                "rules" : []
+              }
+            ]
+          }
+        ]
+      }
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -40,25 +40,91 @@ package com.normation.rudder
 import com.normation.appconfig.ConfigRepository
 import com.normation.appconfig.GenericConfigService
 import com.normation.appconfig.ModifyGlobalPropertyInfo
+import com.normation.cfclerk.domain.TechniqueVersionHelper
+import com.normation.errors
 import com.normation.errors.IOResult
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
-import com.normation.inventory.domain._
+import com.normation.inventory.domain.FullInventory
+import com.normation.inventory.domain.InventoryStatus
+import com.normation.inventory.domain.NodeId
+import com.normation.inventory.domain.Software
 import com.normation.rudder.batch.AsyncWorkflowInfo
 import com.normation.rudder.domain.Constants
 import com.normation.rudder.domain.appconfig.RudderWebProperty
+import com.normation.rudder.domain.archives.RuleArchiveId
 import com.normation.rudder.domain.eventlog
+import com.normation.rudder.domain.nodes.NodeGroup
+import com.normation.rudder.domain.nodes.NodeGroupCategory
+import com.normation.rudder.domain.nodes.NodeGroupCategoryId
+import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
+import com.normation.rudder.domain.policies.AddRuleDiff
+import com.normation.rudder.domain.policies.DeleteRuleDiff
+import com.normation.rudder.domain.policies.DirectiveId
+import com.normation.rudder.domain.policies.GlobalPolicyMode
+import com.normation.rudder.domain.policies.GroupTarget
+import com.normation.rudder.domain.policies.ModifyRuleDiff
+import com.normation.rudder.domain.policies.PolicyMode
+import com.normation.rudder.domain.policies.PolicyModeOverrides
+import com.normation.rudder.domain.policies.Rule
+import com.normation.rudder.domain.policies.RuleId
+import com.normation.rudder.domain.policies.RuleUid
+import com.normation.rudder.domain.policies.TargetExclusion
+import com.normation.rudder.domain.policies.TargetIntersection
+import com.normation.rudder.domain.reports.ComplianceLevel
+import com.normation.rudder.domain.reports.ComponentValueStatusReport
+import com.normation.rudder.domain.reports.DirectiveStatusReport
+import com.normation.rudder.domain.reports.MessageStatusReport
+import com.normation.rudder.domain.reports.NodeConfigId
+import com.normation.rudder.domain.reports.NodeExpectedReports
+import com.normation.rudder.domain.reports.NodeModeConfig
+import com.normation.rudder.domain.reports.NodeStatusReport
+import com.normation.rudder.domain.reports.OverridenPolicy
+import com.normation.rudder.domain.reports.ReportType
+import com.normation.rudder.domain.reports.RuleNodeStatusReport
+import com.normation.rudder.domain.reports.RunComplianceInfo
+import com.normation.rudder.domain.reports.ValueStatusReport
+import com.normation.rudder.facts.nodes.ChangeContext
+import com.normation.rudder.facts.nodes.CoreNodeFact
+import com.normation.rudder.facts.nodes.NodeFact
+import com.normation.rudder.facts.nodes.NodeFactChangeEventCallback
+import com.normation.rudder.facts.nodes.NodeFactChangeEventCC
+import com.normation.rudder.facts.nodes.NodeFactRepository
+import com.normation.rudder.facts.nodes.QueryContext
+import com.normation.rudder.facts.nodes.SelectFacts
+import com.normation.rudder.facts.nodes.SelectNodeStatus
+import com.normation.rudder.reports.AgentRunInterval
+import com.normation.rudder.reports.FullCompliance
+import com.normation.rudder.reports.GlobalComplianceMode
+import com.normation.rudder.repository.CategoryAndNodeGroup
+import com.normation.rudder.repository.FullNodeGroupCategory
+import com.normation.rudder.repository.RoNodeGroupRepository
+import com.normation.rudder.repository.RoRuleRepository
+import com.normation.rudder.repository.WoRuleRepository
+import com.normation.rudder.rest.lift.ComplianceAPIService
+import com.normation.rudder.rule.category.RuleCategoryId
+import com.normation.rudder.services.policies.NodeConfigData
+import com.normation.rudder.services.policies.PolicyId
+import com.normation.rudder.services.reports.ComputeCompliance
+import com.normation.rudder.services.reports.ReportingService
 import com.normation.rudder.services.servers.AllowedNetwork
 import com.normation.rudder.services.servers.PolicyServer
 import com.normation.rudder.services.servers.PolicyServerManagementService
 import com.normation.rudder.services.servers.PolicyServers
 import com.normation.rudder.services.servers.PolicyServersUpdateCommand
 import com.normation.rudder.services.workflows.WorkflowLevelService
-import com.normation.zio._
+import com.normation.zio.UnsafeRun
 import com.typesafe.config.ConfigFactory
+import net.liftweb.common.Box
+import net.liftweb.common.Full
+import org.joda.time.DateTime
+import scala.collection.MapView
+import scala.collection.immutable.SortedMap
 import zio._
 import zio.{System => _}
 import zio.{Tag => _}
+import zio.syntax._
 
 /*
  * Mock services for test, especially repositories, and provides
@@ -117,6 +183,469 @@ class MockSettings(wfservice: WorkflowLevelService, asyncWF: AsyncWorkflowInfo) 
     }
 
     new GenericConfigService(ConfigFactory.empty(), configRepo, asyncWF, wfservice)
+  }
+
+}
+
+class MockCompliance(mockDirectives: MockDirectives) {
+  self =>
+
+  private val directives = mockDirectives.directives
+
+  private def nodeGroupsRepo(nodeGroups: List[NodeGroup]) = new RoNodeGroupRepository {
+    val nodesByGroup = nodeGroups
+      .map(g => (g.id, Chunk.fromIterable(g.serverList)))
+      .toMap
+
+    override def getAllNodeIdsChunk(): IOResult[Map[NodeGroupId, Chunk[NodeId]]] = {
+      nodesByGroup.succeed
+    }
+
+    override def getNodeGroupOpt(id: NodeGroupId): IOResult[Option[(NodeGroup, NodeGroupCategoryId)]] = {
+      nodeGroups.find(_.id == id).map((_, NodeGroupCategoryId("cat1"))).succeed
+    }
+
+    def getFullGroupLibrary():                                 IOResult[FullNodeGroupCategory]                                      = ???
+    def getNodeGroupCategory(id: NodeGroupId):                 IOResult[NodeGroupCategory]                                          = ???
+    def getAll():                                              IOResult[Seq[NodeGroup]]                                             = ???
+    def getAllNodeIds():                                       IOResult[Map[NodeGroupId, Set[NodeId]]]                              = ???
+    def getGroupsByCategory(includeSystem: Boolean):           IOResult[SortedMap[List[NodeGroupCategoryId], CategoryAndNodeGroup]] = ???
+    def findGroupWithAnyMember(nodeIds: Seq[NodeId]):          IOResult[Seq[NodeGroupId]]                                           = ???
+    def findGroupWithAllMember(nodeIds: Seq[NodeId]):          IOResult[Seq[NodeGroupId]]                                           = ???
+    def getRootCategory():                                     NodeGroupCategory                                                    = ???
+    def getRootCategoryPure():                                 IOResult[NodeGroupCategory]                                          = ???
+    def getCategoryHierarchy:                                  IOResult[SortedMap[List[NodeGroupCategoryId], NodeGroupCategory]]    = ???
+    def getAllGroupCategories(includeSystem: Boolean):         IOResult[Seq[NodeGroupCategory]]                                     = ???
+    def getGroupCategory(id: NodeGroupCategoryId):             IOResult[NodeGroupCategory]                                          = ???
+    def getParentGroupCategory(id: NodeGroupCategoryId):       IOResult[NodeGroupCategory]                                          = ???
+    def getParents_NodeGroupCategory(id: NodeGroupCategoryId): IOResult[List[NodeGroupCategory]]                                    = ???
+    def getAllNonSystemCategories():                           IOResult[Seq[NodeGroupCategory]]                                     = ???
+  }
+
+  private object nodeFactRepo extends NodeFactRepository {
+    override def getAll()(implicit qc: QueryContext, status: SelectNodeStatus): IOResult[MapView[NodeId, CoreNodeFact]] = {
+      val _                                           = (qc, status) // ignore "unused" warning
+      def build(id: String, mode: Option[PolicyMode]) = {
+        val nodeFact = NodeConfigData.fact1
+        nodeFact.copy(id = NodeId(id), rudderSettings = nodeFact.rudderSettings.copy(policyMode = mode))
+      }
+      Seq(
+        build("n1", Some(PolicyMode.Enforce)),
+        build("n2", Some(PolicyMode.Enforce)),
+        build("n3", Some(PolicyMode.Enforce)),
+        build("bn1", Some(PolicyMode.Enforce)),
+        build("bn2", Some(PolicyMode.Enforce)),
+        build("bn3", Some(PolicyMode.Enforce)),
+        build("bn4", Some(PolicyMode.Enforce)),
+        build("bn5", Some(PolicyMode.Enforce))
+      ).map(n => (n.id, n)).toMap.view.succeed
+    }
+
+    def registerChangeCallbackAction(callback: NodeFactChangeEventCallback):                   IOResult[Unit]                     = ???
+    def getStatus(id: NodeId)(implicit qc: QueryContext):                                      IOResult[InventoryStatus]          = ???
+    def get(nodeId: NodeId)(implicit qc: QueryContext, status: SelectNodeStatus):              IOResult[Option[CoreNodeFact]]     = ???
+    def slowGet(
+        nodeId:    NodeId
+    )(implicit qc: QueryContext, status: SelectNodeStatus, attrs: SelectFacts): IOResult[Option[NodeFact]] = ???
+    def getNodesbySofwareName(softName: String):                                               IOResult[List[(NodeId, Software)]] = ???
+    def slowGetAll()(implicit qc: QueryContext, status: SelectNodeStatus, attrs: SelectFacts): errors.IOStream[NodeFact]          = ???
+    def save(nodeFact: NodeFact)(implicit cc: ChangeContext, attrs: SelectFacts):              IOResult[NodeFactChangeEventCC]    = ???
+    def updateInventory(inventory: FullInventory, software: Option[Iterable[Software]])(implicit
+        cc:                        ChangeContext
+    ): IOResult[NodeFactChangeEventCC] = ???
+    def changeStatus(nodeId: NodeId, into: InventoryStatus)(implicit cc: ChangeContext):       IOResult[NodeFactChangeEventCC]    = ???
+    def delete(nodeId: NodeId)(implicit cc: ChangeContext):                                    IOResult[NodeFactChangeEventCC]    = ???
+  }
+
+  // We want to ignore rules that are defined in `MockRules` because they may target all nodes and pollute our compliance tests
+  private def rulesRepo(rules: List[Rule]) = new RoRuleRepository with WoRuleRepository {
+    override def getOpt(ruleId: RuleId):        IOResult[Option[Rule]] = {
+      rules.find(_.id == ruleId).succeed
+    }
+    override def getAll(includeSytem: Boolean): IOResult[Seq[Rule]]    = {
+      rules.succeed
+    }
+
+    override def getIds(includeSytem: Boolean):                                                            IOResult[Set[RuleId]]    = ???
+    override def create(rule: Rule, modId: ModificationId, actor: EventActor, reason: Option[String]):     IOResult[AddRuleDiff]    = ???
+    override def update(
+        rule:   Rule,
+        modId:  ModificationId,
+        actor:  EventActor,
+        reason: Option[String]
+    ): IOResult[Option[ModifyRuleDiff]] = ???
+    override def load(rule: Rule, modId: ModificationId, actor: EventActor, reason: Option[String]):       IOResult[Unit]           = ???
+    override def unload(ruleId: RuleId, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Unit]           = ???
+    override def updateSystem(
+        rule:   Rule,
+        modId:  ModificationId,
+        actor:  EventActor,
+        reason: Option[String]
+    ): IOResult[Option[ModifyRuleDiff]] = ???
+    override def delete(id: RuleId, modId: ModificationId, actor: EventActor, reason: Option[String]):     IOResult[DeleteRuleDiff] =
+      ???
+    override def deleteSystemRule(
+        id:     RuleId,
+        modId:  ModificationId,
+        actor:  EventActor,
+        reason: Option[String]
+    ): IOResult[DeleteRuleDiff] = ???
+    override def swapRules(newRules: Seq[Rule]):                                                           IOResult[RuleArchiveId]  = ???
+    override def deleteSavedRuleArchiveId(saveId: RuleArchiveId):                                          IOResult[Unit]           = ???
+  }
+
+  private def reportingService(statusReports: Map[NodeId, NodeStatusReport]): ReportingService = new ReportingService {
+    def findRuleNodeStatusReports(nodeIds: Set[NodeId], filterByRules: Set[RuleId])(implicit
+        qc:                                QueryContext
+    ): Box[Map[NodeId, NodeStatusReport]] = {
+      Full(statusReports)
+    }
+
+    def findDirectiveNodeStatusReports(
+        nodeIds:            Set[NodeId],
+        filterByDirectives: Set[DirectiveId]
+    )(implicit qc:          QueryContext): Box[Map[NodeId, NodeStatusReport]] = ???
+    def findUncomputedNodeStatusReports():                                               Box[Map[NodeId, NodeStatusReport]]      = ???
+    def findRuleNodeCompliance(nodeIds: Set[NodeId], filterByRules: Set[RuleId])(implicit
+        qc:                             QueryContext
+    ): IOResult[Map[NodeId, ComplianceLevel]] = ???
+    def findSystemAndUserRuleCompliances(
+        nodeIds:             Set[NodeId],
+        filterBySystemRules: Set[RuleId],
+        filterByUserRules:   Set[RuleId]
+    )(implicit qc:           QueryContext): IOResult[(Map[NodeId, ComplianceLevel], Map[NodeId, ComplianceLevel])] = ???
+    def findDirectiveRuleStatusReportsByRule(ruleId: RuleId)(implicit qc: QueryContext): IOResult[Map[NodeId, NodeStatusReport]] =
+      ???
+    def findNodeStatusReport(nodeId: NodeId)(implicit qc: QueryContext):                 Box[NodeStatusReport]                   = ???
+    def findUserNodeStatusReport(nodeId: NodeId)(implicit qc: QueryContext):             Box[NodeStatusReport]                   = ???
+    def findSystemNodeStatusReport(nodeId: NodeId)(implicit qc: QueryContext):           Box[NodeStatusReport]                   = ???
+    def getUserNodeStatusReports()(implicit qc: QueryContext):                           Box[Map[NodeId, NodeStatusReport]]      = ???
+    def findStatusReportsForDirective(directiveId: DirectiveId)(implicit
+        qc:                                        QueryContext
+    ): IOResult[Map[NodeId, NodeStatusReport]] = ???
+    def getSystemAndUserCompliance(
+        optNodeIds: Option[Set[NodeId]]
+    )(implicit qc:  QueryContext): IOResult[(Map[NodeId, ComplianceLevel], Map[NodeId, ComplianceLevel])] = ???
+    def computeComplianceFromReports(reports: Map[NodeId, NodeStatusReport]):            Option[(ComplianceLevel, Long)]         = ???
+    def getGlobalUserCompliance()(implicit qc: QueryContext):                            Box[Option[(ComplianceLevel, Long)]]    = ???
+  }
+
+  val complianceAPIService: ComplianceAPIService = {
+    import simpleExample._
+    import complexExample._
+    buildComplianceService(
+      simpleCustomRules ++ complexCustomRules,
+      simpleCustomNodeGroups ++ complexCustomNodeGroups,
+      simpleStatusReports ++ complexStatusReports
+    )
+  }
+
+  private object simpleExample {
+
+    /*
+    Nodes N1 and N2,
+
+    Groups G1 (containing N1 and N2) and G2 (containing N2) and G3 containing N1
+
+    Rules R1 (applying to G1), R2 (applying to G1 but excluding G2), and R3 (applying to G2 and G3)
+     */
+
+    val simpleStatusReports = Map(
+      // R1, R2, R3 apply on N1
+      nodeId(1) -> simpleNodeStatusReport(
+        nodeId(1),
+        Set(
+          simpleRuleNodeStatusReport(nodeId(1), ruleId(1), directives.fileTemplateDirecive1.id, ReportType.EnforceSuccess),
+          simpleRuleNodeStatusReport(nodeId(1), ruleId(2), directives.fileTemplateVariables2.id, ReportType.EnforceRepaired),
+          simpleRuleNodeStatusReport(nodeId(1), ruleId(3), directives.rpmDirective.id, ReportType.EnforceError)
+        )
+      ),
+      // R1, R3 apply on N2
+      nodeId(2) -> simpleNodeStatusReport(
+        nodeId(2),
+        Set(
+          simpleRuleNodeStatusReport(nodeId(2), ruleId(1), directives.fileTemplateDirecive1.id, ReportType.EnforceSuccess),
+          simpleRuleNodeStatusReport(nodeId(2), ruleId(3), directives.rpmDirective.id, ReportType.EnforceError)
+        )
+      )
+    )
+
+    val g1 = NodeGroup(nodeGroupId(1), "G1", "", Nil, None, false, (1 to 2).map(nodeId).toSet, true)
+
+    val g2 = NodeGroup(nodeGroupId(2), "G2", "", Nil, None, false, Set(nodeId(2)), true)
+
+    val g3 = NodeGroup(nodeGroupId(3), "G3", "", Nil, None, false, Set(nodeId(1)), true)
+
+    val r1 = Rule(
+      ruleId(1),
+      "R1",
+      RuleCategoryId("rulecat1"),
+      Set(GroupTarget(g1.id)),
+      Set(directives.fileTemplateDirecive1.id)
+    )
+
+    val r2 = Rule(
+      ruleId(2),
+      "R2",
+      RuleCategoryId("rulecat1"),
+      Set(
+        TargetExclusion(TargetIntersection(Set(GroupTarget(g1.id))), TargetIntersection(Set(GroupTarget(g2.id))))
+      ), // include G1 but not G2
+      Set(directives.fileTemplateDirecive1.id)
+    )
+
+    val r3 = Rule(
+      ruleId(3),
+      "R3",
+      RuleCategoryId("rulecat1"),
+      Set(GroupTarget(g2.id), GroupTarget(g3.id)),
+      Set(directives.fileTemplateDirecive1.id)
+    )
+
+    val simpleCustomRules = List(r1, r2, r3)
+
+    val simpleCustomNodeGroups = List(g1, g2, g3)
+
+    private def nodeId(id: Int):      NodeId      = NodeId("n" + id)
+    private def ruleId(id: Int):      RuleId      = RuleId(RuleUid("r" + id))
+    private def nodeGroupId(id: Int): NodeGroupId = NodeGroupId(NodeGroupUid("g" + id))
+  }
+
+  private object complexExample {
+
+    /*
+    Nodes N1, N2, N3, N4, N5
+
+    Groups G1 (with N1, N2), G2 (N2), G3 (N1), G4 (N3, N4, N5), G5 (N2, N3), G6(N4, N5)
+
+    Directives D1, D2, D3, D4, D5
+
+    Rules
+
+    - R1, which applies D1 to G1
+    - R2, which applies D2 to G1 but not G2
+    - R3, which applies D3 to G2 and G3
+    - R4, which applies D4 to G4 and G5
+    - R5, which applies D5 to G6 but not G4 (so nothing)
+    - R6, which applies D4 to G6 (so we will have skipped on N4 and N5)
+     */
+
+    val g1 = NodeGroup(nodeGroupId(1), "G1", "", Nil, None, false, Set(nodeId(1), nodeId(2)), true)
+    val g2 = NodeGroup(nodeGroupId(2), "G2", "", Nil, None, false, Set(nodeId(2)), true)
+    val g3 = NodeGroup(nodeGroupId(3), "G3", "", Nil, None, false, Set(nodeId(1)), true)
+    val g4 = NodeGroup(nodeGroupId(4), "G4", "", Nil, None, false, Set(nodeId(3), nodeId(4), nodeId(5)), true)
+    val g5 = NodeGroup(nodeGroupId(5), "G5", "", Nil, None, false, Set(nodeId(2), nodeId(3)), true)
+    val g6 = NodeGroup(nodeGroupId(6), "G6", "", Nil, None, false, Set(nodeId(4), nodeId(5)), true)
+
+    val d1 = directives.fileTemplateDirecive1
+    val d2 = directives.fileTemplateVariables2
+    val d3 = directives.rpmDirective
+    val d4 = directives.fileTemplateDirecive1
+    val d5 = directives.fileTemplateVariables2
+
+    val r1 = Rule(
+      ruleId(1),
+      "R1",
+      RuleCategoryId("rulecat1"),
+      Set(GroupTarget(g1.id)),
+      Set(d1.id)
+    )
+
+    val r2 = Rule(
+      ruleId(2),
+      "R2",
+      RuleCategoryId("rulecat1"),
+      Set(
+        TargetExclusion(TargetIntersection(Set(GroupTarget(g1.id))), TargetIntersection(Set(GroupTarget(g2.id))))
+      ), // include G1 but not G2
+      Set(d2.id)
+    )
+
+    val r3 = Rule(
+      ruleId(3),
+      "R3",
+      RuleCategoryId("rulecat1"),
+      Set(GroupTarget(g2.id), GroupTarget(g3.id)),
+      Set(d3.id)
+    )
+
+    val r4 = Rule(
+      ruleId(4),
+      "R4",
+      RuleCategoryId("rulecat1"),
+      Set(GroupTarget(g4.id), GroupTarget(g5.id)),
+      Set(d4.id)
+    )
+
+    val r5 = Rule(
+      ruleId(5),
+      "R5",
+      RuleCategoryId("rulecat1"),
+      Set(
+        TargetExclusion(TargetIntersection(Set(GroupTarget(g6.id))), TargetIntersection(Set(GroupTarget(g4.id))))
+      ), // include G6 but not G4 (no node at all)
+      Set(d5.id)
+    )
+
+    val r6 = Rule(
+      ruleId(6),
+      "R6",
+      RuleCategoryId("rulecat1"),
+      Set(GroupTarget(g6.id)),
+      Set(d4.id)
+    )
+
+    val complexStatusReports = Map(
+      // R1, R2, R3 apply on N1
+      nodeId(1) -> simpleNodeStatusReport(
+        nodeId(1),
+        Set(
+          simpleRuleNodeStatusReport(nodeId(1), ruleId(1), d1.id, ReportType.EnforceSuccess),
+          simpleRuleNodeStatusReport(nodeId(1), ruleId(2), d2.id, ReportType.EnforceRepaired),
+          simpleRuleNodeStatusReport(nodeId(1), ruleId(3), d3.id, ReportType.EnforceError)
+        )
+      ),
+      // R1, R3, R4 apply on N2
+      nodeId(2) -> simpleNodeStatusReport(
+        nodeId(2),
+        Set(
+          simpleRuleNodeStatusReport(nodeId(2), ruleId(1), d1.id, ReportType.EnforceSuccess),
+          simpleRuleNodeStatusReport(nodeId(2), ruleId(3), d3.id, ReportType.EnforceError),
+          simpleRuleNodeStatusReport(nodeId(2), ruleId(4), d4.id, ReportType.EnforceSuccess)
+        )
+      ),
+      // R4 applies on N3
+      nodeId(3) -> simpleNodeStatusReport(
+        nodeId(3),
+        Set(
+          simpleRuleNodeStatusReport(nodeId(3), ruleId(4), d4.id, ReportType.EnforceSuccess)
+        )
+      ),
+      // R4 applies on N4
+      nodeId(4) -> simpleNodeStatusReport(
+        nodeId(4),
+        Set(
+          simpleRuleNodeStatusReport(nodeId(4), ruleId(4), d4.id, ReportType.EnforceSuccess)
+        )
+      ),
+      // R4 applies on N5
+      nodeId(5) -> simpleNodeStatusReport(
+        nodeId(5),
+        Set(
+          simpleRuleNodeStatusReport(nodeId(5), ruleId(4), d4.id, ReportType.EnforceSuccess)
+        )
+      ),
+      // R5 targets nothing at all because no node is targeted
+      // R6 is skipped, there are some reports with 'overrides'
+      nodeId(6) -> simpleNodeStatusReport(
+        nodeId(6),
+        Set(
+          simpleRuleNodeStatusReport(nodeId(6), ruleId(4), d4.id, ReportType.NoAnswer),
+          simpleRuleNodeStatusReport(nodeId(6), ruleId(5), d4.id, ReportType.NoAnswer)
+        ),
+        List(
+          OverridenPolicy(
+            PolicyId(ruleId(6), d4.id, TechniqueVersionHelper("1.0")),
+            PolicyId(ruleId(4), d4.id, TechniqueVersionHelper("1.0"))
+          ),
+          OverridenPolicy(
+            PolicyId(ruleId(6), d4.id, TechniqueVersionHelper("1.0")),
+            PolicyId(ruleId(5), d4.id, TechniqueVersionHelper("1.0"))
+          )
+        )
+      )
+    )
+
+    val complexCustomRules = List(r1, r2, r3, r4, r5, r6)
+
+    val complexCustomNodeGroups = List(g1, g2, g3, g4, g5, g6)
+
+    // prefix all ids with "b" to avoid id collision with simpleExample
+    private def nodeId(id: Int):      NodeId      = NodeId("bn" + id)
+    private def ruleId(id: Int):      RuleId      = RuleId(RuleUid("br" + id))
+    private def nodeGroupId(id: Int): NodeGroupId = NodeGroupId(NodeGroupUid("bg" + id))
+  }
+
+  private def buildComplianceService(
+      customRules:      List[Rule],
+      customNodeGroups: List[NodeGroup],
+      statusesReports:  Map[NodeId, NodeStatusReport]
+  ): ComplianceAPIService = {
+    new ComplianceAPIService(
+      rulesRepo(customRules),
+      nodeFactRepo,
+      nodeGroupsRepo(customNodeGroups),
+      reportingService(statusesReports),
+      mockDirectives.directiveRepo,
+      GlobalComplianceMode(FullCompliance, 0).succeed
+    )
+  }
+
+  private def simpleRuleNodeStatusReport(
+      nodeId:      NodeId,
+      ruleId:      RuleId,
+      directiveId: DirectiveId,
+      reportType:  ReportType
+  ): RuleNodeStatusReport = {
+    RuleNodeStatusReport(
+      nodeId,
+      ruleId,
+      None,
+      None,
+      Map(
+        directiveId -> DirectiveStatusReport(
+          directiveId,
+          List(
+            ValueStatusReport(
+              s"${directiveId.serialize}-component-${ruleId.serialize}-${nodeId.value}",
+              s"${directiveId.serialize}-component-${ruleId.serialize}-${nodeId.value}",
+              List(
+                ComponentValueStatusReport(
+                  s"${directiveId.serialize}-component-value-${ruleId.serialize}-${nodeId.value}",
+                  s"${directiveId.serialize}-component-value-${ruleId.serialize}-${nodeId.value}",
+                  s"report-${ruleId.serialize}-${nodeId.value}",
+                  List(MessageStatusReport(reportType, None))
+                )
+              )
+            )
+          )
+        )
+      ),
+      DateTime.parse("2100-01-01T00:00:00.000Z")
+    )
+  }
+
+  private def simpleNodeStatusReport(
+      nodeId:          NodeId,
+      ruleNodeReports: Set[RuleNodeStatusReport],
+      overrides:       List[OverridenPolicy] = List.empty
+  ): NodeStatusReport = {
+    NodeStatusReport(
+      nodeId,
+      ComputeCompliance(
+        DateTime.parse("2023-01-01T00:00:00.000Z"),
+        NodeExpectedReports(
+          nodeId,
+          NodeConfigId(s"${nodeId.value}-config"),
+          DateTime.parse("2023-01-01T00:00:00.000Z"),
+          None,
+          NodeModeConfig(
+            GlobalComplianceMode(FullCompliance, 0),
+            None,
+            AgentRunInterval(None, 1, 0, 0, 0),
+            None,
+            GlobalPolicyMode(PolicyMode.Enforce, PolicyModeOverrides.Unoverridable),
+            None
+          ),
+          List.empty,
+          List.empty
+        ),
+        DateTime.parse("2024-01-01T00:00:00.000Z")
+      ),
+      RunComplianceInfo.OK,
+      overrides,
+      ruleNodeReports
+    )
   }
 
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -842,7 +842,8 @@ class RestTestSetUp {
   val techniqueRepository: TechniqueRepository   = null
   val techniqueSerializer: TechniqueSerializer   = null
   val resourceFileService: ResourceFileService   = null
-  val settingsService = new MockSettings(workflowLevelService, new AsyncWorkflowInfo())
+  val settingsService   = new MockSettings(workflowLevelService, new AsyncWorkflowInfo())
+  val complianceService = new MockCompliance(mockDirectives)
 
   object archiveAPIModule {
     val archiveBuilderService = new ZipArchiveBuilderService(
@@ -933,7 +934,12 @@ class RestTestSetUp {
       mockNodes.nodeInfoService
     ),
     archiveAPIModule.api,
-    campaignApiModule.api
+    campaignApiModule.api,
+    new ComplianceApi(
+      restExtractorService,
+      complianceService.complianceAPIService,
+      mockDirectives.directiveRepo
+    )
   )
 
   val apiVersions            =

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
@@ -90,6 +90,6 @@ class TestRestFromFileDef extends TraitTestApiFromYamlFiles with AfterAll {
 
   // you can pass a list of file to test exclusively if you don't want to test all .yml
   // files in src/test/resource/${yamlSourceDirectory}
-  doTest(Nil)
+  doTest(List("api_compliance.yml"))
 
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/23935

This adds two endpoints that return compliance computation by node group : 
- one `/compliance/groups/{id}` for global compliance by taking into account any rule that apply to nodes within the group
- another `/compliance/groups/{id}/target` for targeted compliance by taking into account only rules that target the group (using include/exclude targeting)

In the yaml tests I used concrete examples (a simple one and a more complex one) and the result correspond to what is expected with a some caveats : 
- lists are not sorted, and this could cause some issues because sometimes we use the `Set` collection. Maybe we should sort by 'compliance', from the "worst" ones to best ones ? Or by the name of the _node_/_rule_ ? I left them as is so there is no specific order
- when there are 'skipped' reports, with overrides, we remap them to "No report" with the `NoAnswer` report type, which could be confusing (but may be better than omitting it completely). Later we could handle that case specifically to display which rule/directive have been overriden