### PR TITLE
Fixes #24586: Compilation output tab icon in technique is not aligned

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
@@ -339,7 +339,7 @@ showTechnique model technique origin ui editInfo =
             li [ class (activeTabClass Output)  , onClick (SwitchTab Output)] [
               a [] [
                 text "Compilation output "
-              , span [  class  ( "fa ") ] []
+              , span [  class  ( "fas fa-cogs ") ] []
               ]
             ]
             else


### PR DESCRIPTION
https://issues.rudder.io/issues/24586
I changed the icon too, a check mark was misleading since this is error compilation
![image](https://github.com/Normation/rudder/assets/23410978/eb420a96-192c-4283-991a-89b66232ad49)
