### PR TITLE
Fixes #24016: Implement CSP strict headers with nonce and apply to healtcheck page

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/BaseUrl.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/BaseUrl.scala
@@ -55,8 +55,10 @@ class BaseUrl {
    * We still need to have a base url for some javascript
    * But now we use it as a javascript variable
    */
-  def display: NodeSeq = Script(
-    JsRaw(s"""var contextPath = '${S.contextPath}'; var resourcesPath = '${S.contextPath}/${StaticResourceRewrite.prefix}'""")
+  def display: NodeSeq = WithNonce.scriptWithNonce(
+    Script(
+      JsRaw(s"""var contextPath = '${S.contextPath}'; var resourcesPath = '${S.contextPath}/${StaticResourceRewrite.prefix}'""")
+    )
   )
 
   /*I keep the old base url as a reminder <base href={(urlService.baseUrl getOrElse S.hostAndPath)+"/"} />*/

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/CommonLayout.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/CommonLayout.scala
@@ -4,6 +4,10 @@ import com.normation.plugins.DefaultExtendableSnippet
 import com.normation.rudder.domain.logger.ApplicationLogger
 import com.normation.rudder.users.CurrentUser
 import net.liftweb.http.DispatchSnippet
+import net.liftweb.http.js.JE._
+import net.liftweb.http.js.JsCmds._
+import net.liftweb.util._
+import net.liftweb.util.CanBind._
 import scala.xml.NodeSeq
 
 class CommonLayout extends DispatchSnippet with DefaultExtendableSnippet[CommonLayout] {
@@ -21,6 +25,26 @@ class CommonLayout extends DispatchSnippet with DefaultExtendableSnippet[CommonL
       case None    => ApplicationLogger.warn("Authz.init called but user not authenticated")
       case Some(_) => // expected
     }
-    xml
+
+    display(xml) ++ WithNonce.scriptWithNonce(
+      Script(
+        OnLoad(
+          JsRaw(
+            """$('body').toggleClass('sidebar-collapse');"""
+          )
+        )
+      )
+    )
+  }
+
+  def display: CssSel = {
+    "#toggleMenuButton" #> toggleMenuElement
+  }
+
+  val toggleMenuElement = {
+    <a href="#" class="sidebar-toggle p-3" role="button">
+      <i class="fa fa-bars"></i>
+      <span class="visually-hidden">Toggle navigation</span>
+    </a>
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/CustomPageJs.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/CustomPageJs.scala
@@ -1,0 +1,27 @@
+package com.normation.rudder.web.snippet
+
+import net.liftweb.http.DispatchSnippet
+import net.liftweb.http.LiftRules
+import net.liftweb.http.S
+
+/**
+  * We need to provide both lift.js and page js to the client since the scripts appended by lift is hard to intercept.
+  * TODO: find a way to remove these duplicates after merging, or parse the whole html and add nonces to the scripts after merging
+  * , see lift source code : 
+  * https://github.com/lift/framework/blob/master/web/webkit/src/main/scala/net/liftweb/http/LiftSession.scala#L995
+  * 
+  * For now both scripts will be duplicated in the page, it does not induce weird behavior
+  */
+class CustomPageJs extends DispatchSnippet {
+
+  def dispatch: DispatchIt = { case "pageScript" => _ => pageScript }
+
+  def pageScript = {
+    <script data-lift="with-nonce" src="/classpath/lift.js"></script>
+    <script type="text/javascript" data-lift="with-nonce" src={scriptUrl(s"page/${S.renderVersion}.js")}></script>
+  }
+
+  private def scriptUrl(scriptFile: String) = {
+    S.encodeURL(s"/${LiftRules.liftContextRelativePath}/$scriptFile")
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/RegisterToasts.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/RegisterToasts.scala
@@ -76,16 +76,18 @@ class RegisterToasts {
     toasts match {
       case Nil  => NodeSeq.Empty
       case list =>
-        Script(
-          OnLoad(
-            list
-              .map(t => {
-                t match {
-                  case x: ToastNotification.Error   => JsRaw(s"""createErrorNotification("${x.message}")""").cmd
-                  case x: ToastNotification.Success => JsRaw(s"""createSuccessNotification("${x.message}")""").cmd
-                }
-              })
-              .reduce[JsCmd](_ & _)
+        WithNonce.scriptWithNonce(
+          Script(
+            OnLoad(
+              list
+                .map(t => {
+                  t match {
+                    case x: ToastNotification.Error   => JsRaw(s"""createErrorNotification("${x.message}")""").cmd
+                    case x: ToastNotification.Success => JsRaw(s"""createSuccessNotification("${x.message}")""").cmd
+                  }
+                })
+                .reduce[JsCmd](_ & _)
+            )
           )
         )
     }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/SetupRedirect.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/SetupRedirect.scala
@@ -50,7 +50,7 @@ class SetupRedirect extends DispatchSnippet with Loggable {
 
   private[this] val configService = RudderConfig.configService
 
-  def dispatch = { case "display" => _ => Script(display()) }
+  def dispatch = { case "display" => _ => WithNonce.scriptWithNonce(Script(display())) }
 
   def display() = {
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/WithCachedResource.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/WithCachedResource.scala
@@ -107,12 +107,14 @@ object WithCachedResource extends DispatchSnippet {
 
   def render(xhtml: NodeSeq): NodeSeq = {
     xhtml flatMap (_ match {
-      case e: Elem if e.label == "link"                         =>
+      case e: Elem if e.label == "link"     =>
         updateUrl(e, "href") openOr e
-      case e: Elem if (e.label == "script" || e.label == "img") =>
+      case e: Elem if e.label == "script"   =>
+        WithNonce.scriptWithNonce(updateUrl(e, "src") openOr e)
+      case e: Elem if e.label == "img"      =>
         updateUrl(e, "src") openOr e
       // iframe is speciale in the way we update the url
-      case e: Elem if (e.label == "iframe")                     =>
+      case e: Elem if (e.label == "iframe") =>
         attrStr(e.attributes, "src") map { src =>
           e.copy(attributes = {
             MetaData.update(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/WithNonce.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/WithNonce.scala
@@ -1,0 +1,54 @@
+package com.normation.rudder.web.snippet
+
+import net.liftweb.http.RequestVar
+import net.liftweb.http.StatefulSnippet
+import net.liftweb.util.Helpers
+import scala.xml.Elem
+import scala.xml.MetaData
+import scala.xml.Node
+import scala.xml.NodeSeq
+import scala.xml.Null
+import scala.xml.UnprefixedAttribute
+
+object WithNonce extends StatefulSnippet {
+
+  // value for debug purpose should not be empty as it could be confusing knowing how browser inspectors display nonces as ""
+  private val defaultValue = "unknown-value"
+
+  /**
+    * Holder for a base64 nonce value in the lifetime of a request
+    */
+  private object nonce extends RequestVar[String](defaultValue) {}
+
+  def dispatch = { case _ => render }
+
+  def render(xhtml: NodeSeq) = {
+    xhtml.map(scriptWithNonce(_))
+  }
+
+  def scriptWithNonce(base: Node) = {
+    nonce.setIfUnset(generateNonce)
+    val attributes = MetaData.update(base.attributes, base.scope, new UnprefixedAttribute("nonce", getCurrentNonce, Null))
+
+    base match {
+      case e: Elem => e.copy(attributes = attributes)
+      case _ => base
+    }
+  }
+
+  private val base64encoder = java.util.Base64.getEncoder()
+
+  private def generateNonce: String = {
+    base64encoder.encodeToString(Helpers.randomString(20).getBytes("UTF-8"))
+  }
+
+  /**
+    * Get the nonce value defined within the lifetime of the current request, and used in all html tags.
+    *
+    * @return
+    */
+  def getCurrentNonce: String = {
+    nonce.get
+  }
+
+}

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/index.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/index.html
@@ -71,7 +71,7 @@
     </a>
   </div>
 </div>
-<script>
+<script data-lift="with-nonce">
   $(document).ready(function(){
     (function(){
       var urlVars = {};

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/utilities/healthcheck.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/utilities/healthcheck.html
@@ -34,7 +34,7 @@
         </div>
     </div>
 
-    <script>
+    <script data-lift="with-nonce">
   var main = document.getElementById("healthcheck-content")
   var initValues = {
     contextPath : contextPath

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/common-layout.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/common-layout.html
@@ -69,7 +69,7 @@
       <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-notifications.js"></script>
       <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-quicksearch.js"></script>
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/rudder/rudder-elm.js"></script>
-    <script>
+    <script data-lift="with-nonce">
     (function($) {
        $.fn.hasScrollBar = function() {
             return this.get(0) ? this.get(0).scrollHeight > this.innerHeight() : false;
@@ -92,7 +92,7 @@
     </script>
     <script data-lift="SetupRedirect.display" ></script>
     <script data-lift="RegisterToasts.display"></script>
-    <script type="text/javascript">
+    <script type="text/javascript" data-lift="with-nonce">
       // <![CDATA[
       $(document).ready(function() {
         $("a", "form").click(function() { return false; });
@@ -116,12 +116,8 @@
         <nav class="navbar navbar-expand">
           <div class="container-fluid ps-0 pe-0">
             <div class="d-flex align-items-center">
-              <!-- Toggle menu button -->
-              <a href="#" class="sidebar-toggle p-3" role="button" onclick="$('body').toggleClass('sidebar-collapse')">
-                <i class="fa fa-bars"></i>
-                <span class="visually-hidden">Toggle navigation</span>
-              </a>
-
+              <!-- Toggle menu button rendered by server -->
+              <a id="toggleMenuButton"></a>
               <!-- Quick search -->
               <rudder-quicksearch></rudder-quicksearch>
             </div>
@@ -231,7 +227,7 @@
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-bs-dismiss="modal">Close</button>
             <span data-lift="UserInformation.logout">
-              <a href="/logout" class="btn btn-danger">Log out</a>
+              <button id="userInformationLogoutButton" class="btn btn-danger">Log out</button>
             </span>
           </div>
         </div>
@@ -267,4 +263,5 @@
       </div>
     </div>
   </body>
+  <div data-lift="CustomPageJs.pageScript"></div>
 </html>


### PR DESCRIPTION
https://issues.rudder.io/issues/24016

Implementing CSP strict headers : 
```
Content-Security-Policy:
  script-src 'nonce-{RANDOM}' 'strict-dynamic';
  object-src 'none';
  base-uri 'none';
  ...
``` 
Given an html page to be rendered with an HTTP request which should be responded with these strict headers :
* We generate a unique random value during the rendering of request
* We include the nonce value in scripts in the page using `data-lift="with-nonce"` attribute, which will add `nonce="nonce-{RANDOM}"` as attribute to the script 
* For scripts defined in Scala code and generated in the page usually with `Script(OnLoad(JsRaw("...")))`, we also need a call to `WithNonce` to add the attribute to the scripts
* For `onclick` attributes containing javascript code, they are blocked by browser with those strict headers, so we need to create a separate script tag with a nonce attribute, and add it to that element

This PR implements it and applies it to the "Healtcheck" page which now has strict CSP headers :tada: 

> [!TIP]
> To migrate a page so that it works with those strict CSP headers, first step is to add the page regex : https://github.com/Normation/rudder/pull/5315/files#diff-7ad40f3003f8941c211ddaae2aa0bd0d82328a6c9cd8114c492b4a22f3abfe95R102-R105, next is to watch for errors and just follow those steps above to fix console errors due to blocked scripts.

