### PR TITLE
Fixes #24304: Deleted users should change status on file reload 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/users/UserRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/users/UserRepositoryTest.scala
@@ -117,6 +117,11 @@ trait UserRepositoryTest extends Specification with Loggable {
       }
     }
 
+    // BOB is rept removed after setting the users again without BOB
+    val dateBobRemovedIdempotent      = DateTime.parse("2023-09-02T02:03:04Z")
+    val traceBobRemovedIdempotent     = EventTrace(actor, dateBobRemovedIdempotent)
+    val userInfosBobRemovedIdempotent = userInfosBobRemoved
+
     // BOB added back from OIDC
     val dateBobOidc      = DateTime.parse("2023-09-03T03:03:03Z")
     val traceBobOidc     = EventTrace(actor, dateBobOidc)
@@ -180,6 +185,11 @@ trait UserRepositoryTest extends Specification with Loggable {
     "If an user is removed from list, it is marked as 'deleted' (but node erased)" >> {
       repo.setExistingUsers(AUTH_PLUGIN_NAME_LOCAL, userFileBobRemoved, traceBobRemoved).runNow
       repo.getAll().runNow.toUTC must containTheSameElementsAs(userInfosBobRemoved)
+    }
+
+    "If an user is reloaded from the same origin, it should be kept as is" >> {
+      repo.setExistingUsers(AUTH_PLUGIN_NAME_LOCAL, userFileBobRemoved, traceBobRemovedIdempotent).runNow
+      repo.getAll().runNow.toUTC must containTheSameElementsAs(userInfosBobRemovedIdempotent)
     }
 
     "If an user is created by an other module and file reloaded, it's Active and remains so" >> {


### PR DESCRIPTION
https://issues.rudder.io/issues/24304

* The change of not updating user origin should not have been made [in this previous PR](https://github.com/Normation/rudder/pull/5408/files#diff-4a2aaf2f76c5556341804a45895b09d281d02773e3dc0ff723507cced5178652R633) : it breaks tests and users can no longer be set as managed by OIDC when logging-in the first time and already being a file user. 

* Users that are from the same origin should not be taken into account when changing user status (`setExistingUsers`)