### PR TITLE
Fixes #24363: Display compliance for system groups

### DIFF
--- a/webapp/sources/api-doc/components/parameters/target-or-node-group-id.yml
+++ b/webapp/sources/api-doc/components/parameters/target-or-node-group-id.yml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2024 Normation SAS
+name: "targetOrNodeGroupId"
+in: path
+required: true
+description: Id of the node group or rule target
+schema:
+  oneOf:
+    - type: string
+      format: uuid or string
+      example: 47e3f2c0-0b1a-4b1a-9b0a-9e9e9e9e9e9e
+    - $ref: ../schemas/rule-target.yml

--- a/webapp/sources/api-doc/openapi.src.yml
+++ b/webapp/sources/api-doc/openapi.src.yml
@@ -162,9 +162,9 @@ paths:
     $ref: paths/compliance/nodes.yml
   "/compliance/nodes/{nodeId}":
     $ref: paths/compliance/node.yml
-  "/compliance/groups/{nodeGroupId}":
+  "/compliance/groups/{targetOrNodeGroupId}":
     $ref: paths/compliance/group-global.yml
-  "/compliance/groups/{nodeGroupId}/target":
+  "/compliance/groups/{targetOrNodeGroupId}/target":
     $ref: paths/compliance/group-targeted.yml
   "/archives/export":
     $ref: paths/archives/export.yml

--- a/webapp/sources/api-doc/paths/compliance/group-global.yml
+++ b/webapp/sources/api-doc/paths/compliance/group-global.yml
@@ -7,7 +7,7 @@ get:
   parameters:
     - $ref: ../../components/parameters/compliance-level.yml
     - $ref: ../../components/parameters/compliance-percent-precision.yml
-    - $ref: ../../components/parameters/node-group-id.yml
+    - $ref: ../../components/parameters/target-or-node-group-id.yml
   responses:
     "200":
       description: Success

--- a/webapp/sources/api-doc/paths/compliance/group-targeted.yml
+++ b/webapp/sources/api-doc/paths/compliance/group-targeted.yml
@@ -7,7 +7,7 @@ get:
   parameters:
     - $ref: ../../components/parameters/compliance-level.yml
     - $ref: ../../components/parameters/compliance-percent-precision.yml
-    - $ref: ../../components/parameters/node-group-id.yml
+    - $ref: ../../components/parameters/target-or-node-group-id.yml
   responses:
     "200":
       description: Success

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
@@ -38,7 +38,6 @@
 package com.normation.rudder.rest.data
 
 import com.normation.inventory.domain.NodeId
-import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.domain.policies.RuleId
@@ -127,7 +126,7 @@ final case class ByDirectiveByNodeRuleCompliance(
 )
 
 final case class ByNodeGroupCompliance(
-    id:         NodeGroupId,
+    id:         String,
     name:       String,
     compliance: ComplianceLevel,
     mode:       ComplianceModeName,
@@ -838,7 +837,7 @@ object JsonCompliance {
   implicit class JsonByNodeGroupCompliance(val nodeGroup: ByNodeGroupCompliance) extends AnyVal {
 
     def toJson(level: Int, precision: CompliancePrecision): JObject = {
-      (("id"                 -> nodeGroup.id.serialize)
+      (("id"                 -> nodeGroup.id)
       ~ ("name"              -> nodeGroup.name)
       ~ ("compliance"        -> nodeGroup.compliance.complianceWithoutPending(precision))
       ~ ("mode"              -> nodeGroup.mode.name)


### PR DESCRIPTION
https://issues.rudder.io/issues/24363

We need to support either a `groupId` (e.g. an uuid) or a target (e.g. `special:...` or even `group:...`). 

Common fields that we need for the compliance result are `id, name, serverList`, the code is refactored accordingly.

**Screenshots** : 

![Screenshot from 2024-03-08 14-37-36](https://github.com/Normation/rudder/assets/65616064/fa425d38-cf58-442c-bb14-908e42b8550b)

![Screenshot from 2024-03-08 14-34-00](https://github.com/Normation/rudder/assets/65616064/37d6e6a7-1050-43ff-bacf-98b8cc7d9e97)

This one needs some change in the UI (in another PR) :
![image](https://github.com/Normation/rudder/assets/65616064/df2a3a8a-37d7-4e3a-a810-246a6c044346)
