### PR TITLE
Fixes #12791: Have a reset-keys button on the node screen

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -342,7 +342,7 @@ object NodeApi       extends ApiModuleProvider[NodeApi]    {
   }
   final case object NodeInheritedProperties extends NodeApi with GeneralApi with OneParam with StartsAtVersion11 with SortIndex  {
     val z: Int = implicitly[Line].value
-    val description    = "Get all proporeties for that node, included inherited ones"
+    val description    = "Get all properties for that node, included inherited ones"
     val (action, path) = GET / "nodes" / "{id}" / "inheritedProperties"
   }
   final case object ApplyPolicyAllNodes     extends NodeApi with GeneralApi with ZeroParam with StartsAtVersion8 with SortIndex  {
@@ -362,7 +362,7 @@ object NodeApi       extends ApiModuleProvider[NodeApi]    {
   final case object NodeDisplayInheritedProperties
       extends NodeApi with InternalApi with OneParam with StartsAtVersion13 with SortIndex {
     val z: Int = implicitly[Line].value
-    val description    = "Get all proporeties for that node, included inherited ones, for displaying in node property tab (internal)"
+    val description    = "Get all properties for that node, included inherited ones, for displaying in node property tab (internal)"
     val (action, path) = GET / "nodes" / "{id}" / "displayInheritedProperties"
   }
   final case object NodeDetailsTable extends NodeApi with InternalApi with ZeroParam with StartsAtVersion13 with SortIndex {


### PR DESCRIPTION
https://issues.rudder.io/issues/12791

Add a button to reset the key status if:
- current user has write admin rights, 
- current key status is "certified". 

On backend, it's just a call to the relevant `woNodeRepository` function, plus some html/ajax to make it works. 
I needed to extract the div with security info to make it displayable again after change. 
I prefered to rebuild it all than just changing the icon because the key/key status logic is complex and I wanted to use the same logic for displaying (so that nothing change after reload). 


[change-key-status.webm](https://github.com/Normation/rudder/assets/44649/3d406506-21d7-45d1-984e-46bf86ca5b56)
