### PR TITLE
Fixes #24741: Close icon does not close the modal for creating an API account

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/View.elm
@@ -5,7 +5,7 @@ import Accounts.DataTypes exposing (..)
 import Accounts.ViewModals exposing (..)
 import Accounts.ViewUtils exposing (..)
 import Html exposing (..)
-import Html.Attributes exposing (class, disabled, href, placeholder, selected, type_, value)
+import Html.Attributes exposing (attribute, class, disabled, href, placeholder, selected, type_, value)
 import Html.Events exposing (onClick, onInput)
 import List
 import String
@@ -48,7 +48,7 @@ view model =
 
                                   else
                                     text ""
-                                , button [ class "btn btn-success new-icon", onClick (ToggleEditPopup NewAccount) ] [ text "Create an account" ]
+                                , button [ class "btn btn-success new-icon", onClick (ToggleEditPopup NewAccount), attribute "data-bs-target" ("#" ++ accountsModalId), attribute "data-bs-toggle" "modal" ] [ text "Create an account" ]
                                 , div [ class "main-table" ]
                                     [ div [ class "table-container" ]
                                         [ div [ class "dataTables_wrapper_top table-filter" ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewModals.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewModals.elm
@@ -11,6 +11,8 @@ import Html.Events exposing (onCheck, onClick, onInput)
 import SingleDatePicker exposing (Settings, TimePickerVisibility(..))
 import Time.Extra as Time exposing (Interval(..), add)
 
+accountsModalId : String
+accountsModalId = "api-accounts-modal"
 
 displayModals : Model -> Html Msg
 displayModals model =
@@ -220,7 +222,7 @@ displayModals model =
     in
     case model.ui.copyState of
         NoCopy ->
-            div [ class ("modal modal-account fade " ++ modalClass) ]
+            div [ id accountsModalId, class ("modal modal-account fade " ++ modalClass), attribute "aria-modal" "true", attribute "role" "dialog" ]
                 [ div [ class "modal-backdrop fade show", onClick (ToggleEditPopup NoModal) ] []
                 , div [ class "modal-dialog" ]
                     [ div [ class "modal-content" ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewUtils.elm
@@ -10,6 +10,7 @@ import NaturalOrdering as N exposing (compare)
 import Accounts.ApiCalls exposing (..)
 import Accounts.DataTypes exposing (..)
 import Accounts.DatePickerUtils exposing (posixToString, checkIfExpired)
+import Accounts.ViewModals exposing (accountsModalId)
 import String exposing (isEmpty, length, slice)
 
 
@@ -149,9 +150,21 @@ displayAccountsTable model =
             td [class "date"][ text (cleanDate a.creationDate) ]
         , td [class "date"][ text expirationDate ]
         , td []
-          [ button [class "btn btn-default reload-token", title ("Generated: " ++ (cleanDate a.tokenGenerationDate)), onClick (ToggleEditPopup (Confirm Regenerate a.name (CallApi (regenerateToken a))))]
+          [ button 
+            [ class "btn btn-default reload-token"
+            , title ("Generated: " ++ (cleanDate a.tokenGenerationDate))
+            , onClick (ToggleEditPopup (Confirm Regenerate a.name (CallApi (regenerateToken a))))
+            , attribute "data-bs-target" ("#" ++ accountsModalId)
+            , attribute "data-bs-toggle" "modal"
+            ]
             [ span [class "fa fa-repeat"][] ]
-          , button [class "btn btn-default", onClick (ToggleEditPopup (EditAccount a))] [span [class "fa fa-pencil"] [] ]
+          , button 
+            [ class "btn btn-default"
+            , onClick (ToggleEditPopup (EditAccount a))
+            , attribute "data-bs-target" ("#" ++ accountsModalId)
+            , attribute "data-bs-toggle" "modal"
+            ]
+            [ span [class "fa fa-pencil"] [] ]
           , label [for inputId, class "custom-toggle"]
             [ input [type_ "checkbox", id inputId, checked a.enabled, onCheck (\c -> CallApi (saveAccount {a | enabled = c}))][]
             , label [for inputId, class "custom-toggle-group"]
@@ -160,7 +173,13 @@ displayAccountsTable model =
               , label [for inputId, class "toggle-disabled"][text "Disabled"]
               ]
             ]
-          , button [class "btn btn-danger delete-button", onClick (ToggleEditPopup (Confirm Delete a.name (CallApi (deleteAccount a))))] [span [class "fa fa-times-circle"] [] ]
+          , button 
+            [ class "btn btn-danger delete-button"
+            , onClick (ToggleEditPopup (Confirm Delete a.name (CallApi (deleteAccount a)))) 
+            , attribute "data-bs-target" ("#" ++ accountsModalId)
+            , attribute "data-bs-toggle" "modal"
+            ]
+            [ span [class "fa fa-times-circle"] [] ]
           ]
         ]
     filters = model.ui.tableFilters


### PR DESCRIPTION
https://issues.rudder.io/issues/24741

We have the case of the [Bootstrap 5 doc](https://getbootstrap.com/docs/5.2/components/modal/#toggle-between-modals) where we have the same modal for different actions (create, edit, regenerate and delete)