### PR TITLE
Fixes #24487: Missing icon in the rule creation page

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRuleDetails.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRuleDetails.elm
@@ -25,6 +25,10 @@ editionTemplate model details =
     originRule = details.originRule
 
     rule = details.rule
+    policyModeTitle =
+      case originRule of
+        Nothing -> div [][]
+        Just _  -> badgePolicyMode model.policyMode rule.policyMode
     (ruleTitle, isNewRule) = case originRule of
       Nothing -> (span[style "opacity" "0.4"][text "New rule"], True)
       Just r  -> (text r.name, False)
@@ -175,7 +179,7 @@ editionTemplate model details =
     [ div [class "main-header "]
       [ div [class "header-title"]
         [ h1[class classDisabled]
-          [ badgePolicyMode model.policyMode rule.policyMode
+          [ policyModeTitle
           , ruleTitle
           , badgeDisabled
           ]


### PR DESCRIPTION
https://issues.rudder.io/issues/24487
![image](https://github.com/Normation/rudder/assets/23410978/bc5fda49-e2bb-49ac-8789-95e38a90f6c9)
