### PR TITLE
Fixes #24051: Wrong agent type for dsc node in tests

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
@@ -59,6 +59,7 @@ import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.AcceptedInventory
 import com.normation.inventory.domain.AgentType.CfeCommunity
+import com.normation.inventory.domain.AgentType.Dsc
 import com.normation.inventory.domain.AgentVersion
 import com.normation.inventory.domain.Certificate
 import com.normation.inventory.domain.Debian
@@ -392,7 +393,7 @@ ootapja6lKOaIpqp0kmmYN7gFIhp
       rootId,
       None
     ),
-    RudderAgent(CfeCommunity, admin1, AgentVersion("7.0.0"), Certificate("windows-node-dsc-certificate"), Chunk.empty),
+    RudderAgent(Dsc, admin1, AgentVersion("7.0.0"), Certificate("windows-node-dsc-certificate"), Chunk.empty),
     Chunk.empty,
     DateTime.now,
     DateTime.now,

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestComputeSchedule.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestComputeSchedule.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.services.policies
 import com.normation.errors.Inconsistency
 import java.time.Duration
 import java.time.LocalTime
+import java.util.UUID
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -183,5 +184,14 @@ class TestComputeSchedule extends Specification {
     "if the splay time is shorter than the interval, then the splay time length is taken" in {
       ComputeSchedule.computeSplayTime(uuid1, Duration.ofMinutes(10), fiveMinutes) === uuid1Splay
     }
+
+    "Check that the splaytime is strictly smaller that it's duration" in {
+      val ids    = List.fill(100)(UUID.randomUUID().toString)
+      val splays = ids.map(id => ComputeSchedule.computeSplayTime(id, fiveMinutes, fiveMinutes))
+      val starts = ids.map(id => ComputeSchedule.getSplayedStartTime(id, LocalTime.of(0, 0), fiveMinutes, fiveMinutes))
+      (splays must (contain((beLessThan(fiveMinutes)))).foreach) and
+      (starts must (contain(beLessThan(LocalTime.of(0, 5)))))
+    }
+
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestComputeSchedule.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestComputeSchedule.scala
@@ -185,7 +185,7 @@ class TestComputeSchedule extends Specification {
       ComputeSchedule.computeSplayTime(uuid1, Duration.ofMinutes(10), fiveMinutes) === uuid1Splay
     }
 
-    "Check that the splaytime is strictly smaller that it's duration" in {
+    "Check that the splaytime is strictly smaller than its duration" in {
       val ids    = List.fill(100)(UUID.randomUUID().toString)
       val splays = ids.map(id => ComputeSchedule.computeSplayTime(id, fiveMinutes, fiveMinutes))
       val starts = ids.map(id => ComputeSchedule.getSplayedStartTime(id, LocalTime.of(0, 0), fiveMinutes, fiveMinutes))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
@@ -68,6 +68,8 @@ import com.normation.templates.FillTemplatesService
 import com.normation.zio._
 import java.io.File
 import java.nio.charset.StandardCharsets
+import net.liftweb.common.EmptyBox
+import net.liftweb.common.Full
 import net.liftweb.common.Loggable
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.IOUtils
@@ -173,8 +175,13 @@ class TestSystemData {
 
   def policies(nodeInfo: NodeInfo, drafts: List[BoundPolicyDraft]): List[Policy] = {
     MergePolicyService
-      .buildPolicy(nodeInfo, globalPolicyMode, drafts)
-      .getOrElse(throw new RuntimeException("We must be able to build policies from draft in tests!"))
+      .buildPolicy(nodeInfo, globalPolicyMode, drafts) match {
+      case Full(l) => l
+      case eb: EmptyBox =>
+        throw new RuntimeException(
+          s"We must be able to build policies from draft in tests! details ${(eb ?~! "error when getting policy").messageChain}"
+        )
+    }
   }
 
   /// For root, we are using the same system variable and base root node config


### PR DESCRIPTION
https://issues.rudder.io/issues/24051

Same as https://github.com/Normation/rudder/pull/5337 with indent spotlessed and an additional tests for interval check related to question in https://github.com/Normation/rudder-plugins-private/pull/497