### PR TITLE
Fixes #24043: API documentation for compliance by group

### DIFF
--- a/api-doc/package-lock.json
+++ b/api-doc/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@redocly/cli": "^1.5.0"
+        "@redocly/cli": "^1.6.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -58,11 +58,11 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.5.0.tgz",
-      "integrity": "sha512-2E6yhYIs/dj6pFM9ahzuyI4AzFOjmOK1dkwYCtTWT1w5kROlW4HVVgHrxnOIUupRDTD5TdScWSH28n2U1VivWQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.6.0.tgz",
+      "integrity": "sha512-0naVFJGR2tVcpMIHSFRr2HAoyy70qMqDAP6kXcnOdkGkwLRJ8s/5n1STwsym/yZwNkhrt2M0cKT6KAMlTUeCeg==",
       "dependencies": {
-        "@redocly/openapi-core": "1.5.0",
+        "@redocly/openapi-core": "1.6.0",
         "chokidar": "^3.5.1",
         "colorette": "^1.2.0",
         "core-js": "^3.32.1",
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.5.0.tgz",
-      "integrity": "sha512-AnDLoDl1+a7mZO4+lx0KG8zH04BQx4ez6yh403PuNl9/0ygbicPPc9QG/y0/0OImChOA+knKLpJazNFjzhOAeg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.6.0.tgz",
+      "integrity": "sha512-oao6Aey4peLKfagzWGb6N7OBI6CoDWEP4ka/XjrUNZw+UoKVVg3hVBXW4Vr3CJ2O8j6wEa2i+Lbb92VQQsoxwg==",
       "dependencies": {
         "@redocly/ajv": "^8.11.0",
         "@types/node": "^14.11.8",

--- a/api-doc/package.json
+++ b/api-doc/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@redocly/cli": "^1.5.0"
+    "@redocly/cli": "^1.6.0"
   }
 }

--- a/api-doc/redocly.yml
+++ b/api-doc/redocly.yml
@@ -29,6 +29,8 @@ theme:
     expandResponses: '200,201'
     # More readable in central column
     pathInMiddlePanel: true
+    # Nested objects in exemples should be allowed
+    generatedPayloadSamplesMaxDepth: 100
     # Rudder 7 theme
     theme:
       logo:

--- a/webapp/sources/api-doc/code_samples/curl/compliance/group-global.sh
+++ b/webapp/sources/api-doc/code_samples/curl/compliance/group-global.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/compliance/groups/704afe7b-1a65-4d2e-b4c9-54f4f548c316'

--- a/webapp/sources/api-doc/code_samples/curl/compliance/group-targeted.sh
+++ b/webapp/sources/api-doc/code_samples/curl/compliance/group-targeted.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/compliance/groups/704afe7b-1a65-4d2e-b4c9-54f4f548c316/target'

--- a/webapp/sources/api-doc/components/parameters/node-group-id.yml
+++ b/webapp/sources/api-doc/components/parameters/node-group-id.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2024 Normation SAS
+name: "nodeGroupId"
+in: path
+required: true
+description: Id of the node group
+schema:
+  type: string
+  format: uuid or string
+  example: 47e3f2c0-0b1a-4b1a-9b0a-9e9e9e9e9e9e

