### PR TITLE
Fixes #24040: Group compliance view does not give global and targeted compliance definitions

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewNodesCompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewNodesCompliance.elm
@@ -40,33 +40,12 @@ displayNodesComplianceTable model =
     sort =   case List.Extra.find (Tuple3.first >> (==) sortId) fun.rows of
       Just (_,_,sortFun) -> (\i1 i2 -> sortFun (fun.data model i1) (fun.data model i2))
       Nothing -> (\_ _ -> EQ)
-    isGlobalMode = isGlobalCompliance model
   in
     ( if model.ui.loading then
       generateLoadingTable
       else
       div[]
-      [ div [class "table-header extra-filters"]
-        [ div [class "d-inline-flex align-items-baseline pb-3 w-25"]
-          [
-            div [class "btn-group yesno"]
-            [ label [class ("btn btn-default" ++ if isGlobalMode then " active" else ""), style "box-shadow" (if isGlobalMode then "inset 0 3px 5px rgba(0,0,0,.125)" else "none"), onClick (LoadCompliance GlobalCompliance)]
-              [text "Global"]
-            , label [class ("btn btn-default" ++ if isGlobalMode then "" else " active"), style "box-shadow" (if isGlobalMode then "none" else "inset 0 3px 5px rgba(0,0,0,.125)"), onClick (LoadCompliance TargetedCompliance)]
-              [text "Targeted"]
-            ]
-            , span [class "mx-3"]
-              [text "Compliance"]
-          ]
-        ,  div[class "main-filters"]
-          [ input [type_ "text", placeholder "Filter", class "input-sm form-control", value filters.filter, onInput (\s -> (UpdateFilters {filters | filter = s} ))][]
-          , button [class "btn btn-default btn-sm btn-icon", onClick (UpdateComplianceFilters {complianceFilters | showComplianceFilters = not complianceFilters.showComplianceFilters}), style "min-width" "170px"]
-            [ text ((if complianceFilters.showComplianceFilters then "Hide " else "Show ") ++ "compliance filters")
-            , i [class ("fa " ++ (if complianceFilters.showComplianceFilters then "fa-minus" else "fa-plus"))][]
-            ]
-          ]
-        , displayComplianceFilters complianceFilters UpdateComplianceFilters
-        ]
+      [ filtersView model
       , div[class "table-container"]
         [ table [class "dataTable compliance-table"]
           [ thead []

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewRulesCompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewRulesCompliance.elm
@@ -2,7 +2,7 @@ module GroupCompliance.ViewRulesCompliance exposing (..)
 
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import Html.Events exposing (onClick, onInput)
+import Html.Events exposing (onClick)
 import List
 import List.Extra
 import Tuple3
@@ -11,7 +11,7 @@ import Dict
 import GroupCompliance.ApiCalls exposing (..)
 import GroupCompliance.DataTypes exposing (..)
 import GroupCompliance.ViewUtils exposing (..)
-import Compliance.Utils exposing (displayComplianceFilters, filterDetailsByCompliance)
+import Compliance.Utils exposing (filterDetailsByCompliance)
 
 displayRulesComplianceTable : Model -> Html Msg
 displayRulesComplianceTable model =
@@ -38,36 +38,12 @@ displayRulesComplianceTable model =
     sort =   case List.Extra.find (Tuple3.first >> (==) sortId) fun.rows of
       Just (_,_,sortFun) -> (\i1 i2 -> sortFun (fun.data model i1) (fun.data model i2))
       Nothing -> (\_ _ -> EQ)
-    isGlobalMode = isGlobalCompliance model
   in
     ( if model.ui.loading then
       generateLoadingTable
       else
-      div[][ div [class "table-header extra-filters"]
-      [ div [class "d-inline-flex align-items-baseline pb-3 w-25"]
-        [
-          div [class "btn-group yesno"]
-          [ label [class ("btn btn-default" ++ if isGlobalMode then " active" else ""), style "box-shadow" (if isGlobalMode then "inset 0 3px 5px rgba(0,0,0,.125)" else "none"), onClick (LoadCompliance GlobalCompliance)]
-            [text "Global"]
-          , label [class ("btn btn-default" ++ if isGlobalMode then "" else " active"), style "box-shadow" (if isGlobalMode then "none" else "inset 0 3px 5px rgba(0,0,0,.125)"), onClick (LoadCompliance TargetedCompliance)]
-            [text "Targeted"]
-          ]
-          , span [class "mx-3"]
-            [text "Compliance"]
-        ]
-      , div [class "main-filters"]
-        [ input [type_ "text", placeholder "Filter", class "input-sm form-control", value filters.filter
-          , onInput (\s -> (UpdateFilters {filters | filter = s} ))][]
-        , button [class "btn btn-default btn-sm btn-icon", onClick (UpdateComplianceFilters {complianceFilters | showComplianceFilters = not complianceFilters.showComplianceFilters}), style "min-width" "170px"]
-          [ text ((if complianceFilters.showComplianceFilters then "Hide " else "Show ") ++ "compliance filters")
-          , i [class ("fa " ++ (if complianceFilters.showComplianceFilters then "fa-minus" else "fa-plus"))][]
-          ]
-        --TODO later : export csv
-        -- , button [class "btn btn-sm btn-primary btn-export", onClick (CallApi getCSVExport) ]
-        --   [ text "Export " , i [ class "fa fa-download" ] [] ]
-        ]
-      , displayComplianceFilters complianceFilters UpdateComplianceFilters
-      ]
+      div[][ 
+        filtersView model
       , div[class "table-container"]
         [ table [class "dataTable compliance-table"]
           [ thead []

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewUtils.elm
@@ -5,7 +5,7 @@ import Dict exposing (Dict)
 import Either exposing (Either(..))
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import Html.Events exposing (onClick, custom)
+import Html.Events exposing (custom, onClick, onInput)
 import List.Extra
 import List
 import Maybe.Extra
@@ -400,3 +400,55 @@ generateLoadingTable =
       ]
     ]
   ]
+
+filtersView : Model -> Html Msg
+filtersView model = 
+  let 
+    filters = model.ui.ruleFilters
+    complianceFilters = model.ui.complianceFilters
+    isGlobalMode = isGlobalCompliance model
+  in 
+    div [class "table-header extra-filters"]
+      [ div [class "d-inline-flex align-items-baseline pb-3 w-25"]
+        [
+          div [class "btn-group yesno"]
+          [ label 
+            [ class ("btn btn-default" ++ if isGlobalMode then " active" else "")
+              , style "box-shadow" (if isGlobalMode then "inset 0 3px 5px rgba(0,0,0,.125)" else "none")
+              , attribute "data-bs-toggle" "tooltip"
+              , attribute "data-bs-placement" "top"
+              , attribute "data-bs-html" "true"
+              , attribute "title" (buildTooltipContent "Global compliance" "This mode will show the compliance of all rules that apply directives to a node within this group.")
+              , onClick (LoadCompliance GlobalCompliance)
+            ]
+            [text "Global"]
+          , label 
+            [ class ("btn btn-default" ++ if isGlobalMode then "" else " active")
+              , style "box-shadow" (if isGlobalMode then "none" else "inset 0 3px 5px rgba(0,0,0,.125)")
+              , attribute "data-bs-toggle" "tooltip"
+              , attribute "data-bs-placement" "top"
+              , attribute "data-bs-html" "true"
+              , attribute "title" (buildTooltipContent "Targeted compliance" "This mode will show only the compliance of rules that explicitly include this group in their target.")
+              , onClick (LoadCompliance TargetedCompliance)
+            ]
+            [text "Targeted"]
+          ]
+          , span 
+            [ class "mx-3 d-flex flex-nowrap align-items-baseline"
+              , attribute "data-bs-toggle" "tooltip"
+              , attribute "data-bs-placement" "right"
+              , attribute "data-bs-html" "true"
+              , attribute "title" (buildTooltipContent "Global/Targeted compliance" "<b>Global</b> compliance will show the compliance of all rules that apply directives to a node within this group.<br/><b>Targeted</b> compliance will show only the compliance of rules that explicitly include this group in their target.")
+            ]
+            [span [][text "Compliance"], span [class "fa fa-info-circle icon-info"][]]
+        ]
+      , div [class "main-filters"]
+        [ input [type_ "text", placeholder "Filter", class "input-sm form-control", value filters.filter
+          , onInput (\s -> (UpdateFilters {filters | filter = s} ))][]
+        , button [class "btn btn-default btn-sm btn-icon", onClick (UpdateComplianceFilters {complianceFilters | showComplianceFilters = not complianceFilters.showComplianceFilters}), style "min-width" "170px"]
+          [ text ((if complianceFilters.showComplianceFilters then "Hide " else "Show ") ++ "compliance filters")
+          , i [class ("fa " ++ (if complianceFilters.showComplianceFilters then "fa-minus" else "fa-plus"))][]
+          ]
+        ]
+      , displayComplianceFilters complianceFilters UpdateComplianceFilters
+      ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groupcompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groupcompliance.elm
@@ -9,11 +9,13 @@ import GroupCompliance.ApiCalls exposing (..)
 import GroupCompliance.DataTypes exposing (..)
 import GroupCompliance.Init exposing (init)
 import GroupCompliance.View exposing (view)
+import Editor exposing (clearTooltips)
 
 
 -- PORTS / SUBSCRIPTIONS
 port errorNotification   : String -> Cmd msg
 port initTooltips        : String -> Cmd msg
+port clearTooltips       : String -> Cmd msg
 port loadCompliance      : (() -> msg) -> Sub msg
 
 
@@ -136,9 +138,9 @@ update msg model =
           TargetedCompliance -> getTargetedGroupCompliance
         actions =
           if shouldReload then 
-            Cmd.batch [ getCompliance model ]
+            Cmd.batch [ clearTooltips "", getCompliance model, initTooltips "" ]
           else
-            Cmd.none
+            Cmd.batch [ clearTooltips "", initTooltips "" ]
         newModel = {model | complianceScope = complianceScope, ui = {ui | loading = shouldReload, loaded = True}}
       in
       ( newModel

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -209,6 +209,10 @@ class NodeGroupForm(
                      |    initBsTooltips();
                      |  }, 400);
                      |});
+                     |// Clear tooltips
+                     |app.ports.clearTooltips.subscribe(function(msg) {
+                     |  removeBsTooltips();
+                     |});
                      |$$("#complianceLinkTab").on("click", function (){
                      |  app.ports.loadCompliance.send(null);
                      |});

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
@@ -99,9 +99,13 @@
       <div class="col-12 col-sm-6 col-lg-5">
         <div class="form-group show-compliance">
           <div id="groupComplianceSummary">
-            <label>Global compliance</label>
+            <label data-bs-toggle="tooltip" data-bs-placement="right" title="<div class='tooltip-inner-content'>Compliance that takes into account all rules that apply directives to a node within this group</div>">
+              Global compliance
+            </label>
             <div class="groupGlobalComplianceProgressBar"></div>
-            <label>Targeted compliance</label>
+            <label data-bs-toggle="tooltip" data-bs-placement="right" title="<div class='tooltip-inner-content'>Compliance that takes into account only rules that explicitly include this group in their target</div>">
+              Targeted compliance
+            </label>
             <div class="groupTargetedComplianceProgressBar"></div>
           </div>
           <label class="id-label">Group ID</label>


### PR DESCRIPTION
https://issues.rudder.io/issues/24040

Creating the tooltips to explain the meaning of _global compliance_ and _targeted compliance_ : 
* In the compliance tab : 
![Screenshot from 2024-01-18 12-22-28](https://github.com/Normation/rudder/assets/65616064/6b93d435-bcee-432b-9637-49026e56710f)

![Screenshot from 2024-01-18 11-54-51](https://github.com/Normation/rudder/assets/65616064/200d7049-a4ec-4bb5-9b21-169c2820c0bf)

* In the groups parameters tab : 
![Screenshot from 2024-01-18 12-35-36](https://github.com/Normation/rudder/assets/65616064/2dc4b5ad-150c-4f27-bcc2-a11c36bf8d3e)
