### PR TITLE
Fixes #24755: In case a NULL was introduced earlier in sessionid, login is impossible

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
@@ -624,8 +624,9 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
   }
 
   override def getLastPreviousLogin(userId: String, closedSessionsOnly: Boolean = true): IOResult[Option[UserSession]] = {
+    // COALESCE: avoid fatal error on login when NULL was previously - see https://issues.rudder.io/issues/24755
     val selectPart  =
-      fr"select userid, sessionid, creationdate, authmethod, permissions, authz, enddate, endcause from usersessions"
+      fr"select userid, COALESCE (sessionid, '<missing>'), creationdate, authmethod, permissions, authz, enddate, endcause from usersessions"
     val wherePart   = {
       Fragments.whereAndOpt(
         Some(fr"userid = ${userId}"),


### PR DESCRIPTION
https://issues.rudder.io/issues/24755

Rationnal: we prefer to have an incorrect previous `sessionId` (I'm not even sure it's displayed) than makin login impossible. 