### PR TITLE
Fixes #24712: ExpiredCompliance events are pilling up

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
@@ -709,9 +709,10 @@ object ExecutionBatch extends Loggable {
                         )
                       } else {
                         // standard case: we changed version and are waiting for a run with the new one.
+                        // Pending status expires in expirationDate.
                         runType(
                           s"last run at ${t} was for expired configId ${rv.value} and no report received for current configId ${currentConfig.nodeConfigId.value}, but ${now} is before expiration time ${configurationExpirationTime}, Pending",
-                          Pending(currentConfig, Some((t, runConfig)), eolExpiration)
+                          Pending(currentConfig, Some((t, runConfig)), configurationExpirationTime)
                         )
                       }
                     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -117,8 +117,6 @@ object CacheComplianceQueueAction       {
   final case class ExpectedReportAction(action: CacheExpectedReportAction)            extends CacheComplianceQueueAction {
     def nodeId = action.nodeId
   }
-  final case class InitializeCompliance(nodeId: NodeId, nodeCompliance: Option[NodeStatusReport])
-      extends CacheComplianceQueueAction // do we need this?
   final case class UpdateCompliance(nodeId: NodeId, nodeCompliance: NodeStatusReport) extends CacheComplianceQueueAction
   final case class SetNodeNoAnswer(nodeId: NodeId, actionDate: DateTime)              extends CacheComplianceQueueAction
   final case class ExpiredCompliance(nodeId: NodeId)                                  extends CacheComplianceQueueAction
@@ -517,7 +515,12 @@ trait CachedFindRuleNodeStatusReports
     val nodeWithOutdatedCompliance = cache.filter {
       case (id, compliance) =>
         compliance.runInfo match {
-          case t: ExpiringStatus => t.expirationDateTime.isBefore(now)
+          // here, we have a special case for unexpected version: it is useless to recompute compliance until we don't have a new run,
+          // ie the node config was changed elsewhere. It means that "unexpected version" wins above "No report in interval",
+          // ie that that error is bigger.
+          case _: UnexpectedVersion => false
+          // other expiring status
+          case t: ExpiringStatus    => t.expirationDateTime.isBefore(now)
           case _ => false
         }
     }.toSeq


### PR DESCRIPTION
https://issues.rudder.io/issues/24712

Correct three loops (one in pending, two in unexpected handled in one case). Tested in the load server, which is now doing nothing in place of continously expiring / computing compliance. 