### PR TITLE
Fixes #24826: Add an API endpoint to get plugin license info

### DIFF
--- a/webapp/sources/api-doc/code_samples/curl/plugins/get-plugins-settings.sh
+++ b/webapp/sources/api-doc/code_samples/curl/plugins/get-plugins-settings.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" https://rudder.example.com/rudder/api/latest/plugins/settings

--- a/webapp/sources/api-doc/code_samples/curl/plugins/info.sh
+++ b/webapp/sources/api-doc/code_samples/curl/plugins/info.sh
@@ -1,0 +1,1 @@
+curl --header "X-API-Token: yourToken" https://rudder.example.com/rudder/api/latest/plugins/info

--- a/webapp/sources/api-doc/code_samples/curl/plugins/set-plugins-settings.sh
+++ b/webapp/sources/api-doc/code_samples/curl/plugins/set-plugins-settings.sh
@@ -1,0 +1,11 @@
+# settings.json:
+#
+#{
+#  "username": "my-account-login",
+#  "password": "xxxxxxxxx",
+#  "url": "https://download.rudder.io/plugins",
+#  "proxyUrl": ""
+#  "proxyUser": ""
+#  "proxyPassword": ""
+#}
+curl --header "X-API-Token: yourToken" --request POST https://rudder.example.com/rudder/api/latest/plugins/settings --header "Content-type: application/json" --data @dsettings.json

--- a/webapp/sources/api-doc/components/schemas/plugins-info.yml
+++ b/webapp/sources/api-doc/components/schemas/plugins-info.yml
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2020 Normation SAS
+type: object
+required:
+  - details
+properties:
+  # FIXME: required on not depends on where it's used
+  globalLimits:
+    type: object
+    description: Most restrictive limits computed from each plugin license limits
+    properties:
+      licensees:
+        type: array
+        description: list of licensees for these plugins
+        items:
+          type: string
+          description: a licensee
+          example: Customer Inc
+      startDate:
+        type: string
+        description: the latest date of start of validity for plugins
+        example: 2023-08-14T02:00:00+02:00
+      endDate:
+        type: string
+        description: the earliest date of end of validity for plugins
+        example: 2023-08-14T02:00:00+02:00
+      maxNodes:
+        type: integer
+        description: the lowest limit on maximum number of nodes for plugins
+        example: 5000
+  details:
+    type: array
+    description: the list of details for each plugins
+    properties:
+      id:
+        type: string
+        description: internal id of the plugin
+        example: com.normation.plugins.authbackends.AuthBackendsPluginDef
+      name:
+        type: string
+        description: fully qualified name of the plugin
+        example: rudder-plugin-auth-backends
+      shortName:
+        type: string
+        description: short name of the plugin
+        example: auth-backends
+      description:
+        type: string
+        description: description of the plugin
+        example: <p>This plugin provides additional authentication backends for Rudder, like LDAP, OIDC, etc</p>
+      version:
+        type: string
+        description: version of the plugin
+        example: 7.3.12-2.1.0
+      status:
+        type: string
+        description: status of the plugin, enabled or disabled
+        example: enabled
+        enum:
+          - enabled
+          - disabled
+      statusMessage:
+        type: string
+        description: a message explaining the status when disabled
+        example: this plugin is disabled because its end of validity date is in the past
+      license:
+        type: object
+        description: information about the plugin
+        properties:
+          licensee:
+            type: string
+            description: name of the licensee for that plugin
+            example: Customer Inc
+          softwareId:
+            type: string
+            description: the fully qualified name of the plugin for which that license was issued
+            example: rudder-plugin-auth-backends
+          minVersion:
+            type: string
+            description: lowest version of the software for which that license is valid
+            example: 0.0-0.0
+          maxVersion:
+            type: string
+            description: highest version of the software for which that license is valid
+            example: 2023-08-14T02:00:00+02:00
+          startDate:
+            type: string
+            description: start of validity date
+            example: 2023-08-14T02:00:00+02:00
+          endDate:
+            type: string
+            description: end of validity date
+            example: 2023-08-14T02:00:00+02:00
+          maxNodes:
+            type: integer
+            description: maximum number of node in Rudder for that license
+          additionalInfo:
+            type: object
+            description: additional information provided by the license

