### PR TITLE
Fixes #24028: Add policy mode info in group compliance details

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
@@ -144,6 +144,7 @@ final case class ByNodeGroupRuleCompliance(
     id:         RuleId,
     name:       String,
     compliance: ComplianceLevel,
+    policyMode: Option[PolicyMode],
     directives: Seq[ByNodeGroupByRuleDirectiveCompliance]
 )
 
@@ -828,6 +829,7 @@ object JsonCompliance {
           (("id"                 -> rule.id.serialize)
           ~ ("name"              -> rule.name)
           ~ ("compliance"        -> rule.compliance.complianceWithoutPending(precision))
+          ~ ("policyMode"        -> rule.policyMode.map(_.name).getOrElse("default"))
           ~ ("complianceDetails" -> percents(rule.compliance, precision))
           ~ ("directives"        -> directives(rule.directives, level, precision)))
         })
@@ -865,6 +867,7 @@ object JsonCompliance {
             ("id"                  -> rule.id.serialize)
             ~ ("name"              -> rule.name)
             ~ ("compliance"        -> rule.compliance.complianceWithoutPending(precision))
+            ~ ("policyMode"        -> rule.policyMode.map(_.name).getOrElse("default"))
             ~ ("complianceDetails" -> percents(rule.compliance, precision))
             ~ ("directives"        -> byNodeDirectives(rule.directives, level, precision))
           )
@@ -884,6 +887,7 @@ object JsonCompliance {
             ("id"                  -> directive.id.serialize)
             ~ ("name"              -> directive.name)
             ~ ("compliance"        -> directive.compliance.complianceWithoutPending(precision))
+            ~ ("policyMode"        -> directive.policyMode.map(_.name).getOrElse("default"))
             ~ ("complianceDetails" -> percents(directive.compliance, precision))
             ~ ("components"        -> byNodeComponents(directive.components, level, precision))
           )
@@ -969,6 +973,7 @@ object JsonCompliance {
             ("id"                  -> node.id.value)
             ~ ("name"              -> node.name)
             ~ ("compliance"        -> node.compliance.complianceWithoutPending(precision))
+            ~ ("policyMode"        -> node.mode.map(_.name).getOrElse("default"))
             ~ ("complianceDetails" -> percents(node.compliance, precision))
             ~ ("values"            -> values(node.values, level))
           )

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_compliance.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_compliance.yml
@@ -24,6 +24,7 @@ response:
                 "id" : "r1",
                 "name" : "R1",
                 "compliance" : 100.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "successAlreadyOK" : 100.0
                 },
@@ -48,6 +49,7 @@ response:
                             "id" : "n2",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
@@ -75,6 +77,7 @@ response:
                             "id" : "n1",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
@@ -99,6 +102,7 @@ response:
                 "id" : "r3",
                 "name" : "R3",
                 "compliance" : 0.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "error" : 100.0
                 },
@@ -123,6 +127,7 @@ response:
                             "id" : "n1",
                             "name" : "node1.localhost",
                             "compliance" : 0.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "error" : 100.0
                             },
@@ -150,6 +155,7 @@ response:
                             "id" : "n2",
                             "name" : "node1.localhost",
                             "compliance" : 0.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "error" : 100.0
                             },
@@ -174,6 +180,7 @@ response:
                 "id" : "r2",
                 "name" : "R2",
                 "compliance" : 100.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "successRepaired" : 100.0
                 },
@@ -198,6 +205,7 @@ response:
                             "id" : "n1",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successRepaired" : 100.0
                             },
@@ -235,6 +243,7 @@ response:
                     "id" : "r1",
                     "name" : "R1",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
@@ -243,6 +252,7 @@ response:
                         "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
@@ -272,6 +282,7 @@ response:
                     "id" : "r3",
                     "name" : "R3",
                     "compliance" : 0.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "error" : 100.0
                     },
