### PR TITLE
Fixes #23947: Directive compliance page loads infinitely

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/ComponentDirectiveEditForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/ComponentDirectiveEditForm.html
@@ -93,7 +93,7 @@
           <a data-bs-toggle="tab" data-bs-target="#rulesTab" type="button" role="tab">Target rules</a>
         </li>
         <li role="presentation" class="ui-tabs-tab ui-tab" id="complianceNav">
-          <a data-bs-toggle="tab" data-bs-target="#complianceTab" type="button" role="tab">Compliance</a>
+          <a id="#complianceLinkTab" data-bs-toggle="tab" data-bs-target="#complianceTab" type="button" role="tab">Compliance</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
https://issues.rudder.io/issues/23947

The `id` was deleted in the [bootstrap 5 upgrade](https://github.com/Normation/rudder/pull/5169/files#diff-bd1e6a527605fee54932f2d475c7ed5f1428a5ae0dbd4cccbea39b9054b84af8L96)