### PR TITLE
Fixes #24295: API export of groups doesn't export the categories as dependencies

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
@@ -207,6 +207,8 @@ trait RoNodeGroupRepository {
    */
   def getFullGroupLibrary(): IOResult[FullNodeGroupCategory]
 
+  def categoryExists(id: NodeGroupCategoryId): IOResult[Boolean]
+
   /**
    * Get a server group by its id. Fail if not present.
    * @param id

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
@@ -282,6 +282,13 @@ class RoLDAPNodeGroupRepository(
     else getParentGroupCategory(id).flatMap(parent => getParentsForCategory(parent.id, root).map(parents => parent :: parents))
   }
 
+  override def categoryExists(id: NodeGroupCategoryId): IOResult[Boolean] = {
+    for {
+      con           <- ldap
+      categoryEntry <- groupLibMutex.readLock(getCategoryEntry(con, id, "dn"))
+    } yield categoryEntry.nonEmpty
+  }
+
   /**
    * Get a group category by its id
    * */

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
@@ -15,7 +15,7 @@ response:
             "id":"0000f5d3-8c61-4d20-88a7-bb947705ba8a",
             "displayName":"Real nodes",
             "description":"",
-            "category":"GroupRoot",
+            "category":"category1",
             "query":{
               "select":"nodeAndPolicyServer",
               "composition":"or",
@@ -245,7 +245,7 @@ response:
             "id":"0000f5d3-8c61-4d20-88a7-bb947705ba8a",
             "displayName":"Real nodes",
             "description":"",
-            "category":"GroupRoot",
+            "category":"category1",
             "query":{
               "select":"nodeAndPolicyServer",
               "composition":"or",
@@ -1329,7 +1329,7 @@ response:
             "219b9c98-3d1e-44c9-aff5-95b4fc7c4ada"
           ],
           "groups":[
-
+            "0000f5d3-8c61-4d20-88a7-bb947705ba8a"
           ],
           "targets":[]
         }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -2345,6 +2345,10 @@ class MockNodeGroups(nodesRepo: MockNodes) {
       .make(FullNodeGroupCategory(NodeGroupCategoryId("GroupRoot"), "GroupRoot", "root of group categories", Nil, Nil, true))
       .runNow
 
+    override def categoryExists(id: NodeGroupCategoryId): IOResult[Boolean] = {
+      categories.get.map(_.allCategories.keySet.contains(id))
+    }
+
     override def getFullGroupLibrary(): IOResult[FullNodeGroupCategory] = categories.get
 
     override def getNodeGroupOpt(id: NodeGroupId):      IOResult[Option[(NodeGroup, NodeGroupCategoryId)]] = {
@@ -2802,24 +2806,19 @@ class MockNodeGroups(nodesRepo: MockNodes) {
     nodesRepo.nodeIds.filter(_.value.toInt % 5 == 0),
     true
   )
-  val groups: Set[(NodeGroupId, NodeGroup)] = Set(g0, g1, g2, g3, g4, g5, g6).map(g => (g.id, g))
+  val groups: Seq[(NodeGroupId, NodeGroup)] = List(g0, g1, g2, g3, g4, g5, g6).map(g => (g.id, g))
 
-  val groupsTargets: Set[(GroupTarget, NodeGroup)] = groups.map { case (id, g) => (GroupTarget(g.id), g) }
+  val groupsTargets: Seq[(GroupTarget, NodeGroup)] = groups.map { case (id, g) => (GroupTarget(g.id), g) }
 
-  val groupsTargetInfos: Map[NodeGroupId, FullRuleTargetInfo] = (groupsTargets
-    .map(gt => {
-      (
-        gt._1.groupId,
-        FullRuleTargetInfo(
-          FullGroupTarget(gt._1, gt._2),
-          "",
-          "",
-          true,
-          false
-        )
-      )
-    }))
-    .toMap
+  val groupsTargetInfos: Seq[FullRuleTargetInfo] = groupsTargets.map { gt =>
+    FullRuleTargetInfo(
+      FullGroupTarget(gt._1, gt._2),
+      "",
+      "",
+      true,
+      false
+    )
+  }
 
   val groupLib: FullNodeGroupCategory = FullNodeGroupCategory(
     NodeGroupCategoryId("GroupRoot"),
@@ -2831,7 +2830,7 @@ class MockNodeGroups(nodesRepo: MockNodes) {
         "category 1",
         "the first category",
         Nil,
-        Nil,
+        List(groupsTargetInfos.head), // that g0 id:0000f5d3-8c61-4d20-88a7-bb947705ba8
         false
       )
     ),
@@ -2877,7 +2876,8 @@ class MockNodeGroups(nodesRepo: MockNodes) {
         true,
         true
       )
-    ) ++ groupsTargetInfos.valuesIterator,
+      // exclude g0 that is already in subcat category1
+    ) ++ groupsTargetInfos.drop(1),
     true
   )
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -868,7 +868,8 @@ class RestTestSetUp {
     val archiveBuilderService = new ZipArchiveBuilderService(
       new FileArchiveNameService(),
       mockConfigRepo.configurationRepository,
-      mockTechniques.techniqueRevisionRepo
+      mockTechniques.techniqueRevisionRepo,
+      mockNodeGroups.groupsRepo
     )
     val featureSwitchState: Ref[FeatureSwitch] = Ref.make[FeatureSwitch](FeatureSwitch.Disabled).runNow
     // archive name in a Ref to make it simple to change in tests

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1981,8 +1981,14 @@ object RudderConfigInit {
     }
 
     lazy val archiveApi = {
-      val archiveBuilderService =
-        new ZipArchiveBuilderService(new FileArchiveNameService(), configurationRepository, gitParseTechniqueLibrary)
+      val archiveBuilderService = {
+        new ZipArchiveBuilderService(
+          new FileArchiveNameService(),
+          configurationRepository,
+          gitParseTechniqueLibrary,
+          roLdapNodeGroupRepository
+        )
+      }
       // fixe archive name to make it simple to test
       val rootDirName           = "archive".succeed
       new com.normation.rudder.rest.lift.ArchiveApi(


### PR DESCRIPTION
https://issues.rudder.io/issues/24295

The chosen new mapping is one that match the LDAP/UI representation of group categories and groups:

```
archive/
 `- groups
      |- category_with_name
      |     |- category.json // the category info: uuid, name, etc
      |     `- some_group.json // the group as before
      `- some_group_under_root_category.json
```

This mapping is so-so, since the group serialisation also contains the group category id, so we duplicate the information, and if we move a group, it doesn't actually change its category, which is surprising. But I wanted to have the same json serialisation than the one from API.

I hesitated with a mappring like:

```
archive/
 |- group-categories.json // one big json will the categories 
 `- groups
      |- some_group.json // the group as before
      `- some_group_under_root_category.json
``` 

But it was strang to have a mixe of "one item for each groups" and "one big json with lots of categories".
Still, maybe it would be easier to manipulate.