--- a/webapp/sources/api-doc/components/schemas/group-node-compliance-rules.yml
+++ b/webapp/sources/api-doc/components/schemas/group-node-compliance-rules.yml
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2024 Normation SAS
+type: object
+required:
+  - id
+  - name
+  - policyMode
+  - compliance
+  - complianceDetails
+  - directives
+properties:
+  id:
+    type: string
+    format: uuid
+    description: id of the rule
+    example: 835c068d-f01e-44c0-a0f4-7a436d46ad35
+  name:
+    type: string
+    description: Name of the rule
+    example: Test users
+  policyMode:
+    type: string
+    enum:
+      - default
+      - audit
+      - enforce
+    description: Policy mode of the rule
+    example: audit
+  compliance:
+    type: number
+    format: float
+    description: Rule compliance level
+    example: 100.0
+  complianceDetails:
+    type: object
+    properties:
+      successAlreadyOK:
+        type: number
+        format: float
+        example: 66.67
+      noReport:
+        type: number
+        format: float
+        example: 0.0
+      successNotApplicable:
+        type: number
+        format: float
+        example: 33.33
+      unexpectedMissingComponent:
+        type: number
+        format: float
+        example: 0.0
+      error:
+        type: number
+        format: float
+        example: 0.0
+      unexpectedUnknownComponent:
+        type: number
+        format: float
+        example: 0.0
+      successRepaired:
+        type: number
+        format: float
+        example: 0.0
+  directives:
+    type: array
+    items:
+      type: object
+      required:
+        - id
+        - name
+        - compliance
+        - complianceDetails
+        - components
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: id of the directive
+          example: 835c068d-f01e-44c0-a0f4-7a436d46ad35
+        name:
+          type: string
+          description: Name of the directive
+          example: Test users
+        policyMode:
+          type: string
+          enum:
+            - default
+            - audit
+            - enforce
+          description: Policy mode of the directive
+          example: audit
+        compliance:
+          type: number
+          format: float
+          description: Directive compliance level
+          example: 100.0
+        complianceDetails:
+          type: object
+          properties:
+            successAlreadyOK:
+              type: number
+              format: float
+              example: 66.67
+            noReport:
+              type: number
+              format: float
+              example: 0.0
+            successNotApplicable:
+              type: number
+              format: float
+              example: 33.33
+            unexpectedMissingComponent:
+              type: number
+              format: float
+              example: 0.0
+            error:
+              type: number
+              format: float
+              example: 0.0
+            unexpectedUnknownComponent:
+              type: number
+              format: float
+              example: 0.0
+            successRepaired:
+              type: number
+              format: float
+              example: 0.0
+        components:
+          type: array
+          items:
+            type: object
+            required:
+              - name
+              - compliance
+              - complianceDetails
+              - values
+            properties:
+              name:
+                type: string
+                description: Name of the component
+                example: MOTD Configuration
+              compliance:
+                type: number
+                format: float
+                description: Directive compliance level
+                example: 100.0
+              complianceDetails:
+                type: object
+                properties:
+                  successAlreadyOK:
+                    type: number
+                    format: float
+                    example: 100.0
+                  noReport:
+                    type: number
+                    format: float
+                    example: 0.0
+                  successNotApplicable:
+                    type: number
+                    format: float
+                    example: 0.0
+                  unexpectedMissingComponent:
+                    type: number
+                    format: float
+                    example: 0.0
+                  error:
+                    type: number
+                    format: float
+                    example: 0.0
+                  unexpectedUnknownComponent:
+                    type: number
+                    format: float
+                    example: 0.0
+                  successRepaired:
+                    type: number
+                    format: float
+                    example: 0.0
+              values:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - value
+                    - reports
+                  properties:
+                    value:
+                      type: string
+                      example: Hello John Doe
+                    reports:
+                      type: array
+                      items:
+                        type: object
+                        required:
+                          - status
+                        properties:
+                          status:
+                            type: string
+                            example: successAlreadyOK
+                          message:
+                            type: string
+                            example: The MOTD is correctly configured with "Hello John Doe"

--- a/webapp/sources/api-doc/components/schemas/group-node-compliance.yml
+++ b/webapp/sources/api-doc/components/schemas/group-node-compliance.yml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2024 Normation SAS
+type: object
+required:
+  - id
+  - name
+  - policyMode
+  - compliance
+  - complianceDetails
+  - rules
+properties:
+  id:
+    type: string
+    format: uuid
+    description: id of the node
+    example: b6ded8e2-2709-4986-973d-8e5522d20718
+  name:
+    type: string
+    description: Name of the node
+    example: agent1.rudder.local
+  policyMode:
+    type: string
+    enum:
+      - default
+      - audit
+      - enforce
+    description: Policy mode of the node
+    example: audit
+  compliance:
+    type: number
+    format: float
+    description: Node compliance level
+    example: 100.0
+  complianceDetails:
+    type: object
+    properties:
+      successAlreadyOK:
+        type: number
+        format: float
+        example: 100.0
+      noReport:
+        type: number
+        format: float
+        example: 0.0
+      successNotApplicable:
+        type: number
+        format: float
+        example: 0.0
+      unexpectedMissingComponent:
+        type: number
+        format: float
+        example: 0.0
+      error:
+        type: number
+        format: float
+        example: 0.0
+      unexpectedUnknownComponent:
+        type: number
+        format: float
+        example: 0.0
+      successRepaired:
+        type: number
+        format: float
+        example: 0.0
+  rules:
+    type: array
+    items:
+      $ref: group-node-compliance-rules.yml

