### PR TITLE
Fixes #24236: Overriding properties should have the same type as overridden

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -846,6 +846,21 @@ object ParentProperty {
   final case class Global(value: ConfigValue)                               extends ParentProperty {
     val displayName = "Global Parameter"
   }
+
+  // The hierarchy of node properties from top to bottom : Global, Group, Node
+  implicit val ordering: Ordering[ParentProperty] = new Ordering[ParentProperty] {
+    override def compare(x: ParentProperty, y: ParentProperty): Int = {
+      (x, y) match {
+        case (Global(_), Global(_))           => 0
+        case (Global(_), _)                   => -1
+        case (_, Global(_))                   => 1
+        case (Group(_, _, _), Group(_, _, _)) => 0
+        case (Group(_, _, _), _)              => -1
+        case (_, Group(_, _, _))              => 1
+        case (Node(_, _, _), Node(_, _, _))   => 0
+      }
+    }
+  }
 }
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
@@ -343,7 +343,7 @@ class TestMergeGroupProperties extends Specification {
     def getOverrides(groups: List[NodeGroup]): Map[String, String] = {
 
       MergeNodeProperties.checkPropertyMerge(groups.map(_.toTarget), Map()) match {
-        case Left(_)  => throw new IllegalArgumentException(s"Error when overriding properties")
+        case Left(e)  => throw new IllegalArgumentException(s"Error when overriding properties: ${e.fullMsg}")
         case Right(v) => v.map(p => (p.prop.name, GenericProperty.serializeToHocon(p.prop.value))).toMap
       }
     }
@@ -388,7 +388,7 @@ class TestMergeGroupProperties extends Specification {
     }
     "override whatever by simple values" in {
       val child =
-        Map("s" -> "c", "arr" -> "c", "obj" -> "c")
+        Map("s" -> "c", "arr" -> """[-1]""", "obj" -> """{"a":"c"}""")
       val props = checkOverrides(
         Map("s" -> "p", "arr" -> "[1,2]", "obj" -> """{"a":"b"}"""),
         child

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
@@ -102,6 +102,21 @@ response:
                     }
                   }
                 ],
+                "hierarchyStatus":{
+                  "hasChildTypeConflicts":false,
+                  "fullHierarchy":[
+                    {
+                      "kind":"global",
+                      "valueType":"Object"
+                    },
+                    {
+                      "kind":"group",
+                      "name":"Real nodes",
+                      "id":"0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                      "valueType":"Object"
+                    }
+                  ]
+                },
                 "origval":{
                   "array":[5,6],
                   "group":"string",
@@ -119,6 +134,15 @@ response:
                     "value":"some string"
                   }
                 ],
+                "hierarchyStatus":{
+                  "hasChildTypeConflicts":false,
+                  "fullHierarchy":[
+                    {
+                      "kind":"global",
+                      "valueType":"String"
+                    }
+                  ]
+                },
                 "origval":"some string"
               },
               {
@@ -138,6 +162,21 @@ response:
                     "value":"string"
                   }
                 ],
+                "hierarchyStatus":{
+                  "hasChildTypeConflicts":false,
+                  "fullHierarchy":[
+                    {
+                      "kind":"global",
+                      "valueType":"String"
+                    },
+                    {
+                      "kind":"group",
+                      "name":"Real nodes",
+                      "id":"0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                      "valueType":"String"
+                    }
+                  ]
+                },
                 "origval":"string"
               },
               {
@@ -150,6 +189,15 @@ response:
                     "value":"some string"
                   }
                 ],
+                "hierarchyStatus":{
+                  "hasChildTypeConflicts":false,
+                  "fullHierarchy":[
+                    {
+                      "kind":"global",
+                      "valueType":"String"
+                    }
+                  ]
+                },
                 "origval":"some string"
               }
             ]
@@ -183,6 +231,21 @@ response:
                 },
                 "provider":"overridden",
                 "hierarchy":"<p>from <b>Global Parameter</b>:<pre>{\n \"array\":[\n 1,\n 3,\n 2\n ],\n \"json\":{\n \"var1\":\"val1\",\n \"var2\":\"val2\"\n },\n \"string\":\"a string\"\n}\n</pre></p><p>from <b>this group (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>{\n \"array\":[\n 5,\n 6\n ],\n \"group\":\"string\",\n \"json\":{\n \"g1\":\"g1\"\n }\n}\n</pre></p>",
