### PR TITLE
Fixes #23402: In quicksearch, query error are not displayed which leads to infinite loading result

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchQueryParser.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchQueryParser.scala
@@ -98,8 +98,8 @@ object QSRegexQueryParser {
         val in = filters.collect { case FilterAttr(set) => set }.flatten
 
         (for {
-          o <- getObjects(is.toSet) chainError ("Check 'is' filters")
-          a <- getAttributes(in.toSet) chainError ("Check 'in' filters")
+          o <- getObjects(is.toSet) chainError ("The 'is' filter(s) contain unknown value(s)")
+          a <- getAttributes(in.toSet) chainError ("The 'in' filter(s) contain unknown value(s)")
         } yield {
           val (objs, oKeys)  = o
           val (attrs, aKeys) = a
@@ -115,13 +115,7 @@ object QSRegexQueryParser {
             if (attrs.isEmpty) { QSAttribute.all }
             else { attrs }
           )
-        }) chainError {
-          val allNames = (
-            QSMapping.objectNameMapping.keys.map(_.capitalize)
-              ++ QSMapping.attributeNameMapping.keys
-          ).toSeq.sorted.mkString("', '")
-          s"Query containts unknown filter. Please choose among '${allNames}'"
-        }
+        })
     }
   }
 
@@ -233,7 +227,9 @@ object QSRegexQueryParser {
     if (keys == names) {
       Right((values, keys))
     } else {
-      Left(Unexpected(s"Some filters are not know: ${names -- keys}"))
+      Left(Unexpected(s"These filters are not known: [${(names -- keys).mkString("', '")}]")) chainError {
+        s"Please choose among: '${map.keys.mkString("', '")}'"
+      }
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestQuicksearch.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestQuicksearch.scala
@@ -37,6 +37,7 @@
 
 package com.normation.rudder.rest.internal
 
+import com.normation.box._
 import com.normation.rudder.AuthorizationType
 import com.normation.rudder.UserService
 import com.normation.rudder.domain.nodes.NodeGroupUid
@@ -94,9 +95,9 @@ class RestQuicksearch(
           // Should not happen, but for now make one token from it, maybe we should only take head ?
           case Some(values)       => values.mkString("")
         }
-        quicksearch.search(token) match {
+        quicksearch.search(token).toBox match {
           case eb: EmptyBox =>
-            val e = eb ?~! s"Error when looking for object containing ${token}"
+            val e = eb ?~! s"Error when looking for object containing '${token}'"
             toJsonError(None, e.messageChain)
 
           case Full(results) =>

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/QuickSearch/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/QuickSearch/ApiCalls.elm
@@ -1,7 +1,8 @@
 module QuickSearch.ApiCalls exposing (..)
 
 
-import Http exposing (expectJson, get, request)
+import Http exposing (get)
+import Http.Detailed as Detailed
 import Json.Decode exposing (at, list)
 import QuickSearch.Datatypes exposing (..)
 import QuickSearch.JsonDecoder exposing (decoderResult)
@@ -24,7 +25,7 @@ getSearchResult model search =
     req =
       get
         { url     = getUrl model search
-        , expect  = expectJson GetResults (at ["data"] (list decoderResult))
+        , expect  = Detailed.expectJson GetResults (at ["data"] (list decoderResult))
         }
   in
     req

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/QuickSearch/Datatypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/QuickSearch/Datatypes.elm
@@ -1,9 +1,9 @@
 module QuickSearch.Datatypes exposing (..)
 
-
-
 import Debounce exposing (Debounce)
-import Http exposing (Error)
+import Http
+import Http.Detailed
+
 type alias Model =
   { search : String,
     results : List SearchResult,
@@ -44,7 +44,7 @@ type State = Opened | Searching | Closed
 
 type Msg = UpdateFilter Filter
   | UpdateSearch String
-  | GetResults (Result Error (List SearchResult))
+  | GetResults (Result (Http.Detailed.Error String) (Http.Metadata, List SearchResult))
   | DebounceMsg Debounce.Msg
   | Close
   | Open

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/QuickSearch/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/QuickSearch/JsonDecoder.elm
@@ -2,6 +2,9 @@ module QuickSearch.JsonDecoder exposing (..)
 
 import Json.Decode exposing (..)
 import Json.Decode.Pipeline exposing (..)
+import List exposing (drop, head)
+import String exposing (join, split)
+
 import QuickSearch.Datatypes exposing (..)
 
 
@@ -41,3 +44,17 @@ decoderType =
           _ -> fail ("'" ++ v ++ "' is not valid quicksearch result type")
       )
 
+
+decodeErrorDetails : String -> (String, String)
+decodeErrorDetails json =
+  let
+    errorMsg = decodeString (Json.Decode.at ["errorDetails"] string) json
+    msg = case errorMsg of
+      Ok s -> s
+      Err e -> "fail to process errorDetails"
+    errors = split "<-" msg
+    title = head errors
+  in
+  case title of
+    Nothing -> ("" , "")
+    Just s -> (s , (join " \n " (drop 1 (List.map (\err -> "\t ‣ " ++ err) errors))))

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/QuickSearch/Port.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/QuickSearch/Port.elm
@@ -1,0 +1,3 @@
+port module QuickSearch.Port exposing (..)
+
+port errorNotification : String -> Cmd msg

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-elm.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-elm.js
@@ -29,4 +29,7 @@ $(document).ready(function(){
     node  : appNode,
     flags : flags
   });
+  appQuicksearch.ports.errorNotification.subscribe(function (str) {
+    createErrorNotification(str);
+  });
 });


### PR DESCRIPTION
https://issues.rudder.io/issues/23402

This formats errors as a nicer message for the user. There is a caveat when doing error transformation from `PureResult` (`Either`s) to `Box`, which is still the "effect type" in this API : if `.toBox` is not used at the end, we will end up with a exception cause message being serialized with both `err1; cause was : err2` and `err2 <- err3` formats...


![Screenshot from 2023-12-28 18-32-30](https://github.com/Normation/rudder/assets/65616064/add20745-cfcc-4e5c-9578-0004fca713b4)
