### PR TITLE
Fixes #24719: MockLdapServer needs to be a class instantiated for each test

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/MockLdapFactStorage.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/MockLdapFactStorage.scala
@@ -59,7 +59,7 @@ import com.normation.zio.*
 import com.unboundid.ldap.sdk.DN
 import zio.Ref
 
-object MockLdapFactStorage {
+class MockLdapFactStorage {
 
   val tmp: File = File.newTemporaryDirectory("rudder-test-ldap-schema-files-")
   tmp.deleteOnExit(true)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSaveInventory.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSaveInventory.scala
@@ -129,25 +129,26 @@ class TestSaveInventoryGit extends TestSaveInventory {
 @RunWith(classOf[JUnitRunner])
 class TestSaveInventoryLdap extends TestSaveInventory {
 
+  lazy val mockLdapFactStorage = new MockLdapFactStorage()
   def nodeExists(id: String, dit: InventoryDit): Boolean = {
-    MockLdapFactStorage.testServer.entryExists(dit.NODES.NODE.dn(id).toString)
+    mockLdapFactStorage.testServer.entryExists(dit.NODES.NODE.dn(id).toString)
   }
 
   def nodeAsString(id: String, dit: InventoryDit): String = {
     val sb = new java.lang.StringBuilder()
     // we want to check also for the node entry, not only the inventory part
-    MockLdapFactStorage.testServer.getEntry(dit.NODES.NODE.dn(id).toString).toString(sb)
+    mockLdapFactStorage.testServer.getEntry(dit.NODES.NODE.dn(id).toString).toString(sb)
     // we want to check also for the node entry, not only the inventory part
-    MockLdapFactStorage.testServer.getEntry(MockLdapFactStorage.nodeDit.NODES.NODE.dn(id).toString).toString(sb)
+    mockLdapFactStorage.testServer.getEntry(mockLdapFactStorage.nodeDit.NODES.NODE.dn(id).toString).toString(sb)
     sb.toString()
   }
 
-  override def checkPendingNodeExists(id:  String): Boolean = nodeExists(id, MockLdapFactStorage.pendingDIT)
-  override def getPendingNodeAsString(id:  String): String  = nodeAsString(id, MockLdapFactStorage.pendingDIT)
-  override def checkAcceptedNodeExists(id: String): Boolean = nodeExists(id, MockLdapFactStorage.acceptedDIT)
-  override def getAcceptedNodeAsString(id: String): String  = nodeAsString(id, MockLdapFactStorage.acceptedDIT)
+  override def checkPendingNodeExists(id:  String): Boolean = nodeExists(id, mockLdapFactStorage.pendingDIT)
+  override def getPendingNodeAsString(id:  String): String  = nodeAsString(id, mockLdapFactStorage.pendingDIT)
+  override def checkAcceptedNodeExists(id: String): Boolean = nodeExists(id, mockLdapFactStorage.acceptedDIT)
+  override def getAcceptedNodeAsString(id: String): String  = nodeAsString(id, mockLdapFactStorage.acceptedDIT)
 
-  override lazy val factStorage: NodeFactStorage = MockLdapFactStorage.nodeFactStorage
+  override lazy val factStorage: NodeFactStorage = mockLdapFactStorage.nodeFactStorage
 
   //////// for LDAP reposiotyr, in addition to main acceptation test, we are
   //////// checking properties around certificate validation

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
@@ -109,6 +109,8 @@ class TestNodeFactQueryProcessor {
   //org.slf4j.LoggerFactory.getLogger("com.normation.rudder.services.queries").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.TRACE)
   // format: on
 
+  val mockLdapFactStorage = new MockLdapFactStorage()
+
   val nodeRepository: CoreNodeFactRepository = {
 
     object NoopNodeBySoftware extends GetNodesbySofwareName {
@@ -119,7 +121,7 @@ class TestNodeFactQueryProcessor {
       t <- DefaultTenantService.make(Nil)
       r <- CoreNodeFactRepository
              .make(
-               MockLdapFactStorage.nodeFactStorage,
+               mockLdapFactStorage.nodeFactStorage,
                NoopNodeBySoftware,
                t,
                Chunk.empty
@@ -128,7 +130,7 @@ class TestNodeFactQueryProcessor {
   }
 
   val internalLDAPQueryProcessor: InternalLDAPQueryProcessor = {
-    import MockLdapFactStorage.*
+    import mockLdapFactStorage.*
     val rudderDit    = new RudderDit(new DN("ou=Rudder, cn=rudder-configuration"))
     val ditQueryData = new DitQueryData(acceptedDIT, nodeDit, rudderDit, queryData)
     new InternalLDAPQueryProcessor(ldapRo, acceptedDIT, nodeDit, ditQueryData, ldapMapper)


### PR DESCRIPTION
https://issues.rudder.io/issues/24719

Just change the object into a class, and do one instancation by test. Plus we need a lazy somewhere to satisfy JVM init order (objects are lazy)