### PR TITLE
Fixes #24592: Allow technique id starting with a number

### DIFF
--- a/policies/rudderc/src/backends/unix.rs
+++ b/policies/rudderc/src/backends/unix.rs
@@ -15,7 +15,7 @@ use crate::{
     ir::{
         self,
         condition::Condition,
-        technique::{Id, ItemKind},
+        technique::{ItemKind, TechniqueId},
     },
 };
 
@@ -40,7 +40,7 @@ impl Unix {
     }
 
     /// To call the technique in standalone policies
-    fn prelude(technique_id: Id, params: Vec<String>) -> String {
+    fn prelude(technique_id: TechniqueId, params: Vec<String>) -> String {
         // Static content including parts of the system techniques required to run most techniques,
         // i.e. lib loading and global vars (`g.X`).
         let static_prelude = include_str!("unix/prelude.cf");
@@ -76,7 +76,7 @@ impl Backend for Unix {
         fn resolve_module(
             r: ItemKind,
             context: Condition,
-            technique_id: &Id,
+            technique_id: &TechniqueId,
         ) -> Result<Vec<(Promise, Bundle)>> {
             match r {
                 ItemKind::Block(r) => {

--- a/policies/rudderc/src/backends/unix/ncf/method_call.rs
+++ b/policies/rudderc/src/backends/unix/ncf/method_call.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     ir::{
         condition::Condition,
-        technique::{Id, LeafReportingMode, Method},
+        technique::{LeafReportingMode, Method, TechniqueId},
     },
 };
 
@@ -31,7 +31,7 @@ use crate::{
 ///
 /// Plus a calling `Promise`
 pub fn method_call(
-    technique_id: &Id,
+    technique_id: &TechniqueId,
     m: Method,
     condition: Condition,
 ) -> Result<(Promise, Bundle)> {

--- a/policies/rudderc/src/technique.schema.json
+++ b/policies/rudderc/src/technique.schema.json
@@ -19,10 +19,10 @@
     "id": {
       "type": "string",
       "title": "id",
-      "description": "Technique id, must match the '^[a-zA-Z][a-zA-Z0-9_]+$' pattern",
-      "markdownDescription": "```Mandatory```\n\nTechnique id, must respect the ```^[a-zA-Z][a-zA-Z0-9_]+$``` pattern.\n\nUsed implicitly in technique parameters and resource folder variable definitions:\n\n* ```${<technique_id>.<parameter_name>}```\n* ```${<technique_id>.resources_dir}```",
-      "pattern": "^[a-zA-Z][a-zA-Z0-9_]+$",
-      "default": "my_new_technique",
+      "description": "Technique, must match the '^[a-zA-Z0-9_]+$' pattern",
+      "markdownDescription": "```Mandatory```\n\nTechnique id, must respect the ```^[a-zA-Z0-9_]+$``` pattern.\n\nUsed implicitly in technique parameters and resource folder variable definitions:\n\n* ```${<technique_id>.<parameter_name>}```\n* ```${<technique_id>.resources_dir}```",
+      "pattern": "^[a-zA-Z0-9_]+$",
+      "default": "my_technique",
       "examples": [
         "my_new_technique"
       ]

--- a/policies/rudderc/templates/technique.ps1.askama
+++ b/policies/rudderc/templates/technique.ps1.askama
@@ -1,5 +1,5 @@
 {#- Syntax: https://djc.github.io/askama/template_syntax.html -#}
-function {{ id|dsc_case }} {
+function Technique-{{ id|dsc_case }} {
     [CmdletBinding()]
     param (
         [parameter(Mandatory = $true)]

--- a/policies/rudderc/tests/cases/general/escaping/technique.ps1
+++ b/policies/rudderc/tests/cases/general/escaping/technique.ps1
@@ -1,4 +1,4 @@
-﻿function Escaping {
+﻿function Technique-Escaping {
     [CmdletBinding()]
     param (
         [parameter(Mandatory = $true)]

--- a/policies/rudderc/tests/cases/general/form/technique.ps1
+++ b/policies/rudderc/tests/cases/general/form/technique.ps1
@@ -1,4 +1,4 @@
-﻿function Form {
+﻿function Technique-Form {
     [CmdletBinding()]
     param (
         [parameter(Mandatory = $true)]

--- a/policies/rudderc/tests/cases/general/long_method_param_name/technique.ps1
+++ b/policies/rudderc/tests/cases/general/long_method_param_name/technique.ps1
@@ -1,4 +1,4 @@
-﻿function Windows-Long-Param-Names {
+﻿function Technique-Windows-Long-Param-Names {
     [CmdletBinding()]
     param (
         [parameter(Mandatory = $true)]

--- a/policies/rudderc/tests/cases/general/min/technique.ps1
+++ b/policies/rudderc/tests/cases/general/min/technique.ps1
@@ -1,4 +1,4 @@
-﻿function Min {
+﻿function Technique-Min {
     [CmdletBinding()]
     param (
         [parameter(Mandatory = $true)]

--- a/policies/rudderc/tests/cases/general/ntp/technique.ps1
+++ b/policies/rudderc/tests/cases/general/ntp/technique.ps1
@@ -1,4 +1,4 @@
-﻿function Ntp-Technique {
+﻿function Technique-Ntp-Technique {
     [CmdletBinding()]
     param (
         [parameter(Mandatory = $true)]

--- a/policies/rudderc/tests/cases/general/param_in_condition/technique.ps1
+++ b/policies/rudderc/tests/cases/general/param_in_condition/technique.ps1
@@ -1,4 +1,4 @@
-﻿function Param-In-Condition {
+﻿function Technique-Param-In-Condition {
     [CmdletBinding()]
     param (
         [parameter(Mandatory = $true)]

--- a/policies/rudderc/tests/cases/general/reporting/technique.ps1
+++ b/policies/rudderc/tests/cases/general/reporting/technique.ps1
@@ -1,4 +1,4 @@
-﻿function Reporting {
+﻿function Technique-Reporting {
     [CmdletBinding()]
     param (
         [parameter(Mandatory = $true)]

--- a/policies/rudderc/tests/compile.rs
+++ b/policies/rudderc/tests/compile.rs
@@ -59,7 +59,7 @@ fn compile_metadata(methods: &'static Methods, input: &str, source: &Path) {
     //std::fs::write(&ref_file, &output).unwrap();
 
     let reference = read_to_string(ref_file).unwrap();
-    assert_eq!(reference, output);
+    assert_eq!(reference.trim(), output.trim());
 }
 
 /// Compile the given source file with the given target. Panics if compilation fails.
@@ -73,5 +73,5 @@ fn compile_file(methods: &'static Methods, input: &str, source: &Path, target: T
     //std::fs::write(&ref_file, &output).unwrap();
 
     let reference = read_to_string(ref_file).unwrap();
-    assert_eq!(reference, output);
+    assert_eq!(reference.trim(), output.trim());
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/24592

* Create a separate type for technique id as the constraints are different
* Modify the schema accordingly
* Add a `Technique-` prefix to all Windows techniques (for consistency, I prefer to avoid a "surprise" prefix in corner cases).