### PR TITLE
Fixes #24869: Node acceptation or refusal is not logged in event logs in 8.0

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/RemoveNodeService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/RemoveNodeService.scala
@@ -268,7 +268,7 @@ class RemoveNodeServiceImpl(
   // delete pending node is just refusing it
   def deletePendingNode(nodeId: NodeId, mode: DeleteMode, modId: ModificationId, actor: EventActor): IOResult[DeletionResult] = {
     NodeLoggerPure.Delete.debug(s"-> deleting node with ID '${nodeId.value}' from pending nodes (refuse)") *>
-    newNodeManager.refuse(nodeId, modId, actor).toIO.map(_ => DeletionResult.Success)
+    newNodeManager.refuse(nodeId, modId, actor, DateTime.now).toIO.map(_ => DeletionResult.Success)
   }
 
   // this is the core delete that is run on accepted node: pre hook, post hook, move to delete or erase

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -2290,7 +2290,7 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
       } yield pending
     }.toBox
 
-    override def accept(id: NodeId, modId: ModificationId, actor: EventActor): Box[FullInventory] = {
+    override def accept(id: NodeId, modId: ModificationId, actor: EventActor, dateTime: DateTime): Box[FullInventory] = {
       (nodeInfoService.nodeBase.modifyZIO { nodes =>
         nodes.get(id) match {
           case None    => Inconsistency(s"node is missing").fail
@@ -2302,12 +2302,24 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
       }).toBox
     }
 
-    override def refuse(id: NodeId, modId: ModificationId, actor: EventActor): Box[Srv] = ???
+    override def refuse(id: NodeId, modId: ModificationId, actor: EventActor, dateTime: DateTime): Box[Srv] = ???
 
-    override def accept(ids: Seq[NodeId], modId: ModificationId, actor: EventActor, actorIp: String): Box[Seq[FullInventory]] =
+    override def accept(
+        ids:      Seq[NodeId],
+        modId:    ModificationId,
+        actor:    EventActor,
+        actorIp:  String,
+        dateTime: DateTime
+    ): Box[Seq[FullInventory]] =
       ???
 
-    override def refuse(id: Seq[NodeId], modId: ModificationId, actor: EventActor, actorIp: String): Box[Seq[Srv]] = ???
+    override def refuse(
+        id:       Seq[NodeId],
+        modId:    ModificationId,
+        actor:    EventActor,
+        actorIp:  String,
+        dateTime: DateTime
+    ): Box[Seq[Srv]] = ???
 
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/NodeInfoServiceCachedTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/NodeInfoServiceCachedTest.scala
@@ -412,12 +412,13 @@ class NodeInfoServiceCachedTest extends Specification {
 
       // *************** step1 ****************
       // cache does not know about node1 yet
-      acceptNodeAndMachineInNodeOu.acceptOne(nodeInv, modid, actor).forceGet
+      val date     = DateTime.now
+      acceptNodeAndMachineInNodeOu.acceptOne(nodeInv, modid, actor, date).forceGet
       val step1res = nodeInfoService.getNodeInfo(nodeId).forceGet
 
       // *************** step2 ****************
       // second new node step: cache converge
-      acceptInventory.acceptOne(nodeInv, modid, actor).forceGet
+      acceptInventory.acceptOne(nodeInv, modid, actor, date).forceGet
       val step2res = nodeInfoService.getNodeInfo(nodeId).forceGet
 
       (step1res === None) and

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -805,7 +805,7 @@ class NodeApiService15(
     template match {
       case AcceptedNodeTemplate(_, properties, policyMode, state) =>
         newNodeManager
-          .accept(id, ModificationId(uuidGen.newUuid), eventActor)
+          .accept(id, ModificationId(uuidGen.newUuid), eventActor, DateTime.now)
           .toIO
           .mapError(err => CreationError.OnAcceptation((s"Can not accept node '${id.value}': ${err.fullMsg}"))) *>
         NodeSetup(properties, policyMode, state).succeed
@@ -1218,10 +1218,10 @@ class NodeApiService2(
 
     (action match {
       case AcceptNode =>
-        newNodeManager.accept(ids, modId, actor, "").map(_.map(serializeInventory(_, "accepted")))
+        newNodeManager.accept(ids, modId, actor, "", DateTime.now).map(_.map(serializeInventory(_, "accepted")))
 
       case RefuseNode =>
-        newNodeManager.refuse(ids, modId, actor, "").map(_.map(serializeServerInfo(_, "refused")))
+        newNodeManager.refuse(ids, modId, actor, "", DateTime.now).map(_.map(serializeServerInfo(_, "refused")))
 
       case DeleteNode =>
         sequence(ids.map(actualNodeDeletion(_, modId, actor)))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
@@ -142,7 +142,7 @@ class AcceptNode extends Loggable {
     S.clearCurrentNotices
     listNode.foreach { id =>
       val now    = System.currentTimeMillis
-      val accept = newNodeManager.accept(id, modId, CurrentUser.actor)
+      val accept = newNodeManager.accept(id, modId, CurrentUser.actor, DateTime.now)
       if (TimingDebugLogger.isDebugEnabled) {
         TimingDebugLogger.debug(s"Accepting node ${id.value}: ${System.currentTimeMillis - now}ms")
       }
@@ -168,7 +168,7 @@ class AcceptNode extends Loggable {
     S.clearCurrentNotices
     val modId = ModificationId(uuidGen.newUuid)
     listNode.foreach { id =>
-      newNodeManager.refuse(id, modId, CurrentUser.actor) match {
+      newNodeManager.refuse(id, modId, CurrentUser.actor, DateTime.now) match {
         case e: EmptyBox =>
           logger.error(s"Refuse node '${id.value}' lead to Failure.", e)
           S.error(<span class="error">Error while refusing node(s).</span>)


### PR DESCRIPTION
https://issues.rudder.io/issues/24869

For some reason, the "version" i.e. DateTime of the inventory couldn't be retrieved in the _nodefacts_ table after the `HistorizeNodeStateOnChoice` acceptor saved it, maybe it is just the wrong timing or the ordering of acceptors is wrong...

So instead just pass the same datetime into context everywhere and don't rely on that for logging into the event log :grin:...

(I have not tested this PR but it compiles)