### PR TITLE
Fixes #24177: Make spotless only check source of current project

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -279,7 +279,7 @@ limitations under the License.
         <configuration>
           <scala>
             <includes>
-              <include>**/*.scala</include>
+              <include>src/**/*.scala</include>
             </includes>
             <excludes>
               <exclude>**/ConstraintsTest.scala</exclude> <!-- make spotless scalafmt stack overflow, works on intellij: ignore -->


### PR DESCRIPTION
https://issues.rudder.io/issues/24177

The previous pattern was looking for all subdirectories with scala file. This new one only look at the `src` directory, thus limiting to current project scala sources.