### PR TITLE
Fixes #24489: Group page UI is missing several key things

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/DataTypes.elm
@@ -121,6 +121,7 @@ rootGroupCategoryId = "GroupRoot"
 type Msg
   = OpenModal
   | CloseModal
+  | LoadGroupTable
   | LoadMore
   | OpenGroupDetails GroupId
   | OpenCategoryDetails String

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
@@ -109,6 +109,7 @@ class NodeGroupCategoryForm(
             </h1>
             <lift:authz role="group_edit">
               <div class="header-buttons">
+                <directive-close></directive-close>
                 <lift:authz role="node_write">
                   <directive-delete></directive-delete>
                   <directive-save></directive-save>
@@ -130,7 +131,7 @@ class NodeGroupCategoryForm(
             <directive-name></directive-name>
             <directive-description></directive-description>
             <directive-container></directive-container>
-            <div class="form-group row">
+            <div class="form-group">
               <label class="wbBaseFieldLabel">Group category ID</label>
               <input readonly="" class="form-control" value={nodeGroupCategory.id.value}/>
             </div>
@@ -152,7 +153,7 @@ class NodeGroupCategoryForm(
              & "directive-save" #> SHtml.ajaxSubmit("Update", onSubmit _, ("class", "btn btn-success"))
              & "directive-delete" #> deleteButton
            )
-         } else
+         } else {
            (
              "directive-save" #> (
                if (CurrentUser.checkRights(AuthorizationType.Group.Edit))
@@ -163,7 +164,16 @@ class NodeGroupCategoryForm(
                if (CurrentUser.checkRights(AuthorizationType.Group.Write)) deleteButton
                else NodeSeq.Empty
              )
-           ))
+           )
+         })
+      & "directive-close" #> (
+        <button class="btn btn-default" onclick={
+          s"""$$('#${htmlIdCategory}').trigger("group-close-detail")"""
+        }>
+          Close
+          <i class="fa fa-times"></i>
+        </button>
+      )
     )(html)
   }
 
@@ -278,7 +288,7 @@ class NodeGroupCategoryForm(
         },
         parentCategoryId
       ) {
-        override def className             = "form-select"
+        override def className             = "form-select w-100"
         override def labelClassName        = ""
         override def subContainerClassName = ""
         override def validations           =

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -310,6 +310,13 @@ class NodeGroupForm(
       & "group-container" #> groupContainer.toForm_!
       & "group-static" #> groupStatic.toForm_!
       & "group-showgroup" #> nodes
+      & "group-close" #>
+      <button class="btn btn-default" onclick={
+        s"""$$('#${htmlIdCategory}').trigger("group-close-detail")"""
+      }>
+        Close
+        <i class="fa fa-times"></i>
+      </button>
       & "group-clone" #> {
         if (CurrentUser.checkRights(AuthorizationType.Group.Write)) {
           SHtml.ajaxButton(
@@ -333,7 +340,7 @@ class NodeGroupForm(
         } else NodeSeq.Empty
       }
       & "group-delete" #> SHtml.ajaxButton(
-        <span>Delete <i class="fa fa-times-circle"></i></span>,
+        <span>Delete <i class="fa fa-trash"></i></span>,
         () => onSubmitDelete(),
         ("class" -> " btn btn-danger btn-icon")
       )
@@ -389,6 +396,13 @@ class NodeGroupForm(
     & "group-static" #> NodeSeq.Empty
     & "group-showgroup" #> NodeSeq.Empty
     & "group-clone" #> NodeSeq.Empty
+    & "group-close" #>
+    <button class="btn btn-default" onclick={
+      s"""$$('#${htmlIdCategory}').trigger("group-close-detail")"""
+    }>
+      Close
+      <i class="fa fa-times"></i>
+    </button>
     & "group-save" #> NodeSeq.Empty
     & "group-delete" #> NodeSeq.Empty
     & "group-notifications" #> NodeSeq.Empty

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/model/RudderBaseField.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/model/RudderBaseField.scala
@@ -148,7 +148,7 @@ abstract class RudderBaseField extends BaseField {
   def className:             String                = "rudderBaseFieldClassName form-control vresize col-xl-12 col-md-12"
   // def labelClassName : String = "threeCol"
   def containerClassName:    String                = ""
-  def labelClassName:        String                = "col-xl-3 col-md-12 col-sm-12 text-end"
+  def labelClassName:        String                = "col-xl-3 col-md-12 col-sm-12"
   def errorClassName:        String                = "col-xl-9 col-xl-offset-3 col-md-12 col-sm-12 col-sm-offset-0 col-md-offset-0"
   def inputAttributes:       Seq[(String, String)] = Seq.empty
   ///////// method to optionnaly override //////////

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
@@ -196,6 +196,11 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
                |$$("#createCloneGroupPopup").on("hidden.bs.modal", function () {
                |  app.ports.closeModal.send(null)
                |});
+               |// When custom event to close group details fires, we load the group table state in the Elm app
+               |$$("#${htmlId_item}").on("group-close-detail", function () { 
+               |  $$("#${htmlId_item} .main-container").hide(); // guarantee to hide details
+               |  app.ports.loadGroupTable.send(null)
+               |});
                |
                |// Initialize tooltips
                |app.ports.initTooltips.subscribe(function(msg) {

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-groups.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-groups.scss
@@ -34,6 +34,10 @@
 *************************************************************************************
 */
 
+.main-table table tbody > tr {
+  cursor: pointer;
+}
+
 .rudder-template .header-title h1 .group-system:before,
 .rudder-template .header-title h1 .group-system:after{
   margin-left: 8px;

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
@@ -24,6 +24,7 @@
 <div data-lift="node.Groups.groupHierarchy"></div>
 
 <script>
+  var groupCloseEvent = new Event("group-close-detail");
   var hasWriteRights = false;
 </script>
 <lift:authz role="rule_write">

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
@@ -38,6 +38,7 @@
       </h1>
       <lift:authz role="group_edit">
         <div class="header-buttons">
+          <group-close></group-close>
           <lift:authz role="group_write"><group-delete></group-delete></lift:authz>
           <lift:authz role="group_write"><group-clone></group-clone></lift:authz>
           <group-save></group-save>


### PR DESCRIPTION
https://issues.rudder.io/issues/24489
![image](https://github.com/Normation/rudder/assets/65616064/cb7eef5a-ed74-4e63-be61-42fd9a410eee)

* We now have the `Close` button to return on home groups page (since it's diplayed in Elm we need a custom HTML event to conveniently trigger a Elm port for that)
* The new group creation page no longer has label alignment issues (remove `text-end` class)
* The groups table now appears "clickable" on every row, it always redirects to the group details 
* System groups "category" field needed a `w-100` class for full width and consistency between system and non-system groups