### PR TITLE
Fixes #24605: The ul and ol lists have the same markdown rendering

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.scss
@@ -2659,13 +2659,9 @@ table a > i.fa-pencil:hover{
   padding-left: 0;
   padding-right: 0;
 }
-.markdown ul,
-.markdown ol,
-.markdown ul > li,
-.markdown ol > li{
+.markdown ul{
+  padding-left: 2rem;
   list-style: initial;
-  margin-left: 7px;
-  padding: initial;
 }
 .markdown > p:last-child{
   margin-bottom: 0;


### PR DESCRIPTION
https://issues.rudder.io/issues/24605


Numbered lists are now correctly rendered :
![ol-lists](https://github.com/Normation/rudder/assets/9928447/eac6dd63-7424-42b0-8652-6cb1ffa9d8b8)