@@ -280,6 +291,7 @@ response:
                         "id" : "directive2",
                         "name" : "directive2",
                         "compliance" : 0.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "error" : 100.0
                         },
@@ -323,6 +335,7 @@ response:
                     "id" : "r1",
                     "name" : "R1",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
@@ -331,6 +344,7 @@ response:
                         "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
@@ -360,6 +374,7 @@ response:
                     "id" : "r2",
                     "name" : "R2",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successRepaired" : 100.0
                     },
@@ -368,6 +383,7 @@ response:
                         "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
                         "name" : "directive99f4ef91-537b-4e03-97bc-e65b447514cc",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successRepaired" : 100.0
                         },
@@ -397,6 +413,7 @@ response:
                     "id" : "r3",
                     "name" : "R3",
                     "compliance" : 0.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "error" : 100.0
                     },
@@ -405,6 +422,7 @@ response:
                         "id" : "directive2",
                         "name" : "directive2",
                         "compliance" : 0.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "error" : 100.0
                         },
@@ -463,6 +481,7 @@ response:
                 "id" : "r1",
                 "name" : "R1",
                 "compliance" : 100.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "successAlreadyOK" : 100.0
                 },
@@ -487,6 +506,7 @@ response:
                             "id" : "n2",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
@@ -514,6 +534,7 @@ response:
                             "id" : "n1",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
@@ -538,6 +559,7 @@ response:
                 "id" : "r2",
                 "name" : "R2",
                 "compliance" : 100.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "successRepaired" : 100.0
                 },
@@ -562,6 +584,7 @@ response:
                             "id" : "n1",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successRepaired" : 100.0
                             },
@@ -598,6 +621,7 @@ response:
                     "id" : "r1",
                     "name" : "R1",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
@@ -606,6 +630,7 @@ response:
                         "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
@@ -648,6 +673,7 @@ response:
                     "id" : "r1",
                     "name" : "R1",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
@@ -656,6 +682,7 @@ response:
                         "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
@@ -685,6 +712,7 @@ response:
                     "id" : "r2",
                     "name" : "R2",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successRepaired" : 100.0
                     },
@@ -693,6 +721,7 @@ response:
                         "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
                         "name" : "directive99f4ef91-537b-4e03-97bc-e65b447514cc",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successRepaired" : 100.0
                         },
@@ -752,6 +781,7 @@ response:
                 "id" : "r1",
                 "name" : "R1",
                 "compliance" : 100.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "successAlreadyOK" : 100.0
                 },
@@ -776,6 +806,7 @@ response:
                             "id" : "n1",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
@@ -800,6 +831,7 @@ response:
                 "id" : "r3",
                 "name" : "R3",
                 "compliance" : 0.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "error" : 100.0
                 },
@@ -824,6 +856,7 @@ response:
                             "id" : "n1",
                             "name" : "node1.localhost",
                             "compliance" : 0.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "error" : 100.0
                             },
@@ -848,6 +881,7 @@ response:
                 "id" : "r2",
                 "name" : "R2",
                 "compliance" : 100.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "successRepaired" : 100.0
                 },
@@ -872,6 +906,7 @@ response:
                             "id" : "n1",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successRepaired" : 100.0
                             },
@@ -910,6 +945,7 @@ response:
                     "id" : "r1",
                     "name" : "R1",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
@@ -918,6 +954,7 @@ response:
                         "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
@@ -947,6 +984,7 @@ response:
                     "id" : "r2",
                     "name" : "R2",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successRepaired" : 100.0
                     },
@@ -955,6 +993,7 @@ response:
                         "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
                         "name" : "directive99f4ef91-537b-4e03-97bc-e65b447514cc",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successRepaired" : 100.0
                         },
@@ -984,6 +1023,7 @@ response:
                     "id" : "r3",
                     "name" : "R3",
                     "compliance" : 0.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "error" : 100.0
                     },
