### PR TITLE
Fixes #24347: Missing header separator in node search page

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-bootstrap.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-bootstrap.scss
@@ -110,6 +110,7 @@ $input-font-size-sm: 12px;  // previous bootstrap 3 value VS 0.85rem default in 
   padding: 0 15px;
   margin-bottom: 0;
   position: relative;
+  min-height: 4px;
 
   &:before {
     content: "";

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/searchNodes.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/searchNodes.html
@@ -29,6 +29,9 @@
           </p>
         </div>
       </div>
+      <div class="main-navbar">
+        <ul class="nav nav-underline"></ul>
+      </div>
       <div class="one-col-main">
         <div class="template-main">
           <div class="main-container">


### PR DESCRIPTION
https://issues.rudder.io/issues/24347

Here is the result :
![header](https://github.com/Normation/rudder/assets/9928447/663efb45-80d7-4c1c-a248-e88dc243848a)
