### PR TITLE
Fixes #24421: system updates score details is empty when the node is up-to-date

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/SystemUpdateScore.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/SystemUpdateScore.elm
@@ -3,7 +3,7 @@ port module SystemUpdateScore exposing (..)
 import Browser
 import Html
 import Html.String exposing (..)
-import Html.String.Attributes exposing (class, title, attribute)
+import Html.String.Attributes exposing (class, title, attribute, style)
 import Json.Decode exposing (..)
 import Json.Decode.Pipeline exposing (..)
 import String.Extra
@@ -53,13 +53,29 @@ buildScoreDetails details =
             ]
             [ i[class ("fa fa-" ++ iconClass)][], text (" " ++ valueTxt) ]
         Nothing -> text ""
+
   in
-        div[]
-          [ toBadge "security"    "warning" details.security
-          , toBadge "bugfix"      "bug"     details.defect
-          , toBadge "enhancement" "plus"    details.enhancement
-          , toBadge "update"      "box"     details.patch
-          ]
+    if(details.nbPackages == 0) then
+      div[]
+      [ span
+        [ class "badge badge-type up-to-date"
+        , attribute "data-bs-toggle" "tooltip"
+        , attribute "data-bs-placement" "top"
+        , title (buildTooltipContent "System updates" "Everything is up-to-date!")
+        ]
+        [ i[class "fa fa-check-circle", style "margin-right" "0px"][]
+        ]
+      , text ""
+      , text ""
+      , text ""
+      ]
+    else
+      div[]
+        [ toBadge "security"    "warning"      details.security
+        , toBadge "bugfix"      "bug"          details.defect
+        , toBadge "enhancement" "plus"         details.enhancement
+        , toBadge "update"      "box"          details.patch
+        ]
 
 main =
   Browser.element

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-compliance.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-compliance.scss
@@ -344,6 +344,9 @@ $small-prefix : "sm-";
   &.update{
     background-color: #72829D !important;
   }
+  &.up-to-date{
+    background-color: #00a65a !important;
+  }
 
   & .icon-state {
     margin-right: 6px;


### PR DESCRIPTION
https://issues.rudder.io/issues/24421
This what the PR actually does (1)
![up-to-date2](https://github.com/Normation/rudder/assets/23410978/e3d9b6f2-d5ce-472b-94c4-899486320896)

This is an alternative (2)
![up-to-date1](https://github.com/Normation/rudder/assets/23410978/f3765f32-e876-4ed1-ab65-9360feb354c2)

Please choose your favorit one!