### PR TITLE
Fixes #24494: Groups listed on a node webpage should be clickable

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNodeGroupTree.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNodeGroupTree.scala
@@ -156,56 +156,11 @@ object DisplayNodeGroupTree extends Loggable {
       }
 
       override def body = {
-
-        val editButton = {
-          if (!targetActions.isEmpty && !targetInfo.isSystem) {
-            val tooltipId = Helpers.nextFuncName
-            <span class="treeActions">
-              <span class="fa fa-pencil" tooltipid={tooltipId} title=""
-                onclick={linkUtil.redirectToGroupLink(NodeGroupId(NodeGroupUid(groupId))).toJsCmd}
-              ></span>
-              <div class="tooltipContent" id={tooltipId}><div>Configure this group.</div></div>
-            </span>
-          } else {
-            NodeSeq.Empty
-          }
-        }
-
-        val actionButtons = {
-          if (!targetActions.isEmpty) {
-            (targetActions get ("include") match {
-
-              case Some(include) =>
-                val tooltipId = Helpers.nextFuncName
-                <span class="treeActions">
-                        <span class="tooltipable fa action-icon accept" tooltipid={tooltipId} title="" onclick={
-                  include(targetInfo).toJsCmd
-                }></span>
-                        <div class="tooltipContent" id={tooltipId}><div>Include Nodes from this group.</div></div>
-                  </span>
-
-              case None => NodeSeq.Empty
-
-            }) ++
-            (targetActions get ("exclude") match {
-              case Some(exclude) =>
-                val tooltipId = Helpers.nextFuncName
-                <span class="treeActions">
-                  <span class="tooltipable fa action-icon except" tooltipid={tooltipId} title="" onclick={
-                  exclude(targetInfo).toJsCmd
-                }></span>
-                  <div class="tooltipContent" id={tooltipId}><div>Exclude Nodes from this group.</div></div>
-            </span>
-              case None          => NodeSeq.Empty
-            })
-          } else {
-            NodeSeq.Empty
-          }
-        }
-
         val xml = {
           val tooltipId = Helpers.nextFuncName
-          <span class="treeGroupName tooltipable" tooltipid={tooltipId} title="">
+          <span class="treeGroupName tooltipable" tooltipid={tooltipId} title="" onclick={
+            linkUtil.redirectToGroupLink(NodeGroupId(NodeGroupUid(groupId))).toJsCmd
+          }>
             {targetInfo.name}
             {if (targetInfo.isSystem) <small class="greyscala"> - System</small>}
             <small class="greyscala">{
@@ -221,7 +176,6 @@ object DisplayNodeGroupTree extends Loggable {
             <h3>{targetInfo.name}</h3>
             <div>{targetInfo.description}</div>
           </div>
-          <div class="treeActions-container">{actionButtons} {editButton}</div>
         }
 
         onClickNode match {


### PR DESCRIPTION
https://issues.rudder.io/issues/24494
Need to adapt the long for some system group, like `All nodes`

Replacing previous PR: https://github.com/Normation/rudder/pull/5553