@@ -992,6 +1032,7 @@ response:
                         "id" : "directive2",
                         "name" : "directive2",
                         "compliance" : 0.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "error" : 100.0
                         },
@@ -1049,6 +1090,7 @@ response:
                 "id" : "r3",
                 "name" : "R3",
                 "compliance" : 0.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "error" : 100.0
                 },
@@ -1073,6 +1115,7 @@ response:
                             "id" : "n1",
                             "name" : "node1.localhost",
                             "compliance" : 0.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "error" : 100.0
                             },
@@ -1109,6 +1152,7 @@ response:
                     "id" : "r3",
                     "name" : "R3",
                     "compliance" : 0.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "error" : 100.0
                     },
@@ -1117,6 +1161,7 @@ response:
                         "id" : "directive2",
                         "name" : "directive2",
                         "compliance" : 0.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "error" : 100.0
                         },
@@ -1176,6 +1221,7 @@ response:
                 "id" : "br1",
                 "name" : "R1",
                 "compliance" : 100.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "successAlreadyOK" : 100.0
                 },
@@ -1200,6 +1246,7 @@ response:
                             "id" : "bn1",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
@@ -1227,6 +1274,7 @@ response:
                             "id" : "bn2",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
@@ -1251,6 +1299,7 @@ response:
                 "id" : "br3",
                 "name" : "R3",
                 "compliance" : 0.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "error" : 100.0
                 },
@@ -1275,6 +1324,7 @@ response:
                             "id" : "bn1",
                             "name" : "node1.localhost",
                             "compliance" : 0.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "error" : 100.0
                             },
@@ -1302,6 +1352,7 @@ response:
                             "id" : "bn2",
                             "name" : "node1.localhost",
                             "compliance" : 0.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "error" : 100.0
                             },
@@ -1326,6 +1377,7 @@ response:
                 "id" : "br4",
                 "name" : "R4",
                 "compliance" : 100.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "successAlreadyOK" : 100.0
                 },
@@ -1350,6 +1402,7 @@ response:
                             "id" : "bn2",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
@@ -1374,6 +1427,7 @@ response:
                 "id" : "br2",
                 "name" : "R2",
                 "compliance" : 100.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "successRepaired" : 100.0
                 },
@@ -1398,6 +1452,7 @@ response:
                             "id" : "bn1",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successRepaired" : 100.0
                             },
@@ -1435,6 +1490,7 @@ response:
                     "id" : "br1",
                     "name" : "R1",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
@@ -1443,6 +1499,7 @@ response:
                         "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
@@ -1472,6 +1529,7 @@ response:
                     "id" : "br3",
                     "name" : "R3",
                     "compliance" : 0.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "error" : 100.0
                     },
@@ -1480,6 +1538,7 @@ response:
                         "id" : "directive2",
                         "name" : "directive2",
                         "compliance" : 0.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "error" : 100.0
                         },
@@ -1509,6 +1568,7 @@ response:
                     "id" : "br4",
                     "name" : "R4",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
@@ -1517,6 +1577,7 @@ response:
                         "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
@@ -1560,6 +1621,7 @@ response:
                     "id" : "br1",
                     "name" : "R1",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
@@ -1568,6 +1630,7 @@ response:
                         "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
@@ -1597,6 +1660,7 @@ response:
                     "id" : "br2",
                     "name" : "R2",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successRepaired" : 100.0
                     },
@@ -1605,6 +1669,7 @@ response:
                         "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
                         "name" : "directive99f4ef91-537b-4e03-97bc-e65b447514cc",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successRepaired" : 100.0
                         },
@@ -1634,6 +1699,7 @@ response:
                     "id" : "br3",
                     "name" : "R3",
                     "compliance" : 0.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "error" : 100.0
                     },
@@ -1642,6 +1708,7 @@ response:
                         "id" : "directive2",
                         "name" : "directive2",
                         "compliance" : 0.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "error" : 100.0
                         },
