### PR TITLE
Fixes #24466: when we search for a group in the search engine, the group page we arrive on is messed

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/Init.elm
@@ -7,7 +7,7 @@ import Groups.DataTypes exposing (..)
 import Compliance.DataTypes exposing (..)
 
 
-init : { contextPath : String, hasWriteRights : Bool } -> ( Model, Cmd Msg )
+init : { contextPath : String, hasGroupToDisplay : Bool, hasWriteRights : Bool } -> ( Model, Cmd Msg )
 init flags =
   let
     initCategory = Category "" "" "" (SubCategories []) []
@@ -17,7 +17,7 @@ init flags =
     initUI       = UI initFilters NoModal flags.hasWriteRights True
     initModel    = Model flags.contextPath Loading initUI initCategory Dict.empty
     listInitActions =
-      [ getGroupsTree initModel True
+      [ getGroupsTree initModel (not flags.hasGroupToDisplay)
       ]
   in
     ( initModel

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
@@ -142,6 +142,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
                |var main = document.getElementById("groups-app");
                |var initValues = {
                |  contextPath    : contextPath
+               |, hasGroupToDisplay : hasGroupToDisplay
                |, hasWriteRights : hasWriteRights
                |};
                |var app = Elm.Groups.init({node: main, flags: initValues});
@@ -232,13 +233,19 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
    * We want to look for #{ "groupId":"XXXXXXXXXXXX" } or #{"targer":"....."}
    */
   private[this] def parseJsArg(rootCategory: Box[FullNodeGroupCategory]): JsCmd = {
-    def displayDetailsGroup(groupId: String)     = {
+    def displayGroupNotFound:                     JsCmd = SetHtml(
+      htmlId_item,
+      <div class="jumbotron">
+        <h2>Group not found</h2>
+      </div>
+    )
+    def displayDetailsGroup(groupId: String):     JsCmd = {
       val gid = NodeGroupId(NodeGroupUid(groupId))
       rootCategory match {
-        case eb: EmptyBox => Noop
+        case eb: EmptyBox => displayGroupNotFound
         case Full(lib) =>
           lib.allGroups.get(gid) match {
-            case None                  => Noop
+            case None                  => displayGroupNotFound
             case Some(fullGroupTarget) => // so we also have its parent category
               // no modification, so no refreshGroupLib
               refreshTree(htmlTreeNodeId(groupId)) &
@@ -247,13 +254,13 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
           }
       }
     }
-    def displayDetailsTarget(targetName: String) = {
+    def displayDetailsTarget(targetName: String): JsCmd = {
       RuleTarget.unser(targetName) match {
         case Some(t: NonGroupRuleTarget) =>
           refreshTree(htmlTreeNodeId(targetName)) &
           showGroupSection(Left(t), NodeGroupCategoryId("SystemGroups")) &
           JsRaw("initBsTooltips()")
-        case _                           => Noop
+        case _                           => displayGroupNotFound
       }
     }
 
@@ -270,8 +277,10 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
         }
         if( groupId != null && groupId.length > 0) {
           ${SHtml.ajaxCall(JsVar("groupId"), displayDetailsGroup _)._2.toJsCmd};
+          hasGroupToDisplay = true;
         } else if( targetName != null && targetName.length > 0) {
           ${SHtml.ajaxCall(JsVar("targetName"), displayDetailsTarget _)._2.toJsCmd};
+          hasGroupToDisplay = true;
         }
     """)
   }

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
@@ -24,6 +24,7 @@
 <div data-lift="node.Groups.groupHierarchy"></div>
 
 <script>
+  var hasGroupToDisplay = false;
   var hasWriteRights = false;
 </script>
 <lift:authz role="rule_write">


### PR DESCRIPTION
https://issues.rudder.io/issues/24466

The Elm `Groups` app is initialized with the action to fetch the group compliance summary, but when it takes some time (e.g. response time within ~seconds, just `Thread.sleep` to reproduce the bug), it receives the data later.

Upon receiving the API response, Elm still appends the DOM that was associated with the response, i.e. the groups table, even if the server templating already took over and displayed a node details.

**Solution :**
Fetch the data for the table only when it is needed : the only case is when the groups page is rendered with an URI ending with `/groups`. When the URI ends with a hash e.g. `/groups#{"groupId":"..."}` we assume on Elm side that we don't need to fetch that data (and the server template will in place display "Group not found") 