### PR TITLE
Fixes #24757: Unable to log in - Server error

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/User.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/User.scala
@@ -117,7 +117,7 @@ case class UserSession(
     authMethod:   String,
     permissions:  List[String],
     authz:        List[String],
-    tenants:      String,
+    tenants:      Option[String],
     endDate:      Option[DateTime],
     endCause:     Option[String]
 )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
@@ -312,7 +312,7 @@ class InMemoryUserRepository(userBase: Ref[Map[String, UserInfo]], sessionBase: 
       date:              DateTime
   ): IOResult[Unit] = {
     sessionBase.update(
-      UserSession(userId, sessionId, date, authenticatorName, permissions.sorted, authz.sorted, tenants, None, None) :: _
+      UserSession(userId, sessionId, date, authenticatorName, permissions.sorted, authz.sorted, Some(tenants), None, None) :: _
     ) *>
     userBase.update(_.map { case (k, v) => if (k == userId) (k, v.modify(_.lastLogin).setTo(Some(date))) else (k, v) })
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/24757

The `tenants` column in the database is nullable (it is null especially when server is upgraded from 8.0 to 8.1).
Changing the case class changes the doobie Meta and now the null values before migration will not throw an error