### PR TITLE
Fixes #24099: Add a select type for technique parameter

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechnique.scala
@@ -51,8 +51,10 @@ import com.normation.rudder.ncf.Constraint.CheckResult
 import com.normation.rudder.ncf.Constraint.Constraint
 import java.util.regex.Pattern
 import zio.ZIO
+import zio.json.SnakeCase
 import zio.json.jsonDiscriminator
 import zio.json.jsonHint
+import zio.json.jsonMemberNames
 
 sealed trait NcfId {
   def value:        String
@@ -196,7 +198,8 @@ final case class TechniqueParameter(
     name:          String,
     description:   String,
     documentation: Option[String],
-    mayBeEmpty:    Boolean
+    mayBeEmpty:    Boolean,
+    constraints:   Option[Constraints]
 )
 
 object ParameterType {
@@ -275,6 +278,19 @@ object ParameterType {
     private[this] var innerServices: List[ParameterTypeService] = new BasicParameterTypeService :: Nil
   }
 }
+
+case class SelectOption(value: String, name: Option[String])
+
+@jsonMemberNames(SnakeCase)
+case class Constraints(
+    allowEmpty:      Option[Boolean],
+    allowWhiteSpace: Option[Boolean],
+    minLength:       Option[Int],
+    maxLength:       Option[Int],
+    regex:           Option[String],
+    notRegex:        Option[String],
+    select:          Option[List[SelectOption]]
+)
 
 object Constraint {
   sealed trait Constraint {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueSerializer.scala
@@ -66,6 +66,8 @@ class TechniqueSerializer(parameterTypeService: ParameterTypeService) {
   implicit val encoderMethodElem:             JsonEncoder[MethodElem]                  = DeriveJsonEncoder.gen
   implicit val encoderTechniqueParameterType: JsonEncoder[ParameterType.ParameterType] =
     JsonEncoder[String].contramap(s => parameterTypeService.value(s).getOrElse(s.toString))
+  implicit val encoderSelectOption:           JsonEncoder[SelectOption]                = DeriveJsonEncoder.gen
+  implicit val encoderConstraints:            JsonEncoder[Constraints]                 = DeriveJsonEncoder.gen
   implicit val encoderTechniqueParameter:     JsonEncoder[TechniqueParameter]          = DeriveJsonEncoder.gen
   implicit val encoderResourceFileState:      JsonEncoder[ResourceFileState]           = JsonEncoder[String].contramap(_.value)
   implicit val encoderResourceFile:           JsonEncoder[ResourceFile]                = DeriveJsonEncoder.gen
@@ -83,6 +85,8 @@ class TechniqueSerializer(parameterTypeService: ParameterTypeService) {
     case Left(err) => Left(err.fullMsg)
     case Right(r)  => Right(r)
   })
+  implicit val decoderSelectOption:       JsonDecoder[SelectOption]                = DeriveJsonDecoder.gen
+  implicit val decoderConstraints:        JsonDecoder[Constraints]                 = DeriveJsonDecoder.gen
   implicit val decoderTechniqueParameter: JsonDecoder[TechniqueParameter]          = DeriveJsonDecoder.gen
   implicit val decoderMethodElem:         JsonDecoder[MethodElem]                  = DeriveJsonDecoder.gen
   implicit val decoderResourceFileState:  JsonDecoder[ResourceFileState]           =

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/migration/MigrateJsonTechniquesService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/migration/MigrateJsonTechniquesService.scala
@@ -151,7 +151,7 @@ object MigrateJsonTechniquesService {
         desc,
         doc,
         oldTechnique.parameter.map(p =>
-          TechniqueParameter(ParameterId(p.id), canonify(p.name), p.name, Some(p.description), p.mayBeEmpty)
+          TechniqueParameter(ParameterId(p.id), canonify(p.name), p.name, Some(p.description), p.mayBeEmpty, None)
         ),
         oldTechnique.resources.flatMap(s => ResourceFileState.parse(s.state).map(ResourceFile(s.name, _)).toSeq),
         Map(),

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
@@ -513,7 +513,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         "technique parameter",
         Some(" a long description, with line \n break within"),
         // we must ensure that it will lead to: [parameter(Mandatory=$false)]
-        true
+        true,
+        None
       ) :: Nil,
       Nil,
       Map(),
@@ -661,7 +662,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         "version",
         "package version",
         Some("Package version to install"),
-        false
+        false,
+        None
       ) :: Nil,
       Nil,
       Map(),
@@ -752,7 +754,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         "my_custom_condition",
         "my custom condition",
         None,
-        false
+        false,
+        None
       ) :: Nil,
       Nil,
       Map(),

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
@@ -427,7 +427,7 @@ update msg model =
 
                             newValidation =
                                  List.foldl ( \param val ->
-                                   accumulateErrorConstraint  param (Maybe.withDefault [] (Dict.get param.id.value constraints)) val
+                                   accumulateErrorConstraint  param (Maybe.withDefault defaultConstraint (Dict.get param.id.value constraints)) val
                                  ) b.validation realCall.parameters
 
                           in
@@ -497,7 +497,7 @@ update msg model =
           case model.mode of
             TechniqueDetails t o ui editInfo->
               let
-                parameters = List.append t.parameters [  TechniqueParameter paramId "" "" Nothing False ]
+                parameters = List.append t.parameters [  TechniqueParameter paramId "" "" Nothing False defaultConstraint]
               in
                 TechniqueDetails { t | parameters = parameters } o ui editInfo
             _ -> model.mode
@@ -771,8 +771,8 @@ update msg model =
 
                 calls = updateElemIf (getId >> (==) call.id )  (updateParameter paramId newValue) t.elems
                 constraints = case Dict.get call.methodName.value model.methods of
-                           Just m -> Maybe.withDefault [] (Maybe.map (.constraints) (List.Extra.find (.name >> (==) paramId) m.parameters))
-                           Nothing -> []
+                           Just m -> Maybe.withDefault defaultConstraint (Maybe.map (.constraints) (List.Extra.find (.name >> (==) paramId) m.parameters))
+                           Nothing -> defaultConstraint
 
                 updateCallUi = \optCui ->
                   let

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
@@ -25,20 +25,28 @@ type alias Draft = { technique : Technique, origin : Maybe Technique, id : Strin
 
 type AgentValue = Value String | Variable (List AgentValue)
 
-type Constraint =
-    AllowEmpty Bool
-  | AllowWhiteSpace Bool
-  | MaxLength Int
-  | MinLength Int
-  | MatchRegex String
-  | NotMatchRegex String
-  | Select (List String)
+type alias Constraint =
+  { allowEmpty : Maybe Bool
+  , allowWhiteSpace:  Maybe Bool
+  , maxLength: Maybe Int
+  ,  minLength: Maybe Int
+  , matchRegex: Maybe String
+  , notMatchRegex: Maybe String
+  , select: Maybe (List SelectOption)
+  }
+
+type alias SelectOption =
+  { value : String
+  , name : Maybe String
+  }
+
+defaultConstraint = Constraint Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 type alias MethodParameter =
   { name        : ParameterId
   , description : String
   , type_       : String
-  , constraints : List Constraint
+  , constraints : Constraint
   }
 
 type Agent = Cfengine | Dsc
@@ -112,12 +120,15 @@ type alias CallParameter =
   , value : List AgentValue
   }
 
+type ParameterType = StringParameter | SelectParameter (List String)
+
 type alias TechniqueParameter =
   { id          : ParameterId
   , name        : String
   , description : String
   , documentation : Maybe String
   , mayBeEmpty  : Bool
+  , constraints : Constraint
   }
 
 type alias TechniqueCategory =
@@ -217,7 +228,6 @@ type alias TechniqueUiInfo =
   , nameState        : ValidationState TechniqueNameError
   , idState          : ValidationState TechniqueIdError
   , enableDragDrop   : Maybe CallId
-
   }
 
 type alias TechniqueEditInfo =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
@@ -98,7 +98,7 @@ listAllMethodWithErrorOnParameters methodCallList libMethods =
                   let
                     paramConstraints = case (List.head (List.filter (\p -> param.id.value == p.name.value) method.parameters)) of
                       Just paramWithConstraints -> paramWithConstraints.constraints
-                      _                         -> []
+                      _                         -> defaultConstraint
                     state = accumulateErrorConstraint param paramConstraints ValidState
                   in
                   state


### PR DESCRIPTION
https://issues.rudder.io/issues/24099

This feature adds constraints to technique parameter to generate different metadata.xml with support for different inputs. Everything is already ok rudderc side. we juste need to add it into rudder api and also in technique editor  UI 