### PR TITLE
Fixes #24528: Nodes tables height is too small

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -1356,6 +1356,7 @@ function reloadTable(gridId) {
 
 function createNodeTable(gridId, refresh) {
   var isResizing = false,
+    hasHandle = false,
     offsetBottom = 250;
 
   $(function () {
@@ -1365,6 +1366,9 @@ function createNodeTable(gridId, refresh) {
       bottom = $('.main-details > .table-container'),
       handle = $('#drag');
 
+    if (handle.length > 0) {
+      hasHandle = true;
+    }
     handle.on('mousedown', function (e) {
       isResizing = true;
       lastDownY = e.clientY;
@@ -1425,8 +1429,8 @@ function createNodeTable(gridId, refresh) {
     , "deferRender" : true
     , "destroy" : true
     , "pagingType": "full_numbers"
-    , "scrollCollapse": true
-    , "scrollY": "200px"
+    , "scrollCollapse": hasHandle
+    , "scrollY": hasHandle ? "200px" : null
     , "language": {
         "search": ""
     }

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.css
@@ -3,6 +3,10 @@
   line-height: 1.42857143;
 }
 
+#groupNodesTable_wrapper .dataTables_wrapper_top {
+  border-top : none;
+}
+
 /* <WRAPPER TOP> */
 .dataTables_wrapper_top,
 .dataTables_wrapper_bottom {

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
@@ -1069,15 +1069,17 @@ ul {
     margin-bottom: 5px;
     z-index: 10000;
     & > #drag {
-      position: absolute;
-      top: -4px;
-      left: 0;
-      right: 0;
-      height: 12px;
+      line-height: 6px;
+      font-size: 10px;
       cursor: ns-resize;
-
+      border-top: 1px $rudder-border-color-default solid;
+      text-align: center;
+      background-color: $rudder-bg-gray;
       &:active {
         cursor: ns-resize;
+      }
+      & > i.fa {
+        opacity : 0.4;
       }
     }
   }

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
@@ -134,7 +134,7 @@
     </div>
     </div>
     <div class="table-container">
-      <div id="drag"></div>
+      <div id="drag"><i class="fa fa-grip-lines"></i></div>
       <div id="group-shownodestable" class="main-table"></div>
     </div>
   </div>


### PR DESCRIPTION
https://issues.rudder.io/issues/24528

The `scrollY` and `scrollCollapse` datatable parameters set in https://github.com/Normation/rudder/pull/5470#issuecomment-2004165706 should be applied only on "resizable" tables which have a drag element.

Also, the drag element is now more visible in the group page : 
![Peek 2024-03-19 11-30](https://github.com/Normation/rudder/assets/65616064/74bc3454-b7e8-46d2-bcf3-5c769f980d21)
