### PR TITLE
Fixes #24405: Node tabs have onclick event handlers assigned on unrendered elements

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
@@ -660,10 +660,10 @@ function callRemoteRun(nodeId, refreshCompliance) {
   });
 }
 
-function showHideRunLogs(scrollTarget, init, refresh) {
-  $("#AllLogButton").toggle()
-  $("#logRun").toggle()
-  if ( ! $.fn.DataTable.isDataTable( '#complianceLogsGrid' ) ) {
+function showHideRunLogs(scrollTarget, tabId, init, refresh) {
+  $("#allLogButton-" + tabId).toggle()
+  $("#logRun-" + tabId).toggle()
+  if ( ! $.fn.DataTable.isDataTable( '#complianceLogsGrid-' + tabId ) && init !== undefined) {
     init()
   }
   if (refresh !== undefined) {

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder.css
@@ -701,7 +701,6 @@ td.complianceTd, td.parametersTd {
 .btn-state {
   width:128px;
   height:40px;
-  margin-bottom: 10px;
 }
 
 .btn-trigger {

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/reports_server.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/reports_server.html
@@ -13,7 +13,7 @@
 
   <div id="logRun"  class="space-top" style="display:none;">
     <h3 class="page-title space-top">All logs for current run</h3>
-    <button class="btn btn-primary" onclick="showHideRunLogs('#node-compliance-intro')">Hide logs</button>
+    <button id="AllLogHideButton" class="btn btn-primary">Hide logs</button>
     <table id="complianceLogsGrid" cellspacing="0">
     </table>
   </div>


### PR DESCRIPTION
https://issues.rudder.io/issues/24405
We display the `logs` table in two different tabs `Compliance` and `System status`, but having the same `id` for different elements across tables makes it impossible to dispatch event handlers correctly.
Also, the event handlers are not set on the `Show logs` buttons because the tab is has not yet been rendered.  

We just append the tab id to every HTML element, and set the buttons HTML with the correct event handler when the tab is rendered.