### PR TITLE
Fixes #24665: Number of nodes in rule badge is not correct with tenants

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
@@ -329,7 +329,15 @@ object RuleTarget extends Loggable {
           // here, if we don't find the group, we consider it's an error in the
           // target recording, but don't fail, just log it.
           case GroupTarget(groupId)         =>
-            nodes ++ groups.getOrElse(groupId, Chunk.empty)
+            val groupNodes = groups.getOrElse(groupId, Chunk.empty)
+            val filtered   = {
+              if (allNodesAreThere) groupNodes
+              else {
+                val keys = Chunk.fromIterable(allNodes.keys)
+                groupNodes.filter(keys.contains(_))
+              }
+            }
+            nodes ++ filtered
 
           case TargetIntersection(targets) =>
             val nodeSets     = targets.map(t => getNodeIdsChunkRec(Chunk(t), allNodes, groups, allNodesAreThere))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
@@ -353,7 +353,7 @@ object RoNodeGroupRepository {
       allNodeInfos: Map[NodeId, NodeInfo]
   ): Chunk[NodeId] = {
     val allNodes = allNodeInfos.view.mapValues(x => (x.isPolicyServer))
-    RuleTarget.getNodeIdsChunk(targets, allNodes.toMap, allGroups)
+    RuleTarget.getNodeIdsChunk(targets, allNodes.toMap, allGroups, false)
   }
 }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/24665

It's likely an older bug than that, I need to check it better. 
EDIT: it's from 7.3. 
But the only usage of that method in all rudder seems to be for badge, so not too important.