### PR TITLE
Fixes #24497: Node properties override hovers are not well rendered

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ViewUtils.elm
@@ -188,9 +188,11 @@ displayNodePropertyRow model =
                 _ -> "<h4 class='tags-tooltip-title'>" ++ pr ++ "</h4> <div class='tooltip-inner-content'>This property is managed by its provider ‘<b>" ++ pr ++ "</b>’ and can not be modified manually. Check Rudder’s settings to adjust this provider’s configuration.</div>"
             in
               (span
-              [ class "rudder-label label-provider label-sm"
+              [ class "rudder-label label-provider label-sm bs-tooltip"
               , attribute "data-bs-toggle" "tooltip"
               , attribute "data-bs-placement" "right"
+              , attribute "data-bs-html" "true"
+              , attribute "data-bs-container" "body"
               , title pTitle
               ] [ text pr ]
               , (pr == "overridden")


### PR DESCRIPTION
https://issues.rudder.io/issues/24497
![image](https://github.com/Normation/rudder/assets/23410978/525a30d2-9b45-4614-9f2e-4291a3c0c4e4)
