### PR TITLE
Fixes #24723: Tree group is slow to load up because it contains the list of nodes in the tree

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -817,6 +817,23 @@ object RuleInternalApi       extends Enum[RuleInternalApi] with ApiModuleProvide
   def values = findValues
 }
 
+sealed trait GroupInternalApi extends EnumEntry with EndpointSchema with InternalApi with SortIndex {
+  override def dataContainer: Option[String] = Some("groupsinternal")
+}
+
+object GroupInternalApi extends Enum[GroupInternalApi] with ApiModuleProvider[GroupInternalApi] {
+  final case object GetGroupCategoryTree extends GroupInternalApi with ZeroParam with StartsAtVersion14 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Get the tree of groups with bare minimum group information"
+    val (action, path) = GET / "groupsinternal" / "categorytree"
+    override def dataContainer: Option[String] = None
+  }
+
+  def endpoints: List[GroupInternalApi] = values.toList.sortBy(_.z)
+
+  def values = findValues
+}
+
 sealed trait ScoreApi extends EnumEntry with EndpointSchema with InternalApi with SortIndex {
   override def dataContainer: Option[String] = Some("scores")
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/GroupsInternalAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/GroupsInternalAPI.scala
@@ -1,0 +1,48 @@
+package com.normation.rudder.rest.internal
+
+import com.normation.errors.IOResult
+import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.apidata.JsonResponseObjects.*
+import com.normation.rudder.apidata.implicits.*
+import com.normation.rudder.repository.RoNodeGroupRepository
+import com.normation.rudder.rest.ApiModuleProvider
+import com.normation.rudder.rest.ApiPath
+import com.normation.rudder.rest.AuthzToken
+import com.normation.rudder.rest.GroupInternalApi as API
+import com.normation.rudder.rest.implicits.*
+import com.normation.rudder.rest.lift.*
+import io.scalaland.chimney.syntax.*
+import net.liftweb.http.LiftResponse
+import net.liftweb.http.Req
+
+class GroupsInternalApi(
+    groupsInternalApiService: GroupInternalApiService
+) extends LiftApiModuleProvider[API] {
+
+  def schemas: ApiModuleProvider[API] = API
+
+  def getLiftEndpoints(): List[LiftApiModule] = {
+    API.endpoints.map(e => {
+      e match {
+        case API.GetGroupCategoryTree => GetGroupCategoryTree
+      }
+    })
+  }
+
+  object GetGroupCategoryTree extends LiftApiModule0 {
+    val schema: API.GetGroupCategoryTree.type = API.GetGroupCategoryTree
+
+    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      groupsInternalApiService.getGroupCategoryTree().toLiftResponseOne(params, schema, _ => None)
+    }
+  }
+
+}
+
+class GroupInternalApiService(
+    readGroup: RoNodeGroupRepository
+) {
+  def getGroupCategoryTree(): IOResult[JRGroupCategoryInfo] = {
+    readGroup.getFullGroupLibrary().map(_.transformInto[JRGroupCategoryInfo])
+  }
+}

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groupsinternal.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groupsinternal.yml
@@ -1,0 +1,175 @@
+---
+description: Get the tree of groups with bare minimum group information
+method: GET
+url: /secure/api/groupsinternal/categorytree
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getGroupCategoryTree",
+      "result" : "success",
+      "data" : {
+        "id" : "GroupRoot",
+        "name" : "GroupRoot",
+        "description" : "root of group categories",
+        "categories" : [
+          {
+            "id" : "219b9c98-3d1e-44c9-0001-95b4fc7c4ada",
+            "name" : "category 2",
+            "description" : "",
+            "categories" : [],
+            "groups" : [],
+            "targets" : []
+          },
+          {
+            "id" : "219b9c98-3d1e-44c9-aff5-95b4fc7c4ada",
+            "name" : "category 2",
+            "description" : "",
+            "categories" : [],
+            "groups" : [],
+            "targets" : []
+          },
+          {
+            "id" : "category1",
+            "name" : "category 1",
+            "description" : "the first category",
+            "categories" : [
+              {
+                "id" : "219b9c98-3d1e-44c9-0001-95b4fc7c4ada",
+                "name" : "category 2 update",
+                "description" : "category 2",
+                "categories" : [],
+                "groups" : [],
+                "targets" : []
+              },
+              {
+                "id" : "219b9c98-3d1e-44c9-aff5-95b4fc7c4ada",
+                "name" : "category 2 update",
+                "description" : "category2",
+                "categories" : [],
+                "groups" : [],
+                "targets" : []
+              }
+            ],
+            "groups" : [
+              {
+                "id" : "0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                "displayName" : "Real nodes",
+                "description" : "",
+                "category" : "category 1",
+                "dynamic" : false,
+                "enabled" : true,
+                "target" : "group:0000f5d3-8c61-4d20-88a7-bb947705ba8a"
+              }
+            ],
+            "targets" : []
+          }
+        ],
+        "groups" : [
+          {
+            "id" : "00000000-cb9d-4f7b-abda-ca38c5d643ea",
+            "displayName" : "clone from api of debian group",
+            "description" : "Some long description",
+            "category" : "GroupRoot",
+            "dynamic" : true,
+            "enabled" : true,
+            "target" : "group:00000000-cb9d-4f7b-abda-ca38c5d643ea"
+          },
+          {
+            "id" : "6666f5d3-8c61-4d20-88a7-bb947705ba8a",
+            "displayName" : "Nodes id divided by 5",
+            "description" : "",
+            "category" : "GroupRoot",
+            "dynamic" : false,
+            "enabled" : true,
+            "target" : "group:6666f5d3-8c61-4d20-88a7-bb947705ba8a"
+          },
+          {
+            "id" : "4444f5d3-8c61-4d20-88a7-bb947705ba8a",
+            "displayName" : "Odd nodes",
+            "description" : "",
+            "category" : "GroupRoot",
+            "dynamic" : false,
+            "enabled" : true,
+            "target" : "group:4444f5d3-8c61-4d20-88a7-bb947705ba8a"
+          },
+          {
+            "id" : "3333f5d3-8c61-4d20-88a7-bb947705ba8a",
+            "displayName" : "Even nodes",
+            "description" : "",
+            "category" : "GroupRoot",
+            "dynamic" : false,
+            "enabled" : true,
+            "target" : "group:3333f5d3-8c61-4d20-88a7-bb947705ba8a"
+          },
+          {
+            "id" : "00000000-cb9d-4f7b-0001-ca38c5d643ea",
+            "displayName" : "clone from api of debian group",
+            "description" : "Some long description",
+            "category" : "GroupRoot",
+            "dynamic" : true,
+            "enabled" : true,
+            "target" : "group:00000000-cb9d-4f7b-0001-ca38c5d643ea"
+          },
+          {
+            "id" : "5555f5d3-8c61-4d20-88a7-bb947705ba8a",
+            "displayName" : "Nodes id divided by 3",
+            "description" : "",
+            "category" : "GroupRoot",
+            "dynamic" : false,
+            "enabled" : true,
+            "target" : "group:5555f5d3-8c61-4d20-88a7-bb947705ba8a"
+          },
+          {
+            "id" : "a-group-for-root-only",
+            "displayName" : "Serveurs [€ðŋ] cassés",
+            "description" : "Liste de l'ensemble de serveurs cassés à réparer",
+            "category" : "GroupRoot",
+            "dynamic" : true,
+            "enabled" : true,
+            "target" : "group:a-group-for-root-only"
+          },
+          {
+            "id" : "2222f5d3-8c61-4d20-88a7-bb947705ba8a",
+            "displayName" : "only root",
+            "description" : "",
+            "category" : "GroupRoot",
+            "dynamic" : false,
+            "enabled" : true,
+            "target" : "group:2222f5d3-8c61-4d20-88a7-bb947705ba8a"
+          },
+          {
+            "id" : "1111f5d3-8c61-4d20-88a7-bb947705ba8a",
+            "displayName" : "Empty group",
+            "description" : "",
+            "category" : "GroupRoot",
+            "dynamic" : false,
+            "enabled" : true,
+            "target" : "group:1111f5d3-8c61-4d20-88a7-bb947705ba8a"
+          }
+        ],
+        "targets" : [
+          {
+            "id" : "policyServer:root",
+            "displayName" : "special:policyServer_root",
+            "description" : "The root policy server",
+            "enabled" : true,
+            "target" : "policyServer:root"
+          },
+          {
+            "id" : "special:all_exceptPolicyServers",
+            "displayName" : "special:all_exceptPolicyServers",
+            "description" : "All groups without policy servers",
+            "enabled" : true,
+            "target" : "special:all_exceptPolicyServers"
+          },
+          {
+            "id" : "special:all",
+            "displayName" : "special:all",
+            "description" : "All nodes",
+            "enabled" : true,
+            "target" : "special:all"
+          }
+        ]
+      }
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -103,6 +103,8 @@ import com.normation.rudder.repository.*
 import com.normation.rudder.rest.data.Creation
 import com.normation.rudder.rest.data.Creation.CreationError
 import com.normation.rudder.rest.data.NodeSetup
