### PR TITLE
Fixes #24708: Groups node ids list in API is still exhaustive even with restricted tenant access

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/eventlog/EventLog.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/eventlog/EventLog.scala
@@ -20,7 +20,9 @@
 
 package com.normation.eventlog
 
+import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.utils.StringUuidGeneratorImpl
+import io.scalaland.chimney.Transformer
 import org.joda.time.DateTime
 import scala.xml.*
 
@@ -44,6 +46,9 @@ object EventMetadata {
   def withNewId(actor: EventActor, msg: Option[String] = None): EventMetadata = {
     EventMetadata(ModificationId(uuidGen.newUuid), actor, msg)
   }
+
+  implicit val transformChangeContext: Transformer[ChangeContext, EventMetadata] =
+    Transformer.define[ChangeContext, EventMetadata].withFieldRenamed(_.message, _.msg).buildTransformer
 }
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/UpdateDynamicGroups.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/UpdateDynamicGroups.scala
@@ -46,6 +46,8 @@ import com.normation.rudder.domain.eventlog.RudderEventActor
 import com.normation.rudder.domain.logger.DynamicGroupLoggerPure
 import com.normation.rudder.domain.logger.ScheduledJobLogger
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.facts.nodes.ChangeContext
+import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.services.queries.*
 import com.normation.rudder.utils.ParseMaxParallelism
 import com.normation.utils.StringUuidGenerator
