### PR TITLE
Fixes #24124: Links and buttons don't have the right colour since the bootstrap update

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/_rudder-variables.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/_rudder-variables.scss
@@ -1,0 +1,58 @@
+/*
+*************************************************************************************
+* Copyright 2024 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+// --- MAIN COLORS
+$rudder-success : #13BEB7;
+$rudder-primary : #337ab7;
+$rudder-warning : #EF9600;
+$rudder-danger  : #DA291C;
+
+// --- POLICY MODE
+$rudder-audit   : #1384BE;
+$rudder-enforce : #13BE7E;
+
+// --- TEXT & LINK
+$rudder-txt-primary   : #041922;
+$rudder-txt-secondary : #72829D;
+$rudder-txt-link      : #1295C2;
+
+// --- BACKGROUNDS
+$rudder-bg-gray : #F8F9FC;
+
+// --- BORDERS
+$rudder-border-color-default : #D6DEEF;
+$rudder-border-color-danger  : #AC2925;

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-bootstrap.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-bootstrap.scss
@@ -1,0 +1,96 @@
+/*
+*************************************************************************************
+* Copyright 2024 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+@use 'sass:color';
+
+@import "rudder-variables";
+
+// --- VARIABLES
+$primary    : $rudder-primary;
+$success    : $rudder-success;
+$warning    : $rudder-warning;
+$danger     : $rudder-danger;
+$body-color : $rudder-txt-primary;
+$link-color : $rudder-txt-link;
+
+@import "../../node_modules/bootstrap/scss/bootstrap";
+
+/* --- BUTTONS OVERRIDE
+-- Bootstrap is using the WCAG 2.0 algorithm to determine the (text, hover, disabled..) colors of the button following its background color.
+-- According to the WCAG algorithm, the success color we used isn't dark enough to have a white text, so we have to override the btn-success rule
+*/
+.btn{
+  &.btn-success {
+    color: #fff !important;
+    &:hover, &:focus, &:active, &:visited{
+      background-color: color.scale($rudder-success, $lightness: -10%);
+    }
+  }
+  &.btn-danger,
+  &.btn-default {
+    background-color: $rudder-bg-gray;
+    border: 1px solid $rudder-border-color-default;
+    color: $rudder-txt-primary;
+    .fa{
+      color: $rudder-txt-secondary;
+      transition-duration: .2s;
+    }
+  }
+  &.btn-danger {
+    &:focus, &:active, &:hover, &:visited{
+      color: #fff !important;
+      background-color: $rudder-danger;
+      border-color: $rudder-border-color-danger;
+      .fa{
+        color: #fff;
+      }
+    }
+  }
+  &.btn-xs {
+    padding: 1px 5px;
+    font-size: 12px;
+    line-height: 1.5;
+    border-radius: 3px;
+  }
+}
+// --- FORM-GROUP OVERRIDE
+.form-group{
+  margin-bottom: 5px;
+  label{
+    font-weight: bold;
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.css
@@ -46,14 +46,6 @@ a{
   text-decoration: none !important;
 }
 
-/* BOOTSTRAP 5 COMPATIBILITY */
-.form-group{
-  margin-bottom: 5px;
-  label{
-    font-weight: bold;
-  }
-}
-
 ul {
   padding-left: 0;
 }
@@ -228,97 +220,10 @@ pre.json-beautify code.elmsh {
   background-color:transparent !important;
   background:none !important;
 }
-.content-wrapper a,
-.content-wrapper a:focus,
-.content-wrapper a:hover,
-.content-wrapper a:active,
-.content-wrapper .btn,
-.content-wrapper .btn:focus,
-.content-wrapper .btn:hover,
-.content-wrapper .btn:active,
-.modal .btn,
-.modal .btn:focus,
-.modal .btn:hover,
-.modal .btn:active,
-.content-wrapper .form-control,
-.content-wrapper .form-control:focus,
-.content-wrapper .form-control:hover,
-.content-wrapper .form-control:active{
-  outline:none !important;
-}
-.content-wrapper .btn-danger,
-.content-wrapper .btn-default ,
-.modal .btn-danger,
-.modal .btn-default {
-  background-color: #f8f9fc;
-  border: 1px solid #d6deef;
-  color: #041922;
-}
-.content-wrapper .btn.btn-default:focus ,
-.content-wrapper .btn.btn-default:active,
-.content-wrapper .btn.btn-default:hover ,
-.modal .btn.btn-default:focus ,
-.modal .btn.btn-default:active,
-.modal .btn.btn-default:hover {
-  background-color: #eef1f9 ;
-  border-color: #d6deef !important;
-}
-.content-wrapper .btn.btn-danger:focus ,
-.content-wrapper .btn.btn-danger:active,
-.content-wrapper .btn.btn-danger:hover ,
-.modal .btn.btn-danger:focus ,
-.modal .btn.btn-danger:active,
-.modal .btn.btn-danger:hover {
-  color: #fff;
-  background-color: #DA291C;
-  border-color: #ac2925;
-}
-.content-wrapper .btn-danger .fa,
-.content-wrapper .btn-default .fa,
-.modal .btn-danger .fa,
-.modal .btn-default .fa{
-  transition-duration: .2s;
-  color: #738195;
-}
-.content-wrapper .btn.btn-danger:hover .fa,
-.modal .btn.btn-danger:hover .fa,
-.content-wrapper .btn.btn-danger:active .fa,
-.modal .btn.btn-danger:active .fa,
-.content-wrapper .btn.btn-danger:focus .fa,
-.modal .btn.btn-danger:focus .fa{
-  color: #fff;
-}
+
 .content-wrapper .dataTables_wrapper_top .btn-default,
 .content-wrapper .dataTables_wrapper_bottom .btn-default {
   background-color: #fff;
-  border-color: #d6deef;
-}
-.modal .btn-success,
-.modal .btn-success[disabled]:hover,
-.content-wrapper .btn-success,
-.content-wrapper .btn-success[disabled]:hover ,
-.content-wrapper .open > .dropdown-toggle.btn-success{
-  background-color: #13BEB7;
-  border-color: #109f9a;
-  background-image: none !important;
-}
-.modal .btn-success:hover,
-.modal .btn-success:focus:hover,
-.content-wrapper .btn-success:hover,.content-wrapper .btn-success:focus:hover  ,
-.content-wrapper .open > .dropdown-toggle.btn-success:focus,
-.content-wrapper .open > .dropdown-toggle.btn-success:hover{
-  background-color: #11b0a9;
-  border-color: #108f8b;
-}
-.content-wrapper .btn-success:focus,.content-wrapper .btn-success:focus ,
-.modal .btn-success:focus,.modal .btn-success:focus {
-  background-color: #13BEB7;
-  border-color: #109f9a;
-}
-.content-wrapper .btn-success:active,.content-wrapper .btn-success:active:focus ,
-.modal .btn-success:active,.modal .btn-success:active:focus {
-  background-color: #10a19c;
-  border-color: #109f9a;
 }
 
 .sidebar-menu>li>a>.fa{
@@ -454,12 +359,6 @@ pre.json-beautify code.elmsh {
 }
 .ui-widget-content,.portlet-content{
   border-radius:4px;
-}
-
-.ui-widget-content a {
-  color: #1295c2;
-  text-decoration: none !important;
-  transition-duration:.2s;
 }
 
 .inner-portlet #auditMode h3 {

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.css
@@ -76,7 +76,6 @@ ul {
 }
 .content-wrapper .rudder-template .jstree .jstree-node a.jstree-anchor:hover,
 .content-wrapper .rudder-template .jstree .jstree-node.jstree-leaf a.jstree-anchor{
-  color: #1295c2;
   cursor: pointer;
 }
 .content-wrapper .rudder-template .jstree .jstree-anchor .btn.create{
@@ -587,7 +586,6 @@ ul {
 
 .rudder-template .sidebar-navbar ul > li > a,
 .rudder-template .main-navbar ul > li > a{
-  color: #1295c2;
   padding: 0;
   background-color: transparent !important;
   border: none !important;

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-wizard.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-wizard.css
@@ -307,9 +307,6 @@ ul.wizard-timeline > li.activeSection ~ li > .timeline-item .item-dot{
   color: #fff !important;
   transition-duration: .2s;
 }
-.content-wrapper .rudder-template .btn-default:hover {
-  background-color: #9DA4B9;
-}
 .content-wrapper .rudder-template .btn > i{
   margin-left: 6px;
 }

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/technique-editor-filemanager.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/technique-editor-filemanager.css
@@ -289,11 +289,6 @@ body {
   line-height: 100%;
 }
 
-.btn.btn-default {
-  color: #444;
-  background-color: #FAFAFA;
-}
-
 .btn {
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, .26);
   font-weight: 500;

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/common-layout.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/common-layout.html
@@ -18,7 +18,7 @@
 
     <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder.css" media="screen" />
 
-    <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/libs/bootstrap.min.css" media="screen" />
+    <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-bootstrap.css" media="screen" />
 
     <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-compliance.css" media="screen" />
     <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-quicksearch.css" media="screen" />


### PR DESCRIPTION
https://issues.rudder.io/issues/24124

There's still a lot of optimisation to be done on this (like replacing all our colour codes with variables, making sure we override as few bootstrap rules as possible but instead using variable overrides, etc.) but to limit its scope I've just fixed and harmonised the appearance of Rudder's main links and buttons.

This first PR already brings a few changes:

- There is a new **`_rudder-variables.scss`** file
    - the underscore means in Sass that this is a "partial" file, i.e. a file that will only be imported into other scss files. It is not compiled in css
    - it will contain all our colour codes (text, buttons, compliance, policy mode, warning/error etc.). Only variables, no css rules!
    - It is completely independent of bootstrap
    - In future, the code in this file will be divided into several partial files, and all these files will be imported into this file, which will serve as the root, to make code maintenance easier.
    
- We no longer load the **`bootstrap.css`** file directly into common-layout.html, instead I've created a new **`rudder-bootstrap.scss`** file into which bootstrap is imported. This allows :
    - cleanly override bootstrap variables
    - have a file where you can find all the overridden bootstrap rules
    - in the future, not to import ALL bootstrap, but only the modules that interest us