### PR TITLE
Fixes #24817: When there are more nodes than supported by licenses, no logs in webapp states it

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/PluginStatus.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/PluginStatus.scala
@@ -37,6 +37,7 @@
 
 package com.normation.plugins
 
+import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import org.joda.time.DateTime
 
 /**
@@ -77,9 +78,17 @@ trait PluginStatus {
   /*
    * Is the plugin currently enabled (at the moment of the request) ?
    */
-  def isEnabled(): Boolean = current match {
-    case PluginStatusInfo.EnabledNoLicense | _: PluginStatusInfo.EnabledWithLicense => true
-    case _                                                                          => false
+  def isEnabled(): Boolean = {
+    current match {
+      case PluginStatusInfo.EnabledNoLicense | _: PluginStatusInfo.EnabledWithLicense => true
+      case PluginStatusInfo.Disabled(reason, optInfo)                                 =>
+        val name = optInfo match {
+          case Some(i) => s"'${i.softwareId}' "
+          case None    => ""
+        }
+        ApplicationLoggerPure.Plugin.logEffect.warn(s"Plugin ${name}is disabled: ${reason}")
+        false
+    }
   }
 }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/24817

Successfully where to add the check to be useful. 

Now, the log looks like that at start: 

![image](https://github.com/Normation/rudder/assets/44649/61129d80-c20f-4f69-9096-74b449b30329)


At at run time, when a limited feature is triggered: 

![image](https://github.com/Normation/rudder/assets/44649/01febb58-f31f-4daf-bed7-6d1d4b5a637b)

