### PR TITLE
Fixes #24129: For delete API for node, add a message for node already deleted

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -699,7 +699,15 @@ class NodeApiService12(
 
     removeNodeService.removeNodePure(id, mode, modId, actor).toBox match {
       case Full(info) =>
-        toJsonResponse(None, ("nodes" -> JArray(restSerializer.serializeNodeInfo(info, "deleted") :: Nil)))
+        val json = info match {
+          case Some(node) => restSerializer.serializeNodeInfo(node, "deleted")
+          case None       => (
+            ("id"     -> id.value) ~
+            ("status" -> "deleted") ~
+            ("info"   -> "Node with that ID was already deleted or ID doesn't map to an existing node")
+          )
+        }
+        toJsonResponse(None, ("nodes" -> JArray(json :: Nil)))
 
       case eb: EmptyBox =>
         val message = (eb ?~ ("Error when deleting Nodes")).msg


### PR DESCRIPTION
https://issues.rudder.io/issues/24129

Adapt the response to delete so that user using the API can know they perhaps didn't do want they wanted. 
The method seems to use at exactly one place, so it's rather simple to change. 

![image](https://github.com/Normation/rudder/assets/44649/3c3c8953-c138-4707-a9a3-58109d2f50bb)
