### PR TITLE
Fixes #24354: Description in API account is outside of the header

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/View.elm
@@ -25,24 +25,19 @@ view model =
             [ span[] [text "API accounts"]
             ]
           ]
+        , div [class "header-description"]
+          [ p[]
+            [ text "Configure accounts allowed to connect to Rudder's REST API. For API usage, read the dedicated "
+            , a[ href "https://docs.rudder.io/api/" ][ text "documentation" ]
+            , text "."
+            ]
+          ]
         ]
       , div[ class "one-col-main"]
         [ div[ class "template-main"]
           [ div[ class "main-container"]
             [ div[ class "main-details"]
-              [ div[ class "explanation-text"]
-                [ div[]
-                  [ p[][
-                      span[][
-                        text "Configure accounts allowed to connect to Rudder's REST API. For API usage, read the dedicated ",
-                        a[ href "https://docs.rudder.io/api/" ][ text "documentation" ],
-                        text "."
-                      ]
-                    ]
-                  ]
-
-              ]
-              , div [class "parameters-container"] [
+              [ div [class "parameters-container"] [
                 if hasClearTextTokens then
                   div [class "alert alert-warning"]
                     [ i [class "fa fa-exclamation-triangle"][]


### PR DESCRIPTION
https://issues.rudder.io/issues/24354

Here is the result : 
![result](https://github.com/Normation/rudder/assets/9928447/caeeb766-715a-4865-abb4-02949132e379)

