### PR TITLE
Control boxSequence/sequence are using early exist, which is not supp…

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/VariableSpecParser.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/VariableSpecParser.scala
@@ -346,7 +346,7 @@ class VariableSpecParser extends Loggable {
   private[this] def parseAlgoList(algos: String): Seq[HashAlgoConstraint] = {
     if (algos.trim.isEmpty) HashAlgoConstraint.sort(HashAlgoConstraint.algorithms)
     else {
-      Control.sequence(algos.split(",").toSeq)(algo => HashAlgoConstraint.fromString(algo.trim)) match {
+      Control.traverse(algos.split(",").toSeq)(algo => HashAlgoConstraint.fromString(algo.trim)) match {
         case Full(seq) => seq
         case eb: EmptyBox =>
           throw new ConstraintException((eb ?~! s"Error when parsing the list of password hash: '${algos}'").messageChain)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/DebugNodeConfigurationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/DebugNodeConfigurationLogger.scala
@@ -39,7 +39,7 @@ package com.normation.rudder.domain.logger
 
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.services.policies.NodeConfiguration
-import com.normation.utils.Control.sequence
+import com.normation.utils.Control.traverse
 import java.io.File
 import java.io.PrintWriter
 import net.liftweb.common._
@@ -97,7 +97,7 @@ class NodeConfigurationLoggerImpl(
     if (logger.isDebugEnabled) {
       for {
         logTime <- writeIn(new File(path, "lastWritenTime"))(printWriter => Full(printWriter.write(DateTime.now.toString())))
-        configs <- (sequence(nodeConfiguration) { config =>
+        configs <- (traverse(nodeConfiguration) { config =>
                      val logFile = new File(path, config.nodeInfo.hostname + "_" + config.nodeInfo.id.value)
 
                      writeIn(logFile) { printWriter =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
@@ -40,7 +40,7 @@ package com.normation.rudder.domain.policies
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
-import com.normation.utils.Control.sequence
+import com.normation.utils.Control.traverse
 import net.liftweb.common._
 import net.liftweb.json._
 import net.liftweb.json.JsonDSL._
@@ -367,13 +367,13 @@ object RuleTarget extends Loggable {
           Full(TargetUnion())
         case JObject(JField("or", JArray(content)) :: Nil)  =>
           for {
-            targets <- sequence(content)(unserJson)
+            targets <- traverse(content)(unserJson)
           } yield {
             TargetUnion(targets.toSet)
           }
         case JObject(JField("and", JArray(content)) :: Nil) =>
           for {
-            targets <- sequence(content)(unserJson)
+            targets <- traverse(content)(unserJson)
           } yield {
             TargetIntersection(targets.toSet)
           }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/migration/XmlEntityMigration.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/migration/XmlEntityMigration.scala
@@ -209,7 +209,7 @@ trait ControlXmlFileFormatMigration extends XmlFileFormatMigration {
           }
         }
 
-        boxSequence(migrationResults) match {
+        sequence(migrationResults) match {
           case Full(seq) =>
             val numberMigrated = seq.collect { case MigrationSuccess(i) => i }.sum
             migrationEventLogRepository.setMigrationFileFormat(id, toVersion.toLong, DateTime.now)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
@@ -888,7 +888,7 @@ class ClassicTechniqueWriter(
             method_info              <- methods.get(call.method)
             (_, classParameterValue) <- call.parameters.find(_._1 == method_info.classParameter)
 
-            params <- Control.sequence(method_info.parameters) { p =>
+            params <- Control.traverse(method_info.parameters) { p =>
                         for {
                           (_, value) <- Box(call.parameters.find(_._1 == p.id))
                           escaped    <- parameterTypeService.translate(value, p.parameterType, AgentType.CfeCommunity).toBox

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/DirectiveRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/DirectiveRepository.scala
@@ -699,7 +699,7 @@ class InitDirectivesTree(
                                                  toParentCat.id.value
                                                )
                            // now, add items and subcategories, in a "try to do the max you can" way
-                           fullRes          <- boxSequence(
+                           fullRes          <- sequence(
                                                  // Techniques
                                                  bestEffort(fromCat.techniqueIds.groupBy(id => id.name).toSeq) {
                                                    case (name, ids) =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ReportsJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ReportsJdbcRepository.scala
@@ -488,10 +488,10 @@ class ReportsJdbcRepository(doobie: Doobie) extends ReportsRepository with Logga
     */
 
   override def countChangeReportsByBatch(intervals: List[Interval]): Box[(Long, Map[RuleId, Map[Interval, Int]])] = {
-    import com.normation.utils.Control.sequence
+    import com.normation.utils.Control.traverse
     logger.debug(s"Fetching all changes for intervals ${intervals.mkString(",")}")
     val beginTime = System.currentTimeMillis()
-    val box: Box[Seq[Vector[(RuleId, Interval, Int, Long)]]] = sequence(intervals) { interval =>
+    val box: Box[Seq[Vector[(RuleId, Interval, Int, Long)]]] = traverse(intervals) { interval =>
       (transactRunBox(xa => {
         query[(RuleId, Int, Long)](
           s"""select ruleid, count(*) as number, max(id)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/json/JsonExctractorUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/json/JsonExctractorUtils.scala
@@ -122,7 +122,7 @@ trait JsonExtractorUtils[A[_]] {
     json \ key match {
       case JArray(values) =>
         (for {
-          strings   <- sequence(values) {
+          strings   <- traverse(values) {
                          _ match {
                            case JString(s) => Full(s)
                            case x          => Failure(s"Error extracting a string from json: '${x}'")
@@ -143,7 +143,7 @@ trait JsonExtractorUtils[A[_]] {
     trueJson match {
       case JArray(values) =>
         for {
-          converted <- sequence(values)(convertTo(_))
+          converted <- traverse(values)(convertTo(_))
         } yield {
           monad.point(converted.toList)
         }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -1909,7 +1909,7 @@ trait PromiseGeneration_Hooks extends PromiseGenerationService with PromiseGener
    * plugins hooks
    */
   override def beforeDeploymentSync(generationTime: DateTime): Box[Unit] = {
-    sequence(codeHooks.toSeq)(_.beforeDeploymentSync(generationTime)).map(_ => ())
+    traverse(codeHooks.toSeq)(_.beforeDeploymentSync(generationTime)).map(_ => ())
   }
 
   /*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/MergePolicyService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/MergePolicyService.scala
@@ -47,7 +47,7 @@ import com.normation.rudder.domain.logger.PolicyGenerationLogger
 import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.policies.GlobalPolicyMode
 import com.normation.rudder.domain.policies.PolicyMode
-import com.normation.utils.Control.sequence
+import com.normation.utils.Control.traverse
 import net.liftweb.common._
 
 /*
@@ -392,7 +392,7 @@ object MergePolicyService {
                 ) ?~! s"No agent defined for Node ${nodeInfo.hostname}, (id ${nodeInfo.id.value}), at least one should be defined"
       merged <- {
         val drafts = groupedDrafts.toMerge.toSeq
-        sequence(drafts) {
+        traverse(drafts) {
           case (name, seq) =>
             merge(nodeInfo, agent.agentType, mode, seq.toList)
         }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/AgentSpecificLogic.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/AgentSpecificLogic.scala
@@ -42,7 +42,7 @@ import com.normation.inventory.domain.Bsd
 import com.normation.inventory.domain.Linux
 import com.normation.rudder.domain.Constants
 import com.normation.rudder.services.policies.NodeRunHook
-import com.normation.utils.Control.sequence
+import com.normation.utils.Control.traverse
 import net.liftweb.common.Box
 import net.liftweb.common.Failure
 import net.liftweb.common.Full
@@ -163,7 +163,7 @@ class AgentRegister {
   def traverseMap[T](
       agentNodeProps: AgentNodeProperties
   )(default:          () => Box[List[T]], f: AgentSpecificGeneration => Box[List[T]]): Box[List[T]] = {
-    (sequence(pipeline) { handler =>
+    (traverse(pipeline) { handler =>
       if (handler.handle(agentNodeProps)) {
         f(handler)
       } else {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/CmdbQueryParser.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/CmdbQueryParser.scala
@@ -41,7 +41,7 @@ import cats.implicits._
 import com.normation.box._
 import com.normation.rudder.domain.queries._
 import com.normation.rudder.services.queries.CmdbQueryParser._
-import com.normation.utils.Control.sequence
+import com.normation.utils.Control.traverse
 import net.liftweb.common._
 import net.liftweb.json._
 import net.liftweb.json.JsonParser.ParseException
@@ -119,7 +119,7 @@ trait DefaultStringQueryParser extends StringQueryParser {
                  case None    => Full(ResultTransformation.Identity)
                  case Some(x) => ResultTransformation.parse(x).toBox
                }
-      lines <- sequence(query.criteria)(parseLine)
+      lines <- traverse(query.criteria)(parseLine)
     } yield {
       Query(query.returnType, comp, trans, lines.toList)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
@@ -113,7 +113,7 @@ class DynGroupUpdaterServiceImpl(
     for {
       allGroups <- roNodeGroupRepository.getAll().toBox
       dynGroups  = allGroups.filter(_.isDynamic)
-      result    <- com.normation.utils.Control.sequence(dynGroups) { group =>
+      result    <- com.normation.utils.Control.traverse(dynGroups) { group =>
                      for {
                        newGroup   <- computeDynGroup(group)
                        savedGroup <-

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchService.scala
@@ -83,7 +83,7 @@ class FullQuickSearchService(implicit
                    s"User query for '${token}', parsed as user query: '${query.userToken}' on objects: " +
                    s"'${query.objectClass.mkString(", ")}' and attributes '${query.attributes.mkString(", ")}'"
                  )
-      results <- sequence(QSBackend.all.toSeq) { b =>
+      results <- traverse(QSBackend.all.toSeq) { b =>
                    val res = b.search(query)
                    res match {
                      case eb: EmptyBox =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -59,7 +59,7 @@ import com.normation.rudder.reports.execution.AgentRunId
 import com.normation.rudder.reports.execution.RoReportsExecutionRepository
 import com.normation.rudder.repository._
 import com.normation.rudder.services.nodes.NodeInfoService
-import com.normation.utils.Control.sequence
+import com.normation.utils.Control.traverse
 import com.normation.zio._
 import net.liftweb.common._
 import org.joda.time._
@@ -995,7 +995,7 @@ trait DefaultFindRuleNodeStatusReports extends ReportingService {
     var u1, u2 = 0L
 
     val batchedRunsInfos = runInfos.grouped(jdbcMaxBatchSize).toSeq
-    val result           = sequence(batchedRunsInfos) { runBatch =>
+    val result           = traverse(batchedRunsInfos) { runBatch =>
       val t0          = System.nanoTime()
       /*
        * We want to optimize and only query reports for nodes that we

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
@@ -268,15 +268,15 @@ class CommitAndDeployChangeRequestServiceImpl(
     } yield {
       if (cond) {
         (for {
-          directivesOk  <- sequence(changeRequest.directives.values.toSeq) { changes =>
+          directivesOk  <- traverse(changeRequest.directives.values.toSeq) { changes =>
                              // Only check the directive for now
                              CheckDirective(changes).check(changes.changes.initialState.map(_._2))
                            }
-          groupsOk      <- sequence(changeRequest.nodeGroups.values.toSeq) { changes =>
+          groupsOk      <- traverse(changeRequest.nodeGroups.values.toSeq) { changes =>
                              CheckGroup.check(changes.changes.initialState)
                            }
-          rulesOk       <- sequence(changeRequest.rules.values.toSeq)(changes => CheckRule.check(changes.changes.initialState))
-          globalParamOk <- sequence(changeRequest.globalParams.values.toSeq) { changes =>
+          rulesOk       <- traverse(changeRequest.rules.values.toSeq)(changes => CheckRule.check(changes.changes.initialState))
+          globalParamOk <- traverse(changeRequest.globalParams.values.toSeq) { changes =>
                              CheckGlobalParameter.check(changes.changes.initialState)
                            }
         } yield {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
@@ -529,7 +529,7 @@ class DirectiveApiService2(
       _ <- (for {
              // Two step process, could be simplified
              paramEditor       <- editorService.get(technique.id, newDirective.id.uid, newDirective.parameters)
-             checkedParameters <- sequence(paramEditor.mapValueSeq.toSeq)(checkParameters(paramEditor))
+             checkedParameters <- traverse(paramEditor.mapValueSeq.toSeq)(checkParameters(paramEditor))
            } yield { checkedParameters.toMap }) ?~ (s"Error with directive Parameters")
 
       saveDiff <- writeDirective
@@ -670,7 +670,7 @@ class DirectiveApiService2(
       newParameters   <- (for {
                            // Two step process, could be simplified
                            paramEditor       <- editorService.get(updatedTechniqueId, directiveId, updatedDirective.parameters)
-                           checkedParameters <- sequence(paramEditor.mapValueSeq.toSeq)(checkParameters(paramEditor))
+                           checkedParameters <- traverse(paramEditor.mapValueSeq.toSeq)(checkParameters(paramEditor))
                          } yield { checkedParameters.toMap }) ?~ (s"Error with directive Parameters")
     } yield {
       val beforeState = DirectiveState(oldTechnique, oldDirective)
@@ -809,7 +809,7 @@ class DirectiveApiService14(
         _     <- (for {
                    // Two step process, could be simplified
                    paramEditor       <- editorService.get(technique.id, newDirective.id.uid, newDirective.parameters)
-                   checkedParameters <- sequence(paramEditor.mapValueSeq.toSeq)(checkParameters(paramEditor))
+                   checkedParameters <- traverse(paramEditor.mapValueSeq.toSeq)(checkParameters(paramEditor))
                  } yield { checkedParameters.toMap }).toIO.chainError(s"Error with directive Parameters")
         saved <- writeDirective
                    .saveDirective(activeTechnique.id, newDirective, modId, actor, params.reason)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -66,7 +66,7 @@ import com.normation.rudder.services.servers.PolicyServerManagementService
 import com.normation.rudder.services.servers.RelaySynchronizationMethod
 import com.normation.rudder.services.servers.RelaySynchronizationMethod._
 import com.normation.utils.Control.bestEffort
-import com.normation.utils.Control.sequence
+import com.normation.utils.Control.traverse
 import com.normation.utils.StringUuidGenerator
 import com.normation.zio._
 import net.liftweb.common.Box
@@ -929,7 +929,7 @@ class SettingsApi(
         networks <- if (req.json_?) {
                       req.json.getOrElse(JNothing) \ "allowed_networks" match {
                         case JArray(values) =>
-                          sequence(values) {
+                          traverse(values) {
                             _ match {
                               case JString(s) => checkAllowedNetwork(s)
                               case x          => Failure(s"Error extracting a string from json: '${x}'")
@@ -1025,7 +1025,7 @@ class SettingsApi(
         _        <- if (json == JNothing) Failure(msg) else Full(())
         diff     <- try { Full(json.extract[AllowedNetDiff]) }
                     catch { case NonFatal(ex) => Failure(msg) }
-        _        <- sequence(diff.add)(checkAllowedNetwork)
+        _        <- traverse(diff.add)(checkAllowedNetwork)
         // for now, we use inet as the name, too
         nets      = diff.add.map(inet => AllowedNetwork(inet, inet))
         res      <- policyServerManagementService.updateAllowedNetworks(nodeId, nets, diff.delete, modificationId, actor).toBox

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/Section2FieldService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/Section2FieldService.scala
@@ -40,7 +40,7 @@ package com.normation.rudder.web.services
 import com.normation.cfclerk.domain._
 import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.web.model._
-import com.normation.utils.Control.sequence
+import com.normation.utils.Control.traverse
 import net.liftweb.common._
 
 /**
@@ -101,7 +101,7 @@ class Section2FieldService(val fieldFactory: DirectiveFieldFactory, val translat
         case None       => Full("ok")
         case Some(used) =>
           (for {
-            fields <- sequence(used) { id =>
+            fields <- traverse(used) { id =>
                         Box(
                           allFields.get(id)
                         ) ?~! s"Variable '${id}' used by variable '${f.id}' was not found - are you sure all dependant fields are on the same section of the technique?"

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
@@ -54,7 +54,7 @@ import com.normation.rudder.web.services.ComputePolicyMode
 import com.normation.rudder.web.services.CurrentUser
 import com.normation.rudder.web.services.JsTableData
 import com.normation.rudder.web.services.JsTableLine
-import com.normation.utils.Control.sequence
+import com.normation.utils.Control.traverse
 import com.normation.zio._
 import net.liftweb.common._
 import net.liftweb.http._
@@ -469,7 +469,7 @@ class RuleGrid(
 
     rules.map { rule =>
       val trackerVariables: Box[Seq[(Directive, ActiveTechnique, Technique)]] = {
-        sequence(rule.directiveIds.toSeq) { id =>
+        traverse(rule.directiveIds.toSeq) { id =>
           directivesLib.allDirectives.get(id) match {
             case Some((activeTechnique, directive)) =>
               techniqueRepository.getLastTechniqueByName(activeTechnique.techniqueName) match {
@@ -489,7 +489,7 @@ class RuleGrid(
         }
       }
 
-      val targetsInfo = sequence(rule.targets.toSeq) {
+      val targetsInfo = traverse(rule.targets.toSeq) {
         case json: CompositeRuleTarget =>
           val ruleTargetInfo = RuleTargetInfo(json, "", "", true, false)
           Full(ruleTargetInfo)

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/Control.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/Control.scala
@@ -20,6 +20,7 @@
 
 package com.normation.utils
 
+import cats.Applicative
 import net.liftweb.common._
 
 /**
@@ -29,35 +30,27 @@ import net.liftweb.common._
  */
 object Control {
 
+  import cats.syntax.traverse._
+
+  private implicit val boxApplicative: Applicative[Box] = new Applicative[Box] {
+    override def pure[A](x: A): Box[A] = Full(x)
+
+    override def ap[A, B](ff: Box[A => B])(fa: Box[A]): Box[B] = ff.flatMap(f => fa.map(f))
+  }
+
   /**
    * Instance of the application function to Iterable and Box.
    * Transform a TraversableOnce[Box] into a Box[Iterable]
    * note: I don't how to say T<:TravesableOnce , T[Box[U]] => Box[T[U]]
    */
-  def boxSequence[U](seq: Seq[Box[U]]): Box[Seq[U]] = {
-    val buf = scala.collection.mutable.Buffer[U]()
-    seq.foreach {
-      case Full(u) => buf += u
-      case e: EmptyBox => return e
-    }
-    Full(buf.toSeq)
-  }
+  def sequence[U](seq: Seq[Box[U]]): Box[Seq[U]] = seq.sequence
 
   /**
    * Iter on all elements of seq, applying f to each one of them.
-   * If the result of f is Full, continue, else abort the procesing,
+   * If the result of f is Full, continue, else abort the processing,
    * returning the Empty or Failure.
    */
-  def sequence[U, T](seq: Seq[U])(f: U => Box[T]): Box[Seq[T]] = {
-    val buf = scala.collection.mutable.Buffer[T]()
-    seq.foreach { u =>
-      f(u) match {
-        case e: EmptyBox => return e
-        case Full(x) => buf += x
-      }
-    }
-    Full(buf.toSeq)
-  }
+  def traverse[U, T](seq: Seq[U])(f: U => Box[T]): Box[Seq[T]] = seq.traverse(f)
 
   /**
    * A version of sequence that will try to reach the end and accumulate

--- a/webapp/sources/utils/src/test/scala/com/normation/utils/TestControl.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/utils/TestControl.scala
@@ -20,7 +20,7 @@
 
 package com.normation.utils
 
-import Control.sequence
+import Control.traverse
 import net.liftweb.common._
 import org.junit._
 import org.junit.runner.RunWith
@@ -34,13 +34,13 @@ class TestControl {
 
   @Test
   def stopSequenceInOrder(): Unit = {
-    val res = sequence(l)(i => if (i % 4 == 0) Failure(msg(i)) else Full(i))
+    val res = traverse(l)(i => if (i % 4 == 0) Failure(msg(i)) else Full(i))
     assert(res == Failure(msg(4)), "Non parallele sequence traversal should process element in order and failed on first error")
   }
 
   @Test
   def validSequenceKeepOrder(): Unit = {
-    val res = sequence(l)(i => Full(i + 10))
+    val res = traverse(l)(i => Full(i + 10))
     l.zip(res.openOrThrowException("Should succeed!")).foreach {
       case (i, j) => assert(i + 10 == j, s"Non parallele sequence traversal should keep order, but ${i}+10 != ${j}")
     }


### PR DESCRIPTION
…orted in Scala 3

	By the way, sequence has been renamed to traverse and boxSequence to sequence
	because it's how these concepts are called in the community.

	Early exit has been eliminated by ... plug-in cats