### PR TITLE
Fixes #24748: Group property table is cropped

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
@@ -1055,7 +1055,7 @@ ul {
     left: 0;
     right: 0;
     top: 0;
-    bottom: 100px;
+    bottom: 0;
     overflow-y: auto;
   }
   & > .table-container {


### PR DESCRIPTION
https://issues.rudder.io/issues/24748

Since we no longer have the nodes table in the "Properties" tab, we no longer need the bottom spacing ("Parameters" and "Criteria" tabs also don't need this spacing) 