### PR TITLE
Fixes #24498: There is no easy way to copy a property/inventory variable name to clipboard

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/View.elm
@@ -102,8 +102,10 @@ view model =
                 [ thead[]
                   [ tr [class "head"]
                     [ th [class (thClass model.ui.filters Name   ), onClick (UpdateTableFilters (sortTable filters Name   ))][ text "Name"   ]
+                    , th [ (class " col")][] -- column for copy to clipboard property name
                     , th [class (thClass model.ui.filters Format ), onClick (UpdateTableFilters (sortTable filters Format ))][ text "Format" ]
-                    , th [class (thClass model.ui.filters Value  ), onClick (UpdateTableFilters (sortTable filters Value  ))][ text "Value"  ]
+                    , th [class (thClass model.ui.filters Value ++ (" col-8")), onClick (UpdateTableFilters (sortTable filters Value  ))][ text "Value"  ]
+                    , th [][] -- column for copy to clipboard property value
                     , th[class "sorting"] [text "Actions" ]
                     ]
                   ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ViewUtils.elm
@@ -208,17 +208,19 @@ displayNodePropertyRow model =
         case editedProperty of
           Nothing ->
             tr []
-            [ td []
+            [ td [class "property-name"]
               [ div[]
                 [ text p.name
                 , providerBadge
                 ]
               ]
             , td []
+              [ span [class "ion ion-clipboard copy-actions", onClick (Copy  p.name)][]
+              ]
+            , td [class "property-type"]
               [ div []
-                [ 
-                    text formatTxt 
-                  , formatConflict
+                [ text formatTxt
+                , formatConflict
                 ]
               ]
             , td [class "property-value"]
@@ -235,10 +237,10 @@ displayNodePropertyRow model =
                       pre [class "json-beautify"][text (displayJsonValue p.value)]
                   ]
                 , span [class "toggle-icon"][]
-                , button [class "btn btn-xs btn-default btn-clipboard", title "Copy to clipboard", onClick (Copy (displayJsonValue p.value))]
-                  [ i [class "ion ion-clipboard"][]
-                  ]
                 ]
+              ]
+            , td []
+              [ span [class "ion ion-clipboard copy-actions", onClick (Copy (displayJsonValue p.value))][]
               ]
             , td [class "text-center default-actions"]
               [ (if (editRight) then
@@ -271,6 +273,7 @@ displayNodePropertyRow model =
                 , ( if checkFormatConflict then small [class "text-danger"][text "The selected format will conflict with some existing format of the same property"] else text "" )
                 ]
               ]
+            , td [][] -- empty column to clipboard icon for property name
             , td [class "is-edited"]
               [ div [class "format-container"]
                 [ button [type_ "button", class "btn btn-default dropdown-toggle", attribute "data-bs-toggle" "dropdown"]

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -1005,18 +1005,19 @@ object DisplayNode extends Loggable {
   def displayTabInventoryVariable(jsId: JsNodeId, node: CoreNodeFact, sm: FullInventory): NodeSeq = {
     def displayLine(name: String, value: String): NodeSeq = {
       <tr>
-        <td>{name}<button class="btn btn-xs btn-default btn-clipboard" data-clipboard-text={
-        s"""$${node.inventory[${name}]"""
-      }><i class="ion ion-clipboard"></i></button></td>
+        <td>{name}</td>
+        <td>
+          <span class="ion ion-clipboard copy-actions" data-clipboard-text={s"""$${node.inventory[${name}]}"""}></span>
+        </td>
         {
         if (value.strip().isEmpty) {
           <td></td>
         } else {
           <td>
             <pre class="json-inventory-vars">{value}</pre>
-            <button class="btn btn-xs btn-default btn-clipboard" data-clipboard-text={value}>
-              <i class="ion ion-clipboard"></i>
-            </button>
+          </td>
+          <td>
+            <span class="ion ion-clipboard copy-actions" data-clipboard-text={value}></span>
           </td>
         }
       }
@@ -1060,11 +1061,13 @@ object DisplayNode extends Loggable {
         <div class="alert alert-info">
           These are the node inventory variables that can be used in directive inputs with the <b class="code">${{node.inventory[NAME]}}</b> syntax.
         </div>
-        <table class="no-footer dataTable">
+        <table id="inventoryVariablesTab" class="no-footer dataTable">
           <thead>
             <tr class="head">
               <th class="sorting sorting_desc">Name</th>
+              <th></th>
               <th class="sorting">Value</th>
+              <th></th>
             </tr>
           </thead>
           <tbody>

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.css
@@ -445,6 +445,23 @@ td.listclose:after {
   opacity: 1;
 }
 
+.copy-actions {
+  cursor: pointer;
+}
+#nodePropertiesTab > tbody > tr > td > span.copy-actions{
+  opacity:0;
+}
+#nodePropertiesTab > tbody > tr:hover > td > span.copy-actions{
+  opacity: 1;
+}
+
+#inventoryVariablesTab > tbody > tr > td > span.copy-actions{
+  opacity:0;
+}
+#inventoryVariablesTab > tbody > tr:hover > td > span.copy-actions{
+  opacity: 1;
+}
+
 #nodePropertiesTab th:first-child{
   width: 20% !important;
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/24498
V2 (last edit)
![copy-to-clipboard-v2](https://github.com/Normation/rudder/assets/23410978/578f1fb7-a04d-4ae0-8b4c-5569b9e9b270)

-----------------
![property_clipboard](https://github.com/Normation/rudder/assets/23410978/86f706e3-45b8-460c-917a-5110559c4213)
![image](https://github.com/Normation/rudder/assets/23410978/198bd9df-e512-4807-b0cc-4994d2602025)
![image](https://github.com/Normation/rudder/assets/23410978/7b292d44-ac96-4295-8656-556172ac0bb0)
![image](https://github.com/Normation/rudder/assets/23410978/4b0a820a-72a3-40ef-9e39-813509d2c8d6)
![image](https://github.com/Normation/rudder/assets/23410978/44e02038-ba40-4066-bcee-231b95d1439b)
![image](https://github.com/Normation/rudder/assets/23410978/24e87725-6185-4a24-bac2-98a39a447c78)

