### PR TITLE
Fixes #24093: Backport test correction for allowed networks

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -822,7 +822,11 @@ class SettingsApi(
         servers         <- nodeInfoService.getAllSystemNodeIds()
         allowedNetworks <- policyServerManagementService.getAllAllowedNetworks()
       } yield {
-        val toKeep = servers.map(id => (id.value, allowedNetworks.getOrElse(id, Nil).map(_.inet)))
+        val toKeep = servers.map(id => (id.value, allowedNetworks.getOrElse(id, Nil).map(_.inet))).sortWith {
+          case (("root", _), _) => true
+          case (_, ("root", _)) => false
+          case ((a, _), (b, _)) => a < b
+        }
         import net.liftweb.json.JsonDSL._
         JArray(toKeep.toList.map {
           case (nodeid, networks) =>

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_settings.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_settings.yml
@@ -12,14 +12,14 @@ response:
         "settings":{
           "allowed_networks":[
             {
-              "id":"node-dsc",
-              "allowed_networks":[]
-            },
-            {
               "id":"root",
               "allowed_networks":[
                 "192.168.2.0/32"
               ]
+            },
+            {
+              "id":"node-dsc",
+              "allowed_networks":[]
             }
           ],
           "change_message_prompt":"Please enter a reason explaining this change.",


### PR DESCRIPTION
https://issues.rudder.io/issues/24093

Order of nodes in allowed network changes which breaks tests. We fix it to be always root first, then alpha-numerical for other node ID. 