### PR TITLE
Fixes #24085: We need a consistant presence of policyMode in compliance API outputs

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestDirectiveComplianceCsv.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestDirectiveComplianceCsv.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.rest
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.DirectiveUid
+import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.domain.reports.ComplianceLevel
@@ -101,6 +102,7 @@ class TestDirectiveComplianceCsv extends Specification {
           RuleId(RuleUid("r1")),
           "Basic hardening on all systems",
           notUsed,
+          Some(PolicyMode.Enforce),
           Seq(
             ByRuleBlockCompliance(
               "Check Cipher TLS_RSA_WITH_DES_CBC_SHA",

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/JsonDecoder.elm
@@ -22,7 +22,7 @@ decodeNodeCompliance =
     |> required "id"         (map NodeId string)
     |> required "name"       string
     |> required "compliance" float
-    |> required "mode"       string
+    |> required "policyMode" string
     |> required "complianceDetails" decodeComplianceDetails
     |> required "rules"      (list decodeRuleCompliance)
 


### PR DESCRIPTION
https://issues.rudder.io/issues/24085

Basically just adding the _policyMode_ field at every level of the compliance tree.

For nodes and directives, _policyMode_ is already an attribute, but for a rule we need to compute it, so this is a bit less performant as it requires the set of node ids by group to be fetched.
