### PR TITLE
Fixes #24769: Refactoring Elm code related to datatables

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts.elm
@@ -113,12 +113,12 @@ update msg model =
             in
             ( { model | ui = { ui | copyState = NoCopy } }, Cmd.none )
 
-        UpdateTableFilters tableFilters ->
+        UpdateFilters filters ->
             let
                 ui =
                     model.ui
             in
-            ( { model | ui = { ui | tableFilters = tableFilters } }, Cmd.none )
+            ( { model | ui = { ui | filters = filters } }, Cmd.none )
 
         GetAccountsResult res ->
             case res of

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/DataTypes.elm
@@ -7,6 +7,7 @@ import Json.Decode as D exposing (..)
 import SingleDatePicker exposing (DatePicker, Settings, TimePickerVisibility(..), defaultSettings, defaultTimePickerSettings)
 import Time exposing (Posix, Zone)
 
+import Ui.Datatable exposing (TableFilters)
 
 
 --
@@ -31,30 +32,16 @@ type ConfirmModalType
     | Regenerate
 
 
-type SortOrder
-    = Asc
-    | Desc
-
-
 type SortBy
     = Name
     | Id
     | ExpDate
     | CreDate
 
-
 type TenantMode
     = AllAccess -- special "*" permission giving access to objects in any/no tenants
     | NoAccess -- special "-" permission giving access to no object, whatever the tenant or its absence
     | ByTenants --give access to object in any of the listed tenants
-
-
-type alias TableFilters =
-    { sortBy : SortBy
-    , sortOrder : SortOrder
-    , filter : String
-    , authType : String
-    }
 
 
 type alias DatePickerInfo =
@@ -64,9 +51,13 @@ type alias DatePickerInfo =
     , picker : DatePicker Msg
     }
 
+type alias Filters =
+    { tableFilters : TableFilters SortBy
+    , authType : String
+    }
 
 type alias UI =
