### PR TITLE
Fixes #24335: Broken group creation UI

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups.elm
@@ -54,12 +54,12 @@ update msg model =
       let
         ui = model.ui
       in
-        ({ model | ui = { ui | modal = NoModal, loadingGroups = True } }, Cmd.batch [ getGroupsTree model ])
+        ({ model | ui = { ui | modal = NoModal, loadingGroups = True } }, Cmd.batch [ getGroupsTree model False ])
     OpenGroupDetails groupId ->
       ({ model | mode = ExternalTemplate }, Cmd.batch [pushUrl (getIdAnchorKey groupId.value, groupId.value), displayGroupDetails groupId.value])
     OpenCategoryDetails catId ->
       ({ model | mode = ExternalTemplate }, Cmd.batch [pushUrl ("", ""), displayCategoryDetails catId])
-    GetGroupsTreeResult res ->
+    GetGroupsTreeResult res chainInitTable ->
       case res of
         Ok r ->
           let
@@ -69,7 +69,7 @@ update msg model =
           in
             ( 
               newModel
-              , Cmd.batch [ initTooltips (), getInitialGroupCompliance newModel ]  -- reload the table each time we have a new groups tree
+              , Cmd.batch (initTooltips () :: (if chainInitTable then [ getInitialGroupCompliance newModel ] else []))  -- reload the table each time we have a new groups tree
             )
         Err err ->
           processApiError "Getting groups tree" err model

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/ApiCalls.elm
@@ -31,8 +31,8 @@ getGroupsCompliance keepGroups groupIds model =
   in
     req
 
-getGroupsTree : Model -> Cmd Msg
-getGroupsTree model =
+getGroupsTree : Model -> Bool -> Cmd Msg
+getGroupsTree model chainInitTable =
   let
     req =
       request
@@ -40,7 +40,7 @@ getGroupsTree model =
         , headers = []
         , url     = getUrl model ["groups", "tree"] []
         , body    = emptyBody
-        , expect  = expectJson GetGroupsTreeResult decodeGetGroupsTree
+        , expect  = expectJson (\r -> GetGroupsTreeResult r chainInitTable) decodeGetGroupsTree 
         , timeout = Nothing
         , tracker = Nothing
         }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/DataTypes.elm
@@ -125,7 +125,7 @@ type Msg
   | OpenGroupDetails GroupId
   | OpenCategoryDetails String
   | FoldAllCategories Filters
-  | GetGroupsTreeResult (Result Error (Category Group))
+  | GetGroupsTreeResult (Result Error (Category Group)) Bool
   | GetGroupsComplianceResult Bool (Result Error (List GroupComplianceSummary))
   | UpdateGroupFilters      Filters
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/Init.elm
@@ -17,7 +17,7 @@ init flags =
     initUI       = UI initFilters NoModal flags.hasWriteRights True
     initModel    = Model flags.contextPath Loading initUI initCategory Dict.empty
     listInitActions =
-      [ getGroupsTree initModel
+      [ getGroupsTree initModel True
       ]
   in
     ( initModel


### PR DESCRIPTION
https://issues.rudder.io/issues/24335

Currently, as the Elm app is within a part of the Scala web page, sometimes they mix with each other.

When doing a group action : _create, clone, delete_, we simply don't want to reload the home page in Elm with the "compliance group summary table", because the Scala web page already handles the display