### PR TITLE
Fixes #23961: Display of related rules for groups should avoid detailing compliance

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -1310,13 +1310,13 @@ class MockRules() {
       "rulecopyGitFile",
       "90-copy-git-file",
       rootRuleCategory.id,
-      Set(AllTarget),
+      Set(GroupTarget(NodeGroupId(NodeGroupUid("1111f5d3-8c61-4d20-88a7-bb947705ba8a")))), // g1 in MockNodeGroups
       Set(DirectiveId(DirectiveUid("directive-copyGitFile"))),
       "ncf technique rule",
       "",
       true,
       false,
-      NoTags() // long desc / enabled / system / tags
+      NoTags()                                                                             // long desc / enabled / system / tags
     )
 
     val gvd1Rule = Rule(

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -750,6 +750,15 @@ object RuleInternalApi       extends ApiModuleProvider[RuleInternalApi]         
     val (action, path)         = GET / "rulesinternal" / "nodesanddirectives" / "{id}"
     override def dataContainer = None
   }
+
+  // For group page
+  final case object GetGroupRelatedRules extends RuleInternalApi with ZeroParam with StartsAtVersion14 with SortIndex {
+    val z                      = implicitly[Line].value
+    val description            = "List all info of rules in a tree format"
+    val (action, path)         = GET / "rulesinternal" / "relatedtree"
+    override def dataContainer = None
+  }
+
   def endpoints = ca.mrvisser.sealerate.values[RuleInternalApi].toList.sortBy(_.z)
 
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
@@ -3,9 +3,10 @@ package com.normation.rudder.rest.internal
 import com.normation.errors.EitherToIoResult
 import com.normation.errors.IOResult
 import com.normation.rudder.api.ApiVersion
-import com.normation.rudder.apidata.JsonResponseObjects.JRRuleNodesDirectives
+import com.normation.rudder.apidata.JsonResponseObjects._
 import com.normation.rudder.apidata.implicits._
 import com.normation.rudder.domain.logger.TimingDebugLoggerPure
+import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.facts.nodes.NodeFactRepository
 import com.normation.rudder.facts.nodes.QueryContext
@@ -15,17 +16,18 @@ import com.normation.rudder.rest.{RuleInternalApi => API}
 import com.normation.rudder.rest.ApiPath
 import com.normation.rudder.rest.AuthzToken
 import com.normation.rudder.rest.implicits._
-import com.normation.rudder.rest.lift.DefaultParams
-import com.normation.rudder.rest.lift.LiftApiModule
-import com.normation.rudder.rest.lift.LiftApiModuleProvider
-import com.normation.rudder.rest.lift.LiftApiModuleString
+import com.normation.rudder.rest.lift._
+import com.normation.rudder.rule.category.RoRuleCategoryRepository
+import com.normation.rudder.rule.category.RuleCategory
+import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.zio.currentTimeMillis
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
 import zio.syntax._
 
 class RulesInternalApi(
-    ruleInternalApiService: RuleInternalApiService
+    ruleInternalApiService: RuleInternalApiService,
+    ruleApiService:         RuleApiService14
 ) extends LiftApiModuleProvider[API] {
 
   def schemas = API
@@ -34,6 +36,7 @@ class RulesInternalApi(
     API.endpoints.map(e => {
       e match {
         case API.GetRuleNodesAndDirectives => GetRuleNodesAndDirectives
+        case API.GetGroupRelatedRules      => GetGroupRelatedRules
       }
     })
   }
@@ -58,12 +61,37 @@ class RulesInternalApi(
       } yield r).toLiftResponseOne(params, schema, s => Some(s.id))
     }
   }
