### PR TITLE
Fixes #24784: Nodes page has console error from the tree script

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/tree.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/tree.js
@@ -296,8 +296,6 @@ var buildGroupTree = function(id, appContext, initially_select, select_multiple_
    */
   var select_system_node_allowed = false;
 
-  allEventsRegisterTree();
-
   $(id).bind("loaded.jstree", function (event, data) {
     data.instance.open_all();
     initBsTooltips();
@@ -317,8 +315,9 @@ var buildGroupTree = function(id, appContext, initially_select, select_multiple_
         }
       }
     })
+    allEventsRegisterTree();
   }).on("after_open.jstree", function (event, data){
-      attachInlinedEvents(id)
+    attachInlinedEvents(id)
   }).jstree({
     "core" : {
       "animation" : 150,


### PR DESCRIPTION
https://issues.rudder.io/issues/24784

Within the node details page, the group tree was still having disappearing event handlers (even without the console error) : 
* it seems like the previous selectors for tree elements with `lift-event-js-` id was not applied to the _pencils_ (in the `.treeActions` container) 
* the rendering of the tree only populates event handlers when the `ready.jstree` event is fired

N.B. : the use case here and the fix here are specific to the node details page, the groups page renders the tree using Elm and does not use the modified code  