### PR TITLE
Fixes #24441: Cannot translate campaign on boot, leading to skipped events

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -3748,9 +3748,6 @@ object RudderConfigInit {
     cleanOldInventoryBatch.start()
     gitFactRepoGC.start()
     gitConfigRepoGC.start()
-    // todo: scheduler interval should be a property
-    ZioRuntime.unsafeRun(jsonReportsAnalyzer.start(5.seconds).forkDaemon.provideLayer(ZioRuntime.layers))
-    ZioRuntime.unsafeRun(MainCampaignService.start(mainCampaignService))
     rudderUserListProvider.registerCallback(UserRepositoryUpdateOnFileReload.createCallback(userRepository))
     userCleanupBatch.start()
 


### PR DESCRIPTION
https://issues.rudder.io/issues/24441

THose actions should be done after plugin init, which is the case (see postPluginInitActions function), but the removed lines were reintroduced after 