### PR TITLE
Fixes #24140: Have a source of known-tenants in rudder-core

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/TenantService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/TenantService.scala
@@ -1,0 +1,148 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.tenants
+
+import com.normation.errors.IOResult
+import com.normation.errors.IOStream
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.facts.nodes.CoreNodeFact
+import com.normation.rudder.facts.nodes.MinimalNodeFactInterface
+import com.normation.rudder.facts.nodes.NodeFact
+import com.normation.rudder.facts.nodes.QueryContext
+import scala.collection.MapView
+import zio._
+import zio.stream.ZStream
+import zio.syntax._
+
+/*
+ * This interface provide the main entry point for other part of Rudder to know
+ * what tenants are currently known on that server so that they can take their
+ * informed decision based on that.
+ */
+trait TenantService {
+
+  // we use set because tenant list should be small (less than 100) and generally used
+  // in a "contains" way.
+  def getTenants(): IOResult[Set[TenantId]]
+  def updateTenants(ids: Set[TenantId]): IOResult[Unit]
+
+  /*
+   * Check if the node can be seen in the given query context. Return none if it can't.
+   */
+  def nodeFilter[A <: MinimalNodeFactInterface](opt: Option[A])(implicit qc: QueryContext): UIO[Option[A]]
+
+  def nodeFilterStream(s: IOStream[NodeFact])(implicit qc: QueryContext): IOStream[NodeFact]
+
+  /*
+   * Filter a map of nodes based on tenants
+   */
+  def nodeFilterMapView(nodes: Ref[Map[NodeId, CoreNodeFact]])(implicit qc: QueryContext): IOResult[MapView[NodeId, CoreNodeFact]]
+
+  /*
+   * Get the node with ID if it exists on ref map and qc/tenants allows to get it
+   */
+  def nodeGetMapView(nodes: Ref[Map[NodeId, CoreNodeFact]], nodeId: NodeId)(implicit
+      qc:                   QueryContext
+  ): IOResult[Option[CoreNodeFact]]
+
+}
+
+/*
+ * A default implementation that just use a global Ref to store the list of known tenants.
+ */
+object DefaultTenantService {
+  def make(tenantIds: IterableOnce[TenantId]): UIO[DefaultTenantService] = {
+    for {
+      ref <- Ref.make(Set.from(tenantIds))
+    } yield new DefaultTenantService(ref)
+  }
+}
+
+class DefaultTenantService(val tenantIds: Ref[Set[TenantId]]) extends TenantService {
+
+  override def getTenants(): IOResult[Set[TenantId]] = {
+    tenantIds.get
+  }
+
+  override def updateTenants(ids: Set[TenantId]): IOResult[Unit] = {
+    tenantIds.set(ids)
+  }
+
+  override def nodeFilter[A <: MinimalNodeFactInterface](opt: Option[A])(implicit qc: QueryContext): UIO[Option[A]] = {
+    opt match {
+      case Some(n) => tenantIds.get.map(ids => if (qc.nodePerms.nsc.canSee(n)(ids)) Some(n) else None)
+      case None    => None.succeed
+    }
+
+  }
+
+  override def nodeFilterMapView(
+      nodes:     Ref[Map[NodeId, CoreNodeFact]]
+  )(implicit qc: QueryContext): IOResult[MapView[NodeId, CoreNodeFact]] = {
+    if (qc.nodePerms.isNone) {
+      MapView().succeed
+    } else {
+      for {
+        ts <- tenantIds.get
+        ns <- nodes.get
+      } yield ns.view.filter { case (_, n) => qc.nodePerms.canSee(n)(ts) }
+    }
+  }
+
+  override def nodeFilterStream(s: IOStream[NodeFact])(implicit qc: QueryContext): IOStream[NodeFact] = {
+    if (qc.nodePerms.isNone) ZStream.empty
+    else {
+      ZStream
+        .fromZIO(tenantIds.get)
+        .cross(s)
+        .collect { case (tenantIds, n) if (qc.nodePerms.canSee(n)(tenantIds)) => n }
+    }
+  }
+
+  override def nodeGetMapView(nodes: Ref[Map[NodeId, CoreNodeFact]], nodeId: NodeId)(implicit
+      qc:                            QueryContext
+  ): IOResult[Option[CoreNodeFact]] = {
+    if (qc.nodePerms.isNone) None.succeed
+    else {
+      for {
+        ts <- tenantIds.get
+        ns <- nodes.get
+      } yield ns.get(nodeId).filter(qc.nodePerms.canSee(_)(ts))
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/Tenants.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/Tenants.scala
@@ -1,0 +1,63 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.tenants
+
+import scala.util.matching.Regex
+import zio.json._
+
+/*
+ * A node can belong to one (or technically more, but we will limit that for now) `tenant`.
+ * A `tenant` is a segregation limit defining an isolated zone.
+ * Tenants should be \ascii\num_-
+ */
+final case class TenantId(value: String) extends AnyVal {
+  def debugString = value
+}
+
+object TenantId {
+
+  implicit val codecTenant: JsonCodec[TenantId] = new JsonCodec[TenantId](
+    JsonEncoder.string.contramap(_.value),
+    JsonDecoder.string.map(TenantId(_))
+  )
+
+  // Tenant d can only be non empty alpha-num and hyphen. Check externally to avoid perf cost
+  // at instantiation;
+  val checkTenantId: Regex = """^(\p{Alnum}[\p{Alnum}-_]*)$""".r
+
+}

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -142,6 +142,7 @@ import com.normation.rudder.services.servers.PolicyServerManagementService
 import com.normation.rudder.services.servers.PolicyServers
 import com.normation.rudder.services.servers.PolicyServersUpdateCommand
 import com.normation.rudder.services.servers.RelaySynchronizationMethod.Classic
+import com.normation.rudder.tenants.DefaultTenantService
 import com.normation.utils.DateFormaterService
 import com.normation.utils.StringUuidGeneratorImpl
 import com.normation.zio._
@@ -2186,7 +2187,10 @@ class MockNodes() {
 
   val getNodesbySofwareName = new SoftDaoGetNodesbySofwareName(softwareDao)
 
-  val nodeFactRepo: CoreNodeFactRepository = CoreNodeFactRepository.make(nodeFactStorage, getNodesbySofwareName, Chunk()).runNow
+  val tenantService = DefaultTenantService.make(Nil).runNow
+
+  val nodeFactRepo: CoreNodeFactRepository =
+    CoreNodeFactRepository.make(nodeFactStorage, getNodesbySofwareName, tenantService, Chunk()).runNow
 
   object queryProcessor extends QueryProcessor {
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestFullInventoryRepoProxy.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestFullInventoryRepoProxy.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.facts.nodes
 import com.normation.errors._
 import com.normation.inventory.domain._
 import com.normation.inventory.services.core.FullInventoryRepository
+import com.normation.rudder.tenants.DefaultTenantService
 import com.normation.zio._
 import com.normation.zio.ZioRuntime
 import com.softwaremill.quicklens._
@@ -111,7 +112,8 @@ class TestFullInventoryRepoProxy extends Specification {
     for {
       callbacks <- Ref.make(Chunk.empty[NodeFactChangeEventCallback])
       lock      <- ReentrantLock.make()
-      r          = new CoreNodeFactRepository(NoopFactStorage, noopNodeBySoftwareName, pendingRef, acceptedRef, callbacks, lock)
+      tenants   <- DefaultTenantService.make(Nil)
+      r          = new CoreNodeFactRepository(NoopFactStorage, noopNodeBySoftwareName, tenants, pendingRef, acceptedRef, callbacks, lock)
       _         <- r.registerChangeCallbackAction(CoreNodeFactChangeEventCallback("trail", e => callbackLog.update(_.appended(e.event))))
       //      _         <- r.registerChangeCallbackAction(new NodeFactChangeEventCallback("log", e => effectUioUnit(println(s"**** ${e.name}"))))
     } yield {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSaveInventory.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSaveInventory.scala
@@ -61,6 +61,7 @@ import com.normation.rudder.inventory.InventoryProcessor
 import com.normation.rudder.inventory.InventoryProcessStatus
 import com.normation.rudder.inventory.InventoryProcessStatus.Saved
 import com.normation.rudder.inventory.SaveInventoryInfo
+import com.normation.rudder.tenants.DefaultTenantService
 import com.normation.utils.DateFormaterService
 import com.normation.utils.StringUuidGeneratorImpl
 import com.normation.zio._
@@ -450,8 +451,9 @@ trait TestSaveInventory extends Specification with BeforeAfterAll {
       pending   <- Ref.make(Map[NodeId, CoreNodeFact]())
       accepted  <- Ref.make(Map[NodeId, CoreNodeFact]())
       callbacks <- Ref.make(Chunk.empty[NodeFactChangeEventCallback])
+      tenants   <- DefaultTenantService.make(Nil)
       lock      <- ReentrantLock.make()
-      r          = new CoreNodeFactRepository(factStorage, noopNodeBySoftwareName, pending, accepted, callbacks, lock)
+      r          = new CoreNodeFactRepository(factStorage, noopNodeBySoftwareName, tenants, pending, accepted, callbacks, lock)
       _         <- r.registerChangeCallbackAction(CoreNodeFactChangeEventCallback("trail", e => callbackLog.update(_.appended(e.event))))
 //      _         <- r.registerChangeCallbackAction(new NodeFactChangeEventCallback("log", e => effectUioUnit(println(s"**** ${e.name}"))))
     } yield {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -76,6 +76,7 @@ import com.normation.rudder.services.reports.NodeConfigurationService
 import com.normation.rudder.services.reports.NodeConfigurationServiceImpl
 import com.normation.rudder.services.reports.ReportingServiceImpl
 import com.normation.rudder.services.reports.UnexpectedReportInterpretation
+import com.normation.rudder.tenants.DefaultTenantService
 import com.normation.zio._
 import com.softwaremill.quicklens._
 import doobie.implicits._
@@ -120,7 +121,10 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
       build("n4", Some(PolicyMode.Audit))
     ).toMap
 
-    CoreNodeFactRepository.make(NoopFactStorage, NoopGetNodesbySofwareName, Map(), accepted, Chunk.empty).runNow
+    (for {
+      t <- DefaultTenantService.make(Nil)
+      r <- CoreNodeFactRepository.make(NoopFactStorage, NoopGetNodesbySofwareName, t, Map(), accepted, Chunk.empty)
+    } yield r).runNow
   }
 
   val directivesLib = NodeConfigData.directives

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -61,6 +61,7 @@ import com.normation.rudder.score.Score
 import com.normation.rudder.score.ScoreService
 import com.normation.rudder.score.ScoreServiceManager
 import com.normation.rudder.services.policies.NodeConfigData
+import com.normation.rudder.tenants.DefaultTenantService
 import com.normation.zio._
 import com.softwaremill.quicklens._
 import net.liftweb.common.Box
@@ -142,8 +143,12 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
   )
 
   val accepted:     Map[NodeId, CoreNodeFact] = nodes.map { case (n, _, _) => n }.toMap
-  val nodeFactRepo: CoreNodeFactRepository    =
-    CoreNodeFactRepository.make(NoopFactStorage, NoopGetNodesbySofwareName, Map(), accepted, Chunk.empty).runNow
+  val nodeFactRepo: CoreNodeFactRepository    = {
+    (for {
+      t <- DefaultTenantService.make(Nil)
+      r <- CoreNodeFactRepository.make(NoopFactStorage, NoopGetNodesbySofwareName, t, Map(), accepted, Chunk.empty)
+    } yield r).runNow
+  }
 
   class TestCache extends CachedFindRuleNodeStatusReports() {
     val batchSize = 3

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
@@ -264,8 +264,8 @@ trait StartsAtVersion14 extends EndpointSchema { val versions: ApiV.From = ApiV.
 trait StartsAtVersion15 extends EndpointSchema { val versions: ApiV.From = ApiV.From(15) } // Rudder 7.1
 trait StartsAtVersion16 extends EndpointSchema { val versions: ApiV.From = ApiV.From(16) } // Rudder 7.2
 trait StartsAtVersion17 extends EndpointSchema { val versions: ApiV.From = ApiV.From(17) } // Rudder 7.3
-trait StartsAtVersion18 extends EndpointSchema { val versions: ApiV.From = ApiV.From(18) }
-trait StartsAtVersion19 extends EndpointSchema { val versions: ApiV.From = ApiV.From(19) }
+trait StartsAtVersion18 extends EndpointSchema { val versions: ApiV.From = ApiV.From(18) } // Rudder 8.0
+trait StartsAtVersion19 extends EndpointSchema { val versions: ApiV.From = ApiV.From(19) } // Rudder 8.1
 trait StartsAtVersion20 extends EndpointSchema { val versions: ApiV.From = ApiV.From(20) }
 
 // utility extension trait to define the kind of API

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
@@ -48,8 +48,8 @@ import com.normation.rudder.domain.eventlog.RudderEventActor
 import com.normation.rudder.domain.logger.ApplicationLogger
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.facts.nodes.NodeSecurityContext
-import com.normation.rudder.facts.nodes.Tenant
 import com.normation.rudder.rest.RoleApiMapping
+import com.normation.rudder.tenants.TenantId
 import com.normation.rudder.users._
 import com.normation.zio._
 import java.io.File
@@ -619,10 +619,10 @@ object UserFileProcessing {
           .foldLeft(ts)(NodeSecurityContext.ByTenants(Chunk.empty): NodeSecurityContext) {
             case (t1, t2) =>
               t2.strip() match {
-                case "*"                     => t1.plus(NodeSecurityContext.All).succeed
-                case "-"                     => NodeSecurityContext.None.succeed
-                case Tenant.checkTenantId(v) => t1.plus(NodeSecurityContext.ByTenants(Chunk(Tenant(v)))).succeed
-                case x                       =>
+                case "*"                       => t1.plus(NodeSecurityContext.All).succeed
+                case "-"                       => NodeSecurityContext.None.succeed
+                case TenantId.checkTenantId(v) => t1.plus(NodeSecurityContext.ByTenants(Chunk(TenantId(v)))).succeed
+                case x                         =>
                   ApplicationLoggerPure.Authz.warn(
                     s"Value '${x}' is not a valid tenant identifier. It must contains only alpha-num  ascii chars or " +
                     s"'-' and '_' (not in the first) place; or exactly '*' (all tenants) or '-' (none tenants)"

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
@@ -50,9 +50,9 @@ import com.normation.rudder.RudderRoles
 import com.normation.rudder.UncheckedCustomRole
 import com.normation.rudder.api.ApiAclElement
 import com.normation.rudder.facts.nodes.NodeSecurityContext
-import com.normation.rudder.facts.nodes.Tenant
 import com.normation.rudder.rest.AuthorizationApiMapping
 import com.normation.rudder.rest.RoleApiMapping
+import com.normation.rudder.tenants.TenantId
 import com.normation.zio._
 import org.junit.runner.RunWith
 import org.specs2.mutable._
@@ -252,11 +252,11 @@ class RudderUserDetailsTest extends Specification {
     val userDetailList = getUserDetailList(tenantXML_1, "tenantXML_1")
 
     "be able to define one tenants" in {
-      userDetailList.users("user_single").nodePerms === NodeSecurityContext.ByTenants(Chunk(Tenant("zoneA")))
+      userDetailList.users("user_single").nodePerms === NodeSecurityContext.ByTenants(Chunk(TenantId("zoneA")))
     }
 
     "be able to define a list of tenants" in {
-      userDetailList.users("user_multi").nodePerms === NodeSecurityContext.ByTenants(Chunk(Tenant("zoneA"), Tenant("zoneB")))
+      userDetailList.users("user_multi").nodePerms === NodeSecurityContext.ByTenants(Chunk(TenantId("zoneA"), TenantId("zoneB")))
     }
 
     "have no tenants attribute means ALL for compat reason" in {
@@ -276,7 +276,7 @@ class RudderUserDetailsTest extends Specification {
     }
 
     "only have access to sane ascii identifier" in {
-      userDetailList.users("user_ascii").nodePerms === NodeSecurityContext.ByTenants(Chunk(Tenant("zoneA")))
+      userDetailList.users("user_ascii").nodePerms === NodeSecurityContext.ByTenants(Chunk(TenantId("zoneA")))
     }
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/24140

That PR introduce a source of "tenants known in that Rudder server". Only tenants know will be allowed to be used for node access, so that we have a kind of prefiltering before the "user/node/tenant" check on "node tenants/available tenants" 

The filtering is done in a `TenantService` that knows about available tenants and wrap low level methods on node. 
These wrapping are then used  in `CoreNodeFactRepository`. 

Nothing in Rudder core manage that list of available tenants. It will be done in plugins. 

Also add tests to check that the available tenants are doing there job. 