--- a/webapp/sources/api-doc/components/schemas/group-rule-compliance-directives.yml
+++ b/webapp/sources/api-doc/components/schemas/group-rule-compliance-directives.yml
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2024 Normation SAS
+type: object
+required:
+  - id
+  - name
+  - policyMode
+  - compliance
+  - complianceDetails
+  - components
+properties:
+  id:
+    type: string
+    format: uuid
+    description: id of the directive
+    example: 9a1773c9-0889-40b6-be89-f6504443ac1b
+  name:
+    type: string
+    description: Name of the directive
+    example: test directive
+  policyMode:
+    type: string
+    enum:
+      - default
+      - audit
+      - enforce
+    description: Policy mode of the rule
+    example: audit
+  compliance:
+    type: number
+    format: float
+    description: Directive compliance level
+    example: 83.34
+  complianceDetails:
+    type: object
+    properties:
+      successAlreadyOK:
+        type: number
+        format: float
+        example: 66.68
+      noReport:
+        type: number
+        format: float
+        example: 7.45
+      successNotApplicable:
+        type: number
+        format: float
+        example: 16.66
+      unexpectedMissingComponent:
+        type: number
+        format: float
+        example: 2.63
+      error:
+        type: number
+        format: float
+        example: 1.32
+      unexpectedUnknownComponent:
+        type: number
+        format: float
+        example: 2.63
+      successRepaired:
+        type: number
+        format: float
+        example: 2.63
+  components:
+    type: array
+    items:
+      type: object
+      required:
+        - name
+        - compliance
+        - complianceDetails
+        - nodes
+      properties:
+        name:
+          type: string
+          description: Name of the component
+          example: Test users
+        compliance:
+          type: number
+          format: float
+          description: Component compliance level
+          example: 100.0
+        complianceDetails:
+          type: object
+          properties:
+            successAlreadyOK:
+              type: number
+              format: float
+              example: 66.67
+            noReport:
+              type: number
+              format: float
+              example: 0.0
+            successNotApplicable:
+              type: number
+              format: float
+              example: 33.33
+            unexpectedMissingComponent:
+              type: number
+              format: float
+              example: 0.0
+            error:
+              type: number
+              format: float
+              example: 0.0
+            unexpectedUnknownComponent:
+              type: number
+              format: float
+              example: 0.0
+            successRepaired:
+              type: number
+              format: float
+              example: 0.0
+        nodes:
+          type: array
+          items:
+            $ref: node-compliance-component.yml

--- a/webapp/sources/api-doc/components/schemas/group-rule-compliance.yml
+++ b/webapp/sources/api-doc/components/schemas/group-rule-compliance.yml
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2024 Normation SAS
+type: object
+required:
+  - id
+  - name
+  - compliance
+  - complianceDetails
+  - directives
+properties:
+  id:
+    type: string
+    format: uuid
+    description: id of the rule
+    example: 32377fd7-02fd-43d0-aab7-28460a91347b
+  name:
+    type: string
+    description: Name of the rule
+    example: Global configuration for all nodes
+  mode:
+    type: string
+    enum:
+      - full-compliance
+      - changes-only
+      - reports-disabled
+  policyMode:
+    type: string
+    enum:
+      - default
+      - audit
+      - enforce
+    description: Policy mode of the rule
+    example: audit
+  compliance:
+    type: number
+    format: float
+    description: Directive compliance level
+    example: 83.34
+  complianceDetails:
+    type: object
+    properties:
+      successAlreadyOK:
+        type: number
+        format: float
+        example: 100.0
+      noReport:
+        type: number
+        format: float
+        example: 0.0
+      successNotApplicable:
+        type: number
+        format: float
+        example: 0.0
+      unexpectedMissingComponent:
+        type: number
+        format: float
+        example: 0.0
+      error:
+        type: number
+        format: float
+        example: 0.0
+      unexpectedUnknownComponent:
+        type: number
+        format: float
+        example: 0.0
+      successRepaired:
+        type: number
+        format: float
+        example: 0.0
+  directives:
+    type: array
+    items:
+      $ref: group-rule-compliance-directives.yml

--- a/webapp/sources/api-doc/openapi.src.yml
+++ b/webapp/sources/api-doc/openapi.src.yml
@@ -158,6 +158,10 @@ paths:
     $ref: paths/compliance/nodes.yml
   "/compliance/nodes/{nodeId}":
     $ref: paths/compliance/node.yml
+  "/compliance/groups/{nodeGroupId}":
+    $ref: paths/compliance/group-global.yml
+  "/compliance/groups/{nodeGroupId}/target":
+    $ref: paths/compliance/group-targeted.yml
   "/archives/export":
     $ref: paths/archives/export.yml
   "/archives/import":