@@ -319,11 +321,15 @@ class UpdateDynamicGroups(
               results <- dynGroupIds.accumulateParN(maxParallelism) {
                            case dynGroupId =>
                              dynGroupUpdaterService
-                               .update(
-                                 dynGroupId,
-                                 modId,
-                                 RudderEventActor,
-                                 Some("Update group due to batch update of dynamic groups")
+                               .update(dynGroupId)(
+                                 ChangeContext(
+                                   modId,
+                                   RudderEventActor,
+                                   new DateTime(),
+                                   Some("Update group due to batch update of dynamic groups"),
+                                   None,
+                                   QueryContext.systemQC.nodePerms
+                                 )
                                )
                                .toIO
                                .either
@@ -339,11 +345,15 @@ class UpdateDynamicGroups(
               results2 <- dynGroupsWithDependencyIds.accumulateParN(1) {
                             case dynGroupId =>
                               dynGroupUpdaterService
-                                .update(
-                                  dynGroupId,
-                                  modId,
-                                  RudderEventActor,
-                                  Some("Update group due to batch update of dynamic groups")
+                                .update(dynGroupId)(
+                                  ChangeContext(
+                                    modId,
+                                    RudderEventActor,
+                                    new DateTime(),
+                                    Some("Update group due to batch update of dynamic groups"),
+                                    None,
+                                    QueryContext.systemQC.nodePerms
+                                  )
                                 )
                                 .toIO
                                 .either

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/configuration/ConfigurationRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/configuration/ConfigurationRepository.scala
@@ -47,7 +47,6 @@ import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.errors.IOResult
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupCategoryId
-import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.ActiveTechnique
 import com.normation.rudder.domain.policies.Directive
@@ -88,7 +87,6 @@ trait RoConfigurationRepository {
   def getDirective(id: DirectiveId): IOResult[Option[ActiveDirective]]
   def getTechnique(id: TechniqueId): IOResult[Option[(Chunk[TechniqueCategoryName], Technique)]]
   def getRule(id:      RuleId):      IOResult[Option[Rule]]
-  def getGroup(id:     NodeGroupId): IOResult[Option[GroupAndCat]]
 
   def getDirectiveLibrary(ids: Set[DirectiveId]): IOResult[FullActiveTechniqueCategory]
 
@@ -152,15 +150,6 @@ class ConfigurationRepositoryImpl(
         roRuleRepository.getOpt(id)
       case r                      =>
         ruleRevisionRepo.getRuleRevision(id.uid, id.rev)
-    }
-  }
-
-  override def getGroup(id: NodeGroupId): IOResult[Option[GroupAndCat]] = {
-    id.rev match {
-      case GitVersion.DEFAULT_REV =>
-        roNodeGroupRepository.getNodeGroupOpt(id).map(_.map { case (g, c) => GroupAndCat(g, c) })
-      case r                      =>
-        groupRevisionRepo.getGroupRevision(id.uid, id.rev)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
@@ -52,6 +52,7 @@ import com.normation.rudder.domain.queries.KeyValueComparator.HasKey
 import com.normation.rudder.domain.queries.KeyValueComparator as KVC
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.facts.nodes.NodeFact
+import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.repository.RoNodeGroupRepository
 import com.normation.utils.DateFormaterService
 import java.util.function.Predicate
@@ -64,13 +65,13 @@ import zio.*
 import zio.syntax.*
 
 trait SubGroupComparatorRepository {
-  def getNodeIds(groupId: NodeGroupId): IOResult[Chunk[NodeId]]
+  def getNodeIds(groupId: NodeGroupId)(implicit qc: QueryContext): IOResult[Chunk[NodeId]]
   def getGroups: IOResult[Chunk[SubGroupChoice]]
 }
 // default implementation out of test use GroupRepo for that
 class DefaultSubGroupComparatorRepository(repo: RoNodeGroupRepository) extends SubGroupComparatorRepository {
 
-  override def getNodeIds(groupId: NodeGroupId): IOResult[Chunk[NodeId]] = {
+  override def getNodeIds(groupId: NodeGroupId)(implicit qc: QueryContext): IOResult[Chunk[NodeId]] = {
     repo.getNodeGroupOpt(groupId).map {
       case None             => Chunk.empty
       case Some((group, _)) => Chunk.fromIterable(group.serverList)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ItemArchiveManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ItemArchiveManager.scala
@@ -56,6 +56,8 @@ import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.properties.GlobalParameter
+import com.normation.rudder.facts.nodes.ChangeContext
+import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.git.GitArchiveId
 import com.normation.rudder.git.GitCommitId
 import com.normation.rudder.git.GitPath
@@ -104,7 +106,7 @@ trait ItemArchiveManager {
       actor:         EventActor,
       reason:        Option[String],
       includeSystem: Boolean = false
-  ): IOResult[(GitArchiveId, NotArchivedElements)]
+  )(implicit qc: QueryContext): IOResult[(GitArchiveId, NotArchivedElements)]
 
   def exportRules(
       commiter:      PersonIdent,
@@ -133,7 +135,7 @@ trait ItemArchiveManager {
       actor:         EventActor,
       reason:        Option[String],
       includeSystem: Boolean = false
-  ): IOResult[GitArchiveId]
+  )(implicit qc: QueryContext): IOResult[GitArchiveId]
 
   def exportParameters(
       commiter:      PersonIdent,
@@ -154,47 +156,32 @@ trait ItemArchiveManager {
   def importAll(
       archiveId:     GitCommitId,
       commiter:      PersonIdent,
-      modId:         ModificationId,
-      actor:         EventActor,
-      reason:        Option[String],
       includeSystem: Boolean = false
-  ): IOResult[GitCommitId]
+  )(implicit cc: ChangeContext): IOResult[GitCommitId]
 
   def importRules(
       archiveId:     GitCommitId,
       commiter:      PersonIdent,
-      modId:         ModificationId,
-      actor:         EventActor,
-      reason:        Option[String],
       includeSystem: Boolean = false
-  ): IOResult[GitCommitId]
+  )(implicit cc: ChangeContext): IOResult[GitCommitId]
 
   def importTechniqueLibrary(
       archiveId:     GitCommitId,
       commiter:      PersonIdent,
-      modId:         ModificationId,
-      actor:         EventActor,
-      reason:        Option[String],
       includeSystem: Boolean = false
-  ): IOResult[GitCommitId]
+  )(implicit cc: ChangeContext): IOResult[GitCommitId]
 
   def importGroupLibrary(
       archiveId:     GitCommitId,
       commiter:      PersonIdent,
-      modId:         ModificationId,
-      actor:         EventActor,
-      reason:        Option[String],
       includeSystem: Boolean = false
-  ): IOResult[GitCommitId]
+  )(implicit cc: ChangeContext): IOResult[GitCommitId]
 
   def importParameters(
       archiveId:     GitCommitId,
       commiter:      PersonIdent,
-      modId:         ModificationId,
-      actor:         EventActor,
-      reason:        Option[String],
       includeSystem: Boolean = false
-  ): IOResult[GitCommitId]
+  )(implicit cc: ChangeContext): IOResult[GitCommitId]
 
   /**
    * Import the item archive from HEAD (corresponding to last commit)
@@ -203,52 +190,37 @@ trait ItemArchiveManager {
 
   def importHeadAll(
       commiter:      PersonIdent,
-      modId:         ModificationId,
-      actor:         EventActor,
-      reason:        Option[String],
       includeSystem: Boolean = false
-  ): IOResult[GitCommitId] = {
-    importAll(lastGitCommitId, commiter, modId, actor, reason, includeSystem)
+  )(implicit cc: ChangeContext): IOResult[GitCommitId] = {
+    importAll(lastGitCommitId, commiter, includeSystem)
   }
 
   def importHeadRules(
       commiter:      PersonIdent,
-      modId:         ModificationId,
-      actor:         EventActor,
-      reason:        Option[String],
       includeSystem: Boolean = false
-  ): IOResult[GitCommitId] = {
-    importRules(lastGitCommitId, commiter, modId, actor, reason, includeSystem)
+  )(implicit cc: ChangeContext): IOResult[GitCommitId] = {
+    importRules(lastGitCommitId, commiter, includeSystem)
   }
 
   def importHeadTechniqueLibrary(
       commiter:      PersonIdent,
-      modId:         ModificationId,
-      actor:         EventActor,
-      reason:        Option[String],
       includeSystem: Boolean = false
-  ): IOResult[GitCommitId] = {
-    importTechniqueLibrary(lastGitCommitId, commiter, modId, actor, reason, includeSystem)
+  )(implicit cc: ChangeContext): IOResult[GitCommitId] = {
+    importTechniqueLibrary(lastGitCommitId, commiter, includeSystem)
   }
 
   def importHeadGroupLibrary(
       commiter:      PersonIdent,
-      modId:         ModificationId,
-      actor:         EventActor,
-      reason:        Option[String],
       includeSystem: Boolean = false
-  ): IOResult[GitCommitId] = {
-    importGroupLibrary(lastGitCommitId, commiter, modId, actor, reason, includeSystem)
+  )(implicit cc: ChangeContext): IOResult[GitCommitId] = {
+    importGroupLibrary(lastGitCommitId, commiter, includeSystem)
   }
 
   def importHeadParameters(
       commiter:      PersonIdent,
-      modId:         ModificationId,
-      actor:         EventActor,
-      reason:        Option[String],
       includeSystem: Boolean = false
-  ): IOResult[GitCommitId] = {
-    importParameters(lastGitCommitId, commiter, modId, actor, reason)
+  )(implicit cc: ChangeContext): IOResult[GitCommitId] = {
+    importParameters(lastGitCommitId, commiter, includeSystem)
   }
 
   /**
@@ -257,14 +229,11 @@ trait ItemArchiveManager {
   def rollback(
       archiveId:        GitCommitId,
       commiter:         PersonIdent,
-      modId:            ModificationId,
-      actor:            EventActor,
-      reason:           Option[String],
       rollbackedEvents: Seq[EventLog],
       target:           EventLog,
       rollbackType:     String,
       includeSystem:    Boolean = false
-  ): IOResult[GitCommitId]
+  )(implicit cc: ChangeContext): IOResult[GitCommitId]
 
   /**
    * Get the list of tags for the archive type

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
@@ -43,7 +43,9 @@ import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.policies.*
+import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.CoreNodeFact
+import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.utils.Utils
 import com.unboundid.ldif.LDIFChangeRecord
 import scala.collection.MapView
@@ -215,14 +217,18 @@ trait RoNodeGroupRepository {
    * @param id
    * @return
    */
-  def getNodeGroup(id: NodeGroupId): IOResult[(NodeGroup, NodeGroupCategoryId)] = {
+  def getNodeGroup(id: NodeGroupId)(implicit
+      qc: QueryContext
+  ): IOResult[(NodeGroup, NodeGroupCategoryId)] = {
     getNodeGroupOpt(id).notOptional(s"Group with id '${id.serialize}' was not found'")
   }
 
   /**
    * Get the node group corresponding to that ID, or None if none were found.
    */
-  def getNodeGroupOpt(id: NodeGroupId): IOResult[Option[(NodeGroup, NodeGroupCategoryId)]]
+  def getNodeGroupOpt(id: NodeGroupId)(implicit
+      qc: QueryContext
+  ): IOResult[Option[(NodeGroup, NodeGroupCategoryId)]]
 
   /**
    * Fetch the parent category of the NodeGroup
@@ -235,6 +241,7 @@ trait RoNodeGroupRepository {
   /**
    * Get all node groups defined in that repository
    */
+  // TODO: add QC
   def getAll(): IOResult[Seq[NodeGroup]]
 
   /**
@@ -266,7 +273,9 @@ trait RoNodeGroupRepository {
    *   ...    *
    *
    */
-  def getGroupsByCategory(includeSystem: Boolean = false): IOResult[SortedMap[List[NodeGroupCategoryId], CategoryAndNodeGroup]]
+  def getGroupsByCategory(includeSystem: Boolean = false)(implicit
+      qc: QueryContext
+  ): IOResult[SortedMap[List[NodeGroupCategoryId], CategoryAndNodeGroup]]
 
   /**
    * Retrieve all groups that have at least one of the given
@@ -456,12 +465,9 @@ trait WoNodeGroupRepository {
    * if needed
    */
   def move(
-      group:          NodeGroupId,
-      containerId:    NodeGroupCategoryId,
-      modId:          ModificationId,
-      actor:          EventActor,
-      whyDescription: Option[String]
-  ): IOResult[Option[ModifyNodeGroupDiff]]
+      group:       NodeGroupId,
+      containerId: NodeGroupCategoryId
+  )(implicit cc: ChangeContext): IOResult[Option[ModifyNodeGroupDiff]]
 
   /**
    * Delete the given nodeGroup.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/modification/ModificationService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/modification/ModificationService.scala
@@ -39,12 +39,15 @@ package com.normation.rudder.services.modification
 
 import com.normation.box.*
 import com.normation.eventlog.*
+import com.normation.rudder.facts.nodes.ChangeContext
+import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.git.GitCommitId
 import com.normation.rudder.repository.*
 import com.normation.rudder.repository.EventLogRepository
 import com.normation.utils.StringUuidGenerator
 import net.liftweb.common.*
 import org.eclipse.jgit.lib.PersonIdent
+import org.joda.time.DateTime
 
 class ModificationService(
     eventLogRepository:        EventLogRepository,
@@ -76,13 +79,19 @@ class ModificationService(
                         .rollback(
                           x,
                           commiter,
-                          ModificationId(uuidGen.newUuid),
-                          eventLog.principal,
-                          None,
                           rollbackedEvents,
                           target,
                           "after",
                           false
+                        )(
+                          ChangeContext(
+                            ModificationId(uuidGen.newUuid),
+                            eventLog.principal,
+                            new DateTime(),
+                            None,
+                            None,
+                            QueryContext.systemQC.nodePerms
+                          )
                         )
                         .toBox
                   }
@@ -109,13 +118,19 @@ class ModificationService(
                         .rollback(
                           parentCommit,
                           commiter,
-                          ModificationId(uuidGen.newUuid),
-                          eventLog.principal,
-                          None,
                           rollbackedEvents,
                           target,
                           "before",
                           false
+                        )(
+                          ChangeContext(
+                            ModificationId(uuidGen.newUuid),
+                            eventLog.principal,
+                            new DateTime(),
+                            None,
+                            None,
+                            QueryContext.systemQC.nodePerms
+                          )
                         )
                         .toBox
                   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NewNodeManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NewNodeManager.scala
@@ -367,7 +367,7 @@ class RefuseGroups(
       groupIds       <- roGroupRepo.findGroupWithAnyMember(Seq(cnf.id))
       modifiedGroups <- ZIO.foreach(groupIds) { groupId =>
                           for {
-                            groupPair <- roGroupRepo.getNodeGroup(groupId)
+                            groupPair <- roGroupRepo.getNodeGroup(groupId)(cc.toQuery)
                             modGroup   = groupPair._1.copy(serverList = groupPair._1.serverList - cnf.id)
                             msg        = Some("Automatic update of groups due to refusal of node " + cnf.id.value)
                             saved     <- {
@@ -412,7 +412,7 @@ class AcceptHostnameAndIp(
    * search in database nodes having the same hostname as one provided.
    * Only return existing hostname (and so again, we want that to be empty)
    */
-  private[this] def queryForDuplicateHostname(hostnames: Seq[String]): IOResult[Unit] = {
+  private[this] def queryForDuplicateHostname(hostnames: Seq[String])(implicit qc: QueryContext): IOResult[Unit] = {
     val hostnameCriterion = hostnames.toList.map { h =>
       CriterionLine(
         objectType = objectType,
@@ -442,7 +442,7 @@ class AcceptHostnameAndIp(
       acceptDuplicated <- acceptDuplicateHostnames
       _                <- ZIO.when(!acceptDuplicated) {
                             for {
-                              _ <- queryForDuplicateHostname(List(cnf.fqdn))
+                              _ <- queryForDuplicateHostname(List(cnf.fqdn))(cc.toQuery)
                             } yield ()
                           }
     } yield ()

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/QueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/QueryProcessor.scala
@@ -50,13 +50,13 @@ trait QueryProcessor {
    * @param query - the query to process
    * @return
    */
-  def process(query: Query): Box[Seq[NodeId]]
+  def process(query: Query)(implicit qc: QueryContext): Box[Seq[NodeId]]
 
   /**
    * Only get node ids corresponding to that request, with minimal consistency check.
    * This method is useful to maximize performance (low memory, high throughout) for ex for dynamic groups.
    */
-  def processOnlyId(query: Query): Box[Seq[NodeId]]
+  def processOnlyId(query: Query)(implicit qc: QueryContext): Box[Seq[NodeId]]
 }
 
 trait QueryChecker {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
@@ -66,6 +66,7 @@ import zio.syntax.*
 
 @RunWith(classOf[BlockJUnit4ClassRunner])
 class TestNodeFactQueryProcessor {
+  implicit val qc: QueryContext = QueryContext.testQC
   implicit def StringToNodeId(s:  String): NodeId      = NodeId(s)
   implicit def StringToGroupId(s: String): NodeGroupId = NodeGroupId(NodeGroupUid(s))
 
@@ -80,7 +81,7 @@ class TestNodeFactQueryProcessor {
       (SubGroupChoice("AIXSystems", "AIXSystems"), Chunk[NodeId]())
     )
 
-    override def getNodeIds(groupId: NodeGroupId): IOResult[Chunk[NodeId]] = {
+    override def getNodeIds(groupId: NodeGroupId)(implicit qc: QueryContext): IOResult[Chunk[NodeId]] = {
       (groups.find(_._1.id == groupId) match {
         case Some(kv) => kv._2
         case None     => Chunk.empty

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
@@ -237,7 +237,7 @@ class EventLogAPI(
                         case Full(Some((_, crId))) => crId
                         case _                     => None
                       })
-        htmlDetails = eventLogDetail.displayDetails(event, crId)
+        htmlDetails = eventLogDetail.displayDetails(event, crId)(CurrentUser.queryContext)
       } yield {
         val response = {
           (("id"           -> id)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
@@ -49,6 +49,8 @@ import com.normation.rudder.batch.AsyncDeploymentAgent
 import com.normation.rudder.batch.ManualStartDeployment
 import com.normation.rudder.batch.UpdateDynamicGroups
 import com.normation.rudder.domain.logger.ApiLogger
+import com.normation.rudder.facts.nodes.ChangeContext
+import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.git.GitArchiveId
 import com.normation.rudder.git.GitCommitId
 import com.normation.rudder.git.GitFindUtils
@@ -293,6 +295,7 @@ class SystemApi(
     val restExtractor = restExtractorService
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.restoreGroupsLatestArchive(req, params)
     }
   }
@@ -302,6 +305,7 @@ class SystemApi(
     val restExtractor = restExtractorService
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.restoreDirectivesLatestArchive(req, params)
     }
   }
@@ -311,6 +315,7 @@ class SystemApi(
     val restExtractor = restExtractorService
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.restoreRulesLatestArchive(req, params)
     }
   }
@@ -320,6 +325,7 @@ class SystemApi(
     val restExtractor = restExtractorService
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.restoreParametersLatestArchive(req, params)
     }
   }
@@ -329,6 +335,7 @@ class SystemApi(
     val restExtractor = restExtractorService
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.restoreFullLatestArchive(req, params)
     }
   }
@@ -338,6 +345,7 @@ class SystemApi(
     val restExtractor = restExtractorService
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.restoreGroupsLatestCommit(req, params)
     }
   }
@@ -347,6 +355,7 @@ class SystemApi(
     val restExtractor = restExtractorService
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.restoreDirectivesLatestCommit(req, params)
     }
   }
@@ -356,6 +365,7 @@ class SystemApi(
     val restExtractor = restExtractorService
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.restoreRulesLatestCommit(req, params)
     }
   }
@@ -365,6 +375,7 @@ class SystemApi(
     val restExtractor = restExtractorService
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.restoreParametersLatestCommit(req, params)
     }
   }
@@ -374,6 +385,7 @@ class SystemApi(
     val restExtractor = restExtractorService
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.restoreFullLatestCommit(req, params)
     }
   }
@@ -383,6 +395,7 @@ class SystemApi(
     val restExtractor = restExtractorService
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.archiveGroups(req, params)
     }
   }
@@ -418,6 +431,7 @@ class SystemApi(
     val restExtractor = restExtractorService
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.archiveAll(req, params)
     }
   }
@@ -434,6 +448,7 @@ class SystemApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.archiveGroupDateRestore(req, params, dateTime)
     }
   }
@@ -450,6 +465,7 @@ class SystemApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.archiveDirectiveDateRestore(req, params, dateTime)
     }
   }
@@ -466,6 +482,7 @@ class SystemApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.archiveRuleDateRestore(req, params, dateTime)
     }
   }
@@ -482,6 +499,7 @@ class SystemApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.archiveParameterDateRestore(req, params, dateTime)
     }
   }
