### PR TITLE
Fixes #24123: Technique import doesn't refresh the list of method in technique editor

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
@@ -915,7 +915,7 @@ update msg model =
                   callState = (Dict.fromList (List.map (\c -> (c.id.value, defaultMethodUiInfo)) (List.concatMap getAllCalls technique.elems)))
                   blockState = (Dict.fromList (List.map (\c -> (c.id.value, defaultBlockUiInfo)) (List.concatMap getAllBlocks technique.elems)))
                   ui = TechniqueUiInfo General callState blockState [] False Unchanged Unchanged Nothing
-                  editInfo = TechniqueEditInfo "" True (Ok ())
+                  editInfo = TechniqueEditInfo "" False (Ok ())
                 in
                   update (GenerateId FinalizeImport) { model | mode = TechniqueDetails technique (Creation (TechniqueId "")) ui editInfo}
               EditYaml _->


### PR DESCRIPTION
https://issues.rudder.io/issues/24123
IMO we want graphical display of method rather than YAML editor

Before the fix
![bug_import](https://github.com/Normation/rudder/assets/23410978/f0ebd015-f13f-40c5-acbe-3273ce185753)

After the fix
![fixed_import](https://github.com/Normation/rudder/assets/23410978/1016862e-d203-4190-954e-f3a7b911928b)
