### PR TITLE
Fixes #24475: API account UI needs to provide a configuration for tenants

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountDiff.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountDiff.scala
@@ -59,5 +59,6 @@ final case class ModifyApiAccountDiff(
     modExpirationDate:      Option[SimpleDiff[Option[DateTime]]] = None,
     modAPIKind:             Option[SimpleDiff[String]] = None,
     modAccountKind:         Option[SimpleDiff[String]] = None,
-    modAccountAcl:          Option[SimpleDiff[List[ApiAclElement]]] = None
+    modAccountAcl:          Option[SimpleDiff[List[ApiAclElement]]] = None,
+    modAPITenants:          Option[SimpleDiff[String]] = None
 ) extends ApiAccountDiff

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
@@ -683,7 +683,8 @@ object ApiAccountSerialisation {
             (expirationDate.map(DateFormaterService.getDisplayDateTimePicker), Some(authz.kind.name), acl)
         }
       }
-      ("id" -> account.id.value) ~
+
+      ("id"                    -> account.id.value) ~
       ("name"                  -> account.name.value) ~
       ("token"                 -> account.token.value) ~
       ("tokenGenerationDate"   -> DateFormaterService.serialize(account.tokenGenerationDate)) ~
@@ -694,7 +695,8 @@ object ApiAccountSerialisation {
       ("expirationDate"        -> expirationDate) ~
       ("expirationDateDefined" -> expirationDate.isDefined) ~
       ("authorizationType"     -> authzType) ~
-      ("acl"                   -> acl.map(x => Extraction.decompose(x)))
+      ("acl"                   -> acl.map(x => Extraction.decompose(x))) ~
+      ("tenants"               -> account.tenants.serialize)
     }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
@@ -653,6 +653,10 @@ class LDAPDiffMapper(
                                 } yield {
                                   d.copy(modAccountAcl = Some(SimpleDiff(oldAcl, acl)))
                                 }
