### PR TITLE
Fixes #24230: Authentication providers and role mapping settings should be exposed

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
@@ -625,12 +625,13 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
           fr")"
 
         def update(updated: Vector[UserInfo]): ConnectionIO[Int] = {
+          // never update the managedBy of an existing user which may have been provided by another origin
           val sql =
             """insert into users (id, creationdate, status, managedby, name, email, lastlogin, statushistory, otherinfo)
                   values (?,?,?,?,? , ?,?,?,?)
                on conflict (id) do update
-                set (creationdate, status, managedby, name, email, lastlogin, statushistory, otherinfo) =
-                  (EXCLUDED.creationdate, EXCLUDED.status, EXCLUDED.managedby, EXCLUDED.name, EXCLUDED.email, EXCLUDED.lastlogin, EXCLUDED.statushistory, EXCLUDED.otherinfo)"""
+                set (creationdate, status, name, email, lastlogin, statushistory, otherinfo) =
+                  (EXCLUDED.creationdate, EXCLUDED.status, EXCLUDED.name, EXCLUDED.email, EXCLUDED.lastlogin, EXCLUDED.statushistory, EXCLUDED.otherinfo)"""
 
           Update[UserInfo](sql).updateMany(updated)
         }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
@@ -801,7 +801,7 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
 
   // only disabled user can be set back to active
   override def setActive(userId: List[String], trace: EventTrace): IOResult[Unit] = {
-    changeStatus(userId, None, Nil, trace, UserStatus.Active, Some(fr"status = '${UserStatus.Disabled.value}'")).unit
+    changeStatus(userId, None, Nil, trace, UserStatus.Active, Some(fr"status = ${UserStatus.Disabled.value}")).unit
   }
 
   override def getAll(): IOResult[List[UserInfo]] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
@@ -625,13 +625,13 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
           fr")"
 
         def update(updated: Vector[UserInfo]): ConnectionIO[Int] = {
-          // never update the managedBy of an existing user which may have been provided by another origin
+          // never update the user personal information and managedby of an existing user which may have been provided and modified by another origin
           val sql =
             """insert into users (id, creationdate, status, managedby, name, email, lastlogin, statushistory, otherinfo)
                   values (?,?,?,?,? , ?,?,?,?)
                on conflict (id) do update
-                set (creationdate, status, name, email, lastlogin, statushistory, otherinfo) =
-                  (EXCLUDED.creationdate, EXCLUDED.status, EXCLUDED.name, EXCLUDED.email, EXCLUDED.lastlogin, EXCLUDED.statushistory, EXCLUDED.otherinfo)"""
+                set (creationdate, status, lastlogin, statushistory) =
+                  (EXCLUDED.creationdate, EXCLUDED.status, EXCLUDED.lastlogin, EXCLUDED.statushistory)"""
 
           Update[UserInfo](sql).updateMany(updated)
         }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
@@ -832,7 +832,7 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
     params match {
       case Nil       => ZIO.unit
       case h :: tail =>
-        val sql = sql"""update users""" ++ Fragments.set(params: _*) ++ fr"""where id = ${id}"""
+        val sql = fr"""update users""" ++ Fragments.set(params: _*) ++ fr"""where id = ${id}"""
 
         transactIOResult(s"Error when updating user information for '${id}'")(xa => sql.update.run.transact(xa)).unit
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/24230

We need to know providers properties e.g. : Do they override or extend the user roles defined in the `users.xml` file ? Can they write password in the users file ?

These properties will be used in user-management plugin to handle some providers logic regarding roles and also for the logic of the UI : https://github.com/Normation/rudder-plugins/pull/668