### PR TITLE
Fixes #24152: Jstree links are broken

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNodeGroupTree.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNodeGroupTree.scala
@@ -109,7 +109,7 @@ object DisplayNodeGroupTree extends Loggable {
       override val attrs = {
         ("data-jstree" -> s"""{ "type" : "${rel}" }""") ::
         ("catId"       -> category.id.value) ::
-        ("class"       -> "") ::
+        ("class"       -> "groupTreeNode") ::
         Nil
       }
     }
@@ -139,7 +139,7 @@ object DisplayNodeGroupTree extends Loggable {
         else ""
         val excludedClass = if (excluded.contains(targetInfo.target.target)) { "excluded" }
         else { "" }
-        s"$includedClass $excludedClass"
+        s"$includedClass $excludedClass groupTreeNode"
       }
 
       override val attrs = {


### PR DESCRIPTION
https://issues.rudder.io/issues/24152

This looks as a hack but it works as a fix : 
* we store the initial event handlers in the tree, rendered in Scala code by Lift, they always have an `id` prefixed with `lift-event-js-`,
* we create a jstree "plugin" which provides a function `redraw_node` defined by jstree, in which we re-bind the event handler

I think this is the only convenient solution... The plugin would simply delete all events for the node in the DOM if we add an event handler anywhere else

In the groups tree, there was no convenient selector for a node of the tree so I created one "groupTreeNode".

There is also a fix to add _hrefs_ to all nodes of the tree, so that they can be opened in a new tab (e.g. with a middle click)