### PR TITLE
Fixes #24639: Missing tenant information in API result for node details

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
@@ -56,6 +56,7 @@ import com.normation.rudder.domain.properties.*
 import com.normation.rudder.domain.queries.Query
 import com.normation.rudder.domain.servers.Srv
 import com.normation.rudder.domain.workflows.*
+import com.normation.rudder.facts.nodes.SecurityTag
 import com.normation.rudder.repository.FullActiveTechnique
 import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.rule.category.RuleCategory
@@ -124,6 +125,7 @@ trait RestDataSerializer {
       optRunDate:  Option[DateTime],
       inventory:   Option[FullInventory],
       software:    Seq[Software],
+      optTenant:   Option[SecurityTag],
       detailLevel: NodeDetailLevel
   ): JValue
 
@@ -171,9 +173,10 @@ final case class RestDataSerializerImpl(
       optRunDate:  Option[DateTime],
       inventory:   Option[FullInventory],
       software:    Seq[Software],
+      optTenant:   Option[SecurityTag],
       detailLevel: NodeDetailLevel
   ): JValue = {
-    detailLevel.toJson(nodeInfo, status, optRunDate, inventory, software)
+    detailLevel.toJson(nodeInfo, status, optRunDate, inventory, software, optTenant)
   }
 
   def serializeInventory(inventory: FullInventory, status: String): JValue = {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -1357,14 +1357,14 @@ class NodeApiService(
                            inventory = x.toFullInventory
                            software  = x.software.toList.map(_.toSoftware)
                          } yield {
-                           Some((x.toNodeInfo, runs, inventory, software))
+                           Some((x.toNodeInfo, runs, inventory, software, x.rudderSettings.security))
                          }
                      }
     } yield {
       nodeInfo.map {
-        case (node, runs, inventory, software) =>
+        case (node, runs, inventory, software, optTenant) =>
           val runDate = runs.get(nodeId).flatMap(_.map(_.agentRunId.date))
-          restSerializer.serializeInventory(node, state, runDate, Some(inventory), software, detailLevel)
+          restSerializer.serializeInventory(node, state, runDate, Some(inventory), software, optTenant, detailLevel)
       }
     }
   }
@@ -1440,6 +1440,7 @@ class NodeApiService(
           runDate,
           inventories.get(nodeId),
           software.getOrElse(nodeId, Seq()),
+          nodeFact.rudderSettings.security,
           detailLevel
         )
       }


### PR DESCRIPTION
https://issues.rudder.io/issues/24639

Since tenant is not defined in NodeInfo, and that NodeDetails serialization is still based on it, I thought it was easier to just add one more parameter to the serialization methods. 