@@ -1700,6 +1767,7 @@ response:
                 "id" : "br2",
                 "name" : "R2",
                 "compliance" : 100.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "successRepaired" : 100.0
                 },
@@ -1724,6 +1792,7 @@ response:
                             "id" : "bn1",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successRepaired" : 100.0
                             },
@@ -1748,6 +1817,7 @@ response:
                 "id" : "br1",
                 "name" : "R1",
                 "compliance" : 100.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "successAlreadyOK" : 100.0
                 },
@@ -1772,6 +1842,7 @@ response:
                             "id" : "bn1",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
@@ -1799,6 +1870,7 @@ response:
                             "id" : "bn2",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
@@ -1835,6 +1907,7 @@ response:
                     "id" : "br1",
                     "name" : "R1",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
@@ -1843,6 +1916,7 @@ response:
                         "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
@@ -1885,6 +1959,7 @@ response:
                     "id" : "br1",
                     "name" : "R1",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
@@ -1893,6 +1968,7 @@ response:
                         "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
@@ -1922,6 +1998,7 @@ response:
                     "id" : "br2",
                     "name" : "R2",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successRepaired" : 100.0
                     },
@@ -1930,6 +2007,7 @@ response:
                         "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
                         "name" : "directive99f4ef91-537b-4e03-97bc-e65b447514cc",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successRepaired" : 100.0
                         },
@@ -1987,6 +2065,7 @@ response:
                 "id" : "br4",
                 "name" : "R4",
                 "compliance" : 100.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "successAlreadyOK" : 100.0
                 },
@@ -2011,6 +2090,7 @@ response:
                             "id" : "bn5",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
@@ -2038,6 +2118,7 @@ response:
                             "id" : "bn4",
                             "name" : "node1.localhost",
                             "compliance" : 100.0,
+                            "policyMode" : "enforce",
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
@@ -2062,6 +2143,7 @@ response:
                 "id" : "br6",
                 "name" : "R6",
                 "compliance" : 0.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "noReport" : 100.0
                 },
@@ -2083,6 +2165,7 @@ response:
                     "id" : "br4",
                     "name" : "R4",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
@@ -2091,6 +2174,7 @@ response:
                         "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
@@ -2132,6 +2216,7 @@ response:
                     "id" : "br4",
                     "name" : "R4",
                     "compliance" : 100.0,
+                    "policyMode" : "enforce",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
@@ -2140,6 +2225,7 @@ response:
                         "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "name" : "directivee9a1a909-2490-4fc9-95c3-9d0aa01717c9",
                         "compliance" : 100.0,
+                        "policyMode" : "default",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
@@ -2195,6 +2281,7 @@ response:
                 "id" : "br6",
                 "name" : "R6",
                 "compliance" : 0.0,
+                "policyMode" : "enforce",
                 "complianceDetails" : {
                   "noReport" : 100.0
                 },

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -62,6 +62,8 @@ import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.AddRuleDiff
 import com.normation.rudder.domain.policies.DeleteRuleDiff
 import com.normation.rudder.domain.policies.DirectiveId
+import com.normation.rudder.domain.policies.FullGroupTarget
+import com.normation.rudder.domain.policies.FullRuleTargetInfo
 import com.normation.rudder.domain.policies.GlobalPolicyMode
 import com.normation.rudder.domain.policies.GroupTarget
 import com.normation.rudder.domain.policies.ModifyRuleDiff
@@ -205,7 +207,19 @@ class MockCompliance(mockDirectives: MockDirectives) {
       nodeGroups.find(_.id == id).map((_, NodeGroupCategoryId("cat1"))).succeed
     }
 
