### PR TITLE
Fixes #24276: An errors occurs within technique editor resource manager when we create a folder that has the same name than another parent folder

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Action.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Action.elm
@@ -54,9 +54,6 @@ upload api dir file =
 listDirectory : String -> List String -> Cmd Msg
 listDirectory api dir =
   let
-    currentFolder = case List.Extra.last dir of
-      Just  d -> d
-      Nothing -> "/"
 
     body =  Json.Encode.object [
               ("action", Json.Encode.string "list")
@@ -67,7 +64,7 @@ listDirectory api dir =
     api
     (Http.jsonBody body )
     (Decode.at ["result"] (Decode.list fileDecoder))
-    (EnvMsg << (LsGotten currentFolder))
+    (EnvMsg << (LsGotten (getDirPath dir)))
 
 fileDecoder : Decode.Decoder FileMeta
 fileDecoder =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Env.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Env.elm
@@ -17,7 +17,7 @@ import FileManager.Util exposing (..)
 
 handleEnvMsg : EnvMsg -> Model -> (Model, Cmd Msg)
 handleEnvMsg msg model = case msg of
-  Open () -> ({ model | open = True }, Cmd.none)
+  Open () -> ({ model | open = True, dir = ["/"] }, Cmd.none)
   Close -> ({ model | open = False, selected = [] }, close [])
   Accept -> ({ model | open = False, selected = [] }, close <| reverse <| map ((++) (getDirPath model.dir) << .name) model.selected)
   MouseDown maybe pos1 ctrl ->
@@ -86,7 +86,7 @@ handleEnvMsg msg model = case msg of
 
   GetLs dir ->
     let
-      newDir = if List.member dir model.dir then takeWhile (\d -> d /= dir) model.dir else List.append model.dir [dir]
+      newDir = String.split "/" dir
     in
       ({ model | dir = newDir, files = [], load = True }, listDirectory model.api newDir)
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/View.elm
@@ -113,14 +113,14 @@ filesTree model =
           ( fs.childs
             |> List.map (\f ->
               let
-                parents = fs.parents
+                path =  List.append fs.parents [fs.name, f] |> getDirPath
               in
                 li [ ]
                 [ a [ onClick <| EnvMsg <| GetLsTree (List.append fs.parents [fs.name, f] ) ]
                   [ folderIcon 20
                   , text f
                   ]
-                , if List.member f openedDir then listFolders f else text ""
+                , if List.member path openedDir then listFolders path else text ""
                 ]
             )
           )
@@ -238,7 +238,7 @@ renderFile { api, thumbnailsUrl, dir, selected, clipboardDir, clipboardFiles } i
   , title file.name
   , onMouseDown <| (\x y -> EnvMsg <| MouseDown (Just file) x y)
   , onMouseUp <| EnvMsg << (MouseUp <| Just file)
-  , onDoubleClick <| if file.type_ == "dir" then EnvMsg <| GetLs file.name else Download
+  , onDoubleClick <| if file.type_ == "dir" then EnvMsg <| GetLs (getDirPath (List.append dir [ file.name] )) else Download
   ]
   [ renderThumb thumbnailsUrl api (getDirPath dir) file
   , div [ class "fm-name" ] [ text file.name ]
@@ -253,7 +253,7 @@ renderFileList { api, thumbnailsUrl, dir, selected, clipboardDir, clipboardFiles
   , title file.name
   , onMouseDown <| (\x y -> EnvMsg <| MouseDown (Just file) x y)
   , onMouseUp <| EnvMsg << (MouseUp <| Just file)
-  , onDoubleClick <| if file.type_ == "dir" then EnvMsg <| (GetLs file.name) else Download
+  , onDoubleClick <| if file.type_ == "dir" then EnvMsg <| (GetLs (getDirPath (List.append dir [ file.name] ))) else Download
   ]
   [ td[]
     [ div[]


### PR DESCRIPTION
https://issues.rudder.io/issues/24276

We want to reset the current dir of the file manager when opening it. This fix the fact that everyone is lost when using it !

I fixed the recursion problem when a folder had the same name as one of it's parent. It was because a the name of the folder was used as key, so when looking for child file we were getting the parent one, then infinite loop.

I used the full path of the folder instead of just its name