### PR TITLE
Fixes #24036: If REST url ends with .com, then the .com is removed from path segments

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
@@ -351,7 +351,7 @@ trait TwoParam  extends EndpointSchema  {
 //////////
 
 /**
- * This algbra describe how an endpoint maybe serve a request.
+ * This algebra describes how an endpoint maybe serve a request.
  * It maybe serve because we need to check if the endpoint does handle a request before serving it.
  */
 
@@ -648,7 +648,7 @@ trait BuildHandler[REQ, RESP, T, P] {
 
           ///// END OF EVAL FOR ALL WEBAPP REQUESTS /////
 
-          // handle the optionnality and so the fact that API may not handle that path
+          // handle the optionality and so the fact that API may not handle that path
           optEndpoint match {
             case None           => Option.empty[() => RESP]
             case Some(endpoint) =>


### PR DESCRIPTION
https://issues.rudder.io/issues/24036

The problem is that we rely on Lift URL parsing (because URL parsing is complicated and full of worms and we don't want to do by ourself), but lift, being helpfull, remove the last bit if it looks like an extension and put it in an `extension` parameter. 

Here, we just put it back when parsing looking for a REST URL. It won't impact the case where it would be a real site extension, since we don't authorize REST parsing to result in a root site path. 