### PR TITLE
Fixes #24432: Broken pipe when piping rudder-package output

### DIFF
--- a/policies/rudder-cli/src/lib.rs
+++ b/policies/rudder-cli/src/lib.rs
@@ -2,3 +2,30 @@
 // SPDX-FileCopyrightText: 2022 Normation SAS
 
 pub mod logs;
+
+use std::panic;
+use std::process::exit;
+
+// taken from https://github.com/yamafaktory/jql/commit/12f5110b3443c33c09cf60d03fe638c2c266de98
+// under MIT/Apache 2 license
+
+/// Use a custom hook to manage broken pipe errors.
+///
+/// See https://github.com/rust-lang/rust/issues/46016 for cause.
+pub fn custom_panic_hook_ignore_sigpipe() {
+    // Take the hook.
+    let hook = panic::take_hook();
+
+    // Register a custom panic hook.
+    panic::set_hook(Box::new(move |panic_info| {
+        let panic_message = panic_info.to_string();
+
+        // Exit on broken pipe message.
+        if panic_message.contains("Broken pipe") || panic_message.contains("os error 32") {
+            exit(0);
+        }
+
+        // Hook back to default.
+        (hook)(panic_info)
+    }));
+}

--- a/policies/rudderc/src/lib.rs
+++ b/policies/rudderc/src/lib.rs
@@ -10,6 +10,7 @@ use std::{
 #[cfg(not(feature = "embedded-lib"))]
 use anyhow::bail;
 use anyhow::{anyhow, Context, Result};
+use rudder_cli::custom_panic_hook_ignore_sigpipe;
 #[cfg(not(feature = "embedded-lib"))]
 use tracing::debug;
 
@@ -45,6 +46,8 @@ pub const DEFAULT_AGENT_PATH: &str = "/opt/rudder/bin/";
 /// The current process is to stop at first error, and move it up to `main()` where it will
 /// be displayed.
 pub fn run(args: MainArgs) -> Result<()> {
+    custom_panic_hook_ignore_sigpipe();
+
     let input = Path::new(TECHNIQUE_SRC);
     let cwd = PathBuf::from(".");
     let target = PathBuf::from(TARGET_DIR);

--- a/relay/sources/rudder-package/src/lib.rs
+++ b/relay/sources/rudder-package/src/lib.rs
@@ -28,6 +28,7 @@ use std::{
 use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
 use cli::Args;
+use rudder_cli::custom_panic_hook_ignore_sigpipe;
 use tracing::{debug, error, info, warn};
 
 use crate::{
@@ -67,6 +68,8 @@ fn am_i_root() -> Result<bool> {
 
 /// CLI entry point
 pub fn run() -> Result<()> {
+    custom_panic_hook_ignore_sigpipe();
+
     // Read CLI args
     let args = cli::Args::parse();
 


### PR DESCRIPTION
https://issues.rudder.io/issues/24432

There were two big options:
* Catch panics and prevent failure with broken pipe
* Replace `println!` and others by a fallible alternative and handle errors everywhere

As there can be `println!` everywhere and properlt handling these errors early would be expensive, let's go for the ugly solution.