### PR TITLE
Fixes #24729: Allow using a different password hash algorithm for each local user

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
@@ -71,7 +71,6 @@ import com.normation.rudder.users.JsonUpdatedUser
 import com.normation.rudder.users.JsonUpdatedUserInfo
 import com.normation.rudder.users.JsonUser
 import com.normation.rudder.users.JsonUserFormData
-import com.normation.rudder.users.PasswordEncoderType
 import com.normation.rudder.users.RudderAccount
 import com.normation.rudder.users.RudderUserDetail
 import com.normation.rudder.users.Serialisation.*
@@ -335,7 +334,7 @@ class UserManagementApiImpl(
                 }
             })
       } yield {
-        serialize(jsonUsers.sortBy(_.id))(file.encoder)
+        serialize(jsonUsers.sortBy(_.id))
       }).chainError("Error when retrieving user list").toLiftResponseOne(params, schema, _ => None)
     }
   }
@@ -563,14 +562,13 @@ class UserManagementApiImpl(
 
   def serialize(
       users: List[JsonUser]
-  )(passwordEncoder: PasswordEncoderType): JsonAuthConfig = {
-    val encoder: String = passwordEncoder.displayName
+  ): JsonAuthConfig = {
     // Aggregate all provider properties, if any provider can override user roles then it means there is a global override
     val providerRoleExtensions = getProviderRoleExtensions()
     val roleListOverride       = providerRoleExtensions.values.max
     val providersProperties    = providerRoleExtensions.view.mapValues(_.transformInto[JsonProviderProperty]).toMap
 
-    JsonAuthConfig(encoder, roleListOverride, getAuthBackendsProviders(), providersProperties, users)
+    JsonAuthConfig(roleListOverride, getAuthBackendsProviders(), providersProperties, users)
   }
 
   private def transformUser(

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
@@ -149,7 +149,7 @@ object RudderPasswordEncoder {
   object SecurityLevel {
     // Allow simple non-salted hashes
     case object Legacy extends SecurityLevel
-    // Only allow dedicted password hashes (currently bcrypt only)
+    // Only allow dedicated password hashes
     case object Modern extends SecurityLevel
   }
 
@@ -228,8 +228,8 @@ case class RudderPasswordEncoder(
 
   override def encode(rawPassword: CharSequence):                           String  = {
     // The current user management plugin directly calls the encoder based on the
-    // selected hash in the xml file, and it the only place where we dynamically create passwords.
-    // We could (and likely should) use RudderPasswordProvider for encoding but we need to store the algorithm to use
+    // selected hash in the xml file, and it is the only place where we dynamically create passwords.
+    // We could (and likely should) use RudderPasswordProvider for encoding but we need it to store the algorithm to use
     // (as DelegatingPasswordEncoder does) based on the user configuration.
     //
     // This is hence NEVER called in Rudder.
@@ -525,7 +525,7 @@ object UserFileProcessing {
 
       // The rationale here is that if configured hash is bcrypt, it means before 8.2 non-bcrypt hash did not work
       // so no need for legacy support.
-      // FIXME: prevents using bcrypt for new users is still having legavy hashes
+      // FIXME: prevents using bcrypt for new users is still having legacy hashes
       val encoder = if (parsed.encoder == PasswordEncoderType.BCRYPT) { RudderPasswordEncoder(Modern, passwordEncoderDispatcher) }
       else { RudderPasswordEncoder(Legacy, passwordEncoderDispatcher) }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
@@ -202,7 +202,7 @@ object RudderPasswordEncoder {
     // Allow types: 2, 2x, 2y, 2a, 2b
     val bcryptRegex = "^\\$2[abxy]?\\$.+".r
 
-    val hexaRegex = "^[a-fA-F0-9]$"
+    val hexaRegex = "^[a-fA-F0-9]+$"
 
     if (encodedPassword.matches(bcryptRegex.regex)) {
       Right(PasswordEncoderType.BCRYPT)
@@ -216,7 +216,7 @@ object RudderPasswordEncoder {
         case l   => Left(s"Could not recognize a known hash format from hexadecimal encoded string of length ${l}")
       }
     } else {
-      Left(s"Could not recognize a known hash format from encoded password")
+      Left("Could not recognize a known hash format from encoded password")
     }
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
@@ -369,7 +369,11 @@ trait UserDetailListProvider {
 
 trait UserFileSecurityLevelMigration {
   def file: UserFile
-  def migrateToModern(file: File): IOResult[Unit]
+
+  /**
+    * Migrates the provided file to the modern security level, but allow legacy hashes to subsist
+    */
+  def allowLegacy(file: File): IOResult[Unit]
 }
 
 final class FileUserDetailListProvider(
@@ -435,7 +439,7 @@ final class FileUserDetailListProvider(
   override def authConfig: ValidatedUserList = cache.get.runNow
 
   // directly changes the file content !!
-  override def migrateToModern(sourceTargetFile: File): IOResult[Unit] = {
+  override def allowLegacy(sourceTargetFile: File): IOResult[Unit] = {
     // replace "hash" value by "bcrypt", mark unsafe_hashes=true
     for {
       parsedFile <- IOResult.attempt(ConstructingParser.fromFile(sourceTargetFile.toJava, preserveWS = true))

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
@@ -111,6 +111,7 @@ object Serialisation {
   implicit val userStatusEncoder:            JsonEncoder[UserStatus]            = JsonEncoder[String].contramap(_.value)
   implicit val providerRoleExtensionEncoder: JsonEncoder[ProviderRoleExtension] =
     JsonEncoder[String].contramap(_.name)
+  implicit val passwordEncoderTypeEncoder:   JsonEncoder[PasswordEncoderType]   = JsonEncoder[String].contramap(_.name)
 
   implicit val updateUserInfoDecoder: JsonDecoder[UpdateUserInfo] = DeriveJsonDecoder.gen[UpdateUserInfo]
   implicit val updateUserInfoEncoder: JsonEncoder[UpdateUserInfo] = DeriveJsonEncoder.gen[UpdateUserInfo]
@@ -141,11 +142,11 @@ object Serialisation {
 }
 
 final case class JsonAuthConfig(
-    digest:                 String,
     roleListOverride:       ProviderRoleExtension,
     authenticationBackends: Set[String],
     providerProperties:     Map[String, JsonProviderProperty],
-    users:                  List[JsonUser]
+    users:                  List[JsonUser],
+    digest:                 PasswordEncoderType = PasswordEncoderType.DEFAULT // default value
 )
 
 final case class JsonProviderProperty(

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagementService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagementService.scala
@@ -244,7 +244,7 @@ class UserManagementService(
                             e.copy(child = {
                               e.child ++ newUser
                                 .copy(password = {
-                                  getHashEncoderOrPlain((userXML \\ "authentication" \ "@hash").text).encode(newUser.password)
+                                  getHashEncoderOrDefault((userXML \\ "authentication" \ "@hash").text).encode(newUser.password)
                                 })
                                 .toNode
                             })
@@ -339,7 +339,7 @@ class UserManagementService(
                        (user \ "@password").text
                      } else {
                        if (isPreHashed) fileUser.password
-                       else getHashEncoderOrPlain((userXML \\ "authentication" \ "@hash").text).encode(fileUser.password)
+                       else getHashEncoderOrDefault((userXML \\ "authentication" \ "@hash").text).encode(fileUser.password)
                      }
                      val tenants     = (user \ "@tenants").text
                      User.make(newUsername, newPassword, newRoles, tenants).toNode
@@ -392,7 +392,7 @@ class UserManagementService(
     } yield res
   }
 
-  private def getHashEncoderOrPlain(hash: String): PasswordEncoder = {
-    encoderDispatcher.dispatch(PasswordEncoderType.withNameInsensitiveOption(hash).getOrElse(PasswordEncoderType.PlainText))
+  private def getHashEncoderOrDefault(hash: String): PasswordEncoder = {
+    encoderDispatcher.dispatch(PasswordEncoderType.withNameInsensitiveOption(hash).getOrElse(PasswordEncoderType.DEFAULT))
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_usermanagement.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_usermanagement.yml
@@ -8,7 +8,6 @@ response:
       "action" : "getUserInfo",
       "result" : "success",
       "data" : {
-        "digest" : "BCRYPT",
         "roleListOverride" : "override",
         "authenticationBackends" : [
           "file"
@@ -187,7 +186,8 @@ response:
             },
             "tenants" : "none"
           }
-        ]
+        ],
+        "digest" : "BCRYPT"
       }
     }
 ---

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/test-users.xml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/test-users.xml
@@ -1,4 +1,4 @@
-<authentication hash="bcrypt" case-sensitivity="true">
-  <user name="user1" password="1234" permissions="user" tenants="zoneA" />
-  <user name="user2" password="4321" permissions="read_only" />
+<authentication hash="sha-1" case-sensitivity="true">
+  <user name="user1" password="1234" permissions="user" />
+  <user name="user2" password="a94a8fe5ccb19ba61c4c0873d391e987982fbbd3" permissions="read_only" />
 </authentication>

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/test-users.xml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/test-users.xml
@@ -1,4 +1,4 @@
 <authentication hash="sha-1" case-sensitivity="true">
-  <user name="user1" password="1234" permissions="user" />
+  <user name="user1" password="1234" permissions="user" tenants="zoneA" />
   <user name="user2" password="a94a8fe5ccb19ba61c4c0873d391e987982fbbd3" permissions="read_only" />
 </authentication>

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -860,7 +860,7 @@ class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSessi
 
     val roleApiMapping = new RoleApiMapping(AuthorizationApiMapping.Core)
 
-    val res = new FileUserDetailListProvider(roleApiMapping, usersFile)
+    val res = new FileUserDetailListProvider(roleApiMapping, usersFile, passwordEncoderDispatcher)
     res.reload()
     res
   }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -779,7 +779,7 @@ class MockCompliance(mockDirectives: MockDirectives) {
 
 }
 
-class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSession], usersFile: File) {
+class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSession], usersConfigFile: File) {
 
   object userRepo extends UserRepository {
 
@@ -851,7 +851,7 @@ class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSessi
 
   }
 
-  val usersInputStream: () => InputStream = () => IOUtils.toInputStream(usersFile.contentAsString, StandardCharsets.UTF_8)
+  val usersInputStream: () => InputStream = () => IOUtils.toInputStream(usersConfigFile.contentAsString, StandardCharsets.UTF_8)
 
   val passwordEncoderDispatcher = new PasswordEncoderDispatcher(0)
 
@@ -870,7 +870,7 @@ class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSessi
       userRepo,
       userService,
       passwordEncoderDispatcher,
-      UserFile(usersFile.pathAsString, usersInputStream).succeed
+      UserFile(usersConfigFile.pathAsString, usersInputStream).succeed
     )
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -856,7 +856,7 @@ class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSessi
   val passwordEncoderDispatcher = new PasswordEncoderDispatcher(0)
 
   val userService: FileUserDetailListProvider = {
-    val usersFile = UserFile("test-users.xml", usersInputStream)
+    val usersFile = UserFile(usersConfigFile.pathAsString, usersInputStream)
 
     val roleApiMapping = new RoleApiMapping(AuthorizationApiMapping.Core)
 

--- a/webapp/sources/rudder/rudder-web/pom.xml
+++ b/webapp/sources/rudder/rudder-web/pom.xml
@@ -308,5 +308,12 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.normation.rudder</groupId>
+      <artifactId>rudder-rest</artifactId>
+      <version>${rudder-version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -249,14 +249,13 @@ class AppConfigAuth extends ApplicationContextAware {
 
   @Bean def fileAuthenticationProvider: AuthenticationProvider = {
     val provider = new DaoAuthenticationProvider()
-    val encoder  = passwordEncoderDispatcher.dispatch(rudderUserDetailsService.authConfigProvider.authConfig.encoder)
     provider.setUserDetailsService(rudderUserDetailsService)
-    provider.setPasswordEncoder(encoder)
+    provider.setPasswordEncoder(rudderUserDetailsService.authConfigProvider.authConfig.encoder)
 
     // we need to register a callback to update password encoder when needed
     val updatePasswordEncoder = RudderAuthorizationFileReloadCallback(
       "updatePasswordEncoder",
-      (c: ValidatedUserList) => effectUioUnit(provider.setPasswordEncoder(passwordEncoderDispatcher.dispatch(c.encoder)))
+      (c: ValidatedUserList) => effectUioUnit(provider.setPasswordEncoder(c.encoder))
     )
     RudderConfig.rudderUserListProvider.registerCallback(updatePasswordEncoder)
     provider
@@ -264,41 +263,35 @@ class AppConfigAuth extends ApplicationContextAware {
 
   @Bean def rootAdminAuthenticationProvider: AuthenticationProvider = {
     // We want to be able to disable that account.
-    // For that, we let the user either let undefined udder.auth.admin.login,
+    // For that, we let the user either let undefined rudder.auth.admin.login,
     // or let empty udder.auth.admin.login or rudder.auth.admin.password
 
-    val defaultEncoder    = PasswordEncoderType.BCRYPT
-    val (encoder, admins) = if (config.hasPath("rudder.auth.admin.login") && config.hasPath("rudder.auth.admin.password")) {
+    import RudderPasswordEncoder.SecurityLevel.Modern
+
+    // Only support modern algorithms for root admin account
+    val encoder = RudderPasswordEncoder(Modern, passwordEncoderDispatcher)
+    val admins  = if (config.hasPath("rudder.auth.admin.login") && config.hasPath("rudder.auth.admin.password")) {
       val login    = config.getString("rudder.auth.admin.login")
       val password = config.getString("rudder.auth.admin.password")
 
       if (login.isEmpty || password.isEmpty) {
-        (defaultEncoder, Map.empty[String, RudderUserDetail])
+        Map.empty[String, RudderUserDetail]
       } else {
-        // check if the password is in plain text (for compatibility before #19308) or bcrypt-encoded
-        val passwordEncoder = if (password.startsWith("$2y$")) {
-          defaultEncoder
-        } else {
-          PasswordEncoderType.PlainText
-        }
-        (
-          passwordEncoder,
-          Map(
-            login -> RudderUserDetail(
-              RudderAccount.User(
-                login,
-                password
-              ),
-              UserStatus.Active,
-              Set(Role.Administrator),
-              SYSTEM_API_ACL,
-              NodeSecurityContext.All
-            )
+        Map(
+          login -> RudderUserDetail(
+            RudderAccount.User(
+              login,
+              password
+            ),
+            UserStatus.Active,
+            Set(Role.Administrator),
+            SYSTEM_API_ACL,
+            NodeSecurityContext.All
           )
         )
       }
     } else {
-      (defaultEncoder, Map.empty[String, RudderUserDetail])
+      Map.empty[String, RudderUserDetail]
     }
 
     if (admins.isEmpty) {
@@ -320,7 +313,7 @@ class AppConfigAuth extends ApplicationContextAware {
     )
     val provider            = new DaoAuthenticationProvider()
     provider.setUserDetailsService(new RudderInMemoryUserDetailsService(authConfigProvider, rootAccountUserRepo))
-    provider.setPasswordEncoder(passwordEncoderDispatcher.dispatch(encoder)) // force password encoder to the one we want
+    provider.setPasswordEncoder(encoder) // force password encoder to the one we want
     provider
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1523,11 +1523,13 @@ object RudderConfigInit {
 
     lazy val roleApiMapping = new RoleApiMapping(authorizationApiMapping)
 
+    lazy val passwordEncoderDispatcher = new PasswordEncoderDispatcher(RUDDER_BCRYPT_COST)
+
     // rudder user list
     lazy val rudderUserListProvider: FileUserDetailListProvider = {
       UserFileProcessing.getUserResourceFile().either.runNow match {
         case Right(resource) =>
-          new FileUserDetailListProvider(roleApiMapping, resource)
+          new FileUserDetailListProvider(roleApiMapping, resource, passwordEncoderDispatcher)
         case Left(err)       =>
           ApplicationLogger.error(err.fullMsg)
           // make the application not available
@@ -2230,7 +2232,7 @@ object RudderConfigInit {
           new UserManagementService(
             userRepository,
             rudderUserListProvider,
-            new PasswordEncoderDispatcher(RUDDER_BCRYPT_COST),
+            passwordEncoderDispatcher,
             UserFileProcessing.getUserResourceFile()
           ),
           roleApiMapping,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -52,6 +52,7 @@ import bootstrap.liftweb.checks.migration.CheckAddSpecialNodeGroupsDescription
 import bootstrap.liftweb.checks.migration.CheckRemoveRuddercSetting
 import bootstrap.liftweb.checks.migration.CheckTableScore
 import bootstrap.liftweb.checks.migration.CheckTableUsers
+import bootstrap.liftweb.checks.migration.CheckUsersFile
 import bootstrap.liftweb.checks.migration.MigrateChangeValidationEnforceSchema
 import bootstrap.liftweb.checks.migration.MigrateEventLogEnforceSchema
 import bootstrap.liftweb.checks.migration.MigrateJsonTechniquesToYaml
@@ -3325,6 +3326,7 @@ object RudderConfigInit {
       new CheckAddSpecialNodeGroupsDescription(rwLdap),
       new CheckRemoveRuddercSetting(rwLdap),
       new CheckDIT(pendingNodesDitImpl, acceptedNodesDitImpl, removedNodesDitImpl, rudderDitImpl, rwLdap),
+      new CheckUsersFile(rudderUserListProvider),
       new CheckInitUserTemplateLibrary(
         rudderDitImpl,
         rwLdap,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/CheckUsersFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/CheckUsersFile.scala
@@ -1,0 +1,82 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package bootstrap.liftweb.checks.migration
+
+import bootstrap.liftweb.BootstrapChecks
+import bootstrap.liftweb.BootstrapLogger
+import com.normation.errors.*
+import com.normation.rudder.users.RudderPasswordEncoder.SecurityLevel
+import com.normation.rudder.users.UserFileProcessing
+import com.normation.rudder.users.UserFileSecurityLevelMigration
+import com.normation.rudder.users.UserManagementIO
+import com.normation.zio.UnsafeRun
+import zio.*
+
+class CheckUsersFile(migration: UserFileSecurityLevelMigration) extends BootstrapChecks {
+
+  override def description: String = "Check if hash algorithm for user password is a modern one, if not enable unsafe_hashes"
+
+  def allChecks(currentSecurityLevel: SecurityLevel): IOResult[Unit] = {
+    for {
+      _ <- currentSecurityLevel match {
+             case SecurityLevel.Modern => ZIO.unit
+             case SecurityLevel.Legacy => migration.migrateToModern(UserManagementIO.getUserFilePath(migration.file))
+           }
+    } yield {}
+  }
+
+  override def checks(): Unit = {
+    // at startup we need to read the file that may need to be migrated
+    (for {
+      xml        <- UserFileProcessing.readUserFile(migration.file)
+      parsedHash <- UserFileProcessing.parseXmlHash(xml)
+
+      // invalid hash also need to be renamed to modern one
+      securityLevel = parsedHash
+                        .map(SecurityLevel.fromPasswordEncoderType)
+                        .getOrElse(
+                          SecurityLevel.Legacy
+                        )
+      _            <- allChecks(securityLevel)
+    } yield {})
+      .catchAll(err => BootstrapLogger.error("Error when trying to check users file"))
+      .forkDaemon
+      .runNow
+  }
+
+}

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/CheckUsersFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/CheckUsersFile.scala
@@ -55,7 +55,7 @@ class CheckUsersFile(migration: UserFileSecurityLevelMigration) extends Bootstra
     for {
       _ <- currentSecurityLevel match {
              case SecurityLevel.Modern => ZIO.unit
-             case SecurityLevel.Legacy => migration.migrateToModern(UserManagementIO.getUserFilePath(migration.file))
+             case SecurityLevel.Legacy => migration.allowLegacy(UserManagementIO.getUserFilePath(migration.file))
            }
     } yield {}
   }
@@ -74,7 +74,7 @@ class CheckUsersFile(migration: UserFileSecurityLevelMigration) extends Bootstra
                         )
       _            <- allChecks(securityLevel)
     } yield {})
-      .catchAll(err => BootstrapLogger.error("Error when trying to check users file"))
+      .catchAll(err => BootstrapLogger.error(s"Error when trying to check users file: ${err.fullMsg}"))
       .forkDaemon
       .runNow
   }

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
@@ -53,6 +53,7 @@ import com.normation.rudder.facts.nodes.NodeSecurityContext
 import com.normation.rudder.rest.AuthorizationApiMapping
 import com.normation.rudder.rest.RoleApiMapping
 import com.normation.rudder.tenants.TenantId
+import com.normation.rudder.users.PasswordEncoderDispatcher
 import com.normation.rudder.users.UserDetailListProvider
 import com.normation.rudder.users.UserFileProcessing
 import com.normation.rudder.users.ValidatedUserList
@@ -87,8 +88,10 @@ class RudderUserDetailsTest extends Specification {
 
   // org.slf4j.LoggerFactory.getLogger("application.authorization").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.TRACE)
 
+  val passwordEncoderDispatcher = new PasswordEncoderDispatcher(0)
+
   def getUserDetailList(xml: Elem, debugName: String): ValidatedUserList =
-    UserFileProcessing.parseXml(roleApiMapping, xml, debugName, reload = false).force
+    UserFileProcessing.parseXml(roleApiMapping, passwordEncoderDispatcher, xml, debugName, reload = false).force
 
   // also check that we accept both `role` and `roles` tags
   val userXML_1: Elem = <authentication hash="sha512" case-sensitivity="true">

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserPasswordEncoderTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserPasswordEncoderTest.scala
@@ -71,12 +71,14 @@ class RudderUserPasswordEncoderTest extends Specification {
   }
 
   "hash algo for 'admin' password" should {
-    val pass1        = "admin"
-    val pass1_md5    = "21232f297a57a5a743894a0e4a801fc3"
-    val pass1_sha1   = "d033e22ae348aeb5660fc2140aec35850c4da997"
-    val pass1_sha256 = "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
-    val pass1_sha512 =
+    val pass1          = "admin"
+    val pass1_md5      = "21232f297a57a5a743894a0e4a801fc3"
+    val pass1_sha1     = "d033e22ae348aeb5660fc2140aec35850c4da997"
+    val pass1_sha256   = "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
+    val pass1_sha512   =
       "c7ad44cbad762a5da0a452f9e854fdc1e0e7a52a38015f23f3eab1d80b931dd472634dfac71cd34ebc35d16ab7fb8a90c81f975113d6c7538dc69dd8de9077ec"
+    val pass1_bcrypt_a = "$2a$12$mgAVHJ2/312Q.hdWT0EzjOZHrGicXV/2K.1CLsnM3gOYqi5twcwtW"
+    val pass1_bcrypt_y = "$2y$10$QA4RucUAlhOofuPMAnonk.Mvnq4GPSHaq757Hwj7C/pLb9cmZBHdW"
 
     "be ok for md5" in {
       RudderPasswordEncoder.MD5.matches(pass1, pass1_md5) must beTrue
@@ -89,6 +91,12 @@ class RudderUserPasswordEncoderTest extends Specification {
     }
     "be ok for sha512" in {
       RudderPasswordEncoder.SHA512.matches(pass1, pass1_sha512) must beTrue
+    }
+    "be ok for bcrypt a" in {
+      RudderPasswordEncoder.BCRYPT(RudderConfig.RUDDER_BCRYPT_COST).matches(pass1, pass1_bcrypt_a) must beTrue
+    }
+    "be ok for bcrypt y" in {
+      RudderPasswordEncoder.BCRYPT(RudderConfig.RUDDER_BCRYPT_COST).matches(pass1, pass1_bcrypt_y) must beTrue
     }
 
   }

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserPasswordEncoderTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserPasswordEncoderTest.scala
@@ -92,11 +92,12 @@ class RudderUserPasswordEncoderTest extends Specification {
     "be ok for sha512" in {
       RudderPasswordEncoder.SHA512.matches(pass1, pass1_sha512) must beTrue
     }
+    // Use same default BCRYPT cost as in RudderConfig
     "be ok for bcrypt a" in {
-      RudderPasswordEncoder.BCRYPT(RudderConfig.RUDDER_BCRYPT_COST).matches(pass1, pass1_bcrypt_a) must beTrue
+      RudderPasswordEncoder.BCRYPT(12).matches(pass1, pass1_bcrypt_a) must beTrue
     }
     "be ok for bcrypt y" in {
-      RudderPasswordEncoder.BCRYPT(RudderConfig.RUDDER_BCRYPT_COST).matches(pass1, pass1_bcrypt_y) must beTrue
+      RudderPasswordEncoder.BCRYPT(12).matches(pass1, pass1_bcrypt_y) must beTrue
     }
 
   }
@@ -122,6 +123,58 @@ class RudderUserPasswordEncoderTest extends Specification {
       RudderPasswordEncoder.SHA512.matches(pass1, pass1_sha512) must beTrue
     }
 
+  }
+
+  "hash algo recognition" should {
+    val legacy = RudderPasswordEncoder.SecurityLevel.Legacy
+    val modern = RudderPasswordEncoder.SecurityLevel.Modern
+
+    val pass1_md5         = "21232f297a57a5a743894a0e4a801fc3"
+    val pass1_sha1        = "d033e22ae348aeb5660fc2140aec35850c4da997"
+    val pass1_sha256      = "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918"
+    val pass1_sha512      =
+      "c7ad44cbad762a5da0a452f9e854fdc1e0e7a52a38015f23f3eab1d80b931dd472634dfac71cd34ebc35d16ab7fb8a90c81f975113d6c7538dc69dd8de9077ec"
+    val pass1_bcrypt_a    = "$2a$12$mgAVHJ2/312Q.hdWT0EzjOZHrGicXV/2K.1CLsnM3gOYqi5twcwtW"
+    val pass1_bcrypt_y    = "$2y$10$QA4RucUAlhOofuPMAnonk.Mvnq4GPSHaq757Hwj7C/pLb9cmZBHdW"
+    val pass1_invalid_hex = "87d033e22ae348aeb5660fc2140aec35850c4da997"
+    val pass1_invalid_z   = "z033e22ae348aeb5660fc2140aec35850c4da997"
+
+    "be ok for md5" in {
+      RudderPasswordEncoder.getFromEncoded(pass1_md5, legacy) must beRight(beEqualTo(PasswordEncoderType.MD5))
+    }
+    "be ok for sha1" in {
+      RudderPasswordEncoder.getFromEncoded(pass1_sha1, legacy) must beRight(beEqualTo(PasswordEncoderType.SHA1))
+    }
+    "be ok for sha256" in {
+      RudderPasswordEncoder.getFromEncoded(pass1_sha256, legacy) must beRight(beEqualTo(PasswordEncoderType.SHA256))
+    }
+    "be ok for sha512" in {
+      RudderPasswordEncoder.getFromEncoded(pass1_sha512, legacy) must beRight(beEqualTo(PasswordEncoderType.SHA512))
+    }
+    "be ok for bcrypt a" in {
+      RudderPasswordEncoder.getFromEncoded(pass1_bcrypt_a, legacy) must beRight(beEqualTo(PasswordEncoderType.BCRYPT))
+    }
+    "be ok for bcrypt y" in {
+      RudderPasswordEncoder.getFromEncoded(pass1_bcrypt_y, legacy) must beRight(beEqualTo(PasswordEncoderType.BCRYPT))
+    }
+    "reject invalid hex hash" in {
+      RudderPasswordEncoder.getFromEncoded(pass1_invalid_hex, legacy) must beLeft(
+        "Could not recognize a known hash format from hexadecimal encoded string of length 42"
+      )
+    }
+    "reject invalid char in hash" in {
+      RudderPasswordEncoder.getFromEncoded(pass1_invalid_z, legacy) must beLeft(
+        "Could not recognize a known hash format from encoded password"
+      )
+    }
+    "reject unsafe md5 hash in modern mode" in {
+      RudderPasswordEncoder.getFromEncoded(pass1_md5, modern) must beLeft(
+        "Could not recognize a known hash format from encoded password"
+      )
+    }
+    "allow safe bcrypt hash in modern mode" in {
+      RudderPasswordEncoder.getFromEncoded(pass1_bcrypt_y, modern) must beRight(beEqualTo(PasswordEncoderType.BCRYPT))
+    }
   }
 
 }

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestCheckUsersFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestCheckUsersFile.scala
@@ -1,0 +1,56 @@
+package bootstrap.liftweb.checks.migration
+
+import com.normation.errors.IOResult
+import com.normation.rudder.MockUserManagement
+import com.normation.rudder.users.RudderPasswordEncoder.SecurityLevel
+import com.normation.rudder.users.UserFileSecurityLevelMigration
+import com.normation.zio.UnsafeRun
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.AfterAll
+import scala.xml.Elem
+
+@RunWith(classOf[JUnitRunner])
+class TestCheckUsersFile extends Specification with AfterAll {
+  sequential
+
+  val (mockUserManagementTmpDir, mockUserManagement) = MockUserManagement()
+
+  val migration: UserFileSecurityLevelMigration = mockUserManagement.userService
+
+  val checkUsersFile: CheckUsersFile = new CheckUsersFile(migration)
+
+  "CheckUsersFile" should {
+
+    def haveHash(hash: String) = beEqualTo(hash) ^^ ((_: Elem).attribute("hash").get.head.text)
+
+    def haveUnsafeHashes(unsafeHashes: Option[String]) =
+      beEqualTo(unsafeHashes) ^^ ((_: Elem).attribute("unsafe-hashes").flatMap(_.headOption).map(_.text))
+
+    "start with a sha-1 hash and no unsafe-hashes" in {
+      val initialFile = IOResult.attempt(scala.xml.XML.load(migration.file.inputStream())).runNow
+
+      initialFile must (haveHash("sha-1") and haveUnsafeHashes(None))
+    }
+
+    "migrate legacy hash to bcrypt and enable unsafe-hashes" in {
+      val migratedFile = (checkUsersFile.allChecks(SecurityLevel.Legacy) *> IOResult.attempt(
+        scala.xml.XML.load(migration.file.inputStream())
+      )).runNow
+
+      migratedFile must (haveHash("bcrypt") and haveUnsafeHashes(Some("true")))
+    }
+
+    "keep hash unchanged" in {
+      checkUsersFile.checks()
+      val sameMigratedFile =
+        IOResult.attempt(scala.xml.XML.load(migration.file.inputStream())).runNow
+      sameMigratedFile must (haveHash("bcrypt") and haveUnsafeHashes(Some("true")))
+    }
+  }
+
+  override def afterAll(): Unit = {
+    mockUserManagementTmpDir.delete()
+  }
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/24729

* Makes a new `RudderPasswordEncoder` class that acts as a redirection to the correct encoder based on encoded password format
* Try to encapsulate better the internals of password management inside `RudderPasswordEncoder`
* Add a simple `securityLevel` lever to only allow legacy hashes when necessary
* Add the migration logic on the users file, run at startup and on reload, by using a boolean attribute `unsafe-hashes` to still be able to use legacy hashes