### PR TITLE
Fixes #24277: Errors in event log for deleted techniques

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -737,6 +737,8 @@ class EventLogFactoryImpl(
       scala.xml.Utility.trim(<activeTechnique changeType="delete" fileFormat={Constants.XML_CURRENT_FILE_FORMAT.toString}>
         <id>{deleteDiff.technique.id.value}</id>
         <techniqueName>{deleteDiff.technique.techniqueName.value}</techniqueName>
+        <isSystem>{deleteDiff.technique.isSystem}</isSystem>
+        <isEnabled>{deleteDiff.technique._isEnabled}</isEnabled>
       </activeTechnique>)
     }
     DeleteTechnique(


### PR DESCRIPTION
https://issues.rudder.io/issues/24277
I only fixed the problem for deleted Technique, but there is some problem on add and update where the technique is not displayed, but this is a problem for another ticket
![image](https://github.com/Normation/rudder/assets/23410978/e4c9ed59-8241-4719-b7d3-d5a6de2cbee2)