--- a/webapp/sources/api-doc/components/schemas/plugins-settings.yml
+++ b/webapp/sources/api-doc/components/schemas/plugins-settings.yml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2020 Normation SAS
+type: object
+required:
+  - username
+  - password
+properties:
+  # FIXME: required on not depends on where it's used
+  username:
+    type: string
+    description: username to use for Rudder account
+    example: Customer Inc
+  password:
+    type:
+    description: password to access Rudder account
+    example: some password
+  url:
+    type: string
+    description: URL for getting plugins
+    example: https://download.rudder.io/plugins
+  proxyUser:
+    type: string
+    description: if an authenticated proxy is necessary, username of proxy
+    example: proxy_user
+  proxyPassword:
+    type: string
+    description: if an authenticated proxy is necessary, password of the proxy
+    example: some password
+  proxyUrl:
+    type: string
+    description: proxy URL to use
+    example: https://proxy.url

--- a/webapp/sources/api-doc/openapi.src.yml
+++ b/webapp/sources/api-doc/openapi.src.yml
@@ -53,6 +53,8 @@ tags:
     description: Server configuration
   - name: System
     description: Internal components and administration
+  - name: Plugins
+    description: Information about installed plugins
   - name: "🧩 Change requests"
     description: >-
       **Requires that the `changes-validation` plugin is installed on the server.**
@@ -180,6 +182,10 @@ paths:
     $ref: paths/system/healthcheck.yml
   "/system/maintenance/purgeSoftware":
     $ref: paths/system/purge-software.yml
+  "/plugins/info":
+    $ref: paths/plugins/info.yml
+  "/plugins/settings":
+    $ref: paths/plugins/settings.yml
   "/settings":
     $ref: paths/settings/list.yml
   "/settings/{settingId}":

--- a/webapp/sources/api-doc/paths/plugins/info.yml
+++ b/webapp/sources/api-doc/paths/plugins/info.yml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2020 Normation SAS
+get:
+  summary: Information about installed plugins
+  description: Get the list of plugin details and their licenses information
+  operationId: getPluginsInfo
+  responses:
+    "200":
+      description: Settings
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - getPluginsInfo
+              data:
+                type: object
+                description: Plugins info
+                required:
+                  - plugins
+                properties:
+                  parameters:
+                    type: array
+                    items:
+                      $ref: ../../components/schemas/plugins-info.yml
+  tags:
+    - Plugins
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/plugins/info.sh

--- a/webapp/sources/api-doc/paths/plugins/settings.yml
+++ b/webapp/sources/api-doc/paths/plugins/settings.yml
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2020 Normation SAS
+get:
+  summary: Get plugins repository settings
+  description: Get plugins url and proxy settings
+  operationId: pluginSettings
+  responses:
+    "200":
+      description: Settings
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - pluginSettings
+              data:
+                type: object
+                description: Settings
+                required:
+                  - plugins
+                properties:
+                  plugins:
+                    type: array
+                    items:
+                      $ref: ../../components/schemas/plugins-settings.yml
+  tags:
+    - Plugins
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/plugins/get-plugins-settings.sh
+post:
+  summary: Update plugins settings
+  description: Update plugins repository URL and proxy
+  operationId: updateSettings
+  responses:
+    "200":
+      description: Settings
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - result
+              - action
+              - data
+            properties:
+              result:
+                type: string
+                description: Result of the request
+                enum:
+                  - success
+                  - error
+              action:
+                type: string
+                description: The id of the action
+                enum:
+                  - updateSettings
+              data:
+                type: object
+                description: Parameters
+                required:
+                  - plugins
+                properties:
+                  parameters:
+                    type: array
+                    items:
+                      $ref: ../../components/schemas/plugins-settings.yml
+  tags:
+    - Plugins
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/plugins/set-plugins-settings.sh

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/PluginSettings.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/PluginSettings.scala
@@ -40,8 +40,12 @@ package com.normation.plugins
 import better.files.File
 import com.normation.errors
 import com.normation.errors.IOResult
