### PR TITLE
Fixes #24017: Webapp can fail to start with null sessionid error 

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/WEB-INF/web.xml
@@ -73,6 +73,11 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
   </listener>
 
   <listener>
+    <!-- this is needed to be able to create a session id in exceptional cases when we authenticate but don't have one yet -->
+    <listener-class>org.springframework.web.context.request.RequestContextListener</listener-class>
+  </listener>
+
+  <listener>
     <!-- this is needed to actually destroy session in spring-security register when they are invalidated -->
     <listener-class>org.springframework.security.web.session.HttpSessionEventPublisher</listener-class>
   </listener>


### PR DESCRIPTION
https://issues.rudder.io/issues/24017

Spring sees the session id as `null` in this case, authentication could happen when the session has not yet been created.

To create it, we just need to [ServletRequestAttributes#getSessionId()](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/context/request/ServletRequestAttributes.html#getSessionId()) which will create a new one, it will still be the one effectively used to login.