+
+  object GetGroupRelatedRules extends LiftApiModule0 {
+    val schema = API.GetGroupRelatedRules
+
+    /**
+      * Request takes an optional query parameter list to filter rules in the tree
+      * If the parameter is not present, all rules are returned.
+      * All passed invalid or non existing rule ids are ignored.
+      */
+    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      val ruleIdsFilter      = req.params
+        .get("rules")
+        .map(
+          _.flatMap(seq => seq.split(',').map(_.strip()))
+            .flatMap(RuleId.parse(_).toOption)
+        )
+      val getMissingCategory = ruleApiService.getMissingCategories _
+      (for {
+        r <- ruleInternalApiService
+               .getGroupRelatedRules(ruleIdsFilter, getMissingCategory, ruleApiService.MISSING_RULE_CAT_ID)
+      } yield r).toLiftResponseOne(params, schema, _ => None)
+    }
+  }
+
 }
 
 class RuleInternalApiService(
-    readRule:  RoRuleRepository,
-    readGroup: RoNodeGroupRepository,
-    readNodes: NodeFactRepository
+    readRule:         RoRuleRepository,
+    readGroup:        RoNodeGroupRepository,
+    readRuleCategory: RoRuleCategoryRepository,
+    readNodes:        NodeFactRepository
 ) {
   def GetRuleNodesAndDirectives(id: RuleId)(implicit qc: QueryContext): IOResult[JRRuleNodesDirectives] = {
     for {
@@ -90,4 +118,33 @@ class RuleInternalApiService(
       JRRuleNodesDirectives.fromData(id, nodesIds, rule.directiveIds.size)
     }
   }
+
+  def getGroupRelatedRules(
+      ruleIdsFilter:        Option[Seq[RuleId]], // optional list of rule ids to filter the tree with
+      getMissingCategories: (RuleCategory, List[Rule]) => Set[RuleCategory],
+      missingCatId:         RuleCategoryId
+  ): IOResult[JRCategoriesRootEntryInfo] = {
+    for {
+      root              <- readRuleCategory.getRootCategory()
+      rules             <- ruleIdsFilter match {
+                             case None      => readRule.getAll()
+                             case Some(ids) => readRule.getAll().map(_.filter(r => ids.contains(r.id)))
+                           }
+      missingCatContent  = getMissingCategories(root, rules.toList)
+      missingCategory    = RuleCategory(
+                             missingCatId,
+                             "Rules with a missing/deleted category",
+                             "Category that regroup all the missing categories",
+                             missingCatContent.toList
+                           )
+      newChilds          = if (missingCatContent.isEmpty) root.childs else root.childs :+ missingCategory
+      rootAndMissingCat  = root.copy(childs = newChilds)
+      rulesMapByCategory = rules.groupBy(_.categoryId)
+    } yield {
+      JRCategoriesRootEntryInfo(
+        JRRuleCategoryInfo.fromCategory(rootAndMissingCat, rulesMapByCategory, Some(rootAndMissingCat.id.value))
+      )
+    }
+  }
+
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -862,7 +862,7 @@ class RuleApiService14(
 ) {
 
   // this Id is special and use client side to identify missing rules
-  private val MISSING_RULE_CAT_ID = RuleCategoryId("ui-missing-rule-category")
+  val MISSING_RULE_CAT_ID = RuleCategoryId("ui-missing-rule-category")
 
   private def createChangeRequest(
       diff:      ChangeRequestRuleDiff,

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_rules.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_rules.yml
@@ -126,12 +126,12 @@ response:
             "shortDescription":"ncf technique rule",
             "longDescription":"",
             "directives":["directive-copyGitFile"],
-            "targets":["special:all"],
+            "targets":["group:1111f5d3-8c61-4d20-88a7-bb947705ba8a"],
             "enabled":true,
             "system":false,
             "tags":[],
             "policyMode":"enforce",
-            "status":{"value":"Not applied","details":"Directive 'directive-copyGitFile' disabled"}
+            "status":{"value":"Not applied","details":"Empty groups, Directive 'directive-copyGitFile' disabled"}
           }
         ]
       }
@@ -827,19 +827,19 @@ response:
               "tags":[],
               "policyMode":"enforce",
               "status":{"value":"Not applied","details":"Directive 'directive2' disabled"}
-            },{
-              "id":"rulecopyGitFile",
+          },{
+            "id":"rulecopyGitFile",
               "displayName":"90-copy-git-file",
               "categoryId":"rootRuleCategory",
               "shortDescription":"ncf technique rule",
               "longDescription":"",
               "directives":["directive-copyGitFile"],
-              "targets":["special:all"],
+              "targets":["group:1111f5d3-8c61-4d20-88a7-bb947705ba8a"],
               "enabled":true,
               "system":false,
               "tags":[],
               "policyMode":"enforce",
-              "status":{"value":"Not applied","details":"Directive 'directive-copyGitFile' disabled"}
+              "status":{"value":"Not applied","details":"Empty groups, Directive 'directive-copyGitFile' disabled"}
             }
           ]
         }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_rulesinternal.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_rulesinternal.yml
@@ -1,0 +1,192 @@
+---
+description: List all info of rules related to a group in a tree format
+method: GET
+url: /secure/api/rulesinternal/relatedtree
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getGroupRelatedRules",
+      "result" : "success",
+      "data" : {
+        "ruleCategories" : {
+          "id" : "rootRuleCategory",
+          "name" : "Rules",
+          "description" : "This is the main category of Rules",
+          "parent" : "rootRuleCategory",
+          "categories" : [
+            {
+              "id" : "category1",
+              "name" : "Category 1",
+              "description" : "description of category 1",
+              "parent" : "rootRuleCategory",
+              "categories" : [
+                {
+                  "id" : "d882961b-279a-4ba5-0001-5198eaf00d35",
+                  "name" : "category 3 update",
+                  "description" : "category 3",
+                  "parent" : "category1",
+                  "categories" : [],
+                  "rules" : []
+                },
+                {
+                  "id" : "d882961b-279a-4ba5-b755-5198eaf00d35",
+                  "name" : "category 2 update",
+                  "description" : "category 2",
+                  "parent" : "category1",
+                  "categories" : [],
+                  "rules" : []
+                }
+              ],
+              "rules" : []
+            }
+          ],
+          "rules" : [
+            {
+              "id" : "00000000-cb9d-4f7b-0001-ca38c5d643ea",
+              "displayName" : "clonefromapiof50-rule-technique-ncf",
+              "categoryId" : "rootRuleCategory",
+              "shortDescription" : "notandncftechniquerule",
+              "longDescription" : "Somelongdescription",
+              "enabled" : true,
+              "tags" : [
+                {
+                  "customer" : "MyCompany"
+                }
+              ]
+            },
+            {
+              "id" : "00000000-cb9d-4f7b-abda-ca38c5d643ea",
+              "displayName" : "clonefromapiof50-rule-technique-ncf",
+              "categoryId" : "rootRuleCategory",
+              "shortDescription" : "notandncftechniquerule",
+              "longDescription" : "Somelongdescription",
+              "enabled" : true,
+              "tags" : [
+                {
+                  "customer" : "MyCompany"
+                }
+              ]
+            },
+            {
+              "id" : "208716db-2675-43b9-ab57-bfbab84346aa",
+              "displayName" : "50-rule-technique-ncf",
+              "categoryId" : "rootRuleCategory",
+              "shortDescription" : "ncftechniquerule",
+              "longDescription" : "",
+              "enabled" : true,
+              "tags" : [
+                {
+                  "datacenter" : "Paris"
+                },
+                {
+                  "serverType" : "webserver"
+                }
+              ]
+            },
+            {
+              "id" : "ff44fb97-b65e-43c4-b8c2-000000000000",
+              "displayName" : "99-rule-technique-std-lib",
+              "categoryId" : "rootRuleCategory",
+              "shortDescription" : "updatedcopyofdefaultrule",
+              "longDescription" : "",
+              "enabled" : true,
+              "tags" : []
+            },
+            {
+              "id" : "ff44fb97-b65e-43c4-b8c2-0df8d5e8549f",
+              "displayName" : "60-rule-technique-std-lib",
+              "categoryId" : "rootRuleCategory",
+              "shortDescription" : "defaultrule",
+              "longDescription" : "",
+              "enabled" : true,
+              "tags" : []
+            },
+            {
+              "id" : "rule1",
+              "displayName" : "10.Globalconfigurationforallnodes",
+              "categoryId" : "rootRuleCategory",
+              "shortDescription" : "globalconfigforallnodes",
+              "longDescription" : "",
+              "enabled" : true,
+              "tags" : []
+            },
+            {
+              "id" : "rule2",
+              "displayName" : "50.DeployPLOPSTACK",
+              "categoryId" : "rootRuleCategory",
+              "shortDescription" : "globalconfigforallnodes",
+              "longDescription" : "",
+              "enabled" : true,
+              "tags" : []
+            },
+            {
+              "id" : "rulecopyGitFile",
+              "displayName" : "90-copy-git-file",
+              "categoryId" : "rootRuleCategory",
+              "shortDescription" : "ncftechniquerule",
+              "longDescription" : "",
+              "enabled" : true,
+              "tags" : []
+            }
+          ]
+        }
+      }
+    }
+---
+description: List all info of rules related to a group in a tree format with a filter
+method: GET
+url: /secure/api/rulesinternal/relatedtree?rules=rulecopyGitFile
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getGroupRelatedRules",
+      "result" : "success",
+      "data" : {
+        "ruleCategories" : {
+          "id" : "rootRuleCategory",
+          "name" : "Rules",
+          "description" : "This is the main category of Rules",
+          "parent" : "rootRuleCategory",
+          "categories" : [
+            {
+              "id" : "category1",
+              "name" : "Category 1",
+              "description" : "description of category 1",
+              "parent" : "rootRuleCategory",
+              "categories" : [
+                {
+                  "id" : "d882961b-279a-4ba5-0001-5198eaf00d35",
+                  "name" : "category 3 update",
+                  "description" : "category 3",
+                  "parent" : "category1",
+                  "categories" : [],
+                  "rules" : []
+                },
+                {
+                  "id" : "d882961b-279a-4ba5-b755-5198eaf00d35",
+                  "name" : "category 2 update",
+                  "description" : "category 2",
+                  "parent" : "category1",
+                  "categories" : [],
+                  "rules" : []
+                }
+              ],
+              "rules" : []
+            }
+          ],
+          "rules" : [
+            {
+              "id" : "rulecopyGitFile",
+              "displayName" : "90-copy-git-file",
+              "categoryId" : "rootRuleCategory",
+              "shortDescription" : "ncftechniquerule",
+              "longDescription" : "",
+              "enabled" : true,
+              "tags" : []
+            }
+          ]
+        }
+      }
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -102,6 +102,8 @@ import com.normation.rudder.repository._
 import com.normation.rudder.rest.data.Creation
 import com.normation.rudder.rest.data.Creation.CreationError
 import com.normation.rudder.rest.data.NodeSetup
