### PR TITLE
Fixes #24169: Synntax errors in schema script and init order changes

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/resources/reportsSchema.sql
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/reportsSchema.sql
@@ -455,7 +455,7 @@ CREATE TABLE NodeFacts (
 );
 
 
-CREATE TYPE score AS enum ('A', 'B', 'C', 'D', 'E')
+CREATE TYPE score AS enum ('A', 'B', 'C', 'D', 'E');
 
 Create table GlobalScore (
   nodeId  text primary key

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -211,6 +211,8 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
       override def update(newScores: Map[NodeId, List[Score]]): IOResult[Unit] = ().succeed
 
       override def registerScore(newScoreId: String): IOResult[Unit] = ???
+
+      override def init(): IOResult[Unit] = ???
     })
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1290,6 +1290,8 @@ object RudderConfig extends Loggable {
       // is encapsulated in a try/catch ( see net.liftweb.http.provider.HTTPProvider.bootLift )
       rci.allBootstrapChecks.checks()
 
+      rci.scoreService.init().runNow
+
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/CheckTableScore.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/CheckTableScore.scala
@@ -62,7 +62,7 @@ class CheckTableScore(
     val sqlType   = sql"""CREATE TYPE score AS enum ('A', 'B', 'C', 'D', 'E')"""
     val sql1      = sql"""CREATE TABLE IF NOT EXISTS GlobalScore (
       nodeId  text primary key
-    , score   score NOT NULL CHECK (score <> '')
+    , score   score NOT NULL
     , message text NOT NULL CHECK (message <> '')
     , details jsonb NOT NULL
     );"""
@@ -70,7 +70,7 @@ class CheckTableScore(
     val sql2 = sql"""CREATE TABLE IF NOT EXISTS ScoreDetails (
       nodeId  text
     , scoreId text
-    , score   score NOT NULL CHECK (score <> '')
+    , score   score NOT NULL
     , message text NOT NULL CHECK (message <> '')
     , details jsonb NOT NULL
     , PRIMARY KEY (nodeId, scoreId)


### PR DESCRIPTION
https://issues.rudder.io/issues/24169

error in sql script (missing ;)

bootstrap check was not working to create globalscore table because you can't check empty value on an enum. just null

Also change order of init so that bootstrap checks are run before initialisation of score Service (which has at class init time)