### PR TITLE
Fixes #24091: Add manufacturer field in create node API

### DIFF
--- a/webapp/sources/api-doc/components/schemas/node-add.yml
+++ b/webapp/sources/api-doc/components/schemas/node-add.yml
@@ -9,7 +9,8 @@ items:
     - status
     - os
   #  - policyServerId [Optional, by default "root"]
-    - machineType
+  #  - machineType [Optional, default "physical"]
+  #  - machine [Optional, default "physical"]
   #  - state [Optional, by default "enable"]
   #  - policyMode [Optional, by default global mode]
   #  - agentKey [Optional]
@@ -41,15 +42,48 @@ items:
       type: string
       description: The kind of machine for the node (use vm for a generic VM)
       enum:
-        - vmware
         - physical
         - vm
-        - solariszone
-        - qemu
-        - xen
         - aixlpar
-        - hyperv
         - bsdjail
+        - hyperv
+        - qemu
+        - solariszone
+        - vbox
+        - vmware
+        - xen
+    machine:
+      type: object
+      description: The kind of machine for the node (use vm for a generic VM)
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          description: list of groups to include in rule application
+          enum:
+            - Physical
+            - Virtual
+        provider:
+          type: string
+          description: The kind of virtual machine for the node
+          enum:
+            - aixlpar
+            - bsdjail
+            - hyperv
+            - qemu
+            - solariszone
+            - vbox
+            - vmware
+            - xen
+        manufacturer: 
+          type: string
+          description: Manufacturer of the machine
+          example: "corp inc."
+        serialNumber: 
+          type: string
+          description: Manufacturer of the machine
+          example: ece12459-2b90-49c9-ab1e-72e38f797421
     state:
       type: string
       description: Node lifecycle state. Can only be specified when status=accepted. If not specified, enable is used

--- a/webapp/sources/api-doc/components/schemas/timezone.yml
+++ b/webapp/sources/api-doc/components/schemas/timezone.yml
@@ -13,4 +13,4 @@ properties:
   offset:
     type: string
     description: Timezone offset compared to UTC, in +/-HHMM format
-    example: +0200
+    example: "+0200"

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
@@ -102,7 +102,7 @@ response:
       }
     }
 ---
-description: List node with select and include managementTechnologie
+description: List node with select and include managementTechnology
 method: GET
 url: /api/latest/nodes?include=minimal,managementTechnologyDetails&select=nodeAndPolicyServer&where=[{"objectType":"node","attribute":"nodeHostname","comparator":"eq","value":"node1.localhost"}]
 response:
@@ -118,6 +118,149 @@ response:
             "hostname":"node1.localhost",
             "status":"accepted",
             "managementTechnologyDetails":{"cfengineKeys":[],"cfengineUser":"root"}
+          }
+        ]
+      }
+    }
+---
+description: Create a node without a manufacturer, old style
+method: PUT
+url: /api/latest/nodes
+headers:
+  - "Content-Type: application/json"
+body: >-
+  [
+    {
+      "id": "378740d3-c4a9-4474-8485-478e7e52db52",
+      "hostname": "node1.hostname.local",
+      "status": "accepted",
+      "os": {
+        "type": "linux",
+        "name": "debian",
+        "version": "9.5",
+        "fullName": "Debian GNU/Linux 9 (stretch)",
+        "servicePack": "string"
+      },
+      "policyServerId": "root",
+      "machineType": "vmware",
+      "state": "enabled",
+      "policyMode": "enforce",
+      "agentKey": {
+        "value": "-----BEGIN CERTIFICATE-----\nMIIFqDCC[...]3tALNn\n-----END CERTIFICATE-----",
+        "status": "certified"
+      },
+      "properties": [
+        {
+          "name": "datacenter",
+          "value": "AMS2"
+        }
+      ],
+      "ipAddresses": [
+        "192.168.180.90"
+      ],
+      "timezone": {
+        "name": "CEST",
+        "offset": "+0200"
+      }
+    }
+  ]
+response:
+  code: 200
+  content: >-
+    {
+      "action":"createNodes",
+      "result":"success",
+      "data":{
+        "created":[
+          "378740d3-c4a9-4474-8485-478e7e52db52"
+        ],
+        "failed":[]
+      }
+    }
+---
+description: Create a node with a manufacturer, new style
+method: PUT
+url: /api/latest/nodes
+headers:
+  - "Content-Type: application/json"
+body: >-
+  [
+    {
+      "id": "378740d3-c4a9-4474-8485-478e7e52db53",
+      "hostname": "node2.hostname.local",
+      "status": "accepted",
+      "os": {
+        "type": "linux",
+        "name": "debian",
+        "version": "9.5",
+        "fullName": "Debian GNU/Linux 9 (stretch)",
+        "servicePack": "string"
+      },
+      "policyServerId": "root",
+      "machine": {
+        "type":"Virtual",
+        "provider":"vmware",
+        "manufacturer":"corp inc.",
+        "serialNumber": "ece12459-2b90-49c9-ab1e-72e38f797421"
+      },
+      "state": "enabled",
+      "policyMode": "enforce",
+      "agentKey": {
+        "value": "-----BEGIN CERTIFICATE-----\nMIIFqDCC[...]3tALNn\n-----END CERTIFICATE-----",
+        "status": "certified"
+      },
+      "properties": [
+        {
+          "name": "datacenter",
+          "value": "AMS2"
+        }
+      ],
+      "ipAddresses": [
+        "192.168.180.90"
+      ],
+      "timezone": {
+        "name": "CEST",
+        "offset": "+0200"
+      }
+    }
+  ]
+response:
+  code: 200
+  content: >-
+    {
+      "action":"createNodes",
+      "result":"success",
+      "data":{
+        "created":[
+          "378740d3-c4a9-4474-8485-478e7e52db53"
+        ],
+        "failed":[]
+      }
+    }
+---
+description: Check that the new node has a manufacturer
+method: GET
+url: /api/latest/nodes/378740d3-c4a9-4474-8485-478e7e52db53?include=minimal,machine
+response:
+  code: 200
+  content: >-
+    {
+      "action":"nodeDetails",
+      "id":"378740d3-c4a9-4474-8485-478e7e52db53",
+      "result":"success",
+      "data":{
+        "nodes":[
+          {
+            "id":"378740d3-c4a9-4474-8485-478e7e52db53",
+            "hostname":"node2.hostname.local",
+            "status":"accepted",
+            "machine": {
+              "id":"45f70964-7ec9-ed75-61a5-ed7acbde17f4",
+              "type":"Virtual",
+              "provider":"vmware",
+              "manufacturer":"corp inc.",
+              "serialNumber": "ece12459-2b90-49c9-ab1e-72e38f797421"
+            }
           }
         ]
       }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_settings.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_settings.yml
@@ -12,15 +12,13 @@ response:
         "settings":{
           "allowed_networks":[
             {
+              "id":"node-dsc",
+              "allowed_networks":[]
+            },
+            {
               "id":"root",
               "allowed_networks":[
                 "192.168.2.0/32"
-              ]
-            },
-            {
-              "id":"node-dsc",
-              "allowed_networks":[
-
               ]
             }
           ],


### PR DESCRIPTION
https://issues.rudder.io/issues/24091

Trivial change, most of it is just adding test and API doc. 
We just add a new case for `machine` deserialisation and choose either it or the old `machineType`. The new `machine` is an object matching format from the GET which allows `manufacturer`.