### PR TITLE
Fixes #24150: when we have conditions on blocks, the condition text is not correctly positionned when the block is opened

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.css
@@ -999,11 +999,14 @@ button.btn.clipboard:hover {
 }
 /* =====  BLOCK  ===== */
 .method-info .block-name-container{
-  padding: 10px 100px 0 0;
+  padding: 0px 100px 0 0;
 }
 .method-info.closed .block-name-container{
   padding-left: 0;
   padding-top: 0;
+}
+.method-condition:not(.closed){
+  padding-left: 10px;
 }
 /* =====  METHOD  ===== */
 ul.list-unstyled > li{
@@ -1169,7 +1172,7 @@ ul li.hide-method {
   background-color: #337ab7;
   z-index: 100;
 }
-.card-method.showMethodBlock:not(.active) .method .method-info .method-condition,
+.card-method.showMethodBlock .method .method-info .method-condition,
 .card-method.showMethodCall .method .method-info .method-condition{
   padding-left: 10px;
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/24150

Please note that the offset label `Audit from command` that you can see in the gif, for the method after the nested block, is another bug, not introduced by this fix

![condition_position](https://github.com/Normation/rudder/assets/23410978/3424581f-d0b9-46a5-96b9-b45319dfa226)
