### PR TITLE
Fixes #23968: Display a global view of group compliances

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
@@ -236,6 +236,11 @@ trait RoNodeGroupRepository {
   def getAll(): IOResult[Seq[NodeGroup]]
 
   /**
+   * Get all node groups by ids
+   */
+  def getAllByIds(ids: Seq[NodeGroupId]): IOResult[Seq[NodeGroup]]
+
+  /**
    * Get all the node group id and the set of ndoes within
    * Goal is to be more efficient
    */

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -2346,6 +2346,9 @@ class MockNodeGroups(nodesRepo: MockNodes) {
       } yield cat
     }
     override def getAll():                              IOResult[Seq[NodeGroup]]                           = categories.get.map(_.allGroups.values.map(_.nodeGroup).toSeq)
+    override def getAllByIds(ids: Seq[NodeGroupId]):    IOResult[Seq[NodeGroup]]                           = {
+      categories.get.map(_.allGroups.values.map(_.nodeGroup).filter(g => ids.contains(g.id)).toSeq)
+    }
 
     override def getAllNodeIds(): IOResult[Map[NodeGroupId, Set[NodeId]]] =
       categories.get.map(_.allGroups.values.map(_.nodeGroup).map(g => (g.id, g.serverList)).toMap)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -186,6 +186,14 @@ object ComplianceApi       extends ApiModuleProvider[ComplianceApi] {
     val dataContainer: Some[String] = Some("directivesCompliance")
   }
 
