### PR TITLE
Fixes #24632: Node and group properties will not display in 8.1

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -446,39 +446,7 @@ class NodeGroupForm(
       </div>)
 
     def tabProperties = ChooseTemplate(List("templates-hidden", "components", "ComponentNodeProperties"), "nodeproperties-tab")
-    intro ++ tabProperties ++ Script(OnLoad(JsRaw(s"""
-            var main = document.getElementById("nodeproperties-app")
-                                                     |var initValues = {
-                                                     |    contextPath    : "${S.contextPath}"
-                                                     |  , hasNodeWrite   : CanWriteNode
-                                                     |  , hasNodeRead    : CanReadNode
-                                                     |  , nodeId         : "${group.id.uid.value}"
-                                                     |  , objectType     : 'group'
-                                                     |};
-                                                     |var app = Elm.Nodeproperties.init({node: main, flags: initValues});
-                                                     |app.ports.successNotification.subscribe(function(str) {
-                                                     |  createSuccessNotification(str)
-                                                     |});
-                                                     |app.ports.errorNotification.subscribe(function(str) {
-                                                     |  createErrorNotification(str)
-                                                     |});
-                                                     |// Initialize tooltips
-                                                     |app.ports.initTooltips.subscribe(function(msg) {
-                                                     |  setTimeout(function(){
-                                                     |    initBsTooltips();
-                                                     |  }, 400);
-                                                     |});
-                                                     |app.ports.copy.subscribe(function(str) {
-                                                     |  navigator.clipboard.writeText(str);
-                                                     |});
-                                                     |app.ports.initInputs.subscribe(function(str) {
-                                                     |  setTimeout(function(){
-                                                     |    $$(".auto-resize").on("input", autoResize).each(function(){
-                                                     |      autoResize(this);
-                                                     |    });
-                                                     |  }, 10);
-                                                     |});
-                                                     |""".stripMargin)))
+    intro ++ tabProperties
   }
 
   private def loadComplianceBar(isGlobalCompliance: Boolean): Option[JsArray] = {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
@@ -590,7 +590,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
              |window.location.hash = "#"+groupId;
              |
              |// When the tab is shown we need to initialize the Elm app
-             |$$('a[href="#groupPropertiesTab"]').on('show.bs.tab', function() {
+             |$$('#groupPropertiesLinkTab').on('show.bs.tab', function() {
              |  var main = document.getElementById("nodeproperties-app")
              |  if (main) {
              |    var initValues = {
@@ -610,7 +610,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
              |    // Initialize tooltips
              |    app.ports.initTooltips.subscribe(function(msg) {
              |      setTimeout(function(){
-             |        $$('.bs-tooltip').bsTooltip();
+             |        initBsTooltips();
              |      }, 400);
              |    });
              |    app.ports.copy.subscribe(function(str) {

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/groups.html
@@ -6,6 +6,21 @@
   <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-groupcompliance.js"></script>
   <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-grouprelatedrules.js"></script>
   <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-groups.js"></script>
+  <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-nodeproperties.js"></script>
+  <script>
+    var CanWriteNode = false;
+    var CanReadNode  = false;
+  </script>
+  <lift:authz role="node_write">
+    <script>
+      CanWriteNode = true;
+    </script>
+  </lift:authz>
+  <lift:authz role="node_read">
+    <script>
+      CanReadNode = true;
+    </script>
+  </lift:authz>
 </head_merge>
 
 <span data-list="node.Groups.head"></span>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/NodeGroupForm.html
@@ -58,7 +58,7 @@
         <button id="relatedRulesLinkTab" class="nav-link" data-bs-toggle="tab" data-bs-target="#groupRulesTab" type="button" role="tab" aria-controls="groupRulesTab" aria-selected="false">Related rules</button>
       </li>
       <li class="nav-item">
-        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#groupPropertiesTab" type="button" role="tab" aria-controls="groupPropertiesTab" aria-selected="false">Properties</button>
+        <button id="groupPropertiesLinkTab" class="nav-link" data-bs-toggle="tab" data-bs-target="#groupPropertiesTab" type="button" role="tab" aria-controls="groupPropertiesTab" aria-selected="false">Properties</button>
       </li>
       <li class="nav-item">
         <button id="complianceLinkTab" class="nav-link" data-bs-toggle="tab" data-bs-target="#groupComplianceTab" type="button" role="tab" aria-controls="groupComplianceTab" aria-selected="false">Compliance</button>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/server/server_details.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/server/server_details.html
@@ -82,6 +82,23 @@
   }
   </style>
   <div class="main-header">
+    <head_merge>
+      <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-nodeproperties.js"></script>
+      <script>
+        var CanWriteNode = false;
+        var CanReadNode  = false;
+      </script>
+      <lift:authz role="node_write">
+        <script>
+          CanWriteNode = true;
+        </script>
+      </lift:authz>
+      <lift:authz role="node_read">
+        <script>
+          CanReadNode = true;
+        </script>
+      </lift:authz>
+    </head_merge>
     <div id="nodeHeader"></div>
   </div>
   <div id="node_tabs" class="tabs d-flex flex-column overflow-hidden">


### PR DESCRIPTION
https://issues.rudder.io/issues/24632

There was some conflicts to resolve regarding rewrite of HTML/JS in bootstrap 5 (tabs, tooltips).

Also for nodes, the variables and Nodeproperties JS script were removed from a common HTML template shared between groups and nodes, and needs to be added back in nodes HTML page