### PR TITLE
Fixes #24284: Log on user api authorizations should be more concise

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/DataStructures.scala
@@ -259,7 +259,7 @@ object ApiAuthorization       {
   case object RO                                 extends ApiAuthorization { override val kind = ApiAuthorizationKind.RO   }
   final case class ACL(acl: List[ApiAclElement]) extends ApiAuthorization {
     override def kind = ApiAuthorizationKind.ACL
-    override def toString: String = acl.map(_.display).mkString(";")
+    def debugString: String = acl.map(_.display).mkString(";")
   }
 
   /**


### PR DESCRIPTION
https://issues.rudder.io/issues/24284

This will have effect on debug logs that use string interpolations, the change is introduced to fix this one : https://github.com/Normation/rudder-plugins/pull/655/files#diff-8fe302fecad34e77c8d7fa30f3efdf0110c77048e1f14006e4855dc1c60e73d9R658-R659.

Now we should be able to read it more fluently :
```
[2024-02-28 16:18:00+0100] DEBUG auth-backends - Principal 'test-user' final roles: [inventory], and API authz: /settings/global_policy_mode:[GET];/settings/global_policy_mode_overridable:[GET];/user/api/token:[GET,PUT,POST,DELETE];/nodes/details/property/*:[POST];/nodes/details/software/*:[POST];/nodes/*/displayInheritedProperties:[GET];/nodes/*/inheritedProperties:[GET];/nodes/pending/*:[GET];/nodes/details:[POST];/nodes/pending:[GET];/nodes/status:[GET];/nodes/*:[GET];/nodes:[GET];/inventories/info:[GET]
```