### PR TITLE
Fixes #24366: Group compliance stays empty

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -883,10 +883,9 @@ class ComplianceAPIService(
       currentGroupNodeIds = nodeGroup.serverList
 
       t1            <- currentTimeMillis
-      // filter reports only for nodes in the current group and applicable rules to get the compliance consistency at any level
       reportsByNode <- reportingService
                          .findRuleNodeStatusReports(
-                           nodeSettings.keySet -- currentGroupNodeIds,
+                           nodeSettings.keySet,
                            ruleIds
                          )
                          .toIO

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_compliance.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_compliance.yml
@@ -2289,24 +2289,6 @@ response:
               }
             ],
             "nodes" : [
-              {
-                "id" : "bn5",
-                "name" : "node1.localhost",
-                "mode" : "full-compliance",
-                "compliance" : 0.0,
-                "policyMode" : "enforce",
-                "complianceDetails" : {},
-                "rules" : []
-              },
-              {
-                "id" : "bn4",
-                "name" : "node1.localhost",
-                "mode" : "full-compliance",
-                "compliance" : 0.0,
-                "policyMode" : "enforce",
-                "complianceDetails" : {},
-                "rules" : []
-              }
             ]
           }
         ]

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -313,7 +313,10 @@ class MockCompliance(mockDirectives: MockDirectives) {
     def findRuleNodeStatusReports(nodeIds: Set[NodeId], filterByRules: Set[RuleId])(implicit
         qc:                                QueryContext
     ): Box[Map[NodeId, NodeStatusReport]] = {
-      Full(statusReports)
+      val filteredNodeReports = statusReports.view.filterKeys(nodeIds.contains(_)).toMap
+      Full(
+        filterReportsByRules(filteredNodeReports, filterByRules)
+      )
     }
 
     def findDirectiveNodeStatusReports(


### PR DESCRIPTION
https://issues.rudder.io/issues/24366

The existing test did not catch the bug because it the mock was not doing what happens when getting reports : filter by node and rule ids. I added the filters, and also corrected a test which was also wrong (the expected JSON for targeted compliance on nodes should have `nodes: []` in the test case, because the rules are skipped hence there are no node reports)  