### PR TITLE
Fixes #24349: Odd rendering on tooltips in search node page 

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/server/server_details.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/server/server_details.html
@@ -18,7 +18,7 @@
                 <span class="ion ion-checkmark-round check-icon"></span>
               </label>
               <label for="typeQuery" class="form-control">
-                Include Rudder root <span class="icon-info fa fa-question-circle" data-bs-toggle="tooltip" title="The Rudder root server with web application"></span>
+                Include Rudder root <span class="ms-1 fw-normal text-secondary">(The Rudder root server with web application)</span>
               </label>
             </div>
           </li>
@@ -34,7 +34,7 @@
                 <span class="ion ion-checkmark-round check-icon"></span>
               </label>
               <label for="transformResult" class="form-control">
-                Invert result<span class="icon-info fa fa-question-circle" title="Return node(s) not matching query" data-bs-toggle="tooltip"></span>
+                Invert result <span class="ms-1 fw-normal text-secondary">(Return node(s) not matching query)</span>
               </label>
             </div>
           </li>


### PR DESCRIPTION
https://issues.rudder.io/issues/24349

Tooltips are useless here, I propose to replace them with their own text :
![no-tooltip](https://github.com/Normation/rudder/assets/9928447/7d3c62bf-2c11-4be9-8005-ebcd3e345862)