+import com.normation.rudder.rest.internal.RuleInternalApiService
+import com.normation.rudder.rest.internal.RulesInternalApi
 import com.normation.rudder.rest.lift._
 import com.normation.rudder.rest.v1.RestStatus
 import com.normation.rudder.rule.category.RuleCategoryService
@@ -633,14 +635,14 @@ class RestTestSetUp {
     restDataSerializer
   )
 
-  val ruleCategoryService = new RuleCategoryService()
-  val ruleApiService6     = new RuleApiService6(
+  val ruleCategoryService    = new RuleCategoryService()
+  val ruleApiService6        = new RuleApiService6(
     mockRules.ruleCategoryRepo,
     mockRules.ruleRepo,
     mockRules.ruleCategoryRepo,
     restDataSerializer
   )
-  val ruleApiService14    = new RuleApiService14(
+  val ruleApiService14       = new RuleApiService14(
     mockRules.ruleRepo,
     mockRules.ruleRepo,
     mockConfigRepo.configurationRepository,
@@ -654,6 +656,12 @@ class RestTestSetUp {
     mockNodes.nodeFactRepo,
     () => GlobalPolicyMode(Enforce, Always).succeed,
     new RuleApplicationStatusServiceImpl()
+  )
+  val ruleInternalApiService = new RuleInternalApiService(
+    mockRules.ruleRepo,
+    mockNodeGroups.groupsRepo,
+    mockRules.ruleCategoryRepo,
+    mockNodes.nodeFactRepo
   )
 
   val fieldFactory           = new DirectiveFieldFactory {
@@ -908,6 +916,7 @@ class RestTestSetUp {
       directiveApiService14
     ),
     new RuleApi(restExtractorService, zioJsonExtractor, ruleApiService2, ruleApiService6, ruleApiService14, uuidGen),
+    new RulesInternalApi(ruleInternalApiService, ruleApiService14),
     new NodeApi(
       restExtractorService,
       restDataSerializer,

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/ApiCalls.elm
@@ -1,0 +1,27 @@
+module GroupRelatedRules.ApiCalls exposing (..)
+
+import Http exposing (..)
+import Url.Builder exposing (QueryParameter, string)
+
+import GroupRelatedRules.DataTypes exposing (..)
+import GroupRelatedRules.JsonDecoder exposing (..)
+
+getUrl: Model -> List String -> List QueryParameter -> String
+getUrl m url p=
+  Url.Builder.relative (m.contextPath :: "secure" :: "api"  :: url) p
+
+getRulesTree : Model -> RelatedRules -> Cmd Msg
+getRulesTree model relatedRules =
+  let
+    req =
+      request
+        { method  = "GET"
+        , headers = []
+        , url     = getUrl model [ "rulesinternal", "relatedtree" ] [string "rules" (String.join "," (List.map (.value) relatedRules.value))]
+        , body    = emptyBody
+        , expect  = expectJson (GetRulesResult relatedRules) decodeGetRulesTree
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+  in
+    req

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/DataTypes.elm
@@ -1,0 +1,78 @@
+module GroupRelatedRules.DataTypes exposing (..)
+
+import Http exposing (Error)
+import Rules.DataTypes exposing (Msg(..))
+
+-- All our data types
+--
+
+type alias GroupId      = { value : String }
+type alias RuleId       = { value : String }
+type alias DirectiveId  = { value : String }
+type alias RelatedRules = { value : List RuleId }
+
+type alias Category a =
+  { id          : String
+  , name        : String
+  , description : String
+  , subElems    : SubCategories a
+  , elems       : List a
+  }
+
+
+
+type SubCategories a = SubCategories (List (Category a))
+
+type alias Rule =
+  { id               : RuleId
+  , name             : String
+  , categoryId       : String
+  , enabled          : Bool
+  , tags             : List Tag
+  }
+
+type RuleTarget = Composition RuleTarget RuleTarget | And (List RuleTarget) | Or (List RuleTarget) | NodeGroupId String | Special String | Node String
+
+type alias RuleStatus =
+  { value   : String
+  , details : Maybe String
+  }
+
+type alias RulesMeta = 
+  { includedRules : List RuleId
+  , excludedRules : List RuleId
+  }
+
+type alias UI =
+  { ruleTreeFilters : Filters
+  , isAllCatFold    : Bool
+  , loading         : Bool
+  }
+
+type alias Tag =
+  { key   : String
+  , value : String
+  }
+
+type alias Filters =
+  { filter : String
+  , folded : List String
+  , newTag : Tag
+  , tags   : List Tag
+  }
+
+type alias Model =
+  { rulesMeta   : RulesMeta
+  , contextPath : String
+  , ui          : UI
+  , ruleTree    : Category Rule
+  }
+
+type ComplianceScope = GlobalCompliance | TargetedCompliance
+
+type Msg
+  = GoTo String
+  | GetRulesResult RelatedRules (Result Error (Category Rule))
+  | LoadRelatedRulesTree (List RuleId)
+  | UpdateRuleFilters Filters
+  | FoldAllCategories Filters

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/Init.elm
@@ -1,0 +1,18 @@
+module GroupRelatedRules.Init exposing (..)
+
+import GroupRelatedRules.ApiCalls exposing (..)
+import GroupRelatedRules.DataTypes exposing (..)
+import GroupRelatedRules.ViewUtils exposing (emptyCategory)
+
+
+init : { contextPath : String, includedRules : List String, excludedRules : List String} -> ( Model, Cmd Msg )
+init flags =
+  let
+    initFilters   = Filters "" [] (Tag "" "") []
+    initUI        = UI initFilters False True
+    initRulesMeta = (RulesMeta (List.map RuleId flags.includedRules) (List.map RuleId flags.excludedRules))
+    initModel     = Model initRulesMeta flags.contextPath initUI emptyCategory
+  in
+    ( initModel
+    , Cmd.none
+    )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/JsonDecoder.elm
@@ -1,0 +1,35 @@
+module GroupRelatedRules.JsonDecoder exposing (..)
+
+import Json.Decode exposing (..)
+import Json.Decode.Pipeline exposing (..)
+import GroupRelatedRules.DataTypes exposing (..)
+
+decodeGetRulesTree : Decoder (Category Rule)
+decodeGetRulesTree =
+  at [ "data" , "ruleCategories" ] (decodeCategory "id" "categories" "rules" decodeRule)
+
+decodeCategory : String -> String -> String -> Decoder a -> Decoder (Category a)
+decodeCategory idIdentifier categoryIdentifier elemIdentifier elemDecoder =
+  succeed Category
+    |> required idIdentifier  string
+    |> required "name"        string
+    |> required "description" string
+    |> required categoryIdentifier (map SubCategories  (list (lazy (\_ -> (decodeCategory idIdentifier categoryIdentifier elemIdentifier elemDecoder)))))
+    |> required elemIdentifier      (list elemDecoder)
+
+decodeRule : Decoder Rule
+decodeRule =
+  succeed Rule
+    |> required "id"              (map RuleId string)
+    |> required "displayName"      string
+    |> required "categoryId"       string
+    |> required "enabled"          bool
+    |> required "tags"            (list (keyValuePairs string) |> andThen toTags)
+
+toTags : List (List ( String, String )) -> Decoder (List Tag)
+toTags lst =
+  let
+    concatList = List.concat lst
+  in
+    succeed
+      ( List.map (\t -> Tag (Tuple.first t) (Tuple.second t)) concatList )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/View.elm
@@ -1,0 +1,176 @@
+module GroupRelatedRules.View exposing (..)
+
+import Html exposing (..)
+import Html.Attributes exposing (checked, class, disabled, for, href, id, placeholder, type_, value)
+import Html.Events exposing (onClick)
+import List.Extra
+import NaturalOrdering as N
+import Html.Events exposing (onInput)
+
+import GroupRelatedRules.DataTypes exposing (..)
+import GroupRelatedRules.ViewUtils exposing (..)
+import Rules.DataTypes exposing (missingCategoryId)
+import Maybe.Extra
+import Html.Attributes exposing (style)
+
+view : Model -> Html Msg
+view model =
+  let
+    allMissingCategoriesId = List.map .id (getAllMissingCats model.ruleTree)
+    treeFilters = model.ui.ruleTreeFilters
+    newTag      = treeFilters.newTag
+    ruleTreeElem : Rule -> Html Msg
+    ruleTreeElem item =
+      let
+        (classDisabled, badgeDisabled) = if item.enabled /= True then
+            (" item-disabled", span[ class "badge-disabled"][])
+          else
+            ("", text "")
+      in
+        li [class "jstree-node jstree-leaf"]
+        [ i[class "jstree-icon jstree-ocl"][]
+        , a[class ("jstree-anchor"++classDisabled), href (getRuleLink model.contextPath item.id), onClick (GoTo (getRuleLink model.contextPath item.id))]
+          [ i [class "jstree-icon jstree-themeicon fa fa-sitemap jstree-themeicon-custom"][]
+          , span [class "treeGroupName"]
+            [ badgeIncludedExcluded model item.id
+            , text item.name
+            , badgeDisabled
+            , buildTagsTree item.tags
+            ]
+          ]
+        ]
+
+    ruleTreeCategory : (Category Rule) -> Maybe (Html Msg)
+    ruleTreeCategory item =
+      let
+        missingCat = getSubElems item
+          |> List.filter (\c -> c.id == missingCategoryId)
+          |> List.sortWith (\c1 c2 -> N.compare c1.name c2.name)
+          |> List.filterMap ruleTreeCategory
+
+        categories = getSubElems item
+          |> List.filter (\c -> c.id /= missingCategoryId)
+          |> List.sortWith (\c1 c2 -> N.compare c1.name c2.name)
+          |> List.filterMap ruleTreeCategory
+
+        rules = item.elems
+          |> List.filter (\r -> filterSearch model.ui.ruleTreeFilters.filter (searchFieldRules r model))
+          |> List.filter (\r -> filterTags r.tags model.ui.ruleTreeFilters.tags)
+          |> List.sortWith (\r1 r2 -> N.compare r1.name r2.name)
+          |> List.map ruleTreeElem
+
+        childsList  = ul[class "jstree-children"] (List.concat [categories, rules, missingCat])
+
+        mainMissingCat =
+          if(item.id == missingCategoryId) then
+            " main-missing-cat "
+          else
+            ""
+        icons =
+          if(item.id == missingCategoryId) then
+            " fas fa-exclamation-triangle " ++ mainMissingCat
+          else
+            " fa fa-folder "
+        missingCatClass = if(List.member item.id allMissingCategoriesId) then " missing-cat " else ""
+        treeItem =
+          if item.id /= "rootRuleCategory" then
+            if (String.isEmpty model.ui.ruleTreeFilters.filter && List.isEmpty model.ui.ruleTreeFilters.tags) || ((List.length rules > 0) || (List.length categories > 0)) then
+              Just (
+                li[class ("jstree-node" ++ foldedClass model.ui.ruleTreeFilters item.id)]
+                [ i [class "jstree-icon jstree-ocl", onClick (UpdateRuleFilters (foldUnfoldCategory model.ui.ruleTreeFilters item.id))][]
+                , a [class ("jstree-anchor"), href (getRuleCategoryLink model.contextPath item.id), onClick (GoTo (getRuleCategoryLink model.contextPath item.id))]
+                  [ i [class ("jstree-icon jstree-themeicon jstree-themeicon-custom" ++ icons)][]
+                  , span [class ("treeGroupCategoryName " ++ missingCatClass ++ mainMissingCat)][text item.name]
+                  ]
+                , childsList
+                ]
+              )
+            else
+              Nothing
+          else
+            Just childsList
+      in
+        Maybe.Extra.filter (\_ -> model.ruleTree /= emptyCategory) treeItem
+  
+  in 
+    --TODO: use SCSS variable for "34px" input-group-text height (that's the value for the input form height)
+    div [class "shadow-none col-6 col-md-8 col-lg-7"]
+    [ div [class "template-main-header"]
+      [ div [class "header-title"]
+        [ label[][text "Related rules tree"]
+        ]
+      , div [class "header-filter"]
+        [ div [class "input-group flex-nowrap"]
+          [ button [class "input-group-text btn btn-default", type_ "button", style "height" "34px", onClick (FoldAllCategories model.ui.ruleTreeFilters) ][span [class "fa fa-folder fa-folder-open"][]]
+          , input[type_ "text", value model.ui.ruleTreeFilters.filter ,placeholder "Filter", class "form-control", onInput (\s -> UpdateRuleFilters {treeFilters | filter = s})][]
+          , button [class "input-group-text btn btn-default", type_ "button", style "height" "34px", onClick (UpdateRuleFilters {treeFilters | filter = ""})] [span [class "fa fa-times"][]]
+          ]
+        , label [class "btn btn-default more-filters", for "toggle-filters"][]
+        ]
+      , input [type_ "checkbox", id "toggle-filters", class "toggle-filters", checked True][]
+      , div[class "filters-container"]
+        [ div[]
+          [ div [class "form-group"]
+          [ label[for "tag-key"][text "Tags"]
+          , div [class "input-group flex-nowrap"]
+            [ input[type_ "text", value model.ui.ruleTreeFilters.newTag.key, placeholder "key", class "form-control", id "tag-key", onInput (\s -> UpdateRuleFilters {treeFilters | newTag = {newTag | key = s}})][]
+            , span [class "input-group-text", style "height" "34px"][text " = "] 
+            , input[type_ "text", value model.ui.ruleTreeFilters.newTag.value, placeholder "value", class "form-control", onInput (\s -> UpdateRuleFilters {treeFilters | newTag = {newTag | value = s}})][]
+            , button 
+              [ type_ "button"
+              , class "input-group-text btn btn-default"
+              , onClick ( UpdateRuleFilters {treeFilters | tags = ( Tag (String.trim newTag.key) (String.trim newTag.value) ) :: treeFilters.tags , newTag = Tag "" ""})
+              , disabled ((String.isEmpty newTag.key && String.isEmpty newTag.value) || List.member newTag treeFilters.tags)
+              ] [ span[class "fa fa-plus"][]]
+            ]
+          ]
+        , (if List.isEmpty treeFilters.tags then
+          text ""
+        else
+          div [class "only-tags"]
+          [ button [ class "btn btn-default btn-xs pull-right clear-tags", onClick ( UpdateRuleFilters {treeFilters | tags = []})]
+            [ text "Clear all tags"
+            , i [class "fa fa-trash"][]
+            ]
+          ]
+        )
+        , (if List.isEmpty treeFilters.tags then
+          text ""
+        else
+          div [class "tags-container"]
+          ( List.map (\t ->
+            div [class "btn-group btn-group-xs ng-scope"]
+            [ button [class "btn btn-default tags-label", onClick (UpdateRuleFilters {treeFilters | newTag = {newTag | key = t.key, value = t.value}})]
+              [ i [class "fa fa-tag"][]
+              , span [class "tag-key"]
+                [( if String.isEmpty t.key then i [class "fa fa-asterisk"][] else span[][text t.key] )
+                ]
+              , span [class "tag-separator"][text "="]
+              , span [class "tag-value"]
+                [( if String.isEmpty t.value then i [class "fa fa-asterisk"][] else span[][text t.value] )
+                ]
+              ]
+              , button [class "btn btn-default", type_ "button", onClick ( UpdateRuleFilters {treeFilters | tags = (List.Extra.remove t treeFilters.tags)})][ span [class "fa fa-times"][] ]
+              ]
+          ) treeFilters.tags |> List.reverse)
+        )]
+        ]
+      ]
+    , div []
+      [(
+        if model.ui.loading then
+          generateLoadingList
+        else
+          div [class "jstree jstree-default"]
+          [ ul[class "jstree-container-ul jstree-children"]
+            [(case ruleTreeCategory model.ruleTree of
+              Just html -> html
+              Nothing   -> div [class "alert alert-warning"]
+                [ i [class "fa fa-exclamation-triangle"][]
+                , text  ("No rules " ++ if model.ruleTree == emptyCategory then "is related to the group." else "match your filter.")
+                ]
+            )]
+          ]
+      )]
+    ]
+  

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/ViewUtils.elm
@@ -1,0 +1,206 @@
+module GroupRelatedRules.ViewUtils exposing (..)
+
+import List.Extra
+import Html exposing (..)
+import Html.Attributes exposing (..)
+
+import GroupRelatedRules.DataTypes exposing (..)
+import Rules.DataTypes exposing (missingCategoryId)
+
+emptyCategory : Category a
+emptyCategory =
+  Category "" "" "" (SubCategories []) []
+
+getSubElems: Category a -> List (Category a)
+getSubElems cat =
+  case cat.subElems of
+    SubCategories subs -> subs
+
+
+getAllCats: Category a -> List (Category a)
+getAllCats category =
+  let
+    subElems = case category.subElems of SubCategories l -> l
+  in
+    category :: (List.concatMap getAllCats subElems)
+
+-- get all missing categories
+getAllMissingCats: Category a -> List (Category a)
+getAllMissingCats category =
+  let
+    missingCategory = List.filter (\sub -> sub.id == missingCategoryId) (getSubElems category)
+  in
+  List.concatMap getAllCats missingCategory
+
+filterRuleElemsByIds : List String -> Category Rule -> Category Rule
+filterRuleElemsByIds ids category =
+  let
+    copyCat cat = { cat | elems = List.filter (\e -> List.member e.id.value ids) cat.elems }
+    filteredElems = (copyCat category).elems
+  in
+    case category.subElems of
+      SubCategories subCats ->
+        let
+          newSubCats = List.map (filterRuleElemsByIds ids) subCats
+        in
+          { category | subElems = SubCategories newSubCats, elems = filteredElems }
+
+
+generateLoadingList : Html Msg
+generateLoadingList =
+  ul[class "skeleton-loading"]
+  [ li[style "width" "calc(100% - 25px)"][i[][], span[][]]
+  , li[][i[][], span[][]]
+  , li[style "width" "calc(100% - 95px)"][i[][], span[][]]
+  , ul[]
+    [ li[style "width" "calc(100% - 45px)"][i[][], span[][]]
+    , li[style "width" "calc(100% - 125px)"][i[][], span[][]]
+    , li[][i[][], span[][]]
+    ]
+  , li[][i[][], span[][]]
+  ]
+
+badgeIncludedExcluded : Model -> RuleId -> Html Msg
+badgeIncludedExcluded model ruleId =
+  let
+    isIncluded = List.member ruleId model.rulesMeta.includedRules 
+    isExcluded = List.member ruleId model.rulesMeta.excludedRules
+    msg =
+      -- TODO green red
+      if isIncluded then Just "<div style='margin-bottom:5px;'>This rule is <b style='color:#9bc832;'>included</b> by the group.</div>"
+      else if isExcluded then Just "<div style='margin-bottom:5px;'>This rule is <b style='color:#3694d1;'>excluded</b> by the group.</div>"
+      else Nothing
+    labelClass = if isIncluded then "label-included label-green" else if isExcluded then "label-excluded" else ""
+  in
+    case msg of
+      Just m -> span [class ("treeGroupName rudder-label label-sm " ++ labelClass), attribute "data-bs-toggle" "tooltip", attribute "data-bs-placement" "bottom", title (buildTooltipContent "Included/Excluded" m)][]
+      Nothing -> text ""
+
+buildTooltipContent : String -> String -> String
+buildTooltipContent title content =
+  let
+    headingTag = "<h4 class='tags-tooltip-title'>"
+    contentTag = "</h4><div class='tooltip-inner-content'>"
+    closeTag   = "</div>"
+  in
+    headingTag ++ title ++ contentTag ++ content ++ closeTag
+
+buildTagsTree : List Tag -> Html Msg
+buildTagsTree tags =
+  let
+    nbTags = List.length tags
+
+    tooltipContent : List Tag -> String
+    tooltipContent listTags =
+      buildTooltipContent ("Tags <span class='tags-label'><i class='fa fa-tags'></i><b>"++ (String.fromInt nbTags) ++"</b></span>") (String.concat (List.map (\tt -> buildHtmlStringTag tt) listTags))
+  in
+    if (nbTags > 0) then
+      span [class "tags-label", attribute "data-bs-toggle" "tooltip", attribute "data-bs-placement" "top", title (tooltipContent tags)]
+      [ i [class "fa fa-tags"][]
+      , b[][text (String.fromInt nbTags)]
+      ]
+    else
+      text ""
+
+buildHtmlStringTag : Tag -> String
+buildHtmlStringTag tag =
+  let
+    tagOpen  = "<span class='tags-label'>"
+    tagIcon  = "<i class='fa fa-tag'></i>"
+    tagKey   = "<span class='tag-key'>"   ++ htmlEscape tag.key   ++ "</span>"
+    tagSep   = "<span class='tag-separator'>=</span>"
+    tagVal   = "<span class='tag-value'>" ++ htmlEscape tag.value ++ "</span>"
+    tagClose = "</span>"
+  in
+    tagOpen ++ tagIcon ++ tagKey ++ tagSep ++ tagVal ++ tagClose
+
+htmlEscape : String -> String
+htmlEscape s =
+  String.replace "&" "&amp;" s
+    |> String.replace ">" "&gt;"
+    |> String.replace "<" "&lt;"
+    |> String.replace "\"" "&quot;"
+    |> String.replace "'" "&#x27;"
+    |> String.replace "\\" "&#x2F;"
+
+filterSearch : String -> List String -> Bool
+filterSearch filterString searchFields =
+  let
+    -- Join all the fields into one string to simplify the search
+    stringToCheck = searchFields
+      |> String.join "|"
+      |> String.toLower
+
+    searchString  = filterString
+      |> String.toLower
+      |> String.trim
+  in
+    String.contains searchString stringToCheck
+
+filterTags : List Tag -> List Tag -> Bool
+filterTags ruleTags tags =
+  if List.isEmpty tags then
+    True
+  else if List.isEmpty ruleTags then
+    False
+  else
+    --List.Extra.count (\t -> List.Extra.notMember t ruleTags) tags <= 0
+    tags
+      |> List.all (\tag ->
+        if not (String.isEmpty tag.key) && not (String.isEmpty tag.value) then
+          List.member tag ruleTags
+        else if String.isEmpty tag.key then
+          case List.Extra.find (\t -> t.value == tag.value) ruleTags of
+            Just _ -> True
+            Nothing -> False
+        else if String.isEmpty tag.value then
+          case List.Extra.find (\t -> t.key == tag.key) ruleTags of
+            Just _ -> True
+            Nothing -> False
+        else
+          True
+        )
+
+getCategoryName : Model -> String -> String
+getCategoryName model id =
+  let
+    cat = List.Extra.find (.id >> (==) id  ) (getAllCats model.ruleTree)
+  in
+    case cat of
+      Just c -> c.name
+      Nothing -> id
+
+searchFieldRules : Rule -> Model -> List String
+searchFieldRules r model =
+  [ r.id.value
+  , r.name
+  , r.categoryId
+  , getCategoryName model r.categoryId
+  ]
+
+
+foldedClass : Filters -> String -> String
+foldedClass treeFilters catId =
+  if List.member catId treeFilters.folded then
+    " jstree-closed"
+  else
+    " jstree-open"
+
+foldUnfoldCategory : Filters -> String -> Filters
+foldUnfoldCategory treeFilters catId =
+  let
+    foldedList  =
+      if List.member catId treeFilters.folded then
+        List.Extra.remove catId treeFilters.folded
+      else
+        catId :: treeFilters.folded
+  in
+    {treeFilters | folded = foldedList}
+
+getRuleLink : String -> RuleId -> String
+getRuleLink contextPath id =
+  contextPath ++ "/secure/configurationManager/ruleManagement/rule/" ++ id.value
+
+getRuleCategoryLink : String -> String -> String
+getRuleCategoryLink contextPath catId =
+  contextPath ++ "/secure/configurationManager/ruleManagement/ruleCategory/" ++ catId

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Grouprelatedrules.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Grouprelatedrules.elm
@@ -1,0 +1,107 @@
+port module Grouprelatedrules exposing (..)
+
+import Browser
+import Browser.Navigation as Nav
+import Http exposing (..)
+
+import GroupRelatedRules.ApiCalls exposing (..)
+import GroupRelatedRules.DataTypes exposing (..)
+import GroupRelatedRules.Init exposing (init)
+import GroupRelatedRules.View exposing (view)
+import GroupRelatedRules.ViewUtils exposing (..)
+
+
+-- PORTS / SUBSCRIPTIONS
+port errorNotification    : String -> Cmd msg
+port initTooltips         : () -> Cmd msg
+port loadRelatedRulesTree : (List String -> msg) -> Sub msg
+
+subscriptions : Model -> Sub Msg
+subscriptions _ =
+  loadRelatedRulesTree (LoadRelatedRulesTree << List.map RuleId)
+
+main =
+  Browser.element
+    { init = init
+    , view = view
+    , update = update
+    , subscriptions = subscriptions
+    }
+
+--
+-- update loop --
+--
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+  case msg of
+    GoTo link -> (model, Nav.load link)
+    GetRulesResult relatedRules res ->
+      let 
+        ui = model.ui
+        ruleIds = List.map .value relatedRules.value
+        filterRuleTree r =  filterRuleElemsByIds ruleIds r
+      in                     
+        case res of         
+          Ok r -> ({ model | ruleTree = filterRuleTree r, ui = { ui | loading = False } }, initTooltips ())
+          Err err -> processApiError "Getting Rules tree" err model
+    LoadRelatedRulesTree []   -> 
+      let                    
+        ui = model.ui
+      in 
+        ({ model | ruleTree = emptyCategory, ui = { ui | loading = False } }, Cmd.none)
+    LoadRelatedRulesTree ruleIds -> 
+      let
+        ui = model.ui
+      in 
+        ({ model | ui = { ui | loading = True } }, getRulesTree model (RelatedRules ruleIds))
+    UpdateRuleFilters filters ->
+      let
+        ui = model.ui
+      in
+        ({model | ui = { ui | ruleTreeFilters = filters}}, initTooltips ())
+    FoldAllCategories filters ->
+      let
+        -- remove "rootRuleCategory" because we can't fold/unfold root category
+        catIds =
+          getAllCats model.ruleTree
+            |> List.map .id
+            |> List.filter (\id -> id /= "rootRuleCategory")
+        foldedCat =
+          filters.folded
+            |> List.filter (\id -> id /= "rootRuleCategory")
+        ui = model.ui
+        newState =
+          if(List.length foldedCat == (List.length catIds)) then
+            False
+          else
+            True
+        foldedList = {filters | folded = if(newState) then catIds else []}
+      in
+        ({model | ui = { ui | isAllCatFold = newState, ruleTreeFilters = foldedList}}, initTooltips ())
+    
+
+processApiError : String -> Error -> Model -> ( Model, Cmd Msg )
+processApiError apiName err model =
+  let
+    message =
+      case err of
+        Http.BadUrl url ->
+            "The URL " ++ url ++ " was invalid"
+        Http.Timeout ->
+            "Unable to reach the server, try again"
+        Http.NetworkError ->
+            "Unable to reach the server, check your network connection"
+        Http.BadStatus 500 ->
+            "The server had a problem, try again later"
+        Http.BadStatus 400 ->
+            "Verify your information and try again"
+        Http.BadStatus _ ->
+            "Unknown error"
+        Http.BadBody errorMessage ->
+            errorMessage
+
+  in
+    (model, errorNotification ("Error when "++apiName ++", details: \n" ++ message ) )
+
+getUrl : Model -> String
+getUrl model = model.contextPath ++ "/secure/configurationManager/ruleManagement"

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1837,7 +1837,8 @@ object RudderConfigInit {
       deprecated.softwareService
     )
 
-    lazy val ruleInternalApiService = new RuleInternalApiService(roRuleRepository, roNodeGroupRepository, nodeFactRepository)
+    lazy val ruleInternalApiService =
+      new RuleInternalApiService(roRuleRepository, roNodeGroupRepository, roRuleCategoryRepository, nodeFactRepository)
 
     lazy val complianceAPIService = new ComplianceAPIService(
       roRuleRepository,
@@ -2184,7 +2185,7 @@ object RudderConfigInit {
         new InventoryApi(restExtractorService, inventoryWatcher, better.files.File(INVENTORY_DIR_INCOMING)),
         new PluginApi(restExtractorService, pluginSettingsService),
         new RecentChangesAPI(recentChangesService, restExtractorService),
-        new RulesInternalApi(ruleInternalApiService),
+        new RulesInternalApi(ruleInternalApiService, ruleApiService13),
         campaignApi,
         new HookApi(hookApiService),
         archiveApi

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.css
@@ -1073,6 +1073,12 @@ form .tooltip-content p {
 .content-wrapper .rudder-label.label-overriden + .tooltip b, .content-wrapper .label-text.label-overriden:after, .content-wrapper .label-text.label-overriden  + .tooltip b, .text-overriden {
   color: #eda800;
 }
+.content-wrapper .rudder-label.label-included:before,.content-wrapper .label-text.label-included:after{
+  content: "Included";
+}
+.content-wrapper .rudder-label.label-excluded:before,.content-wrapper .label-text.label-excluded:after{
+  content: "Excluded";
+}
 
 .content-wrapper .label-text{
   color: #999;

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.css
@@ -471,6 +471,15 @@ ul {
 .rudder-template .filters-container.hidden:before{
   content: initial;
 }
+.rudder-template .template-main-header .filters-container {
+  margin: 0;
+  padding: 15px;
+  border: 1px solid #d6deef;
+  border-radius: var(--bs-border-radius);
+}
+.rudder-template .template-main-header .filters-container:before {
+  right: 9px;
+}
 
 .rudder-template .filters-container .tags-container .btn-group .btn,
 .rudder-template .filters-container .btn.clear-tags{

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
@@ -4,6 +4,7 @@
   <title>Rudder - Node Groups Management</title>
   <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-groups.css"/>
   <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-groupcompliance.js"></script>
+  <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-grouprelatedrules.js"></script>
 </head_merge>
 
 <span data-list="node.Groups.head"></span>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
@@ -49,7 +49,7 @@
     <ul id="groupTabMenu">
       <li><a href="#groupParametersTab">Parameters</a></li>
       <li><a href="#groupCriteriaTab">Criteria</a></li>
-      <li><a href="#groupRulesTab">Related rules</a></li>
+      <li><a id="relatedRulesLinkTab" href="#groupRulesTab">Related rules</a></li>
       <li><a href="#groupPropertiesTab">Properties</a></li>
       <li><a id="complianceLinkTab" href="#groupComplianceTab">Compliance</a></li>
     </ul>
@@ -103,10 +103,7 @@
       </div>
     </div>
     <div id="groupRulesTab" class="main-form">
-      <div class="alert alert-info">
-        This group is used in following rule targets (either as a target or exception group):
-      </div>
-      <div id="groupRuleTabsContent"></div>
+      <div id="groupRelatedRulesApp"></div>
     </div>
     <div id="groupPropertiesTab" class="main-form">
       <div id="groupPropertiesTabContent"></div>


### PR DESCRIPTION
https://issues.rudder.io/issues/23961


* We display a rules tree in place of the previous table (most code is copied from the sidebar tree in the rules page).
* We have a badge like the one we have for policy mode, but with the `Included` or `Excluded` label instead.
* For that we create a new Elm app `Grouprelatedrules`. We already have another Elm app for groups compliance, which could be merged with this one later when we migrate the groups page to Elm

![image](https://github.com/Normation/rudder/assets/65616064/7d5a02d6-514a-4dd8-a540-b23fdb8619cd)
