### PR TITLE
Fixes #24048: Add margin-bottom to form group

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.css
@@ -44,6 +44,14 @@ code, kbd, pre, samp, .code {
 a{
   text-decoration: none !important;
 }
+
+/* BOOTSTRAP 5 COMPATIBILITY */
+.form-group{
+  margin-bottom: 5px;
+}
+.form-group label{
+  font-weight: bold;
+}
 /*=== FONT AWESOME 5 MISSING ICONS FIX ===*/
 .fa{
   font-weight: bold;


### PR DESCRIPTION
https://issues.rudder.io/issues/24048

A margin-bottom has been added to .form-group elements and the labels inside these elements are now in bold again.