### PR TITLE
Fixes #24372: Don't fail on malformed index entries

### DIFF
--- a/relay/sources/rudder-package/tests/repo_index.json
+++ b/relay/sources/rudder-package/tests/repo_index.json
@@ -37,5 +37,9 @@
       "files.txz": "/opt/rudder/"
     },
     "path": "./8.0/rudder-plugin-vault-8.0.0~rc1-2.1-nightly.rpkg/nightly/rudder-plugin-vault-8.0.0~rc1-2.1-nightly.rpkg"
+  },
+  {
+    "malformed": "entry",
+    "should not": "break index reading"
   }
 ]


### PR DESCRIPTION
https://issues.rudder.io/issues/24372

Parse as a JSON first to avoid crashing on invalid index entries (but still log a warning, this should not happen anyway).