### PR TITLE
Fixes #23998: Completly ignore source target of rules when importing an archive

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -175,23 +175,29 @@ object ArchiveScope       extends Enum[ArchiveScope] {
   }
 }
 
-sealed trait MergePolicy extends EnumEntry         { def value: String }
-object MergePolicy       extends Enum[MergePolicy] {
+// explicitly using the entryName because it's an external API needing special care and grep-ability.
+sealed abstract class MergePolicy(override val entryName: String) extends EnumEntry
+object MergePolicy                                                extends Enum[MergePolicy] {
   // Default merge policy is "override everything", ie what is in the archive replace whatever exists in Rudder
-  case object OverrideAll    extends MergePolicy { val value = "override-all"     }
+  case object OverrideAll     extends MergePolicy("override-all")
   // A merge policy that will keep current groups for rule with an ID common with one of the archive
-  case object KeepRuleGroups extends MergePolicy { val value = "keep-rule-groups" }
+  case object KeepRuleTargets extends MergePolicy("keep-rule-targets")
+
+  // A merge policy that will always delete source groups of rule, and if rule exists, copy destination rule target (keep them)
+  case object IgnoreSourceTargets extends MergePolicy("ignore-source-targets")
 
   val values: IndexedSeq[MergePolicy] = findValues
 
+  override val extraNamesToValuesMap: Map[String, MergePolicy] = Map("keep-rule-groups" -> KeepRuleTargets)
+
   def parse(s: String): Either[String, MergePolicy] = {
-    values.find(_.value == s.toLowerCase.strip()) match {
-      case None    =>
-        Left(
-          s"Error: can not parse '${s}' as a merge policy for archive import. Accepted values are: ${values.mkString(", ")}"
-        )
-      case Some(x) => Right(x)
-    }
+    MergePolicy
+      .withNameInsensitiveEither(s)
+      .left
+      .map(err => {
+        s"Error: can not parse '${s}' as a merge policy for archive import. Accepted values are: ${values
+            .mkString(", ")}. Error was: ${err.getMessage()}"
+      })
   }
 }
 
@@ -1573,12 +1579,19 @@ class SaveArchiveServicebyRepo(
       x <- roRuleRepos.getOpt(r.id)
       _ <- x match {
              case Some(value) =>
-               // if merge policy is `keep-rule-groups`, update rule from archive with existing groups before saving
-               val ruleToSave = if (mergePolicy == MergePolicy.KeepRuleGroups) {
-                 r.copy(targets = value.targets)
-               } else r
+               // if merge policy asks for that, update rule from archive with existing groups before saving so
+               // that the rules use the actual groups meaning something in that instance.
+               val ruleToSave = {
+                 if (mergePolicy == MergePolicy.KeepRuleTargets || mergePolicy == MergePolicy.IgnoreSourceTargets) {
+                   r.copy(targets = value.targets)
+                 } else r
+               }
                woRuleRepos.update(ruleToSave, eventMetadata.modId, eventMetadata.actor, eventMetadata.msg)
-             case None        => woRuleRepos.create(r, eventMetadata.modId, eventMetadata.actor, eventMetadata.msg)
+             case None        =>
+               val ruleToSave = if (mergePolicy == MergePolicy.IgnoreSourceTargets) {
+                 r.copy(targets = Set())
+               } else r
+               woRuleRepos.create(ruleToSave, eventMetadata.modId, eventMetadata.actor, eventMetadata.msg)
            }
     } yield ()
   }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
@@ -349,7 +349,7 @@ class ArchiveApiTest extends Specification with AfterAll with Loggable {
         restTestSetUp.archiveAPIModule.archiveSaver.base.get.runNow match {
           case None         => ko(s"No policies were saved")
           case Some((p, m)) =>
-            (m must beEqualTo(MergePolicy.KeepRuleGroups))
+            (m must beEqualTo(MergePolicy.KeepRuleTargets))
         }
 
       case err => ko(s"I got an error in test: ${err}")

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/lift/MergePolicySpec.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/lift/MergePolicySpec.scala
@@ -1,7 +1,6 @@
 package com.normation.rudder.rest.lift
 
-import com.normation.rudder.rest.lift.MergePolicy.KeepRuleGroups
-import com.normation.rudder.rest.lift.MergePolicy.OverrideAll
+import com.normation.rudder.rest.lift.MergePolicy.*
 import zio.test.*
 import zio.test.Assertion.*
 
@@ -12,7 +11,7 @@ object MergePolicySpec extends ZIOSpecDefault {
       assert(MergePolicy.parse("unsupported"))(
         isLeft(
           containsString(
-            Seq(KeepRuleGroups, OverrideAll).mkString(", ")
+            Seq(KeepRuleTargets, OverrideAll).mkString(", ")
           )
         )
       )

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserManagementServiceTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserManagementServiceTest.scala
@@ -1,7 +1,8 @@
-package com.normation.rudder.users
+package com.normation.rudder.rest.users
 
 import com.normation.rudder.AuthorizationType
 import com.normation.rudder.Role
+import com.normation.rudder.users.UserManagementService
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserSerializationTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserSerializationTest.scala
@@ -1,5 +1,6 @@
-package com.normation.rudder.users
+package com.normation.rudder.rest.users
 
+import com.normation.rudder.users.*
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner


### PR DESCRIPTION
https://issues.rudder.io/issues/23998

Add the new merge policy which is just setting target to empty in addition to previous one when in use.

Also, I want to have a common naming convention, so use a set for names now to keep backward compat with the old name. 