### PR TITLE
Fixes #24170: The active tab indicator no longer works

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/View.elm
@@ -16,16 +16,16 @@ view : Model -> Html Msg
 view model =
   div [class "tab-table-content"]
   ( List.append
-    [ ul [class "ui-tabs-nav"]
-      [ li [class ("ui-tabs-tab ui-tab" ++ (if model.ui.viewMode == RulesView then " active" else ""))]
-        [ a [onClick (ChangeViewMode RulesView)]
-          [ text "By Rules"
-          ]
+    [ ul [class "nav nav-underline"]
+      [ li [class "nav-item"]
+        [ button
+          [ attribute "role" "tab", type_ "button", class ("nav-link " ++ (if model.ui.viewMode == RulesView then " active" else "")), onClick (ChangeViewMode RulesView)]
+          [ text "By Rules" ]
         ]
-      , li [class ("ui-tabs-tab ui-tab" ++ (if model.ui.viewMode == NodesView then " active" else ""))]
-        [ a [onClick (ChangeViewMode NodesView)]
-          [ text "By Nodes"
-          ]
+      , li [class "nav-item"]
+        [ button
+          [ attribute "role" "tab", type_ "button", class ("nav-link " ++ (if model.ui.viewMode == NodesView then " active" else "")), onClick (ChangeViewMode NodesView)]
+          [ text "By Nodes" ]
         ]
       ]
     ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
@@ -157,7 +157,7 @@ showTechnique model technique origin ui editInfo =
     fakeMetadata = Http.Metadata "internal-elm-call" 200 "call from elm app" Dict.empty
     blocksOnError = checkBlocksOnError technique.elems
     areBlockOnError = Dict.isEmpty blocksOnError
-    activeTabClass = (\tab -> "ui-tabs-tab " ++ (if ui.tab == tab then "active" else ""))
+    activeTabClass = (\tab -> if ui.tab == tab then " active" else "")
     creation = case origin of
                  Creation _ -> True
                  Clone _ _ -> True
@@ -303,22 +303,26 @@ showTechnique model technique origin ui editInfo =
           ]
         ]
       ]
-    , div [ class "main-navbar" ] [
-        ul [ class "ui-tabs-nav nav nav-tabs" ] [
-          li [ class (activeTabClass General) , onClick (SwitchTab General)] [
-            a [] [ text "Information" ]
+    , div [ class "main-navbar" ]
+      [ ul [ class "nav nav-underline" ]
+        [ li [ class "nav-item"]
+          [ button
+            [ attribute "role" "tab", type_ "button", class ("nav-link " ++ (activeTabClass General)), onClick (SwitchTab General)]
+            [ text "Information"]
           ]
-        , li [ class (activeTabClass Parameters), onClick (SwitchTab Parameters) ] [
-            a [] [
-              text "Parameters "
+        , li [ class "nav-item"]
+          [ button
+            [ attribute "role" "tab", type_ "button", class ("nav-link " ++ (activeTabClass Parameters)), onClick (SwitchTab Parameters)]
+            [ text "Parameters "
             , span [ class ( "badge badge-secondary badge-resources " ++ if List.isEmpty technique.parameters then "empty" else "") ] [
                 span [] [ text (String.fromInt (List.length technique.parameters)) ]
               ]
             ]
           ]
-        , li [ class (activeTabClass Resources)  , onClick (SwitchTab Resources)] [
-            a [] [
-              text "Resources "
+        , li [ class "nav-item"]
+          [ button
+            [ attribute "role" "tab", type_ "button", class ("nav-link " ++ (activeTabClass Resources)), onClick (SwitchTab Resources)]
+            [ text "Resources "
             , span [  class  ( "badge badge-secondary badge-resources " ++ if List.isEmpty technique.resources then "empty" else "") ] [
                 if ((List.isEmpty technique.resources)|| (List.any (\s -> (s.state == Untouched) || (s.state == Modified)) technique.resources) ) then span [ class "nb-resources" ] [text (String.fromInt (List.length (List.filter  (\s -> s.state == Untouched || s.state == Modified) technique.resources ) ))] else text ""
               , if not (List.isEmpty (List.filter (.state >> (==) New) technique.resources)) then  span [class "nb-resources new"] [ text ((String.fromInt (List.length (List.filter (.state >> (==) New) technique.resources))))] else text ""
@@ -327,14 +331,15 @@ showTechnique model technique origin ui editInfo =
             ]
           ]
         , if (Maybe.Extra.isJust technique.output) then
-            li [ class (activeTabClass Output)  , onClick (SwitchTab Output)] [
-              a [] [
-                text "Compilation output "
-              , span [  class  ( "fa ") ] []
-              ]
+          li [ class "nav-item" ]
+          [ button
+            [ attribute "role" "tab", type_ "button", class ("nav-link " ++ (activeTabClass Output)), onClick (SwitchTab Output)]
+            [ text "Compilation output "
+            , span [ class  ( "fa fa-check") ] []
             ]
-            else
-              text ""
+          ]
+          else
+            text ""
         ]
       ]
     , div [ class "main-details", id "details"]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/View.elm
@@ -16,16 +16,16 @@ view : Model -> Html Msg
 view model =
   div [class "tab-table-content"]
   ( List.append
-    [ ul [class "ui-tabs-nav"]
-      [ li [class ("ui-tabs-tab ui-tab" ++ (if model.ui.viewMode == RulesView then " active" else ""))]
-        [ a [onClick (ChangeViewMode RulesView)]
-          [ text "By Rules"
-          ]
+    [ ul [class "nav nav-underline"]
+      [ li [class "nav-item"]
+        [ button
+          [ attribute "role" "tab", type_ "button", class ("nav-link " ++ (if model.ui.viewMode == RulesView then " active" else "")), onClick (ChangeViewMode RulesView)]
+          [ text "By Rules" ]
         ]
-      , li [class ("ui-tabs-tab ui-tab" ++ (if model.ui.viewMode == NodesView then " active" else ""))]
-        [ a [onClick (ChangeViewMode NodesView)]
-          [ text "By Nodes"
-          ]
+      , li [class "nav-item"]
+        [ button
+          [ attribute "role" "tab", type_ "button", class ("nav-link " ++ (if model.ui.viewMode == NodesView then " active" else "")), onClick (ChangeViewMode NodesView)]
+          [ text "By Rules" ]
         ]
       ]
     ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewCategoryDetails.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewCategoryDetails.elm
@@ -1,7 +1,7 @@
 module Rules.ViewCategoryDetails exposing (..)
 
 import Html exposing (Html, button, div, i, span, text, h1, ul, li, input, a, p, form, label, textarea, select, table, thead, tbody)
-import Html.Attributes exposing (id, class, type_, placeholder, value, for, style)
+import Html.Attributes exposing (id, class, type_, placeholder, value, for, style, attribute)
 import Html.Events exposing (onClick, onInput, onSubmit)
 import List
 import Maybe.Extra
@@ -122,14 +122,19 @@ editionTemplateCat model details =
         [ p[][text ""] ]
       ]
     , div [class "main-navbar" ]
-      [ ul[class "ui-tabs-nav "]
-        [ li[class ("ui-tabs-tab" ++ (if details.tab == Information    then " ui-tabs-active" else ""))]
-          [ a[onClick (UpdateCategoryForm {details | tab = Information})][ text "Information" ]
+      [ ul[class "nav nav-underline"]
+        [ li[class "nav-item"]
+          [ button
+            [ attribute "role" "tab", type_ "button", class ("nav-link" ++ (if details.tab == Information then " active" else "")), onClick (UpdateCategoryForm {details | tab = Information})]
+            [ text "Information" ]
           ]
-        , li[class ("ui-tabs-tab" ++ (if details.tab == Rules    then " ui-tabs-active" else ""))]
-          [ a[onClick (UpdateCategoryForm {details | tab = Rules})][ text "Rules" ]
-          , span[class "badge badge-secondary badge-resources"]
-            [ span [class "nb-resources"] [text (String.fromInt (List.length rulesList))]
+        , li[class "nav-item"]
+          [ button
+            [ attribute "role" "tab", type_ "button", class ("nav-link" ++ (if details.tab == Rules then " active" else "")), onClick (UpdateCategoryForm {details | tab = Rules})]
+            [ text "Rules"
+            , span[class "badge badge-secondary badge-resources"]
+              [ span [class "nb-resources"] [text (String.fromInt (List.length rulesList))]
+              ]
             ]
           ]
         ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRuleDetails.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRuleDetails.elm
@@ -195,13 +195,15 @@ editionTemplate model details =
         [ p[][text (Maybe.Extra.unwrap "" .shortDescription originRule)] ]
       ]
     , div [class "main-navbar" ]
-      [ ul[class "ui-tabs-nav "]
-        [ li[class ("ui-tabs-tab" ++ (if details.tab == Information   then " ui-tabs-active" else ""))]
-          [ a[onClick (UpdateRuleForm {details | tab = Information })]
+      [ ul[class "nav nav-underline"]
+        [ li[class "nav-item"]
+          [ button
+            [ attribute "role" "tab", type_ "button", class ("nav-link" ++ (if details.tab == Information then " active" else "")), onClick (UpdateRuleForm {details | tab = Information})]
             [ text "Information" ]
           ]
-        , li[class ("ui-tabs-tab" ++ (if details.tab == Directives    then " ui-tabs-active" else ""))]
-          [ a[onClick (UpdateRuleForm {details | tab = Directives})]
+        , li[class "nav-item"]
+          [ button
+            [ attribute "role" "tab", type_ "button", class ("nav-link" ++ (if details.tab == Directives then " active" else "")), onClick (UpdateRuleForm {details | tab = Directives})]
             [ text "Directives"
             , span[class "badge badge-secondary badge-resources"]
               [ getNbResourcesBadge nbDirectives "This rule does not apply any directive"
@@ -213,8 +215,9 @@ editionTemplate model details =
         , ( if isNewRule then
           text ""
         else
-          li[class ("ui-tabs-tab" ++ (if details.tab == Nodes        then " ui-tabs-active" else ""))]
-          [ a[onClick (UpdateRuleForm {details | tab = Nodes })]
+          li[class "nav-item"]
+          [ button
+            [ attribute "role" "tab", type_ "button", class ("nav-link" ++ (if details.tab == Nodes then " active" else "")), onClick (UpdateRuleForm {details | tab = Nodes})]
             [ text "Nodes"
             , span[class "badge badge-secondary badge-resources"]
               [ getNbResourcesBadge (Maybe.withDefault 0 (getRuleNbNodes details)) "This rule is not applied on any node"
@@ -222,8 +225,9 @@ editionTemplate model details =
             ]
           ]
         )
-        , li[class ("ui-tabs-tab" ++ (if details.tab == Groups       then " ui-tabs-active" else ""))]
-          [ a[onClick (UpdateRuleForm {details | tab = Groups })]
+        , li[class "nav-item"]
+          [ button
+            [ attribute "role" "tab", type_ "button", class ("nav-link" ++ (if details.tab == Groups then " active" else "")), onClick (UpdateRuleForm {details | tab = Groups})]
             [ text "Groups"
             , span[class "badge badge-secondary badge-resources"]
               [ getGroupsNbResourcesBadge (getRuleNbGroups originRule) (List.length (getTargetIncludedIds (Maybe.Extra.unwrap [] .targets originRule))) "This rule is not applied on any group"
@@ -235,8 +239,9 @@ editionTemplate model details =
         , ( if isNewRule then
           text ""
         else
-          li[class ("ui-tabs-tab" ++ (if details.tab == TechnicalLogs       then " ui-tabs-active" else ""))]
-          [ a[onClick (UpdateRuleForm {details | tab = TechnicalLogs })]
+          li[class "nav-item"]
+          [ button
+            [ attribute "role" "tab", type_ "button", class ("nav-link" ++ (if details.tab == TechnicalLogs then " active" else "")), onClick (UpdateRuleForm {details | tab = TechnicalLogs})]
             [ text "Recent changes"
             , span[class "badge badge-secondary badge-resources"]
               [ span [class "nb-resources"] [text (String.fromFloat (countRecentChanges details.rule.id model.changes))]

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
@@ -372,7 +372,7 @@ $(document).ready(function() {
       return ((a < b) ? 1 : ((a > b) ? -1 : 0));
     }
   } );
-  sidebarControl(".sidebar");
+  sidebarControl();
   initBsTooltips();
 });
 
@@ -773,23 +773,22 @@ function buildScrollSpyNav(){
     });
 }
 
-function sidebarControl(a){
-  var b = this
-    , c = 400;
-  $(document).on("click", a + " li a", function(a) {
+function sidebarControl(){
+  var speed = 400;
+  $(".sidebar li a").on("click", function(a) {
     var d = $(this)
       , e = d.next();
     if (e.is(".treeview-menu") && e.is(":visible"))
-      e.slideUp(c, function() {
+      e.slideUp(speed, function() {
         e.removeClass("menu-open")
       }),
       e.parent("li").removeClass("active");
     else if (e.is(".treeview-menu") && !e.is(":visible")) {
       var f = d.parents("ul").first()
-        , g = f.find("ul:visible").slideUp(c);
+        , g = f.find("ul:visible").slideUp(speed);
       g.removeClass("menu-open");
       var h = d.parent("li");
-      e.slideDown(c, function() {
+      e.slideDown(speed, function() {
         e.addClass("menu-open"),
         f.find("li.active").removeClass("active"),
         h.addClass("active")

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
@@ -99,7 +99,7 @@ class NodeGroupCategoryForm(
 
   def showForm(): NodeSeq = {
     val html = SHtml.ajaxForm(
-      <div id="GroupTabs" class="main-container">
+      <div class="main-container">
         <div class="main-header">
           <div class="header-title">
             <h1>
@@ -117,9 +117,9 @@ class NodeGroupCategoryForm(
           </div>
         </div>
         <div class="main-navbar">
-          <ul id="groupTabMenu" class="ui-tabs-nav ui-widget-header">
-            <li class="ui-tabs-tab ui-tab ui-tabs-active ui-state-active">
-              <a href="#categoryParametersTab">Parameters</a>
+          <ul id="groupTabMenu" class="nav nav-underline">
+            <li class="nav-item">
+              <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#categoryParametersTab" type="button" role="tab" aria-controls="categoryParametersTab" aria-selected="true">Parameters</button>
             </li>
           </ul>
         </div>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -351,7 +351,7 @@ class NodeGroupForm(
                            <li class="nav-item">
                              <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#groupParametersTab" type="button" role="tab" aria-controls="groupParametersTab">Parameters</button>
                            </li>
-                           <li>
+                           <li class="nav-item">
                              <button class="nav-link" data-bs-toggle="tab" data-bs-target="#groupRulesTab" type="button" role="tab" aria-controls="groupRulesTab">Related rules</button>
                            </li>
                          </ul>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -180,10 +180,7 @@ class NodeGroupForm(
   }
 
   def showForm(): NodeSeq = {
-    val html = SHtml.ajaxForm(body) ++
-      Script(
-        OnLoad(JsRaw("$('#GroupTabs').tabs( {active : 0 });"))
-      )
+    val html = SHtml.ajaxForm(body)
 
     nodeGroup match {
       case Left(target)                     => showFormTarget(target)(html) ++ showRelatedRulesTree(target)
@@ -350,9 +347,13 @@ class NodeGroupForm(
     ("group-pendingchangerequest" #> NodeSeq.Empty
     & "#group-name" #> <span>{groupNameString}<span class="group-system"></span></span>
     & "group-name" #> groupName.readOnlyValue
-    & "#groupTabMenu" #> <ul id="groupTabMenu">
-                           <li><a href="#groupParametersTab">Parameters</a></li>
-                           <li><a id="relatedRulesLinkTab" href="#groupRulesTab">Related rules</a></li>
+    & "#groupTabMenu" #> <ul id="groupTabMenu" class="nav nav-underline">
+                           <li class="nav-item">
+                             <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#groupParametersTab" type="button" role="tab" aria-controls="groupParametersTab">Parameters</button>
+                           </li>
+                           <li>
+                             <button class="nav-link" data-bs-toggle="tab" data-bs-target="#groupRulesTab" type="button" role="tab" aria-controls="groupRulesTab">Related rules</button>
+                           </li>
                          </ul>
     & "group-rudderid" #> <div>
                     <label class="wbBaseFieldLabel">Group ID</label>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/ShowNodeDetailsFromNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/ShowNodeDetailsFromNode.scala
@@ -198,7 +198,7 @@ class ShowNodeDetailsFromNode(
   ): NodeSeq = {
     nodeFactRepo.get(nodeId).toBox match {
       case Full(None) =>
-        (<ul id="NodeDetailsTabMenu" class="rudder-ui-tabs ui-tabs-nav"></ul>
+        (<ul id="NodeDetailsTabMenu" class="nav nav-underline"></ul>
           <div class="col-xs-12">
             <div class="info-card critical">
               <div class="card-info">
@@ -230,14 +230,10 @@ class ShowNodeDetailsFromNode(
                 bindNode(nf, withinPopup, globalMode, globalScore) ++ Script(
                   DisplayNode.jsInit(node.id, "") &
                   JsRaw(s"""
-                    $$( "#${detailsId}" ).tabs({ active : ${tab} } );
-                    $$('#nodeInventory .ui-tabs-vertical .ui-tabs-nav li a').on('click',function(){
-                      var tab = $$(this).attr('href');
-                      $$('#nodeInventory .ui-tabs-vertical .ui-tabs-nav li a.active').removeClass('active');
-                      $$(this).addClass('active');
-                      $$('#nodeInventory > .sInventory > .sInventory').hide();
-                      $$(tab).show();
-                    });
+                    var nodeTabs = $$("#${detailsId} .main-navbar > .nav > li ");
+                    var activeTabBtn = nodeTabs.get(${tab}).querySelector("button");
+                    activeTabBtn.classList.add('active');
+                    var activeTab = document.querySelector("#"+activeTabBtn.getAttribute("aria-controls")).classList.add('active', 'show')
                     """) &
                   buildJsTree(groupTreeId)
                 )

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -252,25 +252,59 @@ object DisplayNode extends Loggable {
   def showInventoryVerticalMenu(sm: FullInventory, node: CoreNodeFact, salt: String = ""): NodeSeq = {
     val jsId = JsNodeId(sm.node.main.id, salt)
     val mainTabDeclaration: List[NodeSeq] = {
-      <li><a href={htmlId_#(jsId, "sd_os_")}>Operating system</a></li> ::
-      <li><a href={htmlId_#(jsId, "sd_fs_")}>File systems</a></li> ::
-      <li><a href={htmlId_#(jsId, "sd_net_")}>Network interfaces</a></li> ::
-      <li id="soft_tab"><a href={htmlId_#(jsId, "sd_soft_")}>Software</a></li> ::
-      <li><a href={htmlId_#(jsId, "sd_softUpdates_")}>Software updates</a></li> ::
-      <li><a href={htmlId_#(jsId, "sd_var_")}>Environment</a></li> ::
-      // Hardware content
-      <li><a href={htmlId_#(jsId, "sd_bios_")}>BIOS</a></li> ::
-      <li><a href={htmlId_#(jsId, "sd_controllers_")}>Controllers</a></li> ::
-      <li><a href={htmlId_#(jsId, "sd_memories_")}>Memory</a></li> ::
-      <li><a href={htmlId_#(jsId, "sd_ports_")}>Ports</a></li> ::
-      <li><a href={htmlId_#(jsId, "sd_processors_")}>Processors</a></li> ::
-      <li><a href={htmlId_#(jsId, "sd_slots_")}>Slots</a></li> ::
-      <li><a href={htmlId_#(jsId, "sd_sounds_")}>Sound</a></li> ::
-      <li><a href={htmlId_#(jsId, "sd_storages_")}>Storage</a></li> ::
-      <li><a href={htmlId_#(jsId, "sd_videos_")}>Video</a></li> ::
-      //
-      <li><a href={htmlId_#(jsId, "sd_process_")}>Processes</a></li> ::
-      <li><a href={htmlId_#(jsId, "sd_vm_")}>Virtual machines</a></li> ::
+      <li class="nav-item">
+        <button class="nav-link active" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_os_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_os_")}>Operating system</button>
+      </li> ::
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_fs_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_fs_")}>File systems</button>
+      </li> ::
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_net_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_net_")}>Network interfaces</button>
+        </li> ::
+        <li class="nav-item" id="soft_tab">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_soft_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_soft_")}>Software</button>
+        </li> ::
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_softUpdates_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_softUpdates_")}>Software updates</button>
+        </li> ::
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_var_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_var_")}>Environment</button>
+        </li> ::
+        // Hardware content
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_bios_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_bios_")}>BIOS</button>
+        </li> ::
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_controllers_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_controllers_")}>Controllers</button>
+        </li> ::
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_memories_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_memories_")}>Memory</button>
+        </li> ::
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_ports_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_ports_")}>Ports</button>
+        </li> ::
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_processors_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_processors_")}>Processors</button>
+        </li> ::
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_slots_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_slots_")}>Slots</button>
+        </li> ::
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_sounds_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_sounds_")}>Sound</button>
+        </li> ::
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_storages_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_storages_")}>Storage</button>
+        </li> ::
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_videos_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_videos_")}>Video</button>
+        </li> ::
+        //
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_process_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_process_")}>Processes</button>
+        </li> ::
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target={htmlId_#(jsId, "sd_vm_")} type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_vm_")}>Virtual machines</button>
+        </li> ::
       Nil
     }
 
@@ -297,10 +331,11 @@ object DisplayNode extends Loggable {
 
     val tabId = htmlId(jsId, "node_details_")
 
-    <div id={tabId} class="sInventory ui-tabs-vertical">
-      <ul class="list-tabs-inventory">{mainTabDeclaration}</ul>
-      {tabContent.flatten}
-    </div> ++ Script(OnLoad(JsRaw(s"$$('#${tabId}').tabs()")))
+    <div id={tabId} class="sInventory d-flex">
+      <ul class="list-tabs-inventory nav flex-column pe-3" aria-orientation="vertical">{mainTabDeclaration}</ul>
+      <div class="tab-content">{tabContent.flatten}</div>
+    </div> ++ Script(OnLoad(JsRaw(s"$$('.sInventory .tab-content > .tab-pane:first-child').addClass('active');")))
+
   }
 
   /**
@@ -724,7 +759,7 @@ object DisplayNode extends Loggable {
   private def displayTabGrid[T](
       jsId:  JsNodeId
   )(eltName: String, optSeq: Box[Seq[T]], title: Option[String] = None)(columns: List[(String, T => NodeSeq)]) = {
-    <div id={htmlId(jsId, "sd_" + eltName + "_")} class="sInventory overflow_auto">{
+    <div id={htmlId(jsId, "sd_" + eltName + "_")} class="sInventory tab-pane">{
       optSeq match {
         case Empty                                           =>
           <div class="col-xs-12 alert alert-warning">

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -152,7 +152,6 @@ object DisplayNode extends Loggable {
 
   def jsInit(nodeId: NodeId, salt: String = ""): JsCmd = {
     val jsId           = JsNodeId(nodeId, salt)
-    val detailsId      = htmlId(jsId, "details_")
     val softGridDataId = htmlId(jsId, "soft_grid_data_")
     val softPanelId    = "soft_tab"
     val eltIdswidth    =
@@ -175,8 +174,7 @@ object DisplayNode extends Loggable {
     )
 
     JsRaw("var " + softGridDataId + "= null") &
-    OnLoad(
-      JsRaw("$('#" + detailsId + "').tabs()") & {
+    OnLoad({
         eltIds.map { i =>
           JsRaw(s"""
               $$('#${htmlId(jsId, i + "_")}').dataTable({
@@ -324,16 +322,28 @@ object DisplayNode extends Loggable {
       </div>
       <div class="tabs">
         <div class="main-navbar">
-          <ul class="rudder-ui-tabs">
-            <li><a href={htmlId_#(jsId, "node_summary_")}>Summary</a></li>
-            <li><a href={htmlId_#(jsId, "node_inventory_")}>Inventory</a></li>
+          <ul class="nav nav-underline mx-0">
+            <li class="nav-item">
+              <button class="nav-link active" data-bs-toggle="tab" data-bs-target={
+      htmlId_#(jsId, "node_summary_")
+    } type="button" role="tab" aria-controls={htmlId_#(jsId, "node_summary_")} aria-selected="false">Summary</button>
+            </li>
+            <li class="nav-item">
+              <button class="nav-link" data-bs-toggle="tab" data-bs-target={
+      htmlId_#(jsId, "node_inventory_")
+    } type="button" role="tab" aria-controls={htmlId_#(jsId, "node_inventory_")} aria-selected="false">Inventory</button>
+            </li>
           </ul>
         </div>
-        <div id={htmlId(jsId, "node_summary_")}>
-          {showNodeDetails(nodeFact, globalMode, None, salt)}
-        </div>
-        <div id={htmlId(jsId, "node_inventory_")}>
-          {showInventoryVerticalMenu(sm, nodeFact.toCore)}
+        <div class="tab-content">
+          <div id={htmlId(jsId, "node_summary_")} class="tab-pane active show">
+            <div class="d-flex px-3 py-2">
+              {showNodeDetails(nodeFact, globalMode, None, salt)}
+            </div>
+          </div>
+          <div id={htmlId(jsId, "node_inventory_")} class="tab-pane p-3">
+            {showInventoryVerticalMenu(sm, nodeFact.toCore)}
+          </div>
         </div>
       </div>
     </div>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -53,7 +53,6 @@ import com.normation.rudder.repository.RoRuleRepository
 import com.normation.rudder.services.reports._
 import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.ChooseTemplate
-import com.normation.rudder.web.model.JsNodeId
 import net.liftweb.common._
 import net.liftweb.http.SHtml
 import net.liftweb.http.js.JE._
@@ -98,21 +97,26 @@ class ReportDisplayer(
       addOverriden: Boolean,
       onlySystem:   Boolean
   ): NodeSeq = {
-    val id       = JsNodeId(node.id)
     val callback = {
       SHtml.ajaxInvoke(() =>
         SetHtml(containerId, displayReports(node, getReports, tableId, containerId, addOverriden, onlySystem))
       )
     }
     Script(OnLoad(JsRaw(s"""
-      if($$("[aria-controls='${tabId}']").hasClass('ui-tabs-active')){
+      const triggerEl = document.querySelector("[aria-controls='${tabId}']");
+      if(triggerEl.classList.contains('active')){
         ${callback.toJsCmd}
       }
-      $$("#details_${id}").on( "tabsactivate", function(event, ui) {
-        if(ui.newPanel.attr('id')== '${tabId}') {
-          ${callback.toJsCmd}
-        }
-      });
+      const tabEl = document.querySelectorAll('.nav-underline button[data-bs-toggle="tab"]')
+      var tabId;
+      tabEl.forEach((element) =>
+        element.addEventListener('shown.bs.tab', event => {
+          tabId = event.target.getAttribute("aria-controls");
+          if(tabId = '${tabId}') {
+            ${callback.toJsCmd}
+          }
+        })
+      );
     """)))
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/PendingHistoryGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/PendingHistoryGrid.scala
@@ -120,7 +120,6 @@ object PendingHistoryGrid extends Loggable {
             "sDom": '<"dataTables_wrapper_top"f>rt<"dataTables_wrapper_bottom"lip>'
           });
           $('.dataTables_filter input').attr("placeholder", "Filter");
-          $("#new_servers_tab").tabs();
           """.replaceAll("#table_var#", jsVarNameForId())) & initJsCallBack(entries)
     )
   }

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-bootstrap.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-bootstrap.scss
@@ -44,12 +44,16 @@ $primary    : $rudder-primary;
 $success    : $rudder-success;
 $warning    : $rudder-warning;
 $danger     : $rudder-danger;
+
 $body-color : $rudder-txt-primary;
 $link-color : $rudder-txt-link;
 
+$nav-underline-border-width : 0.2rem;
+$nav-underline-link-active-color: $rudder-txt-primary;
+
 @import "../../node_modules/bootstrap/scss/bootstrap";
 
-/* --- BUTTONS OVERRIDE
+/* --- BUTTONS
 -- Bootstrap is using the WCAG 2.0 algorithm to determine the (text, hover, disabled..) colors of the button following its background color.
 -- According to the WCAG algorithm, the success color we used isn't dark enough to have a white text, so we have to override the btn-success rule
 */
@@ -86,15 +90,38 @@ $link-color : $rudder-txt-link;
     line-height: 1.5;
     border-radius: 3px;
   }
-  
   &.active {
     box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   }
 }
-// --- FORM-GROUP OVERRIDE
+// --- FORM-GROUP
 .form-group{
   margin-bottom: 5px;
   label{
     font-weight: bold;
+  }
+}
+// --- NAV & TABS
+.nav-underline {
+  padding: 0 15px;
+  margin-bottom: 0;
+  position: relative;
+
+  &:before {
+    content: "";
+    width: 100%;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    height: 2px;
+    background-color: $rudder-border-color-default;
+    z-index: 0;
+  }
+  .nav-link {
+    position: relative;
+  }
+  .nav-link.active, .show>.nav-link {
+    font-weight: normal;
+    border-bottom-color: $rudder-txt-link;
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-groups.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-groups.css
@@ -67,14 +67,6 @@ input[disabled] + .save-tooltip {
   display: inline-block;
 }
 
-
-#groupParametersTab,
-#groupCriteriaTab,
-#categoryParametersTab{
-  padding: 0 15px;
-  float: left;
-  width: 100%;
-}
 #groupDetails .radio-inline .radioTextLabel{
   margin:0;
 }

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.css
@@ -447,171 +447,7 @@ pre.json-beautify code.elmsh {
   margin-left: 20px;
   min-width: 95px;
 }
-/* --- NODE PAGE --- */
-.ui-tabs-nav.list-tabs-inventory{
-  margin-bottom: 15px;
-  float: left;
-  width: 12em;
-  border-bottom: none;
-  padding-left: 0;
-}
-.ui-tabs-nav.list-tabs-inventory > .ui-tabs-tab {
-  display: block;
-  border: 1px solid #e8e8e8;
-  border-top: none;
-  border-bottom-width: 2px;
-  transition-duration: .2s;
-  padding: 0;
-}
-.ui-tabs-nav.list-tabs-inventory > .ui-tabs-tab {
-  border: 1px solid #e8e8e8;
-  position: relative;
-}
-.ui-tabs-nav.list-tabs-inventory > .ui-tabs-tab.ui-tabs-active:after{
-  content: "";
-  position: absolute;
-  top: calc(50% - 4px);
-  right: -6px;
-  display: block;
-  width: 10px;
-  height: 10px;
-  border-top: 1px solid #e7e7e7;
-  border-right: 1px solid #e7e7e7;
-  transform: rotate(45deg);
-  background-color: #fff;
-}
-.ui-tabs-nav.list-tabs-inventory > .ui-tabs-tab.ui-tabs-active:before{
-    content:initial;
-}
-.ui-tabs-nav.list-tabs-inventory > .ui-tabs-tab > a{
-  transition-property : background-color;
-  background-color: #F8F9FC;
-  padding: 6px 10px;
-  transition-duration: .2s;
-  display: block;
-}
-.ui-tabs-nav.list-tabs-inventory > .ui-tabs-tab > a:hover{
-  background-color:#fff;
-}
-.ui-tabs-nav.list-tabs-inventory > .ui-tabs-tab.ui-tabs-active > a{
-  background-color: #fff;
-}
-#nodeInventory > .sInventory > div{
-  margin-left: 12em;
-  padding-left: 12px;
-}
-.sInventory > .alert{
-  padding: 15px !important;
-}
-.update-info{
-  margin-left: 8px;
-  font-size: 0.8em;
-  color: #999;
-}
-.update-info:before,
-.update-info:after{
-  padding: 0 3px;
-  position: relative;
-  top: -1px;
-  font-size: .9em;
-}
-.update-info:before{
-  content: "(";
-}
-.update-info:after{
-  content: ")";
-}
-#nodeStateSelect{
-  width:auto;
-}
-#nodeStateSubmit{
-  margin-top:20px;
-}
-.errorSaving.alert-danger{
-  margin-top:10px;
-}
-.errorSaving > .fa{
-  margin-right:8px;
-}
-#addPropTable{
-  width:100%;
-}
-#addPropTable tbody > tr{
-  padding:0;
-}
-#addPropTable tbody > tr > td{
-  border-collapse: collapse;
-  padding:0;
-  vertical-align:top;
-}
-#addPropTable tbody > tr > td > .form-control{
-  min-height:33px;
-}
-#addPropTable tbody > tr > td:first-child{
-  width:235px;
-}
-#addPropTable tbody > tr > td:first-child > input.form-control{
-  border-top-right-radius:0;
-  border-bottom-right-radius:0;
-}
-#addPropTable tbody > tr > td:nth-child(2),#addPropTable tbody > tr > td:last-child{
-  width: 33px;
-}
-#addPropTable tbody > tr > td:nth-child(2) > span{
-  border-left:none;
-  border-right:none;
-  border-radius:0;
-  height: 32px;
-}
-#addPropTable td.json-check-col{
-  width: 80px;
-}
-#addPropTable td.json-check-col > div{
-  position:relative;
-  background-color: #F8F9FC;
-}
-#addPropTable td.json-check-col button{
-  height: 33px;
-  width:100%;
-  border-radius:0px;
-  border-left:none;
-}
-#addPropTable #json-check{
-    position:relative;
-    top:2px;
-}
-#addPropTable tbody > tr > td:nth-child(3) > .form-control{
-  border-left-width:1px;
-  border-radius:0;
-}
-#addPropTable tbody > tr > td:nth-child(2),#addPropTable tbody > tr > td:last-child > .btn{
-  height: 33px;
-  border-top-left-radius:0;
-  border-bottom-left-radius:0;
-}
-#nodeProp .btn-success.new-icon{
-  margin: 5px 0 7px 0;
-}
-#nodeProp .addon-json + textarea{
-  min-height:initial;
-}
-.node-tab-content{
-  float:left;
-  width:100%;
-}
-#serverDetails > .ui-tabs.ui-widget.ui-widget-content{
-  margin:0;
-  padding:0;
-  border:none;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-.content-wrapper #nodePropertiesTab_wrapper label {
-  margin-bottom: 0;
-  font-weight: normal;
-  font-size: 13.2px;
-}
+
 /* --- DIRECTIVE PAGE --- */
 .editTech{
   margin-top:4px;
@@ -2173,7 +2009,7 @@ h3.box-title {
   margin: 0;
   font-size: 20px;
 }
-.box-header.with-border,.nav-tabs-custom>.nav-tabs>li.active>a{
+.box-header.with-border{
   border-color: #d6deef !important;
 }
 .box.has-toolbar{
@@ -2249,13 +2085,6 @@ h3.box-title {
   padding-left: 0px;
 }
 /* ========= */
-
-.nav-tabs-custom>.nav-tabs.pull-right>li{
-  margin-top:-2px;
-}
-.nav-tabs-custom>.nav-tabs>li {
-  margin-right: 0;
-}
 
 .btn.btn-blue{
   background-color: #1384BE !important;
@@ -2392,78 +2221,6 @@ table a > i.fa-pencil:hover{
 }
 /* RULES TABLE */
 
-/* TABS */
-.ui-tabs-nav{
-  border-bottom: 2px solid #d6deef;
-}
-
-.nav-tabs-custom > .nav-tabs{
-  border-bottom: 2px solid #d6deef;
-  float: left;
-  width: 100%;
-  padding: 0 10px;
-}
-.ui-tabs-nav > .ui-tabs-tab,
-.nav-tabs-custom > .nav-tabs > li{
-  display: inline-block;
-  padding: 6px 10px;
-  margin: 0;
-  font-size: 1.2em;
-  outline: none !important;
-  position:relative;
-}
-.nav-tabs-custom > .nav-tabs > li{
-  margin-left: 10px;
-}
-.nav-tabs-custom > .nav-tabs > li{
-  padding: 0;
-}
-.ui-tabs-nav > .ui-tabs-tab > a,
-.nav-tabs-custom > .nav-tabs > li > a{
-  color: #738195;
-  transition-property: color;
-  transition-duration: .2s;
-  font-size: 15px;
-  cursor: pointer;
-}
-.nav-tabs-custom > .nav-tabs > li > a{
-  padding: 6px 0;
-}
-.ui-tabs-nav > .ui-tabs-tab > a:hover,
-.nav-tabs-custom > .nav-tabs > li > a:hover{
-  color: #1295c2;
-}
-
-.ui-tabs-nav > .ui-tabs-tab.ui-tabs-active > a,
-.nav-tabs-custom > .nav-tabs > li.active > a,
-.ui-tabs-nav > .ui-tabs-tab.active > a{
-  color  : #041922 !important;
-  cursor : default;
-}
-.ui-tabs-nav > .ui-tabs-tab:before,
- .nav-tabs-custom > .nav-tabs > li:before{
-  content: "";
-  position: absolute;
-  bottom : -3px;
-  left   : 0;
-  right  : 0;
-  height : 3px;
-  background-color : transparent;
-  transition-property : background-color;
-  transition-duration : .2s;
-  z-index: 1;
-}
-.ui-tabs-nav > .ui-tabs-tab.ui-tabs-active:before,
-.nav-tabs-custom > .nav-tabs > li.active:before,
-.ui-tabs-nav > .ui-tabs-tab.active:before{
-  background-color : #1295c2;
-}
-
-.nav-tabs-custom > .nav-tabs > li,
-.nav-tabs-custom > .nav-tabs > li > a{
-  border: none !important;
-  background-color: transparent !important;
-}
 
 /* UI TOOLTIPS */
 .ui-tooltip {

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-node.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-node.scss
@@ -361,17 +361,8 @@ pre.display-keys > label{
 }
 
 /* INVENTORY TAB */
-#nodeInventory{
-  & > .sInventory {
-    & > div {
-      margin-left: 12em;
-      padding-left: 12px;
-
-      & > .alert:first-child{
-        margin-top: 0;
-      }
-    }
-  }
+.sInventory .tab-pane > .alert:first-child{
+  margin-top: 0;
 }
 [id^=node_details_]{
   & > .sInventory {
@@ -380,59 +371,54 @@ pre.display-keys > label{
     }
   }
 }
+
 .list-tabs-inventory{
-  margin-bottom: 15px;
-  float: left;
-  width: 12em;
-  border-bottom: none;
-  padding-left: 0;
+  width: 13em;
 
-  & > .ui-tabs-tab {
-    display: block;
-    border: 1px solid $rudder-border-color-default;
-    transition-duration: .2s;
-    padding: 0;
-    position: relative;
+  & > .nav-item {
+    & > button {
+      transition-duration: .2s;
+      background-color: $rudder-bg-gray;
+      border: 1px solid $rudder-border-color-default;
+      padding: 6px 10px;
+      color: $rudder-txt-secondary;
+      position:relative;
+      text-align: left;
+      width: 100%;
 
-    & + .ui-tabs-tab {
-      border-top: none;
-    }
-    &.ui-tabs-active {
-      &:after{
-        content: "";
-        position: absolute;
-        top: calc(50% - 4px);
-        right: -6px;
-        display: block;
-        width: 10px;
-        height: 10px;
-        border-top: 1px solid $rudder-border-color-default;
-        border-right: 1px solid $rudder-border-color-default;
-        transform: rotate(45deg);
-        background-color: #fff;
+      &:hover{
+        background-color:#fff;
+        color: $rudder-txt-link;
       }
-      &:before{
-        content:initial;
-      }
-      & > a {
+
+      &.active {
         background-color: #fff;
         color: $rudder-txt-primary;
+        &:after{
+          content: "";
+          position: absolute;
+          top: calc(50% - 4px);
+          right: -6px;
+          display: block;
+          width: 10px;
+          height: 10px;
+          border-top: 1px solid $rudder-border-color-default;
+          border-right: 1px solid $rudder-border-color-default;
+          transform: rotate(45deg);
+          background-color: #fff;
+        }
+        &:before{
+          content:initial;
+        }
       }
     }
-
-    & > a {
-      transition-property : background-color;
-      background-color: $rudder-bg-gray;
-      padding: 6px 10px;
-      transition-duration: .2s;
-      display: block;
-      color: $rudder-txt-secondary;
-      &:hover{
-         background-color:#fff;
-         color: $rudder-txt-link;
-      }
+    & + .nav-item > button {
+      border-top: none;
     }
   }
+}
+.list-tabs-inventory + .tab-content {
+  flex: 1;
 }
 
 #serverDetails > .ui-tabs.ui-widget.ui-widget-content{

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-node.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-node.scss
@@ -35,6 +35,9 @@
 *************************************************************************************
 */
 
+// Modules
+@use 'rudder-variables' as *;
+
 // Variables
 $node-state-size: 14px;
 $node-logo-size: 50px;
@@ -66,7 +69,7 @@ $node-logo-size: 50px;
   margin: 0 !important;
   border-bottom: none !important;
   padding: 15px 15px 10px;
-  color: #041922 !important;
+  color: $rudder-txt-primary !important;
   font-size: 24px !important;
 }
 
@@ -74,32 +77,7 @@ $node-logo-size: 50px;
   padding: 0 15px;
   margin-bottom: 8px;
   font-size: 1.2em;
-  color: #738195;
-}
-
-.rudder-ui-tabs ~ .ui-tabs-panel{
-  padding: 0 15px 15px 15px;
-  float: left;
-  width: 100%;
-}
-#node_summary{
-  display: flex;
-  padding: 0 !important;
-  height: 100%;
-}
-
-.rudder-ui-tabs {
-  border-bottom: 2px solid #d6deef;
-  margin: 0 0 15px 0;
-  position: relative;
-  background-color: #fff;
-  z-index: 10;
-}
-.rudder-ui-tabs > .ui-tabs-tab{
-  display: inline-block;
-  padding: 6px 0px;
-  outline: none !important;
-  position: relative;
+  color: $rudder-txt-secondary;
 }
 
 #nodeDetails {
@@ -112,7 +90,7 @@ $node-logo-size: 50px;
 
 #nodeGroups {
   flex: 30;
-  border-left: 2px solid #d6deef;
+  border-left: 2px solid $rudder-border-color-default;
   margin-top: -15px;
 }
 .jstree-anchor > i.jstree-icon.fa.fa-folder,
@@ -123,12 +101,12 @@ $node-logo-size: 50px;
 #nodeGroups > h3 {
   display: flex;
   align-items: center;
-  color: #041922;
+  color: $rudder-txt-primary;
   padding: 15px 15px 10px !important;
   margin: 0;
   font-size: 1.3rem;
-  background-color: #F8F9FC;
-  border-bottom: 1px solid #D6DEEF;
+  background-color: $rudder-bg-gray;
+  border-bottom: 1px solid $rudder-border-color-default;
 }
 
 .node-state{
@@ -163,7 +141,7 @@ $node-logo-size: 50px;
 }
 .machine-os-info {
   font-size: .8rem;
-  color: #72829D;
+  color: $rudder-txt-secondary;
 
   .icon-info{
     font-size : 1rem;
@@ -181,7 +159,7 @@ $node-logo-size: 50px;
     left: 6px;
     width: 8px;
     height: 8px;
-    background-color: #72829D;
+    background-color: $rudder-txt-secondary;
     border-radius: 50%;
   }
   &:before{
@@ -210,7 +188,7 @@ $node-logo-size: 50px;
   margin-bottom: 15px;
 }
 #nodeDetails h3{
-  color: #041922;
+  color: $rudder-txt-primary;
   display: block;
   margin-bottom: 10px;
   font-size: 1.3rem;
@@ -234,10 +212,6 @@ $node-logo-size: 50px;
   justify-content: center;
   padding: 0 18px !important;
   height: 20px;
-}
-
-.details .ui-tabs-nav.list-tabs-inventory {
-  margin-right: 15px;
 }
 
 /* OS ICONS */
@@ -369,9 +343,9 @@ $node-logo-size: 50px;
 pre.display-keys{
   padding: 12px;
   border-top-left-radius: 0;
-  border: 1px solid #D6DEEF;
+  border: 1px solid $rudder-border-color-default;
   border-radius: 0px 4px 4px 4px;
-  background-color: #F8F9FC;
+  background-color: $rudder-bg-gray;
 }
 pre.display-keys > label:first-child{
   margin-top:0;
@@ -386,6 +360,89 @@ pre.display-keys > label{
   margin-bottom: 10px;
 }
 
+/* INVENTORY TAB */
+#nodeInventory{
+  & > .sInventory {
+    & > div {
+      margin-left: 12em;
+      padding-left: 12px;
+
+      & > .alert:first-child{
+        margin-top: 0;
+      }
+    }
+  }
+}
+[id^=node_details_]{
+  & > .sInventory {
+    & > div {
+      padding-left: 12px;
+    }
+  }
+}
+.list-tabs-inventory{
+  margin-bottom: 15px;
+  float: left;
+  width: 12em;
+  border-bottom: none;
+  padding-left: 0;
+
+  & > .ui-tabs-tab {
+    display: block;
+    border: 1px solid $rudder-border-color-default;
+    transition-duration: .2s;
+    padding: 0;
+    position: relative;
+
+    & + .ui-tabs-tab {
+      border-top: none;
+    }
+    &.ui-tabs-active {
+      &:after{
+        content: "";
+        position: absolute;
+        top: calc(50% - 4px);
+        right: -6px;
+        display: block;
+        width: 10px;
+        height: 10px;
+        border-top: 1px solid $rudder-border-color-default;
+        border-right: 1px solid $rudder-border-color-default;
+        transform: rotate(45deg);
+        background-color: #fff;
+      }
+      &:before{
+        content:initial;
+      }
+      & > a {
+        background-color: #fff;
+        color: $rudder-txt-primary;
+      }
+    }
+
+    & > a {
+      transition-property : background-color;
+      background-color: $rudder-bg-gray;
+      padding: 6px 10px;
+      transition-duration: .2s;
+      display: block;
+      color: $rudder-txt-secondary;
+      &:hover{
+         background-color:#fff;
+         color: $rudder-txt-link;
+      }
+    }
+  }
+}
+
+#serverDetails > .ui-tabs.ui-widget.ui-widget-content{
+  margin:0;
+  padding:0;
+  border:none;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
 /* NODE ERROR */
 .info-card{
   border-radius: 4px;
@@ -398,7 +455,7 @@ pre.display-keys > label{
   font-size: 14px;
 }
 .info-card .card-info h4{
-  color: #337ab7;
+  color: $rudder-primary;
   margin-top: 0;
   padding-left: 30px;
   position: relative;
@@ -416,6 +473,7 @@ pre.display-keys > label{
 .info-card.critical .card-info h4{
   color: #C80004;
 }
+
 /* PROPERIES TAB */
 #inventoryVariables .dataTable .btn-clipboard{
   margin-left: 4px;
@@ -423,7 +481,7 @@ pre.display-keys > label{
 }
 #inventoryVariables .dataTable tr.head th.sorting{
   cursor: default !important;
-  color: #041922;
+  color: $rudder-txt-primary;
 }
 #inventoryVariables .dataTable tr:hover .btn-clipboard{
   visibility: visible;
@@ -444,8 +502,75 @@ pre.display-keys > label{
 }
 #nodeProp .table-header,
 #nodeProp .table-container > .dataTable{
-  border-left: 1px solid #d6deef;
-  border-right: 1px solid #d6deef;
+  border-left: 1px solid $rudder-border-color-default;
+  border-right: 1px solid $rudder-border-color-default;
+}
+#addPropTable{
+  width:100%;
+}
+#addPropTable tbody > tr{
+  padding:0;
+}
+#addPropTable tbody > tr > td{
+  border-collapse: collapse;
+  padding:0;
+  vertical-align:top;
+}
+#addPropTable tbody > tr > td > .form-control{
+  min-height:33px;
+}
+#addPropTable tbody > tr > td:first-child{
+  width:235px;
+}
+#addPropTable tbody > tr > td:first-child > input.form-control{
+  border-top-right-radius:0;
+  border-bottom-right-radius:0;
+}
+#addPropTable tbody > tr > td:nth-child(2),#addPropTable tbody > tr > td:last-child{
+  width: 33px;
+}
+#addPropTable tbody > tr > td:nth-child(2) > span{
+  border-left:none;
+  border-right:none;
+  border-radius:0;
+  height: 32px;
+}
+#addPropTable td.json-check-col{
+  width: 80px;
+}
+#addPropTable td.json-check-col > div{
+  position:relative;
+  background-color: #F8F9FC;
+}
+#addPropTable td.json-check-col button{
+  height: 33px;
+  width:100%;
+  border-radius:0px;
+  border-left:none;
+}
+#addPropTable #json-check{
+    position:relative;
+    top:2px;
+}
+#addPropTable tbody > tr > td:nth-child(3) > .form-control{
+  border-left-width:1px;
+  border-radius:0;
+}
+#addPropTable tbody > tr > td:nth-child(2),#addPropTable tbody > tr > td:last-child > .btn{
+  height: 33px;
+  border-top-left-radius:0;
+  border-bottom-left-radius:0;
+}
+#nodeProp .btn-success.new-icon{
+  margin: 5px 0 7px 0;
+}
+#nodeProp .addon-json + textarea{
+  min-height:initial;
+}
+.content-wrapper #nodePropertiesTab_wrapper label {
+  margin-bottom: 0;
+  font-weight: normal;
+  font-size: 13.2px;
 }
 /* SETTINGS TAB */
 #nodeState > h3.page-title:first-child,
@@ -462,8 +587,15 @@ pre.display-keys > label{
 #reporting-mode-title{
   display: none;
 }
-
-#NodeDetailsTabMenu li a {
-  display: flex;
-  height: 25px;
+#nodeStateSelect{
+  width:auto;
+}
+#nodeStateSubmit{
+  margin-top:20px;
+}
+.errorSaving.alert-danger{
+  margin-top:10px;
+}
+.errorSaving > .fa{
+  margin-right:8px;
 }

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
@@ -34,6 +34,10 @@
 *************************************************************************************
 */
 
+// --- MODULES
+
+@use 'rudder-variables' as *;
+
 /* === RESET === */
 ul {
   list-style-type: none;
@@ -570,22 +574,19 @@ ul {
   position: relative;
   z-index: 1;
 }
-.rudder-template .main-navbar ul{
-  padding: 0 15px;
-  margin-bottom: 0;
+.rudder-template .main-details .nav-underline{
+  margin: 0 -15px;
 }
 .rudder-template .sidebar-navbar ul{
   margin: 10px -15px 0px -15px;
   padding: 0 15px;
 }
-.rudder-template .sidebar-navbar ul > li,
-.rudder-template .main-navbar ul > li{
+.rudder-template .sidebar-navbar ul > li{
   margin-right: 15px;
   padding: 0 0 6px 0;
 }
 
-.rudder-template .sidebar-navbar ul > li > a,
-.rudder-template .main-navbar ul > li > a{
+.rudder-template .sidebar-navbar ul > li > a{
   padding: 0;
   background-color: transparent !important;
   border: none !important;
@@ -602,8 +603,8 @@ ul {
 .rudder-template .main-navbar ul > li > .fa-times:hover {
   opacity: 1;
 }
-.rudder-template .sidebar-navbar ul > li > a .badge,
-.rudder-template .main-navbar ul > li > a .badge,
+.rudder-template .sidebar-navbar ul > li > .badge,
+.rudder-template .main-navbar ul > li > .badge,
 .rudder-template .template-main .main-details .badge,
 .rudder-template .badge{
   background-color: #b1bbcb;
@@ -1013,9 +1014,7 @@ ul {
   float: left;
   width: 100%;
 }
-.rudder-template .tab-table-content > .ui-tabs-nav{
-  margin: 0 -15px -17px -15px;
-}
+
 .tab-table-content .table-title h4,
 .list-container .list-heading h4{
   color: #6A7280;

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder.css
@@ -52,22 +52,6 @@ html {
   height:100%;
 }
 
-
-
-
-/**********************************
- *Node inventory details
- **********************************/
-.sInventory {
-  margin: 0px;
-  padding: 0px;
-}
-
-.sInventory > div {
-  margin: 0px;
-  padding: 0px;
-}
-
 .details {
   margin: 0px;
   padding: 0px;
@@ -1425,14 +1409,6 @@ label span.text-fit{
   outline: 0;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px rgba(208, 208, 208, 0.6);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px rgb(208, 208, 208);
-}
-#serverDetails .sInventory, #nodeInventory, #node_inventory{
-  border : none !important;
-  overflow: visible;
-}
-
-#serverDetails .dataTables_wrapper_top .dataTables_length{
-  padding: 5px;
 }
 #changesChartContainer {
   height: 40vh;

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/manageNewNode.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/manageNewNode.html
@@ -49,7 +49,7 @@
             <li class="nav-item">
               <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#review_new_server" type="button" role="tab" aria-controls="review_new_server" aria-selected="true">Review new nodes</button>
             </li>
-            <li class="ui-tabs-tab" role="presentation">
+            <li class="nav-item" role="presentation">
               <button class="nav-link" data-bs-toggle="tab" data-bs-target="#history" type="button" role="tab" aria-controls="history" aria-selected="true">History</button>
             </li>
           </ul>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/manageNewNode.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/manageNewNode.html
@@ -45,16 +45,12 @@
       </div>
       <div id="new_servers_tab">
         <div class="main-navbar">
-          <ul class="ui-tabs-nav nav nav-tabs">
-            <li class="ui-tabs-tab" role="presentation">
-              <a href="#review_new_server">
-                Review new nodes
-              </a>
+          <ul class="nav nav-underline">
+            <li class="nav-item">
+              <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#review_new_server" type="button" role="tab" aria-controls="review_new_server" aria-selected="true">Review new nodes</button>
             </li>
             <li class="ui-tabs-tab" role="presentation">
-              <a href="#history">
-                History
-              </a>
+              <button class="nav-link" data-bs-toggle="tab" data-bs-target="#history" type="button" role="tab" aria-controls="history" aria-selected="true">History</button>
             </li>
           </ul>
         </div>
@@ -62,41 +58,43 @@
           <div class="template-main">
             <div class="main-container">
               <div class="main-details">
-                <div id="review_new_server">
-                  <div class="callout-fade callout-info">
-                    <div class="marker">
-                      <span class="fa fa-info-circle"></span>
-                    </div>
-                    <p>Click on a node name to view detailed inventory information.</p>
-                    <p>Click on <i class="fa fa-search"></i>to list Rules that would be applied to this node if you accept it.</p>
-                  </div>
-                  <lift:Msgs>[error]</lift:Msgs>
-                  <div  data-lift="lazy-load?template=lazy-load-spinner">
-                    <div data-lift="node.AcceptNode.list">
-                      <pending-servers></pending-servers>
-                      <div id="acceptNodeGrid_paginate_area" class="nodisplay"></div>
-                      <lift:authz role="node_write">
-                        <div class="action-btns">
-                          <pending-refuse></pending-refuse>
-                          <pending-accept></pending-accept>
-                        </div>
-                      </lift:authz>
-                      <pending-errors></pending-errors>
-                    </div>
-                  </div>
-                </div>
-
-                <div id="history">
-                  <div data-lift="lazy-load?template=lazy-load-spinner">
+                <div class="tab-content">
+                  <div id="review_new_server" class="tab-pane active">
                     <div class="callout-fade callout-info">
                       <div class="marker">
                         <span class="fa fa-info-circle"></span>
                       </div>
-                      <p>View history of Nodes that have been accepted or refused.</p>
-                      <p>Click on a node name to view detailed inventory information (as it was at review time).</p>
+                      <p>Click on a node name to view detailed inventory information.</p>
+                      <p>Click on <i class="fa fa-search"></i>to list Rules that would be applied to this node if you accept it.</p>
                     </div>
-                    <div data-lift="node.PendingHistoryGrid.displayAndInit">
-                      <pending-history></pending-history>
+                    <lift:Msgs>[error]</lift:Msgs>
+                    <div  data-lift="lazy-load?template=lazy-load-spinner">
+                      <div data-lift="node.AcceptNode.list">
+                        <pending-servers></pending-servers>
+                        <div id="acceptNodeGrid_paginate_area" class="nodisplay"></div>
+                        <lift:authz role="node_write">
+                          <div class="action-btns">
+                            <pending-refuse></pending-refuse>
+                            <pending-accept></pending-accept>
+                          </div>
+                        </lift:authz>
+                        <pending-errors></pending-errors>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div id="history" class="tab-pane">
+                    <div data-lift="lazy-load?template=lazy-load-spinner">
+                      <div class="callout-fade callout-info">
+                        <div class="marker">
+                          <span class="fa fa-info-circle"></span>
+                        </div>
+                        <p>View history of Nodes that have been accepted or refused.</p>
+                        <p>Click on a node name to view detailed inventory information (as it was at review time).</p>
+                      </div>
+                      <div data-lift="node.PendingHistoryGrid.displayAndInit">
+                        <pending-history></pending-history>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/ComponentDirectiveEditForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/ComponentDirectiveEditForm.html
@@ -54,7 +54,7 @@
         downloadsUrl: apiPath,
         dir: "/",
         hasWriteRights : hasWriteRights,
-        initRun : true;
+        initRun : true
       }
     });
 
@@ -83,18 +83,18 @@
       </div>
     </div>
     <div class="main-navbar">
-      <ul class="ui-tabs-nav" role="tablist">
-        <li role="presentation" class="ui-tabs-tab ui-tab active" id="infoNav">
-          <a class="nav-link active" data-bs-toggle="tab" data-bs-target="#directiveInfo" type="button" role="tab">Information</a>
+      <ul class="nav nav-underline">
+        <li role="presentation" class="nav-item" id="infoNav">
+          <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#directiveInfo" type="button" role="tab" aria-controls="directiveInfo" aria-selected="true">Information</button>
         </li>
-        <li role="presentation" class="ui-tabs-tab ui-tab" id="paramNav">
-          <a data-bs-toggle="tab" data-bs-target="#parametersTab" type="button" role="tab">Parameters</a>
+        <li class="nav-item" id="paramNav">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target="#parametersTab" type="button" role="tab" aria-controls="parametersTab" aria-selected="false">Parameters</button>
         </li>
-        <li role="presentation" class="ui-tabs-tab ui-tab" id="rulesNav">
-          <a data-bs-toggle="tab" data-bs-target="#rulesTab" type="button" role="tab">Target rules</a>
+        <li role="presentation" class="nav-item" id="rulesNav">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target="#rulesTab" type="button" role="tab" aria-controls="rulesTab" aria-selected="false">Target rules</button>
         </li>
-        <li role="presentation" class="ui-tabs-tab ui-tab" id="complianceNav">
-          <a id="complianceLinkTab" data-bs-toggle="tab" data-bs-target="#complianceTab" type="button" role="tab">Compliance</a>
+        <li role="presentation" class="nav-item" id="complianceNav">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target="#complianceTab" type="button" role="tab" aria-controls="complianceTab" aria-selected="false">Compliance</button>
         </li>
       </ul>
     </div>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/ComponentRuleEditForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/ComponentRuleEditForm.html
@@ -53,7 +53,7 @@
 <component-body>
   <div id="editRuleZone">
     <div class="col-xs-12">
-      <div class="box nav-tabs-custom has-toolbar">
+      <div class="box has-toolbar">
         <div class="box-header">
           <h3 class="box-title"><i id="changeIconRule" class="fa fa-gear"></i> Rule</h3>
         </div>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
@@ -29,7 +29,7 @@
 </component-staticbody>
 
 <component-body>
-<div id="GroupTabs" class="main-container">
+<div class="main-container">
   <div class="main-header">
     <div class="header-title">
       <h1>
@@ -46,90 +46,92 @@
     </div>
   </div>
   <div class="main-navbar">
-    <ul id="groupTabMenu" class="ui-tabs-nav" role="tablist">
-      <li role="presentation" class="ui-tabs-tab ui-tab active" data-bs-toggle="tab" data-bs-target="#groupParametersTab" type="button" role="tab">
-        <a href="#groupParametersTab">Parameters</a>
+    <ul id="groupTabMenu" class="nav nav-underline">
+      <li class="nav-item">
+        <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#groupParametersTab" type="button" role="tab" aria-controls="groupParametersTab" aria-selected="true">Parameters</button>
       </li>
-      <li role="presentation" class="ui-tabs-tab ui-tab" data-bs-toggle="tab" data-bs-target="#groupCriteriaTab" type="button" role="tab">
-        <a href="#groupCriteriaTab">Criteria</a>
+      <li class="nav-item">
+        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#groupCriteriaTab" type="button" role="tab" aria-controls="groupCriteriaTab" aria-selected="true">Criteria</button>
       </li>
-      <li role="presentation" class="ui-tabs-tab ui-tab" data-bs-toggle="tab" data-bs-target="#groupRulesTab" type="button" role="tab">
-        <a id="relatedRulesLinkTab" href="#groupRulesTab">Related rules</a>
+      <li class="nav-item">
+        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#groupRulesTab" type="button" role="tab" aria-controls="groupRulesTab" aria-selected="false">Related rules</button>
       </li>
-      <li role="presentation" class="ui-tabs-tab ui-tab" data-bs-toggle="tab" data-bs-target="#groupPropertiesTab" type="button" role="tab">
-        <a href="#groupPropertiesTab">Properties</a>
+      <li class="nav-item">
+        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#groupPropertiesTab" type="button" role="tab" aria-controls="groupPropertiesTab" aria-selected="false">Properties</button>
       </li>
-      <li role="presentation" class="ui-tabs-tab ui-tab" data-bs-toggle="tab" data-bs-target="#groupComplianceTab" type="button" role="tab">
-        <a id="complianceLinkTab" href="#groupComplianceTab">Compliance</a>
+      <li class="nav-item">
+        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#groupComplianceTab" type="button" role="tab" aria-controls="groupComplianceTab" aria-selected="false">Compliance</button>
       </li>
     </ul>
   </div>
   <div class="main-details">
-    <div id="groupParametersTab" class="row">
-      <div class="col-12 col-sm-6 col-lg-7">
-        <div class="main-form">
-          <group-notifications ></group-notifications>
-          <group-pendingchangerequest></group-pendingchangerequest>
-          <group-name></group-name>
-          <div id="longDescriptionFieldMarkdownContainer" class="form-group">
-            <label class="wbBaseFieldLabel"><span class="text-fit">Description</span>
-              <lift:authz role="group_write">
-                <i class="fa fa-pencil text-primary cursorPointer half-opacity" onmouseenter="toggleOpacity(this)" title="Edit description" onmouseout="toggleOpacity(this)" onclick="toggleMarkdownEditor('longDescriptionField')"></i>
-              </lift:authz>
-            </label>
-            <div class="markdown">
-              <div id="longDescriptionFieldMarkdown"></div>
-              <p id="longDescriptionFieldMarkdownEmpty" class="nodisplay half-opacity">No description defined, click on <i class="fa fa-pencil text-primary cursorPointer half-opacity" onmouseenter="toggleOpacity(this)" onmouseout="toggleOpacity(this)" onclick="toggleMarkdownEditor('longDescriptionField')"></i> to edit </p>
+    <div class="tab-content">
+      <div id="groupParametersTab" class="tab-pane active main-form">
+        <div class="col-12 col-sm-6 col-lg-7">
+          <div class="main-form">
+            <group-notifications ></group-notifications>
+            <group-pendingchangerequest></group-pendingchangerequest>
+            <group-name></group-name>
+            <div id="longDescriptionFieldMarkdownContainer" class="form-group">
+              <label class="wbBaseFieldLabel"><span class="text-fit">Description</span>
+                <lift:authz role="group_write">
+                  <i class="fa fa-pencil text-primary cursorPointer half-opacity" onmouseenter="toggleOpacity(this)" title="Edit description" onmouseout="toggleOpacity(this)" onclick="toggleMarkdownEditor('longDescriptionField')"></i>
+                </lift:authz>
+              </label>
+              <div class="markdown">
+                <div id="longDescriptionFieldMarkdown"></div>
+                <p id="longDescriptionFieldMarkdownEmpty" class="nodisplay half-opacity">No description defined, click on <i class="fa fa-pencil text-primary cursorPointer half-opacity" onmouseenter="toggleOpacity(this)" onmouseout="toggleOpacity(this)" onclick="toggleMarkdownEditor('longDescriptionField')"></i> to edit </p>
+              </div>
             </div>
-          </div>
-          <div id="longDescriptionFieldContainer" class="nodisplay form-group">
-            <div id="longDescriptionField">
-              Here comes the longDescription field
+            <div id="longDescriptionFieldContainer" class="nodisplay form-group">
+              <div id="longDescriptionField">
+                Here comes the longDescription field
+              </div>
+              <div id="longDescriptionFieldMarkdownPreviewContainer" class="col-6">
+                <label class="col-12 wbBaseFieldLabel"><span class="text-fit">Preview</span></label>
+                <div id="longDescriptionFieldPreviewMarkdown" class=" col-12 markdown"></div>
+              </div>
             </div>
-            <div id="longDescriptionFieldMarkdownPreviewContainer" class="col-6">
-              <label class="col-12 wbBaseFieldLabel"><span class="text-fit">Preview</span></label>
-              <div id="longDescriptionFieldPreviewMarkdown" class=" col-12 markdown"></div>
-            </div>
-          </div>
-          <group-rudderid></group-rudderid>
-          <group-container></group-container>
-          <group-cfeclasses></group-cfeclasses>
-        </div>
-      </div>
-      <div class="col-12 col-sm-6 col-lg-5">
-        <div class="form-group show-compliance">
-          <div id="groupComplianceSummary">
-            <label data-bs-toggle="tooltip" data-bs-placement="right" title="<div class='tooltip-inner-content'>Compliance that takes into account all rules that apply directives to a node within this group</div>">
-              Global compliance
-            </label>
-            <div class="groupGlobalComplianceProgressBar"></div>
-            <label data-bs-toggle="tooltip" data-bs-placement="right" title="<div class='tooltip-inner-content'>Compliance that takes into account only rules that explicitly include this group in their target</div>">
-              Targeted compliance
-            </label>
-            <div class="groupTargetedComplianceProgressBar"></div>
-          </div>
-          <label class="id-label">Group ID</label>
-          <div class="id-container">
-            <p class="id-value">The node group id</p>
-            <i class="ion ion-clipboard clipboard-icon"></i>
+            <group-rudderid></group-rudderid>
+            <group-container></group-container>
+            <group-cfeclasses></group-cfeclasses>
           </div>
         </div>
+        <div class="col-12 col-sm-6 col-lg-5">
+          <div class="form-group show-compliance">
+            <div id="groupComplianceSummary">
+              <label data-bs-toggle="tooltip" data-bs-placement="right" title="<div class='tooltip-inner-content'>Compliance that takes into account all rules that apply directives to a node within this group</div>">
+                Global compliance
+              </label>
+              <div class="groupGlobalComplianceProgressBar"></div>
+              <label data-bs-toggle="tooltip" data-bs-placement="right" title="<div class='tooltip-inner-content'>Compliance that takes into account only rules that explicitly include this group in their target</div>">
+                Targeted compliance
+              </label>
+              <div class="groupTargetedComplianceProgressBar"></div>
+            </div>
+            <label class="id-label">Group ID</label>
+            <div class="id-container">
+              <p class="id-value">The node group id</p>
+              <i class="ion ion-clipboard clipboard-icon"></i>
+            </div>
+          </div>
+        </div>
       </div>
-    </div>
-    <div id="groupRulesTab" class="main-form">
-      <div id="groupRelatedRulesApp"></div>
-    </div>
-    <div id="groupPropertiesTab" class="main-form">
-      <div id="groupPropertiesTabContent"></div>
-    </div>
-    <div id="groupComplianceTab" class="main-form">
-      <div id="groupComplianceApp"></div>
-    </div>
-    <div id="groupCriteriaTab" class="main-form">
+      <div id="groupRulesTab" class="tab-pane main-form">
+        <div id="groupRelatedRulesApp"></div>
+      </div>
+      <div id="groupPropertiesTab" class="tab-pane main-form">
+        <div id="groupPropertiesTabContent"></div>
+      </div>
+      <div id="groupComplianceTab" class="tab-pane main-form">
+        <div id="groupComplianceApp"></div>
+      </div>
+      <div id="groupCriteriaTab" class="tab-pane main-form">
       <group-static></group-static>
       <div id="SearchNodes">
         <group-showGroup ></group-showGroup>
       </div>
+    </div>
     </div>
   </div>
   <div class="table-container">

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/server/server_details.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/server/server_details.html
@@ -86,51 +86,67 @@
   </div>
   <div id="node_tabs" class="tabs">
     <div class="main-navbar">
-      <ul id="NodeDetailsTabMenu" class="ui-tabs-nav nav nav-tabs">
-        <li class="ui-tabs-tab"><a href="#node_summary">Summary</a></li>
-        <li class="ui-tabs-tab"><a href="#node_reports">Compliance</a></li>
-        <li class="ui-tabs-tab"><a href="#node_inventory">Inventory</a></li>
-        <li class="ui-tabs-tab"><a href="#node_properties">Properties</a></li>
-        <li class="ui-tabs-tab"><a href="#system_status">System status</a></li>
-        <li class="ui-tabs-tab"><a href="#node_logs">Technical logs</a></li>
-        <li class="ui-tabs-tab"><a href="#node_parameters">Settings</a></li>
+      <ul id="NodeDetailsTabMenu" class="nav nav-underline">
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target="#node_summary" type="button" role="tab" aria-controls="node_summary" aria-selected="false">Summary</button>
+        </li>
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target="#node_reports" type="button" role="tab" aria-controls="node_reports" aria-selected="false">Compliance</button>
+        </li>
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target="#node_inventory" type="button" role="tab" aria-controls="node_inventory" aria-selected="false">Inventory</button>
+        </li>
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target="#node_properties" type="button" role="tab" aria-controls="node_properties" aria-selected="false">Properties</button>
+        </li>
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target="#system_status" type="button" role="tab" aria-controls="system_status" aria-selected="false">System status</button>
+        </li>
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target="#node_logs" type="button" role="tab" aria-controls="node_logs" aria-selected="false">Technical logs</button>
+        </li>
+        <li class="nav-item">
+          <button class="nav-link" data-bs-toggle="tab" data-bs-target="#node_parameters" type="button" role="tab" aria-controls="node_parameters" aria-selected="false">Settings</button>
+        </li>
       </ul>
     </div>
     <div class="one-col-main">
       <div class="template-main">
         <div class="main-container">
           <div class="main-details">
+            <div class="tab-content">
+              <div id="node_summary" class="tab-pane">
+                <div class="d-flex">
+                  <div id="nodeDetails"></div>
+                  <div id="nodeGroups">
+                    <h3>Groups containing this node <span class="badge" id="nbGroups"></span></h3>
+                    <div id="node_groupTree"></div>
+                  </div>
+                </div>
+              </div>
 
-            <div id="node_summary">
-              <div id="nodeDetails"></div>
-              <div id="nodeGroups">
-                <h3>Groups containing this node <span class="badge" id="nbGroups"></span></h3>
-                <div id="node_groupTree"></div>
+              <div id="node_inventory" class="tab-pane">
+                <div id="nodeInventory"></div>
+              </div>
+
+              <div id="node_reports" class="tab-pane">
+                <div id="reportsDetails"></div>
+              </div>
+
+              <div id="node_logs" class="tab-pane">
+                <div id="logsDetails"></div>
+              </div>
+
+              <div id="node_properties" class="tab-pane">
+                <div id="nodeProperties"></div>
+              </div>
+
+              <div id="node_parameters" class="tab-pane"></div>
+
+              <div id="system_status" class="tab-pane">
+                <div id="systemStatus"></div>
               </div>
             </div>
-
-            <div id="node_inventory">
-              <div id="nodeInventory"></div>
-            </div>
-
-            <div id="node_reports">
-              <div id="reportsDetails"></div>
-            </div>
-
-            <div id="node_logs">
-              <div id="logsDetails"></div>
-            </div>
-
-            <div id="node_properties">
-              <div id="nodeProperties"></div>
-            </div>
-
-            <div id="node_parameters"></div>
-
-            <div id="system_status">
-              <div id="systemStatus"></div>
-            </div>
-
           </div>
         </div>
       </div>


### PR DESCRIPTION
https://issues.rudder.io/issues/24170

Major changes : 

- Renaming css classes :
    - `ul.ui-tabs-nav` into `ul.nav.nav-underline`
    - `li.ui-tabs-tab` into `li.nav-item`
    - `li > a` into `li > button.nav-link`
- The .active class is no longer applied to the `<li>` element, but to the `<button>` it contains.
- We no longer use jquery's tabs function `$("ul").tabs()`, which added extra CSS classes to our elements.
- A lot of cleaing in the CSS code has been made (using scss Rudder variables, moving certain blocks of code to the right place, deleting old css rules..).