### PR TITLE
Fixes #24011: Archiving allows to read inconsistent active technique category ids 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
@@ -166,12 +166,25 @@ trait BuildCategoryPathName[T] {
 
   // list of directories : don't forget the one for the serialized category.
   // revert the order to start by the root of technique library.
-  def newCategoryDirectory(catId: T, parents: List[T]): File = {
-    parents match {
-      case Nil       => // that's the root
-        getItemDirectory
-      case h :: tail => // skip the head, which is the root category
-        new File(newCategoryDirectory(h, tail), getCategoryName(catId))
+  // Fail if the directory attempting to write to is not under the root directory getItemDirectory
+  def newCategoryDirectory(catId: T, parents: List[T]): IOResult[File] = {
+    def recNewCategoryDirectory(catId: T, parents: List[T]): File = {
+      parents match {
+        case Nil       => // that's the root
+          getItemDirectory
+        case h :: tail => // skip the head, which is the root category
+          new File(recNewCategoryDirectory(h, tail), getCategoryName(catId))
+      }
+    }
+    val target = recNewCategoryDirectory(catId, parents)
+
+    if (target.getCanonicalPath().startsWith(getItemDirectory.getCanonicalPath())) {
+      target.succeed
+    } else {
+      Inconsistency(
+        s"Error when checking required directories '${target.getPath}' to archive in gitRepo.git: relative path must not allow access to parent directories, " +
+        s"only to directories under directory ${getItemDirectory}"
+      ).fail
     }
   }
 }
@@ -351,7 +364,7 @@ class GitActiveTechniqueCategoryArchiverImpl(
   override lazy val tagPrefix = "archives/directives/"
 
   private[this] def newActiveTechniquecFile(uptcId: ActiveTechniqueCategoryId, parents: List[ActiveTechniqueCategoryId]) = {
-    new File(newCategoryDirectory(uptcId, parents), serializedCategoryName)
+    newCategoryDirectory(uptcId, parents).map(new File(_, serializedCategoryName))
   }
 
   private[this] def archiveWithRename(
@@ -361,9 +374,9 @@ class GitActiveTechniqueCategoryArchiverImpl(
       gitCommit:  Option[(ModificationId, PersonIdent, Option[String])]
   ): IOResult[GitPath] = {
 
-    val uptcFile = newActiveTechniquecFile(uptc.id, newParents)
-    val gitPath  = toGitPath(uptcFile)
     for {
+      uptcFile   <- newActiveTechniquecFile(uptc.id, newParents)
+      gitPath     = toGitPath(uptcFile)
       archive    <- writeXml(
                       uptcFile,
                       activeTechniqueCategorySerialisation.serialise(uptc),
@@ -374,13 +387,15 @@ class GitActiveTechniqueCategoryArchiverImpl(
                       case Some((modId, commiter, reason)) =>
                         oldParents match {
                           case Some(olds) =>
-                            commitMvDirectoryWithModId(
-                              modId,
-                              commiter,
-                              toGitPath(newActiveTechniquecFile(uptc.id, olds)),
-                              uptcGitPath,
-                              "Move archive of technique library category with ID '%s'%s".format(uptc.id.value, GET(reason))
-                            )
+                            newActiveTechniquecFile(uptc.id, olds).flatMap(oldUptcFile => {
+                              commitMvDirectoryWithModId(
+                                modId,
+                                commiter,
+                                toGitPath(oldUptcFile),
+                                uptcGitPath,
+                                "Move archive of technique library category with ID '%s'%s".format(uptc.id.value, GET(reason))
+                              )
+                            })
                           case None       =>
                             commitAddFileWithModId(
                               modId,
@@ -409,28 +424,28 @@ class GitActiveTechniqueCategoryArchiverImpl(
       getParents: List[ActiveTechniqueCategoryId],
       gitCommit:  Option[(ModificationId, PersonIdent, Option[String])]
   ): IOResult[GitPath] = {
-    val uptcFile = newActiveTechniquecFile(uptcId, getParents)
-    val gitPath  = toGitPath(uptcFile)
-    if (uptcFile.exists) {
-      for {
-        // don't forget to delete the category *directory*
-        deleted  <- IOResult.attempt(FileUtils.forceDelete(uptcFile))
-        _        <- logPure.debug("Deleted archived technique library category: " + uptcFile.getPath)
-        commited <- gitCommit match {
-                      case Some((modId, commiter, reason)) =>
-                        commitRmFileWithModId(
-                          modId,
-                          commiter,
-                          gitPath,
-                          s"Delete archive of technique library category with ID '${uptcId.value}'${GET(reason)}"
-                        )
-                      case None                            => ZIO.unit
-                    }
-      } yield {
-        GitPath(gitPath)
-      }
-    } else {
-      GitPath(gitPath).succeed
+    for {
+      uptcFile <- newActiveTechniquecFile(uptcId, getParents)
+      gitPath   = toGitPath(uptcFile)
+      // don't forget to delete the category *directory*
+      _        <- ZIO.whenZIO(IOResult.attempt(uptcFile.exists)) {
+                    for {
+                      _ <- IOResult.attempt(FileUtils.forceDelete(uptcFile))
+                      _ <- logPure.debug("Deleted archived technique library category: " + uptcFile.getPath)
+                      _ <- gitCommit match {
+                             case Some((modId, commiter, reason)) =>
+                               commitRmFileWithModId(
+                                 modId,
+                                 commiter,
+                                 gitPath,
+                                 s"Delete archive of technique library category with ID '${uptcId.value}'${GET(reason)}"
+                               )
+                             case None                            => ZIO.unit
+                           }
+                    } yield ()
+                  }
+    } yield {
+      GitPath(gitPath)
     }
   }
 
@@ -446,7 +461,7 @@ class GitActiveTechniqueCategoryArchiverImpl(
       this.archiveActiveTechniqueCategory(uptc, oldParents, gitCommit)
     } else {
       for {
-        deleted  <- deleteActiveTechniqueCategory(uptc.id, oldParents, None)
+        _        <- deleteActiveTechniqueCategory(uptc.id, oldParents, None)
         archived <- archiveWithRename(uptc, Some(oldParents), newParents, gitCommit)
       } yield {
         archived
@@ -605,7 +620,9 @@ class GitActiveTechniqueArchiverImpl(
         Inconsistency(
           s"Active Techniques '${ptName.value}' was asked to be saved in a category which does not exist (empty list of parents, not even the root cateogy was given!)"
         ).fail
-      case h :: tail => new File(new File(newCategoryDirectory(h, tail), ptName.value), activeTechniqueFileName).succeed
+      case h :: tail =>
+        newCategoryDirectory(h, tail).map(catDir => new File(new File(catDir, ptName.value), activeTechniqueFileName))
+
     }
   }
 
@@ -652,20 +669,20 @@ class GitActiveTechniqueArchiverImpl(
       res    <- if (exists) {
                   for {
                     // don't forget to delete the category *directory*
-                    deleted   <- IOResult.attempt(FileUtils.forceDelete(atFile))
-                    _          = logPure.debug(s"Deleted archived technique library template: ${atFile.getPath}")
-                    gitPath    = toGitPath(atFile)
-                    callbacks <- ZIO.foreach(uptModificationCallback.toList)(_.onDelete(ptName, parents, None))
-                    commited  <- gitCommit match {
-                                   case Some((modId, commiter, reason)) =>
-                                     commitRmFileWithModId(
-                                       modId,
-                                       commiter,
-                                       gitPath,
-                                       s"Delete archive of technique library template for technique name '${ptName.value}'${GET(reason)}"
-                                     )
-                                   case None                            => ZIO.unit
-                                 }
+                    _      <- IOResult.attempt(FileUtils.forceDelete(atFile))
+                    _       = logPure.debug(s"Deleted archived technique library template: ${atFile.getPath}")
+                    gitPath = toGitPath(atFile)
+                    _      <- ZIO.foreach(uptModificationCallback.toList)(_.onDelete(ptName, parents, None))
+                    _      <- gitCommit match {
+                                case Some((modId, commiter, reason)) =>
+                                  commitRmFileWithModId(
+                                    modId,
+                                    commiter,
+                                    gitPath,
+                                    s"Delete archive of technique library template for technique name '${ptName.value}'${GET(reason)}"
+                                  )
+                                case None                            => ZIO.unit
+                              }
                   } yield {
                     GitPath(gitPath)
                   }
@@ -757,7 +774,7 @@ class GitDirectiveArchiverImpl(
             .format(directiveId.value, ptName.value)
         ).fail
       case h :: tail =>
-        new File(new File(newCategoryDirectory(h, tail), ptName.value), directiveId.value + ".xml").succeed
+        newCategoryDirectory(h, tail).map(catDir => new File(new File(catDir, ptName.value), directiveId.value + ".xml"))
     }
   }
 
@@ -808,19 +825,19 @@ class GitDirectiveArchiverImpl(
       exists <- IOResult.attempt(piFile.exists)
       res    <- if (exists) {
                   for {
-                    deleted  <- IOResult.attempt(FileUtils.forceDelete(piFile))
-                    _        <- logPure.debug(s"Deleted archive of directive: '${piFile.getPath}'")
-                    gitPath   = toGitPath(piFile)
-                    commited <- gitCommit match {
-                                  case Some((modId, commiter, reason)) =>
-                                    commitRmFileWithModId(
-                                      modId,
-                                      commiter,
-                                      gitPath,
-                                      s"Delete archive of directive with ID '${directiveId.value}'${GET(reason)}"
-                                    )
-                                  case None                            => ZIO.unit
-                                }
+                    _      <- IOResult.attempt(FileUtils.forceDelete(piFile))
+                    _      <- logPure.debug(s"Deleted archive of directive: '${piFile.getPath}'")
+                    gitPath = toGitPath(piFile)
+                    _      <- gitCommit match {
+                                case Some((modId, commiter, reason)) =>
+                                  commitRmFileWithModId(
+                                    modId,
+                                    commiter,
+                                    gitPath,
+                                    s"Delete archive of directive with ID '${directiveId.value}'${GET(reason)}"
+                                  )
+                                case None                            => ZIO.unit
+                              }
                   } yield {
                     GitPath(gitPath)
                   }
@@ -864,7 +881,7 @@ class GitNodeGroupArchiverImpl(
   override lazy val tagPrefix = "archives/groups/"
 
   private[this] def newNgFile(ngcId: NodeGroupCategoryId, parents: List[NodeGroupCategoryId]) = {
-    new File(newCategoryDirectory(ngcId, parents), serializedCategoryName)
+    newCategoryDirectory(ngcId, parents).map(new File(_, serializedCategoryName))
   }
 
   override def archiveNodeGroupCategory(
@@ -872,9 +889,9 @@ class GitNodeGroupArchiverImpl(
       parents:   List[NodeGroupCategoryId],
       gitCommit: Option[(ModificationId, PersonIdent, Option[String])]
   ): IOResult[GitPath] = {
-    val ngcFile = newNgFile(ngc.id, parents)
 
     for {
+      ngcFile <- newNgFile(ngc.id, parents)
       archive <- writeXml(
                    ngcFile,
                    nodeGroupCategorySerialisation.serialise(ngc),
@@ -901,28 +918,28 @@ class GitNodeGroupArchiverImpl(
       getParents: List[NodeGroupCategoryId],
       gitCommit:  Option[(ModificationId, PersonIdent, Option[String])]
   ): IOResult[GitPath] = {
-    val ngcFile = newNgFile(ngcId, getParents)
-    val gitPath = toGitPath(ngcFile)
-    if (ngcFile.exists) {
-      for {
-        // don't forget to delete the category *directory*
-        deleted  <- IOResult.attempt(FileUtils.forceDelete(ngcFile))
-        _        <- logPure.debug(s"Deleted archived node group category: ${ngcFile.getPath}")
-        commited <- gitCommit match {
-                      case Some((modId, commiter, reason)) =>
-                        commitRmFileWithModId(
-                          modId,
-                          commiter,
-                          gitPath,
-                          s"Delete archive of node group category with ID '${ngcId.value}'${GET(reason)}"
-                        )
-                      case None                            => ZIO.unit
-                    }
-      } yield {
-        GitPath(gitPath)
-      }
-    } else {
-      GitPath(gitPath).succeed
+    for {
+      ngcFile <- newNgFile(ngcId, getParents)
+      gitPath  = toGitPath(ngcFile)
+      // don't forget to delete the category *directory*
+      _       <- ZIO.whenZIO(IOResult.attempt(ngcFile.exists)) {
+                   for {
+                     _ <- IOResult.attempt(FileUtils.forceDelete(ngcFile))
+                     _ <- logPure.debug(s"Deleted archived node group category: ${ngcFile.getPath}")
+                     _ <- gitCommit match {
+                            case Some((modId, commiter, reason)) =>
+                              commitRmFileWithModId(
+                                modId,
+                                commiter,
+                                gitPath,
+                                s"Delete archive of node group category with ID '${ngcId.value}'${GET(reason)}"
+                              )
+                            case None                            => ZIO.unit
+                          }
+                   } yield ()
+                 }
+    } yield {
+      GitPath(gitPath)
     }
   }
 
@@ -947,39 +964,37 @@ class GitNodeGroupArchiverImpl(
     if (oldParents == newParents) { // actually, it's an archive, not a move
       this.archiveNodeGroupCategory(ngc, oldParents, gitCommit)
     } else {
-
-      val oldNgcDir     = newNgFile(ngc.id, oldParents).getParentFile
-      val newNgcXmlFile = newNgFile(ngc.id, newParents)
-      val newNgcDir     = newNgcXmlFile.getParentFile
-
       for {
-        archive <- writeXml(
-                     newNgcXmlFile,
-                     nodeGroupCategorySerialisation.serialise(ngc),
-                     "Archived node group category: " + newNgcXmlFile.getPath
-                   )
-        canMove <- IOResult.attempt(null != oldNgcDir && oldNgcDir.exists)
-        moved   <- ZIO.when(canMove) {
-                     ZIO.whenZIO(IOResult.attempt(oldNgcDir.isDirectory)) {
-                       // move content except category.xml
-                       ZIO.foreach(oldNgcDir.listFiles.toSeq.filter(f => f.getName != serializedCategoryName)) { f =>
-                         IOResult.attempt(FileUtils.moveToDirectory(f, newNgcDir, false))
-                       }
-                     } *>
-                     // in all case, delete the file at the old directory path
-                     IOResult.attempt(FileUtils.deleteQuietly(oldNgcDir))
-                   }
-        commit  <- gitCommit match {
-                     case Some((modId, commiter, reason)) =>
-                       commitMvDirectoryWithModId(
-                         modId,
-                         commiter,
-                         toGitPath(oldNgcDir),
-                         toGitPath(newNgcDir),
-                         "Move archive of node group category with ID '%s'%s".format(ngc.id.value, GET(reason))
-                       )
-                     case None                            => ZIO.unit
-                   }
+        oldNgcDir     <- newNgFile(ngc.id, oldParents).map(_.getParentFile)
+        newNgcXmlFile <- newNgFile(ngc.id, newParents)
+        newNgcDir      = newNgcXmlFile.getParentFile
+        archive       <- writeXml(
+                           newNgcXmlFile,
+                           nodeGroupCategorySerialisation.serialise(ngc),
+                           "Archived node group category: " + newNgcXmlFile.getPath
+                         )
+        canMove       <- IOResult.attempt(null != oldNgcDir && oldNgcDir.exists)
+        moved         <- ZIO.when(canMove) {
+                           ZIO.whenZIO(IOResult.attempt(oldNgcDir.isDirectory)) {
+                             // move content except category.xml
+                             ZIO.foreach(oldNgcDir.listFiles.toSeq.filter(f => f.getName != serializedCategoryName)) { f =>
+                               IOResult.attempt(FileUtils.moveToDirectory(f, newNgcDir, false))
+                             }
+                           } *>
+                           // in all case, delete the file at the old directory path
+                           IOResult.attempt(FileUtils.deleteQuietly(oldNgcDir))
+                         }
+        commit        <- gitCommit match {
+                           case Some((modId, commiter, reason)) =>
+                             commitMvDirectoryWithModId(
+                               modId,
+                               commiter,
+                               toGitPath(oldNgcDir),
+                               toGitPath(newNgcDir),
+                               "Move archive of node group category with ID '%s'%s".format(ngc.id.value, GET(reason))
+                             )
+                           case None                            => ZIO.unit
+                         }
       } yield {
         GitPath(toGitPath(archive))
       }
@@ -1005,7 +1020,7 @@ class GitNodeGroupArchiverImpl(
 
   private[this] def newNgFile(ngId: NodeGroupId, parents: List[NodeGroupCategoryId]) = {
     parents match {
-      case h :: t => new File(newCategoryDirectory(h, t), ngId.withDefaultRev.serialize + ".xml").succeed
+      case h :: t => newCategoryDirectory(h, t).map(new File(_, ngId.withDefaultRev.serialize + ".xml"))
       case Nil    =>
         Inconsistency(
           "The given parent category list for node group with id '%s' is empty, what is forbidden".format(
@@ -1054,18 +1069,18 @@ class GitNodeGroupArchiverImpl(
       res    <- if (exists) {
                   for {
                     // don't forget to delete the category *directory*
-                    deleted  <- IOResult.attempt(FileUtils.forceDelete(ngFile))
-                    _        <- logPure.debug(s"Deleted archived node group: ${ngFile.getPath}")
-                    commited <- gitCommit match {
-                                  case Some((modId, commiter, reason)) =>
-                                    commitRmFileWithModId(
-                                      modId,
-                                      commiter,
-                                      gitPath,
-                                      s"Delete archive of node group with ID '${ngId.withDefaultRev.serialize}'${GET(reason)}"
-                                    )
-                                  case None                            => ZIO.unit
-                                }
+                    _ <- IOResult.attempt(FileUtils.forceDelete(ngFile))
+                    _ <- logPure.debug(s"Deleted archived node group: ${ngFile.getPath}")
+                    _ <- gitCommit match {
+                           case Some((modId, commiter, reason)) =>
+                             commitRmFileWithModId(
+                               modId,
+                               commiter,
+                               gitPath,
+                               s"Delete archive of node group with ID '${ngId.withDefaultRev.serialize}'${GET(reason)}"
+                             )
+                           case None                            => ZIO.unit
+                         }
                   } yield {
                     GitPath(gitPath)
                   }
@@ -1201,4 +1216,5 @@ class GitParameterArchiverImpl(
       GitPath(gitPath).succeed
     }
   }
+
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/xml/TestCategoryPathUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/xml/TestCategoryPathUtils.scala
@@ -1,0 +1,82 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.repository.xml
+
+import com.normation.errors.Inconsistency
+import com.normation.zio.UnsafeRun
+import java.io.File
+import java.nio.file.Files
+import org.specs2.mutable.Specification
+
+class TestCategoryPathUtils extends Specification with BuildCategoryPathName[String] {
+
+  override val getItemDirectory: File = Files.createTempDirectory("rudder-test-").toFile()
+
+  override def getCategoryName(categoryId: String): String = categoryId
+
+  val buildCategoryPathName = (parent: String) => newCategoryDirectory("foo", List(parent)).runNow
+
+  "BuildCategoryPathName" should {
+    val fooDir = new File(getItemDirectory, "foo").getAbsolutePath
+    "build a path with a single category" in {
+      val path = buildCategoryPathName("foo")
+      path.getAbsolutePath must beEqualTo(fooDir)
+    }
+
+    "build a path with a single category with a trailing slash" in {
+      val path = buildCategoryPathName("foo/")
+      path.getAbsolutePath must beEqualTo(fooDir)
+    }
+
+    "build a path with a single category with a leading slash" in {
+      val path = buildCategoryPathName("/foo")
+      path.getAbsolutePath must beEqualTo(fooDir)
+    }
+
+    "throw an exception when building an illegal path outside of the root directory" in {
+      newCategoryDirectory("../foo", List("some-parent")).either.runNow must beEqualTo(
+        Left(
+          Inconsistency(
+            s"Error when checking required directories '${getItemDirectory}/../foo' to archive in gitRepo.git: relative path must not allow access to parent directories, " +
+            s"only to directories under directory ${getItemDirectory}"
+          )
+        )
+      )
+    }
+  }
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/24011

A lot of changes but the main one is throwing an error when accessing files outside the root configuration directory in with git (`/var/rudder/configuration-repository`) : https://github.com/Normation/rudder/pull/5314/files#diff-bb5734a3493073add0df1291f147ac6cd515b8a211f543610446796ed2374441R169-R187...

This should avoid this method to be identified as vulnerable by any smart vulnerability scanners that could also detect the initial vulnerability...