### PR TITLE
Fixes #24504: The pending nodes history is not working anymore

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
@@ -560,7 +560,6 @@ class EventLogDetailsServiceImpl(
       actorIp      <-
         (details \ "actorIp").headOption.map(_.text) ?~! ("Missing attribute 'actorIp' in entry type node : " + entry.toString())
     } yield {
-      println("OK: found inventory log details")
       InventoryLogDetails(
         nodeId = NodeId(nodeId),
         inventoryVersion = ISODateTimeFormat.dateTimeParser.parseDateTime(version),

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
@@ -560,6 +560,7 @@ class EventLogDetailsServiceImpl(
       actorIp      <-
         (details \ "actorIp").headOption.map(_.text) ?~! ("Missing attribute 'actorIp' in entry type node : " + entry.toString())
     } yield {
+      println("OK: found inventory log details")
       InventoryLogDetails(
         nodeId = NodeId(nodeId),
         inventoryVersion = ISODateTimeFormat.dateTimeParser.parseDateTime(version),

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/HistoryLogRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/HistoryLogRepository.scala
@@ -53,9 +53,9 @@ trait ReadOnlyHistoryLogRepository[ID, V, T, HLog <: HistoryLog[ID, V, T]] {
   def get(id: ID, version: V): IOResult[HLog]
 
   /**
-    * Get all records, and filter records since version if provided
+    * Get all records
     */
-  def getAll(version: Option[V]): IOResult[Seq[HLog]]
+  def getAll(): IOResult[Seq[HLog]]
 
   /**
    * Return the list of version for ID.

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/HistoryLogRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/HistoryLogRepository.scala
@@ -53,6 +53,11 @@ trait ReadOnlyHistoryLogRepository[ID, V, T, HLog <: HistoryLog[ID, V, T]] {
   def get(id: ID, version: V): IOResult[HLog]
 
   /**
+    * Get all records, and filter records since version if provided
+    */
+  def getAll(version: Option[V]): IOResult[Seq[HLog]]
+
+  /**
    * Return the list of version for ID.
    * @return
    *   Failure(message) if an error happened

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/FileHistoryLogRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/FileHistoryLogRepository.scala
@@ -162,20 +162,18 @@ class FileHistoryLogRepository[ID: ClassTag, T](
     } yield DefaultHLog(id, version, data)
   }
 
-  def getAll(version: Option[DateTime]): IOResult[Seq[HLog]] = {
+  def getAll(): IOResult[Seq[HLog]] = {
     for {
       r   <- root
       ids <- getIds
       res <- ZIO
                .foreach(ids) { id =>
-                 // use parser to parse each file within idDir, if version is gte to the one given
                  for {
                    i  <- idDir(id)
                    vs <- ZIO
                            .attempt(
                              i.listFiles.toSeq
                                .flatMap(f => sToV(f.getName))
-                               .filter(v => version.forall(v.isAfter(_)))
                            )
                            .mapError(e => InventoryError.System(s"Error when listing file in '${i.getAbsolutePath}'"))
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/FileHistoryLogRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/FileHistoryLogRepository.scala
@@ -162,6 +162,34 @@ class FileHistoryLogRepository[ID: ClassTag, T](
     } yield DefaultHLog(id, version, data)
   }
 
+  def getAll(version: Option[DateTime]): IOResult[Seq[HLog]] = {
+    for {
+      r   <- root
+      ids <- getIds
+      res <- ZIO
+               .foreach(ids) { id =>
+                 // use parser to parse each file within idDir, if version is gte to the one given
+                 for {
+                   i  <- idDir(id)
+                   vs <- ZIO
+                           .attempt(
+                             i.listFiles.toSeq
+                               .flatMap(f => sToV(f.getName))
+                               .filter(v => version.forall(v.isAfter(_)))
+                           )
+                           .mapError(e => InventoryError.System(s"Error when listing file in '${i.getAbsolutePath}'"))
+
+                   hlogs <- ZIO.foreach(vs)(v => {
+                              parser
+                                .fromFile(new File(i, vToS(v)))
+                                .mapError(e => InventoryError.System(s"Error when reading file in '${i.getAbsolutePath}'"))
+                                .map(d => DefaultHLog(id, v, d))
+                            })
+                 } yield hlogs
+               }
+    } yield res.flatten
+  }
+
   // we don't want to catch exception here
   private def exists(id: ID) = {
     for {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/InventoryHistoryJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/InventoryHistoryJdbcRepository.scala
@@ -36,7 +36,6 @@ import doobie.Read
 import doobie.Write
 import doobie.implicits.*
 import doobie.implicits.toSqlInterpolator
-import doobie.util.fragments
 import org.joda.time.DateTime
 import zio.interop.catz.*
 import zio.json.*
@@ -151,11 +150,8 @@ class InventoryHistoryJdbcRepository(
     transactIOResult(s"error when getting node '${id.value}' accept/refuse fact")(xa => q.query[FactLog].unique.transact(xa))
   }
 
-  override def getAll(version: Option[DateTime]): IOResult[Seq[FactLog]] = {
-    val q = {
-      sql"select nodeId, acceptRefuseEvent, acceptRefuseFact from nodefacts" ++
-      fragments.whereAndOpt(version.map(v => fr"where (acceptRefuseEvent->>'date')::TIMESTAMP >= ${v}"))
-    }
+  override def getAll(): IOResult[Seq[FactLog]] = {
+    val q = sql"select nodeId, acceptRefuseEvent, acceptRefuseFact from nodefacts"
 
     transactIOResult(s"error when getting all node accept/refuse facts")(xa => q.query[FactLog].to[Seq].transact(xa))
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/InventoryHistoryJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/InventoryHistoryJdbcRepository.scala
@@ -36,6 +36,7 @@ import doobie.Read
 import doobie.Write
 import doobie.implicits.*
 import doobie.implicits.toSqlInterpolator
+import doobie.util.fragments
 import org.joda.time.DateTime
 import zio.interop.catz.*
 import zio.json.*
@@ -148,6 +149,15 @@ class InventoryHistoryJdbcRepository(
     }
 
     transactIOResult(s"error when getting node '${id.value}' accept/refuse fact")(xa => q.query[FactLog].unique.transact(xa))
+  }
+
+  override def getAll(version: Option[DateTime]): IOResult[Seq[FactLog]] = {
+    val q = {
+      sql"select nodeId, acceptRefuseEvent, acceptRefuseFact from nodefacts" ++
+      fragments.whereAndOpt(version.map(v => fr"where (acceptRefuseEvent->>'date')::TIMESTAMP >= ${v}"))
+    }
+
+    transactIOResult(s"error when getting all node accept/refuse facts")(xa => q.query[FactLog].to[Seq].transact(xa))
   }
 
   /**

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/history/impl/TestFileHistoryLogRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/history/impl/TestFileHistoryLogRepository.scala
@@ -89,6 +89,7 @@ class TestFileHistoryLogRepository {
     // now we have exaclty one id1, with two revisions, and head is data1time2
     assertEquals(Right(List(id1)), repos.getIds.map(_.toList).runNow)
     assertEquals(Right(data1time2 :: data1time1 :: Nil), repos.versions(id1).map(_.toList).runNow)
+    assertEquals(Right(List(DefaultHLog(id1, data1time1, data1), DefaultHLog(id1, data1time2, data1))), repos.getAll(None).runNow)
 
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/history/impl/TestFileHistoryLogRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/history/impl/TestFileHistoryLogRepository.scala
@@ -89,7 +89,7 @@ class TestFileHistoryLogRepository {
     // now we have exaclty one id1, with two revisions, and head is data1time2
     assertEquals(Right(List(id1)), repos.getIds.map(_.toList).runNow)
     assertEquals(Right(data1time2 :: data1time1 :: Nil), repos.versions(id1).map(_.toList).runNow)
-    assertEquals(Right(List(DefaultHLog(id1, data1time2, data1), DefaultHLog(id1, data1time1, data1))), repos.getAll().runNow)
+    assertEquals(Right(Seq(DefaultHLog(id1, data1time1, data1), DefaultHLog(id1, data1time2, data1))), repos.getAll().runNow)
 
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/history/impl/TestFileHistoryLogRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/history/impl/TestFileHistoryLogRepository.scala
@@ -89,7 +89,7 @@ class TestFileHistoryLogRepository {
     // now we have exaclty one id1, with two revisions, and head is data1time2
     assertEquals(Right(List(id1)), repos.getIds.map(_.toList).runNow)
     assertEquals(Right(data1time2 :: data1time1 :: Nil), repos.versions(id1).map(_.toList).runNow)
-    assertEquals(Right(List(DefaultHLog(id1, data1time1, data1), DefaultHLog(id1, data1time2, data1))), repos.getAll(None).runNow)
+    assertEquals(Right(List(DefaultHLog(id1, data1time2, data1), DefaultHLog(id1, data1time1, data1))), repos.getAll().runNow)
 
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/PendingHistoryGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/PendingHistoryGrid.scala
@@ -79,7 +79,7 @@ object PendingHistoryGrid extends Loggable {
     val eventLogsResult = logService.getInventoryEventLogs()
 
     val eventLogs    = eventLogsResult.getOrElse(List.empty).map(Left(_))
-    val nodeFactLogs = history.getAll(None).map(_.map(Right(_))).catchAll(_ => List.empty.succeed).runNow
+    val nodeFactLogs = history.getAll().map(_.map(Right(_))).catchAll(_ => List.empty.succeed).runNow
 
     eventLogsResult match {
       case _: Failure => NodeSeq.Empty

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/PendingHistoryGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/PendingHistoryGrid.scala
@@ -90,7 +90,11 @@ object PendingHistoryGrid extends Loggable {
             case x                           => Right(x)
           }
         }
-        display(entries) ++ Script(initJs(deleted))
+        val sortedEntries                                                                        = entries.sortBy {
+          case Left(e: InventoryEventLog) => e.creationDate
+          case Right(f)                   => f.datetime
+        }(Ordering[DateTime].reverse)
+        display(sortedEntries) ++ Script(initJs(deleted))
     }
 
   }

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateNodeAcceptationInventories.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateNodeAcceptationInventories.scala
@@ -192,6 +192,13 @@ trait TestMigrateNodeAcceptationInventories extends Specification with AfterAll 
       } yield FactLog(id, version, FactLogData(fact, EventActor("rudder-migration"), AcceptedInventory))
     }
 
+    override def getAll(): IOResult[Seq[FactLog]] = {
+      for {
+        ids <- getIds
+        res <- ZIO.foreach(ids)(id => versions(id).flatMap(ZIO.foreach(_)(v => get(id, v))))
+      } yield res.flatten
+    }
+
     override def versions(id: NodeId): IOResult[Seq[DateTime]] = {
       for {
         files <- IOResult.attempt(nodeDir(id).list.toSeq)


### PR DESCRIPTION
https://issues.rudder.io/issues/24504
:warning: **We need to add event logs for deletion, acceptation, refusal events and consider migrating back** 

We need to use both sources for compatibility : 
* the event logs
* the nodefacts

I added a `getAll` method for nodefacts, and did not eventually filter by date. There is a dilemna : if we filter nodefacts since the most recent event log, we are sure to not get duplicates and have a consistent history. But normally we completely switch to nodefacts when we apply the migration, so there is no reason that it would be inconsistent if we don't filter...