### PR TITLE
Fixes #22197: We can accept a node with an existing hostname even if node_accept_duplicated_hostname is false

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
@@ -885,15 +885,6 @@ class AcceptHostnameAndIp(
    * Only return existing hostname (and so again, we want that to be empty)
    */
   private[this] def queryForDuplicateHostname(hostnames: Seq[String]): Box[Unit] = {
-    def failure(duplicates: Seq[String], name: String) = {
-      Failure(
-        "There is already a node with %s %s in database. You can not add it again.".format(
-          name,
-          duplicates.mkString("'", "' or '", "'")
-        )
-      )
-    }
-
     val hostnameCriterion = hostnames.toList.map { h =>
       CriterionLine(
         objectType = objectType,
@@ -909,13 +900,9 @@ class AcceptHostnameAndIp(
       // if not, we don't group them that the duplicate appears in the list
       noDuplicatesH <- if (duplicatesH.isEmpty) Full({})
                        else {
-                         // get the hostname from nodeInfoService
-                         for {
-                           nodesInfo <- nodeInfoService.getNodeInfosSeq(duplicatesH).toBox
-                           hostnames  = nodesInfo.map(ni => ni.hostname)
-                         } yield {
-                           failure(hostnames, "Hostname")
-                         }
+                         Failure(
+                           s"There is already a ${duplicatesH.size} node(s) with hostname '${name}' in Rudder. You can not add it again."
+                         )
                        }
     } yield {}
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
@@ -900,7 +900,8 @@ class AcceptHostnameAndIp(
       // if not, we don't group them that the duplicate appears in the list
       noDuplicatesH <- if (duplicatesH.isEmpty) Full({})
                        else {
-                         val startMessage = if (duplicates.size >= 2) { "There are already ${duplicatesH.size} nodes" } { "There is already a node" }
+                         val startMessage =
+                           if (duplicatesH.size >= 2) "There are already ${duplicatesH.size} nodes" else "There is already a node"
                          Failure(
                            s"${startMessage} with hostname '${name}' in Rudder. You can not add it again."
                          )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
@@ -900,8 +900,9 @@ class AcceptHostnameAndIp(
       // if not, we don't group them that the duplicate appears in the list
       noDuplicatesH <- if (duplicatesH.isEmpty) Full({})
                        else {
+                         val startMessage = if (duplicates.size >= 2) { "There are already ${duplicatesH.size} nodes" } { "There is already a node" }
                          Failure(
-                           s"There is already a ${duplicatesH.size} node(s) with hostname '${name}' in Rudder. You can not add it again."
+                           s"${startMessage} with hostname '${name}' in Rudder. You can not add it again."
                          )
                        }
     } yield {}

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2915,11 +2915,11 @@ object RudderConfigInit {
     lazy val newNodeManagerImpl = {
       // the sequence of unit process to accept a new inventory
       val unitAcceptors = {
+        acceptHostnameAndIp ::
         historizeNodeStateOnChoice ::
         updateFactRepoOnChoice ::
         acceptNodeAndMachineInNodeOu ::
         acceptInventory ::
-        acceptHostnameAndIp ::
         Nil
       }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/22197

Not sure what happened in the last refactoring, but here, the failure was yield (as a `Full(Failure(..))` in place of being flatMapped. 

Also: I remove the possibility to write several time the hostname, we know they are all the same, since that's what we are checking. 

Finaly, move that check in first place, because it's really useless to move into accepted, then rollback into pending if the hostname is duplicated: just start by checking if it's ok or not to move. 