+  final case object GetNodeGroupComplianceSummary
+      extends ComplianceApi with GeneralApi with ZeroParam with StartsAtVersion17 with SortIndex {
+    val z              = implicitly[Line].value
+    val description    = "Get a node group's compliance summary"
+    val (action, path) = GET / "compliance" / "summary" / "groups"
+    val dataContainer  = Some("groupCompliance")
+  }
+
   final case object GetNodeGroupComplianceId
       extends ComplianceApi with GeneralApi with OneParam with StartsAtVersion17 with SortIndex {
     val z: Int = implicitly[Line].value

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
@@ -132,7 +132,8 @@ object AuthorizationApiMapping {
           ComplianceApi.GetGlobalCompliance.x :: ComplianceApi.GetRulesCompliance.x :: ComplianceApi.GetRulesComplianceId.x ::
           ComplianceApi.GetNodesCompliance.x :: ComplianceApi.GetNodeComplianceId.x :: ChangesApi.GetRuleRepairedReports.x ::
           ChangesApi.GetRecentChanges.x :: ComplianceApi.GetDirectiveComplianceId.x ::
-          ComplianceApi.GetDirectivesCompliance.x :: ComplianceApi.GetNodeGroupComplianceId.x :: ComplianceApi.GetNodeGroupComplianceTargetId.x :: Nil
+          ComplianceApi.GetDirectivesCompliance.x :: ComplianceApi.GetNodeGroupComplianceId.x :: ComplianceApi.GetNodeGroupComplianceTargetId.x ::
+          ComplianceApi.GetNodeGroupComplianceSummary.x :: Nil
         case Compliance.Write => Nil
         case Compliance.Edit  => Nil
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -222,6 +222,7 @@ class MockCompliance(mockDirectives: MockDirectives) {
 
     def getNodeGroupCategory(id: NodeGroupId):                 IOResult[NodeGroupCategory]                                          = ???
     def getAll():                                              IOResult[Seq[NodeGroup]]                                             = ???
+    def getAllByIds(ids: Seq[NodeGroupId]):                    IOResult[Seq[NodeGroup]]                                             = ???
     def getAllNodeIds():                                       IOResult[Map[NodeGroupId, Set[NodeId]]]                              = ???
     def getGroupsByCategory(includeSystem: Boolean):           IOResult[SortedMap[List[NodeGroupCategoryId], CategoryAndNodeGroup]] = ???
     def findGroupWithAnyMember(nodeIds: Seq[NodeId]):          IOResult[Seq[NodeGroupId]]                                           = ???

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/View.elm
@@ -93,7 +93,6 @@ view model =
         Maybe.Extra.filter (\_ -> model.ruleTree /= emptyCategory) treeItem
   
   in 
-    --TODO: use SCSS variable for "34px" input-group-text height (that's the value for the input form height)
     div [class "shadow-none col-6 col-md-8 col-lg-7"]
     [ div [class "template-main-header"]
       [ div [class "header-title"]
@@ -101,9 +100,9 @@ view model =
         ]
       , div [class "header-filter"]
         [ div [class "input-group flex-nowrap"]
-          [ button [class "input-group-text btn btn-default", type_ "button", style "height" "34px", onClick (FoldAllCategories model.ui.ruleTreeFilters) ][span [class "fa fa-folder fa-folder-open"][]]
+          [ button [class "input-group-text btn btn-default", type_ "button", onClick (FoldAllCategories model.ui.ruleTreeFilters) ][span [class "fa fa-folder fa-folder-open"][]]
           , input[type_ "text", value model.ui.ruleTreeFilters.filter ,placeholder "Filter", class "form-control", onInput (\s -> UpdateRuleFilters {treeFilters | filter = s})][]
-          , button [class "input-group-text btn btn-default", type_ "button", style "height" "34px", onClick (UpdateRuleFilters {treeFilters | filter = ""})] [span [class "fa fa-times"][]]
+          , button [class "input-group-text btn btn-default", type_ "button", onClick (UpdateRuleFilters {treeFilters | filter = ""})] [span [class "fa fa-times"][]]
           ]
         , label [class "btn btn-default more-filters", for "toggle-filters"][]
         ]
@@ -114,7 +113,7 @@ view model =
           [ label[for "tag-key"][text "Tags"]
           , div [class "input-group flex-nowrap"]
             [ input[type_ "text", value model.ui.ruleTreeFilters.newTag.key, placeholder "key", class "form-control", id "tag-key", onInput (\s -> UpdateRuleFilters {treeFilters | newTag = {newTag | key = s}})][]
-            , span [class "input-group-text", style "height" "34px"][text " = "] 
+            , span [class "input-group-text"][text " = "] 
             , input[type_ "text", value model.ui.ruleTreeFilters.newTag.value, placeholder "value", class "form-control", onInput (\s -> UpdateRuleFilters {treeFilters | newTag = {newTag | value = s}})][]
             , button 
               [ type_ "button"

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups.elm
@@ -1,0 +1,149 @@
+port module Groups exposing (..)
+
+import Browser
+import Dict
+import Dict.Extra
+import Http exposing (..)
+
+import GroupCompliance.ApiCalls exposing (..)
+import GroupCompliance.ViewUtils exposing (..)
+
+import Groups.ApiCalls exposing (..)
+import Groups.DataTypes exposing (..)
+import Groups.Init exposing (init)
+import Groups.View exposing (view)
+import Groups.ViewUtils exposing (..)
+
+
+-- PORTS / SUBSCRIPTIONS
+port errorNotification      : String -> Cmd msg
+port initTooltips           : () -> Cmd msg
+port pushUrl                : (String, String) -> Cmd msg
+port displayCategoryDetails : String -> Cmd msg
+port displayGroupDetails    : String -> Cmd msg
+port adjustComplianceCols   : () -> Cmd msg
+port createGroupModal       : () -> Cmd msg
+port closeModal             : (() -> msg) -> Sub msg
+
+subscriptions : Model -> Sub Msg
+subscriptions _ = Sub.batch
+  [ closeModal (\_ -> CloseModal)
+  ]
+
+main =
+  Browser.element
+    { init = init
+    , view = view
+    , update = update
+    , subscriptions = subscriptions
+    }
+
+--
+-- update loop --
+--
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+  case msg of
+    OpenModal -> 
+      let
+        ui = model.ui
+        -- we need to reload to make sure we are not in a details page, or else some external elements will replace our Elm dom elements
+      in
+       ({ model | mode = Loading, groupsCompliance = Dict.empty, ui = { ui | modal = ExternalModal, loadingGroups = True } }, createGroupModal ())
+    CloseModal -> 
+      let
+        ui = model.ui
+      in
+        ({ model | ui = { ui | modal = NoModal, loadingGroups = True } }, Cmd.batch [ getGroupsTree model ])
+    OpenGroupDetails groupId ->
+      ({ model | mode = ExternalTemplate }, Cmd.batch [pushUrl (getIdAnchorKey groupId.value, groupId.value), displayGroupDetails groupId.value])
+    OpenCategoryDetails catId ->
+      ({ model | mode = ExternalTemplate }, Cmd.batch [pushUrl ("", ""), displayCategoryDetails catId])
+    GetGroupsTreeResult res ->
+      case res of
+        Ok r ->
+          let
+            ui = model.ui
+            newUi = { ui | loadingGroups = True }
+            newModel = { model | groupsTree = r, mode = if (model.mode == Loading) then LoadingTable else model.mode, ui = newUi }
+          in
+            ( 
+              newModel
+              , Cmd.batch [ initTooltips (), getInitialGroupCompliance newModel ]  -- reload the table each time we have a new groups tree
+            )
+        Err err ->
+          processApiError "Getting groups tree" err model
+    GetGroupsComplianceResult keepGroups res ->
+      case res of
+        Ok r ->
+          let
+            modelUi = model.ui
+            currentGroups = if keepGroups then model.groupsCompliance else Dict.empty
+          in 
+            ( { model | 
+                  groupsCompliance = (Dict.Extra.fromListBy (.id >> .value) r) |> Dict.union currentGroups
+                  , mode = if (model.mode == LoadingTable) then GroupTable else model.mode
+                  , ui = { modelUi | loadingGroups = False }
+              }
+              , Cmd.batch [adjustComplianceCols (), initTooltips ()]
+            )
+        Err err ->
+          processApiError "Getting compliance" err model
+    LoadMore ->
+      let
+        ui = model.ui
+        newUi = { ui | loadingGroups = True }
+        nextIds = nextGroupIds model
+      in
+        ({model | mode = LoadingTable, ui = newUi}, getGroupsCompliance True nextIds model)
+    UpdateGroupFilters filters ->
+      let
+        ui = model.ui
+        newUi = { ui | groupFilters = filters }
+      in
+        ({model | ui = newUi}, initTooltips ())
+    FoldAllCategories filters ->
+      let
+        -- remove rootGroupCategoryId because we can't fold/unfold root category
+        catIds =
+          getAllCats model.groupsTree
+            |> List.map .id
+            |> List.filter (\id -> id /= rootGroupCategoryId)
+        foldedCat =
+          filters.treeFilters.folded
+            |> List.filter (\id -> id /= rootGroupCategoryId)
+        ui = model.ui
+        newState =
+          if(List.length foldedCat == (List.length catIds)) then
+            False
+          else
+            True
+        treeFilters = filters.treeFilters
+        foldedList = {filters | treeFilters = {treeFilters | folded = if(newState) then catIds else []}}
+      in
+        ({model | ui = { ui | groupFilters = foldedList}}, initTooltips ())
+
+    
+
+processApiError : String -> Error -> Model -> ( Model, Cmd Msg )
+processApiError apiName err model =
+  let
+    message =
+      case err of
+        Http.BadUrl url ->
+            "The URL " ++ url ++ " was invalid"
+        Http.Timeout ->
+            "Unable to reach the server, try again"
+        Http.NetworkError ->
+            "Unable to reach the server, check your network connection"
+        Http.BadStatus 500 ->
+            "The server had a problem, try again later"
+        Http.BadStatus 400 ->
+            "Verify your information and try again"
+        Http.BadStatus _ ->
+            "Unknown error"
+        Http.BadBody errorMessage ->
+            errorMessage
+
+  in
+    (model, errorNotification ("Error when "++apiName ++", details: \n" ++ message ) )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/ApiCalls.elm
@@ -1,0 +1,52 @@
+module Groups.ApiCalls exposing (..)
+
+import Url.Builder exposing (string, QueryParameter)
+import Http exposing (emptyBody, expectJson, request)
+
+import Groups.DataTypes exposing (..)
+import Groups.JsonDecoder exposing (..)
+import GroupRelatedRules.DataTypes exposing (GroupId)
+--
+-- This files contains all API calls for the Group compliance UI
+--
+
+getUrl: Model -> List String -> List QueryParameter -> String
+getUrl m url p=
+  Url.Builder.relative (m.contextPath :: "secure" :: "api"  :: url) p
+
+getGroupsCompliance : Bool -> List GroupId -> Model -> Cmd Msg
+getGroupsCompliance keepGroups groupIds model =
+  let
+    req =
+      request
+        { method  = "GET"
+        , headers = []
+        , url     = getUrl model [ "compliance", "summary", "groups"] [string "groups" (String.join "," (List.map (.value) groupIds))]
+
+        , body    = emptyBody
+        , expect  = expectJson (GetGroupsComplianceResult keepGroups) decodeGetGroupsCompliance
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+  in
+    req
+
+getGroupsTree : Model -> Cmd Msg
+getGroupsTree model =
+  let
+    req =
+      request
+        { method  = "GET"
+        , headers = []
+        , url     = getUrl model ["groups", "tree"] []
+        , body    = emptyBody
+        , expect  = expectJson GetGroupsTreeResult decodeGetGroupsTree
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+  in
+    req
+
+-- Reset the group compliance summary and fetch the first batch. Needs the tree to be populated in order to fetch group ids
+getInitialGroupCompliance : Model -> Cmd Msg
+getInitialGroupCompliance model = getGroupsCompliance False (nextGroupIds model) model

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/DataTypes.elm
@@ -1,0 +1,164 @@
+module Groups.DataTypes exposing (..)
+
+import Dict exposing (Dict)
+import Http exposing (Error)
+import NaturalOrdering as N
+
+import Compliance.DataTypes exposing (ComplianceDetails)
+import GroupRelatedRules.DataTypes exposing (GroupId)
+import Set
+
+type alias Model =
+  { contextPath : String
+  , mode        : Mode
+  , ui          : UI
+  , groupsTree  : Category Group
+  , groupsCompliance : Dict String GroupComplianceSummary
+  }
+
+type Mode
+  = Loading
+  | LoadingTable
+  | GroupTable
+  | ExternalTemplate
+
+type alias GroupComplianceSummary =
+  { id       : GroupId
+  , targeted : ComplianceSummaryValue
+  , global   : ComplianceSummaryValue
+  }
+
+type alias ComplianceSummaryValue =
+  { compliance        : Float
+  , complianceDetails : ComplianceDetails
+  }
+
+type alias Category a =
+  { id          : String
+  , name        : String
+  , description : String
+  , subElems    : SubCategories a
+  , elems       : List a
+  }
+
+type SubCategories a = SubCategories (List (Category a))
+
+type alias Group =
+  { id          : GroupId
+  , name        : String
+  , description : String
+  , category    : Maybe String
+  , nodeIds     : List String
+  , dynamic     : Bool
+  , enabled     : Bool
+  , target      : String
+  }
+
+getAllElems: Category a -> List a
+getAllElems category =
+  let
+    subElems = case category.subElems of SubCategories l -> l
+  in
+    List.append category.elems (List.concatMap getAllElems subElems)
+
+-- Get all groups for which the compliance summary is defined
+getElemsWithCompliance: Model -> List Group
+getElemsWithCompliance model =
+  let
+    getElemsWithComplianceRec : Category Group -> List Group
+    getElemsWithComplianceRec category =
+      let
+        subElems = case category.subElems of SubCategories l -> l
+      in
+        List.append
+          (List.filter (\e -> Dict.member e.id.value model.groupsCompliance) category.elems)
+          (List.concatMap getElemsWithComplianceRec subElems)
+  in
+    getElemsWithComplianceRec model.groupsTree
+
+getSubElems: Category a -> List (Category a)
+getSubElems cat =
+  case cat.subElems of
+    SubCategories subs -> subs
+
+type alias UI =
+  { groupFilters   : Filters
+  , modal          : ModalState
+  , hasWriteRights : Bool
+  , loadingGroups  : Bool
+  }
+
+type ModalState = NoModal | ExternalModal
+
+type alias Filters =
+  { tableFilters : TableFilters
+  , treeFilters  : TreeFilters
+  }
+
+type SortBy
+  = Name
+  | Parent
+  | GlobalCompliance
+  | TargetedCompliance
+
+type alias TableFilters =
+  { sortBy     : SortBy
+  , sortOrder  : SortOrder
+  , filter     : String
+  }
+
+type alias TreeFilters =
+  { filter : String
+  , folded : List String
+  }
+
+type SortOrder = Asc | Desc
+
+-- The fixed group category ID for the root group category
+rootGroupCategoryId : String
+rootGroupCategoryId = "GroupRoot"
+  
+type Msg
+  = OpenModal
+  | CloseModal
+  | LoadMore
+  | OpenGroupDetails GroupId
+  | OpenCategoryDetails String
+  | FoldAllCategories Filters
+  | GetGroupsTreeResult (Result Error (Category Group))
+  | GetGroupsComplianceResult Bool (Result Error (List GroupComplianceSummary))
+  | UpdateGroupFilters      Filters
+
+groupTableBatchSize : number
+groupTableBatchSize = 20
+
+-- Get all group ids in the tree, sorted the way they are top-down in the tree view : by name
+treeIds : Category Group -> List GroupId
+treeIds category =
+  let
+    sortByName = List.sortWith (\c1 c2 -> N.compare c1.name c2.name)
+    subElems = case category.subElems of SubCategories l -> sortByName l
+  in
+    category.elems
+        |> sortByName
+        |> List.map .id
+        |> List.append (subElems |> List.concatMap treeIds)
+
+-- Compute next ids to load in the group table
+nextGroupIds : Model -> List GroupId
+nextGroupIds model =
+  let
+    allGroupIds = treeIds model.groupsTree |> List.map (.value)
+    knownGroupIds = model.groupsCompliance |> Dict.keys
+    groupById = model.groupsTree |> getAllElems |> List.map (\g -> (g.id.value, g)) |> Dict.fromList
+    getGroupNameById id = case Dict.get id groupById of
+      Just g -> g.name
+      Nothing -> ""
+    diff = Set.diff (Set.fromList allGroupIds) (Set.fromList knownGroupIds) |> Set.toList
+    res =
+      diff
+        |> List.sortWith (\c1 c2 -> N.compare (getGroupNameById c1) (getGroupNameById c2))
+        |> List.take groupTableBatchSize
+        |> List.map GroupId
+  in
+    res

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/Init.elm
@@ -1,0 +1,25 @@
+module Groups.Init exposing (..)
+
+import Dict
+
+import Groups.ApiCalls exposing (..)
+import Groups.DataTypes exposing (..)
+import Compliance.DataTypes exposing (..)
+
+
+init : { contextPath : String, hasWriteRights : Bool } -> ( Model, Cmd Msg )
+init flags =
+  let
+    initCategory = Category "" "" "" (SubCategories []) []
+    initTableFilters  = (TableFilters Name Asc "")
+    initTreeFilters   = (TreeFilters "" [])
+    initFilters       = Filters initTableFilters initTreeFilters
+    initUI       = UI initFilters NoModal flags.hasWriteRights True
+    initModel    = Model flags.contextPath Loading initUI initCategory Dict.empty
+    listInitActions =
+      [ getGroupsTree initModel
+      ]
+  in
+    ( initModel
+    , Cmd.batch listInitActions
+    )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/JsonDecoder.elm
@@ -1,0 +1,70 @@
+module Groups.JsonDecoder exposing (..)
+
+import Json.Decode exposing (..)
+import Json.Decode.Pipeline exposing (..)
+
+import Groups.DataTypes exposing (..)
+import GroupCompliance.DataTypes exposing (GroupId)
+import Compliance.JsonDecoder exposing (decodeComplianceDetails)
+
+
+decodeGetGroupsCompliance : Decoder (List GroupComplianceSummary)
+decodeGetGroupsCompliance =
+  at [ "data" , "nodeGroups" ] (list decodeGroupCompliance)
+
+decodeGroupCompliance : Decoder GroupComplianceSummary
+decodeGroupCompliance =
+  succeed GroupComplianceSummary
+    |> required "id" (map GroupId string)
+    |> required "targeted" decodeComplianceSummaryValue
+    |> required "global" decodeComplianceSummaryValue
+
+decodeComplianceSummaryValue : Decoder ComplianceSummaryValue
+decodeComplianceSummaryValue =
+  succeed ComplianceSummaryValue
+    |> required "compliance" float
+    |> required "complianceDetails" decodeComplianceDetails
+
+decodeGetGroupsTree : Decoder (Category Group)
+decodeGetGroupsTree =
+  at ["data", "groupCategories"] decodeCategoryGroupTarget
+
+decodeCategoryGroupTarget : Decoder (Category Group)
+decodeCategoryGroupTarget =
+  succeed ( \id name description categories groups targets ->
+    let
+      elems = if id == rootGroupCategoryId then groups else (List.append groups targets)
+    in
+      Category id name description categories elems
+    )
+    |> required "id"          string
+    |> required "name"        string
+    |> required "description" string
+    |> required "categories"  (map SubCategories  (list (lazy (\_ -> decodeCategoryGroupTarget))))
+    |> required "groups"      (list decodeGroup)
+    |> required "targets"     (list decodeTarget)
+
+
+decodeGroup : Decoder Group
+decodeGroup =
+  succeed Group
+    |> required "id"          (map GroupId string)
+    |> required "displayName" string
+    |> required "description" string
+    |> optional "category"    (map Just string) Nothing
+    |> required "nodeIds"    (list string)
+    |> required "dynamic"     bool
+    |> required "enabled"     bool
+    |> required "target"      string
+
+decodeTarget : Decoder Group
+decodeTarget =
+  succeed Group
+    |> required "id"          (map GroupId string)
+    |> required "displayName" string
+    |> required "description" string
+    |> optional "category"    (map Just string) Nothing
+    |> hardcoded []
+    |> hardcoded True
+    |> required "enabled"     bool
+    |> required "target"      string

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/View.elm
@@ -1,0 +1,163 @@
+module Groups.View exposing (..)
+
+import Html exposing (..)
+import Html.Attributes exposing (checked, class, for, href, id, placeholder, style, title, type_, value)
+import Html.Events exposing (onClick, onInput)
+import NaturalOrdering as N
+import List
+import String
+
+import Groups.DataTypes exposing (..)
+import Groups.ViewGroupsTable exposing (..)
+import Groups.ViewUtils exposing (..)
+
+view : Model -> Html Msg
+view model = 
+  let
+    groupsList = getElemsWithCompliance model
+    groupTreeElem : Group -> Html Msg
+    groupTreeElem item =
+      let
+        (classDisabled, badgeDisabled) = if item.enabled /= True then
+            (" item-disabled", span[ class "badge-disabled"][])
+          else
+            ("", text "")
+        -- TODO: uncomment when group details will be implemented in Elm
+        -- classFocus =
+        --   case model.mode of
+        --     GroupForm rDetails ->
+        --       if (rDetails.group.id.value == item.id.value) then " focused " else ""
+        --     _ -> ""
+      in
+        li [class "jstree-node jstree-leaf"]
+        [ i[class "jstree-icon jstree-ocl"][]
+        , a[class ("jstree-anchor"++classDisabled {- ++classFocus -}), href (getGroupLink model.contextPath item.id.value), onClick (OpenGroupDetails item.id)]
+          [ i [class "jstree-icon jstree-themeicon fa fa-sitemap jstree-themeicon-custom"][]
+          , span [class "treeGroupName", title (buildTooltipContent item.name item.description)]
+            [ text item.name
+            , small [class "greyscala"] [text (" - " ++ if item.dynamic then "Dynamic" else "Static")]
+            , badgeDisabled
+            ]
+          ]
+        ]
+
+    groupTreeCategory : (Category Group) -> Maybe (Html Msg)
+    groupTreeCategory item =
+      let
+        categories = getSubElems item
+          |> List.sortWith (\c1 c2 -> N.compare c1.name c2.name)
+          |> List.filterMap groupTreeCategory
+
+        groups = item.elems
+          |> List.filter (\r -> filterSearch model.ui.groupFilters.treeFilters.filter (searchFieldGroups r model))
+          |> List.sortWith (\r1 r2 -> N.compare r1.name r2.name)
+          |> List.map groupTreeElem
+
+        childsList  = ul[class "jstree-children"] (List.concat [categories, groups])
+
+        icons = " fa fa-folder "
+        -- TODO: uncomment when group details will be implemented in Elm
+        -- classFocus =
+        --   case model.mode of
+        --     CategoryForm cDetails ->
+        --       if (cDetails.category.id == item.id) then " focused " else ""
+        --     _ -> ""
+        treeItem =
+          if item.id /= rootGroupCategoryId then
+            if (String.isEmpty model.ui.groupFilters.treeFilters.filter) || ((List.length groups > 0) || (List.length categories > 0)) then
+              Just (
+                li[class ("jstree-node" ++ foldedClass model.ui.groupFilters.treeFilters item.id)]
+                [ i [class "jstree-icon jstree-ocl", onClick (UpdateGroupFilters (foldUnfoldCategory model.ui.groupFilters item.id))][]
+                , a [class ("jstree-anchor"{- ++ classFocus -}), onClick (OpenCategoryDetails item.id)]
+                  [ i [class ("jstree-icon jstree-themeicon jstree-themeicon-custom" ++ icons)][]
+                  , span [class "treeGroupCategoryName"][text item.name]
+                  ]
+                , childsList
+                ]
+              )
+            else
+              Nothing
+          else
+            Just childsList
+      in
+        treeItem
+
+    groupFilters = model.ui.groupFilters
+    treeFilters = groupFilters.treeFilters
+
+    templateMain = case model.mode of
+      Loading -> generateLoadingTable
+      LoadingTable -> generateLoadingTable
+      GroupTable   ->
+        div [class "main-table"]
+        [ div [class "table-container"]
+          [ table [ class "no-footer dataTable"]
+            [ thead [] [groupsTableHeader model.ui.groupFilters]
+            , tbody [] (buildGroupsTable model groupsList)
+            ]
+            , if hasMoreGroups model then
+                div [ class "d-flex justify-content-center py-2" ] 
+                [ button [class "btn btn-default btn-icon load-more", onClick LoadMore] [text "Load more...", i [class "fa fa-plus-circle"] []]
+                ]
+              else text ""
+          ]
+        ]
+      ExternalTemplate -> text ""
+
+    modal = case model.ui.modal of
+      NoModal -> text ""
+      ExternalModal -> div [class "modal-backdrop fade show", style "height" "100%"] []
+  in
+    div [class "rudder-template"]
+    [ div [class "template-sidebar sidebar-left"]
+      [ div [class "sidebar-header"]
+        [ div [class "header-title"]
+          [ h1[]
+            [ span[][text "Groups"]
+            ]
+          , ( if model.ui.hasWriteRights then
+              div [class "header-buttons"]
+              --[ button [class "btn btn-default", type_ "button", onClick (GenerateId (\s -> NewCategory s      ))][text "Add category"]
+              --, button [class "btn btn-success", type_ "button", onClick (GenerateId (\s -> NewGroup (GroupId s) ))][text "Create", i[class "fa fa-plus-circle"][]]
+              --]
+              [ button [id "newItem", class "btn btn-success", type_ "button", onClick OpenModal][text "Create", i[class "fa fa-plus-circle"][]]
+              ]
+            else
+              text ""
+            )
+          ]
+        , div [class "header-filter"]
+          [ div [class "input-group flex-nowrap"]
+            [ button [class "input-group-text btn btn-default", type_ "button", onClick (FoldAllCategories model.ui.groupFilters) ][span [class "fa fa-folder fa-folder-open"][]]
+              , input[type_ "text", value model.ui.groupFilters.treeFilters.filter, placeholder "Filter", class "form-control", onInput (\s -> UpdateGroupFilters {groupFilters | treeFilters = {treeFilters | filter = s}})][]
+              , button [class "input-group-text btn btn-default", type_ "button", onClick (UpdateGroupFilters {groupFilters | treeFilters = {treeFilters | filter = ""}})] [span [class "fa fa-times"][]]
+              ]
+            , label [class "btn btn-default more-filters", for "toggle-filters"][]
+            ]
+        , input [type_ "checkbox", id "toggle-filters", class "toggle-filters", checked True][]
+        ]
+      , div [class "sidebar-body"]
+        [ div [class "sidebar-list"][(
+          if model.mode == Loading then
+            generateLoadingList
+          else
+            div [class "jstree jstree-default"]
+            [ ul[class "jstree-container-ul jstree-children"]
+              [(case groupTreeCategory model.groupsTree of
+                Just html -> html
+                Nothing   -> div [class "alert alert-warning"]
+                  [ i [class "fa fa-exclamation-triangle"][]
+                  , text  "No groups match your filter."
+                  ]
+              )]
+            ]
+          )]
+        ]
+     ]
+     -- The content of "ajaxItemContainer" can be replaced with external template, when model has the ExternalTemplate mode
+    , div [class "template-main", id "ajaxItemContainer"]
+      [ 
+        templateMain
+      ]
+    , modal
+    ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/ViewGroupsTable.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/ViewGroupsTable.elm
@@ -1,0 +1,64 @@
+module Groups.ViewGroupsTable exposing (..)
+
+import Maybe
+import Html exposing (Html, i, text, td, th, tr)
+import Html.Attributes exposing (class, colspan, rowspan)
+import Html.Events exposing (onClick)
+
+import Compliance.Html exposing (buildComplianceBar)
+import Compliance.Utils exposing (defaultComplianceFilter)
+import Groups.DataTypes exposing (..)
+import Groups.ViewUtils exposing (..)
+
+buildGroupsTable : Model -> List Group -> List(Html Msg)
+buildGroupsTable model groups =
+  let
+    groupsList       = groups
+    sortedGroupsList = groupsList
+      |> List.filter (\r -> filterSearch model.ui.groupFilters.treeFilters.filter (searchFieldGroups r model))
+      |> List.sortWith (getSortFunction model)
+
+    rowTable : Group -> Html Msg
+    rowTable r =
+      let
+        categoryName = text (Maybe.withDefault "Groups" (Maybe.map (getCategoryName model) r.category))
+
+        (targetedCompliance, globalCompliance) =
+          case getGroupCompliance model r.id of
+            Just co ->
+              (buildComplianceBar defaultComplianceFilter co.targeted.complianceDetails
+              , buildComplianceBar defaultComplianceFilter co.global.complianceDetails
+              )
+            Nothing -> (text "No report", text "No report")
+
+      in
+            tr[onClick (OpenGroupDetails r.id)]
+            [ td[]
+              [ text r.name
+              ]
+            , td[][ categoryName       ]
+            , td[class ("compliance-col")][ globalCompliance   ]
+            , td[class ("compliance-col")][ targetedCompliance ]
+            ]
+  in
+    if List.length sortedGroupsList > 0 then
+      List.map rowTable sortedGroupsList
+    else
+      [ tr[][td [class "empty", colspan 5][i [class "fa fa-exclamation-triangle"][], text "No groups match your filters."]]]
+
+groupsTableHeader : Filters -> Html Msg
+groupsTableHeader groupFilters =
+ tr [class "head"]
+ [ th [ class (thClass groupFilters.tableFilters Name) , rowspan 1, colspan 1
+       , onClick (UpdateGroupFilters (sortTable groupFilters Name))
+       ] [ text "Name" ]
+ , th [ class (thClass groupFilters.tableFilters Parent) , rowspan 1, colspan 1
+      , onClick (UpdateGroupFilters (sortTable groupFilters Parent))
+      ] [ text "Category" ]
+ , th [ class ((thClass groupFilters.tableFilters GlobalCompliance) ++ " compliance-col"), rowspan 1, colspan 1
+      , onClick (UpdateGroupFilters (sortTable groupFilters GlobalCompliance))
+      ] [ text "Global compliance" ]
+ , th [ class ((thClass groupFilters.tableFilters TargetedCompliance) ++ " compliance-col"), rowspan 1, colspan 1
+      , onClick (UpdateGroupFilters (sortTable groupFilters TargetedCompliance))
+      ] [ text "Targeted compliance" ]
+ ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/ViewUtils.elm
@@ -1,0 +1,224 @@
+module Groups.ViewUtils exposing (..)
+
+import Dict
+import Maybe
+import Maybe.Extra
+import NaturalOrdering
+import List.Extra
+
+import Groups.DataTypes exposing (..)
+import Compliance.Utils exposing (getAllComplianceValues)
+import GroupCompliance.DataTypes exposing (GroupId)
+import Html exposing (Html, div, span, table, tbody, td, th, thead, tr)
+import Html.Attributes exposing (class, style)
+import Html exposing (ul)
+import Html exposing (li)
+import Html exposing (i)
+
+getAllCats: Category a -> List (Category a)
+getAllCats category =
+  let
+    subElems = case category.subElems of SubCategories l -> l
+  in
+    category :: (List.concatMap getAllCats subElems)
+
+getCategoryName : Model -> String -> String
+getCategoryName model id =
+  let
+    cat = List.Extra.find (.id >> (==) id  ) (getAllCats model.groupsTree)
+  in
+    case cat of
+      Just c -> c.name
+      Nothing -> id
+
+getGroupCompliance : Model -> GroupId -> Maybe GroupComplianceSummary
+getGroupCompliance model rId =
+  Dict.get rId.value model.groupsCompliance
+
+filterSearch : String -> List String -> Bool
+filterSearch filterString searchFields =
+  let
+    -- Join all the fields into one string to simplify the search
+    stringToCheck = searchFields
+      |> String.join "|"
+      |> String.toLower
+
+    searchString  = filterString
+      |> String.toLower
+      |> String.trim
+  in
+    String.contains searchString stringToCheck
+
+searchFieldGroups : Group -> Model -> List String
+searchFieldGroups g model =
+  [ g.id.value
+  , g.name
+  ] ++ Maybe.Extra.toList g.category ++ Maybe.Extra.toList (Maybe.map (getCategoryName model) g.category)
+
+getSortFunction : Model -> Group -> Group -> Order
+getSortFunction model g1 g2 =
+  let
+    getCompliance : Maybe ComplianceSummaryValue -> Float
+    getCompliance rc =
+      case rc of
+        Just c  ->
+          let
+            allComplianceValues = getAllComplianceValues c.complianceDetails
+          in
+            if ( allComplianceValues.okStatus.value + allComplianceValues.nonCompliant.value + allComplianceValues.error.value + allComplianceValues.unexpected.value + allComplianceValues.pending.value + allComplianceValues.reportsDisabled.value + allComplianceValues.noReport.value == 0 ) then
+              -1.0
+            else
+              c.compliance
+        Nothing -> -2.0
+    groupGlobalCompliance g = getCompliance <| Maybe.map (.global) (getGroupCompliance model g.id)
+    groupTargetedCompliance g = getCompliance <| Maybe.map (.targeted) (getGroupCompliance model g.id)
+    order = case model.ui.groupFilters.tableFilters.sortBy of
+      Name       -> NaturalOrdering.compare g1.name g2.name
+      Parent     ->
+        let
+          categoryOrEmpty g = Maybe.withDefault "" (Maybe.map (getCategoryName model) g.category)
+          o = NaturalOrdering.compare (categoryOrEmpty g1) (categoryOrEmpty g2)
+        in
+          case o of
+            EQ -> NaturalOrdering.compare g1.name g2.name
+            _  -> o
+
+      GlobalCompliance ->
+        compare (groupGlobalCompliance g1) (groupGlobalCompliance g2)
+      TargetedCompliance ->
+        compare (groupTargetedCompliance g1) (groupTargetedCompliance g2)
+  in
+    if model.ui.groupFilters.tableFilters.sortOrder == Asc then
+      order
+    else
+      case order of
+        LT -> GT
+        EQ -> EQ
+        GT -> LT
+
+
+generateLoadingTable : Html Msg
+generateLoadingTable =
+  div [class "table-container skeleton-loading"]
+  [ table [class "dataTable"]
+    [ thead []
+      [ tr [class "head"]
+        [ th [][ span[][] ]
+        , th [][ span[][] ]
+        , th [][ span[][] ]
+        , th [][ span[][] ]
+        , th [][ span[][] ]
+        ]
+      ]
+    , tbody []
+      [ tr[] [ td[][span[style "width" "45%"][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      , tr[] [ td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      , tr[] [ td[][span[style "width" "30%"][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      , tr[] [ td[][span[style "width" "75%"][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      , tr[] [ td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      , tr[] [ td[][span[style "width" "45%"][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      , tr[] [ td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      , tr[] [ td[][span[style "width" "70%"][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      , tr[] [ td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      , tr[] [ td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      , tr[] [ td[][span[style "width" "80%"][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      , tr[] [ td[][span[style "width" "30%"][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      , tr[] [ td[][span[style "width" "75%"][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      , tr[] [ td[][span[style "width" "45%"][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      , tr[] [ td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      , tr[] [ td[][span[style "width" "70%"][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      , tr[] [ td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]], td[][span[][]] ]
+      ]
+    ]
+  ]
+
+generateLoadingList : Html Msg
+generateLoadingList =
+  ul[class "skeleton-loading"]
+  [ li[style "width" "calc(100% - 25px)"][i[][], span[][]]
+  , li[][i[][], span[][]]
+  , li[style "width" "calc(100% - 95px)"][i[][], span[][]]
+  , ul[]
+    [ li[style "width" "calc(100% - 45px)"][i[][], span[][]]
+    , li[style "width" "calc(100% - 125px)"][i[][], span[][]]
+    , li[][i[][], span[][]]
+    ]
+  , li[][i[][], span[][]]
+  ]
+
+thClass : TableFilters -> SortBy -> String
+thClass tableFilters sortBy =
+  if sortBy == tableFilters.sortBy then
+    case  tableFilters.sortOrder of
+      Asc  -> "sorting_asc"
+      Desc -> "sorting_desc"
+  else
+    "sorting"
+
+sortTable : Filters -> SortBy -> Filters
+sortTable filters sortBy =
+  let
+    tableFilters = filters.tableFilters
+    order =
+      case tableFilters.sortOrder of
+        Asc -> Desc
+        Desc -> Asc
+  in
+    if sortBy == tableFilters.sortBy then
+      {filters | tableFilters = {tableFilters | sortOrder = order}}
+    else
+      {filters | tableFilters = {tableFilters | sortBy = sortBy, sortOrder = Asc}}
+
+buildTooltipContent : String -> String -> String
+buildTooltipContent title content =
+  let
+    headingTag = "<h4 class='tags-tooltip-title'>"
+    contentTag = "</h4><div class='tooltip-inner-content'>"
+    closeTag   = "</div>"
+  in
+    headingTag ++ title ++ contentTag ++ content ++ closeTag
+
+foldedClass : TreeFilters -> String -> String
+foldedClass treeFilters catId =
+  if List.member catId treeFilters.folded then
+    " jstree-closed"
+  else
+    " jstree-open"
+
+foldUnfoldCategory : Filters -> String -> Filters
+foldUnfoldCategory filters catId =
+  let
+    treeFilters = filters.treeFilters
+    foldedList  =
+      if List.member catId treeFilters.folded then
+        List.Extra.remove catId treeFilters.folded
+      else
+        catId :: treeFilters.folded
+  in
+    {filters | treeFilters = {treeFilters | folded = foldedList}}
+
+getIdAnchorKey : String -> String
+getIdAnchorKey id =
+  if String.startsWith "special:" id || String.startsWith "policyServer:" id then
+    "target"
+  else
+    "groupId"
+
+getGroupLink : String -> String -> String
+getGroupLink contextPath id =
+  let
+    anchorKey = getIdAnchorKey id
+  in
+    contextPath ++ """/secure/nodeManager/groups#{\"""" ++ anchorKey ++ """\":\"""" ++ id ++ """\"}"""
+
+hasMoreGroups : Model -> Bool
+hasMoreGroups model =
+  let
+    countTreeElements : Category Group -> Int
+    countTreeElements category =
+      let
+        subElems = case category.subElems of SubCategories l -> l
+      in
+        (List.length category.elems) + List.sum (List.map countTreeElements subElems)
+  in
+    (countTreeElements model.groupsTree) > (Dict.size model.groupsCompliance)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -738,7 +738,7 @@ class NodeGroupForm(
               val updateCategory = newCategory.getOrElse(parentCategoryId)
               successPopup & onSuccessCallback(Left((Right(newGroup), updateCategory))) &
               (if (action == DGModAction.Delete)
-                 SetHtml(htmlId_item, NodeSeq.Empty)
+                 RedirectTo("/secure/nodeManager/groups")
                else
                  Noop)
             }

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
@@ -5,56 +5,31 @@
   <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-groups.css"/>
   <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-groupcompliance.js"></script>
   <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-grouprelatedrules.js"></script>
+  <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-groups.js"></script>
 </head_merge>
 
 <span data-list="node.Groups.head"></span>
-<div class="rudder-template">
-  <div class="template-sidebar sidebar-left" data-lift="node.Groups.groupHierarchy">
-      <div class="sidebar-header">
-        <div class="header-title">
-          <h1>Groups</h1>
-          <div class="header-buttons">
-            <lift:Authz role="group_write">
-              <div id="newItem">Here comes the New item Button</div>
-            </lift:Authz>
-          </div>
-        </div>
-        <div class="header-filter">
-          <div class="input-group">
-            <button type="button" class="btn btn-default" onclick="toggleTree('#groupTree', this);">
-              <span class="fa fa-folder fa-folder-open"></span>
-            </button>
-            <input class="form-control" placeholder="Filter" id="groupSearch" onkeydown="refuseEnter(event);" onkeyup="searchTree('#groupSearch', '#groupTree');">
-            <button type="button" class="btn btn-default" onclick="clearSearchFieldTree('#groupSearch', '#groupTree');" >
-              <span class="fa fa-times"></span>
-            </button>
-          </div>
-        </div>
-
-      </div>
-      <div class="sidebar-body">
-        <div id="groupTree" class="sidebar-list">Here comes the Groups Tree</div>
-      </div>
-  </div>
-
-  <div class="template-main" id="ajaxItemContainer">
-    <div class="jumbotron">
-      <h1>Groups</h1>
-      <p>A group is based on a query over inventory data that defines a set of nodes, on which specific policies can then be applied.</p>
-      <p>Group categories are there to visually organize groups, and have no effect on the content of the groups or the applied configuration.</p>
-      <p>There is a set of pre-defined groups (called system groups), that covers Rudder-related classification.</p>
-    </div>
-    <div data-lift="node.Groups.initRightPanel"></div>
-  </div>
-
+<div id="groups-app">
 </div>
 
 
-<div id="createGroupPopup" class="modal fade" tabindex="-1">
+<div id="createGroupPopup" data-bs-target="#createGroupPopup" class="modal fade" tabindex="-1">
   <div id="createGroupContainer"></div>
 </div>
 
 <div data-lift="node.Groups.detailsPopup"></div>
 
+<div data-lift="node.Groups.initRightPanel"></div>
+
+<div data-lift="node.Groups.groupHierarchy"></div>
+
+<script>
+  var hasWriteRights = false;
+</script>
+<lift:authz role="rule_write">
+  <script>
+    hasWriteRights = true;
+  </script>
+</lift:authz>
 </lift:surround>
 


### PR DESCRIPTION
https://issues.rudder.io/issues/23968

Display all groups compliances summary in the home "Groups" UI : 
* we needed a separate API endpoint to format both "targeted" and "global" compliance summary in two compliance bars, for all groups : `api/compliance/summary/groups`,
* rendering of the compliance table displaying the compliance bars is made in Elm (as in the "Rules" UI); that introduced the need to migrate the groups tree on the sidebar to Elm, as well as boostraping a new Elm app for 'groups'. At some point, the previous Scala code (with liftweb) needs to display the details of the group, of a category, and the modal to create a group/category. So, quite a few Elm ports and subscription are added to make the state of the Elm app consistent with the display with lift...

![Screenshot from 2024-01-03 18-40-11](https://github.com/Normation/rudder/assets/65616064/ddd3f52d-8ef7-449d-b970-c17372f9b22f)
