### PR TITLE
Fixes #24813: More change to prepare scala 3 migration

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/AgentTypes.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/AgentTypes.scala
@@ -98,7 +98,7 @@ sealed trait AgentType extends EnumEntry {
 
 object AgentType extends Enum[AgentType] {
 
-  final case object CfeEnterprise extends AgentType {
+  case object CfeEnterprise extends AgentType {
     override def id           = "cfengine-nova"
     override def oldShortName = "nova"
     override def displayName  = "CFEngine Enterprise"
@@ -109,7 +109,7 @@ object AgentType extends Enum[AgentType] {
     override val defaultPolicyExtension = ".cf"
   }
 
-  final case object CfeCommunity extends AgentType {
+  case object CfeCommunity extends AgentType {
     override def id           = "cfengine-community"
     override def oldShortName = "community"
     override def displayName  = "Rudder"
@@ -120,7 +120,7 @@ object AgentType extends Enum[AgentType] {
     override val defaultPolicyExtension = ".cf"
   }
 
-  final case object Dsc extends AgentType {
+  case object Dsc extends AgentType {
     override def id           = "dsc"
     override def oldShortName = "dsc"
     override def displayName  = "Rudder Windows"

--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/DataTypes.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/DataTypes.scala
@@ -210,7 +210,7 @@ final class Version(val value: String) extends AnyVal {
   override def toString(): String = "[%s]".format(value)
 }
 object Version {
-  implicit val ord: Ordering[Version] = _.value compareTo _.value
+  implicit val ord: Ordering[Version] = Ordering.by(_.value)
 }
 
 object InventoryProcessingLogger extends NamedZioLogger {

--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/MemorySize.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/MemorySize.scala
@@ -54,7 +54,7 @@ final case class MemorySize(size: Long) extends AnyVal {
 
 object MemorySize {
 
-  val ord: Ordering[MemorySize] = _.size compareTo _.size
+  val ord: Ordering[MemorySize] = Ordering.by(_.size)
 
   /*
    * We should accept:

--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/NodeInventory.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/NodeInventory.scala
@@ -332,39 +332,39 @@ object ParseOSType {
     (osType.toLowerCase, osName.toLowerCase, fullName.toLowerCase) match {
       case ("mswin32", _, x) =>
         // in windows, relevant information are in the fullName string
-        if (x contains "xp") WindowsXP
-        else if (x contains "vista") WindowsVista
-        else if (x contains "seven") WindowsSeven
-        else if (x contains "10") Windows10
-        else if (x contains "2000") Windows2000
-        else if (x contains "2003") Windows2003
-        else if (x contains "2008 r2") Windows2008R2 // must be before 2008 for obvious reason
-        else if (x contains "2008") Windows2008
-        else if (x contains "2012 r2") Windows2012R2
-        else if (x contains "2012") Windows2012
-        else if (x contains "2016 r2") Windows2016R2
-        else if (x contains "2016") Windows2016
-        else if (x contains "2019") Windows2019
-        else if (x contains "2022") Windows2022
+        if (x.contains("xp")) WindowsXP
+        else if (x.contains("vista")) WindowsVista
+        else if (x.contains("seven")) WindowsSeven
+        else if (x.contains("10")) Windows10
+        else if (x.contains("2000")) Windows2000
+        else if (x.contains("2003")) Windows2003
+        else if (x.contains("2008 r2")) Windows2008R2 // must be before 2008 for obvious reason
+        else if (x.contains("2008")) Windows2008
+        else if (x.contains("2012 r2")) Windows2012R2
+        else if (x.contains("2012")) Windows2012
+        else if (x.contains("2016 r2")) Windows2016R2
+        else if (x.contains("2016")) Windows2016
+        else if (x.contains("2019")) Windows2019
+        else if (x.contains("2022")) Windows2022
         else UnknownWindowsType
 
       case ("linux", x, _) =>
-        if (x contains "debian") Debian
-        else if (x contains "ubuntu") Ubuntu
-        else if (x contains "kali") Kali
-        else if (x contains "redhat") Redhat
-        else if (x contains "centos") Centos
-        else if (x contains "fedora") Fedora
-        else if (x contains "suse") Suse
-        else if (x contains "android") Android
-        else if (x contains "oracle") Oracle
-        else if (x contains "scientific") Scientific
-        else if (x contains "slackware") Slackware
-        else if (x contains "mint") Mint
-        else if (x contains "amazon linux") AmazonLinux
-        else if (x contains "rocky") RockyLinux
-        else if (x contains "almalinux") AlmaLinux
-        else if (x contains "raspbian") Raspbian
+        if (x.contains("debian")) Debian
+        else if (x.contains("ubuntu")) Ubuntu
+        else if (x.contains("kali")) Kali
+        else if (x.contains("redhat")) Redhat
+        else if (x.contains("centos")) Centos
+        else if (x.contains("fedora")) Fedora
+        else if (x.contains("suse")) Suse
+        else if (x.contains("android")) Android
+        else if (x.contains("oracle")) Oracle
+        else if (x.contains("scientific")) Scientific
+        else if (x.contains("slackware")) Slackware
+        else if (x.contains("mint")) Mint
+        else if (x.contains("amazon linux")) AmazonLinux
+        else if (x.contains("rocky")) RockyLinux
+        else if (x.contains("almalinux")) AlmaLinux
+        else if (x.contains("raspbian")) Raspbian
         else UnknownLinuxType
 
       case ("solaris", _, _) => SolarisOS
@@ -474,10 +474,10 @@ sealed abstract class SoftwareUpdateKind(override val entryName: String) extends
 }
 
 object SoftwareUpdateKind                                                    extends Enum[SoftwareUpdateKind] {
-  final case object None                extends SoftwareUpdateKind("none")
-  final case object Defect              extends SoftwareUpdateKind("defect")
-  final case object Security            extends SoftwareUpdateKind("security")
-  final case object Enhancement         extends SoftwareUpdateKind("enhancement")
+  case object None                      extends SoftwareUpdateKind("none")
+  case object Defect                    extends SoftwareUpdateKind("defect")
+  case object Security                  extends SoftwareUpdateKind("security")
+  case object Enhancement               extends SoftwareUpdateKind("enhancement")
   final case class Other(value: String) extends SoftwareUpdateKind("other")
 
   def values: IndexedSeq[SoftwareUpdateKind] = findValues

--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/services/provisioning/InventorySaver.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/services/provisioning/InventorySaver.scala
@@ -79,7 +79,7 @@ trait PipelinedInventorySaver[R] extends InventorySaver[R] with Loggable {
 
   val preCommitPipeline: Seq[PreCommit]
   val basePostPipeline:  Seq[PostCommit[R]]
-  private[this] val postCommitPipeline: Ref[Seq[PostCommit[R]]] = Ref.make(basePostPipeline).runNow
+  private val postCommitPipeline: Ref[Seq[PostCommit[R]]] = Ref.make(basePostPipeline).runNow
 
   def registerPostCommitHook(hook: PostCommit[R]): UIO[Unit] = postCommitPipeline.update(hook +: _)
 

--- a/webapp/sources/ldap-inventory/inventory-api/src/test/scala/com/normation/inventory/domain/MemoryTest.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/test/scala/com/normation/inventory/domain/MemoryTest.scala
@@ -56,11 +56,11 @@ class MemoryTest extends Specification {
   "Parsing memory type" should {
 
     "work for all valid value" in {
-      validMemoryValue.map { case (value, result) => MemorySize.parse(value) mustEqual (Some(result)) }
+      validMemoryValue.map { case (value, result) => MemorySize.parse(value) must beSome(result) }
     }
 
     "fail for all invalid value" in {
-      invalidMemoryValue.map(MemorySize.parse(_) mustEqual (None))
+      invalidMemoryValue.map(MemorySize.parse(_) must beNone)
     }
 
   }

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionInventoryParser.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionInventoryParser.scala
@@ -77,7 +77,7 @@ class FusionInventoryParser(
 
   // extremely specialized convert used for optional field only, that
   // log the error in place of using a box
-  private[this] def convert[T](input: Option[String], tag: String, format: String, conv: String => T): Option[T] = {
+  private def convert[T](input: Option[String], tag: String, format: String, conv: String => T): Option[T] = {
     try {
       input.map(s => conv(s))
     } catch {
@@ -90,11 +90,11 @@ class FusionInventoryParser(
   }
 
   // same as above, but handle conversion to int
-  private[this] def optInt(n: NodeSeq, tag: String):    Option[Int]    =
+  private def optInt(n: NodeSeq, tag: String):    Option[Int]    =
     convert(optText(n \ tag), tag, "Int", java.lang.Integer.parseInt)
-  private[this] def optFloat(n: NodeSeq, tag: String):  Option[Float]  =
+  private def optFloat(n: NodeSeq, tag: String):  Option[Float]  =
     convert(optText(n \ tag), tag, "Float", java.lang.Float.parseFloat)
-  private[this] def optDouble(n: NodeSeq, tag: String): Option[Double] =
+  private def optDouble(n: NodeSeq, tag: String): Option[Double] =
     convert(optText(n \ tag), tag, "Double", java.lang.Double.parseDouble)
 
   private def optTextHead(n: NodeSeq): Option[String] = for {
@@ -517,7 +517,7 @@ class FusionInventoryParser(
    * it updates the slotNumber (two memories can not share the same slot), setting position
    * in the list as key. And yes, that may be unstable from one inventory to the next one.
    */
-  private[this] def demux(inventory: Inventory): Inventory = {
+  private def demux(inventory: Inventory): Inventory = {
     // how can that be better ?
     var r = inventory
     r = r
@@ -555,7 +555,7 @@ class FusionInventoryParser(
     r
   }
 
-  private[this] def demuxMemories(
+  private def demuxMemories(
       memories: Seq[com.normation.inventory.domain.MemorySlot]
   ): Seq[com.normation.inventory.domain.MemorySlot] = {
     val duplicatedSlotsAndMemory =
@@ -577,7 +577,7 @@ class FusionInventoryParser(
    * One interface can have several IP/mask/gateway/subnets. We have to
    * merge them when it's the case.
    */
-  private[this] def demuxSameInterfaceDifferentIp(inventory: Inventory): Inventory = {
+  private def demuxSameInterfaceDifferentIp(inventory: Inventory): Inventory = {
     val nets = inventory.node.networks
       .groupBy(_.name)
       .map {
@@ -613,7 +613,7 @@ class FusionInventoryParser(
    * - things with x86_64 / x86 / i*86 in their name => x86_64 / x86 / i*86
    * - IA-64, i[3-9]86, x86, x86_64, arm.*, other => identical [lower case]
    */
-  private[this] def normalizeArch(os: OsDetails)(s: String): String = {
+  private def normalizeArch(os: OsDetails)(s: String): String = {
     val ix86   = """.*(i[3-9]86).*""".r
     val x86    = """.*(x86|32-bit).*""".r
     val x86_64 = """.*(x86_64|amd64|64-bit).*""".r
@@ -1068,7 +1068,7 @@ class FusionInventoryParser(
     }
   }
 
-  private[this] val DUMMY_MEM_SLOT_NUMBER = "DUMMY"
+  private val DUMMY_MEM_SLOT_NUMBER = "DUMMY"
 
   /**
    * For memory, the numslot is used for key.

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestPreParsing.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestPreParsing.scala
@@ -56,7 +56,7 @@ import zio.*
 @RunWith(classOf[JUnitRunner])
 class TestPreParsing extends Specification {
 
-  implicit private[this] class TestParser(pre: PreInventoryParser) {
+  implicit private class TestParser(pre: PreInventoryParser) {
 
     def fromXml(checkName: String, is: InputStream): IOResult[NodeSeq] = {
       ZIO.attempt(XML.load(is)).mapError(SystemError("error in test", _))

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestReportParsing.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestReportParsing.scala
@@ -61,7 +61,7 @@ import zio.*
 @RunWith(classOf[JUnitRunner])
 class TestInventoryParsing extends Specification with Loggable {
 
-  implicit private[this] class TestParser(parser: FusionInventoryParser) {
+  implicit private class TestParser(parser: FusionInventoryParser) {
     def parse(inventoryRelativePath: String): IOResult[Inventory] = {
       val url = this.getClass.getClassLoader.getResource(inventoryRelativePath)
       if (null == url) {
@@ -177,7 +177,7 @@ class TestInventoryParsing extends Specification with Loggable {
 
       val expected = List(
         CustomProperty("hook1_k1", JInt(42)),
-        CustomProperty("hook1_k2", JBool(true)),
+        CustomProperty("hook1_k2", JBool(value = true)),
         CustomProperty("hook1_k3", JString("a string")),
         CustomProperty(
           "hook2",

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestSignatureService.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestSignatureService.scala
@@ -58,7 +58,7 @@ class TestSignatureService extends Specification with Loggable {
 
   Security.addProvider(new BouncyCastleProvider())
 
-  private[this] def getInputStream(path: String): IOResult[InputStream] = {
+  private def getInputStream(path: String): IOResult[InputStream] = {
     ZIO.attempt {
       val url = this.getClass.getClassLoader.getResource(path)
       if (null == url) {
@@ -70,7 +70,7 @@ class TestSignatureService extends Specification with Loggable {
     }.mapError(e => SystemError(s"Error opening '${path}'", e))
   }
 
-  implicit private[this] class TestParser(parser: FusionInventoryParser) {
+  implicit private class TestParser(parser: FusionInventoryParser) {
     def parse(inventoryRelativePath: String): IOResult[Inventory] = {
       ZIO.acquireReleaseWith(getInputStream(inventoryRelativePath))(is => effectUioUnit(is.close)) { is =>
         parser.fromXml("inventory", is)
@@ -78,7 +78,7 @@ class TestSignatureService extends Specification with Loggable {
     }
   }
 
-  private[this] object TestInventoryDigestServiceV1 extends ParseInventoryDigestFileV1 with GetKey with CheckInventoryDigest {
+  private object TestInventoryDigestServiceV1 extends ParseInventoryDigestFileV1 with GetKey with CheckInventoryDigest {
 
     /**
      * Get key in V1 will get the key from inventory data.

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/FullInventoryRepositoryImpl.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/FullInventoryRepositoryImpl.scala
@@ -70,14 +70,14 @@ class FullInventoryRepositoryImpl(
   /**
    * Get the expected DN of a machine from its ID and status
    */
-  private[this] def dnMachine(uuid: MachineUuid, inventoryStatus: InventoryStatus) = {
+  private def dnMachine(uuid: MachineUuid, inventoryStatus: InventoryStatus) = {
     inventoryDitService.getDit(inventoryStatus).MACHINES.MACHINE.dn(uuid)
   }
-  private[this] def dn(uuid: NodeId, inventoryStatus: InventoryStatus)             = {
+  private def dn(uuid: NodeId, inventoryStatus: InventoryStatus)             = {
     // TODO: scala3 migration - bug: https://github.com/lampepfl/dotty/issues/16467
     inventoryDitService.getDit(inventoryStatus).NODES.NODE.dn(uuid.value)
   }
-  private[this] def nodeDn(inventoryStatus: InventoryStatus)                       = {
+  private def nodeDn(inventoryStatus: InventoryStatus)                       = {
     inventoryDitService.getDit(inventoryStatus).NODES.dn
   }
 
@@ -88,7 +88,7 @@ class FullInventoryRepositoryImpl(
    * index 2: Removed
    *
    */
-  private[this] def getExistingMachineDN(con: RwLDAPConnection, id: MachineUuid): LDAPIOResult[Seq[(Boolean, DN)]] = {
+  private def getExistingMachineDN(con: RwLDAPConnection, id: MachineUuid): LDAPIOResult[Seq[(Boolean, DN)]] = {
     val status = Seq(AcceptedInventory, PendingInventory, RemovedInventory)
     ZIO.foreach(status) { x =>
       val d = dnMachine(id, x)
@@ -99,7 +99,7 @@ class FullInventoryRepositoryImpl(
   /*
    * find the first dn matching ID, starting with accepted, then pending, then deleted
    */
-  private[this] def findDnForId[ID](
+  private def findDnForId[ID](
       con: RwLDAPConnection,
       id:  ID,
       fdn: (ID, InventoryStatus) => DN
@@ -181,7 +181,7 @@ class FullInventoryRepositoryImpl(
    * Update the list of node, setting the container value to the one given.
    * Delete the attribute if None.
    */
-  private[this] def updateNodes(
+  private def updateNodes(
       con:          RwLDAPConnection,
       nodes:        Map[InventoryStatus, Set[LDAPEntry]],
       newMachineId: Option[(MachineUuid, InventoryStatus)]
@@ -326,6 +326,7 @@ class FullInventoryRepositoryImpl(
       nodesTree <- con
                      .getTreeFilter(
                        dit.NODES.dn,
+                       // scala 3.3.3 resolve U as String in NODE unless we tell it it's NodeId
                        buildSubTreeFilter[NodeId](dit.NODES.dn, nodeIds.toList, id => dit.NODES.NODE.dn(id).toString)
                      )
                      .notOptional(s"Missing node root tree")
@@ -358,7 +359,7 @@ class FullInventoryRepositoryImpl(
   }
 
   override def get(id: NodeId, inventoryStatus: InventoryStatus): IOResult[Option[FullInventory]] = {
-    getWithSoftware(id, inventoryStatus, false).map(_.map(_._1))
+    getWithSoftware(id, inventoryStatus, getSoftware = false).map(_.map(_._1))
   }
 
   // if getSoftware is true, return the seq of software UUIDs, else an empty seq in addition to inventory.

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryDit.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryDit.scala
@@ -80,7 +80,7 @@ abstract class ENTRY[T <: Product](val rdnAttribute: T, val rdnValue: T) {
  */
 trait AbstractDit {
   val BASE_DN: DN
-  private[this] val ditEntries = scala.collection.mutable.Buffer[LDAPEntry]()
+  private val ditEntries = scala.collection.mutable.Buffer[LDAPEntry]()
 
   /**
    * Register an entry to be available in the default DIT structure (what means that if
@@ -135,7 +135,7 @@ final case class InventoryDit(val BASE_DN: DN, val SOFTWARE_BASE_DN: DN, val nam
 
   object SOFTWARE extends OU("Software", SOFTWARE_BASE_DN) {
     // TODO: migration-scala3 - bug: https://github.com/lampepfl/dotty/issues/16437
-    private[this] def software: OU = this
+    private def software: OU = this
     object SOFT extends UUID_ENTRY[SoftwareUuid](OC_SOFTWARE, A_SOFTWARE_UUID, software.dn) {
 
       def idFromDN(dn: DN): Either[MalformedDN, SoftwareUuid] = {
@@ -152,7 +152,7 @@ final case class InventoryDit(val BASE_DN: DN, val SOFTWARE_BASE_DN: DN, val nam
   }
 
   object NODES extends OU("Nodes", BASE_DN) {
-    private[this] def servers: OU = this
+    private def servers: OU = this
 
     object NODE extends UUID_ENTRY[NodeId](OC_NODE, A_NODE_UUID, servers.dn) {
 
@@ -218,7 +218,7 @@ final case class InventoryDit(val BASE_DN: DN, val SOFTWARE_BASE_DN: DN, val nam
   }
 
   object MACHINES extends OU("Machines", BASE_DN) {
-    private[this] def machines: OU = this
+    private def machines: OU = this
     object MACHINE extends UUID_ENTRY[MachineUuid](OC_MACHINE, A_MACHINE_UUID, machines.dn) {
 
       def idFromDN(dn: DN): InventoryMappingPure[MachineUuid] = {

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryMapper.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryMapper.scala
@@ -459,7 +459,7 @@ class InventoryMapper(
   // perhaps that should be in DIT ?
   // def machineType2Filter(mt : MachineType) : Filter = BuildFilter.IS(machineType2ObjectClass(mt).name)
 
-  private[this] def machineType2ObjectClass(mt: MachineType): LDAPObjectClass = {
+  private def machineType2ObjectClass(mt: MachineType): LDAPObjectClass = {
     mt match {
       case VirtualMachineType(UnknownVmType) => OC_OC_VM
       case VirtualMachineType(VirtualBox)    => OC_OC_VM_VIRTUALBOX
@@ -537,7 +537,7 @@ class InventoryMapper(
    * If the mapping goes bad or the entry type is unknown, the
    * MachineInventory is returned as it was, and the error is logged
    */
-  private[this] def mapAndAddElementGeneric[U, T](
+  private def mapAndAddElementGeneric[U, T](
       from: U,
       e:    LDAPEntry,
       name: String,
@@ -555,7 +555,7 @@ class InventoryMapper(
     }
   }
 
-  private[this] def mapAndAddMachineElement(entry: LDAPEntry, machine: MachineInventory): UIO[MachineInventory] = {
+  private def mapAndAddMachineElement(entry: LDAPEntry, machine: MachineInventory): UIO[MachineInventory] = {
     def mapAndAdd[T](
         name: String,
         f:    LDAPEntry => InventoryMappingPure[T],
@@ -908,7 +908,7 @@ class InventoryMapper(
    * If the mapping goes bad or the entry type is unknown, the
    * NodeInventory is returned as it was, and the error is logged
    */
-  private[this] def mapAndAddNodeElement(entry: LDAPEntry, node: NodeInventory): UIO[NodeInventory] = {
+  private def mapAndAddNodeElement(entry: LDAPEntry, node: NodeInventory): UIO[NodeInventory] = {
     def mapAndAdd[T](
         name: String,
         f:    LDAPEntry => InventoryMappingPure[T],
@@ -1094,8 +1094,8 @@ class InventoryMapper(
       accounts           = entry.valuesFor(A_ACCOUNT).toSeq
       serverIps          = entry.valuesFor(A_LIST_OF_IP).toSeq
       timezone           = (entry(A_TIMEZONE_NAME), entry(A_TIMEZONE_OFFSET)) match {
-                             case (Some(name), Some(offset)) => Some(NodeTimezone(name, offset))
-                             case _                          => None
+                             case (Some(tzName), Some(offset)) => Some(NodeTimezone(tzName, offset))
+                             case _                            => None
                            }
       customProperties  <- {
         import CustomPropertiesSerialization.Unserialize

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/ReadOnlySoftwareInventoryDAOImpl.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/ReadOnlySoftwareInventoryDAOImpl.scala
@@ -62,7 +62,7 @@ class ReadOnlySoftwareDAOImpl(
     mapper:              InventoryMapper
 ) extends ReadOnlySoftwareDAO {
 
-  private[this] def search(con: RoLDAPConnection, ids: Seq[SoftwareUuid]): IOResult[Seq[Software]] = {
+  private def search(con: RoLDAPConnection, ids: Seq[SoftwareUuid]): IOResult[Seq[Software]] = {
     val NB_BATCH_SOFTWARE = 2000
 
     // fetching 10 000 software make this method timeout

--- a/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestInventory.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestInventory.scala
@@ -48,7 +48,7 @@ import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.Modification
 import com.unboundid.ldap.sdk.ModificationType
 import org.junit.runner.*
-import org.specs2.matcher.MatchResult
+import org.specs2.execute
 import org.specs2.mutable.*
 import org.specs2.runner.*
 import scala.annotation.nowarn
@@ -80,7 +80,7 @@ class TestInventory extends Specification {
   }
 
   implicit class TestIsOK[E, T](thing: ZIO[Any, E, T]) {
-    def isOK: MatchResult[Either[E, T]] = thing.testRun must beRight
+    def isOK: execute.Result = thing.testRun must beRight
   }
 
   implicit class ForceGetE[E, A](opt: Either[E, A]) {
@@ -227,12 +227,12 @@ class TestInventory extends Specification {
       // it throws exception if not success
       ldap.server.modify(dn, new Modification(ModificationType.ADD, "localAccountName", "TEST", "test"))
 
-      (try {
+      try {
         ldap.server.assertValueExists(dn, "localAccountName", java.util.Arrays.asList("TEST", "test"))
         ok("success")
       } catch {
         case ae: AssertionError => ko(ae.getMessage)
-      }): MatchResult[Any]
+      }
     }
   }
 
@@ -448,17 +448,17 @@ class TestInventory extends Specification {
   "Softwares" should {
     "Find 2 software referenced by nodes with the repository" in {
       val softwares = readOnlySoftware.getSoftwaresForAllNodes().testRun
-      softwares.map(_.size) must beEqualTo(Right(2))
+      softwares.map(_.size) must beRight(2)
     }
 
     "Find 3 software in ou=software with the repository" in {
       val softwares = readOnlySoftware.getAllSoftwareIds().testRun
-      softwares.map(_.size) must beEqualTo(Right(3))
+      softwares.map(_.size) must beRight(3)
     }
 
     "Purge one unreferenced software with the SoftwareService" in {
       val purgedSoftwares = softwareService.deleteUnreferencedSoftware().testRun
-      purgedSoftwares must beEqualTo(Right(1))
+      purgedSoftwares must beRight(1)
     }
   }
 

--- a/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestNodeUnserialisation.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestNodeUnserialisation.scala
@@ -281,7 +281,7 @@ class TestNodeUnserialisation extends Specification {
 
     "correctly unserialize software updates node from 7_0" in {
       val date = JsonSerializers.parseSoftwareUpdateDateTime("2022-01-26T00:00:00Z")
-      (date must beRight()) and (node(linux70Ldif).softwareUpdates(0) must beEqualTo(
+      (date must beRight) and (node(linux70Ldif).softwareUpdates(0) must beEqualTo(
         SoftwareUpdate(
           "rudder-agent",
           Some("7.0.0-realease"),

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/AixPasswordHashAlgo.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/AixPasswordHashAlgo.scala
@@ -196,7 +196,7 @@ object AixPasswordHashAlgo extends Loggable {
   /////
 
   /// ssha1 revert to smd5 - but all post-java6 JVM should be ok
-  final private[this] lazy val ssha1impl = getSecretKeFactory(ShaSpec.SHA1) match {
+  final private lazy val ssha1impl = getSecretKeFactory(ShaSpec.SHA1) match {
     case Full(skf) => doSsha(ShaSpec.SHA1, skf) _
     case e: EmptyBox =>
       // this should not happen, because PBKDF2WithHmacSHA1 is
@@ -211,7 +211,7 @@ object AixPasswordHashAlgo extends Loggable {
   }
 
   /// ssha256 reverts to ssha1 - not so bad
-  final private[this] lazy val ssha256impl = getSecretKeFactory(ShaSpec.SHA256) match {
+  final private lazy val ssha256impl = getSecretKeFactory(ShaSpec.SHA256) match {
     case Full(skf) => doSsha(ShaSpec.SHA256, skf) _
     case e: EmptyBox =>
       // this may happen on Java 7 and older version, because PBKDF2WithHmacSHA256
@@ -226,7 +226,7 @@ object AixPasswordHashAlgo extends Loggable {
   }
 
   /// ssha512 reverts to ssha1 - no so bad
-  final private[this] lazy val ssha512impl = getSecretKeFactory(ShaSpec.SHA512) match {
+  final private lazy val ssha512impl = getSecretKeFactory(ShaSpec.SHA512) match {
     case Full(skf) => doSsha(ShaSpec.SHA512, skf) _
     case e: EmptyBox =>
       // this may happen on Java 7 and older version, because PBKDF2WithHmacSHA512
@@ -359,7 +359,7 @@ object AixPasswordHashAlgo extends Loggable {
    * as a parameter and chars taken from the Sha-Crypt
    * Base 64 table.
    */
-  private[this] def getRandomSalt(size: Int): String = {
+  private def getRandomSalt(size: Int): String = {
     val chars = for {
       i <- (0 until size).toArray
     } yield {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/HashAlgoConstraint.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/HashAlgoConstraint.scala
@@ -85,25 +85,25 @@ object HashAlgoConstraint extends Enum[HashAlgoConstraint] {
    * Simple standard hash: MD5, SHA-1,256,512
    */
   object MD5 extends HashAlgoConstraint("md5") {
-    private[this] val md = MessageDigest.getInstance("MD5")
+    private val md = MessageDigest.getInstance("MD5")
     override def hash(input: Array[Byte]): String = Hex.encodeHexString(md.digest(input))
 
   }
 
   object SHA1 extends HashAlgoConstraint("sha1") {
-    private[this] val md = MessageDigest.getInstance("SHA-1")
+    private val md = MessageDigest.getInstance("SHA-1")
     override def hash(input: Array[Byte]): String = Hex.encodeHexString(md.digest(input))
 
   }
 
   object SHA256 extends HashAlgoConstraint("sha256") {
-    private[this] val md = MessageDigest.getInstance("SHA-256")
+    private val md = MessageDigest.getInstance("SHA-256")
     override def hash(input: Array[Byte]): String = Hex.encodeHexString(md.digest(input))
 
   }
 
   object SHA512 extends HashAlgoConstraint("sha512") {
-    private[this] val md = MessageDigest.getInstance("SHA-512")
+    private val md = MessageDigest.getInstance("SHA-512")
     override def hash(input: Array[Byte]): String = Hex.encodeHexString(md.digest(input))
 
   }
@@ -256,7 +256,7 @@ object HashAlgoConstraint extends Enum[HashAlgoConstraint] {
    * So there is the regex to read them back.
    */
 
-  private[this] val format = """([\w-]+):(.*)""".r
+  private val format = """([\w-]+):(.*)""".r
 
   def unserialize(value: String): PureResult[(HashAlgoConstraint, String)] = {
     value match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/Technique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/Technique.scala
@@ -149,19 +149,19 @@ object TechniqueGenerationMode extends Enum[TechniqueGenerationMode] {
    * but if the directive parameters are merged.
    * This is the historical way of working for Rudder techniques.
    */
-  final case object MergeDirectives extends TechniqueGenerationMode("merged")
+  case object MergeDirectives extends TechniqueGenerationMode("merged")
 
   /*
    * The technique supports several independant directives (and so,
    * several technique version or modes).
    */
-  final case object MultipleDirectives extends TechniqueGenerationMode("separated")
+  case object MultipleDirectives extends TechniqueGenerationMode("separated")
 
   /*
    * The technique supports several independant directives (and so,
    * several technique version or modes).
    */
-  final case object MultipleDirectivesWithParameters extends TechniqueGenerationMode("separated-with-parameters")
+  case object MultipleDirectivesWithParameters extends TechniqueGenerationMode("separated-with-parameters")
 
   def values: IndexedSeq[TechniqueGenerationMode] = findValues
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/TechniqueCategory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/TechniqueCategory.scala
@@ -111,7 +111,7 @@ object TechniqueCategoryId {
     }
   }
 
-  private[this] val empty = """^[\s]*$""".r
+  private val empty = """^[\s]*$""".r
 
   /**
    * Build a category id from a path.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/VariableAndSection.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/VariableAndSection.scala
@@ -83,7 +83,7 @@ sealed trait Variable {
 
   // the comments below contains implementations and should be reused in SelectVariable and SelectOne variable
 
-  private[this] def checkValueForVariable(seq: Seq[String]): Either[LoadTechniqueError, Seq[String]] = {
+  private def checkValueForVariable(seq: Seq[String]): Either[LoadTechniqueError, Seq[String]] = {
     (spec match {
       case vl: ValueLabelVariableSpec =>
         if ((null != vl.valueslabels) && (vl.valueslabels.size > 0)) {
@@ -402,7 +402,7 @@ object Variable {
 
   // define our own alternatives of matchCopy because we want v.values to be the default
   // values
-  def matchCopy(v: Variable): Variable = matchCopy(v, false)
+  def matchCopy(v: Variable): Variable = matchCopy(v, setMultivalued = false)
   def matchCopy(v: Variable, setMultivalued: Boolean): Variable = matchCopy(v, v.values, setMultivalued)
 
   def matchCopy(v: Variable, values: Seq[String], setMultivalued: Boolean = false): Variable = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
@@ -172,7 +172,7 @@ class GitTechniqueReader(
    * As it is required that the git repository is in  a parent of the
    * technique library, it's just removing start of the string.
    */
-  private[this] def toTechniquePath(path: String): TechniquePath = {
+  private def toTechniquePath(path: String): TechniquePath = {
     canonizedRelativePath match {
       case Some(relative) if (path.startsWith(relative)) =>
         TechniquePath(path.substring(relative.size, path.size))
@@ -183,7 +183,7 @@ class GitTechniqueReader(
   // can not set private because of "outer ref cannot be checked" scalac bug
   private case class NoRootCategory(msg: String) extends Exception(msg)
 
-  private[this] val currentTechniquesInfoCache: Ref[TechniquesInfo] = semaphore
+  private val currentTechniquesInfoCache: Ref[TechniquesInfo] = semaphore
     .withPermit(
       for {
         currentRevTree <- revisionProvider.currentRevTreeId
@@ -220,7 +220,7 @@ class GitTechniqueReader(
     .flatMap(Ref.make(_))
     .runNow
 
-  private[this] val nextTechniquesInfoCache: Ref[(ObjectId, TechniquesInfo)] = {
+  private val nextTechniquesInfoCache: Ref[(ObjectId, TechniquesInfo)] = {
     (for {
       a <- revisionProvider.currentRevTreeId
       b <- currentTechniquesInfoCache.get
@@ -229,7 +229,7 @@ class GitTechniqueReader(
   }
 
   // a non empty list IS the indicator of differences between current and next
-  private[this] val modifiedTechniquesCache: Ref[Map[TechniqueName, TechniquesLibraryUpdateType]] =
+  private val modifiedTechniquesCache: Ref[Map[TechniqueName, TechniquesLibraryUpdateType]] =
     Ref.make(Map[TechniqueName, TechniquesLibraryUpdateType]()).runNow
 
   override def getModifiedTechniques: Map[TechniqueName, TechniquesLibraryUpdateType] = {
@@ -502,14 +502,14 @@ class GitTechniqueReader(
       .runNow
   }
 
-  private[this] def needReloadPure = for {
+  private def needReloadPure = for {
     nextId <- revisionProvider.currentRevTreeId
     cache  <- nextTechniquesInfoCache.get
   } yield nextId != cache._1
 
   override def needReload() = needReloadPure.runNow
 
-  private[this] def processRevTreeId(db: Repository, id: ObjectId, parseDescriptor: Boolean = true): IOResult[TechniquesInfo] = {
+  private def processRevTreeId(db: Repository, id: ObjectId, parseDescriptor: Boolean = true): IOResult[TechniquesInfo] = {
     /*
      * Global process : the logic is completely different
      * from a standard "directory then subdirectories" walk, because
@@ -561,7 +561,7 @@ class GitTechniqueReader(
     }
   }
 
-  private[this] def processDirectiveDefaultName(db: Repository, revTreeId: ObjectId): Map[String, String] = {
+  private def processDirectiveDefaultName(db: Repository, revTreeId: ObjectId): Map[String, String] = {
     // a first walk to find categories
     val tw = new TreeWalk(db)
     tw.setFilter(new ExactFileTreeFilter(canonizedRelativePath, directiveDefaultName))
@@ -600,7 +600,7 @@ class GitTechniqueReader(
 
   }
 
-  private[this] def processTechniques(
+  private def processTechniques(
       gitRepo:           Repository,
       revTreeId:         ObjectId,
       techniqueInfosRef: Ref[InternalTechniquesInfo],
@@ -637,7 +637,7 @@ class GitTechniqueReader(
     ZIO.scoped(managed.flatMap(tw => rec(tw)))
   }
 
-  private[this] def processCategories(
+  private def processCategories(
       db:              Repository,
       revTreeId:       ObjectId,
       infosRef:        Ref[InternalTechniquesInfo],
@@ -751,7 +751,7 @@ class GitTechniqueReader(
    * We remove each category for which parent category is not defined.
    */
   @scala.annotation.tailrec
-  private[this] def recToRemove(
+  private def recToRemove(
       catId:           SubTechniqueCategoryId,
       toRemove:        Set[SubTechniqueCategoryId],
       maybeCategories: Map[TechniqueCategoryId, TechniqueCategory]
@@ -769,7 +769,7 @@ class GitTechniqueReader(
     }
   }
 
-  private[this] val dummyTechnique = Technique(
+  private val dummyTechnique = Technique(
     TechniqueId(
       TechniqueName("dummy"),
       TechniqueVersion.parse("1.0").getOrElse(throw new RuntimeException("Version of dummy technique is not parsable"))
@@ -782,7 +782,7 @@ class GitTechniqueReader(
     None
   )
 
-  private[this] def processTechnique(
+  private def processTechnique(
       is:              ZIO[Any with Scope, RudderError, InputStream],
       filePath:        String,
       techniquesInfo:  Ref[InternalTechniquesInfo],
@@ -924,7 +924,7 @@ class GitTechniqueReader(
    * as a category, but the user did a mistake: signal it,
    * but DO use the folder as a category.
    */
-  private[this] def extractMaybeCategory(
+  private def extractMaybeCategory(
       descriptorObjectId: ObjectId,
       db:                 Repository,
       filePath:           String,
@@ -972,7 +972,7 @@ class GitTechniqueReader(
   /**
    * Load a descriptor document.
    */
-  private[this] def loadDescriptorFile(
+  private def loadDescriptorFile(
       managedStream: ZIO[Any with Scope, RudderError, InputStream],
       filePath:      String
   ): IOResult[Elem] = {
@@ -1011,7 +1011,7 @@ class GitTechniqueReader(
    * As we may have files&templates outside technique, we
    * need to keep track of there relative id
    */
-  private[this] def getTechniquePath(techniqueInfos: TechniquesInfo): Set[(TechniquePath, TechniqueId)] = {
+  private def getTechniquePath(techniqueInfos: TechniquesInfo): Set[(TechniquePath, TechniqueId)] = {
     val set        = scala.collection.mutable.Set[(TechniquePath, TechniqueId)]()
     techniqueInfos.rootCategory.techniqueIds.foreach(id => set += ((TechniquePath("/" + id.serialize), id)))
     techniqueInfos.subCategories.foreach {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/SystemVariableSpecServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/SystemVariableSpecServiceImpl.scala
@@ -49,7 +49,7 @@ import com.normation.rudder.reports.ComplianceModeName
 
 class SystemVariableSpecServiceImpl extends SystemVariableSpecService {
 
-  private[this] val varSpecs: Seq[SystemVariableSpec] = Seq(
+  private val varSpecs: Seq[SystemVariableSpec] = Seq(
     SystemVariableSpec(
       "ALLOWCONNECT",
       "List of ip allowed to connect to the node (policyserver + children if any)",
@@ -409,7 +409,7 @@ class SystemVariableSpecServiceImpl extends SystemVariableSpecService {
     )
   )
 
-  private[this] val varSpecsMap = varSpecs.map(x => (x.name -> x)).toMap
+  private val varSpecsMap = varSpecs.map(x => (x.name -> x)).toMap
 
   override def get(varName: String): Either[MissingSystemVariable, SystemVariableSpec] =
     varSpecsMap.get(varName).toRight(MissingSystemVariable(varName))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/TechniqueRepositoryImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/TechniqueRepositoryImpl.scala
@@ -60,8 +60,8 @@ class TechniqueRepositoryImpl(
   /**
    * Callback to call on technique lib update
    */
-  private[this] var callbacks = refLibCallbacks.sortBy(_.order)
-  val logger                  = TechniqueReaderLoggerPure.logEffect
+  private var callbacks = refLibCallbacks.sortBy(_.order)
+  val logger            = TechniqueReaderLoggerPure.logEffect
 
   /*
    * TechniquesInfo:
@@ -69,7 +69,7 @@ class TechniqueRepositoryImpl(
    * - techniques: Map[TechniqueName, SortedMap[TechniqueVersion, Technique]]
    * - categories: SortedMap[TechniqueCategoryId, TechniqueCategory]
    */
-  private[this] var techniqueInfosCache: TechniquesInfo = {
+  private var techniqueInfosCache: TechniquesInfo = {
     /*
      * readTechniques result is updated only on
      * techniqueReader.getModifiedTechniques,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/SectionSpecParser.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/SectionSpecParser.scala
@@ -127,7 +127,7 @@ class SectionSpecParser(variableParser: VariableSpecParser) extends Loggable {
   }
 
   // method that actually parse a <SECTIONS> or <SECTION> tag
-  private[this] def parseSection(root: Node, id: TechniqueId, policyName: String): Either[LoadTechniqueError, SectionSpec] = {
+  private def parseSection(root: Node, id: TechniqueId, policyName: String): Either[LoadTechniqueError, SectionSpec] = {
 
     val optName = {
       val n = Utils.getAttributeText(root, "name", "")
@@ -227,7 +227,7 @@ class SectionSpecParser(variableParser: VariableSpecParser) extends Loggable {
     }
   }
 
-  private[this] def parseChildren(
+  private def parseChildren(
       sectionName: String,
       node:        Node,
       id:          TechniqueId,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/VariableSpecParser.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/VariableSpecParser.scala
@@ -104,7 +104,7 @@ final case class EmptyReportKeysValue(sectionName: String) extends Exception(
 
 class VariableSpecParser extends Loggable {
 
-  private[this] val reservedVariableName = DEFAULT_COMPONENT_KEY :: TRACKINGKEY :: Nil
+  private val reservedVariableName = DEFAULT_COMPONENT_KEY :: TRACKINGKEY :: Nil
 
   def parseTrackerVariableSpec(node: Node): Either[LoadTechniqueError, TrackerVariableSpec] = {
     val id = (node \ ("@reporting")).headOption.map(_.text)
@@ -343,7 +343,7 @@ class VariableSpecParser extends Loggable {
     }
   }
 
-  private[this] def parseAlgoList(algos: String): Seq[HashAlgoConstraint] = {
+  private def parseAlgoList(algos: String): Seq[HashAlgoConstraint] = {
     if (algos.trim.isEmpty) HashAlgoConstraint.sort(HashAlgoConstraint.values)
     else {
       Control.traverse(algos.split(",").toSeq)(algo => HashAlgoConstraint.parse(algo.trim).toOption) match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlwriters/SectionSpecWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlwriters/SectionSpecWriter.scala
@@ -17,10 +17,10 @@ trait SectionSpecWriter {
 
 class SectionSpecWriterImpl extends SectionSpecWriter {
 
-  private[this] def createXmlTextNode(label: String, content: String): Elem =
+  private def createXmlTextNode(label: String, content: String): Elem =
     <tag>{Text(content)}</tag>.copy(label = label)
 
-  private[this] def createXmlNode(label: String, children: Seq[Node]): Elem =
+  private def createXmlNode(label: String, children: Seq[Node]): Elem =
     <tag>{children}</tag>.copy(label = label)
 
   def serialize(rootSection: Option[SectionSpec]): Box[NodeSeq] = {
@@ -38,14 +38,14 @@ class SectionSpecWriterImpl extends SectionSpecWriter {
 
   }
 
-  private[this] def serializeChild(section: SectionChildSpec): NodeSeq = {
+  private def serializeChild(section: SectionChildSpec): NodeSeq = {
     section match {
       case s: SectionSpec         => serializeSection(s)
       case v: SectionVariableSpec => serializeVariable(v)
     }
   }
 
-  private[this] def serializeSection(section: SectionSpec): NodeSeq = {
+  private def serializeSection(section: SectionSpec): NodeSeq = {
     val children = section.children.flatMap(serializeChild(_)).foldLeft(NodeSeq.Empty)((a, b) => a ++ b)
     val xml      = (createXmlNode(SECTION, children)
       % Attribute(SECTION_NAME, Text(section.name), Null)
@@ -56,7 +56,7 @@ class SectionSpecWriterImpl extends SectionSpecWriter {
     section.componentKey.map(key => xml % Attribute(SECTION_COMPONENT_KEY, Text(key), Null)).getOrElse(xml)
 
   }
-  private[this] def serializeVariable(variable: SectionVariableSpec): NodeSeq = {
+  private def serializeVariable(variable: SectionVariableSpec): NodeSeq = {
     // special case for derived password that are invisible
     variable.constraint.typeName match {
       case _: DerivedPasswordVType => NodeSeq.Empty
@@ -106,7 +106,7 @@ class SectionSpecWriterImpl extends SectionSpecWriter {
     }
   }
 
-  private[this] def serializeItem(item: ValueLabel): NodeSeq = {
+  private def serializeItem(item: ValueLabel): NodeSeq = {
     val value = createXmlTextNode(CONSTRAINT_ITEM_VALUE, item.value)
     val label = createXmlTextNode(CONSTRAINT_ITEM_LABEL, item.label)
     val child = Seq(value, label)
@@ -114,7 +114,7 @@ class SectionSpecWriterImpl extends SectionSpecWriter {
     createXmlNode(CONSTRAINT_ITEM, child)
   }
 
-  private[this] def serializeConstraint(constraint: Constraint): NodeSeq = {
+  private def serializeConstraint(constraint: Constraint): NodeSeq = {
     val constraintType = createXmlTextNode(CONSTRAINT_TYPE, constraint.typeName.name)
     val empty          = createXmlTextNode(CONSTRAINT_MAYBEEMPTY, constraint.mayBeEmpty.toString)
     val regexp         = constraint.typeName match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountRepository.scala
@@ -109,10 +109,10 @@ final class RoLDAPApiAccountRepository(
       ApiAccountName("Rudder system account"),
       ApiToken(ApiToken.generate_secret(tokenGen, "-system")),
       "For internal use",
-      true,
-      DateTime.now,
-      DateTime.now,
-      NodeSecurityContext.All
+      isEnabled = true,
+      creationDate = DateTime.now,
+      tokenGenerationDate = DateTime.now,
+      tenants = NodeSecurityContext.All
     )
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/DataStructures.scala
@@ -110,15 +110,15 @@ case class ApiVersion(
 sealed abstract class HttpAction(override val entryName: String) extends EnumEntry        {
   def name: String = entryName
 }
-final case object HttpAction                                     extends Enum[HttpAction] {
+case object HttpAction                                           extends Enum[HttpAction] {
 
-  final case object HEAD   extends HttpAction("head")
-  final case object GET    extends HttpAction("get")
+  case object HEAD   extends HttpAction("head")
+  case object GET    extends HttpAction("get")
   // perhaps we should have an "accepted content type"
   // for update verbs
-  final case object PUT    extends HttpAction("put")
-  final case object POST   extends HttpAction("post")
-  final case object DELETE extends HttpAction("delete")
+  case object PUT    extends HttpAction("put")
+  case object POST   extends HttpAction("post")
+  case object DELETE extends HttpAction("delete")
 
   // no PATCH for now
 
@@ -255,9 +255,9 @@ final case class ApiAclElement(path: AclPath, actions: Set[HttpAction]) {
 sealed abstract class ApiAuthorizationKind(override val entryName: String) extends EnumEntry { def name: String = entryName }
 
 object ApiAuthorizationKind extends Enum[ApiAuthorizationKind] {
-  final case object None extends ApiAuthorizationKind("none")
-  final case object RO   extends ApiAuthorizationKind("ro")
-  final case object RW   extends ApiAuthorizationKind("rw")
+  case object None extends ApiAuthorizationKind("none")
+  case object RO   extends ApiAuthorizationKind("ro")
+  case object RW   extends ApiAuthorizationKind("rw")
   /*
    * An ACL (Access Control List) is the exhaustive list of
    * authorized path + the set of action on each path.
@@ -265,7 +265,7 @@ object ApiAuthorizationKind extends Enum[ApiAuthorizationKind] {
    * It's a list, so ordered. If a path matches several entries in the
    * ACL list, only the first one is considered.
    */
-  final case object ACL  extends ApiAuthorizationKind("acl")
+  case object ACL  extends ApiAuthorizationKind("acl")
 
   def values: IndexedSeq[ApiAuthorizationKind] = findValues
 
@@ -314,19 +314,19 @@ object ApiAuthorization       {
 sealed trait ApiAccountType extends EnumEntry            { def name: String }
 object ApiAccountType       extends Enum[ApiAccountType] {
   // system token get special authorization and lifetime
-  final case object System    extends ApiAccountType { val name = "system" }
+  case object System    extends ApiAccountType { val name = "system" }
   // a token linked to an user account
-  final case object User      extends ApiAccountType { val name = "user"   }
+  case object User      extends ApiAccountType { val name = "user"   }
   // a standard API token, that can be only for public API access
-  final case object PublicApi extends ApiAccountType { val name = "public" }
+  case object PublicApi extends ApiAccountType { val name = "public" }
 
   def values: IndexedSeq[ApiAccountType] = findValues
 }
 
 sealed trait ApiAccountKind { def kind: ApiAccountType }
 object ApiAccountKind       {
-  final case object System extends ApiAccountKind { val kind: ApiAccountType.System.type = ApiAccountType.System }
-  final case object User   extends ApiAccountKind { val kind: ApiAccountType.User.type = ApiAccountType.User     }
+  case object System extends ApiAccountKind { val kind: ApiAccountType.System.type = ApiAccountType.System }
+  case object User   extends ApiAccountKind { val kind: ApiAccountType.User.type = ApiAccountType.User     }
   final case class PublicApi(
       authorizations: ApiAuthorization,
       expirationDate: Option[DateTime]

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -469,7 +469,7 @@ class ZioJsonExtractor(queryParser: CmdbQueryParser with JsonQueryLexer) {
     def parse[A](key: String, decoder: JsonDecoder[A]):                    PureResult[Option[A]] = {
       optGet(key) match {
         case None    => Right(None)
-        case Some(x) => decoder.decodeJson(x).map(Some(_)).left.map(Unexpected)
+        case Some(x) => decoder.decodeJson(x).map(Some(_)).left.map(Unexpected.apply)
       }
     }
     def parse2[A](key: String, decoder: String => PureResult[A]):          PureResult[Option[A]] = {
@@ -481,7 +481,7 @@ class ZioJsonExtractor(queryParser: CmdbQueryParser with JsonQueryLexer) {
     def parseString[A](key: String, decoder: String => Either[String, A]): PureResult[Option[A]] = {
       optGet(key) match {
         case None    => Right(None)
-        case Some(x) => decoder(x).map(Some(_)).left.map(Inconsistency)
+        case Some(x) => decoder(x).map(Some(_)).left.map(Inconsistency.apply)
       }
     }
   }
@@ -581,7 +581,7 @@ class ZioJsonExtractor(queryParser: CmdbQueryParser with JsonQueryLexer) {
         enabled,
         parameters,
         priority,
-        params.optGet("techniqueName").map(TechniqueName),
+        params.optGet("techniqueName").map(TechniqueName.apply),
         tv,
         policyMode,
         tags,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -305,7 +305,8 @@ object JsonResponseObjects {
     }
   }
   object JRDirective          {
-    def empty(id: String): JRDirective = JRDirective(None, id, "", "", "", "", "", Map(), 5, false, false, "", List())
+    def empty(id: String): JRDirective =
+      JRDirective(None, id, "", "", "", "", "", Map(), 5, enabled = false, system = false, policyMode = "", tags = List())
 
     def fromDirective(technique: Technique, directive: Directive, crId: Option[ChangeRequestId]): JRDirective = {
       directive
@@ -408,7 +409,8 @@ object JsonResponseObjects {
 
   object JRRule {
     // create an empty json rule with just ID set
-    def empty(id: String): JRRule = JRRule(None, id, "", "", "", "", Nil, Nil, false, false, Nil, None, None)
+    def empty(id: String): JRRule =
+      JRRule(None, id, "", "", "", "", Nil, Nil, enabled = false, system = false, tags = Nil, policyMode = None, status = None)
 
     // create from a rudder business rule
     def fromRule(
@@ -867,7 +869,21 @@ object JsonResponseObjects {
   }
 
   object JRGroup {
-    def empty(id: String): JRGroup = JRGroup(None, id, "", "", "", None, Nil, false, false, Nil, Nil, "", false)
+    def empty(id: String): JRGroup = JRGroup(
+      None,
+      id,
+      "",
+      "",
+      "",
+      None,
+      Nil,
+      dynamic = false,
+      enabled = false,
+      groupClass = Nil,
+      properties = Nil,
+      target = "",
+      system = false
+    )
 
     def fromGroup(group: NodeGroup, catId: NodeGroupCategoryId, crId: Option[ChangeRequestId]): JRGroup = {
       group
@@ -1044,19 +1060,21 @@ trait RudderJsonEncoders {
     case Some(x)                                               => Some(x.value)
   }
   implicit val inheritModeEncoder:      JsonEncoder[InheritMode]              = JsonEncoder[String].contramap(_.value)
-  implicit val globalParameterEncoder:  JsonEncoder[JRGlobalParameter]        = DeriveJsonEncoder.gen.contramap(g => {
-    // when inheritMode or property provider are set to their default value, don't write them
-    g.modify(_.inheritMode)
-      .using {
-        case Some(InheritMode.Default) => None
-        case x                         => x
-      }
-      .modify(_.provider)
-      .using {
-        case Some(PropertyProvider.defaultPropertyProvider) => None
-        case x                                              => x
-      }
-  })
+  implicit val globalParameterEncoder:  JsonEncoder[JRGlobalParameter]        = DeriveJsonEncoder
+    .gen[JRGlobalParameter]
+    .contramap(g => {
+      // when inheritMode or property provider are set to their default value, don't write them
+      g.modify(_.inheritMode)
+        .using {
+          case Some(InheritMode.Default) => None
+          case x                         => x
+        }
+        .modify(_.provider)
+        .using {
+          case Some(PropertyProvider.defaultPropertyProvider) => None
+          case x                                              => x
+        }
+    })
 
   implicit val propertyJRParentProperty: JsonEncoder[JRParentProperty] = DeriveJsonEncoder.gen
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
@@ -142,7 +142,7 @@ final case class RestDataSerializerImpl(
     diffService:   DiffService
 ) extends RestDataSerializer with Loggable {
 
-  private[this] def serializeMachineType(machine: Option[MachineType]): JValue = {
+  private def serializeMachineType(machine: Option[MachineType]): JValue = {
     machine match {
       case None                           => "No machine Inventory"
       case Some(UnknownMachineType)       => "Unknown"
@@ -356,9 +356,9 @@ final case class RestDataSerializerImpl(
     (("from" -> convert(diff.oldValue))
     ~ ("to"  -> convert(diff.newValue)))
   }
-  private[this] val create = "create"
-  private[this] val delete = "delete"
-  private[this] val modify = "modify"
+  private val create = "create"
+  private val delete = "delete"
+  private val modify = "modify"
 
   def serializeRuleChange(change: RuleChange): Box[JValue] = {
 
@@ -579,14 +579,14 @@ final case class RestDataSerializerImpl(
           val technique = readTechnique.get(TechniqueId(techniqueName, directive.techniqueVersion))
 
           val result = change.initialState match {
-            case Some((techniqueName, initialState, initialRootSection)) =>
-              val diff = diffService.diffDirective(initialState, initialRootSection, directive, rootSection, techniqueName)
+            case Some((techniqueName_, initialState, initialRootSection)) =>
+              val diff = diffService.diffDirective(initialState, initialRootSection, directive, rootSection, techniqueName_)
               technique
                 .flatMap(t =>
                   initialRootSection.flatMap(rootSection => serializeDirectiveDiff(diff, initialState, t, rootSection))
                 )
                 .getOrElse(JString("Error while fetching technique"))
-            case None                                                    => JString(s"Error while fetching initial state of change request.")
+            case None                                                     => JString(s"Error while fetching initial state of change request.")
           }
           (("action" -> modify)
           ~ ("change" -> result))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AbstractScheduler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AbstractScheduler.scala
@@ -136,7 +136,7 @@ trait AbstractScheduler {
       }
     }
 
-    override protected def messageHandler: PartialFunction[AbstractActorUpdateMessage, Unit] = {
+    override protected def messageHandler: PartialFunction[AbstractActorUpdateMessage, Unit] = PartialFunction.fromFunction {
 
       // --------------------------------------------
       // Ask for a new process
@@ -187,13 +187,9 @@ trait AbstractScheduler {
             }
         }
 
-      // --------------------------------------------
-      // Unexpected messages
-      // --------------------------------------------
-      case x                                                               => logger.debug(s"[${displayName}] scheduler don't know how to process message: '${x}'")
     }
 
-    private[this] object TaskProcessor extends SpecializedLiftActor[StartProcessing] {
+    private object TaskProcessor extends SpecializedLiftActor[StartProcessing] {
 
       override protected def messageHandler: PartialFunction[StartProcessing, Unit] = {
         // --------------------------------------------

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AsyncDeploymentActor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AsyncDeploymentActor.scala
@@ -159,7 +159,7 @@ final class AsyncDeploymentActor(
   val timeFormat = "yyyy-MM-dd HH:mm:ss"
 
   // message from the deployment agent to the manager
-  sealed private[this] case class DeploymentResult(
+  sealed private case class DeploymentResult(
       id:         Long,
       modId:      ModificationId,
       start:      DateTime,
@@ -170,21 +170,20 @@ final class AsyncDeploymentActor(
   )
 
   // message from manager to deployment agent
-  private[this] case class NewDeployment(id: Long, modId: ModificationId, started: DateTime, actor: EventActor, eventLogId: Int)
+  private case class NewDeployment(id: Long, modId: ModificationId, started: DateTime, actor: EventActor, eventLogId: Int)
 
-  private[this] var lastFinishedDeployement: CurrentDeploymentStatus = getLastFinishedDeployment
-  private[this] var currentDeployerState:    DeployerState           = IdleDeployer
-  private[this] var currentDeploymentId = lastFinishedDeployement match {
+  private var lastFinishedDeployement: CurrentDeploymentStatus = getLastFinishedDeployment
+  private var currentDeployerState:    DeployerState           = IdleDeployer
+  private var currentDeploymentId = lastFinishedDeployement match {
     case NoStatus => 0L
     case a: SuccessStatus => a.id
     case a: ErrorStatus   => a.id
-    case _ => 0L
   }
 
   def getStatus:       CurrentDeploymentStatus = lastFinishedDeployement
   def getCurrentState: DeployerState           = currentDeployerState
 
-  private[this] def getLastFinishedDeployment: CurrentDeploymentStatus = {
+  private def getLastFinishedDeployment: CurrentDeploymentStatus = {
     eventLogger.getLastDeployement() match {
       case Empty =>
         PolicyGenerationLogger.manager.debug("Could not find a last policy update")
@@ -205,7 +204,7 @@ final class AsyncDeploymentActor(
    */
   override def createUpdate: DeploymentStatus = DeploymentStatus(lastFinishedDeployement, currentDeployerState)
 
-  private[this] def WithDetails(xml: NodeSeq)(implicit actor: EventActor, reason: Option[String] = None) = {
+  private def WithDetails(xml: NodeSeq)(implicit actor: EventActor, reason: Option[String] = None) = {
     EventLogDetails(
       modificationId = None,
       principal = actor,
@@ -217,7 +216,7 @@ final class AsyncDeploymentActor(
   // deprecated flag file to trigger policy generation at start
   val triggerPolicyUpdateFlagPath = "/opt/rudder/etc/trigger-policy-generation"
 
-  private[this] def logTriggerError(v: PureResult[PolicyGenerationTrigger]) = {
+  private def logTriggerError(v: PureResult[PolicyGenerationTrigger]) = {
     v match {
       case Left(err) =>
         val msg =
@@ -447,7 +446,7 @@ final class AsyncDeploymentActor(
    * The internal agent that will actually do the deployment
    * Long time running process, I/O consuming.
    */
-  private[this] object DeployerAgent extends LiftActor {
+  private object DeployerAgent extends LiftActor {
 
     def doDeployement(bootSemaphore: Promise[Nothing, Unit], delay: IOResult[Duration], nd: NewDeployment): UIO[Unit] = {
       val prog = for {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportLogger.scala
@@ -96,7 +96,7 @@ class AutomaticReportLogger(
     /*
      * List of all reports kind processed by the logger
      */
-    private[this] val reportsKind = {
+    private val reportsKind = {
       List(
         Reports.LOG_REPAIRED,
         Reports.LOG_WARN,
@@ -107,7 +107,7 @@ class AutomaticReportLogger(
       )
     }
 
-    override protected def messageHandler: PartialFunction[StartAutomaticReporting.type, Unit] = {
+    override protected def messageHandler: PartialFunction[StartAutomaticReporting.type, Unit] = PartialFunction.fromFunction {
       case StartAutomaticReporting =>
         propertyRepository.getReportLoggerLastId match {
           // Report logger was not running before, try to log the last hundred reports and initialize lastId
@@ -159,8 +159,6 @@ class AutomaticReportLogger(
         LAPinger.schedule(this, StartAutomaticReporting, reportLogInterval * 1000L * 60)
         () // ok for the unit value discarded
 
-      case _ =>
-        logger.error("Wrong message received by non compliant reports logger, do nothing")
     }
 
     /*
@@ -173,7 +171,7 @@ class AutomaticReportLogger(
      * Both bounds are inclusive (so both fromId and maxId will be logged if
      * they are non-compliant reports).
      */
-    private[this] def logReportsBetween(lastProcessedId: Long, maxId: Long): Unit = {
+    private def logReportsBetween(lastProcessedId: Long, maxId: Long): Unit = {
 
       /*
        * Log all non-compliant reports between fromId and maxId (both inclusive), limited to batch size max.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportsCleaner.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportsCleaner.scala
@@ -93,7 +93,7 @@ object AutomaticReportsCleaning {
   /**
    *  Build an hourly frequency
    */
-  private[this] def buildHourly(min: Int): Box[CleanFrequency] = {
+  private def buildHourly(min: Int): Box[CleanFrequency] = {
 
     if (min >= 0 && min <= 59)
       Full(Hourly(min))
@@ -104,7 +104,7 @@ object AutomaticReportsCleaning {
   /**
    *  Build a daily frequency
    */
-  private[this] def buildDaily(min: Int, hour: Int): Box[CleanFrequency] = {
+  private def buildDaily(min: Int, hour: Int): Box[CleanFrequency] = {
 
     if (min >= 0 && min <= 59) {
       if (hour >= 0 && hour <= 23)
@@ -119,7 +119,7 @@ object AutomaticReportsCleaning {
   /**
    *  Build a weekly frequency
    */
-  private[this] def buildWeekly(min: Int, hour: Int, day: String): Option[CleanFrequency] = {
+  private def buildWeekly(min: Int, hour: Int, day: String): Option[CleanFrequency] = {
 
     if (min >= 0 && min <= 59) {
       if (hour >= 0 && hour <= 23) {
@@ -434,21 +434,20 @@ class AutomaticReportsCleaning(
       extends DatabaseCleanerActor {
     updateManager =>
 
-    private[this] val reportLogger = ReportLogger
-    private[this] val automatic    = reportsttl > 0
+    private val reportLogger = ReportLogger
+    private val automatic    = reportsttl > 0
     // compliancettl may be disabled, it's managed with the Option[DeleteCommand.ComplianceLevel]
     // We don't handle the case where compliancelevel cleaning would be enabled and reports
     // disable, because really, if someone has enough free space to keep ruddersysevent forever,
     // they can handle compliance forever, too.
-    private[this] var currentState: CleanerState = IdleCleaner
-    private[this] var lastRun:      DateTime     = DateTime.now()
+    private var currentState: CleanerState = IdleCleaner
 
     def isIdle: Boolean = currentState == IdleCleaner
 
-    private[this] def formatDate(date: DateTime): String = date.toString("yyyy-MM-dd HH:mm")
+    private def formatDate(date: DateTime): String = date.toString("yyyy-MM-dd HH:mm")
     val logger = ScheduledJobLogger
 
-    private[this] def activeCleaning(
+    private def activeCleaning(
         reports:     DeleteCommand.Reports,
         compliances: Option[DeleteCommand.ComplianceLevel],
         message:     DatabaseCleanerMessage,
@@ -480,12 +479,11 @@ class AutomaticReportsCleaning(
               )
             )
           }
-          lastRun = DateTime.now
           currentState = IdleCleaner
       }
     }
 
-    override protected def messageHandler: PartialFunction[DatabaseCleanerMessage, Unit] = {
+    override protected def messageHandler: PartialFunction[DatabaseCleanerMessage, Unit] = PartialFunction.fromFunction {
       /*
        * Ask to check if need to be launched
        * If idle   => check
@@ -567,8 +565,6 @@ class AutomaticReportsCleaning(
           case ActiveCleaner => reportLogger.info("Reports database: A database cleaning is already running, please try later")
         }
       }
-      case _                  =>
-        reportLogger.error("Wrong message for automatic reports %s ".format(cleanaction.name.toLowerCase()))
     }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/CheckPolicyTemplateLibrary.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/CheckPolicyTemplateLibrary.scala
@@ -88,8 +88,8 @@ class CheckTechniqueLibrary(
 
     val logger = ScheduledJobLogger
 
-    private[this] val isAutomatic        = updateInterval > 0
-    private[this] val realUpdateInterval = {
+    private val isAutomatic        = updateInterval > 0
+    private val realUpdateInterval = {
       if (updateInterval < TECHLIB_MINIMUM_UPDATE_INTERVAL && isAutomatic) {
         logger.warn(s"Value '${updateInterval}' for ${propertyName} is too small, using '${TECHLIB_MINIMUM_UPDATE_INTERVAL}'")
         TECHLIB_MINIMUM_UPDATE_INTERVAL

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/UpdateDynamicGroups.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/UpdateDynamicGroups.scala
@@ -139,10 +139,10 @@ class UpdateDynamicGroups(
     private var lastUpdateTime = new DateTime(0)
     private var avoidedUpdate  = 0L
     private var currentState: DynamicGroupUpdaterStates = IdleGroupUpdater
-    private var onePending               = false
-    private var needDeployment           = false
-    private[this] val isAutomatic        = updateInterval > 0
-    private[this] val realUpdateInterval = {
+    private var onePending         = false
+    private var needDeployment     = false
+    private val isAutomatic        = updateInterval > 0
+    private val realUpdateInterval = {
       if (updateInterval < DYNGROUP_MINIMUM_UPDATE_INTERVAL && isAutomatic) {
         ScheduledJobLogger.warn(
           s"Value '${updateInterval}' for ${propertyName} is too small, using '${DYNGROUP_MINIMUM_UPDATE_INTERVAL}'"
@@ -155,7 +155,7 @@ class UpdateDynamicGroups(
 
     def isIdle(): Boolean = currentState == IdleGroupUpdater
 
-    private[this] def processUpdate(force: Boolean) = {
+    private def processUpdate(force: Boolean) = {
       val need = dynGroupService.changesSince(lastUpdateTime).getOrElse(true)
       // if there was a delayedUpdate, we need to force re-computation of groups, or
       // if there is one pending (which
@@ -200,7 +200,7 @@ class UpdateDynamicGroups(
       }
     }
 
-    private[this] def displayNodechange(nodes: Set[NodeId]): String = {
+    private def displayNodechange(nodes: Set[NodeId]): String = {
       if (nodes.nonEmpty) {
         nodes.map(_.value).mkString("[ ", ", ", " ]")
       } else {
@@ -208,7 +208,7 @@ class UpdateDynamicGroups(
       }
     }
 
-    override protected def messageHandler: PartialFunction[GroupUpdateMessage, Unit] = {
+    override protected def messageHandler: PartialFunction[GroupUpdateMessage, Unit] = PartialFunction.fromFunction {
 
       //
       // Ask for a new dynamic group update
@@ -286,14 +286,9 @@ class UpdateDynamicGroups(
           asyncDeploymentAgent ! AutomaticStartDeployment(modId, RudderEventActor)
           needDeployment = false
         }
-
-      //
-      // Unexpected messages
-      //
-      case x                                                                      => DynamicGroupLoggerPure.logEffect.debug(s"Dynamic group updater can't process this message: '${x}'")
     }
 
-    private[this] object LAUpdateDyngroup extends SpecializedLiftActor[StartDynamicUpdate] {
+    private object LAUpdateDyngroup extends SpecializedLiftActor[StartDynamicUpdate] {
 
       override protected def messageHandler: PartialFunction[StartDynamicUpdate, Unit] = {
         //

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JSONReportsHandler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JSONReportsHandler.scala
@@ -51,7 +51,7 @@ trait JSONReportsHandler {
 
 case class JSONReportsAnalyser(reportsRepository: ReportsRepository, propRepo: RudderPropertiesRepository) {
 
-  private[this] var handlers: List[JSONReportsHandler] = Nil
+  private var handlers: List[JSONReportsHandler] = Nil
 
   def addHandler(handler: JSONReportsHandler): Unit = handlers = handler :: handlers
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JsonCampaignSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JsonCampaignSerializer.scala
@@ -67,7 +67,7 @@ trait JSONTranslateCampaign {
 
 class CampaignSerializer {
 
-  private[this] var tranlaters: List[JSONTranslateCampaign] = Nil
+  private var tranlaters: List[JSONTranslateCampaign] = Nil
   import CampaignSerializer.*
 
   def getJson(campaign: Campaign): ZIO[Any, RudderError, Json] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/MainCampaignService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/MainCampaignService.scala
@@ -72,13 +72,13 @@ class MainCampaignService(
     endDelay:     Int
 ) {
 
-  private[this] var services:              List[CampaignHandler]       = Nil
+  private var services:                    List[CampaignHandler]       = Nil
   def registerService(s: CampaignHandler): ZIO[Any, RudderError, Unit] = {
     services = s :: services
     init()
   }
 
-  private[this] var inner: Option[CampaignScheduler] = None
+  private var inner: Option[CampaignScheduler] = None
 
   def deleteCampaign(c: CampaignId): ZIO[Any, RudderError, Unit] = {
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
@@ -42,6 +42,7 @@ import cats.data.*
 import com.normation.NamedZioLogger
 import com.normation.box.*
 import com.normation.errors.*
+import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.RuleId
@@ -178,7 +179,7 @@ object Doobie {
   implicit val DateTimeMeta: Meta[DateTime] =
     Meta[java.sql.Timestamp].imap(ts => new DateTime(ts.getTime()))(dt => new java.sql.Timestamp(dt.getMillis))
 
-  implicit val ReadRuleId:       Get[RuleId]      = {
+  implicit val ReadRuleId: Get[RuleId] = {
     Get[String].map(r => {
       RuleId.parse(r) match {
         case Right(rid) => rid
@@ -187,9 +188,19 @@ object Doobie {
       }
     })
   }
-  implicit val PutRuleId:        Put[RuleId]      = {
+  implicit val PutRuleId:  Put[RuleId] = {
     Put[String].contramap(_.serialize)
   }
+
+  implicit val GetNodeId: Get[NodeId] = Get[String].tmap(NodeId.apply)
+  implicit val PutNodeId: Put[NodeId] = Put[String].tcontramap(_.value)
+
+  implicit val GetNodeConfigId: Get[NodeConfigId] = Get[String].tmap(NodeConfigId.apply)
+  implicit val PutNodeConfigId: Put[NodeConfigId] = Put[String].tcontramap(_.value)
+
+  implicit val GetModificationId: Get[ModificationId] = Get[String].tmap(ModificationId.apply)
+  implicit val PutModificationId: Put[ModificationId] = Put[String].tcontramap(_.value)
+
   implicit val ReadDirectiveId:  Get[DirectiveId] = {
     Get[String].map(r => {
       DirectiveId.parse(r) match {
@@ -279,7 +290,7 @@ object Doobie {
       (ps, n, e) => {
         val sqlXml = ps.getConnection.createSQLXML
         val osw    = new java.io.OutputStreamWriter(sqlXml.setBinaryStream())
-        XML.write(osw, e, "UTF-8", false, null)
+        XML.write(osw, e, "UTF-8", xmlDecl = false, doctype = null)
         osw.close()
         ps.setObject(n, sqlXml)
       },

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/NodeDit.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/NodeDit.scala
@@ -51,7 +51,7 @@ class NodeDit(val BASE_DN: DN) extends AbstractDit {
   dit.register(NODES.model)
 
   object NODES extends OU("Nodes", BASE_DN) {
-    private[this] def nodes = this
+    private def nodes = this
 
     object NODE extends ENTRY1(A_NODE_UUID) {
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderDit.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderDit.scala
@@ -166,9 +166,9 @@ class RudderDit(val BASE_DN: DN) extends AbstractDit {
       parentDN,
       name,
       description,
-      false,
-      OC_RULE_CATEGORY,
-      A_RULE_CATEGORY_UUID
+      isSystem = false,
+      objectClass = OC_RULE_CATEGORY,
+      objectClassUuid = A_RULE_CATEGORY_UUID
     )
   }
 
@@ -197,7 +197,7 @@ class RudderDit(val BASE_DN: DN) extends AbstractDit {
         objectClass = OC_TECHNIQUE_CATEGORY,
         objectClassUuid = A_TECHNIQUE_CATEGORY_UUID
       ) {
-    private[this] def activeTechniques = this
+    private def activeTechniques = this
 
     // method that check is an entry if of the given type
 
@@ -257,7 +257,7 @@ class RudderDit(val BASE_DN: DN) extends AbstractDit {
   }
 
   object RULES extends OU("Rules", BASE_DN) {
-    private[this] def rules = this
+    private def rules = this
 
     def getRuleUid(dn: DN): Box[String] = singleRdnValue(dn, A_RULE_UUID)
 
@@ -355,7 +355,7 @@ class RudderDit(val BASE_DN: DN) extends AbstractDit {
         objectClass = OC_GROUP_CATEGORY,
         objectClassUuid = A_GROUP_CATEGORY_UUID
       ) {
-    private[this] def group = this
+    private def group = this
 
     val rootCategoryId: NodeGroupCategoryId = NodeGroupCategoryId(this.uuid)
 
@@ -510,7 +510,7 @@ class RudderDit(val BASE_DN: DN) extends AbstractDit {
   }
 
   object PARAMETERS extends OU("Parameters", BASE_DN) {
-    private[this] def parameters = this
+    private def parameters = this
 
     def getParameter(dn: DN): Box[String] = singleRdnValue(dn, A_PARAMETER_NAME)
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderLDAPConstants.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderLDAPConstants.scala
@@ -357,7 +357,7 @@ object RudderLDAPConstants extends Loggable {
       case (k, seq) =>
         seq.zipWithIndex.map {
           case (s, i) =>
-            policyVariableToString(k, i, s, true)
+            policyVariableToString(k, i, s, mayBeEmpty = true)
         }
     }.toSeq
   }
@@ -383,7 +383,7 @@ object RudderLDAPConstants extends Loggable {
    * the expected format for an LDAP attribute values
    */
   def parametersToSeq(targets: Seq[ParameterForConfiguration]): Seq[String] = {
-    targets.map(p => policyVariableToString(p.name, 0, p.value, true))
+    targets.map(p => policyVariableToString(p.name, 0, p.value, mayBeEmpty = true))
   }
 
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/appconfig/RudderWebProperty.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/appconfig/RudderWebProperty.scala
@@ -65,8 +65,8 @@ final case class RudderWebProperty(
 sealed trait FeatureSwitch extends EnumEntry           { def name: String }
 object FeatureSwitch       extends Enum[FeatureSwitch] {
 
-  final case object Enabled  extends FeatureSwitch { override val name = "enabled"  }
-  final case object Disabled extends FeatureSwitch { override val name = "disabled" }
+  case object Enabled  extends FeatureSwitch { override val name = "enabled"  }
+  case object Disabled extends FeatureSwitch { override val name = "disabled" }
 
   val values: IndexedSeq[FeatureSwitch] = findValues
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/DebugComplianceLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/DebugComplianceLogger.scala
@@ -163,7 +163,7 @@ object ComplianceDebugLogger extends Logger {
 
   implicit class AgentRunConfigurationToLog(val info: (NodeId, ComplianceMode, ResolvedAgentRunInterval)) extends AnyVal {
 
-    private[this] def log(c: ComplianceMode, r: ResolvedAgentRunInterval): String = {
+    private def log(c: ComplianceMode, r: ResolvedAgentRunInterval): String = {
       val h = c.mode match {
         case ChangesOnly => s", hearbeat every ${r.heartbeatPeriod} run(s)"
         case _           => ""

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
@@ -79,13 +79,13 @@ case object Node {
       inventory.node.main.hostname,
       inventory.node.description.getOrElse(""),
       NodeState.Enabled,
-      false,
-      false,
-      inventory.node.inventoryDate.getOrElse(new DateTime(0)),
-      ReportingConfiguration(None, None, None),
-      Nil,
-      None,
-      None
+      isSystem = false,
+      isPolicyServer = false,
+      creationDate = inventory.node.inventoryDate.getOrElse(new DateTime(0)),
+      nodeReportingConfiguration = ReportingConfiguration(None, None, None),
+      properties = Nil,
+      policyMode = None,
+      securityTag = None
     )
   }
 }
@@ -96,11 +96,11 @@ sealed abstract class NodeState(override val entryName: String) extends EnumEntr
 
 object NodeState extends Enum[NodeState] {
 
-  final case object Initializing  extends NodeState("initializing")
-  final case object Enabled       extends NodeState("enabled")
-  final case object EmptyPolicies extends NodeState("empty-policies")
-  final case object Ignored       extends NodeState("ignored")
-  final case object PreparingEOL  extends NodeState("preparing-eol")
+  case object Initializing  extends NodeState("initializing")
+  case object Enabled       extends NodeState("enabled")
+  case object EmptyPolicies extends NodeState("empty-policies")
+  case object Ignored       extends NodeState("ignored")
+  case object PreparingEOL  extends NodeState("preparing-eol")
 
   def values: IndexedSeq[NodeState] = findValues
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeInfo.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeInfo.scala
@@ -71,9 +71,9 @@ sealed trait NodeKind extends EnumEntry      {
   def isPolicyServer: Boolean
 }
 object NodeKind       extends Enum[NodeKind] {
-  final case object Root  extends NodeKind { val name = "root"; val isPolicyServer = true  }
-  final case object Relay extends NodeKind { val name = "relay"; val isPolicyServer = true }
-  final case object Node  extends NodeKind { val name = "node"; val isPolicyServer = false }
+  case object Root  extends NodeKind { val name = "root"; val isPolicyServer = true  }
+  case object Relay extends NodeKind { val name = "relay"; val isPolicyServer = true }
+  case object Node  extends NodeKind { val name = "node"; val isPolicyServer = false }
 
   def values: IndexedSeq[NodeKind] = findValues
 
@@ -155,12 +155,6 @@ final case class NodeInfo(
       case Some((AgentType.Dsc, _)) =>
         PolicyGenerationLogger.info(
           s"Node '${hostname}' (${id.value}) is a Windows node and a we do not know how to generate a hash yet"
-        )
-        ""
-
-      case Some((_, _)) =>
-        PolicyGenerationLogger.info(
-          s"Node '${hostname}' (${id.value}) has an unsuported key type (CFEngine agent with certificate?) and a we do not know how to generate a hash yet"
         )
         ""
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Directive.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Directive.scala
@@ -234,7 +234,7 @@ object SectionVal {
     </section>
   }
 
-  private[this] def innerSectionXML(section: SectionVal):                                      NodeSeq    = {
+  private def innerSectionXML(section: SectionVal):                                            NodeSeq    = {
     // variables
     section.variables.toSeq.sortBy(_._1).map {
       case (variable, value) =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/PolicyMode.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/PolicyMode.scala
@@ -48,8 +48,8 @@ object PolicyMode extends Enum[PolicyMode] {
   // value which corresponds to a default policy mode, its value depending on context
   val defaultValue: String = "default"
 
-  final case object Audit   extends PolicyMode { val name = "audit"   }
-  final case object Enforce extends PolicyMode { val name = "enforce" }
+  case object Audit   extends PolicyMode { val name = "audit"   }
+  case object Enforce extends PolicyMode { val name = "enforce" }
 
   val values: IndexedSeq[PolicyMode] = findValues
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
@@ -37,6 +37,7 @@
 
 package com.normation.rudder.domain.policies
 
+import cats.implicits.*
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
@@ -47,6 +48,7 @@ import net.liftweb.json.JsonDSL.*
 import scala.collection.MapView
 import scala.util.matching.Regex
 import zio.Chunk
+import zio.interop.catz.chunkStdInstances
 
 /**
  * A target is either
@@ -247,52 +249,49 @@ object RuleTarget extends Loggable {
       allNodesAreThere: Boolean = true // if we are working on a subset of node, set to false
   ): Set[NodeId] = {
 
-    targets.foldLeft(Set[NodeId]()) {
-      case (nodes, target) =>
-        target match {
-          case AllTarget                    => return allNodes.keySet.toSet
-          case AllTargetExceptPolicyServers => nodes ++ allNodes.collect { case (k, isPolicyServer) if (!isPolicyServer) => k }
-          case AllPolicyServers             => nodes ++ allNodes.collect { case (k, isPolicyServer) if (isPolicyServer) => k }
-          case PolicyServerTarget(nodeId)   =>
-            if (allNodesAreThere) {
-              nodes + nodeId
-            } else {
-              // nodeId may not be in allNodes
-              allNodes.keySet.contains(nodeId) match {
-                case true => nodes + nodeId
-                case _    => nodes
-              }
-            }
-
-          // here, if we don't find the group, we consider it's an error in the
-          // target recording, but don't fail, just log it.
-          case GroupTarget(groupId)         =>
-            nodes ++ groups.getOrElse(groupId, Set())
-
-          case TargetIntersection(targets) =>
-            val nodeSets     = targets.map(t => getNodeIds(Set(t), allNodes, groups, allNodesAreThere))
-            // Compute the intersection of the sets of Nodes
-            val intersection = nodeSets.foldLeft(allNodes.keySet) {
-              case (currentIntersection, nodes) => currentIntersection.intersect(nodes)
-            }
-            nodes ++ intersection
-
-          case TargetUnion(targets) =>
-            val nodeSets = targets.map(t => getNodeIds(Set(t), allNodes, groups, allNodesAreThere))
-            // Compute the union of the sets of Nodes
-            val union    = nodeSets.foldLeft(Set[NodeId]()) { case (currentUnion, nodes) => currentUnion.union(nodes) }
-            nodes ++ union
-
-          case TargetExclusion(included, excluded) =>
-            // Compute the included Nodes
-            val includedNodes = getNodeIds(Set(included), allNodes, groups, allNodesAreThere)
-            // Compute the excluded Nodes
-            val excludedNodes = getNodeIds(Set(excluded), allNodes, groups, allNodesAreThere)
-            // Remove excluded nodes from included nodes
-            val result        = includedNodes -- excludedNodes
-            nodes ++ result
+    targets.toList.traverse {
+      case AllTarget                    => Left(allNodes.keySet.toSet)
+      case AllTargetExceptPolicyServers => Right(allNodes.collect { case (k, isPolicyServer) if (!isPolicyServer) => k }.toSet)
+      case AllPolicyServers             => Right(allNodes.collect { case (k, isPolicyServer) if (isPolicyServer) => k }.toSet)
+      case PolicyServerTarget(nodeId)   =>
+        if (allNodesAreThere) {
+          Right(Set(nodeId))
+        } else {
+          // nodeId may not be in allNodes
+          allNodes.keySet.contains(nodeId) match {
+            case true => Right(Set(nodeId))
+            case _    => Right(Set.empty)
+          }
         }
-    }
+
+      // here, if we don't find the group, we consider it's an error in the
+      // target recording, but don't fail, just log it.
+      case GroupTarget(groupId)         =>
+        Right(groups.getOrElse(groupId, Set.empty))
+
+      case TargetIntersection(targets) =>
+        val nodeSets     = targets.map(t => getNodeIds(Set(t), allNodes, groups, allNodesAreThere))
+        // Compute the intersection of the sets of Nodes
+        val intersection = nodeSets.foldLeft(allNodes.keySet.toSet) {
+          case (currentIntersection, nodes) => currentIntersection.intersect(nodes)
+        }
+        Right(intersection)
+
+      case TargetUnion(targets) =>
+        val nodeSets = targets.map(t => getNodeIds(Set(t), allNodes, groups, allNodesAreThere))
+        // Compute the union of the sets of Nodes
+        val union    = nodeSets.foldLeft(Set[NodeId]()) { case (currentUnion, nodes) => currentUnion.union(nodes) }
+        Right(union)
+
+      case TargetExclusion(included, excluded) =>
+        // Compute the included Nodes
+        val includedNodes = getNodeIds(Set(included), allNodes, groups, allNodesAreThere)
+        // Compute the excluded Nodes
+        val excludedNodes = getNodeIds(Set(excluded), allNodes, groups, allNodesAreThere)
+        // Remove excluded nodes from included nodes
+        val result        = includedNodes -- excludedNodes
+        Right(result)
+    }.map(_.toSet.flatten).merge
   }
 
   /**
@@ -319,48 +318,39 @@ object RuleTarget extends Loggable {
       groups:   Map[NodeGroupId, Chunk[NodeId]]
   ): Chunk[NodeId] = {
 
-    targets.foldLeft(Chunk[NodeId]()) {
-      case (nodes, target) =>
-        target match {
-          case AllTarget                    => return Chunk.fromIterable(allNodes.keys)
-          case AllTargetExceptPolicyServers => nodes ++ allNodes.collect { case (k, isPolicyServer) if (!isPolicyServer) => k }
-          case AllPolicyServers             => nodes ++ allNodes.collect { case (k, isPolicyServer) if (isPolicyServer) => k }
-          case PolicyServerTarget(nodeId)   =>
-            nodes :+ nodeId
+    targets.traverse {
+      case AllTarget                    => Left(Chunk.fromIterable(allNodes.keys))
+      case AllTargetExceptPolicyServers => Right(allNodes.collect { case (k, isPolicyServer) if (!isPolicyServer) => k })
+      case AllPolicyServers             => Right(allNodes.collect { case (k, isPolicyServer) if (isPolicyServer) => k })
+      case PolicyServerTarget(nodeId)   => Right(Set(nodeId))
 
-          // here, if we don't find the group, we consider it's an error in the
-          // target recording, but don't fail, just log it.
-          case GroupTarget(groupId)         =>
-            val groupNodes = groups.getOrElse(groupId, Chunk.empty)
-            val filtered   = {
-              groupNodes
-            }
-            nodes ++ filtered
+      // here, if we don't find the group, we consider it's an error in the
+      // target recording, but don't fail, just log it.
+      case GroupTarget(groupId) => Right(groups.getOrElse(groupId, Chunk.empty))
 
-          case TargetIntersection(targets) =>
-            val nodeSets     = targets.map(t => getNodeIdsChunkRec(Chunk(t), allNodes, groups))
-            // Compute the intersection of the sets of Nodes
-            val intersection = nodeSets.foldLeft(Chunk.fromIterable(allNodes.keys)) {
-              case (currentIntersection, nodes) => currentIntersection.intersect(nodes)
-            }
-            nodes ++ intersection
-
-          case TargetUnion(targets) =>
-            val nodeSets = targets.map(t => getNodeIdsChunkRec(Chunk(t), allNodes, groups))
-            // Compute the union of the sets of Nodes
-            val union    = nodeSets.foldLeft(Chunk[NodeId]()) { case (currentUnion, nodes) => currentUnion.concat(nodes) }
-            nodes ++ union
-
-          case TargetExclusion(included, excluded) =>
-            // Compute the included Nodes
-            val includedNodes = getNodeIdsChunkRec(Chunk(included), allNodes, groups)
-            // Compute the excluded Nodes
-            val excludedNodes = getNodeIdsChunkRec(Chunk(excluded), allNodes, groups)
-            // Remove excluded nodes from included nodes
-            val result        = includedNodes.filterNot(id => excludedNodes.contains(id))
-            nodes ++ result
+      case TargetIntersection(targets) =>
+        val nodeSets     = targets.map(t => getNodeIdsChunkRec(Chunk(t), allNodes, groups))
+        // Compute the intersection of the sets of Nodes
+        val intersection = nodeSets.foldLeft(Chunk.fromIterable(allNodes.keys)) {
+          case (currentIntersection, nodes) => currentIntersection.intersect(nodes)
         }
-    }
+        Right(intersection)
+
+      case TargetUnion(targets) =>
+        val nodeSets = targets.map(t => getNodeIdsChunkRec(Chunk(t), allNodes, groups))
+        // Compute the union of the sets of Nodes
+        val union    = nodeSets.foldLeft(Chunk[NodeId]()) { case (currentUnion, nodes) => currentUnion.concat(nodes) }
+        Right(union)
+
+      case TargetExclusion(included, excluded) =>
+        // Compute the included Nodes
+        val includedNodes = getNodeIdsChunkRec(Chunk(included), allNodes, groups)
+        // Compute the excluded Nodes
+        val excludedNodes = getNodeIdsChunkRec(Chunk(excluded), allNodes, groups)
+        // Remove excluded nodes from included nodes
+        val result        = includedNodes.filterNot(id => excludedNodes.contains(id))
+        Right(result)
+    }.map(_.flatten).merge
   }
 
   /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -99,9 +99,9 @@ object InheritMode {
     def value: Char
   }
 
-  final case object ObjectMode extends Enum[ObjectMode] {
-    final case object Override extends ObjectMode { override val value = 'o' }
-    final case object Merge    extends ObjectMode { override val value = 'm' }
+  case object ObjectMode extends Enum[ObjectMode] {
+    case object Override extends ObjectMode { override val value = 'o' }
+    case object Merge    extends ObjectMode { override val value = 'm' }
 
     val values: IndexedSeq[ObjectMode] = findValues
 
@@ -112,10 +112,10 @@ object InheritMode {
     def value: Char
   }
 
-  final case object ArrayMode extends Enum[ArrayMode] {
-    final case object Override extends ArrayMode { override val value = 'o' }
-    final case object Append   extends ArrayMode { override val value = 'a' }
-    final case object Prepend  extends ArrayMode { override val value = 'p' }
+  case object ArrayMode extends Enum[ArrayMode] {
+    case object Override extends ArrayMode { override val value = 'o' }
+    case object Append   extends ArrayMode { override val value = 'a' }
+    case object Prepend  extends ArrayMode { override val value = 'p' }
 
     val values: IndexedSeq[ArrayMode] = findValues
 
@@ -126,10 +126,10 @@ object InheritMode {
     def value: Char
   }
 
-  final case object StringMode extends Enum[StringMode] {
-    final case object Override extends StringMode { override val value = 'o' }
-    final case object Append   extends StringMode { override val value = 'a' }
-    final case object Prepend  extends StringMode { override val value = 'p' }
+  case object StringMode extends Enum[StringMode] {
+    case object Override extends StringMode { override val value = 'o' }
+    case object Append   extends StringMode { override val value = 'a' }
+    case object Prepend  extends StringMode { override val value = 'p' }
 
     val values: IndexedSeq[StringMode] = findValues
 
@@ -139,8 +139,8 @@ object InheritMode {
   def parseString(s: String): PureResult[InheritMode] = s.toList match {
     case obj :: arr :: str :: Nil =>
       (ObjectMode.parse(obj), ArrayMode.parse(arr), StringMode.parse(str)) match {
-        case (Some(o), Some(a), Some(s)) => Right(InheritMode(o, a, s))
-        case _                           =>
+        case (Some(o), Some(a), Some(s_)) => Right(InheritMode(o, a, s_))
+        case _                            =>
           Left(Inconsistency(s"Impossible to parse string as inherit mode option, expecting: [mo][oap][oap] but got: ${s}"))
       }
     case _                        =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
@@ -41,7 +41,6 @@ import com.normation.errors.*
 import com.normation.inventory.domain.AgentType
 import com.normation.inventory.domain.NodeId
 import com.normation.inventory.ldap.core.LDAPConstants.*
-import com.normation.inventory.ldap.core.LDAPConstants.A_PROCESS
 import com.normation.rudder.domain.RudderLDAPConstants.A_NODE_GROUP_UUID
 import com.normation.rudder.domain.RudderLDAPConstants.A_NODE_PROPERTY
 import com.normation.rudder.domain.RudderLDAPConstants.A_STATE
@@ -306,36 +305,36 @@ class NodeQueryCriteriaData(groupRepo: () => SubGroupComparatorRepository) {
     ObjectCriterion(
       A_PROCESS,
       Chunk(
-        Criterion("pid", JsonFixedKeyComparator(A_PROCESS, "pid", false), UnsupportedByNodeMinimalApi),
+        Criterion("pid", JsonFixedKeyComparator(A_PROCESS, "pid", quoteValue = false), UnsupportedByNodeMinimalApi),
         Criterion(
           "commandName",
-          JsonFixedKeyComparator(A_PROCESS, "commandName", true),
+          JsonFixedKeyComparator(A_PROCESS, "commandName", quoteValue = true),
           UnsupportedByNodeMinimalApi
         ),
         Criterion(
           "cpuUsage",
-          JsonFixedKeyComparator(A_PROCESS, "cpuUsage", false),
+          JsonFixedKeyComparator(A_PROCESS, "cpuUsage", quoteValue = false),
           UnsupportedByNodeMinimalApi
         ),
         Criterion(
           "memory",
-          JsonFixedKeyComparator(A_PROCESS, "memory", false),
+          JsonFixedKeyComparator(A_PROCESS, "memory", quoteValue = false),
           UnsupportedByNodeMinimalApi
         ),
-        Criterion("tty", JsonFixedKeyComparator(A_PROCESS, "tty", true), UnsupportedByNodeMinimalApi),
+        Criterion("tty", JsonFixedKeyComparator(A_PROCESS, "tty", quoteValue = true), UnsupportedByNodeMinimalApi),
         Criterion(
           "virtualMemory",
-          JsonFixedKeyComparator(A_PROCESS, "virtualMemory", false),
+          JsonFixedKeyComparator(A_PROCESS, "virtualMemory", quoteValue = false),
           UnsupportedByNodeMinimalApi
         ),
         Criterion(
           "started",
-          JsonFixedKeyComparator(A_PROCESS, "started", true),
+          JsonFixedKeyComparator(A_PROCESS, "started", quoteValue = true),
           UnsupportedByNodeMinimalApi
         ),
         Criterion(
           "user",
-          JsonFixedKeyComparator(A_PROCESS, "user", true),
+          JsonFixedKeyComparator(A_PROCESS, "user", quoteValue = true),
           UnsupportedByNodeMinimalApi
         )
       )
@@ -711,7 +710,6 @@ trait NodeCriterionKeyValueMatcher[A] extends NodeCriterionMatcher {
           res    <- MatchHolderZio[A](DebugInfo(KVC.JsonSelect.id, Some(value)), extractor(n), matcher).matches
         } yield res
 
-      case c => MatchHolder[A](DebugInfo(s"unknown comparator: ${c}", Some(value)), Chunk(), _ => false).matches
     }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ComplianceLevel.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ComplianceLevel.scala
@@ -600,7 +600,7 @@ object ComplianceLevelSerialisation {
     )
   }
 
-  private[this] def parse[T](json: JValue, convert: BigInt => T) = {
+  private def parse[T](json: JValue, convert: BigInt => T) = {
     def N(n: JValue): T = convert(n match {
       case JInt(i) => i
       case _       => 0

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
@@ -206,13 +206,13 @@ object ExpectedReportsSerialisation {
    * This object will be used for the JSON serialisation
    * to / from database
    */
-  final case class JsonNodeExpectedReports protected (
+  final case class JsonNodeExpectedReports private[reports] (
       modes:               NodeModeConfig,
       ruleExpectedReports: List[RuleExpectedReports],
       overrides:           List[OverridenPolicy]
   )
 
-  val v0: TechniqueVersion = TechniqueVersion
+  val v00: TechniqueVersion = TechniqueVersion
     .parse("0.0")
     .getOrElse(throw new IllegalArgumentException(s"Initialisation error for default technique version in overrides"))
 
@@ -397,7 +397,7 @@ object ExpectedReportsSerialisation {
     }
 
     final case class JsonPolicy7_1(rid: RuleId, did: DirectiveId)  {
-      def transform: PolicyId = PolicyId(rid, did, v0)
+      def transform: PolicyId = PolicyId(rid, did, v00)
     }
     implicit class _JsonPolicy7_1(x: PolicyId)                     {
       def transform: JsonPolicy7_1 = JsonPolicy7_1(x.ruleId, x.directiveId)
@@ -597,8 +597,6 @@ object ExpectedReportsSerialisation {
         }
       case Right(v: Version7_1.JsonNodeExpectedReports7_1) =>
         Full(v.transform)
-      case Right(_)                                        =>
-        Failure(s"Error: found node expected report in an unsupported format, please force regenerate policies: '${s}'")
     }
   }
 
@@ -628,7 +626,7 @@ object NodeConfigIdSerializer {
   import org.joda.time.format.ISODateTimeFormat
 
   // date are ISO format
-  private[this] val isoDateTime = ISODateTimeFormat.dateTime
+  private val isoDateTime = ISODateTimeFormat.dateTime
 
   /*
    * In the database, we only keep creation time.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/workflows/ChangeRequest.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/workflows/ChangeRequest.scala
@@ -242,7 +242,7 @@ final case class DirectiveChange(
     val nextChanges:  Seq[DirectiveChangeItem]
 ) extends Change[(TechniqueName, Directive, Option[SectionSpec]), ChangeRequestDirectiveDiff, DirectiveChangeItem] {
   @scala.annotation.tailrec
-  private[this] def recChange(
+  private def recChange(
       previousState: Box[DirectiveChangeItem],
       nexts:         List[DirectiveChangeItem]
   ): Box[DirectiveChangeItem] = {
@@ -296,7 +296,7 @@ final case class NodeGroupChange(
     val nextChanges:  Seq[NodeGroupChangeItem]
 ) extends Change[NodeGroup, ChangeRequestNodeGroupDiff, NodeGroupChangeItem] {
   @scala.annotation.tailrec
-  private[this] def recChange(
+  private def recChange(
       previousState: Box[NodeGroupChangeItem],
       nexts:         List[NodeGroupChangeItem]
   ): Box[NodeGroupChangeItem] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
@@ -188,7 +188,7 @@ object SoftwareFact {
       Some(sf.name),
       None,
       Some(sf.version),
-      sf.publisher.map(SoftwareEditor),
+      sf.publisher.map(SoftwareEditor.apply),
       None,
       sf.licenseName.map(l => License(l, sf.licenseDescription, sf.productId, sf.productKey, sf.oem, sf.expirationDate)),
       sf.sourceName,
@@ -771,7 +771,7 @@ object NodeFact {
       .modify(_.lastInventoryDate)
       .setTo(inventory.node.inventoryDate)
       .modify(_.ipAddresses)
-      .setTo(Chunk.fromIterable(inventory.node.serverIps.map(IpAddress)))
+      .setTo(Chunk.fromIterable(inventory.node.serverIps.map(IpAddress.apply)))
       .modify(_.timezone)
       .setTo(inventory.node.timezone)
       .modify(_.machine)
@@ -949,12 +949,6 @@ trait MinimalNodeFactInterface {
       case (AgentType.Dsc, _) =>
         PolicyGenerationLogger.info(
           s"Node '${fqdn}' (${id.value}) is a Windows node and a we do not know how to generate a hash yet"
-        )
-        ""
-
-      case (_, _) =>
-        PolicyGenerationLogger.info(
-          s"Node '${fqdn}' (${id.value}) has an unsuported key type (CFEngine agent with certificate?) and a we do not know how to generate a hash yet"
         )
         ""
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactChangeEventCallback.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactChangeEventCallback.scala
@@ -361,19 +361,19 @@ class HistorizeNodeState(
     change.event match {
       case NodeFactChangeEvent.NewPending(node, attrs)                 =>
         NodeLoggerPure.debug(s"Save new  in node fact fs") *>
-        save(node, change.cc.eventDate, false, PendingInventory)
+        save(node, change.cc.eventDate, alsoJDBC = false, status = PendingInventory)
       case NodeFactChangeEvent.UpdatedPending(oldNode, newNode, attrs) =>
         NodeLoggerPure.debug(s"Update pending in node fact fs") *>
-        save(newNode, change.cc.eventDate, false, PendingInventory)
+        save(newNode, change.cc.eventDate, alsoJDBC = false, status = PendingInventory)
       case NodeFactChangeEvent.Accepted(node, attrs)                   =>
         NodeLoggerPure.debug(s"Accept in node fact fs and postgres") *>
-        save(node, change.cc.eventDate, true, AcceptedInventory) // callback done post accept
+        save(node, change.cc.eventDate, alsoJDBC = true, status = AcceptedInventory) // callback done post accept
       case NodeFactChangeEvent.Refused(node, attrs)                    =>
         NodeLoggerPure.debug(s"Refused in node fact fs and postgres") *>
-        save(node, change.cc.eventDate, true, AcceptedInventory)
+        save(node, change.cc.eventDate, alsoJDBC = true, status = AcceptedInventory)
       case NodeFactChangeEvent.Updated(oldNode, newNode, attrs)        =>
         NodeLoggerPure.debug(s"Update in node fact fs") *>
-        save(newNode, change.cc.eventDate, false, AcceptedInventory)
+        save(newNode, change.cc.eventDate, alsoJDBC = false, status = AcceptedInventory)
       case NodeFactChangeEvent.Deleted(node, attrs)                    =>
         NodeLoggerPure.debug(s"Delete in node fact fs") *>
         delete(node.id)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
@@ -770,9 +770,9 @@ class CoreNodeFactRepository(
   override def updateInventory(inventory: FullInventory, software: Option[Iterable[Software]])(implicit
       cc: ChangeContext
   ): IOResult[NodeFactChangeEventCC] = {
-    val nodeId         = inventory.node.main.id
-    implicit val attrs = if (software.isEmpty) SelectFacts.noSoftware else SelectFacts.all
-    implicit val qc    = cc.toQuery
+    val nodeId = inventory.node.main.id
+    implicit val attrs: SelectFacts  = if (software.isEmpty) SelectFacts.noSoftware else SelectFacts.all
+    implicit val qc:    QueryContext = cc.toQuery
     ZIO.scoped(
       for {
         _          <- lock.withLock

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactStorage.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactStorage.scala
@@ -71,7 +71,7 @@ import com.unboundid.ldap.sdk.DN
 import java.nio.charset.StandardCharsets
 import org.eclipse.jgit.lib.PersonIdent
 import org.joda.time.DateTime
-import scala.annotation.nowarn
+import scala.annotation.unused
 import zio.*
 import zio.json.*
 import zio.stream.ZStream
@@ -321,12 +321,10 @@ object NoopFactStorage extends NodeFactStorage {
     StorageChangeEventStatus.Noop(nodeId).succeed
   override def delete(nodeId: NodeId)(implicit attrs: SelectFacts):                         IOResult[StorageChangeEventDelete] =
     StorageChangeEventDelete.Noop(nodeId).succeed
-  @nowarn("msg=parameter attrs in method getAllPending is never used")
-  override def getAllPending()(implicit attrs:  SelectFacts = SelectFacts.default): IOStream[NodeFact] = ZStream.empty
-  @nowarn("msg=parameter attrs in method getAllAccepted is never used")
-  override def getAllAccepted()(implicit attrs: SelectFacts = SelectFacts.default): IOStream[NodeFact] = ZStream.empty
-  override def getPending(nodeId:               NodeId)(implicit attrs: SelectFacts): IOResult[Option[NodeFact]] = None.succeed
-  override def getAccepted(nodeId:              NodeId)(implicit attrs: SelectFacts): IOResult[Option[NodeFact]] = None.succeed
+  override def getAllPending()(implicit @unused attrs:  SelectFacts = SelectFacts.default): IOStream[NodeFact] = ZStream.empty
+  override def getAllAccepted()(implicit @unused attrs: SelectFacts = SelectFacts.default): IOStream[NodeFact] = ZStream.empty
+  override def getPending(nodeId:                       NodeId)(implicit attrs: SelectFacts): IOResult[Option[NodeFact]] = None.succeed
+  override def getAccepted(nodeId:                      NodeId)(implicit attrs: SelectFacts): IOResult[Option[NodeFact]] = None.succeed
 }
 
 /*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitFindUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitFindUtils.scala
@@ -254,18 +254,18 @@ class FileTreeFilter(rootDirectories: List[String], endPaths: List[String]) exte
 
   // paths must not end with "/"
 
-  private[this] val startRawPaths = rootDirectories.filter(_ != "").map { p =>
+  private val startRawPaths = rootDirectories.filter(_ != "").map { p =>
     val pp = p.reverse.dropWhile(_ == '/').reverse
     JConstants.encode(pp)
   }
 
-  private[this] val endRawPaths = endPaths.filter(_ != "").map(e => JConstants.encode(e))
+  private val endRawPaths = endPaths.filter(_ != "").map(e => JConstants.encode(e))
 
   /**
    * create the comparator that filter for given paths. An empty list is
    * an accept ALL filter (no filtering).
    */
-  private[this] def pathComparator(walker: TreeWalk, paths: List[Array[Byte]], test: Array[Byte] => Boolean) = {
+  private def pathComparator(walker: TreeWalk, paths: List[Array[Byte]], test: Array[Byte] => Boolean) = {
     paths.size == 0 || paths.exists(p => test(p))
   }
 
@@ -303,10 +303,10 @@ class FileTreeFilter(rootDirectories: List[String], endPaths: List[String]) exte
  * slash ("/").
  */
 class ExactFileTreeFilter(rootDirectory: Option[String], fileName: String) extends TreeFilter {
-  private[this] val fileRawPath     = JConstants.encode("/" + fileName)
-  private[this] val rootFileRawPath = JConstants.encode(fileName)
+  private val fileRawPath     = JConstants.encode("/" + fileName)
+  private val rootFileRawPath = JConstants.encode(fileName)
 
-  private[this] val rawRootPath = {
+  private val rawRootPath = {
     rootDirectory match {
       case None       => JConstants.encode("")
       case Some(path) => JConstants.encode(path)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitItemRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitItemRepository.scala
@@ -381,7 +381,7 @@ trait GitArchiverFullCommitUtils extends NamedZioLogger {
    * much easier access, since it returns a REF that need to be parsed..
    * So just keep the working workaround.
    */
-  private[this] def listTagWorkaround: IOResult[Seq[RevTag]] = {
+  private def listTagWorkaround: IOResult[Seq[RevTag]] = {
     import org.eclipse.jgit.errors.IncorrectObjectTypeException
     import org.eclipse.jgit.lib.*
     import org.eclipse.jgit.revwalk.*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitRevisionProvider.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitRevisionProvider.scala
@@ -104,7 +104,7 @@ class SimpleGitRevisionProvider(refPath: String, repo: GitRepositoryProvider) ex
     )
   }
 
-  private[this] val currentId = Ref.make[ObjectId](getAvailableRevTreeId.runNow).runNow
+  private val currentId = Ref.make[ObjectId](getAvailableRevTreeId.runNow).runNow
 
   override def getAvailableRevTreeId: IOResult[ObjectId] = {
     IOResult.attempt {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunNuCommand.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunNuCommand.scala
@@ -113,8 +113,7 @@ object RunNuCommand {
    * command and signal the completion to the caller.
    * Exit code, stdout and stderr content are accumulated in CmdResult data structure.
    */
-  private[this] class CmdProcessHandler(promise: Promise[Nothing, CmdResult])
-      extends NuAbstractCharsetHandler(StandardCharsets.UTF_8) {
+  private class CmdProcessHandler(promise: Promise[Nothing, CmdResult]) extends NuAbstractCharsetHandler(StandardCharsets.UTF_8) {
     val stderr = new java.lang.StringBuilder()
     val stdout = new java.lang.StringBuilder()
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryFileWatcher.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryFileWatcher.scala
@@ -52,7 +52,7 @@ import java.util.concurrent.TimeUnit
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.filefilter.TrueFileFilter
 import org.joda.time.DateTime
-import scala.annotation.nowarn
+import scala.annotation.unused
 import scala.concurrent.ExecutionContext
 import zio.*
 import zio.syntax.*
@@ -291,8 +291,7 @@ object Watchers                                                   {
         // When we call "stop" on the FileMonitor, it always throws a ClosedWatchServiceException.
         // It seems to be because the "run" in start continue to try to execute its
         // action on the stop watcher. We need to catch that.
-        @nowarn("msg=parameter executionContext in method start is never used")
-        override def start()(implicit executionContext: ExecutionContext): Unit = {
+        override def start()(implicit @unused executionContext: ExecutionContext): Unit = {
           (
             (
               IOResult.attempt(this.watch(root, 0)) *>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/metrics/HistorizeNodeCountService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/metrics/HistorizeNodeCountService.scala
@@ -290,7 +290,7 @@ object CommitLogServiceImpl {
     for {
       _    <- IOResult.attempt(File(gitRoot).createDirectoryIfNotExists(createParents = true))
       // by default, commit by rudder system user with no signature
-      info <- Ref.make(CommitInformation(RudderEventActor.name, None, false))
+      info <- Ref.make(CommitInformation(RudderEventActor.name, None, sign = false))
       repo <- GitRepositoryProviderImpl.make(gitRoot)
     } yield {
       new CommitLogServiceImpl(repo, info)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/migration/XmlEntityMigration.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/migration/XmlEntityMigration.scala
@@ -39,7 +39,7 @@ object TestLabel {
 
 object TestIsElem {
 
-  private[this] def failBadElemType(xml: NodeSeq) = {
+  private def failBadElemType(xml: NodeSeq) = {
     Failure("Not expected type of NodeSeq (wish it was an Elem): " + xml)
   }
 
@@ -392,7 +392,7 @@ trait BatchElementMigration[T <: MigrableEntity] extends XmlFileFormatMigration 
     recProcessOneBatch(MigrationProcessResult(0, 0))
   }
 
-  private[this] def migrate(
+  private def migrate(
       elements:    Vector[T],
       errorLogger: Failure => Unit
   ): Vector[T] = {
@@ -504,7 +504,7 @@ object DefaultXmlEventLogMigration extends XmlEntityMigration {
     }
   }
 
-  private[this] def migrate5_6(xml: Elem): Box[Elem] = {
+  private def migrate5_6(xml: Elem): Box[Elem] = {
     XmlMigration_5_6.other(xml)
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechnique.scala
@@ -275,7 +275,7 @@ object ParameterType {
     }
 
     def addNewParameterService(service: ParameterTypeService): Unit = innerServices = service :: innerServices
-    private[this] var innerServices: List[ParameterTypeService] = new BasicParameterTypeService :: Nil
+    private var innerServices: List[ParameterTypeService] = new BasicParameterTypeService :: Nil
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechniqueReader.scala
@@ -100,7 +100,7 @@ class EditorTechniqueReaderImpl(
     }
   }
 
-  private[this] val methodsCache = Ref.Synchronized.make((Instant.EPOCH, Map[BundleName, GenericMethod]())).runNow
+  private val methodsCache = Ref.Synchronized.make((Instant.EPOCH, Map[BundleName, GenericMethod]())).runNow
 
   def getMethodsMetadata: IOResult[Map[BundleName, GenericMethod]] = {
     for {
@@ -110,7 +110,7 @@ class EditorTechniqueReaderImpl(
     }
   }
 
-  private[this] def readMethodsMetadataFile(
+  private def readMethodsMetadataFile(
       cache: (Instant, Map[BundleName, GenericMethod])
   ): IOResult[(Instant, Map[BundleName, GenericMethod])] = {
     if (methodsFile.exists()) {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
@@ -118,12 +118,12 @@ trait TechniqueCompiler {
     val compileYaml = compileAtPath(techniquePath)
     val success     = TechniqueCompilationOutput(
       TechniqueCompilerApp.Rudderc,
-      false,
-      0,
-      Chunk.empty,
-      "no compilation needed: artifact are up-to-date",
-      "",
-      ""
+      fallbacked = false,
+      resultCode = 0,
+      fileStatus = Chunk.empty,
+      msg = "no compilation needed: artifact are up-to-date",
+      stdout = "",
+      stderr = ""
     ).succeed
 
     for {
@@ -452,7 +452,15 @@ class TechniqueCompilerWithFallback(
 
     // recover from rudderc if result says so
     def recoverIfNeeded(app: TechniqueCompilerApp, r: RuddercResult): IOResult[TechniqueCompilationOutput] = {
-      val ltc = TechniqueCompilationOutput(app, false, r.code, r.fileStatus, r.msg, r.stdout, r.stderr)
+      val ltc = TechniqueCompilationOutput(
+        app,
+        fallbacked = false,
+        resultCode = r.code,
+        fileStatus = r.fileStatus,
+        msg = r.msg,
+        stdout = r.stdout,
+        stderr = r.stderr
+      )
       r match {
         case _: RuddercResult.Fail =>
           // fallback but keep rudderc error for logs
@@ -468,9 +476,17 @@ class TechniqueCompilerWithFallback(
       case Some(TechniqueCompilerApp.Webapp)  => // in that case, we can't fallback even more, so the result is final
         fallbackCompiler.compileTechnique(technique)
       case Some(TechniqueCompilerApp.Rudderc) =>
-        ruddercAll.map(r =>
-          TechniqueCompilationOutput(TechniqueCompilerApp.Rudderc, false, r.code, r.fileStatus, r.msg, r.stdout, r.stderr)
-        )
+        ruddercAll.map(r => {
+          TechniqueCompilationOutput(
+            TechniqueCompilerApp.Rudderc,
+            fallbacked = false,
+            resultCode = r.code,
+            fileStatus = r.fileStatus,
+            msg = r.msg,
+            stdout = r.stdout,
+            stderr = r.stderr
+          )
+        })
     }
   }
 
@@ -520,11 +536,11 @@ class WebappTechniqueCompiler(
     getTechniqueRelativePath: EditorTechnique => String, // get the technique path relative to git root.
     val baseConfigRepoPath:   String                     // root of config repos
 ) extends TechniqueCompiler {
-  private[this] val cfengineTechniqueWriter =
+  private val cfengineTechniqueWriter =
     new ClassicTechniqueWriter(baseConfigRepoPath, parameterTypeService, getTechniqueRelativePath)
-  private[this] val dscTechniqueWriter      =
+  private val dscTechniqueWriter      =
     new DSCTechniqueWriter(baseConfigRepoPath, translater, parameterTypeService, getTechniqueRelativePath)
-  private[this] val agentSpecific           = cfengineTechniqueWriter :: dscTechniqueWriter :: Nil
+  private val agentSpecific           = cfengineTechniqueWriter :: dscTechniqueWriter :: Nil
 
   override def compileTechnique(technique: EditorTechnique): IOResult[TechniqueCompilationOutput] = {
     for {
@@ -539,12 +555,12 @@ class WebappTechniqueCompiler(
     } yield {
       TechniqueCompilationOutput(
         TechniqueCompilerApp.Webapp,
-        false,
-        0,
-        TechniqueFiles.Generated.all.map(f => ResourceFile(f, ResourceFileState.New)),
-        s"Technique '${getTechniqueRelativePath(technique)}' written by webapp",
-        "",
-        ""
+        fallbacked = false,
+        resultCode = 0,
+        fileStatus = TechniqueFiles.Generated.all.map(f => ResourceFile(f, ResourceFileState.New)),
+        msg = s"Technique '${getTechniqueRelativePath(technique)}' written by webapp",
+        stdout = "",
+        stderr = ""
       )
     }
   }
@@ -902,7 +918,7 @@ class ClassicTechniqueWriter(
                       }
           } yield {
             val condition = canonifyCondition(call, parentBlocks)
-            createCallingBundle(condition, call, classParameterValue, params, false)
+            createCallingBundle(condition, call, classParameterValue, params, forNaReport = false)
           })
         case block: MethodBlock =>
           val bundleAndMethodCallsList  = block.calls.flatMap(bundleMethodCall(block :: parentBlocks))
@@ -993,7 +1009,7 @@ class ClassicTechniqueWriter(
                 val params =
                   s""""${message}"""" :: s""""${escapedClassParameterValue}"""" :: s""""${classPrefix}"""" :: "@{args}" :: Nil
 
-                createCallingBundle(condition, call, classParameterValue, params, true)
+                createCallingBundle(condition, call, classParameterValue, params, forNaReport = true)
               }
 
               // Write report if the method does not support CFEngine ...

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/ReportingConfiguration.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/ReportingConfiguration.scala
@@ -125,7 +125,7 @@ sealed trait AgentReportingProtocol extends EnumEntry {
   def value: String
 }
 
-final case object AgentReportingHTTPS extends AgentReportingProtocol {
+case object AgentReportingHTTPS extends AgentReportingProtocol {
   val value = "HTTPS"
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionRepository.scala
@@ -109,7 +109,7 @@ class CachedReportsExecutionRepository(
    * can be used for a given node) is given by the presence of the
    * nodeid in map's keys.
    */
-  private[this] var cache = Map[NodeId, Option[AgentRunWithNodeConfig]]()
+  private var cache = Map[NodeId, Option[AgentRunWithNodeConfig]]()
 
   override def clearCache(): Unit = semaphore
     .withPermit(IOResult.attempt {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionService.scala
@@ -171,7 +171,7 @@ class ReportsExecutionService(
    * The hook method where the other method needing to happen when
    * new reports are processed are called.
    */
-  private[this] def hookForChanges(lowestId: Long, highestId: Long): Unit = {
+  private def hookForChanges(lowestId: Long, highestId: Long): Unit = {
     val startHooks = System.currentTimeMillis
 
     // notify changes updates

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/DirectiveRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/DirectiveRepository.scala
@@ -289,8 +289,8 @@ final case class FullActiveTechniqueCategory(
             SortedMap[TechniqueVersion, DateTime]() ++ newTimes,
             SortedMap[TechniqueVersion, Technique]() ++ newTechs,
             Nil,
-            true,
-            false
+            isEnabled = true,
+            isSystem = false
           )
         case Some(fat) =>
           fat.modify(_.acceptationDatetimes).using(_ ++ newTimes).modify(_.techniques).using(_ ++ newTechs)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ItemArchiveManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ItemArchiveManager.scala
@@ -186,7 +186,7 @@ trait ItemArchiveManager {
   /**
    * Import the item archive from HEAD (corresponding to last commit)
    */
-  private[this] def lastGitCommitId = GitCommitId("HEAD")
+  private def lastGitCommitId = GitCommitId("HEAD")
 
   def importHeadAll(
       commiter:      PersonIdent,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
@@ -111,17 +111,6 @@ class ComplianceJdbcRepository(
     "badpolicymode"
   )
 
-  implicit val ComplianceLevelRead:  Read[ComplianceLevel]  = {
-    Read[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)].map(tuple =>
-      ComplianceLevel.apply _ tupled tuple
-    )
-  }
-  implicit val ComplianceLevelWrite: Write[ComplianceLevel] = {
-    Write[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)].contramap(comp =>
-      ComplianceLevel.unapply(comp).get
-    )
-  }
-
   /*
    * Save a list of node compliance reports
    */

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/EventLogJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/EventLogJdbcRepository.scala
@@ -54,7 +54,6 @@ import doobie.postgres.implicits.*
 import doobie.util.fragments
 import scala.xml.*
 import zio.interop.catz.*
-import zio.syntax.*
 
 /**
  * The EventLog repository
@@ -97,11 +96,6 @@ class EventLogJdbcRepository(
         } yield {
           saved
         }
-
-      case _ =>
-        Inconsistency(
-          s"Eventlog with type '${eventLog.eventType} has invalid XML for details (it must be a well formed document with only one root): ${eventLog.details}'"
-        ).fail
     }
   }
 
@@ -111,7 +105,7 @@ class EventLogJdbcRepository(
    * see unreconized event log (even if it means looking to XML,
    * it's better than missing an important info)
    */
-  private[this] def toEventLog(pair: (String, EventLogDetails)): EventLog = {
+  private def toEventLog(pair: (String, EventLogDetails)): EventLog = {
     val (eventType, eventLogDetails) = pair
     EventLogReportsMapper.mapEventLog(
       EventTypeFactory(eventType),
@@ -301,7 +295,7 @@ private object EventLogReportsMapper extends NamedZioLogger {
 
   override def loggerName: String = this.getClass.getName
 
-  private[this] val logFilters = {
+  private val logFilters = {
     WorkflowStepChanged ::
     NodeEventLogsFilter.eventList :::
     AssetsEventLogsFilter.eventList :::

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ExpectedReportsJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ExpectedReportsJdbcRepository.scala
@@ -630,7 +630,7 @@ class UpdateExpectedReportsJdbcRepository(
     })
   }
 
-  private[this] def updateNodeConfigIdInfo(configInfos: Map[NodeId, Vector[NodeConfigIdInfo]]): ConnectionIO[Set[NodeId]] = {
+  private def updateNodeConfigIdInfo(configInfos: Map[NodeId, Vector[NodeConfigIdInfo]]): ConnectionIO[Set[NodeId]] = {
     if (configInfos.isEmpty) {
       Set.empty[NodeId].pure[ConnectionIO]
     } else {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ReportsJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ReportsJdbcRepository.scala
@@ -63,19 +63,19 @@ class ReportsJdbcRepository(doobie: Doobie) extends ReportsRepository with Logga
   val reports      = "ruddersysevents"
   val archiveTable = "archivedruddersysevents"
 
-  private[this] val reportsExecutionTable = "reportsexecution"
-  private[this] val common_reports_column =
+  private val reportsExecutionTable = "reportsexecution"
+  private val common_reports_column =
     "executiondate, ruleid, directiveid, nodeid, reportid, component, keyvalue, executiontimestamp, eventtype, msg"
   // When we want reports we already know the type (request with where clause on eventtype) we do not want eventtype in request because it will be used as value for message in corresponding case class
-  private[this] val typed_reports_column  =
+  private val typed_reports_column  =
     "executiondate, ruleid, directiveid, nodeid, reportid, component, keyvalue, executiontimestamp, msg"
 
   // just an utility to remove multiple spaces in query so that we can vertically align them an see what part are changing - the use
   // of greek p is to discurage use elsewhere
-  private[this] def þ(s: String) = s.replaceAll("""\s+""", " ")
-  private[this] val baseQuery  = þ(s"select     ${common_reports_column} from RudderSysEvents         where 1=1 ")
-  private[this] val typedQuery = þ(s"select     ${typed_reports_column}  from RudderSysEvents         where 1=1 ")
-  private[this] val idQuery    = þ(s"select id, ${common_reports_column} from ruddersysevents         where 1=1 ")
+  private def þ(s: String) = s.replaceAll("""\s+""", " ")
+  private val baseQuery  = þ(s"select     ${common_reports_column} from RudderSysEvents         where 1=1 ")
+  private val typedQuery = þ(s"select     ${typed_reports_column}  from RudderSysEvents         where 1=1 ")
+  private val idQuery    = þ(s"select id, ${common_reports_column} from ruddersysevents         where 1=1 ")
 
   // We assume that this method is called with a limited list of runs
   override def getExecutionReports(
@@ -270,19 +270,19 @@ class ReportsJdbcRepository(doobie: Doobie) extends ReportsRepository with Logga
   }
 
   // Utilitary methods for reliable archiving of reports
-  private[this] def getHighestArchivedReports(): Box[Option[Long]] = {
+  private def getHighestArchivedReports(): Box[Option[Long]] = {
     transactRunBox(xa =>
       query[Long]("select id from archivedruddersysevents order by id desc limit 1").option.transact(xa)
     ) ?~! "Could not fetch the highest archived report in the database"
   }
 
-  private[this] def getLowestReports(): Box[Option[Long]] = {
+  private def getLowestReports(): Box[Option[Long]] = {
     transactRunBox(xa =>
       query[Long]("select id from ruddersysevents order by id asc limit 1").option.transact(xa)
     ) ?~! "Could not fetch the lowest report in the database"
   }
 
-  private[this] def getHighestIdBeforeDate(date: DateTime): Box[Option[Long]] = {
+  private def getHighestIdBeforeDate(date: DateTime): Box[Option[Long]] = {
     transactRunBox(xa => {
       query[Long](
         s"select id from ruddersysevents where executionTimeStamp < '${date.toString("yyyy-MM-dd")}' order by id desc limit 1"

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
@@ -282,7 +282,7 @@ class LDAPDiffMapper(
                                case version =>
                                  for {
                                    d <- diff
-                                   v <- TechniqueVersion.parse(version).leftMap(Unexpected)
+                                   v <- TechniqueVersion.parse(version).leftMap(Unexpected.apply)
                                  } yield {
                                    d.copy(modTechniqueVersion = Some(SimpleDiff(oldPi.techniqueVersion, v)))
                                  }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -287,16 +287,16 @@ class LDAPEntityMapper(
                     inventoryEntry(A_DESCRIPTION).getOrElse(""),
                     NodeState.Enabled,
                     inventoryEntry.getAsBoolean(A_IS_SYSTEM).getOrElse(false),
-                    false, // we don't know anymore if it was a policy server
+                    isPolicyServer = false, // we don't know anymore if it was a policy server
 
-                    new DateTime(0), // we don't know anymore the acceptation date
+                    creationDate = new DateTime(0), // we don't know anymore the acceptation date
 
                     ReportingConfiguration(None, None, None), // we don't know anymore agent run frequency
 
-                    Nil, // we forgot node properties
+                    properties = Nil, // we forgot node properties
 
-                    None,
-                    None
+                    policyMode = None,
+                    securityTag = None
                   )
       nodeInfo <- inventoryEntriesToNodeInfos(node, inventoryEntry, machineEntry)
     } yield {
@@ -326,7 +326,7 @@ class LDAPEntityMapper(
     }
   }
 
-  private[this] def inventoryEntriesToNodeInfos(
+  private def inventoryEntriesToNodeInfos(
       node:           Node,
       inventoryEntry: LDAPEntry,
       machineEntry:   Option[LDAPEntry]
@@ -570,7 +570,7 @@ class LDAPEntityMapper(
           case (v, d) =>
             TechniqueVersion
               .parse(v)
-              .leftMap(Unexpected)
+              .leftMap(Unexpected.apply)
               .flatMap(version => {
                 try {
                   Right((version, GeneralizedTime(d).dateTime))
@@ -678,7 +678,7 @@ class LDAPEntityMapper(
     if (e.isA(OC_RUDDER_NODE_GROUP)) {
       // OK, translate
       for {
-        id         <- e.required(A_NODE_GROUP_UUID).flatMap(NodeGroupId.parse(_).left.map(MalformedDN))
+        id         <- e.required(A_NODE_GROUP_UUID).flatMap(NodeGroupId.parse(_).left.map(MalformedDN.apply))
         name       <- e.required(A_NAME)
         query       = e(A_QUERY_NODE_GROUP)
         nodeIds     = e.valuesFor(A_NODE_UUID).map(x => NodeId(x))
@@ -726,7 +726,7 @@ class LDAPEntityMapper(
   def entryToGroupNodeIds(e: LDAPEntry): InventoryMappingPure[(NodeGroupId, Set[NodeId])] = {
     if (e.isA(OC_RUDDER_NODE_GROUP)) {
       for {
-        id     <- e.required(A_NODE_GROUP_UUID).flatMap(NodeGroupId.parse(_).left.map(MalformedDN))
+        id     <- e.required(A_NODE_GROUP_UUID).flatMap(NodeGroupId.parse(_).left.map(MalformedDN.apply))
         nodeIds = e.valuesFor(A_NODE_UUID).map(x => NodeId(x))
       } yield {
         (id, nodeIds)
@@ -742,7 +742,7 @@ class LDAPEntityMapper(
   def entryToGroupNodeIdsChunk(e: LDAPEntry): InventoryMappingPure[(NodeGroupId, Chunk[NodeId])] = {
     if (e.isA(OC_RUDDER_NODE_GROUP)) {
       for {
-        id     <- e.required(A_NODE_GROUP_UUID).flatMap(NodeGroupId.parse(_).left.map(MalformedDN))
+        id     <- e.required(A_NODE_GROUP_UUID).flatMap(NodeGroupId.parse(_).left.map(MalformedDN.apply))
         nodeIds = e.valuesForChunk(A_NODE_UUID).map(x => NodeId(x))
       } yield {
         (id, nodeIds)
@@ -832,7 +832,7 @@ class LDAPEntityMapper(
                              case None        => Right(None)
                              case Some(value) => PolicyMode.parse(value).map(Some(_))
                            }
-        version         <- TechniqueVersion.parse(s_version).leftMap(Unexpected)
+        version         <- TechniqueVersion.parse(s_version).leftMap(Unexpected.apply)
         name             = e(A_NAME).getOrElse(id)
         params           = parsePolicyVariables(e.valuesFor(A_DIRECTIVE_VARIABLES).toSeq)
         shortDescription = e(A_DESCRIPTION).getOrElse("")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPGitRevisionProvider.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPGitRevisionProvider.scala
@@ -73,7 +73,7 @@ class LDAPGitRevisionProvider(
     )
   }
 
-  private[this] var currentId = {
+  private var currentId = {
     val setID = for {
       id <- getAvailableRevTreeId
       _  <- setCurrentRevTreeId(id)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
@@ -69,8 +69,6 @@ import com.normation.rudder.domain.RudderLDAPConstants.OC_GROUP_CATEGORY
 import com.normation.rudder.domain.RudderLDAPConstants.OC_RUDDER_NODE_GROUP
 import com.normation.rudder.domain.RudderLDAPConstants.OC_SPECIAL_TARGET
 import com.normation.rudder.domain.nodes.*
-import com.normation.rudder.domain.nodes.NodeGroupCategory
-import com.normation.rudder.domain.nodes.NodeGroupCategoryId
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.domain.policies.GroupTarget
 import com.normation.rudder.facts.nodes.ChangeContext
@@ -110,7 +108,7 @@ class RoLDAPNodeGroupRepository(
    * the given category which MUST be mapped to an entry with the given
    * DN in the LDAP backend, accessible with the given connection.
    */
-  private[this] def addSubEntries(category: NodeGroupCategory, dn: DN, con: RoLDAPConnection): IOResult[NodeGroupCategory] = {
+  private def addSubEntries(category: NodeGroupCategory, dn: DN, con: RoLDAPConnection): IOResult[NodeGroupCategory] = {
     for {
       res <- con.searchOne(
                dn,
@@ -495,7 +493,7 @@ class RoLDAPNodeGroupRepository(
     }
   }
 
-  private[this] def findGroupWithFilter(filter: Filter): IOResult[Seq[NodeGroupId]] = {
+  private def findGroupWithFilter(filter: Filter): IOResult[Seq[NodeGroupId]] = {
     groupLibMutex.readLock {
       for {
         con      <- ldap
@@ -661,7 +659,7 @@ class WoLDAPNodeGroupRepository(
   /**
    * Check if a group category exist with the given name
    */
-  private[this] def categoryExists(con: RoLDAPConnection, name: String, parentDn: DN): IOResult[Boolean] = {
+  private def categoryExists(con: RoLDAPConnection, name: String, parentDn: DN): IOResult[Boolean] = {
     groupLibMutex.readLock(
       con
         .searchOne(parentDn, AND(IS(OC_GROUP_CATEGORY), EQ(A_NAME, name)), A_GROUP_CATEGORY_UUID)
@@ -676,7 +674,7 @@ class WoLDAPNodeGroupRepository(
   /**
    * Check if a group category exist with the given name
    */
-  private[this] def categoryExists(
+  private def categoryExists(
       con:       RoLDAPConnection,
       name:      String,
       parentDn:  DN,
@@ -700,7 +698,7 @@ class WoLDAPNodeGroupRepository(
   /**
    * Check if a nodeGroup exists(id already exists) and name is unique
    */
-  private[this] def checkNodeGroupExists(con: RoLDAPConnection, group: NodeGroup): IOResult[Boolean] = {
+  private def checkNodeGroupExists(con: RoLDAPConnection, group: NodeGroup): IOResult[Boolean] = {
     groupLibMutex.readLock(
       con
         .searchSub(
@@ -721,7 +719,7 @@ class WoLDAPNodeGroupRepository(
   /**
    * Check if another nodeGroup exist with the given name
    */
-  private[this] def checkNameAlreadyInUse(con: RoLDAPConnection, name: String, id: NodeGroupId): IOResult[Boolean] = {
+  private def checkNameAlreadyInUse(con: RoLDAPConnection, name: String, id: NodeGroupId): IOResult[Boolean] = {
     groupLibMutex.readLock(
       con
         .searchSub(
@@ -737,7 +735,7 @@ class WoLDAPNodeGroupRepository(
     )
   }
 
-  private[this] def getContainerDn(con: RoLDAPConnection, id: NodeGroupCategoryId): IOResult[DN] = {
+  private def getContainerDn(con: RoLDAPConnection, id: NodeGroupCategoryId): IOResult[DN] = {
     groupLibMutex.readLock {
       con
         .searchSub(rudderDit.GROUP.dn, AND(IS(OC_GROUP_CATEGORY), EQ(A_GROUP_CATEGORY_UUID, id.value)), A_GROUP_CATEGORY_UUID)
@@ -949,7 +947,7 @@ class WoLDAPNodeGroupRepository(
                        } else ZIO.unit
       categoryEntry <- getCategoryEntry(con, into).notOptional(s"Entry with ID '${into.value}' was not found")
       entry          = mapper.nodeGroupToLdap(nodeGroup, categoryEntry.dn)
-      result        <- con.save(entry, true)
+      result        <- con.save(entry, removeMissingAttributes = true)
       diff          <- diffMapper.addChangeRecords2NodeGroupDiff(entry.dn, result).toIO
       loggedAction  <- actionlogEffect.saveAddNodeGroup(modId, principal = actor, addDiff = diff, reason = reason)
       // We dont want to check if this is a system group or not, because new groups are not systems (see constructor)
@@ -982,7 +980,7 @@ class WoLDAPNodeGroupRepository(
                          categoryEntry.dn,
                          s"Only the ${policyServer.target} policy server"
                        )
-      result        <- con.save(entry, true)
+      result        <- con.save(entry, removeMissingAttributes = true)
     } yield {
       result
     })
@@ -1007,7 +1005,7 @@ class WoLDAPNodeGroupRepository(
     })
   }
 
-  private[this] def internalUpdate(
+  private def internalUpdate(
       nodeGroup:       NodeGroup,
       modId:           ModificationId,
       actor:           EventActor,
@@ -1084,7 +1082,7 @@ class WoLDAPNodeGroupRepository(
     // note: this is not protected by a lock because of the risk of calling it in a read lock
     // in a subclass. All callers must call it in a `writeLock`.
     for {
-      result       <- con.save(entry, true).chainError(s"Error when saving entry: ${entry}")
+      result       <- con.save(entry, removeMissingAttributes = true).chainError(s"Error when saving entry: ${entry}")
       optDiff      <- diffMapper
                         .modChangeRecords2NodeGroupDiff(existing, result)
                         .toIO
@@ -1118,7 +1116,7 @@ class WoLDAPNodeGroupRepository(
       actor:  EventActor,
       reason: Option[String]
   ): IOResult[Option[ModifyNodeGroupDiff]] = {
-    internalUpdate(group, modId, actor, reason, true, true)
+    internalUpdate(group, modId, actor, reason, systemCall = true, onlyUpdateNodes = true)
   }
 
   override def update(
@@ -1127,7 +1125,7 @@ class WoLDAPNodeGroupRepository(
       actor:     EventActor,
       reason:    Option[String]
   ): IOResult[Option[ModifyNodeGroupDiff]] = {
-    internalUpdate(nodeGroup, modId, actor, reason, false, false)
+    internalUpdate(nodeGroup, modId, actor, reason, systemCall = false, onlyUpdateNodes = false)
   }
 
   override def updateSystemGroup(
@@ -1136,7 +1134,7 @@ class WoLDAPNodeGroupRepository(
       actor:     EventActor,
       reason:    Option[String]
   ): IOResult[Option[ModifyNodeGroupDiff]] = {
-    internalUpdate(nodeGroup, modId, actor, reason, true, false)
+    internalUpdate(nodeGroup, modId, actor, reason, systemCall = true, onlyUpdateNodes = false)
   }
 
   // this one does not seem able to use internalUpdate

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
@@ -92,7 +92,9 @@ class WoLDAPNodeRepository(
         _             <- checkNodeModification(oldNode, node)
         // here goes the check that we are not updating policy server
         nodeEntry      = mapper.nodeToEntry(node)
-        result        <- con.save(nodeEntry, true, Seq()).chainError(s"Error when saving node entry in repository: ${nodeEntry}")
+        result        <- con
+                           .save(nodeEntry, removeMissingAttributes = true)
+                           .chainError(s"Error when saving node entry in repository: ${nodeEntry}")
         // only record an event log if there is an actual change
         _             <- result match {
                            case LDIFNoopChangeRecord(_) => ZIO.unit

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPRuleRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPRuleRepository.scala
@@ -143,7 +143,7 @@ class WoLDAPRuleRepository(
   /**
    * Check if a configuration exist with the given name, and another id
    */
-  private[this] def nodeRuleNameExists(con: RoLDAPConnection, name: String, id: RuleId): IOResult[Boolean] = {
+  private def nodeRuleNameExists(con: RoLDAPConnection, name: String, id: RuleId): IOResult[Boolean] = {
     val filter = AND(AND(IS(OC_RULE), EQ(A_NAME, name), NOT(EQ(A_RULE_UUID, id.uid.value))))
     con
       .searchSub(rudderDit.RULES.dn, filter)
@@ -154,7 +154,7 @@ class WoLDAPRuleRepository(
       })
   }
 
-  private[this] def internalDeleteRule(
+  private def internalDeleteRule(
       id:         RuleId,
       modId:      ModificationId,
       actor:      EventActor,
@@ -283,7 +283,7 @@ class WoLDAPRuleRepository(
     })
   }
 
-  private[this] def internalUpdate(
+  private def internalUpdate(
       rule:       Rule,
       modId:      ModificationId,
       actor:      EventActor,
@@ -316,7 +316,8 @@ class WoLDAPRuleRepository(
                              s"Cannot update rule with name ${rule.name}: this name is already in use.".fail
                            }
         crEntry          = mapper.rule2Entry(rule)
-        result          <- con.save(crEntry, true).chainError(s"Error when saving rule entry in repository: ${crEntry}")
+        result          <-
+          con.save(crEntry, removeMissingAttributes = true).chainError(s"Error when saving rule entry in repository: ${crEntry}")
         optDiff         <- diffMapper
                              .modChangeRecords2RuleDiff(existingEntry, result)
                              .toIO
@@ -341,7 +342,7 @@ class WoLDAPRuleRepository(
   }
 
   def update(rule: Rule, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Option[ModifyRuleDiff]] = {
-    internalUpdate(rule, modId, actor, reason, false)
+    internalUpdate(rule, modId, actor, reason, systemCall = false)
   }
 
   def updateSystem(
@@ -350,7 +351,7 @@ class WoLDAPRuleRepository(
       actor:  EventActor,
       reason: Option[String]
   ): IOResult[Option[ModifyRuleDiff]] = {
-    internalUpdate(rule, modId, actor, reason, true)
+    internalUpdate(rule, modId, actor, reason, systemCall = true)
   }
 
   /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapGroupLibrary.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapGroupLibrary.scala
@@ -198,7 +198,7 @@ class ImportGroupLibraryImpl(
             groups        <- ZIO.foreach(content.groups) { nodeGroup =>
                                val nodeGroupEntry = mapper.nodeGroupToLdap(nodeGroup, categoryEntry.dn)
                                con
-                                 .save(nodeGroupEntry, true)
+                                 .save(nodeGroupEntry, removeMissingAttributes = true)
                                  .chainError("Error when persisting group entry with DN '%s' in LDAP".format(nodeGroupEntry.dn))
                              }
             subCategories <- ZIO.foreach(content.categories)(cat => recSaveUserLib(categoryEntry.dn, cat))
@@ -320,7 +320,7 @@ class ImportGroupLibraryImpl(
               categoryIds += cat.id
               categoryNamesByParent += (cat.name -> (parent.id :: categoryNamesByParent.getOrElse(cat.name, Nil)))
 
-              val subCategories = content.categories.flatMap(c => recSanitizeCategory(c, cat, false)).toSet
+              val subCategories = content.categories.flatMap(c => recSanitizeCategory(c, cat, isRoot = false)).toSet
               val subNodeGroups = content.groups.flatMap(sanitizeNodeGroup(_)).toSet
 
               // remove from sub cat groups that where not correct
@@ -345,7 +345,7 @@ class ImportGroupLibraryImpl(
         }
       }
 
-      recSanitizeCategory(userLib, userLib.category, true).notOptional(
+      recSanitizeCategory(userLib, userLib.category, isRoot = true).notOptional(
         "Error when trying to sanitize serialised user library for consistency errors"
       )
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapPolicyLibrary.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapPolicyLibrary.scala
@@ -125,7 +125,7 @@ class ImportTechniqueLibraryImpl(
                                    pisSaved <- ZIO.foreach(directives) { directive =>
                                                  val piEntry = mapper.userDirective2Entry(directive, uptEntry.dn)
                                                  con
-                                                   .save(piEntry, true)
+                                                   .save(piEntry, removeMissingAttributes = true)
                                                    .chainError(
                                                      "Error when persisting directive entry with DN '%s' in LDAP".format(piEntry.dn)
                                                    )
@@ -134,7 +134,7 @@ class ImportTechniqueLibraryImpl(
                                    "OK"
                                  }
                              }
-            subCategories <- ZIO.foreach(content.categories)(cat => recSaveUserLib(categoryEntry.dn, cat, false))
+            subCategories <- ZIO.foreach(content.categories)(cat => recSaveUserLib(categoryEntry.dn, cat, isRoot = false))
           } yield {
             () // unit is expected
           }
@@ -279,7 +279,7 @@ class ImportTechniqueLibraryImpl(
               categoryIds += cat.id
               categoryNamesByParent += (cat.name -> (parent.id :: categoryNamesByParent.getOrElse(cat.name, Nil)))
 
-              val subCategories = content.categories.flatMap(c => recSanitizeCategory(c, cat, false))
+              val subCategories = content.categories.flatMap(c => recSanitizeCategory(c, cat, isRoot = false))
               val subUPTs       = content.templates.flatMap(sanitizeUPT(_))
 
               Some(
@@ -296,7 +296,7 @@ class ImportTechniqueLibraryImpl(
         }
       }
 
-      recSanitizeCategory(userLib, userLib.category, true).notOptional(
+      recSanitizeCategory(userLib, userLib.category, isRoot = true).notOptional(
         "Error when trying to sanitize serialised user library for consistency errors"
       )
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
@@ -94,7 +94,7 @@ class GitRuleArchiverImpl(
   override val relativePath = ruleRootDir
   override val tagPrefix    = "archives/configurations-rules/"
 
-  private[this] def newCrFile(ruleId: RuleId) = new File(getItemDirectory, ruleId.serialize + ".xml")
+  private def newCrFile(ruleId: RuleId) = new File(getItemDirectory, ruleId.serialize + ".xml")
 
   def archiveRule(rule: Rule, doCommit: Option[(ModificationId, PersonIdent, Option[String])]): IOResult[GitPath] = {
     val crFile  = newCrFile(rule.id)
@@ -416,11 +416,11 @@ class GitActiveTechniqueCategoryArchiverImpl(
 
   override lazy val tagPrefix = "archives/directives/"
 
-  private[this] def newActiveTechniquecFile(uptcId: ActiveTechniqueCategoryId, parents: List[ActiveTechniqueCategoryId]) = {
+  private def newActiveTechniquecFile(uptcId: ActiveTechniqueCategoryId, parents: List[ActiveTechniqueCategoryId]) = {
     newCategoryDirectory(uptcId, parents).map(new File(_, serializedCategoryName))
   }
 
-  private[this] def archiveWithRename(
+  private def archiveWithRename(
       uptc:       ActiveTechniqueCategory,
       oldParents: Option[List[ActiveTechniqueCategoryId]],
       newParents: List[ActiveTechniqueCategoryId],
@@ -666,7 +666,7 @@ class GitActiveTechniqueArchiverImpl(
   override lazy val relativePath = techniqueLibraryRootDir
   override def getCategoryName(categoryId: ActiveTechniqueCategoryId) = categoryId.value
 
-  private[this] def newActiveTechniqueFile(ptName: TechniqueName, parents: List[ActiveTechniqueCategoryId]) = {
+  private def newActiveTechniqueFile(ptName: TechniqueName, parents: List[ActiveTechniqueCategoryId]) = {
     // parents can not be null: we must have at least the root category
     parents match {
       case Nil       =>
@@ -815,7 +815,7 @@ class GitDirectiveArchiverImpl(
   override lazy val relativePath = techniqueLibraryRootDir
   override def getCategoryName(categoryId: ActiveTechniqueCategoryId) = categoryId.value
 
-  private[this] def newPiFile(
+  private def newPiFile(
       directiveId: DirectiveUid,
       ptName:      TechniqueName,
       parents:     List[ActiveTechniqueCategoryId]
@@ -933,7 +933,7 @@ class GitNodeGroupArchiverImpl(
 
   override lazy val tagPrefix = "archives/groups/"
 
-  private[this] def newNgFile(ngcId: NodeGroupCategoryId, parents: List[NodeGroupCategoryId]) = {
+  private def newNgFile(ngcId: NodeGroupCategoryId, parents: List[NodeGroupCategoryId]) = {
     newCategoryDirectory(ngcId, parents).map(new File(_, serializedCategoryName))
   }
 
@@ -1071,7 +1071,7 @@ class GitNodeGroupArchiverImpl(
     )
   }
 
-  private[this] def newNgFile(ngId: NodeGroupId, parents: List[NodeGroupCategoryId]) = {
+  private def newNgFile(ngId: NodeGroupId, parents: List[NodeGroupCategoryId]) = {
     parents match {
       case h :: t => newCategoryDirectory(h, t).map(new File(_, ngId.withDefaultRev.serialize + ".xml"))
       case Nil    =>
@@ -1207,7 +1207,7 @@ class GitParameterArchiverImpl(
   override val relativePath = parameterRootDir
   override val tagPrefix    = "archives/parameters/"
 
-  private[this] def newParameterFile(parameterName: String) = new File(getItemDirectory, parameterName + ".xml")
+  private def newParameterFile(parameterName: String) = new File(getItemDirectory, parameterName + ".xml")
 
   def archiveParameter(
       parameter: GlobalParameter,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitParseRudderObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitParseRudderObjects.scala
@@ -398,9 +398,9 @@ class GitParseGroupLibrary(
                       group    <- groupUnserialiser.unserialise(groupXml).toIO
                       // h is path relative to config-repo, so may contains only one "/" (rules/ruleId.xml)
                       catId     = h.split('/').toList.reverse match {
-                                    case Nil | _ :: Nil      => // assume root category even if Nil
+                                    case Nil | _ :: Nil       => // assume root category even if Nil
                                       NodeGroupCategoryId("GroupRoot")
-                                    case group :: catId :: _ =>
+                                    case group_ :: catId :: _ =>
                                       NodeGroupCategoryId(catId)
                                   }
                       // we need to correct ID revision to the one we just looked-up.
@@ -462,7 +462,7 @@ class GitParseTechniqueLibrary(
   ): IOResult[Option[(Chunk[TechniqueCategoryName], Technique)]] = {
     val root = GitRootCategory.getGitDirectoryPath(libRootDirectory).root
     (for {
-      v      <- TechniqueVersion(version, rev).left.map(Inconsistency).toIO
+      v      <- TechniqueVersion(version, rev).left.map(Inconsistency.apply).toIO
       id      = TechniqueId(name, v)
       _      <- ConfigurationLoggerPure.revision.debug(s"Looking for technique: ${id.debugString}")
       treeId <- GitFindUtils.findRevTreeFromRevString(repo.db, rev.value)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/ItemArchiveManagerImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/ItemArchiveManagerImpl.scala
@@ -126,7 +126,7 @@ class ItemArchiveManagerImpl(
   override def loggerName: String = this.getClass.getName
 
   // Clean a directory only if it exists, all exception are caught by the tryo
-  private[this] def cleanExistingDirectory(directory: File): IOResult[Unit] = {
+  private def cleanExistingDirectory(directory: File): IOResult[Unit] = {
     IOResult.attempt {
       if (directory.exists) FileUtils.cleanDirectory(directory)
       else ()
@@ -158,7 +158,7 @@ class ItemArchiveManagerImpl(
     }
   }
 
-  private[this] def exportRuleCategories(
+  private def exportRuleCategories(
       commiter: PersonIdent,
       modId:    ModificationId,
       actor:    EventActor,
@@ -236,7 +236,7 @@ class ItemArchiveManagerImpl(
    * - if a directive fails, we record that failure.
    * At the end, we can't have total failure for that part, so we don't have a IOResult
    */
-  private[this] def exportElements(
+  private def exportElements(
       elements: Seq[(List[ActiveTechniqueCategoryId], CategoryWithActiveTechniques)]
   ): IOResult[NotArchivedElements] = {
     ZIO.foldLeft(elements)(NotArchivedElements(Seq(), Seq(), Seq())) {
@@ -351,10 +351,10 @@ class ItemArchiveManagerImpl(
     useSemaphoreOrFail(
       for {
         _           <- GitArchiveLoggerPure.info("Importing full archive with id '%s'".format(archiveId.value))
-        rules       <- importRulesAndDeploy(archiveId, includeSystem, false)
-        userLib     <- importTechniqueLibraryAndDeploy(archiveId, includeSystem, false)
-        groupLIb    <- importGroupLibraryAndDeploy(archiveId, includeSystem, false)
-        parameters  <- importParametersAndDeploy(archiveId, false)
+        rules       <- importRulesAndDeploy(archiveId, includeSystem, deploy = false)
+        userLib     <- importTechniqueLibraryAndDeploy(archiveId, includeSystem, deploy = false)
+        groupLIb    <- importGroupLibraryAndDeploy(archiveId, includeSystem, deploy = false)
+        parameters  <- importParametersAndDeploy(archiveId, includeSystem = false)
         eventLogged <- eventLogger.saveEventLog(modId, new ImportFullArchive(actor, archiveId, message))
         commit      <- restoreCommitAtHead(
                          commiter,
@@ -388,7 +388,7 @@ class ItemArchiveManagerImpl(
     )
   }
 
-  private[this] def importRuleCategories(archiveId: GitCommitId): IOResult[GitCommitId] = {
+  private def importRuleCategories(archiveId: GitCommitId): IOResult[GitCommitId] = {
     for {
       _        <- GitArchiveLoggerPure.info("Importing rule categories archive with id '%s'".format(archiveId.value))
       parsed   <- parseRuleCategories.getArchive(archiveId)
@@ -398,7 +398,7 @@ class ItemArchiveManagerImpl(
     }
   }
 
-  private[this] def importRulesAndDeploy(
+  private def importRulesAndDeploy(
       archiveId:     GitCommitId,
       includeSystem: Boolean,
       deploy:        Boolean = true
@@ -438,7 +438,7 @@ class ItemArchiveManagerImpl(
     )
   }
 
-  private[this] def importTechniqueLibraryAndDeploy(
+  private def importTechniqueLibraryAndDeploy(
       archiveId:     GitCommitId,
       includeSystem: Boolean,
       deploy:        Boolean = true
@@ -471,7 +471,7 @@ class ItemArchiveManagerImpl(
     )
   }
 
-  private[this] def importGroupLibraryAndDeploy(
+  private def importGroupLibraryAndDeploy(
       archiveId:     GitCommitId,
       includeSystem: Boolean,
       deploy:        Boolean = true
@@ -505,7 +505,7 @@ class ItemArchiveManagerImpl(
     )
   }
 
-  private[this] def importParametersAndDeploy(
+  private def importParametersAndDeploy(
       archiveId:     GitCommitId,
       includeSystem: Boolean,
       deploy:        Boolean = true
@@ -544,10 +544,10 @@ class ItemArchiveManagerImpl(
     useSemaphoreOrFail(
       for {
         _           <- GitArchiveLoggerPure.info(s"Importing full archive with id '${archiveId.value}'")
-        rules       <- importRulesAndDeploy(archiveId, includeSystem, false)
-        userLib     <- importTechniqueLibraryAndDeploy(archiveId, includeSystem, false)
-        groupLIb    <- importGroupLibraryAndDeploy(archiveId, includeSystem, false)
-        parameters  <- importParametersAndDeploy(archiveId, false)
+        rules       <- importRulesAndDeploy(archiveId, includeSystem, deploy = false)
+        userLib     <- importTechniqueLibraryAndDeploy(archiveId, includeSystem, deploy = false)
+        groupLIb    <- importGroupLibraryAndDeploy(archiveId, includeSystem, deploy = false)
+        parameters  <- importParametersAndDeploy(archiveId, includeSystem = false)
         eventLogged <- eventLogger.saveEventLog(modId, new Rollback(actor, rollbackedEvents, target, rollbackType, message))
         commit      <- restoreCommitAtHead(
                          commiter,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/RudderPrettyPrinter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/RudderPrettyPrinter.scala
@@ -159,7 +159,7 @@ class RudderPrettyPrinter(width: Int, step: Int) {
     case _                                                     =>
       val test = {
         val sb = new StringBuilder()
-        Utility.serialize(node, pscope, sb, false)
+        Utility.serialize(node, pscope, sb, stripComments = false)
         if (doPreserve(node)) sb.toString
         else TextBuffer.fromString(sb.toString).toText(0).data
       }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/GitRuleCategoryArchiver.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/GitRuleCategoryArchiver.scala
@@ -135,7 +135,7 @@ class GitRuleCategoryArchiverImpl(
 
   def getCategoryName(categoryId: RuleCategoryId): String = categoryId.value
 
-  private[this] def categoryFile(category: RuleCategoryId, parents: List[RuleCategoryId]) =
+  private def categoryFile(category: RuleCategoryId, parents: List[RuleCategoryId]) =
     newCategoryDirectory(category, parents).map(new File(_, categoryFileName))
 
   def archiveRuleCategory(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/ImportRuleCategoryLibrary.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/ImportRuleCategoryLibrary.scala
@@ -37,7 +37,6 @@
 
 package com.normation.rudder.rule.category
 
-import cats.implicits.*
 import com.normation.errors.*
 import com.normation.ldap.sdk.LDAPConnectionProvider
 import com.normation.ldap.sdk.RwLDAPConnection
@@ -186,7 +185,7 @@ class ImportRuleCategoryLibraryImpl(
               val currentStatus = parentCategories.getOrElse(Nil)
               categoryNamesByParent += (cat.name -> (parent.id :: currentStatus))
 
-              val subCategories = cat.childs.flatMap(recSanitizeCategory(_, cat, false))
+              val subCategories = cat.childs.flatMap(recSanitizeCategory(_, cat, isRoot = false))
 
               Some(cat.copy(childs = subCategories))
           }
@@ -194,7 +193,7 @@ class ImportRuleCategoryLibraryImpl(
       }
 
       IOResult
-        .attempt(recSanitizeCategory(rootCategory, rootCategory, true))
+        .attempt(recSanitizeCategory(rootCategory, rootCategory, isRoot = true))
         .notOptional("Error when trying to sanitize serialised user library for consistency errors")
     }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/LDAPRuleCategoryRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/LDAPRuleCategoryRepository.scala
@@ -148,7 +148,7 @@ class RoLDAPRuleCategoryRepository(
    * Build the hierarchy defined by the list of categories, filling children.
    * The starting point is given by the root id.
    */
-  private[this] def buildHierarchy(rootDn: DN, categories: List[(DN, RuleCategory)]): IOResult[RuleCategory] = {
+  private def buildHierarchy(rootDn: DN, categories: List[(DN, RuleCategory)]): IOResult[RuleCategory] = {
     def getChildren(parentDn: DN): List[RuleCategory] = categories.collect {
       case (dn, r) if (dn.getParent == parentDn) =>
         val cc = getChildren(dn)
@@ -182,7 +182,7 @@ class WoLDAPRuleCategoryRepository(
   /**
    * Check if a category exist with the given name
    */
-  private[this] def categoryExists(
+  private def categoryExists(
       con:      RoLDAPConnection,
       name:     String,
       parentDn: DN
@@ -203,7 +203,7 @@ class WoLDAPRuleCategoryRepository(
   /**
    * Check if a category exist with the given name
    */
-  private[this] def categoryExists(
+  private def categoryExists(
       con:       RoLDAPConnection,
       name:      String,
       parentDn:  DN,
@@ -229,7 +229,7 @@ class WoLDAPRuleCategoryRepository(
   /**
    * Return the list of parents for that category, from the root category
    */
-  private[this] def getParents(id: RuleCategoryId): IOResult[List[RuleCategory]] = {
+  private def getParents(id: RuleCategoryId): IOResult[List[RuleCategory]] = {
     for {
       root    <- getRootCategory()
       parents <- root.findParents(id).leftMap(s => Inconsistency(s)).toIO

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/RuleCategoryService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/RuleCategoryService.scala
@@ -69,7 +69,7 @@ class RuleCategoryService {
 
   // transform a list of Rule categrory to a short fqdn for Rule category
   // short fqdn is the path list of all parents to the root category, minus the root category
-  private[this] def toShortFqdn(parents: List[RuleCategory]): String = {
+  private def toShortFqdn(parents: List[RuleCategory]): String = {
     parents.tail.map(_.name).mkString(" » ")
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/ScoreService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/ScoreService.scala
@@ -56,10 +56,10 @@ trait ScoreService {
 }
 
 class ScoreServiceImpl(globalScoreRepository: GlobalScoreRepository, scoreRepository: ScoreRepository) extends ScoreService {
-  private[this] val cache:      Ref[Map[NodeId, GlobalScore]] = Ref.make(Map.empty[NodeId, GlobalScore]).runNow
-  private[this] val scoreCache: Ref[Map[NodeId, List[Score]]] = Ref.make(Map.empty[NodeId, List[Score]]).runNow
+  private val cache:      Ref[Map[NodeId, GlobalScore]] = Ref.make(Map.empty[NodeId, GlobalScore]).runNow
+  private val scoreCache: Ref[Map[NodeId, List[Score]]] = Ref.make(Map.empty[NodeId, List[Score]]).runNow
 
-  private[this] val availableScore: Ref[List[(String, String)]] =
+  private val availableScore: Ref[List[(String, String)]] =
     Ref.make((ComplianceScore.scoreId, "Compliance") :: (SystemUpdateScore.scoreId, "System updates") :: Nil).runNow
 
   def init(): IOResult[Unit] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/ChangeRequestEventLogService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/ChangeRequestEventLogService.scala
@@ -112,7 +112,7 @@ class ChangeRequestEventLogServiceImpl(
     getFirstOrLastLog(id, "creationDate desc")
   }
 
-  private[this] def getFirstOrLastLog(id: ChangeRequestId, sortMethod: String): Box[Option[ChangeRequestEventLog]] = {
+  private def getFirstOrLastLog(id: ChangeRequestId, sortMethod: String): Box[Option[ChangeRequestEventLog]] = {
     eventLogRepository
       .getEventLogByChangeRequest(
         id,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
@@ -204,7 +204,7 @@ class EventLogDetailsServiceImpl(
    * An utility method that is able the parse a <X<from>....</from><to>...</to></X>
    * attribute and extract it into a SimpleDiff class.
    */
-  private[this] def getFromTo[T](opt: Option[NodeSeq], f: NodeSeq => Box[T]): Box[Option[SimpleDiff[T]]] = {
+  private def getFromTo[T](opt: Option[NodeSeq], f: NodeSeq => Box[T]): Box[Option[SimpleDiff[T]]] = {
     opt match {
       case None    => Full(None)
       case Some(x) =>
@@ -222,7 +222,7 @@ class EventLogDetailsServiceImpl(
   /**
    * Special case of getFromTo for strings.
    */
-  private[this] def getFromToString(opt: Option[NodeSeq]) = getFromTo[String](opt, (s: NodeSeq) => Full(s.text))
+  private def getFromToString(opt: Option[NodeSeq]) = getFromTo[String](opt, (s: NodeSeq) => Full(s.text))
 
   def getEntryContent(xml: NodeSeq): Box[Elem] = {
     if (xml.size == 1) {
@@ -358,7 +358,7 @@ class EventLogDetailsServiceImpl(
   /**
    * Map XML into a rule
    */
-  private[this] def getRuleFromXML(xml: NodeSeq, changeType: String): Box[Rule] = {
+  private def getRuleFromXML(xml: NodeSeq, changeType: String): Box[Rule] = {
     for {
       entry           <- getEntryContent(xml)
       crXml           <- (entry \ "rule").headOption ?~! ("Entry type is not a rule: " + entry.toString())
@@ -377,7 +377,7 @@ class EventLogDetailsServiceImpl(
   /**
    * Map XML into a directive
    */
-  private[this] def getDirectiveFromXML(xml: NodeSeq, changeType: String): Box[(TechniqueName, Directive, SectionVal)] = {
+  private def getDirectiveFromXML(xml: NodeSeq, changeType: String): Box[(TechniqueName, Directive, SectionVal)] = {
     for {
       entry           <- getEntryContent(xml)
       directiveXml    <- (entry \ "directive").headOption ?~! ("Entry type is not a directive: " + entry.toString())
@@ -515,7 +515,7 @@ class EventLogDetailsServiceImpl(
   /**
    * Map XML into a node group
    */
-  private[this] def getNodeGroupFromXML(xml: NodeSeq, changeType: String): Box[NodeGroup] = {
+  private def getNodeGroupFromXML(xml: NodeSeq, changeType: String): Box[NodeGroup] = {
     for {
       entry           <- getEntryContent(xml)
       groupXml        <- (entry \ "nodeGroup").headOption ?~! ("Entry type is not a nodeGroup: " + entry.toString())
@@ -540,7 +540,7 @@ class EventLogDetailsServiceImpl(
   /**
    * Get inventory details
    */
-  private[this] def getInventoryLogDetails(xml: NodeSeq, action: String): Box[InventoryLogDetails] = {
+  private def getInventoryLogDetails(xml: NodeSeq, action: String): Box[InventoryLogDetails] = {
     for {
       entry        <- getEntryContent(xml)
       details      <- (entry \ "node").headOption ?~! ("Entry type is not a node: " + entry.toString())
@@ -679,7 +679,7 @@ class EventLogDetailsServiceImpl(
   /**
    * Map XML into a technique
    */
-  private[this] def getTechniqueFromXML(xml: NodeSeq, changeType: String): Box[ActiveTechnique] = {
+  private def getTechniqueFromXML(xml: NodeSeq, changeType: String): Box[ActiveTechnique] = {
     for {
       entry           <- getEntryContent(xml)
       techniqueXml    <- (entry \ "activeTechnique").headOption ?~! ("Entry type is not a technique: " + entry.toString())
@@ -959,7 +959,7 @@ class EventLogDetailsServiceImpl(
     }
   }
 
-  private[this] def extractAgentRun(xml: NodeSeq)(details: NodeSeq) = {
+  private def extractAgentRun(xml: NodeSeq)(details: NodeSeq) = {
     if ((details \ "_").isEmpty) { // no children
       Full(None)
     } else {
@@ -994,7 +994,7 @@ class EventLogDetailsServiceImpl(
     }
   }
 
-  private[this] def extractHeartbeatConfiguration(xml: NodeSeq)(details: NodeSeq) = {
+  private def extractHeartbeatConfiguration(xml: NodeSeq)(details: NodeSeq) = {
     if ((details \ "_").isEmpty) { // no children
       Full(None)
     } else {
@@ -1011,7 +1011,7 @@ class EventLogDetailsServiceImpl(
     }
   }
 
-  private[this] def extractNodeProperties(xml: NodeSeq)(details: NodeSeq): Box[Seq[NodeProperty]] = {
+  private def extractNodeProperties(xml: NodeSeq)(details: NodeSeq): Box[Seq[NodeProperty]] = {
     if (details.isEmpty) Full(Seq())
     else {
       for {
@@ -1036,7 +1036,7 @@ class EventLogDetailsServiceImpl(
   }
 
   // extract tags, with mention to the entryType when reporting errors
-  private[this] def extractTags(entryType: String)(details: NodeSeq): Box[Tags] = {
+  private def extractTags(entryType: String)(details: NodeSeq): Box[Tags] = {
     if (details.isEmpty) Full(Tags(Set()))
     else {
       val tags = traverse(details \\ "tag") { prop =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckNotificationService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckNotificationService.scala
@@ -56,7 +56,7 @@ class HealthcheckNotificationService(
     } yield {}
   }
 
-  private[this] def reloadCache(ref: Ref[List[HealthcheckResult]]): UIO[Unit] = {
+  private def reloadCache(ref: Ref[List[HealthcheckResult]]): UIO[Unit] = {
     for {
       checks <- healthcheckService.runAll
       _      <- ref.set(checks)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckService.scala
@@ -59,7 +59,7 @@ class HealthcheckService(checks: List[Check]) {
     } yield res
   }
 
-  private[this] def logHealthcheck(name: CheckName, check: HealthcheckResult): zio.UIO[Unit] = {
+  private def logHealthcheck(name: CheckName, check: HealthcheckResult): zio.UIO[Unit] = {
     val msg = s"${name.value}: ${check.msg}"
     check match {
       case _: Critical => logger.error(msg)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/MarshallingUtil.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/MarshallingUtil.scala
@@ -42,7 +42,7 @@ import scala.xml.*
 object MarshallingUtil {
 
   def createElem(label: String, fileFormat: String)(children: NodeSeq): Elem = {
-    Elem(null, label, new UnprefixedAttribute("fileFormat", fileFormat, Null), TopScope, false, children*)
+    Elem(null, label, new UnprefixedAttribute("fileFormat", fileFormat, Null), TopScope, minimizeEmpty = false, child = children*)
   }
 
   def createTrimedElem(label: String, fileFormat: String)(children: NodeSeq): Elem = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
@@ -330,7 +330,6 @@ class ChangeRequestChangesSerialisationImpl(
           case AddNodeGroupDiff(group)      => <diff action="add">{nodeGroupSerializer.serialise(group)}</diff>
           case DeleteNodeGroupDiff(group)   => <diff action="delete">{nodeGroupSerializer.serialise(group)}</diff>
           case ModifyToNodeGroupDiff(group) => <diff action="modifyTo">{nodeGroupSerializer.serialise(group)}</diff>
-          case _                            => "should not be here"
         }
       }
       </change>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -423,7 +423,7 @@ class ActiveTechniqueCategoryUnserialisationImpl extends ActiveTechniqueCategory
 class ActiveTechniqueUnserialisationImpl extends ActiveTechniqueUnserialisation {
 
   // we expect acceptation date to be in ISO-8601 format
-  private[this] val dateFormatter = ISODateTimeFormat.dateTime
+  private val dateFormatter = ISODateTimeFormat.dateTime
 
   def unserialise(entry: XNode): Box[ActiveTechnique] = {
     for {
@@ -780,7 +780,7 @@ class GlobalParameterUnserialisationImpl extends GlobalParameterUnserialisation 
 
 class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
   // we expect acceptation date to be in ISO-8601 format
-  private[this] val dateFormatter = ISODateTimeFormat.dateTime
+  private val dateFormatter = ISODateTimeFormat.dateTime
 
   // <acl>
   //   <authz path="/foo/bar/$baz", actions="get, post, patch" />

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/modification/ModificationService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/modification/ModificationService.scala
@@ -82,7 +82,7 @@ class ModificationService(
                           rollbackedEvents,
                           target,
                           "after",
-                          false
+                          includeSystem = false
                         )(
                           ChangeContext(
                             ModificationId(uuidGen.newUuid),
@@ -121,7 +121,7 @@ class ModificationService(
                           rollbackedEvents,
                           target,
                           "before",
-                          false
+                          includeSystem = false
                         )(
                           ChangeContext(
                             ModificationId(uuidGen.newUuid),

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/MergeNodeProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/MergeNodeProperties.scala
@@ -185,13 +185,13 @@ object GroupProp {
         case FullOtherTarget(t)         => // target:all nodes, only root, only managed node, etc
           Right(
             GroupProp(
-              Nil,  // they don't have properties for now
+              Nil,                // they don't have properties for now
               NodeGroupId(NodeGroupUid(t.target)),
-              And,  // for simplification, since they don't have properties it doesn't matter
+              And,                // for simplification, since they don't have properties it doesn't matter
               ResultTransformation.Identity,
-              true, // these special targets behave as dynamic groups
-              Nil,  // terminal leaf
-              target.name
+              isDynamic = true,   // these special targets behave as dynamic groups
+              parentGroups = Nil, // terminal leaf
+              groupName = target.name
             )
           )
         case FullGroupTarget(t, g)      =>
@@ -255,7 +255,7 @@ object MergeNodeProperties {
                                    NodeGroupId
                                      .parse(parentId)
                                      .left
-                                     .map(Inconsistency)
+                                     .map(Inconsistency.apply)
                                      .flatMap(pId => {
                                        if (acc.isDefinedAt(pId)) Right(Nil)
                                        else {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NewNodeManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NewNodeManager.scala
@@ -276,7 +276,7 @@ class ComposedNewNodeManager[A](
   /**
    * Refuse one server
    */
-  private[this] def refuseOne(cnf: CoreNodeFact)(implicit cc: ChangeContext): IOResult[Unit] = {
+  private def refuseOne(cnf: CoreNodeFact)(implicit cc: ChangeContext): IOResult[Unit] = {
     ZIO
       .foreach(unitRefusors)(r => {
         r.refuseOne(cnf)
@@ -399,8 +399,8 @@ class AcceptHostnameAndIp(
 ) extends UnitCheckAcceptInventory {
 
   // some constant data for the query about hostname on node
-  private[this] val objectType       = ditQueryData.criteriaMap(OC_NODE)
-  private[this] val hostnameCriteria = objectType.criteria
+  private val objectType       = ditQueryData.criteriaMap(OC_NODE)
+  private val hostnameCriteria = objectType.criteria
     .find(c => c.name == A_HOSTNAME)
     .getOrElse(
       throw new IllegalArgumentException(
@@ -412,7 +412,7 @@ class AcceptHostnameAndIp(
    * search in database nodes having the same hostname as one provided.
    * Only return existing hostname (and so again, we want that to be empty)
    */
-  private[this] def queryForDuplicateHostname(hostnames: Seq[String])(implicit qc: QueryContext): IOResult[Unit] = {
+  private def queryForDuplicateHostname(hostnames: Seq[String])(implicit qc: QueryContext): IOResult[Unit] = {
     val hostnameCriterion = hostnames.toList.map { h =>
       CriterionLine(
         objectType = objectType,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodePropertiesProviderInfo.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodePropertiesProviderInfo.scala
@@ -75,7 +75,7 @@ final case class ProviderKeyInfo(
 
 class NodePropertiesProviderInfo() {
 
-  private[this] val providers = collection.mutable.Buffer[NodePropertiesProviderInfoExtension]()
+  private val providers = collection.mutable.Buffer[NodePropertiesProviderInfoExtension]()
 
   def getInfo(provider: PropertyProvider, key: String): Box[Option[ProviderKeyInfo]] = {
     providers.find(p => p.isDefined(provider)) match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/PropertyEngineService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/PropertyEngineService.scala
@@ -20,7 +20,7 @@ trait PropertyEngineService {
 
 class PropertyEngineServiceImpl(listOfEngine: List[RudderPropertyEngine]) extends PropertyEngineService {
 
-  private[this] val engines: Ref[Map[String, RudderPropertyEngine]] = (for {
+  private val engines: Ref[Map[String, RudderPropertyEngine]] = (for {
     v <- Ref.make[Map[String, RudderPropertyEngine]](listOfEngine.map(e => e.name.toLowerCase -> e).toMap)
   } yield v).runNow
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/RemoveNodeService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/RemoveNodeService.scala
@@ -112,8 +112,8 @@ sealed trait DeleteMode extends EnumEntry {
 
 object DeleteMode extends Enum[DeleteMode] {
 
-  final case object MoveToRemoved extends DeleteMode { val name = "move"  }
-  final case object Erase         extends DeleteMode { val name = "erase" }
+  case object MoveToRemoved extends DeleteMode { val name = "move"  }
+  case object Erase         extends DeleteMode { val name = "erase" }
 
   val values: IndexedSeq[DeleteMode] = findValues
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/InventoryHistoryJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/InventoryHistoryJdbcRepository.scala
@@ -26,6 +26,7 @@ import com.normation.inventory.domain.AcceptedInventory
 import com.normation.inventory.domain.InventoryStatus
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.db.Doobie
+import com.normation.rudder.db.Doobie.*
 import com.normation.rudder.facts.nodes.NodeFact
 import com.normation.rudder.services.nodes.history.HistoryLog
 import com.normation.rudder.services.nodes.history.HistoryLogRepository

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DependencyAndDeletionService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DependencyAndDeletionService.scala
@@ -241,7 +241,7 @@ class DependencyAndDeletionServiceImpl(
    * - have a target ;
    * - the target is enable ;
    */
-  private[this] def filterRules(rules: Seq[Rule], groupLib: FullNodeGroupCategory): IOResult[Seq[Rule]] = {
+  private def filterRules(rules: Seq[Rule], groupLib: FullNodeGroupCategory): IOResult[Seq[Rule]] = {
     val switchableCr: Seq[(Rule, Set[RuleTarget])] = {
       // only rule with "own status == true" and completly defined
       // (else their states can't change)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -534,7 +534,7 @@ trait PromiseGenerationService {
     )
     result
   }
-  private[this] val periodFormatter = {
+  private val periodFormatter = {
     new PeriodFormatterBuilder()
       .appendDays()
       .appendSuffix(" day", " days")
@@ -839,7 +839,7 @@ class PromiseGenerationServiceImpl(
     with PromiseGeneration_BuildNodeContext with PromiseGeneration_buildRuleVals with PromiseGeneration_buildNodeConfigurations
     with PromiseGeneration_updateAndWriteRule with PromiseGeneration_setExpectedReports with PromiseGeneration_Hooks {
 
-  private[this] var dynamicsGroupsUpdate: Option[UpdateDynamicGroups] = None
+  private var dynamicsGroupsUpdate: Option[UpdateDynamicGroups] = None
 
   // We need to register the update dynamic group after instantiation of the class
   // as the deployment service, the async deployment and the dynamic group update have cyclic dependencies
@@ -851,7 +851,7 @@ class PromiseGenerationServiceImpl(
     dynamicsGroupsUpdate.map(groupUpdate(_)).getOrElse(Failure("Dynamic group update is not registered, this is an error"))
 
   }
-  private[this] def groupUpdate(updateDynamicGroups: UpdateDynamicGroups): Box[Unit] = {
+  private def groupUpdate(updateDynamicGroups: UpdateDynamicGroups): Box[Unit] = {
     // Trigger a manual update if one is not pending (otherwise it goes in infinit loop)
     // It doesn't expose anything about its ending, so we need to wait for the update to be idle
     if (updateDynamicGroups.isIdle()) {
@@ -1820,7 +1820,7 @@ object RuleExpectedReportBuilder extends Loggable {
                   case None     =>
                     varReportId match {
                       case None     =>
-                        innerExpandedVars.zip(innerUnexpandedVars).map(ExpectedValueMatch.tupled)
+                        innerExpandedVars.zip(innerUnexpandedVars).map(ExpectedValueMatch.apply.tupled)
                       case Some(id) =>
                         innerExpandedVars.map(v => ExpectedValueId(v, id))
                     }
@@ -1886,7 +1886,7 @@ object RuleExpectedReportBuilder extends Loggable {
       List(
         ValueExpectedReport(
           technique.id.name.value,
-          trackingVarCard._1.toList.zip(trackingVarCard._2.toList).map(ExpectedValueMatch.tupled)
+          trackingVarCard._1.toList.zip(trackingVarCard._2.toList).map(ExpectedValueMatch.apply.tupled)
         )
       )
     } else {
@@ -1907,7 +1907,7 @@ trait PromiseGeneration_Hooks extends PromiseGenerationService with PromiseGener
   /*
    * Plugin hooks
    */
-  private[this] val codeHooks = collection.mutable.Buffer[PromiseGenerationHooks]()
+  private val codeHooks = collection.mutable.Buffer[PromiseGenerationHooks]()
 
   def appendPreGenCodeHook(hook: PromiseGenerationHooks): Unit = {
     this.codeHooks.append(hook)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/InterpolatedValueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/InterpolatedValueCompiler.scala
@@ -179,7 +179,7 @@ object PropertyParserTokens {
 
   // here, we have node property option
   sealed trait PropertyOption                       extends Any
-  final case object InterpreteOnNode                extends PropertyOption
+  case object InterpreteOnNode                      extends PropertyOption
   final case class DefaultValue(value: List[Token]) extends AnyVal with PropertyOption
 
   def containsVariable(tokens: List[Token]): Boolean = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/JavascriptEngine.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/JavascriptEngine.scala
@@ -68,8 +68,8 @@ import zio.syntax.*
 sealed trait HashOsType extends EnumEntry
 
 object HashOsType extends Enum[HashOsType] {
-  final case object AixHash   extends HashOsType
-  final case object CryptHash extends HashOsType // linux, bsd,...
+  case object AixHash   extends HashOsType
+  case object CryptHash extends HashOsType // linux, bsd,...
 
   val values: IndexedSeq[HashOsType] = findValues
 }
@@ -347,7 +347,7 @@ object JsRudderLibBinding {
   import java.util.HashMap as JHMap
   import javax.script.SimpleBindings
 
-  private[this] def toBindings(k: String, v: JsRudderLibImpl): Bindings = {
+  private def toBindings(k: String, v: JsRudderLibImpl): Bindings = {
     val m = new JHMap[String, Object]()
     m.put(k, v)
     new SimpleBindings(m)
@@ -580,7 +580,7 @@ object JsEngine {
 
   final class SandboxedJsEngine private (jsEngine: GraalEngine, pool: ExecutorService, maxTime: FiniteDuration) extends JsEngine {
 
-    private[this] trait KillingThread {
+    private trait KillingThread {
 
       /**
        * Force stop the thread, throws a the ThreadDeath error.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/RuleValService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/RuleValService.scala
@@ -71,7 +71,7 @@ class RuleValServiceImpl(
   /*
    * return variable merged when they have the same component name & reportid.
    */
-  private[this] def buildVariables(
+  private def buildVariables(
       variableSpecs: Seq[(List[SectionSpec], VariableSpec)],
       context:       Map[String, Seq[String]]
   ): Box[Map[ComponentId, Variable]] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
@@ -673,7 +673,7 @@ class SystemVariableServiceImpl(
 
   // obtaining variable values from (failable) properties.
   // If property fails, variable will be empty.
-  private[this] def getProp[T](specName: String, getter: () => Box[T]): SystemVariable = {
+  private def getProp[T](specName: String, getter: () => Box[T]): SystemVariable = {
     // try to get the user configured value, else log an error and use the default value.
     val variable = systemVariableSpecService.get(specName).toVariable()
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueAcceptationDatetimeUpdater.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueAcceptationDatetimeUpdater.scala
@@ -313,7 +313,13 @@ class TechniqueAcceptationUpdater(
                                      s"Technique '${name}' (${versions.map(_.debugString).mkString(",")})' is deleted " +
                                      s"but an active technique is still present in tree: disabling it."
                                    ) *>
-                                   rwActiveTechniqueRepo.changeStatus(activeTechnique.id, false, modId, actor, reason)
+                                   rwActiveTechniqueRepo.changeStatus(
+                                     activeTechnique.id,
+                                     status = false,
+                                     modId = modId,
+                                     actor = actor,
+                                     reason = reason
+                                   )
                                  }
 
                                case (TechniqueUpdated(name, mods), Some(activeTechnique)) =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepository.scala
@@ -363,7 +363,7 @@ object NodeConfigurationHash {
    * Also, variable with no values are equivalent to no variable, so we
    * remove them.
    */
-  private[this] def variablesToHash(variables: Iterable[Variable]): Int = {
+  private def variablesToHash(variables: Iterable[Variable]): Int = {
     val z = variables.map(x => (x.spec.name, x.values)).filterNot(_._2.isEmpty).toSet
     z.hashCode
   }
@@ -408,7 +408,7 @@ trait NodeConfigurationHashRepository {
 
 class InMemoryNodeConfigurationHashRepository extends NodeConfigurationHashRepository {
 
-  private[this] val repository = scala.collection.mutable.Map[NodeId, NodeConfigurationHash]()
+  private val repository = scala.collection.mutable.Map[NodeId, NodeConfigurationHash]()
 
   /**
    * Delete a node by its id
@@ -601,7 +601,7 @@ class LdapNodeConfigurationHashRepository(
    * "best effort" way. Bad config are logged as error.
    * We fail if the entry is not of the expected type
    */
-  private[this] def fromLdap(entry: Option[LDAPEntry]): IOResult[Set[NodeConfigurationHash]] = {
+  private def fromLdap(entry: Option[LDAPEntry]): IOResult[Set[NodeConfigurationHash]] = {
     entry match {
       case None    => Set.empty[NodeConfigurationHash].succeed
       case Some(e) =>
@@ -625,7 +625,7 @@ class LdapNodeConfigurationHashRepository(
     }
   }
 
-  private[this] def toLdap(nodeConfigs: Set[NodeConfigurationHash]): LDAPEntry = {
+  private def toLdap(nodeConfigs: Set[NodeConfigurationHash]): LDAPEntry = {
     val caches = nodeConfigs.map(x => NodeConfigurationHash.toJson(x))
     val entry  = rudderDit.NODE_CONFIGS.model
     entry.resetValuesTo(A_NODE_CONFIG, caches.toSeq*)
@@ -636,7 +636,7 @@ class LdapNodeConfigurationHashRepository(
    * Delete node config matching predicate.
    * Return the list of remaining ids.
    */
-  private[this] def deleteCacheMatching(shouldDeleteConfig: NodeConfigurationHash => Boolean): IOResult[Set[NodeId]] = {
+  private def deleteCacheMatching(shouldDeleteConfig: NodeConfigurationHash => Boolean): IOResult[Set[NodeId]] = {
     for {
       ldap         <- ldapCon
       currentEntry <- ldap.get(rudderDit.NODE_CONFIGS.dn)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/AgentSpecificLogic.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/AgentSpecificLogic.scala
@@ -101,7 +101,7 @@ class AgentRegister {
   /**
    * Ordered list of handlers, init with the default agent (CFEngine for linux)
    */
-  private[this] var pipeline: List[AgentSpecificGeneration] = {
+  private var pipeline: List[AgentSpecificGeneration] = {
     CFEngineAgentSpecificGeneration :: Nil
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/BuildBundleSequence.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/BuildBundleSequence.scala
@@ -445,10 +445,10 @@ object CfengineBundleVariables {
 
     BundleSequenceVariables(
       formatBundleFileInputFiles(systemInputs.map(_.path)),
-      formatMethodsUsebundle(escape, systemBundles, Nil, false),
+      formatMethodsUsebundle(escape, systemBundles, Nil, cleanDryRunEnd = false),
       formatBundleFileInputFiles(userInputs.map(_.path)), // only user bundle may be set on PolicyMode = Verify
 
-      formatMethodsUsebundle(escape, userBundles, runHooks, true)
+      formatMethodsUsebundle(escape, userBundles, runHooks, cleanDryRunEnd = true)
     )
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PathComputer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PathComputer.scala
@@ -80,8 +80,8 @@ class PathComputerImpl(
     chainDepthLimit: Int = 20 // max number of relay, to detect cycles
 ) extends PathComputer with Loggable {
 
-  private[this] val promisesPrefix = "/rules"
-  private[this] val newPostfix     = ".new"
+  private val promisesPrefix = "/rules"
+  private val newPostfix     = ".new"
 
   /**
    * Compute

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
@@ -276,7 +276,7 @@ class PolicyWriterServiceImpl(
     }
   }
 
-  private[this] def writeNodePropertiesFile(agentNodeConfig: AgentNodeConfiguration) = {
+  private def writeNodePropertiesFile(agentNodeConfig: AgentNodeConfiguration) = {
 
     def generateNodePropertiesJson(properties: Seq[NodeProperty]): JValue = {
       import net.liftweb.json.JsonDSL.*
@@ -297,7 +297,7 @@ class PolicyWriterServiceImpl(
     } yield ()
   }
 
-  private[this] def writeRudderParameterFile(agentNodeConfig: AgentNodeConfiguration): IOResult[Unit] = {
+  private def writeRudderParameterFile(agentNodeConfig: AgentNodeConfiguration): IOResult[Unit] = {
     def generateParametersJson(parameters: Set[ParameterEntry]): JValue = {
       import com.normation.rudder.domain.properties.JsonPropertySerialisation.*
       import net.liftweb.json.JsonDSL.*
@@ -723,7 +723,7 @@ class PolicyWriterServiceImpl(
    *
    * Note: just making traverse for prepared technique/writePromisesFiles parallel increase latency by x5
    */
-  private[this] def writePolicies(
+  private def writePolicies(
       preparedTemplates: Seq[AgentNodeWritableConfiguration],
       writeTimer:        WriteTimer,
       fillTimer:         FillTemplateTimer
@@ -804,7 +804,7 @@ class PolicyWriterServiceImpl(
     }.unit
   }
 
-  private[this] def writeOtherResources(
+  private def writeOtherResources(
       preparedTemplates: Seq[AgentNodeWritableConfiguration],
       writeTimer:        WriteTimer,
       globalPolicyMode:  GlobalPolicyMode,
@@ -873,7 +873,7 @@ class PolicyWriterServiceImpl(
    * Note that a node without any agent configured won't
    * have any promise written.
    */
-  private[this] def calculatePathsForNodeConfigurations(
+  private def calculatePathsForNodeConfigurations(
       configs:             Seq[NodeConfiguration],
       rootNodeConfigId:    NodeId,
       allNodeInfos:        Map[NodeId, NodeInfo],
@@ -921,7 +921,7 @@ class PolicyWriterServiceImpl(
    * We are returning a map where keys are (TechniqueResourceId, AgentType) because
    * for a given resource IDs, you can have different out path for different agent.
    */
-  private[this] def readTemplateFromFileSystem(
+  private def readTemplateFromFileSystem(
       templatesToRead: Seq[ToRead]
   )(implicit
       timeout:         Duration,
@@ -970,7 +970,7 @@ class PolicyWriterServiceImpl(
    * We are returning a map where keys are (TechniqueResourceId, AgentType) because
    * for a given resource IDs, you can have different out path for different agent.
    */
-  private[this] def readResourcesFromFileSystem(
+  private def readResourcesFromFileSystem(
       staticResourceToRead: Seq[ToRead]
   )(implicit
       timeout:              Duration,
@@ -1002,7 +1002,7 @@ class PolicyWriterServiceImpl(
     } yield res
   }
 
-  private[this] def writeDirectiveCsv(
+  private def writeDirectiveCsv(
       paths:      NodePoliciesPaths,
       policies:   Seq[Policy],
       policyMode: GlobalPolicyMode
@@ -1036,7 +1036,7 @@ class PolicyWriterServiceImpl(
     }
   }
 
-  private[this] def writeSystemVarJson(
+  private def writeSystemVarJson(
       paths:     NodePoliciesPaths,
       variables: Map[String, Variable]
   ): IOResult[List[AgentSpecificFile]] = {
@@ -1058,7 +1058,7 @@ class PolicyWriterServiceImpl(
    * symbolic link toward root.pem if it's the same)
    * https://issues.rudder.io/issues/19529
    */
-  private[this] def writePolicyServerPem(
+  private def writePolicyServerPem(
       paths:                    NodePoliciesPaths,
       policyServerCertificates: PolicyServerCertificates
   ): IOResult[List[AgentSpecificFile]] = {
@@ -1093,7 +1093,7 @@ class PolicyWriterServiceImpl(
     }
   }
 
-  private[this] def systemVariableToJson(vars: Map[String, Variable]): String = {
+  private def systemVariableToJson(vars: Map[String, Variable]): String = {
     // only keep system variables, sort them by name
     import net.liftweb.json.*
 
@@ -1138,7 +1138,7 @@ class PolicyWriterServiceImpl(
    * Move the generated promises from the new folder to their final folder, backuping previous promises in the way
    * @param folders : (Container identifier, (base folder, new folder of the policies, backup folder of the policies) )
    */
-  private[this] def movePromisesToFinalPosition(folders: Seq[NodePoliciesPaths], maxParallelism: Int): IOResult[Unit] = {
+  private def movePromisesToFinalPosition(folders: Seq[NodePoliciesPaths], maxParallelism: Int): IOResult[Unit] = {
     // We need to sort the folders by "depth", so that we backup and move the deepest one first
     // 2020-01: FAR and NCH are not sure why we need to do that. But it seems that we can parallelize it nonetheless.
     val sortedFolder = folders.sortBy(x => x.baseFolder.count(_ == '/')).reverse
@@ -1271,7 +1271,7 @@ class PolicyWriterServiceImpl(
   /**
    * Copy a resource file from a technique to the node promises directory
    */
-  private[this] def copyResourceFile(
+  private def copyResourceFile(
       file:              TechniqueFile,
       isRootServer:      Boolean,
       agentType:         AgentType,
@@ -1304,7 +1304,7 @@ class PolicyWriterServiceImpl(
   /**
    * Move the machine policies folder to the backup folder if it's not None, else ignore backup.
    */
-  private[this] def backupNodeFolder(
+  private def backupNodeFolder(
       nodeFolder:    File,
       backupFolder:  Option[File],
       mvOptions:     Option[File.CopyOptions],
@@ -1340,7 +1340,7 @@ class PolicyWriterServiceImpl(
    * Move the newly created folder to the final location, ie we move
    *  var/rudder/share/00000038-55a2-4b97-8529-5154cbb63a18/rules.new/ into var/rudder/share/00000038-55a2-4b97-8529-5154cbb63a18/rules
    */
-  private[this] def moveNewNodeFolder(
+  private def moveNewNodeFolder(
       src:           File,
       dest:          File,
       mvOptions:     Option[File.CopyOptions],
@@ -1377,7 +1377,7 @@ class PolicyWriterServiceImpl(
    * @param nodeFolder
    * @param backupFolder
    */
-  private[this] def restoreBackupNodeFolder(
+  private def restoreBackupNodeFolder(
       nodeFolder:    String,
       backupFolder:  String,
       mvOptions:     Option[File.CopyOptions],

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PrepareTemplateVariables.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PrepareTemplateVariables.scala
@@ -245,7 +245,7 @@ class PrepareTemplateVariablesImpl(
     }
   }
 
-  private[this] def prepareTechniqueTemplate(
+  private def prepareTechniqueTemplate(
       agentNodeProps:      AgentNodeProperties,
       policies:            List[Policy],
       parameters:          Seq[ParameterEntry],
@@ -254,8 +254,10 @@ class PrepareTemplateVariablesImpl(
       generationTimestamp: Long
   ): IOResult[Seq[PreparedTechnique]] = {
 
-    val rudderParametersVariable = STVariable(PARAMETER_VARIABLE, true, parameters.to(ArraySeq), true)
-    val generationVariable       = STVariable("GENERATIONTIMESTAMP", false, ArraySeq(generationTimestamp), true)
+    val rudderParametersVariable =
+      STVariable(PARAMETER_VARIABLE, mayBeEmpty = true, values = parameters.to(ArraySeq), isSystem = true)
+    val generationVariable       =
+      STVariable("GENERATIONTIMESTAMP", mayBeEmpty = false, values = ArraySeq(generationTimestamp), isSystem = true)
 
     for {
       variableHandler    <-
@@ -321,7 +323,7 @@ class PrepareTemplateVariablesImpl(
   }
 
   // Create a STVariable from a Variable
-  private[this] def stVariableFromVariable(
+  private def stVariableFromVariable(
       v:                Variable,
       variableEscaping: AgentSpecificGeneration,
       nodeId:           NodeId,
@@ -344,7 +346,7 @@ class PrepareTemplateVariablesImpl(
     }
   }
 
-  private[this] def prepareVariables(
+  private def prepareVariables(
       agentNodeProps:       AgentNodeProperties,
       agentVariableHandler: AgentSpecificGeneration,
       policy:               Policy,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/CmdbQueryParser.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/CmdbQueryParser.scala
@@ -127,38 +127,35 @@ trait DefaultStringQueryParser extends StringQueryParser {
 
   def parseLine(line: StringCriterionLine): Box[CriterionLine] = {
 
-    val objectType = criterionObjects.getOrElse(
-      line.objectType,
-      return Failure(
-        s"The object type '${line.objectType}' is unknown in line 'line'. Possible object types: [${criterionObjects.keySet.toList.sorted
-            .mkString(",")}] ".format(line)
-      )
-    )
+    (for {
+      objectType <-
+        criterionObjects
+          .get(line.objectType)
+          .toRight(
+            s"The object type '${line.objectType}' is unknown in line 'line'. Possible object types: [${criterionObjects.keySet.toList.sorted
+                .mkString(",")}] ".format(line)
+          )
+      criterion  <- objectType.criterionForName(line.attribute).toRight {
+                      s"The attribute '${line.attribute}' is unknown for type '${line.objectType}' in line '${line}'. Possible attributes: [${objectType.criteria.map(_.name).sorted.mkString(", ")}]"
+                    }
 
-    val criterion = objectType.criterionForName(line.attribute).getOrElse {
-      return Failure(
-        s"The attribute '${line.attribute}' is unknown for type '${line.objectType}' in line '${line}'. Possible attributes: [${objectType.criteria.map(_.name).sorted.mkString(", ")}]"
-      )
-    }
+      comparator <- criterion.cType.comparatorForString(line.comparator).toRight {
+                      s"The comparator '${line.comparator}' is unknown for attribute '${line.attribute}' in line '${line}'. Possible comparators:: [${criterion.cType.comparators.map(_.id).sorted.mkString(", ")}]"
+                    }
 
-    val comparator = criterion.cType.comparatorForString(line.comparator).getOrElse {
-      return Failure(
-        s"The comparator '${line.comparator}' is unknown for attribute '${line.attribute}' in line '${line}'. Possible comparators:: [${criterion.cType.comparators.map(_.id).sorted.mkString(", ")}]"
-      )
-    }
+      /*
+       * Only validate the fact that if the comparator requires a value, then a value is provided.
+       * Providing an error when none is required is not an error
+       */
+      value      <- line.value match {
+                      case Some(x) => Right(x)
+                      case None    =>
+                        if (comparator.hasValue)
+                          Left("Missing required value for comparator '%s' in line '%s'".format(line.comparator, line))
+                        else Right("")
+                    }
+    } yield CriterionLine(objectType, criterion, comparator, value)).toBox
 
-    /*
-     * Only validate the fact that if the comparator require a value, then a value is provided.
-     * Providing an error when none is required is not an error
-     */
-    val value = line.value match {
-      case Some(x) => x
-      case None    =>
-        if (comparator.hasValue)
-          return Failure("Missing required value for comparator '%s' in line '%s'".format(line.comparator, line))
-        else ""
-    }
-    Full(CriterionLine(objectType, criterion, comparator, value))
   }
 
 }
@@ -261,51 +258,30 @@ trait JsonQueryLexer extends QueryLexer {
   }
 
   def parseCriterion(json: Any): Box[StringCriterionLine] = {
-    def failureMissing(param: String, line: Map[String, String])          = Failure(
-      "Missing expected '%s' query parameter in criterion '%s'".format(OBJECT, line)
-    )
-    def failureEmpty(param: String, line: Map[String, String])            = Failure(
-      "Parameter '%s' must be non empty in criterion '%s'".format(OBJECT, line)
-    )
-    def failureBadParam(param: String, line: Map[String, String], x: Any) =
-      Failure("Bad query format for '%s' parameter in line '%s'. Expecting a string, found '%s'".format(OBJECT, line, x))
 
     json match {
       case l: Map[?, ?] =>
         l.head match {
-          case (x: String, y: String) =>
+          case (_: String, _: String) =>
             val line = l.asInstanceOf[Map[String, String]] // is map always homogenous ?
             // First, parse the line. Then, try to bind name with object
 
-            // mandatory object type, attribute, comparator ; optionnal value
-            // object type
-            val objectType = line.get(OBJECT) match {
-              case None            => return failureMissing(OBJECT, line)
-              case Some(x: String) => if (x.nonEmpty) x else return failureEmpty(OBJECT, line)
-              case Some(x)         => return failureBadParam(OBJECT, line, x)
+            def getMandatoryAttribute(attribute: String) = {
+              line.get(attribute) match {
+                case None                  => Failure("Missing expected '%s' query parameter in criterion '%s'".format(attribute, line))
+                case Some(x) if x.nonEmpty => Full(x)
+                case Some(x)               => Failure("Parameter '%s' must be non empty in criterion '%s'".format(attribute, line))
+              }
             }
 
-            // attribute
-            val attribute = line.get(ATTRIBUTE) match {
-              case None            => return failureMissing(ATTRIBUTE, line)
-              case Some(x: String) => if (x.nonEmpty) x else return failureEmpty(ATTRIBUTE, line)
-              case Some(x)         => return failureBadParam(ATTRIBUTE, line, x)
-            }
+            def getOptionalAttribute(attribute: String) = line.get(attribute).filter(_.nonEmpty)
 
-            // comparator
-            val comparator = line.get(COMPARATOR) match {
-              case None            => return failureMissing(COMPARATOR, line)
-              case Some(x: String) => if (x.nonEmpty) x else return failureEmpty(COMPARATOR, line)
-              case Some(x)         => return failureBadParam(COMPARATOR, line, x)
-            }
-
-            // value
-            val value = line.get(VALUE) match {
-              case None            => None
-              case Some(x: String) => if (x.nonEmpty) Some(x) else None
-              case Some(x)         => return failureBadParam(VALUE, line, x)
-            }
-            Full(StringCriterionLine(objectType, attribute, comparator, value))
+            for {
+              objectType <- getMandatoryAttribute(OBJECT)
+              attribute  <- getMandatoryAttribute(ATTRIBUTE)
+              comparator <- getMandatoryAttribute(COMPARATOR)
+              value       = getOptionalAttribute(VALUE)
+            } yield StringCriterionLine(objectType, attribute, comparator, value)
 
           case _ => Failure("Bad query format for criterion line. Expecting an (string,string), found '%s'".format(l.head))
         }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupService.scala
@@ -104,7 +104,7 @@ class DynGroupServiceImpl(
   /**
    * Get all dyn groups
    */
-  private[this] val dynGroupFilter = {
+  private val dynGroupFilter = {
     AND(
       IS(OC_RUDDER_NODE_GROUP),
       EQ(A_IS_DYNAMIC, true.toLDAPString),
@@ -116,7 +116,7 @@ class DynGroupServiceImpl(
    * don't get back
    * the list of members (we don't need them)
    */
-  private[this] def dynGroupAttrs = (LDAPConstants.OC(OC_RUDDER_NODE_GROUP).attributes - LDAPConstants.A_NODE_UUID).toSeq
+  private def dynGroupAttrs = (LDAPConstants.OC(OC_RUDDER_NODE_GROUP).attributes - LDAPConstants.A_NODE_UUID).toSeq
 
   override def getAllDynGroups(): Box[Seq[NodeGroup]] = {
     for {
@@ -421,22 +421,22 @@ class CheckPendingNodeInDynGroups(
     val (nodep, withdep) = dynGroups.partition(_.dependencies.isEmpty)
 
     // start the process ! End at the end, transform the result into a map.
-    val res = recProcess(nodep, withdep, Nil)
+    val result = recProcess(nodep, withdep, Nil)
     // end result
     NodeLoggerPure.PendingNode.Policies.ifDebugEnabled(
-      res.foldZIO(
+      result.foldZIO(
         err => NodeLoggerPure.PendingNode.Policies.debug(s"Errror when executing request: ${err.fullMsg}"),
         r => NodeLoggerPure.PendingNode.Policies.debug("Result: " + r.debugString)
       )
     ) *>
-    res
+    result
   }
 
   /**
    * Transform the map of (groupid => seq(nodeids) into a map of
    * (nodeid => seq(groupids)
    */
-  private[this] def swapMap(source: Seq[(NodeGroupId, Set[NodeId])]): Map[NodeId, Seq[NodeGroupId]] = {
+  private def swapMap(source: Seq[(NodeGroupId, Set[NodeId])]): Map[NodeId, Seq[NodeGroupId]] = {
     val dest = scala.collection.mutable.Map[NodeId, List[NodeGroupId]]()
     for {
       (gid, seqNodeIds) <- source

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
@@ -633,7 +633,7 @@ class InternalLDAPQueryProcessor(
    *   that in `queryAndChekNodeId` where we know about server roles
    * - step2: filter out nodes based on a given list of acceptable entries
    */
-  private[this] def postFilterNode(
+  private def postFilterNode(
       entries:        Seq[NodeId],
       returnType:     QueryReturnType,
       limitToNodeIds: Option[Seq[NodeId]]
@@ -647,7 +647,7 @@ class InternalLDAPQueryProcessor(
   /*
    * From the list of DN to query with their filters, build a list of LDAPObjectType
    */
-  private[this] def createLDAPObjects(query: LDAPNodeQuery, debugId: Long): IOResult[Map[DnType, Map[String, LDAPObjectType]]] = {
+  private def createLDAPObjects(query: LDAPNodeQuery, debugId: Long): IOResult[Map[DnType, Map[String, LDAPObjectType]]] = {
     ZIO
       .foreach(query.objectTypesFilters) {
         case (dnType, mapOtSubQueries) =>
@@ -710,7 +710,7 @@ class InternalLDAPQueryProcessor(
   }
 
   // execute a query with special filter based on the composition
-  private[this] def executeQuery(
+  private def executeQuery(
       base:           DN,
       scope:          SearchScope,
       objectFilter:   LDAPObjectTypeFilter,
@@ -732,10 +732,6 @@ class InternalLDAPQueryProcessor(
                            }
 
                            (filterToApply, currentAttributes ++ getAdditionnalAttributes(Set(r))).succeed
-
-                         case (_, sf) =>
-                           Inconsistency("Unknow special filter, can not build a request with it: " + sf).fail
-
                        }
         finalFilter <- params._1 match {
                          case None    => Inconsistency("No filter (neither standard nor special) for request, can not process!").fail
@@ -795,7 +791,6 @@ class InternalLDAPQueryProcessor(
       val sf = specialFilters.groupBy {
         case r: RegexFilter    => "regex"
         case r: NotRegexFilter => "notregex"
-        case _ => "other"
       }
 
       for {
@@ -838,7 +833,7 @@ class InternalLDAPQueryProcessor(
     }
   }
 
-  private[this] def getDnsForObjectType(
+  private def getDnsForObjectType(
       lot:         LDAPObjectType,
       composition: CriterionComposition,
       debugId:     Long
@@ -879,7 +874,7 @@ class InternalLDAPQueryProcessor(
    * from special filter.
    * Special filter are handled in their own place
    */
-  private[this] def unspecialiseFilters(filters: Set[ExtendedFilter]): PureResult[(Set[Filter], Set[SpecialFilter])] = {
+  private def unspecialiseFilters(filters: Set[ExtendedFilter]): PureResult[(Set[Filter], Set[SpecialFilter])] = {
     val start = Right((Set(), Set())): Either[RudderError, (Set[Filter], Set[SpecialFilter])]
     filters.foldLeft(start) {
       case (Right((ldapFilters, specials)), LDAPFilter(f))         => Right((ldapFilters + f, specials))
@@ -892,11 +887,11 @@ class InternalLDAPQueryProcessor(
    * Special filters may need some attributes to work.
    * That method allows to get them
    */
-  private[this] def getAdditionnalAttributes(filters: Set[SpecialFilter]): Set[String] = {
+  private def getAdditionnalAttributes(filters: Set[SpecialFilter]): Set[String] = {
     filters.flatMap { case f: GeneralRegexFilter => Set(f.attributeName) }
   }
 
-  private[this] def postProcessQueryResults(
+  private def postProcessQueryResults(
       results:        Seq[LDAPEntry],
       specialFilters: Set[(CriterionComposition, SpecialFilter)],
       debugId:        Long
@@ -980,8 +975,6 @@ class InternalLDAPQueryProcessor(
 
         case SimpleNotRegexFilter(attr, regexText) =>
           regexNotMatch(attr, regexText, entries, x => Some(x))
-
-        case x => Inconsistency(s"Don't know how to post process query results for filter '${x}'").fail
       }
     }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchBackendImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchBackendImpl.scala
@@ -113,7 +113,7 @@ object QSNodeFactBackend extends Loggable {
 
   implicit class QSAttributeFilter(val a: QSAttribute) extends AnyVal {
 
-    private[this] def toMatch(node: CoreNodeFact): Option[Set[(String, String)]] = {
+    private def toMatch(node: CoreNodeFact): Option[Set[(String, String)]] = {
 
       def someSet(v: String)         = Some(Set((v, v)))
       def optSet(v:  Option[String]) = v.map(x => Set((x, x)))
@@ -225,7 +225,7 @@ object QSDirectiveBackend extends Loggable {
 
   implicit class QSAttributeFilter(val a: QSAttribute) extends AnyVal {
 
-    private[this] def toMatch(at: FullActiveTechnique, dir: Directive): Option[Set[(String, String)]] = {
+    private def toMatch(at: FullActiveTechnique, dir: Directive): Option[Set[(String, String)]] = {
 
       val enableToken  = Set("true", "enable", "enabled", "isenable", "isenabled")
       val disableToken = Set("false", "disable", "disabled", "isdisable", "isdisabled")
@@ -345,7 +345,7 @@ object QSLdapBackend {
   /**
    * Mapping between attribute and their ldap name
    */
-  private[this] val attributeNameMapping: Map[QSAttribute, String] = {
+  private val attributeNameMapping: Map[QSAttribute, String] = {
     val m: Map[QSAttribute, String] = Map(
       Name              -> A_NAME,
       Description       -> A_DESCRIPTION,
@@ -570,10 +570,10 @@ object QSLdapBackend {
 
     def toResult(query: Query): Option[QuickSearchResult] = {
       def getId(e: LDAPEntry): Option[QuickSearchResultId] = {
-        if (e.isA(OC_RULE)) { e(A_RULE_UUID).map(QRRuleId) }
-        else if (e.isA(OC_RUDDER_NODE_GROUP)) { e(A_NODE_GROUP_UUID).map(QRGroupId) }
+        if (e.isA(OC_RULE)) { e(A_RULE_UUID).map(QRRuleId.apply) }
+        else if (e.isA(OC_RUDDER_NODE_GROUP)) { e(A_NODE_GROUP_UUID).map(QRGroupId.apply) }
         else if (e.isA(OC_PARAMETER)) {
-          e(A_PARAMETER_NAME).map(QRParameterId)
+          e(A_PARAMETER_NAME).map(QRParameterId.apply)
           // no directive
         } else { None }
       }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchDomain.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchDomain.scala
@@ -61,9 +61,9 @@ final case class Query(
 sealed trait QSBackend extends EnumEntry
 
 object QSBackend extends Enum[QSBackend] {
-  final case object LdapBackend      extends QSBackend
-  final case object DirectiveBackend extends QSBackend
-  final case object NodeFactBackend  extends QSBackend
+  case object LdapBackend      extends QSBackend
+  case object DirectiveBackend extends QSBackend
+  case object NodeFactBackend  extends QSBackend
 
   final val values: IndexedSeq[QSBackend] = findValues
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchQueryParser.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchQueryParser.scala
@@ -156,44 +156,44 @@ object QSRegexQueryParser {
   ///// this is the entry point /////
   /////
 
-  private[this] def all[A: P]: P[QF] = P(Start ~ (nominal | onlyFilters) ~ End)
+  private def all[A: P]: P[QF] = P(Start ~ (nominal | onlyFilters) ~ End)
 
   /////
   ///// different structure of queries
   /////
 
   // degenerated case with only filters, no query string
-  private[this] def onlyFilters[A: P]: P[QF] = P(filter.rep(1)) map { case f => (EmptyQuery, f.toList) }
+  private def onlyFilters[A: P]: P[QF] = P(filter.rep(1)) map { case f => (EmptyQuery, f.toList) }
 
   // nonimal case: zero of more filter, a query string, zero or more filter
-  private[this] def nominal[A: P]: P[QF] = P(filter.rep(0) ~/ (case0 | case1)) map {
+  private def nominal[A: P]: P[QF] = P(filter.rep(0) ~/ (case0 | case1)) map {
     case (f1, (q, f2)) => (check(q), f1.toList ::: f2.toList)
   }
 
   // need the two following rules so that so the parsing is correctly done for filter in the end
-  private[this] def case0[A: P]: P[QF] = P(queryInMiddle ~ filter.rep(1)) map { case (q, f) => (check(q), f.toList) }
-  private[this] def case1[A: P]: P[QF] = P(queryAtEnd) map { case q => (check(q), Nil) }
+  private def case0[A: P]: P[QF] = P(queryInMiddle ~ filter.rep(1)) map { case (q, f) => (check(q), f.toList) }
+  private def case1[A: P]: P[QF] = P(queryAtEnd) map { case q => (check(q), Nil) }
 
   /////
   ///// simple elements: filters
   /////
 
   // deal with filters: they all start with "in:"
-  private[this] def filter[A:     P]: P[Filter] = P(filterAttr | filterType)
-  private[this] def filterType[A: P]: P[Filter] = P(IgnoreCase("is:") ~ filterKeys) map { FilterType }
-  private[this] def filterAttr[A: P]: P[Filter] = P(IgnoreCase("in:") ~ filterKeys) map { FilterAttr }
+  private def filter[A:     P]: P[Filter] = P(filterAttr | filterType)
+  private def filterType[A: P]: P[Filter] = P(IgnoreCase("is:") ~ filterKeys) map { FilterType.apply }
+  private def filterAttr[A: P]: P[Filter] = P(IgnoreCase("in:") ~ filterKeys) map { FilterAttr.apply }
 
   // the keys part
-  private[this] def filterKeys[A: P]: P[Set[String]] = P(filterKey.rep(sep = ",")) map { l => l.toSet }
-  private[this] def filterKey[A:  P]: P[String]      = P(CharsWhileIn("""\\-._a-zA-Z0-9""").!)
+  private def filterKeys[A: P]: P[Set[String]] = P(filterKey.rep(sep = ",")) map { l => l.toSet }
+  private def filterKey[A:  P]: P[String]      = P(CharsWhileIn("""\\-._a-zA-Z0-9""").!)
 
   /////
   ///// simple elements: query string
   /////
 
   // we need to case, because regex are bad to look-ahead and see if there is still filter after. .+? necessary to stop at first filter
-  private[this] def queryInMiddle[A: P]: P[QueryString] = P((!("in:" | "is:") ~ AnyChar).rep(1).!) map { x => CharSeq(x.trim) }
-  private[this] def queryAtEnd[A:    P]: P[QueryString] = P(AnyChar.rep(1).!) map { x => CharSeq(x.trim) }
+  private def queryInMiddle[A: P]: P[QueryString] = P((!("in:" | "is:") ~ AnyChar).rep(1).!) map { x => CharSeq(x.trim) }
+  private def queryAtEnd[A:    P]: P[QueryString] = P(AnyChar.rep(1).!) map { x => CharSeq(x.trim) }
 
   /////
   ///// utility methods
@@ -203,7 +203,7 @@ object QSRegexQueryParser {
    * Check that the query is not empty (else, say it is the EmptyQuery),
    * and trimed it.
    */
-  private[this] def check(qs: QueryString) = qs match {
+  private def check(qs: QueryString) = qs match {
     case EmptyQuery => EmptyQuery
     case CharSeq(s) =>
       val trimed = s.trim
@@ -214,7 +214,7 @@ object QSRegexQueryParser {
       }
   }
 
-  private[this] def getMapping[T](names: Set[String], map: Map[String, T]): PureResult[(Set[T], Set[String])] = {
+  private def getMapping[T](names: Set[String], map: Map[String, T]): PureResult[(Set[T], Set[String])] = {
     val pairs  = names.flatMap { name =>
       map.get(name.toLowerCase) match {
         case Some(obj) => Some((obj, name))
@@ -240,7 +240,7 @@ object QSRegexQueryParser {
    * Returned the set of matching attribute, and set of matching names for the
    * inputs
    */
-  private[this] def getObjects(names: Set[String]): PureResult[(Set[QSObject], Set[String])] = {
+  private def getObjects(names: Set[String]): PureResult[(Set[QSObject], Set[String])] = {
     import QSMapping.*
     getMapping(names, objectNameMapping)
   }
@@ -249,7 +249,7 @@ object QSRegexQueryParser {
    * Mapping between a string and actual attributes.
    * We try to be kind with users: not case sensitive, not plural sensitive
    */
-  private[this] def getAttributes(names: Set[String]): PureResult[(Set[QSAttribute], Set[String])] = {
+  private def getAttributes(names: Set[String]): PureResult[(Set[QSAttribute], Set[String])] = {
     import QSMapping.*
     getMapping(names, attributeNameMapping).map {
       case (attrs, keys) =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
@@ -389,7 +389,7 @@ object ExecutionBatch extends Loggable {
    * Utility method to factor out common logging task and be assured that
    * the log message is actually sync with the info type.
    */
-  private[this] def runType(traceMessage: String, runType: RunAndConfigInfo)(implicit nodeId: NodeId): RunAndConfigInfo = {
+  private def runType(traceMessage: String, runType: RunAndConfigInfo)(implicit nodeId: NodeId): RunAndConfigInfo = {
     val msg = if (traceMessage.trim.isEmpty) "" else ": " + traceMessage
     ComplianceDebugLogger.node(nodeId).debug(s"Run config for node ${nodeId.value}: ${runType.logName} ${msg}")
     runType
@@ -1266,7 +1266,7 @@ object ExecutionBatch extends Loggable {
     (computed ::: newStatus).toSet
   }
 
-  private[this] def buildUnexpectedReports(mergeInfo: MergeInfo, reports: Seq[Reports]): Set[RuleNodeStatusReport] = {
+  private def buildUnexpectedReports(mergeInfo: MergeInfo, reports: Seq[Reports]): Set[RuleNodeStatusReport] = {
     reports
       .groupBy(x => x.ruleId)
       .map {
@@ -1313,7 +1313,7 @@ object ExecutionBatch extends Loggable {
   /**
    * Build unexpected reports for the given reports
    */
-  private[this] def buildUnexpectedDirectives(reports: Seq[Reports]): Seq[DirectiveStatusReport] = {
+  private def buildUnexpectedDirectives(reports: Seq[Reports]): Seq[DirectiveStatusReport] = {
     reports.map { r =>
       DirectiveStatusReport(
         r.directiveId,
@@ -1681,7 +1681,7 @@ object ExecutionBatch extends Loggable {
    * to be the "unexpanded" one, and that so, the expanded value is lost.
    *
    */
-  private[this] def buildNoReportIdComponentValueStatus(
+  private def buildNoReportIdComponentValueStatus(
       expectedValue:       ExpectedValue,
       filteredReports:     Seq[Reports],
       componentGotReports: Boolean, // does the component got at least one report?

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeChangesService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeChangesService.scala
@@ -114,7 +114,7 @@ trait NodeChangesService {
    * sequence, which is also ordered by date.
    */
 
-  final private[this] def getInterval(since: DateTime, to: DateTime): List[Interval] = {
+  final private def getInterval(since: DateTime, to: DateTime): List[Interval] = {
     if (to.isBefore(since)) {
       Nil
     } else {
@@ -195,7 +195,7 @@ class CachedNodeChangesServiceImpl(
 
   override val changesMaxAge = changeService.changesMaxAge
 
-  private[this] val cache = Ref.make[Option[ChangesCache]](None).runNow // this is a bug if it does not work
+  private val cache = Ref.make[Option[ChangesCache]](None).runNow // this is a bug if it does not work
 
   // when the class is instanciated, ask for a cache init
   ZioRuntime.runNow((for {
@@ -268,7 +268,7 @@ class CachedNodeChangesServiceImpl(
     )
   }
 
-  private[this] def cacheToLog(changes: ChangesByRule): String = {
+  private def cacheToLog(changes: ChangesByRule): String = {
     changes.map {
       case (ruleId, x) =>
         val byInt = x.map {
@@ -285,7 +285,7 @@ class CachedNodeChangesServiceImpl(
    * are removed from the result.
    * For a given rule, on a given interval, changes from change1 and change2 are added.
    */
-  private[this] def merge(on: Seq[Interval], changes1: ChangesByRule, changes2: ChangesByRule): ChangesByRule = {
+  private def merge(on: Seq[Interval], changes1: ChangesByRule, changes2: ChangesByRule): ChangesByRule = {
     // shortcut that get map(k1)(k2) and return an empty seq if key not found
     def get(changes: ChangesByRule, ruleId: RuleId, i: Interval): Int = {
       changes.getOrElse(ruleId, Map()).getOrElse(i, 0)
@@ -477,7 +477,7 @@ object NodeChanges {
   val startFormat = "HH:mm"
   val endFormat   = "- HH:mm"
 
-  private[this] def displayPeriod(interval: Interval) = {
+  private def displayPeriod(interval: Interval) = {
     JsArray(
       Str(interval.getStart().toString(day)) :: Str(interval.getStart().toString(startFormat)) :: Str(
         interval.getEnd().toString(endFormat)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeConfigurationService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeConfigurationService.scala
@@ -130,7 +130,7 @@ class CachedNodeConfigurationService(
    * Ref allows atomic action on the map, but concurrent non-atomic changes (ex: if
    * you need to something iterativelly to update the cache) still need to be behind a semaphore.
    */
-  private[this] val cache = Ref.make(Map.empty[NodeId, Option[NodeExpectedReports]]).runNow
+  private val cache = Ref.make(Map.empty[NodeId, Option[NodeExpectedReports]]).runNow
 
   /**
    * The queue of invalidation request.
@@ -139,12 +139,12 @@ class CachedNodeConfigurationService(
    * invalidation request.
    * // unsure if its a CacheComplianceQueueAction or another queueaction
    */
-  private[this] val invalidateNodeConfigurationRequest = Queue.dropping[Chunk[(NodeId, CacheExpectedReportAction)]](1).runNow
+  private val invalidateNodeConfigurationRequest = Queue.dropping[Chunk[(NodeId, CacheExpectedReportAction)]](1).runNow
 
   /**
    * We need a semaphore to protect queue content merge-update
    */
-  private[this] val invalidateMergeUpdateSemaphore = Semaphore.make(1).runNow
+  private val invalidateMergeUpdateSemaphore = Semaphore.make(1).runNow
 
   // Init to do
   // what's the best method ? init directly from db, fetching all nodeconfigurations
@@ -191,7 +191,7 @@ class CachedNodeConfigurationService(
   /**
    * Do something with the action we received
    */
-  private[this] def performAction(action: CacheExpectedReportAction): IOResult[Unit] = {
+  private def performAction(action: CacheExpectedReportAction): IOResult[Unit] = {
     import CacheExpectedReportAction.*
     // in a semaphore
     semaphore.withPermit(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
@@ -185,8 +185,8 @@ trait ReportingService {
       // BE CAREFUL: reports is a SET - and it's likely that
       // some compliance will be equals. So change to seq.
       ComplianceLevel.sum(report.reports.toSeq.collect {
-        case report if (ruleIds.contains(report.ruleId)) =>
-          report.compliance
+        case report_ if (ruleIds.contains(report_.ruleId)) =>
+          report_.compliance
       })
     }
   }
@@ -203,8 +203,8 @@ trait ReportingService {
       // BE CAREFUL: reports is a SET - and it's likely that
       // some compliance will be equals. So change to seq.
       ComplianceLevel.sum(report.reports.toSeq.collect {
-        case report if (ruleIds.contains(report.ruleId)) =>
-          report.compliance
+        case report_ if (ruleIds.contains(report_.ruleId)) =>
+          report_.compliance
       })
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -368,7 +368,7 @@ trait CachedFindRuleNodeStatusReports
    * * we restart Rudder, in normal mode: we take the last (most recent execution) *computed*
    * * * we may have outdated info in this case, but that's not an ssue as it will restore itself really fast
    */
-  private[this] var cache = Map.empty[NodeId, NodeStatusReport]
+  private var cache = Map.empty[NodeId, NodeStatusReport]
 
   /**
    * The queue of invalidation request.
@@ -376,12 +376,12 @@ trait CachedFindRuleNodeStatusReports
    * It's a List and not a Set, because we want to keep the precedence in
    * invalidation request.
    */
-  private[this] val invalidateComplianceRequest = Queue.dropping[Chunk[(NodeId, CacheComplianceQueueAction)]](1).runNow
+  private val invalidateComplianceRequest = Queue.dropping[Chunk[(NodeId, CacheComplianceQueueAction)]](1).runNow
 
   /**
    * We need a semaphore to protect queue content merge-update
    */
-  private[this] val invalidateMergeUpdateSemaphore = Semaphore.make(1).runNow
+  private val invalidateMergeUpdateSemaphore = Semaphore.make(1).runNow
 
   /**
    * Update logic. We take message from queue one at a time, and process.
@@ -414,7 +414,7 @@ trait CachedFindRuleNodeStatusReports
    * Do something with the action we received
    * All actions must have *exactly* the *same* type
    */
-  private[this] def performAction(actions: Chunk[CacheComplianceQueueAction]): IOResult[Unit] = {
+  private def performAction(actions: Chunk[CacheComplianceQueueAction]): IOResult[Unit] = {
     import CacheComplianceQueueAction.*
     import CacheExpectedReportAction.*
 
@@ -490,13 +490,13 @@ trait CachedFindRuleNodeStatusReports
    * It is necessary to keep global order so that we serialize compliance in order
    * and don't loose information
    */
-  private[this] def groupQueueActionByType(l: Chunk[CacheComplianceQueueAction]): Chunk[Chunk[CacheComplianceQueueAction]] = {
+  private def groupQueueActionByType(l: Chunk[CacheComplianceQueueAction]): Chunk[Chunk[CacheComplianceQueueAction]] = {
     l.headOption.map { x =>
       val (h, t) = l.span(x.getClass == _.getClass); groupQueueActionByType(t).prepended(h)
     }.getOrElse(Chunk.empty)
   }
 
-  private[this] def cacheToLog(c: Map[NodeId, NodeStatusReport]): String = {
+  private def cacheToLog(c: Map[NodeId, NodeStatusReport]): String = {
     import com.normation.rudder.domain.logger.ComplianceDebugLogger.RunAndConfigInfoToLog
 
     // display compliance value and expiration date.
@@ -568,7 +568,7 @@ trait CachedFindRuleNodeStatusReports
    * This is handled in higher level of the app and leads to "no data available" in
    * place of compliance bar.
    */
-  private[this] def checkAndGetCache(
+  private def checkAndGetCache(
       nodeIdsToCheck: Set[NodeId]
   )(implicit qc: QueryContext): IOResult[Map[NodeId, NodeStatusReport]] = {
     if (nodeIdsToCheck.isEmpty) {
@@ -920,7 +920,7 @@ trait DefaultFindRuleNodeStatusReports extends ReportingService {
    * A value is return for ALL nodeIds, so the assertion nodeIds == returnedMap.keySet holds.
    *
    */
-  private[this] def getNodeRunInfos(
+  private def getNodeRunInfos(
       nodeIds:        Set[NodeId],
       complianceMode: GlobalComplianceMode
   ): IOResult[Map[NodeId, RunAndConfigInfo]] = {
@@ -990,7 +990,7 @@ trait DefaultFindRuleNodeStatusReports extends ReportingService {
     }
   }
 
-  private[this] def getUnComputedNodeRunInfos(complianceMode: GlobalComplianceMode): Box[Map[NodeId, RunAndConfigInfo]] = {
+  private def getUnComputedNodeRunInfos(complianceMode: GlobalComplianceMode): Box[Map[NodeId, RunAndConfigInfo]] = {
     val t0 = System.currentTimeMillis
     for {
       runs              <- agentRunRepository.getNodesAndUncomputedCompliance().toBox
@@ -1017,7 +1017,7 @@ trait DefaultFindRuleNodeStatusReports extends ReportingService {
    * Each runInfo get a result, even if we don't have information about it.
    * So runInfos.keySet == returnedMap.keySet holds.
    */
-  private[this] def buildNodeStatusReports(
+  private def buildNodeStatusReports(
       runInfos:                 Map[NodeId, RunAndConfigInfo],
       ruleIds:                  Set[RuleId],
       directiveIds:             Set[DirectiveId],

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/PolicyServerManagementService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/PolicyServerManagementService.scala
@@ -508,11 +508,11 @@ class PolicyServerManagementServiceImpl(
 sealed trait RelaySynchronizationMethod extends EnumEntry                        { def value: String }
 object RelaySynchronizationMethod       extends Enum[RelaySynchronizationMethod] {
 
-  final case object Classic extends RelaySynchronizationMethod { val value = "classic" }
+  case object Classic extends RelaySynchronizationMethod { val value = "classic" }
 
-  final case object Rsync extends RelaySynchronizationMethod { val value = "rsync" }
+  case object Rsync extends RelaySynchronizationMethod { val value = "rsync" }
 
-  final case object Disabled extends RelaySynchronizationMethod { val value = "disabled" }
+  case object Disabled extends RelaySynchronizationMethod { val value = "disabled" }
 
   final val values: IndexedSeq[RelaySynchronizationMethod] = findValues
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/system/DebugInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/system/DebugInfoService.scala
@@ -61,7 +61,7 @@ class DebugInfoServiceImpl extends DebugInfoService {
 
   val logger: NamedZioLogger = NamedZioLogger(this.getClass.getName)
 
-  private[this] def execScript(): IOResult[Promise[Nothing, CmdResult]] = {
+  private def execScript(): IOResult[Promise[Nothing, CmdResult]] = {
     val environment = java.lang.System.getenv.asScala.toMap
     val timeOut     = Duration(30, TimeUnit.SECONDS)
     val scriptPath  = "/opt/rudder/bin/rudder-debug-info"
@@ -75,7 +75,7 @@ class DebugInfoServiceImpl extends DebugInfoService {
   // We want to get its binary representation into an Array of byte
   // In order for the API to build an InMemoryResponse
 
-  private[this] def getScriptResult(): IOResult[DebugInfoScriptResult] = {
+  private def getScriptResult(): IOResult[DebugInfoScriptResult] = {
     IOResult.attempt(s"Could not get file debug info result file") {
       val resultPath = s"/var/rudder/debug/info/debug-info-latest.tar.gz"
       val result     = Paths.get(resultPath).toRealPath()

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/ChangeRequestService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/ChangeRequestService.scala
@@ -99,7 +99,7 @@ object ChangeRequestService {
     changeRequest
   }
 
-  private[this] def rulechange(
+  private def rulechange(
       baseRule:  Rule,
       finalRule: Rule,
       actor:     EventActor,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
@@ -153,7 +153,7 @@ class CommitAndDeployChangeRequestServiceImpl(
   /**
    * Look if the configuration change request is mergeable
    */
-  private[this] def isMergeableConfigurationChangeRequest(
+  private def isMergeableConfigurationChangeRequest(
       changeRequest: ConfigurationChangeRequest
   )(implicit qc: QueryContext): Boolean = {
 
@@ -207,7 +207,7 @@ class CommitAndDeployChangeRequestServiceImpl(
 
     implicit val changeRequestId = changeRequest.id.value
 
-    final case object CheckRule extends CheckChanges[Rule] {
+    case object CheckRule extends CheckChanges[Rule] {
       def failureMessage(rule:   Rule) = s"Rule ${rule.name} (id: ${rule.id.serialize})"
       def getCurrentValue(rule:  Rule) = roRuleRepository.get(rule.id).toBox
       def compareMethod(initial: Rule, current: Rule) = CheckDivergenceForMerge.compareRules(initial, current)
@@ -305,7 +305,7 @@ class CommitAndDeployChangeRequestServiceImpl(
    * So, what to do ?
    * Returns the modificationId, plus a boolean indicating if we need to trigger a deployment
    */
-  private[this] def saveConfigurationChangeRequest(cr: ConfigurationChangeRequest)(implicit cc: ChangeContext): Box[Boolean] = {
+  private def saveConfigurationChangeRequest(cr: ConfigurationChangeRequest)(implicit cc: ChangeContext): Box[Boolean] = {
     import cc.modId
 
     def doDirectiveChange(directiveChanges: DirectiveChanges): Box[TriggerDeploymentDiff] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/WorkflowService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/WorkflowService.scala
@@ -158,7 +158,7 @@ trait WorkflowLevelService {
 // and default implementation is: no
 class DefaultWorkflowLevel(val defaultWorkflowService: WorkflowService) extends WorkflowLevelService {
   // Alternative level provider
-  private[this] var level: Option[WorkflowLevelService] = None
+  private var level: Option[WorkflowLevelService] = None
 
   def overrideLevel(l: WorkflowLevelService): Unit = {
     PluginLogger.info(s"Update Validation Workflow level to '${l.name}'")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/TenantService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/TenantService.scala
@@ -112,7 +112,7 @@ object DefaultTenantService {
   def make(tenantIds: IterableOnce[TenantId]): UIO[DefaultTenantService] = {
     for {
       ref <- Ref.make(Set.from(tenantIds))
-    } yield new DefaultTenantService(false, ref)
+    } yield new DefaultTenantService(_tenantsEnabled = false, tenantIds = ref)
   }
 }
 
@@ -168,7 +168,7 @@ class DefaultTenantService(private var _tenantsEnabled: Boolean, val tenantIds: 
       ZStream
         .fromZIO(getTenants())
         .cross(s)
-        .collect { case (tenantIds, n) if (qc.nodePerms.canSee(n)(tenantIds)) => n }
+        .collect { case (_tenantIds, n) if (qc.nodePerms.canSee(n)(_tenantIds)) => n }
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/User.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/User.scala
@@ -127,7 +127,7 @@ object UserSerialization {
     JsonEncoder.string.contramap(_.value),
     JsonDecoder.string.mapOrFail(s => UserStatus.parse(s))
   )
-  implicit val codecEventActor:    JsonCodec[EventActor]    = DeriveJsonCodec.gen
+  implicit val codecEventActor:    JsonCodec[EventActor]    = DeriveJsonCodec.gen[EventActor]
   implicit val codecDateTime:      JsonCodec[DateTime]      = new JsonCodec[DateTime](
     JsonEncoder.string.contramap(_.toString(DateFormaterService.rfcDateformatWithMillis)),
     JsonDecoder.string.mapOrFail { s =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
@@ -774,7 +774,13 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
       xa =>
         (
           for {
-            selected <- select(userIds, notLoggedSince, true, excludeFromOrigin, andSelectFragment)
+            selected <- select(
+                          userIds,
+                          notLoggedSince,
+                          defaultToNone = true,
+                          excludeFromOrigin = excludeFromOrigin,
+                          andSelectFragment = andSelectFragment
+                        )
             updated   = selected.map {
                           case (id, hist) =>
                             (
@@ -839,7 +845,13 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
       (for {
         // we need to give a date here, else select won't select anyone
         selected <-
-          select(userIds, None, false, excludeFromOrigin, Some(Fragment.const(s"status = '${UserStatus.Deleted.value}'")))
+          select(
+            userIds,
+            None,
+            defaultToNone = false,
+            excludeFromOrigin = excludeFromOrigin,
+            andSelectFragment = Some(Fragment.const(s"status = '${UserStatus.Deleted.value}'"))
+          )
         toDelete  = deletedSince match {
                       case None        => selected.map(_._1)
                       case Some(limit) =>

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/JsonSpecMatcher.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/JsonSpecMatcher.scala
@@ -30,9 +30,9 @@ trait JsonSpecMatcher { self: MustMatchers with Specification =>
 
   def equalsJsonSemantic(res: String): Matcher[String] = {
     res.fromJson[Json] match {
-      case Right(json) =>
-        new JsonEqualityMatcher(json).toStringMatcher
-      case Left(_)     => (s: String) => ko(s"The provided json is not valid, cannot do semantic comparison of $s with $res")
+      case Right(json_) =>
+        new JsonEqualityMatcher(json_).toStringMatcher
+      case Left(_)      => (s: String) => ko(s"The provided json is not valid, cannot do semantic comparison of $s with $res")
     }
   }
 }
@@ -65,7 +65,7 @@ private object JsonSpecMatcher {
     // intercept the match (json against json) to display 'expected' and 'actual' with prettifed format
     private def jsonMatchResult(s: Expectable[String]): MatchResult[Any] = stringAsJson(s) match {
       case MatchFailure(ok, ko, expectable, trace, FailureDetails(actual, expected)) =>
-        MatchFailure(ok, ko, expectable, trace, FailureDetails(prettyPrint(actual), prettyPrint(expected)))
+        MatchFailure.create(ok(), ko(), expectable, trace, FailureDetails(prettyPrint(actual), prettyPrint(expected)))
       case other                                                                     => other
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/HashAlgoTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/HashAlgoTest.scala
@@ -50,7 +50,7 @@ class HashAlgoTest extends Specification {
    * the algo is not present. We must account of that to not have spurious
    * falling tests.
    */
-  private[this] def isAvailable(sha: ShaSpec) = {
+  private def isAvailable(sha: ShaSpec) = {
     AixPasswordHashAlgo.getSecretKeFactory(sha).isDefined
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/SectionTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/SectionTest.scala
@@ -125,7 +125,7 @@ class SectionTest extends Specification {
     }
   }
 
-  private[this] def getUniqueSection(name: String): SectionSpec = {
+  private def getUniqueSection(name: String): SectionSpec = {
     implicit val sects = rootSectionsOk.filterByName(name)
     beUnique
 
@@ -138,55 +138,55 @@ class SectionTest extends Specification {
     }
   }
 
-  private[this] def beEmpty(implicit section: SectionSpec) = {
+  private def beEmpty(implicit section: SectionSpec) = {
     "be empty" in {
       section.children.size mustEqual 0
     }
   }
 
-  private[this] def haveNbChildren(nbChildren: Int)(implicit section: SectionSpec) = {
+  private def haveNbChildren(nbChildren: Int)(implicit section: SectionSpec) = {
     "have %d children".format(nbChildren) in {
       section.children.size mustEqual nbChildren
     }
   }
 
-  private[this] def containNbVariables(nbVariables: Int)(implicit section: SectionSpec) = {
+  private def containNbVariables(nbVariables: Int)(implicit section: SectionSpec) = {
     "contain %d variables".format(nbVariables) in {
       section.getAllVariables.size mustEqual nbVariables
     }
   }
 
-  private[this] def beUnique(implicit children: Seq[SectionChildSpec]) = {
+  private def beUnique(implicit children: Seq[SectionChildSpec]) = {
     "be unique" in {
       children.size mustEqual 1
     }
   }
 
-  private[this] def beSection(implicit sectionChild: SectionChildSpec) = {
+  private def beSection(implicit sectionChild: SectionChildSpec) = {
     "be a section" in {
       sectionChild.isInstanceOf[SectionSpec]
     }
   }
 
-  private[this] def beMultivalued(implicit section: SectionSpec) = {
+  private def beMultivalued(implicit section: SectionSpec) = {
     "be multivalued" in {
       section.isMultivalued
     }
   }
 
-  private[this] def beHighPriority(implicit section: SectionSpec) = {
+  private def beHighPriority(implicit section: SectionSpec) = {
     "be of high priority (default) " in {
       section.displayPriority mustEqual HighDisplayPriority
     }
   }
 
-  private[this] def beLowPriority(implicit section: SectionSpec) = {
+  private def beLowPriority(implicit section: SectionSpec) = {
     "be of low priority (non default) " in {
       section.displayPriority mustEqual LowDisplayPriority
     }
   }
 
-  private[this] def readFile(fileName: String): Elem = {
+  private def readFile(fileName: String): Elem = {
     val doc = {
       try {
         XML.load(ClassLoader.getSystemResourceAsStream(fileName))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/TechniqueTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/TechniqueTest.scala
@@ -133,7 +133,7 @@ class TechniqueTest extends Specification {
     }
   }
 
-  private[this] def readFile(fileName: String): Elem = {
+  private def readFile(fileName: String): Elem = {
     val doc = {
       try {
         XML.load(ClassLoader.getSystemResourceAsStream(fileName))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/TechniqueVersionTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/TechniqueVersionTest.scala
@@ -51,22 +51,42 @@ class TechniqueVersionTest extends Specification {
   sequential
 
   "technique version are simple" should {
-    TechniqueVersion.parse("1.0-alpha5") must beLeft()
-    TechniqueVersion.parse("1.0-SNAPSHOT") must beLeft()
-    TechniqueVersion.parse("1.0-beta1") must beLeft()
-    TechniqueVersion.parse("1.0~anything") must beLeft()
-    TechniqueVersion.parse("1.0~1") must beLeft()
-    TechniqueVersion.parse("1.a") must beLeft()
-    TechniqueVersion.parse("1:a") must beLeft()
-    TechniqueVersion.parse("1.0") must beRight()
-    TechniqueVersion.parse("4.8.1.5") must beRight()
-    val v = TechniqueVersion(
-      Version(0, PartType.Numeric(1), VersionPart.After(Separator.Dot, PartType.Numeric(0)) :: Nil),
-      Revision("21dae29cc95a8b492325a0fb7625eac07fae3868")
-    )
-    TechniqueVersion.parse("1.0+21dae29cc95a8b492325a0fb7625eac07fae3868") must beRight(
-      v.getOrElse(throw new Exception("error in test init"))
-    )
+    "technique version parse for 1.0-alpha5" in {
+      TechniqueVersion.parse("1.0-alpha5") must beLeft
+    }
+    "technique version parse for 1.0-SNAPSHOT" in {
+      TechniqueVersion.parse("1.0-SNAPSHOT") must beLeft
+    }
+    "technique version parse for 1.0-beta1" in {
+      TechniqueVersion.parse("1.0-beta1") must beLeft
+    }
+    "technique version parse for 1.0~anything" in {
+      TechniqueVersion.parse("1.0~anything") must beLeft
+    }
+    "technique version parse for 1.0~1" in {
+      TechniqueVersion.parse("1.0~1") must beLeft
+    }
+    "technique version parse for 1.a" in {
+      TechniqueVersion.parse("1.a") must beLeft
+    }
+    "technique version parse for 1:a" in {
+      TechniqueVersion.parse("1:a") must beLeft
+    }
+    "technique version parse for 1.0" in {
+      TechniqueVersion.parse("1.0") must beRight
+    }
+    "technique version parse for 4.8.1.5" in {
+      TechniqueVersion.parse("4.8.1.5") must beRight
+    }
+    "technique version parse for 1.0+21dae29cc95a8b492325a0fb7625eac07fae3868" in {
+      val v = TechniqueVersion(
+        Version(0, PartType.Numeric(1), VersionPart.After(Separator.Dot, PartType.Numeric(0)) :: Nil),
+        Revision("21dae29cc95a8b492325a0fb7625eac07fae3868")
+      )
+      TechniqueVersion.parse("1.0+21dae29cc95a8b492325a0fb7625eac07fae3868") must beRight(
+        v.getOrElse(throw new Exception("error in test init"))
+      )
+    }
   }
 
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/VariableTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/VariableTest.scala
@@ -174,8 +174,8 @@ class VariableTest extends Specification {
   }
 
   "Variable" should {
-    val v                 = InputVariable(InputVariableSpec(refName, refDescription, id = None), Seq())
-    implicit val variable = v.copyWithSavedValue(refValue).orThrow
+    val v = InputVariable(InputVariableSpec(refName, refDescription, id = None), Seq())
+    implicit val variable: InputVariable = v.copyWithSavedValue(refValue).orThrow
 
     haveName()
     haveDescription()
@@ -183,8 +183,8 @@ class VariableTest extends Specification {
   }
 
   "Multivalued variable" should {
-    val variable   = InputVariable(InputVariableSpec(refName, refDescription, multivalued = true, id = None), Seq())
-    implicit val v = variable.copyWithSavedValues(listValue.split(";").toSeq).orThrow
+    val variable = InputVariable(InputVariableSpec(refName, refDescription, multivalued = true, id = None), Seq())
+    implicit val v: InputVariable = variable.copyWithSavedValues(listValue.split(";").toSeq).orThrow
 
     haveName()
     haveDescription()
@@ -192,8 +192,8 @@ class VariableTest extends Specification {
   }
 
   "Select variable" should {
-    val variable   = SelectVariable(SelectVariableSpec(refName, refDescription, valueslabels = refItem, id = None), Seq())
-    implicit val v = variable.copyWithSavedValue(refValue).orThrow
+    val variable = SelectVariable(SelectVariableSpec(refName, refDescription, valueslabels = refItem, id = None), Seq())
+    implicit val v: SelectVariable = variable.copyWithSavedValue(refValue).orThrow
 
     haveName()
     haveDescription()
@@ -201,8 +201,8 @@ class VariableTest extends Specification {
   }
 
   "Input variable" should {
-    val variable   = InputVariable(InputVariableSpec(refName, refDescription, id = None), Seq())
-    implicit val v = variable.copyWithSavedValue(refValue).orThrow
+    val variable = InputVariable(InputVariableSpec(refName, refDescription, id = None), Seq())
+    implicit val v: InputVariable = variable.copyWithSavedValue(refValue).orThrow
 
     haveName()
     haveDescription()
@@ -210,8 +210,8 @@ class VariableTest extends Specification {
   }
 
   "Nulled variable" should {
-    val variable   = InputVariable(InputVariableSpec(refName, refDescription, id = None), Seq())
-    implicit val v = variable.copyWithSavedValue(null).orThrow
+    val variable = InputVariable(InputVariableSpec(refName, refDescription, id = None), Seq())
+    implicit val v: InputVariable = variable.copyWithSavedValue(null).orThrow
 
     haveName()
     haveDescription()
@@ -219,8 +219,8 @@ class VariableTest extends Specification {
   }
 
   "Valid variable" should {
-    val variable   = InputVariable(InputVariableSpec(refName, refDescription, id = None), Seq())
-    implicit val v = variable.copyWithSavedValue(refValue).orThrow
+    val variable = InputVariable(InputVariableSpec(refName, refDescription, id = None), Seq())
+    implicit val v: InputVariable = variable.copyWithSavedValue(refValue).orThrow
 
     haveName()
     haveDescription()
@@ -231,7 +231,7 @@ class VariableTest extends Specification {
     val variable =
       InputVariable(InputVariableSpec(refName, refDescription, constraint = Constraint(BooleanVType), id = None), Seq())
 
-    implicit val v = variable.copyWithSavedValue("true").orThrow
+    implicit val v: InputVariable = variable.copyWithSavedValue("true").orThrow
     haveName()
     haveDescription()
     haveValue(true)
@@ -241,7 +241,7 @@ class VariableTest extends Specification {
     val variable =
       InputVariable(InputVariableSpec(refName, refDescription, constraint = Constraint(BooleanVType), id = None), Seq())
 
-    implicit val v = variable.copyWithSavedValue("false").orThrow
+    implicit val v: InputVariable = variable.copyWithSavedValue("false").orThrow
     haveValue(false)
   }
 
@@ -518,7 +518,7 @@ class VariableTest extends Specification {
   /// Utility methods
   ///
 
-  private[this] def checkType(typeName: String, varName: String) = {
+  private def checkType(typeName: String, varName: String) = {
     "An input with a type '%s'".format(typeName) should {
       val input = variables(varName)
       "have a constraint with a type '%s'".format(typeName) in {
@@ -527,72 +527,72 @@ class VariableTest extends Specification {
     }
   }
 
-  private[this] def beAnInput(implicit variable: Variable) = {
+  private def beAnInput(implicit variable: Variable) = {
     "Be an input variable" in {
       variable.spec.isInstanceOf[InputVariableSpec]
     }
   }
 
-  private[this] def beASelect1(implicit variable: Variable) = {
+  private def beASelect1(implicit variable: Variable) = {
     "Be an input select 1" in {
       variable.spec.isInstanceOf[SelectOneVariableSpec]
     }
   }
 
-  private[this] def beASelect(implicit variable: Variable) = {
+  private def beASelect(implicit variable: Variable) = {
     "Be an input select" in {
       variable.spec.isInstanceOf[SelectVariableSpec]
     }
   }
 
-  private[this] def beAPassword(implicit variable: Variable) = {
+  private def beAPassword(implicit variable: Variable) = {
     "Be an input password input" in {
       variable.spec.isInstanceOf[InputVariableSpec] and
       variable.spec.constraint.typeName.name == "password"
     }
   }
 
-  private[this] def beAPredefVal(implicit variable: Variable) = {
+  private def beAPredefVal(implicit variable: Variable) = {
     "Be an PREDEF val" in {
       variable.spec.isInstanceOf[PredefinedValuesVariableSpec]
     }
   }
 
-  private[this] def haveDescription(description: String = refDescription)(implicit variable: Variable) = {
+  private def haveDescription(description: String = refDescription)(implicit variable: Variable) = {
     "have description '%s'".format(description) in {
       variable.spec.description mustEqual description
     }
   }
 
-  private[this] def haveName(name: String = refName)(implicit variable: Variable) = {
+  private def haveName(name: String = refName)(implicit variable: Variable) = {
     "have name '%s'".format(name) in {
       variable.spec.name mustEqual name
     }
   }
 
-  private[this] def haveValue[T](value: T = refValue)(implicit variable: Variable) = {
+  private def haveValue[T](value: T = refValue)(implicit variable: Variable) = {
     "have value '%s'".format(value) in {
       variable.getValidatedValue(identity).getOrElse(throw new Exception("for test")).head mustEqual value
     }
   }
 
-  private[this] def saveHaveValue(value: String = refValue)(implicit variable: Variable) = {
+  private def saveHaveValue(value: String = refValue)(implicit variable: Variable) = {
     haveValue(value)(variable.copyWithSavedValue(value).orThrow)
   }
 
-  private[this] def haveNbValues(nbValues: Int)(implicit variable: Variable) = {
+  private def haveNbValues(nbValues: Int)(implicit variable: Variable) = {
     "have %d values".format(nbValues) in {
       variable.values.length mustEqual nbValues
     }
   }
 
-  private[this] def haveType(typeName: String)(implicit variable: Variable) = {
+  private def haveType(typeName: String)(implicit variable: Variable) = {
     "have type " + typeName in {
       variable.spec.constraint.typeName.name mustEqual typeName
     }
   }
 
-  private[this] def provideAndHaveValues(values: String*)(implicit variable: Variable) = {
+  private def provideAndHaveValues(values: String*)(implicit variable: Variable) = {
     s"have both provided values and set values '${values.mkString(",")}'" in {
       variable match {
         case v: PredefinedValuesVariable =>
@@ -603,13 +603,13 @@ class VariableTest extends Specification {
     }
   }
 
-  private[this] def notBeMultivalued(implicit variable: Variable) = {
+  private def notBeMultivalued(implicit variable: Variable) = {
     "not be multivalued (because it is not a valid tag of variable spec)" in {
       !variable.spec.multivalued
     }
   }
 
-  private[this] def haveNoAlgo(implicit variable: Variable) = {
+  private def haveNoAlgo(implicit variable: Variable) = {
     s"Have an user defined hash algorithm (and so none constrained)" in {
       variable.spec.constraint.typeName match {
         case PasswordVType(algos) => algos must containTheSameElementsAs(HashAlgoConstraint.values)
@@ -618,7 +618,7 @@ class VariableTest extends Specification {
     }
   }
 
-  private[this] def haveAlgo(algos: List[HashAlgoConstraint])(implicit variable: Variable) = {
+  private def haveAlgo(algos: List[HashAlgoConstraint])(implicit variable: Variable) = {
     s"Have hash algorithm of type ${algos.map(_.prefix).mkString(",")}" in {
       variable.spec.constraint.typeName match {
         case PasswordVType(a) => a ==== (algos)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitPackageReaderTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitPackageReaderTest.scala
@@ -191,31 +191,31 @@ trait JGitPackageReaderSpec extends Specification with Loggable with AfterAll {
     "...and version 2.0" in techniques(1).version === TechniqueVersionHelper("2.0")
     "...with 3 templates" in {
       infos.techniques(techniques(0).name)(techniques(0).version).agentConfigs(0).templates.toSet === Set(
-        TechniqueTemplate(tmlId, s"p1_1/1.0/${tmlId.name}.cf", true),
-        TechniqueTemplate(templateId, s"bob.txt", false),
-        TechniqueTemplate(template2Id, s"p1_1/1.0/${template2Id.name}.cf", true)
+        TechniqueTemplate(tmlId, s"p1_1/1.0/${tmlId.name}.cf", included = true),
+        TechniqueTemplate(templateId, s"bob.txt", included = false),
+        TechniqueTemplate(template2Id, s"p1_1/1.0/${template2Id.name}.cf", included = true)
       )
     }
     "...with a template from which we can read 'The template content\\non two lines.'" in {
-      assertResourceContent(tmlId, true, "The template content\non two lines.")
+      assertResourceContent(tmlId, isTemplate = true, expectedContent = "The template content\non two lines.")
     }
     "...with an absolute template from which we can read " in {
-      assertResourceContent(templateId, true, templateContent)
+      assertResourceContent(templateId, isTemplate = true, expectedContent = templateContent)
     }
     "...with an absolute template2 from which we can read " in {
-      assertResourceContent(template2Id, true, template2Content)
+      assertResourceContent(template2Id, isTemplate = true, expectedContent = template2Content)
     }
     "...with 2 files" in {
       infos.techniques(techniques(0).name)(techniques(0).version).agentConfigs(0).files.toSet === Set(
-        TechniqueFile(file1, s"p1_1/1.0/${file1.name}", false),
-        TechniqueFile(file2, s"file2", false)
+        TechniqueFile(file1, s"p1_1/1.0/${file1.name}", included = false),
+        TechniqueFile(file2, s"file2", included = false)
       )
     }
     "...with a file1 from which we can read" in {
-      assertResourceContent(file1, false, f1Content)
+      assertResourceContent(file1, isTemplate = false, expectedContent = f1Content)
     }
     "...with a file2 from which we can read" in {
-      assertResourceContent(file2, false, "This is the content of file 2")
+      assertResourceContent(file2, isTemplate = false, expectedContent = "This is the content of file 2")
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/TechniqueRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/TechniqueRepositoryTest.scala
@@ -160,8 +160,16 @@ class TechniqueRepositoryTest extends Specification with Loggable with AfterAll 
       ActiveTechnique(ActiveTechniqueId("empty"), techniqueName, Map()).succeed
     }
     // ALL the following methods are useless for our test
-    override def getFullDirectiveLibrary(): IOResult[FullActiveTechniqueCategory] =
-      FullActiveTechniqueCategory(ActiveTechniqueCategoryId("Active Techniques"), "", "", Nil, Nil, true).succeed
+    override def getFullDirectiveLibrary(): IOResult[FullActiveTechniqueCategory] = {
+      FullActiveTechniqueCategory(
+        ActiveTechniqueCategoryId("Active Techniques"),
+        name = "",
+        description = "",
+        subCategories = Nil,
+        activeTechniques = Nil,
+        isSystem = true
+      ).succeed
+    }
     override def getDirective(directiveId: DirectiveUid): IOResult[Option[Directive]] = ???
     override def getDirectiveWithContext(directiveId: DirectiveUid): IOResult[Option[(Technique, ActiveTechnique, Directive)]] =
       ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/xmlparsers/ParseTechniqueTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/xmlparsers/ParseTechniqueTest.scala
@@ -83,7 +83,7 @@ class ParseTechniqueTest extends Specification {
     technique.agentConfigs.map(_.agentType) must containTheSameElementsAs(List(AgentType.CfeCommunity))
   }
 
-  private[this] def readFile(fileName: String): Elem = {
+  private def readFile(fileName: String): Elem = {
     val doc = {
       try {
         XML.load(ClassLoader.getSystemResourceAsStream(fileName))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/xmlparsers/TestXmlUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/xmlparsers/TestXmlUtils.scala
@@ -92,28 +92,28 @@ class TestXmlUtils {
   @Test def testGetOne(): Unit = {
 
     // C is unique in the subtree
-    sameNodes(c_n, child_C, false)
-    sameNodes(c_n, child_C, true)
+    sameNodes(c_n, child_C, treeScope = false)
+    sameNodes(c_n, child_C, treeScope = true)
 
     // B is unique only at the first level
-    sameNodes(b_n, child_B(sub_A), false)
-    errorNotUnique(b_n, true)
+    sameNodes(b_n, child_B(sub_A), treeScope = false)
+    errorNotUnique(b_n, treeScope = true)
 
     // A is not unique at any scope
-    errorNotUnique(a_n, true)
-    errorNotUnique(a_n, false)
+    errorNotUnique(a_n, treeScope = true)
+    errorNotUnique(a_n, treeScope = false)
 
     // X does not exist
-    errorNotUnique(x_n, true)
-    errorNotUnique(x_n, false)
+    errorNotUnique(x_n, treeScope = true)
+    errorNotUnique(x_n, treeScope = false)
 
     // Sub A does not exist at first level and is not unique in subtree
-    errorNotUnique(subA_n, true)
-    errorNotUnique(subA_n, false)
+    errorNotUnique(subA_n, treeScope = true)
+    errorNotUnique(subA_n, treeScope = false)
 
     // sub B does not exist at first level but is unique in subtree
-    errorNotUnique(subB_n, false)
-    sameNodes(subB_n, sub_B, true)
+    errorNotUnique(subB_n, treeScope = false)
+    sameNodes(subB_n, sub_B, treeScope = true)
 
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -401,8 +401,8 @@ class MockDirectives(mockTechniques: MockTechniques) {
       None,
       "",
       5,
-      true,
-      true // short desc / policyMode / long desc / prio / enabled / system
+      _isEnabled = true,
+      isSystem = true // short desc / policyMode / long desc / prio / enabled / system
     )
 
     val archiveTechnique: Technique =
@@ -416,8 +416,8 @@ class MockDirectives(mockTechniques: MockTechniques) {
       None,
       "",
       5,
-      true,
-      false
+      _isEnabled = true,
+      isSystem = false
     )
 
     // we have one rule with several system technique for root server config
@@ -433,8 +433,8 @@ class MockDirectives(mockTechniques: MockTechniques) {
         None,
         "",
         5,
-        true,
-        true // short desc / policyMode / long desc / prio / enabled / system
+        _isEnabled = true,
+        isSystem = true // short desc / policyMode / long desc / prio / enabled / system
       )
       (technique, directive)
     }
@@ -456,8 +456,8 @@ class MockDirectives(mockTechniques: MockTechniques) {
       None,
       "",
       5,
-      true,
-      true // short desc / policyMode / long desc / prio / enabled / system
+      _isEnabled = true,
+      isSystem = true // short desc / policyMode / long desc / prio / enabled / system
     )
 
     //
@@ -479,8 +479,8 @@ class MockDirectives(mockTechniques: MockTechniques) {
       None,
       "",
       5,
-      true,
-      false // short desc / policyMode / long desc / prio / enabled / system
+      _isEnabled = true,
+      isSystem = false // short desc / policyMode / long desc / prio / enabled / system
     )
 
     /*
@@ -839,8 +839,10 @@ class MockDirectives(mockTechniques: MockTechniques) {
       })
     }
 
-    override def getParentsForActiveTechniqueCategory(id: ActiveTechniqueCategoryId): IOResult[List[ActiveTechniqueCategory]] =
-      ???
+    // scalafmt makes scalameta ScalametaParser to fail for now
+    // format: off
+    override def getParentsForActiveTechniqueCategory(id: ActiveTechniqueCategoryId): IOResult[List[ActiveTechniqueCategory]] = ???
+    // format: on
 
     override def getParentsForActiveTechnique(id: ActiveTechniqueId): IOResult[ActiveTechniqueCategory] = ???
 
@@ -1074,7 +1076,7 @@ class MockRules() {
     "Rules",
     "This is the main category of Rules",
     RuleCategory(RuleCategoryId("category1"), "Category 1", "description of category 1", Nil) :: Nil,
-    true
+    isSystem = true
   )
 
   object ruleCategoryRepo extends RoRuleCategoryRepository with WoRuleCategoryRepository {
@@ -1194,8 +1196,8 @@ class MockRules() {
       Set(DirectiveId(DirectiveUid("common-root"))),
       "common-root rule",
       "",
-      true,
-      true,
+      isEnabledStatus = true,
+      isSystem = true,
       NoTags() // long desc / enabled / system / tags
     )
 
@@ -1207,8 +1209,8 @@ class MockRules() {
       Set(DirectiveId(DirectiveUid("Server Roles"))),
       "Server Roles rule",
       "",
-      true,
-      true,
+      isEnabledStatus = true,
+      isSystem = true,
       NoTags() // long desc / enabled / system / tags
     )
 
@@ -1220,8 +1222,8 @@ class MockRules() {
       Set(DirectiveId(DirectiveUid("Distribute Policy"))),
       "Distribute Policy rule",
       "",
-      true,
-      true,
+      isEnabledStatus = true,
+      isSystem = true,
       NoTags() // long desc / enabled / system / tags
     )
 
@@ -1233,8 +1235,8 @@ class MockRules() {
       Set(DirectiveId(DirectiveUid("inventory-all"))),
       "Inventory all rule",
       "",
-      true,
-      true,
+      isEnabledStatus = true,
+      isSystem = true,
       NoTags() // long desc / enabled / system / tags
     )
 
@@ -1246,8 +1248,8 @@ class MockRules() {
       Set(DirectiveId(DirectiveUid("directive1"))),
       "global config for all nodes",
       "",
-      true,
-      false,
+      isEnabledStatus = true,
+      isSystem = false,
       NoTags() // long desc / enabled / system / tags
     )
 
@@ -1259,8 +1261,8 @@ class MockRules() {
       Set(DirectiveId(DirectiveUid("directive2"))),
       "global config for all nodes",
       "",
-      true,
-      false,
+      isEnabledStatus = true,
+      isSystem = false,
       NoTags() // long desc / enabled / system / tags
     )
 
@@ -1278,8 +1280,8 @@ class MockRules() {
       ),
       "default rule",
       "",
-      true,
-      false,
+      isEnabledStatus = true,
+      isSystem = false,
       NoTags() // long desc / enabled / system / tags
     )
 
@@ -1293,8 +1295,8 @@ class MockRules() {
       ),
       "updated copy of default rule",
       "",
-      true,
-      false,
+      isEnabledStatus = true,
+      isSystem = false,
       NoTags()                                                            // long desc / enabled / system / tags
     )
 
@@ -1306,8 +1308,8 @@ class MockRules() {
       Set(DirectiveId(DirectiveUid("16d86a56-93ef-49aa-86b7-0d10102e4ea9"))),
       "ncf technique rule",
       "",
-      true,
-      false, // long desc / enabled / system
+      isEnabledStatus = true,
+      isSystem = false, // long desc / enabled / system
 
       MkTags(("datacenter", "Paris"), ("serverType", "webserver"))
     )
@@ -1320,8 +1322,8 @@ class MockRules() {
       Set(DirectiveId(DirectiveUid("directive-copyGitFile"))),
       "ncf technique rule",
       "",
-      true,
-      false,
+      isEnabledStatus = true,
+      isSystem = false,
       NoTags()                                                                             // long desc / enabled / system / tags
     )
 
@@ -1333,8 +1335,8 @@ class MockRules() {
       Set(DirectiveId(DirectiveUid("gvd-directive1")), DirectiveId(DirectiveUid("gvd-directive2"))),
       "test gvd ordering rule",
       "",
-      true,
-      false,
+      isEnabledStatus = true,
+      isSystem = false,
       NoTags() // long desc / enabled / system / tags
     )
 
@@ -1740,15 +1742,15 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
   val rootNode: Node     = Node(
     rootId,
     "root",
-    "",
-    NodeState.Enabled,
-    true,
-    true,
-    DateTime.parse("2021-01-30T01:20+01:00"),
-    emptyNodeReportingConfiguration,
-    Nil,
-    Some(PolicyMode.Enforce),
-    None
+    description = "",
+    state = NodeState.Enabled,
+    isSystem = true,
+    isPolicyServer = true,
+    creationDate = DateTime.parse("2021-01-30T01:20+01:00"),
+    nodeReportingConfiguration = emptyNodeReportingConfiguration,
+    properties = Nil,
+    policyMode = Some(PolicyMode.Enforce),
+    securityTag = None
   )
   val root:     NodeInfo = NodeInfo(
     rootNode,
@@ -1817,15 +1819,15 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
   val node1Node: Node = Node(
     id1,
     "node1",
-    "",
-    NodeState.Enabled,
-    false,
-    false,
-    DateTime.parse("2021-01-30T01:20+01:00"),
-    emptyNodeReportingConfiguration,
-    Nil,
-    Some(PolicyMode.Enforce),
-    None
+    description = "",
+    state = NodeState.Enabled,
+    isSystem = false,
+    isPolicyServer = false,
+    creationDate = DateTime.parse("2021-01-30T01:20+01:00"),
+    nodeReportingConfiguration = emptyNodeReportingConfiguration,
+    properties = Nil,
+    policyMode = Some(PolicyMode.Enforce),
+    securityTag = None
   )
 
   val node1: NodeInfo = NodeInfo(
@@ -1918,16 +1920,15 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
   val dscNode1Node: Node = Node(
     NodeId("node-dsc"),
     "node-dsc",
-    "",
-    NodeState.Enabled,
-    true,
-    true, // is relay server
-
-    DateTime.parse("2021-01-30T01:20+01:00"),
-    emptyNodeReportingConfiguration,
-    Nil,
-    None,
-    None
+    description = "",
+    state = NodeState.Enabled,
+    isSystem = true,
+    isPolicyServer = true, // is relay server
+    creationDate = DateTime.parse("2021-01-30T01:20+01:00"),
+    nodeReportingConfiguration = emptyNodeReportingConfiguration,
+    properties = Nil,
+    policyMode = None,
+    securityTag = None
   )
 
   val dscNode1: NodeInfo = NodeInfo(
@@ -2035,8 +2036,21 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     }
   ).toSet
 
-  def newNode(id: NodeId): Node =
-    Node(id, "", "", NodeState.Enabled, false, false, DateTime.now, ReportingConfiguration(None, None, None), Nil, None, None)
+  def newNode(id: NodeId): Node = {
+    Node(
+      id,
+      "",
+      description = "",
+      state = NodeState.Enabled,
+      isSystem = false,
+      isPolicyServer = false,
+      creationDate = DateTime.now,
+      nodeReportingConfiguration = ReportingConfiguration(None, None, None),
+      properties = Nil,
+      policyMode = None,
+      securityTag = None
+    )
+  }
 
   val nodes: Map[NodeId, NodeInfo] = (
     Set(root, node1, node2) ++ nodeIds.map { id =>
@@ -2329,7 +2343,16 @@ class MockNodeGroups(nodesRepo: MockNodes) {
     implicit val ordering: NodeGroupCategoryOrdering.type = com.normation.rudder.repository.NodeGroupCategoryOrdering
 
     val categories: Ref.Synchronized[FullNodeGroupCategory] = Ref.Synchronized
-      .make(FullNodeGroupCategory(NodeGroupCategoryId("GroupRoot"), "GroupRoot", "root of group categories", Nil, Nil, true))
+      .make(
+        FullNodeGroupCategory(
+          NodeGroupCategoryId("GroupRoot"),
+          name = "GroupRoot",
+          description = "root of group categories",
+          subCategories = Nil,
+          targetInfos = Nil,
+          isSystem = true
+        )
+      )
       .runNow
 
     override def categoryExists(id: NodeGroupCategoryId): IOResult[Boolean] = {
@@ -2737,65 +2760,75 @@ class MockNodeGroups(nodesRepo: MockNodes) {
 
   val g0:     NodeGroup                     = NodeGroup(
     NodeGroupId(NodeGroupUid("0000f5d3-8c61-4d20-88a7-bb947705ba8a")),
-    "Real nodes",
-    "",
-    g0props,
-    None,
-    false,
-    Set(MockNodes.rootId, MockNodes.node1.id, MockNodes.node2.id),
-    true
+    name = "Real nodes",
+    description = "",
+    properties = g0props,
+    query = None,
+    isDynamic = false,
+    serverList = Set(MockNodes.rootId, MockNodes.node1.id, MockNodes.node2.id),
+    _isEnabled = true
   )
-  val g1:     NodeGroup                     =
-    NodeGroup(NodeGroupId(NodeGroupUid("1111f5d3-8c61-4d20-88a7-bb947705ba8a")), "Empty group", "", Nil, None, false, Set(), true)
+  val g1:     NodeGroup                     = {
+    NodeGroup(
+      NodeGroupId(NodeGroupUid("1111f5d3-8c61-4d20-88a7-bb947705ba8a")),
+      name = "Empty group",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = false,
+      serverList = Set(),
+      _isEnabled = true
+    )
+  }
   val g2:     NodeGroup                     = NodeGroup(
     NodeGroupId(NodeGroupUid("2222f5d3-8c61-4d20-88a7-bb947705ba8a")),
-    "only root",
-    "",
-    Nil,
-    None,
-    false,
-    Set(NodeId("root")),
-    true
+    name = "only root",
+    description = "",
+    properties = Nil,
+    query = None,
+    isDynamic = false,
+    serverList = Set(NodeId("root")),
+    _isEnabled = true
   )
   val g3:     NodeGroup                     = NodeGroup(
     NodeGroupId(NodeGroupUid("3333f5d3-8c61-4d20-88a7-bb947705ba8a")),
-    "Even nodes",
-    "",
-    Nil,
-    None,
-    false,
-    MockNodes.nodeIds.filter(_.value.toInt % 2 == 0),
-    true
+    name = "Even nodes",
+    description = "",
+    properties = Nil,
+    query = None,
+    isDynamic = false,
+    serverList = MockNodes.nodeIds.filter(_.value.toInt % 2 == 0),
+    _isEnabled = true
   )
   val g4:     NodeGroup                     = NodeGroup(
     NodeGroupId(NodeGroupUid("4444f5d3-8c61-4d20-88a7-bb947705ba8a")),
-    "Odd nodes",
-    "",
-    Nil,
-    None,
-    false,
-    MockNodes.nodeIds.filter(_.value.toInt % 2 != 0),
-    true
+    name = "Odd nodes",
+    description = "",
+    properties = Nil,
+    query = None,
+    isDynamic = false,
+    serverList = MockNodes.nodeIds.filter(_.value.toInt % 2 != 0),
+    _isEnabled = true
   )
   val g5:     NodeGroup                     = NodeGroup(
     NodeGroupId(NodeGroupUid("5555f5d3-8c61-4d20-88a7-bb947705ba8a")),
-    "Nodes id divided by 3",
-    "",
-    Nil,
-    None,
-    false,
-    MockNodes.nodeIds.filter(_.value.toInt % 3 == 0),
-    true
+    name = "Nodes id divided by 3",
+    description = "",
+    properties = Nil,
+    query = None,
+    isDynamic = false,
+    serverList = MockNodes.nodeIds.filter(_.value.toInt % 3 == 0),
+    _isEnabled = true
   )
   val g6:     NodeGroup                     = NodeGroup(
     NodeGroupId(NodeGroupUid("6666f5d3-8c61-4d20-88a7-bb947705ba8a")),
-    "Nodes id divided by 5",
-    "",
-    Nil,
-    None,
-    false,
-    MockNodes.nodeIds.filter(_.value.toInt % 5 == 0),
-    true
+    name = "Nodes id divided by 5",
+    description = "",
+    properties = Nil,
+    query = None,
+    isDynamic = false,
+    serverList = MockNodes.nodeIds.filter(_.value.toInt % 5 == 0),
+    _isEnabled = true
   )
   val groups: Seq[(NodeGroupId, NodeGroup)] = List(g0, g1, g2, g3, g4, g5, g6).map(g => (g.id, g))
 
@@ -2804,10 +2837,10 @@ class MockNodeGroups(nodesRepo: MockNodes) {
   val groupsTargetInfos: Seq[FullRuleTargetInfo] = groupsTargets.map { gt =>
     FullRuleTargetInfo(
       FullGroupTarget(gt._1, gt._2),
-      "",
-      "",
-      true,
-      false
+      name = "",
+      description = "",
+      isEnabled = true,
+      isSystem = false
     )
   }
 
@@ -2818,11 +2851,11 @@ class MockNodeGroups(nodesRepo: MockNodes) {
     List(
       FullNodeGroupCategory(
         NodeGroupCategoryId("category1"),
-        "category 1",
-        "the first category",
-        Nil,
-        List(groupsTargetInfos.head), // that g0 id:0000f5d3-8c61-4d20-88a7-bb947705ba8
-        false
+        name = "category 1",
+        description = "the first category",
+        subCategories = Nil,
+        targetInfos = List(groupsTargetInfos.head), // that g0 id:0000f5d3-8c61-4d20-88a7-bb947705ba8
+        isSystem = false
       )
     ),
     List(
@@ -2831,44 +2864,44 @@ class MockNodeGroups(nodesRepo: MockNodes) {
           GroupTarget(NodeGroupId(NodeGroupUid("a-group-for-root-only"))),
           NodeGroup(
             NodeGroupId(NodeGroupUid("a-group-for-root-only")),
-            "Serveurs [€ðŋ] cassés",
-            "Liste de l'ensemble de serveurs cassés à réparer",
-            Nil,
-            None,
-            true,
-            Set(NodeId("root")),
-            true,
-            false
+            name = "Serveurs [€ðŋ] cassés",
+            description = "Liste de l'ensemble de serveurs cassés à réparer",
+            properties = Nil,
+            query = None,
+            isDynamic = true,
+            serverList = Set(NodeId("root")),
+            _isEnabled = true,
+            isSystem = false
           )
         ),
-        "Serveurs [€ðŋ] cassés",
-        "Liste de l'ensemble de serveurs cassés à réparer",
-        true,
-        false
+        name = "Serveurs [€ðŋ] cassés",
+        description = "Liste de l'ensemble de serveurs cassés à réparer",
+        isEnabled = true,
+        isSystem = false
       ),
       FullRuleTargetInfo(
         FullOtherTarget(PolicyServerTarget(NodeId("root"))),
-        "special:policyServer_root",
-        "The root policy server",
-        true,
-        true
+        name = "special:policyServer_root",
+        description = "The root policy server",
+        isEnabled = true,
+        isSystem = true
       ),
       FullRuleTargetInfo(
         FullOtherTarget(AllTargetExceptPolicyServers),
-        "special:all_exceptPolicyServers",
-        "All groups without policy servers",
-        true,
-        true
+        name = "special:all_exceptPolicyServers",
+        description = "All groups without policy servers",
+        isEnabled = true,
+        isSystem = true
       ),
       FullRuleTargetInfo(
         FullOtherTarget(AllTarget),
-        "special:all",
-        "All nodes",
-        true,
-        true
+        name = "special:all",
+        description = "All nodes",
+        isEnabled = true,
+        isSystem = true
       )
     ) ++ groupsTargetInfos.drop(1),
-    true
+    isSystem = true
   )
 
   // init with full lib
@@ -3122,13 +3155,13 @@ class MockCampaign() {
       }
 
       val campaignIdFiltered: CampaignEvent => Boolean = campaignId match {
-        case None     => eventIdFiltered
-        case Some(id) => ev => eventIdFiltered(ev) || ev.campaignId != id
+        case None      => eventIdFiltered
+        case Some(id_) => ev => eventIdFiltered(ev) || ev.campaignId != id_
       }
 
       val campaignTypeFiltered: CampaignEvent => Boolean = campaignType match {
-        case None     => campaignIdFiltered
-        case Some(id) => ev => campaignIdFiltered(ev) && ev.campaignType != id
+        case None      => campaignIdFiltered
+        case Some(id_) => ev => campaignIdFiltered(ev) && ev.campaignType != id_
       }
 
       val stateFiltered: CampaignEvent => Boolean = states match {
@@ -3137,12 +3170,12 @@ class MockCampaign() {
       }
 
       val afterDateFiltered:  CampaignEvent => Boolean = afterDate match {
-        case None     => stateFiltered
-        case Some(id) => ev => stateFiltered(ev) && ev.end.isAfter(id)
+        case None      => stateFiltered
+        case Some(id_) => ev => stateFiltered(ev) && ev.end.isAfter(id_)
       }
       val beforeDateFiltered: CampaignEvent => Boolean = beforeDate match {
-        case None     => afterDateFiltered
-        case Some(id) => ev => afterDateFiltered(ev) && ev.start.isBefore(id)
+        case None      => afterDateFiltered
+        case Some(id_) => ev => afterDateFiltered(ev) && ev.start.isBefore(id_)
       }
       for {
         i      <- items.get.map(_.values)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/DBCommon.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/DBCommon.scala
@@ -37,7 +37,6 @@
 
 package com.normation.rudder.db
 
-import cats.implicits.*
 import com.normation.rudder.db.Doobie.*
 import com.normation.rudder.migration.MigrableEntity
 import com.normation.rudder.migration.MigrationEventLogRepository
@@ -115,12 +114,12 @@ trait DBCommon extends Specification with Loggable with BeforeAfterAll {
   override def beforeAll(): Unit = initDb()
   override def afterAll():  Unit = cleanDb()
 
-  def initDb(): AnyVal = {
+  def initDb(): Unit = {
     if (sqlInit.trim.size > 0) {
       // Postgres'JDBC driver just accept multiple statement
       // in one query. No need to try to split ";" etc.
       doobie.transactRunEither(xa => Update0(sqlInit, None).run.transact(xa)) match {
-        case Right(x) => x
+        case Right(_) => ()
         case Left(ex) => throw ex
       }
     }
@@ -128,7 +127,7 @@ trait DBCommon extends Specification with Loggable with BeforeAfterAll {
 
   def cleanDb(): Unit = {
     if (sqlClean.trim.size > 0) doobie.transactRunEither(xa => Update0(sqlClean, None).run.transact(xa)) match {
-      case Right(x) => x
+      case Right(x) => ()
       case Left(ex) => throw ex
     }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/nodes/NodePropertiesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/nodes/NodePropertiesTest.scala
@@ -116,7 +116,7 @@ class NodePropertiesTest extends Specification with Loggable with BoxSpecMatcher
 
   "updating/deleting with different owners" should {
     // do an update and a delete of the prop
-    def updateAndDelete(prop: NodeProperty) = {
+    def updateAndDelete(prop: NodeProperty): List[PureResult[?]] = {
       List(
         CompareProperties.updateProperties(baseProps, Some(prop :: Nil)),
         CompareProperties.updateProperties(baseProps, Some(prop.withValue("") :: Nil))
@@ -124,39 +124,51 @@ class NodePropertiesTest extends Specification with Loggable with BoxSpecMatcher
     }
 
     "works if providers goes from default to an other" in {
-      List(
-        updateAndDelete(NodeProperty("none", "xxx".toConfigValue, None, P1)),
-        updateAndDelete(NodeProperty("none", "xxx".toConfigValue, None, P2)),
-        updateAndDelete(NodeProperty("default", "xxx".toConfigValue, None, P1)),
-        updateAndDelete(NodeProperty("default", "xxx".toConfigValue, None, P2))
-      ).flatten must contain((res: PureResult[List[NodeProperty]]) => res must beAnInstanceOf[Right[?, ?]]).foreach
+      val input  = {
+        List(
+          NodeProperty("none", "xxx".toConfigValue, None, P1),
+          NodeProperty("none", "xxx".toConfigValue, None, P2),
+          NodeProperty("default", "xxx".toConfigValue, None, P1),
+          NodeProperty("default", "xxx".toConfigValue, None, P2)
+        )
+      }
+      val actual = input.flatMap(updateAndDelete)
+      actual must contain((x: PureResult[?]) => x must beRight).foreach
     }
 
     "works if providers goes from anything to system" in {
-      List(
-        updateAndDelete(NodeProperty("none", "xxx".toConfigValue, None, Some(PropertyProvider.systemPropertyProvider))),
-        updateAndDelete(NodeProperty("p1", "xxx".toConfigValue, None, Some(PropertyProvider.systemPropertyProvider))),
-        updateAndDelete(NodeProperty("default", "xxx".toConfigValue, None, Some(PropertyProvider.systemPropertyProvider))),
-        updateAndDelete(NodeProperty("default", "xxx".toConfigValue, None, Some(PropertyProvider.systemPropertyProvider)))
-      ).flatten must contain((res: PureResult[List[NodeProperty]]) => res must beAnInstanceOf[Right[?, ?]]).foreach
+      val input  = {
+        List(
+          NodeProperty("none", "xxx".toConfigValue, None, Some(PropertyProvider.systemPropertyProvider)),
+          NodeProperty("p1", "xxx".toConfigValue, None, Some(PropertyProvider.systemPropertyProvider)),
+          NodeProperty("default", "xxx".toConfigValue, None, Some(PropertyProvider.systemPropertyProvider)),
+          NodeProperty("default", "xxx".toConfigValue, None, Some(PropertyProvider.systemPropertyProvider))
+        )
+      }
+      val actual = input.flatMap(updateAndDelete)
+      actual must contain((x: PureResult[?]) => x must beRight).foreach
     }
 
     "fails for different, non default providers" in {
-      List(
-        updateAndDelete(NodeProperty("p1", "xxx".toConfigValue, None, None)),
-        updateAndDelete(NodeProperty("p1", "xxx".toConfigValue, None, RudderP)),
-        updateAndDelete(NodeProperty("p1", "xxx".toConfigValue, None, P2)),
-        updateAndDelete(NodeProperty("p2", "xxx".toConfigValue, None, None)),
-        updateAndDelete(NodeProperty("p2", "xxx".toConfigValue, None, RudderP)),
-        updateAndDelete(NodeProperty("p2", "xxx".toConfigValue, None, P1))
-      ).flatten must contain((res: PureResult[List[NodeProperty]]) => res must beAnInstanceOf[Left[?, ?]]).foreach
+      val input  = List(
+        NodeProperty("p1", "xxx".toConfigValue, None, None),
+        NodeProperty("p1", "xxx".toConfigValue, None, RudderP),
+        NodeProperty("p1", "xxx".toConfigValue, None, P2),
+        NodeProperty("p2", "xxx".toConfigValue, None, None),
+        NodeProperty("p2", "xxx".toConfigValue, None, RudderP),
+        NodeProperty("p2", "xxx".toConfigValue, None, P1)
+      )
+      val actual = input.flatMap(updateAndDelete)
+      actual must contain((x: PureResult[?]) => x must beLeft).foreach
     }
 
     "be ok with compatible one (default)" in {
-      List(
-        updateAndDelete(NodeProperty("none", "xxx".toConfigValue, None, RudderP)),
-        updateAndDelete(NodeProperty("default", "xxx".toConfigValue, None, None))
-      ).flatten must contain((res: PureResult[List[NodeProperty]]) => res must beAnInstanceOf[Right[?, ?]]).foreach
+      val input  = List(
+        NodeProperty("none", "xxx".toConfigValue, None, RudderP),
+        NodeProperty("default", "xxx".toConfigValue, None, None)
+      )
+      val actual = input.flatMap(updateAndDelete)
+      actual must contain((x: PureResult[?]) => x must beRight).foreach
     }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
@@ -30,8 +30,21 @@ class RuleTargetTest extends Specification with Loggable {
     NodeId(s"${i}")
   }).toSet
 
-  def newNode(id: NodeId): Node =
-    Node(id, "", "", NodeState.Enabled, false, false, DateTime.now, ReportingConfiguration(None, None, None), List(), None, None)
+  def newNode(id: NodeId): Node = {
+    Node(
+      id,
+      "",
+      "",
+      NodeState.Enabled,
+      isSystem = false,
+      isPolicyServer = false,
+      creationDate = DateTime.now,
+      nodeReportingConfiguration = ReportingConfiguration(None, None, None),
+      properties = List(),
+      policyMode = None,
+      securityTag = None
+    )
+  }
 
   val allNodeIds: Set[NodeId]           = nodeIds + NodeId("root")
   val nodes:      Map[NodeId, NodeInfo] = allNodeIds.map { id =>
@@ -63,9 +76,9 @@ class RuleTargetTest extends Specification with Loggable {
     "",
     Nil,
     None,
-    false,
-    Set(),
-    true
+    isDynamic = false,
+    serverList = Set(),
+    _isEnabled = true
   )
   val g2: NodeGroup = NodeGroup(
     NodeGroupId(NodeGroupUid("2")),
@@ -73,9 +86,9 @@ class RuleTargetTest extends Specification with Loggable {
     "",
     Nil,
     None,
-    false,
-    Set(NodeId("root")),
-    true
+    isDynamic = false,
+    serverList = Set(NodeId("root")),
+    _isEnabled = true
   )
   val g3: NodeGroup = NodeGroup(
     NodeGroupId(NodeGroupUid("3")),
@@ -83,9 +96,9 @@ class RuleTargetTest extends Specification with Loggable {
     "",
     Nil,
     None,
-    false,
-    nodeIds.filter(_.value.toInt == 2),
-    true
+    isDynamic = false,
+    serverList = nodeIds.filter(_.value.toInt == 2),
+    _isEnabled = true
   )
   val g4: NodeGroup = NodeGroup(
     NodeGroupId(NodeGroupUid("4")),
@@ -93,9 +106,9 @@ class RuleTargetTest extends Specification with Loggable {
     "",
     Nil,
     None,
-    false,
-    nodeIds.filter(_.value.toInt != 2),
-    true
+    isDynamic = false,
+    serverList = nodeIds.filter(_.value.toInt != 2),
+    _isEnabled = true
   )
   val g5: NodeGroup = NodeGroup(
     NodeGroupId(NodeGroupUid("5")),
@@ -103,9 +116,9 @@ class RuleTargetTest extends Specification with Loggable {
     "",
     Nil,
     None,
-    false,
-    nodeIds.filter(_.value.toInt == 3),
-    true
+    isDynamic = false,
+    serverList = nodeIds.filter(_.value.toInt == 3),
+    _isEnabled = true
   )
   val g6: NodeGroup = NodeGroup(
     NodeGroupId(NodeGroupUid("6")),
@@ -113,9 +126,9 @@ class RuleTargetTest extends Specification with Loggable {
     "",
     Nil,
     None,
-    false,
-    nodeIds.filter(_.value.toInt == 5),
-    true
+    isDynamic = false,
+    serverList = nodeIds.filter(_.value.toInt == 5),
+    _isEnabled = true
   )
 
   val groups: Set[NodeGroup] = Set(g1, g2, g3, g4, g5, g6)
@@ -128,8 +141,8 @@ class RuleTargetTest extends Specification with Loggable {
         FullGroupTarget(gt._1, gt._2),
         "",
         "",
-        true,
-        false
+        isEnabled = true,
+        isSystem = false
       )
     }))
     .toList

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/ExpectedReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/ExpectedReportTest.scala
@@ -67,8 +67,8 @@ import org.specs2.runner.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ExpectedReportTest extends Specification {
-  implicit private[this] def r2n(s: String): RuleId      = RuleId(RuleUid(s))
-  implicit private[this] def d2n(s: String): DirectiveId = DirectiveId(DirectiveUid(s), GitVersion.DEFAULT_REV)
+  implicit private def r2n(s: String): RuleId      = RuleId(RuleUid(s))
+  implicit private def d2n(s: String): DirectiveId = DirectiveId(DirectiveUid(s), GitVersion.DEFAULT_REV)
 
   val parse: String => Box[JsonNodeExpectedReports] = ExpectedReportsSerialisation.parseJsonNodeExpectedReports _
   def serialize(e: ExpectedReportsSerialisation.JsonNodeExpectedReports) = {
@@ -118,8 +118,8 @@ class ExpectedReportTest extends Specification {
               DirectiveExpectedReports(
                 "common-hasPolicyServer-root",
                 None,
-                true,
-                List(
+                isSystem = true,
+                components = List(
                   ValueExpectedReport(
                     "Update",
                     List(
@@ -166,8 +166,8 @@ class ExpectedReportTest extends Specification {
               DirectiveExpectedReports(
                 "dc0eaf47-356a-4a44-877d-e3873f75385b",
                 None,
-                false,
-                List(
+                isSystem = false,
+                components = List(
                   ValueExpectedReport(
                     "Package",
                     List(
@@ -185,8 +185,8 @@ class ExpectedReportTest extends Specification {
               DirectiveExpectedReports(
                 "cbc2377f-ce6d-47fe-902b-8d92a484b184",
                 None,
-                false,
-                List(
+                isSystem = false,
+                components = List(
                   BlockExpectedReport(
                     "my main component",
                     ReportingLogic.WeightedReport,
@@ -216,8 +216,8 @@ class ExpectedReportTest extends Specification {
               DirectiveExpectedReports(
                 "rudder-service-apache-root",
                 None,
-                true,
-                List(
+                isSystem = true,
+                components = List(
                   ValueExpectedReport(
                     "Apache service",
                     List(
@@ -254,8 +254,8 @@ class ExpectedReportTest extends Specification {
               DirectiveExpectedReports(
                 "inventory-all",
                 None,
-                true,
-                List(
+                isSystem = true,
+                components = List(
                   ValueExpectedReport(
                     "Inventory",
                     List(

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
@@ -59,9 +59,9 @@ import scala.io.Source
 
 @RunWith(classOf[JUnitRunner])
 class StatusReportTest extends Specification {
-  implicit private[this] def s2n(s: String): NodeId      = NodeId(s)
-  implicit private[this] def r2n(s: String): RuleId      = RuleId(RuleUid(s))
-  implicit private[this] def d2n(s: String): DirectiveId = DirectiveId(DirectiveUid(s), GitVersion.DEFAULT_REV)
+  implicit private def s2n(s: String): NodeId      = NodeId(s)
+  implicit private def r2n(s: String): RuleId      = RuleId(RuleUid(s))
+  implicit private def d2n(s: String): DirectiveId = DirectiveId(DirectiveUid(s), GitVersion.DEFAULT_REV)
 
   sequential
 
@@ -335,7 +335,7 @@ class StatusReportTest extends Specification {
     }
   }
 
-  private[this] def parse(s: String): List[RuleNodeStatusReport] = {
+  private def parse(s: String): List[RuleNodeStatusReport] = {
 
     def ?(s: String): Option[String] = s.trim match {
       case "" | "\"\"" => None
@@ -390,7 +390,7 @@ class StatusReportTest extends Specification {
       .toList
   }
 
-  private[this] def toRT(s: String): ReportType = s.toLowerCase match {
+  private def toRT(s: String): ReportType = s.toLowerCase match {
     case "success"              => EnforceSuccess
     case "error"                => EnforceError
     case "noanswer"             => NoAnswer
@@ -402,7 +402,7 @@ class StatusReportTest extends Specification {
     case s                      => throw new IllegalArgumentException(s)
   }
 
-  private[this] def aggregate(nr: Iterable[RuleNodeStatusReport]): AggregatedStatusReport = {
+  private def aggregate(nr: Iterable[RuleNodeStatusReport]): AggregatedStatusReport = {
     AggregatedStatusReport(nr)
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestFullInventoryRepoProxy.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestFullInventoryRepoProxy.scala
@@ -283,7 +283,7 @@ class TestFullInventoryRepoProxy extends Specification {
             node0 === n0_
             and node1 === n1_
             and node2 === n2_
-            and (node3 isLeft) // no move to delete
+            and (node3 must beLeft) // no move to delete
           )
         }
       )

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSaveInventory.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSaveInventory.scala
@@ -118,7 +118,7 @@ class TestSaveInventoryGit extends TestSaveInventory {
     val gitFactRepoGC       = new GitGC(gitFactRepoProvider, cronSchedule)
     gitFactRepoGC.start()
     // we need to use the default group available, not rudder, else CI complains
-    val storage             = new GitNodeFactStorageImpl(gitFactRepoProvider, None, true)
+    val storage             = new GitNodeFactStorageImpl(gitFactRepoProvider, None, actuallyCommit = true)
     storage.checkInit().runOrDie(err => new RuntimeException(s"Error when checking fact repository init: " + err.fullMsg))
 
     storage
@@ -544,7 +544,7 @@ trait TestSaveInventory extends Specification with BeforeAfterAll {
       )) and
       (receivedInventoryFile(nodeName).exists must beTrue) and
       (checkPendingNodeExists(nodeId) must beTrue) and
-      (factRepo.get(nodeId).runNow must beSome()) and
+      (factRepo.get(nodeId).runNow must beSome) and
       (getLogName must beEqualTo(Chunk("newPending")).eventually(2, 100.millis.asScala))
     }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSelectFacts.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSelectFacts.scala
@@ -77,10 +77,10 @@ class TestSelectFacts extends Specification {
 
   "masking 1" >> {
     (SelectFacts.mask(nodeFact1)(SelectFacts.all) === nodeFact1) and
-    (nodeFact1.software must not beEmpty) and
-    (nodeFact1.environmentVariables must not beEmpty) and
-    (nodeFact1.bios must not beEmpty) and
-    (nodeFact1.softwareUpdate must not beEmpty)
+    (nodeFact1.software must not(beEmpty)) and
+    (nodeFact1.environmentVariables must not(beEmpty)) and
+    (nodeFact1.bios must not(beEmpty)) and
+    (nodeFact1.softwareUpdate must not(beEmpty))
   }
 
   "masking 2" >> {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/metrics/NodeCountHistorizationTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/metrics/NodeCountHistorizationTest.scala
@@ -67,7 +67,7 @@ class NodeCountHistorizationTest extends Specification with BeforeAfter {
   val rudder: CommitInformation = CommitInformation(
     "rudder-a32c5441-daa5-4244-8792-17f1a43cd9bd",
     Some("rudder+a32c5441-daa5-4244-8792-17f1a43cd9bd@rudder.io"),
-    false
+    sign = false
   )
 
   override def before: Any = {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
@@ -330,7 +330,7 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
 
   import ParameterType.*
   val defaultConstraint: List[Constraint.Constraint]    =
-    Constraint.AllowEmpty(false) :: Constraint.AllowWhiteSpace(false) :: Constraint.MaxLength(16384) :: Nil
+    Constraint.AllowEmpty(allow = false) :: Constraint.AllowWhiteSpace(allow = false) :: Constraint.MaxLength(16384) :: Nil
   val methods:           Map[BundleName, GenericMethod] = (GenericMethod(
     BundleName("package_install_version"),
     "Package install version",
@@ -447,8 +447,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
           ),
           "any",
           "Customized component",
-          false,
-          None
+          disabledReporting = false,
+          policyMode = None
         ) ::
         MethodCall(
           BundleName("command_execution"),
@@ -456,8 +456,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
           Map((ParameterId("command"), "Write-Host \"testing special characters ` è &é 'à é \"")),
           "windows",
           "Command execution",
-          true,
-          Some(Enforce)
+          disabledReporting = true,
+          policyMode = Some(Enforce)
         ) :: Nil,
         Some(Audit)
       ) ::
@@ -467,8 +467,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         Map((ParameterId("service_name"), "${node.properties[apache_package_name]}")),
         "package_install_version_${node.properties[apache_package_name]}_repaired",
         "Customized component",
-        false,
-        Some(Audit)
+        disabledReporting = false,
+        policyMode = Some(Audit)
       ) ::
       MethodCall(
         BundleName("package_install"),
@@ -476,8 +476,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         Map((ParameterId("package_name"), "openssh-server")),
         "redhat",
         "Package install",
-        false,
-        None
+        disabledReporting = false,
+        policyMode = None
       ) ::
       MethodCall(
         BundleName("command_execution"),
@@ -485,8 +485,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         Map((ParameterId("command"), "/bin/echo \"testing special characters ` è &é 'à é \"\\")),
         "cfengine-community",
         "Command execution",
-        false,
-        Some(Audit)
+        disabledReporting = false,
+        policyMode = Some(Audit)
       ) ::
       MethodCall(
         BundleName("package_state_windows"),
@@ -494,8 +494,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         Map((ParameterId("package_name"), "vim")),
         "dsc",
         "Package state windows",
-        false,
-        None
+        disabledReporting = false,
+        policyMode = None
       ) ::
       MethodCall(
         BundleName("_logger"),
@@ -503,8 +503,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         Map((ParameterId("message"), "NA"), (ParameterId("old_class_prefix"), "NA")),
         "any",
         "Not sure we should test it ...",
-        false,
-        None
+        disabledReporting = false,
+        policyMode = None
       ) :: Nil,
       "This Technique exists only to see if Rudder creates Technique correctly.",
       "",
@@ -514,8 +514,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         Some("technique parameter"),
         Some(" a long description, with line \n break within"),
         // we must ensure that it will lead to: [parameter(Mandatory=$false)]
-        true,
-        None
+        mayBeEmpty = true,
+        constraints = None
       ) :: Nil,
       Nil,
       Map(),
@@ -653,8 +653,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         ),
         "any",
         "Test component$&é)à\\'\"",
-        false,
-        Some(Audit)
+        disabledReporting = false,
+        policyMode = Some(Audit)
       ) :: Nil,
       "This Technique exists only to see if Rudder creates Technique correctly.",
       "",
@@ -663,8 +663,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         "version",
         Some("package version"),
         Some("Package version to install"),
-        false,
-        None
+        mayBeEmpty = false,
+        constraints = None
       ) :: Nil,
       Nil,
       Map(),
@@ -727,7 +727,7 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
 
     "Should not generate expected additional rudder reporting content for our technique" in {
       val resultFile = new JFile(s"${basePath}/${reportingPath_any}")
-      resultFile must not exist
+      resultFile must not(exist)
     }
   }
 
@@ -745,8 +745,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         ),
         "${my_custom_condition}",
         "Command execution",
-        false,
-        None
+        disabledReporting = false,
+        policyMode = None
       ) :: Nil,
       "",
       "",
@@ -755,8 +755,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
         "my_custom_condition",
         Some("my custom condition"),
         None,
-        false,
-        None
+        mayBeEmpty = false,
+        constraints = None
       ) :: Nil,
       Nil,
       Map(),
@@ -872,12 +872,12 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
       val value5 = "sdfsqdfsqfsdf sfhdskjhdfs jkhsdkfjhksqdhf"
       val value6 = ""
 
-      Constraint.AllowWhiteSpace(false).check(value1) must equalTo(Constraint.OK)
-      Constraint.AllowWhiteSpace(false).check(value2) must equalTo(Constraint.OK)
-      Constraint.AllowWhiteSpace(false).check(value3) must equalTo(Constraint.OK)
-      Constraint.AllowWhiteSpace(false).check(value4) must equalTo(Constraint.OK)
-      Constraint.AllowWhiteSpace(false).check(value5) must equalTo(Constraint.OK)
-      Constraint.AllowWhiteSpace(false).check(value6) must equalTo(Constraint.OK)
+      Constraint.AllowWhiteSpace(allow = false).check(value1) must equalTo(Constraint.OK)
+      Constraint.AllowWhiteSpace(allow = false).check(value2) must equalTo(Constraint.OK)
+      Constraint.AllowWhiteSpace(allow = false).check(value3) must equalTo(Constraint.OK)
+      Constraint.AllowWhiteSpace(allow = false).check(value4) must equalTo(Constraint.OK)
+      Constraint.AllowWhiteSpace(allow = false).check(value5) must equalTo(Constraint.OK)
+      Constraint.AllowWhiteSpace(allow = false).check(value6) must equalTo(Constraint.OK)
     }
 
     "Correctly refuse text starting or ending with withspace" in {
@@ -889,10 +889,10 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
       val value3 = " "
       val value4 = "sdfsqdfsqfsdf sfhdskjhdfs jkhsdkfjhksqdhf "
 
-      Constraint.AllowWhiteSpace(false).check(value1) must haveClass[Constraint.NOK]
-      Constraint.AllowWhiteSpace(false).check(value2) must haveClass[Constraint.NOK]
-      Constraint.AllowWhiteSpace(false).check(value3) must haveClass[Constraint.NOK]
-      Constraint.AllowWhiteSpace(false).check(value4) must haveClass[Constraint.NOK]
+      Constraint.AllowWhiteSpace(allow = false).check(value1) must haveClass[Constraint.NOK]
+      Constraint.AllowWhiteSpace(allow = false).check(value2) must haveClass[Constraint.NOK]
+      Constraint.AllowWhiteSpace(allow = false).check(value3) must haveClass[Constraint.NOK]
+      Constraint.AllowWhiteSpace(allow = false).check(value4) must haveClass[Constraint.NOK]
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriterFallback.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriterFallback.scala
@@ -176,7 +176,7 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
   import ParameterType.*
 
   val defaultConstraint: List[Constraint.Constraint] =
-    Constraint.AllowEmpty(false) :: Constraint.AllowWhiteSpace(false) :: Constraint.MaxLength(16384) :: Nil
+    Constraint.AllowEmpty(allow = false) :: Constraint.AllowWhiteSpace(allow = false) :: Constraint.MaxLength(16384) :: Nil
 
   val methods: Map[BundleName, GenericMethod] = (
     GenericMethod(
@@ -232,8 +232,8 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
         Map((ParameterId("package_name"), "openssh-server")),
         "redhat",
         "Package install",
-        false,
-        Some(Enforce)
+        disabledReporting = false,
+        policyMode = Some(Enforce)
       ) :: Nil,
       "",
       "",
@@ -307,7 +307,17 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
       initDirectories(compiler, technique)
       val res                = compiler.compileTechnique(technique).runNow
 
-      (res must beEqualTo(TechniqueCompilationOutput(Rudderc, false, 0, Chunk.empty, "ok", "stdout", ""))) and
+      (res must beEqualTo(
+        TechniqueCompilationOutput(
+          Rudderc,
+          fallbacked = false,
+          resultCode = 0,
+          fileStatus = Chunk.empty,
+          msg = "ok",
+          stdout = "stdout",
+          stderr = ""
+        )
+      )) and
       (compilationConfigFile.exists must beFalse) and
       (compilationOutputFile.exists must beFalse) and
       checkXML(CreatedByRudderc) and
@@ -320,7 +330,17 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
       initDirectories(compiler, technique)
       val res                = compiler.compileTechnique(technique).runNow
 
-      (res must beEqualTo(TechniqueCompilationOutput(Rudderc, false, 7, Chunk.empty, "nok:user", "stdout", "stderr"))) and
+      (res must beEqualTo(
+        TechniqueCompilationOutput(
+          Rudderc,
+          fallbacked = false,
+          resultCode = 7,
+          fileStatus = Chunk.empty,
+          msg = "nok:user",
+          stdout = "stdout",
+          stderr = "stderr"
+        )
+      )) and
       (compilationConfigFile.exists must beFalse) and
       (compilationOutputFile.exists must beTrue) and
       checkXML(Missing) and
@@ -333,7 +353,17 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
       initDirectories(compiler, technique)
       val res                = compiler.compileTechnique(technique).runNow
 
-      (res must beEqualTo(TechniqueCompilationOutput(Webapp, true, -42, Chunk.empty, "nok:empty", "stdout", "stderr"))) and
+      (res must beEqualTo(
+        TechniqueCompilationOutput(
+          Webapp,
+          fallbacked = true,
+          resultCode = -42,
+          fileStatus = Chunk.empty,
+          msg = "nok:empty",
+          stdout = "stdout",
+          stderr = "stderr"
+        )
+      )) and
       (compilationConfigFile.exists must beFalse) and
       (compilationOutputFile.exists must beTrue) and
       checkXML(CreatedByWebapp) and
@@ -346,7 +376,17 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
       initDirectories(compiler, technique)
       val res                = compiler.compileTechnique(technique).runNow
 
-      (res must beEqualTo(TechniqueCompilationOutput(Webapp, true, 50, Chunk.empty, "nok:empty", "stdout", "stderr"))) and
+      (res must beEqualTo(
+        TechniqueCompilationOutput(
+          Webapp,
+          fallbacked = true,
+          resultCode = 50,
+          fileStatus = Chunk.empty,
+          msg = "nok:empty",
+          stdout = "stdout",
+          stderr = "stderr"
+        )
+      )) and
       (compilationConfigFile.exists must beFalse) and
       (compilationOutputFile.exists must beTrue) and
       checkXML(CreatedByWebapp) and
@@ -359,7 +399,17 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
       initDirectories(compiler, technique)
       val res                = compiler.compileTechnique(technique).runNow
 
-      (res must beEqualTo(TechniqueCompilationOutput(Webapp, true, 60, Chunk.empty, "nok:xml", "stdout", "stderr"))) and
+      (res must beEqualTo(
+        TechniqueCompilationOutput(
+          Webapp,
+          fallbacked = true,
+          resultCode = 60,
+          fileStatus = Chunk.empty,
+          msg = "nok:xml",
+          stdout = "stdout",
+          stderr = "stderr"
+        )
+      )) and
       (compilationConfigFile.exists must beFalse) and
       (compilationOutputFile.exists must beTrue) and
       checkXML(CreatedByWebapp) and
@@ -372,7 +422,17 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
       initDirectories(compiler, technique)
       val res                = compiler.compileTechnique(technique).runNow
 
-      (res must beEqualTo(TechniqueCompilationOutput(Webapp, true, 70, Chunk.empty, "nok:cfe", "stdout", "stderr"))) and
+      (res must beEqualTo(
+        TechniqueCompilationOutput(
+          Webapp,
+          fallbacked = true,
+          resultCode = 70,
+          fileStatus = Chunk.empty,
+          msg = "nok:cfe",
+          stdout = "stdout",
+          stderr = "stderr"
+        )
+      )) and
       (compilationConfigFile.exists must beFalse) and
       (compilationOutputFile.exists must beTrue) and
       checkXML(CreatedByWebapp) and
@@ -385,7 +445,17 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
       initDirectories(compiler, technique)
       val res                = compiler.compileTechnique(technique).runNow
 
-      (res must beEqualTo(TechniqueCompilationOutput(Webapp, true, 80, Chunk.empty, "nok:ps1", "stdout", "stderr"))) and
+      (res must beEqualTo(
+        TechniqueCompilationOutput(
+          Webapp,
+          fallbacked = true,
+          resultCode = 80,
+          fileStatus = Chunk.empty,
+          msg = "nok:ps1",
+          stdout = "stdout",
+          stderr = "stderr"
+        )
+      )) and
       (compilationConfigFile.exists must beFalse) and
       (compilationOutputFile.exists must beTrue) and
       checkXML(CreatedByWebapp) and
@@ -418,17 +488,17 @@ class TestEditorTechniqueWriterFallback extends Specification with ContentMatche
       (res must beEqualTo(
         TechniqueCompilationOutput(
           Webapp,
-          false,
-          0,
-          Chunk(
+          fallbacked = false,
+          resultCode = 0,
+          fileStatus = Chunk(
             ResourceFile("metadata.xml", New),
             ResourceFile("rudder_reporting.cf", New),
             ResourceFile("technique.cf", New),
             ResourceFile("technique.ps1", New)
           ),
-          "Technique 'techniqueOK' written by webapp",
-          "",
-          ""
+          msg = "Technique 'techniqueOK' written by webapp",
+          stdout = "",
+          stderr = ""
         )
       )) and
       (compilationConfigFile.exists must beTrue) and

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -87,7 +87,6 @@ import org.joda.time.DateTime
 import org.joda.time.Duration
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
-import scala.annotation.nowarn
 import scala.collection.SortedMap
 import scala.concurrent.duration.FiniteDuration
 import zio.*
@@ -173,7 +172,6 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
     def getGlobalUserCompliance()(implicit qc: QueryContext): Box[Option[(ComplianceLevel, Long)]] = null
     def findUncomputedNodeStatusReports(): Box[Map[NodeId, NodeStatusReport]] = null
 
-    @nowarn()
     def getUserNodeStatusReports()(implicit qc: QueryContext):                  Box[Map[NodeId, NodeStatusReport]] = Full(Map())
     def getSystemAndUserCompliance(
         optNodeIds: Option[Set[NodeId]]
@@ -196,8 +194,8 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
 
   lazy val agentRunService: agentRunService = new agentRunService
   class agentRunService extends AgentRunIntervalService() {
-    private[this] val interval = Duration.standardMinutes(5)
-    private[this] val nodes    = Seq("n0", "n1", "n2", "n3", "n4").map(n => (NodeId(n), ResolvedAgentRunInterval(interval, 1))).toMap
+    private val interval = Duration.standardMinutes(5)
+    private val nodes    = Seq("n0", "n1", "n2", "n3", "n4").map(n => (NodeId(n), ResolvedAgentRunInterval(interval, 1))).toMap
     def getGlobalAgentRun():                                  Box[AgentRunInterval]                      = Full(AgentRunInterval(None, interval.toStandardMinutes.getMinutes, 0, 0, 0))
     def getNodeReportingConfigurations(nodeIds: Set[NodeId]): Box[Map[NodeId, ResolvedAgentRunInterval]] = {
       Full(nodes.view.filterKeys(x => nodeIds.contains(x)).toMap)
@@ -950,9 +948,9 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
 //  }
 
   implicit def toReport(t: (DateTime, String, String, String, String, String, String, DateTime, String, String)): Reports = {
-    implicit def toRuleId(s:      String) = RuleId(RuleUid(s))
-    implicit def toDirectiveId(s: String) = DirectiveId(DirectiveUid(s), GitVersion.DEFAULT_REV)
-    implicit def toNodeId(s:      String) = NodeId(s)
+    implicit def toRuleId(s:      String): RuleId      = RuleId(RuleUid(s))
+    implicit def toDirectiveId(s: String): DirectiveId = DirectiveId(DirectiveUid(s), GitVersion.DEFAULT_REV)
+    implicit def toNodeId(s:      String): NodeId      = NodeId(s)
 
     Reports(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -87,6 +87,7 @@ import org.joda.time.DateTime
 import org.joda.time.Duration
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
+import scala.annotation.nowarn
 import scala.collection.SortedMap
 import scala.concurrent.duration.FiniteDuration
 import zio.*
@@ -172,6 +173,7 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
     def getGlobalUserCompliance()(implicit qc: QueryContext): Box[Option[(ComplianceLevel, Long)]] = null
     def findUncomputedNodeStatusReports(): Box[Map[NodeId, NodeStatusReport]] = null
 
+    @nowarn("msg=parameter.*is never used")
     def getUserNodeStatusReports()(implicit qc: QueryContext):                  Box[Map[NodeId, NodeStatusReport]] = Full(Map())
     def getSystemAndUserCompliance(
         optNodeIds: Option[Set[NodeId]]

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsTest.scala
@@ -81,9 +81,9 @@ class ReportsTest extends DBCommon {
   sequential
 
   implicit def toReport(t: (DateTime, String, String, String, String, String, String, DateTime, String, String)): Reports = {
-    implicit def toRuleId(s:      String) = RuleId(RuleUid(s))
-    implicit def toDirectiveId(s: String) = DirectiveId(DirectiveUid(s))
-    implicit def toNodeId(s:      String) = NodeId(s)
+    implicit def toRuleId(s:      String): RuleId      = RuleId(RuleUid(s))
+    implicit def toDirectiveId(s: String): DirectiveId = DirectiveId(DirectiveUid(s))
+    implicit def toNodeId(s:      String): NodeId      = NodeId(s)
 
     Reports(t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
   }
@@ -131,9 +131,10 @@ class ReportsTest extends DBCommon {
     }
 
     "find reports for node 0,1,2" in {
-      val runs   = Set(("n0", run1), ("n1", run1), ("n2", run1))
-      val result = repostsRepo.getExecutionReports(runs, Set(), Set()).open
-      result.values.flatten.toSeq must contain(exactly(reports("n0") ++ reports("n1").reverse.tail ++ reports("n2"): _*))
+      val runs = Set(("n0", run1), ("n1", run1), ("n2", run1))
+      val result: Map[NodeId, Seq[Reports]] = repostsRepo.getExecutionReports(runs, Set(), Set()).open
+      val actual: Seq[Reports]              = result.values.toSeq.flatten
+      actual must contain(exactly(reports("n0") ++ reports("n1").reverse.tail ++ reports("n2"): _*))
     }
 
     "not find report for none existing agent run id" in {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/eventlog/NodeEventLogFormatV6Test.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/eventlog/NodeEventLogFormatV6Test.scala
@@ -76,7 +76,7 @@ class NodeEventLogFormatV6Test extends Specification {
     modHeartbeat = Some(
       SimpleDiff(
         None,
-        Some(HeartbeatConfiguration(true, 20))
+        Some(HeartbeatConfiguration(overrides = true, heartbeatPeriod = 20))
       )
     ),
     modAgentRun = None,

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/marshalling/TestXmlUnserialisation.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/marshalling/TestXmlUnserialisation.scala
@@ -90,9 +90,9 @@ class TestXmlUnserialisation extends Specification with BoxSpecMatcher {
     None,
     "",
     5,
-    true,
-    false,
-    Tags(Set())
+    _isEnabled = true,
+    isSystem = false,
+    tags = Tags(Set())
   )
 
   "when unserializing, we" should {
@@ -163,9 +163,9 @@ class TestXmlUnserialisation extends Specification with BoxSpecMatcher {
         )
       ),
       Some(Query(NodeReturnType, And, Identity, List())),
-      true,
-      Set(),
-      true
+      isDynamic = true,
+      serverList = Set(),
+      _isEnabled = true
     )
 
     val xml    = nodeGroupSerialisation.serialise(group)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
@@ -76,7 +76,8 @@ class TestMergeGroupProperties extends Specification {
   sequential
 
   implicit class ToTarget(g: NodeGroup) {
-    def toTarget:    FullRuleTargetInfo = FullRuleTargetInfo(FullGroupTarget(GroupTarget(g.id), g), g.name, "", true, true)
+    def toTarget:    FullRuleTargetInfo =
+      FullRuleTargetInfo(FullGroupTarget(GroupTarget(g.id), g), g.name, "", isEnabled = true, isSystem = true)
     def toCriterion: CriterionLine      =
       CriterionLine(null, Criterion("some ldap attr", SubGroupComparator(null), null), null, g.id.serialize)
   }
@@ -134,29 +135,39 @@ class TestMergeGroupProperties extends Specification {
 
   val parent1: NodeGroup = NodeGroup(
     NodeGroupId(NodeGroupUid("parent1")),
-    "parent1",
-    "",
-    List(GroupProperty("foo", GitVersion.DEFAULT_REV, "bar1".toConfigValue, None, None)),
-    Some(Query(NodeReturnType, And, Identity, List())),
-    true,
-    Set(),
-    true
+    name = "parent1",
+    description = "",
+    properties = List(GroupProperty("foo", GitVersion.DEFAULT_REV, "bar1".toConfigValue, None, None)),
+    query = Some(Query(NodeReturnType, And, Identity, List())),
+    isDynamic = true,
+    serverList = Set(),
+    _isEnabled = true
   )
   val parent2Prop = GroupProperty("foo", GitVersion.DEFAULT_REV, "bar2".toConfigValue, None, None)
   val parent2: NodeGroup = NodeGroup(
     NodeGroupId(NodeGroupUid("parent2")),
-    "parent2",
-    "",
-    List(parent2Prop),
-    Some(Query(NodeReturnType, And, Identity, List())),
-    true,
-    Set(),
-    true
+    name = "parent2",
+    description = "",
+    properties = List(parent2Prop),
+    query = Some(Query(NodeReturnType, And, Identity, List())),
+    isDynamic = true,
+    serverList = Set(),
+    _isEnabled = true
   )
   val childProp = GroupProperty("foo", GitVersion.DEFAULT_REV, "baz".toConfigValue, None, None)
   val query: Query     = Query(NodeReturnType, And, Identity, List(parent1.toCriterion))
-  val child: NodeGroup =
-    NodeGroup(NodeGroupId(NodeGroupUid("child")), "child", "", List(childProp), Some(query), true, Set(), true)
+  val child: NodeGroup = {
+    NodeGroup(
+      NodeGroupId(NodeGroupUid("child")),
+      name = "child",
+      description = "",
+      properties = List(childProp),
+      query = Some(query),
+      isDynamic = true,
+      serverList = Set(),
+      _isEnabled = true
+    )
+  }
   val nodeInfo =
     NodeConfigData.node1.modify(_.node.properties).setTo(NodeProperty("foo", "barNode".toConfigValue, None, None) :: Nil)
 
@@ -203,23 +214,23 @@ class TestMergeGroupProperties extends Specification {
     "be able to detect conflict" in {
       val parent1 = NodeGroup(
         NodeGroupId(NodeGroupUid("parent1")),
-        "parent1",
-        "",
-        List(GroupProperty("dns", GitVersion.DEFAULT_REV, "1.1.1.1".toConfigValue, None, None)),
-        Some(Query(NodeReturnType, And, Identity, List())),
-        true,
-        Set(),
-        true
+        name = "parent1",
+        description = "",
+        properties = List(GroupProperty("dns", GitVersion.DEFAULT_REV, "1.1.1.1".toConfigValue, None, None)),
+        query = Some(Query(NodeReturnType, And, Identity, List())),
+        isDynamic = true,
+        serverList = Set(),
+        _isEnabled = true
       )
       val parent2 = NodeGroup(
         NodeGroupId(NodeGroupUid("parent2")),
-        "parent2",
-        "",
-        List(GroupProperty("dns", GitVersion.DEFAULT_REV, "9.9.9.9".toConfigValue, None, None)),
-        Some(Query(NodeReturnType, And, Identity, List())),
-        true,
-        Set(),
-        true
+        name = "parent2",
+        description = "",
+        properties = List(GroupProperty("dns", GitVersion.DEFAULT_REV, "9.9.9.9".toConfigValue, None, None)),
+        query = Some(Query(NodeReturnType, And, Identity, List())),
+        isDynamic = true,
+        serverList = Set(),
+        _isEnabled = true
       )
 
       val merged = MergeNodeProperties.checkPropertyMerge(parent1.toTarget :: parent2.toTarget :: Nil, Map())
@@ -233,33 +244,33 @@ class TestMergeGroupProperties extends Specification {
     "be able to correct conflict" in {
       val parent1    = NodeGroup(
         NodeGroupId(NodeGroupUid("parent1")),
-        "parent1",
-        "",
-        List(GroupProperty("dns", GitVersion.DEFAULT_REV, "1.1.1.1".toConfigValue, None, None)),
-        Some(Query(NodeReturnType, And, Identity, List())),
-        true,
-        Set(),
-        true
+        name = "parent1",
+        description = "",
+        properties = List(GroupProperty("dns", GitVersion.DEFAULT_REV, "1.1.1.1".toConfigValue, None, None)),
+        query = Some(Query(NodeReturnType, And, Identity, List())),
+        isDynamic = true,
+        serverList = Set(),
+        _isEnabled = true
       )
       val parent2    = NodeGroup(
         NodeGroupId(NodeGroupUid("parent2")),
-        "parent2",
-        "",
-        List(GroupProperty("dns", GitVersion.DEFAULT_REV, "9.9.9.9".toConfigValue, None, None)),
-        Some(Query(NodeReturnType, And, Identity, List())),
-        true,
-        Set(),
-        true
+        name = "parent2",
+        description = "",
+        properties = List(GroupProperty("dns", GitVersion.DEFAULT_REV, "9.9.9.9".toConfigValue, None, None)),
+        query = Some(Query(NodeReturnType, And, Identity, List())),
+        isDynamic = true,
+        serverList = Set(),
+        _isEnabled = true
       )
       val prioritize = NodeGroup(
         NodeGroupId(NodeGroupUid("parent3")),
-        "parent3",
-        "",
-        Nil,
-        Some(Query(NodeReturnType, And, Identity, List(parent1.toCriterion, parent2.toCriterion))),
-        true,
-        Set(),
-        true
+        name = "parent3",
+        description = "",
+        properties = Nil,
+        query = Some(Query(NodeReturnType, And, Identity, List(parent1.toCriterion, parent2.toCriterion))),
+        isDynamic = true,
+        serverList = Set(),
+        _isEnabled = true
       )
 
       val merged   =
@@ -279,43 +290,43 @@ class TestMergeGroupProperties extends Specification {
     "one can solve conflicts at parent level" in {
       val parent1    = NodeGroup(
         NodeGroupId(NodeGroupUid("parent1")),
-        "parent1",
-        "",
-        List(GroupProperty("dns", GitVersion.DEFAULT_REV, "1.1.1.1".toConfigValue, None, None)),
-        Some(Query(NodeReturnType, And, Identity, List())),
-        true,
-        Set(),
-        true
+        name = "parent1",
+        description = "",
+        properties = List(GroupProperty("dns", GitVersion.DEFAULT_REV, "1.1.1.1".toConfigValue, None, None)),
+        query = Some(Query(NodeReturnType, And, Identity, List())),
+        isDynamic = true,
+        serverList = Set(),
+        _isEnabled = true
       )
       val parent2    = NodeGroup(
         NodeGroupId(NodeGroupUid("parent2")),
-        "parent2",
-        "",
-        List(GroupProperty("dns", GitVersion.DEFAULT_REV, "9.9.9.9".toConfigValue, None, None)),
-        Some(Query(NodeReturnType, And, Identity, List())),
-        true,
-        Set(),
-        true
+        name = "parent2",
+        description = "",
+        properties = List(GroupProperty("dns", GitVersion.DEFAULT_REV, "9.9.9.9".toConfigValue, None, None)),
+        query = Some(Query(NodeReturnType, And, Identity, List())),
+        isDynamic = true,
+        serverList = Set(),
+        _isEnabled = true
       )
       val prioritize = NodeGroup(
         NodeGroupId(NodeGroupUid("parent3")),
-        "parent3",
-        "",
-        Nil,
-        Some(Query(NodeReturnType, And, Identity, List(parent1.toCriterion, parent2.toCriterion))),
-        true,
-        Set(),
-        true
+        name = "parent3",
+        description = "",
+        properties = Nil,
+        query = Some(Query(NodeReturnType, And, Identity, List(parent1.toCriterion, parent2.toCriterion))),
+        isDynamic = true,
+        serverList = Set(),
+        _isEnabled = true
       )
       val parent4    = NodeGroup(
         NodeGroupId(NodeGroupUid("parent4")),
-        "parent4",
-        "",
-        Nil,
-        Some(Query(NodeReturnType, And, Identity, List(parent1.toCriterion))),
-        true,
-        Set(),
-        true
+        name = "parent4",
+        description = "",
+        properties = Nil,
+        query = Some(Query(NodeReturnType, And, Identity, List(parent1.toCriterion))),
+        isDynamic = true,
+        serverList = Set(),
+        _isEnabled = true
       )
 
       val merged   = MergeNodeProperties.checkPropertyMerge(List(parent1, parent2, prioritize, parent4).map(_.toTarget), Map())
@@ -359,23 +370,23 @@ class TestMergeGroupProperties extends Specification {
       }.toList
       val parent                            = NodeGroup(
         NodeGroupId(NodeGroupUid("parent1")),
-        "parent1",
-        "",
-        toProps(parentProps),
-        Some(Query(NodeReturnType, And, Identity, List())),
-        true,
-        Set(),
-        true
+        name = "parent1",
+        description = "",
+        properties = toProps(parentProps),
+        query = Some(Query(NodeReturnType, And, Identity, List())),
+        isDynamic = true,
+        serverList = Set(),
+        _isEnabled = true
       )
       val child                             = NodeGroup(
         NodeGroupId(NodeGroupUid("child")),
-        "child",
-        "",
-        toProps(childProps),
-        Some(Query(NodeReturnType, And, Identity, List(parent1.toCriterion))),
-        true,
-        Set(),
-        true
+        name = "child",
+        description = "",
+        properties = toProps(childProps),
+        query = Some(Query(NodeReturnType, And, Identity, List(parent1.toCriterion))),
+        isDynamic = true,
+        serverList = Set(),
+        _isEnabled = true
       )
       parent :: child :: Nil
     }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/history/impl/TestFileHistoryLogRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/history/impl/TestFileHistoryLogRepository.scala
@@ -38,7 +38,8 @@ final case class SystemError(cause: Throwable) extends RudderError {
 
 object StringMarshaller extends FileMarshalling[String] {
   // simply read / write file content
-  override def fromFile(in: File): IOResult[String] = ZIO.attempt(FileUtils.readFileToString(in, "UTF-8")).mapError(SystemError)
+  override def fromFile(in: File):              IOResult[String] =
+    ZIO.attempt(FileUtils.readFileToString(in, "UTF-8")).mapError(SystemError.apply)
   override def toFile(out: File, data: String): IOResult[String] = ZIO.attempt {
     FileUtils.writeStringToFile(out, data, "UTF-8")
     data

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
@@ -529,32 +529,83 @@ ootapja6lKOaIpqp0kmmYN7gFIhp
    */
 
   val g0id:   NodeGroupId                   = NodeGroupId(NodeGroupUid("0"))
-  val g0:     NodeGroup                     = NodeGroup(g0id, "Real nodes", "", Nil, None, false, Set(rootId, node1.id, node2.id), true)
-  val g1:     NodeGroup                     = NodeGroup(NodeGroupId(NodeGroupUid("1")), "Empty group", "", Nil, None, false, Set(), true)
-  val g2:     NodeGroup                     = NodeGroup(NodeGroupId(NodeGroupUid("2")), "only root", "", Nil, None, false, Set(NodeId("root")), true)
-  val g3:     NodeGroup                     =
-    NodeGroup(NodeGroupId(NodeGroupUid("3")), "Even nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt == 2), true)
-  val g4:     NodeGroup                     =
-    NodeGroup(NodeGroupId(NodeGroupUid("4")), "Odd nodes", "", Nil, None, false, nodeIds.filter(_.value.toInt != 2), true)
+  val g0:     NodeGroup                     = {
+    NodeGroup(
+      g0id,
+      name = "Real nodes",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = false,
+      serverList = Set(rootId, node1.id, node2.id),
+      _isEnabled = true
+    )
+  }
+  val g1:     NodeGroup                     = NodeGroup(
+    NodeGroupId(NodeGroupUid("1")),
+    name = "Empty group",
+    description = "",
+    properties = Nil,
+    query = None,
+    isDynamic = false,
+    serverList = Set(),
+    _isEnabled = true
+  )
+  val g2:     NodeGroup                     = {
+    NodeGroup(
+      NodeGroupId(NodeGroupUid("2")),
+      name = "only root",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = false,
+      serverList = Set(NodeId("root")),
+      _isEnabled = true
+    )
+  }
+  val g3:     NodeGroup                     = {
+    NodeGroup(
+      NodeGroupId(NodeGroupUid("3")),
+      name = "Even nodes",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = false,
+      serverList = nodeIds.filter(_.value.toInt == 2),
+      _isEnabled = true
+    )
+  }
+  val g4:     NodeGroup                     = {
+    NodeGroup(
+      NodeGroupId(NodeGroupUid("4")),
+      name = "Odd nodes",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = false,
+      serverList = nodeIds.filter(_.value.toInt != 2),
+      _isEnabled = true
+    )
+  }
   val g5:     NodeGroup                     = NodeGroup(
     NodeGroupId(NodeGroupUid("5")),
-    "Nodes id divided by 3",
-    "",
-    Nil,
-    None,
-    false,
-    nodeIds.filter(_.value.toInt == 3),
-    true
+    name = "Nodes id divided by 3",
+    description = "",
+    properties = Nil,
+    query = None,
+    isDynamic = false,
+    serverList = nodeIds.filter(_.value.toInt == 3),
+    _isEnabled = true
   )
   val g6:     NodeGroup                     = NodeGroup(
     NodeGroupId(NodeGroupUid("6")),
-    "Nodes id divided by 5",
-    "",
-    Nil,
-    None,
-    false,
-    nodeIds.filter(_.value.toInt == 5),
-    true
+    name = "Nodes id divided by 5",
+    description = "",
+    properties = Nil,
+    query = None,
+    isDynamic = false,
+    serverList = nodeIds.filter(_.value.toInt == 5),
+    _isEnabled = true
   )
   val groups: Set[(NodeGroupId, NodeGroup)] = Set(g0, g1, g2, g3, g4, g5, g6).map(g => (g.id, g))
 
@@ -566,10 +617,10 @@ ootapja6lKOaIpqp0kmmYN7gFIhp
         gt._1.groupId,
         FullRuleTargetInfo(
           FullGroupTarget(gt._1, gt._2),
-          "",
-          "",
-          true,
-          false
+          name = "",
+          description = "",
+          isEnabled = true,
+          isSystem = false
         )
       )
     }))
@@ -802,11 +853,11 @@ class TestNodeConfiguration(
   // the group lib
   val emptyGroupLib: FullNodeGroupCategory = FullNodeGroupCategory(
     NodeGroupCategoryId("/"),
-    "/",
-    "root of group categories",
-    List(),
-    List(),
-    true
+    name = "/",
+    description = "root of group categories",
+    subCategories = List(),
+    targetInfos = List(),
+    isSystem = true
   )
 
   val groupLib: FullNodeGroupCategory = emptyGroupLib.copy(
@@ -816,41 +867,41 @@ class TestNodeConfiguration(
           GroupTarget(NodeGroupId(NodeGroupUid("a-group-for-root-only"))),
           NodeGroup(
             NodeGroupId(NodeGroupUid("a-group-for-root-only")),
-            "Serveurs [€ðŋ] cassés",
-            "Liste de l'ensemble de serveurs cassés à réparer",
-            Nil,
-            None,
-            true,
-            Set(NodeId("root")),
-            true,
-            false
+            name = "Serveurs [€ðŋ] cassés",
+            description = "Liste de l'ensemble de serveurs cassés à réparer",
+            properties = Nil,
+            query = None,
+            isDynamic = true,
+            serverList = Set(NodeId("root")),
+            _isEnabled = true,
+            isSystem = false
           )
         ),
-        "Serveurs [€ðŋ] cassés",
-        "Liste de l'ensemble de serveurs cassés à réparer",
-        true,
-        false
+        name = "Serveurs [€ðŋ] cassés",
+        description = "Liste de l'ensemble de serveurs cassés à réparer",
+        isEnabled = true,
+        isSystem = false
       ),
       FullRuleTargetInfo(
         FullOtherTarget(PolicyServerTarget(NodeId("root"))),
-        "special:policyServer_root",
-        "The root policy server",
-        true,
-        true
+        name = "special:policyServer_root",
+        description = "The root policy server",
+        isEnabled = true,
+        isSystem = true
       ),
       FullRuleTargetInfo(
         FullOtherTarget(AllTargetExceptPolicyServers),
-        "special:all_exceptPolicyServers",
-        "All groups without policy servers",
-        true,
-        true
+        name = "special:all_exceptPolicyServers",
+        description = "All groups without policy servers",
+        isEnabled = true,
+        isSystem = true
       ),
       FullRuleTargetInfo(
         FullOtherTarget(AllTarget),
-        "special:all",
-        "All nodes",
-        true,
-        true
+        name = "special:all",
+        description = "All nodes",
+        isEnabled = true,
+        isSystem = true
       )
     )
   )
@@ -928,13 +979,13 @@ class TestNodeConfiguration(
       ("POLICYSERVER_ID", Seq("${rudder.node.id}")),
       ("POLICYSERVER_ADMIN", Seq("${rudder.node.admin}"))
     ),
-    "common-root",
-    "",
-    None,
-    "",
-    5,
-    true,
-    true
+    name = "common-root",
+    shortDescription = "",
+    policyMode = None,
+    longDescription = "",
+    priority = 5,
+    _isEnabled = true,
+    isSystem = true
   )
 
   def common(nodeId: NodeId, allNodeInfos: Map[NodeId, NodeInfo]): BoundPolicyDraft = {
@@ -953,14 +1004,14 @@ class TestNodeConfiguration(
   val archiveDirective: Directive = Directive(
     DirectiveId(DirectiveUid("test_import_export_archive_directive"), GitVersion.DEFAULT_REV),
     TechniqueVersionHelper("1.0"),
-    Map(),
-    "test_import_export_archive_directive",
-    "",
-    None,
-    "",
-    5,
-    true,
-    false
+    parameters = Map(),
+    name = "test_import_export_archive_directive",
+    shortDescription = "",
+    policyMode = None,
+    longDescription = "",
+    priority = 5,
+    _isEnabled = true,
+    isSystem = false
   )
 
   // we have one rule with several system technique for root server config
@@ -1070,12 +1121,12 @@ class TestNodeConfiguration(
     val id = PolicyId(RuleId("rule1"), DirectiveId(DirectiveUid("directive1+rev1")), TechniqueVersionHelper("1.0+rev2"))
     draft(
       id,
-      "10. Global configuration for all nodes",
-      "10. Clock Configuration",
-      clockTechnique,
-      clockVariables,
-      false,
-      Some(PolicyMode.Enforce)
+      ruleName = "10. Global configuration for all nodes",
+      directiveName = "10. Clock Configuration",
+      technique = clockTechnique,
+      variableMap = clockVariables,
+      system = false,
+      policyMode = Some(PolicyMode.Enforce)
     )
   }
   /*
@@ -1122,12 +1173,12 @@ class TestNodeConfiguration(
     val id = PolicyId(RuleId("rule2"), DirectiveId(DirectiveUid("directive2")), TechniqueVersionHelper("1.0"))
     draft(
       id,
-      "50. Deploy PLOP STACK",
-      "20. Install PLOP STACK main rpm",
-      rpmTechnique,
-      rpmVariables,
-      false,
-      Some(PolicyMode.Audit)
+      ruleName = "50. Deploy PLOP STACK",
+      directiveName = "20. Install PLOP STACK main rpm",
+      technique = rpmTechnique,
+      variableMap = rpmVariables,
+      system = false,
+      policyMode = Some(PolicyMode.Audit)
     )
   }
 
@@ -1154,12 +1205,12 @@ class TestNodeConfiguration(
     )
     draft(
       id,
-      "60-rule-technique-std-lib",
-      "Package management.",
-      pkgTechnique,
-      pkgVariables,
-      false,
-      Some(PolicyMode.Enforce)
+      ruleName = "60-rule-technique-std-lib",
+      directiveName = "Package management.",
+      technique = pkgTechnique,
+      variableMap = pkgVariables,
+      system = false,
+      policyMode = Some(PolicyMode.Enforce)
     )
   }
 
@@ -1188,12 +1239,12 @@ class TestNodeConfiguration(
     )
     draft(
       id,
-      "60-rule-technique-std-lib",
-      "10-File template 1",
-      fileTemplateTechnique,
-      fileTemplateVariables1,
-      false,
-      Some(PolicyMode.Enforce)
+      ruleName = "60-rule-technique-std-lib",
+      directiveName = "10-File template 1",
+      technique = fileTemplateTechnique,
+      variableMap = fileTemplateVariables1,
+      system = false,
+      policyMode = Some(PolicyMode.Enforce)
     )
   }
   lazy val fileTemplateVariables2 = {
@@ -1219,12 +1270,12 @@ class TestNodeConfiguration(
     )
     draft(
       id,
-      "60-rule-technique-std-lib",
-      "20-File template 2",
-      fileTemplateTechnique,
-      fileTemplateVariables2.map(a => (ComponentId(a._1, Nil, None), a._2)),
-      false,
-      Some(PolicyMode.Enforce)
+      ruleName = "60-rule-technique-std-lib",
+      directiveName = "20-File template 2",
+      technique = fileTemplateTechnique,
+      variableMap = fileTemplateVariables2.map(a => (ComponentId(a._1, Nil, None), a._2)),
+      system = false,
+      policyMode = Some(PolicyMode.Enforce)
     )
   }
 
@@ -1237,12 +1288,12 @@ class TestNodeConfiguration(
     )
     draft(
       id,
-      "99-rule-technique-std-lib",
-      "20-File template 2",
-      fileTemplateTechnique,
-      fileTemplateVariables2.map(a => (ComponentId(a._1, Nil, None), a._2)),
-      false,
-      Some(PolicyMode.Enforce)
+      ruleName = "99-rule-technique-std-lib",
+      directiveName = "20-File template 2",
+      technique = fileTemplateTechnique,
+      variableMap = fileTemplateVariables2.map(a => (ComponentId(a._1, Nil, None), a._2)),
+      system = false,
+      policyMode = Some(PolicyMode.Enforce)
     )
   }
 
@@ -1263,12 +1314,12 @@ class TestNodeConfiguration(
     )
     draft(
       id,
-      "50-rule-technique-ncf",
-      "Create a file",
-      ncf1Technique,
-      ncf1Variables.map(a => (ComponentId(a._1, Nil, Some(s"reportId_${a._1}")), a._2)),
-      false,
-      Some(PolicyMode.Enforce)
+      ruleName = "50-rule-technique-ncf",
+      directiveName = "Create a file",
+      technique = ncf1Technique,
+      variableMap = ncf1Variables.map(a => (ComponentId(a._1, Nil, Some(s"reportId_${a._1}")), a._2)),
+      system = false,
+      policyMode = Some(PolicyMode.Enforce)
     )
   }
 
@@ -1279,12 +1330,12 @@ class TestNodeConfiguration(
     val id = PolicyId(RuleId("rule1"), DirectiveId(DirectiveUid("directive1")), TechniqueVersionHelper("1.0"))
     draft(
       id,
-      "10. Global configuration for all nodes",
-      "10. test18205",
-      test18205Technique,
-      Map(),
-      false,
-      Some(PolicyMode.Enforce)
+      ruleName = "10. Global configuration for all nodes",
+      directiveName = "10. test18205",
+      technique = test18205Technique,
+      variableMap = Map(),
+      system = false,
+      policyMode = Some(PolicyMode.Enforce)
     )
   }
 
@@ -1323,12 +1374,12 @@ class TestNodeConfiguration(
     )
     draft(
       id,
-      "90-copy-git-file",
-      "Copy git file",
-      copyGitFileTechnique,
-      copyGitFileVariable(i).map(a => (ComponentId(a._1, Nil, None), a._2)),
-      false,
-      Some(PolicyMode.Enforce)
+      ruleName = "90-copy-git-file",
+      directiveName = "Copy git file",
+      technique = copyGitFileTechnique,
+      variableMap = copyGitFileVariable(i).map(a => (ComponentId(a._1, Nil, None), a._2)),
+      system = false,
+      policyMode = Some(PolicyMode.Enforce)
     )
   }
 
@@ -1390,12 +1441,12 @@ class TestNodeConfiguration(
     val id = PolicyId(RuleId("rule1"), DirectiveId(DirectiveUid("directive1")), TechniqueVersionHelper("1.0"))
     draft(
       id,
-      "10. Global configuration for all nodes",
-      "99. Generic Variable Def #1",
-      gvdTechnique,
-      gvdVariables1.map(a => (ComponentId(a._1, Nil, None), a._2)),
-      false,
-      Some(PolicyMode.Enforce)
+      ruleName = "10. Global configuration for all nodes",
+      directiveName = "99. Generic Variable Def #1",
+      technique = gvdTechnique,
+      variableMap = gvdVariables1.map(a => (ComponentId(a._1, Nil, None), a._2)),
+      system = false,
+      policyMode = Some(PolicyMode.Enforce)
     ).copy(
       priority = 0 // we want to make sure this one will be merged in first position
     )
@@ -1411,13 +1462,13 @@ class TestNodeConfiguration(
     val id = PolicyId(RuleId("rule1"), DirectiveId(DirectiveUid("directive2")), TechniqueVersionHelper("1.0"))
     draft(
       id,
-      "10. Global configuration for all nodes",
-      "00. Generic Variable Def #2", // sort name comes before sort name of directive 1
+      ruleName = "10. Global configuration for all nodes",
+      directiveName = "00. Generic Variable Def #2", // sort name comes before sort name of directive 1
 
-      gvdTechnique,
-      gvdVariables2.map(a => (ComponentId(a._1, Nil, None), a._2)),
-      false,
-      Some(PolicyMode.Enforce)
+      technique = gvdTechnique,
+      variableMap = gvdVariables2.map(a => (ComponentId(a._1, Nil, None), a._2)),
+      system = false,
+      policyMode = Some(PolicyMode.Enforce)
     ).copy(
       priority = 10 // we want to make sure this one will be merged in last position
     )

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
@@ -96,25 +96,26 @@ class RuleValServiceTest extends Specification {
   }
   def makeComponentSectionSpec(name: String):                                         SectionSpec                  = {
     SectionSpec(
-      name,
-      true,
-      true,
-      Some(reportKeysVariableName(name)),
-      HighDisplayPriority,
-      "",
-      Seq(makePredefinedSectionSpec(name, ("variable_" + name, Seq("variable_" + name + "one", "variable_" + name + "two"))))
+      name = name,
+      isMultivalued = true,
+      isComponent = true,
+      componentKey = Some(reportKeysVariableName(name)),
+      displayPriority = HighDisplayPriority,
+      description = "",
+      children =
+        Seq(makePredefinedSectionSpec(name, ("variable_" + name, Seq("variable_" + name + "one", "variable_" + name + "two"))))
     )
   }
 
   def makeRootSectionSpec(): SectionSpec = {
     SectionSpec(
-      "root section",
-      false,
-      false,
-      None,
-      HighDisplayPriority,
-      "",
-      Seq(
+      name = "root section",
+      isMultivalued = false,
+      isComponent = false,
+      componentKey = None,
+      displayPriority = HighDisplayPriority,
+      description = "",
+      children = Seq(
         makeComponentSectionSpec("component1"),
         makeComponentSectionSpec("component2")
       )
@@ -124,16 +125,16 @@ class RuleValServiceTest extends Specification {
   def makeMetaTechnique(id: TechniqueId): Technique = {
     Technique(
       id,
-      "meta" + id,
-      "",
-      AgentConfig(AgentType.CfeCommunity, Nil, Nil, Nil, Nil) :: Nil,
-      TrackerVariableSpec(None, None),
-      makeRootSectionSpec(),
-      None,
-      Set(),
-      false,
-      "",
-      false
+      name = "meta" + id,
+      description = "",
+      agentConfigs = AgentConfig(AgentType.CfeCommunity, Nil, Nil, Nil, Nil) :: Nil,
+      trackerVariableSpec = TrackerVariableSpec(None, None),
+      rootSection = makeRootSectionSpec(),
+      deprecrationInfo = None,
+      systemVariableSpecs = Set(),
+      isMultiInstance = false,
+      longDescription = "",
+      isSystem = false
     )
   }
 
@@ -142,37 +143,37 @@ class RuleValServiceTest extends Specification {
   val directive: Directive = Directive(
     DirectiveId(directiveId, GitVersion.DEFAULT_REV),
     techniqueId.version,
-    Map(),
-    "MyDirective",
-    "shortDescription",
-    None,
-    "longDescription",
-    5,
-    true,
-    false
+    parameters = Map(),
+    name = "MyDirective",
+    shortDescription = "shortDescription",
+    policyMode = None,
+    longDescription = "longDescription",
+    priority = 5,
+    _isEnabled = true,
+    isSystem = false
   )
 
   val rule: Rule = Rule(
     ruleId,
-    "Rule Name",
-    RuleCategoryId("cat1"),
-    Set(GroupTarget(NodeGroupId(NodeGroupUid("nodeGroupId")))),
-    Set(DirectiveId(directiveId)),
-    "",
-    "",
-    true,
-    false
+    name = "Rule Name",
+    categoryId = RuleCategoryId("cat1"),
+    targets = Set(GroupTarget(NodeGroupId(NodeGroupUid("nodeGroupId")))),
+    directiveIds = Set(DirectiveId(directiveId)),
+    shortDescription = "",
+    longDescription = "",
+    isEnabledStatus = true,
+    isSystem = false
   )
 
   val fullActiveTechnique: FullActiveTechnique = {
     FullActiveTechnique(
       ActiveTechniqueId("activeTechId"),
       techniqueId.name,
-      SortedMap((techniqueId.version, new DateTime())),
-      SortedMap((techniqueId.version, technique)),
-      List(directive),
-      true,
-      false
+      acceptationDatetimes = SortedMap((techniqueId.version, new DateTime())),
+      techniques = SortedMap((techniqueId.version, technique)),
+      directives = List(directive),
+      isEnabled = true,
+      isSystem = false
     )
   }
 
@@ -180,11 +181,11 @@ class RuleValServiceTest extends Specification {
   val fullActiveTechniqueCategory: FullActiveTechniqueCategory = {
     FullActiveTechniqueCategory(
       ActiveTechniqueCategoryId("id"),
-      "name",
-      "description",
-      Nil,
-      List(fullActiveTechnique),
-      false
+      name = "name",
+      description = "description",
+      subCategories = Nil,
+      activeTechniques = List(fullActiveTechnique),
+      isSystem = false
     )
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
@@ -101,55 +101,73 @@ class TestBuildNodeConfiguration extends Specification {
 
   val allNodes:     MapView[NodeId, CoreNodeFact] = ((1 to 1000).map(newNode) :+ factRoot).map(n => (n.id, n)).toMap.view
   // only one group with all nodes
-  val group:        NodeGroup                     =
-    NodeGroup(NodeGroupId(NodeGroupUid("allnodes")), "allnodes", "", Nil, None, false, allNodes.keySet.toSet, true)
+  val group:        NodeGroup                     = {
+    NodeGroup(
+      NodeGroupId(NodeGroupUid("allnodes")),
+      name = "allnodes",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = false,
+      serverList = allNodes.keySet.toSet,
+      _isEnabled = true
+    )
+  }
   val groupLib:     FullNodeGroupCategory         = FullNodeGroupCategory(
     NodeGroupCategoryId("test_root"),
     "",
     "",
     Nil,
-    List(FullRuleTargetInfo(FullGroupTarget(GroupTarget(group.id), group), "", "", true, false))
+    List(
+      FullRuleTargetInfo(
+        FullGroupTarget(GroupTarget(group.id), group),
+        name = "",
+        description = "",
+        isEnabled = true,
+        isSystem = false
+      )
+    )
   )
   val directives:   Map[DirectiveId, Directive]   =
     (1 to 1000).map(i => data.rpmDirective("rpm" + i, "somepkg" + i)).map(d => (d.id, d)).toMap
   val directiveLib: FullActiveTechniqueCategory   = FullActiveTechniqueCategory(
     ActiveTechniqueCategoryId("root"),
-    "root",
-    "",
-    Nil,
-    List(
+    name = "root",
+    description = "",
+    subCategories = Nil,
+    activeTechniques = List(
       FullActiveTechnique(
         ActiveTechniqueId("common"),
-        data.commonTechnique.id.name,
-        SortedMap(data.commonTechnique.id.version -> DateTime.now),
-        SortedMap(data.commonTechnique.id.version -> data.commonTechnique),
-        List(data.commonDirective),
-        true,
-        true
+        techniqueName = data.commonTechnique.id.name,
+        acceptationDatetimes = SortedMap(data.commonTechnique.id.version -> DateTime.now),
+        techniques = SortedMap(data.commonTechnique.id.version -> data.commonTechnique),
+        directives = List(data.commonDirective),
+        isEnabled = true,
+        isSystem = true
       ),
       FullActiveTechnique(
         ActiveTechniqueId("rpmPackageInstallation"),
-        data.rpmTechnique.id.name,
-        SortedMap(data.rpmTechnique.id.version -> DateTime.now),
-        SortedMap(data.rpmTechnique.id.version -> data.rpmTechnique),
-        directives.values.toList,
-        true,
-        true
+        techniqueName = data.rpmTechnique.id.name,
+        acceptationDatetimes = SortedMap(data.rpmTechnique.id.version -> DateTime.now),
+        techniques = SortedMap(data.rpmTechnique.id.version -> data.rpmTechnique),
+        directives = directives.values.toList,
+        isEnabled = true,
+        isSystem = true
       )
     ),
-    true
+    isSystem = true
   )
 
   val rule: Rule = Rule(
     RuleId(RuleUid("rule")),
-    "rule",
-    RuleCategoryId("rootcat"),
-    Set(GroupTarget(group.id)),
-    directiveLib.allDirectives.keySet,
-    "",
-    "",
-    true,
-    true
+    name = "rule",
+    categoryId = RuleCategoryId("rootcat"),
+    targets = Set(GroupTarget(group.id)),
+    directiveIds = directiveLib.allDirectives.keySet,
+    shortDescription = "",
+    longDescription = "",
+    isEnabledStatus = true,
+    isSystem = true
   )
   val propertyEngineService = new PropertyEngineServiceImpl(List.empty)
   val valueCompiler         = new InterpolatedValueCompilerImpl(propertyEngineService)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestNodeAndGlobalParameterLookup.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestNodeAndGlobalParameterLookup.scala
@@ -37,7 +37,6 @@
 
 package com.normation.rudder.services.policies
 
-import cats.implicits.*
 import com.normation.cfclerk.domain.InputVariable
 import com.normation.cfclerk.domain.InputVariableSpec
 import com.normation.cfclerk.domain.Variable

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PolicyAgregationTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PolicyAgregationTest.scala
@@ -130,19 +130,19 @@ class PolicyAgregationTest extends Specification {
     val v = InputVariable(InputVariableSpec("card", "description for " + varName, multivalued = true, id = None), values)
     BoundPolicyDraft(
       id,
-      "rule name",
-      "directive name",
+      ruleName = "rule name",
+      directiveName = "directive name",
       technique,
-      DateTime.now,
-      Map(ComponentId(v.spec.name, Nil, None) -> v),
-      Map(ComponentId(v.spec.name, Nil, None) -> v),
+      acceptationDate = DateTime.now,
+      expandedVars = Map(ComponentId(v.spec.name, Nil, None) -> v),
+      originalVars = Map(ComponentId(v.spec.name, Nil, None) -> v),
       trackerVariable,
-      5,
-      false,
-      None,
-      BundleOrder(id.ruleId.serialize),
-      BundleOrder(id.directiveId.serialize),
-      Set()
+      priority = 5,
+      isSystem = false,
+      policyMode = None,
+      ruleOrder = BundleOrder(id.ruleId.serialize),
+      directiveOrder = BundleOrder(id.directiveId.serialize),
+      overrides = Set()
     )
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PrepareTemplateVariableTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PrepareTemplateVariableTest.scala
@@ -91,12 +91,12 @@ class PrepareTemplateVariableTest extends Specification {
         Promiser(x),
         DirectiveId(DirectiveUid(directiveId)),
         TID("not-used-here"),
-        Nil,
-        y :: Nil,
-        Nil,
-        false,
-        PolicyMode.Enforce,
-        false
+        pre = Nil,
+        main = y :: Nil,
+        post = Nil,
+        isSystem = false,
+        policyMode = PolicyMode.Enforce,
+        enableMethodReporting = false
       )
   }
 
@@ -106,11 +106,21 @@ class PrepareTemplateVariableTest extends Specification {
   "Preparing the string for writting usebundle of directives" should {
 
     "correctly write nothing at all when the list of bundle is emtpy" in {
-      CfengineBundleVariables.formatMethodsUsebundle(CFEngineAgentSpecificGeneration.escape, Nil, Nil, false) === List("")
+      CfengineBundleVariables.formatMethodsUsebundle(
+        CFEngineAgentSpecificGeneration.escape,
+        Nil,
+        Nil,
+        cleanDryRunEnd = false
+      ) === List("")
     }
 
     "write exactly - including escaped quotes" in {
-      val actual   = CfengineBundleVariables.formatMethodsUsebundle(CFEngineAgentSpecificGeneration.escape, bundles, Nil, false)
+      val actual   = CfengineBundleVariables.formatMethodsUsebundle(
+        CFEngineAgentSpecificGeneration.escape,
+        bundles,
+        Nil,
+        cleanDryRunEnd = false
+      )
       val expected = {
         List(
           raw"""      "Global configuration for all nodes/20. Install jdk version 1.0"                    usebundle => set_dry_run_mode("false");
@@ -206,7 +216,12 @@ bundle agent run_directive5
 
       // spaces inserted at the begining of promises in rudder_directives.cf are due to string template, not the formated string - strange
 
-      val actual   = CfengineBundleVariables.formatMethodsUsebundle(CFEngineAgentSpecificGeneration.escape, bundles, hooks, false)
+      val actual   = CfengineBundleVariables.formatMethodsUsebundle(
+        CFEngineAgentSpecificGeneration.escape,
+        bundles,
+        hooks,
+        cleanDryRunEnd = false
+      )
       val expected = {
         List(
           raw"""      "pre-run-hook"                                                                      usebundle => package-install('{"parameters":{"package":"vim","action":"update-only"},"reports":[{"id":"r1@@d1@@0","mode":"enforce","technique":"tech1","name":"cmpt1","value":"val1"},{"id":"r1@@d1@@0","mode":"enforce","technique":"tech1","name":"cmpt1","value":"val1"}]}');

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
@@ -37,6 +37,7 @@
 
 package com.normation.rudder.services.policies.write
 
+import com.normation.BoxMatchers
 import com.normation.BoxSpecMatcher
 import com.normation.GitVersion.Revision
 import com.normation.cfclerk.domain.TechniqueResourceId
@@ -231,7 +232,7 @@ final private case class RegexFileContent(regex: List[String]) extends LinesCont
   override def name(f: File): String = FileLinesContent.name(f)
 }
 
-trait TechniquesTest extends Specification with Loggable with BoxSpecMatcher with ContentMatchers with AfterAll {
+trait TechniquesTest extends Specification with Loggable with BoxSpecMatcher with ContentMatchers with AfterAll with BoxMatchers {
 
   val testSystemData = new TestSystemData()
   import testSystemData.*
@@ -332,7 +333,7 @@ class WriteSystemTechniquesTest extends TechniquesTest {
 
     "correctly write the expected policies files with default installation" in {
       val (rootPath, writer) = getPromiseWriter("root-default-install")
-      (writeNodeConfigWithUserDirectives(writer) mustFull) and
+      (writeNodeConfigWithUserDirectives(writer) must beFull) and
       compareWith(rootPath, "root-default-install")
     }
 
@@ -374,13 +375,13 @@ class WriteSystemTechniquesTest extends TechniquesTest {
       inventory.mkdirs()
       addCrap(inventory.getAbsolutePath + "/test-inventory.pl")
 
-      (writeNodeConfigWithUserDirectives(writer) mustFull) and
+      (writeNodeConfigWithUserDirectives(writer) must beFull) and
       compareWith(rootPath, "root-default-install")
     }
 
     "correctly write the expected policies files when 2 directives configured" in {
       val (rootPath, writer) = getPromiseWriter("root-with-two-directives")
-      (writeNodeConfigWithUserDirectives(writer, clock, rpm) mustFull) and
+      (writeNodeConfigWithUserDirectives(writer, clock, rpm) must beFull) and
       compareWith(
         rootPath,
         "root-with-two-directives",
@@ -392,7 +393,7 @@ class WriteSystemTechniquesTest extends TechniquesTest {
 
     "correctly write the expected policies files with a multi-policy configured, skipping fileTemplate3 from bundle order" in {
       val (rootPath, writer) = getPromiseWriter("root-with-one-multipolicy")
-      (writeNodeConfigWithUserDirectives(writer, fileTemplate1, fileTemplate2, fileTemplate3) mustFull) and
+      (writeNodeConfigWithUserDirectives(writer, fileTemplate1, fileTemplate2, fileTemplate3) must beFull) and
       compareWith(
         rootPath,
         "root-with-one-multipolicy",
@@ -504,7 +505,7 @@ class WriteSystemTechniquesTest extends TechniquesTest {
         parallelism
       )
 
-      (written mustFull) and
+      (written must beFull) and
       compareWith(
         rootPath.getParentFile / cfeNode.id.value,
         "node-cfe-with-two-directives",
@@ -543,7 +544,7 @@ class WriteSystemTechniquesTest extends TechniquesTest {
         parallelism
       )
 
-      (written mustFull) and
+      (written must beFull) and
       compareWith(rootPath.getParentFile / cfeNode.id.value, "node-gen-var-def-override", Nil)
     }
   }
@@ -596,7 +597,7 @@ class WriteSystemTechniques500Test extends TechniquesTest {
         parallelism
       )
 
-      (written mustFull) and
+      (written must beFull) and
       compareWith(rootPath.getParentFile / root.id.value, "root-sys-var-false", Nil)
     }
   }
@@ -637,7 +638,7 @@ class WriteSystemTechniques500Test extends TechniquesTest {
         parallelism
       )
 
-      (written mustFull) and
+      (written must beFull) and
       compareWith(rootPath.getParentFile / cfeNode.id.value, "node-cfe-with-500-directives", Nil)
     }
   }
@@ -742,7 +743,7 @@ class WriteSystemTechniqueWithRevisionTest extends TechniquesTest {
       // specify technique revision to use in policy
       val revisedClock       = changeRev(clock, Revision(initCommit))
       (initCommit must be_!==(head)) and
-      (writeNodeConfigWithUserDirectives(writer, revisedClock) mustFull) and
+      (writeNodeConfigWithUserDirectives(writer, revisedClock) must beFull) and
       compareWith(
         rootPath,
         "technique-and-revisions",

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
@@ -203,7 +203,7 @@ class TestNodeFactQueryProcessor {
       Nil
     )
 
-    testQueries(q0 :: q1 :: q2 :: Nil, false)
+    testQueries(q0 :: q1 :: q2 :: Nil, doInternalQueryTest = false)
   }
 
   @Test def basicQueriesOnOneNodeParameter(): Unit = {
@@ -257,7 +257,7 @@ class TestNodeFactQueryProcessor {
       q2_2.awaited
     )
 
-    testQueries(q2_0 :: q2_0_ :: q2_1 :: q2_1_ :: q2_2 :: q2_2_ :: Nil, true)
+    testQueries(q2_0 :: q2_0_ :: q2_1 :: q2_1_ :: q2_2 :: q2_2_ :: Nil, doInternalQueryTest = true)
   }
 
   // group of group, with or/and composition
@@ -375,7 +375,7 @@ class TestNodeFactQueryProcessor {
       s(1) :: Nil
     )
 
-    testQueries(q1 :: q2 :: q3 :: q4 :: q5 :: q6 :: q7 :: q8 :: q9 :: q10 :: Nil, false)
+    testQueries(q1 :: q2 :: q3 :: q4 :: q5 :: q6 :: q7 :: q8 :: q9 :: q10 :: Nil, doInternalQueryTest = false)
   }
 
   // group of group, with or/and composition
@@ -434,7 +434,7 @@ class TestNodeFactQueryProcessor {
       s(2) :: Nil
     )
 
-    testQueries(q1 :: q2 :: q3 :: q4 :: q5 :: Nil, true)
+    testQueries(q1 :: q2 :: q3 :: q4 :: q5 :: Nil, doInternalQueryTest = true)
   }
 
   @Test def machineComponentQueries(): Unit = {
@@ -448,7 +448,7 @@ class TestNodeFactQueryProcessor {
       s(6) :: s(7) :: Nil
     )
 
-    testQueries(q3 :: Nil, true)
+    testQueries(q3 :: Nil, doInternalQueryTest = true)
   }
 
   @Test def softwareQueries(): Unit = {
@@ -473,7 +473,7 @@ class TestNodeFactQueryProcessor {
       s(2) :: Nil
     )
 
-    testQueries(q1 :: q2 :: Nil, true)
+    testQueries(q1 :: q2 :: Nil, doInternalQueryTest = true)
   }
 
   @Test def logicalElementQueries(): Unit = {
@@ -518,7 +518,7 @@ class TestNodeFactQueryProcessor {
       s(2) :: Nil
     )
 
-    testQueries(q1 :: q2 :: q3 :: q3bis :: Nil, true)
+    testQueries(q1 :: q2 :: q3 :: q3bis :: Nil, doInternalQueryTest = true)
   }
 
   @Test def networkInterfaceElementQueries(): Unit = {
@@ -543,7 +543,7 @@ class TestNodeFactQueryProcessor {
       s(1) :: s(2) :: s(3) :: Nil
     )
 
-    testQueries(q1 :: q2 :: Nil, true)
+    testQueries(q1 :: q2 :: Nil, doInternalQueryTest = true)
   }
 
   @Test def regexQueries(): Unit = {
@@ -727,7 +727,10 @@ class TestNodeFactQueryProcessor {
       s.filterNot(n => n == s(1))
     )
 
-    testQueries(q0 :: q1 :: q1_ :: q2 :: q2_ :: q3 :: q3_2 :: q4 :: q5 :: q6 :: q7 :: q8 :: q9 :: q10 :: q11 :: Nil, false)
+    testQueries(
+      q0 :: q1 :: q1_ :: q2 :: q2_ :: q3 :: q3_2 :: q4 :: q5 :: q6 :: q7 :: q8 :: q9 :: q10 :: q11 :: Nil,
+      doInternalQueryTest = false
+    )
   }
 
   @Test def regexQueriesInventories(): Unit = {
@@ -842,7 +845,7 @@ class TestNodeFactQueryProcessor {
     //      """).openOrThrowException("For tests"),
     //      s.filterNot(n => n == s(2)) )
 
-    testQueries(q0 :: q2 :: q2_ :: q5 :: q8 :: q9 :: q10 :: q11 :: Nil, true)
+    testQueries(q0 :: q2 :: q2_ :: q5 :: q8 :: q9 :: q10 :: q11 :: Nil, doInternalQueryTest = true)
   }
 
   @Test def invertQueries(): Unit = {
@@ -904,7 +907,7 @@ class TestNodeFactQueryProcessor {
       sr
     )
 
-    testQueries(q0 :: q1 :: q2 :: q3 :: q4 :: Nil, true)
+    testQueries(q0 :: q1 :: q2 :: q3 :: q4 :: Nil, doInternalQueryTest = true)
   }
 
   @Test def dateQueries(): Unit = {
@@ -941,7 +944,7 @@ class TestNodeFactQueryProcessor {
       :: q("q13", "notEq", 14, root +: s)
       :: q("q14", "notEq", 16, root +: s)
       :: Nil,
-      true
+      doInternalQueryTest = true
     )
   }
 
@@ -967,7 +970,7 @@ class TestNodeFactQueryProcessor {
       sr
     )
 
-    testQueries(q0 :: q1 :: Nil, false)
+    testQueries(q0 :: q1 :: Nil, doInternalQueryTest = false)
   }
 
   @Test def agentTypeQueries: Unit = {
@@ -1022,7 +1025,7 @@ class TestNodeFactQueryProcessor {
       sr(6) :: Nil
     )
 
-    testQueries(allCfengine :: community :: nova :: dsc :: notCfengine :: Nil, true)
+    testQueries(allCfengine :: community :: nova :: dsc :: notCfengine :: Nil, doInternalQueryTest = true)
   }
 
   /**
@@ -1050,7 +1053,7 @@ class TestNodeFactQueryProcessor {
       s(1) :: Nil
     )
 
-    testQueries(q1 :: q2 :: Nil, true)
+    testQueries(q1 :: q2 :: Nil, doInternalQueryTest = true)
   }
 
   /**
@@ -1078,7 +1081,7 @@ class TestNodeFactQueryProcessor {
       s(2) :: s(3) :: Nil
     )
 
-    testQueries(q1 :: q2 :: Nil, true)
+    testQueries(q1 :: q2 :: Nil, doInternalQueryTest = true)
   }
 
   @Test def nodeStateQueries(): Unit = {
@@ -1103,7 +1106,7 @@ class TestNodeFactQueryProcessor {
       s(0) :: s(1) :: s(2) :: s(3) :: s(4) :: s(5) :: s(6) :: Nil
     )
 
-    testQueries(q1 :: q2 :: Nil, true)
+    testQueries(q1 :: q2 :: Nil, doInternalQueryTest = true)
   }
 
   @Test def nodeProperties(): Unit = {
@@ -1195,7 +1198,7 @@ class TestNodeFactQueryProcessor {
     val andQueries = q1 :: q2 :: q3 :: q4 :: q5 :: q6 :: q7 :: q8 :: Nil
     // And and Or must yield same results when there is only one criteria for node prop, see: #19538
     val orQueries  = andQueries.map(_.modify(_.query.composition).setTo(Or))
-    testQueries(andQueries ::: orQueries, false)
+    testQueries(andQueries ::: orQueries, doInternalQueryTest = false)
   }
 
   /*
@@ -1258,7 +1261,7 @@ class TestNodeFactQueryProcessor {
       s(5) :: s(6) :: Nil
     )
 
-    testQueries(q1 :: q2 :: q3 :: q4 :: q5 :: Nil, true)
+    testQueries(q1 :: q2 :: q3 :: q4 :: q5 :: Nil, doInternalQueryTest = true)
   }
 
   @Test def testLdapAndNodeInfoQuery(): Unit = {
@@ -1293,7 +1296,7 @@ class TestNodeFactQueryProcessor {
       Nil
     )
 
-    testQueries(q1 :: q2 :: q3 :: Nil, false)
+    testQueries(q1 :: q2 :: q3 :: Nil, doInternalQueryTest = false)
   }
 
   @Test def nodePropertiesFailingReq(): Unit = {
@@ -1331,7 +1334,7 @@ class TestNodeFactQueryProcessor {
       Nil
     )
 
-    testQueries(q1 :: Nil, true)
+    testQueries(q1 :: Nil, doInternalQueryTest = true)
   }
 
   private def testQueries(queries: Seq[TestQuery], doInternalQueryTest: Boolean): Unit = {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestPendingNodePolicies.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestPendingNodePolicies.scala
@@ -131,7 +131,7 @@ class TestPendingNodePolicies extends Specification {
   val dummyQuery1: Query = Query(null, Or, Identity, List(cl))  // will return 1 node
 
   def ng(id: String, q: Query, dyn: Boolean = true): NodeGroup =
-    NodeGroup(NodeGroupId(NodeGroupUid(id)), id, id, Nil, Some(q), dyn, Set(), true, false)
+    NodeGroup(NodeGroupId(NodeGroupUid(id)), id, id, Nil, Some(q), dyn, Set(), _isEnabled = true, isSystem = false)
 
   // groups
   val c: NodeGroup = ng("c", dummyQuery1) // ok
@@ -140,8 +140,8 @@ class TestPendingNodePolicies extends Specification {
 
   val d: NodeGroup = ng("d", dummyQuery1) // ok
 
-  val f: NodeGroup = ng("f", dummyQuery1, false) // no
-  val e: NodeGroup = ng("e", andQuery(f))        // no
+  val f: NodeGroup = ng("f", dummyQuery1, dyn = false) // no
+  val e: NodeGroup = ng("e", andQuery(f))              // no
 
   val h: NodeGroup = ng("h", dummyQuery0) // no
   val g: NodeGroup = ng("g", andQuery(h)) // no even if remaning query returns node

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ComplianceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ComplianceTest.scala
@@ -135,14 +135,15 @@ class ComplianceTest extends Specification {
       case Nil | _ :: Nil | _ :: _ :: Nil =>
         Failure(s"The file ${filename} is empty or contains only headers")
       case h :: lines                     =>
-        val fileHeaders = h.split("""\|""").map(_.trim.toLowerCase)
+        val fileHeaders: Array[String] = h.split("""\|""").map(_.trim.toLowerCase)
         val headerPairs = headers.map(_.trim.toLowerCase).zip(fileHeaders)
 
         if (fileHeaders.size == headers.size && headerPairs.forall { case (h1, h2) => h1 == h2 }) {
+          def splitLine(line: String): Array[String] =
+            line.split("""\|""").map(l => if (l.endsWith("+")) l.substring(0, l.size - 2).trim else l.trim)
+
           val cleaned = lines
-            .map(
-              _.split("""\|""").map(l => if (l.endsWith("+")) l.substring(0, l.size - 2).trim else l.trim)
-            )
+            .map(splitLine)
             .filter(_.size == headers.size)
 
           // merged line which need to be

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -124,9 +124,9 @@ class ExecutionBatchTest extends Specification {
             case (directiveId, components) =>
               DirectiveExpectedReports(
                 directiveId,
-                None,
-                false,
-                components
+                policyMode = None,
+                isSystem = false,
+                components = components
                   .map(componentName =>
                     ValueExpectedReport(componentName, ExpectedValueMatch(componentName, componentName) :: Nil)
                   )
@@ -391,8 +391,8 @@ class ExecutionBatchTest extends Specification {
         DirectiveExpectedReports(
           "policy",
           None,
-          false,
-          List(
+          isSystem = false,
+          components = List(
             new ValueExpectedReport("component", ExpectedValueMatch("value", "value") :: Nil)
           )
         )
@@ -1382,7 +1382,7 @@ class ExecutionBatchTest extends Specification {
       None
     )
     val directiveExpectedReports =
-      DirectiveExpectedReports(DirectiveId(DirectiveUid("policy")), None, false, expectedComponent :: Nil)
+      DirectiveExpectedReports(DirectiveId(DirectiveUid("policy")), None, isSystem = false, components = expectedComponent :: Nil)
     val ruleExpectedReports      = RuleExpectedReports(RuleId("cr"), directiveExpectedReports :: Nil)
     val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now())
 
@@ -1553,8 +1553,14 @@ class ExecutionBatchTest extends Specification {
       ) :: Nil,
       None
     )
-    val directiveExpectedReports =
-      DirectiveExpectedReports(DirectiveId(DirectiveUid("policy")), None, false, expectedComponent :: Nil)
+    val directiveExpectedReports = {
+      DirectiveExpectedReports(
+        DirectiveId(DirectiveUid("policy")),
+        policyMode = None,
+        isSystem = false,
+        components = expectedComponent :: Nil
+      )
+    }
     val ruleExpectedReports      = RuleExpectedReports(RuleId("cr"), directiveExpectedReports :: Nil)
     val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now())
 
@@ -1692,8 +1698,14 @@ class ExecutionBatchTest extends Specification {
       ) :: Nil,
       None
     )
-    val directiveExpectedReports =
-      DirectiveExpectedReports(DirectiveId(DirectiveUid("policy")), None, false, expectedComponent :: Nil)
+    val directiveExpectedReports = {
+      DirectiveExpectedReports(
+        DirectiveId(DirectiveUid("policy")),
+        policyMode = None,
+        isSystem = false,
+        components = expectedComponent :: Nil
+      )
+    }
     val ruleExpectedReports      = RuleExpectedReports(RuleId("cr"), directiveExpectedReports :: Nil)
     val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now())
 
@@ -1904,7 +1916,7 @@ class ExecutionBatchTest extends Specification {
       None
     )
     val directiveExpectedReports =
-      DirectiveExpectedReports(DirectiveId(DirectiveUid("policy")), None, false, expectedComponent :: Nil)
+      DirectiveExpectedReports(DirectiveId(DirectiveUid("policy")), None, isSystem = false, components = expectedComponent :: Nil)
     val ruleExpectedReports      = RuleExpectedReports(RuleId("cr"), directiveExpectedReports :: Nil)
     val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now())
 
@@ -2112,7 +2124,7 @@ class ExecutionBatchTest extends Specification {
       None
     )
     val directiveExpectedReports =
-      DirectiveExpectedReports(DirectiveId(DirectiveUid("policy")), None, false, expectedComponent :: Nil)
+      DirectiveExpectedReports(DirectiveId(DirectiveUid("policy")), None, isSystem = false, components = expectedComponent :: Nil)
     val ruleExpectedReports      = RuleExpectedReports(RuleId("cr"), directiveExpectedReports :: Nil)
     val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now())
 
@@ -2775,17 +2787,17 @@ class ExecutionBatchTest extends Specification {
     val d1 = DirectiveExpectedReports(
       "d1",
       None,
-      false,
-      List(
+      isSystem = false,
+      components = List(
         ValueExpectedReport("Package", List(ExpectedValueMatch("vim", "vim"))),
         ValueExpectedReport("Post-modification script", List(ExpectedValueMatch("vim", "vim")))
       )
     )
     val d2 = DirectiveExpectedReports(
-      "d2",
-      None,
-      false,
-      List(
+      directiveId = "d2",
+      policyMode = None,
+      isSystem = false,
+      components = List(
         BlockExpectedReport(
           "block1",
           ReportingLogic.WeightedReport,
@@ -3364,10 +3376,10 @@ class ExecutionBatchTest extends Specification {
         12,
         List(
           DirectiveExpectedReports(
-            "policy",
-            None,
-            false,
-            List(
+            directiveId = "policy",
+            policyMode = None,
+            isSystem = false,
+            components = List(
               new ValueExpectedReport("component", ExpectedValueMatch("value", "value") :: Nil)
             ) // here, we automatically must have "value" infered as unexpanded var
           )
@@ -3415,10 +3427,10 @@ class ExecutionBatchTest extends Specification {
         12,
         List(
           DirectiveExpectedReports(
-            "policy",
-            None,
-            false,
-            List(new ValueExpectedReport("component", ExpectedValueMatch("value", "value") :: Nil))
+            directiveId = "policy",
+            policyMode = None,
+            isSystem = false,
+            components = List(new ValueExpectedReport("component", ExpectedValueMatch("value", "value") :: Nil))
           )
         )
       ),
@@ -3458,10 +3470,10 @@ class ExecutionBatchTest extends Specification {
         12,
         List(
           DirectiveExpectedReports(
-            "policy",
-            None,
-            false,
-            List(new ValueExpectedReport("component", ExpectedValueMatch("value", "value") :: Nil))
+            directiveId = "policy",
+            policyMode = None,
+            isSystem = false,
+            components = List(new ValueExpectedReport("component", ExpectedValueMatch("value", "value") :: Nil))
           )
         )
       ),
@@ -3511,10 +3523,10 @@ class ExecutionBatchTest extends Specification {
         12,
         List(
           DirectiveExpectedReports(
-            "policy",
-            None,
-            false,
-            List(new ValueExpectedReport("component", ExpectedValueMatch("value", "value") :: Nil))
+            directiveId = "policy",
+            policyMode = None,
+            isSystem = false,
+            components = List(new ValueExpectedReport("component", ExpectedValueMatch("value", "value") :: Nil))
           )
         )
       ),
@@ -3551,10 +3563,10 @@ class ExecutionBatchTest extends Specification {
         12,
         List(
           DirectiveExpectedReports(
-            "policy",
-            None,
-            false,
-            List(new ValueExpectedReport("component", ExpectedValueMatch("value", "value") :: Nil))
+            directiveId = "policy",
+            policyMode = None,
+            isSystem = false,
+            components = List(new ValueExpectedReport("component", ExpectedValueMatch("value", "value") :: Nil))
           )
         )
       ),
@@ -3601,19 +3613,19 @@ class ExecutionBatchTest extends Specification {
         12,
         List(
           DirectiveExpectedReports(
-            "policy",
-            None,
-            false,
-            List(
+            directiveId = "policy",
+            policyMode = None,
+            isSystem = false,
+            components = List(
               new ValueExpectedReport("component", ExpectedValueMatch("value", "value") :: Nil),
               new ValueExpectedReport("component2", ExpectedValueMatch("value", "value") :: Nil)
             )
           ),
           DirectiveExpectedReports(
-            "policy2",
-            None,
-            false,
-            List(
+            directiveId = "policy2",
+            policyMode = None,
+            isSystem = false,
+            components = List(
               new ValueExpectedReport("component", ExpectedValueMatch("value", "value") :: Nil),
               new ValueExpectedReport("component2", ExpectedValueMatch("value", "value") :: Nil)
             )
@@ -3722,19 +3734,19 @@ class ExecutionBatchTest extends Specification {
         12,
         List(
           DirectiveExpectedReports(
-            "policy",
-            None,
-            false,
-            List(
+            directiveId = "policy",
+            policyMode = None,
+            isSystem = false,
+            components = List(
               new ValueExpectedReport("component", ExpectedValueMatch("value", "value") :: Nil),
               new ValueExpectedReport("component2", ExpectedValueMatch("value", "value") :: Nil)
             )
           ),
           DirectiveExpectedReports(
-            "policy2",
-            None,
-            false,
-            List(
+            directiveId = "policy2",
+            policyMode = None,
+            isSystem = false,
+            components = List(
               new ValueExpectedReport("component", ExpectedValueMatch("value", "value") :: Nil),
               new ValueExpectedReport("component2", ExpectedValueMatch("value", "value") :: Nil)
             )
@@ -3875,10 +3887,10 @@ class ExecutionBatchTest extends Specification {
         12,
         List(
           DirectiveExpectedReports(
-            "policy",
-            None,
-            false,
-            List(
+            directiveId = "policy",
+            policyMode = None,
+            isSystem = false,
+            components = List(
               new ValueExpectedReport(
                 "component",
                 List(
@@ -4013,10 +4025,10 @@ class ExecutionBatchTest extends Specification {
         12,
         List(
           DirectiveExpectedReports(
-            "policy",
-            None,
-            false,
-            List(
+            directiveId = "policy",
+            policyMode = None,
+            isSystem = false,
+            components = List(
               ValueExpectedReport("component", ExpectedValueMatch(("""some\"text"""), ("""some\text""")) :: Nil)
             )
           )
@@ -4058,10 +4070,10 @@ class ExecutionBatchTest extends Specification {
         12,
         List(
           DirectiveExpectedReports(
-            "policy",
-            None,
-            false,
-            List(
+            directiveId = "policy",
+            policyMode = None,
+            isSystem = false,
+            components = List(
               ValueExpectedReport(
                 "component",
                 ExpectedValueMatch("""${sys.workdir}/inputs/\"test""", """${sys.workdir}/inputs/\"test""") :: Nil
@@ -4105,10 +4117,10 @@ class ExecutionBatchTest extends Specification {
         12,
         List(
           DirectiveExpectedReports(
-            "policy",
-            None,
-            false,
-            List(
+            directiveId = "policy",
+            policyMode = None,
+            isSystem = false,
+            components = List(
               ValueExpectedReport(
                 "component",
                 ExpectedValueMatch("""${sys.workdir}/inputs/"test""", """${sys.workdir}/inputs/"test""") :: Nil

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
@@ -434,7 +434,7 @@ class GenericConfigService(
    * Parsing can't fail: in case of bad data in base, we still want to return a correct
    * value (not sure why ? At least, we could save back the value in base ?)
    */
-  private[this] def get[T](name: String)(implicit converter: RudderWebProperty => T): IOResult[T] = {
+  private def get[T](name: String)(implicit converter: RudderWebProperty => T): IOResult[T] = {
     for {
       params   <- repos.getConfigParameters()
       needSave <- Ref.make(false)
@@ -452,42 +452,42 @@ class GenericConfigService(
     } yield value
   }
 
-  private[this] def getIO[T](name: String)(implicit converter: RudderWebProperty => IOResult[T]): IOResult[T] = {
+  private def getIO[T](name: String)(implicit converter: RudderWebProperty => IOResult[T]): IOResult[T] = {
     get[IOResult[T]](name).flatten
   }
 
-  private[this] def save[T](name: String, value: T, modifyGlobalPropertyInfo: Option[ModifyGlobalPropertyInfo] = None)(implicit
+  private def save[T](name: String, value: T, modifyGlobalPropertyInfo: Option[ModifyGlobalPropertyInfo] = None)(implicit
       ser: T => String
   ): IOResult[RudderWebProperty] = {
     val p = RudderWebProperty(RudderWebPropertyName(name), ser(value), "")
     repos.saveConfigParameter(p, modifyGlobalPropertyInfo)
   }
 
-  implicit private[this] def serInt(x:           Int):           String = x.toString
-  implicit private[this] def serPolicyMode(x:    PolicyMode):    String = x.name
-  implicit private[this] def serFeatureSwitch(x: FeatureSwitch): String = x.name
+  implicit private def serInt(x:           Int):           String = x.toString
+  implicit private def serPolicyMode(x:    PolicyMode):    String = x.name
+  implicit private def serFeatureSwitch(x: FeatureSwitch): String = x.name
 
-  implicit private[this] def toBoolean(p: RudderWebProperty): Boolean = p.value.toLowerCase match {
+  implicit private def toBoolean(p: RudderWebProperty): Boolean = p.value.toLowerCase match {
     case "true" | "1" => true
     case _            => false
   }
-  implicit private[this] def serBoolean(x: Boolean): String = if (x) "true" else "false"
+  implicit private def serBoolean(x: Boolean): String = if (x) "true" else "false"
 
   // default is HTTPS, in particular for ""
-  implicit private[this] def toReportProtocol(p: RudderWebProperty): AgentReportingProtocol = p.value match {
+  implicit private def toReportProtocol(p: RudderWebProperty): AgentReportingProtocol = p.value match {
     case _ => AgentReportingHTTPS
   }
 
-  implicit private[this] def toOptionPolicyMode(p: RudderWebProperty): Option[PolicyMode] = {
+  implicit private def toOptionPolicyMode(p: RudderWebProperty): Option[PolicyMode] = {
     PolicyMode.values.find(_.name == p.value.toLowerCase())
   }
 
-  implicit private[this] def serOptionPolicyMode(x: Option[PolicyMode]): String = x match {
+  implicit private def serOptionPolicyMode(x: Option[PolicyMode]): String = x match {
     case None    => "default"
     case Some(p) => p.name
   }
 
-  implicit private[this] def toOptionSendMetrics(p: RudderWebProperty): Option[SendMetrics] = {
+  implicit private def toOptionSendMetrics(p: RudderWebProperty): Option[SendMetrics] = {
     p.value.toLowerCase match {
       case "true" | "1" | "complete" => Some(SendMetrics.CompleteMetrics)
       case "minimal"                 => Some(SendMetrics.MinimalMetrics)
@@ -496,30 +496,30 @@ class GenericConfigService(
     }
   }
 
-  implicit private[this] def serSendMetrics(x: Option[SendMetrics]): String = x match {
+  implicit private def serSendMetrics(x: Option[SendMetrics]): String = x match {
     case None                              => "default"
     case Some(SendMetrics.NoMetrics)       => "no"
     case Some(SendMetrics.MinimalMetrics)  => "minimal"
     case Some(SendMetrics.CompleteMetrics) => "complete"
   }
 
-  implicit private[this] def toNodeState(p: RudderWebProperty): NodeState = {
+  implicit private def toNodeState(p: RudderWebProperty): NodeState = {
     NodeState.parse(p.value).getOrElse(NodeState.Enabled) // default value is "enabled"
   }
 
-  implicit private[this] def serState(x: NodeState): String = x.name
+  implicit private def serState(x: NodeState): String = x.name
 
-  implicit private[this] def toRelaySynchronisationMethod(p: RudderWebProperty): RelaySynchronizationMethod = p.value match {
+  implicit private def toRelaySynchronisationMethod(p: RudderWebProperty): RelaySynchronizationMethod = p.value match {
     case Rsync.value    => Rsync
     case Disabled.value => Disabled
     case _              => Classic // default is classic
   }
 
-  implicit private[this] def toString(p: RudderWebProperty): String = p.value
+  implicit private def toString(p: RudderWebProperty): String = p.value
 
-  implicit private[this] def toUnit(p: IOResult[RudderWebProperty]): IOResult[Unit] = p.map(_ => ())
+  implicit private def toUnit(p: IOResult[RudderWebProperty]): IOResult[Unit] = p.map(_ => ())
 
-  implicit private[this] def toInt(p: RudderWebProperty): IOResult[Int] = {
+  implicit private def toInt(p: RudderWebProperty): IOResult[Int] = {
     try {
       Integer.parseInt(p).succeed
     } catch {
@@ -527,7 +527,7 @@ class GenericConfigService(
     }
   }
 
-  implicit private[this] def toDuration(p: RudderWebProperty): IOResult[Duration] = {
+  implicit private def toDuration(p: RudderWebProperty): IOResult[Duration] = {
     try {
       Duration(p).succeed
     } catch {
@@ -535,11 +535,11 @@ class GenericConfigService(
     }
   }
 
-  implicit private[this] def toPolicyGenerationTrigger(p: RudderWebProperty): IOResult[PolicyGenerationTrigger] = {
+  implicit private def toPolicyGenerationTrigger(p: RudderWebProperty): IOResult[PolicyGenerationTrigger] = {
     PolicyGenerationTrigger(p).toIO
   }
 
-  implicit private[this] def serPolicyGenerationTrigger(x: PolicyGenerationTrigger): String = {
+  implicit private def serPolicyGenerationTrigger(x: PolicyGenerationTrigger): String = {
     x match {
       case PolicyGenerationTrigger.AllGeneration        => "all"
       case PolicyGenerationTrigger.NoGeneration         => "none"
@@ -550,7 +550,7 @@ class GenericConfigService(
   /**
    * A feature switch is defaulted to Disabled is parsing fails.
    */
-  implicit private[this] def toFeatureSwitch(p: RudderWebProperty): FeatureSwitch = FeatureSwitch.parse(p.value) match {
+  implicit private def toFeatureSwitch(p: RudderWebProperty): FeatureSwitch = FeatureSwitch.parse(p.value) match {
     case Full(status) => status
     case eb: EmptyBox =>
       val e = eb ?~! s"Error when trying to parse property '${p.name.value}' with value '${p.value}' into a feature switch status"

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/Authorizations.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/Authorizations.scala
@@ -86,9 +86,9 @@ object ActionType {
   // we restrict the set of action types to only these three one to avoid future problem with named custom role
   sealed trait VALUE extends EnumEntry   { def name: String }
   object VALUE       extends Enum[VALUE] {
-    final case object READ  extends VALUE { val name = "read"  }
-    final case object WRITE extends VALUE { val name = "write" }
-    final case object EDIT  extends VALUE { val name = "edit"  }
+    case object READ  extends VALUE { val name = "read"  }
+    case object WRITE extends VALUE { val name = "write" }
+    case object EDIT  extends VALUE { val name = "edit"  }
 
     val values: IndexedSeq[VALUE] = findValues
     val all:    Set[VALUE]        = values.toSet
@@ -117,87 +117,87 @@ object AuthorizationType {
   case object AnyRights extends AuthorizationType { val authzKind = "any"; val action = "rights" }
 
   // UIs and action related to Rudder app management (settings menu, etc)
-  final case object Administration extends Enum[Administration] {
-    final case object Read  extends Administration with ActionType.Read with AuthorizationType
-    final case object Edit  extends Administration with ActionType.Edit with AuthorizationType
-    final case object Write extends Administration with ActionType.Write with AuthorizationType
+  case object Administration extends Enum[Administration] {
+    case object Read  extends Administration with ActionType.Read with AuthorizationType
+    case object Edit  extends Administration with ActionType.Edit with AuthorizationType
+    case object Write extends Administration with ActionType.Write with AuthorizationType
     val values: IndexedSeq[Administration] = findValues
   }
   //
-  final case object Compliance     extends Enum[Compliance]     {
-    final case object Read  extends Compliance with ActionType.Read with AuthorizationType
-    final case object Edit  extends Compliance with ActionType.Edit with AuthorizationType
-    final case object Write extends Compliance with ActionType.Write with AuthorizationType
+  case object Compliance     extends Enum[Compliance]     {
+    case object Read  extends Compliance with ActionType.Read with AuthorizationType
+    case object Edit  extends Compliance with ActionType.Edit with AuthorizationType
+    case object Write extends Compliance with ActionType.Write with AuthorizationType
     val values: IndexedSeq[Compliance] = findValues
   }
   // configure param, techniques, directives, rules, groups
-  final case object Configuration  extends Enum[Configuration]  {
-    final case object Read  extends Configuration with ActionType.Read with AuthorizationType
-    final case object Edit  extends Configuration with ActionType.Edit with AuthorizationType
-    final case object Write extends Configuration with ActionType.Write with AuthorizationType
+  case object Configuration  extends Enum[Configuration]  {
+    case object Read  extends Configuration with ActionType.Read with AuthorizationType
+    case object Edit  extends Configuration with ActionType.Edit with AuthorizationType
+    case object Write extends Configuration with ActionType.Write with AuthorizationType
 
     val values: IndexedSeq[Configuration] = findValues
   }
   // in workflow, ability to merge a change
-  final case object Deployer       extends Enum[Deployer]       {
-    final case object Read  extends Deployer with ActionType.Read with AuthorizationType
-    final case object Edit  extends Deployer with ActionType.Edit with AuthorizationType
-    final case object Write extends Deployer with ActionType.Write with AuthorizationType
+  case object Deployer       extends Enum[Deployer]       {
+    case object Read  extends Deployer with ActionType.Read with AuthorizationType
+    case object Edit  extends Deployer with ActionType.Edit with AuthorizationType
+    case object Write extends Deployer with ActionType.Write with AuthorizationType
     val values: IndexedSeq[Deployer] = findValues
   }
   // in rudder, ability to start/interact with a policy generation
-  final case object Deployment     extends Enum[Deployment]     {
-    final case object Read  extends Deployment with ActionType.Read with AuthorizationType
-    final case object Edit  extends Deployment with ActionType.Edit with AuthorizationType
-    final case object Write extends Deployment with ActionType.Write with AuthorizationType
+  case object Deployment     extends Enum[Deployment]     {
+    case object Read  extends Deployment with ActionType.Read with AuthorizationType
+    case object Edit  extends Deployment with ActionType.Edit with AuthorizationType
+    case object Write extends Deployment with ActionType.Write with AuthorizationType
     val values: IndexedSeq[Deployment] = findValues
   }
-  final case object Directive      extends Enum[Directive]      {
-    final case object Read  extends Directive with ActionType.Read with AuthorizationType
-    final case object Edit  extends Directive with ActionType.Edit with AuthorizationType
-    final case object Write extends Directive with ActionType.Write with AuthorizationType
+  case object Directive      extends Enum[Directive]      {
+    case object Read  extends Directive with ActionType.Read with AuthorizationType
+    case object Edit  extends Directive with ActionType.Edit with AuthorizationType
+    case object Write extends Directive with ActionType.Write with AuthorizationType
     val values: IndexedSeq[Directive] = findValues
   }
-  final case object Group          extends Enum[Group]          {
-    final case object Read  extends Group with ActionType.Read with AuthorizationType
-    final case object Edit  extends Group with ActionType.Edit with AuthorizationType
-    final case object Write extends Group with ActionType.Write with AuthorizationType
+  case object Group          extends Enum[Group]          {
+    case object Read  extends Group with ActionType.Read with AuthorizationType
+    case object Edit  extends Group with ActionType.Edit with AuthorizationType
+    case object Write extends Group with ActionType.Write with AuthorizationType
     val values: IndexedSeq[Group] = findValues
   }
-  final case object Node           extends Enum[Node]           {
-    final case object Read  extends Node with ActionType.Read with AuthorizationType
-    final case object Edit  extends Node with ActionType.Edit with AuthorizationType
-    final case object Write extends Node with ActionType.Write with AuthorizationType
+  case object Node           extends Enum[Node]           {
+    case object Read  extends Node with ActionType.Read with AuthorizationType
+    case object Edit  extends Node with ActionType.Edit with AuthorizationType
+    case object Write extends Node with ActionType.Write with AuthorizationType
     val values: IndexedSeq[Node] = findValues
   }
-  final case object Rule           extends Enum[Rule]           {
-    final case object Read  extends Rule with ActionType.Read with AuthorizationType
-    final case object Edit  extends Rule with ActionType.Edit with AuthorizationType
-    final case object Write extends Rule with ActionType.Write with AuthorizationType
+  case object Rule           extends Enum[Rule]           {
+    case object Read  extends Rule with ActionType.Read with AuthorizationType
+    case object Edit  extends Rule with ActionType.Edit with AuthorizationType
+    case object Write extends Rule with ActionType.Write with AuthorizationType
     val values: IndexedSeq[Rule] = findValues
   }
-  final case object Parameter      extends Enum[Parameter]      {
-    final case object Read  extends Parameter with ActionType.Read with AuthorizationType
-    final case object Edit  extends Parameter with ActionType.Edit with AuthorizationType
-    final case object Write extends Parameter with ActionType.Write with AuthorizationType
+  case object Parameter      extends Enum[Parameter]      {
+    case object Read  extends Parameter with ActionType.Read with AuthorizationType
+    case object Edit  extends Parameter with ActionType.Edit with AuthorizationType
+    case object Write extends Parameter with ActionType.Write with AuthorizationType
     val values: IndexedSeq[Parameter] = findValues
   }
-  final case object Technique      extends Enum[Technique]      {
-    final case object Read  extends Technique with ActionType.Read with AuthorizationType
-    final case object Edit  extends Technique with ActionType.Edit with AuthorizationType
-    final case object Write extends Technique with ActionType.Write with AuthorizationType
+  case object Technique      extends Enum[Technique]      {
+    case object Read  extends Technique with ActionType.Read with AuthorizationType
+    case object Edit  extends Technique with ActionType.Edit with AuthorizationType
+    case object Write extends Technique with ActionType.Write with AuthorizationType
     val values: IndexedSeq[Technique] = findValues
   }
-  final case object UserAccount    extends Enum[UserAccount]    {
-    final case object Read  extends UserAccount with ActionType.Read with AuthorizationType
-    final case object Edit  extends UserAccount with ActionType.Edit with AuthorizationType
-    final case object Write extends UserAccount with ActionType.Write with AuthorizationType
+  case object UserAccount    extends Enum[UserAccount]    {
+    case object Read  extends UserAccount with ActionType.Read with AuthorizationType
+    case object Edit  extends UserAccount with ActionType.Edit with AuthorizationType
+    case object Write extends UserAccount with ActionType.Write with AuthorizationType
     val values: IndexedSeq[UserAccount] = findValues
   }
-  final case object Validator      extends Enum[Validator]      {
-    final case object Read  extends Validator with ActionType.Read with AuthorizationType
-    final case object Edit  extends Validator with ActionType.Edit with AuthorizationType
-    final case object Write extends Validator with ActionType.Write with AuthorizationType
+  case object Validator      extends Enum[Validator]      {
+    case object Read  extends Validator with ActionType.Read with AuthorizationType
+    case object Edit  extends Validator with ActionType.Edit with AuthorizationType
+    case object Write extends Validator with ActionType.Write with AuthorizationType
     val values: IndexedSeq[Validator] = findValues
   }
 
@@ -214,7 +214,7 @@ object AuthorizationType {
    */
   def allKind: Set[AuthorizationType] = allKindsMap
 
-  private[this] var allKindsMap: Set[AuthorizationType] = {
+  private var allKindsMap: Set[AuthorizationType] = {
     Set(
       AnyRights
     ) ++ Administration.values ++ Compliance.values ++ Configuration.values ++ Deployer.values ++ Deployment.values ++
@@ -369,14 +369,14 @@ object Role       extends Enum[Role] {
   }
 
   // a special account, with all rights, present and future, even if declared at runtime.
-  final case object Administrator extends Role {
+  case object Administrator extends Role {
     val name = "administrator";
 
     def rights = Rights.AnyRights
   }
 
   // a special Role that means that a user has no rights at all. That role must super-seed any other right given by other roles
-  final case object NoRights extends Role {
+  case object NoRights extends Role {
     val name = "no_rights";
 
     def rights: Rights = Rights(Set(A.NoRights))

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala
@@ -85,7 +85,7 @@ trait ApiAuthorizationLevelService {
 
 // and default implementation is: no
 class DefaultApiAuthorizationLevel(logger: Log) extends ApiAuthorizationLevelService {
-  private[this] var level:                            Option[ApiAuthorizationLevelService] = None
+  private var level:                                  Option[ApiAuthorizationLevelService] = None
   def overrideLevel(l: ApiAuthorizationLevelService): Unit                                 = {
     logger.info(s"Update API authorization level to '${l.name}'")
     level = Some(l)
@@ -204,9 +204,9 @@ object AuthzForApi {
   def withValues(api: EndpointSchema, values: List[AclPathSegment]): ApiAclElement = {
     def recReplace(api: List[ApiPathSegment], values: List[AclPathSegment]): List[AclPathSegment] = {
       api match {
-        case Nil                             => Nil
-        case ApiPathSegment.Segment(v) :: t  => AclPathSegment.Segment(v) :: recReplace(t, values)
-        case ApiPathSegment.Resource(v) :: t => // if we have a replacement value, use it
+        case Nil                               => Nil
+        case ApiPathSegment.Segment(v) :: t    => AclPathSegment.Segment(v) :: recReplace(t, values)
+        case (_: ApiPathSegment.Resource) :: t => // if we have a replacement value, use it
           values match {
             case Nil     => AclPathSegment.Wildcard :: recReplace(t, Nil)
             case v :: vv => v :: recReplace(t, vv)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -64,61 +64,61 @@ trait SortIndex {
 
 sealed trait CampaignApi extends EnumEntry with EndpointSchema with GeneralApi with SortIndex
 object CampaignApi       extends Enum[CampaignApi] with ApiModuleProvider[CampaignApi] {
-  final case object GetCampaigns              extends CampaignApi with ZeroParam with StartsAtVersion16 with SortIndex {
+  case object GetCampaigns              extends CampaignApi with ZeroParam with StartsAtVersion16 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get all campaigns"
     val (action, path) = GET / "campaigns"
     val dataContainer: Some[String] = Some("campaigns")
   }
-  final case object GetCampaignEvents         extends CampaignApi with ZeroParam with StartsAtVersion16 with SortIndex {
+  case object GetCampaignEvents         extends CampaignApi with ZeroParam with StartsAtVersion16 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get all campaigns events"
     val (action, path) = GET / "campaigns" / "events"
     val dataContainer: Some[String] = Some("campaignEvents")
   }
-  final case object GetCampaignEventDetails   extends CampaignApi with OneParam with StartsAtVersion16 with SortIndex  {
+  case object GetCampaignEventDetails   extends CampaignApi with OneParam with StartsAtVersion16 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get a campaigns events details"
     val (action, path) = GET / "campaigns" / "events" / "{id}"
     val dataContainer: Some[String] = Some("campaignEvents")
   }
-  final case object SaveCampaign              extends CampaignApi with ZeroParam with StartsAtVersion16 with SortIndex {
+  case object SaveCampaign              extends CampaignApi with ZeroParam with StartsAtVersion16 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Save a campaign"
     val (action, path) = POST / "campaigns"
     val dataContainer: Some[String] = Some("campaigns")
   }
-  final case object ScheduleCampaign          extends CampaignApi with OneParam with StartsAtVersion16 with SortIndex  {
+  case object ScheduleCampaign          extends CampaignApi with OneParam with StartsAtVersion16 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Schedule an event for a campaign"
     val (action, path) = POST / "campaigns" / "{id}" / "schedule"
     val dataContainer: Some[String] = Some("campaigns")
   }
-  final case object GetCampaignDetails        extends CampaignApi with OneParam with StartsAtVersion16 with SortIndex  {
+  case object GetCampaignDetails        extends CampaignApi with OneParam with StartsAtVersion16 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get a campaign"
     val (action, path) = GET / "campaigns" / "{id}"
     val dataContainer: Some[String] = Some("campaigns")
   }
-  final case object DeleteCampaign            extends CampaignApi with OneParam with StartsAtVersion16 with SortIndex  {
+  case object DeleteCampaign            extends CampaignApi with OneParam with StartsAtVersion16 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Delete a campaign"
     val (action, path) = DELETE / "campaigns" / "{id}"
     val dataContainer: Option[String] = None
   }
-  final case object GetCampaignEventsForModel extends CampaignApi with OneParam with StartsAtVersion16 with SortIndex  {
+  case object GetCampaignEventsForModel extends CampaignApi with OneParam with StartsAtVersion16 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get events for a campaign"
     val (action, path) = GET / "campaigns" / "{id}" / "events"
     val dataContainer: Some[String] = Some("campaignEvents")
   }
-  final case object SaveCampaignEvent         extends CampaignApi with OneParam with StartsAtVersion16 with SortIndex  {
+  case object SaveCampaignEvent         extends CampaignApi with OneParam with StartsAtVersion16 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Save a campaign event"
     val (action, path) = POST / "campaigns" / "events" / "{id}"
     val dataContainer: Some[String] = Some("campaignEvents")
   }
-  final case object DeleteCampaignEvent       extends CampaignApi with OneParam with StartsAtVersion16 with SortIndex  {
+  case object DeleteCampaignEvent       extends CampaignApi with OneParam with StartsAtVersion16 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Delete a campaign event"
     val (action, path) = DELETE / "campaigns" / "events" / "{id}"
@@ -132,64 +132,59 @@ object CampaignApi       extends Enum[CampaignApi] with ApiModuleProvider[Campai
 sealed trait ComplianceApi extends EnumEntry with EndpointSchema with SortIndex
 object ComplianceApi       extends Enum[ComplianceApi] with ApiModuleProvider[ComplianceApi] {
 
-  final case object GetRulesCompliance extends ComplianceApi with GeneralApi with ZeroParam with StartsAtVersion7 with SortIndex {
+  case object GetRulesCompliance   extends ComplianceApi with GeneralApi with ZeroParam with StartsAtVersion7 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get compliance information for all rules"
     val (action, path) = GET / "compliance" / "rules"
     val dataContainer: Some[String] = Some("rules")
   }
-  final case object GetRulesComplianceId
-      extends ComplianceApi with GeneralApi with OneParam with StartsAtVersion7 with SortIndex {
+  case object GetRulesComplianceId extends ComplianceApi with GeneralApi with OneParam with StartsAtVersion7 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get compliance information for the given rule"
     val (action, path) = GET / "compliance" / "rules" / "{id}"
     val dataContainer: Some[String] = Some("rules")
   }
-  final case object GetNodesCompliance extends ComplianceApi with GeneralApi with ZeroParam with StartsAtVersion7 with SortIndex {
+  case object GetNodesCompliance   extends ComplianceApi with GeneralApi with ZeroParam with StartsAtVersion7 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get compliance information for all nodes"
     val (action, path) = GET / "compliance" / "nodes"
     val dataContainer: Some[String] = Some("nodes")
   }
 
-  final case object GetNodeSystemCompliance
-      extends ComplianceApi with InternalApi with OneParam with StartsAtVersion7 with SortIndex  {
+  case object GetNodeSystemCompliance extends ComplianceApi with InternalApi with OneParam with StartsAtVersion7 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get compliance information for the given node"
     val (action, path) = GET / "compliance" / "nodes" / "{id}" / "system"
     val dataContainer: Some[String] = Some("nodes")
   }
-  final case object GetNodeComplianceId extends ComplianceApi with GeneralApi with OneParam with StartsAtVersion7 with SortIndex {
+  case object GetNodeComplianceId     extends ComplianceApi with GeneralApi with OneParam with StartsAtVersion7 with SortIndex   {
     val z: Int = implicitly[Line].value
     val description    = "Get compliance information for the given node"
     val (action, path) = GET / "compliance" / "nodes" / "{id}"
     val dataContainer: Some[String] = Some("nodes")
   }
-  final case object GetGlobalCompliance
-      extends ComplianceApi with GeneralApi with ZeroParam with StartsAtVersion10 with SortIndex {
+  case object GetGlobalCompliance     extends ComplianceApi with GeneralApi with ZeroParam with StartsAtVersion10 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get the global compliance (alike what one has on Rudder main dashboard)"
     val (action, path) = GET / "compliance"
     val dataContainer: Some[String] = Some("globalCompliance")
   }
 
-  final case object GetDirectiveComplianceId
-      extends ComplianceApi with GeneralApi with OneParam with StartsAtVersion17 with SortIndex {
+  case object GetDirectiveComplianceId extends ComplianceApi with GeneralApi with OneParam with StartsAtVersion17 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get a directive's compliance"
     val (action, path) = GET / "compliance" / "directives" / "{id}"
     val dataContainer: Some[String] = Some("directiveCompliance")
   }
 
-  final case object GetDirectivesCompliance
-      extends ComplianceApi with GeneralApi with ZeroParam with StartsAtVersion17 with SortIndex {
+  case object GetDirectivesCompliance extends ComplianceApi with GeneralApi with ZeroParam with StartsAtVersion17 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get all directive's compliance"
     val (action, path) = GET / "compliance" / "directives"
     val dataContainer: Some[String] = Some("directivesCompliance")
   }
 
-  final case object GetNodeGroupComplianceSummary
+  case object GetNodeGroupComplianceSummary
       extends ComplianceApi with GeneralApi with ZeroParam with StartsAtVersion17 with SortIndex {
     val z              = implicitly[Line].value
     val description    = "Get a node group's compliance summary"
@@ -197,15 +192,14 @@ object ComplianceApi       extends Enum[ComplianceApi] with ApiModuleProvider[Co
     val dataContainer: Some[String] = Some("groupCompliance")
   }
 
-  final case object GetNodeGroupComplianceId
-      extends ComplianceApi with GeneralApi with OneParam with StartsAtVersion17 with SortIndex {
+  case object GetNodeGroupComplianceId extends ComplianceApi with GeneralApi with OneParam with StartsAtVersion17 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get a node group's global compliance"
     val (action, path) = GET / "compliance" / "groups" / "{id}"
     val dataContainer: Some[String] = Some("groupCompliance")
   }
 
-  final case object GetNodeGroupComplianceTargetId
+  case object GetNodeGroupComplianceTargetId
       extends ComplianceApi with GeneralApi with OneParam with StartsAtVersion17 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get a node group's targeted compliance"
@@ -223,43 +217,42 @@ sealed trait GroupApi extends EnumEntry with EndpointSchema with SortIndex    {
 }
 object GroupApi       extends Enum[GroupApi] with ApiModuleProvider[GroupApi] {
   // API v2
-  final case object ListGroups   extends GroupApi with GeneralApi with ZeroParam with StartsAtVersion2 with SortIndex {
+  case object ListGroups               extends GroupApi with GeneralApi with ZeroParam with StartsAtVersion2 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "List all groups with their information"
     val (action, path) = GET / "groups"
   }
-  final case object CreateGroup  extends GroupApi with GeneralApi with ZeroParam with StartsAtVersion2 with SortIndex {
+  case object CreateGroup              extends GroupApi with GeneralApi with ZeroParam with StartsAtVersion2 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Create a new group"
     val (action, path) = PUT / "groups"
   }
-  final case object GetGroupTree extends GroupApi with GeneralApi with ZeroParam with StartsAtVersion6 with SortIndex {
+  case object GetGroupTree             extends GroupApi with GeneralApi with ZeroParam with StartsAtVersion6 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "List all group categories and group in a tree format"
     val (action, path) = GET / "groups" / "tree"
   }
-  final case object GroupDetails extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex  {
+  case object GroupDetails             extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get information about the given group"
     val (action, path) = GET / "groups" / "{id}"
   }
-  final case object DeleteGroup  extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex  {
+  case object DeleteGroup              extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Delete given group"
     val (action, path) = DELETE / "groups" / "{id}"
   }
-  final case object UpdateGroup  extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex  {
+  case object UpdateGroup              extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Update given group"
     val (action, path) = POST / "groups" / "{id}"
   }
-  final case object ReloadGroup  extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex  {
+  case object ReloadGroup              extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Update given dynamic group node list"
     val (action, path) = GET / "groups" / "{id}" / "reload"
   }
-  final case object GroupInheritedProperties
-      extends GroupApi with GeneralApi with OneParam with StartsAtVersion11 with SortIndex {
+  case object GroupInheritedProperties extends GroupApi with GeneralApi with OneParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get all proporeties for that group, included inherited ones"
     val (action, path) = GET / "groups" / "{id}" / "inheritedProperties"
@@ -267,32 +260,32 @@ object GroupApi       extends Enum[GroupApi] with ApiModuleProvider[GroupApi] {
   // API v5 updates 'Create' methods but no new endpoints
   // API v6
 
-  final case object GroupDisplayInheritedProperties
+  case object GroupDisplayInheritedProperties
       extends GroupApi with InternalApi with OneParam with StartsAtVersion13 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    =
       "Get all proporeties for that group, included inherited ones, for displaying in group property tab (internal)"
     val (action, path) = GET / "groups" / "{id}" / "displayInheritedProperties"
   }
-  final case object GetGroupCategoryDetails extends GroupApi with GeneralApi with OneParam with StartsAtVersion6 with SortIndex {
+  case object GetGroupCategoryDetails extends GroupApi with GeneralApi with OneParam with StartsAtVersion6 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get information about the given group category"
     val (action, path) = GET / "groups" / "categories" / "{id}"
     override def dataContainer: Some[String] = Some("groupCategories")
   }
-  final case object DeleteGroupCategory extends GroupApi with GeneralApi with OneParam with StartsAtVersion6 with SortIndex {
+  case object DeleteGroupCategory extends GroupApi with GeneralApi with OneParam with StartsAtVersion6 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Delete given group category"
     val (action, path) = DELETE / "groups" / "categories" / "{id}"
     override def dataContainer: Some[String] = Some("groupCategories")
   }
-  final case object UpdateGroupCategory extends GroupApi with GeneralApi with OneParam with StartsAtVersion6 with SortIndex {
+  case object UpdateGroupCategory extends GroupApi with GeneralApi with OneParam with StartsAtVersion6 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Update information for given group category"
     val (action, path) = POST / "groups" / "categories" / "{id}"
     override def dataContainer: Some[String] = Some("groupCategories")
   }
-  final case object CreateGroupCategory extends GroupApi with GeneralApi with ZeroParam with StartsAtVersion6 with SortIndex {
+  case object CreateGroupCategory extends GroupApi with GeneralApi with ZeroParam with StartsAtVersion6 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Create a new group category"
     val (action, path) = PUT / "groups" / "categories"
@@ -309,42 +302,42 @@ sealed trait DirectiveApi extends EnumEntry with EndpointSchema with GeneralApi 
 }
 object DirectiveApi       extends Enum[DirectiveApi] with ApiModuleProvider[DirectiveApi]      {
 
-  final case object ListDirectives     extends DirectiveApi with ZeroParam with StartsAtVersion2 with SortIndex  {
+  case object ListDirectives     extends DirectiveApi with ZeroParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "List all directives"
     val (action, path) = GET / "directives"
   }
-  final case object DirectiveTree      extends DirectiveApi with ZeroParam with StartsAtVersion14 with SortIndex {
+  case object DirectiveTree      extends DirectiveApi with ZeroParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get Directive tree"
     val (action, path) = GET / "directives" / "tree"
   }
-  final case object DirectiveDetails   extends DirectiveApi with OneParam with StartsAtVersion2 with SortIndex   {
+  case object DirectiveDetails   extends DirectiveApi with OneParam with StartsAtVersion2 with SortIndex   {
     val z: Int = implicitly[Line].value
     val description    = "Get information about given directive"
     val (action, path) = GET / "directives" / "{id}"
   }
-  final case object DirectiveRevisions extends DirectiveApi with OneParam with StartsAtVersion14 with SortIndex  {
+  case object DirectiveRevisions extends DirectiveApi with OneParam with StartsAtVersion14 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get revisions for given directive"
     val (action, path) = GET / "directives" / "{id}" / "revisions"
   }
-  final case object CreateDirective    extends DirectiveApi with ZeroParam with StartsAtVersion2 with SortIndex  {
+  case object CreateDirective    extends DirectiveApi with ZeroParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Create a new directive or clone an existing one"
     val (action, path) = PUT / "directives"
   }
-  final case object DeleteDirective    extends DirectiveApi with OneParam with StartsAtVersion2 with SortIndex   {
+  case object DeleteDirective    extends DirectiveApi with OneParam with StartsAtVersion2 with SortIndex   {
     val z: Int = implicitly[Line].value
     val description    = "Delete given directive"
     val (action, path) = DELETE / "directives" / "{id}"
   }
-  final case object CheckDirective     extends DirectiveApi with OneParam with StartsAtVersion2 with SortIndex   {
+  case object CheckDirective     extends DirectiveApi with OneParam with StartsAtVersion2 with SortIndex   {
     val z: Int = implicitly[Line].value
     val description    = "Check if the given directive can be migrated to target technique version"
     val (action, path) = POST / "directives" / "{id}" / "check"
   }
-  final case object UpdateDirective    extends DirectiveApi with OneParam with StartsAtVersion2 with SortIndex   {
+  case object UpdateDirective    extends DirectiveApi with OneParam with StartsAtVersion2 with SortIndex   {
     val z: Int = implicitly[Line].value
     val description    = "Update given directive information"
     val (action, path) = POST / "directives" / "{id}"
@@ -360,65 +353,65 @@ sealed trait NodeApi extends EnumEntry with EndpointSchema with SortIndex  {
 }
 object NodeApi       extends Enum[NodeApi] with ApiModuleProvider[NodeApi] {
 
-  final case object ListAcceptedNodes  extends NodeApi with GeneralApi with ZeroParam with StartsAtVersion2 with SortIndex  {
+  case object ListAcceptedNodes  extends NodeApi with GeneralApi with ZeroParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "List all accepted nodes with configurable details level"
     val (action, path) = GET / "nodes"
   }
-  final case object GetNodesStatus     extends NodeApi with GeneralApi with ZeroParam with StartsAtVersion13 with SortIndex {
+  case object GetNodesStatus     extends NodeApi with GeneralApi with ZeroParam with StartsAtVersion13 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get the status (pending, accepted, unknown) of the comma separated list of nodes given by `ids` parameter"
     val (action, path) = GET / "nodes" / "status"
   }
-  final case object ListPendingNodes   extends NodeApi with GeneralApi with ZeroParam with StartsAtVersion2 with SortIndex  {
+  case object ListPendingNodes   extends NodeApi with GeneralApi with ZeroParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "List all pending nodes with configurable details level"
     val (action, path) = GET / "nodes" / "pending"
   }
-  final case object PendingNodeDetails extends NodeApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex   {
+  case object PendingNodeDetails extends NodeApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex   {
     val z: Int = implicitly[Line].value
     val description    = "Get information about the given pending node"
     val (action, path) = GET / "nodes" / "pending" / "{id}"
   }
-  final case object NodeDetails        extends NodeApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex   {
+  case object NodeDetails        extends NodeApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex   {
     val z: Int = implicitly[Line].value
     val description    = "Get information about the given accepted node"
     val (action, path) = GET / "nodes" / "{id}"
   }
 
-  final case object NodeInheritedProperties extends NodeApi with GeneralApi with OneParam with StartsAtVersion11 with SortIndex {
+  case object NodeInheritedProperties extends NodeApi with GeneralApi with OneParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get all properties for that node, included inherited ones"
     val (action, path) = GET / "nodes" / "{id}" / "inheritedProperties"
   }
 
-  final case object NodeGlobalScore extends NodeApi with InternalApi with OneParam with StartsAtVersion19 with SortIndex {
+  case object NodeGlobalScore extends NodeApi with InternalApi with OneParam with StartsAtVersion19 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get global score for a Node"
     val (action, path) = GET / "nodes" / "{id}" / "score"
     override def dataContainer: Option[String] = None
   }
 
-  final case object NodeScoreDetails extends NodeApi with InternalApi with OneParam with StartsAtVersion19 with SortIndex {
+  case object NodeScoreDetails extends NodeApi with InternalApi with OneParam with StartsAtVersion19 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get all score details for a Node"
     val (action, path) = GET / "nodes" / "{id}" / "score" / "details"
     override def dataContainer: Option[String] = None
   }
 
-  final case object NodeScoreDetail extends NodeApi with InternalApi with TwoParam with StartsAtVersion19 with SortIndex {
+  case object NodeScoreDetail extends NodeApi with InternalApi with TwoParam with StartsAtVersion19 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get a score details for a Node"
     val (action, path) = GET / "nodes" / "{id}" / "score" / "details" / "{name}"
     override def dataContainer: Some[String] = Some("score")
   }
 
-  final case object ApplyPolicyAllNodes     extends NodeApi with GeneralApi with ZeroParam with StartsAtVersion8 with SortIndex {
+  case object ApplyPolicyAllNodes     extends NodeApi with GeneralApi with ZeroParam with StartsAtVersion8 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Ask all nodes to start a run with the given policy"
     val (action, path) = POST / "nodes" / "applyPolicy"
   }
-  final case object ChangePendingNodeStatus extends NodeApi with GeneralApi with ZeroParam with StartsAtVersion2 with SortIndex {
+  case object ChangePendingNodeStatus extends NodeApi with GeneralApi with ZeroParam with StartsAtVersion2 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Accept or refuse pending nodes"
     val (action, path) = POST / "nodes" / "pending"
@@ -427,49 +420,49 @@ object NodeApi       extends Enum[NodeApi] with ApiModuleProvider[NodeApi] {
   // WARNING: read_only user can access this endpoint
   //    No modifications are performed here
   //    POST over GET is required here because we can provide too many information to be passed as URL parameters
-  final case object NodeDisplayInheritedProperties
+  case object NodeDisplayInheritedProperties
       extends NodeApi with InternalApi with OneParam with StartsAtVersion13 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get all properties for that node, included inherited ones, for displaying in node property tab (internal)"
     val (action, path) = GET / "nodes" / "{id}" / "displayInheritedProperties"
   }
-  final case object NodeDetailsTable extends NodeApi with InternalApi with ZeroParam with StartsAtVersion13 with SortIndex {
+  case object NodeDetailsTable extends NodeApi with InternalApi with ZeroParam with StartsAtVersion13 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Getting data to build a Node table"
     val (action, path) = POST / "nodes" / "details"
   }
-  final case object NodeDetailsSoftware extends NodeApi with InternalApi with OneParam with StartsAtVersion13 with SortIndex {
+  case object NodeDetailsSoftware extends NodeApi with InternalApi with OneParam with StartsAtVersion13 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Getting a software version for a set of Nodes"
     val (action, path) = POST / "nodes" / "details" / "software" / "{software}"
   }
-  final case object NodeDetailsProperty extends NodeApi with InternalApi with OneParam with StartsAtVersion13 with SortIndex {
+  case object NodeDetailsProperty extends NodeApi with InternalApi with OneParam with StartsAtVersion13 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Getting a property value for a set of Nodes"
     val (action, path) = POST / "nodes" / "details" / "property" / "{property}"
   }
-  final case object UpdateNode extends NodeApi with GeneralApi with OneParam with StartsAtVersion5 with SortIndex {
+  case object UpdateNode extends NodeApi with GeneralApi with OneParam with StartsAtVersion5 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Update given node information (node properties, policy mode...)"
     val (action, path) = POST / "nodes" / "{id}"
   }
-  final case object DeleteNode extends NodeApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex {
+  case object DeleteNode extends NodeApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Delete given node"
     val (action, path) = DELETE / "nodes" / "{id}"
   }
-  final case object ChangePendingNodeStatus2 extends NodeApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex {
+  case object ChangePendingNodeStatus2 extends NodeApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex {
     val z: Int = implicitly[Line].value
     override val name  = "ChangePendingNodeStatus"
     val description    = "Accept or refuse given pending node"
     val (action, path) = POST / "nodes" / "pending" / "{id}"
   }
-  final case object ApplyPolicy extends NodeApi with GeneralApi with OneParam with StartsAtVersion8 with SortIndex {
+  case object ApplyPolicy extends NodeApi with GeneralApi with OneParam with StartsAtVersion8 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Ask given node to start a run with the given policy"
     val (action, path) = POST / "nodes" / "{id}" / "applyPolicy"
   }
-  final case object CreateNodes extends NodeApi with GeneralApi with ZeroParam with StartsAtVersion16 with SortIndex {
+  case object CreateNodes extends NodeApi with GeneralApi with ZeroParam with StartsAtVersion16 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Create one of more new nodes"
     val (action, path) = PUT / "nodes"
@@ -484,13 +477,13 @@ sealed trait ChangesApi extends EnumEntry with EndpointSchema with InternalApi w
 }
 object ChangesApi       extends Enum[ChangesApi] with ApiModuleProvider[ChangesApi]           {
 
-  final case object GetRecentChanges extends ChangesApi with ZeroParam with StartsAtVersion14 with SortIndex {
+  case object GetRecentChanges extends ChangesApi with ZeroParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get changes for all Rules over the last 3 days (internal)"
     val (action, path) = GET / "changes"
   }
 
-  final case object GetRuleRepairedReports extends ChangesApi with OneParam with StartsAtVersion14 with SortIndex {
+  case object GetRuleRepairedReports extends ChangesApi with OneParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get all repaired report for a Rule in a interval of time specified as parameter(internal)"
     val (action, path) = GET / "changes" / "{ruleId}"
@@ -505,27 +498,27 @@ sealed trait ParameterApi extends EnumEntry with EndpointSchema with GeneralApi 
 }
 object ParameterApi       extends Enum[ParameterApi] with ApiModuleProvider[ParameterApi]      {
 
-  final case object ListParameters   extends ParameterApi with ZeroParam with StartsAtVersion2 with SortIndex {
+  case object ListParameters   extends ParameterApi with ZeroParam with StartsAtVersion2 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "List all global parameters"
     val (action, path) = GET / "parameters"
   }
-  final case object CreateParameter  extends ParameterApi with ZeroParam with StartsAtVersion2 with SortIndex {
+  case object CreateParameter  extends ParameterApi with ZeroParam with StartsAtVersion2 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Create a new parameter"
     val (action, path) = PUT / "parameters"
   }
-  final case object ParameterDetails extends ParameterApi with OneParam with StartsAtVersion2 with SortIndex  {
+  case object ParameterDetails extends ParameterApi with OneParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get information about the given parameter"
     val (action, path) = GET / "parameters" / "{id}"
   }
-  final case object DeleteParameter  extends ParameterApi with OneParam with StartsAtVersion2 with SortIndex  {
+  case object DeleteParameter  extends ParameterApi with OneParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Delete given parameter"
     val (action, path) = DELETE / "parameters" / "{id}"
   }
-  final case object UpdateParameter  extends ParameterApi with OneParam with StartsAtVersion2 with SortIndex  {
+  case object UpdateParameter  extends ParameterApi with OneParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Update information about given parameter"
     val (action, path) = POST / "parameters" / "{id}"
@@ -540,44 +533,44 @@ sealed trait SettingsApi extends EnumEntry with EndpointSchema with GeneralApi w
   override def dataContainer: Some[String] = Some("settings")
 }
 object SettingsApi       extends Enum[SettingsApi] with ApiModuleProvider[SettingsApi]        {
-  final case object GetAllSettings        extends SettingsApi with ZeroParam with StartsAtVersion6 with SortIndex  {
+  case object GetAllSettings        extends SettingsApi with ZeroParam with StartsAtVersion6 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get information about all Rudder settings"
     val (action, path) = GET / "settings"
   }
-  final case object GetAllAllowedNetworks extends SettingsApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object GetAllAllowedNetworks extends SettingsApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "List all allowed networks"
     val (action, path) = GET / "settings" / "allowed_networks"
   }
-  final case object GetAllowedNetworks    extends SettingsApi with OneParam with StartsAtVersion11 with SortIndex  {
+  case object GetAllowedNetworks    extends SettingsApi with OneParam with StartsAtVersion11 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "List all allowed networks for one relay"
     val (action, path) = GET / "settings" / "allowed_networks" / "{nodeId}"
   }
-  final case object ModifyAllowedNetworks extends SettingsApi with OneParam with StartsAtVersion11 with SortIndex  {
+  case object ModifyAllowedNetworks extends SettingsApi with OneParam with StartsAtVersion11 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Update all allowed networks for one relay"
     val (action, path) = POST / "settings" / "allowed_networks" / "{nodeId}"
   }
 
-  final case object ModifyDiffAllowedNetworks extends SettingsApi with OneParam with StartsAtVersion11 with SortIndex {
+  case object ModifyDiffAllowedNetworks extends SettingsApi with OneParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Modify some allowed networks for one relay with a diff structure"
     val (action, path) = POST / "settings" / "allowed_networks" / "{nodeId}" / "diff"
   }
 
-  final case object GetSetting     extends SettingsApi with OneParam with StartsAtVersion6 with SortIndex  {
+  case object GetSetting     extends SettingsApi with OneParam with StartsAtVersion6 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get information about given Rudder setting"
     val (action, path) = GET / "settings" / "{key}"
   }
-  final case object ModifySettings extends SettingsApi with ZeroParam with StartsAtVersion6 with SortIndex {
+  case object ModifySettings extends SettingsApi with ZeroParam with StartsAtVersion6 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Update Rudder settings"
     val (action, path) = POST / "settings"
   }
-  final case object ModifySetting  extends SettingsApi with OneParam with StartsAtVersion6 with SortIndex  {
+  case object ModifySetting  extends SettingsApi with OneParam with StartsAtVersion6 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Update given Rudder setting"
     val (action, path) = POST / "settings" / "{key}"
@@ -593,12 +586,12 @@ sealed trait PluginApi extends EnumEntry with EndpointSchema with GeneralApi wit
 }
 object PluginApi       extends Enum[PluginApi] with ApiModuleProvider[PluginApi]            {
 
-  final case object GetPluginsSettings    extends PluginApi with ZeroParam with StartsAtVersion14 with SortIndex {
+  case object GetPluginsSettings    extends PluginApi with ZeroParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "List plugin system settings"
     val (action, path) = GET / "plugins" / "settings"
   }
-  final case object UpdatePluginsSettings extends PluginApi with ZeroParam with StartsAtVersion14 with SortIndex {
+  case object UpdatePluginsSettings extends PluginApi with ZeroParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Update plugin system settings"
     val (action, path) = POST / "plugins" / "settings"
@@ -613,75 +606,75 @@ sealed trait TechniqueApi extends EnumEntry with EndpointSchema with GeneralApi 
 }
 object TechniqueApi       extends Enum[TechniqueApi] with ApiModuleProvider[TechniqueApi]      {
 
-  final case object GetTechniques             extends TechniqueApi with ZeroParam with StartsAtVersion6 with SortIndex  {
+  case object GetTechniques             extends TechniqueApi with ZeroParam with StartsAtVersion6 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get all Techniques metadata"
     val (action, path) = GET / "techniques"
   }
-  final case object UpdateTechniques          extends TechniqueApi with ZeroParam with StartsAtVersion14 with SortIndex {
+  case object UpdateTechniques          extends TechniqueApi with ZeroParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "reload techniques metadata from file system"
     val (action, path) = POST / "techniques" / "reload"
   }
-  final case object GetAllTechniqueCategories extends TechniqueApi with ZeroParam with StartsAtVersion14 with SortIndex {
+  case object GetAllTechniqueCategories extends TechniqueApi with ZeroParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get all technique categories"
     val (action, path) = GET / "techniques" / "categories"
   }
-  final case object ListTechniques            extends TechniqueApi with ZeroParam with StartsAtVersion14 with SortIndex {
+  case object ListTechniques            extends TechniqueApi with ZeroParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "List all techniques version"
     val (action, path) = GET / "techniques" / "versions"
   }
-  final case object ListTechniquesDirectives  extends TechniqueApi with OneParam with StartsAtVersion6 with SortIndex   {
+  case object ListTechniquesDirectives  extends TechniqueApi with OneParam with StartsAtVersion6 with SortIndex   {
     val z: Int = implicitly[Line].value
     val description    = "List directives derived from given technique"
     val (action, path) = GET / "techniques" / "{name}" / "directives"
     override def dataContainer: Some[String] = Some("directives")
   }
-  final case object ListTechniqueDirectives   extends TechniqueApi with TwoParam with StartsAtVersion6 with SortIndex   {
+  case object ListTechniqueDirectives   extends TechniqueApi with TwoParam with StartsAtVersion6 with SortIndex   {
     val z: Int = implicitly[Line].value
     val description    = "List directives derived from given technique for given version"
     val (action, path) = GET / "techniques" / "{name}" / "{version}" / "directives"
     override def dataContainer: Some[String] = Some("directives")
   }
-  final case object TechniqueRevisions        extends TechniqueApi with TwoParam with StartsAtVersion14 with SortIndex  {
+  case object TechniqueRevisions        extends TechniqueApi with TwoParam with StartsAtVersion14 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get revisions for given technique"
     val (action, path) = GET / "techniques" / "{name}" / "{version}" / "revisions"
   }
 
-  final case object UpdateTechnique        extends TechniqueApi with TwoParam with StartsAtVersion14 with SortIndex  {
+  case object UpdateTechnique        extends TechniqueApi with TwoParam with StartsAtVersion14 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Update technique created with technique editor"
     val (action, path) = POST / "techniques" / "{techniqueId}" / "{version}"
   }
-  final case object CreateTechnique        extends TechniqueApi with ZeroParam with StartsAtVersion14 with SortIndex {
+  case object CreateTechnique        extends TechniqueApi with ZeroParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Create a new technique in Rudder from a technique in the technique editor"
     val (action, path) = PUT / "techniques"
   }
-  final case object DeleteTechnique        extends TechniqueApi with TwoParam with StartsAtVersion14 with SortIndex  {
+  case object DeleteTechnique        extends TechniqueApi with TwoParam with StartsAtVersion14 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Delete a technique from technique editor"
     val (action, path) = DELETE / "techniques" / "{techniqueId}" / "{techniqueVersion}"
   }
-  final case object GetResources           extends TechniqueApi with TwoParam with StartsAtVersion14 with SortIndex  {
+  case object GetResources           extends TechniqueApi with TwoParam with StartsAtVersion14 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get currently deployed resources of a technique"
     val (action, path) = GET / "techniques" / "{techniqueId}" / "{techniqueVersion}" / "resources"
   }
-  final case object GetNewResources        extends TechniqueApi with TwoParam with StartsAtVersion14 with SortIndex  {
+  case object GetNewResources        extends TechniqueApi with TwoParam with StartsAtVersion14 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get resources of a technique draft"
     val (action, path) = GET / "drafts" / "{techniqueId}" / "{techniqueVersion}" / "resources"
   }
-  final case object GetTechniqueAllVersion extends TechniqueApi with OneParam with StartsAtVersion14 with SortIndex  {
+  case object GetTechniqueAllVersion extends TechniqueApi with OneParam with StartsAtVersion14 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get all Techniques metadata"
     val (action, path) = GET / "techniques" / "{techniqueId}"
   }
-  final case object GetTechnique           extends TechniqueApi with TwoParam with StartsAtVersion14 with SortIndex  {
+  case object GetTechnique           extends TechniqueApi with TwoParam with StartsAtVersion14 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get all Techniques metadata"
     val (action, path) = GET / "techniques" / "{techniqueId}" / "{techniqueVersion}"
@@ -689,17 +682,17 @@ object TechniqueApi       extends Enum[TechniqueApi] with ApiModuleProvider[Tech
   /*
    * Method are returned sorted alpha-numericaly
    */
-  final case object GetMethods             extends TechniqueApi with ZeroParam with StartsAtVersion14 with SortIndex {
+  case object GetMethods             extends TechniqueApi with ZeroParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get all methods metadata"
     val (action, path) = GET / "methods"
   }
-  final case object UpdateMethods          extends TechniqueApi with ZeroParam with StartsAtVersion14 with SortIndex {
+  case object UpdateMethods          extends TechniqueApi with ZeroParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "reload methods metadata from file system"
     val (action, path) = POST / "methods" / "reload"
   }
-  final case object CheckTechnique         extends TechniqueApi with ZeroParam with StartsAtVersion16 with SortIndex {
+  case object CheckTechnique         extends TechniqueApi with ZeroParam with StartsAtVersion16 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Check if a techniques is valid yaml, with rudderc compilation, with various output (json ? yaml ?)"
     val (action, path) = POST / "techniques" / "check"
@@ -715,57 +708,57 @@ sealed trait RuleApi extends EnumEntry with EndpointSchema with GeneralApi with 
 }
 object RuleApi       extends Enum[RuleApi] with ApiModuleProvider[RuleApi]                {
 
-  final case object ListRules              extends RuleApi with ZeroParam with StartsAtVersion2 with SortIndex {
+  case object ListRules              extends RuleApi with ZeroParam with StartsAtVersion2 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "List all rules with their information"
     val (action, path) = GET / "rules"
   }
-  final case object CreateRule             extends RuleApi with ZeroParam with StartsAtVersion2 with SortIndex {
+  case object CreateRule             extends RuleApi with ZeroParam with StartsAtVersion2 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Create a new rule"
     val (action, path) = PUT / "rules"
   }
   // must be before rule details, else it is never reached
-  final case object GetRuleTree            extends RuleApi with ZeroParam with StartsAtVersion6 with SortIndex {
+  case object GetRuleTree            extends RuleApi with ZeroParam with StartsAtVersion6 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get rule categories and rule structured in a tree format"
     val (action, path) = GET / "rules" / "tree"
     override def dataContainer: Option[String] = None
   }
-  final case object RuleDetails            extends RuleApi with OneParam with StartsAtVersion2 with SortIndex  {
+  case object RuleDetails            extends RuleApi with OneParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get information about given rule"
     val (action, path) = GET / "rules" / "{id}"
   }
-  final case object DeleteRule             extends RuleApi with OneParam with StartsAtVersion2 with SortIndex  {
+  case object DeleteRule             extends RuleApi with OneParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Delete given rule"
     val (action, path) = DELETE / "rules" / "{id}"
   }
-  final case object UpdateRule             extends RuleApi with OneParam with StartsAtVersion2 with SortIndex  {
+  case object UpdateRule             extends RuleApi with OneParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Update information about given rule"
     val (action, path) = POST / "rules" / "{id}"
   }
-  final case object GetRuleCategoryDetails extends RuleApi with OneParam with StartsAtVersion6 with SortIndex  {
+  case object GetRuleCategoryDetails extends RuleApi with OneParam with StartsAtVersion6 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Get information about given rule category"
     val (action, path) = GET / "rules" / "categories" / "{id}"
     override def dataContainer: Option[String] = None
   }
-  final case object DeleteRuleCategory     extends RuleApi with OneParam with StartsAtVersion6 with SortIndex  {
+  case object DeleteRuleCategory     extends RuleApi with OneParam with StartsAtVersion6 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Delete given category"
     val (action, path) = DELETE / "rules" / "categories" / "{id}"
     override def dataContainer: Some[String] = Some("rulesCategories")
   }
-  final case object UpdateRuleCategory     extends RuleApi with OneParam with StartsAtVersion6 with SortIndex  {
+  case object UpdateRuleCategory     extends RuleApi with OneParam with StartsAtVersion6 with SortIndex  {
     val z: Int = implicitly[Line].value
     val description    = "Update information about given rule category"
     val (action, path) = POST / "rules" / "categories" / "{id}"
     override def dataContainer: Option[String] = None
   }
-  final case object CreateRuleCategory     extends RuleApi with ZeroParam with StartsAtVersion6 with SortIndex {
+  case object CreateRuleCategory     extends RuleApi with ZeroParam with StartsAtVersion6 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Create a new rule category"
     val (action, path) = PUT / "rules" / "categories"
@@ -773,13 +766,13 @@ object RuleApi       extends Enum[RuleApi] with ApiModuleProvider[RuleApi]      
   }
 
   // internal, because non definitive, API to load/unload a specific revision from git to ldap
-  final case object LoadRuleRevisionForGeneration   extends RuleApi with OneParam with StartsAtVersion14 with SortIndex {
+  case object LoadRuleRevisionForGeneration   extends RuleApi with OneParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Load a revision of a rule from config-repo to ldap, ready for next generation"
     val (action, path) = POST / "rules" / "revision" / "load" / "{id}"
     override def dataContainer: Option[String] = None
   }
-  final case object UnloadRuleRevisionForGeneration extends RuleApi with OneParam with StartsAtVersion14 with SortIndex {
+  case object UnloadRuleRevisionForGeneration extends RuleApi with OneParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    =
       "Unload a revision of a rule from ldap, it will not be used in next generation. Only rule with a revision can be unloaded"
@@ -797,7 +790,7 @@ sealed trait RuleInternalApi extends EnumEntry with EndpointSchema with Internal
 }
 object RuleInternalApi       extends Enum[RuleInternalApi] with ApiModuleProvider[RuleInternalApi] {
   // For the rule detail page
-  final case object GetRuleNodesAndDirectives extends RuleInternalApi with OneParam with StartsAtVersion14 with SortIndex {
+  case object GetRuleNodesAndDirectives extends RuleInternalApi with OneParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get the list of nodes and directives of a rule"
     val (action, path) = GET / "rulesinternal" / "nodesanddirectives" / "{id}"
@@ -805,7 +798,7 @@ object RuleInternalApi       extends Enum[RuleInternalApi] with ApiModuleProvide
   }
 
   // For group page
-  final case object GetGroupRelatedRules extends RuleInternalApi with ZeroParam with StartsAtVersion14 with SortIndex {
+  case object GetGroupRelatedRules extends RuleInternalApi with ZeroParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "List all info of rules in a tree format"
     val (action, path) = GET / "rulesinternal" / "relatedtree"
@@ -822,7 +815,7 @@ sealed trait GroupInternalApi extends EnumEntry with EndpointSchema with Interna
 }
 
 object GroupInternalApi extends Enum[GroupInternalApi] with ApiModuleProvider[GroupInternalApi] {
-  final case object GetGroupCategoryTree extends GroupInternalApi with ZeroParam with StartsAtVersion14 with SortIndex {
+  case object GetGroupCategoryTree extends GroupInternalApi with ZeroParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get the tree of groups with bare minimum group information"
     val (action, path) = GET / "groupsinternal" / "categorytree"
@@ -840,7 +833,7 @@ sealed trait ScoreApi extends EnumEntry with EndpointSchema with InternalApi wit
 
 object ScoreApi extends Enum[ScoreApi] with ApiModuleProvider[ScoreApi] {
 
-  final case object GetScoreList extends ScoreApi with ZeroParam with StartsAtVersion19 with SortIndex {
+  case object GetScoreList extends ScoreApi with ZeroParam with StartsAtVersion19 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "List all info of all available scores"
     val (action, path) = GET / "scores" / "list"
@@ -856,19 +849,19 @@ sealed trait SystemApi extends EnumEntry with EndpointSchema with GeneralApi wit
 }
 object SystemApi       extends Enum[SystemApi] with ApiModuleProvider[SystemApi]            {
 
-  final case object Info extends SystemApi with ZeroParam with StartsAtVersion10 with SortIndex {
+  case object Info extends SystemApi with ZeroParam with StartsAtVersion10 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get information about system installation (version, etc)"
     val (action, path) = GET / "system" / "info"
   }
 
-  final case object Status extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object Status extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get Api status"
     val (action, path) = GET / "system" / "status"
   }
 
-  final case object DebugInfo extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object DebugInfo extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Launch the support info script and get the result"
     val (action, path) = GET / "system" / "debug" / "info"
@@ -878,31 +871,31 @@ object SystemApi       extends Enum[SystemApi] with ApiModuleProvider[SystemApi]
   // For now, the techniques reload endpoint is implemented in the System API
   // but moving it inside the Techniques API should be discussed.
 
-  final case object ReloadAll extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object ReloadAll extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "reload both techniques and dynamic groups"
     val (action, path) = POST / "system" / "reload"
   }
 
-  final case object TechniquesReload extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object TechniquesReload extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "reload all techniques" // automatically done every 5 minutes
     val (action, path) = POST / "system" / "reload" / "techniques"
   }
 
-  final case object DyngroupsReload extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object DyngroupsReload extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "reload all dynamic groups"
     val (action, path) = POST / "system" / "reload" / "groups"
   }
 
-  final case object PoliciesUpdate extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object PoliciesUpdate extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "update policies"
     val (action, path) = POST / "system" / "update" / "policies"
   }
 
-  final case object PoliciesRegenerate extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object PoliciesRegenerate extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "regenerate all policies"
     val (action, path) = POST / "system" / "regenerate" / "policies"
@@ -910,31 +903,31 @@ object SystemApi       extends Enum[SystemApi] with ApiModuleProvider[SystemApi]
 
   // Archive list endpoints
 
-  final case object ArchivesGroupsList extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object ArchivesGroupsList extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "list groups archives"
     val (action, path) = GET / "system" / "archives" / "groups"
   }
 
-  final case object ArchivesDirectivesList extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object ArchivesDirectivesList extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "list directives archives"
     val (action, path) = GET / "system" / "archives" / "directives"
   }
 
-  final case object ArchivesRulesList extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object ArchivesRulesList extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "list rules archives"
     val (action, path) = GET / "system" / "archives" / "rules"
   }
 
-  final case object ArchivesParametersList extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object ArchivesParametersList extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "list parameters archives"
     val (action, path) = GET / "system" / "archives" / "parameters"
   }
 
-  final case object ArchivesFullList extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object ArchivesFullList extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "list all archives"
     val (action, path) = GET / "system" / "archives" / "full"
@@ -944,62 +937,62 @@ object SystemApi       extends Enum[SystemApi] with ApiModuleProvider[SystemApi]
 
   // Latest archive
 
-  final case object RestoreGroupsLatestArchive extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object RestoreGroupsLatestArchive extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "restore groups latest archive"
     val (action, path) = POST / "system" / "archives" / "groups" / "restore" / "latestArchive"
   }
 
-  final case object RestoreDirectivesLatestArchive extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object RestoreDirectivesLatestArchive extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "restore directives latest archive"
     val (action, path) = POST / "system" / "archives" / "directives" / "restore" / "latestArchive"
   }
 
-  final case object RestoreRulesLatestArchive extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object RestoreRulesLatestArchive extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "restore rules latest archive"
     val (action, path) = POST / "system" / "archives" / "rules" / "restore" / "latestArchive"
   }
 
-  final case object RestoreParametersLatestArchive extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object RestoreParametersLatestArchive extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "restore parameters latest archive"
     val (action, path) = POST / "system" / "archives" / "parameters" / "restore" / "latestArchive"
   }
 
-  final case object RestoreFullLatestArchive extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object RestoreFullLatestArchive extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "restore all latest archive"
     val (action, path) = POST / "system" / "archives" / "full" / "restore" / "latestArchive"
   }
 
   // Latest commit
-  final case object RestoreGroupsLatestCommit extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object RestoreGroupsLatestCommit extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "restore groups latest commit"
     val (action, path) = POST / "system" / "archives" / "groups" / "restore" / "latestCommit"
   }
 
-  final case object RestoreDirectivesLatestCommit extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object RestoreDirectivesLatestCommit extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "restore directives latest commit"
     val (action, path) = POST / "system" / "archives" / "directives" / "restore" / "latestCommit"
   }
 
-  final case object RestoreRulesLatestCommit extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object RestoreRulesLatestCommit extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "restore rules latest commit"
     val (action, path) = POST / "system" / "archives" / "rules" / "restore" / "latestCommit"
   }
 
-  final case object RestoreParametersLatestCommit extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object RestoreParametersLatestCommit extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "restore parameters latest commit"
     val (action, path) = POST / "system" / "archives" / "parameters" / "restore" / "latestCommit"
   }
 
-  final case object RestoreFullLatestCommit extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object RestoreFullLatestCommit extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "restore full latest commit"
     val (action, path) = POST / "system" / "archives" / "full" / "restore" / "latestCommit"
@@ -1007,31 +1000,31 @@ object SystemApi       extends Enum[SystemApi] with ApiModuleProvider[SystemApi]
 
   // Restore a particular entity base on its datetime
 
-  final case object ArchiveGroupDateRestore extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
+  case object ArchiveGroupDateRestore extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "restore a group archive created on date passed as parameter"
     val (action, path) = POST / "system" / "archives" / "groups" / "restore" / "{dateTime}"
   }
 
-  final case object ArchiveDirectiveDateRestore extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
+  case object ArchiveDirectiveDateRestore extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "restore a directive archive created on date passed as parameter"
     val (action, path) = POST / "system" / "archives" / "directives" / "restore" / "{dateTime}"
   }
 
-  final case object ArchiveRuleDateRestore extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
+  case object ArchiveRuleDateRestore extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "restore a rule archive created on date passed as parameter"
     val (action, path) = POST / "system" / "archives" / "rules" / "restore" / "{dateTime}"
   }
 
-  final case object ArchiveParameterDateRestore extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
+  case object ArchiveParameterDateRestore extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "restore a parameter archive created on date passed as parameter"
     val (action, path) = POST / "system" / "archives" / "parameters" / "restore" / "{dateTime}"
   }
 
-  final case object ArchiveFullDateRestore extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
+  case object ArchiveFullDateRestore extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "restore a full archive created on date passed as parameter"
     val (action, path) = POST / "system" / "archives" / "full" / "restore" / "{dateTime}"
@@ -1039,31 +1032,31 @@ object SystemApi       extends Enum[SystemApi] with ApiModuleProvider[SystemApi]
 
   // Archive endpoints
 
-  final case object ArchiveGroups extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object ArchiveGroups extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "archive groups"
     val (action, path) = POST / "system" / "archives" / "groups"
   }
 
-  final case object ArchiveDirectives extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object ArchiveDirectives extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "archive directives"
     val (action, path) = POST / "system" / "archives" / "directives"
   }
 
-  final case object ArchiveRules extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object ArchiveRules extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "archive rules"
     val (action, path) = POST / "system" / "archives" / "rules"
   }
 
-  final case object ArchiveParameters extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object ArchiveParameters extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "archive parameters"
     val (action, path) = POST / "system" / "archives" / "parameters"
   }
 
-  final case object ArchiveFull extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
+  case object ArchiveFull extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "archive full"
     val (action, path) = POST / "system" / "archives" / "full"
@@ -1071,31 +1064,31 @@ object SystemApi       extends Enum[SystemApi] with ApiModuleProvider[SystemApi]
 
   // ZIP Archive endpoints
 
-  final case object GetGroupsZipArchive extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
+  case object GetGroupsZipArchive extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get a groups zip archive based on its commit id"
     val (action, path) = GET / "system" / "archives" / "groups" / "zip" / "{commitId}"
   }
 
-  final case object GetDirectivesZipArchive extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
+  case object GetDirectivesZipArchive extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get a directives zip archive based on its commit id"
     val (action, path) = GET / "system" / "archives" / "directives" / "zip" / "{commitId}"
   }
 
-  final case object GetRulesZipArchive extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
+  case object GetRulesZipArchive extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get a rules zip archive based on its commit id"
     val (action, path) = GET / "system" / "archives" / "rules" / "zip" / "{commitId}"
   }
 
-  final case object GetParametersZipArchive extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
+  case object GetParametersZipArchive extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get a parameters zip archive based on its commit id"
     val (action, path) = GET / "system" / "archives" / "parameters" / "zip" / "{commitId}"
   }
 
-  final case object GetAllZipArchive extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
+  case object GetAllZipArchive extends SystemApi with OneParam with StartsAtVersion11 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get a full zip archive based on its commit id"
     val (action, path) = GET / "system" / "archives" / "full" / "zip" / "{commitId}"
@@ -1104,13 +1097,13 @@ object SystemApi       extends Enum[SystemApi] with ApiModuleProvider[SystemApi]
   // Health check endpoints
 
   // This endpoint run all checks to return the result
-  final case object GetHealthcheckResult extends SystemApi with ZeroParam with StartsAtVersion13 with SortIndex {
+  case object GetHealthcheckResult extends SystemApi with ZeroParam with StartsAtVersion13 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Result of a health check run"
     val (action, path) = GET / "system" / "healthcheck"
   }
 
-  final case object PurgeSoftware extends SystemApi with ZeroParam with StartsAtVersion13 with SortIndex {
+  case object PurgeSoftware extends SystemApi with ZeroParam with StartsAtVersion13 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Trigger an async purge of softwares"
     val (action, path) = POST / "system" / "maintenance" / "purgeSoftware"
@@ -1126,19 +1119,19 @@ sealed trait InfoApi extends EnumEntry with EndpointSchema with GeneralApi with 
 }
 object InfoApi       extends Enum[InfoApi] with ApiModuleProvider[InfoApi]                {
 
-  final case object ApiGeneralInformations extends InfoApi with ZeroParam with StartsAtVersion6 with SortIndex {
+  case object ApiGeneralInformations extends InfoApi with ZeroParam with StartsAtVersion6 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get information about Rudder public API"
     val (action, path) = GET / "info"
   }
 
-  final case object ApiInformations extends InfoApi with OneParam with StartsAtVersion10 with SortIndex {
+  case object ApiInformations extends InfoApi with OneParam with StartsAtVersion10 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get detailed information about Rudder public API with the given name"
     val (action, path) = GET / "info" / "details" / "{id}"
   }
 
-  final case object ApiSubInformations extends InfoApi with OneParam with StartsAtVersion10 with SortIndex {
+  case object ApiSubInformations extends InfoApi with OneParam with StartsAtVersion10 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get information about Rudder public API starting with given path"
     val (action, path) = GET / "info" / "{id}"
@@ -1153,7 +1146,7 @@ sealed trait HookApi extends EnumEntry with EndpointSchema with InternalApi with
   override def dataContainer: Option[String] = None // nothing normalized here ?
 }
 object HookApi       extends Enum[HookApi] with ApiModuleProvider[HookApi]                 {
-  final case object GetHooks extends HookApi with ZeroParam with StartsAtVersion16 with SortIndex {
+  case object GetHooks extends HookApi with ZeroParam with StartsAtVersion16 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get all hooks"
     val (action, path) = GET / "hooks"
@@ -1175,32 +1168,32 @@ sealed trait InventoryApi extends EnumEntry with EndpointSchema with GeneralApi 
 }
 object InventoryApi       extends Enum[InventoryApi] with ApiModuleProvider[InventoryApi]      {
 
-  final case object QueueInformation extends InventoryApi with ZeroParam with StartsAtVersion12 with SortIndex {
+  case object QueueInformation extends InventoryApi with ZeroParam with StartsAtVersion12 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get information about inventory current processing status"
     val (action, path) = GET / "inventories" / "info"
   }
 
-  final case object UploadInventory extends InventoryApi with ZeroParam with StartsAtVersion12 with SortIndex {
+  case object UploadInventory extends InventoryApi with ZeroParam with StartsAtVersion12 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    =
       "Upload an inventory (parameter 'file' and its signature (parameter 'signature') with 'content-disposition:file' attachement format"
     val (action, path) = POST / "inventories" / "upload"
   }
 
-  final case object FileWatcherStart extends InventoryApi with ZeroParam with StartsAtVersion12 with SortIndex {
+  case object FileWatcherStart extends InventoryApi with ZeroParam with StartsAtVersion12 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Start inventory file watcher (inotify)"
     val (action, path) = POST / "inventories" / "watcher" / "start"
   }
 
-  final case object FileWatcherStop extends InventoryApi with ZeroParam with StartsAtVersion12 with SortIndex {
+  case object FileWatcherStop extends InventoryApi with ZeroParam with StartsAtVersion12 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Stop inventory file watcher (inotify)"
     val (action, path) = POST / "inventories" / "watcher" / "stop"
   }
 
-  final case object FileWatcherRestart extends InventoryApi with ZeroParam with StartsAtVersion12 with SortIndex {
+  case object FileWatcherRestart extends InventoryApi with ZeroParam with StartsAtVersion12 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Restart inventory file watcher (inotify)"
     val (action, path) = POST / "inventories" / "watcher" / "restart"
@@ -1221,23 +1214,23 @@ sealed trait UserApi extends EnumEntry with EndpointSchema with InternalApi with
   override def dataContainer: Option[String] = None
 }
 object UserApi       extends Enum[UserApi] with ApiModuleProvider[UserApi]                 {
-  final case object GetApiToken    extends UserApi with ZeroParam with StartsAtVersion10 with SortIndex {
+  case object GetApiToken    extends UserApi with ZeroParam with StartsAtVersion10 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get information about user personal UserApi token"
     val (action, path) = GET / "user" / "api" / "token"
   }
-  final case object CreateApiToken extends UserApi with ZeroParam with StartsAtVersion10 with SortIndex {
+  case object CreateApiToken extends UserApi with ZeroParam with StartsAtVersion10 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Create user personal UserApi token"
     val (action, path) = PUT / "user" / "api" / "token"
   }
-  final case object DeleteApiToken extends UserApi with ZeroParam with StartsAtVersion10 with SortIndex {
+  case object DeleteApiToken extends UserApi with ZeroParam with StartsAtVersion10 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Delete user personal UserApi token"
     val (action, path) = DELETE / "user" / "api" / "token"
   }
 
-  final case object UpdateApiToken extends UserApi with ZeroParam with StartsAtVersion10 with SortIndex {
+  case object UpdateApiToken extends UserApi with ZeroParam with StartsAtVersion10 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Update user personal UserApi token"
     val (action, path) = POST / "user" / "api" / "token"
@@ -1265,12 +1258,12 @@ object ArchiveApi       extends Enum[ArchiveApi] with ApiModuleProvider[ArchiveA
    * - tech_ids = techniqueName/1.0[,other tech ids]
    * - scope = all (default), none, directives, techniques (implies directive), groups
    */
-  final case object ExportSimple extends ArchiveApi with ZeroParam with StartsAtVersion16 with SortIndex {
+  case object ExportSimple extends ArchiveApi with ZeroParam with StartsAtVersion16 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Export the list of objects with their dependencies in a policy archive"
     val (action, path) = GET / "archives" / "export"
   }
-  final case object Import       extends ArchiveApi with ZeroParam with StartsAtVersion16 with SortIndex {
+  case object Import       extends ArchiveApi with ZeroParam with StartsAtVersion16 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Import policy archive"
     val (action, path) = POST / "archives" / "import"

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -126,7 +126,7 @@ final case class RestExtractorService(
    * Params Extractors
    */
 
-  private[this] def extractOneValue[T](params: Map[String, List[String]], key: String)(
+  private def extractOneValue[T](params: Map[String, List[String]], key: String)(
       to: (String) => Box[T] = ((value: String) => Full(value))
   ) = {
     params.get(key) match {
@@ -136,7 +136,7 @@ final case class RestExtractorService(
     }
   }
 
-  private[this] def extractList[T](params: Map[String, List[String]], key: String)(
+  private def extractList[T](params: Map[String, List[String]], key: String)(
       to: (List[String]) => Box[T]
   ): Box[Option[T]] = {
     params.get(key) match {
@@ -148,7 +148,7 @@ final case class RestExtractorService(
   /*
    * Convert value functions
    */
-  private[this] def toBoolean(value: String): Box[Boolean] = {
+  private def toBoolean(value: String): Box[Boolean] = {
     value match {
       case "true"  => Full(true)
       case "false" => Full(false)
@@ -156,7 +156,7 @@ final case class RestExtractorService(
     }
   }
 
-  private[this] def toNodeStatusAction(value: String): Box[NodeStatusAction] = {
+  private def toNodeStatusAction(value: String): Box[NodeStatusAction] = {
     value.toLowerCase match {
       case "accept" | "accepted"            => Full(AcceptNode)
       case "refuse" | "refused"             => Full(RefuseNode)
@@ -164,7 +164,7 @@ final case class RestExtractorService(
       case _                                => Failure(s"value for nodestatus action should be accept, refuse, delete")
     }
   }
-  private[this] def toInt(value: String):              Box[Int]              = {
+  private def toInt(value: String):              Box[Int]              = {
     try {
       Full(value.toInt)
     } catch {
@@ -172,11 +172,11 @@ final case class RestExtractorService(
     }
   }
 
-  private[this] def toQuery(value: String): Box[Query] = {
+  private def toQuery(value: String): Box[Query] = {
     queryParser(value)
   }
 
-  private[this] def toQueryCriterion(value: String): Box[List[StringCriterionLine]] = {
+  private def toQueryCriterion(value: String): Box[List[StringCriterionLine]] = {
     JsonParser.parseOpt(value) match {
       case None        => Failure("Could not parse 'select' cause in api query ")
       case Some(value) =>
@@ -186,19 +186,19 @@ final case class RestExtractorService(
     }
   }
 
-  private[this] def toQueryReturnType(value: String): Box[QueryReturnType] = {
+  private def toQueryReturnType(value: String): Box[QueryReturnType] = {
     QueryReturnType(value).toBox
   }
 
-  private[this] def toQueryComposition(value: String): Box[Option[String]] = {
+  private def toQueryComposition(value: String): Box[Option[String]] = {
     Full(Some(value))
   }
 
-  private[this] def toQueryTransform(value: String): Box[Option[String]] = {
+  private def toQueryTransform(value: String): Box[Option[String]] = {
     Full(if (value.isEmpty) None else Some(value))
   }
 
-  private[this] def toMinimalSizeString(minimalSize: Int)(value: String): Box[String] = {
+  private def toMinimalSizeString(minimalSize: Int)(value: String): Box[String] = {
     if (value.size >= minimalSize) {
       Full(value)
     } else {
@@ -206,7 +206,7 @@ final case class RestExtractorService(
     }
   }
 
-  private[this] def toParameterName(value: String): Box[String] = {
+  private def toParameterName(value: String): Box[String] = {
     toMinimalSizeString(1)(value) match {
       case Full(value) =>
         if (GenericProperty.patternName.matcher(value).matches)
@@ -217,11 +217,11 @@ final case class RestExtractorService(
     }
   }
 
-  private[this] def toDirectiveParam(value: String): Box[Map[String, Seq[String]]] = {
+  private def toDirectiveParam(value: String): Box[Map[String, Seq[String]]] = {
     parseSectionVal(parse(value)).map(SectionVal.toMapVariables(_))
   }
 
-  private[this] def extractJsonDirectiveParam(json: JValue): Box[Option[Map[String, Seq[String]]]] = {
+  private def extractJsonDirectiveParam(json: JValue): Box[Option[Map[String, Seq[String]]]] = {
     json \ "parameters" match {
       case JObject(Nil) | JNothing => Full(None)
       case x @ JObject(_)          => parseSectionVal(x).map(x => Some(SectionVal.toMapVariables(x)))
@@ -229,26 +229,26 @@ final case class RestExtractorService(
     }
   }
 
-  private[this] def toNodeGroupCategoryId(value: String): Box[NodeGroupCategoryId] = {
+  private def toNodeGroupCategoryId(value: String): Box[NodeGroupCategoryId] = {
     Full(NodeGroupCategoryId(value))
   }
-  private[this] def toRuleCategoryId(value: String):      Box[RuleCategoryId]      = {
+  private def toRuleCategoryId(value: String):      Box[RuleCategoryId]      = {
     Full(RuleCategoryId(value))
   }
 
-  private[this] def toGroupCategoryId(value: String): Box[NodeGroupCategoryId] = {
+  private def toGroupCategoryId(value: String): Box[NodeGroupCategoryId] = {
     Full(NodeGroupCategoryId(value))
   }
 
-  private[this] def toApiAccountId(value: String): Box[ApiAccountId] = {
+  private def toApiAccountId(value: String): Box[ApiAccountId] = {
     Full(ApiAccountId(value))
   }
 
-  private[this] def toApiAccountName(value: String): Box[ApiAccountName] = {
+  private def toApiAccountName(value: String): Box[ApiAccountName] = {
     Full(ApiAccountName(value))
   }
 
-  private[this] def toWorkflowStatus(value: String): Box[Seq[WorkflowNodeId]] = {
+  private def toWorkflowStatus(value: String): Box[Seq[WorkflowNodeId]] = {
     val possiblestates = workflowLevelService.getWorkflowService().stepsValue
     value.toLowerCase match {
       case "open"   => Full(workflowLevelService.getWorkflowService().openSteps)
@@ -262,7 +262,7 @@ final case class RestExtractorService(
     }
   }
 
-  private[this] def toWorkflowTargetStatus(value: String): Box[WorkflowNodeId] = {
+  private def toWorkflowTargetStatus(value: String): Box[WorkflowNodeId] = {
     val possiblestates = workflowLevelService.getWorkflowService().stepsValue
     possiblestates.find(_.value.equalsIgnoreCase(value)) match {
       case Some(state) => Full(state)
@@ -273,7 +273,7 @@ final case class RestExtractorService(
     }
   }
 
-  private[this] def toNodeDetailLevel(value: String): Box[NodeDetailLevel] = {
+  private def toNodeDetailLevel(value: String): Box[NodeDetailLevel] = {
     val fields = value.split(",")
     if (fields.contains("full")) {
       Full(FullDetailLevel)
@@ -313,7 +313,7 @@ final case class RestExtractorService(
    *
    * So in all case, the result is exactly ONE target.
    */
-  private[this] def toRuleTarget(parameters: Map[String, List[String]], key: String): Box[Option[RuleTarget]] = {
+  private def toRuleTarget(parameters: Map[String, List[String]], key: String): Box[Option[RuleTarget]] = {
     parameters.get(key) match {
       case Some(values) =>
         traverse(values)(value => RuleTarget.unser(value)).flatMap(mergeTarget)
@@ -336,7 +336,7 @@ final case class RestExtractorService(
     }
   }
 
-  private[this] def mergeTarget(seq: Seq[RuleTarget]): Box[Option[RuleTarget]] = {
+  private def mergeTarget(seq: Seq[RuleTarget]): Box[Option[RuleTarget]] = {
     seq match {
       case Seq()         => Full(None)
       case head +: Seq() => Full(Some(head))
@@ -355,7 +355,7 @@ final case class RestExtractorService(
   /*
    * Convert List Functions
    */
-  private[this] def convertListToDirectiveId(values: Seq[String]): Box[Set[DirectiveId]] = {
+  private def convertListToDirectiveId(values: Seq[String]): Box[Set[DirectiveId]] = {
     def toDirectiveId(value: String): Box[DirectiveId] = {
       // TODO: parse value correctly
       readDirective.getDirective(DirectiveUid(value)).notOptional(s"Directive '$value' not found").map(_.id).toBox
@@ -363,7 +363,7 @@ final case class RestExtractorService(
     traverse(values)(toDirectiveId).map(_.toSet)
   }
 
-  private[this] def convertListToNodeId(values: List[String]): Box[List[NodeId]] = {
+  private def convertListToNodeId(values: List[String]): Box[List[NodeId]] = {
     Full(values.map(NodeId(_)))
   }
 
@@ -725,14 +725,14 @@ final case class RestExtractorService(
     ((json \ "name"), (json \ "value")) match {
       case (JString(nameValue), value) =>
         val provider    = (json \ "provider") match {
-          case JString(value) => Some(PropertyProvider(value))
+          case JString(string) => Some(PropertyProvider(string))
           // if not defined of not a string, use default
-          case _              => None
+          case _               => None
         }
         val inheritMode = (json \ "inheritMode") match {
-          case JString(value) => InheritMode.parseString(value).toOption
+          case JString(string) => InheritMode.parseString(string).toOption
           // if not defined of not a string, use default
-          case _              => None
+          case _               => None
         }
         (for {
           _ <- PropertyParser.validPropertyName(nameValue)
@@ -902,7 +902,7 @@ final case class RestExtractorService(
   // this extractTagsFromJson is exclusively used when updating TAG in the POST API request. We want to extract tags as a List
   // of {key1,value1 ... keyN,valueN}
 
-  private[this] def extractTagsFromJson(value: JValue): Box[Option[Tags]] = {
+  private def extractTagsFromJson(value: JValue): Box[Option[Tags]] = {
     implicit val formats = DefaultFormats
     if (value == JNothing) Full(None) // missing tag in json means user doesn't want to update them
     else {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestUtils.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestUtils.scala
@@ -96,10 +96,10 @@ object RestUtils extends Loggable {
         case "latest" => Full(latest)
         case value    =>
           tryo(value.toInt) match {
-            case Full(version) =>
-              availableVersions.find(_.value == version) match {
+            case Full(version_) =>
+              availableVersions.find(_.value == version_) match {
                 case Some(apiVersion) => Full(apiVersion)
-                case None             => Failure(s" ${version} is not a valid api version")
+                case None             => Failure(s" ${version_} is not a valid api version")
               }
             // Never empty due to tryo
             case eb: EmptyBox => eb
@@ -202,18 +202,18 @@ object RestUtils extends Loggable {
     toJsonError(
       None,
       JString(s"Version used does not exist, please use one of the following: ${versions.mkString("[ ", ", ", " ]")} ")
-    )(action, false)
+    )(action, prettify = false)
   }
 
   def missingResponse(version: Int, action: String): LiftResponse = {
     toJsonError(None, JString(s"Version ${version} exists for this API function, but it's implementation is missing"))(
       action,
-      false
+      prettify = false
     )
   }
 
   def unauthorized: LiftResponse =
-    effectiveResponse(None, JString("You are not authorized to access that API"), ForbiddenError, "", false)
+    effectiveResponse(None, JString("You are not authorized to access that API"), ForbiddenError, "", prettify = false)
 
   def response(
       restExtractor: RestExtractorService,

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
@@ -70,7 +70,7 @@ class AuthorizationMappingListEndpoint(endpoints: List[EndpointSchema]) extends 
  */
 class ExtensibleAuthorizationApiMapping(base: List[AuthorizationApiMapping]) extends AuthorizationApiMapping {
 
-  private[this] var mappers: List[AuthorizationApiMapping] = base
+  private var mappers: List[AuthorizationApiMapping] = base
 
   def addMapper(mapper: AuthorizationApiMapping): Unit = {
     // no need to add again and again the default mapper - it's ok, we have it.

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonResponse.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonResponse.scala
@@ -165,7 +165,7 @@ object RudderJsonResponse {
   def successZero(schema: ResponseSchema, msg: String)(implicit
       prettify: Boolean
   ): LiftJsonResponse[JsonRudderApiResponse[String]] = {
-    implicit val enc = DeriveJsonEncoder.gen[JsonRudderApiResponse[String]]
+    implicit val enc: JsonEncoder[JsonRudderApiResponse[String]] = DeriveJsonEncoder.gen
     generic.success(JsonRudderApiResponse.success(schema, None, msg))
   }
   // errors

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
@@ -538,7 +538,7 @@ object JsonCompliance {
         ~ ("nodes"             -> byNodes(directive.nodes, level, precision))
     )
 
-    private[this] def byNodes(
+    private def byNodes(
         nodes:     Seq[ByDirectiveNodeCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -558,7 +558,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def byRule(
+    private def byRule(
         rules:     Seq[ByDirectiveByNodeRuleCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -578,7 +578,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def byNodeByDirectiveByComponents(
+    private def byNodeByDirectiveByComponents(
         comps:     Seq[ByRuleByNodeByDirectiveByComponentCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -601,7 +601,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def byNodeByComponents(
+    private def byNodeByComponents(
         comps:     Seq[ByRuleComponentCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -624,7 +624,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def rules(
+    private def rules(
         rules:     Seq[ByDirectiveByRuleCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -644,7 +644,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def components(
+    private def components(
         comps:     Seq[ByRuleComponentCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -683,7 +683,7 @@ object JsonCompliance {
         })
       }
     }
-    private[this] def nodes(
+    private def nodes(
         nodes:     Seq[ByRuleNodeCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -735,7 +735,7 @@ object JsonCompliance {
         ~ ("nodes"             -> byNodes(rule.nodes, level, precision))
     )
 
-    private[this] def directives(
+    private def directives(
         directives: Seq[ByRuleDirectiveCompliance],
         level:      Int,
         precision:  CompliancePrecision
@@ -757,7 +757,7 @@ object JsonCompliance {
         })
       }
     }
-    private[this] def byNodes(
+    private def byNodes(
         nodes:     Seq[GroupComponentCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -777,7 +777,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def byNodesByDirectives(
+    private def byNodesByDirectives(
         directives: Seq[ByRuleByNodeByDirectiveCompliance],
         level:      Int,
         precision:  CompliancePrecision
@@ -796,7 +796,7 @@ object JsonCompliance {
         })
       }
     }
-    private[this] def components(
+    private def components(
         comps:     Seq[ByRuleComponentCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -819,7 +819,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def byNodeByDirectiveByComponents(
+    private def byNodeByDirectiveByComponents(
         comps:     Seq[ByRuleByNodeByDirectiveByComponentCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -858,7 +858,7 @@ object JsonCompliance {
         })
       }
     }
-    private[this] def nodes(
+    private def nodes(
         nodes:     Seq[ByRuleNodeCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -893,7 +893,7 @@ object JsonCompliance {
       ~ ("nodes"             -> byNode(nodeGroup.nodes, level, precision)))
     }
 
-    private[this] def byRule(
+    private def byRule(
         rules:     Seq[ByNodeGroupRuleCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -911,7 +911,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def byNode(
+    private def byNode(
         nodes:     Seq[ByNodeGroupNodeCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -930,7 +930,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def byNodeRules(
+    private def byNodeRules(
         rules:     Seq[ByNodeRuleCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -950,7 +950,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def byNodeDirectives(
+    private def byNodeDirectives(
         directives: Seq[ByNodeDirectiveCompliance],
         level:      Int,
         precision:  CompliancePrecision
@@ -970,7 +970,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def byNodeComponents(
+    private def byNodeComponents(
         comps:     List[ComponentStatusReport],
         level:     Int,
         precision: CompliancePrecision
@@ -993,7 +993,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def directives(
+    private def directives(
         directives: Seq[ByNodeGroupByRuleDirectiveCompliance],
         level:      Int,
         precision:  CompliancePrecision
@@ -1013,7 +1013,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def components(
+    private def components(
         comps:     Seq[ByRuleComponentCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -1036,7 +1036,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def nodes(
+    private def nodes(
         nodes:     Seq[ByRuleNodeCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -1056,7 +1056,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def values(values: Seq[ComponentValueStatusReport], level: Int): Option[JsonAST.JValue] = {
+    private def values(values: Seq[ComponentValueStatusReport], level: Int): Option[JsonAST.JValue] = {
       if (level < 5) None
       else {
         Some(values.map { value =>
@@ -1103,7 +1103,7 @@ object JsonCompliance {
         ~ ("rules"             -> rules(n.nodeCompliances, level, precision))
     )
 
-    private[this] def rules(
+    private def rules(
         rules:     Seq[ByNodeRuleCompliance],
         level:     Int,
         precision: CompliancePrecision
@@ -1123,7 +1123,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def directives(
+    private def directives(
         directives: Seq[ByNodeDirectiveCompliance],
         level:      Int,
         precision:  CompliancePrecision
@@ -1143,7 +1143,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def components(
+    private def components(
         comps:     List[ComponentStatusReport],
         level:     Int,
         precision: CompliancePrecision
@@ -1166,7 +1166,7 @@ object JsonCompliance {
       }
     }
 
-    private[this] def values(componentValues: List[ComponentValueStatusReport], level: Int): Option[JsonAST.JValue] = {
+    private def values(componentValues: List[ComponentValueStatusReport], level: Int): Option[JsonAST.JValue] = {
       if (level < 5) None
       else {
         Some(componentValues.map {
@@ -1214,7 +1214,7 @@ object JsonCompliance {
    * the semantic of unexpected / missing and no answer is not clear at all.
    *
    */
-  private[this] def percents(c: ComplianceLevel, precision: CompliancePrecision): Map[String, Double] = {
+  private def percents(c: ComplianceLevel, precision: CompliancePrecision): Map[String, Double] = {
     import ReportType.*
 
     // we want at most `precision` decimals

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/CreateNodeData.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/CreateNodeData.scala
@@ -279,7 +279,7 @@ object Validation {
 
           getMachine(id, tpe)
             .modify(_.manufacturer)
-            .setToIfDefined(nodeDetails.machine.map(_.manufacturer.map(Manufacturer)))
+            .setToIfDefined(nodeDetails.machine.map(_.manufacturer.map(Manufacturer.apply)))
             .modify(_.systemSerialNumber)
             .setToIfDefined(nodeDetails.machine.map(_.serialNumber))
         }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
@@ -141,13 +141,13 @@ class EventLogAPI(
         }
       }
 
-      implicit val prettify = restExtractor
+      implicit val prettify: Boolean = restExtractor
         .extractBoolean("prettify")(req)(identity)
         .getOrElse(Some(false))
         .getOrElse(
           false
         )
-      implicit val action: String = "eventFilterDetails"
+      implicit val action:   String  = "eventFilterDetails"
       OldInternalApiAuthz.withWriteAdmin((for {
         json   <- req.json
         draw   <- CompleteJson.extractJsonInt(json, "draw")
@@ -182,16 +182,16 @@ class EventLogAPI(
                  }
 
         dateCriteria = (optStartDate, optEndDate) match {
-                         case (None, None)                                    => None
-                         case (Some(start), None)                             => Some(fr" creationDate >= ${start.toSql}")
-                         case (None, Some(end))                               => Some(fr" creationDate <= ${end.toSql}")
-                         case (Some(start), Some(end)) if end.isBefore(start) =>
+                         case (None, None)                                        => None
+                         case (Some(start_), None)                                => Some(fr" creationDate >= ${start_.toSql}")
+                         case (None, Some(end_))                                  => Some(fr" creationDate <= ${end_.toSql}")
+                         case (Some(start_), Some(end_)) if end_.isBefore(start_) =>
                            Some(
-                             fr" creationDate >= ${end.toSql} and creationDate <= ${start.toSql}"
+                             fr" creationDate >= ${end_.toSql} and creationDate <= ${start_.toSql}"
                            )
-                         case (Some(start), Some(end))                        =>
+                         case (Some(start_), Some(end_))                          =>
                            Some(
-                             fr" creationDate >= ${start.toSql} and creationDate <= ${end.toSql}"
+                             fr" creationDate >= ${start_.toSql} and creationDate <= ${end_.toSql}"
                            )
                        }
 
@@ -228,8 +228,9 @@ class EventLogAPI(
       })
 
     case Get(id :: "details" :: Nil, req) =>
-      implicit val prettify = restExtractor.extractBoolean("prettify")(req)(identity).getOrElse(Some(false)).getOrElse(false)
-      implicit val action: String = "eventDetails"
+      implicit val prettify: Boolean =
+        restExtractor.extractBoolean("prettify")(req)(identity).getOrElse(Some(false)).getOrElse(false)
+      implicit val action:   String  = "eventDetails"
       OldInternalApiAuthz.withReadAdmin((for {
         realId     <- Box.tryo(id.toLong)
         event      <- repos.getEventLogById(realId).toBox
@@ -254,8 +255,9 @@ class EventLogAPI(
       })
 
     case Get(id :: "details" :: "rollback" :: Nil, req) =>
-      implicit val prettify = restExtractor.extractBoolean("prettify")(req)(identity).getOrElse(Some(false)).getOrElse(false)
-      implicit val action: String = "eventRollback"
+      implicit val prettify: Boolean =
+        restExtractor.extractBoolean("prettify")(req)(identity).getOrElse(Some(false)).getOrElse(false)
+      implicit val action:   String  = "eventRollback"
 
       OldInternalApiAuthz.withReadAdmin((for {
         reqParam     <- req.params.get("action") match {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestApiAccounts.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestApiAccounts.scala
@@ -37,13 +37,13 @@ class RestApiAccounts(
 
   serve {
     case Get("secure" :: "apiaccounts" :: Nil, req) =>
-      implicit val prettify = restExtractor
+      implicit val prettify: Boolean = restExtractor
         .extractBoolean("prettify")(req)(identity)
         .getOrElse(Some(false))
         .getOrElse(
           false
         )
-      implicit val action: String = "getAllAccounts"
+      implicit val action:   String  = "getAllAccounts"
 
       // here, 'write' and not 'read' because some tokens may have admin write access,
       // and we want to avoid escalation
@@ -76,13 +76,13 @@ class RestApiAccounts(
       })
 
     case "secure" :: "apiaccounts" :: Nil JsonPut body -> req =>
-      implicit val prettify = restExtractor
+      implicit val prettify: Boolean = restExtractor
         .extractBoolean("prettify")(req)(identity)
         .getOrElse(Some(false))
         .getOrElse(
           false
         )
-      implicit val action: String = "updateAccount"
+      implicit val action:   String  = "updateAccount"
 
       OldInternalApiAuthz.withWriteAdmin(req.json match {
         case Full(json) =>
@@ -145,14 +145,14 @@ class RestApiAccounts(
       })
 
     case "secure" :: "apiaccounts" :: tokenId :: Nil JsonPost body -> req =>
-      val apiTokenId        = ApiAccountId(tokenId)
-      implicit val prettify = restExtractor
+      val apiTokenId = ApiAccountId(tokenId)
+      implicit val prettify: Boolean = restExtractor
         .extractBoolean("prettify")(req)(identity)
         .getOrElse(Some(false))
         .getOrElse(
           false
         )
-      implicit val action: String = "updateAccount"
+      implicit val action:   String  = "updateAccount"
 
       OldInternalApiAuthz.withWriteAdmin(req.json match {
         case Full(json) =>
@@ -182,14 +182,14 @@ class RestApiAccounts(
       })
 
     case Delete("secure" :: "apiaccounts" :: tokenId :: Nil, req) =>
-      val apiTokenId        = ApiAccountId(tokenId)
-      implicit val prettify = restExtractor
+      val apiTokenId = ApiAccountId(tokenId)
+      implicit val prettify: Boolean = restExtractor
         .extractBoolean("prettify")(req)(identity)
         .getOrElse(Some(false))
         .getOrElse(
           false
         )
-      implicit val action: String = "deleteAccount"
+      implicit val action:   String  = "deleteAccount"
 
       OldInternalApiAuthz.withWriteAdmin(readApi.getById(apiTokenId).either.runNow match {
         case Right(Some(account)) =>
@@ -214,14 +214,14 @@ class RestApiAccounts(
       })
 
     case Post("secure" :: "apiaccounts" :: tokenId :: "regenerate" :: Nil, req) =>
-      val apiTokenId        = ApiAccountId(tokenId)
-      implicit val prettify = restExtractor
+      val apiTokenId = ApiAccountId(tokenId)
+      implicit val prettify: Boolean = restExtractor
         .extractBoolean("prettify")(req)(identity)
         .getOrElse(Some(false))
         .getOrElse(
           false
         )
-      implicit val action: String = "regenerateAccount"
+      implicit val action:   String  = "regenerateAccount"
 
       OldInternalApiAuthz.withWriteAdmin(readApi.getById(apiTokenId).either.runNow match {
         case Right(Some(account)) =>
@@ -255,7 +255,7 @@ class RestApiAccounts(
               logger.error(msg)
               toJsonError(None, s"Could not regenerate account ${tokenId} cause: ${err.fullMsg}")(
                 "regenerateAccount",
-                true
+                prettify = true
               )
           }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestCompletion.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestCompletion.scala
@@ -109,10 +109,10 @@ class RestCompletion(
       fetchTags match {
         case eb: EmptyBox =>
           val e = eb ?~! s"Error when looking for object containing ${token}"
-          toJsonError(None, e.messageChain)("quicksearch", false)
+          toJsonError(None, e.messageChain)("quicksearch", prettify = false)
 
         case Full(results) =>
-          toJsonResponse(None, results.map(("value", _)))("completeTags", false)
+          toJsonResponse(None, results.map(("value", _)))("completeTags", prettify = false)
       }
 
     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestQuicksearch.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestQuicksearch.scala
@@ -108,7 +108,7 @@ class RestQuicksearch(
     }
   }
 
-  private[this] def filter(results: Set[QuickSearchResult]) = {
+  private def filter(results: Set[QuickSearchResult]) = {
     import com.normation.rudder.services.quicksearch.QuickSearchResultId.*
 
     val user = userService.getCurrentUser
@@ -140,7 +140,7 @@ class RestQuicksearch(
    *   crunching the browser with thousands of answers
    */
 
-  private[this] def prepare(results: Set[QuickSearchResult], maxByKind: Int): JValue = {
+  private def prepare(results: Set[QuickSearchResult], maxByKind: Int): JValue = {
     val filteredResult = filter(results)
     // group by kind, and build the summary for each
     val map            = filteredResult.groupBy(_.id.tpe).map {
@@ -178,13 +178,13 @@ class RestQuicksearch(
   }
 
   // private case class cannot be final because of scalac bug
-  private[this] case class ResultTypeSummary(
+  private case class ResultTypeSummary(
       tpe:            String,
       originalNumber: Int,
       returnedNumber: Int
   )
 
-  implicit private[this] class JsonResultTypeSummary(t: ResultTypeSummary) {
+  implicit private class JsonResultTypeSummary(t: ResultTypeSummary) {
 
     val desc: String = if (t.originalNumber <= t.returnedNumber) {
       s"${t.originalNumber} found"
@@ -201,7 +201,7 @@ class RestQuicksearch(
     }
   }
 
-  implicit private[this] class JsonSearchResult(r: QuickSearchResult) {
+  implicit private class JsonSearchResult(r: QuickSearchResult) {
     import com.normation.inventory.domain.NodeId
     import com.normation.rudder.domain.nodes.NodeGroupId
     import com.normation.rudder.domain.policies.DirectiveUid
@@ -211,11 +211,11 @@ class RestQuicksearch(
     def toJson: JObject = {
       import linkUtil.*
       val url = r.id match {
-        case QRNodeId(v)      => nodeLink(NodeId(v))
-        case QRRuleId(v)      => ruleLink(RuleId(RuleUid(v)))
-        case QRDirectiveId(v) => directiveLink(DirectiveUid(v))
-        case QRGroupId(v)     => groupLink(NodeGroupId(NodeGroupUid(v)))
-        case QRParameterId(v) => globalParameterLink(v)
+        case QRNodeId(value)      => nodeLink(NodeId(value))
+        case QRRuleId(value)      => ruleLink(RuleId(RuleUid(value)))
+        case QRDirectiveId(value) => directiveLink(DirectiveUid(value))
+        case QRGroupId(value)     => groupLink(NodeGroupId(NodeGroupUid(value)))
+        case QRParameterId(value) => globalParameterLink(value)
       }
 
       // limit description length to avoid having a whole file printed

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/SharedFilesAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/SharedFilesAPI.scala
@@ -277,7 +277,7 @@ class SharedFilesAPI(
               case Some(values)      =>
                 Failure("Too many values in request for path of file to download")
             }
-          case Some(action :: Nil)     =>
+          case Some(action_ :: Nil)    =>
             Failure("Action not supported")
           case Some(actions)           =>
             Failure("Too many values in request for action")

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -154,11 +154,11 @@ sealed trait ArchiveScope extends EnumEntry          { def value: String }
 object ArchiveScope       extends Enum[ArchiveScope] {
 
   // using nodep/alldep to avoid confusion with "none" in scala code
-  final case object AllDep     extends ArchiveScope { val value = "all"        }
-  final case object NoDep      extends ArchiveScope { val value = "none"       }
-  final case object Directives extends ArchiveScope { val value = "directives" }
-  final case object Techniques extends ArchiveScope { val value = "techniques" }
-  final case object Groups     extends ArchiveScope { val value = "groups"     }
+  case object AllDep     extends ArchiveScope { val value = "all"        }
+  case object NoDep      extends ArchiveScope { val value = "none"       }
+  case object Directives extends ArchiveScope { val value = "directives" }
+  case object Techniques extends ArchiveScope { val value = "techniques" }
+  case object Groups     extends ArchiveScope { val value = "groups"     }
 
   val values:           IndexedSeq[ArchiveScope]     = findValues
   def parse(s: String): Either[String, ArchiveScope] = {
@@ -175,9 +175,9 @@ object ArchiveScope       extends Enum[ArchiveScope] {
 sealed trait MergePolicy extends EnumEntry         { def value: String }
 object MergePolicy       extends Enum[MergePolicy] {
   // Default merge policy is "override everything", ie what is in the archive replace whatever exists in Rudder
-  final case object OverrideAll    extends MergePolicy { val value = "override-all"     }
+  case object OverrideAll    extends MergePolicy { val value = "override-all"     }
   // A merge policy that will keep current groups for rule with an ID common with one of the archive
-  final case object KeepRuleGroups extends MergePolicy { val value = "keep-rule-groups" }
+  case object KeepRuleGroups extends MergePolicy { val value = "keep-rule-groups" }
 
   val values: IndexedSeq[MergePolicy] = findValues
 
@@ -335,7 +335,7 @@ class ArchiveApi(
             _       <- checkArchiveService.check(archive)
             _       <- saveArchiveService.save(archive, merge)(authzToken.qc)
             _       <- ApplicationLoggerPure.Archive.info(s"Uploaded archive '${zip.fileName}' processed successfully")
-          } yield JRArchiveImported(true)
+          } yield JRArchiveImported(success = true)
       }).tapError(err => ApplicationLoggerPure.Archive.error(s"Error when processing uploaded archive: ${err.fullMsg}"))
 
       prog.toLiftResponseOne(params, schema, _ => None)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
@@ -450,7 +450,7 @@ class DirectiveApiService2(
 
   def serialize: (Technique, Directive, Option[ChangeRequestId]) => JValue = restDataSerializer.serializeDirective _
 
-  private[this] def createChangeRequestAndAnswer(
+  private def createChangeRequestAndAnswer(
       diff:            ChangeRequestDirectiveDiff,
       technique:       Technique,
       activeTechnique: ActiveTechnique,
@@ -518,7 +518,7 @@ class DirectiveApiService2(
     }
   }
 
-  private[this] def actualDirectiveCreation(
+  private def actualDirectiveCreation(
       restDirective:   RestDirective,
       baseDirective:   Directive,
       activeTechnique: ActiveTechnique,
@@ -654,7 +654,7 @@ class DirectiveApiService2(
   }
 
   // A function to check if Variables passed as parameter are correct
-  private[this] def checkParameters(paramEditor: DirectiveEditor)(parameterValues: (String, Seq[String])) = {
+  private def checkParameters(paramEditor: DirectiveEditor)(parameterValues: (String, Seq[String])) = {
     try {
       val s = Seq((paramEditor.variableSpecs(parameterValues._1).toVariable(parameterValues._2)))
       RudderLDAPConstants.variableToSeq(s)
@@ -666,7 +666,7 @@ class DirectiveApiService2(
     }
   }
 
-  private[this] def updateDirectiveModel(directiveId: DirectiveUid, restDirective: RestDirective) = {
+  private def updateDirectiveModel(directiveId: DirectiveUid, restDirective: RestDirective) = {
     for {
       (oldTechnique, activeTechnique, oldDirective) <-
         readDirective.getDirectiveWithContext(directiveId).notOptional(s"Could not find Directive ${directiveId.value}").toBox
@@ -1000,7 +1000,7 @@ class DirectiveApiService14(
   }
 
   // A function to check if Variables passed as parameter are correct
-  private[this] def checkParameters(paramEditor: DirectiveEditor)(parameterValues: (String, Seq[String])) = {
+  private def checkParameters(paramEditor: DirectiveEditor)(parameterValues: (String, Seq[String])) = {
     try {
       val s = Seq((paramEditor.variableSpecs(parameterValues._1).toVariable(parameterValues._2)))
       RudderLDAPConstants.variableToSeq(s)
@@ -1012,7 +1012,7 @@ class DirectiveApiService14(
     }
   }
 
-  private[this] def updateDirectiveModel(directiveId: DirectiveUid, restDirective: JQDirective): IOResult[DirectiveUpdate] = {
+  private def updateDirectiveModel(directiveId: DirectiveUid, restDirective: JQDirective): IOResult[DirectiveUpdate] = {
     for {
       triple                                       <- readDirective.getDirectiveWithContext(directiveId).notOptional(s"Could not find Directive ${directiveId.value}")
       (oldTechnique, activeTechnique, oldDirective) = triple

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -725,7 +725,7 @@ class GroupApiService2(
   import RestUtils.*
   import restDataSerializer.*
 
-  private[this] def createChangeRequestAndAnswer(
+  private def createChangeRequestAndAnswer(
       id:           String,
       diff:         ChangeRequestNodeGroupDiff,
       group:        NodeGroup,
@@ -843,7 +843,8 @@ class GroupApiService2(
           // If enable is missing in parameter consider it to true
           val defaultEnabled = restGroup.enabled.getOrElse(true)
           // create from scratch - base rule is the same with default values
-          val baseGroup      = NodeGroup(groupId, name, "", Nil, None, true, Set(), defaultEnabled)
+          val baseGroup      =
+            NodeGroup(groupId, name, "", Nil, None, isDynamic = true, serverList = Set(), _isEnabled = defaultEnabled)
 
           // if only the name parameter is set, consider it to be enabled
           // if not if workflow are enabled, consider it to be disabled
@@ -1087,7 +1088,7 @@ class GroupApiService14(
     restDataSerializer:   RestDataSerializer
 ) {
 
-  private[this] def createChangeRequest(
+  private def createChangeRequest(
       diff:   ChangeRequestNodeGroupDiff,
       change: NodeGroupChangeRequest,
       params: DefaultParams,
@@ -1174,7 +1175,8 @@ class GroupApiService14(
           // If enable is missing in parameter consider it to true
           val defaultEnabled = restGroup.enabled.getOrElse(true)
           // create from scratch - base rule is the same with default values
-          val baseGroup      = NodeGroup(groupId, name, "", Nil, None, true, Set(), defaultEnabled)
+          val baseGroup      =
+            NodeGroup(groupId, name, "", Nil, None, isDynamic = true, serverList = Set(), _isEnabled = defaultEnabled)
 
           // if only the name parameter is set, consider it to be enabled
           // if not if workflow are enabled, consider it to be disabled

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/LiftApiDispatcher.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/LiftApiDispatcher.scala
@@ -166,7 +166,7 @@ class LiftHandler(
 
   val logger: Log = LiftApiProcessingLogger
 
-  private[this] var _apis = List.empty[LiftApiModule]
+  private var _apis = List.empty[LiftApiModule]
   def apis():                                   List[LiftApiModule] = _apis
   def addModule(module: LiftApiModule):         Unit                = {
     _apis = _apis :+ module
@@ -263,7 +263,7 @@ class LiftHandler(
       case ApiError.BadParam(x, _)   => "Bad parameters for request: " + x
       case ApiError.Authz(x, _)      => "Authorization error: " + x
     }
-    Full(RestUtils.toJsonError(None, JString(msg))(error.apiName, true))
+    Full(RestUtils.toJsonError(None, JString(msg))(error.apiName, prettify = true))
   }
 
   // Get the lift object that can be added in lift rooting logic

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
@@ -297,7 +297,7 @@ class ParameterApiService2(
 
   import restDataSerializer.serializeParameter as serialize
 
-  private[this] def createChangeRequestAndAnswer(
+  private def createChangeRequestAndAnswer(
       id:           String,
       diff:         ChangeRequestGlobalParameterDiff,
       parameter:    GlobalParameter,
@@ -453,7 +453,7 @@ class ParameterApiService14(
     workflowLevelService: WorkflowLevelService
 ) {
 
-  private[this] def createChangeRequest(
+  private def createChangeRequest(
       diff:      ChangeRequestGlobalParameterDiff,
       parameter: GlobalParameter,
       change:    GlobalParamChangeRequest,

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -573,7 +573,7 @@ class RuleApiService2(
 
   import restDataSerializer.serializeRule as serialize
 
-  private[this] def createChangeRequestAndAnswer(
+  private def createChangeRequestAndAnswer(
       id:     String,
       diff:   ChangeRequestRuleDiff,
       change: RuleChangeRequest,
@@ -1152,7 +1152,7 @@ class RuleApiService14(
           s"<${rId.value}>",
           s"Category ${rId.value} has been deleted, please move rules to available categories",
           List(),
-          false
+          isSystem = false
         )
       })
   }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -294,7 +294,7 @@ class SettingsApi(
         case _          =>
           req.params.get("value") match {
             case Some(value :: Nil) => parseParam(value)
-            case Some(values)       => Failure("Too much values defined, only need one")
+            case Some(_)            => Failure("Too much values defined, only need one")
             case None               => Failure("No value defined in request")
           }
       }
@@ -312,7 +312,7 @@ class SettingsApi(
             case Some(value :: Nil) => parseParam(value).map(Some(_))
             // Not sure it can happen, but still treat it as empty value
             case Some(Nil)          => Full(None)
-            case Some(values)       => Failure("Too much values defined, only need one")
+            case Some(_)            => Failure("Too much values defined, only need one")
             case None               => Full(None)
           }
       }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
@@ -642,7 +642,7 @@ class SystemApiService13(
         RestUtils.toJsonResponse(None, JArray(json))
       case eb: EmptyBox =>
         val message = (eb ?~ s"Error when trying to run healthcheck").messageChain
-        RestUtils.toJsonError(None, message)(action, true)
+        RestUtils.toJsonError(None, message)(action, prettify = true)
     }
   }
 
@@ -676,7 +676,7 @@ class SystemApiService11(
   // The private methods are the internal behavior of the API.
   // They are helper functions called by the public method (implemented lower) to avoid code repetition.
 
-  private[this] def reloadTechniquesWrapper(req: Req): Either[String, JField] = {
+  private def reloadTechniquesWrapper(req: Req): Either[String, JField] = {
     ApiLogger.info(s"Trigger dynamic group reload")
     updatePTLibService.update(
       ModificationId(uuidGen.newUuid),
@@ -694,7 +694,7 @@ class SystemApiService11(
 
   // For now we are not able to give information about the group reload process.
   // We still send OK instead to inform the endpoint has correctly triggered.
-  private[this] def reloadDyngroupsWrapper(): Either[String, JField] = {
+  private def reloadDyngroupsWrapper(): Either[String, JField] = {
     ApiLogger.info(s"Trigger dynamic group reload")
     updateDynamicGroups.forceStartUpdate
     Right(JField("groups", "Started"))
@@ -705,7 +705,7 @@ class SystemApiService11(
     * (the most recent is the first in the array)
     * { "archiveType" : [ { "id" : "datetimeID", "date": "human readable date" , "commiter": "name", "gitPath": "path" }, ... ]
     */
-  private[this] def formatList(archiveType: String, availableArchives: Map[DateTime, GitArchiveId]): JField = {
+  private def formatList(archiveType: String, availableArchives: Map[DateTime, GitArchiveId]): JField = {
     val ordered = availableArchives.toList.sortWith { case ((d1, _), (d2, _)) => d1.isAfter(d2) }.map {
       case (date, tag) =>
         // archiveId is contained in gitPath, archive is archives/<kind>/archiveId
@@ -719,16 +719,16 @@ class SystemApiService11(
     JField(archiveType, ordered)
   }
 
-  private[this] def listTags(list: () => IOResult[Map[DateTime, GitArchiveId]], archiveType: String): Either[String, JField] = {
+  private def listTags(list: () => IOResult[Map[DateTime, GitArchiveId]], archiveType: String): Either[String, JField] = {
     list().either.runNow.fold(
       err => Left(s"Error when trying to list available archives for ${archiveType}. Error was: ${err.fullMsg}"),
       map => Right(formatList(archiveType, map))
     )
   }
 
-  private[this] def newModId = ModificationId(uuidGen.newUuid)
+  private def newModId = ModificationId(uuidGen.newUuid)
 
-  private[this] def restoreLatestArchive(
+  private def restoreLatestArchive(
       req:         Req,
       list:        () => IOResult[Map[DateTime, GitArchiveId]],
       restore:     (GitCommitId, PersonIdent, Boolean) => IOResult[GitCommitId],
@@ -753,7 +753,7 @@ class SystemApiService11(
     )
   }
 
-  private[this] def restoreLatestCommit(
+  private def restoreLatestCommit(
       req:         Req,
       restore:     (PersonIdent, Boolean) => IOResult[GitCommitId],
       archiveType: String
@@ -772,7 +772,7 @@ class SystemApiService11(
     )
   }
 
-  private[this] def restoreByDatetime(
+  private def restoreByDatetime(
       req:         Req,
       list:        () => IOResult[Map[DateTime, GitArchiveId]],
       restore:     (GitCommitId, PersonIdent, Boolean) => IOResult[GitCommitId],
@@ -804,7 +804,7 @@ class SystemApiService11(
     )
   }
 
-  private[this] def archive(
+  private def archive(
       req:         Req,
       archive:     (PersonIdent, ModificationId, EventActor, Option[String], Boolean) => IOResult[GitArchiveId],
       archiveType: String
@@ -827,18 +827,18 @@ class SystemApiService11(
     )
   }
 
-  private[this] val format = new DateTimeFormatterBuilder()
+  private val format = new DateTimeFormatterBuilder()
     .append(DateTimeFormat.forPattern("YYYY-MM-dd"))
     .appendLiteral('T')
     .append(DateTimeFormat.forPattern("hhmmss"))
     .toFormatter
 
-  private[this] val directiveFiles = List("directives", "techniques", "parameters", "ncf")
-  private[this] val ruleFiles      = List("rules", "ruleCategories")
-  private[this] val parameterFiles = List("parameters")
-  private[this] val allFiles       = "groups" :: ruleFiles ::: directiveFiles ::: parameterFiles
+  private val directiveFiles = List("directives", "techniques", "parameters", "ncf")
+  private val ruleFiles      = List("rules", "ruleCategories")
+  private val parameterFiles = List("parameters")
+  private val allFiles       = "groups" :: ruleFiles ::: directiveFiles ::: parameterFiles
 
-  private[this] def getZip(
+  private def getZip(
       commitId:    String,
       paths:       List[String],
       archiveType: String

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
@@ -151,8 +151,9 @@ class TechniqueApi(
           case API.TechniqueRevisions        => TechniqueRevisions
           case API.UpdateTechnique           => UpdateTechnique
           case API.CreateTechnique           => CreateTechnique
-          case API.GetResources              => new GetResources[API.GetResources.type](false, API.GetResources)
-          case API.GetNewResources           => new GetResources[API.GetNewResources.type](true, API.GetNewResources)
+          case API.GetResources              => new GetResources[API.GetResources.type](newTechnique = false, schema = API.GetResources)
+          case API.GetNewResources           =>
+            new GetResources[API.GetNewResources.type](newTechnique = true, schema = API.GetNewResources)
           case API.DeleteTechnique           => DeleteTechnique
           case API.GetMethods                => GetMethods
           case API.UpdateMethods             => UpdateMethods

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserAuthorisationLevel.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserAuthorisationLevel.scala
@@ -52,7 +52,7 @@ trait UserAuthorisationLevel {
 // and default implementation is: no
 class DefaultUserAuthorisationLevel() extends UserAuthorisationLevel {
   // Alternative level provider
-  private[this] var level: Option[UserAuthorisationLevel] = None
+  private var level: Option[UserAuthorisationLevel] = None
 
   def overrideLevel(l: UserAuthorisationLevel): Unit = {
     PluginLogger.info(s"Update User Authorisations level to '${l.name}'")

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/DirectiveEditor.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/DirectiveEditor.scala
@@ -50,13 +50,14 @@ import net.liftweb.util.BaseField
 import net.liftweb.util.Helpers
 import org.slf4j
 import org.slf4j.LoggerFactory
+import scala.reflect.ClassTag
 import scala.xml.*
 
 /**
  * A displayable field has 2 methods :
  * -> toHtmlNodeSeq and toFormNodeSeq : to display the form
  */
-trait DisplayableField extends {
+trait DisplayableField {
   def toHtmlNodeSeq: NodeSeq
 
   def toFormNodeSeq: NodeSeq
@@ -95,16 +96,10 @@ sealed trait SectionChildField extends DisplayableField with Loggable {
 trait DirectiveField extends BaseField with SectionChildField {
   val id: String
 
-  /**
-   * Get the manifest of the given type
-   * Use like: val manifest = manifest[MY_TYPE]
-   */
-  def manifestOf[T](implicit m: Manifest[T]): Manifest[T] = m
-
 //  This check is always going to fail: at this point id is always null
 //  require(!isEmpty(id), s"A field ID can not be null nor empty")
 
-  def manifest: Manifest[ValueType]
+  def manifest: ClassTag[ValueType]
   override def required_? = true
 
   // deprecated but has to be defined
@@ -527,7 +522,7 @@ final case class MultivaluedSectionField(
   /**
    * Command to correct display and behaviour after modifying sections
    */
-  private[this] def postModificationJS(): JsExp = {
+  private def postModificationJS(): JsExp = {
     JsRaw("""initBsTooltips(); """)
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/FilePermissions.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/FilePermissions.scala
@@ -303,9 +303,9 @@ object FilePerms {
     if (isEmpty(perms)) None
     else {
       perms.toList match {
-        case Perm(x) :: Nil                       => Some(FilePerms(x))
-        case Perm(x) :: Perm(y) :: Nil            => Some(FilePerms(x, y))
-        case Perm(x) :: Perm(y) :: Perm(z) :: Nil => Some(FilePerms(x, y, z))
+        case Perm(u) :: Nil                       => Some(FilePerms(u))
+        case Perm(u) :: Perm(g) :: Nil            => Some(FilePerms(u, g))
+        case Perm(u) :: Perm(g) :: Perm(o) :: Nil => Some(FilePerms(u, g, o))
         case _                                    => None
       }
     }
@@ -320,7 +320,7 @@ object FilePerms {
   }
   def unapply(ugo: (String, String, String)): Option[(Perm, Perm, Perm)] = {
     ugo match {
-      case (Perm(x), Perm(y), Perm(z)) => Some((x, y, z))
+      case (Perm(u), Perm(g), Perm(o)) => Some((u, g, o))
       case _                           => None
     }
   }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/ComputePolicyMode.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/ComputePolicyMode.scala
@@ -84,7 +84,7 @@ object ComputePolicyMode {
 
   // Here we are resolving conflict when we have an overridable global mode between mode of a Node, mode of a Directive and we are using global mode to use as default when both are not overriding
   // we do not pass a GlobalPolicyMode, but only the PolicyMode from it so we indicate that we don't want to treat overridabilty here
-  private[this] def matchMode(
+  private def matchMode(
       nodeMode:      Option[PolicyMode],
       directiveMode: Option[PolicyMode],
       globalMode:    PolicyMode
@@ -125,7 +125,7 @@ object ComputePolicyMode {
   // * A unique policy mode of one element of type A as base (generally a Directive or a Node)
   // * multiples Policy modes of a set elements of type B that we will look into it to understand what's going on
   // The other parameters (uniqueKind/multipleKind, mixedExplnation) are used to build explanation message
-  private[this] def genericComputeMode(
+  private def genericComputeMode(
       uniqueMode:       Option[PolicyMode],
       uniqueKind:       String,
       multipleModes:    Set[Option[PolicyMode]],

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/DiffDisplayer.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/DiffDisplayer.scala
@@ -96,8 +96,8 @@ final case class Modified[T](
     newValue: T
 ) extends DiffItem[T] {
 
-  private[this] val delete = Deleted(oldValue)
-  private[this] val add    = Added(oldValue)
+  private val delete = Deleted(oldValue)
+  private val add    = Added(oldValue)
 
   def display(implicit displayer: T => NodeSeq): NodeSeq =
     delete.display ++ add.display
@@ -105,7 +105,7 @@ final case class Modified[T](
 
 class DiffDisplayer(linkUtil: LinkUtil) extends Loggable {
 
-  implicit private[this] def displayDirective(directiveId: DirectiveId): Elem = {
+  implicit private def displayDirective(directiveId: DirectiveId): Elem = {
     <span> Directive {linkUtil.createDirectiveLink(directiveId.uid)}</span>
   }
   def displayDirectiveChangeList(
@@ -219,7 +219,7 @@ class DiffDisplayer(linkUtil: LinkUtil) extends Loggable {
   }
 
   //
-  private[this] val ruleCategoryService = new RuleCategoryService()
+  private val ruleCategoryService = new RuleCategoryService()
 
   def displayRuleCategory(
       rootCategory: RuleCategory,
@@ -227,7 +227,7 @@ class DiffDisplayer(linkUtil: LinkUtil) extends Loggable {
       newCategory:  Option[RuleCategoryId]
   ): Elem = {
 
-    def getCategoryFullName(category: RuleCategoryId)                = {
+    def getCategoryFullName(category: RuleCategoryId) = {
       ruleCategoryService.shortFqdn(rootCategory, category) match {
         case Full(fqdn) => fqdn
         case eb: EmptyBox =>
@@ -235,7 +235,7 @@ class DiffDisplayer(linkUtil: LinkUtil) extends Loggable {
           category.value
       }
     }
-    implicit def displayRuleCategory(ruleCategoryId: RuleCategoryId) = {
+    implicit def displayRuleCategory(ruleCategoryId: RuleCategoryId): Elem = {
       <span>{getCategoryFullName(ruleCategoryId)}</span>
     }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -98,7 +98,7 @@ class EventLogDetailsGenerator(
     diffDisplayer:       DiffDisplayer
 ) extends Loggable {
 
-  private[this] val xmlPretty = new scala.xml.PrettyPrinter(80, 2)
+  private val xmlPretty = new scala.xml.PrettyPrinter(80, 2)
 
   // convention: "X" means "ignore"
 
@@ -1125,7 +1125,7 @@ class EventLogDetailsGenerator(
     } </td>
   }
 
-  private[this] def agentRunDetails(ar: AgentRunInterval): NodeSeq = {
+  private def agentRunDetails(ar: AgentRunInterval): NodeSeq = {
     (
       "#override" #> ar.overrides.map(_.toString()).getOrElse("false")
       & "#interval" #> ar.interval
@@ -1143,7 +1143,7 @@ class EventLogDetailsGenerator(
     )
   }
 
-  private[this] def heartbeatDetails(hb: HeartbeatConfiguration):                                      NodeSeq = {
+  private def heartbeatDetails(hb: HeartbeatConfiguration):                                      NodeSeq = {
     (
       "#override" #> hb.overrides
       & "#interval" #> hb.heartbeatPeriod
@@ -1155,18 +1155,18 @@ class EventLogDetailsGenerator(
     )
   }
 
-  private[this] def displaySimpleDiff[T](
+  private def displaySimpleDiff[T](
       diff:    Option[SimpleDiff[T]],
       name:    String,
       default: String
   ): NodeSeq = displaySimpleDiff(diff, name).getOrElse(Text(default))
 
-  private[this] def displaySimpleDiff[T](
+  private def displaySimpleDiff[T](
       diff: Option[SimpleDiff[T]],
       name: String
   ): Option[NodeSeq] = diff.map(value => displayFormDiff(value, name))
 
-  private[this] def displayFormDiff[T](
+  private def displayFormDiff[T](
       diff: SimpleDiff[T],
       name: String
   )(implicit fun: T => String = (t: T) => t.toString): NodeSeq = {
@@ -1187,7 +1187,7 @@ class EventLogDetailsGenerator(
       )
     )
   }
-  private[this] def displaydirectiveInnerFormDiff(diff: SimpleDiff[SectionVal], eventId: Option[Int]): NodeSeq = {
+  private def displaydirectiveInnerFormDiff(diff: SimpleDiff[SectionVal], eventId: Option[Int]): NodeSeq = {
     eventId match {
       case None     => NodeSeq.Empty
       case Some(id) =>
@@ -1206,7 +1206,7 @@ class EventLogDetailsGenerator(
     }
   }
 
-  private[this] def displayExportArchiveDetails(gitArchiveId: GitArchiveId, rawData: NodeSeq) = {
+  private def displayExportArchiveDetails(gitArchiveId: GitArchiveId, rawData: NodeSeq) = {
     <div class="evloglmargin">
       <h4>Details of the new archive:</h4>
       <ul class="evlogviewpad">
@@ -1219,7 +1219,7 @@ class EventLogDetailsGenerator(
     </div>
   }
 
-  private[this] def displayImportArchiveDetails(gitCommitId: GitCommitId, rawData: NodeSeq) = {
+  private def displayImportArchiveDetails(gitCommitId: GitCommitId, rawData: NodeSeq) = {
     <div class="evloglmargin">
       <h4>Details of the restored archive:</h4>
       <ul class="evlogviewpad">
@@ -1229,7 +1229,7 @@ class EventLogDetailsGenerator(
     </div>
   }
 
-  private[this] def nodeGroupDetails(nodes: Set[NodeId]): NodeSeq = {
+  private def nodeGroupDetails(nodes: Set[NodeId]): NodeSeq = {
     val res = nodes.toSeq match {
       case Seq() => NodeSeq.Empty
       case t     =>
@@ -1243,8 +1243,8 @@ class EventLogDetailsGenerator(
 
   }
 
-  private[this] def ruleDetails(xml: NodeSeq, rule: Rule, groupLib: FullNodeGroupCategory, rootRuleCategory: RuleCategory)(
-      implicit qc: QueryContext
+  private def ruleDetails(xml: NodeSeq, rule: Rule, groupLib: FullNodeGroupCategory, rootRuleCategory: RuleCategory)(implicit
+      qc: QueryContext
   ) = {
     (
       "#ruleID" #> rule.id.serialize &
@@ -1259,7 +1259,7 @@ class EventLogDetailsGenerator(
     )(xml)
   }
 
-  private[this] def directiveDetails(xml: NodeSeq, ptName: TechniqueName, directive: Directive, sectionVal: SectionVal) = (
+  private def directiveDetails(xml: NodeSeq, ptName: TechniqueName, directive: Directive, sectionVal: SectionVal) = (
     "#directiveID" #> directive.id.serialize &
       "#directiveName" #> directive.name &
       "#ptVersion" #> directive.techniqueVersion.debugString &
@@ -1273,7 +1273,7 @@ class EventLogDetailsGenerator(
       "#longDescription" #> directive.longDescription
   )(xml)
 
-  private[this] def groupDetails(xml: NodeSeq, group: NodeGroup) = (
+  private def groupDetails(xml: NodeSeq, group: NodeGroup) = (
     "#groupID" #> group.id.withDefaultRev.serialize &
       "#groupName" #> group.name &
       "#shortDescription" #> group.description &
@@ -1297,20 +1297,20 @@ class EventLogDetailsGenerator(
       "#isSystem" #> group.isSystem
   )(xml)
 
-  private[this] def techniqueDetails(xml: NodeSeq, technique: ActiveTechnique) = (
+  private def techniqueDetails(xml: NodeSeq, technique: ActiveTechnique) = (
     "#techniqueID" #> technique.id.value &
       "#techniqueName" #> technique.techniqueName.value &
       "#isEnabled" #> technique.isEnabled &
       "#isSystem" #> technique.isSystem
   )(xml)
 
-  private[this] def globalParameterDetails(xml: NodeSeq, globalParameter: GlobalParameter) = (
+  private def globalParameterDetails(xml: NodeSeq, globalParameter: GlobalParameter) = (
     "#name" #> globalParameter.name &
       "#value" #> globalParameter.valueAsString &
       "#description" #> globalParameter.description
   )(xml)
 
-  private[this] def apiAccountDetails(xml: NodeSeq, apiAccount: ApiAccount) = (
+  private def apiAccountDetails(xml: NodeSeq, apiAccount: ApiAccount) = (
     "#id" #> apiAccount.id.value &
       "#name" #> apiAccount.name.value &
       "#token" #> apiAccount.token.value &
@@ -1320,20 +1320,20 @@ class EventLogDetailsGenerator(
       "#tokenGenerationDate" #> DateFormaterService.getDisplayDate(apiAccount.tokenGenerationDate)
   )(xml)
 
-  private[this] def mapSimpleDiffT[T](opt: Option[SimpleDiff[T]], t: T => String) = opt.map { diff =>
+  private def mapSimpleDiffT[T](opt: Option[SimpleDiff[T]], t: T => String) = opt.map { diff =>
     ".diffOldValue *" #> t(diff.oldValue) &
     ".diffNewValue *" #> t(diff.newValue)
   }
 
-  private[this] def mapSimpleDiff[T](opt: Option[SimpleDiff[T]]) = mapSimpleDiffT(opt, (x: T) => x.toString)
+  private def mapSimpleDiff[T](opt: Option[SimpleDiff[T]]) = mapSimpleDiffT(opt, (x: T) => x.toString)
 
-  private[this] def mapSimpleDiff[T](opt: Option[SimpleDiff[T]], id: DirectiveId) = opt.map { diff =>
+  private def mapSimpleDiff[T](opt: Option[SimpleDiff[T]], id: DirectiveId) = opt.map { diff =>
     ".diffOldValue *" #> diff.oldValue.toString &
     ".diffNewValue *" #> diff.newValue.toString &
     "#directiveID" #> id.serialize
   }
 
-  private[this] def mapComplexDiff[T](opt: Option[SimpleDiff[T]])(display: T => NodeSeq) = {
+  private def mapComplexDiff[T](opt: Option[SimpleDiff[T]])(display: T => NodeSeq) = {
     opt match {
       case None       => NodeSeq.Empty
       case Some(diff) =>
@@ -1352,7 +1352,7 @@ class EventLogDetailsGenerator(
   /*
    * Special diff for json: use a json diff tool.
    */
-  private[this] def jsonDiff(diff: Option[SimpleDiff[JValue]]): NodeSeq = {
+  private def jsonDiff(diff: Option[SimpleDiff[JValue]]): NodeSeq = {
     val s = Random.nextInt(100000)
 
     def stringify(jValue: JValue): String = {
@@ -1383,7 +1383,7 @@ class EventLogDetailsGenerator(
   /*
    * Special diff for tags as a list of key-value pair using a simple line diff against "key=value" tag format
    */
-  private[this] def tagsDiff(opt: Option[SimpleDiff[Tags]]) = {
+  private def tagsDiff(opt: Option[SimpleDiff[Tags]]) = {
     def tagsToLines(tags: Tags): String = {
       tags.tags.toList.sortBy(_.name.value).map(t => s" ${t.name.value}=${t.value.value} ").mkString("\n")
     }
@@ -1395,7 +1395,7 @@ class EventLogDetailsGenerator(
   /*
    * Special diff for node properties using a json diff tool.
    */
-  private[this] def nodePropertiesDiff(opt: Option[SimpleDiff[List[NodeProperty]]]): NodeSeq = {
+  private def nodePropertiesDiff(opt: Option[SimpleDiff[List[NodeProperty]]]): NodeSeq = {
     def toJson(props: List[NodeProperty]): JObject = {
       props.toDataJson
     }
@@ -1403,7 +1403,7 @@ class EventLogDetailsGenerator(
     jsonDiff(opt.map(diff => SimpleDiff(toJson(diff.oldValue), toJson(diff.newValue))))
   }
 
-  private[this] def promotedNodeDetails(id: NodeId, name: String) = (
+  private def promotedNodeDetails(id: NodeId, name: String) = (
     "#nodeID" #> id.value &
       "#nodeName" #> name
   )(
@@ -1412,7 +1412,7 @@ class EventLogDetailsGenerator(
       <li><b>Hostname: </b><value id="nodeName"/></li>
     </ul>
   )
-  private[this] def nodeDetails(details: InventoryLogDetails)     = (
+  private def nodeDetails(details: InventoryLogDetails)     = (
     "#nodeID" #> details.nodeId.value &
       "#nodeName" #> details.hostname &
       "#os" #> details.fullOsName &
@@ -1426,12 +1426,12 @@ class EventLogDetailsGenerator(
     </ul>
   )
 
-  private[this] def secretDetails(xml: NodeSeq, secret: Secret) = (
+  private def secretDetails(xml: NodeSeq, secret: Secret) = (
     "#name" #> secret.name &
       "#description" #> secret.description
   )(xml)
 
-  private[this] val crDetailsXML = {
+  private val crDetailsXML = {
     <div>
       <h4>Rule overview:</h4>
       <ul class="evlogviewpad">
@@ -1448,7 +1448,7 @@ class EventLogDetailsGenerator(
     </div>
   }
 
-  private[this] val piDetailsXML = {
+  private val piDetailsXML = {
     <div>
       <h4>Directive overview:</h4>
       <ul class="evlogviewpad">
@@ -1465,7 +1465,7 @@ class EventLogDetailsGenerator(
     </div>
   }
 
-  private[this] val groupDetailsXML = {
+  private val groupDetailsXML = {
     <div>
       <h4>Group overview:</h4>
       <ul class="evlogviewpad">
@@ -1481,7 +1481,7 @@ class EventLogDetailsGenerator(
     </div>
   }
 
-  private[this] val techniqueDetailsXML = {
+  private val techniqueDetailsXML = {
     <div>
       <h4>Technique overview:</h4>
       <ul class="evlogviewpad">
@@ -1493,7 +1493,7 @@ class EventLogDetailsGenerator(
     </div>
   }
 
-  private[this] val globalParamDetailsXML = {
+  private val globalParamDetailsXML = {
     <div>
       <h4>Global Parameter overview:</h4>
       <ul class="evlogviewpad">
@@ -1505,7 +1505,7 @@ class EventLogDetailsGenerator(
     </div>
   }
 
-  private[this] val apiAccountDetailsXML = {
+  private val apiAccountDetailsXML = {
     <div>
       <h4>API account overview:</h4>
       <ul class="evlogviewpad">
@@ -1523,7 +1523,7 @@ class EventLogDetailsGenerator(
     </div>
   }
 
-  private[this] val apiAccountModDetailsXML = {
+  private val apiAccountModDetailsXML = {
     <xml:group>
       {liModDetailsXML("name", "Name")}
       {liModDetailsXML("token", "Token")}
@@ -1536,7 +1536,7 @@ class EventLogDetailsGenerator(
     </xml:group>
   }
 
-  private[this] def liModDetailsXML(id: String, name: String) = (
+  private def liModDetailsXML(id: String, name: String) = (
     <div id={id}>
       <b>{name} changed:</b>
       <ul class="evlogviewpad">
@@ -1546,7 +1546,7 @@ class EventLogDetailsGenerator(
     </div>
   )
 
-  private[this] def liModDirectiveDetailsXML(id: String, name: String) = (
+  private def liModDirectiveDetailsXML(id: String, name: String) = (
     <div id={id}>
       <b>{name} changed:</b>
       <ul class="evlogviewpad">
@@ -1555,7 +1555,7 @@ class EventLogDetailsGenerator(
     </div>
   )
 
-  private[this] val groupModDetailsXML = {
+  private val groupModDetailsXML = {
     <xml:group>
       {liModDetailsXML("name", "Name")}
       {liModDetailsXML("shortDescription", "Description")}
@@ -1567,7 +1567,7 @@ class EventLogDetailsGenerator(
     </xml:group>
   }
 
-  private[this] val crModDetailsXML = {
+  private val crModDetailsXML = {
     <xml:group>
       {liModDetailsXML("name", "Name")}
       {liModDetailsXML("category", "Category")}
@@ -1580,7 +1580,7 @@ class EventLogDetailsGenerator(
     </xml:group>
   }
 
-  private[this] val piModDirectiveDetailsXML = {
+  private val piModDirectiveDetailsXML = {
     <xml:group>
       {liModDetailsXML("name", "Name")}
       {liModDetailsXML("shortDescription", "Description")}
@@ -1595,7 +1595,7 @@ class EventLogDetailsGenerator(
     </xml:group>
   }
 
-  private[this] val globalParamModDetailsXML = {
+  private val globalParamModDetailsXML = {
     <xml:group>
       {liModDetailsXML("name", "Name")}
       {liModDetailsXML("value", "Value")}
@@ -1604,7 +1604,7 @@ class EventLogDetailsGenerator(
     </xml:group>
   }
 
-  private[this] val secretXML = {
+  private val secretXML = {
     <div>
       <h4>Secret overview:</h4>
       <ul class="evlogviewpad">
@@ -1614,7 +1614,7 @@ class EventLogDetailsGenerator(
     </div>
   }
 
-  private[this] val secretModDetailsXML = {
+  private val secretModDetailsXML = {
     <xml:group>
       {liModDetailsXML("name", "Name")}
       {liModDetailsXML("value", "Value")}
@@ -1622,7 +1622,7 @@ class EventLogDetailsGenerator(
     </xml:group>
   }
 
-  private[this] def displayRollbackDetails(rollbackInfo: RollbackInfo, id: Int) = {
+  private def displayRollbackDetails(rollbackInfo: RollbackInfo, id: Int) = {
     val rollbackedEvents = rollbackInfo.rollbacked
     <div class="evloglmargin">
       <div style="width:50%; float:left;">
@@ -1730,7 +1730,7 @@ class EventLogDetailsGenerator(
         """))
   }
 
-  private[this] def authorizedNetworksXML() = (
+  private def authorizedNetworksXML() = (
     <div>
       <b>Networks authorized on policy server were updated:</b>
       <table class="eventLogUpdatePolicy">

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/Section2FieldService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/Section2FieldService.scala
@@ -94,7 +94,7 @@ class Section2FieldService(val fieldFactory: DirectiveFieldFactory, val translat
   }
 
   // bound used section fields to
-  private[this] def boundUsedFields(section: SectionField, bounds: Map[String, Seq[String]]): SectionField = {
+  private def boundUsedFields(section: SectionField, bounds: Map[String, Seq[String]]): SectionField = {
     val allFields = section.getAllDirectVariables
     allFields.values.foreach { f =>
       bounds.get(f.id) match {
@@ -158,7 +158,7 @@ class Section2FieldService(val fieldFactory: DirectiveFieldFactory, val translat
       }
     }
 
-    val readOnlySection = section.children.collect { case x: PredefinedValuesVariableSpec => x }.size > 0
+    val readOnlySection = section.children.collect { case a: PredefinedValuesVariableSpec => a }.size > 0
     if (section.isMultivalued) {
       val sectionFields = {
         for (sectionMap <- seqOfSectionMap)
@@ -168,7 +168,10 @@ class Section2FieldService(val fieldFactory: DirectiveFieldFactory, val translat
         sectionFields,
         () => {
           // here, valuesByName is empty, we are creating a new map.
-          boundUsedFields(createSingleSectionField(section, Map(), createDefaultMap(section), true, usedFields), usedFields)
+          boundUsedFields(
+            createSingleSectionField(section, Map(), createDefaultMap(section), isNewPolicy = true, usedFields = usedFields),
+            usedFields
+          )
         },
         priorityToVisibility(section.displayPriority),
         readOnlySection
@@ -178,7 +181,7 @@ class Section2FieldService(val fieldFactory: DirectiveFieldFactory, val translat
     }
   }
 
-  private[this] def createVarField(varSpec: VariableSpec, valueOpt: Option[String]): (DirectiveField, (String, () => String)) = {
+  private def createVarField(varSpec: VariableSpec, valueOpt: Option[String]): (DirectiveField, (String, () => String)) = {
     val fieldKey = varSpec.name
     val field    = fieldFactory.forType(varSpec, fieldKey)
 
@@ -208,7 +211,7 @@ class Section2FieldService(val fieldFactory: DirectiveFieldFactory, val translat
     (field, varMappings)
   }
 
-  private[this] def createSingleSectionField(
+  private def createSingleSectionField(
       sectionSpec:  SectionSpec,
       valuesByName: Map[String, Seq[String]],
       sectionMap:   Map[String, Option[String]],
@@ -236,7 +239,7 @@ class Section2FieldService(val fieldFactory: DirectiveFieldFactory, val translat
     )
   }
 
-  private[this] def createSingleSectionFieldForMultisec(
+  private def createSingleSectionFieldForMultisec(
       sectionSpec: SectionSpec,
       sectionMap:  Map[String, Option[String]],
       isNewPolicy: Boolean,
@@ -333,7 +336,7 @@ class Section2FieldService(val fieldFactory: DirectiveFieldFactory, val translat
    * - Low priority => hidden
    * - High priority => displayed
    */
-  private[this] def priorityToVisibility(priority: DisplayPriority): Boolean = {
+  private def priorityToVisibility(priority: DisplayPriority): Boolean = {
     priority match {
       case LowDisplayPriority  => false
       case HighDisplayPriority => true

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/Translator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/Translator.scala
@@ -44,6 +44,7 @@ import org.apache.commons.io.FilenameUtils
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.format.DateTimeFormatter
 import scala.collection.mutable.Map as MutMap
+import scala.reflect.ClassTag
 
 class Serializer[T](techniques: (String, T => String)*) {
   // all the known properties for that type
@@ -107,7 +108,7 @@ class Translator[T](val to: Serializer[T], val from: Unserializer[T])
 
 class Translators {
 
-  private val reg: MutMap[Manifest[?], Translator[?]] = MutMap()
+  private val reg: MutMap[ClassTag[?], Translator[?]] = MutMap()
 
   /**
    * Add a translator for the given type.
@@ -117,7 +118,7 @@ class Translators {
    * @param t
    * @param m
    */
-  def add[T](t: Translator[T])(implicit m: Manifest[T]): Unit = {
+  def add[T](t: Translator[T])(implicit m: ClassTag[T]): Unit = {
     get(m) match {
       case None           => reg += (m -> t)
       case Some(existing) => {
@@ -128,7 +129,7 @@ class Translators {
     }
   }
 
-  def get[T](implicit m: Manifest[T]): Option[Translator[T]] = {
+  def get[T](implicit m: ClassTag[T]): Option[Translator[T]] = {
     reg.get(m) match {
       case Some(t: Translator[T @unchecked]) => Some[Translator[T]](t)
       case _                                 => None

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/UserPropertyService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/UserPropertyService.scala
@@ -61,7 +61,7 @@ trait UserPropertyService {
 
 class UserPropertyServiceImpl(val opt: ReasonsMessageInfo) extends UserPropertyService {
 
-  private[this] val impl =
+  private val impl =
     new StatelessUserPropertyService(() => opt.enabled.succeed, () => opt.mandatory.succeed, () => opt.explanation.succeed)
 
   override val reasonsFieldBehavior = impl.reasonsFieldBehavior

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -213,13 +213,13 @@ class MockCompliance(mockDirectives: MockDirectives) {
     def getFullGroupLibrary(): IOResult[FullNodeGroupCategory] = {
       FullNodeGroupCategory(
         NodeGroupCategoryId("GroupRoot"),
-        "GroupRoot",
-        "root of group categories",
-        Nil,
-        nodeGroups.map(g => {
+        name = "GroupRoot",
+        description = "root of group categories",
+        subCategories = Nil,
+        targetInfos = nodeGroups.map(g => {
           FullRuleTargetInfo(FullGroupTarget(GroupTarget(g.id), g), g.name, g.description, g.isEnabled, g.isSystem)
         }),
-        true
+        isSystem = true
       ).succeed
     }
 
@@ -397,11 +397,38 @@ class MockCompliance(mockDirectives: MockDirectives) {
       )
     )
 
-    val g1: NodeGroup = NodeGroup(nodeGroupId(1), "G1", "", Nil, None, false, (1 to 2).map(nodeId).toSet, true)
+    val g1: NodeGroup = NodeGroup(
+      nodeGroupId(1),
+      name = "G1",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = false,
+      serverList = (1 to 2).map(nodeId).toSet,
+      _isEnabled = true
+    )
 
-    val g2: NodeGroup = NodeGroup(nodeGroupId(2), "G2", "", Nil, None, false, Set(nodeId(2)), true)
+    val g2: NodeGroup = NodeGroup(
+      nodeGroupId(2),
+      name = "G2",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = false,
+      serverList = Set(nodeId(2)),
+      _isEnabled = true
+    )
 
-    val g3: NodeGroup = NodeGroup(nodeGroupId(3), "G3", "", Nil, None, false, Set(nodeId(1)), true)
+    val g3: NodeGroup = NodeGroup(
+      nodeGroupId(3),
+      name = "G3",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = false,
+      serverList = Set(nodeId(1)),
+      _isEnabled = true
+    )
 
     val r1: Rule = Rule(
       ruleId(1),
@@ -457,12 +484,66 @@ class MockCompliance(mockDirectives: MockDirectives) {
     - R6, which applies D4 to G6 (so we will have skipped on N4 and N5)
      */
 
-    val g1: NodeGroup = NodeGroup(nodeGroupId(1), "G1", "", Nil, None, false, Set(nodeId(1), nodeId(2)), true)
-    val g2: NodeGroup = NodeGroup(nodeGroupId(2), "G2", "", Nil, None, false, Set(nodeId(2)), true)
-    val g3: NodeGroup = NodeGroup(nodeGroupId(3), "G3", "", Nil, None, false, Set(nodeId(1)), true)
-    val g4: NodeGroup = NodeGroup(nodeGroupId(4), "G4", "", Nil, None, false, Set(nodeId(3), nodeId(4), nodeId(5)), true)
-    val g5: NodeGroup = NodeGroup(nodeGroupId(5), "G5", "", Nil, None, false, Set(nodeId(2), nodeId(3)), true)
-    val g6: NodeGroup = NodeGroup(nodeGroupId(6), "G6", "", Nil, None, false, Set(nodeId(4), nodeId(5)), true)
+    val g1: NodeGroup = NodeGroup(
+      nodeGroupId(1),
+      name = "G1",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = false,
+      serverList = Set(nodeId(1), nodeId(2)),
+      _isEnabled = true
+    )
+    val g2: NodeGroup = NodeGroup(
+      nodeGroupId(2),
+      name = "G2",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = false,
+      serverList = Set(nodeId(2)),
+      _isEnabled = true
+    )
+    val g3: NodeGroup = NodeGroup(
+      nodeGroupId(3),
+      name = "G3",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = false,
+      serverList = Set(nodeId(1)),
+      _isEnabled = true
+    )
+    val g4: NodeGroup = NodeGroup(
+      nodeGroupId(4),
+      name = "G4",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = false,
+      serverList = Set(nodeId(3), nodeId(4), nodeId(5)),
+      _isEnabled = true
+    )
+    val g5: NodeGroup = NodeGroup(
+      nodeGroupId(5),
+      name = "G5",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = false,
+      serverList = Set(nodeId(2), nodeId(3)),
+      _isEnabled = true
+    )
+    val g6: NodeGroup = NodeGroup(
+      nodeGroupId(6),
+      name = "G6",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = false,
+      serverList = Set(nodeId(4), nodeId(5)),
+      _isEnabled = true
+    )
 
     val d1 = directives.fileTemplateDirecive1
     val d2 = directives.fileTemplateVariables2

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/RuleTests.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/RuleTests.scala
@@ -88,10 +88,10 @@ class RuleTest extends Specification with Loggable {
 
   val root: RuleCategory = RuleCategory(
     RuleCategoryId("rootRuleCategory"),
-    "Root category",
-    "base root category",
-    subCat,
-    true
+    name = "Root category",
+    description = "base root category",
+    childs = subCat,
+    isSystem = true
   )
 
   "Testing rule utility tools" should {
@@ -132,17 +132,17 @@ class RuleTest extends Specification with Loggable {
       )
       val cat1  = RuleCategory(
         RuleCategoryId("missing-cat1"),
-        "<missing-cat1>",
-        s"Category missing-cat1 has been deleted, please move rules to available categories",
-        List(),
-        false
+        name = "<missing-cat1>",
+        description = s"Category missing-cat1 has been deleted, please move rules to available categories",
+        childs = List(),
+        isSystem = false
       )
       val cat2  = RuleCategory(
         RuleCategoryId("missing-cat2"),
-        "<missing-cat2>",
-        s"Category missing-cat2 has been deleted, please move rules to available categories",
-        List(),
-        false
+        name = "<missing-cat2>",
+        description = s"Category missing-cat2 has been deleted, please move rules to available categories",
+        childs = List(),
+        isSystem = false
       )
       restTestSetUp.ruleApiService14.getMissingCategories(root, rules) shouldEqual (Set(cat1, cat2))
     }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -177,6 +177,8 @@ import org.specs2.matcher.MatchResult
 import scala.collection.MapView
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
+import scala.reflect.ClassTag
+import scala.reflect.classTag
 import scala.xml.Elem
 import scala.xml.NodeSeq
 import zio.*
@@ -662,9 +664,9 @@ class RestTestSetUp {
     override def forType(fieldType: VariableSpec, id: String): DirectiveField = default(id)
     override def default(withId: String): DirectiveField = new DirectiveField {
       self => type ValueType = String
-      def manifest = manifestOf[String]
-      lazy val id  = withId
-      def name     = id
+      def manifest: ClassTag[String] = classTag[String]
+      lazy val id = withId
+      def name    = id
       override val uniqueFieldId: Box[String]                      = Full(id)
       protected var _x:           String                           = getDefaultValue
       def validate:               List[FieldError]                 = Nil
@@ -950,8 +952,14 @@ class RestTestSetUp {
     )
   )
 
-  val apiVersions: List[ApiVersion] =
-    ApiVersion(14, true) :: ApiVersion(15, true) :: ApiVersion(16, true) :: ApiVersion(17, true) :: ApiVersion(18, false) :: Nil
+  val apiVersions: List[ApiVersion] = {
+    ApiVersion(14, deprecated = true) ::
+    ApiVersion(15, deprecated = true) ::
+    ApiVersion(16, deprecated = true) ::
+    ApiVersion(17, deprecated = true) ::
+    ApiVersion(18, deprecated = false) ::
+    Nil
+  }
   val (rudderApi, liftRules) = TraitTestApiFromYamlFiles.buildLiftRules(apiModules, apiVersions, Some(userService))
 
   liftRules.statelessDispatch.append(RestStatus)
@@ -1032,7 +1040,7 @@ class RestTest(liftRules: LiftRules) {
     }
   }
 
-  private[this] def mockRequest(path: String, method: String) = {
+  private def mockRequest(path: String, method: String) = {
     val mockReq = new MockHttpServletRequest("http://localhost:8080")
 
     val (p, queryString) = {
@@ -1055,7 +1063,7 @@ class RestTest(liftRules: LiftRules) {
   def POST(path:   String): MockHttpServletRequest = mockRequest(path, "POST")
   def DELETE(path: String): MockHttpServletRequest = mockRequest(path, "DELETE")
 
-  private[this] def mockJsonRequest(path: String, method: String, data: JValue) = {
+  private def mockJsonRequest(path: String, method: String, data: JValue) = {
     val mockReq = mockRequest(path, method)
     mockReq.body = data
     mockReq

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SystemApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SystemApiTest.scala
@@ -512,7 +512,7 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
     }
   }
 
-  private[this] def contentArchiveDiff(req: Req, matcher: List[File], action: String) = {
+  private def contentArchiveDiff(req: Req, matcher: List[File], action: String) = {
     import com.normation.rudder.git.ZipUtils
 
     restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() match {

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
@@ -207,7 +207,7 @@ trait TraitTestApiFromYamlFiles extends Specification with BoxSpecMatcher with J
 
     for {
       // base, directly from classpath
-      baseFiles <- listFilesUnder(baseDir, true).map(_.filter(only))
+      baseFiles <- listFilesUnder(baseDir, mandatory = true).map(_.filter(only))
       baseIs     = baseFiles.map { name =>
                      (
                        name,
@@ -217,7 +217,7 @@ trait TraitTestApiFromYamlFiles extends Specification with BoxSpecMatcher with J
                      )
                    }
       // templates: need copy to tmp file
-      templates <- listFilesUnder(templateDir, false).map(_.filter(only))
+      templates <- listFilesUnder(templateDir, mandatory = false).map(_.filter(only))
       copied    <- ZIO.foreach(templates)(t => copyTransform(Paths.get(templateDir, t), tmpDir))
       allYamls  <- ZIO.foreach(baseIs ++ copied) { case (name, input) => loadYamls(input).map(y => (name, y)) }
     } yield {

--- a/webapp/sources/rudder/rudder-templates-cli/src/main/scala/com/normation/templates/cli/TemplateCli.scala
+++ b/webapp/sources/rudder/rudder-templates-cli/src/main/scala/com/normation/templates/cli/TemplateCli.scala
@@ -354,7 +354,7 @@ object ParseVariables extends Loggable {
                 }
 
               // in any other case, parse as value
-              case (name, value)                    => Some(STVariable(name, true, parseAsValue(value), false))
+              case (name, value)                    => Some(STVariable(name, mayBeEmpty = true, values = parseAsValue(value), isSystem = false))
             }
           }.toSet
 

--- a/webapp/sources/rudder/rudder-templates-cli/src/test/scala/com/normation/templates/cli/JsonVariablesTest.scala
+++ b/webapp/sources/rudder/rudder-templates-cli/src/test/scala/com/normation/templates/cli/JsonVariablesTest.scala
@@ -62,14 +62,14 @@ class JsonVariablesTest extends Specification {
          }
         """
       val variables = Seq(
-        STVariable("key1", true, ArraySeq(true), false),
-        STVariable("key2", true, ArraySeq("some value"), false),
-        STVariable("key3", true, ArraySeq("42"), false),
-        STVariable("key4", true, ArraySeq("some", "more", "values", true, false), false),
-        STVariable("key5", false, ArraySeq("k5"), true),
-        STVariable("key6", true, ArraySeq("a1", "a2", "a3"), false),
-        STVariable("key7", true, ArraySeq(""), false),
-        STVariable("key8", true, ArraySeq(), false)
+        STVariable("key1", mayBeEmpty = true, values = ArraySeq(true), isSystem = false),
+        STVariable("key2", mayBeEmpty = true, values = ArraySeq("some value"), isSystem = false),
+        STVariable("key3", mayBeEmpty = true, values = ArraySeq("42"), isSystem = false),
+        STVariable("key4", mayBeEmpty = true, values = ArraySeq("some", "more", "values", true, false), isSystem = false),
+        STVariable("key5", mayBeEmpty = false, values = ArraySeq("k5"), isSystem = true),
+        STVariable("key6", mayBeEmpty = true, values = ArraySeq("a1", "a2", "a3"), isSystem = false),
+        STVariable("key7", mayBeEmpty = true, values = ArraySeq(""), isSystem = false),
+        STVariable("key8", mayBeEmpty = true, values = ArraySeq.empty[String], isSystem = false)
       )
 
       ParseVariables.fromString(json).runNow must containTheSameElementsAs(variables)

--- a/webapp/sources/rudder/rudder-templates/src/main/scala/com/normation/templates/FillTemplatesService.scala
+++ b/webapp/sources/rudder/rudder-templates/src/main/scala/com/normation/templates/FillTemplatesService.scala
@@ -247,7 +247,7 @@ object FillTemplateThreadUnsafe {
       _         = replaceId match {
                     case None             => // nothing
                     case Some((from, to)) =>
-                      val variable = STVariable(from, true, ArraySeq(to), true)
+                      val variable = STVariable(from, mayBeEmpty = true, values = ArraySeq(to), isSystem = true)
                       template.setAttribute(variable.name, variable.values.unsafeArray)
                   }
       t1       <- currentTimeNanos
@@ -282,7 +282,7 @@ class FillTemplatesService {
    * If a content is not in the cache, it will create the StringTemplate instance, and return it
    *
    */
-  private[this] val cache = ZioRuntime.unsafeRun(Ref.make(Map[String, Promise[RudderError, SynchronizedFileTemplate]]()))
+  private val cache = ZioRuntime.unsafeRun(Ref.make(Map[String, Promise[RudderError, SynchronizedFileTemplate]]()))
 
   def clearCache(): IOResult[Unit] = {
     cache.set(Map())

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -220,7 +220,7 @@ object Boot {
  */
 object PluginsInfo {
 
-  private[this] var _plugins = Map[PluginName, RudderPluginDef]()
+  private var _plugins = Map[PluginName, RudderPluginDef]()
 
   def registerPlugin(plugin: RudderPluginDef): Unit = {
     _plugins = _plugins + (plugin.name -> plugin)
@@ -264,8 +264,8 @@ object StaticResourceRewrite extends RestHelper {
   // the resource directory we want to server that way
   val resources: Set[String] = Set("javascript", "style", "images", "toserve")
   serve {
-    case Get(prefix :: resource :: tail, req) if (resources.contains(resource)) =>
-      val resourcePath = req.uri.replaceFirst(prefix + "/", "")
+    case Get(prefix_ :: resource :: tail, req) if (resources.contains(resource)) =>
+      val resourcePath = req.uri.replaceFirst(prefix_ + "/", "")
       () => {
         for {
           url <- LiftRules.getResource(resourcePath)
@@ -291,9 +291,9 @@ object StaticResourceRewrite extends RestHelper {
  */
 object FatalException {
 
-  private[this] var fatalException = Set[String]()
+  private var fatalException = Set[String]()
   // need to be pre-allocated
-  private[this] val format         = org.joda.time.format.ISODateTimeFormat.dateTime()
+  private val format         = org.joda.time.format.ISODateTimeFormat.dateTime()
   /*
    * Call that method with the list of fatal exception to set-up the
    * UncaughtExceptionHandler.
@@ -948,12 +948,12 @@ class Boot extends Loggable {
   // Run a health check
   RudderConfig.healthcheckNotificationService.init
 
-  private[this] def addPluginsMenuTo(plugins: List[RudderPluginDef], menus: List[Menu]): List[Menu] = {
+  private def addPluginsMenuTo(plugins: List[RudderPluginDef], menus: List[Menu]): List[Menu] = {
     // return the updated siteMap
     plugins.foldLeft(menus) { case (prev, mutator) => mutator.updateSiteMap(prev) }
   }
 
-  private[this] def initPlugins(): List[RudderPluginDef] = {
+  private def initPlugins(): List[RudderPluginDef] = {
     import scala.jdk.CollectionConverters.*
 
     val reflections = new Reflections("bootstrap.rudder.plugin", "com.normation.plugins")

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/BootstrapChecks.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/BootstrapChecks.scala
@@ -70,7 +70,7 @@ object BootstrapLogger extends NamedZioLogger {
 
 class SequentialImmediateBootStrapChecks(_checkActions: BootstrapChecks*) extends BootstrapChecks {
 
-  private[this] val checkActions = collection.mutable.Buffer[BootstrapChecks](_checkActions*)
+  private val checkActions = collection.mutable.Buffer[BootstrapChecks](_checkActions*)
 
   def appendBootstrapChecks(check: BootstrapChecks): Unit = {
     checkActions.append(check)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
@@ -297,12 +297,13 @@ final class FileUserDetailListProvider(roleApiMapping: RoleApiMapping, authorisa
    * You will have to "reload" after application full init (to allows plugin override);
    * We also set case sensitivity to false as a default (which will be updated with the actual data from the file on reload).
    */
-  private[this] val cache = Ref.make(ValidatedUserList(PasswordEncoder.PlainText, false, Nil, Map())).runNow
+  private val cache =
+    Ref.make(ValidatedUserList(PasswordEncoder.PlainText, isCaseSensitive = false, customRoles = Nil, users = Map())).runNow
 
   /**
    * Callbacks for who need to be informed of a successfully users list reload
    */
-  private[this] val callbacks = Ref.make(List.empty[RudderAuthorizationFileReloadCallback]).runNow
+  private val callbacks = Ref.make(List.empty[RudderAuthorizationFileReloadCallback]).runNow
 
   /**
    * Reload the list of users. Only update the cache if there is no errors.

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/CheckMigrationXmlFileFormat.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/CheckMigrationXmlFileFormat.scala
@@ -69,7 +69,7 @@ trait CheckMigrationXmlFileFormat extends BootstrapChecks {
     })
   }
 
-  private[this] def handleFailure(error: Either[EmptyBox, Throwable]): Unit = {
+  private def handleFailure(error: Either[EmptyBox, Throwable]): Unit = {
     val msg =
       s"Error when migrating XML FileFormat' datas from format ${controler.fromVersion} to ${controler.toVersion} in database"
     val e   = error match {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/onetimeinit/CheckInitXmlExport.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/onetimeinit/CheckInitXmlExport.scala
@@ -81,7 +81,7 @@ class CheckInitXmlExport(
                     ModificationId(uuidGen.newUuid),
                     RudderEventActor,
                     Some("Initialising configuration-repository sub-system"),
-                    false
+                    includeSystem = false
                   )(QueryContext.systemQC)
                 } else {
                   BootstrapLogger.trace("At least a full archive of configuration items done, no need for further initialisation") *>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/DefaultExtendableSnippet.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/DefaultExtendableSnippet.scala
@@ -46,7 +46,7 @@ import com.normation.rudder.domain.logger.PluginLogger
 trait DefaultExtendableSnippet[T] extends ExtendableSnippet[T] {
   self: T =>
 
-  private[this] def extensionRegister = RudderConfig.snippetExtensionRegister
+  private def extensionRegister = RudderConfig.snippetExtensionRegister
 
   override def beforeSnippetExtensionSeq: Seq[SnippetExtensionPoint[T]] = {
     PluginLogger.trace(s"Looking for pre-extension for snippet '${extendsAt.value}'")

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/ExtendableSnippet.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/ExtendableSnippet.scala
@@ -134,7 +134,7 @@ trait ExtendableSnippet[T] extends DispatchSnippet {
     (ExtendableSnippet.chached[T](extendsAt, computeDispatch))(this)
   }
 
-  private[this] def computeDispatch(snippet: T): DispatchIt = {
+  private def computeDispatch(snippet: T): DispatchIt = {
     val all = (beforeSnippetExtensionSeq.map(_.compose(snippet)) :+
       mainDispatch) ++
       afterSnippetExtensionSeq.map(_.compose(snippet))
@@ -158,7 +158,7 @@ trait ExtendableSnippet[T] extends DispatchSnippet {
 object ExtendableSnippet {
   type DispatchIt = PartialFunction[String, NodeSeq => NodeSeq]
 
-  private[this] val cache = scala.collection.mutable.Map.empty[SnippetExtensionKey, _ => DispatchIt]
+  private val cache = scala.collection.mutable.Map.empty[SnippetExtensionKey, _ => DispatchIt]
 
   def chached[T](forSnippet: SnippetExtensionKey, withDefault: => T => DispatchIt): T => DispatchIt = {
     if (true) withDefault

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/SnippetExtensionRegister.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/SnippetExtensionRegister.scala
@@ -73,9 +73,9 @@ trait SnippetExtensionRegister {
  */
 class SnippetExtensionRegisterImpl extends SnippetExtensionRegister {
 
-  private[this] val extendsBefore = scala.collection.mutable.Map.empty[SnippetExtensionKey, Seq[SnippetExtensionPoint[?]]]
+  private val extendsBefore = scala.collection.mutable.Map.empty[SnippetExtensionKey, Seq[SnippetExtensionPoint[?]]]
 
-  private[this] val extendsAfter = scala.collection.mutable.Map.empty[SnippetExtensionKey, Seq[SnippetExtensionPoint[?]]]
+  private val extendsAfter = scala.collection.mutable.Map.empty[SnippetExtensionKey, Seq[SnippetExtensionPoint[?]]]
 
   /**
    * register the given extension. The extension is added

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
@@ -56,13 +56,13 @@ import scala.xml.*
 
 class AsyncDeployment extends CometActor with CometListener with Loggable {
 
-  private[this] val asyncDeploymentAgent = RudderConfig.asyncDeploymentAgent
+  private val asyncDeploymentAgent = RudderConfig.asyncDeploymentAgent
 
   // current states of the deployment
-  private[this] var deploymentStatus = DeploymentStatus(NoStatus, IdleDeployer)
+  private var deploymentStatus = DeploymentStatus(NoStatus, IdleDeployer)
   // we need to get current user from SpringSecurity because it is not set in session anymore,
   // and comet doesn't know about requests
-  private[this] val currentUser:         Option[RudderUserDetail] = FindCurrentUser.get()
+  private val currentUser:               Option[RudderUserDetail] = FindCurrentUser.get()
   def havePerm(perm: AuthorizationType): Boolean                  = {
     currentUser match {
       case None    => false
@@ -76,17 +76,17 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
 
   override def lowPriority: PartialFunction[Any, Unit] = { case d: DeploymentStatus => deploymentStatus = d; reRender() }
 
-  private[this] def displayTime(label: String, time: DateTime): NodeSeq = {
+  private def displayTime(label: String, time: DateTime): NodeSeq = {
     val t = time.toString("yyyy-MM-dd HH:mm:ssZ")
     val d = DateFormaterService.getFormatedPeriod(time, DateTime.now)
     // exceptionally not putting {} to remove the node
     <span>{label + t}</span><div class="help-block">{"↳ " + d} ago</div>
   }
-  private[this] def displayDate(label: String, time: DateTime): NodeSeq = {
+  private def displayDate(label: String, time: DateTime): NodeSeq = {
     val t = time.toString("yyyy-MM-dd HH:mm:ssZ")
     <span class="dropdown-header">{label + t}</span>
   }
-  private[this] def updateDuration = {
+  private def updateDuration = {
     val content = deploymentStatus.current match {
       case SuccessStatus(_, _, end, _) => displayTime("Ended at ", end)
       case ErrorStatus(_, _, end, _)   => displayTime("Ended at ", end)
@@ -102,7 +102,7 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
 
   val deployementErrorMessage: Regex = """(.*)!errormessage!(.*)""".r
 
-  private[this] def statusBackground: String = {
+  private def statusBackground: String = {
     deploymentStatus.processing match {
       case IdleDeployer =>
         deploymentStatus.current match {
@@ -118,7 +118,7 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
     }
   }
 
-  private[this] def lastStatus = {
+  private def lastStatus = {
     def commonStatement(
         start:        DateTime,
         end:          DateTime,
@@ -197,11 +197,11 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
     }
   }
 
-  private[this] def closePopup(): JsCmd = {
+  private def closePopup(): JsCmd = {
     JsRaw("""hideBsModal('generatePoliciesDialog')""")
   }
 
-  private[this] def fullPolicyGeneration: NodeSeq = {
+  private def fullPolicyGeneration: NodeSeq = {
     if (havePerm(AuthorizationType.Deployment.Write)) {
       SHtml.ajaxButton(
         "Regenerate",
@@ -219,7 +219,7 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
     } else NodeSeq.Empty
   }
 
-  private[this] def showGeneratePoliciesPopup: NodeSeq = {
+  private def showGeneratePoliciesPopup: NodeSeq = {
     val callback = JsRaw("initBsModal('generatePoliciesDialog')")
     if (havePerm(AuthorizationType.Deployer.Write)) {
       SHtml.a(
@@ -229,7 +229,7 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
       )
     } else NodeSeq.Empty
   }
-  private[this] def layout = {
+  private def layout = {
     if (havePerm(AuthorizationType.Deployment.Read)) {
 
       <li class={"nav-item dropdown notifications-menu " ++ statusBackground}>
@@ -249,7 +249,7 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
     } else NodeSeq.Empty
   }
 
-  private[this] def errorPopup = {
+  private def errorPopup = {
     <div class="modal fade" tabindex="-1" id="errorDetailsDialog" data-bs-backdrop="false">
         <div class="modal-dialog">
             <div class="modal-content">
@@ -277,7 +277,7 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
       </div>
   }
 
-  private[this] def generatePoliciesPopup = {
+  private def generatePoliciesPopup = {
     <div class="modal fade" tabindex="-1" id="generatePoliciesDialog" aria-hidden="true" data-bs-backdrop="false" data-bs-dismiss="modal">
       <div class="modal-dialog">
         <div class="modal-content">

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveApplicationManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveApplicationManagement.scala
@@ -85,8 +85,8 @@ final case class DirectiveApplicationManagement(
 ) extends Loggable {
 
   // Utility Types
-  private[this] type Category   = RuleCategory
-  private[this] type CategoryId = RuleCategoryId
+  private type Category   = RuleCategory
+  private type CategoryId = RuleCategoryId
 
   /*
    * Initial Values
@@ -95,18 +95,18 @@ final case class DirectiveApplicationManagement(
   // Rules
 
   // Applying Rules At the beginning
-  private[this] val applyingRules = rules.filter(_.directiveIds.contains(directive.id))
+  private val applyingRules = rules.filter(_.directiveIds.contains(directive.id))
 
   // Applying Rules Id
-  private[this] val applyingRulesId = applyingRules.map(_.id)
+  private val applyingRulesId = applyingRules.map(_.id)
 
   // Map to get a Rule form its id
-  private[this] val rulesMap = rules.groupMapReduce(_.id)(identity)((a, b) => a)
+  private val rulesMap = rules.groupMapReduce(_.id)(identity)((a, b) => a)
 
   // Categories
 
   // Map to get children categories from a category
-  private[this] val categories = {
+  private val categories = {
     def mapCategories(cat: Category, map: Map[CategoryId, List[CategoryId]] = Map.empty): Map[CategoryId, List[CategoryId]] = {
       cat.childs.foldRight(map)(mapCategories) + (cat.id -> cat.childs.map(_.id))
     }
@@ -115,14 +115,14 @@ final case class DirectiveApplicationManagement(
   }
 
   // Map ti get parent category from a category
-  private[this] val parentCategories = {
+  private val parentCategories = {
     categories.flatMap { case (parent, childs) => childs.map((_ -> parent)) }
   }
 
   // Category -> Rule
 
   // Utility method to complete the map (add Rules to parents)
-  private[this] def completeMapping(baseMap: Map[CategoryId, List[RuleId]]): Map[CategoryId, List[RuleId]] = {
+  private def completeMapping(baseMap: Map[CategoryId, List[RuleId]]): Map[CategoryId, List[RuleId]] = {
     def toApply(category: CategoryId, rules: List[RuleId], map: Map[CategoryId, List[RuleId]]): Map[CategoryId, List[RuleId]] = {
       val updatedMap = map.updated(category, (map.get(category).getOrElse(Nil) ++ rules).distinct)
       parentCategories.get(category) match {
@@ -135,13 +135,13 @@ final case class DirectiveApplicationManagement(
   }
 
   // Get Rules from a category
-  private[this] val rulesByCategory = completeMapping(rules.groupMap(_.categoryId)(_.id)).withDefaultValue(Nil)
+  private val rulesByCategory = completeMapping(rules.groupMap(_.categoryId)(_.id)).withDefaultValue(Nil)
 
   // Get applying Rules fror each category at the beginning
-  private[this] val applyingRulesbyCategory = completeMapping(applyingRules.groupMap(_.categoryId)(_.id)).withDefaultValue(Nil)
+  private val applyingRulesbyCategory = completeMapping(applyingRules.groupMap(_.categoryId)(_.id)).withDefaultValue(Nil)
 
   // Current State, this variable will contains the application state of all Rules and categories
-  private[this] var currentApplyingRules = applyingRulesbyCategory.withDefaultValue(Nil)
+  private var currentApplyingRules = applyingRulesbyCategory.withDefaultValue(Nil)
 
   // Get rules that needs to be updated , and divide them by those who are new application and those who don't apply the Directive annymore
   def checkRulesToUpdate: (List[Rule], List[Rule]) = {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
@@ -103,15 +103,15 @@ class DirectiveEditForm(
 
   val currentDirectiveSettingForm = new LocalSnippet[DirectiveEditForm]
 
-  private[this] val directiveEditorService = RudderConfig.directiveEditorService
-  private[this] val techniqueRepo          = RudderConfig.techniqueRepository
-  private[this] val roRuleRepo             = RudderConfig.roRuleRepository
-  private[this] val roRuleCategoryRepo     = RudderConfig.roRuleCategoryRepository
-  private[this] val workflowLevelService   = RudderConfig.workflowLevelService
-  private[this] val ncfTechniqueService    = RudderConfig.ncfTechniqueReader
+  private val directiveEditorService = RudderConfig.directiveEditorService
+  private val techniqueRepo          = RudderConfig.techniqueRepository
+  private val roRuleRepo             = RudderConfig.roRuleRepository
+  private val roRuleCategoryRepo     = RudderConfig.roRuleCategoryRepository
+  private val workflowLevelService   = RudderConfig.workflowLevelService
+  private val ncfTechniqueService    = RudderConfig.ncfTechniqueReader
 
-  private[this] val htmlId_save     = htmlId_policyConf + "Save"
-  private[this] val parameterEditor = {
+  private val htmlId_save     = htmlId_policyConf + "Save"
+  private val parameterEditor = {
     directiveEditorService.get(technique.id, directive.id.uid, directive.parameters) match {
       case Full(pe)         => pe
       case Empty            => {
@@ -317,7 +317,7 @@ class DirectiveEditForm(
         } else NodeSeq.Empty
       } &
       "#nameField" #> { directiveName.toForm_! } &
-      "#tagField *" #> tagsEditForm.tagsForm("directiveTags", "directiveEditTagsApp", updateTag, false) &
+      "#tagField *" #> tagsEditForm.tagsForm("directiveTags", "directiveEditTagsApp", updateTag, isRule = false) &
       "#directiveID *" #> { directive.id.uid.value } &
       "#shortDescriptionField" #> directiveShortDescription.toForm_! &
       "#longDescriptionField" #> directiveLongDescription.toForm_! &
@@ -382,7 +382,7 @@ class DirectiveEditForm(
 
   }
 
-  private[this] def clonePopup(): JsCmd = {
+  private def clonePopup(): JsCmd = {
     SetHtml("basePopup", newCreationPopup(technique, activeTechnique)) &
     JsRaw(s""" initBsModal("basePopup"); """)
   }
@@ -391,7 +391,7 @@ class DirectiveEditForm(
 
   def addFormMsg(msg: NodeSeq): Unit = formTracker.addFormError(msg)
 
-  private[this] def onFailure(hasVariableErrors: Boolean = false): JsCmd = {
+  private def onFailure(hasVariableErrors: Boolean = false): JsCmd = {
     formTracker.addFormError(error("There was a problem with your request."))
     val cmd = if (hasVariableErrors) {
       showVariablesErrorNotifications()
@@ -402,7 +402,7 @@ class DirectiveEditForm(
     cmd
   }
 
-  private[this] def onNothingToDo(): JsCmd = {
+  private def onNothingToDo(): JsCmd = {
     formTracker.addFormError(error("There are no modifications to save."))
     showErrorNotifications()
   }
@@ -412,11 +412,11 @@ class DirectiveEditForm(
     onFailureCallback() & Replace("notification", displayNotifications())
   }
 
-  private[this] def showErrorNotifications(): JsCmd = {
+  private def showErrorNotifications(): JsCmd = {
     onFailureCallback() & Replace("editForm", showDirectiveForm())
   }
 
-  private[this] def showIsSingle(): NodeSeq = {
+  private def showIsSingle(): NodeSeq = {
     <span>
       {
       if (technique.isMultiInstance) {
@@ -428,7 +428,7 @@ class DirectiveEditForm(
     </span>
   }
 
-  private[this] def showParametersLink(): NodeSeq = {
+  private def showParametersLink(): NodeSeq = {
     if (isADirectiveCreation) {
       <div class="callout-fade callout-info">
         <div class="marker">
@@ -451,7 +451,7 @@ class DirectiveEditForm(
     }
   }
 
-  private[this] def displayPrivateDrafts: Option[NodeSeq] = {
+  private def displayPrivateDrafts: Option[NodeSeq] = {
 //TODO
 //    for {
 //      drafts <- roDraftChangeRequestRepository.getAll(actor, directive.id)
@@ -459,13 +459,13 @@ class DirectiveEditForm(
     None
   }
 
-  private[this] def displayChangeRequests: Option[NodeSeq] = {
+  private def displayChangeRequests: Option[NodeSeq] = {
     None
   }
 
   ///////////// fields for Directive settings ///////////////////
 
-  private[this] val directiveName = new WBTextField("Name", directive.name) {
+  private val directiveName = new WBTextField("Name", directive.name) {
     override def setFilter             = notNull _ :: trim _ :: Nil
     override def className             = "form-control"
     override def labelClassName        = "col-sm-12"
@@ -475,7 +475,7 @@ class DirectiveEditForm(
       valMinLen(1, "Name must not be empty") _ :: Nil
   }
 
-  private[this] val directiveShortDescription = {
+  private val directiveShortDescription = {
     new WBTextField("Short description", directive.shortDescription) {
       override def className             = "form-control"
       override def labelClassName        = "col-sm-12"
@@ -486,7 +486,7 @@ class DirectiveEditForm(
     }
   }
 
-  private[this] val directiveLongDescription = {
+  private val directiveLongDescription = {
     new WBTextAreaField("Description", directive.longDescription) {
       override def setFilter             = notNull _ :: trim _ :: Nil
       override def className             = "form-control"
@@ -504,7 +504,7 @@ class DirectiveEditForm(
     }
   }
 
-  private[this] val directivePriority = {
+  private val directivePriority = {
     val priorities = List(
       (0, "Highest"),
       (1, "+4"),
@@ -550,7 +550,7 @@ class DirectiveEditForm(
     }
   }
 
-  private[this] var newTags = directive.tags
+  private var newTags = directive.tags
 
   def updateTag(boxTag: Box[Tags]): Unit = {
     boxTag match {
@@ -571,7 +571,7 @@ class DirectiveEditForm(
     }
     s"${version.serialize} ${deprecationInfo}"
   }
-  private[this] val globalOverrideText = globalMode.overridable match {
+  private val globalOverrideText = globalMode.overridable match {
     case Always        =>
       <div>
         You may override the agent policy mode on this directive.
@@ -585,7 +585,7 @@ class DirectiveEditForm(
       </p>
   }
 
-  private[this] val policyModesLabel = {
+  private val policyModesLabel = {
     val tooltipContent = {
       s"""
          |<div>
@@ -611,7 +611,7 @@ class DirectiveEditForm(
     </label>
   }
 
-  private[this] val policyModes = {
+  private val policyModes = {
     val l           = Seq(
       "global",
       "audit",
@@ -643,7 +643,7 @@ class DirectiveEditForm(
 
   val versions: Seq[(TechniqueVersion, String)] = techniques.keys.map(v => (v, showDeprecatedVersion(v))).toSeq.sortBy(_._1)
 
-  private[this] val directiveVersion = {
+  private val directiveVersion = {
     val attributes = ("id" -> "selectVersion") ::
       (if (isADirectiveCreation) {
          ("disabled" -> "true") :: Nil
@@ -666,15 +666,15 @@ class DirectiveEditForm(
     }
   }
 
-  private[this] val formTracker = {
+  private val formTracker = {
     val l = List(directiveName, directiveShortDescription, directiveLongDescription) // ++ crReasons
     new FormTracker(l)
   }
 
-  private[this] def error(msg: String) = <span class="error">{msg}</span>
+  private def error(msg: String) = <span class="error">{msg}</span>
 
   // Returns true if there is any error
-  private[this] def checkVariables(): Boolean = {
+  private def checkVariables(): Boolean = {
     !parameterEditor.mapValueSeq.forall { vars =>
       try {
         val s = Seq(parameterEditor.variableSpecs(vars._1).toVariable(vars._2))
@@ -688,7 +688,7 @@ class DirectiveEditForm(
     }
   }
 
-  private[this] def onSubmitSave(): JsCmd = {
+  private def onSubmitSave(): JsCmd = {
     val hasVariableErrors = checkVariables()
 
     if (formTracker.hasErrors) {
@@ -766,7 +766,7 @@ class DirectiveEditForm(
   }
 
   // action must be 'enable' or 'disable'
-  private[this] def onSubmitDisable(action: DGModAction): JsCmd = {
+  private def onSubmitDisable(action: DGModAction): JsCmd = {
     displayConfirmationPopup(
       action,
       directive.copy(_isEnabled = !directive._isEnabled),
@@ -775,7 +775,7 @@ class DirectiveEditForm(
     )
   }
 
-  private[this] def onSubmitDelete(): JsCmd = {
+  private def onSubmitDelete(): JsCmd = {
     displayConfirmationPopup(
       DGModAction.Delete,
       directive,
@@ -787,7 +787,7 @@ class DirectiveEditForm(
   /*
    * Create the confirmation pop-up
    */
-  private[this] def displayConfirmationPopup(
+  private def displayConfirmationPopup(
       action:       DGModAction,
       newDirective: Directive,
       baseRules:    List[Rule],
@@ -863,7 +863,7 @@ class DirectiveEditForm(
     }
   }
 
-  private[this] def displayNotifications(): NodeSeq = {
+  private def displayNotifications(): NodeSeq = {
     val notifications = formTracker.formErrors
 
     if (notifications.isEmpty) {
@@ -875,7 +875,7 @@ class DirectiveEditForm(
     }
   }
 
-  private[this] def newCreationPopup(technique: Technique, activeTechnique: ActiveTechnique): NodeSeq = {
+  private def newCreationPopup(technique: Technique, activeTechnique: ActiveTechnique): NodeSeq = {
 
     val popup = new CreateCloneDirectivePopup(
       technique.name,
@@ -890,7 +890,7 @@ class DirectiveEditForm(
 
   ///////////// success pop-up ///////////////
 
-  private[this] def successNotification(msg: String): JsCmd = {
+  private def successNotification(msg: String): JsCmd = {
     JsRaw(s"""createSuccessNotification("${msg}")""")
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
@@ -75,10 +75,10 @@ class NodeGroupCategoryForm(
 
   var _nodeGroupCategory: NodeGroupCategory = nodeGroupCategory.copy()
 
-  private[this] val roGroupCategoryRepository  = RudderConfig.roNodeGroupRepository
-  private[this] val woGroupCategoryRepository  = RudderConfig.woNodeGroupRepository
-  private[this] val uuidGen                    = RudderConfig.stringUuidGenerator
-  private[this] val categoryHierarchyDisplayer = RudderConfig.categoryHierarchyDisplayer
+  private val roGroupCategoryRepository  = RudderConfig.roNodeGroupRepository
+  private val woGroupCategoryRepository  = RudderConfig.woNodeGroupRepository
+  private val uuidGen                    = RudderConfig.stringUuidGenerator
+  private val categoryHierarchyDisplayer = RudderConfig.categoryHierarchyDisplayer
 
   val categories: Seq[NodeGroupCategory] = roGroupCategoryRepository.getAllNonSystemCategories().toBox match {
     case eb: EmptyBox =>
@@ -183,7 +183,7 @@ class NodeGroupCategoryForm(
    * Delete button is only enabled is that category
    * has zero child
    */
-  private[this] def deleteButton: NodeSeq = {
+  private def deleteButton: NodeSeq = {
 
     if (parentCategory.isDefined && _nodeGroupCategory.children.isEmpty && _nodeGroupCategory.items.isEmpty) {
       val popupContent = {
@@ -223,7 +223,7 @@ class NodeGroupCategoryForm(
     }
   }
 
-  private[this] def onDelete(): JsCmd = {
+  private def onDelete(): JsCmd = {
     woGroupCategoryRepository
       .delete(
         _nodeGroupCategory.id,
@@ -245,7 +245,7 @@ class NodeGroupCategoryForm(
   }
 
   ///////////// fields for category settings ///////////////////
-  private[this] val name = new WBTextField("Category name", _nodeGroupCategory.name) {
+  private val name = new WBTextField("Category name", _nodeGroupCategory.name) {
     override def setFilter             = notNull _ :: trim _ :: Nil
     override def className             = "form-control"
     override def labelClassName        = ""
@@ -254,7 +254,7 @@ class NodeGroupCategoryForm(
       valMinLen(1, "Name must not be empty") _ :: Nil
   }
 
-  private[this] val description = new WBTextAreaField("Category description", _nodeGroupCategory.description.toString) {
+  private val description = new WBTextAreaField("Category description", _nodeGroupCategory.description.toString) {
     override def setFilter             = notNull _ :: trim _ :: Nil
     override def className             = "form-control"
     override def labelClassName        = ""
@@ -266,7 +266,7 @@ class NodeGroupCategoryForm(
   /**
    * If there is no parent, it is its own parent
    */
-  private[this] val container = parentCategory match {
+  private val container = parentCategory match {
     case x: EmptyBox =>
       new WBSelectField(
         "Parent category: ",
@@ -296,28 +296,28 @@ class NodeGroupCategoryForm(
       }
   }
 
-  private[this] val formTracker = new FormTracker(name, description, container)
+  private val formTracker = new FormTracker(name, description, container)
 
-  private[this] var notifications = List.empty[NodeSeq]
+  private var notifications = List.empty[NodeSeq]
 
-  private[this] def updateFormClientSide: JsCmd = {
+  private def updateFormClientSide: JsCmd = {
     SetHtml(htmlIdCategory, showForm())
   }
 
-  private[this] def error(msg: String) = <span class="col-sm-12 errors-container">{msg}</span>
+  private def error(msg: String) = <span class="col-sm-12 errors-container">{msg}</span>
 
-  private[this] def onSuccess: JsCmd = {
+  private def onSuccess: JsCmd = {
 
     notifications ::= <span class="greenscala">Category was correctly updated</span>
     updateFormClientSide
   }
 
-  private[this] def onFailure: JsCmd = {
+  private def onFailure: JsCmd = {
     formTracker.addFormError(error("There was a problem with your request."))
     updateFormClientSide & JsRaw("""scrollToElement("notifications","#ajaxItemContainer");""")
   }
 
-  private[this] def onSubmit(): JsCmd = {
+  private def onSubmit(): JsCmd = {
     if (formTracker.hasErrors) {
       onFailure & onFailureCallback()
     } else {
@@ -357,7 +357,7 @@ class NodeGroupCategoryForm(
     }
   }
 
-  private[this] def updateAndDisplayNotifications(): NodeSeq = {
+  private def updateAndDisplayNotifications(): NodeSeq = {
 
     val notifications = formTracker.formErrors
     formTracker.cleanErrors
@@ -375,7 +375,7 @@ class NodeGroupCategoryForm(
   }
 
   ///////////// success pop-up ///////////////
-  private[this] def successPopup: JsCmd = {
+  private def successPopup: JsCmd = {
     JsRaw("""createSuccessNotification()""")
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -105,22 +105,22 @@ class NodeGroupForm(
     onFailureCallback: () => JsCmd = { () => Noop }
 ) extends DispatchSnippet with DefaultExtendableSnippet[NodeGroupForm] with Loggable {
   import NodeGroupForm.*
-  implicit private[this] val qc: QueryContext = CurrentUser.queryContext
+  implicit private val qc: QueryContext = CurrentUser.queryContext
 
-  private[this] val nodeFactRepo               = RudderConfig.nodeFactRepository
-  private[this] val categoryHierarchyDisplayer = RudderConfig.categoryHierarchyDisplayer
-  private[this] val workflowLevelService       = RudderConfig.workflowLevelService
-  private[this] val dependencyService          = RudderConfig.dependencyAndDeletionService
-  private[this] val roNodeGroupRepository      = RudderConfig.roNodeGroupRepository
-  private[this] val complianceService          = RudderConfig.complianceService
-  private[this] val ruleRepository             = RudderConfig.roRuleRepository
+  private val nodeFactRepo               = RudderConfig.nodeFactRepository
+  private val categoryHierarchyDisplayer = RudderConfig.categoryHierarchyDisplayer
+  private val workflowLevelService       = RudderConfig.workflowLevelService
+  private val dependencyService          = RudderConfig.dependencyAndDeletionService
+  private val roNodeGroupRepository      = RudderConfig.roNodeGroupRepository
+  private val complianceService          = RudderConfig.complianceService
+  private val ruleRepository             = RudderConfig.roRuleRepository
 
-  private[this] val nodeGroupCategoryForm = new LocalSnippet[NodeGroupCategoryForm]
-  private[this] val nodeGroupForm         = new LocalSnippet[NodeGroupForm]
-  private[this] val searchNodeComponent   = new LocalSnippet[SearchNodeComponent]
+  private val nodeGroupCategoryForm = new LocalSnippet[NodeGroupCategoryForm]
+  private val nodeGroupForm         = new LocalSnippet[NodeGroupForm]
+  private val searchNodeComponent   = new LocalSnippet[SearchNodeComponent]
 
-  private[this] var query:   Option[Query]      = nodeGroup.toOption.flatMap(_.query)
-  private[this] var srvList: Box[Seq[NodeInfo]] = getNodeList(nodeGroup)
+  private var query:   Option[Query]      = nodeGroup.toOption.flatMap(_.query)
+  private var srvList: Box[Seq[NodeInfo]] = getNodeList(nodeGroup)
 
   private def setSearchNodeComponent: Unit = {
     searchNodeComponent.set(
@@ -138,13 +138,13 @@ class NodeGroupForm(
     )
   }
 
-  private[this] def getNodeList(target: Either[NonGroupRuleTarget, NodeGroup]): Box[Seq[NodeInfo]] = {
+  private def getNodeList(target: Either[NonGroupRuleTarget, NodeGroup]): Box[Seq[NodeInfo]] = {
 
     for {
       nodes <- nodeFactRepo.getAll()(CurrentUser.queryContext).toBox
       setIds = target match {
-                 case Right(nodeGroup) => nodeGroup.serverList
-                 case Left(target)     =>
+                 case Right(nodeGroup_) => nodeGroup_.serverList
+                 case Left(target)      =>
                    val allNodes = nodes.mapValues(_.rudderSettings.kind.isPolicyServer)
                    RuleTarget.getNodeIds(Set(target), allNodes, Map())
                }
@@ -153,7 +153,7 @@ class NodeGroupForm(
     }
   }
 
-  private[this] def saveButtonCallBack(searchStatus: Boolean, query: Option[Query]): JsCmd = {
+  private def saveButtonCallBack(searchStatus: Boolean, query: Option[Query]): JsCmd = {
     JsRaw(s"""$$('#${saveButtonId}').prop("disabled", ${searchStatus})""")
   }
 
@@ -196,7 +196,7 @@ class NodeGroupForm(
     }) ++ Script(OnLoad(JsRaw(s"""new ClipboardJS('[data-clipboard-text]');""")))
   }
 
-  private[this] def showRelatedRulesTree(target: RuleTarget): NodeSeq = {
+  private def showRelatedRulesTree(target: RuleTarget): NodeSeq = {
     val relatedRules                     = {
       dependencyService
         .targetDependencies(target)
@@ -266,17 +266,17 @@ class NodeGroupForm(
       )
     )
   }
-  private[this] val groupNameString = nodeGroup.fold(
+  private val groupNameString = nodeGroup.fold(
     t => rootCategory.allTargets.get(t).map(_.name).getOrElse(t.target),
     _.name
   )
 
-  private[this] def showComplianceForGroup(progressBarSelector: String, optComplianceArray: Option[JsArray]) = {
+  private def showComplianceForGroup(progressBarSelector: String, optComplianceArray: Option[JsArray]) = {
     val complianceHtml = optComplianceArray.map(js => s"buildComplianceBar(${js.toJsCmd})").getOrElse("\"No report\"")
     Script(JsRaw(s"""$$("${progressBarSelector}").html(${complianceHtml});"""))
   }
 
-  private[this] def showFormNodeGroup(nodeGroup: NodeGroup): CssSel = {
+  private def showFormNodeGroup(nodeGroup: NodeGroup): CssSel = {
     val nodesSel = "#gridResult" #> NodeSeq.Empty
     val nodes    = nodesSel(searchNodeComponent.get match {
       case Full(req) => req.buildQuery(true)
@@ -362,7 +362,7 @@ class NodeGroupForm(
     )
   }
 
-  private[this] def showFormTarget(target: SimpleTarget): CssSel = {
+  private def showFormTarget(target: SimpleTarget): CssSel = {
     ("group-pendingchangerequest" #> NodeSeq.Empty
     & "#group-name" #> <span>{groupNameString}<span class="group-system"></span></span>
     & "group-name" #> groupName.readOnlyValue
@@ -464,7 +464,7 @@ class NodeGroupForm(
 
   ///////////// fields for category settings ///////////////////
 
-  private[this] val groupName = {
+  private val groupName = {
     new WBTextField("Group name", groupNameString) {
       override def setFilter             = notNull _ :: trim _ :: Nil
       override def className             = "form-control"
@@ -476,7 +476,7 @@ class NodeGroupForm(
     }
   }
 
-  private[this] val groupDescription = {
+  private val groupDescription = {
     val desc = nodeGroup.fold(
       t => rootCategory.allTargets.get(t).map(_.description).getOrElse(""),
       _.description
@@ -499,7 +499,7 @@ class NodeGroupForm(
     }
   }
 
-  private[this] val groupStatic = {
+  private val groupStatic = {
     val text = nodeGroup match {
       case Left(_)  => "dynamic"
       case Right(g) => if (g.isDynamic) "dynamic" else "static"
@@ -525,7 +525,7 @@ class NodeGroupForm(
     }
   }
 
-  private[this] val groupContainer = new WBSelectField(
+  private val groupContainer = new WBSelectField(
     "Category",
     (categoryHierarchyDisplayer.getCategoriesHierarchy(rootCategory, None).map { case (id, name) => (id.value -> name) }),
     parentCategoryId.value
@@ -535,20 +535,20 @@ class NodeGroupForm(
     override def subContainerClassName = ""
   }
 
-  private[this] val formTracker = new FormTracker(List(groupName, groupDescription, groupContainer, groupStatic))
+  private val formTracker = new FormTracker(List(groupName, groupDescription, groupContainer, groupStatic))
 
-  private[this] def updateFormClientSide(): JsCmd = {
+  private def updateFormClientSide(): JsCmd = {
     SetHtml(htmlIdCategory, showForm())
   }
 
-  private[this] def error(msg: String) = <span class="error">{msg}</span>
+  private def error(msg: String) = <span class="error">{msg}</span>
 
-  private[this] def onFailure: JsCmd = {
+  private def onFailure: JsCmd = {
     formTracker.addFormError(error("There was a problem with your request."))
     updateFormClientSide() & JsRaw("""scrollToElement("errorNotification","#ajaxItemContainer");""")
   }
 
-  private[this] def onSubmit(): JsCmd = {
+  private def onSubmit(): JsCmd = {
     // submit can be done only for node group, not system one
     nodeGroup match {
       case Left(target) => Noop
@@ -589,7 +589,7 @@ class NodeGroupForm(
 
           isDynamic = groupStatic.get match { case "dynamic" => true; case _ => false },
           query = query,
-          serverList = srvList.getOrElse(Set()).map(_.id).toSet
+          serverList = srvList.getOrElse(Set.empty[NodeInfo]).map(_.id).toSet
         )
 
         /*
@@ -710,7 +710,7 @@ class NodeGroupForm(
     }
   }
 
-  private[this] def onSubmitDelete(): JsCmd = {
+  private def onSubmitDelete(): JsCmd = {
     nodeGroup match {
       case Left(_)   => Noop
       case Right(ng) =>
@@ -727,7 +727,7 @@ class NodeGroupForm(
    * Create the confirmation pop-up
    */
 
-  private[this] def displayConfirmationPopup(
+  private def displayConfirmationPopup(
       action:             DGModAction,
       newGroup:           NodeGroup,
       newCategory:        Option[NodeGroupCategoryId],
@@ -787,10 +787,10 @@ class NodeGroupForm(
     }
   }
 
-  def createPopup(name: String):           JsCmd = {
+  def createPopup(name: String):     JsCmd = {
     JsRaw(s"""initBsModal("${name}");""")
   }
-  private[this] def showCloneGroupPopup(): JsCmd = {
+  private def showCloneGroupPopup(): JsCmd = {
 
     val popupSnippet = new LocalSnippet[CreateCloneGroupPopup]
     popupSnippet.set(
@@ -811,17 +811,17 @@ class NodeGroupForm(
     createPopup("createCloneGroupPopup")
   }
 
-  private[this] def displayACategory(category: NodeGroupCategory): JsCmd = {
+  private def displayACategory(category: NodeGroupCategory): JsCmd = {
     refreshRightPanel(CategoryForm(category))
   }
 
-  private[this] def refreshRightPanel(panel: RightPanel): JsCmd = SetHtml(htmlId_item, setAndShowRightPanel(panel))
+  private def refreshRightPanel(panel: RightPanel): JsCmd = SetHtml(htmlId_item, setAndShowRightPanel(panel))
 
   /**
    *  Manage the state of what should be displayed on the right panel.
    * It could be nothing, a group edit form, or a category edit form.
    */
-  private[this] def setAndShowRightPanel(panel: RightPanel): NodeSeq = {
+  private def setAndShowRightPanel(panel: RightPanel): NodeSeq = {
     panel match {
       case NoPanel                 => NodeSeq.Empty
       case GroupForm(group, catId) =>
@@ -836,7 +836,7 @@ class NodeGroupForm(
     }
   }
 
-  private[this] def showGroupSection(
+  private def showGroupSection(
       group:            Either[NonGroupRuleTarget, NodeGroup],
       parentCategoryId: NodeGroupCategoryId
   ): JsCmd = {
@@ -849,7 +849,7 @@ class NodeGroupForm(
     JsRaw(s"""this.window.location.hash = "#" + JSON.stringify({${js}})""")
   }
 
-  private[this] def updateAndDisplayNotifications(): NodeSeq = {
+  private def updateAndDisplayNotifications(): NodeSeq = {
 
     val notifications = formTracker.formErrors
     formTracker.cleanErrors
@@ -866,7 +866,7 @@ class NodeGroupForm(
     }
   }
 
-  private[this] def successPopup: JsCmd = {
+  private def successPopup: JsCmd = {
     JsRaw("""createSuccessNotification()""")
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/PendingChangeRequestDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/PendingChangeRequestDisplayer.scala
@@ -59,10 +59,10 @@ import scala.xml.NodeSeq
  */
 object PendingChangeRequestDisplayer extends Loggable {
 
-  private[this] val workflowLevel = RudderConfig.workflowLevelService
-  private[this] val linkUtil      = RudderConfig.linkUtil
+  private val workflowLevel = RudderConfig.workflowLevelService
+  private val linkUtil      = RudderConfig.linkUtil
 
-  private[this] def displayPendingChangeRequest(xml: NodeSeq, crs: Box[Seq[ChangeRequest]]): NodeSeq = {
+  private def displayPendingChangeRequest(xml: NodeSeq, crs: Box[Seq[ChangeRequest]]): NodeSeq = {
     crs match {
       case eb: EmptyBox =>
         val e = eb ?~! "Error when trying to lookup pending change request"
@@ -93,7 +93,7 @@ object PendingChangeRequestDisplayer extends Loggable {
 
   private type checkFunction[T] = (T, Boolean) => Box[Seq[ChangeRequest]]
 
-  private[this] def checkChangeRequest[T](
+  private def checkChangeRequest[T](
       xml:   NodeSeq,
       id:    T,
       check: checkFunction[T]

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleCategoryTree.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleCategoryTree.scala
@@ -72,13 +72,13 @@ class RuleCategoryTree(
     updateComponent:         () => JsCmd
 ) extends DispatchSnippet with Loggable {
 
-  private[this] val roRuleCategoryRepository = RudderConfig.roRuleCategoryRepository
-  private[this] val woRuleCategoryRepository = RudderConfig.woRuleCategoryRepository
-  private[this] val ruleCategoryService      = RudderConfig.ruleCategoryService
-  private[this] val uuidGen                  = RudderConfig.stringUuidGenerator
-  private[this] var root                     = rootCategory
+  private val roRuleCategoryRepository = RudderConfig.roRuleCategoryRepository
+  private val woRuleCategoryRepository = RudderConfig.woRuleCategoryRepository
+  private val ruleCategoryService      = RudderConfig.ruleCategoryService
+  private val uuidGen                  = RudderConfig.stringUuidGenerator
+  private var root                     = rootCategory
 
-  private[this] var selectedCategoryId = rootCategory.id
+  private var selectedCategoryId = rootCategory.id
 
   def getSelected: RuleCategoryId = {
     if (root.contains(selectedCategoryId)) {
@@ -128,7 +128,7 @@ class RuleCategoryTree(
   def selectCategory(): JsCmd = {
     (for {
       rootCategory <- roRuleCategoryRepository.getRootCategory().toBox
-      fqdn         <- ruleCategoryService.bothFqdn(rootCategory, selectedCategoryId, true)
+      fqdn         <- ruleCategoryService.bothFqdn(rootCategory, selectedCategoryId, rootInCaps = true)
     } yield {
       fqdn
     }) match {
@@ -144,9 +144,9 @@ class RuleCategoryTree(
         Noop
     }
   }
-  private[this] val isDirectiveApplication = directive.isDefined
+  private val isDirectiveApplication = directive.isDefined
 
-  private[this] def moveCategory(arg: String): JsCmd = {
+  private def moveCategory(arg: String): JsCmd = {
     // parse arg, which have to  be json object with sourceGroupId, destCatId
     try {
       (for {
@@ -226,7 +226,7 @@ class RuleCategoryTree(
     )
   }
 
-  private[this] def categoryNode(category: RuleCategory): JsTreeNode = new JsTreeNode {
+  private def categoryNode(category: RuleCategory): JsTreeNode = new JsTreeNode {
 
     override val attrs = ("data-jstree" -> """{ "type" : "category" }""") :: ("id", category.id.value) :: Nil
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleDisplayer.scala
@@ -66,10 +66,10 @@ class RuleDisplayer(
     graphRecentChanges:  DisplayColumn
 ) extends DispatchSnippet with Loggable {
 
-  private[this] val ruleRepository       = RudderConfig.roRuleRepository
-  private[this] val roCategoryRepository = RudderConfig.roRuleCategoryRepository
+  private val ruleRepository       = RudderConfig.roRuleRepository
+  private val roCategoryRepository = RudderConfig.roRuleCategoryRepository
 
-  private[this] val htmlId_popup = "createRuleCategoryPopup"
+  private val htmlId_popup = "createRuleCategoryPopup"
 
   def getRootCategory(): Box[RuleCategory] = {
     directive match {
@@ -80,7 +80,7 @@ class RuleDisplayer(
     }
   }
 
-  private[this] var root: Box[RuleCategory] = {
+  private var root: Box[RuleCategory] = {
     getRootCategory()
   }
 
@@ -92,17 +92,17 @@ class RuleDisplayer(
   }
 
   // refresh the rule grid
-  private[this] def refreshGrid = {
+  private def refreshGrid = {
     SetHtml(gridId, viewRules)
   }
 
   // refresh the rule category Tree
-  private[this] def refreshTree = {
+  private def refreshTree = {
     root = getRootCategory()
     ruleCategoryTree.map(tree => SetHtml("categoryTreeParent", viewCategories(tree))).getOrElse(Noop)
   }
 
-  private[this] val ruleCategoryTree = {
+  private val ruleCategoryTree = {
     root.map(
       new RuleCategoryTree(
         "categoryTree",
@@ -173,7 +173,8 @@ class RuleDisplayer(
       case Some(d) =>
         d.checkRules match {
           case (toCheck, toUncheck) =>
-            (toCheck.map(r => action(r.id, true)) ++ toUncheck.map(r => action(r.id, false))).foldLeft(Noop)(_ & _)
+            (toCheck.map(r => action(r.id, status = true)) ++ toUncheck.map(r => action(r.id, status = false)))
+              .foldLeft(Noop)(_ & _)
         }
       case None    => Noop
     }
@@ -209,7 +210,7 @@ class RuleDisplayer(
 
     <div>
       {
-      ruleGrid.rulesGridWithUpdatedInfo(None, !directive.isDefined, false) ++
+      ruleGrid.rulesGridWithUpdatedInfo(None, showActionsColumn = !directive.isDefined, isPopup = false) ++
       Script(OnLoad(ruleGrid.asyncDisplayAllRules(None).applied))
     }
     </div>
@@ -365,7 +366,7 @@ class RuleDisplayer(
   }
 
   // Popup
-  private[this] def creationPopup(category: Option[RuleCategory], ruleCategoryTree: RuleCategoryTree) = {
+  private def creationPopup(category: Option[RuleCategory], ruleCategoryTree: RuleCategoryTree) = {
     val rootCategory = ruleCategoryTree.getRoot
     new RuleCategoryPopup(
       rootCategory,
@@ -381,7 +382,7 @@ class RuleDisplayer(
   /**
     * Create the popup
     */
-  private[this] def showCategoryPopup(category: Option[RuleCategory]): JsCmd = {
+  private def showCategoryPopup(category: Option[RuleCategory]): JsCmd = {
     val popupHtml = {
       ruleCategoryTree match {
         case Full(ruleCategoryTree) =>
@@ -403,7 +404,7 @@ class RuleDisplayer(
   /**
     * Create the delete popup
     */
-  private[this] def showDeleteCategoryPopup(category: RuleCategory): JsCmd = {
+  private def showDeleteCategoryPopup(category: RuleCategory): JsCmd = {
     val popupHtml = {
       ruleCategoryTree match {
         case Full(ruleCategoryTree) =>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
@@ -95,42 +95,42 @@ class RuleGrid(
     graphRecentChanges:   DisplayColumn
 ) extends DispatchSnippet with Loggable {
 
-  sealed private[this] trait Line { val rule: Rule }
+  sealed private trait Line { val rule: Rule }
 
-  private[this] case class OKLine(
+  private case class OKLine(
       rule:              Rule,
       applicationStatus: ApplicationStatus,
       trackerVariables:  Seq[(Directive, ActiveTechnique, Technique)],
       targets:           Set[RuleTargetInfo]
   ) extends Line
 
-  private[this] case class ErrorLine(
+  private case class ErrorLine(
       rule:             Rule,
       trackerVariables: Box[Seq[(Directive, ActiveTechnique, Technique)]],
       targets:          Box[Set[RuleTargetInfo]]
   ) extends Line
 
-  private[this] val getFullNodeGroupLib      = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
-  private[this] val getFullDirectiveLib      = RudderConfig.roDirectiveRepository.getFullDirectiveLibrary _
-  private[this] val getRuleApplicationStatus = RudderConfig.ruleApplicationStatus.isApplied _
-  private[this] val getRootRuleCategory      = RudderConfig.roRuleCategoryRepository.getRootCategory _
+  private val getFullNodeGroupLib      = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
+  private val getFullDirectiveLib      = RudderConfig.roDirectiveRepository.getFullDirectiveLibrary _
+  private val getRuleApplicationStatus = RudderConfig.ruleApplicationStatus.isApplied _
+  private val getRootRuleCategory      = RudderConfig.roRuleCategoryRepository.getRootCategory _
 
-  private[this] val recentChanges          = RudderConfig.recentChangesService
-  private[this] val techniqueRepository    = RudderConfig.techniqueRepository
-  private[this] val categoryService        = RudderConfig.ruleCategoryService
-  private[this] val asyncComplianceService = RudderConfig.asyncComplianceService
-  private[this] val configService          = RudderConfig.configService
+  private val recentChanges          = RudderConfig.recentChangesService
+  private val techniqueRepository    = RudderConfig.techniqueRepository
+  private val categoryService        = RudderConfig.ruleCategoryService
+  private val asyncComplianceService = RudderConfig.asyncComplianceService
+  private val configService          = RudderConfig.configService
 
   // used to error tempering
-  private[this] val roRuleRepository = RudderConfig.roRuleRepository
-  private[this] val woRuleRepository = RudderConfig.woRuleRepository
-  private[this] val uuidGen          = RudderConfig.stringUuidGenerator
-  private[this] val nodeFactRepo     = RudderConfig.nodeFactRepository
+  private val roRuleRepository = RudderConfig.roRuleRepository
+  private val woRuleRepository = RudderConfig.woRuleRepository
+  private val uuidGen          = RudderConfig.stringUuidGenerator
+  private val nodeFactRepo     = RudderConfig.nodeFactRepository
 
   /////  local variables /////
-  private[this] val htmlId_rulesGridId       = "grid_" + htmlId_rulesGridZone
-  private[this] val htmlId_reportsPopup      = "popup_" + htmlId_rulesGridZone
-  private[this] val htmlId_modalReportsPopup = "modal_" + htmlId_rulesGridZone
+  private val htmlId_rulesGridId       = "grid_" + htmlId_rulesGridZone
+  private val htmlId_reportsPopup      = "popup_" + htmlId_rulesGridZone
+  private val htmlId_modalReportsPopup = "modal_" + htmlId_rulesGridZone
 
   /*
    * Compliance and recent changes columns (not forced):
@@ -155,11 +155,11 @@ class RuleGrid(
    * ---------------------------------------------------------
    */
   import DisplayColumn.*
-  private[this] val showComplianceAndChangesColumn = columnCompliance match {
+  private val showComplianceAndChangesColumn = columnCompliance match {
     case Force(display) => display
     case FromConfig     => configService.rudder_ui_display_ruleComplianceColumns().toBox.openOr(true)
   }
-  private[this] val showChangesGraph               = showComplianceAndChangesColumn && (graphRecentChanges match {
+  private val showChangesGraph               = showComplianceAndChangesColumn && (graphRecentChanges match {
     case Force(display) => display
     case FromConfig     => configService.display_changes_graph().toBox.openOr(true)
   })
@@ -170,7 +170,7 @@ class RuleGrid(
   )
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = {
-    case "rulesGrid" => { (_: NodeSeq) => rulesGridWithUpdatedInfo(None, true, false) }
+    case "rulesGrid" => { (_: NodeSeq) => rulesGridWithUpdatedInfo(None, showActionsColumn = true, isPopup = false) }
   }
 
   /**
@@ -314,7 +314,7 @@ class RuleGrid(
 
   //////////////////////////////// utility methods ////////////////////////////////
 
-  private[this] def selectAllVisibleRules(status: Boolean): JsCmd = {
+  private def selectAllVisibleRules(status: Boolean): JsCmd = {
     directiveApplication match {
       case Some(directiveApp) =>
         def moveCategory(arg: String): JsCmd = {
@@ -359,7 +359,7 @@ class RuleGrid(
     }
   }
 
-  private[this] def changesFuture(rules: Seq[Rule]): Future[Box[Map[RuleId, Map[Interval, Int]]]] = {
+  private def changesFuture(rules: Seq[Rule]): Future[Box[Map[RuleId, Map[Interval, Int]]]] = {
     Future {
       if (rules.isEmpty) {
         Full(Map())
@@ -379,7 +379,7 @@ class RuleGrid(
   }
 
   // Ajax call back to get recent changes
-  private[this] def ajaxChanges(future: Future[Box[Map[RuleId, Map[Interval, Int]]]]): JsCmd = {
+  private def ajaxChanges(future: Future[Box[Map[RuleId, Map[Interval, Int]]]]): JsCmd = {
     SHtml.ajaxInvoke(() => {
       // Is my future completed ?
       if (future.isCompleted) {
@@ -419,7 +419,7 @@ class RuleGrid(
    * First: transform all Rules to Lines
    * Second: Transform all of those lines into javascript datas to send in the function
    */
-  private[this] def getRulesTableData(
+  private def getRulesTableData(
       rules:            Seq[Rule],
       nodeFacts:        MapView[NodeId, CoreNodeFact],
       groupLib:         FullNodeGroupCategory,
@@ -472,7 +472,7 @@ class RuleGrid(
   /*
    * Convert Rules to Data used in Datatables Lines
    */
-  private[this] def convertRulesToLines(
+  private def convertRulesToLines(
       directivesLib:    FullActiveTechniqueCategory,
       groupsLib:        FullNodeGroupCategory,
       arePolicyServers: MapView[NodeId, Boolean],
@@ -507,7 +507,7 @@ class RuleGrid(
 
       val targetsInfo = traverse(rule.targets.toSeq) {
         case json: CompositeRuleTarget =>
-          val ruleTargetInfo = RuleTargetInfo(json, "", "", true, false)
+          val ruleTargetInfo = RuleTargetInfo(json, name = "", description = "", isEnabled = true, isSystem = false)
           Full(ruleTargetInfo)
         case target =>
           groupsLib.allTargets.get(target) match {
@@ -579,7 +579,7 @@ class RuleGrid(
   /*
    * Generates Data for a line of the table
    */
-  private[this] def getRuleData(
+  private def getRuleData(
       line:             Line,
       groupsLib:        FullNodeGroupCategory,
       nodeFacts:        MapView[NodeId, CoreNodeFact],

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
@@ -97,24 +97,24 @@ class SearchNodeComponent(
   import SearchNodeComponent.*
 
   // our local copy of things we work on
-  private[this] var query   = _query.map(x => x.copy())
-  private[this] var srvList = _srvList.map(x => Seq() ++ x)
+  private var query   = _query.map(x => x.copy())
+  private var srvList = _srvList.map(x => Seq() ++ x)
 
-  private[this] val queryProcessor = RudderConfig.acceptedNodeQueryProcessor
+  private val queryProcessor = RudderConfig.acceptedNodeQueryProcessor
 
-  private[this] val nodeInfoService = RudderConfig.nodeInfoService
+  private val nodeInfoService = RudderConfig.nodeInfoService
 
   // The portlet for the server detail
-  private[this] def searchNodes: NodeSeq = ChooseTemplate(
+  private def searchNodes: NodeSeq = ChooseTemplate(
     List("templates-hidden", "server", "server_details"),
     "query-searchnodes"
   )
 
-  private[this] def nodesTable = ChooseTemplate(
+  private def nodesTable = ChooseTemplate(
     List("templates-hidden", "server", "server_details"),
     "nodes-table"
   )
-  private[this] def queryline: NodeSeq = {
+  private def queryline: NodeSeq = {
     <tr class="error"></tr>
   <tr class="query_line">
     <td class="first objectType"></td>
@@ -125,7 +125,7 @@ class SearchNodeComponent(
     <td class="last addLine"></td>
   </tr>
   }
-  private[this] def content = {
+  private def content = {
     val select = ("content-query ^*" #> "not relevant for ^* operator")
     select(searchNodes)
   }
@@ -346,7 +346,7 @@ class SearchNodeComponent(
      */
     def showQueryAndGridContent(): NodeSeq = {
       (
-        "content-query" #> { (x: NodeSeq) => displayQuery(x, false) }
+        "content-query" #> { (x: NodeSeq) => displayQuery(x, isGroupPage = false) }
         & "update-gridresult" #> srvGrid.displayAndInit(Some(Seq()), "serverGrid")
       )(searchNodes)
     }
@@ -390,11 +390,11 @@ class SearchNodeComponent(
         $$('#groupTabMenu').ready(function () {
           $$('#groupTabMenu [role="tab"]').on("show.bs.tab", function (e) {
             var isNextTabShowing = tabs.includes(e.target.getAttribute('aria-controls'));
-            var isPreviousTabShowing = 
+            var isPreviousTabShowing =
               !e.relatedTarget || tabs.includes(e.relatedTarget.getAttribute('aria-controls')); // initial tab shows nodes table
             if (!isPreviousTabShowing && isNextTabShowing) {
               handleNodesTableDisplayByGroupTab(true);
-            } 
+            }
             if (isPreviousTabShowing && !isNextTabShowing) {
               handleNodesTableDisplayByGroupTab(false);
             }
@@ -527,10 +527,10 @@ object SearchNodeComponent {
     val comparators  = optionComparatorsFor(ot, a)
     val compNames    = comparators.map(_._1)
     val selectedComp = compNames match {
-      case a :: _ =>
+      case b :: _ =>
         compNames.filter(_ == c_oldVal) match {
           case x :: _ => x
-          case Nil    => a
+          case Nil    => b
         }
       case Nil    => ""
     }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/ShowNodeDetailsFromNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/ShowNodeDetailsFromNode.scala
@@ -93,13 +93,13 @@ class ShowNodeDetailsFromNode(
 ) extends DispatchSnippet with DefaultExtendableSnippet[ShowNodeDetailsFromNode] with Loggable {
   import ShowNodeDetailsFromNode.*
 
-  private[this] val nodeFactRepo         = RudderConfig.nodeFactRepository
-  private[this] val reportDisplayer      = RudderConfig.reportDisplayer
-  private[this] val logDisplayer         = RudderConfig.logDisplayer
-  private[this] val uuidGen              = RudderConfig.stringUuidGenerator
-  private[this] val asyncDeploymentAgent = RudderConfig.asyncDeploymentAgent
-  private[this] val configService        = RudderConfig.configService
-  private[this] val scoreService         = RudderConfig.rci.scoreService
+  private val nodeFactRepo         = RudderConfig.nodeFactRepository
+  private val reportDisplayer      = RudderConfig.reportDisplayer
+  private val logDisplayer         = RudderConfig.logDisplayer
+  private val uuidGen              = RudderConfig.stringUuidGenerator
+  private val asyncDeploymentAgent = RudderConfig.asyncDeploymentAgent
+  private val configService        = RudderConfig.configService
+  private val scoreService         = RudderConfig.rci.scoreService
 
   def agentPolicyModeEditForm = new AgentPolicyModeEditForm()
 
@@ -193,7 +193,7 @@ class ShowNodeDetailsFromNode(
     dispatch(dispatchName)(NodeSeq.Empty)
   }
 
-  private[this] def privateDisplay(withinPopup: Boolean, displayDetailsMode: DisplayDetailsMode)(implicit
+  private def privateDisplay(withinPopup: Boolean, displayDetailsMode: DisplayDetailsMode)(implicit
       qr: QueryContext
   ): NodeSeq = {
     nodeFactRepo.get(nodeId).toBox match {
@@ -289,8 +289,8 @@ class ShowNodeDetailsFromNode(
       "reportsDetails",
       "reportsGrid",
       RudderConfig.reportingService.findUserNodeStatusReport(_),
-      true,
-      false
+      addOverriden = true,
+      onlySystem = false
     ) &
     "#systemStatus *" #> reportDisplayer.asyncDisplay(
       node,
@@ -298,8 +298,8 @@ class ShowNodeDetailsFromNode(
       "systemStatus",
       "systemStatusGrid",
       RudderConfig.reportingService.findSystemNodeStatusReport(_),
-      false,
-      true
+      addOverriden = false,
+      onlySystem = true
     ) &
     "#nodeProperties *" #> DisplayNode.displayTabProperties(id, nodeFact, sm) &
     "#logsDetails *" #> Script(OnLoad(logDisplayer.asyncDisplay(node.id, None, "logsGrid"))) &

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TagsEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TagsEditForm.scala
@@ -33,14 +33,14 @@ class TagsEditForm(tags: Tags, objectId: String) extends Loggable {
       s"#${controllerId} *+" #> valueInput
     }
 
-    css(tagTemplate(controllerId, appId, true, isRule))
+    css(tagTemplate(controllerId, appId, isEditForm = true, isRule = isRule))
   }
 
   def viewTags(controllerId: String, appId: String, isRule: Boolean): NodeSeq = {
-    tagTemplate(controllerId, appId, false, isRule)
+    tagTemplate(controllerId, appId, isEditForm = false, isRule = isRule)
   }
 
-  private[this] def tagTemplate(controllerId: String, appId: String, isEditForm: Boolean, isRule: Boolean): NodeSeq = {
+  private def tagTemplate(controllerId: String, appId: String, isEditForm: Boolean, isRule: Boolean): NodeSeq = {
 
     val (filterId, objectType) = if (isRule) {
       ("showFiltersRules", "rule")

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueCategoryEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueCategoryEditForm.scala
@@ -65,15 +65,15 @@ class TechniqueCategoryEditForm(
     onFailureCallback: () => JsCmd = { () => Noop }
 ) extends DispatchSnippet with Loggable {
 
-  private[this] val htmlId_categoryDetailsForm = "categoryDetailsForm"
+  private val htmlId_categoryDetailsForm = "categoryDetailsForm"
 
-  private[this] val activeTechniqueCategoryRepository = RudderConfig.woDirectiveRepository
-  private[this] val uuidGen                           = RudderConfig.stringUuidGenerator
+  private val activeTechniqueCategoryRepository = RudderConfig.woDirectiveRepository
+  private val uuidGen                           = RudderConfig.stringUuidGenerator
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "showForm" => { _ => showForm() } }
 
-  private[this] var currentCategory = givenCategory
-  def getCategory                   = currentCategory
+  private var currentCategory = givenCategory
+  def getCategory             = currentCategory
 
   def showForm(): NodeSeq = {
     <div id={htmlId_form} class="object-details">
@@ -107,7 +107,7 @@ class TechniqueCategoryEditForm(
     </div>
   }
 
-  private[this] def deleteCategory(): JsCmd = {
+  private def deleteCategory(): JsCmd = {
     activeTechniqueCategoryRepository
       .deleteCategory(
         currentCategory.id,
@@ -134,7 +134,7 @@ class TechniqueCategoryEditForm(
     }
   }
 
-  private[this] def error(msg: String) = <span class="error">{msg}</span>
+  private def error(msg: String) = <span class="error">{msg}</span>
 
   /////////////////////  Category Details Form  /////////////////////
 
@@ -175,7 +175,7 @@ class TechniqueCategoryEditForm(
 
   var categoryNotifications: List[NodeSeq] = Nil
 
-  private[this] def categoryDetailsForm: NodeSeq = {
+  private def categoryDetailsForm: NodeSeq = {
     val html = SHtml.ajaxForm(<div id={htmlId_categoryDetailsForm}>
         <update-notifications></update-notifications>
         <update-name></update-name>
@@ -269,7 +269,7 @@ class TechniqueCategoryEditForm(
   }
 
   ///////////// success pop-up ///////////////
-  private[this] def successPopup: JsCmd = {
+  private def successPopup: JsCmd = {
     JsRaw("""createSuccessNotification()""")
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueEditForm.scala
@@ -102,17 +102,17 @@ class TechniqueEditForm(
   import TechniqueEditForm.*
 
   // find Technique
-  private[this] val techniqueRepository         = RudderConfig.techniqueRepository
-  private[this] val roActiveTechniqueRepository = RudderConfig.roDirectiveRepository
-  private[this] val rwActiveTechniqueRepository = RudderConfig.woDirectiveRepository
-  private[this] val uuidGen                     = RudderConfig.stringUuidGenerator
+  private val techniqueRepository         = RudderConfig.techniqueRepository
+  private val roActiveTechniqueRepository = RudderConfig.roDirectiveRepository
+  private val rwActiveTechniqueRepository = RudderConfig.woDirectiveRepository
+  private val uuidGen                     = RudderConfig.stringUuidGenerator
   // transform Technique variable to human viewable HTML fields
-  private[this] val directiveEditorService      = RudderConfig.directiveEditorService
-  private[this] val dependencyService           = RudderConfig.dependencyAndDeletionService
-  private[this] val asyncDeploymentAgent        = RudderConfig.asyncDeploymentAgent
-  private[this] val userPropertyService         = RudderConfig.userPropertyService
+  private val directiveEditorService      = RudderConfig.directiveEditorService
+  private val dependencyService           = RudderConfig.dependencyAndDeletionService
+  private val asyncDeploymentAgent        = RudderConfig.asyncDeploymentAgent
+  private val userPropertyService         = RudderConfig.userPropertyService
 
-  private[this] var currentActiveTechnique: Box[ActiveTechnique] = Box(activeTechnique).or {
+  private var currentActiveTechnique: Box[ActiveTechnique] = Box(activeTechnique).or {
     for {
       tech          <- Box(technique)
       optActiveTech <- roActiveTechniqueRepository.getActiveTechnique(tech.id.name).toBox
@@ -144,11 +144,11 @@ class TechniqueEditForm(
   def showRemovePopupForm(): NodeSeq = {
     currentActiveTechnique match {
       case e: EmptyBox => NodeSeq.Empty
-      case Full(activeTechnique) =>
+      case Full(activeTechnique_) =>
         (
           "#deleteActionDialog *" #> { (n: NodeSeq) => SHtml.ajaxForm(n) } andThen
-          "#dialogDeleteButton" #> { deleteButton(activeTechnique.id) % ("id" -> "deleteButton") } &
-          "#deleteItemDependencies *" #> dialogDeleteTree("deleteItemDependencies", activeTechnique) &
+          "#dialogDeleteButton" #> { deleteButton(activeTechnique_.id) % ("id" -> "deleteButton") } &
+          "#deleteItemDependencies *" #> dialogDeleteTree("deleteItemDependencies", activeTechnique_) &
           ".reasonsFieldset" #> {
             crReasonsDisablePopup.map { f =>
               "#explanationMessage" #> <h4 class="col-xl-12 col-md-12 col-sm-12 audit-title">Change Audit Log</h4> &
@@ -163,13 +163,13 @@ class TechniqueEditForm(
   def showDisactivatePopupForm(): NodeSeq = {
     currentActiveTechnique match {
       case e: EmptyBox => NodeSeq.Empty
-      case Full(activeTechnique) =>
+      case Full(activeTechnique_) =>
         (
           "#disableActionDialog *" #> { (n: NodeSeq) => SHtml.ajaxForm(n) } andThen
-          "#dialogDisableButton" #> { disableButton(activeTechnique) % ("id" -> "disableButton") } &
-          "#dialogDisableTitle" #> { if (activeTechnique.isEnabled) "Disable" else "Enable" } &
-          "#dialogDisableLabel" #> { if (activeTechnique.isEnabled) "disable" else "enable" } &
-          "#disableItemDependencies *" #> dialogDisableTree("disableItemDependencies", activeTechnique) &
+          "#dialogDisableButton" #> { disableButton(activeTechnique_) % ("id" -> "disableButton") } &
+          "#dialogDisableTitle" #> { if (activeTechnique_.isEnabled) "Disable" else "Enable" } &
+          "#dialogDisableLabel" #> { if (activeTechnique_.isEnabled) "disable" else "enable" } &
+          "#disableItemDependencies *" #> dialogDisableTree("disableItemDependencies", activeTechnique_) &
           ".reasonsFieldset" #> {
             crReasonsDisablePopup.map { f =>
               "#explanationMessage" #> <h4 class="col-xl-12 col-md-12 col-sm-12 audit-title">Change Audit Log</h4> &
@@ -256,7 +256,7 @@ class TechniqueEditForm(
     """)))
   }
 
-  private[this] val crReasons = {
+  private val crReasons = {
     import com.normation.rudder.web.services.ReasonBehavior.*
     (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled  => None
@@ -265,7 +265,7 @@ class TechniqueEditForm(
     }
   }
 
-  private[this] val crReasonsRemovePopup = {
+  private val crReasonsRemovePopup = {
     import com.normation.rudder.web.services.ReasonBehavior.*
     (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled  => None
@@ -274,7 +274,7 @@ class TechniqueEditForm(
     }
   }
 
-  private[this] val crReasonsDisablePopup = {
+  private val crReasonsDisablePopup = {
     import com.normation.rudder.web.services.ReasonBehavior.*
     (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled  => None
@@ -298,21 +298,21 @@ class TechniqueEditForm(
     }
   }
 
-  private[this] val formTracker = {
+  private val formTracker = {
     new FormTracker(crReasons.toList)
   }
 
-  private[this] val formTrackerRemovePopup = {
+  private val formTrackerRemovePopup = {
     new FormTracker(crReasonsRemovePopup.toList)
   }
 
-  private[this] val formTrackerDisactivatePopup = {
+  private val formTrackerDisactivatePopup = {
     new FormTracker(crReasonsDisablePopup.toList)
   }
 
   ////////////// Callbacks //////////////
 
-  private[this] def onSuccess(): JsCmd = {
+  private def onSuccess(): JsCmd = {
     // MUST BE THIS WAY, because the parent may change some reference to JsNode
     // and so, our AJAX could be broken
     cleanTrackers()
@@ -321,34 +321,34 @@ class TechniqueEditForm(
     successPopup
   }
 
-  private[this] def cleanTrackers(): Unit = {
+  private def cleanTrackers(): Unit = {
     formTracker.clean
     formTrackerRemovePopup.clean
     formTrackerDisactivatePopup.clean
   }
 
-  private[this] def onFailure(): JsCmd = {
+  private def onFailure(): JsCmd = {
     formTracker.addFormError(error("There was a problem with your request"))
     updateFormClientSide()
   }
 
-  private[this] def onFailureRemovePopup(): JsCmd = {
+  private def onFailureRemovePopup(): JsCmd = {
     formTrackerRemovePopup.addFormError(error("There was a problem with your request"))
     updateRemoveFormClientSide()
   }
 
-  private[this] def onFailureDisablePopup(): JsCmd = {
+  private def onFailureDisablePopup(): JsCmd = {
     formTrackerDisactivatePopup.addFormError(error("There was a problem with your request"))
     updateDisableFormClientSide()
   }
 
-  private[this] def updateRemoveFormClientSide(): JsCmd = {
+  private def updateRemoveFormClientSide(): JsCmd = {
     val jsDisplayRemoveDiv = JsRaw("""initBsModal("deleteActionDialog");""")
     Replace("deleteActionDialog", this.showRemovePopupForm()) &
     jsDisplayRemoveDiv
   }
 
-  private[this] def updateDisableFormClientSide(): JsCmd = {
+  private def updateDisableFormClientSide(): JsCmd = {
     val jsDisplayRemoveDiv = JsRaw("""initBsModal("disableActionDialog")""")
     Replace("disableActionDialog", this.showDisactivatePopupForm()) &
     jsDisplayRemoveDiv
@@ -356,7 +356,7 @@ class TechniqueEditForm(
 
   ///////////// Delete /////////////
 
-  private[this] def deleteButton(id: ActiveTechniqueId): Elem = {
+  private def deleteButton(id: ActiveTechniqueId): Elem = {
 
     def deleteActiveTechnique(): JsCmd = {
       if (formTrackerRemovePopup.hasErrors) {
@@ -373,7 +373,7 @@ class TechniqueEditForm(
           } yield {
             deploy
           }) match {
-            case Full(x)          =>
+            case Full(_)          =>
               formTrackerRemovePopup.clean
               onSuccessCallback() &
               SetHtml(htmlId_technique, <div id={htmlId_technique}>Technique successfully deleted</div>) &
@@ -393,13 +393,13 @@ class TechniqueEditForm(
     SHtml.ajaxSubmit("Delete", deleteActiveTechnique _)
   }
 
-  private[this] def dialogDeleteTree(htmlId: String, activeTechnique: ActiveTechnique): NodeSeq = {
+  private def dialogDeleteTree(htmlId: String, activeTechnique: ActiveTechnique): NodeSeq = {
     (new TechniqueTree(htmlId, activeTechnique.id, DontCare)).tree()
   }
 
   ///////////// Enable / disable /////////////
 
-  private[this] def disableButton(activeTechnique: ActiveTechnique): Elem = {
+  private def disableButton(activeTechnique: ActiveTechnique): Elem = {
     def switchActivation(status: Boolean)(): JsCmd = {
       if (formTrackerDisactivatePopup.hasErrors) {
         onFailureDisablePopup()
@@ -417,7 +417,7 @@ class TechniqueEditForm(
     }
   }
 
-  private[this] def dialogDisableWarning(activeTechnique: ActiveTechnique): NodeSeq = {
+  private def dialogDisableWarning(activeTechnique: ActiveTechnique): NodeSeq = {
     if (activeTechnique.isEnabled) {
       <h2>Disabling this Technique will also affect the following Directives and Rules.</h2>
     } else {
@@ -425,7 +425,7 @@ class TechniqueEditForm(
     }
   }
 
-  private[this] def dialogDisableTree(htmlId: String, activeTechnique: ActiveTechnique): NodeSeq = {
+  private def dialogDisableTree(htmlId: String, activeTechnique: ActiveTechnique): NodeSeq = {
     val switchFilterStatus = if (activeTechnique.isEnabled) OnlyDisableable else OnlyEnableable
     (new TechniqueTree(htmlId, activeTechnique.id, switchFilterStatus)).tree()
   }
@@ -489,7 +489,7 @@ class TechniqueEditForm(
     }</div>
   }
 
-  private[this] def showParameters(technique: Technique): NodeSeq = {
+  private def showParameters(technique: Technique): NodeSeq = {
     directiveEditorService.get(technique.id, DirectiveUid("just-for-read-only")) match {
       case Full(pe) => pe.toHtmlNodeSeq
       case e: EmptyBox =>
@@ -499,7 +499,7 @@ class TechniqueEditForm(
     }
   }
 
-  private[this] def showIsSingle(technique: Technique): NodeSeq = {
+  private def showIsSingle(technique: Technique): NodeSeq = {
     <span>
       {
       if (technique.isMultiInstance) {
@@ -552,13 +552,13 @@ class TechniqueEditForm(
   /////////////////////////////// Edit form ///////////////////////////////
   /////////////////////////////////////////////////////////////////////////
 
-  private[this] def updateFormClientSide(): JsCmd = {
+  private def updateFormClientSide(): JsCmd = {
     SetHtml(htmlId_technique, this.showCrForm())
   }
 
-  private[this] def error(msg: String) = <span class="error">{msg}</span>
+  private def error(msg: String) = <span class="error">{msg}</span>
 
-  private[this] def statusAndDeployTechnique(uactiveTechniqueId: ActiveTechniqueId, status: Boolean): JsCmd = {
+  private def statusAndDeployTechnique(uactiveTechniqueId: ActiveTechniqueId, status: Boolean): JsCmd = {
     val modId = ModificationId(uuidGen.newUuid)
     (for {
       save   <- rwActiveTechniqueRepository
@@ -571,7 +571,7 @@ class TechniqueEditForm(
     } yield {
       save
     }) match {
-      case Full(x) => onSuccess()
+      case Full(_) => onSuccess()
       case Empty   =>
         formTracker.addFormError(error("An error occurred while saving the Technique"))
         onFailure()
@@ -581,7 +581,7 @@ class TechniqueEditForm(
     }
   }
 
-  private[this] def updateAndDisplayNotifications(formTracker: FormTracker): NodeSeq = {
+  private def updateAndDisplayNotifications(formTracker: FormTracker): NodeSeq = {
     val notifications = formTracker.formErrors
     formTracker.cleanErrors
     if (notifications.isEmpty) {
@@ -594,7 +594,7 @@ class TechniqueEditForm(
   }
 
   ///////////// success pop-up ///////////////
-  private[this] def successPopup: JsCmd = {
+  private def successPopup: JsCmd = {
     JsRaw("""createSuccessNotification()""")
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueTree.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueTree.scala
@@ -108,7 +108,7 @@ class TechniqueTree(
     }
   }
 
-  private[this] def categoryNode(
+  private def categoryNode(
       category:        ActiveTechniqueCategory,
       subCat:          List[ActiveTechniqueCategory],
       dep:             TechniqueDependencies,
@@ -128,7 +128,7 @@ class TechniqueTree(
     }
   }
 
-  private[this] def techniqueNode(
+  private def techniqueNode(
       dep:             TechniqueDependencies,
       technique:       Technique,
       activeTechnique: ActiveTechnique
@@ -143,7 +143,7 @@ class TechniqueTree(
                                                                                       else Nil)
   }
 
-  private[this] def directiveNode(dep: TechniqueDependencies, id: DirectiveUid): JsTreeNode = {
+  private def directiveNode(dep: TechniqueDependencies, id: DirectiveUid): JsTreeNode = {
     val (directive, ruleIds) = dep.directives(id)
 
     new JsTreeNode {
@@ -158,7 +158,7 @@ class TechniqueTree(
     }
   }
 
-  private[this] def ruleNode(id: RuleId): JsTreeNode = {
+  private def ruleNode(id: RuleId): JsTreeNode = {
     ruleRepository.get(id).toBox match {
       case Full(rule) =>
         new JsTreeNode {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateActiveTechniqueCategoryPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateActiveTechniqueCategoryPopup.scala
@@ -69,11 +69,11 @@ class CreateActiveTechniqueCategoryPopup(
     "technique-createcategorypopup"
   )
 
-  private[this] val activeTechniqueCategoryRepository   = RudderConfig.roDirectiveRepository
-  private[this] val rwActiveTechniqueCategoryRepository = RudderConfig.woDirectiveRepository
-  private[this] val uuidGen                             = RudderConfig.stringUuidGenerator
+  private val activeTechniqueCategoryRepository   = RudderConfig.roDirectiveRepository
+  private val rwActiveTechniqueCategoryRepository = RudderConfig.woDirectiveRepository
+  private val uuidGen                             = RudderConfig.stringUuidGenerator
 
-  private[this] val categories = activeTechniqueCategoryRepository.getAllActiveTechniqueCategories().toBox
+  private val categories = activeTechniqueCategoryRepository.getAllActiveTechniqueCategories().toBox
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "popupContent" => popupContent _ }
 
@@ -95,7 +95,7 @@ class CreateActiveTechniqueCategoryPopup(
   }
 
 ///////////// fields for category settings ///////////////////
-  private[this] val categoryName = new WBTextField("Name", "") {
+  private val categoryName = new WBTextField("Name", "") {
     override def setFilter      = notNull _ :: trim _ :: Nil
     override def errorClassName = "col-xl-12 errors-container"
     override def inputField     =
@@ -104,7 +104,7 @@ class CreateActiveTechniqueCategoryPopup(
       valMinLen(1, "Name must not be empty") _ :: Nil
   }
 
-  private[this] val categoryDescription = new WBTextAreaField("Description", "") {
+  private val categoryDescription = new WBTextAreaField("Description", "") {
     override def setFilter      = notNull _ :: trim _ :: Nil
     override def inputField     = super.inputField % ("class" -> "form-control col-xl-12 col-md-12 col-sm-12") % ("tabindex" -> "2")
     override def errorClassName = "col-xl-12 errors-container"
@@ -112,7 +112,7 @@ class CreateActiveTechniqueCategoryPopup(
 
   }
 
-  private[this] val categoryContainer = {
+  private val categoryContainer = {
     new WBSelectField("Parent category: ", (categories.getOrElse(Seq()).map(x => (x.id.value -> x.name))), "") {
       override def className   = "form-select col-xl-12 col-md-12 col-sm-12"
       override def validations =
@@ -120,24 +120,24 @@ class CreateActiveTechniqueCategoryPopup(
     }
   }
 
-  private[this] val formTracker = new FormTracker(categoryName, categoryDescription, categoryContainer)
+  private val formTracker = new FormTracker(categoryName, categoryDescription, categoryContainer)
 
-  private[this] var notifications = List.empty[NodeSeq]
+  private var notifications = List.empty[NodeSeq]
 
-  private[this] def error(msg: String) = Text(msg)
+  private def error(msg: String) = Text(msg)
 
-  private[this] def closePopup(): JsCmd = {
+  private def closePopup(): JsCmd = {
     JsRaw("""hideBsModal('createActiveTechniqueCategoryPopup');""")
   }
 
   /**
    * Update the form when something happened
    */
-  private[this] def updateFormClientSide(): JsCmd = {
+  private def updateFormClientSide(): JsCmd = {
     SetHtml("createActiveTechniquesCategoryContainer", popupContent(NodeSeq.Empty))
   }
 
-  private[this] def onSubmit(): JsCmd = {
+  private def onSubmit(): JsCmd = {
     if (formTracker.hasErrors) {
       onFailure & onFailureCallback()
     } else {
@@ -171,12 +171,12 @@ class CreateActiveTechniqueCategoryPopup(
     }
   }
 
-  private[this] def onFailure: JsCmd = {
+  private def onFailure: JsCmd = {
     formTracker.addFormError(error("There was a problem with your request"))
     updateFormClientSide()
   }
 
-  private[this] def updateAndDisplayNotifications(): NodeSeq = {
+  private def updateAndDisplayNotifications(): NodeSeq = {
     notifications :::= formTracker.formErrors
     formTracker.cleanErrors
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
@@ -84,10 +84,10 @@ class CreateCategoryOrGroupPopup(
     "groups-creategrouppopup"
   )
 
-  private[this] val woNodeGroupRepository      = RudderConfig.woNodeGroupRepository
-  private[this] val categoryHierarchyDisplayer = RudderConfig.categoryHierarchyDisplayer
-  private[this] val uuidGen                    = RudderConfig.stringUuidGenerator
-  private[this] val userPropertyService        = RudderConfig.userPropertyService
+  private val woNodeGroupRepository      = RudderConfig.woNodeGroupRepository
+  private val categoryHierarchyDisplayer = RudderConfig.categoryHierarchyDisplayer
+  private val uuidGen                    = RudderConfig.stringUuidGenerator
+  private val userPropertyService        = RudderConfig.userPropertyService
 
   var createContainer = false // issue #1190 always create a group by default
 
@@ -96,7 +96,7 @@ class CreateCategoryOrGroupPopup(
   /**
    * If we create a category, the info about the group is hidden (default), otherwise we show it
    */
-  private[this] def initJs: JsCmd = {
+  private def initJs: JsCmd = {
     JsRaw("""
         $('input[value="Group"]').click(
           function() {
@@ -150,7 +150,7 @@ class CreateCategoryOrGroupPopup(
   }
 
   ///////////// fields for category settings ///////////////////
-  private[this] val piName = new WBTextField("Name", "") {
+  private val piName = new WBTextField("Name", "") {
     override def setFilter      = notNull _ :: trim _ :: Nil
     override def errorClassName = "col-xl-12 errors-container"
     override def inputField     =
@@ -159,7 +159,7 @@ class CreateCategoryOrGroupPopup(
       valMinLen(1, "Name must not be empty.") _ :: Nil
   }
 
-  private[this] val piDescription = new WBTextAreaField("Description", "") {
+  private val piDescription = new WBTextAreaField("Description", "") {
     override def setFilter      = notNull _ :: trim _ :: Nil
     override def inputField     = super.inputField % ("style" -> "height:5em") % ("tabindex" -> "4")
     override def errorClassName = "col-xl-12 errors-container"
@@ -167,7 +167,7 @@ class CreateCategoryOrGroupPopup(
 
   }
 
-  private[this] val piStatic = new WBRadioField(
+  private val piStatic = new WBRadioField(
     "Group type",
     Seq("dynamic", "static"),
     "dynamic",
@@ -190,7 +190,7 @@ class CreateCategoryOrGroupPopup(
       valMinLen(1, "Please choose a group type.") _ :: Nil
   }
 
-  private[this] val piItemType = {
+  private val piItemType = {
     new WBRadioField(
       "Item to create",
       Seq("Group", "Category"),
@@ -212,7 +212,7 @@ class CreateCategoryOrGroupPopup(
     }
   }
 
-  private[this] val piContainer = new WBSelectField(
+  private val piContainer = new WBSelectField(
     "Parent category",
     (categoryHierarchyDisplayer.getCategoriesHierarchy(rootCategory, None).map { case (id, name) => (id.value -> name) }),
     selectedCategory.map(_.value).getOrElse("")
@@ -225,24 +225,24 @@ class CreateCategoryOrGroupPopup(
       valMinLen(1, "Please select a category") _ :: Nil
   }
 
-  private[this] val formTracker = new FormTracker(piName, piDescription, piContainer, piStatic)
+  private val formTracker = new FormTracker(piName, piDescription, piContainer, piStatic)
 
-  private[this] var notifications = List.empty[NodeSeq]
+  private var notifications = List.empty[NodeSeq]
 
-  private[this] def error(msg: String) = Text(msg)
+  private def error(msg: String) = Text(msg)
 
-  private[this] def closePopup(): JsCmd = {
+  private def closePopup(): JsCmd = {
     JsRaw("""hideBsModal('createGroupPopup');""")
   }
 
   /**
    * Update the form when something happened
    */
-  private[this] def updateFormClientSide(): JsCmd = {
+  private def updateFormClientSide(): JsCmd = {
     SetHtml("createGroupContainer", popupContent())
   }
 
-  private[this] def onSubmit(): JsCmd = {
+  private def onSubmit(): JsCmd = {
     if (formTracker.hasErrors) {
       onFailure & onFailureCallback()
     } else {
@@ -281,7 +281,7 @@ class CreateCategoryOrGroupPopup(
         val isDynamic = piStatic.get match { case "dynamic" => true; case _ => false }
         val srvList   = groupGenerator.map(_.serverList).getOrElse(Set[NodeId]())
         val nodeId    = NodeGroupId(NodeGroupUid(uuidGen.newUuid))
-        val nodeGroup = NodeGroup(nodeId, piName.get, piDescription.get, Nil, query, isDynamic, srvList, true)
+        val nodeGroup = NodeGroup(nodeId, piName.get, piDescription.get, Nil, query, isDynamic, srvList, _isEnabled = true)
         woNodeGroupRepository
           .create(
             nodeGroup,
@@ -310,7 +310,7 @@ class CreateCategoryOrGroupPopup(
     }
   }
 
-  private[this] val piReasons = {
+  private val piReasons = {
     import com.normation.rudder.web.services.ReasonBehavior.*
     (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled  => None
@@ -335,11 +335,11 @@ class CreateCategoryOrGroupPopup(
     }
   }
 
-  private[this] def onFailure: JsCmd = {
+  private def onFailure: JsCmd = {
     updateFormClientSide()
   }
 
-  private[this] def updateAndDisplayNotifications(): NodeSeq = {
+  private def updateAndDisplayNotifications(): NodeSeq = {
     notifications :::= formTracker.formErrors
     formTracker.cleanErrors
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneDirectivePopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneDirectivePopup.scala
@@ -93,10 +93,10 @@ class CreateCloneDirectivePopup(
     onFailureCallback:    () => JsCmd = { () => Noop }
 ) extends DispatchSnippet with Loggable {
 
-  private[this] val uuidGen               = RudderConfig.stringUuidGenerator
-  private[this] val userPropertyService   = RudderConfig.userPropertyService
-  private[this] val roDirectiveRepository = RudderConfig.roDirectiveRepository
-  private[this] val woDirectiveRepository = RudderConfig.woDirectiveRepository
+  private val uuidGen               = RudderConfig.stringUuidGenerator
+  private val userPropertyService   = RudderConfig.userPropertyService
+  private val roDirectiveRepository = RudderConfig.roDirectiveRepository
+  private val woDirectiveRepository = RudderConfig.woDirectiveRepository
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "popupContent" => { _ => popupContent() } }
 
@@ -124,7 +124,7 @@ class CreateCloneDirectivePopup(
 
   ///////////// fields for category settings ///////////////////
 
-  private[this] val reasons = {
+  private val reasons = {
     import com.normation.rudder.web.services.ReasonBehavior.*
     (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled  => None
@@ -150,7 +150,7 @@ class CreateCloneDirectivePopup(
     }
   }
 
-  private[this] val directiveName = new WBTextField("Name", "Copy of <%s>".format(directive.name)) {
+  private val directiveName = new WBTextField("Name", "Copy of <%s>".format(directive.name)) {
     override def setFilter      = notNull _ :: trim _ :: Nil
     override def errorClassName = "col-xl-12 errors-container"
     override def inputField     =
@@ -159,7 +159,7 @@ class CreateCloneDirectivePopup(
       valMinLen(1, "Name must not be empty") _ :: Nil
   }
 
-  private[this] val directiveShortDescription = {
+  private val directiveShortDescription = {
     new WBTextAreaField("Short description", directive.shortDescription) {
       override def setFilter      = notNull _ :: trim _ :: Nil
       override def inputField     = super.inputField % ("style" -> "height:7em") % ("tabindex" -> "2")
@@ -168,24 +168,24 @@ class CreateCloneDirectivePopup(
     }
   }
 
-  private[this] val formTracker = new FormTracker(directiveName :: directiveShortDescription :: reasons.toList)
+  private val formTracker = new FormTracker(directiveName :: directiveShortDescription :: reasons.toList)
 
-  private[this] var notifications = List.empty[NodeSeq]
+  private var notifications = List.empty[NodeSeq]
 
-  private[this] def error(msg: String) = Text(msg)
+  private def error(msg: String) = Text(msg)
 
-  private[this] def closePopup(): JsCmd = {
+  private def closePopup(): JsCmd = {
     JsRaw("""hideBsModal('basePopup');""")
   }
 
   /**
    * Update the form when something happened
    */
-  private[this] def updateFormClientSide(): JsCmd = {
+  private def updateFormClientSide(): JsCmd = {
     SetHtml(htmlId_popupContainer, popupContent())
   }
 
-  private[this] def onSubmit(): JsCmd = {
+  private def onSubmit(): JsCmd = {
 
     if (formTracker.hasErrors) {
       onFailure & onFailureCallback()
@@ -215,7 +215,7 @@ class CreateCloneDirectivePopup(
               reasons.map(_.get)
             )
             .toBox match {
-            case Full(directive) => {
+            case Full(_) => {
               closePopup() & onSuccessCallback(cloneDirective)
             }
             case eb: EmptyBox =>
@@ -235,12 +235,12 @@ class CreateCloneDirectivePopup(
     }
   }
 
-  private[this] def onFailure: JsCmd = {
+  private def onFailure: JsCmd = {
     formTracker.addFormError(error("There was a problem with your request"))
     updateFormClientSide()
   }
 
-  private[this] def updateAndDisplayNotifications(): NodeSeq = {
+  private def updateAndDisplayNotifications(): NodeSeq = {
     notifications :::= formTracker.formErrors
     formTracker.cleanErrors
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
@@ -35,14 +35,14 @@ class CreateCloneGroupPopup(
     onFailureCallback: () => JsCmd = { () => Noop }
 ) extends DispatchSnippet with Loggable {
 
-  private[this] val roNodeGroupRepository = RudderConfig.roNodeGroupRepository
-  private[this] val woNodeGroupRepository = RudderConfig.woNodeGroupRepository
-  private[this] val uuidGen               = RudderConfig.stringUuidGenerator
-  private[this] val userPropertyService   = RudderConfig.userPropertyService
+  private val roNodeGroupRepository = RudderConfig.roNodeGroupRepository
+  private val woNodeGroupRepository = RudderConfig.woNodeGroupRepository
+  private val uuidGen               = RudderConfig.stringUuidGenerator
+  private val userPropertyService   = RudderConfig.userPropertyService
 
-  private[this] val categories       = roNodeGroupRepository.getAllNonSystemCategories()
+  private val categories       = roNodeGroupRepository.getAllNonSystemCategories()
   // Fetch the parent category, if any
-  private[this] val parentCategoryId =
+  private val parentCategoryId =
     nodeGroup.flatMap(x => roNodeGroupRepository.getNodeGroupCategory(x.id).toBox).map(_.id.value).getOrElse("")
 
   var createContainer = false
@@ -83,18 +83,18 @@ class CreateCloneGroupPopup(
     "groups-createclonegrouppopup"
   )
 
-  private[this] def closePopup(): JsCmd = {
+  private def closePopup(): JsCmd = {
     JsRaw("""hideBsModal('createCloneGroupPopup');""")
   }
 
-  private[this] def onFailure()(implicit qc: QueryContext): JsCmd = {
+  private def onFailure()(implicit qc: QueryContext): JsCmd = {
     onFailureCallback() &
     updateFormClientSide()
   }
 
-  private[this] def error(msg: String) = <span class="col-xl-12 errors-container">{msg}</span>
+  private def error(msg: String) = <span class="col-xl-12 errors-container">{msg}</span>
 
-  private[this] def onSubmit()(implicit qc: QueryContext): JsCmd = {
+  private def onSubmit()(implicit qc: QueryContext): JsCmd = {
     nodeGroup match {
       case None     => Noop
       case Some(ng) =>
@@ -158,7 +158,7 @@ class CreateCloneGroupPopup(
               query,
               isDynamic,
               srvList,
-              true
+              _isEnabled = true
             )
 
             woNodeGroupRepository
@@ -188,7 +188,7 @@ class CreateCloneGroupPopup(
     }
   }
 
-  private[this] def updateAndDisplayNotifications(formTracker: FormTracker): NodeSeq = {
+  private def updateAndDisplayNotifications(formTracker: FormTracker): NodeSeq = {
 
     val notifications = formTracker.formErrors
     formTracker.cleanErrors
@@ -207,7 +207,7 @@ class CreateCloneGroupPopup(
 
   ///////////// fields for category settings ///////////////////
 
-  private[this] val groupReasons = {
+  private val groupReasons = {
     import com.normation.rudder.web.services.ReasonBehavior.*
     (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled  => None
@@ -232,7 +232,7 @@ class CreateCloneGroupPopup(
     }
   }
 
-  private[this] val groupName = {
+  private val groupName = {
     new WBTextField("Name", nodeGroup.map(x => "Copy of <%s>".format(x.name)).getOrElse("")) {
       override def setFilter      = notNull _ :: trim _ :: Nil
       override def errorClassName = "col-xl-12 errors-container"
@@ -243,14 +243,14 @@ class CreateCloneGroupPopup(
     }
   }
 
-  private[this] val groupDescription = new WBTextAreaField("Description", nodeGroup.map(x => x.description).getOrElse("")) {
+  private val groupDescription = new WBTextAreaField("Description", nodeGroup.map(x => x.description).getOrElse("")) {
     override def setFilter      = notNull _ :: trim _ :: Nil
     override def inputField     = super.inputField % ("style" -> "height:5em") % ("tabindex" -> "3")
     override def errorClassName = "col-xl-12 errors-container"
     override def validations: List[String => List[FieldError]] = Nil
   }
 
-  private[this] val isStatic = {
+  private val isStatic = {
     new WBRadioField(
       "Group type",
       Seq("static", "dynamic"),
@@ -270,7 +270,7 @@ class CreateCloneGroupPopup(
     }
   }
 
-  private[this] val groupContainer = {
+  private val groupContainer = {
     new WBSelectField("Parent category", (categories.toBox.getOrElse(Seq()).map(x => (x.id.value -> x.name))), parentCategoryId) {
       override def inputField =
         super.inputField % ("onkeydown" -> "return processKey(event , 'createCOGSaveButton')") % ("tabindex" -> "2")
@@ -280,7 +280,7 @@ class CreateCloneGroupPopup(
     }
   }
 
-  private[this] def initJs: JsCmd = {
+  private def initJs: JsCmd = {
     JsShowId("createGroupHiddable") & {
       if (groupGenerator != None) {
         JsHideId("itemCreation")
@@ -290,11 +290,11 @@ class CreateCloneGroupPopup(
     }
   }
 
-  private[this] val formTracker = {
+  private val formTracker = {
     new FormTracker(groupName, groupDescription, groupContainer, isStatic)
   }
 
-  private[this] def updateFormClientSide()(implicit qc: QueryContext): JsCmd = {
+  private def updateFormClientSide()(implicit qc: QueryContext): JsCmd = {
     SetHtml("createCloneGroupContainer", popupContent())
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
@@ -79,8 +79,8 @@ class CreateOrUpdateGlobalParameterPopup(
     onFailureCallback: () => JsCmd = { () => Noop }
 ) extends DispatchSnippet with Loggable {
 
-  private[this] val userPropertyService = RudderConfig.userPropertyService
-  private[this] val uuidGen             = RudderConfig.stringUuidGenerator
+  private val userPropertyService = RudderConfig.userPropertyService
+  private[this] val uuidGen       = RudderConfig.stringUuidGenerator
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = {
     case "popupContent" => { _ => popupContent()(CurrentUser.queryContext) }
@@ -96,8 +96,8 @@ class CreateOrUpdateGlobalParameterPopup(
     case GlobalParamModAction.Create => "Add a global property"
   }
 
-  private[this] val workflowEnabled = workflowService.needExternalValidation()
-  private[this] val titleWorkflow   = workflowEnabled match {
+  private val workflowEnabled = workflowService.needExternalValidation()
+  private val titleWorkflow   = workflowEnabled match {
     case true  =>
       <h4 class="col-xl-12 col-md-12 col-sm-12 audit-title">Change Request</h4>
               <hr class="css-fix"/>
@@ -108,7 +108,7 @@ class CreateOrUpdateGlobalParameterPopup(
     case false => NodeSeq.Empty
   }
 
-  private[this] def globalParamDiffFromAction(newParameter: GlobalParameter): Box[ChangeRequestGlobalParameterDiff] = {
+  private def globalParamDiffFromAction(newParameter: GlobalParameter): Box[ChangeRequestGlobalParameterDiff] = {
     change.previousGlobalParam match {
       case None    =>
         if ((change.action == GlobalParamModAction.Update) || (change.action == GlobalParamModAction.Create))
@@ -136,7 +136,7 @@ class CreateOrUpdateGlobalParameterPopup(
     }
   }
 
-  private[this] def onSubmit()(implicit qc: QueryContext): JsCmd = {
+  private def onSubmit()(implicit qc: QueryContext): JsCmd = {
     if (formTracker.hasErrors) {
       onFailure
     } else {
@@ -195,23 +195,23 @@ class CreateOrUpdateGlobalParameterPopup(
     }
   }
 
-  private[this] def onFailure(implicit qc: QueryContext): JsCmd = {
+  private def onFailure(implicit qc: QueryContext): JsCmd = {
     formTracker.addFormError(error("The form contains some errors, please correct them"))
     updateFormClientSide()
   }
 
-  private[this] def closePopup(): JsCmd = {
+  private def closePopup(): JsCmd = {
     JsRaw("""hideBsModal('createGlobalParameterPopup');""")
   }
 
   /**
    * Update the form when something happened
    */
-  private[this] def updateFormClientSide()(implicit qc: QueryContext): JsCmd = {
+  private def updateFormClientSide()(implicit qc: QueryContext): JsCmd = {
     SetHtml(CreateOrUpdateGlobalParameterPopup.htmlId_popupContainer, popupContent())
   }
 
-  private[this] def updateAndDisplayNotifications(formTracker: FormTracker): NodeSeq = {
+  private def updateAndDisplayNotifications(formTracker: FormTracker): NodeSeq = {
     val notifications = formTracker.formErrors
     formTracker.cleanErrors
 
@@ -225,9 +225,9 @@ class CreateOrUpdateGlobalParameterPopup(
   }
 
   ////////////////////////// fields for form ////////////////////////
-  private[this] val patternName = Pattern.compile("[a-zA-Z0-9_]+");
+  private val patternName = Pattern.compile("[a-zA-Z0-9_]+");
 
-  private[this] val parameterName = new WBTextField("Name", change.previousGlobalParam.map(_.name).getOrElse("")) {
+  private val parameterName = new WBTextField("Name", change.previousGlobalParam.map(_.name).getOrElse("")) {
     override def setFilter      = notNull _ :: trim _ :: Nil
     override def errorClassName = "col-xl-12 errors-container"
     override def inputField     = (change.previousGlobalParam match {
@@ -241,7 +241,7 @@ class CreateOrUpdateGlobalParameterPopup(
   }
 
   // The value may be empty
-  private[this] val parameterFormat = {
+  private val parameterFormat = {
 
     val defaultMode = change.previousGlobalParam.map { p =>
       if (p.value.valueType() == ConfigValueType.STRING) "string" else "json"
@@ -269,7 +269,7 @@ class CreateOrUpdateGlobalParameterPopup(
   }
 
   // The value may be empty
-  private[this] val parameterValue = {
+  private val parameterValue = {
     new WBTextAreaField("Value", change.previousGlobalParam.map(p => p.valueAsString).getOrElse("")) {
       override def setFilter      = trim _ :: Nil
       override def inputField     = (change.action match {
@@ -281,7 +281,7 @@ class CreateOrUpdateGlobalParameterPopup(
     }
   }
 
-  private[this] val parameterDescription = {
+  private val parameterDescription = {
     new WBTextAreaField("Description", change.previousGlobalParam.map(_.description).getOrElse("")) {
       override def setFilter      = notNull _ :: trim _ :: Nil
       override def inputField     = (change.action match {
@@ -293,7 +293,7 @@ class CreateOrUpdateGlobalParameterPopup(
     }
   }
 
-  private[this] val parameterInheritMode = {
+  private val parameterInheritMode = {
     new WBTextField("Inherit Mode", change.previousGlobalParam.flatMap(_.inheritMode.map(_.value)).getOrElse("")) {
       override val maxLen         = 3
       override def setFilter      = trim _ :: Nil
@@ -310,15 +310,15 @@ class CreateOrUpdateGlobalParameterPopup(
     }
   }
 
-  private[this] def defaultClassName = change.action match {
+  private def defaultClassName = change.action match {
     case GlobalParamModAction.Update => "btn-success"
     case GlobalParamModAction.Create => "btn-success"
     case GlobalParamModAction.Delete => "btn-danger"
   }
 
-  private[this] val defaultRequestName =
+  private val defaultRequestName =
     s"${change.action.name.capitalize} Global Parameter " + change.previousGlobalParam.map(_.name).getOrElse("")
-  private[this] val changeRequestName  = new WBTextField("Change request title", defaultRequestName) {
+  private val changeRequestName  = new WBTextField("Change request title", defaultRequestName) {
     override def setFilter      = notNull _ :: trim _ :: Nil
     override def errorClassName = "col-xl-12 errors-container"
     override def inputField     =
@@ -329,7 +329,7 @@ class CreateOrUpdateGlobalParameterPopup(
 
   val parameterOverridable = true
 
-  private[this] val paramReasons = {
+  private val paramReasons = {
     import com.normation.rudder.web.services.ReasonBehavior.*
     (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled  => None
@@ -354,7 +354,7 @@ class CreateOrUpdateGlobalParameterPopup(
     }
   }
 
-  private[this] val formTracker = {
+  private val formTracker = {
     val fields = parameterName :: parameterValue :: paramReasons.toList ::: {
       if (workflowEnabled) changeRequestName :: Nil
       else Nil
@@ -362,7 +362,7 @@ class CreateOrUpdateGlobalParameterPopup(
     new FormTracker(fields)
   }
 
-  private[this] def error(msg: String) = Text(msg)
+  private def error(msg: String) = Text(msg)
 
   def popupContent()(implicit qc: QueryContext): NodeSeq = {
     val (buttonName, classForButton) = workflowEnabled match {
@@ -417,7 +417,7 @@ class CreateOrUpdateGlobalParameterPopup(
     ).apply(formXml())
 
   }
-  private[this] def formXml(): NodeSeq = {
+  private def formXml(): NodeSeq = {
     SHtml.ajaxForm(
       <div class="modal-dialog">
         <div class="modal-content">

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateRulePopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateRulePopup.scala
@@ -84,10 +84,10 @@ class CreateOrCloneRulePopup(
     "rule-createrulepopup"
   )
 
-  private[this] val woRuleRepository           = RudderConfig.woRuleRepository
-  private[this] val uuidGen                    = RudderConfig.stringUuidGenerator
-  private[this] val userPropertyService        = RudderConfig.userPropertyService
-  private[this] val categoryHierarchyDisplayer = RudderConfig.categoryHierarchyDisplayer
+  private val woRuleRepository           = RudderConfig.woRuleRepository
+  private val uuidGen                    = RudderConfig.stringUuidGenerator
+  private val userPropertyService        = RudderConfig.userPropertyService
+  private val categoryHierarchyDisplayer = RudderConfig.categoryHierarchyDisplayer
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "popupContent" => _ => popupContent() }
 
@@ -132,7 +132,7 @@ class CreateOrCloneRulePopup(
 
   ///////////// fields for category settings ///////////////////
 
-  private[this] val reason = {
+  private val reason = {
     import com.normation.rudder.web.services.ReasonBehavior.*
     (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled  => None
@@ -158,7 +158,7 @@ class CreateOrCloneRulePopup(
     }
   }
 
-  private[this] val ruleName = new WBTextField("Name", clonedRule.map(r => "Copy of <%s>".format(r.name)).getOrElse("")) {
+  private val ruleName = new WBTextField("Name", clonedRule.map(r => "Copy of <%s>".format(r.name)).getOrElse("")) {
     override def setFilter      = notNull _ :: trim _ :: Nil
     override def errorClassName = "col-xl-12 errors-container"
     override def inputField     =
@@ -167,7 +167,7 @@ class CreateOrCloneRulePopup(
       valMinLen(1, "Name must not be empty") _ :: Nil
   }
 
-  private[this] val ruleShortDescription = new WBTextAreaField("Description", clonedRule.map(_.shortDescription).getOrElse("")) {
+  private val ruleShortDescription = new WBTextAreaField("Description", clonedRule.map(_.shortDescription).getOrElse("")) {
     override def setFilter      = notNull _ :: trim _ :: Nil
     override def inputField     = super.inputField % ("style" -> "height:7em") % ("tabindex" -> "2")
     override def errorClassName = "col-xl-12 errors-container"
@@ -175,7 +175,7 @@ class CreateOrCloneRulePopup(
 
   }
 
-  private[this] val category = {
+  private val category = {
     new WBSelectField(
       "Category",
       categoryHierarchyDisplayer.getRuleCategoryHierarchy(rootRuleCategory, None).map { case (id, name) => (id.value -> name) },
@@ -187,24 +187,24 @@ class CreateOrCloneRulePopup(
     }
   }
 
-  private[this] val formTracker = new FormTracker(ruleName :: ruleShortDescription :: reason.toList)
+  private val formTracker = new FormTracker(ruleName :: ruleShortDescription :: reason.toList)
 
-  private[this] var notifications = List.empty[NodeSeq]
+  private var notifications = List.empty[NodeSeq]
 
-  private[this] def error(msg: String) = <span class="col-xl-12 errors-container">{msg}</span>
+  private def error(msg: String) = <span class="col-xl-12 errors-container">{msg}</span>
 
-  private[this] def closePopup(): JsCmd = {
+  private def closePopup(): JsCmd = {
     JsRaw("""hideBsModal('createRulePopup');""")
   }
 
   /**
    * Update the form when something happened
    */
-  private[this] def updateFormClientSide(): JsCmd = {
+  private def updateFormClientSide(): JsCmd = {
     SetHtml(htmlId_popupContainer, popupContent())
   }
 
-  private[this] def onSubmit(): JsCmd = {
+  private def onSubmit(): JsCmd = {
     if (formTracker.hasErrors) {
       onFailure & onFailureCallback()
     } else {
@@ -245,11 +245,11 @@ class CreateOrCloneRulePopup(
     }
   }
 
-  private[this] def onFailure: JsCmd = {
+  private def onFailure: JsCmd = {
     updateFormClientSide()
   }
 
-  private[this] def updateAndDisplayNotifications(): NodeSeq = {
+  private def updateAndDisplayNotifications(): NodeSeq = {
     notifications :::= formTracker.formErrors
     formTracker.cleanErrors
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/GiveReasonPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/GiveReasonPopup.scala
@@ -71,10 +71,10 @@ class GiveReasonPopup(
     "reason-givereasonpopup"
   )
 
-  private[this] val uuidGen                     = RudderConfig.stringUuidGenerator
-  private[this] val rwActiveTechniqueRepository = RudderConfig.woDirectiveRepository
-  private[this] val userPropertyService         = RudderConfig.userPropertyService
-  private[this] val techniqueRepository         = RudderConfig.techniqueRepository
+  private val uuidGen                     = RudderConfig.stringUuidGenerator
+  private val rwActiveTechniqueRepository = RudderConfig.woDirectiveRepository
+  private val userPropertyService         = RudderConfig.userPropertyService
+  private val techniqueRepository         = RudderConfig.techniqueRepository
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "popupContent" => popupContent _ }
 
@@ -101,7 +101,7 @@ class GiveReasonPopup(
   }
 
 ///////////// fields for category settings ///////////////////
-  private[this] val crReasons = {
+  private val crReasons = {
     (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled  => None
       case Mandatory => Some(buildReasonField(true, "subContainerReasonField"))
@@ -125,25 +125,25 @@ class GiveReasonPopup(
     }
   }
 
-  private[this] val formTracker = {
+  private val formTracker = {
     val fields = List() ++ crReasons
     new FormTracker(fields)
   }
 
-  private[this] def error(msg: String) = <span class="col-xl-12 errors-container">{msg}</span>
+  private def error(msg: String) = <span class="col-xl-12 errors-container">{msg}</span>
 
-  private[this] def closePopup(): JsCmd = {
+  private def closePopup(): JsCmd = {
     JsRaw("""hideBsModal('createActiveTechniquePopup');""")
   }
 
   /**
    * Update the form when something happened
    */
-  private[this] def updateFormClientSide(): JsCmd = {
+  private def updateFormClientSide(): JsCmd = {
     SetHtml("createActiveTechniquesContainer", popupContent(NodeSeq.Empty))
   }
 
-  private[this] def onSubmit(): JsCmd = {
+  private def onSubmit(): JsCmd = {
     if (formTracker.hasErrors) {
       onFailure & onFailureCallback(sourceActiveTechniqueId.value, destCatId.value)
     } else {
@@ -157,10 +157,10 @@ class GiveReasonPopup(
                         ActiveTechniqueCategoryId(destCatId.value),
                         ptName,
                         techniqueRepository.getTechniqueVersions(ptName).toSeq,
-                        false,
-                        ModificationId(uuidGen.newUuid),
-                        CurrentUser.actor,
-                        crReasons.map(_.get)
+                        isSystem = false,
+                        modId = ModificationId(uuidGen.newUuid),
+                        actor = CurrentUser.actor,
+                        reason = crReasons.map(_.get)
                       )
                       .toBox
                     ?~! errorMess.format(sourceActiveTechniqueId.value, destCatId.value)
@@ -185,7 +185,7 @@ class GiveReasonPopup(
     }
   }
 
-  private[this] def onFailure: JsCmd = {
+  private def onFailure: JsCmd = {
     formTracker.addFormError(error("There was a problem with your request"))
     updateFormClientSide()
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ModificationValidationPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ModificationValidationPopup.scala
@@ -206,26 +206,26 @@ class ModificationValidationPopup(
 
   import ModificationValidationPopup.*
 
-  private[this] val userPropertyService   = RudderConfig.userPropertyService
-  private[this] val dependencyService     = RudderConfig.dependencyAndDeletionService
-  private[this] val uuidGen               = RudderConfig.stringUuidGenerator
-  private[this] val techniqueRepo         = RudderConfig.techniqueRepository
-  private[this] val asyncDeploymentAgent  = RudderConfig.asyncDeploymentAgent
-  private[this] val woNodeGroupRepository = RudderConfig.woNodeGroupRepository
-  private[this] val woDirectiveRepository = RudderConfig.woDirectiveRepository
+  private val userPropertyService   = RudderConfig.userPropertyService
+  private val dependencyService     = RudderConfig.dependencyAndDeletionService
+  private val uuidGen               = RudderConfig.stringUuidGenerator
+  private val techniqueRepo         = RudderConfig.techniqueRepository
+  private val asyncDeploymentAgent  = RudderConfig.asyncDeploymentAgent
+  private val woNodeGroupRepository = RudderConfig.woNodeGroupRepository
+  private val woDirectiveRepository = RudderConfig.woDirectiveRepository
 
   // fonction to read state of things
-  private[this] val getGroupLib = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
+  private val getGroupLib = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "popupContent" => { _ => popupContent() } }
 
-  private[this] val disabled = item match {
+  private val disabled = item match {
     case Left(item)  => !item.newDirective.isEnabled
     case Right(item) => !item.newGroup.isEnabled
   }
 
-  private[this] val validationRequired                               = workflowService.needExternalValidation()
-  private[this] val (defaultRequestName, itemType, itemName, action) = {
+  private val validationRequired                               = workflowService.needExternalValidation()
+  private val (defaultRequestName, itemType, itemName, action) = {
     item match {
       case Left(DirectiveChangeRequest(action, t, a, r, d, opt, add, remove)) =>
         (s"${action.name} Directive ${d.name}", "Directive", d.name, action)
@@ -234,12 +234,12 @@ class ModificationValidationPopup(
     }
   }
 
-  private[this] val explanation: NodeSeq = explanationMessages(itemType, action, disabled)
+  private val explanation: NodeSeq = explanationMessages(itemType, action, disabled)
   // When there is no rules, we need to remove the warning message
-  private[this] val explanationNoWarning = ("#dialogDisableWarning" #> NodeSeq.Empty).apply(explanation)
-  private[this] val groupLib             = getGroupLib()
+  private val explanationNoWarning = ("#dialogDisableWarning" #> NodeSeq.Empty).apply(explanation)
+  private val groupLib             = getGroupLib()
 
-  private[this] val rules = {
+  private val rules = {
     action match {
       case DGModAction.CreateSolo =>
         Full(Set[Rule]())
@@ -257,7 +257,7 @@ class ModificationValidationPopup(
   }
 
   // must be here because used in val popupWarningMessages
-  private[this] val crReasons = {
+  private val crReasons = {
     import com.normation.rudder.web.services.ReasonBehavior.*
     (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled  => None
@@ -365,14 +365,21 @@ class ModificationValidationPopup(
     )(html)
   }
 
-  private[this] def showDependentRules(rules: Set[Rule]): NodeSeq = {
+  private def showDependentRules(rules: Set[Rule]): NodeSeq = {
     action match {
       case DGModAction.CreateSolo => NodeSeq.Empty
-      case x if (rules.size <= 0) => NodeSeq.Empty
-      case x                      =>
-        val noDisplay = DisplayColumn.Force(false)
-        val cmp       = new RuleGrid("remove_popup_grid", None, false, None, noDisplay, noDisplay)
-        cmp.rulesGridWithUpdatedInfo(Some(rules.toSeq), false, true)
+      case _ if (rules.size <= 0) => NodeSeq.Empty
+      case _                      =>
+        val noDisplay = DisplayColumn.Force(display = false)
+        val cmp       = new RuleGrid(
+          "remove_popup_grid",
+          None,
+          showCheckboxColumn = false,
+          directiveApplication = None,
+          columnCompliance = noDisplay,
+          graphRecentChanges = noDisplay
+        )
+        cmp.rulesGridWithUpdatedInfo(Some(rules.toSeq), showActionsColumn = false, isPopup = true)
     }
   }
 
@@ -394,7 +401,7 @@ class ModificationValidationPopup(
     }
   }
 
-  private[this] val changeRequestName = new WBTextField("Change request title", defaultRequestName) {
+  private val changeRequestName = new WBTextField("Change request title", defaultRequestName) {
     override def setFilter      = notNull _ :: trim _ :: Nil
     override def errorClassName = "col-xl-12 errors-container"
     override def inputField     =
@@ -403,7 +410,7 @@ class ModificationValidationPopup(
       valMinLen(1, "Name must not be empty") _ :: Nil
   }
 
-  private[this] val changeRequestDescription = new WBTextAreaField("Description", "") {
+  private val changeRequestDescription = new WBTextAreaField("Description", "") {
     override def setFilter      = notNull _ :: trim _ :: Nil
     override def inputField     = super.inputField % ("style" -> "height:7em") % ("tabindex" -> "2") % ("class" -> "nodisplay")
     override def errorClassName = "col-xl-12 errors-container"
@@ -412,7 +419,7 @@ class ModificationValidationPopup(
   }
 
   // The formtracker needs to check everything only if its not a creation and there is workflow
-  private[this] val formTracker = {
+  private val formTracker = {
     (validationRequired, action) match {
       case (false, _)                     => new FormTracker(crReasons.toList)
       case (true, DGModAction.CreateSolo) => new FormTracker(crReasons.toList)
@@ -426,9 +433,9 @@ class ModificationValidationPopup(
     }
   }
 
-  private[this] def error(msg: String) = <span class="col-xl-12 errors-container">{msg}</span>
+  private def error(msg: String) = <span class="col-xl-12 errors-container">{msg}</span>
 
-  private[this] def closePopup(): JsCmd = {
+  private def closePopup(): JsCmd = {
     JsRaw("""hideBsModal('confirmUpdateActionDialog');
             |hideBsModal('basePopup');""".stripMargin)
   }
@@ -436,15 +443,15 @@ class ModificationValidationPopup(
   /**
    * Update the form when something happened
    */
-  private[this] def updateFormClientSide(): JsCmd = {
+  private def updateFormClientSide(): JsCmd = {
     SetHtml(htmlId_popupContainer, popupContent())
   }
 
-  private[this] def onSubmitStartWorkflow(): JsCmd = {
+  private def onSubmitStartWorkflow(): JsCmd = {
     onSubmit()
   }
 
-  private[this] def DirectiveDiffFromAction(
+  private def DirectiveDiffFromAction(
       techniqueName: TechniqueName,
       directive:     Directive,
       initialState:  Option[Directive]
@@ -479,7 +486,7 @@ class ModificationValidationPopup(
     }
   }
 
-  private[this] def groupDiffFromAction(
+  private def groupDiffFromAction(
       group:        NodeGroup,
       initialState: Option[NodeGroup]
   ): Box[ChangeRequestNodeGroupDiff] = {
@@ -500,7 +507,7 @@ class ModificationValidationPopup(
     }
   }
 
-  private[this] def saveChangeRequest(): JsCmd = {
+  private def saveChangeRequest(): JsCmd = {
     // we only have quick change request now
     val boxcr = item match {
       case Left(
@@ -656,7 +663,7 @@ class ModificationValidationPopup(
     }
   }
 
-  private[this] def saveAndDeployDirective(
+  private def saveAndDeployDirective(
       directive:         Directive,
       activeTechniqueId: ActiveTechniqueId,
       why:               Option[String]
@@ -686,14 +693,14 @@ class ModificationValidationPopup(
     }
   }
 
-  private[this] def onFailure: JsCmd = {
+  private def onFailure: JsCmd = {
     formTracker.addFormError(error("There was a problem with your request"))
     updateFormClientSide() & JsRaw(
       """scrollToElementPopup('#notifications', 'confirmUpdateActionDialogconfirmUpdateActionDialog')"""
     )
   }
 
-  private[this] def updateAndDisplayNotifications(): NodeSeq = {
+  private def updateAndDisplayNotifications(): NodeSeq = {
     val notifications = formTracker.formErrors
     formTracker.cleanErrors
     if (notifications.isEmpty) NodeSeq.Empty

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleCategoryPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleCategoryPopup.scala
@@ -84,9 +84,9 @@ class RuleCategoryPopup(
     "component-deletepopup"
   )
 
-  private[this] val woRulecategoryRepository   = RudderConfig.woRuleCategoryRepository
-  private[this] val categoryHierarchyDisplayer = RudderConfig.categoryHierarchyDisplayer
-  private[this] val uuidGen                    = RudderConfig.stringUuidGenerator
+  private val woRulecategoryRepository   = RudderConfig.woRuleCategoryRepository
+  private val categoryHierarchyDisplayer = RudderConfig.categoryHierarchyDisplayer
+  private val uuidGen                    = RudderConfig.stringUuidGenerator
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "popupContent" => { _ => popupContent() } }
 
@@ -150,7 +150,7 @@ class RuleCategoryPopup(
 
   ///////////// fields for category settings ///////////////////
 
-  private[this] val categoryName = new WBTextField("Name", targetCategory.map(_.name).getOrElse("")) {
+  private val categoryName = new WBTextField("Name", targetCategory.map(_.name).getOrElse("")) {
     override def setFilter             = notNull _ :: trim _ :: Nil
     override def subContainerClassName = "col-xl-9 col-md-12 col-sm-12"
     override def errorClassName        = "col-xl-12 errors-container"
@@ -160,7 +160,7 @@ class RuleCategoryPopup(
       valMinLen(1, "The name must not be empty.") _ :: Nil
   }
 
-  private[this] val categoryDescription = new WBTextAreaField("Description", targetCategory.map(_.description).getOrElse("")) {
+  private val categoryDescription = new WBTextAreaField("Description", targetCategory.map(_.description).getOrElse("")) {
     override def subContainerClassName = "col-xl-9 col-md-12 col-sm-12"
     override def setFilter             = notNull _ :: trim _ :: Nil
     override def inputField            = super.inputField % ("tabindex" -> "4")
@@ -171,7 +171,7 @@ class RuleCategoryPopup(
 
   val categories: RuleCategory = targetCategory.map(rootCategory.filter(_)).getOrElse(rootCategory)
 
-  private[this] val categoryParent = {
+  private val categoryParent = {
     new WBSelectField(
       "Parent",
       categoryHierarchyDisplayer.getRuleCategoryHierarchy(categories, None).map { case (id, name) => (id.value -> name) },
@@ -185,28 +185,28 @@ class RuleCategoryPopup(
     }
   }
 
-  private[this] val formTracker = new FormTracker(categoryName, categoryDescription, categoryParent)
+  private val formTracker = new FormTracker(categoryName, categoryDescription, categoryParent)
 
-  private[this] var notifications = List.empty[NodeSeq]
+  private var notifications = List.empty[NodeSeq]
 
-  private[this] def error(msg: String) = <span class="col-xl-12 errors-container">{msg}</span>
+  private def error(msg: String) = <span class="col-xl-12 errors-container">{msg}</span>
 
-  private[this] def closePopup(): JsCmd = {
+  private def closePopup(): JsCmd = {
     JsRaw("""hideBsModal('createRuleCategoryPopup');""")
   }
 
   /**
    * Update the form when something happened
    */
-  private[this] def updateFormClientSide(): JsCmd = {
+  private def updateFormClientSide(): JsCmd = {
     SetHtml("RuleCategoryCreationContainer", popupContent())
   }
 
-  private[this] def onSubmitDelete(): JsCmd = {
+  private def onSubmitDelete(): JsCmd = {
     targetCategory match {
       case Some(category) =>
         val modId = new ModificationId(uuidGen.newUuid)
-        woRulecategoryRepository.delete(category.id, modId, CurrentUser.actor, None, true).toBox match {
+        woRulecategoryRepository.delete(category.id, modId, CurrentUser.actor, None, checkEmpty = true).toBox match {
           case Full(x) =>
             closePopup() &
             onSuccessCallback(x.value) &
@@ -223,7 +223,7 @@ class RuleCategoryPopup(
     }
   }
 
-  private[this] def onSubmit(): JsCmd = {
+  private def onSubmit(): JsCmd = {
 
     if (formTracker.hasErrors) {
       onFailure & onFailureCallback()
@@ -235,7 +235,7 @@ class RuleCategoryPopup(
             categoryName.get,
             categoryDescription.get,
             Nil,
-            false
+            isSystem = false
           )
 
           val parent = RuleCategoryId(categoryParent.get)
@@ -268,11 +268,11 @@ class RuleCategoryPopup(
     }
   }
 
-  private[this] def onFailure: JsCmd = {
+  private def onFailure: JsCmd = {
     updateFormClientSide()
   }
 
-  private[this] def updateAndDisplayNotifications(): NodeSeq = {
+  private def updateAndDisplayNotifications(): NodeSeq = {
     notifications :::= formTracker.formErrors
     formTracker.cleanErrors
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleModificationValidationPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleModificationValidationPopup.scala
@@ -103,8 +103,8 @@ class RuleModificationValidationPopup(
 
   import RuleModificationValidationPopup.*
 
-  private[this] val userPropertyService = RudderConfig.userPropertyService
-  private[this] val uuidGen             = RudderConfig.stringUuidGenerator
+  private val userPropertyService = RudderConfig.userPropertyService
+  private[this] val uuidGen       = RudderConfig.stringUuidGenerator
 
   val validationNeeded: Boolean = workflowService.needExternalValidation()
 
@@ -167,7 +167,7 @@ class RuleModificationValidationPopup(
 
   ///////////// fields for category settings ///////////////////
 
-  private[this] val crReasons = {
+  private val crReasons = {
     import com.normation.rudder.web.services.ReasonBehavior.*
     (userPropertyService.reasonsFieldBehavior: @unchecked) match {
       case Disabled  => None
@@ -193,9 +193,9 @@ class RuleModificationValidationPopup(
     }
   }
 
-  private[this] val defaultRequestName = s"${changeRequest.action.name.capitalize} Rule ${changeRequest.newRule.name}"
+  private val defaultRequestName = s"${changeRequest.action.name.capitalize} Rule ${changeRequest.newRule.name}"
 
-  private[this] val changeRequestName = new WBTextField("Change request title", defaultRequestName) {
+  private val changeRequestName = new WBTextField("Change request title", defaultRequestName) {
     override def setFilter      = notNull _ :: trim _ :: Nil
     override def errorClassName = "col-xl-12 errors-container"
     override def inputField     =
@@ -205,7 +205,7 @@ class RuleModificationValidationPopup(
   }
 
   // The formtracker needs to check everything only if there is workflow
-  private[this] val formTracker = {
+  private val formTracker = {
     val fields = crReasons.toList ::: {
       if (validationNeeded) changeRequestName :: Nil
       else Nil
@@ -214,20 +214,20 @@ class RuleModificationValidationPopup(
     new FormTracker(fields)
   }
 
-  private[this] def error(msg: String) = <span>{msg}</span>
+  private def error(msg: String) = <span>{msg}</span>
 
-  private[this] def closePopup(): JsCmd = {
+  private def closePopup(): JsCmd = {
     JsRaw("""hideBsModal('confirmUpdateActionDialog');""")
   }
 
   /**
    * Update the form when something happened
    */
-  private[this] def updateFormClientSide(): JsCmd = {
+  private def updateFormClientSide(): JsCmd = {
     SetHtml(htmlId_popupContainer, popupContent())
   }
 
-  private[this] def ruleDiffFromAction(): Box[ChangeRequestRuleDiff] = {
+  private def ruleDiffFromAction(): Box[ChangeRequestRuleDiff] = {
     import RuleModAction.*
 
     changeRequest.previousRule match {
@@ -298,12 +298,12 @@ class RuleModificationValidationPopup(
     }
   }
 
-  private[this] def onFailure: JsCmd = {
+  private def onFailure: JsCmd = {
     formTracker.addFormError(error("There was a problem with your request"))
     updateFormClientSide()
   }
 
-  private[this] def updateAndDisplayNotifications(): NodeSeq = {
+  private def updateAndDisplayNotifications(): NodeSeq = {
     val notifications = formTracker.formErrors
     formTracker.cleanErrors
     if (notifications.isEmpty) NodeSeq.Empty

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/model/RudderBaseField.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/model/RudderBaseField.scala
@@ -53,13 +53,13 @@ import scala.xml.*
  * A simple class that allows to register error information
  * about a form and its fields
  */
-class FormTracker(private[this] var _fields: List[RudderBaseField] = Nil) extends FieldContainer {
+class FormTracker(private var _fields: List[RudderBaseField] = Nil) extends FieldContainer {
 
   def this(fields: RudderBaseField*) = this(fields.toList)
 
   type FormError = NodeSeq
 
-  private[this] var _formErrors = List.empty[FormError]
+  private var _formErrors = List.empty[FormError]
 
   override def allFields: List[RudderBaseField] = _fields.toList
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/AsyncComplianceService.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/AsyncComplianceService.scala
@@ -63,7 +63,7 @@ class AsyncComplianceService(
 
   // Trait containing all functions to compute compliance asynchronously
   // Compliance a grouped  by a Type
-  private[this] trait ComplianceBy[Kind] {
+  private trait ComplianceBy[Kind] {
     // Rules and Nodes we are computing compliances on
     val nodeIds: Set[NodeId]
     val ruleIds: Set[RuleId]
@@ -120,7 +120,7 @@ class AsyncComplianceService(
     }
   }
 
-  private[this] class NodeSystemCompliance(
+  private class NodeSystemCompliance(
       val nodeIds: Set[NodeId],
       val ruleIds: Set[RuleId]
   ) extends ComplianceBy[NodeId] {
@@ -142,7 +142,7 @@ class AsyncComplianceService(
 
   }
 
-  private[this] class NodeCompliance(
+  private class NodeCompliance(
       val nodeIds: Set[NodeId],
       val ruleIds: Set[RuleId]
   ) extends ComplianceBy[NodeId] {
@@ -165,7 +165,7 @@ class AsyncComplianceService(
 
   }
 
-  private[this] class RuleCompliance(
+  private class RuleCompliance(
       val nodeIds: Set[NodeId],
       val ruleIds: Set[RuleId]
   ) extends ComplianceBy[RuleId] {
@@ -191,7 +191,7 @@ class AsyncComplianceService(
   }
 
   // Compute compliance from a defined kind
-  private[this] def compliance[Kind](kind: ComplianceBy[Kind], tableId: String): JsCmd = {
+  private def compliance[Kind](kind: ComplianceBy[Kind], tableId: String): JsCmd = {
     SHtml.ajaxInvoke(() => {
       // Is my future completed ?
       if (kind.futureCompliance.isCompleted) {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ComplianceData.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ComplianceData.scala
@@ -509,7 +509,7 @@ object ComplianceData extends Loggable {
   }
 
   // From Node Point of view
-  private[this] def getDirectivesComplianceDetails(
+  private def getDirectivesComplianceDetails(
       directivesReport: List[DirectiveStatusReport],
       directiveLib:     FullActiveTechniqueCategory,
       globalPolicyMode: GlobalPolicyMode,
@@ -522,7 +522,7 @@ object ComplianceData extends Loggable {
       val techniqueName             =
         fullActiveTechnique.techniques.get(directive.techniqueVersion).map(_.name).getOrElse("Unknown technique")
       val techniqueVersion          = directive.techniqueVersion
-      val components                = getComponentsComplianceDetails(directiveStatus.components, true)
+      val components                = getComponentsComplianceDetails(directiveStatus.components, includeMessage = true)
       val (policyMode, explanation) = computeMode(directive.policyMode)
       val directiveTags             = JsonTagSerialisation.serializeTags(directive.tags)
       DirectiveComplianceLine(
@@ -542,7 +542,7 @@ object ComplianceData extends Loggable {
   //////////////// Component Report ///////////////
 
   // From Node Point of view
-  private[this] def getComponentsComplianceDetails(
+  private def getComponentsComplianceDetails(
       components:     List[ComponentStatusReport],
       includeMessage: Boolean
   ): JsTableData[ComponentComplianceLine] = {
@@ -578,7 +578,7 @@ object ComplianceData extends Loggable {
   //////////////// Value Report ///////////////
 
   // From Node Point of view
-  private[this] def getValuesComplianceDetails(
+  private def getValuesComplianceDetails(
       values: List[ComponentValueStatusReport]
   ): JsTableData[ComponentValueComplianceLine] = {
     val valuesComplianceData = for {
@@ -601,7 +601,7 @@ object ComplianceData extends Loggable {
     JsTableData(valuesComplianceData)
   }
 
-  private[this] def getDisplayStatusFromSeverity(severity: String): String = {
+  private def getDisplayStatusFromSeverity(severity: String): String = {
     S.?(s"reports.severity.${severity}")
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayDirectiveTree.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayDirectiveTree.scala
@@ -114,8 +114,8 @@ object AgentCompat {
 
 object DisplayDirectiveTree extends Loggable {
 
-  private[this] val linkUtil    = RudderConfig.linkUtil
-  private[this] val userService = RudderConfig.userService
+  private val linkUtil    = RudderConfig.linkUtil
+  private val userService = RudderConfig.userService
 
   /**
    * Display the directive tree, optionaly filtering out
@@ -146,17 +146,17 @@ object DisplayDirectiveTree extends Loggable {
         nodeId:   String
     ): JsTreeNode = new JsTreeNode {
 
-      private[this] val localOnClickTechnique = onClickTechnique.map(_.curried(category))
+      private val localOnClickTechnique = onClickTechnique.map(_.curried(category))
 
-      private[this] val localOnClickDirective = onClickDirective.map(_.curried(category))
+      private val localOnClickDirective = onClickDirective.map(_.curried(category))
 
-      private[this] val tooltipContent = s"""
+      private val tooltipContent = s"""
         <h4>${category.name}</h4>
         <div class="tooltip-content">
           <p>${category.description}</p>
         </div>
       """
-      private[this] val xml            = (
+      private val xml            = (
         <span class="treeActiveTechniqueCategoryName" data-bs-toggle="tooltip" data-bs-placement="top" title={
           tooltipContent
         }>
@@ -204,7 +204,7 @@ object DisplayDirectiveTree extends Loggable {
         onClickDirective: Option[FullActiveTechnique => Directive => JsCmd]
     ): JsTreeNode = new JsTreeNode {
 
-      private[this] val localOnClickDirective = onClickDirective.map(f => f(activeTechnique))
+      private val localOnClickDirective = onClickDirective.map(f => f(activeTechnique))
 
       def isDeprecated = {
         activeTechnique.techniques.values.forall(t => t.deprecrationInfo.isDefined)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -94,11 +94,11 @@ import zio.syntax.*
  */
 object DisplayNode extends Loggable {
 
-  private[this] val nodeFactRepository   = RudderConfig.nodeFactRepository
-  private[this] val removeNodeService    = RudderConfig.removeNodeService
-  private[this] val asyncDeploymentAgent = RudderConfig.asyncDeploymentAgent
-  private[this] val uuidGen              = RudderConfig.stringUuidGenerator
-  private[this] val linkUtil             = RudderConfig.linkUtil
+  private val nodeFactRepository   = RudderConfig.nodeFactRepository
+  private val removeNodeService    = RudderConfig.removeNodeService
+  private val asyncDeploymentAgent = RudderConfig.asyncDeploymentAgent
+  private val uuidGen              = RudderConfig.stringUuidGenerator
+  private val linkUtil             = RudderConfig.linkUtil
 
   private def escapeJs(in:   String):         JsExp   = Str(escape(in))
   private def escapeHTML(in: String):         NodeSeq = Text(escape(in))
@@ -690,14 +690,14 @@ object DisplayNode extends Loggable {
     val nodeId      = nodeFact.id
     val publicKeyId = s"publicKey-${nodeId.value}"
     val cfKeyHash   = nodeFactRepository.get(nodeId).either.runNow match {
-      case Right(Some(nodeFact)) if (nodeFact.keyHashCfengine.nonEmpty) =>
-        <div><label>Key hash:</label> <samp>{nodeFact.keyHashCfengine}</samp></div>
-      case _                                                            => NodeSeq.Empty
+      case Right(Some(nodeFact_)) if (nodeFact_.keyHashCfengine.nonEmpty) =>
+        <div><label>Key hash:</label> <samp>{nodeFact_.keyHashCfengine}</samp></div>
+      case _                                                              => NodeSeq.Empty
     }
     val curlHash    = nodeFactRepository.get(nodeId).either.runNow match {
-      case Right(Some(nodeFact)) if (nodeFact.keyHashCfengine.nonEmpty) =>
-        <div><label>Key hash:</label> <samp>sha256//{nodeFact.keyHashBase64Sha256}</samp></div>
-      case _                                                            => NodeSeq.Empty
+      case Right(Some(nodeFact_)) if (nodeFact_.keyHashCfengine.nonEmpty) =>
+        <div><label>Key hash:</label> <samp>sha256//{nodeFact_.keyHashBase64Sha256}</samp></div>
+      case _                                                              => NodeSeq.Empty
     }
 
     val agent     = nodeFact.rudderAgent
@@ -1276,7 +1276,7 @@ object DisplayNode extends Loggable {
     )
   }
 
-  private[this] def removeNode(node: MinimalNodeFactInterface): JsCmd = {
+  private def removeNode(node: MinimalNodeFactInterface): JsCmd = {
     implicit val cc: ChangeContext = ChangeContext(
       ModificationId(uuidGen.newUuid),
       CurrentUser.actor,
@@ -1299,7 +1299,7 @@ object DisplayNode extends Loggable {
     }
   }
 
-  private[this] def onFailure(
+  private def onFailure(
       node:    MinimalNodeFactInterface,
       message: String
   ): JsCmd = {
@@ -1313,17 +1313,17 @@ object DisplayNode extends Loggable {
     RedirectTo("/secure/nodeManager/nodes")
   }
 
-  private[this] def onSuccess(node: MinimalNodeFactInterface): JsCmd = {
+  private def onSuccess(node: MinimalNodeFactInterface): JsCmd = {
     RegisterToasts.register(ToastNotification.Success(s"Node '${node.fqdn}' [${node.id.value}] was correctly deleted"))
     RedirectTo("/secure/nodeManager/nodes")
   }
 
-  private[this] def isRootNode(n: NodeId): Boolean = {
+  private def isRootNode(n: NodeId): Boolean = {
     n.value.equals("root");
   }
 
   import com.normation.rudder.domain.nodes.NodeState
-  private[this] def getNodeState(nodeState: NodeState): String = {
+  private def getNodeState(nodeState: NodeState): String = {
     S.?(s"node.states.${nodeState.name}")
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNodeGroupTree.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNodeGroupTree.scala
@@ -61,7 +61,7 @@ import scala.xml.NodeSeq.seqToNodeSeq
  */
 object DisplayNodeGroupTree extends Loggable {
 
-  private[this] val linkUtil = RudderConfig.linkUtil
+  private val linkUtil = RudderConfig.linkUtil
 
   /**
    * Display the group tree, optionnaly filtering out
@@ -83,10 +83,10 @@ object DisplayNodeGroupTree extends Loggable {
         category: FullNodeGroupCategory
     ): JsTreeNode = new JsTreeNode {
 
-      private[this] val localOnClickTarget = onClickTarget.map(_.curried(category))
+      private val localOnClickTarget = onClickTarget.map(_.curried(category))
 
-      private[this] val tooltipContent = s"<h4>${category.name}</h4>\n<div class='tooltip-content'>${category.description}</div>"
-      private[this] val xml            = (
+      private val tooltipContent = s"<h4>${category.name}</h4>\n<div class='tooltip-content'>${category.description}</div>"
+      private val xml            = (
         <span class="treeGroupCategoryName" data-bs-toggle="tooltip" title={tooltipContent}>{category.name}</span>
       )
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/EventListDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/EventListDisplayer.scala
@@ -60,7 +60,7 @@ import scala.xml.*
  */
 class EventListDisplayer(repos: EventLogRepository) extends Loggable {
 
-  private[this] val gridName = "eventLogsGrid"
+  private val gridName = "eventLogsGrid"
 
   def display(refreshEvents: () => Box[Seq[EventLog]]): NodeSeq = {
     // common part between last events and interval

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/JsTreeUtilService.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/JsTreeUtilService.scala
@@ -143,7 +143,7 @@ class JsTreeUtilService(
     sort(x.name, y.name)
   }
 
-  private[this] def sort(x: String, y: String): Boolean = {
+  private def sort(x: String, y: String): Boolean = {
     if (String.CASE_INSENSITIVE_ORDER.compare(x, y) > 0) false else true
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/NodeGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/NodeGrid.scala
@@ -235,7 +235,7 @@ final class NodeGrid(
     "#header *+" #> headers &
     "#lines *" #> lines).apply(tableTemplate)
   }
-  private[this] val datatableXml = {
+  private val datatableXml = {
     <tr class="nodetr curspoint" jsuuid="id" nodeid="nodeid" nodestatus="status">
       <td class="curspoint"><span class="hostname listopen"></span></td>
       <td class="fullos curspoint"></td>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -160,7 +160,7 @@ class ReportDisplayer(
     AnonFunc(ajaxCall)
   }
 
-  private[this] def displayIntro(report: NodeStatusReport): NodeSeq = {
+  private def displayIntro(report: NodeStatusReport): NodeSeq = {
 
     def explainCompliance(info: RunAndConfigInfo): NodeSeq = {
       val dateFormat = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ssZ")
@@ -360,7 +360,7 @@ class ReportDisplayer(
     </div>
   }
 
-  private[this] def displayReports(
+  private def displayReports(
       node:         CoreNodeFact,
       getReports:   NodeId => Box[NodeStatusReport],
       tabId:        String,
@@ -492,7 +492,7 @@ class ReportDisplayer(
     }
   }
 
-  private[this] def showReportDetail(
+  private def showReportDetail(
       node:           CoreNodeFact,
       withCompliance: Boolean,
       onlySystem:     Boolean
@@ -549,7 +549,7 @@ class ReportDisplayer(
   }
 
   // this method cannot return an IOResult, as it uses S.
-  private[this] def getComplianceData(
+  private def getComplianceData(
       nodeId:       NodeId,
       reportStatus: NodeStatusReport,
       addOverriden: Boolean
@@ -672,7 +672,7 @@ class ReportDisplayer(
     }
   }
 
-  private[this] def getComponents(
+  private def getComponents(
       status:            ReportType,
       nodeStatusReports: NodeStatusReport,
       directiveLib:      FullActiveTechniqueCategory
@@ -703,7 +703,7 @@ class ReportDisplayer(
     }
   }
 
-  private[this] def buildTable(name1: String, name2: String, colums: String): NodeSeq = {
+  private def buildTable(name1: String, name2: String, colums: String): NodeSeq = {
     Script(JsRaw(s"""
      var oTable${name1} = $$('#${name2}').dataTable({
        "asStripeClasses": [ 'color1', 'color2' ],

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/Authz.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/Authz.scala
@@ -56,7 +56,7 @@ class Authz extends DispatchSnippet with Loggable {
    * current user - having even one "no_rights"
    * make it true
    */
-  private[this] def noRights(): Boolean = {
+  private def noRights(): Boolean = {
     CurrentUser.getRights.authorizationTypes.contains(AuthorizationType.NoRights)
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -156,11 +156,11 @@ object HomePage {
 
 class HomePage extends StatefulSnippet {
 
-  private[this] val ldap             = RudderConfig.roLDAPConnectionProvider
-  private[this] val pendingNodesDit  = RudderConfig.pendingNodesDit
-  private[this] val rudderDit        = RudderConfig.rudderDit
-  private[this] val reportingService = RudderConfig.reportingService
-  private[this] val roRuleRepo       = RudderConfig.roRuleRepository
+  private val ldap             = RudderConfig.roLDAPConnectionProvider
+  private val pendingNodesDit  = RudderConfig.pendingNodesDit
+  private val rudderDit        = RudderConfig.rudderDit
+  private val reportingService = RudderConfig.reportingService
+  private val roRuleRepo       = RudderConfig.roRuleRepository
 
   override val dispatch: DispatchIt = {
     case "pendingNodes"       => pendingNodes
@@ -407,7 +407,7 @@ class HomePage extends StatefulSnippet {
   /**
    * Get the count of agent version name -> size for accepted nodes
    */
-  private[this] def getRudderAgentVersion(nodeFacts: MapView[NodeId, CoreNodeFact]): Map[String, Int] = {
+  private def getRudderAgentVersion(nodeFacts: MapView[NodeId, CoreNodeFact]): Map[String, Int] = {
     val n2            = System.currentTimeMillis
     val agentSoftware = nodeFacts.map(_._2.rudderAgent.toAgentInfo)
     val agentVersions = agentSoftware.flatMap(_.version)
@@ -420,37 +420,37 @@ class HomePage extends StatefulSnippet {
     res
   }
 
-  private[this] def countPendingNodes(): Box[Int] = {
+  private def countPendingNodes(): Box[Int] = {
     ldap.flatMap(con => con.searchOne(pendingNodesDit.NODES.dn, ALL, "1.1")).map(x => x.size)
   }.toBox
 
-  private[this] def countAcceptedNodes(nodeFacts: MapView[NodeId, CoreNodeFact]): Box[Int] = {
+  private def countAcceptedNodes(nodeFacts: MapView[NodeId, CoreNodeFact]): Box[Int] = {
     Full(nodeFacts.size)
   }
 
-  private[this] def countAllRules(): Box[Int] = {
+  private def countAllRules(): Box[Int] = {
     roRuleRepo.getIds().map(_.size).toBox
   }
 
-  private[this] def countAllDirectives(): Box[Int] = {
+  private def countAllDirectives(): Box[Int] = {
     ldap.flatMap { con =>
       con.searchSub(rudderDit.ACTIVE_TECHNIQUES_LIB.dn, AND(IS(OC_DIRECTIVE), EQ(A_IS_SYSTEM, FALSE.toLDAPString)), "1.1")
     }.map(x => x.size)
   }.toBox
 
-  private[this] def countAllTechniques(): Box[Int] = {
+  private def countAllTechniques(): Box[Int] = {
     ldap.flatMap { con =>
       con.searchSub(rudderDit.ACTIVE_TECHNIQUES_LIB.dn, AND(IS(OC_ACTIVE_TECHNIQUE), EQ(A_IS_SYSTEM, FALSE.toLDAPString)), "1.1")
     }.map(x => x.size)
   }.toBox
 
-  private[this] def countAllGroups(): Box[Int] = {
+  private def countAllGroups(): Box[Int] = {
     ldap
       .flatMap(con => con.searchSub(rudderDit.GROUP.dn, OR(IS(OC_RUDDER_NODE_GROUP), IS(OC_SPECIAL_TARGET)), "1.1"))
       .map(x => x.size)
   }.toBox
 
-  private[this] def displayCount(count: () => Box[Int], name: String) = {
+  private def displayCount(count: () => Box[Int], name: String) = {
     Text((count() match {
       case Empty => 0
       case m: Failure =>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/SetupRedirect.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/SetupRedirect.scala
@@ -50,7 +50,7 @@ import scala.xml.NodeSeq
 
 class SetupRedirect extends DispatchSnippet with Loggable {
 
-  private[this] val configService = RudderConfig.configService
+  private val configService = RudderConfig.configService
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = {
     case "display" => _ => WithNonce.scriptWithNonce(Script(display()))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ApiAccounts.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ApiAccounts.scala
@@ -48,7 +48,7 @@ import scala.xml.NodeSeq
 
 class ApiAccounts extends DispatchSnippet with DefaultExtendableSnippet[ApiAccounts] {
 
-  private[this] val relativePath = RudderConfig.restApiAccounts.relativePath.mkString("/", "/", "")
+  private val relativePath = RudderConfig.restApiAccounts.relativePath.mkString("/", "/", "")
 
   def mainDispatch: Map[String, NodeSeq => NodeSeq] = Map(
     "render" -> render,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/Archives.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/Archives.scala
@@ -61,13 +61,13 @@ import scala.xml.NodeSeq
 
 class Archives extends DispatchSnippet with Loggable {
 
-  private[this] val DL_NAME = "Download as zip"
+  private val DL_NAME = "Download as zip"
 
-  private[this] val itemArchiver       = RudderConfig.itemArchiveManager
-  private[this] val personIdentService = RudderConfig.personIdentService
-  private[this] val uuidGen            = RudderConfig.stringUuidGenerator
+  private val itemArchiver       = RudderConfig.itemArchiveManager
+  private val personIdentService = RudderConfig.personIdentService
+  private val uuidGen            = RudderConfig.stringUuidGenerator
 
-  private[this] val noElements = NotArchivedElements(Seq(), Seq(), Seq())
+  private val noElements = NotArchivedElements(Seq(), Seq(), Seq())
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = {
     case "allForm"              => allForm(CurrentUser.queryContext)
@@ -98,7 +98,7 @@ class Archives extends DispatchSnippet with Loggable {
    * Export all items (CR, Active Techniques library, groups)
    * Advertise on success and error
    */
-  private[this] def allForm(implicit qc: QueryContext) = {
+  private def allForm(implicit qc: QueryContext) = {
     actionFormBuilder(
       formName = "allForm",
       archiveButtonId = "exportAllButton",
@@ -121,7 +121,7 @@ class Archives extends DispatchSnippet with Loggable {
     )
   }
 
-  private[this] def rulesForm = {
+  private def rulesForm = {
     actionFormBuilder(
       formName = "rulesForm",
       archiveButtonId = "exportRulesButton",
@@ -143,7 +143,7 @@ class Archives extends DispatchSnippet with Loggable {
     )
   }
 
-  private[this] def directiveLibraryForm = {
+  private def directiveLibraryForm = {
     actionFormBuilder(
       formName = "directiveLibraryForm",
       archiveButtonId = "exportDirectiveLibraryButton",
@@ -166,7 +166,7 @@ class Archives extends DispatchSnippet with Loggable {
     )
   }
 
-  private[this] def groupLibraryForm(implicit qc: QueryContext) = {
+  private def groupLibraryForm(implicit qc: QueryContext) = {
     actionFormBuilder(
       formName = "groupLibraryForm",
       archiveButtonId = "exportGroupLibraryButton",
@@ -189,7 +189,7 @@ class Archives extends DispatchSnippet with Loggable {
     )
   }
 
-  private[this] def parametersForm = {
+  private def parametersForm = {
     actionFormBuilder(
       formName = "parametersForm",
       archiveButtonId = "exportParametersButton",
@@ -215,7 +215,7 @@ class Archives extends DispatchSnippet with Loggable {
   /**
    * Create a form with a validation button for an export or an import
    */
-  private[this] def actionFormBuilder(
+  private def actionFormBuilder(
       formName: String, // the element name to update on error/succes
 
       archiveButtonId: String, // input button
@@ -406,7 +406,7 @@ class Archives extends DispatchSnippet with Loggable {
   }
 
   ///////////// success pop-up ///////////////
-  private[this] def successPopup: JsCmd = {
+  private def successPopup: JsCmd = {
     JsRaw("""createSuccessNotification()""")
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ClearCache.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ClearCache.scala
@@ -50,7 +50,7 @@ import util.Helpers.*
 
 class ClearCache extends DispatchSnippet with Loggable {
 
-  private[this] val clearCacheService = RudderConfig.clearCacheService
+  private val clearCacheService = RudderConfig.clearCacheService
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "render" => clearCache() }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DatabaseManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DatabaseManagement.scala
@@ -55,13 +55,13 @@ import scala.xml.*
 
 class DatabaseManagement extends DispatchSnippet with Loggable {
 
-  private[this] val databaseManager = RudderConfig.databaseManager
-  private[this] val dbCleaner       = RudderConfig.automaticReportsCleaning
+  private val databaseManager = RudderConfig.databaseManager
+  private val dbCleaner       = RudderConfig.automaticReportsCleaning
 
-  private[this] var from:   String            = ""
-  val archiveAction:        ArchiveAction     = ArchiveAction(databaseManager, dbCleaner)
-  val deleteAction:         DeleteAction      = DeleteAction(databaseManager, dbCleaner)
-  private[this] var action: CleanReportAction = archiveAction
+  private var from:   String            = ""
+  val archiveAction:  ArchiveAction     = ArchiveAction(databaseManager, dbCleaner)
+  val deleteAction:   DeleteAction      = DeleteAction(databaseManager, dbCleaner)
+  private var action: CleanReportAction = archiveAction
 
   val DATETIME_FORMAT = "yyyy-MM-dd"
   val DATETIME_PARSER: DateTimeFormatter = DateTimeFormat.forPattern(DATETIME_FORMAT)
@@ -173,7 +173,7 @@ class DatabaseManagement extends DispatchSnippet with Loggable {
     }
   }
 
-  private[this] def showConfirmationDialog(date: DateTime, action: CleanReportAction): JsCmd = {
+  private def showConfirmationDialog(date: DateTime, action: CleanReportAction): JsCmd = {
     val cancel: JsCmd = {
       SetHtml("confirm", NodeSeq.Empty) &
       JsRaw(""" $('#archiveReports').show();
@@ -221,7 +221,7 @@ class DatabaseManagement extends DispatchSnippet with Loggable {
     showDialog
   }
 
-  private[this] def displayDate(entry: Box[Option[DateTime]]): NodeSeq = {
+  private def displayDate(entry: Box[Option[DateTime]]): NodeSeq = {
     entry match {
       case Full(dateOption) =>
         dateOption match {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DyngroupReloading.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DyngroupReloading.scala
@@ -48,8 +48,8 @@ import scala.xml.NodeSeq
 
 class DyngroupReloading extends DispatchSnippet with Loggable {
 
-  private[this] val updateDynamicGroups         = RudderConfig.updateDynamicGroups
-  private[this] val updateDynamicGroupsInterval = RudderConfig.RUDDER_BATCH_DYNGROUP_UPDATEINTERVAL
+  private val updateDynamicGroups         = RudderConfig.updateDynamicGroups
+  private val updateDynamicGroupsInterval = RudderConfig.RUDDER_BATCH_DYNGROUP_UPDATEINTERVAL
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "render" => reload }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/EditPolicyServerAllowedNetwork.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/EditPolicyServerAllowedNetwork.scala
@@ -62,19 +62,19 @@ import util.Helpers.*
 
 class EditPolicyServerAllowedNetwork extends DispatchSnippet with Loggable {
 
-  private[this] val psService            = RudderConfig.policyServerManagementService
-  private[this] val eventLogService      = RudderConfig.eventLogRepository
-  private[this] val asyncDeploymentAgent = RudderConfig.asyncDeploymentAgent
-  private[this] val uuidGen              = RudderConfig.stringUuidGenerator
-  private[this] val nodeInfoService      = RudderConfig.nodeInfoService
-  private[this] var addNetworkField      = ""
+  private val psService            = RudderConfig.policyServerManagementService
+  private val eventLogService      = RudderConfig.eventLogRepository
+  private val asyncDeploymentAgent = RudderConfig.asyncDeploymentAgent
+  private val uuidGen              = RudderConfig.stringUuidGenerator
+  private val nodeInfoService      = RudderConfig.nodeInfoService
+  private var addNetworkField      = ""
   /*
    * We are forced to use that class to deals with multiple request
    * not processed in order (ex: one request add an item, the second remove
    * item at index 0, the third remove item at index 0. Now, any order for
    * these requests have to be considered and lead to the same result.
    */
-  private[this] case class VH(id: Long = nextNum, var net: String = "") {
+  private case class VH(id: Long = nextNum, var net: String = "") {
     override def hashCode = id.hashCode
     override def equals(x: Any): Boolean = x match {
       case VH(i, _) => id == i
@@ -82,10 +82,10 @@ class EditPolicyServerAllowedNetwork extends DispatchSnippet with Loggable {
     }
   }
 
-  private[this] val policyServers = nodeInfoService.getAllSystemNodeIds().toBox
+  private val policyServers = nodeInfoService.getAllSystemNodeIds().toBox
 
   // we need to store that out of the form, so that the changes are persisted at redraw
-  private[this] val allowedNetworksMap = scala.collection.mutable.Map[NodeId, Buffer[VH]]()
+  private val allowedNetworksMap = scala.collection.mutable.Map[NodeId, Buffer[VH]]()
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = {
     case "render" =>
@@ -267,7 +267,7 @@ class EditPolicyServerAllowedNetwork extends DispatchSnippet with Loggable {
   }
 
   ///////////// success pop-up ///////////////
-  private[this] def successNotification: JsCmd = {
+  private def successNotification: JsCmd = {
     JsRaw(""" createSuccessNotification() """)
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/EventLogsViewer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/EventLogsViewer.scala
@@ -46,8 +46,8 @@ import net.liftweb.http.DispatchSnippet
 import scala.xml.NodeSeq
 
 class EventLogsViewer extends DispatchSnippet with Loggable {
-  private[this] val repos     = RudderConfig.eventLogRepository
-  private[this] val eventList = RudderConfig.eventListDisplayer
+  private val repos     = RudderConfig.eventLogRepository
+  private val eventList = RudderConfig.eventListDisplayer
 
   def getLastEvents: Box[Seq[EventLog]] = {
     repos.getEventLogByCriteria(None, Some(1000), List(Fragment.const("id DESC"))).toBox

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/PluginManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/PluginManagement.scala
@@ -58,7 +58,7 @@ class PluginManagement extends DispatchSnippet with Loggable {
     ).apply(xml)
   }
 
-  private[this] def displayPlugin(p: RudderPluginDef)(xml: NodeSeq): NodeSeq = {
+  private def displayPlugin(p: RudderPluginDef)(xml: NodeSeq): NodeSeq = {
     val rudderPluginVersion = p.version.rudderAbi.toVersionStringNoEpoch
     // we compare on string, since we are just looking for an exact match.
     val versionWarning      = if (RudderConfig.rudderFullVersion != rudderPluginVersion) {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/PropertiesManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/PropertiesManagement.scala
@@ -74,11 +74,11 @@ import scala.xml.Text
  */
 class PropertiesManagement extends DispatchSnippet with Loggable {
 
-  private[this] val configService: ReadConfigService with UpdateConfigService = RudderConfig.configService
-  private[this] val asyncDeploymentAgent = RudderConfig.asyncDeploymentAgent
-  private[this] val uuidGen              = RudderConfig.stringUuidGenerator
+  private val configService: ReadConfigService with UpdateConfigService = RudderConfig.configService
+  private val asyncDeploymentAgent = RudderConfig.asyncDeploymentAgent
+  private val uuidGen              = RudderConfig.stringUuidGenerator
 
-  private[this] val genericReasonMessage = Some("Property modified from Rudder preference page")
+  private val genericReasonMessage = Some("Property modified from Rudder preference page")
 
   def startNewPolicyGeneration(): Unit = {
     val modId = ModificationId(uuidGen.newUuid)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/TechniqueLibraryManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/TechniqueLibraryManagement.scala
@@ -80,22 +80,22 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
 
   import TechniqueLibraryManagement.*
 
-  private[this] val techniqueRepository         = RudderConfig.techniqueRepository
-  private[this] val updatePTLibService          = RudderConfig.updateTechniqueLibrary
-  private[this] val roActiveTechniqueRepository = RudderConfig.roDirectiveRepository
-  private[this] val rwActiveTechniqueRepository = RudderConfig.woDirectiveRepository
-  private[this] val uuidGen                     = RudderConfig.stringUuidGenerator
+  private val techniqueRepository         = RudderConfig.techniqueRepository
+  private val updatePTLibService          = RudderConfig.updateTechniqueLibrary
+  private val roActiveTechniqueRepository = RudderConfig.roDirectiveRepository
+  private val rwActiveTechniqueRepository = RudderConfig.woDirectiveRepository
+  private val uuidGen                     = RudderConfig.stringUuidGenerator
   // transform Technique variable to human viewable HTML fields
-  private[this] val treeUtilService             = RudderConfig.jsTreeUtilService
-  private[this] val userPropertyService         = RudderConfig.userPropertyService
-  private[this] val updateTecLibInterval        = RudderConfig.RUDDER_BATCH_TECHNIQUELIBRARY_UPDATEINTERVAL
+  private val treeUtilService             = RudderConfig.jsTreeUtilService
+  private val userPropertyService         = RudderConfig.userPropertyService
+  private val updateTecLibInterval        = RudderConfig.RUDDER_BATCH_TECHNIQUELIBRARY_UPDATEINTERVAL
 
   // the popup component to create user technique category
-  private[this] val creationPopup = new LocalSnippet[CreateActiveTechniqueCategoryPopup]
+  private val creationPopup = new LocalSnippet[CreateActiveTechniqueCategoryPopup]
 
   // the popup component to give reason when moving techniques from Reference
   // Technique Library to Active Technique Library
-  private[this] val giveReasonPopup = new LocalSnippet[GiveReasonPopup]
+  private val giveReasonPopup = new LocalSnippet[GiveReasonPopup]
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = {
     case "head"                   => { _ => head() }
@@ -110,15 +110,15 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
   // current states for the page - they will be kept only for the duration
   // of one request and its followng Ajax requests
 
-  private[this] val rootCategoryId = roActiveTechniqueRepository.getActiveTechniqueLibrary.map(_.id).toBox
+  private val rootCategoryId = roActiveTechniqueRepository.getActiveTechniqueLibrary.map(_.id).toBox
 
-  private[this] val currentTechniqueDetails         = new LocalSnippet[TechniqueEditForm]
-  private[this] val currentTechniqueCategoryDetails = new LocalSnippet[TechniqueCategoryEditForm]
+  private val currentTechniqueDetails         = new LocalSnippet[TechniqueEditForm]
+  private val currentTechniqueCategoryDetails = new LocalSnippet[TechniqueCategoryEditForm]
 
-  private[this] val techniqueId: Box[String] = S.param("techniqueId")
+  private val techniqueId: Box[String] = S.param("techniqueId")
 
   // create a new Technique edit form and update currentTechniqueDetails
-  private[this] def updateCurrentTechniqueDetails(technique: Option[Technique], activeTechnique: Option[ActiveTechnique]) = {
+  private def updateCurrentTechniqueDetails(technique: Option[Technique], activeTechnique: Option[ActiveTechnique]) = {
     currentTechniqueDetails.set(
       Full(
         new TechniqueEditForm(
@@ -134,7 +134,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
   }
 
   // create a new Technique edit form and update currentTechniqueDetails
-  private[this] def updateCurrentTechniqueCategoryDetails(category: ActiveTechniqueCategory) = {
+  private def updateCurrentTechniqueCategoryDetails(category: ActiveTechniqueCategory) = {
     currentTechniqueCategoryDetails.set(
       rootCategoryId.map { rootCategoryId =>
         new TechniqueCategoryEditForm(
@@ -154,11 +154,11 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
     TechniqueEditForm.staticInit
   }
 
-  private[this] def setCreationPopup: Unit = {
+  private def setCreationPopup: Unit = {
     creationPopup.set(Full(new CreateActiveTechniqueCategoryPopup(onSuccessCallback = { () => refreshTree() })))
   }
 
-  private[this] def setGiveReasonPopup(s: ActiveTechniqueId, d: ActiveTechniqueCategoryId): Unit = {
+  private def setGiveReasonPopup(s: ActiveTechniqueId, d: ActiveTechniqueCategoryId): Unit = {
     giveReasonPopup.set(
       Full(
         new GiveReasonPopup(
@@ -175,7 +175,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
   /**
    * Create the popup
    */
-  private[this] def createPopup: NodeSeq = {
+  private def createPopup: NodeSeq = {
     creationPopup.get match {
       case Failure(m, _, _) => <span class="error">Error: {m}</span>
       case Empty            => <div>The component is not set</div>
@@ -186,7 +186,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
   /**
    * Create the reason popup
    */
-  private[this] def createReasonPopup: NodeSeq = {
+  private def createReasonPopup: NodeSeq = {
     giveReasonPopup.get match {
       case Failure(m, _, _) => <span class="error">Error: {m}</span>
       case Empty            => <div>The component is not set</div>
@@ -390,7 +390,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
 
   ///////////////////// Callback function for Drag'n'drop in the tree /////////////////////
 
-  private[this] def moveTechnique(arg: String): JsCmd = {
+  private def moveTechnique(arg: String): JsCmd = {
     // parse arg, which have to  be json object with sourceactiveTechniqueId, destCatId
     try {
       (for {
@@ -441,7 +441,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
     }
   }
 
-  private[this] def moveCategory(arg: String): JsCmd = {
+  private def moveCategory(arg: String): JsCmd = {
     // parse arg, which have to  be json object with sourceactiveTechniqueId, destCatId
     try {
       (for {
@@ -493,7 +493,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
     }
   }
 
-  private[this] def bindTechnique(arg: String): JsCmd = {
+  private def bindTechnique(arg: String): JsCmd = {
     // parse arg, which have to be json object with sourceactiveTechniqueId, destCatId
     try {
       (for {
@@ -516,10 +516,10 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
                             ActiveTechniqueCategoryId(destCatId),
                             ptName,
                             techniqueRepository.getTechniqueVersions(ptName).toSeq,
-                            false,
-                            ModificationId(uuidGen.newUuid),
-                            CurrentUser.actor,
-                            Some("Active technique added by user from UI")
+                            isSystem = false,
+                            modId = ModificationId(uuidGen.newUuid),
+                            actor = CurrentUser.actor,
+                            reason = Some("Active technique added by user from UI")
                           )
                           .toBox
                         ?~! errorMess.format(sourceactiveTechniqueId, destCatId))
@@ -549,7 +549,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
     }
   }
 
-  private[this] def onSuccessReasonPopup(id: ActiveTechniqueId): JsCmd = {
+  private def onSuccessReasonPopup(id: ActiveTechniqueId): JsCmd = {
     val jsStr = """setTimeout(function() { $("[activeTechniqueId=%s]")
       .attempt("highlight", {}, 2000)}, 100)"""
     refreshTree() &
@@ -562,17 +562,17 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
     Alert(errorMessage.format(srcActiveTechId, destCatId))
   }
 
-  private[this] def refreshTree(): JsCmd = {
+  private def refreshTree(): JsCmd = {
     Replace(htmlId_techniqueLibraryTree, systemLibrary()) &
     Replace(htmlId_activeTechniquesTree, userLibrary()) &
     OnLoad(After(TimeSpan(100), JsRaw("""initBsTooltips();""")))
   }
 
-  private[this] def refreshActiveTreeLibrary(): JsCmd = {
+  private def refreshActiveTreeLibrary(): JsCmd = {
     Replace(htmlId_activeTechniquesTree, userLibrary())
   }
 
-  private[this] def refreshBottomPanel(id: ActiveTechniqueId): JsCmd = {
+  private def refreshBottomPanel(id: ActiveTechniqueId): JsCmd = {
     for {
       activeTechnique <- roActiveTechniqueRepository.getActiveTechniqueByActiveTechnique(id).toBox.flatMap(Box(_))
       technique       <- techniqueRepository.getLastTechniqueByName(activeTechnique.techniqueName)
@@ -587,7 +587,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
   /**
    * Javascript to initialize the reference library tree
    */
-  private[this] def buildReferenceLibraryJsTree: JsExp = JsRaw(
+  private def buildReferenceLibraryJsTree: JsExp = JsRaw(
     """buildReferenceTechniqueTree('#%s','%s','%s')""".format(
       htmlId_techniqueLibraryTree, {
         techniqueId match {
@@ -602,7 +602,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
   /**
    * Javascript to initialize the user library tree
    */
-  private[this] def buildUserLibraryJsTree: JsExp = JsRaw(
+  private def buildUserLibraryJsTree: JsExp = JsRaw(
     """buildActiveTechniqueTree('#%s', '%s', %s ,'%s')""".format(
       htmlId_activeTechniquesTree,
       htmlId_techniqueLibraryTree,
@@ -612,7 +612,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
   )
 
   // ajax function that update the bottom of the page when a Technique is clicked
-  private[this] def onClickTemplateNode(technique: Option[Technique], activeTechnique: Option[ActiveTechnique]): JsCmd = {
+  private def onClickTemplateNode(technique: Option[Technique], activeTechnique: Option[ActiveTechnique]): JsCmd = {
     updateCurrentTechniqueDetails(technique, activeTechnique)
 
     // update UI
@@ -626,7 +626,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
    *   - Techniques
    * - no action can be done with such node.
    */
-  private[this] def jsTreeNodeOf_ptCategory(category: TechniqueCategory): JsTreeNode = {
+  private def jsTreeNodeOf_ptCategory(category: TechniqueCategory): JsTreeNode = {
 
     def jsTreeNodeOf_pt(technique: Technique): JsTreeNode = new JsTreeNode {
 
@@ -703,7 +703,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
    * @param category
    * @return
    */
-  private[this] def jsTreeNodeOf_uptCategory(category: ActiveTechniqueCategory): JsTreeNode = {
+  private def jsTreeNodeOf_uptCategory(category: ActiveTechniqueCategory): JsTreeNode = {
     /*
      * Transform a ActiveTechnique into a JsTree leaf
      */
@@ -754,10 +754,10 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
             rwActiveTechniqueRepository
               .changeStatus(
                 activeTechnique.id,
-                false,
-                ModificationId(uuidGen.newUuid),
-                RudderEventActor,
-                Some(msg)
+                status = false,
+                modId = ModificationId(uuidGen.newUuid),
+                actor = RudderEventActor,
+                reason = Some(msg)
               )
               .toBox match {
               case eb: EmptyBox =>
@@ -838,7 +838,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
     }
   }
 
-  private[this] def showCreateActiveTechniqueCategoryPopup(): JsCmd = {
+  private def showCreateActiveTechniqueCategoryPopup(): JsCmd = {
     setCreationPopup
 
     // update UI
@@ -848,7 +848,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
 
   }
 
-  private[this] def showGiveReasonPopup(
+  private def showGiveReasonPopup(
       sourceActiveTechniqueId: ActiveTechniqueId,
       destCatId:               ActiveTechniqueCategoryId
   ): JsCmd = {
@@ -860,7 +860,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
     JsRaw("""initBsModal("createActiveTechniquePopup")""")
   }
 
-  private[this] def reloadTechniqueLibrary(isTechniqueLibraryPage: Boolean): NodeSeq = {
+  private def reloadTechniqueLibrary(isTechniqueLibraryPage: Boolean): NodeSeq = {
 
     def initJs    = SetHtml("techniqueLibraryUpdateInterval", <span>{updateTecLibInterval}</span>)
     def process() = {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
@@ -90,13 +90,13 @@ final case class JsonDirectiveRId(directiveId: String, rev: Option[String])
 class DirectiveManagement extends DispatchSnippet with Loggable {
   import DirectiveManagement.*
 
-  private[this] val techniqueRepository = RudderConfig.techniqueRepository
-  private[this] val getDirectiveLib     = () => RudderConfig.roDirectiveRepository.getFullDirectiveLibrary()
-  private[this] val getRules            = () => RudderConfig.roRuleRepository.getAll()
-  private[this] val uuidGen             = RudderConfig.stringUuidGenerator
-  private[this] val linkUtil            = RudderConfig.linkUtil
-  private[this] val configService       = RudderConfig.configService
-  private[this] val configRepo          = RudderConfig.configurationRepository
+  private val techniqueRepository = RudderConfig.techniqueRepository
+  private val getDirectiveLib     = () => RudderConfig.roDirectiveRepository.getFullDirectiveLibrary()
+  private val getRules            = () => RudderConfig.roRuleRepository.getAll()
+  private val uuidGen             = RudderConfig.stringUuidGenerator
+  private val linkUtil            = RudderConfig.linkUtil
+  private val configService       = RudderConfig.configService
+  private val configRepo          = RudderConfig.configurationRepository
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = {
     case "head"                 => { _ => head() }
@@ -109,7 +109,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
   }
 
   // must be initialized on first call of "techniqueDetails"
-  private[this] var techniqueDetails: MemoizeTransform = null
+  private var techniqueDetails: MemoizeTransform = null
 
   // the current DirectiveEditForm component
   val currentDirectiveSettingForm = new LocalSnippet[DirectiveEditForm]
@@ -124,7 +124,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
   var directiveLibrary: errors.IOResult[FullActiveTechniqueCategory] = getDirectiveLib()
   var rules:            errors.IOResult[Seq[Rule]]                   = getRules()
 
-  private[this] val directiveId: Box[String] = S.param("directiveId")
+  private val directiveId: Box[String] = S.param("directiveId")
 
   /**
    * Head information (JsTree dependencies,...)
@@ -143,7 +143,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
    *
    * We want to look for #{ "directiveId":"XXXXXXXXXXXX" , "rev":"XXXX" }
    */
-  private[this] def parseJsArg(): JsCmd = {
+  private def parseJsArg(): JsCmd = {
 
     def displayDetails(jsonId: String) = {
       implicit val format = json.DefaultFormats
@@ -192,8 +192,8 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
                 Some(onClickActiveTechnique),
                 Some(onClickDirective),
                 Some(newDirective),
-                false,
-                false
+                addEditLink = false,
+                addActionBtns = false
               )
             }</ul>
 
@@ -213,7 +213,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
     ) ++ Script(OnLoad(buildJsTree()))
   }
 
-  private[this] def buildJsTree(): JsCmd = {
+  private def buildJsTree(): JsCmd = {
 
     JsRaw(s"""
         var directiveId = null;
@@ -339,7 +339,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
         }
     })
   }
-  private[this] val (monoMessage, multiMessage, limitedMessage) = {
+  private val (monoMessage, multiMessage, limitedMessage) = {
     (
       "A unique directive derived from that technique can be deployed on a given server.",
       """Several directives derived from that technique can be deployed on a given server.
@@ -350,7 +350,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
     )
   }
 
-  private[this] def showIsSingle(technique: Technique): NodeSeq = {
+  private def showIsSingle(technique: Technique): NodeSeq = {
     <span>
       {
       if (technique.isMultiInstance) {
@@ -376,7 +376,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
     </span>
   }
 
-  private[this] def showVersions(
+  private def showVersions(
       activeTechnique: FullActiveTechnique,
       validTechniques: Seq[(TechniqueVersion, Technique, DateTime)]
   ): NodeSeq = {
@@ -461,7 +461,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
   }
 
   ///////////// finish migration pop-up ///////////////
-  private[this] def displayFinishMigrationPopup: JsCmd = {
+  private def displayFinishMigrationPopup: JsCmd = {
     JsRaw(""" callPopupWithTimeout(200,"finishMigrationPopup") """)
   }
 
@@ -469,7 +469,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
    * Configure a Rudder internal Technique to be usable in the
    * user Technique (private) library.
    */
-  private[this] def showDirectiveDetails(): NodeSeq = {
+  private def showDirectiveDetails(): NodeSeq = {
     currentDirectiveSettingForm.get match {
       case Failure(m, ex, _) =>
         <div id={htmlId_policyConf} class="col-lg-offset-2 col-lg-8" style="margin-top:50px">
@@ -529,7 +529,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
     }
   }
 
-  private[this] def newDirective(technique: Technique, activeTechnique: FullActiveTechnique) = {
+  private def newDirective(technique: Technique, activeTechnique: FullActiveTechnique) = {
     configService.rudder_global_policy_mode().toBox match {
       case Full(globalMode) =>
         val allDefaults          = techniqueRepository.getTechniquesInfo().directivesDefaultNames
@@ -545,7 +545,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
             None,
             "",
             5,
-            true
+            _isEnabled = true
           )
         }
         updateDirectiveSettingForm(
@@ -553,8 +553,8 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
           activeTechnique.toActiveTechnique(),
           directive,
           None,
-          true,
-          globalMode
+          isADirectiveCreation = true,
+          globalMode = globalMode
         )
         // Update UI
         Replace(htmlId_policyConf, showDirectiveDetails()) &
@@ -599,7 +599,14 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
           case Left(updatedDirective) => updatedDirective
           case _                      => directive // Only the id, get it from the library
         }
-        updateDirectiveSettingForm(techniques, activeTechnique, newDirective, oldDirective, false, globalMode)
+        updateDirectiveSettingForm(
+          techniques,
+          activeTechnique,
+          newDirective,
+          oldDirective,
+          isADirectiveCreation = false,
+          globalMode = globalMode
+        )
       case eb: EmptyBox =>
         currentDirectiveSettingForm.set(eb)
     }
@@ -618,11 +625,11 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
     After(TimeSpan(0), JsRaw("""removeBsTooltips();initBsTooltips();"""))
   }
 
-  private[this] case class MissingTechniqueException(directive: Directive) extends Exception(
+  private case class MissingTechniqueException(directive: Directive) extends Exception(
         s"Directive ${directive.name} (${directive.id.uid.value}) is bound to a technique without any valid version available"
       )
 
-  private[this] def updateDirectiveSettingForm(
+  private def updateDirectiveSettingForm(
       techniques:           Map[TechniqueVersion, Technique],
       activeTechnique:      ActiveTechnique,
       directive:            Directive,
@@ -688,7 +695,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
    * If it is given a directive, it updated the form, else goes to the changerequest page
    */
 
-  private[this] def directiveEditFormSuccessCallBack()(returns: Either[Directive, ChangeRequestId]): JsCmd = {
+  private def directiveEditFormSuccessCallBack()(returns: Either[Directive, ChangeRequestId]): JsCmd = {
 
     returns match {
       case Left(dir) => // ok, we've received a directive, show it
@@ -700,11 +707,11 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
     }
   }
 
-  private[this] def onRemoveSuccessCallBack(): JsCmd = {
+  private def onRemoveSuccessCallBack(): JsCmd = {
     updateDirectiveLibrary()
   }
 
-  private[this] def updateDirectiveLibrary(): JsCmd = {
+  private def updateDirectiveLibrary(): JsCmd = {
     directiveLibrary = getDirectiveLib()
     rules = getRules()
     Replace(htmlId_activeTechniquesTree, displayDirectiveLibrary())
@@ -712,11 +719,11 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
 
   //////////////// display trees ////////////////////////
 
-  private[this] def onClickDirective(cat: FullActiveTechniqueCategory, at: FullActiveTechnique, directive: Directive): JsCmd = {
+  private def onClickDirective(cat: FullActiveTechniqueCategory, at: FullActiveTechnique, directive: Directive): JsCmd = {
     updateDirectiveForm(Left(directive), None)
   }
 
-  private[this] def onClickActiveTechnique(cat: FullActiveTechniqueCategory, fullActiveTechnique: FullActiveTechnique): JsCmd = {
+  private def onClickActiveTechnique(cat: FullActiveTechniqueCategory, fullActiveTechnique: FullActiveTechnique): JsCmd = {
     currentTechnique = fullActiveTechnique.newestAvailableTechnique.map(fat => (fullActiveTechnique, fat.id.version))
     currentDirectiveSettingForm.set(Empty)
     // Update UI

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/ParameterManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/ParameterManagement.scala
@@ -59,15 +59,15 @@ import scala.xml.*
 
 class ParameterManagement extends DispatchSnippet with Loggable {
 
-  private[this] val roParameterService   = RudderConfig.roParameterService
-  private[this] val workflowLevelService = RudderConfig.workflowLevelService
+  private val roParameterService   = RudderConfig.roParameterService
+  private val workflowLevelService = RudderConfig.workflowLevelService
 
-  private[this] val gridName      = "globalParametersGrid"
-  private[this] val gridContainer = "ParamGrid"
-  private[this] val linkUtil      = RudderConfig.linkUtil
+  private val gridName      = "globalParametersGrid"
+  private val gridContainer = "ParamGrid"
+  private val linkUtil      = RudderConfig.linkUtil
 
   // the current GlobalParameterForm component
-  private[this] val parameterPopup = new LocalSnippet[CreateOrUpdateGlobalParameterPopup]
+  private val parameterPopup = new LocalSnippet[CreateOrUpdateGlobalParameterPopup]
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "display" => { _ => display()(CurrentUser.queryContext) } }
 
@@ -126,7 +126,7 @@ class ParameterManagement extends DispatchSnippet with Loggable {
     ).apply(dataTableXml(gridName)) ++ Script(initJs())
   }
 
-  private[this] def dataTableXml(gridName: String) = {
+  private def dataTableXml(gridName: String) = {
     <div id={gridContainer}>
       <div id="actions_zone">
         <div class="createParameter"/>
@@ -156,9 +156,9 @@ class ParameterManagement extends DispatchSnippet with Loggable {
 
   }
 
-  private[this] def jsVarNameForId(tableId: String) = "oTable" + tableId
+  private def jsVarNameForId(tableId: String) = "oTable" + tableId
 
-  private[this] def initJs(): JsCmd = {
+  private def initJs(): JsCmd = {
     OnLoad(
       JsRaw(s"""
           /* Event handler function */
@@ -231,7 +231,7 @@ class ParameterManagement extends DispatchSnippet with Loggable {
     )
   }
 
-  private[this] def showPopup(
+  private def showPopup(
       action:    GlobalParamModAction,
       parameter: Option[GlobalParameter]
   )(implicit qc: QueryContext): JsCmd = {
@@ -258,7 +258,7 @@ class ParameterManagement extends DispatchSnippet with Loggable {
     }
   }
 
-  private[this] def workflowCallBack(action: GlobalParamModAction, workflowEnabled: Boolean)(
+  private def workflowCallBack(action: GlobalParamModAction, workflowEnabled: Boolean)(
       returns: Either[GlobalParameter, ChangeRequestId]
   )(implicit qc: QueryContext): JsCmd = {
     if ((!workflowEnabled) & (action == GlobalParamModAction.Delete)) {
@@ -284,20 +284,20 @@ class ParameterManagement extends DispatchSnippet with Loggable {
     }
   }
 
-  private[this] def updateGrid()(implicit qc: QueryContext): JsCmd = {
+  private def updateGrid()(implicit qc: QueryContext): JsCmd = {
     Replace(gridContainer, display())
   }
 
   ///////////// success pop-up ///////////////
-  private[this] def successPopup: JsCmd = {
+  private def successPopup: JsCmd = {
     JsRaw("""createSuccessNotification()""")
   }
 
-  private[this] def onSuccessDeleteCallback()(implicit qc: QueryContext): JsCmd = {
+  private def onSuccessDeleteCallback()(implicit qc: QueryContext): JsCmd = {
     updateGrid() & successPopup
   }
 
-  private[this] def closePopup(): JsCmd = {
+  private def closePopup(): JsCmd = {
     JsRaw(s"""hideBsModal('${CreateOrUpdateGlobalParameterPopup.htmlId_popupContainer}');""")
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
@@ -311,6 +311,7 @@ class AcceptNode extends Loggable {
           (selectAll, { e => <input type="checkbox" name="serverids" value={e.id.value.toString}/> })
         ),
         """,{ "sWidth": "10%" },{ "sWidth": "11%", "bSortable":false },{ "sWidth": "2%", "bSortable":false }""",
+        searchable = true,
         paginate = true
       )
     }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
@@ -83,12 +83,12 @@ object Groups {
 class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with Loggable {
   import Groups.*
 
-  private[this] val getFullGroupLibrary   = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
-  private[this] val woNodeGroupRepository = RudderConfig.woNodeGroupRepository
-  private[this] val uuidGen               = RudderConfig.stringUuidGenerator
-  private[this] val linkUtil              = RudderConfig.linkUtil
+  private val getFullGroupLibrary   = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
+  private val woNodeGroupRepository = RudderConfig.woNodeGroupRepository
+  private val uuidGen               = RudderConfig.stringUuidGenerator
+  private val linkUtil              = RudderConfig.linkUtil
 
-  private[this] var boxGroupLib = getFullGroupLibrary().toBox
+  private var boxGroupLib = getFullGroupLibrary().toBox
 
   val mainDispatch: Map[String, NodeSeq => NodeSeq] = {
     Map(
@@ -100,15 +100,15 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
   }
 
   // the current nodeGroupCategoryForm component
-  private[this] val nodeGroupCategoryForm = new LocalSnippet[NodeGroupCategoryForm]
+  private val nodeGroupCategoryForm = new LocalSnippet[NodeGroupCategoryForm]
 
   // the current nodeGroupForm component
-  private[this] val nodeGroupForm = new LocalSnippet[NodeGroupForm]
+  private val nodeGroupForm = new LocalSnippet[NodeGroupForm]
 
   // the popup component
-  private[this] val creationPopup = new LocalSnippet[CreateCategoryOrGroupPopup]
+  private val creationPopup = new LocalSnippet[CreateCategoryOrGroupPopup]
 
-  private[this] var selectedCategoryId = boxGroupLib.map(_.id)
+  private var selectedCategoryId = boxGroupLib.map(_.id)
 
   /**
    * Head of the portlet, nothing much yet
@@ -201,7 +201,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
                |  app.ports.closeModal.send(null)
                |});
                |// When custom event to close group details fires, we load the group table state in the Elm app
-               |$$("#${htmlId_item}").on("group-close-detail", function () { 
+               |$$("#${htmlId_item}").on("group-close-detail", function () {
                |  $$("#${htmlId_item} .main-container").hide(); // guarantee to hide details
                |  app.ports.loadGroupTable.send(null)
                |});
@@ -240,7 +240,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
    *
    * We want to look for #{ "groupId":"XXXXXXXXXXXX" } or #{"targer":"....."}
    */
-  private[this] def parseJsArg(rootCategory: Box[FullNodeGroupCategory])(implicit qc: QueryContext): JsCmd = {
+  private def parseJsArg(rootCategory: Box[FullNodeGroupCategory])(implicit qc: QueryContext): JsCmd = {
     def displayGroupNotFound:                     JsCmd = SetHtml(
       htmlId_item,
       <div class="jumbotron">
@@ -295,13 +295,13 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
 
   ////////////////////////////////////////////////////////////////////////////////////
 
-  private[this] def htmlTreeNodeId(id: String) = "jsTree-" + id
+  private def htmlTreeNodeId(id: String) = "jsTree-" + id
 
   /**
    *  Manage the state of what should be displayed on the right panel.
    * It could be nothing, a group edit form, or a category edit form.
    */
-  private[this] def setAndShowRightPanel(panel: RightPanel, rootCategory: FullNodeGroupCategory)(implicit
+  private def setAndShowRightPanel(panel: RightPanel, rootCategory: FullNodeGroupCategory)(implicit
       qc: QueryContext
   ): NodeSeq = {
     panel match {
@@ -336,7 +336,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
   }
 
   // utility to refresh right panel
-  private[this] def refreshRightPanel(panel: RightPanel)(implicit qc: QueryContext): JsCmd = {
+  private def refreshRightPanel(panel: RightPanel)(implicit qc: QueryContext): JsCmd = {
     boxGroupLib match {
       case Full(lib) => SetHtml(htmlId_item, setAndShowRightPanel(panel, lib))
       case eb: EmptyBox =>
@@ -348,11 +348,11 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
 
   // that must be separated from refreshTree/refreshRightPanel
   // to avoid duplicate refresh or useless one (when only displaying without modification)
-  private[this] def refreshGroupLib(): Unit = {
+  private def refreshGroupLib(): Unit = {
     boxGroupLib = getFullGroupLibrary().toBox
   }
 
-  private[this] def setCreationPopup(rootCategory: FullNodeGroupCategory)(implicit qc: QueryContext): Unit = {
+  private def setCreationPopup(rootCategory: FullNodeGroupCategory)(implicit qc: QueryContext): Unit = {
     creationPopup.set(
       Full(
         new CreateCategoryOrGroupPopup(
@@ -367,14 +367,14 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
     )
   }
 
-  private[this] def onSuccessCallback()(implicit qc: QueryContext) = { (id: String) =>
+  private def onSuccessCallback()(implicit qc: QueryContext) = { (id: String) =>
     { refreshGroupLib(); refreshTree(htmlTreeNodeId(id)) }
   }
 
   /**
    * build the tree of categories and group and init its JS
    */
-  private[this] def buildGroupTree(selectedNode: String)(implicit qc: QueryContext): NodeSeq = {
+  private def buildGroupTree(selectedNode: String)(implicit qc: QueryContext): NodeSeq = {
     boxGroupLib match {
       case eb: EmptyBox =>
         val e = eb ?~! "Can not get the group library"
@@ -436,7 +436,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
   /**
    * Create the popup
    */
-  private[this] def createPopup: NodeSeq = {
+  private def createPopup: NodeSeq = {
     creationPopup.get match {
       case Failure(m, _, _) => <span class="error">Error: {m}</span>
       case Empty            => <div>The component is not set</div>
@@ -445,7 +445,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
   }
 
   ///////////////////// Callback function for Drag'n'drop in the tree /////////////////////
-  private[this] def moveGroup(lib: FullNodeGroupCategory)(arg: String)(implicit qc: QueryContext): JsCmd = {
+  private def moveGroup(lib: FullNodeGroupCategory)(arg: String)(implicit qc: QueryContext): JsCmd = {
     // parse arg, which have to  be json object with sourceGroupId, destCatId
     try {
       (for {
@@ -503,7 +503,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
     }
   }
 
-  private[this] def moveCategory(lib: FullNodeGroupCategory)(arg: String)(implicit qc: QueryContext): JsCmd = {
+  private def moveCategory(lib: FullNodeGroupCategory)(arg: String)(implicit qc: QueryContext): JsCmd = {
     // parse arg, which have to  be json object with sourceGroupId, destCatId
     try {
       (for {
@@ -560,7 +560,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
 
   ////////////////////
 
-  private[this] def refreshTree(selectedNode: String)(implicit qc: QueryContext): JsCmd = {
+  private def refreshTree(selectedNode: String)(implicit qc: QueryContext): JsCmd = {
     Replace(htmlId_groupTree, buildGroupTree(selectedNode))
   }
 
@@ -571,7 +571,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
   /**
     * @return None if the category is not found
     */
-  private[this] def displayCategory(categoryId: String)(implicit qc: QueryContext): Option[JsCmd] = {
+  private def displayCategory(categoryId: String)(implicit qc: QueryContext): Option[JsCmd] = {
     for {
       groupLib <- boxGroupLib.toOption
       category <- groupLib.allCategories.get(NodeGroupCategoryId(categoryId))
@@ -580,7 +580,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
     }
   }
 
-  private[this] def displayCategory(category: NodeGroupCategory)(implicit qc: QueryContext): JsCmd = {
+  private def displayCategory(category: NodeGroupCategory)(implicit qc: QueryContext): JsCmd = {
     selectedCategoryId = Full(category.id)
     // update UI - no modification here, so no refreshGroupLib
     refreshRightPanel(CategoryForm(category)) &
@@ -588,11 +588,11 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
   }
 
   // adaptater
-  private[this] def fullDisplayCategory(category: FullNodeGroupCategory)(implicit qc: QueryContext) = displayCategory(
+  private def fullDisplayCategory(category: FullNodeGroupCategory)(implicit qc: QueryContext) = displayCategory(
     category.toNodeGroupCategory
   )
 
-  private[this] def showGroupSection(g: Either[NonGroupRuleTarget, NodeGroup], parentCategoryId: NodeGroupCategoryId)(implicit
+  private def showGroupSection(g: Either[NonGroupRuleTarget, NodeGroup], parentCategoryId: NodeGroupCategoryId)(implicit
       qc: QueryContext
   ) = {
     val value = g.fold(_.target, _.id.serialize)
@@ -646,7 +646,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
 
   }
 
-  private[this] def showTargetInfo(parentCategory: FullNodeGroupCategory, targetInfo: FullRuleTargetInfo)(implicit
+  private def showTargetInfo(parentCategory: FullNodeGroupCategory, targetInfo: FullRuleTargetInfo)(implicit
       qc: QueryContext
   ): JsCmd = {
     // update UI - no modeification here, so no refreshGroupLib
@@ -660,7 +660,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
     }
   }
 
-  private[this] def showPopup()(implicit qc: QueryContext): JsCmd = {
+  private def showPopup()(implicit qc: QueryContext): JsCmd = {
 
     boxGroupLib match {
       case eb: EmptyBox => Alert("Error when trying to get the list of categories")

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Node.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Node.scala
@@ -62,9 +62,9 @@ import net.liftweb.http.StatefulSnippet
 
 class NodeDetails extends StatefulSnippet with Loggable {
 
-  private[this] val getFullGroupLibrary = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
+  private val getFullGroupLibrary = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
 
-  private[this] val groupLibrary = getFullGroupLibrary().toBox match {
+  private val groupLibrary = getFullGroupLibrary().toBox match {
     case Full(x) => x
     case eb: EmptyBox =>
       val e = eb ?~! "Major error: can not get the node group library"

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/SearchNodes.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/SearchNodes.scala
@@ -80,14 +80,14 @@ import scala.xml.NodeSeq.seqToNodeSeq
 
 class SearchNodes extends StatefulSnippet with Loggable {
 
-  private[this] val queryParser         = RudderConfig.cmdbQueryParser
-  private[this] val getFullGroupLibrary = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
-  private[this] val linkUtil            = RudderConfig.linkUtil
+  private val queryParser         = RudderConfig.cmdbQueryParser
+  private val getFullGroupLibrary = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
+  private val linkUtil            = RudderConfig.linkUtil
 
   // the popup component to create the group
-  private[this] val creationPopup = new LocalSnippet[CreateCategoryOrGroupPopup]
+  private val creationPopup = new LocalSnippet[CreateCategoryOrGroupPopup]
 
-  private[this] val groupLibrary = getFullGroupLibrary().toBox match {
+  private val groupLibrary = getFullGroupLibrary().toBox match {
     case Full(x) => x
     case eb: EmptyBox =>
       val e = eb ?~! "Major error: can not get the node group library"
@@ -125,7 +125,7 @@ class SearchNodes extends StatefulSnippet with Loggable {
     </head>
   }
 
-  private[this] def setCreationPopup(query: Option[Query], serverList: Box[Seq[NodeInfo]]): Unit = {
+  private def setCreationPopup(query: Option[Query], serverList: Box[Seq[NodeInfo]]): Unit = {
     creationPopup.set(
       Full(
         new CreateCategoryOrGroupPopup(
@@ -133,14 +133,14 @@ class SearchNodes extends StatefulSnippet with Loggable {
           Some(
             new NodeGroup(
               NodeGroupId(NodeGroupUid("temporary")),
-              null,
-              null,
-              Nil,
-              query,
-              true,
-              serverList.openOr(Seq[NodeInfo]()).map(_.id).toSet,
-              true,
-              false
+              name = null,
+              description = null,
+              properties = Nil,
+              query = query,
+              isDynamic = true,
+              serverList = serverList.openOr(Seq[NodeInfo]()).map(_.id).toSet,
+              _isEnabled = true,
+              isSystem = false
             )
           ),
           rootCategory = groupLibrary,
@@ -154,7 +154,7 @@ class SearchNodes extends StatefulSnippet with Loggable {
     )
   }
 
-  private[this] def setSearchComponent(query: Option[Query]): SearchNodeComponent = {
+  private def setSearchComponent(query: Option[Query]): SearchNodeComponent = {
     def showNodeDetails(nodeId: String, displayCompliance: Boolean): JsCmd = {
       linkUtil.redirectToNodeLink(NodeId(nodeId))
     }
@@ -196,7 +196,7 @@ class SearchNodes extends StatefulSnippet with Loggable {
    * - pass an empty string if hash is undefined or empty
    * - pass a json-serialised structure in other cases
    */
-  private[this] def parseHashtag()(implicit qc: QueryContext): JsCmd = {
+  private def parseHashtag()(implicit qc: QueryContext): JsCmd = {
     def executeQuery(query: String): JsCmd = {
       val sc = if (query.nonEmpty) {
         val parsed = queryParser(query)
@@ -224,7 +224,7 @@ class SearchNodes extends StatefulSnippet with Loggable {
   /**
    * Create the popup
    */
-  private[this] def createPopup: NodeSeq = {
+  private def createPopup: NodeSeq = {
     creationPopup.get match {
       case Failure(m, _, _) => <span class="error">Error: {m}</span>
       case Empty            => <div>The component is not set</div>
@@ -232,7 +232,7 @@ class SearchNodes extends StatefulSnippet with Loggable {
     }
   }
 
-  private[this] def showPopup():                                      JsCmd = {
+  private def showPopup():                                            JsCmd = {
     searchNodeComponent.get match {
       case Full(r) =>
         setCreationPopup(r.getQuery(), r.getSrvList())

--- a/webapp/sources/rudder/rudder-web/src/main/scala/net/liftweb/http/LocalSnippet.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/net/liftweb/http/LocalSnippet.scala
@@ -105,7 +105,7 @@ import scala.reflect.ClassTag
  *
  */
 class LocalSnippet[T <: DispatchSnippet](implicit m: ClassTag[T]) {
-  private[this] var _snippet: Box[T] = Empty
+  private var _snippet: Box[T] = Empty
 
   val name = m.runtimeClass.getSimpleName
 

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
@@ -85,7 +85,7 @@ class RudderUserDetailsTest extends Specification {
   // org.slf4j.LoggerFactory.getLogger("application.authorization").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.TRACE)
 
   def getUserDetailList(xml: Elem, debugName: String, extendedAuthz: Boolean = true): ValidatedUserList =
-    UserFileProcessing.parseXml(roleApiMapping, xml, debugName, extendedAuthz, false).force
+    UserFileProcessing.parseXml(roleApiMapping, xml, debugName, extendedAuthz, reload = false).force
 
   // also check that we accept both `role` and `roles` tags
   val userXML_1: Elem = <authentication hash="sha512" case-sensitivity="true">

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/Section2FieldServiceTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/Section2FieldServiceTest.scala
@@ -156,7 +156,12 @@ class Section2FieldServiceTest extends Specification {
     def apply(): SectionField = {
 
       val rootSectSpec = createRootSectionSpec
-      ConfigSection2FieldService.section2FieldService.createSectionField(rootSectSpec, Map(), true, Map())
+      ConfigSection2FieldService.section2FieldService.createSectionField(
+        rootSectSpec,
+        Map(),
+        isNewPolicy = true,
+        usedFields = Map()
+      )
     }
 
     def createRootSectionSpec: SectionSpec = {

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPEntry.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPEntry.scala
@@ -77,7 +77,7 @@ class LDAPEntry(private val _backed: UnboundidEntry) {
 
   lazy val optDn: Option[DN] = if (NULL_DN == dn) None else Some(dn)
 
-  private[this] lazy val listRdns: List[RDN] = dn.getRDNs.toList
+  private lazy val listRdns: List[RDN] = dn.getRDNs.toList
 
   private val _parentDn: Option[DN] = listRdns match {
     case r :: Nil => None
@@ -89,7 +89,7 @@ class LDAPEntry(private val _backed: UnboundidEntry) {
     case r :: _ =>
       // update RDN attribute content
       // start to delete old values, and then add new one (corner case with multivaluated attrs in rdn
-      for (attr: String <- r.getAttributeNames.toSet) this deleteAttribute attr
+      for (attr: String <- r.getAttributeNames.toSet) this.deleteAttribute(attr)
       for (i <- 0 until r.getAttributeNames.size) {
         this.addValues(r.getAttributeNames()(i), r.getAttributeValues()(i))
       }
@@ -358,7 +358,7 @@ object LDAPEntry {
     val emptyAttrs = Buffer[String]()
     for (a <- target.attributes.toSeq) {
       if (!a.hasValue) {
-        target deleteAttribute a.getName // remove the attribute
+        target.deleteAttribute(a.getName) // remove the attribute
         emptyAttrs += a.getName
       }
     }

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/schema/LDAPSchema.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/schema/LDAPSchema.scala
@@ -32,7 +32,7 @@ package com.normation.ldap.sdk.schema
 class LDAPSchema {
   type S = scala.collection.immutable.Set[LDAPObjectClass]
   import scala.collection.mutable.Map as MutMap
-  def S: Seq[LDAPObjectClass] => Set[LDAPObjectClass] = scala.collection.immutable.Set[LDAPObjectClass] _
+  def S: Seq[LDAPObjectClass] => Set[LDAPObjectClass] = scala.collection.immutable.Set[LDAPObjectClass]
 
   /**
    * map of class name (lower case) -> object class

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/Control.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/Control.scala
@@ -65,7 +65,7 @@ object Control {
       f(u) match {
         case e: EmptyBox =>
           val fail = e match {
-            case f: Failure => f
+            case failure: Failure => failure
             // these case should never happen, because Empty is verbotten, so took a
             // not to bad solution - u.toString can be very ugly, so limit size.
             case Empty => Failure(s"An error occured while processing: ${u.toString().take(20)}")

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/DateFormaterService.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/DateFormaterService.scala
@@ -97,7 +97,7 @@ object DateFormaterService {
   def getDisplayDateTimePicker(date: DateTime): String = {
     date.toString(dateFormatTimePicker)
   }
-  private[this] val periodFormatter = new PeriodFormatterBuilder()
+  private val periodFormatter = new PeriodFormatterBuilder()
     .appendDays()
     .appendSuffix(" day", " days")
     .appendSeparator(", ")

--- a/webapp/sources/utils/src/test/scala/com/normation/utils/TestStandardFieldValidation.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/utils/TestStandardFieldValidation.scala
@@ -30,7 +30,7 @@ class TestStandardFieldValidation extends Specification {
   "hostname, which are really FQDN in rudder" should {
     "be allowed to have . and _" in {
 
-      HostnameRegex.checkHostname("windows_24.host.domain") must beRight()
+      HostnameRegex.checkHostname("windows_24.host.domain") must beRight
 
     }
 

--- a/webapp/sources/utils/src/test/scala/com/normation/utils/VersionTest.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/utils/VersionTest.scala
@@ -167,7 +167,7 @@ class VersionTest extends Specification {
     }
   }
 
-  private[this] def equalVersions(version1: String, version2: String) = {
+  private def equalVersions(version1: String, version2: String) = {
     // the actual comparison test
     "be so that '%s' == '%s'".format(version1, version2) in {
       forceParse(version1) == forceParse(version2) must beTrue
@@ -181,7 +181,7 @@ class VersionTest extends Specification {
   }
 
   // test if version1 < version2
-  private[this] def increasingVersions(version1: String, version2: String) = {
+  private def increasingVersions(version1: String, version2: String) = {
     // the actual comparison test
     "be so that '%s' < '%s'".format(version1, version2) in {
       forceParse(version1) < forceParse(version2) must beTrue

--- a/webapp/sources/utils/src/test/scala/zio/yaml/ZioYamlTest.scala
+++ b/webapp/sources/utils/src/test/scala/zio/yaml/ZioYamlTest.scala
@@ -40,7 +40,7 @@ class ZioYamlTest extends Specification {
   implicit val codecParam:           JsonCodec[Param]     = DeriveJsonCodec.gen
   implicit val codecSimpleContainer: JsonCodec[Container] = DeriveJsonCodec.gen
 
-  val c: Container = Container("foo", 42, List(Param("p1", true)))
+  val c: Container = Container("foo", 42, List(Param("p1", mandatory = true)))
 
   "demonstrating correct encoding with our ZIO Yaml" >> {
 


### PR DESCRIPTION
https://issues.rudder.io/issues/24813

See https://github.com/Normation/rudder/pull/5548 for the original PR. 
I didn't saw anything strange, test pass, rudder seems to work. 
Some commit warrant a second sight: 

-  provide a total function for messageHandler to avoid pattern matching catchall for future values
   https://github.com/Normation/rudder/pull/5548/commits/c5098e0d5b46fadbb2fec23b12a4816bcad5eb33
- (*) rewrite early return function to functional style  https://github.com/Normation/rudder/pull/5548/commits/613dcfe42cc9f12a5c042489c988bdaf8ece3062

That's all, other seems quite automatic / not risky.