### PR TITLE
Fixes #24172: Active buttons no longer have shadow

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewUtils.elm
@@ -414,7 +414,6 @@ filtersView model =
           div [class "btn-group yesno"]
           [ label 
             [ class ("btn btn-default" ++ if isGlobalMode then " active" else "")
-              , style "box-shadow" (if isGlobalMode then "inset 0 3px 5px rgba(0,0,0,.125)" else "none")
               , attribute "data-bs-toggle" "tooltip"
               , attribute "data-bs-placement" "top"
               , attribute "data-bs-html" "true"
@@ -424,7 +423,6 @@ filtersView model =
             [text "Global"]
           , label 
             [ class ("btn btn-default" ++ if isGlobalMode then "" else " active")
-              , style "box-shadow" (if isGlobalMode then "none" else "inset 0 3px 5px rgba(0,0,0,.125)")
               , attribute "data-bs-toggle" "tooltip"
               , attribute "data-bs-placement" "top"
               , attribute "data-bs-html" "true"

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-bootstrap.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-bootstrap.scss
@@ -86,6 +86,10 @@ $link-color : $rudder-txt-link;
     line-height: 1.5;
     border-radius: 3px;
   }
+  
+  &.active {
+    box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  }
 }
 // --- FORM-GROUP OVERRIDE
 .form-group{


### PR DESCRIPTION
https://issues.rudder.io/issues/24172

![image](https://github.com/Normation/rudder/assets/65616064/317070a5-2671-4fea-894a-384cc8192bef)


* Added the shadow of active buttons in bootstrap 3 here with the new bootstrap 5 version.
* Some hardcoded style was already patched in Elm code previously, now it can be removed.

I don't know if the shadow color should go in the `rudder-variables` partial, it seems too specific to be reused anywhere else for now... 