### PR TITLE
Fixes #24575: Make a clear separation between the modification message and change audit log

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-bootstrap.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-bootstrap.scss
@@ -68,6 +68,9 @@ $input-font-size-sm: 12px;  // previous bootstrap 3 value VS 0.85rem default in 
 // --- NAV
 $nav-underline-border-width : 0.2rem;
 
+// --- MODAL
+$modal-md: 600px;
+
 
 @import "../../node_modules/bootstrap/scss/bootstrap";
 

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.scss
@@ -2035,6 +2035,16 @@ h3.box-title {
   font-weight: 900;
 }
 
+/* === MODAL === */
+.modal h4.audit-title {
+  padding-left: 0px;
+  padding-bottom: 8px;
+  margin-bottom: 25px;
+  border-bottom: 1px solid #d6deef;
+  margin-top: 20px;
+  font-size: 17.5px;
+}
+
 /* JUMBOTRON */
 .rudder-jumbotron > .jumbotron{
   background-color:transparent;


### PR DESCRIPTION
https://issues.rudder.io/issues/24575

* The [default modal size](https://getbootstrap.com/docs/5.0/components/modal/#optional-sizes) has changed from 600px to 500px, but we are comfortable with the previous value  
* The CSS for the title has disappeared some at some point in time...

![image](https://github.com/Normation/rudder/assets/65616064/561c726d-1702-4e6f-9dcf-c026afd4a88c)
