### PR TITLE
Fixes #24744: Score explanation should not move score element when text is too long

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Score/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Score/View.elm
@@ -29,7 +29,7 @@ view model =
         [ div[class "score-badge"]
           [ getScoreBadge Nothing complianceScore.value False
           ]
-        , div[class "score-breakdown ps-5 flex-grow-1 flex-column"]
+        , div[class "score-breakdown ps-5 flex-column"]
            [ h3[][text "Score breakdown"]
            , div[class "d-flex"](scoreBreakdownList complianceScore.details model.scoreInfo)
            ]

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-compliance.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-compliance.scss
@@ -250,6 +250,7 @@ $small-prefix : "sm-";
   label{
     color: #72829D;
     font-weight: bold;
+    white-space: nowrap;
   }
   .score-breakdown {
     .badge-compliance-score{
@@ -262,7 +263,6 @@ $small-prefix : "sm-";
   .score-explanation {
     border-left: 2px solid #D6DEEF;
     position: relative;
-
     &:before {
       height: 14px;
       width: 14px;


### PR DESCRIPTION
https://issues.rudder.io/issues/24744
![image](https://github.com/Normation/rudder/assets/23410978/707e9808-ed07-454b-ba0d-7a741bd85854)