@@ -498,6 +516,7 @@ class SystemApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
+      implicit val qc: QueryContext = authzToken.qc
       apiv11service.archiveFullDateRestore(req, params, dateTime)
     }
   }
@@ -712,7 +731,7 @@ class SystemApiService11(
   private[this] def restoreLatestArchive(
       req:         Req,
       list:        () => IOResult[Map[DateTime, GitArchiveId]],
-      restore:     (GitCommitId, PersonIdent, ModificationId, EventActor, Option[String], Boolean) => IOResult[GitCommitId],
+      restore:     (GitCommitId, PersonIdent, Boolean) => IOResult[GitCommitId],
       archiveType: String
   ): Either[String, JField] = {
     (for {
@@ -724,9 +743,6 @@ class SystemApiService11(
       restored   <- restore(
                       tag.commit,
                       commiter,
-                      newModId,
-                      RestUtils.getActor(req),
-                      Some("Restore latest archive required from REST API"),
                       false
                     )
     } yield {
@@ -739,16 +755,13 @@ class SystemApiService11(
 
   private[this] def restoreLatestCommit(
       req:         Req,
-      restore:     (PersonIdent, ModificationId, EventActor, Option[String], Boolean) => IOResult[GitCommitId],
+      restore:     (PersonIdent, Boolean) => IOResult[GitCommitId],
       archiveType: String
   ): Either[String, JField] = {
     (for {
       commiter <- personIdentService.getPersonIdentOrDefault(RestUtils.getActor(req).name)
       restored <- restore(
                     commiter,
-                    newModId,
-                    RestUtils.getActor(req),
-                    Some("Restore archive from latest commit on HEAD required from REST API"),
                     false
                   )
     } yield {
@@ -762,7 +775,7 @@ class SystemApiService11(
   private[this] def restoreByDatetime(
       req:         Req,
       list:        () => IOResult[Map[DateTime, GitArchiveId]],
-      restore:     (GitCommitId, PersonIdent, ModificationId, EventActor, Option[String], Boolean) => IOResult[GitCommitId],
+      restore:     (GitCommitId, PersonIdent, Boolean) => IOResult[GitCommitId],
       datetime:    String,
       archiveType: String
   ): Either[String, JField] = {
@@ -781,9 +794,6 @@ class SystemApiService11(
       restored   <- restore(
                       tag.commit,
                       commiter,
-                      newModId,
-                      RestUtils.getActor(req),
-                      Some("Restore archive for date time %s requested from REST API".format(datetime)),
                       false
                     )
     } yield {
@@ -933,9 +943,17 @@ class SystemApiService11(
 
   // Archive RESTORE based on a date given as the last part of the URL
 
-  def archiveGroupDateRestore(req: Req, params: DefaultParams, dateTime: String): LiftResponse = {
+  def archiveGroupDateRestore(req: Req, params: DefaultParams, dateTime: String)(implicit qc: QueryContext): LiftResponse = {
     implicit val action   = "archiveGroupDateRestore"
     implicit val prettify = params.prettify
+    implicit val cc: ChangeContext = ChangeContext(
+      newModId,
+      qc.actor,
+      new DateTime(),
+      Some(s"Restore archive for date time ${dateTime} requested from REST API"),
+      None,
+      qc.nodePerms
+    )
 
     restoreByDatetime(
       req,
@@ -949,9 +967,17 @@ class SystemApiService11(
     }
   }
 
-  def archiveDirectiveDateRestore(req: Req, params: DefaultParams, dateTime: String): LiftResponse = {
+  def archiveDirectiveDateRestore(req: Req, params: DefaultParams, dateTime: String)(implicit qc: QueryContext): LiftResponse = {
     implicit val action   = "archiveDirectiveDateRestore"
     implicit val prettify = params.prettify
+    implicit val cc: ChangeContext = ChangeContext(
+      newModId,
+      qc.actor,
+      new DateTime(),
+      Some(s"Restore archive for date time ${dateTime} requested from REST API"),
+      None,
+      qc.nodePerms
+    )
 
     restoreByDatetime(
       req,
@@ -965,9 +991,17 @@ class SystemApiService11(
     }
   }
 
-  def archiveRuleDateRestore(req: Req, params: DefaultParams, dateTime: String): LiftResponse = {
+  def archiveRuleDateRestore(req: Req, params: DefaultParams, dateTime: String)(implicit qc: QueryContext): LiftResponse = {
     implicit val action   = "archiveRuleDateRestore"
     implicit val prettify = params.prettify
+    implicit val cc: ChangeContext = ChangeContext(
+      newModId,
+      qc.actor,
+      new DateTime(),
+      Some(s"Restore archive for date time ${dateTime} requested from REST API"),
+      None,
+      qc.nodePerms
+    )
 
     restoreByDatetime(req, () => itemArchiveManager.getRulesTags, itemArchiveManager.importRules, dateTime, "rule") match {
       case Left(error)  => toJsonError(None, error)
@@ -975,9 +1009,17 @@ class SystemApiService11(
     }
   }
 
-  def archiveParameterDateRestore(req: Req, params: DefaultParams, dateTime: String): LiftResponse = {
+  def archiveParameterDateRestore(req: Req, params: DefaultParams, dateTime: String)(implicit qc: QueryContext): LiftResponse = {
     implicit val action   = "archiveParameterDateRestore"
     implicit val prettify = params.prettify
+    implicit val cc: ChangeContext = ChangeContext(
+      newModId,
+      qc.actor,
+      new DateTime(),
+      Some(s"Restore archive for date time ${dateTime} requested from REST API"),
+      None,
+      qc.nodePerms
+    )
 
     restoreByDatetime(
       req,
@@ -991,9 +1033,17 @@ class SystemApiService11(
     }
   }
 
-  def archiveFullDateRestore(req: Req, params: DefaultParams, dateTime: String): LiftResponse = {
+  def archiveFullDateRestore(req: Req, params: DefaultParams, dateTime: String)(implicit qc: QueryContext): LiftResponse = {
     implicit val action   = "archiveFullDateRestore"
     implicit val prettify = params.prettify
+    implicit val cc: ChangeContext = ChangeContext(
+      newModId,
+      qc.actor,
+      new DateTime(),
+      Some(s"Restore archive for date time ${dateTime} requested from REST API"),
+      None,
+      qc.nodePerms
+    )
 
     restoreByDatetime(req, () => itemArchiveManager.getFullArchiveTags, itemArchiveManager.importAll, dateTime, "full") match {
       case Left(error)  => toJsonError(None, error)
@@ -1003,7 +1053,7 @@ class SystemApiService11(
 
   // Archiving endpoints
 
-  def archiveGroups(req: Req, params: DefaultParams): LiftResponse = {
+  def archiveGroups(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
     implicit val action   = "archiveGroups"
     implicit val prettify = params.prettify
 
@@ -1041,7 +1091,7 @@ class SystemApiService11(
     }
   }
 
-  def archiveAll(req: Req, params: DefaultParams): LiftResponse = {
+  def archiveAll(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
     implicit val action   = "archiveAll"
     implicit val prettify = params.prettify
 
@@ -1053,11 +1103,18 @@ class SystemApiService11(
 
   // All archives RESTORE functions implemented by the API (latest archive or latest commit)
 
-  def restoreGroupsLatestArchive(req: Req, params: DefaultParams): LiftResponse = {
+  def restoreGroupsLatestArchive(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
 
     implicit val action   = "restoreGroupsLatestArchive"
     implicit val prettify = params.prettify
-
+    implicit val cc: ChangeContext = ChangeContext(
+      newModId,
+      qc.actor,
+      new DateTime(),
+      Some("Restore latest archive required from REST API"),
+      None,
+      qc.nodePerms
+    )
     restoreLatestArchive(
       req,
       () => itemArchiveManager.getGroupLibraryTags,
@@ -1069,10 +1126,18 @@ class SystemApiService11(
     }
   }
 
-  def restoreDirectivesLatestArchive(req: Req, params: DefaultParams): LiftResponse = {
+  def restoreDirectivesLatestArchive(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
 
     implicit val action   = "restoreDirectivesLatestArchive"
     implicit val prettify = params.prettify
+    implicit val cc: ChangeContext = ChangeContext(
+      newModId,
+      qc.actor,
+      new DateTime(),
+      Some("Restore latest archive required from REST API"),
+      None,
+      qc.nodePerms
+    )
 
     restoreLatestArchive(
       req,
@@ -1085,9 +1150,17 @@ class SystemApiService11(
     }
   }
 
-  def restoreRulesLatestArchive(req: Req, params: DefaultParams): LiftResponse = {
+  def restoreRulesLatestArchive(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
     implicit val action   = "restoreRulesLatestArchive"
     implicit val prettify = params.prettify
+    implicit val cc: ChangeContext = ChangeContext(
+      newModId,
+      qc.actor,
+      new DateTime(),
+      Some("Restore latest archive required from REST API"),
+      None,
+      qc.nodePerms
+    )
 
     restoreLatestArchive(req, () => itemArchiveManager.getRulesTags, itemArchiveManager.importRules, "rules") match {
       case Left(error)  => toJsonError(None, error)
@@ -1095,9 +1168,17 @@ class SystemApiService11(
     }
   }
 
-  def restoreParametersLatestArchive(req: Req, params: DefaultParams): LiftResponse = {
+  def restoreParametersLatestArchive(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
     implicit val action   = "restoreParametersLatestArchive"
     implicit val prettify = params.prettify
+    implicit val cc: ChangeContext = ChangeContext(
+      newModId,
+      qc.actor,
+      new DateTime(),
+      Some("Restore latest archive required from REST API"),
+      None,
+      qc.nodePerms
+    )
 
     restoreLatestArchive(
       req,
@@ -1110,10 +1191,18 @@ class SystemApiService11(
     }
   }
 
-  def restoreFullLatestArchive(req: Req, params: DefaultParams): LiftResponse = {
+  def restoreFullLatestArchive(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
 
     implicit val action   = "restoreFullLatestArchive"
     implicit val prettify = params.prettify
+    implicit val cc: ChangeContext = ChangeContext(
+      newModId,
+      qc.actor,
+      new DateTime(),
+      Some("Restore latest archive required from REST API"),
+      None,
+      qc.nodePerms
+    )
 
     restoreLatestArchive(req, () => itemArchiveManager.getFullArchiveTags, itemArchiveManager.importAll, "full") match {
       case Left(error)  => toJsonError(None, error)
@@ -1121,10 +1210,18 @@ class SystemApiService11(
     }
   }
 
-  def restoreGroupsLatestCommit(req: Req, params: DefaultParams): LiftResponse = {
+  def restoreGroupsLatestCommit(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
 
     implicit val action   = "restoreGroupsLatestCommit"
     implicit val prettify = params.prettify
+    implicit val cc: ChangeContext = ChangeContext(
+      newModId,
+      qc.actor,
+      new DateTime(),
+      Some("Restore archive from latest commit on HEAD required from REST API"),
+      None,
+      qc.nodePerms
+    )
 
     restoreLatestCommit(req, itemArchiveManager.importHeadGroupLibrary, "groups") match {
       case Left(error)  => toJsonError(None, error)
@@ -1132,10 +1229,18 @@ class SystemApiService11(
     }
   }
 
-  def restoreDirectivesLatestCommit(req: Req, params: DefaultParams): LiftResponse = {
+  def restoreDirectivesLatestCommit(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
 
     implicit val action   = "restoreDirectivesLatestCommit"
     implicit val prettify = params.prettify
+    implicit val cc: ChangeContext = ChangeContext(
+      newModId,
+      qc.actor,
+      new DateTime(),
+      Some("Restore archive from latest commit on HEAD required from REST API"),
+      None,
+      qc.nodePerms
+    )
 
     restoreLatestCommit(req, itemArchiveManager.importHeadTechniqueLibrary, "directives") match {
       case Left(error)  => toJsonError(None, error)
@@ -1143,10 +1248,18 @@ class SystemApiService11(
     }
   }
 
-  def restoreRulesLatestCommit(req: Req, params: DefaultParams): LiftResponse = {
+  def restoreRulesLatestCommit(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
 
     implicit val action   = "restoreRulesLatestCommit"
     implicit val prettify = params.prettify
+    implicit val cc: ChangeContext = ChangeContext(
+      newModId,
+      qc.actor,
+      new DateTime(),
+      Some("Restore latest archive required from REST API"),
+      None,
+      qc.nodePerms
+    )
 
     restoreLatestCommit(req, itemArchiveManager.importHeadRules, "rules") match {
       case Left(error)  => toJsonError(None, error)
@@ -1154,20 +1267,36 @@ class SystemApiService11(
     }
   }
 
-  def restoreParametersLatestCommit(req: Req, params: DefaultParams): LiftResponse = {
+  def restoreParametersLatestCommit(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
 
     implicit val action   = "restoreParametersLatestCommit"
     implicit val prettify = params.prettify
+    implicit val cc: ChangeContext = ChangeContext(
+      newModId,
+      qc.actor,
+      new DateTime(),
+      Some("Restore latest archive required from REST API"),
+      None,
+      qc.nodePerms
+    )
 
     restoreLatestCommit(req, itemArchiveManager.importHeadParameters, "parameters") match {
       case Left(error)  => toJsonError(None, error)
       case Right(field) => toJsonResponse(None, JObject(field))
     }
   }
-  def restoreFullLatestCommit(req: Req, params: DefaultParams): LiftResponse = {
+  def restoreFullLatestCommit(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
 
     implicit val action   = "restoreFullLatestCommit"
     implicit val prettify = params.prettify
+    implicit val cc: ChangeContext = ChangeContext(
+      newModId,
+      qc.actor,
+      new DateTime(),
+      Some("Restore latest archive required from REST API"),
+      None,
+      qc.nodePerms
+    )
 
     restoreLatestCommit(req, itemArchiveManager.importHeadAll, "full") match {
       case Left(error)  => toJsonError(None, error)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/JsInitContextLinkUtil.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/JsInitContextLinkUtil.scala
@@ -43,6 +43,7 @@ import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleTarget
 import com.normation.rudder.domain.workflows.ChangeRequestId
+import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.repository.RoDirectiveRepository
 import com.normation.rudder.repository.RoNodeGroupRepository
 import com.normation.rudder.repository.RoRuleRepository
@@ -140,7 +141,7 @@ class LinkUtil(
     }
   }
 
-  def createGroupLink(id: NodeGroupId): Elem = {
+  def createGroupLink(id: NodeGroupId)(implicit qc: QueryContext): Elem = {
     roGroupRepository.getNodeGroup(id).either.runNow match {
       case Right((group, _)) => <span> <a href={baseGroupLink(id)}>{group.name}</a> (Rudder ID: {id.serialize})</span>
       case Left(err)         =>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/DiffDisplayer.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/DiffDisplayer.scala
@@ -38,6 +38,7 @@
 package com.normation.rudder.web.services
 
 import com.normation.rudder.domain.policies.*
+import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.rule.category.RuleCategory
 import com.normation.rudder.rule.category.RuleCategoryId
@@ -138,7 +139,7 @@ class DiffDisplayer(linkUtil: LinkUtil) extends Loggable {
       oldTargets: Seq[RuleTarget],
       newTargets: Seq[RuleTarget],
       groupLib:   FullNodeGroupCategory
-  ): NodeSeq = {
+  )(implicit qc: QueryContext): NodeSeq = {
 
     implicit def displayNodeGroup(target: RuleTarget): NodeSeq = {
       target match {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -53,6 +53,7 @@ import com.normation.rudder.domain.queries.Query
 import com.normation.rudder.domain.secret.Secret
 import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.rudder.domain.workflows.WorkflowStepChange
+import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.git.GitArchiveId
 import com.normation.rudder.git.GitCommitId
 import com.normation.rudder.reports.AgentRunInterval
@@ -250,7 +251,7 @@ class EventLogDetailsGenerator(
     }
   }
 
-  def displayDetails(event: EventLog, changeRequestId: Option[ChangeRequestId]): NodeSeq = {
+  def displayDetails(event: EventLog, changeRequestId: Option[ChangeRequestId])(implicit qc: QueryContext): NodeSeq = {
 
     val groupLib         = nodeGroupRepository
       .getFullGroupLibrary()
@@ -1242,7 +1243,9 @@ class EventLogDetailsGenerator(
 
   }
 
-  private[this] def ruleDetails(xml: NodeSeq, rule: Rule, groupLib: FullNodeGroupCategory, rootRuleCategory: RuleCategory) = {
+  private[this] def ruleDetails(xml: NodeSeq, rule: Rule, groupLib: FullNodeGroupCategory, rootRuleCategory: RuleCategory)(
+      implicit qc: QueryContext
+  ) = {
     (
       "#ruleID" #> rule.id.serialize &
       "#ruleName" #> rule.name &

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -204,7 +204,9 @@ class MockCompliance(mockDirectives: MockDirectives) {
       nodesByGroup.succeed
     }
 
-    override def getNodeGroupOpt(id: NodeGroupId): IOResult[Option[(NodeGroup, NodeGroupCategoryId)]] = {
+    override def getNodeGroupOpt(
+        id: NodeGroupId
+    )(implicit qc: QueryContext): IOResult[Option[(NodeGroup, NodeGroupCategoryId)]] = {
       nodeGroups.find(_.id == id).map((_, NodeGroupCategoryId("cat1"))).succeed
     }
 
@@ -226,9 +228,11 @@ class MockCompliance(mockDirectives: MockDirectives) {
     def getAll(): IOResult[Seq[NodeGroup]] = ???
     def getAllByIds(ids: Seq[NodeGroupId]): IOResult[Seq[NodeGroup]] = ???
     def getAllNodeIds(): IOResult[Map[NodeGroupId, Set[NodeId]]] = ???
-    def getGroupsByCategory(includeSystem: Boolean):     IOResult[SortedMap[List[NodeGroupCategoryId], CategoryAndNodeGroup]] = ???
-    def findGroupWithAnyMember(nodeIds:    Seq[NodeId]): IOResult[Seq[NodeGroupId]]                                           = ???
-    def findGroupWithAllMember(nodeIds:    Seq[NodeId]): IOResult[Seq[NodeGroupId]]                                           = ???
+    def getGroupsByCategory(includeSystem: Boolean)(implicit
+        qc: QueryContext
+    ): IOResult[SortedMap[List[NodeGroupCategoryId], CategoryAndNodeGroup]] = ???
+    def findGroupWithAnyMember(nodeIds: Seq[NodeId]): IOResult[Seq[NodeGroupId]] = ???
+    def findGroupWithAllMember(nodeIds: Seq[NodeId]): IOResult[Seq[NodeGroupId]] = ???
     def getRootCategory():     NodeGroupCategory                                                 = ???
     def getRootCategoryPure(): IOResult[NodeGroupCategory]                                       = ???
     def getCategoryHierarchy:  IOResult[SortedMap[List[NodeGroupCategoryId], NodeGroupCategory]] = ???

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
@@ -54,6 +54,7 @@ import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
+import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.git.ZipUtils
 import com.normation.rudder.ncf.ResourceFile
 import com.normation.rudder.ncf.ResourceFileState
@@ -88,6 +89,7 @@ import zio.ZIO
 @nowarn("msg=a type was inferred to be `\\w+`; this may indicate a programming error.")
 @RunWith(classOf[JUnitRunner])
 class ArchiveApiTest extends Specification with AfterAll with Loggable {
+  implicit val qc: QueryContext = QueryContext.testQC
 
   val restTestSetUp = RestTestSetUp.newEnv
   val restTest      = new RestTest(restTestSetUp.liftRules)

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -495,7 +495,8 @@ class RestTestSetUp {
         actor:         EventActor,
         reason:        Option[String],
         includeSystem: Boolean
-    ): IOResult[(GitArchiveId, NotArchivedElements)] = ZIO.succeed((fakeGitArchiveId, fakeNotArchivedElements))
+    )(implicit qc: QueryContext): IOResult[(GitArchiveId, NotArchivedElements)] =
+      ZIO.succeed((fakeGitArchiveId, fakeNotArchivedElements))
     override def exportRules(
         commiter:      PersonIdent,
         modId:         ModificationId,
@@ -516,7 +517,7 @@ class RestTestSetUp {
         actor:         EventActor,
         reason:        Option[String],
         includeSystem: Boolean
-    ): IOResult[GitArchiveId] = ZIO.succeed(fakeGitArchiveId)
+    )(implicit qc: QueryContext): IOResult[GitArchiveId] = ZIO.succeed(fakeGitArchiveId)
     override def exportParameters(
         commiter:      PersonIdent,
         modId:         ModificationId,
@@ -527,54 +528,36 @@ class RestTestSetUp {
     override def importAll(
         archiveId:     GitCommitId,
         commiter:      PersonIdent,
-        modId:         ModificationId,
-        actor:         EventActor,
-        reason:        Option[String],
         includeSystem: Boolean
-    ): IOResult[GitCommitId] = ZIO.succeed(fakeGitCommitId)
+    )(implicit cc: ChangeContext): IOResult[GitCommitId] = ZIO.succeed(fakeGitCommitId)
     override def importRules(
         archiveId:     GitCommitId,
         commiter:      PersonIdent,
-        modId:         ModificationId,
-        actor:         EventActor,
-        reason:        Option[String],
         includeSystem: Boolean
-    ): IOResult[GitCommitId] = ZIO.succeed(fakeGitCommitId)
+    )(implicit cc: ChangeContext): IOResult[GitCommitId] = ZIO.succeed(fakeGitCommitId)
     override def importTechniqueLibrary(
         archiveId:     GitCommitId,
         commiter:      PersonIdent,
-        modId:         ModificationId,
-        actor:         EventActor,
-        reason:        Option[String],
         includeSystem: Boolean
-    ): IOResult[GitCommitId] = ZIO.succeed(fakeGitCommitId)
+    )(implicit cc: ChangeContext): IOResult[GitCommitId] = ZIO.succeed(fakeGitCommitId)
     override def importGroupLibrary(
         archiveId:     GitCommitId,
         commiter:      PersonIdent,
-        modId:         ModificationId,
-        actor:         EventActor,
-        reason:        Option[String],
         includeSystem: Boolean
-    ): IOResult[GitCommitId] = ZIO.succeed(fakeGitCommitId)
+    )(implicit cc: ChangeContext): IOResult[GitCommitId] = ZIO.succeed(fakeGitCommitId)
     override def importParameters(
         archiveId:     GitCommitId,
         commiter:      PersonIdent,
-        modId:         ModificationId,
-        actor:         EventActor,
-        reason:        Option[String],
         includeSystem: Boolean
-    ): IOResult[GitCommitId] = ZIO.succeed(fakeGitCommitId)
+    )(implicit cc: ChangeContext): IOResult[GitCommitId] = ZIO.succeed(fakeGitCommitId)
     override def rollback(
         archiveId:        GitCommitId,
         commiter:         PersonIdent,
-        modId:            ModificationId,
-        actor:            EventActor,
-        reason:           Option[String],
         rollbackedEvents: Seq[EventLog],
         target:           EventLog,
         rollbackType:     String,
         includeSystem:    Boolean
-    ): IOResult[GitCommitId] = ZIO.succeed(fakeGitCommitId)
+    )(implicit cc: ChangeContext): IOResult[GitCommitId] = ZIO.succeed(fakeGitCommitId)
 
     /**
       * These methods are called by the Archive API to get the git archives.
@@ -880,8 +863,8 @@ class RestTestSetUp {
     val zipArchiveReader = new ZipArchiveReaderImpl(mockLdapQueryParsing.queryParser, mockTechniques.techniqueParser)
     // a mock save archive that stores result in a ref
     object archiveSaver   extends SaveArchiveService  {
-      val base:                                                                               Ref[Option[(PolicyArchive, MergePolicy)]] = Ref.make(Option.empty[(PolicyArchive, MergePolicy)]).runNow
-      override def save(archive: PolicyArchive, mergePolicy: MergePolicy, actor: EventActor): IOResult[Unit]                            = {
+      val base:                                                                                       Ref[Option[(PolicyArchive, MergePolicy)]] = Ref.make(Option.empty[(PolicyArchive, MergePolicy)]).runNow
+      override def save(archive: PolicyArchive, mergePolicy: MergePolicy)(implicit qc: QueryContext): IOResult[Unit]                            = {
         base.set(Some((archive, mergePolicy))).unit
       }
     }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2109,7 +2109,8 @@ object RudderConfigInit {
           roRuleRepository,
           woRuleRepository,
           updateTechniqueLibrary,
-          asyncDeploymentAgent
+          asyncDeploymentAgent,
+          stringUuidGenerator
         ),
         new CheckArchiveServiceImpl(techniqueRepository)
       )
@@ -2785,6 +2786,7 @@ object RudderConfigInit {
       rudderDitImpl,
       roLdap,
       ldapEntityMapper,
+      nodeFactRepository,
       groupLibReadWriteMutex
     )
     lazy val roNodeGroupRepository: RoNodeGroupRepository = roLdapNodeGroupRepository
@@ -3583,7 +3585,7 @@ object RudderConfigInit {
 
       lazy val internalPendingQueryProcessor = {
         val subGroup = new SubGroupComparatorRepository {
-          override def getNodeIds(groupId: NodeGroupId): IOResult[Chunk[NodeId]] = Chunk.empty.succeed
+          override def getNodeIds(groupId: NodeGroupId)(implicit qc: QueryContext): IOResult[Chunk[NodeId]] = Chunk.empty.succeed
 
           override def getGroups: IOResult[Chunk[SubGroupChoice]] = Chunk.empty.succeed
         }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/onetimeinit/CheckInitXmlExport.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/onetimeinit/CheckInitXmlExport.scala
@@ -42,6 +42,7 @@ import bootstrap.liftweb.BootstrapLogger
 import com.normation.box.*
 import com.normation.eventlog.ModificationId
 import com.normation.rudder.domain.eventlog.RudderEventActor
+import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.repository.ItemArchiveManager
 import com.normation.rudder.services.user.PersonIdentService
 import com.normation.utils.StringUuidGenerator
@@ -81,7 +82,7 @@ class CheckInitXmlExport(
                     RudderEventActor,
                     Some("Initialising configuration-repository sub-system"),
                     false
-                  )
+                  )(QueryContext.systemQC)
                 } else {
                   BootstrapLogger.trace("At least a full archive of configuration items done, no need for further initialisation") *>
                   ZIO.unit

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
@@ -51,6 +51,8 @@ import com.normation.rudder.domain.queries.And
 import com.normation.rudder.domain.queries.CriterionComposition
 import com.normation.rudder.domain.queries.CriterionLine
 import com.normation.rudder.domain.queries.Or
+import com.normation.rudder.facts.nodes.QueryContext
+import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.ChooseTemplate
 import net.liftweb.common.*
 import net.liftweb.http.DispatchSnippet
@@ -142,7 +144,7 @@ class SearchNodeComponent(
    */
   def getQuery(): Option[Query] = query
 
-  var dispatch: DispatchIt = { case "showQuery" => { _ => buildQuery(false) } }
+  var dispatch: DispatchIt = { case "showQuery" => { _ => buildQuery(false)(CurrentUser.queryContext) } }
 
   var initUpdate = true // this is true when we arrive on the page, or when we've done an search
 
@@ -152,7 +154,7 @@ class SearchNodeComponent(
 
   val errors: mutable.Map[CriterionLine, String] = MutMap[CriterionLine, String]()
 
-  def buildQuery(isGroupsPage: Boolean): NodeSeq = {
+  def buildQuery(isGroupsPage: Boolean)(implicit qc: QueryContext): NodeSeq = {
 
     if (None == query) query = Some(Query(NodeReturnType, And, ResultTransformation.Identity, List(defaultLine)))
     val lines       = ArrayBuffer[CriterionLine]()

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
@@ -6,6 +6,7 @@ import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.policies.NonGroupRuleTarget
+import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.ChooseTemplate
 import com.normation.rudder.web.model.FormTracker
@@ -46,9 +47,11 @@ class CreateCloneGroupPopup(
 
   var createContainer = false
 
-  def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "popupContent" => { _ => popupContent() } }
+  def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = {
+    case "popupContent" => { _ => popupContent()(CurrentUser.queryContext) }
+  }
 
-  def popupContent(): NodeSeq = {
+  def popupContent()(implicit qc: QueryContext): NodeSeq = {
     S.appendJs(initJs)
     SHtml.ajaxForm(
       (
@@ -84,14 +87,14 @@ class CreateCloneGroupPopup(
     JsRaw("""hideBsModal('createCloneGroupPopup');""")
   }
 
-  private[this] def onFailure(): JsCmd = {
+  private[this] def onFailure()(implicit qc: QueryContext): JsCmd = {
     onFailureCallback() &
     updateFormClientSide()
   }
 
   private[this] def error(msg: String) = <span class="col-xl-12 errors-container">{msg}</span>
 
-  private[this] def onSubmit(): JsCmd = {
+  private[this] def onSubmit()(implicit qc: QueryContext): JsCmd = {
     nodeGroup match {
       case None     => Noop
       case Some(ng) =>
@@ -291,7 +294,7 @@ class CreateCloneGroupPopup(
     new FormTracker(groupName, groupDescription, groupContainer, isStatic)
   }
 
-  private[this] def updateFormClientSide(): JsCmd = {
+  private[this] def updateFormClientSide()(implicit qc: QueryContext): JsCmd = {
     SetHtml("createCloneGroupContainer", popupContent())
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/SearchNodes.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/SearchNodes.scala
@@ -46,6 +46,8 @@ import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.policies.NonGroupRuleTarget
 import com.normation.rudder.domain.queries.Query
+import com.normation.rudder.facts.nodes.QueryContext
+import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.components.SearchNodeComponent
 import com.normation.rudder.web.components.popup.CreateCategoryOrGroupPopup
 import net.liftweb.common.*
@@ -100,16 +102,16 @@ class SearchNodes extends StatefulSnippet with Loggable {
   var dispatch: DispatchIt = {
     case "showQuery"   =>
       searchNodeComponent.get match {
-        case Full(component) => { _ => queryForm(component) }
+        case Full(component) => { _ => queryForm(component)(CurrentUser.queryContext) }
         case _               => { _ => <div>loading...</div><div></div> }
       }
-    case "head"        => head _
+    case "head"        => head(_)(CurrentUser.queryContext)
     case "createGroup" => createGroup _
   }
 
   var activateSubmitButton = true
 
-  def head(html: NodeSeq): NodeSeq = {
+  def head(html: NodeSeq)(implicit qc: QueryContext): NodeSeq = {
 
     // add a function name to force reparse hashtag for other js elt of the page
 
@@ -180,7 +182,7 @@ class SearchNodes extends StatefulSnippet with Loggable {
     )
   }
 
-  def queryForm(sc: SearchNodeComponent): Elem = {
+  def queryForm(sc: SearchNodeComponent)(implicit qc: QueryContext): Elem = {
     SHtml.ajaxForm(sc.buildQuery(false))
   }
 
@@ -194,7 +196,7 @@ class SearchNodes extends StatefulSnippet with Loggable {
    * - pass an empty string if hash is undefined or empty
    * - pass a json-serialised structure in other cases
    */
-  private[this] def parseHashtag(): JsCmd = {
+  private[this] def parseHashtag()(implicit qc: QueryContext): JsCmd = {
     def executeQuery(query: String): JsCmd = {
       val sc = if (query.nonEmpty) {
         val parsed = queryParser(query)


### PR DESCRIPTION
https://issues.rudder.io/issues/24708

Everything that needs to "get a group" from LDAP now needs to have a `QueryContext`. 

It propagates in many directions, up to plugins, which need to be merged along this PR : 
* https://github.com/Normation/rudder-plugins/pull/705
* https://github.com/Normation/rudder-plugins-private/pull/578