### PR TITLE
Fixes #24792: relayd stops runlog processing on invalid run info

### DIFF
--- a/relay/sources/relayd/src/processing/reporting.rs
+++ b/relay/sources/relayd/src/processing/reporting.rs
@@ -78,7 +78,13 @@ async fn serve(job_config: Arc<JobConfig>, mut rx: mpsc::Receiver<ReceivedFile>)
 
         // Check run info
         // FIXME make async
-        let info = RunInfo::try_from(file.as_ref()).map_err(|e| warn!("received: {}", e))?;
+        let info = match RunInfo::try_from(file.as_ref()) {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("received: {:?}", e);
+                continue;
+            }
+        };
 
         let node_span = span!(
             Level::INFO,

--- a/relay/sources/relayd/tests/processing_reporting.rs
+++ b/relay/sources/relayd/tests/processing_reporting.rs
@@ -89,6 +89,7 @@ fn it_reads_and_inserts_a_runlog() {
     let file_old = "target/tmp/reporting/incoming/2017-08-24T15:55:01+00:00@e745a140-40bc-4b86-b6dc-084488fc906b.log";
     let file_new = "target/tmp/reporting/incoming/2018-08-24T15:55:01+00:00@e745a140-40bc-4b86-b6dc-084488fc906b.log";
     let file_broken = "target/tmp/reporting/incoming/2018-02-24T15:55:01+00:00@e745a140-40bc-4b86-b6dc-084488fc906b.log";
+    let file_broken_name = "target/tmp/reporting/incoming/bob.log";
     let file_unknown = "target/tmp/reporting/incoming/2018-02-24T15:55:01+00:00@e745a140-40bc-4b86-b6dc-084488fc906d.log";
     let file_broken_failed = "target/tmp/reporting/failed/2018-02-24T15:55:01+00:00@e745a140-40bc-4b86-b6dc-084488fc906b.log";
     let file_unknown_failed = "target/tmp/reporting/failed/2018-02-24T15:55:01+00:00@e745a140-40bc-4b86-b6dc-084488fc906d.log";
@@ -114,6 +115,8 @@ fn it_reads_and_inserts_a_runlog() {
     assert!(start_number(&mut db, 1).is_ok());
 
     copy("tests/files/config/main.conf", file_broken).unwrap();
+    // Ensure it does not bother processing
+    copy("tests/files/config/main.conf", file_broken_name).unwrap();
     copy("tests/files/config/main.conf", file_unknown).unwrap();
 
     thread::sleep(time::Duration::from_millis(500));


### PR DESCRIPTION
https://issues.rudder.io/issues/24792