### PR TITLE
Fixes #24105: Machine is not correctly create with node create API

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/NewNodeManager.scala
@@ -900,10 +900,12 @@ class AcceptHostnameAndIp(
       // if not, we don't group them that the duplicate appears in the list
       noDuplicatesH <- if (duplicatesH.isEmpty) Full({})
                        else {
-                         val startMessage =
-                           if (duplicatesH.size >= 2) "There are already ${duplicatesH.size} nodes" else "There is already a node"
+                         val startMessage = {
+                           if (duplicatesH.size >= 2) s"There are already ${duplicatesH.size} nodes"
+                           else "There is already a node"
+                         }
                          Failure(
-                           s"${startMessage} with hostname '${name}' in Rudder. You can not add it again."
+                           s"${startMessage} with hostname '${hostnames.mkString(", ")}' in Rudder. You can not add it again."
                          )
                        }
     } yield {}

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/CreateNodeData.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/CreateNodeData.scala
@@ -201,10 +201,10 @@ object ResultHolder {
 
     def errorToJson(error: CreationError): JValue = {
       error match {
-        case CreationError.OnAcceptation(msg)   => JString(s"[accept] ${msg}")
-        case CreationError.OnSaveInventory(msg) => JString(s"[save inventory] ${msg}")
-        case CreationError.OnSaveNode(msg)      => JString(s"[save node] ${msg}")
-        case CreationError.OnValidation(nel)    => JArray(nel.map(e => JString(s"[validation] ${e.msg}")).toList)
+        case x: CreationError.OnAcceptation   => JString(x.errorMsg)
+        case x: CreationError.OnSaveInventory => JString(x.errorMsg)
+        case x: CreationError.OnSaveNode      => JString(x.errorMsg)
+        case CreationError.OnValidation(nel) => JArray(nel.map(e => JString(s"[validation] ${e.msg}")).toList)
       }
     }
   }
@@ -212,14 +212,24 @@ object ResultHolder {
 
 object Creation {
 
-  sealed trait CreationError
+  sealed trait CreationError {
+    def errorMsg: String
+  }
 
   object CreationError {
 
-    final case class OnValidation(validations: NonEmptyList[Validation.NodeValidationError]) extends CreationError
-    final case class OnSaveInventory(message: String)                                        extends CreationError
-    final case class OnSaveNode(message: String)                                             extends CreationError
-    final case class OnAcceptation(message: String)                                          extends CreationError
+    final case class OnValidation(validations: NonEmptyList[Validation.NodeValidationError]) extends CreationError {
+      override def errorMsg: String = s"[validation] ${validations.map(_.msg).toList.mkString("; ")}"
+    }
+    final case class OnSaveInventory(message: String)                                        extends CreationError {
+      override def errorMsg: String = s"[save inventory] ${message}"
+    }
+    final case class OnSaveNode(message: String)                                             extends CreationError {
+      override def errorMsg: String = s"[save node] ${message}"
+    }
+    final case class OnAcceptation(message: String)                                          extends CreationError {
+      override def errorMsg: String = s"[accept] ${message}"
+    }
   }
 
 }
@@ -260,7 +270,7 @@ object Validation {
             case (Some(mt), None) => mt
           }
 
-          getMachine(id, status, tpe)
+          getMachine(id, tpe)
             .modify(_.manufacturer)
             .setToIfDefined(nodeDetails.machine.map(_.manufacturer.map(Manufacturer)))
             .modify(_.systemSerialNumber)
@@ -383,7 +393,7 @@ object Validation {
     ).mapN(NodeSummary(id, status, root, _, os, _, _))
   }
 
-  def getMachine(id: NodeId, status: InventoryStatus, machineType: String): MachineInventory = {
+  def getMachine(id: NodeId, machineType: String): MachineInventory = {
     val machineId = MachineUuid(IdGenerator.md5Hash(id.value))
     val machine   = machineType.toLowerCase match {
       case "virtual" => "vm"
@@ -391,7 +401,7 @@ object Validation {
     }
     MachineInventory(
       machineId,
-      status,
+      PendingInventory, // machine and node are created in Pending, then accepted is requested status is Accepted
       Machine.values.find(_.name == machine).getOrElse(Machine.MPhysical).tpe,
       Some(machineId.value)
     )


### PR DESCRIPTION
https://issues.rudder.io/issues/24105

So the problem was only for node created in `Accepted` status. For them, we created the machine directly in `Accepted`, while the node part was created in `Pending`, then accepted. 
So at one point, we have a machine in `Accepted`, and the node is still in `Pending`. So we clean the machine because we chose at some point to enforce the fact that machine and node must have the same status (when we deeply linked machine to node with the machine id being a hash of the node id). And there is no machine with the correct ID in pending. 
Works as expected. We just need to also create the machine in pending.

Other changes are just better logs and log correction. 