### PR TITLE
Fixes #24416: Elm properties app is loaded multiple times

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -317,39 +317,7 @@ class NodeGroupForm(
       </div>)
 
     def tabProperties = ChooseTemplate(List("templates-hidden", "components", "ComponentNodeProperties"), "nodeproperties-tab")
-    intro ++ tabProperties ++ Script(OnLoad(JsRaw(s"""
-            var main = document.getElementById("nodeproperties-app")
-                                                     |var initValues = {
-                                                     |    contextPath    : "${S.contextPath}"
-                                                     |  , hasNodeWrite   : CanWriteNode
-                                                     |  , hasNodeRead    : CanReadNode
-                                                     |  , nodeId         : "${group.id.uid.value}"
-                                                     |  , objectType     : 'group'
-                                                     |};
-                                                     |var app = Elm.Nodeproperties.init({node: main, flags: initValues});
-                                                     |app.ports.successNotification.subscribe(function(str) {
-                                                     |  createSuccessNotification(str)
-                                                     |});
-                                                     |app.ports.errorNotification.subscribe(function(str) {
-                                                     |  createErrorNotification(str)
-                                                     |});
-                                                     |// Initialize tooltips
-                                                     |app.ports.initTooltips.subscribe(function(msg) {
-                                                     |  setTimeout(function(){
-                                                     |    $$('.bs-tooltip').bsTooltip();
-                                                     |  }, 400);
-                                                     |});
-                                                     |app.ports.copy.subscribe(function(str) {
-                                                     |  navigator.clipboard.writeText(str);
-                                                     |});
-                                                     |app.ports.initInputs.subscribe(function(str) {
-                                                     |  setTimeout(function(){
-                                                     |    $$(".auto-resize").on("input", autoResize).each(function(){
-                                                     |      autoResize(this);
-                                                     |    });
-                                                     |  }, 10);
-                                                     |});
-                                                     |""".stripMargin)))
+    intro ++ tabProperties
   }
 
   ///////////// fields for category settings ///////////////////

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
@@ -3,6 +3,21 @@
 <head_merge>
   <title>Rudder - Node Groups Management</title>
   <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-groups.css"/>
+  <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-nodeproperties.js"></script>
+  <script>
+    var CanWriteNode = false;
+    var CanReadNode  = false;
+  </script>
+  <lift:authz role="node_write">
+    <script>
+      CanWriteNode = true;
+    </script>
+  </lift:authz>
+  <lift:authz role="node_read">
+    <script>
+      CanReadNode = true;
+    </script>
+  </lift:authz>
 </head_merge>
 
 <span data-list="node.Groups.head"></span>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/ComponentNodeProperties.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/ComponentNodeProperties.html
@@ -2,21 +2,6 @@
   <div id="tabPropsId">
     <h3 class="page-title foldable" onclick="$('#nodeProp').toggle(); $(this).toggleClass('folded');">Properties <i class="fa fa-chevron-down"></i></h3>
     <div id="nodeproperties-app" class="portlet-content"></div>
-    <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-nodeproperties.js"></script>
-    <script>
-      var CanWriteNode = false;
-      var CanReadNode  = false;
-    </script>
-    <lift:authz role="node_write">
-      <script>
-        CanWriteNode = true;
-      </script>
-    </lift:authz>
-    <lift:authz role="node_read">
-      <script>
-        CanReadNode = true;
-      </script>
-    </lift:authz>
 
     <div id="inventoryVariables"></div>
   </div>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
@@ -47,10 +47,10 @@
   </div>
   <div class="main-navbar">
     <ul id="groupTabMenu">
-      <li><a href="#groupParametersTab">Parameters</a></li>
-      <li><a href="#groupCriteriaTab">Criteria</a></li>
-      <li><a href="#groupRulesTab">Related rules</a></li>
-      <li><a href="#groupPropertiesTab">Properties</a></li>
+      <li><a data-toggle="tab" href="#groupParametersTab">Parameters</a></li>
+      <li><a data-toggle="tab" href="#groupCriteriaTab">Criteria</a></li>
+      <li><a data-toggle="tab" href="#groupRulesTab">Related rules</a></li>
+      <li><a data-toggle="tab" href="#groupPropertiesTab">Properties</a></li>
     </ul>
   </div>
   <div class="main-details">


### PR DESCRIPTION
https://issues.rudder.io/issues/24416

The fix consist of : 
* loading the script when the group page loads, or else it will be loaded multiple times
* mounting and initializing an Elm app for node properties when the "Properties" tab content is shown
So we just move everything related to the Elm app "earlier" in the HTML structure, from `NodeGroupForm` details to the main `Group` page.

Caveats of this is that a new Elm app will be initialized each time the "Properties" tab is shown, but changing the Elm model to re-render with every group change action is heavier (we would likely need to make Elm apps global variables, to call ports on every action from the Scala templates). We could do that in another PR.