### PR TITLE
Fixes #24408: Button for archiving/deleting reports is not visible

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DatabaseManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DatabaseManagement.scala
@@ -179,8 +179,9 @@ class DatabaseManagement extends DispatchSnippet with Loggable {
       JsRaw(""" $('#archiveReports').show();
                 $('#cleanParam').show(); """)
     }
-
-    val dialog = {
+    val btnClass = if (action.name == "archive") { "btn-primary" }
+    else { "btn-danger" }
+    val dialog   = {
       <div class="callout-fade callout-info">
         <div class="marker"><span class="fa fa-exclamation-triangle"></span></div>
         Are you sure you want to
@@ -202,7 +203,7 @@ class DatabaseManagement extends DispatchSnippet with Loggable {
             JsRaw("""$('#cleanResultText').html('%s, you can see more details in the webapp log file (<span class="text-bold">/var/log/rudder/core/rudder-webapp.log</span>)');
                  $('#cleanResult').show();""".format(askResult)) & cancel & updateValue
           },
-          ("class", "btn btn-action")
+          ("class", ("btn " ++ btnClass))
         )
       }
         </div>


### PR DESCRIPTION
https://issues.rudder.io/issues/24408

Result :
![archive-btn](https://github.com/Normation/rudder/assets/9928447/4ec55d1b-b7b4-4b53-b84e-5c6e549d517a)