+                              case A_API_TENANT                  =>
+                                diff.map(
+                                  _.copy(modAPITenants = Some(SimpleDiff(oldAccount.tenants.serialize, mod.getOptValueDefault("-"))))
+                                )
 
                               case x => Left(Err.UnexpectedObject("Unknown diff attribute: " + x))
                             }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -1144,6 +1144,7 @@ class LDAPEntityMapper(
     mod.resetValuesTo(A_DESCRIPTION, principal.description)
     mod.resetValuesTo(A_IS_ENABLED, principal.isEnabled.toLDAPString)
     mod.resetValuesTo(A_API_KIND, principal.kind.kind.name)
+    mod.resetValuesTo(A_API_TENANT, principal.tenants.serialize)
 
     principal.kind match {
       case ApiAccountKind.PublicApi(authz, exp) =>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -1059,8 +1059,7 @@ final case class RestExtractorService(
       expirationValue   <- extractJsonString(json, "expirationDate", DateFormaterService.parseDateTimePicker(_).toBox)
       authType          <- extractJsonString(json, "authorizationType", ApiAuthorizationKind.parse)
       tenants           <- extractJsonString(json, "tenants", s => NodeSecurityContext.parse(Some(s)).toBox)
-
-      acl <- extractJsonArray(json, "acl")((extractApiACLFromJSON _)).map(_.getOrElse(Nil))
+      acl               <- extractJsonArray(json, "acl")((extractApiACLFromJSON _)).map(_.getOrElse(Nil))
     } yield {
 
       val auth       = authType match {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestApiAccounts.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestApiAccounts.scala
@@ -302,15 +302,16 @@ final case class RestApiAccount(
 
   // Id cannot change if already defined
   def update(account: ApiAccount): ApiAccount = {
-    val nameUpdate   = name.getOrElse(account.name)
-    val enableUpdate = enabled.getOrElse(account.isEnabled)
-    val descUpdate   = description.getOrElse(account.description)
-    val kind         = account.kind match {
+    val nameUpdate    = name.getOrElse(account.name)
+    val enableUpdate  = enabled.getOrElse(account.isEnabled)
+    val descUpdate    = description.getOrElse(account.description)
+    val tenantsUpdate = tenants.getOrElse(account.tenants)
+    val kind          = account.kind match {
       case ApiAccountKind.PublicApi(a, e) =>
         ApiAccountKind.PublicApi(authz.getOrElse(a), expiration.getOrElse(e))
       case x                              => x
     }
 
-    account.copy(name = nameUpdate, isEnabled = enableUpdate, description = descUpdate, kind = kind)
+    account.copy(name = nameUpdate, isEnabled = enableUpdate, description = descUpdate, kind = kind, tenants = tenantsUpdate)
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts.elm
@@ -1,218 +1,374 @@
 module Accounts exposing (..)
 
+import Accounts.ApiCalls exposing (..)
+import Accounts.DataTypes as TenantMode exposing (..)
+import Accounts.DatePickerUtils exposing (..)
+import Accounts.Init exposing (..)
+import Accounts.JsonDecoder exposing (decodeErrorDetails)
+import Accounts.JsonEncoder exposing (encodeAccountTenants, encodeTokenAcl)
+import Accounts.View exposing (view)
+import Accounts.ViewUtils exposing (..)
 import Browser
 import Dict
 import Dict.Extra
 import Http exposing (..)
 import Http.Detailed as Detailed
-import Result
+import Json.Encode exposing (..)
 import List.Extra
 import Random
-import UUID
-import Json.Encode exposing (..)
+import Result
 import SingleDatePicker exposing (Settings, TimePickerVisibility(..), defaultSettings, defaultTimePickerSettings)
 import Task
 import Time exposing (Month(..), Posix, Zone)
 import Time.Extra as Time exposing (Interval(..), add)
+import UUID
 
-import Accounts.ApiCalls exposing (..)
-import Accounts.DataTypes exposing (..)
-import Accounts.DatePickerUtils exposing (..)
-import Accounts.Init exposing (..)
-import Accounts.JsonEncoder exposing (encodeTokenAcl)
-import Accounts.JsonDecoder exposing (decodeErrorDetails)
-import Accounts.View exposing (view)
-import Accounts.ViewUtils exposing (..)
 
-main = Browser.element
-  { init          = init
-  , view          = view
-  , update        = update
-  , subscriptions = subscriptions
-  }
+
+{--
+This application manage the list of API Accounts and their token properties.
+The general behavior is:
+- there is a list of API Accounts with action buttons for editing, deleting, token generation, etc
+- new one can be created
+- action button create a modal window
+- there is a main data type about current state of modal (none, new account, editing, etc)
+--}
+
+
+main =
+    Browser.element
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = subscriptions
+        }
+
 
 generator : Random.Generator String
-generator = Random.map (UUID.toString) UUID.generator
+generator =
+    Random.map UUID.toString UUID.generator
+
+
 
 --
 -- update loop --
 --
+
+
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
-  case msg of
-    Copy s -> (model, copy s)
+    case msg of
+        Copy s ->
+            ( model, copy s )
 
-    -- Generate random id
-    GenerateId nextMsg ->
-      (model, Random.generate nextMsg generator)
+        -- Generate random id
+        GenerateId nextMsg ->
+            ( model, Random.generate nextMsg generator )
 
-    -- Do an API call
-    CallApi call ->
-      (model, call model)
+        -- Do an API call
+        CallApi call ->
+            ( model, call model )
 
-    -- neutral element
-    Ignore ->
-      (model , successNotification "")
+        -- neutral element
+        Ignore ->
+            ( model, successNotification "" )
 
-    ToggleEditPopup modalState ->
-      let
-        ui = model.ui
-        currentTime = model.ui.datePickerInfo.currentTime
-        expDate     = add Month 1 model.ui.datePickerInfo.zone currentTime
-        (editAccount, tokenId, acl) = case modalState of
-          NewAccount    -> (Just (Account "" "" "" "rw" "" True "" "" "" True (Just expDate) Nothing), "", [])
-          EditAccount a -> (Just a, a.id, case a.acl of
-            Just ac -> ac
-            Nothing -> []
-            )
-          _ -> (Nothing, "", [])
-      in
-        ( { model | ui = {ui | modalState = modalState}, editAccount = editAccount }, shareAcl (encodeTokenAcl tokenId acl) )
-
-    CloseCopyPopup ->
-      let
-        ui = model.ui
-      in
-        ({ model | ui = {ui | copyState = NoCopy}}, Cmd.none)
-
-    UpdateTableFilters tableFilters ->
-      let
-        ui = model.ui
-      in
-        ({model | ui = { ui | tableFilters = tableFilters}}, Cmd.none)
-
-    GetAccountsResult res ->
-      case  res of
-        Ok (metadata, apiResult) ->
-          let
-            modelUi  = model.ui
-            accounts = apiResult.accounts
-            aclPluginEnabled = apiResult.aclPluginEnabled
-            initAclPlugin = if aclPluginEnabled && not modelUi.pluginAclInit then initAcl "" else Cmd.none
-          in
-            ( { model | accounts = accounts, aclPluginEnabled = aclPluginEnabled, ui = { modelUi | loadingAccounts = False, pluginAclInit = True } }
-              , Cmd.batch [initTooltips "", initAclPlugin]
-            )
-        Err err ->
-          processApiError "Getting API accounts list" err model
-
-    UpdateAccountForm account ->
-      ({model | editAccount = Just account}, Cmd.none)
-
-    SaveAccount (Ok (metadata, account)) ->
-      let
-        ui = model.ui
-        copyState = case ui.modalState of
-          NewAccount -> Token account.token
-          _ -> NoCopy
-        action = case ui.modalState of
-          NewAccount -> "created"
-          _ -> "updated"
-
-        newModel = {model | ui = {ui | modalState = NoModal, copyState = copyState }, editAccount = Nothing}
-      in
-        (newModel, Cmd.batch [(successNotification ("Account '"++ account.name ++"' successfully " ++ action)) , (getAccounts newModel)])
-
-    SaveAccount (Err err) ->
-      processApiError "Saving account" err model
-
-    ConfirmActionAccount actionType (Ok (metadata, account)) ->
-      let
-        ui = model.ui
-        copyState = case actionType of
-          Delete     -> NoCopy
-          Regenerate -> Token account.token
-        newModel = {model | ui = {ui | modalState = NoModal, copyState = copyState }}
-        message  = case actionType of
-          Delete     -> "deleted"
-          Regenerate -> "regenerated token of"
-      in
-        (newModel, Cmd.batch [successNotification ("Successfully " ++ message ++ " API account '" ++ account.name ++  "'"), (getAccounts model)])
-
-    ConfirmActionAccount actionType (Err err) ->
-      let
-        action = case actionType of
-          Delete     -> "Deleting"
-          Regenerate -> "regenerating token of"
-      in
-        processApiError (action ++ " API account") err model
-
-    GetCheckedAcl (Ok acl) ->
-      let
-        newAccount = case model.editAccount of
-          Just ac -> Just { ac | acl = Just acl }
-          Nothing -> Nothing
-        newModel = { model | editAccount = newAccount }
-      in
-        (newModel, Cmd.none)
-
-    GetCheckedAcl (Err err) ->
-        (model, errorNotification ("Error when selecting custom ACL" ))
-
-    -- DATEPICKER
-    OpenPicker posix->
-      let
-        ui = model.ui
-        datePicker = ui.datePickerInfo
-      in
-      ( { model | ui = { ui | datePickerInfo = { datePicker | picker = SingleDatePicker.openPicker (userDefinedDatePickerSettings datePicker.zone datePicker.currentTime posix) posix (Just posix) datePicker.picker }}}, Cmd.none )
-
-    UpdatePicker subMsg ->
-      let
-        
-        
-        ui = model.ui
-        datePicker = ui.datePickerInfo
-        selectedDate = case datePicker.pickedTime of
-          Nothing -> datePicker.currentTime
-          Just d -> d
-        ( newPicker, maybeNewTime ) =  SingleDatePicker.update (userDefinedDatePickerSettings datePicker.zone datePicker.currentTime selectedDate) subMsg datePicker.picker
-        newModel = case model.editAccount of
-          Nothing -> model
-          Just a  ->
+        ToggleEditPopup modalState ->
             let
-              newTime    = case maybeNewTime of
-                Just t  -> Just t
-                Nothing -> a.expirationDate
-              newAccount = Just {a | expirationDate = newTime}
+                ui =
+                    model.ui
+
+                currentTime =
+                    model.ui.datePickerInfo.currentTime
+
+                expDate =
+                    add Month 1 model.ui.datePickerInfo.zone currentTime
+
+                editAccount =
+                    case modalState of
+                        NewAccount ->
+                            Just (Account "" "" "" "rw" "" True "" "" "" True (Just expDate) Nothing TenantMode.AllAccess Nothing)
+
+                        EditAccount a ->
+                            Just a
+
+                        _ ->
+                            Nothing
+
+                tokenId =
+                    editAccount |> Maybe.map .id |> Maybe.withDefault ""
+
+                acl =
+                    editAccount |> Maybe.andThen .acl |> Maybe.withDefault []
+
+                tenants =
+                    editAccount |> Maybe.andThen .selectedTenants |> Maybe.withDefault []
             in
-              { model | ui = { ui | datePickerInfo = { datePicker | picker = newPicker, pickedTime = newTime }}, editAccount = newAccount}
-      in
-        ( newModel , Cmd.none )
+            ( { model | ui = { ui | modalState = modalState }, editAccount = editAccount }, Cmd.batch [ shareAcl (encodeTokenAcl tokenId acl), focusAccountTenants (encodeAccountTenants tokenId tenants) ] )
 
-    AdjustTimeZone newZone ->
-      let
-        ui = model.ui
-        datePicker = ui.datePickerInfo
-        newModel = { model | ui = { ui | datePickerInfo = { datePicker | zone = newZone }}}
-      in
-        ( newModel, getAccounts newModel )
+        CloseCopyPopup ->
+            let
+                ui =
+                    model.ui
+            in
+            ( { model | ui = { ui | copyState = NoCopy } }, Cmd.none )
 
-    Tick newTime ->
-      let
-        ui = model.ui
-        datePicker = ui.datePickerInfo
-      in
-        ( { model | ui = { ui | datePickerInfo = { datePicker | currentTime = newTime }}}, Cmd.none )
+        UpdateTableFilters tableFilters ->
+            let
+                ui =
+                    model.ui
+            in
+            ( { model | ui = { ui | tableFilters = tableFilters } }, Cmd.none )
+
+        GetAccountsResult res ->
+            case res of
+                Ok ( metadata, apiResult ) ->
+                    let
+                        modelUi =
+                            model.ui
+
+                        accounts =
+                            apiResult.accounts
+
+                        aclPluginEnabled =
+                            apiResult.aclPluginEnabled
+
+                        tenantsPluginEnabled =
+                            apiResult.tenantsPluginEnabled
+
+                        initAclPlugin =
+                            if aclPluginEnabled && not modelUi.pluginAclInit then
+                                initAcl ""
+
+                            else
+                                Cmd.none
+
+                        initTenantsPlugin =
+                            if apiResult.tenantsPluginEnabled && not modelUi.pluginTenantsInit then
+                                initTenants ""
+
+                            else
+                                Cmd.none
+                    in
+                    ( { model | accounts = accounts, aclPluginEnabled = aclPluginEnabled, tenantsPluginEnabled = tenantsPluginEnabled, ui = { modelUi | loadingAccounts = False, pluginAclInit = True, pluginTenantsInit = True } }
+                    , Cmd.batch [ initTooltips "", initAclPlugin, initTenantsPlugin ]
+                    )
+
+                Err err ->
+                    processApiError "Getting API accounts list" err model
+
+        UpdateAccountForm account ->
+            ( { model | editAccount = Just account }, Cmd.none )
+
+        SaveAccount (Ok ( metadata, account )) ->
+            let
+                ui =
+                    model.ui
+
+                copyState =
+                    case ui.modalState of
+                        NewAccount ->
+                            Token account.token
+
+                        _ ->
+                            NoCopy
+
+                action =
+                    case ui.modalState of
+                        NewAccount ->
+                            "created"
+
+                        _ ->
+                            "updated"
+
+                newModel =
+                    { model | ui = { ui | modalState = NoModal, copyState = copyState }, editAccount = Nothing }
+            in
+            ( newModel, Cmd.batch [ successNotification ("Account '" ++ account.name ++ "' successfully " ++ action), getAccounts newModel ] )
+
+        SaveAccount (Err err) ->
+            processApiError "Saving account" err model
+
+        ConfirmActionAccount actionType (Ok ( metadata, account )) ->
+            let
+                ui =
+                    model.ui
+
+                copyState =
+                    case actionType of
+                        Delete ->
+                            NoCopy
+
+                        Regenerate ->
+                            Token account.token
+
+                newModel =
+                    { model | ui = { ui | modalState = NoModal, copyState = copyState } }
+
+                message =
+                    case actionType of
+                        Delete ->
+                            "deleted"
+
+                        Regenerate ->
+                            "regenerated token of"
+            in
+            ( newModel, Cmd.batch [ successNotification ("Successfully " ++ message ++ " API account '" ++ account.name ++ "'"), getAccounts model ] )
+
+        ConfirmActionAccount actionType (Err err) ->
+            let
+                action =
+                    case actionType of
+                        Delete ->
+                            "Deleting"
+
+                        Regenerate ->
+                            "regenerating token of"
+            in
+            processApiError (action ++ " API account") err model
+
+        GetCheckedAcl (Ok acl) ->
+            let
+                newAccount =
+                    case model.editAccount of
+                        Just ac ->
+                            Just { ac | acl = Just acl }
+
+                        Nothing ->
+                            Nothing
+
+                newModel =
+                    { model | editAccount = newAccount }
+            in
+            ( newModel, Cmd.none )
+
+        GetCheckedAcl (Err err) ->
+            ( model, errorNotification "Error when selecting custom ACL" )
+
+        GetCheckedTenants (Ok selectedTenants) ->
+            let
+                newAccount =
+                    case model.editAccount of
+                        Just ac ->
+                            case selectedTenants of
+                                [] ->
+                                    Just { ac | selectedTenants = Nothing }
+
+                                l ->
+                                    Just { ac | selectedTenants = Just (List.sort l) }
+
+                        Nothing ->
+                            Nothing
+
+                newModel =
+                    { model | editAccount = newAccount }
+            in
+            ( newModel, Cmd.none )
+
+        GetCheckedTenants (Err err) ->
+            ( model, errorNotification "Error when selecting tenants from list" )
+
+        -- DATEPICKER
+        OpenPicker posix ->
+            let
+                ui =
+                    model.ui
+
+                datePicker =
+                    ui.datePickerInfo
+            in
+            ( { model | ui = { ui | datePickerInfo = { datePicker | picker = SingleDatePicker.openPicker (userDefinedDatePickerSettings datePicker.zone datePicker.currentTime posix) posix (Just posix) datePicker.picker } } }, Cmd.none )
+
+        UpdatePicker subMsg ->
+            let
+                ui =
+                    model.ui
+
+                datePicker =
+                    ui.datePickerInfo
+
+                selectedDate =
+                    case datePicker.pickedTime of
+                        Nothing ->
+                            datePicker.currentTime
+
+                        Just d ->
+                            d
+
+                ( newPicker, maybeNewTime ) =
+                    SingleDatePicker.update (userDefinedDatePickerSettings datePicker.zone datePicker.currentTime selectedDate) subMsg datePicker.picker
+
+                newModel =
+                    case model.editAccount of
+                        Nothing ->
+                            model
+
+                        Just a ->
+                            let
+                                newTime =
+                                    case maybeNewTime of
+                                        Just t ->
+                                            Just t
+
+                                        Nothing ->
+                                            a.expirationDate
+
+                                newAccount =
+                                    Just { a | expirationDate = newTime }
+                            in
+                            { model | ui = { ui | datePickerInfo = { datePicker | picker = newPicker, pickedTime = newTime } }, editAccount = newAccount }
+            in
+            ( newModel, Cmd.none )
+
+        AdjustTimeZone newZone ->
+            let
+                ui =
+                    model.ui
+
+                datePicker =
+                    ui.datePickerInfo
+
+                newModel =
+                    { model | ui = { ui | datePickerInfo = { datePicker | zone = newZone } } }
+            in
+            ( newModel, getAccounts newModel )
+
+        Tick newTime ->
+            let
+                ui =
+                    model.ui
+
+                datePicker =
+                    ui.datePickerInfo
+            in
+            ( { model | ui = { ui | datePickerInfo = { datePicker | currentTime = newTime } } }, Cmd.none )
+
 
 processApiError : String -> Detailed.Error String -> Model -> ( Model, Cmd Msg )
 processApiError apiName err model =
-  let
-    modelUi = model.ui
-    message =
-      case err of
-        Detailed.BadUrl url ->
-          "The URL " ++ url ++ " was invalid"
-        Detailed.Timeout ->
-          "Unable to reach the server, try again"
-        Detailed.NetworkError ->
-          "Unable to reach the server, check your network connection"
-        Detailed.BadStatus metadata body ->
-          let
-            (title, errors) = decodeErrorDetails body
-          in
-            title ++ "\n" ++ errors
-        Detailed.BadBody metadata body msg ->
-          msg
-  in
-    ({ model | ui = { modelUi | loadingAccounts = False}}, errorNotification ("Error when "++apiName ++", details: \n" ++ message ) )
+    let
+        modelUi =
+            model.ui
+
+        message =
+            case err of
+                Detailed.BadUrl url ->
+                    "The URL " ++ url ++ " was invalid"
+
+                Detailed.Timeout ->
+                    "Unable to reach the server, try again"
+
+                Detailed.NetworkError ->
+                    "Unable to reach the server, check your network connection"
+
+                Detailed.BadStatus metadata body ->
+                    let
+                        ( title, errors ) =
+                            decodeErrorDetails body
+                    in
+                    title ++ "\n" ++ errors
+
+                Detailed.BadBody metadata body msg ->
+                    msg
+    in
+    ( { model | ui = { modelUi | loadingAccounts = False } }, errorNotification ("Error when " ++ apiName ++ ", details: \n" ++ message) )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/DataTypes.elm
@@ -1,103 +1,147 @@
 module Accounts.DataTypes exposing (..)
 
+import Html exposing (Html)
 import Http exposing (Error)
 import Http.Detailed
 import Json.Decode as D exposing (..)
-import SingleDatePicker exposing (Settings, TimePickerVisibility(..), defaultSettings, defaultTimePickerSettings, DatePicker)
+import SingleDatePicker exposing (DatePicker, Settings, TimePickerVisibility(..), defaultSettings, defaultTimePickerSettings)
 import Time exposing (Posix, Zone)
+
+
 
 --
 -- All our data types
 --
 
-type ModalState = NoModal | NewAccount | EditAccount Account | Confirm ConfirmModalType String Msg
 
-type CopyState = NoCopy | Token String
+type ModalState
+    = NoModal
+    | NewAccount
+    | EditAccount Account
+    | Confirm ConfirmModalType String Msg
+
+
+type CopyState
+    = NoCopy
+    | Token String
+
 
 type ConfirmModalType
-  = Delete
-  | Regenerate
+    = Delete
+    | Regenerate
 
-type SortOrder = Asc | Desc
+
+type SortOrder
+    = Asc
+    | Desc
+
 
 type SortBy
-  = Name
-  | Id
-  | ExpDate
-  | CreDate
+    = Name
+    | Id
+    | ExpDate
+    | CreDate
+
+
+type TenantMode
+    = AllAccess -- special "*" permission giving access to objects in any/no tenants
+    | NoAccess -- special "-" permission giving access to no object, whatever the tenant or its absence
+    | ByTenants --give access to object in any of the listed tenants
+
 
 type alias TableFilters =
-  { sortBy    : SortBy
-  , sortOrder : SortOrder
-  , filter    : String
-  , authType  : String
-  }
+    { sortBy : SortBy
+    , sortOrder : SortOrder
+    , filter : String
+    , authType : String
+    }
+
 
 type alias DatePickerInfo =
-  { currentTime : Posix
-  , zone        : Zone
-  , pickedTime  : Maybe Posix
-  , picker      : DatePicker Msg
-  }
+    { currentTime : Posix
+    , zone : Zone
+    , pickedTime : Maybe Posix
+    , picker : DatePicker Msg
+    }
+
 
 type alias UI =
-  { tableFilters    : TableFilters
-  , modalState      : ModalState
-  , copyState       : CopyState
-  , hasWriteRights  : Bool
-  , loadingAccounts : Bool
-  , datePickerInfo  : DatePickerInfo
-  , pluginAclInit   : Bool
-  }
+    { tableFilters : TableFilters
+    , modalState : ModalState
+    , copyState : CopyState
+    , hasWriteRights : Bool
+    , loadingAccounts : Bool
+    , datePickerInfo : DatePickerInfo
+    , pluginAclInit : Bool
+    , pluginTenantsInit : Bool
+    }
+
+
+type alias ModalUI msg =
+    { displayAcl : Bool
+    , displayTenants : Bool
+    , saveAction : Msg
+    , body : Html msg
+    }
+
 
 type alias Account =
-  { id                    : String
-  , name                  : String
-  , description           : String
-  , authorisationType     : String
-  , kind                  : String
-  , enabled               : Bool
-  , creationDate          : String
-  , token                 : String
-  , tokenGenerationDate   : String
-  , expirationDateDefined : Bool
-  , expirationDate        : Maybe Posix
-  , acl                   : Maybe (List AccessControl)
-  }
+    { id : String
+    , name : String
+    , description : String
+    , authorisationType : String
+    , kind : String
+    , enabled : Bool
+    , creationDate : String
+    , token : String
+    , tokenGenerationDate : String
+    , expirationDateDefined : Bool
+    , expirationDate : Maybe Posix
+    , acl : Maybe (List AccessControl)
+    , tenantMode : TenantMode
+    , selectedTenants : Maybe (List String) -- non empty list only
+    }
+
 
 type alias AccessControl =
-  { path : String
-  , verb : String
-  }
+    { path : String
+    , verb : String
+    }
+
 
 type alias ApiResult =
-  { aclPluginEnabled : Bool
-  , accounts         : List Account
-  }
+    { aclPluginEnabled : Bool
+    , tenantsPluginEnabled : Bool
+    , accounts : List Account
+    }
+
 
 type alias Model =
-  { contextPath      : String
-  , ui               : UI
-  , accounts         : List Account
-  , aclPluginEnabled : Bool
-  , editAccount      : Maybe Account
-  }
+    { contextPath : String
+    , ui : UI
+    , accounts : List Account
+    , aclPluginEnabled : Bool
+    , tenantsPluginEnabled : Bool
+    , editAccount : Maybe Account
+    }
+
 
 type Msg
-  = Copy String
-  | GenerateId (String -> Msg)
-  | CallApi (Model -> Cmd Msg)
-  | GetCheckedAcl (Result D.Error (List AccessControl))
-  | ToggleEditPopup ModalState
-  | CloseCopyPopup
-  | GetAccountsResult (Result (Http.Detailed.Error String) ( Http.Metadata, ApiResult))
-  | Ignore
-  | UpdateTableFilters TableFilters
-  | UpdateAccountForm Account
-  | SaveAccount (Result (Http.Detailed.Error String) ( Http.Metadata, Account))
-  | ConfirmActionAccount ConfirmModalType (Result (Http.Detailed.Error String) ( Http.Metadata, Account))
-  -- DATEPICKER
-  | OpenPicker Posix
-  | UpdatePicker SingleDatePicker.Msg
-  | AdjustTimeZone Zone
-  | Tick Posix
+    = Copy String
+    | GenerateId (String -> Msg)
+    | CallApi (Model -> Cmd Msg)
+    | GetCheckedAcl (Result D.Error (List AccessControl))
+    | GetCheckedTenants (Result D.Error (List String))
+    | ToggleEditPopup ModalState
+    | CloseCopyPopup
+    | GetAccountsResult (Result (Http.Detailed.Error String) ( Http.Metadata, ApiResult ))
+    | Ignore
+    | UpdateTableFilters TableFilters
+    | UpdateAccountForm Account
+    | SaveAccount (Result (Http.Detailed.Error String) ( Http.Metadata, Account ))
+    | ConfirmActionAccount ConfirmModalType (Result (Http.Detailed.Error String) ( Http.Metadata, Account ))
+      -- DATEPICKER
+    | OpenPicker Posix
+    | UpdatePicker SingleDatePicker.Msg
+    | AdjustTimeZone Zone
+    | Tick Posix

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/Init.elm
@@ -1,47 +1,88 @@
 port module Accounts.Init exposing (..)
 
-import Http exposing (Error)
-import SingleDatePicker exposing (Settings, TimePickerVisibility(..), defaultSettings)
-import Task
-import Time exposing (Month(..), Posix, Zone)
-import Time.Extra as Time exposing (Interval(..))
-import Json.Decode exposing (..)
-import Json.Decode.Pipeline as D exposing (..)
-
-import Accounts.ApiCalls exposing (..)
 import Accounts.DataTypes exposing (..)
 import Accounts.DatePickerUtils exposing (..)
 import Accounts.JsonDecoder exposing (decodeAcl)
+import Json.Decode exposing (..)
+import SingleDatePicker exposing (Settings, TimePickerVisibility(..))
+import Task
+import Time exposing (Month(..), Posix, Zone)
+
 
 
 -- PORTS / SUBSCRIPTIONS
 
+
 port successNotification : String -> Cmd msg
-port errorNotification   : String -> Cmd msg
-port initTooltips        : String -> Cmd msg
-port copy                : String -> Cmd msg
-port initAcl             : String -> Cmd msg
-port shareAcl            : Value  -> Cmd msg
-port getCheckedAcl       : (Json.Decode.Value -> msg) -> Sub msg
+
+
+port errorNotification : String -> Cmd msg
+
+
+port initTooltips : String -> Cmd msg
+
+
+
+-- for desktop copy to clipboard
+
+
+port copy : String -> Cmd msg
+
+
+
+-- port used to tell the ApiAuthorization plugin extension to init itself if present and get/send ACL for accounts
+
+
+port initAcl : String -> Cmd msg
+
+
+port shareAcl : Value -> Cmd msg
+
+
+port getCheckedAcl : (Json.Decode.Value -> msg) -> Sub msg
+
+
+
+-- port used to tell the ApiTenants plugin extension to init itself if present and get/send tenants for accounts
+
+
+port initTenants : String -> Cmd msg
+
+
+port focusAccountTenants : Value -> Cmd msg
+
+
+port getCheckedTenants : (Json.Decode.Value -> msg) -> Sub msg
+
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-  Sub.batch
-  [ SingleDatePicker.subscriptions (userDefinedDatePickerSettings model.ui.datePickerInfo.zone model.ui.datePickerInfo.currentTime model.ui.datePickerInfo.currentTime) model.ui.datePickerInfo.picker
-  , Time.every 1000 Tick -- Update of the current time every second
-  , getCheckedAcl (GetCheckedAcl << decodeValue (Json.Decode.list decodeAcl))
-  ]
+    Sub.batch
+        [ SingleDatePicker.subscriptions (userDefinedDatePickerSettings model.ui.datePickerInfo.zone model.ui.datePickerInfo.currentTime model.ui.datePickerInfo.currentTime) model.ui.datePickerInfo.picker
+        , Time.every 1000 Tick -- Update of the current time every second
+        , getCheckedAcl (GetCheckedAcl << decodeValue (Json.Decode.list decodeAcl))
+        , getCheckedTenants (GetCheckedTenants << decodeValue (Json.Decode.list string))
+        ]
+
 
 init : { contextPath : String, hasWriteRights : Bool } -> ( Model, Cmd Msg )
 init flags =
-  let
-    initDatePicker = DatePickerInfo (Time.millisToPosix 0) Time.utc Nothing (SingleDatePicker.init UpdatePicker)
-    initFilters    = TableFilters Name Asc "" ""
-    initUi         = UI initFilters NoModal NoCopy False True initDatePicker False
-    initModel      = Model flags.contextPath initUi [] False Nothing
-    initActions    =
-      [ Task.perform Tick Time.now
-      , Task.perform AdjustTimeZone Time.here
-      ]
-  in
-    ( initModel , Cmd.batch initActions )
+    let
+        initDatePicker =
+            DatePickerInfo (Time.millisToPosix 0) Time.utc Nothing (SingleDatePicker.init UpdatePicker)
+
+        initFilters =
+            TableFilters Name Asc "" ""
+
+        initUi =
+            UI initFilters NoModal NoCopy False True initDatePicker False False
+
+        initModel =
+            Model flags.contextPath initUi [] False False Nothing
+
+        initActions =
+            [ Task.perform Tick Time.now
+            , Task.perform AdjustTimeZone Time.here
+            ]
+    in
+    ( initModel, Cmd.batch initActions )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/JsonDecoder.elm
@@ -1,66 +1,132 @@
 module Accounts.JsonDecoder exposing (..)
 
-import Dict exposing (Dict)
+import Accounts.DataTypes as TenantMode exposing (..)
+import Accounts.DatePickerUtils exposing (stringToPosix)
 import Json.Decode exposing (..)
 import Json.Decode.Pipeline exposing (..)
-import String exposing (join, split)
 import List exposing (drop, head)
+import String exposing (join, split)
 
-import Accounts.DataTypes exposing (..)
-import Accounts.DatePickerUtils exposing (stringToPosix)
 
 
 -- GENERAL
-decodeGetAccounts datePickerInfo=
-  at [ "data" ] (decodeResult datePickerInfo)
+
+
+decodeGetAccounts datePickerInfo =
+    at [ "data" ] (decodeResult datePickerInfo)
+
 
 decodeAccount : DatePickerInfo -> Decoder Account
 decodeAccount datePickerInfo =
-  succeed Account
-    |> required "id"                    string
-    |> required "name"                  string
-    |> required "description"           string
-    |> required "authorizationType"     string
-    |> required "kind"                  string
-    |> required "enabled"               bool
-    |> required "creationDate"          string
-    |> required "token"                 string
-    |> required "tokenGenerationDate"   string
-    |> required "expirationDateDefined" bool
-    |> optional "expirationDate"        ( string
-      |> andThen (\s -> case stringToPosix datePickerInfo s of
-        Just date -> succeed (Just date)
-        Nothing   -> fail "Expiration date invalid : bad format"
-      )
-    ) Nothing
-    |> optional "acl" (map Just (list <| decodeAcl)) Nothing
+    succeed Account
+        |> required "id" string
+        |> required "name" string
+        |> required "description" string
+        |> required "authorizationType" string
+        |> required "kind" string
+        |> required "enabled" bool
+        |> required "creationDate" string
+        |> required "token" string
+        |> required "tokenGenerationDate" string
+        |> required "expirationDateDefined" bool
+        |> optional "expirationDate"
+            (string
+                |> andThen
+                    (\s ->
+                        case stringToPosix datePickerInfo s of
+                            Just date ->
+                                succeed (Just date)
+
+                            Nothing ->
+                                fail "Expiration date invalid : bad format"
+                    )
+            )
+            Nothing
+        |> optional "acl" (map Just (list <| decodeAcl)) Nothing
+        |> required "tenants" (string |> andThen toTenantMode)
+        |> required "tenants" (string |> andThen toTenantList)
+
 
 decodeAcl : Decoder AccessControl
 decodeAcl =
-  succeed AccessControl
-    |> required "path" string
-    |> required "verb" string
+    succeed AccessControl
+        |> required "path" string
+        |> required "verb" string
 
-decodeResult : DatePickerInfo -> Decoder (ApiResult)
+
+
+-- the string for a tenant mode is '*', '-', or a comma separated list of non-empty string
+
+
+parseTenants : String -> ( TenantMode, Maybe (List String) )
+parseTenants str =
+    let
+        listToTenantMode =
+            \l ->
+                case l of
+                    [] ->
+                        ( TenantMode.NoAccess, Nothing )
+
+                    nonEmptyList ->
+                        ( ByTenants, Just nonEmptyList )
+    in
+    case str of
+        "*" ->
+            ( TenantMode.AllAccess, Nothing )
+
+        "-" ->
+            ( TenantMode.NoAccess, Nothing )
+
+        tenantIds ->
+            String.split "," tenantIds |> listToTenantMode
+
+
+toTenantMode : String -> Decoder TenantMode
+toTenantMode str =
+    succeed (Tuple.first (parseTenants str))
+
+
+toTenantList : String -> Decoder (Maybe (List String))
+toTenantList str =
+    succeed (Tuple.second (parseTenants str))
+
+
+decodeResult : DatePickerInfo -> Decoder ApiResult
 decodeResult datePickerInfo =
-  succeed ApiResult
-    |> required "aclPluginEnabled" bool
-    |> required "accounts" (list (decodeAccount datePickerInfo))
+    succeed ApiResult
+        |> required "aclPluginEnabled" bool
+        |> required "tenantsPluginEnabled" bool
+        |> required "accounts" (list (decodeAccount datePickerInfo))
+
 
 decodePostAccount : DatePickerInfo -> Decoder Account
 decodePostAccount datePickerInfo =
-  at [ "data" , "accounts" ] (index 0 (decodeAccount datePickerInfo))
+    at [ "data", "accounts" ] (index 0 (decodeAccount datePickerInfo))
 
-decodeErrorDetails : String -> (String, String)
+
+decodeErrorDetails : String -> ( String, String )
 decodeErrorDetails json =
-  let
-    errorMsg = decodeString (Json.Decode.at ["errorDetails"] string) json
-    msg = case errorMsg of
-      Ok s -> s
-      Err e -> "fail to process errorDetails"
-    errors = split "<-" msg
-    title = head errors
-  in
-  case title of
-    Nothing -> ("" , "")
-    Just s -> (s , (join " \n " (drop 1 (List.map (\err -> "\t ‣ " ++ err) errors))))
+    let
+        errorMsg =
+            decodeString (Json.Decode.at [ "errorDetails" ] string) json
+
+        msg =
+            case errorMsg of
+                Ok s ->
+                    s
+
+                Err e ->
+                    "fail to process errorDetails"
+
+        errors =
+            split "<-" msg
+
+        title =
+            head errors
+    in
+    case title of
+        Nothing ->
+            ( "", "" )
+
+        Just s ->
+            ( s, join " \n " (drop 1 (List.map (\err -> "\t ‣ " ++ err) errors)) )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/JsonEncoder.elm
@@ -1,52 +1,84 @@
 module Accounts.JsonEncoder exposing (..)
 
-import Json.Encode exposing (..)
-import Date
-
 import Accounts.DataTypes exposing (..)
 import Accounts.DatePickerUtils exposing (posixToString)
+import Json.Encode exposing (..)
 
 
 encodeAccount : DatePickerInfo -> Account -> Value
 encodeAccount datePickerInfo account =
-  let
-    (expirationDate, expirationDateDefined) = case account.expirationDate of
-      Just d  -> ([("expirationDate", string (posixToString datePickerInfo d))], account.expirationDateDefined)
-      Nothing -> ([], False)
+    let
+        ( expirationDate, expirationDateDefined ) =
+            case account.expirationDate of
+                Just d ->
+                    ( [ ( "expirationDate", string (posixToString datePickerInfo d) ) ], account.expirationDateDefined )
 
-    acl = case account.acl of
-      Just a  -> [("acl", list encodeAcl a)]
-      Nothing -> []
+                Nothing ->
+                    ( [], False )
 
-  in
-    object (
-      [ ( "id"                    , string account.id                  )
-      , ( "name"                  , string account.name                )
-      , ( "description"           , string account.description         )
-      , ( "authorizationType"     , string account.authorisationType   )
-      , ( "kind"                  , string account.kind                )
-      , ( "enabled"               , bool account.enabled               )
-      , ( "creationDate"          , string account.creationDate        )
-      , ( "token"                 , string account.token               )
-      , ( "tokenGenerationDate"   , string account.tokenGenerationDate )
-      , ( "expirationDateDefined" , bool expirationDateDefined         )
-      ]
-      |> List.append expirationDate
-      |> List.append acl
-    )
+        acl =
+            case account.acl of
+                Just a ->
+                    [ ( "acl", list encodeAcl a ) ]
+
+                Nothing ->
+                    []
+    in
+    object
+        ([ ( "id", string account.id )
+         , ( "name", string account.name )
+         , ( "description", string account.description )
+         , ( "authorizationType", string account.authorisationType )
+         , ( "kind", string account.kind )
+         , ( "enabled", bool account.enabled )
+         , ( "creationDate", string account.creationDate )
+         , ( "token", string account.token )
+         , ( "tokenGenerationDate", string account.tokenGenerationDate )
+         , ( "expirationDateDefined", bool expirationDateDefined )
+         , ( "tenants", string (encodeTenants account.tenantMode account.selectedTenants) )
+         ]
+            |> List.append expirationDate
+            |> List.append acl
+        )
+
 
 encodeAcl : AccessControl -> Value
 encodeAcl acl =
-  object (
-    [ ( "path" , string acl.path )
-    , ( "verb" , string acl.verb )
-    ]
-  )
+    object
+        [ ( "path", string acl.path )
+        , ( "verb", string acl.verb )
+        ]
+
 
 encodeTokenAcl : String -> List AccessControl -> Value
 encodeTokenAcl tokenId acl =
-  object (
-    [ ( "id"  , string tokenId    )
-    , ( "acl" , list encodeAcl acl )
-    ]
-  )
+    object
+        [ ( "id", string tokenId )
+        , ( "acl", list encodeAcl acl )
+        ]
+
+
+encodeTenants : TenantMode -> Maybe (List String) -> String
+encodeTenants mode selected =
+    case mode of
+        AllAccess ->
+            "*"
+
+        NoAccess ->
+            "-"
+
+        ByTenants ->
+            case selected |> Maybe.withDefault [] of
+                [] ->
+                    "-"
+
+                l ->
+                    String.join "," l
+
+
+encodeAccountTenants : String -> List String -> Value
+encodeAccountTenants accountId tenants =
+    object
+        [ ( "id", string accountId )
+        , ( "tenants", list string tenants )
+        ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/View.elm
@@ -1,91 +1,106 @@
 module Accounts.View exposing (..)
 
-import Html exposing (..)
-import Html.Attributes exposing (class, colspan, disabled, href, id, placeholder, rowspan, selected, style, type_, value)
-import Html.Events exposing (onClick, onInput)
-import List
-import String
-
 import Accounts.ApiCalls exposing (..)
 import Accounts.DataTypes exposing (..)
 import Accounts.ViewModals exposing (..)
 import Accounts.ViewUtils exposing (..)
+import Html exposing (..)
+import Html.Attributes exposing (class, disabled, href, placeholder, selected, type_, value)
+import Html.Events exposing (onClick, onInput)
+import List
+import String
 
 
 view : Model -> Html Msg
 view model =
-  let
-    hasClearTextTokens = List.any (\a -> (String.length a.token) > 0) model.accounts
-  in
-    div[ class "rudder-template"]
-    [ div[ class "one-col"]
-      [ div[ class "main-header"]
-        [ div[ class "header-title"]
-          [ h1[]
-            [ span[] [text "API accounts"]
-            ]
-          ]
-        , div [class "header-description"]
-          [ p[]
-            [ text "Configure accounts allowed to connect to Rudder's REST API. For API usage, read the dedicated "
-            , a[ href "https://docs.rudder.io/api/" ][ text "documentation" ]
-            , text "."
-            ]
-          ]
-        ]
-      , div[ class "one-col-main"]
-        [ div[ class "template-main"]
-          [ div[ class "main-container"]
-            [ div[ class "main-details"]
-              [ div [class "parameters-container"] [
-                if hasClearTextTokens then
-                  div [class "alert alert-warning"]
-                    [ i [class "fa fa-exclamation-triangle"][]
-                    , text "You have API accounts with tokens generated on a previous Rudder versions, those for which the "
-                    , text "beginning of the token value is displayed in the table. They are now deprecated, you should "
-                    , text "re-generate or replace them for improved security."
+    let
+        hasClearTextTokens =
+            List.any (\a -> String.length a.token > 0) model.accounts
+    in
+    div [ class "rudder-template" ]
+        [ div [ class "one-col" ]
+            [ div [ class "main-header" ]
+                [ div [ class "header-title" ]
+                    [ h1 []
+                        [ span [] [ text "API accounts" ]
+                        ]
                     ]
-                else
-                  text ""
-                , button [class "btn btn-success new-icon", onClick (ToggleEditPopup NewAccount) ][ text "Create an account" ]
-                , div [class "main-table"]
-                  [ div [class "table-container"]
-                    [ div [class "dataTables_wrapper_top table-filter"]
-                      [ div [class "form-group"]
-                        [ input [class "form-control", type_ "text", value model.ui.tableFilters.filter, placeholder "Filter...", onInput (\s ->
-                            let
-                              tableFilters = model.ui.tableFilters
-                            in
-                              UpdateTableFilters {tableFilters | filter = s}
-                          )][]
+                , div [ class "header-description" ]
+                    [ p []
+                        [ text "Configure accounts allowed to connect to Rudder's REST API. For API usage, read the dedicated "
+                        , a [ href "https://docs.rudder.io/api/" ] [ text "documentation" ]
+                        , text "."
                         ]
-                      , div [class "form-group"]
-                        [ select [class "form-select" , onInput (\authType ->
-                          let
-                            tableFilters = model.ui.tableFilters
-                          in
-                            UpdateTableFilters {tableFilters | authType = authType}
-                          )]
-                          [ option [selected True, value model.ui.tableFilters.authType, disabled True][ text "Filter on access level" ]
-                          , option [value ""    ][ text "All accounts" ]
-                          , option [value "none"][ text "No access"    ]
-                          , option [value "ro"  ][ text "Read only"    ]
-                          , option [value "rw"  ][ text "Full access"  ]
-                          , option [value "acl" ][ text "Custom ACL"   ]
-                          ]
-                        ]
-                      , div [class "end"]
-                        [ button [class "btn btn-default", onClick (CallApi getAccounts)][ i[class "fa fa-refresh"][] ]
-                        ]
-                      ]
-                    , displayAccountsTable model
                     ]
-                  ]
                 ]
-              ]
+            , div [ class "one-col-main" ]
+                [ div [ class "template-main" ]
+                    [ div [ class "main-container" ]
+                        [ div [ class "main-details" ]
+                            [ div [ class "parameters-container" ]
+                                [ if hasClearTextTokens then
+                                    div [ class "alert alert-warning" ]
+                                        [ i [ class "fa fa-exclamation-triangle" ] []
+                                        , text "You have API accounts with tokens generated on a previous Rudder versions, those for which the "
+                                        , text "beginning of the token value is displayed in the table. They are now deprecated, you should "
+                                        , text "re-generate or replace them for improved security."
+                                        ]
+
+                                  else
+                                    text ""
+                                , button [ class "btn btn-success new-icon", onClick (ToggleEditPopup NewAccount) ] [ text "Create an account" ]
+                                , div [ class "main-table" ]
+                                    [ div [ class "table-container" ]
+                                        [ div [ class "dataTables_wrapper_top table-filter" ]
+                                            [ div [ class "form-group" ]
+                                                [ input
+                                                    [ class "form-control"
+                                                    , type_ "text"
+                                                    , value model.ui.tableFilters.filter
+                                                    , placeholder "Filter..."
+                                                    , onInput
+                                                        (\s ->
+                                                            let
+                                                                tableFilters =
+                                                                    model.ui.tableFilters
+                                                            in
+                                                            UpdateTableFilters { tableFilters | filter = s }
+                                                        )
+                                                    ]
+                                                    []
+                                                ]
+                                            , div [ class "form-group" ]
+                                                [ select
+                                                    [ class "form-select"
+                                                    , onInput
+                                                        (\authType ->
+                                                            let
+                                                                tableFilters =
+                                                                    model.ui.tableFilters
+                                                            in
+                                                            UpdateTableFilters { tableFilters | authType = authType }
+                                                        )
+                                                    ]
+                                                    [ option [ selected True, value model.ui.tableFilters.authType, disabled True ] [ text "Filter on access level" ]
+                                                    , option [ value "" ] [ text "All accounts" ]
+                                                    , option [ value "none" ] [ text "No access" ]
+                                                    , option [ value "ro" ] [ text "Read only" ]
+                                                    , option [ value "rw" ] [ text "Full access" ]
+                                                    , option [ value "acl" ] [ text "Custom ACL" ]
+                                                    ]
+                                                ]
+                                            , div [ class "end" ]
+                                                [ button [ class "btn btn-default", onClick (CallApi getAccounts) ] [ i [ class "fa fa-refresh" ] [] ]
+                                                ]
+                                            ]
+                                        , displayAccountsTable model
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
             ]
-          ]
+        , displayModals model
         ]
-      ]
-    , displayModals model
-    ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewModals.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewModals.elm
@@ -1,177 +1,309 @@
 module Accounts.ViewModals exposing (..)
 
-import Html exposing (..)
-import Html.Attributes exposing (attribute, checked, class, disabled, for, id, name, placeholder, readonly, selected, size, style, title, type_, value)
-import Html.Events exposing (onClick, onInput, custom, onCheck)
-import SingleDatePicker exposing (Settings, TimePickerVisibility(..), defaultSettings, defaultTimePickerSettings)
-import Task
-import Time exposing (Month(..), Posix, Zone)
-import Time.Extra as Time exposing (Interval(..), add)
-
 import Accounts.ApiCalls exposing (..)
 import Accounts.DataTypes exposing (..)
 import Accounts.DatePickerUtils exposing (..)
+import Accounts.JsonDecoder exposing (parseTenants)
+import Accounts.JsonEncoder exposing (encodeTenants)
+import Html exposing (..)
+import Html.Attributes exposing (attribute, checked, class, disabled, for, id, name, placeholder, selected, style, title, type_, value)
+import Html.Events exposing (onCheck, onClick, onInput)
+import SingleDatePicker exposing (Settings, TimePickerVisibility(..))
+import Time.Extra as Time exposing (Interval(..), add)
 
 
 displayModals : Model -> Html Msg
 displayModals model =
-  let
-    (checkEmptyBtn, checkEmptyWarning, checkAlreadyUsedName) =
-      case model.editAccount of
-        Nothing -> (False, False, False)
-        Just account ->
-          case model.ui.modalState of
-            NewAccount    -> ( String.isEmpty account.name , False , List.member account.name (List.map .name model.accounts) )
-            EditAccount a -> ( String.isEmpty account.name , String.isEmpty account.name , (a.name/=account.name && List.member account.name (List.map .name model.accounts)) )
-            _ -> ( False , False , False )
+    let
+        ( checkEmptyBtn, checkEmptyWarning, checkAlreadyUsedName ) =
+            case model.editAccount of
+                Nothing ->
+                    ( False, False, False )
 
-    modalClass = if model.ui.modalState == NoModal then "" else " show"
+                Just account ->
+                    case model.ui.modalState of
+                        NewAccount ->
+                            ( String.isEmpty account.name, False, List.member account.name (List.map .name model.accounts) )
 
-    (modalTitle, btnTxt, btnClass) = case model.ui.modalState of
-       NoModal       -> ( "" , "Save", "default")
-       NewAccount    -> ( "Create a new API account"             , "Create" , "success" )
-       EditAccount a -> ( "Update account '" ++ a.name ++ "'"    , "Update" , "success" )
-       Confirm Delete a call     -> ( "Delete API account '" ++ a ++ "'", "Confirm"  , "danger" )
-       Confirm Regenerate a call -> ( "Regenerate token of API account '" ++ a ++ "'", "Confirm", "primary")
+                        EditAccount a ->
+                            ( String.isEmpty account.name, String.isEmpty account.name, a.name /= account.name && List.member account.name (List.map .name model.accounts) )
 
-    (popupBody, saveAction, displayAcl) = case model.ui.modalState of
-      NoModal                  -> ( text "" , Ignore, False)
-      Confirm modalType a call ->
-        let
-          subTitle = case modalType of
-            Delete     -> "delete"
-            Regenerate -> "regenerate token of"
-        in
-          ( div[]
-            [ h4 [class "text-center"][text ("You are about to " ++ subTitle ++ " an API account.")]
-            , div [class "alert alert-warning"]
-              [ i [class "fa fa-exclamation-triangle"][]
-              , text "If you continue, any scripts using this will no longer be able to connect to Rudder's API."
-              ]
-            ]
-          , call
-          , False
-          )
-      _ ->
-        case model.editAccount of
-          Nothing -> ( text "" , Ignore, False )
-          Just account ->
-            let
-              datePickerValue = getDateString model.ui.datePickerInfo model.ui.datePickerInfo.pickedTime
-              (expirationDate, selectedDate) = case account.expirationDate of
-                Just d  -> (( if account.expirationDateDefined then (posixToString model.ui.datePickerInfo d) else "Never" ), d)
-                Nothing -> ("Never", (add Month 1 model.ui.datePickerInfo.zone model.ui.datePickerInfo.currentTime))
-              aclList = case account.acl of
-                Just l  -> l
-                Nothing -> []
+                        _ ->
+                            ( False, False, False )
 
-              displayWarningName =
-                if checkEmptyWarning then
-                  span[class "warning-info"] [i[class "fa fa-warning"][], text " This field is required"]
-                else if checkAlreadyUsedName then
-                  span[class "warning-info"] [i[class "fa fa-warning"][], text " This name is already used"]
-                else
-                  text ""
-            in
-              ( form [name "newAccount", class ("newAccount" ++ if SingleDatePicker.isOpen model.ui.datePickerInfo.picker then " datepicker-open" else "") ]
-                [ div [class ("form-group" ++ if checkEmptyWarning || checkAlreadyUsedName then " has-warning" else "")]
-                  [ label [for "newAccount-name"][text "Name", displayWarningName]
-                  , input [id "newAccount-name", type_ "text", class "form-control", value account.name, onInput (\s -> UpdateAccountForm {account | name = s} )][]
-                  ]
-                , div [class "form-group"]
-                  [ label [for "newAccount-description"][text "Description"]
-                  , textarea [id "newAccount-description", class "form-control vresize float-inherit", value account.description, onInput (\s -> UpdateAccountForm {account | description = s} )][]
-                  ]
-                , div [class "form-group"]
-                  [ label [for "newAccount-expiration", class "mb-1"]
-                    [ text "Expiration date"
-                    , label [for "selectDate", class "custom-toggle toggle-secondary"]
-                      [ input [type_ "checkbox", id "selectDate", checked account.expirationDateDefined, onCheck (\c ->  UpdateAccountForm {account | expirationDateDefined = c} )][]
-                      , label [for "selectDate", class "custom-toggle-group"]
-                        [ label [for "selectDate", class "toggle-enabled" ][text "Defined"]
-                        , span  [class "cursor"][]
-                        , label [for "selectDate", class "toggle-disabled"][text "Undefined"]
-                        ]
-                      ]
-                    , ( if checkIfExpired model.ui.datePickerInfo account then
-                        span[class "warning-info"][ i[class "fa fa-warning"][], text " Expiration date has passed"]
-                      else
-                        text ""
-                      )
-                    ]
-                  , div [ class "elm-datepicker-container" ]
-                    [ button [ type_ "button", class "form-control btn-datepicker", disabled (not account.expirationDateDefined), onClick (OpenPicker selectedDate), placeholder "Select an expiration date"]
-                      [ text expirationDate
-                      ]
-                    , SingleDatePicker.view (userDefinedDatePickerSettings model.ui.datePickerInfo.zone model.ui.datePickerInfo.currentTime selectedDate) model.ui.datePickerInfo.picker
-                    ]
-                  ]
-                , div [class "form-group"]
-                  [ label [for "newAccount-access"][text "Access level"]
-                  , select [id "newAccount-access", class "form-select", onInput (\s -> UpdateAccountForm {account | authorisationType = s} )]
-                    [ option [value "ro"  , selected (account.authorisationType == "ro"   )] [ text "Read only"   ]
-                    , option [value "rw"  , selected (account.authorisationType == "rw"   )] [ text "Full access" ]
-                    , option [value "acl" , selected (account.authorisationType == "acl"  ), disabled (not model.aclPluginEnabled) ] [ text ("Custom ACL" ++ if model.aclPluginEnabled then "" else " (Plugin needed)") ]
-                    ]
-                  ]
-                ]
-              , (CallApi (saveAccount account))
-              , account.authorisationType == "acl"
-              )
-  in
+        modalClass =
+            if model.ui.modalState == NoModal then
+                ""
+
+            else
+                " show"
+
+        ( modalTitle, btnTxt, btnClass ) =
+            case model.ui.modalState of
+                NoModal ->
+                    ( "", "Save", "default" )
+
+                NewAccount ->
+                    ( "Create a new API account", "Create", "success" )
+
+                EditAccount a ->
+                    ( "Update account '" ++ a.name ++ "'", "Update", "success" )
+
+                Confirm Delete a call ->
+                    ( "Delete API account '" ++ a ++ "'", "Confirm", "danger" )
+
+                Confirm Regenerate a call ->
+                    ( "Regenerate token of API account '" ++ a ++ "'", "Confirm", "primary" )
+
+        modalUI =
+            case model.ui.modalState of
+                NoModal ->
+                    ModalUI False False Ignore (text "")
+
+                Confirm modalType a call ->
+                    let
+                        subTitle =
+                            case modalType of
+                                Delete ->
+                                    "delete"
+
+                                Regenerate ->
+                                    "regenerate token of"
+                    in
+                    ModalUI False
+                        False
+                        call
+                        (div []
+                            [ h4 [ class "text-center" ] [ text ("You are about to " ++ subTitle ++ " an API account.") ]
+                            , div [ class "alert alert-warning" ]
+                                [ i [ class "fa fa-exclamation-triangle" ] []
+                                , text "If you continue, any scripts using this will no longer be able to connect to Rudder's API."
+                                ]
+                            ]
+                        )
+
+                _ ->
+                    case model.editAccount of
+                        Nothing ->
+                            ModalUI False False Ignore (text "")
+
+                        Just account ->
+                            let
+                                ( expirationDate, selectedDate ) =
+                                    case account.expirationDate of
+                                        Just d ->
+                                            ( if account.expirationDateDefined then
+                                                posixToString model.ui.datePickerInfo d
+
+                                              else
+                                                "Never"
+                                            , d
+                                            )
+
+                                        Nothing ->
+                                            ( "Never", add Month 1 model.ui.datePickerInfo.zone model.ui.datePickerInfo.currentTime )
+
+                                displayWarningName =
+                                    if checkEmptyWarning then
+                                        span [ class "warning-info" ] [ i [ class "fa fa-warning" ] [], text " This field is required" ]
+
+                                    else if checkAlreadyUsedName then
+                                        span [ class "warning-info" ] [ i [ class "fa fa-warning" ] [], text " This name is already used" ]
+
+                                    else
+                                        text ""
+
+                                -- if the plugin is disable, only show a read-only view of tenants. Else, it's an option among all, none, a list
+                                displayTenantAccess =
+                                    if model.tenantsPluginEnabled then
+                                        select [ id "newAccount-tenants", class "form-select", onInput (\s -> UpdateAccountForm { account | tenantMode = Tuple.first (parseTenants s) }) ]
+                                            [ option [ value "*", selected (account.tenantMode == AllAccess) ] [ text "Access to all tenants" ]
+                                            , option [ value "-", selected (account.tenantMode == NoAccess) ] [ text "Access to no tenant" ]
+                                            , option [ value "list", selected (account.tenantMode == ByTenants) ]
+                                                [ text
+                                                    ("Access to restricted list of tenants: "
+                                                        ++ (case account.selectedTenants of
+                                                                Just tenants ->
+                                                                    String.join ", " tenants
+
+                                                                Nothing ->
+                                                                    "-"
+                                                           )
+                                                    )
+                                                ]
+                                            ]
+
+                                    else
+                                        span [] [ text (": " ++ encodeTenants account.tenantMode account.selectedTenants) ]
+                            in
+                            ModalUI (account.authorisationType == "acl" && model.aclPluginEnabled)
+                                (account.tenantMode == ByTenants && model.tenantsPluginEnabled)
+                                (CallApi (saveAccount account))
+                                (form
+                                    [ name "newAccount"
+                                    , class
+                                        ("newAccount"
+                                            ++ (if SingleDatePicker.isOpen model.ui.datePickerInfo.picker then
+                                                    " datepicker-open"
+
+                                                else
+                                                    ""
+                                               )
+                                        )
+                                    ]
+                                    [ div
+                                        [ class
+                                            ("form-group"
+                                                ++ (if checkEmptyWarning || checkAlreadyUsedName then
+                                                        " has-warning"
+
+                                                    else
+                                                        ""
+                                                   )
+                                            )
+                                        ]
+                                        [ label [ for "newAccount-name" ] [ text "Name", displayWarningName ]
+                                        , input [ id "newAccount-name", type_ "text", class "form-control", value account.name, onInput (\s -> UpdateAccountForm { account | name = s }) ] []
+                                        ]
+                                    , div [ class "form-group" ]
+                                        [ label [ for "newAccount-description" ] [ text "Description" ]
+                                        , textarea [ id "newAccount-description", class "form-control vresize float-inherit", value account.description, onInput (\s -> UpdateAccountForm { account | description = s }) ] []
+                                        ]
+                                    , div [ class "form-group" ]
+                                        [ label [ for "newAccount-expiration", class "mb-1" ]
+                                            [ text "Expiration date"
+                                            , label [ for "selectDate", class "custom-toggle toggle-secondary" ]
+                                                [ input [ type_ "checkbox", id "selectDate", checked account.expirationDateDefined, onCheck (\c -> UpdateAccountForm { account | expirationDateDefined = c }) ] []
+                                                , label [ for "selectDate", class "custom-toggle-group" ]
+                                                    [ label [ for "selectDate", class "toggle-enabled" ] [ text "Defined" ]
+                                                    , span [ class "cursor" ] []
+                                                    , label [ for "selectDate", class "toggle-disabled" ] [ text "Undefined" ]
+                                                    ]
+                                                ]
+                                            , if checkIfExpired model.ui.datePickerInfo account then
+                                                span [ class "warning-info" ] [ i [ class "fa fa-warning" ] [], text " Expiration date has passed" ]
+
+                                              else
+                                                text ""
+                                            ]
+                                        , div [ class "elm-datepicker-container" ]
+                                            [ button [ type_ "button", class "form-control btn-datepicker", disabled (not account.expirationDateDefined), onClick (OpenPicker selectedDate), placeholder "Select an expiration date" ]
+                                                [ text expirationDate
+                                                ]
+                                            , SingleDatePicker.view (userDefinedDatePickerSettings model.ui.datePickerInfo.zone model.ui.datePickerInfo.currentTime selectedDate) model.ui.datePickerInfo.picker
+                                            ]
+                                        ]
+                                    , div [ class "form-group" ]
+                                        [ label [ for "newAccount-tenants" ] [ text "Access to tenants" ]
+                                        , displayTenantAccess
+                                        ]
+                                    , div [ class "form-group" ]
+                                        [ label [ for "newAccount-access" ] [ text "Access level" ]
+                                        , select [ id "newAccount-access", class "form-select", onInput (\s -> UpdateAccountForm { account | authorisationType = s }) ]
+                                            [ option [ value "ro", selected (account.authorisationType == "ro") ] [ text "Read only" ]
+                                            , option [ value "rw", selected (account.authorisationType == "rw") ] [ text "Full access" ]
+                                            , option [ value "acl", selected (account.authorisationType == "acl"), disabled (not model.aclPluginEnabled) ]
+                                                [ text
+                                                    ("Custom ACL"
+                                                        ++ (if model.aclPluginEnabled then
+                                                                ""
+
+                                                            else
+                                                                " (Plugin needed)"
+                                                           )
+                                                    )
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                )
+    in
     case model.ui.copyState of
-      NoCopy ->
-        div [class ("modal modal-account fade " ++ modalClass)]
-        [ div [class "modal-backdrop fade show", onClick (ToggleEditPopup NoModal)][]
-        , div [class "modal-dialog"]
-          [ div [class "modal-content"]
-            [ div [class "modal-header"]
-              [ h5 [class "modal-title"] [text modalTitle]
-              , button [type_ "button", class "btn-close", attribute "data-bs-dismiss" "modal", attribute "aria-label" "Close"][]
-              ]
-            , div [class "modal-body"]
-              [ popupBody
-                -- ACL plugin container
-              , div [id "apiauthorization-app", style "display" (if displayAcl then "block" else "none")]
-                [ div [id "apiauthorization-content"][]
-                ]
-              ]
-            , div [class "modal-footer"]
-              [ button [type_ "button", class "btn btn-default", onClick (ToggleEditPopup NoModal)] [ text "Close" ]
-              , button [type_ "button", class ("btn btn-" ++ btnClass), onClick saveAction, disabled (checkEmptyBtn || checkAlreadyUsedName) ][text btnTxt]
-              ]
-            ]
-          ]
-        ]
-      Token txt ->
-        -- Almost a modal as it is a notification that requires user interaction (copy)
-        div [class "modal fade show", style "display" "block"]
-        [ div [class "modal-backdrop fade show", onClick (CloseCopyPopup)][]
-        , div [class "modal-dialog"]
-          [ div [class "modal-content"]
-            [ div [class "modal-header"]
-              [ h5 [class "modal-title"] [text "Copy the token"]
-              , button [type_ "button", class "btn-close", attribute "data-bs-dismiss" "modal", attribute "aria-label" "Close", onClick (CloseCopyPopup)][]
-              ]
-            , div [class "modal-body"]
-              [ div[]
-                [ div [class "alert alert-info"]
-                  [ i [class "fa fa-exclamation-triangle"][]
-                  , text "This is the only time the token value will be available."
-                  ]
-                , div []
-                  [ span [class "token-txt"]
-                    [ text txt ]
-                  , a [ class "btn-goto always clipboard", title "Copy to clipboard", onClick (Copy txt) ]
-                    [ i [class "ion ion-clipboard"][] ]
-                  ]
-                ]
-              ]
-            , div [class "modal-footer"]
-              [button [type_ "button", class ("btn btn-success"), onClick (CloseCopyPopup) ][text "Close"]
-              ]
-            ]
-          ]
-        ]
+        NoCopy ->
+            div [ class ("modal modal-account fade " ++ modalClass) ]
+                [ div [ class "modal-backdrop fade show", onClick (ToggleEditPopup NoModal) ] []
+                , div [ class "modal-dialog" ]
+                    [ div [ class "modal-content" ]
+                        [ div [ class "modal-header" ]
+                            [ h5 [ class "modal-title" ] [ text modalTitle ]
+                            , button [ type_ "button", class "btn-close", attribute "data-bs-dismiss" "modal", attribute "aria-label" "Close" ] []
+                            ]
+                        , div [ class "modal-body" ]
+                            [ modalUI.body
 
+                            -- Tenants plugin container
+                            , div
+                                [ id "tenantapiaccounts-app"
+                                , style "display"
+                                    (if modalUI.displayTenants then
+                                        "block"
 
+                                     else
+                                        "none"
+                                    )
+                                ]
+                                [ if modalUI.displayTenants then
+                                    h4 [] [ text "Select tenants for account:" ]
+
+                                  else
+                                    text ""
+                                , div [ id "tenantapiaccounts-content" ] []
+                                ]
+
+                            -- ACL plugin container
+                            , div
+                                [ id "apiauthorization-app"
+                                , style "display"
+                                    (if modalUI.displayAcl then
+                                        "block"
+
+                                     else
+                                        "none"
+                                    )
+                                ]
+                                [ if modalUI.displayAcl then
+                                    h4 [] [ text "Select ACL for account:" ]
+
+                                  else
+                                    text ""
+                                , div [ id "apiauthorization-content" ] []
+                                ]
+                            ]
+                        , div [ class "modal-footer" ]
+                            [ button [ type_ "button", class "btn btn-default", onClick (ToggleEditPopup NoModal) ] [ text "Close" ]
+                            , button [ type_ "button", class ("btn btn-" ++ btnClass), onClick modalUI.saveAction, disabled (checkEmptyBtn || checkAlreadyUsedName) ] [ text btnTxt ]
+                            ]
+                        ]
+                    ]
+                ]
+
+        Token txt ->
+            -- Almost a modal as it is a notification that requires user interaction (copy)
+            div [ class "modal fade show", style "display" "block" ]
+                [ div [ class "modal-backdrop fade show", onClick CloseCopyPopup ] []
+                , div [ class "modal-dialog" ]
+                    [ div [ class "modal-content" ]
+                        [ div [ class "modal-header" ]
+                            [ h5 [ class "modal-title" ] [ text "Copy the token" ]
+                            , button [ type_ "button", class "btn-close", attribute "data-bs-dismiss" "modal", attribute "aria-label" "Close", onClick CloseCopyPopup ] []
+                            ]
+                        , div [ class "modal-body" ]
+                            [ div []
+                                [ div [ class "alert alert-info" ]
+                                    [ i [ class "fa fa-exclamation-triangle" ] []
+                                    , text "This is the only time the token value will be available."
+                                    ]
+                                , div []
+                                    [ span [ class "token-txt" ]
+                                        [ text txt ]
+                                    , a [ class "btn-goto always clipboard", title "Copy to clipboard", onClick (Copy txt) ]
+                                        [ i [ class "ion ion-clipboard" ] [] ]
+                                    ]
+                                ]
+                            ]
+                        , div [ class "modal-footer" ]
+                            [ button [ type_ "button", class "btn btn-success", onClick CloseCopyPopup ] [ text "Close" ]
+                            ]
+                        ]
+                    ]
+                ]

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/administration/apiManagement.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/administration/apiManagement.html
@@ -50,6 +50,7 @@
       });
     </script>
     <div id="acl-app"></div>
+    <div id="tenants-app"></div>
   </div>
 
   <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-accounts.js"></script>


### PR DESCRIPTION
https://issues.rudder.io/issues/24475

:warning: 
There is `a lot` of changes that are due to the use of `elm-format` which is extremely happy to give new lines everywhere. I think the result is a bit better, but hell, do they love spaces. You should really look at diff with `?w=1`.

That PR adds the infrastructure to be able to configure tenants for API account. 
The logic is similar to the `api-authorization` plugin: 
- on rudder core, we have check in place to see if the plugin is enable or not, 
- if the plugin is disable, we only diplay the current tenants for the account, in a non updatable way, 
- if the plugin is enable, the the user can change tenants. 

We have three kind of tenants: 
- `*` means "all tenants", and is the defaults for compat reason
- `-` meains "no tenants", and the poor accout won't be able to do much with nodes, 
- last option is a list of tenants. On that case, we display a list of selectable tenants with the details (description, doc, etc). 


There is the corresponding changes in backend for API parsing on post/put, diff event update, etc. Nothing fancy. 
In LDAP, we just have one attribute in API account, `apiTenants`, which is just the string for the chosen tenants (ie `*`, `-`, or `tenant1,tenant2,etc` - like for users in `rudder-users.xml`).

There is one thing that is really not cool: the ACL plugins is appending its content at the end of the modal, and so do that new plugin, because we need and existing anchor when the page is init to init the corresponding elm app. And the place where it would be logic to put the list of tenant (just below the select for tenant mode) does not always exist (and certainly not when the page is loaded). 


This is the UI when plugin is disabled: 
![image](https://github.com/Normation/rudder/assets/44649/a26a7371-785c-44a7-8ca2-593c5f323ee6)

And when it's enabled: 

![image](https://github.com/Normation/rudder/assets/44649/1b65fe7d-475b-4c26-863f-755415d6c344)


