### PR TITLE
Fixes #24749:  Disabled LDAP users can still login and use Rudder

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -329,7 +329,7 @@ class AppConfigAuth extends ApplicationContextAware {
    * Map an user from XML user config file
    */
   @Bean def rudderXMLUserDetails: UserDetailsContextMapper = {
-    new RudderXmlUserDetailsContextMapper(RudderConfig.rudderUserListProvider)
+    new RudderXmlUserDetailsContextMapper(rudderUserDetailsService)
   }
 
   // userSessionLogEvent must not be lazy, because not used by anybody directly
@@ -432,7 +432,7 @@ class RudderInMemoryUserDetailsService(val authConfigProvider: UserDetailListPro
 /**
  * Spring context mapper
  */
-class RudderXmlUserDetailsContextMapper(authConfigProvider: UserDetailListProvider) extends UserDetailsContextMapper {
+class RudderXmlUserDetailsContextMapper(userDetailsService: UserDetailsService) extends UserDetailsContextMapper {
   // we are not able to try to save user in the XML file
   def mapUserToContext(user: UserDetails, ctx: DirContextAdapter): Unit = ()
 
@@ -441,11 +441,7 @@ class RudderXmlUserDetailsContextMapper(authConfigProvider: UserDetailListProvid
       username:    String,
       authorities: Collection[? <: GrantedAuthority]
   ): UserDetails = {
-    authConfigProvider.authConfig.users
-      .getOrElse(
-        username,
-        RudderUserDetail(RudderAccount.User(username, ""), UserStatus.Disabled, Set(Role.NoRights), ApiAuthorization.None)
-      )
+    userDetailsService.loadUserByUsername(username)
   }
 }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/24749

Authentication validation should be the same as with "file" or "OIDC" : call `loadUserByUsername`, which takes into account the user status from the database to refuse authentication of disabled users.

There is some slight change in behavior : for LDAP users which were not found in the "users.xml" file we proceeded with a successful login but with no rights. Now, we fail at the login step. It is more consistent with the behavior for disabled users from "file" or "OIDC" backends.