### PR TITLE
Fixes #24278: Incorrect error message about change request creation failure when it is not needed

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/Rules.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/rules/sources/Rules.elm
@@ -350,7 +350,7 @@ update msg model =
                           ]
                       in
                         linkSuccessNotification encodeToastInfo
-                    Nothing -> errorNotification("Error while trying to create change request")
+                    Nothing -> defaultNotif
                   else
                   defaultNotif
                   )


### PR DESCRIPTION
https://issues.rudder.io/issues/24278

This can happen when change requests are enabled but the Rule may not need a validation change request at all (e.g. groups are empty). So the CR id is not mandatory.

If the Rule API forgets to return the CR id in the JSON, it will be a matter of fixing the API logic.