### PR TITLE
Fixes #24420: Missing space between badge score and number

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/SystemUpdateScore.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/SystemUpdateScore.elm
@@ -51,7 +51,7 @@ buildScoreDetails details =
             , attribute "data-bs-placement" "top"
             , title (buildTooltipContent "System updates" titleTxt)
             ]
-            [ i[class ("fa fa-" ++ iconClass)][], text valueTxt ]
+            [ i[class ("fa fa-" ++ iconClass)][], text (" " ++ valueTxt) ]
         Nothing -> text ""
   in
         div[]


### PR DESCRIPTION
https://issues.rudder.io/issues/24420