### PR TITLE
Fixes #24547: When the group tab section is too large it cannot be scrolled

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -1397,6 +1397,9 @@ function createNodeTable(gridId, refresh) {
       isResizing = false;
       return false;
     });
+
+    // we need to assign an initial bottom to the top and bottom elements in order to make them initially scrollable
+    top.css('bottom', Math.max(bottom.height(), 120));
   });
 
   var cacheId = gridId + "_columns"


### PR DESCRIPTION
https://issues.rudder.io/issues/24547

Fortunately when switching tab the scroll bar appears briefly on Firefox and we now see that it is scrollable (in Chrome it will always be displayed when the content is scrollable)
![Peek 2024-03-26 11-23](https://github.com/Normation/rudder/assets/65616064/3947abb7-1fc9-4961-8dab-e08be7b99bcb)
