### PR TITLE
Fixes #24857: Update elm dependencies

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/elm.json
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/elm.json
@@ -37,7 +37,7 @@
             "justinmimbs/time-extra": "1.1.1",
             "jzxhuang/http-extras": "2.1.0",
             "mcordova47/elm-natural-ordering": "1.1.0",
-            "mercurymedia/elm-datetime-picker": "8.0.0",
+            "mercurymedia/elm-datetime-picker": "8.0.1",
             "pablen/toasty": "1.2.0",
             "pablohirafuji/elm-markdown": "2.0.5",
             "pablohirafuji/elm-syntax-highlight": "3.5.0",
@@ -53,16 +53,17 @@
             "TSFoster/elm-md5": "2.0.1",
             "TSFoster/elm-sha1": "2.1.1",
             "danfishgold/base64-bytes": "1.1.0",
-            "elm-community/basics-extra": "4.1.0",
             "kuon/elm-string-normalize": "1.0.5",
-            "rtfeldman/elm-hex": "1.0.0",
-            "the-sett/elm-pretty-printer": "2.2.3"
+            "rtfeldman/elm-hex": "1.0.0"
         }
     },
     "test-dependencies": {
         "direct": {
             "elm-explorations/test": "2.1.2"
         },
-        "indirect": {}
+        "indirect": {
+            "elm-community/basics-extra": "4.1.0",
+            "the-sett/elm-pretty-printer": "2.2.3"
+        }
     }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/24857

Only one package wasn't up to date : `mercurymedia/elm-datetime-picker` (from **8.0.0** to **8.0.1**)