### PR TITLE
Fixes #24856: 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
@@ -87,19 +87,20 @@ class GitRuleArchiverImpl(
     override val gitModificationRepository: GitModificationRepository,
     override val encoding:                  String,
     override val groupOwner:                String
-) extends GitRuleArchiver with XmlArchiverUtils with NamedZioLogger with GitConfigItemRepository with GitArchiverFullCommitUtils {
+) extends GitRuleArchiver with XmlArchiverUtils with NamedZioLogger with GitConfigItemRepository with GitArchiverFullCommitUtils
+    with BuildFilePaths[RuleId] {
 
   override def loggerName: String = this.getClass.getName
   override val relativePath = ruleRootDir
   override val tagPrefix    = "archives/configurations-rules/"
 
-  private[this] def newCrFile(ruleId: RuleId) = new File(getItemDirectory, ruleId.serialize + ".xml")
+  override def getFileName(ruleId: RuleId): String = ruleId.serialize + ".xml"
 
   def archiveRule(rule: Rule, doCommit: Option[(ModificationId, PersonIdent, Option[String])]): IOResult[GitPath] = {
-    val crFile  = newCrFile(rule.id)
-    val gitPath = toGitPath(crFile)
-
     for {
+      crFile <- newFile(rule.id).toIO
+      gitPath = toGitPath(crFile)
+
       archive <- writeXml(
                    crFile,
                    ruleSerialisation.serialise(rule),
@@ -126,27 +127,27 @@ class GitRuleArchiverImpl(
   }
 
   def deleteRule(ruleId: RuleId, doCommit: Option[(ModificationId, PersonIdent, Option[String])]): IOResult[GitPath] = {
-    val crFile  = newCrFile(ruleId)
-    val gitPath = toGitPath(crFile)
-    if (crFile.exists) {
-      for {
-        deleted  <- IOResult.attempt(FileUtils.forceDelete(crFile))
-        _        <- logPure.debug("Deleted archive of rule: " + crFile.getPath)
-        commited <- doCommit match {
-                      case Some((modId, commiter, reason)) =>
-                        commitRmFileWithModId(
-                          modId,
-                          commiter,
-                          gitPath,
-                          s"Delete archive of rule with ID '${ruleId.serialize}'${GET(reason)}"
-                        )
-                      case None                            => ZIO.unit
-                    }
-      } yield {
-        GitPath(gitPath)
-      }
-    } else {
-      GitPath(gitPath).succeed
+    for {
+      crFile <- newFile(ruleId).toIO
+      gitPath = toGitPath(crFile)
+      _      <- ZIO.whenZIO(IOResult.attempt(crFile.exists)) {
+                  for {
+                    deleted <- IOResult.attempt(FileUtils.forceDelete(crFile))
+                    _       <- logPure.debug("Deleted archive of rule: " + crFile.getPath)
+                    _       <- doCommit match {
+                                 case Some((modId, commiter, reason)) =>
+                                   commitRmFileWithModId(
+                                     modId,
+                                     commiter,
+                                     gitPath,
+                                     s"Delete archive of rule with ID '${ruleId.serialize}'${GET(reason)}"
+                                   )
+                                 case None                            => ZIO.unit
+                               }
+                  } yield ()
+                }
+    } yield {
+      GitPath(gitPath)
     }
   }
 
@@ -187,6 +188,35 @@ trait BuildCategoryPathName[T] {
       ).fail
     }
   }
+}
+
+/**
+ * An utility trait that enforces file system access to local items in git repository.
+ * It should be the prefered way to build paths within a local item repository (e.g. rules), otherwise there would be security concerns.
+ */
+trait BuildFilePaths[T] {
+
+  def getItemDirectory: File
+
+  def getFileName(itemId: T): String
+
+  /**
+   * Returns the file path in the git repository for the item.
+   */
+  def newFile(itemId: T): PureResult[File] = {
+    val target = new File(getItemDirectory, getFileName(itemId))
+    if (target.getCanonicalPath().startsWith(getItemDirectory.getCanonicalPath())) {
+      Right(target)
+    } else {
+      Left(
+        Inconsistency(
+          s"Error when checking required directories '${target.getPath}' to archive in gitRepo.git: relative path must not allow access to parent directories, " +
+          s"only to directories under directory ${getItemDirectory}"
+        )
+      )
+    }
+  }
+
 }
 
 ///////////////////////////////////////////////////////////////
@@ -1148,32 +1178,32 @@ class GitParameterArchiverImpl(
     override val encoding:                  String,
     override val groupOwner:                String
 ) extends GitParameterArchiver with NamedZioLogger with GitConfigItemRepository with XmlArchiverUtils
-    with GitArchiverFullCommitUtils {
+    with GitArchiverFullCommitUtils with BuildFilePaths[String] {
 
   override def loggerName: String = this.getClass.getName
   override val relativePath = parameterRootDir
   override val tagPrefix    = "archives/parameters/"
 
-  private[this] def newParameterFile(parameterName: String) = new File(getItemDirectory, parameterName + ".xml")
+  override def getFileName(parameterName: String) = parameterName + ".xml"
 
   def archiveParameter(
       parameter: GlobalParameter,
       doCommit:  Option[(ModificationId, PersonIdent, Option[String])]
   ): IOResult[GitPath] = {
-    val paramFile = newParameterFile(parameter.name)
-    val gitPath   = toGitPath(paramFile)
     for {
-      archive <- writeXml(
-                   paramFile,
-                   parameterSerialisation.serialise(parameter),
-                   "Archived parameter: " + paramFile.getPath
-                 )
-      commit  <- doCommit match {
-                   case Some((modId, commiter, reason)) =>
-                     val msg = "Archive parameter with name '%s'%s".format(parameter.name, GET(reason))
-                     commitAddFileWithModId(modId, commiter, gitPath, msg)
-                   case None                            => ZIO.unit
-                 }
+      paramFile <- newFile(parameter.name).toIO
+      gitPath    = toGitPath(paramFile)
+      archive   <- writeXml(
+                     paramFile,
+                     parameterSerialisation.serialise(parameter),
+                     "Archived parameter: " + paramFile.getPath
+                   )
+      commit    <- doCommit match {
+                     case Some((modId, commiter, reason)) =>
+                       val msg = "Archive parameter with name '%s'%s".format(parameter.name, GET(reason))
+                       commitAddFileWithModId(modId, commiter, gitPath, msg)
+                     case None                            => ZIO.unit
+                   }
     } yield {
       GitPath(gitPath)
     }
@@ -1193,27 +1223,27 @@ class GitParameterArchiverImpl(
       parameterName: String,
       doCommit:      Option[(ModificationId, PersonIdent, Option[String])]
   ): IOResult[GitPath] = {
-    val paramFile = newParameterFile(parameterName)
-    val gitPath   = toGitPath(paramFile)
-    if (paramFile.exists) {
-      for {
-        deleted  <- IOResult.attempt(FileUtils.forceDelete(paramFile))
-        _        <- logPure.debug(s"Deleted archive of parameter: ${paramFile.getPath}")
-        commited <- doCommit match {
-                      case Some((modId, commiter, reason)) =>
-                        commitRmFileWithModId(
-                          modId,
-                          commiter,
-                          gitPath,
-                          s"Delete archive of parameter with name '${parameterName}'${GET(reason)}"
-                        )
-                      case None                            => ZIO.unit
-                    }
-      } yield {
-        GitPath(gitPath)
-      }
-    } else {
-      GitPath(gitPath).succeed
+    for {
+      paramFile <- newFile(parameterName).toIO
+      gitPath    = toGitPath(paramFile)
+      _         <- ZIO.whenZIO(IOResult.attempt(paramFile.exists)) {
+                     for {
+                       deleted <- IOResult.attempt(FileUtils.forceDelete(paramFile))
+                       _       <- logPure.debug(s"Deleted archive of parameter: ${paramFile.getPath}")
+                       _       <- doCommit match {
+                                    case Some((modId, commiter, reason)) =>
+                                      commitRmFileWithModId(
+                                        modId,
+                                        commiter,
+                                        gitPath,
+                                        s"Delete archive of parameter with name '${parameterName}'${GET(reason)}"
+                                      )
+                                    case None                            => ZIO.unit
+                                  }
+                     } yield ()
+                   }
+    } yield {
+      GitPath(gitPath)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/xml/TestBuildPathUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/xml/TestBuildPathUtils.scala
@@ -41,8 +41,11 @@ import com.normation.errors.Inconsistency
 import com.normation.zio.UnsafeRun
 import java.io.File
 import java.nio.file.Files
+import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class TestCategoryPathUtils extends Specification with BuildCategoryPathName[String] {
 
   override val getItemDirectory: File = Files.createTempDirectory("rudder-test-").toFile()
@@ -78,5 +81,31 @@ class TestCategoryPathUtils extends Specification with BuildCategoryPathName[Str
         )
       )
     }
+  }
+}
+
+@RunWith(classOf[JUnitRunner])
+class TestBuildFilePathsUtils extends Specification with BuildFilePaths[String] {
+
+  val tmpDir = Files.createTempDirectory("rudder-test-").toFile()
+
+  override val getItemDirectory: File = tmpDir
+
+  override def getFileName(name: String): String = name + ".txt"
+
+  "BuildPath" should {
+    "build a path with a name" in {
+      newFile("foo") must beRight(new File(getItemDirectory, "foo.txt"))
+    }
+
+    "build a path with an illegal path outside of the root directory" in {
+      newFile("../foo") must beLeft(
+        Inconsistency(
+          s"Error when checking required directories '${getItemDirectory}/../foo.txt' to archive in gitRepo.git: relative path must not allow access to parent directories, " +
+          s"only to directories under directory ${getItemDirectory}"
+        )
+      )
+    }
+
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/24856

Restrict paths to "local" ones i.e. `rules/` for `GitRuleArchiverImpl` class and `parameters/` for `GitParameterArchiverImpl`.

Ideally we should remove all `new File(_)` calls and replace with validated ones, I checked and found only those two, the remaining ones act on categories, for which we made very similar changes in https://github.com/Normation/rudder/pull/5314  but with additional "category" parent (e.g. `techniques/application/cat1/`)