-    { tableFilters : TableFilters
+    { filters : Filters
     , modalState : ModalState
     , copyState : CopyState
     , hasWriteRights : Bool
@@ -136,7 +127,7 @@ type Msg
     | CloseCopyPopup
     | GetAccountsResult (Result (Http.Detailed.Error String) ( Http.Metadata, ApiResult ))
     | Ignore
-    | UpdateTableFilters TableFilters
+    | UpdateFilters Filters
     | UpdateAccountForm Account
     | SaveAccount (Result (Http.Detailed.Error String) ( Http.Metadata, Account ))
     | ConfirmActionAccount ConfirmModalType (Result (Http.Detailed.Error String) ( Http.Metadata, Account ))

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/Init.elm
@@ -8,6 +8,7 @@ import SingleDatePicker exposing (Settings, TimePickerVisibility(..))
 import Task
 import Time exposing (Month(..), Posix, Zone)
 
+import Ui.Datatable exposing (defaultTableFilters)
 
 
 -- PORTS / SUBSCRIPTIONS
@@ -71,8 +72,7 @@ init flags =
         initDatePicker =
             DatePickerInfo (Time.millisToPosix 0) Time.utc Nothing (SingleDatePicker.init UpdatePicker)
 
-        initFilters =
-            TableFilters Name Asc "" ""
+        initFilters = Filters (defaultTableFilters Name) ""
 
         initUi =
             UI initFilters NoModal NoCopy False True initDatePicker False False

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/View.elm
@@ -56,15 +56,17 @@ view model =
                                                 [ input
                                                     [ class "form-control"
                                                     , type_ "text"
-                                                    , value model.ui.tableFilters.filter
+                                                    , value model.ui.filters.tableFilters.filter
                                                     , placeholder "Filter..."
                                                     , onInput
                                                         (\s ->
                                                             let
+                                                                filters =
+                                                                    model.ui.filters
                                                                 tableFilters =
-                                                                    model.ui.tableFilters
+                                                                    filters.tableFilters
                                                             in
-                                                            UpdateTableFilters { tableFilters | filter = s }
+                                                            UpdateFilters { filters | tableFilters = { tableFilters | filter = s }}
                                                         )
                                                     ]
                                                     []
@@ -75,13 +77,13 @@ view model =
                                                     , onInput
                                                         (\authType ->
                                                             let
-                                                                tableFilters =
-                                                                    model.ui.tableFilters
+                                                                filters =
+                                                                    model.ui.filters
                                                             in
-                                                            UpdateTableFilters { tableFilters | authType = authType }
+                                                            UpdateFilters { filters | authType = authType }
                                                         )
                                                     ]
-                                                    [ option [ selected True, value model.ui.tableFilters.authType, disabled True ] [ text "Filter on access level" ]
+                                                    [ option [ selected True, value model.ui.filters.authType, disabled True ] [ text "Filter on access level" ]
                                                     , option [ value "" ] [ text "All accounts" ]
                                                     , option [ value "none" ] [ text "No access" ]
                                                     , option [ value "ro" ] [ text "Read only" ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewUtils.elm
@@ -13,40 +13,18 @@ import Accounts.DatePickerUtils exposing (posixToString, checkIfExpired)
 import Accounts.ViewModals exposing (accountsModalId)
 import String exposing (isEmpty, length, slice)
 
+import Ui.Datatable exposing (thClass, sortTable, SortOrder(..), filterSearch)
+
 
 --
 -- DATATABLE
 --
 
-thClass : TableFilters -> SortBy -> String
-thClass tableFilters sortBy =
-  if sortBy == tableFilters.sortBy then
-    case  tableFilters.sortOrder of
-      Asc  -> "sorting_asc"
-      Desc -> "sorting_desc"
-  else
-    "sorting"
-
-sortTable : TableFilters -> SortBy -> TableFilters
-sortTable tableFilters sortBy =
-  let
-    order =
-      case tableFilters.sortOrder of
-        Asc -> Desc
-        Desc -> Asc
-  in
-    if sortBy == tableFilters.sortBy then
-      { tableFilters | sortOrder = order}
-    else
-      { tableFilters | sortBy = sortBy, sortOrder = Asc}
-
-
 getSortFunction : Model -> Account -> Account -> Order
 getSortFunction model a1 a2 =
   let
     datePickerInfo = model.ui.datePickerInfo
-    order = case model.ui.tableFilters.sortBy of
-      Name    -> N.compare a1.name a2.name
+    order = case model.ui.filters.tableFilters.sortBy of
       Id      -> N.compare a1.id a2.id
       ExpDate ->
         let
@@ -59,8 +37,9 @@ getSortFunction model a1 a2 =
         in
           N.compare expDate1 expDate2
       CreDate -> N.compare a1.creationDate a2.creationDate
+      _       -> N.compare a1.name a2.name
   in
-    if model.ui.tableFilters.sortOrder == Asc then
+    if model.ui.filters.tableFilters.sortOrder == Asc then
       order
     else
       case order of
@@ -79,20 +58,6 @@ searchField datePickerInfo a =
 
 cleanDate: String -> String
 cleanDate date = slice 0 16 (String.replace "T" " " date)
-
-filterSearch : String -> List String -> Bool
-filterSearch filterString searchFields =
-  let
-    -- Join all the fields into one string to simplify the search
-    stringToCheck = searchFields
-      |> String.join "|"
-      |> String.toLower
-
-    searchString  = filterString
-      |> String.toLower
-      |> String.trim
-  in
-    String.contains searchString stringToCheck
 
 filterByAuthType : String -> String -> Bool
 filterByAuthType filterAuthType authType=
@@ -182,22 +147,23 @@ displayAccountsTable model =
             [ span [class "fa fa-times-circle"] [] ]
           ]
         ]
-    filters = model.ui.tableFilters
+    filters = model.ui.filters
+    tableFilters = filters.tableFilters
     filteredAccounts = model.accounts
-      |> List.filter (\a -> filterSearch model.ui.tableFilters.filter (searchField model.ui.datePickerInfo a))
-      |> List.filter (\a -> filterByAuthType model.ui.tableFilters.authType a.authorisationType)
+      |> List.filter (\a -> filterSearch tableFilters.filter (searchField model.ui.datePickerInfo a))
+      |> List.filter (\a -> filterByAuthType filters.authType a.authorisationType)
       |> List.sortWith (getSortFunction model)
   in
     table [class "dataTable"]
     [ thead []
       [ tr [class "head"]
-        [ th [class (thClass model.ui.tableFilters Name    ), onClick (UpdateTableFilters (sortTable filters Name    ))][ text "Account name"    ]
-        , th [class (thClass model.ui.tableFilters Id      ), onClick (UpdateTableFilters (sortTable filters Id      ))][ text "Account id"           ]
+        [ th [class (thClass tableFilters Name    ), onClick (UpdateFilters {filters | tableFilters = (sortTable tableFilters Name    )})][ text "Account name"    ]
+        , th [class (thClass tableFilters Id      ), onClick (UpdateFilters {filters | tableFilters = (sortTable tableFilters Id      )})][ text "Account id"           ]
         , if hasClearTextTokens then
             th [][ text "Token" ]
           else
-            th [class (thClass model.ui.tableFilters CreDate ), onClick (UpdateTableFilters (sortTable filters CreDate ))][ text "Creation date" ]
-        , th [class (thClass model.ui.tableFilters ExpDate ), onClick (UpdateTableFilters (sortTable filters ExpDate ))][ text "Expiration date" ]
+            th [class (thClass tableFilters CreDate ), onClick (UpdateFilters {filters | tableFilters = (sortTable tableFilters CreDate )})][ text "Creation date" ]
+        , th [class (thClass tableFilters ExpDate ), onClick (UpdateFilters {filters | tableFilters = (sortTable tableFilters ExpDate )})][ text "Expiration date" ]
         , th [][ text "Actions" ]
         ]
       ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/DataTypes.elm
@@ -5,6 +5,7 @@ import Http exposing (Error)
 
 import Compliance.DataTypes exposing (..)
 import Rules.DataTypes exposing (RuleCompliance)
+import Ui.Datatable exposing (TableFilters, SortOrder)
 --
 -- All our data types
 --
@@ -47,18 +48,11 @@ type alias NodeCompliance =
   , rules             : List (RuleCompliance ValueCompliance)
   }
 
-
-type alias TableFilters =
-  { sortOrder  : SortOrder
-  , filter     : String
-  , openedRows : Dict String (String, SortOrder)
-  }
-
-type SortOrder = Asc | Desc
+type SortBy = Name
 
 type alias UI =
-  { ruleFilters       : TableFilters
-  , nodeFilters       : TableFilters
+  { ruleFilters       : TableFilters SortBy
+  , nodeFilters       : TableFilters SortBy
   , complianceFilters : ComplianceFilters
   , viewMode          : ViewMode
   , loading           : Bool
@@ -77,7 +71,7 @@ type alias Model =
 
 type Msg
   = Ignore
-  | UpdateFilters       TableFilters
+  | UpdateFilters       (TableFilters SortBy)
   | UpdateComplianceFilters ComplianceFilters
   | GoTo                String
   | ChangeViewMode      ViewMode

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/Init.elm
@@ -6,11 +6,13 @@ import DirectiveCompliance.ApiCalls exposing (..)
 import DirectiveCompliance.DataTypes exposing (..)
 import Compliance.DataTypes exposing (..)
 import Compliance.Utils exposing (defaultComplianceFilter)
+import Ui.Datatable exposing (defaultTableFilters )
+
 
 init : { directiveId : String, contextPath : String } -> ( Model, Cmd Msg )
 init flags =
   let
-    initFilters  = (TableFilters Asc "" Dict.empty)
+    initFilters  = (defaultTableFilters Name)
     initUI       = UI initFilters initFilters defaultComplianceFilter RulesView True False
     initModel    = Model (DirectiveId flags.directiveId) flags.contextPath "" initUI Nothing
     listInitActions =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ViewNodesCompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ViewNodesCompliance.elm
@@ -13,6 +13,7 @@ import DirectiveCompliance.ApiCalls exposing (..)
 import DirectiveCompliance.DataTypes exposing (..)
 import DirectiveCompliance.ViewUtils exposing (..)
 import Compliance.Utils exposing (displayComplianceFilters, filterDetailsByCompliance)
+import Ui.Datatable exposing (filterSearch, SortOrder(..), generateLoadingTable)
 
 
 displayNodesComplianceTable : Model -> Html Msg
@@ -42,7 +43,7 @@ displayNodesComplianceTable model =
       Nothing -> (\_ _ -> EQ)
   in
     ( if model.ui.loading then
-      generateLoadingTable
+      generateLoadingTable True 2
       else
       div[]
       [ div [class "table-header extra-filters"]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ViewRulesCompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ViewRulesCompliance.elm
@@ -5,7 +5,6 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onInput)
 import List
 import List.Extra
-import String
 import Tuple3
 import Dict
 
@@ -13,6 +12,8 @@ import DirectiveCompliance.ApiCalls exposing (..)
 import DirectiveCompliance.DataTypes exposing (..)
 import DirectiveCompliance.ViewUtils exposing (..)
 import Compliance.Utils exposing (displayComplianceFilters, filterDetailsByCompliance)
+import Ui.Datatable exposing (filterSearch, SortOrder(..), generateLoadingTable)
+
 
 displayRulesComplianceTable : Model -> Html Msg
 displayRulesComplianceTable model =
@@ -41,7 +42,7 @@ displayRulesComplianceTable model =
       Nothing -> (\_ _ -> EQ)
   in
     ( if model.ui.loading then
-      generateLoadingTable
+      generateLoadingTable True 2
       else
       div[][ div [class "table-header extra-filters"]
       [ div[class "main-filters"]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ViewUtils.elm
@@ -14,9 +14,12 @@ import Tuple3
 import NaturalOrdering as N
 
 import DirectiveCompliance.DataTypes exposing (..)
+
 import Compliance.DataTypes exposing (..)
 import Compliance.Utils exposing (..)
 import Compliance.Html exposing (buildComplianceBar)
+import Ui.Datatable exposing (SortOrder(..))
+
 
 onCustomClick : msg -> Html.Attribute msg
 onCustomClick msg =
@@ -258,20 +261,6 @@ searchFieldNodeCompliance n =
   , n.name
   ]
 
-filterSearch : String -> List String -> Bool
-filterSearch filterString searchFields =
-  let
-    -- Join all the fields into one string to simplify the search
-    stringToCheck = searchFields
-      |> String.join "|"
-      |> String.toLower
-
-    searchString  = filterString
-      |> String.toLower
-      |> String.trim
-  in
-    String.contains searchString stringToCheck
-
 
 htmlEscape : String -> String
 htmlEscape s =
@@ -339,40 +328,3 @@ goToBtn link =
 goToIcon : Html Msg
 goToIcon =
   span [ class "btn-goto" ] [ i[class "fa fa-pen"][] ]
-
-generateLoadingTable : Html Msg
-generateLoadingTable =
-  div [class "table-container skeleton-loading", style "margin-top" "17px"]
-  [ div [class "dataTables_wrapper_top table-filter"]
-    [ div [class "form-group"]
-      [ span[][]
-      ]
-    ]
-  , table [class "dataTable"]
-    [ thead []
-      [ tr [class "head"]
-        [ th [][ span[][] ]
-        , th [][ span[][] ]
-        ]
-      ]
-    , tbody []
-      [ tr[] [ td[][span[style "width" "45%"][]], td[][span[][]]]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "30%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "75%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "45%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "70%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "80%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "30%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "75%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "45%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "70%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      ]
-    ]
-  ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Directivecompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Directivecompliance.elm
@@ -16,6 +16,8 @@ import DirectiveCompliance.DataTypes exposing (..)
 import DirectiveCompliance.Init exposing (init)
 import DirectiveCompliance.View exposing (view)
 
+import Ui.Datatable exposing (SortOrder(..))
+
 
 -- PORTS / SUBSCRIPTIONS
 port errorNotification   : String -> Cmd msg

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Env.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Env.elm
@@ -15,6 +15,8 @@ import FileManager.Model exposing (..)
 import FileManager.Vec exposing (..)
 import FileManager.Util exposing (..)
 
+import Ui.Datatable exposing (SortOrder(..))
+
 handleEnvMsg : EnvMsg -> Model -> (Model, Cmd Msg)
 handleEnvMsg msg model = case msg of
   Open () -> ({ model | open = True, dir = ["/"] }, Cmd.none)
@@ -117,10 +119,11 @@ handleEnvMsg msg model = case msg of
             in
               Dict.insert folder (TreeItem folder parents childs) model.tree
 
-        filters = model.filters
-        newFilters = {filters | opened = folder :: filters.opened}
+        tableFilters = model.tableFilters
+        openedRows = Dict.insert folder (folder, Asc) tableFilters.openedRows
+        newFilters = {tableFilters | openedRows = openedRows}
       in
-        ({ model | files = files, selected = [], load = False, tree = newTree, filters = newFilters }, Cmd.none)
+        ({ model | files = files, selected = [], load = False, tree = newTree, tableFilters = newFilters }, Cmd.none)
     Err _ -> (model, Cmd.none)
 
   Refresh result -> case result of

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Model.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Model.elm
@@ -6,6 +6,8 @@ import Http exposing (Error)
 import FileManager.Vec exposing (..)
 import Dict exposing (Dict)
 
+import Ui.Datatable exposing (TableFilters)
+
 type alias Flags =
   { api: String
   , thumbnailsUrl: String
@@ -18,15 +20,6 @@ type alias Flags =
 type ViewMode = ListView | GridView
 
 type SortBy = FileName | FileSize | FileDate | FileRights
-
-type SortOrder = Asc | Desc
-
-type alias Filters =
-  { filter : String
-  , sortBy : SortBy
-  , sortOrder : SortOrder
-  , opened : List String
-  }
 
 type alias Model =
   { api: String
@@ -56,9 +49,9 @@ type alias Model =
   , clipboardFiles: List FileMeta
   , uploadQueue: List File
   , hasWriteRights: Bool
-  , viewMode : ViewMode
-  , filters  : Filters
-  , tree     : Dict String TreeItem
+  , viewMode: ViewMode
+  , tableFilters: TableFilters SortBy
+  , tree: Dict String TreeItem
   }
 
 type alias TreeItem =
@@ -96,7 +89,7 @@ type Msg
   | UpdateApiPath String
   | None
   | ChangeViewMode ViewMode
-  | UpdateFilters Filters
+  | UpdateTableFilters (TableFilters SortBy)
 
 type EnvMsg
   = Open ()

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Update.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Update.elm
@@ -3,17 +3,20 @@ module FileManager.Update exposing (..)
 import Browser.Navigation exposing (reload)
 import File.Download
 import File.Select
-import FileManager.Port exposing (errorNotification)
 import List exposing (map, filter)
 import Http
 import Maybe
 import Dict exposing (Dict)
 
+import FileManager.Port exposing (errorNotification)
 import FileManager.Model exposing (..)
 import FileManager.Vec exposing (..)
 import FileManager.Action exposing (..)
 import FileManager.Env exposing (handleEnvMsg)
 import FileManager.Util exposing (getDirPath, processApiError)
+
+import Ui.Datatable exposing (defaultTableFilters)
+
 
 init : Flags -> (Model, Cmd Msg)
 init flags = (initModel flags, let { api, dir, initRun } = flags in if initRun then listDirectory api [dir] else Cmd.none )
@@ -48,7 +51,7 @@ initModel { api, thumbnailsUrl, downloadsUrl, dir, hasWriteRights } =
   , uploadQueue = []
   , hasWriteRights = hasWriteRights
   , viewMode = GridView
-  , filters = Filters "" FileName Asc []
+  , tableFilters = defaultTableFilters FileName
   , tree = Dict.empty
   }
 
@@ -98,7 +101,7 @@ update msg model = case msg of
     )
   CloseNameDialog ->
       ({ model | dialogState = Closed }, Cmd.none)
-  Name name ->
+  FileManager.Model.Name name ->
    let
      dialogState = case model.dialogState of
                      Closed -> Closed
@@ -156,6 +159,6 @@ update msg model = case msg of
 
   ChangeViewMode viewMode -> ({model | viewMode = viewMode}, Cmd.none)
 
-  UpdateFilters filters -> ({model | filters = filters}, Cmd.none)
+  UpdateTableFilters tableFilters -> ({model | tableFilters = tableFilters}, Cmd.none)
 
   None -> (model, Cmd.none)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/DataTypes.elm
@@ -1,10 +1,12 @@
 module GroupCompliance.DataTypes exposing (..)
 
-import Dict exposing (Dict)
 import Http exposing (Error)
 
 import Compliance.DataTypes exposing (..)
 import Rules.DataTypes exposing (RuleCompliance)
+import Ui.Datatable exposing (TableFilters, SortOrder)
+
+
 --
 -- All our data types
 --
@@ -57,18 +59,11 @@ type alias NodeCompliance =
   , rules             : List (RuleCompliance ValueCompliance)
   }
 
-
-type alias TableFilters =
-  { sortOrder  : SortOrder
-  , filter     : String
-  , openedRows : Dict String (String, SortOrder)
-  }
-
-type SortOrder = Asc | Desc
+type SortBy = Name
 
 type alias UI =
-  { ruleFilters       : TableFilters
-  , nodeFilters       : TableFilters
+  { ruleFilters       : TableFilters SortBy
+  , nodeFilters       : TableFilters SortBy
   , complianceFilters : ComplianceFilters
   , viewMode          : ViewMode
   , loading           : Bool
@@ -90,7 +85,7 @@ type ComplianceScope = GlobalCompliance | TargetedCompliance
 
 type Msg
   = Ignore
-  | UpdateFilters       TableFilters
+  | UpdateFilters       (TableFilters SortBy)
   | UpdateComplianceFilters ComplianceFilters
   | GoTo                String
   | ChangeViewMode      ViewMode

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/Init.elm
@@ -5,12 +5,12 @@ import Dict
 import GroupCompliance.ApiCalls exposing (..)
 import GroupCompliance.DataTypes exposing (..)
 import Compliance.DataTypes exposing (..)
-
+import Ui.Datatable exposing (TableFilters, SortOrder(..), defaultTableFilters)
 
 init : { groupId : String, contextPath : String } -> ( Model, Cmd Msg )
 init flags =
   let
-    initFilters  = (TableFilters Asc "" Dict.empty)
+    initFilters  = defaultTableFilters Name
     initUI       = UI initFilters initFilters (ComplianceFilters False False []) RulesView True False
     initModel    = Model (GroupId flags.groupId) flags.contextPath "" initUI Nothing GlobalCompliance
     listInitActions =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewNodesCompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewNodesCompliance.elm
@@ -5,14 +5,13 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onInput)
 import List
 import List.Extra
-import String
 import Tuple3
 import Dict
 
-import GroupCompliance.ApiCalls exposing (..)
 import GroupCompliance.DataTypes exposing (..)
 import GroupCompliance.ViewUtils exposing (..)
-import Compliance.Utils exposing (displayComplianceFilters, filterDetailsByCompliance)
+import Compliance.Utils exposing (filterDetailsByCompliance)
+import Ui.Datatable exposing (filterSearch, SortOrder(..), generateLoadingTable)
 
 
 displayNodesComplianceTable : Model -> Html Msg
@@ -42,7 +41,7 @@ displayNodesComplianceTable model =
       Nothing -> (\_ _ -> EQ)
   in
     ( if model.ui.loading then
-      generateLoadingTable
+      generateLoadingTable True 2
       else
       div[]
       [ filtersView model

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewRulesCompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewRulesCompliance.elm
@@ -8,10 +8,11 @@ import List.Extra
 import Tuple3
 import Dict
 
-import GroupCompliance.ApiCalls exposing (..)
 import GroupCompliance.DataTypes exposing (..)
 import GroupCompliance.ViewUtils exposing (..)
 import Compliance.Utils exposing (filterDetailsByCompliance)
+import Ui.Datatable exposing (filterSearch, SortOrder(..), generateLoadingTable)
+
 
 displayRulesComplianceTable : Model -> Html Msg
 displayRulesComplianceTable model =
@@ -40,7 +41,7 @@ displayRulesComplianceTable model =
       Nothing -> (\_ _ -> EQ)
   in
     ( if model.ui.loading then
-      generateLoadingTable
+      generateLoadingTable True 2
       else
       div[][ 
         filtersView model

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewUtils.elm
@@ -17,6 +17,8 @@ import NaturalOrdering as N
 import GroupCompliance.DataTypes exposing (..)
 import Compliance.DataTypes exposing (..)
 import Compliance.Utils exposing (..)
+import Ui.Datatable exposing (SortOrder(..))
+
 
 isGlobalCompliance : Model -> Bool
 isGlobalCompliance model =
@@ -71,17 +73,17 @@ byComponentCompliance subFun complianceFilters =
   let
     name = \item ->
       case item of
-        Block b -> b.component
-        Value c -> c.component
+        Compliance.DataTypes.Block b -> b.component
+        Compliance.DataTypes.Value c -> c.component
     compliance = \item ->
       case item of
-        Block b -> b.complianceDetails
-        Value c -> c.complianceDetails
+        Compliance.DataTypes.Block b -> b.complianceDetails
+        Compliance.DataTypes.Value c -> c.complianceDetails
   in
     ItemFun
     ( \item model sortId ->
       case item of
-        Block b ->
+        Compliance.DataTypes.Block b ->
           let
             sortFunction =  subItemOrder (byComponentCompliance subFun complianceFilters) model sortId
           in
@@ -89,7 +91,7 @@ byComponentCompliance subFun complianceFilters =
             |> List.filter (filterByCompliance complianceFilters)
             |> List.sortWith sortFunction
             |> List.map Left
-        Value c ->
+        Compliance.DataTypes.Value c ->
           let
             sortFunction =  subItemOrder subFun model sortId
           in
@@ -110,8 +112,8 @@ byComponentCompliance subFun complianceFilters =
     ))
     ( \x ->
       case x of
-        Block _ -> (List.map Tuple3.first (byComponentCompliance subFun complianceFilters).rows)
-        Value _ ->  (List.map Tuple3.first subFun.rows)
+        Compliance.DataTypes.Block _ -> (List.map Tuple3.first (byComponentCompliance subFun complianceFilters).rows)
+        Compliance.DataTypes.Value _ ->  (List.map Tuple3.first subFun.rows)
     )
     (always True)
 
@@ -268,20 +270,6 @@ searchFieldNodeCompliance n =
   , n.name
   ]
 
-filterSearch : String -> List String -> Bool
-filterSearch filterString searchFields =
-  let
-    -- Join all the fields into one string to simplify the search
-    stringToCheck = searchFields
-      |> String.join "|"
-      |> String.toLower
-
-    searchString  = filterString
-      |> String.toLower
-      |> String.trim
-  in
-    String.contains searchString stringToCheck
-
 -- WARNING:
 --
 -- Here the content is an HTML so it need to be already escaped.
@@ -363,43 +351,6 @@ goToBtn link =
 goToIcon : Html Msg
 goToIcon =
   span [ class "btn-goto" ] [ i[class "fa fa-pen"][] ]
-
-generateLoadingTable : Html Msg
-generateLoadingTable =
-  div [class "table-container skeleton-loading", style "margin-top" "17px"]
-  [ div [class "dataTables_wrapper_top table-filter"]
-    [ div [class "form-group"]
-      [ span[][]
-      ]
-    ]
-  , table [class "dataTable"]
-    [ thead []
-      [ tr [class "head"]
-        [ th [][ span[][] ]
-        , th [][ span[][] ]
-        ]
-      ]
-    , tbody []
-      [ tr[] [ td[][span[style "width" "45%"][]], td[][span[][]]]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "30%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "75%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "45%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "70%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "80%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "30%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "75%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "45%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "70%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      ]
-    ]
-  ]
 
 filtersView : Model -> Html Msg
 filtersView model = 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/DataTypes.elm
@@ -1,7 +1,9 @@
 module GroupRelatedRules.DataTypes exposing (..)
 
 import Http exposing (Error)
-import Rules.DataTypes exposing (Msg(..))
+
+import Ui.Datatable exposing (Category)
+
 
 -- All our data types
 --
@@ -10,18 +12,6 @@ type alias GroupId      = { value : String }
 type alias RuleId       = { value : String }
 type alias DirectiveId  = { value : String }
 type alias RelatedRules = { value : List RuleId }
-
-type alias Category a =
-  { id          : String
-  , name        : String
-  , description : String
-  , subElems    : SubCategories a
-  , elems       : List a
-  }
-
-
-
-type SubCategories a = SubCategories (List (Category a))
 
 type alias Rule =
   { id               : RuleId

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/Init.elm
@@ -1,8 +1,8 @@
 module GroupRelatedRules.Init exposing (..)
 
-import GroupRelatedRules.ApiCalls exposing (..)
 import GroupRelatedRules.DataTypes exposing (..)
-import GroupRelatedRules.ViewUtils exposing (emptyCategory)
+
+import Ui.Datatable exposing (emptyCategory)
 
 
 init : { contextPath : String, includedRules : List String, excludedRules : List String} -> ( Model, Cmd Msg )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/JsonDecoder.elm
@@ -2,7 +2,11 @@ module GroupRelatedRules.JsonDecoder exposing (..)
 
 import Json.Decode exposing (..)
 import Json.Decode.Pipeline exposing (..)
+
 import GroupRelatedRules.DataTypes exposing (..)
+
+import Ui.Datatable exposing (Category, SubCategories(..))
+
 
 decodeGetRulesTree : Decoder (Category Rule)
 decodeGetRulesTree =
@@ -14,7 +18,7 @@ decodeCategory idIdentifier categoryIdentifier elemIdentifier elemDecoder =
     |> required idIdentifier  string
     |> required "name"        string
     |> required "description" string
-    |> required categoryIdentifier (map SubCategories  (list (lazy (\_ -> (decodeCategory idIdentifier categoryIdentifier elemIdentifier elemDecoder)))))
+    |> required categoryIdentifier (map Ui.Datatable.SubCategories  (list (lazy (\_ -> (decodeCategory idIdentifier categoryIdentifier elemIdentifier elemDecoder)))))
     |> required elemIdentifier      (list elemDecoder)
 
 decodeRule : Decoder Rule

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/View.elm
@@ -2,16 +2,17 @@ module GroupRelatedRules.View exposing (..)
 
 import Html exposing (..)
 import Html.Attributes exposing (checked, class, disabled, for, href, id, placeholder, type_, value)
-import Html.Events exposing (onClick)
+import Html.Events exposing (onClick, onInput)
 import List.Extra
 import NaturalOrdering as N
-import Html.Events exposing (onInput)
+import Maybe.Extra
 
 import GroupRelatedRules.DataTypes exposing (..)
 import GroupRelatedRules.ViewUtils exposing (..)
+
 import Rules.DataTypes exposing (missingCategoryId)
-import Maybe.Extra
-import Html.Attributes exposing (style)
+import Ui.Datatable exposing (filterSearch, emptyCategory, Category, getSubElems)
+
 
 view : Model -> Html Msg
 view model =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/ViewUtils.elm
@@ -6,23 +6,8 @@ import Html.Attributes exposing (..)
 
 import GroupRelatedRules.DataTypes exposing (..)
 import Rules.DataTypes exposing (missingCategoryId)
+import Ui.Datatable exposing (Category, SubCategories(..), getSubElems, getAllCats)
 
-emptyCategory : Category a
-emptyCategory =
-  Category "" "" "" (SubCategories []) []
-
-getSubElems: Category a -> List (Category a)
-getSubElems cat =
-  case cat.subElems of
-    SubCategories subs -> subs
-
-
-getAllCats: Category a -> List (Category a)
-getAllCats category =
-  let
-    subElems = case category.subElems of SubCategories l -> l
-  in
-    category :: (List.concatMap getAllCats subElems)
 
 -- get all missing categories
 getAllMissingCats: Category a -> List (Category a)
@@ -39,7 +24,7 @@ filterRuleElemsByIds ids category =
     filteredElems = (copyCat category).elems
   in
     case category.subElems of
-      SubCategories subCats ->
+      Ui.Datatable.SubCategories subCats ->
         let
           newSubCats = List.map (filterRuleElemsByIds ids) subCats
         in
@@ -122,20 +107,6 @@ htmlEscape s =
     |> String.replace "\"" "&quot;"
     |> String.replace "'" "&#x27;"
     |> String.replace "\\" "&#x2F;"
-
-filterSearch : String -> List String -> Bool
-filterSearch filterString searchFields =
-  let
-    -- Join all the fields into one string to simplify the search
-    stringToCheck = searchFields
-      |> String.join "|"
-      |> String.toLower
-
-    searchString  = filterString
-      |> String.toLower
-      |> String.trim
-  in
-    String.contains searchString stringToCheck
 
 filterTags : List Tag -> List Tag -> Bool
 filterTags ruleTags tags =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groupcompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groupcompliance.elm
@@ -9,8 +9,7 @@ import GroupCompliance.ApiCalls exposing (..)
 import GroupCompliance.DataTypes exposing (..)
 import GroupCompliance.Init exposing (init)
 import GroupCompliance.View exposing (view)
-import Editor exposing (clearTooltips)
-
+import Ui.Datatable exposing (TableFilters, SortOrder(..))
 
 -- PORTS / SUBSCRIPTIONS
 port errorNotification   : String -> Cmd msg

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Grouprelatedrules.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Grouprelatedrules.elm
@@ -10,6 +10,8 @@ import GroupRelatedRules.Init exposing (init)
 import GroupRelatedRules.View exposing (view)
 import GroupRelatedRules.ViewUtils exposing (..)
 
+import Ui.Datatable exposing (Category, emptyCategory, getAllCats)
+
 
 -- PORTS / SUBSCRIPTIONS
 port errorNotification    : String -> Cmd msg

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups.elm
@@ -5,14 +5,14 @@ import Dict
 import Dict.Extra
 import Http exposing (..)
 
-import GroupCompliance.ApiCalls exposing (..)
-import GroupCompliance.ViewUtils exposing (..)
 
 import Groups.ApiCalls exposing (..)
 import Groups.DataTypes exposing (..)
 import Groups.Init exposing (init)
 import Groups.View exposing (view)
 import Groups.ViewUtils exposing (..)
+
+import Ui.Datatable exposing (getAllCats)
 
 
 -- PORTS / SUBSCRIPTIONS

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/DataTypes.elm
@@ -8,6 +8,9 @@ import Compliance.DataTypes exposing (ComplianceDetails)
 import GroupRelatedRules.DataTypes exposing (GroupId)
 import Set
 
+import Ui.Datatable exposing (TableFilters, Category, SubCategories(..), getAllElems)
+
+
 type alias Model =
   { contextPath : String
   , mode        : Mode
@@ -33,16 +36,6 @@ type alias ComplianceSummaryValue =
   , complianceDetails : ComplianceDetails
   }
 
-type alias Category a =
-  { id          : String
-  , name        : String
-  , description : String
-  , subElems    : SubCategories a
-  , elems       : List a
-  }
-
-type SubCategories a = SubCategories (List (Category a))
-
 type alias Group =
   { id          : GroupId
   , name        : String
@@ -53,12 +46,6 @@ type alias Group =
   , target      : String
   }
 
-getAllElems: Category a -> List a
-getAllElems category =
-  let
-    subElems = case category.subElems of SubCategories l -> l
-  in
-    List.append category.elems (List.concatMap getAllElems subElems)
 
 -- Get all groups for which the compliance summary is defined
 getElemsWithCompliance: Model -> List Group
@@ -90,7 +77,7 @@ type alias UI =
 type ModalState = NoModal | ExternalModal
 
 type alias Filters =
-  { tableFilters : TableFilters
+  { tableFilters : TableFilters SortBy
   , treeFilters  : TreeFilters
   }
 
@@ -100,18 +87,11 @@ type SortBy
   | GlobalCompliance
   | TargetedCompliance
 
-type alias TableFilters =
-  { sortBy     : SortBy
-  , sortOrder  : SortOrder
-  , filter     : String
-  }
-
 type alias TreeFilters =
   { filter : String
   , folded : List String
   }
 
-type SortOrder = Asc | Desc
 
 -- The fixed group category ID for the root group category
 rootGroupCategoryId : String

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/Init.elm
@@ -4,14 +4,15 @@ import Dict
 
 import Groups.ApiCalls exposing (..)
 import Groups.DataTypes exposing (..)
-import Compliance.DataTypes exposing (..)
+
+import Ui.Datatable exposing (defaultTableFilters, Category, SubCategories(..))
 
 
 init : { contextPath : String, hasGroupToDisplay : Bool, hasWriteRights : Bool } -> ( Model, Cmd Msg )
 init flags =
   let
     initCategory = Category "" "" "" (SubCategories []) []
-    initTableFilters  = (TableFilters Name Asc "")
+    initTableFilters  = defaultTableFilters Name
     initTreeFilters   = (TreeFilters "" [])
     initFilters       = Filters initTableFilters initTreeFilters
     initUI       = UI initFilters NoModal flags.hasWriteRights True

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/JsonDecoder.elm
@@ -5,7 +5,9 @@ import Json.Decode.Pipeline exposing (..)
 
 import Groups.DataTypes exposing (..)
 import GroupCompliance.DataTypes exposing (GroupId)
+
 import Compliance.JsonDecoder exposing (decodeComplianceDetails)
+import Ui.Datatable exposing (Category, SubCategories(..))
 
 
 decodeGetGroupsCompliance : Decoder (List GroupComplianceSummary)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/View.elm
@@ -11,6 +11,9 @@ import Groups.DataTypes exposing (..)
 import Groups.ViewGroupsTable exposing (..)
 import Groups.ViewUtils exposing (..)
 
+import Ui.Datatable exposing (filterSearch, Category, generateLoadingTable)
+
+
 view : Model -> Html Msg
 view model = 
   let
@@ -86,8 +89,8 @@ view model =
     treeFilters = groupFilters.treeFilters
 
     templateMain = case model.mode of
-      Loading -> generateLoadingTable
-      LoadingTable -> generateLoadingTable
+      Loading -> generateLoadingTable False 5
+      LoadingTable -> generateLoadingTable False 5
       GroupTable   ->
         div [class "main-table"]
         [ div [class "table-container"]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/ViewGroupsTable.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/ViewGroupsTable.elm
@@ -5,10 +5,13 @@ import Html exposing (Html, i, text, td, th, tr)
 import Html.Attributes exposing (class, colspan, rowspan)
 import Html.Events exposing (onClick)
 
-import Compliance.Html exposing (buildComplianceBar)
-import Compliance.Utils exposing (defaultComplianceFilter)
 import Groups.DataTypes exposing (..)
 import Groups.ViewUtils exposing (..)
+
+import Compliance.Html exposing (buildComplianceBar)
+import Compliance.Utils exposing (defaultComplianceFilter)
+import Ui.Datatable exposing (filterSearch, sortTable, thClass)
+
 
 buildGroupsTable : Model -> List Group -> List(Html Msg)
 buildGroupsTable model groups =
@@ -48,17 +51,20 @@ buildGroupsTable model groups =
 
 groupsTableHeader : Filters -> Html Msg
 groupsTableHeader groupFilters =
- tr [class "head"]
- [ th [ class (thClass groupFilters.tableFilters Name) , rowspan 1, colspan 1
-       , onClick (UpdateGroupFilters (sortTable groupFilters Name))
+  let
+    tableFilters = groupFilters.tableFilters
+  in
+    tr [class "head"]
+    [ th [ class (thClass tableFilters Name) , rowspan 1, colspan 1
+       , onClick (UpdateGroupFilters { groupFilters | tableFilters = (sortTable tableFilters Name)})
        ] [ text "Name" ]
- , th [ class (thClass groupFilters.tableFilters Parent) , rowspan 1, colspan 1
-      , onClick (UpdateGroupFilters (sortTable groupFilters Parent))
+    , th [ class (thClass tableFilters Parent) , rowspan 1, colspan 1
+      , onClick (UpdateGroupFilters { groupFilters | tableFilters = (sortTable tableFilters Parent)})
       ] [ text "Category" ]
- , th [ class ((thClass groupFilters.tableFilters GlobalCompliance) ++ " compliance-col"), rowspan 1, colspan 1
-      , onClick (UpdateGroupFilters (sortTable groupFilters GlobalCompliance))
+    , th [ class ((thClass tableFilters GlobalCompliance) ++ " compliance-col"), rowspan 1, colspan 1
+      , onClick (UpdateGroupFilters { groupFilters | tableFilters = (sortTable tableFilters GlobalCompliance)})
       ] [ text "Global compliance" ]
- , th [ class ((thClass groupFilters.tableFilters TargetedCompliance) ++ " compliance-col"), rowspan 1, colspan 1
-      , onClick (UpdateGroupFilters (sortTable groupFilters TargetedCompliance))
+    , th [ class ((thClass tableFilters TargetedCompliance) ++ " compliance-col"), rowspan 1, colspan 1
+      , onClick (UpdateGroupFilters { groupFilters | tableFilters = (sortTable tableFilters TargetedCompliance)})
       ] [ text "Targeted compliance" ]
- ]
+    ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/DataTypes.elm
@@ -1,10 +1,10 @@
 module NodeCompliance.DataTypes exposing (..)
 
-import Dict exposing (Dict)
 import Http exposing (Error)
 
 import Compliance.DataTypes exposing (..)
-import Rules.DataTypes exposing (Rule, Directive)
+import Ui.Datatable exposing (TableFilters, SortOrder)
+
 
 --
 -- All our data types
@@ -14,6 +14,7 @@ type alias RuleId      = { value : String }
 type alias DirectiveId = { value : String }
 type alias NodeId      = { value : String }
 
+type SortBy = Name
 
 type alias NodeCompliance =
   { nodeId            : NodeId
@@ -43,16 +44,9 @@ type alias DirectiveCompliance value =
   , components        : List (ComponentCompliance value)
   }
 
-type alias TableFilters =
-  { sortOrder  : SortOrder
-  , filter     : String
-  , openedRows : Dict String (String, SortOrder)
-  }
-
-type SortOrder = Asc | Desc
 
 type alias UI =
-  { tableFilters      : TableFilters
+  { tableFilters      : (TableFilters SortBy)
   , complianceFilters : ComplianceFilters
   , loading           : Bool
   }
@@ -68,7 +62,7 @@ type alias Model =
 
 type Msg
   = Ignore
-  | UpdateFilters       TableFilters
+  | UpdateFilters       (TableFilters SortBy)
   | UpdateComplianceFilters ComplianceFilters
   | GoTo                String
   | ToggleRow           String String

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/Init.elm
@@ -5,11 +5,13 @@ import Dict exposing (Dict)
 import NodeCompliance.ApiCalls exposing (..)
 import NodeCompliance.DataTypes exposing (..)
 import Compliance.DataTypes exposing (..)
+import Ui.Datatable exposing (defaultTableFilters)
+
 
 init : { nodeId : String, contextPath : String, onlySystem : Bool} -> ( Model, Cmd Msg )
 init flags =
   let
-    initFilters  = (TableFilters Asc "" Dict.empty)
+    initFilters  = defaultTableFilters Name
     initUI       = UI initFilters (ComplianceFilters False False []) True
     initModel    = Model (DirectiveId flags.nodeId) flags.contextPath "" initUI Nothing flags.onlySystem
     listInitActions =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/View.elm
@@ -9,10 +9,10 @@ import Tuple3
 import Dict
 import List.Extra
 
-import NodeCompliance.ApiCalls exposing (..)
 import NodeCompliance.DataTypes exposing (..)
 import NodeCompliance.ViewUtils exposing (..)
 import Compliance.Utils exposing (displayComplianceFilters, filterDetailsByCompliance)
+import Ui.Datatable exposing (filterSearch, SortOrder(..), generateLoadingTable)
 
 
 view : Model -> Html Msg
@@ -46,7 +46,7 @@ view model =
           Nothing -> (\_ _ -> EQ)
       in
         ( if mod.ui.loading then
-          generateLoadingTable
+          generateLoadingTable True 2
           else
           div[]
           [ div [class "table-header extra-filters"]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/ViewUtils.elm
@@ -16,6 +16,8 @@ import NodeCompliance.DataTypes exposing (..)
 import Compliance.DataTypes exposing (..)
 import Compliance.Utils exposing (..)
 import Compliance.Html exposing (buildComplianceBar)
+import Ui.Datatable exposing (SortOrder(..))
+
 
 onCustomClick : msg -> Html.Attribute msg
 onCustomClick msg =
@@ -248,20 +250,6 @@ searchFieldNodeCompliance n =
   , n.name
   ]
 
-filterSearch : String -> List String -> Bool
-filterSearch filterString searchFields =
-  let
-    -- Join all the fields into one string to simplify the search
-    stringToCheck = searchFields
-      |> String.join "|"
-      |> String.toLower
-
-    searchString  = filterString
-      |> String.toLower
-      |> String.trim
-  in
-    String.contains searchString stringToCheck
-
 
 htmlEscape : String -> String
 htmlEscape s =
@@ -328,40 +316,3 @@ goToBtn link =
 goToIcon : Html Msg
 goToIcon =
   span [ class "btn-goto" ] [ i[class "fa fa-pen"][] ]
-
-generateLoadingTable : Html Msg
-generateLoadingTable =
-  div [class "table-container skeleton-loading", style "margin-top" "17px"]
-  [ div [class "dataTables_wrapper_top table-filter"]
-    [ div [class "form-group"]
-      [ span[][]
-      ]
-    ]
-  , table [class "dataTable"]
-    [ thead []
-      [ tr [class "head"]
-        [ th [][ span[][] ]
-        , th [][ span[][] ]
-        ]
-      ]
-    , tbody []
-      [ tr[] [ td[][span[style "width" "45%"][]], td[][span[][]]]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "30%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "75%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "45%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "70%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "80%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "30%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "75%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "45%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      , tr[] [ td[][span[style "width" "70%"][]], td[][span[][]] ]
-      , tr[] [ td[][span[][]], td[][span[][]] ]
-      ]
-    ]
-  ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/DataTypes.elm
@@ -4,6 +4,9 @@ import List.Extra
 import Http exposing (Error)
 import Dict exposing (Dict)
 import Json.Encode exposing (Value)
+
+import Ui.Datatable exposing (TableFilters)
+
 --
 -- All our data types
 --
@@ -40,19 +43,10 @@ type alias ParentGroupProperty = { id : String, name : String, valueType : Strin
 type alias ParentNodeProperty = { id : String, name : String, valueType : String }
 type ParentProperty = ParentGlobal ParentGlobalProperty | ParentGroup ParentGroupProperty | ParentNode ParentNodeProperty
 
-
-type SortOrder = Asc | Desc
-
 type SortBy
   = Name
   | Format
   | Value
-
-type alias TableFilters =
-  { sortBy    : SortBy
-  , sortOrder : SortOrder
-  , filter    : String
-  }
 
 type alias UI =
   { hasNodeWrite     : Bool
@@ -61,7 +55,7 @@ type alias UI =
   , modalState       : ModalState
   , editedProperties : Dict String EditProperty
   , showMore         : List String
-  , filters          : TableFilters
+  , filters          : TableFilters SortBy
   }
 
 type alias Model =
@@ -86,7 +80,7 @@ type Msg
   | ToggleEditPopup ModalState
   | ClosePopup Msg
   | ToggleEditProperty String EditProperty Bool
-  | UpdateTableFilters TableFilters
+  | UpdateTableFilters (TableFilters SortBy)
   | ShowMore String
 
 valueTypeToValueFormat : String -> ValueFormat

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/Init.elm
@@ -5,11 +5,13 @@ import Dict exposing (Dict)
 import NodeProperties.DataTypes exposing (..)
 import NodeProperties.ApiCalls exposing (getNodeProperties)
 
+import Ui.Datatable exposing (defaultTableFilters)
+
 
 init : { contextPath : String, hasNodeWrite : Bool, hasNodeRead : Bool, nodeId : String, objectType : String} -> ( Model, Cmd Msg )
 init flags =
   let
-    initUi = UI flags.hasNodeWrite flags.hasNodeRead True NoModal Dict.empty [] (TableFilters Name Asc "")
+    initUi = UI flags.hasNodeWrite flags.hasNodeRead True NoModal Dict.empty [] (defaultTableFilters Name)
     initModel = Model flags.contextPath flags.nodeId flags.objectType [] (EditProperty "" "" StringFormat True True False) initUi
   in
     ( initModel

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/View.elm
@@ -10,6 +10,8 @@ import NodeProperties.DataTypes exposing (..)
 import NodeProperties.ViewUtils exposing (..)
 import NodeProperties.ApiCalls exposing (getNodeProperties)
 
+import Ui.Datatable exposing (thClass, sortTable)
+
 
 view : Model -> Html Msg
 view model =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ViewUtils.elm
@@ -1,58 +1,19 @@
 module NodeProperties.ViewUtils exposing (..)
 
 import Html exposing (..)
-import Html.Attributes exposing (id, class, href, type_, attribute, disabled, for, checked, selected, value, title, placeholder, style, tabindex    )
+import Html.Attributes exposing (id, class, type_, attribute, value, title, placeholder, style, tabindex)
 import Html.Events exposing (onClick, onInput)
 import Json.Decode exposing (decodeValue)
-import Maybe.Extra exposing (isJust)
 import List.Extra
 import Dict exposing (Dict)
 import Json.Encode exposing (..)
-import NaturalOrdering as N exposing (compare)
+import NaturalOrdering as N
 import SyntaxHighlight exposing (useTheme, gitHub, json, toInlineHtml)
 
 import NodeProperties.DataTypes exposing (..)
 import NodeProperties.ApiCalls exposing (deleteProperty)
-import Json.Decode exposing (decodeString)
-import Set exposing (Set)
 
-
-searchString : String -> String
-searchString str = str
-  |> String.toLower
-  |> String.trim
-
-filterSearch : String -> List String -> Bool
-filterSearch filterString searchFields =
-  let
-    -- Join all the fields into one string to simplify the search
-    stringToCheck = searchFields
-      |> String.join "|"
-      |> String.toLower
-  in
-    String.contains (searchString filterString) stringToCheck
-
-thClass : TableFilters -> SortBy -> String
-thClass tableFilters sortBy =
-  if sortBy == tableFilters.sortBy then
-    case  tableFilters.sortOrder of
-      Asc  -> "sorting_asc"
-      Desc -> "sorting_desc"
-  else
-    "sorting"
-
-sortTable : TableFilters -> SortBy -> TableFilters
-sortTable tableFilters sortBy =
-  let
-    order =
-      case tableFilters.sortOrder of
-        Asc -> Desc
-        Desc -> Asc
-  in
-    if sortBy == tableFilters.sortBy then
-      { tableFilters | sortOrder = order}
-    else
-      { tableFilters | sortBy = sortBy, sortOrder = Asc}
+import Ui.Datatable exposing (SortOrder(..), filterSearch)
 
 
 getFormat : Property -> ValueFormat
@@ -118,7 +79,6 @@ getSortFunction : Model -> Property -> Property -> Order
 getSortFunction model p1 p2 =
   let
     order = case model.ui.filters.sortBy of
-      Name    -> N.compare p1.name p2.name
       Format  ->
         let
           formatP1 = getFormat p1
@@ -130,6 +90,7 @@ getSortFunction model p1 p2 =
             (StringFormat, JsonFormat) -> GT
             (JsonFormat, StringFormat) -> LT
       Value   -> N.compare (Json.Encode.encode 0 p1.value) (Json.Encode.encode 0 p2.value)
+      _       -> N.compare p1.name p2.name
   in
     if model.ui.filters.sortOrder == Asc then
       order

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Nodecompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Nodecompliance.elm
@@ -10,6 +10,8 @@ import NodeCompliance.DataTypes exposing (..)
 import NodeCompliance.Init exposing (init)
 import NodeCompliance.View exposing (view)
 
+import Ui.Datatable exposing (SortOrder(..))
+
 
 -- PORTS / SUBSCRIPTIONS
 port errorNotification   : String -> Cmd msg

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
@@ -12,12 +12,14 @@ import Random
 import UUID
 import Json.Encode exposing (..)
 
-
 import Rules.ApiCalls exposing (..)
 import Rules.DataTypes exposing (..)
 import Rules.Init exposing (init)
 import Rules.View exposing (view)
 import Rules.ViewUtils exposing (..)
+
+import Ui.Datatable exposing (SortOrder(..), Category, SubCategories(..))
+
 
 -- PORTS / SUBSCRIPTIONS
 port linkSuccessNotification : Value -> Cmd msg

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ApiCalls.elm
@@ -3,7 +3,6 @@ module Rules.ApiCalls exposing (..)
 import Http exposing (..)
 import Time.Iso8601
 import Time.ZonedDateTime exposing (ZonedDateTime)
-import Url
 import Url.Builder exposing (QueryParameter, int, string)
 import Maybe.Extra exposing (isJust)
 import List.Extra exposing (find)
@@ -12,6 +11,8 @@ import Rules.DataTypes exposing (..)
 import Rules.JsonDecoder exposing (..)
 import Rules.JsonEncoder exposing (..)
 import Rules.ChangeRequest exposing (changeRequestParameters, decodeGetChangeRequestSettings, decodePendingChangeRequests)
+
+import Ui.Datatable exposing (getAllElems, Category)
 
 --
 -- This files contains all API calls for the Rules UI

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
@@ -6,6 +6,7 @@ import Http exposing (Error)
 import Rules.ChangeRequest exposing (ChangeRequest, ChangeRequestSettings)
 import Time.ZonedDateTime exposing (ZonedDateTime)
 
+import Ui.Datatable exposing (TableFilters, SortOrder, Category, getAllElems, getAllCats, getSubElems)
 
 
 --
@@ -101,19 +102,6 @@ type alias NodeInfo =
     }
 
 
-type alias Category a =
-    { id : String
-    , name : String
-    , description : String
-    , subElems : SubCategories a
-    , elems : List a
-    }
-
-
-type SubCategories a
-    = SubCategories (List (Category a))
-
-
 type alias Group =
     { id : String
     , name : String
@@ -123,36 +111,6 @@ type alias Group =
     , enabled : Bool
     , target : String
     }
-
-
-getAllElems : Category a -> List a
-getAllElems category =
-    let
-        subElems =
-            case category.subElems of
-                SubCategories l ->
-                    l
-    in
-    List.append category.elems (List.concatMap getAllElems subElems)
-
-
-getSubElems : Category a -> List (Category a)
-getSubElems cat =
-    case cat.subElems of
-        SubCategories subs ->
-            subs
-
-
-getAllCats : Category a -> List (Category a)
-getAllCats category =
-    let
-        subElems =
-            case category.subElems of
-                SubCategories l ->
-                    l
-    in
-    category :: List.concatMap getAllCats subElems
-
 
 
 -- get all missing categories
@@ -214,11 +172,6 @@ type alias DirectiveCompliance value =
     , skippedDetails : Maybe SkippedDetails
     , components : List (ComponentCompliance value)
     }
-
-
-type SortOrder
-    = Asc
-    | Desc
 
 
 type alias NodeValueCompliance =
@@ -283,22 +236,6 @@ type Mode
     | CategoryForm CategoryDetails
 
 
-type SortBy
-    = Name
-    | Parent
-    | Status
-    | Compliance
-    | RuleChanges
-
-
-type alias TableFilters =
-    { sortBy : SortBy
-    , sortOrder : SortOrder
-    , filter : String
-    , unfolded : List String
-    }
-
-
 type alias TreeFilters =
     { filter : String
     , folded : List String
@@ -306,9 +243,15 @@ type alias TreeFilters =
     , tags : List Tag
     }
 
+type SortBy
+    = Name
+    | Parent
+    | Status
+    | Compliance
+    | RuleChanges
 
 type alias Filters =
-    { tableFilters : TableFilters
+    { tableFilters : TableFilters SortBy
     , treeFilters : TreeFilters
     }
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/Init.elm
@@ -4,14 +4,16 @@ import Dict
 
 import Rules.ApiCalls exposing (..)
 import Rules.DataTypes exposing (..)
-import Compliance.DataTypes exposing (..)
+
 import Compliance.Utils exposing (defaultComplianceFilter)
+import Ui.Datatable exposing (defaultTableFilters, Category, SubCategories(..))
+
 
 init : { contextPath : String, hasWriteRights : Bool } -> ( Model, Cmd Msg )
 init flags =
   let
     initCategory = Category "" "" "" (SubCategories []) []
-    initFilters  = Filters (TableFilters Name Asc "" []) (TreeFilters "" [] (Tag "" "") [])
+    initFilters  = Filters (defaultTableFilters Name) (TreeFilters "" [] (Tag "" "") [])
     initUI       = UI initFilters initFilters initFilters defaultComplianceFilter NoModal flags.hasWriteRights True False False Nothing
     initModel    = Model flags.contextPath Loading "" initCategory initCategory initCategory Dict.empty Dict.empty Dict.empty Dict.empty initUI
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/JsonDecoder.elm
@@ -13,7 +13,7 @@ import Tuple
 import Rules.DataTypes exposing (..)
 import Compliance.DataTypes exposing (..)
 import Compliance.JsonDecoder exposing (decodeComplianceDetails)
-
+import Ui.Datatable exposing (Category, SubCategories(..))
 
 -- GENERAL
 decodeGetPolicyMode : Decoder String

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/JsonEncoder.elm
@@ -3,7 +3,9 @@ module Rules.JsonEncoder exposing (..)
 import Json.Encode exposing (..)
 
 import Rules.DataTypes exposing (..)
-import Rules.ChangeRequest exposing (ChangeRequestSettings)
+
+import Ui.Datatable exposing (Category)
+
 
 encodeRuleDetails: Rule -> Value
 encodeRuleDetails ruleDetails =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/View.elm
@@ -7,7 +7,7 @@ import List
 import List.Extra
 import Maybe.Extra exposing (isNothing)
 import String
-import NaturalOrdering as N exposing (compare)
+import NaturalOrdering as N
 
 import Rules.ApiCalls exposing (..)
 import Rules.DataTypes exposing (..)
@@ -16,6 +16,9 @@ import Rules.ViewRulesTable exposing (..)
 import Rules.ViewRuleDetails exposing (..)
 import Rules.ViewUtils exposing (..)
 import Rules.ChangeRequest exposing (ChangeRequestSettings)
+
+import Ui.Datatable exposing (filterSearch, Category, getSubElems, generateLoadingTable)
+
 
 view : Model -> Html Msg
 view model =
@@ -110,7 +113,7 @@ view model =
     newTag      = ruleFilters.treeFilters.newTag
 
     templateMain = case model.mode of
-      Loading -> generateLoadingTable
+      Loading -> generateLoadingTable False 5
       RuleTable   ->
         div [class "main-table"]
         [ div [class "table-container"]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewCategoryDetails.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewCategoryDetails.elm
@@ -13,6 +13,8 @@ import Rules.ViewRulesTable exposing (buildRulesTable)
 import Rules.ViewTabContent exposing (buildListCategories)
 import Rules.ViewUtils exposing (btnSave, getListRules, rulesTableHeader)
 
+import Ui.Datatable exposing (getSubElems, getAllCats)
+
 
 --
 -- This file contains all methods to display the details of the selected category.

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRulesTable.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRulesTable.elm
@@ -12,6 +12,8 @@ import Rules.ViewUtils exposing (..)
 
 import Compliance.Utils exposing (getAllComplianceValues, defaultComplianceFilter)
 import Compliance.Html exposing (buildComplianceBar)
+import Ui.Datatable exposing (SortOrder(..), filterSearch)
+
 
 --
 -- This file contains all methods to display the Rules table
@@ -21,7 +23,6 @@ getSortFunction : Model -> Rule -> Rule -> Order
 getSortFunction model r1 r2 =
   let
     order = case model.ui.ruleFilters.tableFilters.sortBy of
-      Name       -> NaturalOrdering.compare r1.name r2.name
       RuleChanges->
         let
           getChanges = \r -> countRecentChanges r.id model.changes
@@ -56,6 +57,7 @@ getSortFunction model r1 r2 =
           r2Compliance = getCompliance (getRuleCompliance model r2.id)
         in
           compare r1Compliance r2Compliance
+      _ -> NaturalOrdering.compare r1.name r2.name
   in
     if model.ui.ruleFilters.tableFilters.sortOrder == Asc then
       order

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabContent.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabContent.elm
@@ -17,9 +17,11 @@ import Rules.DataTypes exposing (..)
 import Rules.ViewRepairedReports
 import Rules.ViewUtils exposing (..)
 import Rules.ChangeRequest exposing (toLabel)
+
 import Compliance.DataTypes exposing (..)
 import Compliance.Utils exposing (displayComplianceFilters, filterDetailsByCompliance, defaultComplianceFilter)
 import Compliance.Html exposing (buildComplianceBar)
+import Ui.Datatable exposing (SortOrder(..), filterSearch, Category, getSubElems, getAllElems)
 
 
 --

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Ui/Datatable.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Ui/Datatable.elm
@@ -1,0 +1,172 @@
+module Ui.Datatable exposing (..)
+
+import Dict exposing (Dict)
+import Html exposing (Html, table, thead, tbody, tr, th, td, div, span, text)
+import Html.Attributes exposing (class, style)
+
+type SortOrder
+    = Asc
+    | Desc
+{--
+type SortBy
+    = Hostname
+    | PolicyServer
+    | Ram
+    | AgentVersion
+    | Software String
+    | NodeProperty String Bool
+    | PolicyMode
+    | IpAddresses
+    | MachineType
+    | Kernel
+    | Os
+    | NodeCompliance
+    | LastRun
+    | InventoryDate
+    | Name
+    | Id
+    | ExpDate
+    | CreDate
+    | Parent
+    | Status
+    | Compliance
+    | RuleChanges
+    | FileName
+    | FileSize
+    | FileDate
+    | FileRights
+    | GlobalCompliance
+    | TargetedCompliance
+    | Format
+    | Value
+--}
+type alias TableFilters sortBy =
+  { sortBy     : sortBy
+  , sortOrder  : SortOrder
+  , filter     : String
+  , openedRows : Dict String (String, SortOrder)
+  }
+
+defaultTableFilters : sortBy -> TableFilters sortBy
+defaultTableFilters sortBy =
+    TableFilters sortBy Asc "" Dict.empty
+
+thClass : TableFilters sortBy -> sortBy -> String
+thClass tableFilters sortBy =
+  if sortBy == tableFilters.sortBy then
+    case  tableFilters.sortOrder of
+      Asc  -> "sorting_asc"
+      Desc -> "sorting_desc"
+  else
+    "sorting"
+
+sortTable : TableFilters sortBy -> sortBy -> TableFilters sortBy
+sortTable tableFilters sortBy =
+  let
+    order =
+      case tableFilters.sortOrder of
+        Asc -> Desc
+        Desc -> Asc
+  in
+    if sortBy == tableFilters.sortBy then
+      { tableFilters | sortOrder = order}
+    else
+      { tableFilters | sortBy = sortBy, sortOrder = Asc}
+
+filterSearch : String -> List String -> Bool
+filterSearch filterString searchFields =
+    let
+        -- Join all the fields into one string to simplify the search
+        stringToCheck =
+            searchFields
+                |> String.join "|"
+                |> String.toLower
+
+        searchString =
+            filterString
+                |> String.toLower
+                |> String.trim
+    in
+        String.contains searchString stringToCheck
+
+
+
+--
+-- COMPLIANCE TABLES
+--
+type alias Category a =
+  { id          : String
+  , name        : String
+  , description : String
+  , subElems    : SubCategories a
+  , elems       : List a
+  }
+
+type SubCategories a = SubCategories (List (Category a))
+
+getAllElems : Category a -> List a
+getAllElems category =
+    let
+        subElems =
+            case category.subElems of
+                SubCategories l ->
+                    l
+    in
+    List.append category.elems (List.concatMap getAllElems subElems)
+
+
+getSubElems : Category a -> List (Category a)
+getSubElems cat =
+    case cat.subElems of
+        SubCategories subs ->
+            subs
+
+
+getAllCats : Category a -> List (Category a)
+getAllCats category =
+    let
+        subElems =
+            case category.subElems of
+                SubCategories l ->
+                    l
+    in
+    category :: List.concatMap getAllCats subElems
+
+
+emptyCategory : Category a
+emptyCategory =
+    Category "" "" "" (SubCategories []) []
+
+
+---
+--- LOADING ANIMATION
+---
+generateLoadingTable : Bool -> Int -> Html msg
+generateLoadingTable withFilter nbColumns =
+    let
+        nbRows = 20
+        filter =
+            if withFilter then
+                div [class "dataTables_wrapper_top table-filter"]
+                [ div [class "form-group"]
+                    [ span[][]
+                    ]
+                ]
+            else
+                text ""
+    in
+        div [class "table-container skeleton-loading"]
+          [ filter
+          , table [class "dataTable"]
+            [ thead []
+              [ tr [class "head"]
+                ( List.repeat nbColumns (th [][ span[][] ])
+                )
+              ]
+            , tbody []
+              ( List.repeat nbRows
+                ( tr [] ( List.repeat (nbColumns) ( td[][span[][]] ) )
+                )
+              )
+            ]
+          ]

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
@@ -1193,6 +1193,7 @@ ul {
 .rudder-template .table-container.skeleton-loading th > span{
   width: 50%;
   height: 20px;
+  min-width: 25%;
 }
 .rudder-template ul.skeleton-loading > ul{
   padding: 0 0 0 50px;
@@ -1200,6 +1201,23 @@ ul {
 .rudder-template .template-main .main-table .table-container.skeleton-loading .dataTables_wrapper_top.table-filter{
   margin-top: 50px;
 }
+
+
+// Randomize width of loading table elements
+@function randomWidth($min, $max) {
+  $rand: random();
+  $randomW: $min + floor($rand * (($max - $min) + 1));
+  @return $randomW * 1%;
+}
+$nbRows: 20;
+@for $i from 1 through $nbRows {
+  .rudder-template .table-container.skeleton-loading tr {
+    &:nth-child(#{$i}) td:first-child > span{
+      width: randomWidth(25, 85);
+    }
+  }
+}
+
 /* === TOGGLE CHECKBOX ===*/
 .rudder-template .toggle-checkbox-container{
   width: 100%;


### PR DESCRIPTION
https://issues.rudder.io/issues/24769

There is now a new 'UI' folder that will contain all the modules linked to UI components (datatables, trees, notifications, etc.).

I've created an initial Datatable.elm module that groups together all the factorisable code for managing datables, and all this duplicated code has been removed from the applications. Now you just need to import this module to be able to use its functions