+                "hierarchyStatus":{
+                  "hasChildTypeConflicts":false,
+                  "fullHierarchy":[
+                    {
+                      "kind":"global",
+                      "valueType":"Object"
+                    },
+                    {
+                      "kind":"group",
+                      "name":"Real nodes",
+                      "id":"0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                      "valueType":"Object"
+                    }
+                  ]
+                },
                 "origval":{
                   "array":[5,6],
                   "group":"string",
@@ -195,6 +258,15 @@ response:
                 "inheritMode":"opa",
                 "provider":"inherited",
                 "hierarchy":"<p>from <b>Global Parameter</b>:<pre>\"some string\"</pre></p>",
+                "hierarchyStatus":{
+                  "hasChildTypeConflicts":false,
+                  "fullHierarchy":[
+                    {
+                      "kind":"global",
+                      "valueType":"String"
+                    }
+                  ]
+                },
                 "origval":"some string"
               },
               {
@@ -203,6 +275,21 @@ response:
                 "inheritMode":"map",
                 "provider":"overridden",
                 "hierarchy":"<p>from <b>Global Parameter</b>:<pre>\"some string\"</pre></p><p>from <b>this group (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>\"string\"</pre></p>",
+                "hierarchyStatus":{
+                  "hasChildTypeConflicts":false,
+                  "fullHierarchy":[
+                    {
+                      "kind":"global",
+                      "valueType":"String"
+                    },
+                    {
+                      "kind":"group",
+                      "name":"Real nodes",
+                      "id":"0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                      "valueType":"String"
+                    }
+                  ]
+                },
                 "origval":"string"
               },
               {
@@ -210,6 +297,15 @@ response:
                 "value":"some string",
                 "provider":"inherited",
                 "hierarchy":"<p>from <b>Global Parameter</b>:<pre>\"some string\"</pre></p>",
+                "hierarchyStatus":{
+                  "hasChildTypeConflicts":false,
+                  "fullHierarchy":[
+                    {
+                      "kind":"global",
+                      "valueType":"String"
+                    }
+                  ]
+                },
                 "origval":"some string"
               }
             ]

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -837,6 +837,7 @@ class RestTestSetUp {
   )
   val groupService6               = new GroupApiService6(mockNodeGroups.groupsRepo, mockNodeGroups.groupsRepo, restDataSerializer)
   val groupService14              = new GroupApiService14(
+    mockNodes.nodeFactRepo,
     mockNodeGroups.groupsRepo,
     mockNodeGroups.groupsRepo,
     mockParameters.paramsRepo,

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/View.elm
@@ -1,5 +1,7 @@
 module NodeProperties.View exposing (..)
 
+import List.Extra
+
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onInput)
@@ -22,6 +24,7 @@ view model =
       checkAlreadyUsedName = checkUsedName trimmedName model.properties
       checkEmptyVal        = String.isEmpty trimmedVal
       checkPristineVal     = not newProperty.pristineValue
+      checkFormatConflict  = List.Extra.find (\p -> p.name == trimmedName && (getFormat p) /= newProperty.format) model.properties /= Nothing
       checkFormatVal       = newProperty.errorFormat
       checks  = [checkEmptyName, checkAlreadyUsedName, checkEmptyVal, checkFormatVal]
       filters = model.ui.filters
@@ -95,9 +98,10 @@ view model =
               ]
             ]
           , div[class "errors"]
-            [ (if (checkEmptyName && checkPristineName) then div [class "text-danger"][text "Name is required"] else text "")
-            , (if checkAlreadyUsedName then div [class "text-danger"][text "This name is already used by another property"] else text "")
-            , (if (checkEmptyVal && checkPristineVal)  then div [ class "text-danger"][text "Value is required"] else text "")
+            [ (if (checkEmptyName && checkPristineName) then div [class "text-danger"][text "Name is required."] else text "")
+            , (if checkAlreadyUsedName then div [class "text-danger"][text "This name is already used by another property."] else text "")
+            , (if (checkEmptyVal && checkPristineVal)  then div [ class "text-danger"][text "Value is required."] else text "")
+            , (if checkFormatConflict then div [ class "text-danger"][text "The selected format is conflicting with the format of the existing property."] else text "")
             ]
           ]
           else

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Nodeproperties.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Nodeproperties.elm
@@ -48,7 +48,21 @@ update msg model =
       ( model , apiCall model)
 
     UpdateNewProperty newProperty ->
-      ({model | newProperty = newProperty}, Cmd.none)
+      let
+        possibleFormats = getPossibleFormatsFromPropertyName model newProperty.name
+        prop = 
+          if newProperty.format /= model.newProperty.format then
+            { newProperty | format = newProperty.format }
+          else
+            -- infer format from existing properties
+            if List.length possibleFormats <= 1 then
+              case List.head possibleFormats of
+                Just format -> { newProperty | format = format }
+                Nothing -> newProperty
+            else
+              newProperty
+      in
+        ({model | newProperty = prop}, Cmd.none)
 
     UpdateProperty key newProperty ->
       let

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1776,6 +1776,7 @@ object RudderConfigInit {
 
     lazy val groupApiService14 = {
       new GroupApiService14(
+        nodeFactRepository,
         roNodeGroupRepository,
         woNodeGroupRepository,
         roLDAPParameterRepository,


### PR DESCRIPTION
https://issues.rudder.io/issues/24236


Add a warning field for when a property has some conflict over it's "type hierarchy".

It can be seen in node properties tabs, in different cases : 
* when creating a new property (but we try to infer the property type when we can [here](https://github.com/Normation/rudder/pull/5471/commits/f1ed1b7aa29a5b417c9332118715e5784772371f)) : 
![image](https://github.com/Normation/rudder/assets/65616064/f840680b-7280-4908-9398-309942ca3ca9)

* when editing an existing property : 
![image](https://github.com/Normation/rudder/assets/65616064/dadbf468-d841-4257-91b0-b443f8da9e06)

* when node property already exists and has type hierarchy conflicts : ![image](https://github.com/Normation/rudder/assets/65616064/9dbb4926-e6a3-4044-bc95-45336852eee4)


N.B. : The feature is available in both "node" and "group" details.