+import com.normation.rudder.rest.internal.GroupInternalApiService
+import com.normation.rudder.rest.internal.GroupsInternalApi
 import com.normation.rudder.rest.internal.RuleInternalApiService
 import com.normation.rudder.rest.internal.RulesInternalApi
 import com.normation.rudder.rest.lift.*
@@ -643,14 +645,14 @@ class RestTestSetUp {
     restDataSerializer
   )
 
-  val ruleCategoryService    = new RuleCategoryService()
-  val ruleApiService6        = new RuleApiService6(
+  val ruleCategoryService     = new RuleCategoryService()
+  val ruleApiService6         = new RuleApiService6(
     mockRules.ruleCategoryRepo,
     mockRules.ruleRepo,
     mockRules.ruleCategoryRepo,
     restDataSerializer
   )
-  val ruleApiService14       = new RuleApiService14(
+  val ruleApiService14        = new RuleApiService14(
     mockRules.ruleRepo,
     mockRules.ruleRepo,
     mockConfigRepo.configurationRepository,
@@ -665,12 +667,13 @@ class RestTestSetUp {
     () => GlobalPolicyMode(Enforce, Always).succeed,
     new RuleApplicationStatusServiceImpl()
   )
-  val ruleInternalApiService = new RuleInternalApiService(
+  val ruleInternalApiService  = new RuleInternalApiService(
     mockRules.ruleRepo,
     mockNodeGroups.groupsRepo,
     mockRules.ruleCategoryRepo,
     mockNodes.nodeFactRepo
   )
+  val groupInternalApiService = new GroupInternalApiService(mockNodeGroups.groupsRepo)
 
   val fieldFactory:         DirectiveFieldFactory = new DirectiveFieldFactory {
     override def forType(fieldType: VariableSpec, id: String): DirectiveField = default(id)
@@ -928,6 +931,7 @@ class RestTestSetUp {
     ),
     new RuleApi(restExtractorService, zioJsonExtractor, ruleApiService2, ruleApiService6, ruleApiService14, uuidGen),
     new RulesInternalApi(ruleInternalApiService, ruleApiService14),
+    new GroupsInternalApi(groupInternalApiService),
     new NodeApi(
       restExtractorService,
       restDataSerializer,

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/ApiCalls.elm
@@ -38,7 +38,7 @@ getGroupsTree model chainInitTable =
       request
         { method  = "GET"
         , headers = []
-        , url     = getUrl model ["groups", "tree"] []
+        , url     = getUrl model ["groupsinternal", "categorytree"] []
         , body    = emptyBody
         , expect  = expectJson (\r -> GetGroupsTreeResult r chainInitTable) decodeGetGroupsTree 
         , timeout = Nothing

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/DataTypes.elm
@@ -48,7 +48,6 @@ type alias Group =
   , name        : String
   , description : String
   , category    : Maybe String
-  , nodeIds     : List String
   , dynamic     : Bool
   , enabled     : Bool
   , target      : String

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/JsonDecoder.elm
@@ -27,7 +27,7 @@ decodeComplianceSummaryValue =
 
 decodeGetGroupsTree : Decoder (Category Group)
 decodeGetGroupsTree =
-  at ["data", "groupCategories"] decodeCategoryGroupTarget
+  at ["data"] decodeCategoryGroupTarget
 
 decodeCategoryGroupTarget : Decoder (Category Group)
 decodeCategoryGroupTarget =
@@ -52,7 +52,6 @@ decodeGroup =
     |> required "displayName" string
     |> required "description" string
     |> optional "category"    (map Just string) Nothing
-    |> required "nodeIds"    (list string)
     |> required "dynamic"     bool
     |> required "enabled"     bool
     |> required "target"      string
@@ -64,7 +63,6 @@ decodeTarget =
     |> required "displayName" string
     |> required "description" string
     |> optional "category"    (map Just string) Nothing
-    |> hardcoded []
     |> hardcoded True
     |> required "enabled"     bool
     |> required "target"      string

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1866,6 +1866,8 @@ object RudderConfigInit {
     lazy val ruleInternalApiService =
       new RuleInternalApiService(roRuleRepository, roNodeGroupRepository, roRuleCategoryRepository, nodeFactRepository)
 
+    lazy val groupInternalApiService = new GroupInternalApiService(roNodeGroupRepository)
+
     lazy val complianceAPIService = new ComplianceAPIService(
       roRuleRepository,
       nodeFactRepository,
@@ -2222,6 +2224,7 @@ object RudderConfigInit {
         new PluginApi(restExtractorService, pluginSettingsService),
         new RecentChangesAPI(recentChangesService, restExtractorService),
         new RulesInternalApi(ruleInternalApiService, ruleApiService13),
+        new GroupsInternalApi(groupInternalApiService),
         campaignApi,
         new HookApi(hookApiService),
         archiveApi,


### PR DESCRIPTION
https://issues.rudder.io/issues/24723

Adding an internal groups API and using it instead of the public one.

All the JSON datatype is made with zio-json and chimney, and it is almost the same model as a full group category, because all the information is needed in the Elm app except the node ids.

Also added API tests for that (FYI the tests for the public groups API does not have one for the tree endpoint)