### PR TITLE
Fixes #23956: Rudder agent scheduled runs are not triggered at regular interval

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/SystemVariableSpecServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/SystemVariableSpecServiceImpl.scala
@@ -272,6 +272,16 @@ class SystemVariableSpecServiceImpl extends SystemVariableSpecService {
       multivalued = false,
       constraint = Constraint(typeName = IntegerVType())
     ),
+    // see https://issues.rudder.io/issues/23956
+    // This variable contains a pre-computed real agent first run time, including
+    // a pre-computed splay-time derived from the UUID, and stable given an UUID and
+    // a rudder version (but still opaque)
+    SystemVariableSpec(
+      "AGENT_RUN_STARTTIME",
+      "The pre-computed time at which agent should start running, including a precomputed random splaytime",
+      multivalued = false,
+      constraint = Constraint(typeName = BasicStringVType())
+    ),
     SystemVariableSpec(
       "AGENT_RUN_SCHEDULE",
       "Schedule for the executor daemon",

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
@@ -157,17 +157,16 @@ final case class ParamInterpolationContext(
 final case class InterpolationContext(
     nodeInfo:         NodeInfo,
     policyServerInfo: NodeInfo,
-    globalPolicyMode: GlobalPolicyMode,          // environment variable for that server
+    globalPolicyMode: GlobalPolicyMode,
+    // environment variable for that server
     // must be a case insensitive Map !!!!
-
-    nodeContext:      TreeMap[String, Variable], // parameters for this node
+    nodeContext:      TreeMap[String, Variable],
+    // parameters for this node
     // must be a case SENSITIVE Map !!!!
-
-    parameters:       Map[String, ConfigValue],  // the depth of the interpolation context evaluation
+    parameters:       Map[String, ConfigValue], // the depth of the interpolation context evaluation
     // used as a lazy, trivial, mostly broken way to detect cycle in interpretation
     // for ex: param a => param b => param c => ..... => param a
     // should not be evaluated
-
     depth:            Int
 ) extends GenericInterpolationContext[ConfigValue]
 
@@ -251,13 +250,13 @@ final case class NodeRunHook(
 )
 
 final case class NodeConfiguration(
-    nodeInfo:    NodeInfo,
-    modesConfig: NodeModeConfig, // sorted list of policies for the node.
-
-    policies: List[Policy], // the merged pre-/post-run hooks
-
-    runHooks: List[NodeRunHook], // environment variable for that server
-
+    nodeInfo:     NodeInfo,
+    modesConfig:  NodeModeConfig,
+    // sorted list of policies for the node.
+    policies:     List[Policy],
+    // the merged pre-/post-run hooks
+    runHooks:     List[NodeRunHook],
+    // environment variable for that server
     nodeContext:  Map[String, Variable],
     parameters:   Set[ParameterForConfiguration],
     isRootServer: Boolean = false

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
@@ -60,6 +60,10 @@ import com.normation.rudder.reports._
 import com.normation.rudder.services.servers.PolicyServerManagementService
 import com.normation.rudder.services.servers.RelaySynchronizationMethod
 import com.normation.zio._
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 import net.liftweb.common.Box
 import net.liftweb.common.EmptyBox
 import net.liftweb.common.Failure
@@ -251,11 +255,14 @@ class SystemVariableServiceImpl(
 
     val varAllowedNetworks = systemVariableSpecService.get("ALLOWED_NETWORKS").toVariable(allowedNetworks)
 
-    val agentRunParams = {
+    // a triplet of agent run, start hour, the string schedule in cfengine format
+    val agentRunParams: PureResult[(AgentRunInterval, LocalTime, String)] = {
       if (nodeInfo.isPolicyServer) {
         val policyServerSchedule =
           """ "Min00", "Min05", "Min10", "Min15", "Min20", "Min25", "Min30", "Min35", "Min40", "Min45", "Min50", "Min55" """
-        Right((AgentRunInterval(Some(false), 5, 0, 0, 0), policyServerSchedule))
+        // root server has no splaytime
+        val startHour            = LocalTime.of(0, 0)
+        Right((AgentRunInterval(Some(false), 5, 0, 0, 0), startHour, policyServerSchedule))
       } else {
         val runInterval = nodeInfo.nodeReportingConfiguration.agentRunInterval match {
           case Some(nodeRunInterval) if nodeRunInterval.overrides.getOrElse(false) =>
@@ -264,15 +271,17 @@ class SystemVariableServiceImpl(
             globalAgentRun
         }
         for {
-          schedule <- ComputeSchedule
-                        .computeSchedule(
-                          runInterval.startHour,
-                          runInterval.startMinute,
-                          runInterval.interval
-                        )
-                        .chainError(s"Could not compute the run schedule for node ${nodeInfo.id.value}")
+          res <- ComputeSchedule
+                   .computeSchedule(runInterval.startHour, runInterval.startMinute, runInterval.interval)
+                   .chainError(s"Could not compute the run schedule for node ${nodeInfo.id.value}")
         } yield {
-          (runInterval, schedule)
+          val (startTime, schedule) = res
+          val splayedStartTime      = ComputeSchedule.getSplayedStartTime(
+            nodeInfo.id.value,
+            startTime,
+            Duration.ofMinutes(runInterval.interval.toLong)
+          )
+          (runInterval, splayedStartTime, schedule)
         }
       }
     }
@@ -298,7 +307,7 @@ class SystemVariableServiceImpl(
     }
 
     val agentRunVariables = (agentRunParams.map {
-      case (runInterval, schedule) =>
+      case (runInterval, startTime, schedule) =>
         // The heartbeat should be strictly shorter than the run execution, otherwise they may be skipped
         val heartbeat = runInterval.interval * heartBeatFrequency - 1
         val vars      = {
@@ -307,6 +316,7 @@ class SystemVariableServiceImpl(
           systemVariableSpecService.get("AGENT_RUN_SCHEDULE").toVariable(Seq(schedule)) ::
           systemVariableSpecService.get("RUDDER_HEARTBEAT_INTERVAL").toVariable(Seq(heartbeat.toString)) ::
           systemVariableSpecService.get("RUDDER_REPORT_MODE").toVariable(Seq(globalComplianceMode.name)) ::
+          systemVariableSpecService.get("AGENT_RUN_STARTTIME").toVariable(Seq(ComputeSchedule.formatStartTime(startTime))) ::
           Nil
         }
         vars.map(v => v.spec.name -> v).toMap
@@ -577,7 +587,7 @@ class SystemVariableServiceImpl(
     }
 
     import net.liftweb.json.{prettyRender, JObject, JString, JField}
-    // Utilitaty method to convert NodeInfo to JSON
+    // Utility method to convert NodeInfo to JSON
     def nodeInfoToJson(nodeInfo: NodeInfo): List[JField] = {
       JField("hostname", JString(nodeInfo.hostname)) ::
       JField("policyServerId", JString(nodeInfo.policyServerId.value)) ::
@@ -653,11 +663,15 @@ class SystemVariableServiceImpl(
 }
 
 object ComputeSchedule {
+  /*
+   * Compute agent schedule. Return the actual real start hour/minute based on the execution interval
+   * and the run string in CFEngine format
+   */
   def computeSchedule(
       startHour:         Int,
       startMinute:       Int,
       executionInterval: Int
-  ): PureResult[String] = {
+  ): PureResult[(java.time.LocalTime, String)] = {
 
     val minutesFreq = executionInterval % 60
     val hoursFreq: Int = executionInterval / 60
@@ -676,16 +690,49 @@ object ComputeSchedule {
         val actualStartMinute = startMinute % minutesFreq
         val mins              = Range(actualStartMinute, 60, minutesFreq) // range doesn't return the end range
         // val mins = for ( min <- 0 to 59; if ((min%minutesFreq) == actualStartMinute) ) yield { min }
-        Right(mins.map("\"Min" + "%02d".format(_) + "\"").mkString(", "))
+        Right((LocalTime.of(0, actualStartMinute), mins.map("\"Min" + "%02d".format(_) + "\"").mkString(", ")))
 
       case _ =>
         // hour is not 0, then we don't have minutes
         val actualStartHour = startHour % hoursFreq
         val hours           = Range(actualStartHour, 24, hoursFreq)
         val minutesFormat   = "Min" + "%02d".format(startMinute)
-        Right(hours.map("\"Hr" + "%02d".format(_) + "." + minutesFormat + "\"").mkString(", "))
+        Right(
+          (
+            LocalTime.of(actualStartHour, startMinute),
+            hours.map("\"Hr" + "%02d".format(_) + "." + minutesFormat + "\"").mkString(", ")
+          )
+        )
     }
 
+  }
+
+  /*
+   * An algorithm to get a splaytime in seconds from a node ID and a execution interval.
+   *
+   * There is no guarantee about the distribution of splay, and you must use random input
+   * to have a change to get something barely random (uuids are ok for that, and it's the
+   * use case).
+   */
+  def computeSplayTime(nodeId: String, interval: Duration): Duration = {
+    if (nodeId.isEmpty) Duration.ofSeconds(0)
+    else {
+      val bigInt       = BigInt.apply(nodeId.getBytes(StandardCharsets.UTF_8))
+      val secondPerDay = 86400
+      Duration.ofSeconds(bigInt.mod(interval.getSeconds).mod(secondPerDay).toLong)
+    }
+  }
+
+  /*
+   * Convert an agent schedule into the starttime string which include the splaytime
+   */
+  def getSplayedStartTime(nodeId: String, startTime: LocalTime, interval: Duration): LocalTime = {
+    startTime.plus(computeSplayTime(nodeId, interval))
+  }
+
+  def formatStartTime(startTime: LocalTime): String = {
+    // the withNano(0) is to only print "hh:mm:ss", not "hh:mm:ss.sss"
+    startTime.withNano(0).format(DateTimeFormatter.ISO_TIME)
   }
 
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-cfe-with-500-directives/rules/cfengine-community/rudder.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-cfe-with-500-directives/rules/cfengine-community/rudder.json
@@ -2,6 +2,7 @@
   "AGENT_RUN_INTERVAL":"5",
   "AGENT_RUN_SCHEDULE":"\"Min01\", \"Min06\", \"Min11\", \"Min16\", \"Min21\", \"Min26\", \"Min31\", \"Min36\", \"Min41\", \"Min46\", \"Min51\", \"Min56\"",
   "AGENT_RUN_SPLAYTIME":"4",
+  "AGENT_RUN_STARTTIME":"00:05:12",
   "AGENT_TYPE":"cfengine-community",
   "ALLOWED_NETWORKS":[],
   "CFENGINE_OUTPUTS_TTL":"7",

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-cfe-with-two-directives/rules/cfengine-community/rudder.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-cfe-with-two-directives/rules/cfengine-community/rudder.json
@@ -2,6 +2,7 @@
   "AGENT_RUN_INTERVAL":"5",
   "AGENT_RUN_SCHEDULE":"\"Min01\", \"Min06\", \"Min11\", \"Min16\", \"Min21\", \"Min26\", \"Min31\", \"Min36\", \"Min41\", \"Min46\", \"Min51\", \"Min56\"",
   "AGENT_RUN_SPLAYTIME":"4",
+  "AGENT_RUN_STARTTIME":"00:05:12",
   "AGENT_TYPE":"cfengine-community",
   "ALLOWED_NETWORKS":[],
   "CFENGINE_OUTPUTS_TTL":"7",

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-gen-var-def-override/rules/cfengine-community/rudder.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-gen-var-def-override/rules/cfengine-community/rudder.json
@@ -2,6 +2,7 @@
   "AGENT_RUN_INTERVAL":"5",
   "AGENT_RUN_SCHEDULE":"\"Min01\", \"Min06\", \"Min11\", \"Min16\", \"Min21\", \"Min26\", \"Min31\", \"Min36\", \"Min41\", \"Min46\", \"Min51\", \"Min56\"",
   "AGENT_RUN_SPLAYTIME":"4",
+  "AGENT_RUN_STARTTIME":"00:05:12",
   "AGENT_TYPE":"cfengine-community",
   "ALLOWED_NETWORKS":[],
   "CFENGINE_OUTPUTS_TTL":"7",

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-default-install/rudder.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-default-install/rudder.json
@@ -2,6 +2,7 @@
   "AGENT_RUN_INTERVAL":"5",
   "AGENT_RUN_SCHEDULE":" \"Min00\", \"Min05\", \"Min10\", \"Min15\", \"Min20\", \"Min25\", \"Min30\", \"Min35\", \"Min40\", \"Min45\", \"Min50\", \"Min55\" ",
   "AGENT_RUN_SPLAYTIME":"0",
+  "AGENT_RUN_STARTTIME":"00:00:00",
   "AGENT_TYPE":"cfengine-community",
   "ALLOWED_NETWORKS":[
     "192.168.12.0/24",

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-sys-var-false/rudder.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-sys-var-false/rudder.json
@@ -2,6 +2,7 @@
   "AGENT_RUN_INTERVAL":"5",
   "AGENT_RUN_SCHEDULE":" \"Min00\", \"Min05\", \"Min10\", \"Min15\", \"Min20\", \"Min25\", \"Min30\", \"Min35\", \"Min40\", \"Min45\", \"Min50\", \"Min55\" ",
   "AGENT_RUN_SPLAYTIME":"0",
+  "AGENT_RUN_STARTTIME":"00:00:00",
   "AGENT_TYPE":"cfengine-community",
   "ALLOWED_NETWORKS":[
     "192.168.12.0/24",

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-one-multipolicy/rudder.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-one-multipolicy/rudder.json
@@ -2,6 +2,7 @@
   "AGENT_RUN_INTERVAL":"5",
   "AGENT_RUN_SCHEDULE":" \"Min00\", \"Min05\", \"Min10\", \"Min15\", \"Min20\", \"Min25\", \"Min30\", \"Min35\", \"Min40\", \"Min45\", \"Min50\", \"Min55\" ",
   "AGENT_RUN_SPLAYTIME":"0",
+  "AGENT_RUN_STARTTIME":"00:00:00",
   "AGENT_TYPE":"cfengine-community",
   "ALLOWED_NETWORKS":[
     "192.168.12.0/24",

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-two-directives/rudder.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-two-directives/rudder.json
@@ -2,6 +2,7 @@
   "AGENT_RUN_INTERVAL":"5",
   "AGENT_RUN_SCHEDULE":" \"Min00\", \"Min05\", \"Min10\", \"Min15\", \"Min20\", \"Min25\", \"Min30\", \"Min35\", \"Min40\", \"Min45\", \"Min50\", \"Min55\" ",
   "AGENT_RUN_SPLAYTIME":"0",
+  "AGENT_RUN_STARTTIME":"00:00:00",
   "AGENT_TYPE":"cfengine-community",
   "ALLOWED_NETWORKS":[
     "192.168.12.0/24",

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/technique-and-revisions/rudder.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/technique-and-revisions/rudder.json
@@ -2,6 +2,7 @@
   "AGENT_RUN_INTERVAL":"5",
   "AGENT_RUN_SCHEDULE":" \"Min00\", \"Min05\", \"Min10\", \"Min15\", \"Min20\", \"Min25\", \"Min30\", \"Min35\", \"Min40\", \"Min45\", \"Min50\", \"Min55\" ",
   "AGENT_RUN_SPLAYTIME":"0",
+  "AGENT_RUN_STARTTIME":"00:00:00",
   "AGENT_TYPE":"cfengine-community",
   "ALLOWED_NETWORKS":[
     "192.168.12.0/24",

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestComputeSchedule.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestComputeSchedule.scala
@@ -38,6 +38,8 @@
 package com.normation.rudder.services.policies
 
 import com.normation.errors.Inconsistency
+import java.time.Duration
+import java.time.LocalTime
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -52,24 +54,39 @@ class TestComputeSchedule extends Specification {
   "A schedule with 5 minutes interval" should {
     "be the default one when starting at 0:00" in {
       ComputeSchedule.computeSchedule(0, 0, 5) must beEqualTo(
-        Right(""""Min00", "Min05", "Min10", "Min15", "Min20", "Min25", "Min30", "Min35", "Min40", "Min45", "Min50", "Min55"""")
+        Right(
+          (
+            LocalTime.of(0, 0),
+            """"Min00", "Min05", "Min10", "Min15", "Min20", "Min25", "Min30", "Min35", "Min40", "Min45", "Min50", "Min55""""
+          )
+        )
       )
     }
 
-    "be the default one when starting at 4:00" in {
+    "be the default one when starting at 4:00 because interval < start hour so we start hour % interval" in {
       ComputeSchedule.computeSchedule(4, 0, 5) must beEqualTo(
-        Right(""""Min00", "Min05", "Min10", "Min15", "Min20", "Min25", "Min30", "Min35", "Min40", "Min45", "Min50", "Min55"""")
+        Right(
+          (
+            LocalTime.of(0, 0),
+            """"Min00", "Min05", "Min10", "Min15", "Min20", "Min25", "Min30", "Min35", "Min40", "Min45", "Min50", "Min55""""
+          )
+        )
       )
     }
 
-    "be the default one of by 2 minutes when starting at 4:02" in {
+    "be the default one (midnight) of by 2 minutes when starting at 4:02 with an interval of 2 min" in {
       ComputeSchedule.computeSchedule(4, 2, 5) must beEqualTo(
-        Right(""""Min02", "Min07", "Min12", "Min17", "Min22", "Min27", "Min32", "Min37", "Min42", "Min47", "Min52", "Min57"""")
+        Right(
+          (
+            LocalTime.of(0, 2),
+            """"Min02", "Min07", "Min12", "Min17", "Min22", "Min27", "Min32", "Min37", "Min42", "Min47", "Min52", "Min57""""
+          )
+        )
       )
     }
   }
 
-  "A squedule with non trivial interval" should {
+  "A schedule with non trivial interval" should {
     "fail if a mix of hours and minutes" in {
       ComputeSchedule.computeSchedule(0, 0, 63) must beEqualTo(
         Left(
@@ -83,16 +100,73 @@ class TestComputeSchedule extends Specification {
     "be every hours if defined with an interval of 1 hour" in {
       ComputeSchedule.computeSchedule(0, 0, 60) must beEqualTo(
         Right(
-          """"Hr00.Min00", "Hr01.Min00", "Hr02.Min00", "Hr03.Min00", "Hr04.Min00", "Hr05.Min00", "Hr06.Min00", "Hr07.Min00", "Hr08.Min00", "Hr09.Min00", "Hr10.Min00", "Hr11.Min00", "Hr12.Min00", "Hr13.Min00", "Hr14.Min00", "Hr15.Min00", "Hr16.Min00", "Hr17.Min00", "Hr18.Min00", "Hr19.Min00", "Hr20.Min00", "Hr21.Min00", "Hr22.Min00", "Hr23.Min00""""
+          (
+            LocalTime.of(0, 0),
+            """"Hr00.Min00", "Hr01.Min00", "Hr02.Min00", "Hr03.Min00", "Hr04.Min00", "Hr05.Min00", "Hr06.Min00", "Hr07.Min00", "Hr08.Min00", "Hr09.Min00", "Hr10.Min00", "Hr11.Min00", "Hr12.Min00", "Hr13.Min00", "Hr14.Min00", "Hr15.Min00", "Hr16.Min00", "Hr17.Min00", "Hr18.Min00", "Hr19.Min00", "Hr20.Min00", "Hr21.Min00", "Hr22.Min00", "Hr23.Min00""""
+          )
         )
       )
     }
-    "be every two hours if defined with an interval of 2 hours, and off by some minutes" in {
+    "be every two hours if defined with an interval of 2 hours, and off by some minutes, but starts at 1 because 3%2" in {
       ComputeSchedule.computeSchedule(3, 12, 120) must beEqualTo(
         Right(
-          """"Hr01.Min12", "Hr03.Min12", "Hr05.Min12", "Hr07.Min12", "Hr09.Min12", "Hr11.Min12", "Hr13.Min12", "Hr15.Min12", "Hr17.Min12", "Hr19.Min12", "Hr21.Min12", "Hr23.Min12""""
+          (
+            LocalTime.of(1, 12),
+            """"Hr01.Min12", "Hr03.Min12", "Hr05.Min12", "Hr07.Min12", "Hr09.Min12", "Hr11.Min12", "Hr13.Min12", "Hr15.Min12", "Hr17.Min12", "Hr19.Min12", "Hr21.Min12", "Hr23.Min12""""
+          )
         )
       )
     }
+    "be every 4 hours if defined with an interval of 4h with the same start time if it's lower than interval" in {
+      ComputeSchedule.computeSchedule(3, 12, 240) must beEqualTo(
+        Right(
+          (
+            LocalTime.of(3, 12),
+            """"Hr03.Min12", "Hr07.Min12", "Hr11.Min12", "Hr15.Min12", "Hr19.Min12", "Hr23.Min12""""
+          )
+        )
+      )
+    }
+  }
+
+  "The pre-computed splay-timed hour" should {
+    val fiveMinutes = Duration.ofMinutes(5)
+
+    val uuid1        = "365ceac5-a766-48f1-83d9-283f867b2d3d"
+    // the random splay from that uuid1: 2min 8s for interval 5min
+    val uuid1Splay   = Duration.ofSeconds(128)
+    // for 6h interval: 3h 37m 8s
+    val uuid1Splay6h = Duration.ofSeconds(3 * 3600 + 37 * 60 + 8)
+
+    val uuid2      = "6daff2fe-0e49-4200-8b8f-0724b59c9dca"
+    // the random splay from that uuid2: 1min 1s
+    val uuid2Splay = Duration.ofSeconds(61)
+
+    "be 0 when nodeId is empty" in {
+      ComputeSchedule.computeSplayTime("", fiveMinutes) must beEqualTo(Duration.ofSeconds(0))
+    }
+
+    "be stable for a given uuid" in {
+      val d1 = ComputeSchedule.computeSplayTime(uuid1, fiveMinutes)
+      val d2 = ComputeSchedule.computeSplayTime(uuid1, fiveMinutes)
+
+      (d1 === uuid1Splay) and (d2 === uuid1Splay)
+    }
+
+    "adapt to bigger interval" in {
+      ComputeSchedule.computeSplayTime(uuid1, Duration.ofHours(6)) === uuid1Splay6h
+    }
+
+    "be different for different uuids" in {
+      val d1 = ComputeSchedule.computeSplayTime(uuid1, fiveMinutes)
+      val d2 = ComputeSchedule.computeSplayTime(uuid2, fiveMinutes)
+
+      (d1 === uuid1Splay) and (d2 === uuid2Splay)
+    }
+
+    "leads to the correct string" in {
+      ComputeSchedule.formatStartTime(ComputeSchedule.getSplayedStartTime(uuid1, LocalTime.of(3, 0), fiveMinutes)) === "03:02:08"
+    }
+
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/23956

We want to present a new value in `rudder.json`. For that, we need to create a new  `SystemVariable` and its spec. 

The content of the variable is the real start time + a splay time derived from node ID.

The splay time computation was the easy part, and we just assume that the input is random (it's supposed to be an uuid) and get its byte as a BitInt, then just `modulo` so that it fits in the expected interval given by agent run period (in seconds).

I chose to use `java.time` structure since it seems that we will need to switch to it in a near futur, at least we can start to use them on new, isolated content. 

The hardest part was to rediscover that the `start hour` and `start minutes` in the `AgentRunInterval` data structure are not really the start time of the agent. They are more like a shift from midnight modulo agent run interval, which means that if the agent run is 5 minutes, whatever `start hour` contains, the actual start hour will always be `0`.

Finaly, that new data does not impact any of the existing system vars, and in particular it DOES NOT change the schedule string used by CFEngine agent - which is by design, since the agent will do localy its splaytime computation.  