### PR TITLE
Fixes #24854: Cannot open a directive if we search in the directive tree with the filter

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/tree.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/tree.js
@@ -474,6 +474,8 @@ var buildDirectiveTree = function(id, initially_select, appContext, select_limit
       });
     }).on("after_open.jstree", function (event, data){
       attachInlinedEvents(id)
+    }).on("redraw.jstree", function (event, data){
+      attachInlinedEvents(id)
     }).jstree({
       "core" : {
         "animation" : 150,


### PR DESCRIPTION
https://issues.rudder.io/issues/24854

We need rebind the event handler also when a node is redrawn (which happens when changing the search filter)  