### PR TITLE
Fixes #24839: We cannot login with a user login containing uppercase letter if the option case-sensitivity is set to false

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
@@ -38,7 +38,9 @@ package com.normation.rudder.users
  */
 
 import cats.data.NonEmptyList
+import com.normation.errors.Inconsistency
 import com.normation.errors.IOResult
+import com.normation.errors.SystemError
 import com.normation.rudder.db.Doobie
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.utils.DateFormaterService
@@ -47,6 +49,7 @@ import doobie.*
 import doobie.free.connection.unit as connectionUnit
 import doobie.implicits.*
 import doobie.postgres.implicits.*
+import doobie.util.invariant.UnexpectedContinuation
 import org.joda.time.DateTime
 import zio.*
 import zio.interop.catz.*
@@ -195,7 +198,7 @@ trait UserRepository {
    */
   def getAll(): IOResult[List[UserInfo]]
 
-  def get(userId: String): IOResult[Option[UserInfo]]
+  def get(userId: String, isCaseSensitive: Boolean = true): IOResult[Option[UserInfo]]
 }
 
 object UserRepository {
@@ -487,8 +490,14 @@ class InMemoryUserRepository(userBase: Ref[Map[String, UserInfo]], sessionBase: 
     }
   }
 
-  override def get(userId: String): IOResult[Option[UserInfo]] = {
-    userBase.get.map(_.get(userId))
+  override def get(userId: String, isCaseSensitive: Boolean): IOResult[Option[UserInfo]] = {
+    userBase.get.flatMap(_.collect {
+      case (k, v) if (if (isCaseSensitive) k == userId else k.equalsIgnoreCase(userId)) => v
+    } match {
+      case Nil      => ZIO.none
+      case u :: Nil => ZIO.some(u)
+      case _        => Left(Inconsistency(s"Multiple users found for id '${userId}'")).toIO
+    })
   }
 
   override def updateInfo(
@@ -860,10 +869,17 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
     transactIOResult(s"Error when retrieving user information")(xa => sql.query[UserInfo].to[List].transact(xa))
   }
 
-  override def get(userId: String): IOResult[Option[UserInfo]] = {
-    val sql = sql"""select * from users where id = ${userId}"""
+  override def get(userId: String, isCaseSensitive: Boolean): IOResult[Option[UserInfo]] = {
+    val filter = if (isCaseSensitive) fr"id = ${userId} " else fr"lower(id) = ${userId.toLowerCase()}"
+    val sql    = fr"""select * from users where""" ++ filter
 
-    transactIOResult(s"Error when retrieving user information for '${userId}'")(xa => sql.query[UserInfo].option.transact(xa))
+    // When resultset is exhausted, it means we have many conflicting users, we raise an Inconsistency error
+    transactIOResult(s"Error when retrieving user information for '${userId}'")(xa =>
+      sql.query[UserInfo].option.transact(xa)
+    ).mapError {
+      case SystemError(_, UnexpectedContinuation) => Inconsistency(s"Multiple users found for id '${userId}'")
+      case e                                      => e
+    }
   }
 
   override def updateInfo(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
@@ -281,8 +281,15 @@ trait UserDetailListProvider {
    */
   def getUserByName(username: String): PureResult[RudderUserDetail] = {
     val conf = authConfig
-    val u    = if (conf.isCaseSensitive) username else username.toLowerCase()
-    conf.users.get(u).toRight(Unexpected(s"User with username '${username}' was not found"))
+    conf.users
+      .get(username)
+      .orElse(
+        conf.users.collectFirst {
+          case (u, userDetail) if !conf.isCaseSensitive && u.toLowerCase() == username.toLowerCase() => userDetail
+        }
+      )
+      .toRight(Unexpected(s"User with username '${username}' was not found"))
+
   }
 }
 

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
@@ -95,7 +95,7 @@ class RudderUserDetailsTest extends Specification {
     <user name="ADMIN" role="administrator" password="c7ad44cbad762a5da0a452f9e854fdc1e0e7a52a38015f23f3eab1d80b931dd472634dfac71cd34ebc35d16ab7fb8a90c81f975113d6c7538dc69dd8de9077ec"/>
   </authentication>
 
-  val userXML_empty: Elem = <authentication>
+  val userXML_empty: Elem = <authentication case-sensitivity="false">
     <user name="admin" roles="administrator"/>
   </authentication>
 
@@ -111,6 +111,27 @@ class RudderUserDetailsTest extends Specification {
 
     (userDetailList.isCaseSensitive must beFalse) and
     (userDetailList.users.size must beEqualTo(0))
+  }
+
+  "retrieving user by name with case sensitivity" >> {
+    val userDetailListProvider = new UserDetailListProvider {
+      override def authConfig: ValidatedUserList = getUserDetailList(userXML_1, "userXML_1")
+
+    }
+
+    (userDetailListProvider.getUserByName("admin") must beRight) and (
+      userDetailListProvider.getUserByName("Admin") must beLeft
+    )
+  }
+
+  "retrieving user by name *without* case sensitivity" >> {
+    val userDetailListProvider = new UserDetailListProvider {
+      override def authConfig: ValidatedUserList = getUserDetailList(userXML_empty, "userXML_empty")
+    }
+
+    (userDetailListProvider.getUserByName("admin") must beRight) and (
+      userDetailListProvider.getUserByName("Admin") must beRight
+    )
   }
 
   "an account without password field get a random 32 chars pass" >> {


### PR DESCRIPTION
https://issues.rudder.io/issues/24839

To load a user we both need to consider case-sensitivity when : 
* getting the user id from the database => we need to search with `LOWER(id)`
* getting the user name from the users xml file (which is a map with the original file usernames as keys) => we search the key matching a case-insensitive comparison, there will only be one result because we already ignore duplicates when validating the file