--- a/webapp/sources/api-doc/paths/compliance/group-global.yml
+++ b/webapp/sources/api-doc/paths/compliance/group-global.yml
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2024 Normation SAS
+get:
+  summary: Compliance details by group (global)
+  description: Get compliance of a group with all rules that apply to a node within the group.
+  operationId: getNodeGroupComplianceId
+  parameters:
+    - $ref: ../../components/parameters/compliance-level.yml
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
+    - $ref: ../../components/parameters/node-group-id.yml
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+                example: success
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - getNodeGroupComplianceId
+              data:
+                type: object
+                required:
+                  - nodeGroups
+                properties:
+                  nodeGroups:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - mode
+                        - compliance
+                        - complianceDetails
+                        - rules
+                        - nodes
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                          description: id of the group
+                          example: 47e3f2c0-0b1a-4b1a-9b0a-9e9e9e9e9e9e
+                        mode:
+                          type: string
+                          enum:
+                            - full-compliance
+                            - changes-only
+                            - reports-disabled
+                        compliance:
+                          type: number
+                          format: float
+                          description: Group compliance level
+                          example: 57.43
+                        complianceDetails:
+                          type: object
+                          properties:
+                            successAlreadyOK:
+                              type: number
+                              format: float
+                              example: 48.68
+                            noReport:
+                              type: number
+                              format: float
+                              example: 36.18
+                            successNotApplicable:
+                              type: number
+                              format: float
+                              example: 5.92
+                            unexpectedMissingComponent:
+                              type: number
+                              format: float
+                              example: 2.63
+                            error:
+                              type: number
+                              format: float
+                              example: 1.32
+                            unexpectedUnknownComponent:
+                              type: number
+                              format: float
+                              example: 2.63
+                            successRepaired:
+                              type: number
+                              format: float
+                              example: 2.63
+                        rules:
+                          type: array
+                          items:
+                            $ref: ../../components/schemas/group-rule-compliance.yml
+                        nodes:
+                          type: array
+                          items:
+                            $ref: ../../components/schemas/group-node-compliance.yml
+  tags:
+    - Compliance
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/compliance/group-global.sh
+                        
+

--- a/webapp/sources/api-doc/paths/compliance/group-targeted.yml
+++ b/webapp/sources/api-doc/paths/compliance/group-targeted.yml
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2024 Normation SAS
+get:
+  summary: Compliance details by group (targeted)
+  description: Get compliance of a group with only rules that explicitly include the group.
+  operationId: getNodeGroupComplianceTargetId
+  parameters:
+    - $ref: ../../components/parameters/compliance-level.yml
+    - $ref: ../../components/parameters/compliance-percent-precision.yml
+    - $ref: ../../components/parameters/node-group-id.yml
+  responses:
+    "200":
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+                example: success
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - getNodeGroupComplianceTargetId
+              data:
+                type: object
+                required:
+                  - nodeGroups
+                properties:
+                  nodeGroups:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - mode
+                        - compliance
+                        - complianceDetails
+                        - rules
+                        - nodes
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                          description: id of the group
+                          example: 47e3f2c0-0b1a-4b1a-9b0a-9e9e9e9e9e9e
+                        mode:
+                          type: string
+                          enum:
+                            - full-compliance
+                            - changes-only
+                            - reports-disabled
+                        compliance:
+                          type: number
+                          format: float
+                          description: Group compliance level
+                          example: 57.43
+                        complianceDetails:
+                          type: object
+                          properties:
+                            successAlreadyOK:
+                              type: number
+                              format: float
+                              example: 48.68
+                            noReport:
+                              type: number
+                              format: float
+                              example: 36.18
+                            successNotApplicable:
+                              type: number
+                              format: float
+                              example: 5.92
+                            unexpectedMissingComponent:
+                              type: number
+                              format: float
+                              example: 2.63
+                            error:
+                              type: number
+                              format: float
+                              example: 1.32
+                            unexpectedUnknownComponent:
+                              type: number
+                              format: float
+                              example: 2.63
+                            successRepaired:
+                              type: number
+                              format: float
+                              example: 2.63
+                        rules:
+                          type: array
+                          items:
+                            $ref: ../../components/schemas/group-rule-compliance.yml
+                        nodes:
+                          type: array
+                          items:
+                            $ref: ../../components/schemas/group-node-compliance.yml
+  tags:
+    - Compliance
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/compliance/group-targeted.sh


### PR DESCRIPTION
https://issues.rudder.io/issues/24043

Add public API documentation for these endpoints : 
  * `/api/compliance/groups/{groupId}` (global compliance) 
  * `/api/compliance/groups/{groupId}/target` (targeted compliance)

Also, there was a limitation in redocly to generate examples for nested objects, so we set the config parameter `generatedPayloadSamplesMaxDepth` to `100`. We also update redocly to `1.6.0`

 