### PR TITLE
Fixes #24034: Group compliance tab is loaded only with a double-click

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -212,7 +212,7 @@ class NodeGroupForm(
                      |  }, 400);
                      |});
                      |$$("#complianceLinkTab").on("click", function (){
-                     |  app.ports.loadCompliance.send("");
+                     |  app.ports.loadCompliance.send(null);
                      |});
                      |""".stripMargin)
           )

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
@@ -46,12 +46,22 @@
     </div>
   </div>
   <div class="main-navbar">
-    <ul id="groupTabMenu">
-      <li><a href="#groupParametersTab">Parameters</a></li>
-      <li><a href="#groupCriteriaTab">Criteria</a></li>
-      <li><a id="relatedRulesLinkTab" href="#groupRulesTab">Related rules</a></li>
-      <li><a href="#groupPropertiesTab">Properties</a></li>
-      <li><a id="complianceLinkTab" href="#groupComplianceTab">Compliance</a></li>
+    <ul id="groupTabMenu" class="ui-tabs-nav" role="tablist">
+      <li role="presentation" class="ui-tabs-tab ui-tab active" data-bs-toggle="tab" data-bs-target="#groupParametersTab" type="button" role="tab">
+        <a href="#groupParametersTab">Parameters</a>
+      </li>
+      <li role="presentation" class="ui-tabs-tab ui-tab" data-bs-toggle="tab" data-bs-target="#groupCriteriaTab" type="button" role="tab">
+        <a href="#groupCriteriaTab">Criteria</a>
+      </li>
+      <li role="presentation" class="ui-tabs-tab ui-tab" data-bs-toggle="tab" data-bs-target="#groupRulesTab" type="button" role="tab">
+        <a id="relatedRulesLinkTab" href="#groupRulesTab">Related rules</a>
+      </li>
+      <li role="presentation" class="ui-tabs-tab ui-tab" data-bs-toggle="tab" data-bs-target="#groupPropertiesTab" type="button" role="tab">
+        <a href="#groupPropertiesTab">Properties</a>
+      </li>
+      <li role="presentation" class="ui-tabs-tab ui-tab" data-bs-toggle="tab" data-bs-target="#groupComplianceTab" type="button" role="tab">
+        <a id="complianceLinkTab" href="#groupComplianceTab">Compliance</a>
+      </li>
     </ul>
   </div>
   <div class="main-details">


### PR DESCRIPTION
https://issues.rudder.io/issues/24034

There is a `not` that was missing in the boolean condition reloading the tab with new data...

Also added accessibility in the html of groups tabs