### PR TITLE
Fixes #24381: Display of group compliance in group information should be on the right

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -182,7 +182,7 @@ class NodeGroupForm(
   def showForm(): NodeSeq = {
     val html = SHtml.ajaxForm(body)
 
-    nodeGroup match {
+    (nodeGroup match {
       case Left(target)                     =>
         showFormTarget(target)(html) ++ showRelatedRulesTree(target) ++ showGroupCompliance(target.target)
       case Right(group) if (group.isSystem) =>
@@ -193,7 +193,7 @@ class NodeGroupForm(
         showFormNodeGroup(group)(html) ++ showRelatedRulesTree(GroupTarget(group.id)) ++ showGroupCompliance(
           group.id.uid.value
         )
-    }
+    }) ++ Script(OnLoad(JsRaw(s"""new ClipboardJS('[data-clipboard-text]');""")))
   }
 
   private[this] def showRelatedRulesTree(target: RuleTarget): NodeSeq = {
@@ -288,7 +288,14 @@ class NodeGroupForm(
       & "group-name" #> groupName.toForm_!
       & "group-rudderid" #> <div class="form-group">
                       <label class="wbBaseFieldLabel">Group ID</label>
-                      <input readonly="" class="form-control" value={nodeGroup.id.serialize}/>
+                      <div class="position-relative align-items-center">
+                        <input readonly="" class="form-control" value={nodeGroup.id.serialize}/>
+                          <a class="my-2 mx-3 position-absolute end-0 top-0" title="Copy to clipboard" data-clipboard-text={
+        nodeGroup.id.serialize
+      }>
+                            <i class="fa fa-clipboard"></i>
+                        </a>
+                      </div>
                     </div>
       & "group-cfeclasses" #> <div class="form-group">
                           <label class="wbBaseFieldLabel toggle-cond cond-hidden" onclick="$(this).toggleClass('cond-hidden')"><span class="text-fit">Agent conditions</span><i class="fa fa-chevron-down"></i></label>
@@ -345,7 +352,6 @@ class NodeGroupForm(
         ".groupTargetedComplianceProgressBar",
         loadComplianceBar(false)
       )
-      & ".id-value *" #> nodeGroup.id.serialize
     )
   }
 
@@ -366,7 +372,14 @@ class NodeGroupForm(
                          </ul>
     & "group-rudderid" #> <div>
                     <label class="wbBaseFieldLabel">Group ID</label>
-                    <input readonly="" class="form-control" value={target.target}/>
+                    <div class="position-relative align-items-center">
+                      <input readonly="" class="form-control" value={target.target}/>
+                        <a class="my-2 mx-3 position-absolute end-0 top-0" title="Copy to clipboard" data-clipboard-text={
+      target.target
+    }>
+                          <i class="fa fa-clipboard"></i>
+                      </a>
+                    </div>
                   </div>
     & "group-cfeclasses" #> NodeSeq.Empty
     & "#longDescriptionField" #> (groupDescription.toForm_! ++ Script(
@@ -391,9 +404,7 @@ class NodeGroupForm(
     & ".groupTargetedComplianceProgressBar *" #> showComplianceForGroup(
       ".groupTargetedComplianceProgressBar",
       loadComplianceBar(false)
-    )
-    & ".id-label" #> NodeSeq.Empty
-    & ".id-container" #> NodeSeq.Empty)
+    ))
   }
 
   def showGroupProperties(group: NodeGroup): NodeSeq = {
@@ -537,7 +548,7 @@ class NodeGroupForm(
     (categoryHierarchyDisplayer.getCategoriesHierarchy(rootCategory, None).map { case (id, name) => (id.value -> name) }),
     parentCategoryId.value
   ) {
-    override def className             = "form-select"
+    override def className             = "form-select w-100"
     override def labelClassName        = ""
     override def subContainerClassName = ""
   }

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
@@ -66,7 +66,7 @@
   </div>
   <div class="main-details">
     <div class="tab-content tab-content-split">
-      <div id="groupParametersTab" class="tab-pane active main-form">
+      <div id="groupParametersTab" class="tab-pane active main-form row d-flex">
         <div class="col-12 col-md-6 col-xl-7">
           <div class="main-form">
             <group-notifications ></group-notifications>
@@ -108,11 +108,6 @@
                 Targeted compliance
               </label>
               <div class="groupTargetedComplianceProgressBar"></div>
-            </div>
-            <label class="id-label">Group ID</label>
-            <div class="id-container">
-              <p class="id-value">The node group id</p>
-              <i class="ion ion-clipboard clipboard-icon"></i>
             </div>
           </div>
         </div>


### PR DESCRIPTION
https://issues.rudder.io/issues/24381

New screenshot : 
![image](https://github.com/Normation/rudder/assets/65616064/64ab2a06-ed99-48ce-b9e1-b4832b1af5bf)

* The tab display needs to be flex to have the compliance on the right side
* The group ID was in duplication, we keep the one on the left-side and add the clipboard icon to it
* The category select dropdown didn't have a full width  
* (sorry for the empty compliance in the screenshot, I didn't setup any)