### PR TITLE
Fixes #24845: Option to force validation of change requests cannot be set via API

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
@@ -103,7 +103,6 @@ trait ReadConfigService {
   def rudder_workflow_self_validation(): IOResult[Boolean]
   def rudder_workflow_self_deployment(): IOResult[Boolean]
   def rudder_workflow_validate_all():    IOResult[Boolean]
-  def set_rudder_workflow_validate_all(value: Boolean): IOResult[Unit]
 
   /**
    * CFEngine server properties
@@ -249,6 +248,7 @@ trait UpdateConfigService {
   def set_rudder_workflow_enabled(value:         Boolean): IOResult[Unit]
   def set_rudder_workflow_self_validation(value: Boolean): IOResult[Unit]
   def set_rudder_workflow_self_deployment(value: Boolean): IOResult[Unit]
+  def set_rudder_workflow_validate_all(value:    Boolean): IOResult[Unit]
 
   /**
    * Set CFEngine server properties
@@ -589,18 +589,16 @@ class GenericConfigService(
   def set_rudder_ui_changeMessage_explanation(value: String):  IOResult[Unit] = save("rudder_ui_changeMessage_explanation", value)
 
   ///// workflows /////
-  def rudder_workflow_enabled():                        IOResult[Boolean] = {
+  def rudder_workflow_enabled():         IOResult[Boolean] = {
     if (workflowLevel.workflowLevelAllowsEnable) {
       get("rudder_workflow_enabled")
     } else {
       false.succeed
     }
   }
-  def rudder_workflow_self_validation():                IOResult[Boolean] = get("rudder_workflow_self_validation")
-  def rudder_workflow_self_deployment():                IOResult[Boolean] = get("rudder_workflow_self_deployment")
-  def rudder_workflow_validate_all():                   IOResult[Boolean] = get("rudder_workflow_validate_all")
-  def set_rudder_workflow_validate_all(value: Boolean): IOResult[Unit]    =
-    save("rudder_workflow_validate_all", value).unit
+  def rudder_workflow_self_validation(): IOResult[Boolean] = get("rudder_workflow_self_validation")
+  def rudder_workflow_self_deployment(): IOResult[Boolean] = get("rudder_workflow_self_deployment")
+  def rudder_workflow_validate_all():    IOResult[Boolean] = get("rudder_workflow_validate_all")
 
   def set_rudder_workflow_enabled(value: Boolean): IOResult[Unit] = {
     if (workflowLevel.workflowLevelAllowsEnable) {
@@ -614,6 +612,7 @@ class GenericConfigService(
   }
   def set_rudder_workflow_self_validation(value: Boolean): IOResult[Unit] = save("rudder_workflow_self_validation", value)
   def set_rudder_workflow_self_deployment(value: Boolean): IOResult[Unit] = save("rudder_workflow_self_deployment", value)
+  def set_rudder_workflow_validate_all(value:    Boolean): IOResult[Unit] = save("rudder_workflow_validate_all", value).unit
 
   ///// CFEngine server /////
   def cfengine_server_denybadclocks(): IOResult[Boolean] = get("cfengine_server_denybadclocks")

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -113,6 +113,7 @@ class SettingsApi(
     RestChangeRequestEnabled ::
     RestChangeRequestSelfValidation ::
     RestChangeRequestSelfDeployment ::
+    RestChangeRequestValidateAll ::
     RestChangesGraphs ::
     RestJSEngine ::
     RestSendMetrics ::
@@ -530,6 +531,13 @@ class SettingsApi(
     def get: IOResult[Boolean]                                       = configService.rudder_workflow_self_validation()
     def set: (Boolean, EventActor, Option[String]) => IOResult[Unit] = (value: Boolean, _, _) =>
       configService.set_rudder_workflow_self_validation(value)
+  }
+  case object RestChangeRequestValidateAll    extends RestBooleanSetting                      {
+    val key                   = "enable_validate_all"
+    val startPolicyGeneration = true
+    def get: IOResult[Boolean]                                       = configService.rudder_workflow_validate_all()
+    def set: (Boolean, EventActor, Option[String]) => IOResult[Unit] = (value: Boolean, _, _) =>
+      configService.set_rudder_workflow_validate_all(value)
   }
   case object RestRequireTimeSynch            extends RestBooleanSetting                      {
     val key                   = "require_time_synchronization"

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_settings.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_settings.yml
@@ -29,6 +29,7 @@ response:
           "enable_javascript_directives":"enabled",
           "enable_self_deployment":true,
           "enable_self_validation":false,
+          "enable_validate_all":false,
           "first_run_hour":0,
           "first_run_minute":0,
           "global_policy_mode":"enforce",


### PR DESCRIPTION
https://issues.rudder.io/issues/24845

The setting key in the API : `enable_validate_all`