+import com.normation.utils.DateFormaterService
+import java.time.ZonedDateTime
 import java.util.Properties
-import zio.ZIO
+import org.joda.time.DateTime
+import zio.*
+import zio.json.*
 
 case class PluginSettings(
     url:           String,
@@ -52,14 +56,115 @@ case class PluginSettings(
     proxyPassword: Option[String]
 )
 
+/*
+ * Information about registered plugins that can be used
+ * for API and monitoring things.
+ */
+final case class JsonPluginsDetails(
+    globalLimits: Option[JsonGlobalPluginLimits],
+    // plugins should be sorted by id
+    details:      Seq[JsonPluginDetails]
+)
+object JsonPluginsDetails {
+  implicit val encoderJsonPluginsDetails: JsonEncoder[JsonPluginsDetails] = DeriveJsonEncoder.gen
+
+  def buildDetails(plugins: Seq[JsonPluginDetails]): JsonPluginsDetails = {
+    val limits = JsonGlobalPluginLimits.getGlobalLimits(plugins.flatMap(_.license))
+    JsonPluginsDetails(limits, plugins)
+  }
+}
+
+/*
+ * Global limit information about plugins (the most restrictive)
+ */
+final case class JsonGlobalPluginLimits(
+    licensees: Option[Chunk[String]],
+    // for now, min/max version is not used and is always 00-99
+    startDate: Option[ZonedDateTime],
+    endDate:   Option[ZonedDateTime],
+    maxNodes:  Option[Int]
+)
+object JsonGlobalPluginLimits {
+  import DateFormaterService.JodaTimeToJava
+  import DateFormaterService.json.encoderZonedDateTime
+  implicit val encoderGlobalPluginLimits: JsonEncoder[JsonGlobalPluginLimits] = DeriveJsonEncoder.gen
+
+  def empty = JsonGlobalPluginLimits(None, None, None, None)
+  // from a list of plugins, create the global limits
+  def getGlobalLimits(licenses: Seq[PluginLicenseInfo]): Option[JsonGlobalPluginLimits] = {
+    def comp[A](a: Option[A], b: Option[A], compare: (A, A) => A): Option[A] = (a, b) match {
+      case (None, None)       => None
+      case (Some(x), None)    => Some(x)
+      case (None, Some(y))    => Some(y)
+      case (Some(x), Some(y)) => Some(compare(x, y))
+    }
+
+    val limits = licenses.foldLeft(empty) {
+      case (lim, lic) =>
+        JsonGlobalPluginLimits(
+          lim.licensees match {
+            case Some(l) => Some(l.appended(lic.licensee).distinct.sorted)
+            case None    => Some(Chunk(lic.licensee))
+          }, // I'm not sure what we want here nor its meaning
+          comp[ZonedDateTime](lim.startDate, Some(lic.startDate.toJava), (x, y) => if (x.isAfter(y)) x else y),
+          comp[ZonedDateTime](lim.endDate, Some(lic.endDate.toJava), (x, y) => if (x.isBefore(y)) x else y),
+          comp[Int](lim.maxNodes, lic.maxNodes, (x, y) => if (x < y) x else y)
+        )
+    }
+    if (limits == empty) None else Some(limits)
+  }
+}
+
+trait JsonPluginStatus   {
+  def value: String
+}
+object JsonPluginStatus  {
+  case object Enabled  extends JsonPluginStatus { override val value: String = "enabled"  }
+  case object Disabled extends JsonPluginStatus { override val value: String = "disabled" }
+}
+
+final case class JsonPluginDetails(
+    id:            String,
+    name:          String,
+    shortName:     String,
+    description:   String,
+    version:       String,
+    status:        JsonPluginStatus,
+    statusMessage: Option[String],
+    license:       Option[PluginLicenseInfo]
+)
+object JsonPluginDetails {
+  implicit val encoderPluginStatusRest: JsonEncoder[JsonPluginStatus]  = JsonEncoder[String].contramap(_.value)
+  implicit val encoderPluginDetails:    JsonEncoder[JsonPluginDetails] = DeriveJsonEncoder.gen
+}
+
+/*
+ * This object gives main information about license information.
+ * It is designated to be read to the user. No string information
+ * should be used for comparison.
+ */
+final case class PluginLicenseInfo(
+    licensee:   String,
+    softwareId: String,
+    minVersion: String,
+    maxVersion: String,
+    startDate:  DateTime,
+    endDate:    DateTime,
+    maxNodes:   Option[Int],
+    @jsonField("additionalInfo")
+    others:     Map[String, String]
+)
+object PluginLicenseInfo {
+  import DateFormaterService.json.encoderDateTime
+  implicit val encoderPluginLicenseInfo: JsonEncoder[PluginLicenseInfo] = DeriveJsonEncoder.gen
+}
+
 trait PluginSettingsService {
   def readPluginSettings(): IOResult[PluginSettings]
   def writePluginSettings(settings: PluginSettings): IOResult[Unit]
 }
 
-class FilePluginSettingsService(
-    pluginConfFile: File
-) extends PluginSettingsService {
+class FilePluginSettingsService(pluginConfFile: File) extends PluginSettingsService {
 
   def readPluginSettings(): ZIO[Any, errors.RudderError, PluginSettings] = {
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -517,6 +517,11 @@ sealed trait PluginApi extends EndpointSchema with GeneralApi with SortIndex {
 }
 object PluginApi       extends ApiModuleProvider[PluginApi]                  {
 
+  final case object GetPluginsInfo        extends PluginApi with ZeroParam with StartsAtVersion14 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "List plugin information"
+    val (action, path) = GET / "plugins" / "info"
+  }
   final case object GetPluginsSettings    extends PluginApi with ZeroParam with StartsAtVersion14 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "List plugin system settings"

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestPluginInfo.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestPluginInfo.scala
@@ -1,0 +1,217 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.rest
+
+import com.normation.plugins.JsonPluginDetails
+import com.normation.plugins.JsonPluginsDetails
+import com.normation.plugins.JsonPluginStatus
+import com.normation.plugins.PluginLicenseInfo
+import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.rest.lift.LiftApiModuleProvider
+import com.normation.rudder.rest.lift.PluginApi
+import net.liftweb.common.Full
+import net.liftweb.http.InMemoryResponse
+import net.liftweb.mocks.MockHttpServletRequest
+import org.joda.time.DateTime
+import org.junit.runner.RunWith
+import org.specs2.mutable.*
+import org.specs2.runner.JUnitRunner
+import zio.syntax.*
+
+// test that the "+" in path is correctly kept as a "+", not changed into " "
+// See: https://issues.rudder.io/issues/20943
+
+@RunWith(classOf[JUnitRunner])
+class TestRestPluginInfo extends Specification {
+
+  // we are testing error cases, so we don't want to output error log for them
+  org.slf4j.LoggerFactory
+    .getLogger("com.normation.rudder.rest.RestUtils")
+    .asInstanceOf[ch.qos.logback.classic.Logger]
+    .setLevel(ch.qos.logback.classic.Level.OFF)
+
+  /*
+   * we have three plugins:
+   * - freePlugin doesn't have any limit,
+   * - limitedPlugin has limits and is enabled
+   * - disabledPlugin has limits and is disabled
+   */
+  val pluginInfo = JsonPluginsDetails.buildDetails(
+    List(
+      JsonPluginDetails(
+        "freePluginId",
+        "rudder-plugin-free-plugin",
+        "free-plugin",
+        "A description for the free plugin",
+        "2.3.0",
+        JsonPluginStatus.Enabled,
+        None,
+        None
+      ),
+      JsonPluginDetails(
+        "LimitedPluginId",
+        "rudder-plugin-limited-plugin",
+        "limited-plugin",
+        "A description for the limited plugin",
+        "4.4.0",
+        JsonPluginStatus.Enabled,
+        None,
+        Some(
+          PluginLicenseInfo(
+            "Rudder corporation ltd",
+            "LimitedPluginId",
+            "0.0-0.0",
+            "99.99-99.99",
+            DateTime.parse("2024-01-01T00:00:00Z"),
+            DateTime.parse("2024-12-31T23:59:59Z"),
+            Some(1000),
+            Map()
+          )
+        )
+      ),
+      JsonPluginDetails(
+        "DisabledPluginId",
+        "rudder-plugin-disabled-plugin",
+        "disabled-plugin",
+        "A description for the disabled plugin",
+        "1.3.5",
+        JsonPluginStatus.Disabled,
+        Some(
+          "This license for 'rudder-plugin-disabled-plugin' is disabled to '50' nodes but Rudder currently manages '132' nodes."
+        ),
+        Some(
+          PluginLicenseInfo(
+            "Rudder corporation ltd",
+            "DisabledPluginId",
+            "0.0-0.0",
+            "99.99-99.99",
+            DateTime.parse("2024-03-03T00:00:00Z"),
+            DateTime.parse("2024-06-30T12:00:00Z"),
+            Some(50),
+            Map()
+          )
+        )
+      )
+    )
+  )
+
+  val pluginApi = new PluginApi(null, null, pluginInfo.succeed)
+  val apiModules: List[LiftApiModuleProvider[? <: EndpointSchema with SortIndex]] = List(pluginApi)
+
+  val (handlers, rules) = TraitTestApiFromYamlFiles.buildLiftRules(apiModules, List(ApiVersion(42, deprecated = false)), None)
+  val test              = new RestTest(rules)
+
+  sequential
+
+  ///// tests ////
+
+  "Getting plugin info should" >> {
+    val mockReq = new MockHttpServletRequest("http://localhost:8080")
+    mockReq.method = "GET"
+    mockReq.path = "/api/latest/plugins/info"
+    mockReq.body = ""
+    mockReq.headers = Map()
+    mockReq.contentType = "application/json"
+
+    // authorize space in response formatting
+    val expected = {
+      """{"action":"getPluginsInfo","result":"success","data":{"plugins":[{
+        |"globalLimits":
+        |{"licensees":["Rudder corporation ltd"],
+        |"startDate":"2024-03-03T00:00:00Z",
+        |"endDate":"2024-06-30T12:00:00Z",
+        |"maxNodes":50
+        |},
+        |"details":[
+        |{
+        |"id":"freePluginId",
+        |"name":"rudder-plugin-free-plugin",
+        |"shortName":"free-plugin",
+        |"description":"A description for the free plugin",
+        |"version":"2.3.0",
+        |"status":"enabled"
+        |},{
+        |"id":"LimitedPluginId",
+        |"name":"rudder-plugin-limited-plugin",
+        |"shortName":"limited-plugin",
+        |"description":"A description for the limited plugin",
+        |"version":"4.4.0",
+        |"status":"enabled",
+        |"license":{
+        |"licensee":"Rudder corporation ltd",
+        |"softwareId":"LimitedPluginId",
+        |"minVersion":"0.0-0.0",
+        |"maxVersion":"99.99-99.99",
+        |"startDate":"2024-01-01T00:00:00Z",
+        |"endDate":"2024-12-31T23:59:59Z",
+        |"maxNodes":1000,
+        |"additionalInfo":{}
+        |}
+        |},{
+        |"id":"DisabledPluginId",
+        |"name":"rudder-plugin-disabled-plugin",
+        |"shortName":"disabled-plugin",
+        |"description":"A description for the disabled plugin",
+        |"version":"1.3.5",
+        |"status":"disabled",
+        |"statusMessage":"This license for 'rudder-plugin-disabled-plugin' is disabled to '50' nodes but Rudder currently manages '132' nodes.",
+        |"license":{
+        |"licensee":"Rudder corporation ltd",
+        |"softwareId":"DisabledPluginId",
+        |"minVersion":"0.0-0.0",
+        |"maxVersion":"99.99-99.99",
+        |"startDate":"2024-03-03T00:00:00Z",
+        |"endDate":"2024-06-30T12:00:00Z",
+        |"maxNodes":50,
+        |"additionalInfo":{}
+        |}
+        |}
+        |]
+        |}]
+        |}}""".stripMargin.replaceAll("""\n""", "")
+    }
+
+    test.execRequestResponse(mockReq)(response => {
+      response.map { r =>
+        val rr = r.toResponse.asInstanceOf[InMemoryResponse]
+        (rr.code, new String(rr.data, "UTF-8"))
+      } must beEqualTo(Full((200, expected)))
+    })
+
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -44,6 +44,7 @@ import com.normation.eventlog.EventLogDetails
 import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.InventoryProcessingLogger
 import com.normation.plugins.AlwaysEnabledPluginStatus
+import com.normation.plugins.JsonPluginsDetails
 import com.normation.plugins.PluginLicenseInfo
 import com.normation.plugins.PluginName
 import com.normation.plugins.PluginStatus
@@ -148,6 +149,10 @@ object PluginsInfo {
   }
 
   def plugins = _plugins
+
+  def pluginInfos: JsonPluginsDetails = {
+    JsonPluginsDetails.buildDetails(_plugins.values.toList.sortBy(_.name.value).map(_.toJsonPluginDetails))
+  }
 
   def pluginApisDef: List[EndpointSchema] = {
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1364,6 +1364,7 @@ object RudderConfigInit {
     lazy val pluginSettingsService = new FilePluginSettingsService(
       root / "opt" / "rudder" / "etc" / "rudder-pkg" / "rudder-pkg.conf"
     )
+
     /////////////////////////////////////////////////
     ////////// pluggable service providers //////////
     /////////////////////////////////////////////////
@@ -2123,7 +2124,7 @@ object RudderConfigInit {
           builtTimestamp
         ),
         new InventoryApi(restExtractorService, inventoryWatcher, better.files.File(INVENTORY_DIR_INCOMING)),
-        new PluginApi(restExtractorService, pluginSettingsService),
+        new PluginApi(restExtractorService, pluginSettingsService, PluginsInfo.pluginInfos.succeed),
         new RecentChangesAPI(recentChangesService, restExtractorService),
         new RulesInternalApi(restExtractorService, ruleInternalApiService),
         campaignApi,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/PluginStatus.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/PluginStatus.scala
@@ -38,7 +38,6 @@
 package com.normation.plugins
 
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
-import org.joda.time.DateTime
 
 /**
  * This file defined an entry point for license information and other
@@ -51,22 +50,6 @@ object PluginStatusInfo {
   final case class EnabledWithLicense(i: PluginLicenseInfo)                     extends PluginStatusInfo
   final case class Disabled(reason: String, details: Option[PluginLicenseInfo]) extends PluginStatusInfo
 }
-
-/*
- * This object gives main information about license information.
- * It is destinated to be read to the user. No string information
- * should be used for comparison.
- */
-final case class PluginLicenseInfo(
-    licensee:   String,
-    softwareId: String,
-    minVersion: String,
-    maxVersion: String,
-    startDate:  DateTime,
-    endDate:    DateTime,
-    maxNodes:   Option[Int],
-    others:     Map[String, String]
-)
 
 trait PluginStatus {
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPlugin.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPlugin.scala
@@ -128,6 +128,30 @@ final case class PluginName(value: String) {
   }
 }
 
+object RudderPluginDef {
+
+  implicit class ToJsonPluginDetails(plugin: RudderPluginDef) {
+    def toJsonPluginDetails: JsonPluginDetails = {
+      val (status, licence, msg) = plugin.status.current match {
+        case PluginStatusInfo.EnabledNoLicense       => (JsonPluginStatus.Enabled, None, None)
+        case PluginStatusInfo.EnabledWithLicense(i)  => (JsonPluginStatus.Enabled, Some(i), None)
+        case PluginStatusInfo.Disabled(msg, None)    => (JsonPluginStatus.Disabled, None, Some(msg))
+        case PluginStatusInfo.Disabled(msg, Some(i)) => (JsonPluginStatus.Disabled, Some(i), Some(msg))
+      }
+      JsonPluginDetails(
+        plugin.id,
+        plugin.name.value,
+        plugin.shortName,
+        plugin.description.toString(),
+        plugin.version.pluginVersion.toVersionStringNoEpoch,
+        status,
+        msg,
+        licence
+      )
+    }
+  }
+}
+
 /**
  * Definition of a rudder plugins
  */

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/DateFormaterService.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/DateFormaterService.scala
@@ -39,6 +39,8 @@ package com.normation.utils
 
 import com.normation.errors.Inconsistency
 import com.normation.errors.PureResult
+import java.time.ZonedDateTime
+import java.time.ZoneId
 import org.joda.time.DateTime
 import org.joda.time.DateTimeFieldType
 import org.joda.time.Duration
@@ -49,8 +51,21 @@ import org.joda.time.format.DateTimeFormatterBuilder
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.format.PeriodFormatterBuilder
 import scala.util.control.NonFatal
+import zio.json.*
 
 object DateFormaterService {
+
+  implicit class JodaTimeToJava(d: DateTime) {
+    def toJava: ZonedDateTime = ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli(d.getMillis), ZoneId.of(d.getZone.getID))
+  }
+
+  object json {
+    implicit val encoderDateTime:      JsonEncoder[DateTime]      = JsonEncoder[String].contramap(serialize)
+    implicit val decoderDateTime:      JsonDecoder[DateTime]      = JsonDecoder[String].mapOrFail(parseDate(_).left.map(_.fullMsg))
+    implicit val encoderZonedDateTime: JsonEncoder[ZonedDateTime] = JsonEncoder[String].contramap(serializeZDT)
+    implicit val decoderZonedDateTime: JsonDecoder[ZonedDateTime] =
+      JsonDecoder[String].mapOrFail(parseDateZDT(_).left.map(_.fullMsg))
+  }
 
   val displayDateFormat: DateTimeFormatter = new DateTimeFormatterBuilder()
     .append(DateTimeFormat.forPattern("YYYY-MM-dd"))
@@ -75,9 +90,19 @@ object DateFormaterService {
    */
   def serialize(datetime: DateTime): String = datetime.toString(ISODateTimeFormat.dateTimeNoMillis)
 
+  def serializeZDT(datetime: ZonedDateTime): String = datetime.format(java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+
   def parseDate(date: String): PureResult[DateTime] = {
     try {
       Right(ISODateTimeFormat.dateTimeNoMillis().parseDateTime(date))
+    } catch {
+      case NonFatal(ex) => Left(Inconsistency(s"String '${date}' can't be parsed as an ISO date/time: ${ex.getMessage}"))
+    }
+  }
+
+  def parseDateZDT(date: String): PureResult[ZonedDateTime] = {
+    try {
+      Right(ZonedDateTime.parse(date, java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME))
     } catch {
       case NonFatal(ex) => Left(Inconsistency(s"String '${date}' can't be parsed as an ISO date/time: ${ex.getMessage}"))
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/24826

Add a public API to get information about the installed plugins and their limits. 
The returned JSON structure start by global limits if any, which are computed to present the most restrictive limits (ie, if a plugin limits to 200 nodes and one to 500, then 200 is given). 

Then, we have an array with installed plugins and their specific limits if any. 

Most of the PR is documentation for that API, and for the plugins repo setting API, which was missing. 

There is nothing complicated at all, but two noticable points: 
- I've started using `java.time` API, and added the relevant formatter/etc in `DateTimeFormaterService` ; 
- plugin's license object needed to be migrated from `rudder-web` to `rudder-rest`; 
