### PR TITLE
Fixes #24112: We must not generate policies for nodes without a well formed certificate

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeInfo.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeInfo.scala
@@ -115,7 +115,7 @@ final case class NodeInfo(
 
   /**
    * Get a digest of the key in the proprietary CFEngine digest format. It is
-   * formated as expected by CFEngine authentication module, i.e with the
+   * formatted as expected by CFEngine authentication module, i.e with the
    * "MD5=" prefix for community agent (resp. "SHA=") prefix for enterprise agent).
    */
   lazy val keyHashCfengine: String = {


### PR DESCRIPTION
https://issues.rudder.io/issues/24112

So, we want to not generate policies for nodes without a correct security token, for the value of correct == "is pasable as what it's supposed to be". 

We also want to skip these node from appearing into `nodesList.json`. 

=> check that in `system variable` part of node config handling:
- for policy servers, just avoid nodes with an empty `keyHashBase64Sha256` which does what need to be done to check parsability etc 
- for nodes, add a "check security token" check, which uses the same heuristic. The node will be avoided in that case. 

With the change, we get that kind of error message:
![image](https://github.com/Normation/rudder/assets/44649/9fd0d98d-8267-423a-bdc7-6ccb33079b58)
