### PR TITLE
Fixes #24591: Tenant should be displayed in Node UI detailed

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -53,6 +53,7 @@ import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.facts.nodes.MinimalNodeFactInterface
 import com.normation.rudder.facts.nodes.NodeFact
 import com.normation.rudder.facts.nodes.QueryContext
+import com.normation.rudder.facts.nodes.SecurityTag
 import com.normation.rudder.facts.nodes.SelectFacts
 import com.normation.rudder.services.servers.DeleteMode
 import com.normation.rudder.users.CurrentUser
@@ -623,7 +624,10 @@ object DisplayNode extends Loggable {
       }
     }
        </div>
-       {displayServerRole(nodeFact)}
+       {
+      displayServerRole(nodeFact) ++
+      displayTenant(nodeFact)
+    }
        <div><label>Agent:</label> {
       val capabilities = {
         if (nodeFact.rudderAgent.capabilities.isEmpty) "no extra capabilities"
@@ -739,6 +743,16 @@ object DisplayNode extends Loggable {
         <div><label>Role:</label> Deleted node</div>
       case PendingInventory  =>
         <div><label>Role:</label> Pending node</div>
+    }
+  }
+
+  // Display the node tenant if defined (ie if different from "no tenant"
+  private def displayTenant(nodeFact: NodeFact): NodeSeq = {
+    nodeFact.rudderSettings.security match {
+      case Some(SecurityTag(tenants)) if (tenants.nonEmpty) =>
+        <div><label>Tenant:</label> {tenants.map(_.value).mkString(", ")}</div>
+      case _                                                =>
+        NodeSeq.Empty
     }
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/24591

Nothing special in the code, this looks like that on a node with a tenant: 

![image](https://github.com/Normation/rudder/assets/44649/32c86ab3-5117-4691-9312-0e215aee958f)
