### PR TITLE
Fixes #24183: Add an Alias type of Role to track role mapping

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderProviderManager.java
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderProviderManager.java
@@ -169,7 +169,13 @@ public class RudderProviderManager implements org.springframework.security.authe
                                   ApplicationLogger.warn(() -> "Rudder does not know how to get sessionId from '"+className+"'. Please report to developers that message");
                                   sessionId = Integer.toHexString(result.getDetails().hashCode());
                                 }
-                                JZioRuntime.runNow(userRepository.logStartSession(details.getUsername(), details.roles().map(x -> x.name()).toList(), com.normation.rudder.users.SessionId.apply(sessionId), p.name(), org.joda.time.DateTime.now()));
+                                JZioRuntime.runNow(userRepository.logStartSession(
+                                  details.getUsername(),
+                                  com.normation.rudder.Role.toDisplayNames(details.roles()),
+                                  com.normation.rudder.users.SessionId.apply(sessionId),
+                                  p.name(),
+                                  org.joda.time.DateTime.now()
+                                ));
                             }
                         }
                     }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/UserInformation.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/UserInformation.scala
@@ -91,13 +91,16 @@ class UserInformation extends DispatchSnippet with DefaultExtendableSnippet[User
       "Log out",
       JE.Call("logout"),
       { () =>
-        S.session match {
-          case Full(session) => // we have a session, try to know who is login out
-            UserLogout.cleanUpSession(session, "User asked for logout")
-          case e: EmptyBox => // no session ? Strange, but ok, nobody is login
-            ApplicationLogger.debug("Logout called for a non existing session, nothing more done")
+        {
+          val redirect = (S.session match {
+            case Full(session) => // we have a session, try to know who is login out
+              UserLogout.cleanUpSession(session, "User asked for logout")
+            case e: EmptyBox => // no session ? Strange, but ok, nobody is login
+              ApplicationLogger.debug("Logout called for a non existing session, nothing more done")
+              None
+          })
+          JsCmds.RedirectTo(redirect.map(_.toString).getOrElse("/"))
         }
-        JsCmds.RedirectTo("/")
       },
       ("class", "btn btn-danger")
     )


### PR DESCRIPTION
https://issues.rudder.io/issues/24183

- add an `Role.Alias` type that is just an alias of an other Role. It use the other role `name` so that rudder internal resolution is transparent for it, but allows to have an additionnal `aliasName` (typically provided by an external source to avoid referencing Rudder internal name)
- add a facility to transform roles into meaningfull string usable in log/session log
- also add some facility to provide a `logout` redirect URL. This is a bit of work, since we don't use Spring security logout for historical reasons (it didn't work well with lift logout, session cleaning, etc)
