### PR TITLE
Fixes #23881: When the documentation of a technique is very long, the user has to scroll a long way before creating a directive from this technique

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.css
@@ -3090,6 +3090,8 @@ table a > i.fa-pencil:hover{
   border: 1px solid #d6deef;
   border-radius: 4px;
   background-color: #F8F9FC;
+  max-height: 400px;
+  overflow: auto;
 }
 .markdown > :first-child{
   margin-top: 0;


### PR DESCRIPTION
https://issues.rudder.io/issues/23881

Added a maximum height for markdown containers, and auto scroll when content exceeds this height. Here is the result:

![long-description](https://github.com/Normation/rudder/assets/9928447/d87fb3df-df4d-4199-858f-21d7cb5f654f)
