### PR TITLE
Fixes #24703: OS type / name are not always compared lower case

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/NodeInventory.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/NodeInventory.scala
@@ -329,9 +329,8 @@ final case class Windows(
 object ParseOSType {
 
   def getType(osType: String, osName: String, fullName: String): OsType = {
-    (osType, osName) match {
-      case ("mswin32", _) =>
-        val x = fullName.toLowerCase
+    (osType.toLowerCase, osName.toLowerCase, fullName.toLowerCase) match {
+      case ("mswin32", _, x) =>
         // in windows, relevant information are in the fullName string
         if (x contains "xp") WindowsXP
         else if (x contains "vista") WindowsVista
@@ -349,7 +348,7 @@ object ParseOSType {
         else if (x contains "2022") Windows2022
         else UnknownWindowsType
 
-      case ("linux", x) =>
+      case ("linux", x, _) =>
         if (x contains "debian") Debian
         else if (x contains "ubuntu") Ubuntu
         else if (x contains "kali") Kali
@@ -368,11 +367,11 @@ object ParseOSType {
         else if (x contains "raspbian") Raspbian
         else UnknownLinuxType
 
-      case ("solaris", _) => SolarisOS
+      case ("solaris", _, _) => SolarisOS
 
-      case ("aix", _) => AixOS
+      case ("aix", _, _) => AixOS
 
-      case ("freebsd", _) => FreeBSD
+      case ("freebsd", _, _) => FreeBSD
 
       case _ => UnknownOSType
     }

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionInventoryParser.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionInventoryParser.scala
@@ -776,8 +776,8 @@ class FusionInventoryParser(
      * FQDN           : the fully qualified hostname
      */
     val osDetail: OsDetails = {
-      val osType = optText(xml \\ "KERNEL_NAME").getOrElse("").toLowerCase
-      val osName = optText(xml \\ "NAME").getOrElse("").toLowerCase
+      val osType = optText(xml \\ "KERNEL_NAME").getOrElse("")
+      val osName = optText(xml \\ "NAME").getOrElse("")
 
       val fullName      = optText(xml \\ "FULL_NAME").getOrElse("")
       val kernelVersion = new Version(optText(xml \\ "KERNEL_VERSION").getOrElse("N/A"))

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/CreateNodeData.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/CreateNodeData.scala
@@ -473,9 +473,6 @@ object Validation {
   // this part is adapted from inventory extraction. It should be factored out
   // and not duplicated, obviously
   def getos(tpe: String, name: String, vers: String, fullName: String, srvPk: Option[String]): OsDetails = {
-    val osType = tpe.toLowerCase
-    val osName = name.toLowerCase
-
     val kernelVersion = new Version("N/A")
 
     val version = new Version(vers match {
@@ -490,7 +487,7 @@ object Validation {
     }
 
     // find os type, and name
-    val os = ParseOSType.getType(osType, osName, osName + " " + fullName.toLowerCase)
+    val os = ParseOSType.getType(tpe, name, name + " " + fullName)
     ParseOSType.getDetails(os, fullName, version, servicePack, kernelVersion)
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/24703

moved all the `toLowerCase` in the method so that callers don't have to wonder if they should do it or not (what they can't know without looking at the implementation otherwise). 
And so json unserialization is not changed (because it was the faulty one). 

Also homogenize the pattern matching. Windows matches on fullname, Linux on name, but it can be made consistant. 