### PR TITLE
Fixes #24097: Skipped directive does not show in node compliance tree

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Compliance/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Compliance/DataTypes.elm
@@ -57,3 +57,8 @@ type alias ComplianceFilters =
   , selectedStatus        : List String
   }
 
+type alias SkippedDetails =
+    { overridingRuleId   : String
+    , overridingRuleName : String
+    }
+

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/DataTypes.elm
@@ -39,6 +39,7 @@ type alias DirectiveCompliance value =
   , compliance        : Float
   , policyMode        : String
   , complianceDetails : ComplianceDetails
+  , skippedDetails    : Maybe SkippedDetails 
   , components        : List (ComponentCompliance value)
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/JsonDecoder.elm
@@ -44,7 +44,14 @@ decodeDirectiveCompliance elem decoder =
     |> required "compliance" float
     |> required "policyMode" string
     |> required "complianceDetails" decodeComplianceDetails
+    |> optional "skippedDetails" (maybe decodeSkippedDirectiveDetails) Nothing
     |> required "components" (list (decodeComponentCompliance elem decoder ))
+
+decodeSkippedDirectiveDetails : Decoder SkippedDetails
+decodeSkippedDirectiveDetails =
+  succeed SkippedDetails
+    |> required "overridingRuleId" string
+    |> required "overridingRuleName" string
 
 decodeComplianceDetails : Decoder ComplianceDetails
 decodeComplianceDetails =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/ViewUtils.elm
@@ -50,6 +50,15 @@ badgePolicyMode globalPolicyMode policyMode =
   in
     span [class ("treeGroupName tooltipable bs-tooltip rudder-label label-sm label-" ++ mode), attribute "data-toggle" "tooltip", attribute "data-placement" "bottom", attribute "data-container" "body", attribute "data-html" "true", attribute "data-original-title" (buildTooltipContent "Policy mode" msg)][]
 
+badgeSkipped : SkippedDetails -> Html Msg
+badgeSkipped { overridingRuleId, overridingRuleName } =
+    let
+        msg =
+            "This directive is skipped because it is overridden by the rule <b>" ++ overridingRuleName ++ "</b> (with id " ++ overridingRuleId ++ ")."
+    in
+    span [ class "treeGroupName tooltipable bs-tooltip rudder-label label-sm label-overriden", attribute "data-toggle" "tooltip", attribute "data-placement" "bottom", attribute "data-container" "body", attribute "data-html" "true", attribute "data-original-title" (buildTooltipContent "Skipped directive" msg) ] []
+
+
 subItemOrder : ItemFun item subItem data ->  Model -> String -> (item -> item -> Order)
 subItemOrder fun model id  =
   case List.Extra.find (Tuple3.first >> (==) id) fun.rows of
@@ -167,7 +176,7 @@ byDirectiveCompliance model subFun complianceFilters =
       |> List.sortWith sortFunction
     )
     (\m i ->  i )
-    [ ("Directive", \i  -> span [] [ (badgePolicyMode model.policyMode i.policyMode), text i.name, if (model.onlySystem) then text "" else goToBtn (getDirectiveLink contextPath i.directiveId) ],  (\d1 d2 -> N.compare d1.name d2.name ))
+    [ ("Directive", \i  -> span [] [ i.skippedDetails |> Maybe.map badgeSkipped |> Maybe.withDefault (badgePolicyMode model.policyMode i.policyMode), text i.name, if (model.onlySystem) then text "" else goToBtn (getDirectiveLink contextPath i.directiveId) ],  (\d1 d2 -> N.compare d1.name d2.name ))
     , ("Compliance", \i -> buildComplianceBar complianceFilters  i.complianceDetails,  (\(d1) (d2) -> Basics.compare d1.compliance d2.compliance ))
     ]
     (.directiveId >> .value)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
@@ -237,12 +237,6 @@ type alias ValueLine =
     }
 
 
-type alias SkippedDetails =
-    { overridingRuleId : RuleId
-    , overridingRuleName : String
-    }
-
-
 type alias Report =
     { status : String
     , message : Maybe String

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/JsonDecoder.elm
@@ -209,7 +209,7 @@ decodeDirectiveCompliance elem decoder =
 decodeSkippedDirectiveDetails : Decoder SkippedDetails
 decodeSkippedDirectiveDetails =
   succeed SkippedDetails
-    |> required "overridingRuleId" (map RuleId string)
+    |> required "overridingRuleId" string
     |> required "overridingRuleName" string
 
 decodeRuleChanges: Decoder (Dict String (List Changes))

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewUtils.elm
@@ -724,7 +724,7 @@ badgeSkipped : SkippedDetails -> Html Msg
 badgeSkipped { overridingRuleId, overridingRuleName } =
     let
         msg =
-            "This directive is skipped because it is overridden by the rule <b>" ++ overridingRuleName ++ "</b> (with id " ++ overridingRuleId.value ++ ")."
+            "This directive is skipped because it is overridden by the rule <b>" ++ overridingRuleName ++ "</b> (with id " ++ overridingRuleId ++ ")."
     in
     span [ class "treeGroupName tooltipable bs-tooltip rudder-label label-sm label-overriden", attribute "data-toggle" "tooltip", attribute "data-placement" "bottom", attribute "data-container" "body", attribute "data-html" "true", attribute "data-original-title" (buildTooltipContent "Skipped directive" msg) ] []
 


### PR DESCRIPTION
https://issues.rudder.io/issues/24097

Essentially the same as https://github.com/Normation/rudder/pull/5600, and with some refactoring : 
* move the Elm model for `SkippedDirective` to the Elm `Compliance.Datatypes` module
* compute the skipped directives in a method which takes the conversion `DirectiveComplianceOverride => T` as a param, either `ByRuleDirectiveCompliance` or `ByRuleDirectiveCompliance` (this PR) 

![Screenshot from 2024-04-25 17-48-22](https://github.com/Normation/rudder/assets/65616064/d482bf88-9296-48e7-9de1-fcb95280da10)