-    def getFullGroupLibrary():                                 IOResult[FullNodeGroupCategory]                                      = ???
+    def getFullGroupLibrary(): IOResult[FullNodeGroupCategory] = {
+      FullNodeGroupCategory(
+        NodeGroupCategoryId("GroupRoot"),
+        "GroupRoot",
+        "root of group categories",
+        Nil,
+        nodeGroups.map(g => {
+          FullRuleTargetInfo(FullGroupTarget(GroupTarget(g.id), g), g.name, g.description, g.isEnabled, g.isSystem)
+        }),
+        true
+      ).succeed
+    }
+
     def getNodeGroupCategory(id: NodeGroupId):                 IOResult[NodeGroupCategory]                                          = ???
     def getAll():                                              IOResult[Seq[NodeGroup]]                                             = ???
     def getAllNodeIds():                                       IOResult[Map[NodeGroupId, Set[NodeId]]]                              = ???

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/DataTypes.elm
@@ -25,6 +25,7 @@ type alias RuleCompliance value =
   { ruleId            : RuleId
   , name              : String
   , compliance        : Float
+  , policyMode        : String
   , complianceDetails : ComplianceDetails
   , directives        : List (DirectiveCompliance value)
   }
@@ -42,6 +43,7 @@ type alias NodeValueCompliance =
   { nodeId            : NodeId
   , name              : String
   , compliance        : Float
+  , policyMode        : String
   , complianceDetails : ComplianceDetails
   , values : List ValueCompliance
   }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/JsonDecoder.elm
@@ -48,6 +48,7 @@ decodeNodeCompliance =
     |> required "id"     (map NodeId string)
     |> required "name"    string
     |> required "compliance" float
+    |> required "policyMode" string
     |> required "complianceDetails" decodeComplianceDetails
     |> required "values" (list decodeValueCompliance)
 
@@ -63,6 +64,7 @@ decodeRuleCompliance elem decoder =
     |> required "id"         (map RuleId string)
     |> required "name"       string
     |> required "compliance" float
+    |> required "policyMode" string
     |> required "complianceDetails" decodeComplianceDetails
     |> required "directives" (list (decodeDirectiveCompliance elem decoder ))
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewUtils.elm
@@ -154,7 +154,7 @@ byRuleCompliance model subFun complianceFilters =
       |> List.sortWith sortFunction
     )
     (\_ i ->  i )
-    [ ("Rule", \i  -> span [] [ (badgePolicyMode model.policyMode "default"), text i.name , goToBtn (getRuleLink contextPath i.ruleId) ],  (\r1 r2 -> N.compare r1.name r2.name ))
+    [ ("Rule", \i  -> span [] [ (badgePolicyMode model.policyMode i.policyMode), text i.name , goToBtn (getRuleLink contextPath i.ruleId) ],  (\r1 r2 -> N.compare r1.name r2.name ))
     , ("Compliance", \i -> buildComplianceBar complianceFilters  i.complianceDetails,  (\(r1) (r2) -> Basics.compare r1.compliance r2.compliance ))
     ]
     (.ruleId >> .value)
@@ -197,7 +197,7 @@ nodeValueCompliance mod complianceFilters =
         |> List.sortWith sortFunction
     )
     (\_ i -> i)
-    [ ("Node", (\nId -> span[][text nId.name, goToBtn (getNodeLink mod.contextPath nId.nodeId.value)]),  (\d1 d2 -> N.compare d1.name d2.name))
+    [ ("Node", (\nId -> span[][ (badgePolicyMode mod.policyMode nId.policyMode), text nId.name, goToBtn (getNodeLink mod.contextPath nId.nodeId.value) ]),  (\d1 d2 -> N.compare d1.name d2.name))
     , ("Compliance", .complianceDetails >> buildComplianceBar complianceFilters ,  (\d1 d2 -> Basics.compare d1.compliance d2.compliance))
     ]
     (.nodeId >> .value)


### PR DESCRIPTION
https://issues.rudder.io/issues/24028

We did not display the policy mode of a rule/node but now we do : 
![image](https://github.com/Normation/rudder/assets/65616064/01580dca-d5a1-448d-b46d-fe67142bd9b8)
 