### PR TITLE
Fixes #24897: 

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ApiCalls.elm
@@ -23,7 +23,7 @@ getAccounts model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "apiaccounts" ] []
         , body    = emptyBody
         , expect  = Detailed.expectJson GetAccountsResult (decodeGetAccounts model.ui.datePickerInfo)
@@ -42,7 +42,7 @@ saveAccount account model =
     req =
       request
         { method  = method
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model url []
         , body    = encodeAccount model.ui.datePickerInfo account |> jsonBody
         , expect  = Detailed.expectJson SaveAccount (decodePostAccount model.ui.datePickerInfo)
@@ -58,7 +58,7 @@ deleteAccount account model =
     req =
       request
         { method  = "DELETE"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model ["apiaccounts", account.id] []
         , body    = emptyBody
         , expect  = Detailed.expectJson (ConfirmActionAccount Delete) (decodePostAccount model.ui.datePickerInfo)
@@ -74,7 +74,7 @@ regenerateToken account model =
     req =
       request
         { method  = "POST"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model ["apiaccounts", account.id, "regenerate"] []
         , body    = emptyBody
         , expect  = Detailed.expectJson (ConfirmActionAccount Regenerate) (decodePostAccount model.ui.datePickerInfo)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Agentpolicymode/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Agentpolicymode/ApiCalls.elm
@@ -22,7 +22,7 @@ getGlobalPolicyMode model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "settings", "global_policy_mode" ] []
         , body    = emptyBody
         , expect  = expectJson GetGlobalPolicyModeResult decodeGetPolicyMode
@@ -38,7 +38,7 @@ getPolicyModeOverridable model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "settings", "global_policy_mode_overridable" ] []
         , body    = emptyBody
         , expect  = expectJson GetPolicyModeOverridableResult decodeGetPolicyModeOverridable
@@ -54,7 +54,7 @@ getNodePolicyMode model nodeId =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "nodes", nodeId ] []
         , body    = emptyBody
         , expect  = expectJson GetNodePolicyModeResult decodeGetNodeDetails
@@ -73,7 +73,7 @@ saveChanges model =
     req =
       request
         { method  = "POST"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model url []
         , body    = encodeSettings model.selectedSettings |> jsonBody
         , expect  = expectJson SaveChanges decoder

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ApiCalls.elm
@@ -21,7 +21,7 @@ getPolicyMode model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "settings", "global_policy_mode" ] []
         , body    = emptyBody
         , expect  = expectJson GetPolicyModeResult decodeGetPolicyMode
@@ -37,7 +37,7 @@ getDirectiveCompliance model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "compliance", "directives", model.directiveId.value ] []
         , body    = emptyBody
         , expect  = expectJson GetDirectiveComplianceResult decodeGetDirectiveCompliance
@@ -53,7 +53,7 @@ getCSVExport model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "compliance", "directives", model.directiveId.value ] [ Url.Builder.string "format" "csv"]
         , body    = emptyBody
         , expect  = expectString Export

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ApiCalls.elm
@@ -41,7 +41,7 @@ getTechniques  model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model "techniques"
         , body    = emptyBody
         , expect  = Detailed.expectJson GetTechniques ( Json.Decode.at ["data", "techniques" ] (Json.Decode.map (List.filterMap identity) (Json.Decode.list (decodeTechniqueMaybe))))
@@ -58,7 +58,7 @@ getTechniqueYaml  model technique =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model "techniques/"++technique.id.value++"/"++technique.version++"?format=yaml"
         , body    = emptyBody
         , expect  = Detailed.expectJson GetYaml ( Json.Decode.at ["data", "techniques" ] (headList  (Json.Decode.list (Json.Decode.at ["content"] Json.Decode.string))))
@@ -81,7 +81,7 @@ checkTechnique mode model =
     req =
       request
         { method  = "POST"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model "techniques/check?input="++input++"&output="++output
         , body    =  body
         , expect  = expect
@@ -96,7 +96,7 @@ getTechniquesCategories model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model "techniques/categories"
         , body    = emptyBody
         , expect  = Detailed.expectJson GetCategories ( Json.Decode.at ["data", "techniqueCategories" ] ( decodeCategory))
@@ -112,7 +112,7 @@ getMethods  model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model "methods"
         , body    = emptyBody
         , expect  = Detailed.expectJson GetMethods ( Json.Decode.at ["data", "methods" ] ( Json.Decode.map (Dict.fromList) (Json.Decode.keyValuePairs decodeMethod) ))
@@ -132,7 +132,7 @@ saveTechnique  technique creation internalId model  =
     req =
       request
         { method  = if creation then "PUT" else "POST"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model "techniques" ++ (if creation then "" else "/"++technique.id.value++"/"++technique.version)
         , body    = encoder |> jsonBody
         , expect  = Detailed.expectJson SaveTechnique ( Json.Decode.at ["data", "techniques" ] ( list decodeTechnique ) |> headList)
@@ -149,7 +149,7 @@ deleteTechnique  technique model =
     req =
       request
         { method  = "DELETE"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model "techniques/" ++ technique.id.value ++ "/" ++ technique.version
         , body    = emptyBody
         , expect  = Detailed.expectJson DeleteTechnique ( Json.Decode.at ["data", "techniques" ] ( decodeDeleteTechniqueResponse ))
@@ -169,7 +169,7 @@ getRessources state model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model url
         , body    = emptyBody
         , expect  = Detailed.expectJson GetTechniqueResources ( Json.Decode.at ["data", "resources" ] ( Json.Decode.list decodeResource ))
@@ -188,7 +188,7 @@ copyResourcesToDraft draftId technique optId model =
     req =
       request
         { method  = "POST"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = url
         , body    = emptyBody
         , expect  = Detailed.expectWhatever CopyResources

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Action.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Action.elm
@@ -19,7 +19,7 @@ get :  String -> Decoder a -> (Result Http.Error a -> msg) -> Cmd msg
 get url decoder handler =
   request
     { method = "GET"
-    , headers = []
+    , headers = [header "X-Requested-With" "XMLHttpRequest"]
     , url = url
     , body = emptyBody
     , expect = expectJson handler decoder
@@ -31,7 +31,7 @@ post :  String -> Body -> Decoder a -> (Result Http.Error a -> msg) -> Cmd msg
 post  url body decoder handler =
   request
     { method = "POST"
-    , headers = []
+    , headers = [header "X-Requested-With" "XMLHttpRequest"]
     , url = url
     , body = body
     , expect = expectJson handler decoder
@@ -43,7 +43,7 @@ upload : String -> String -> File -> Cmd Msg
 upload api dir file =
   request
     { method = "POST"
-    , headers = []
+    , headers = [header "X-Requested-With" "XMLHttpRequest"]
     , url = api
     , body = Http.multipartBody [ Http.stringPart "destination" dir, Http.filePart "file" file ]
     , expect = Http.expectWhatever Uploaded

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Filters/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Filters/ApiCalls.elm
@@ -25,7 +25,7 @@ getCompletionTags model completion =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model param []
         , body    = emptyBody
         , expect  = expectJson (GetCompletionTags completion) decodeCompletionTags

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ApiCalls.elm
@@ -21,7 +21,7 @@ getPolicyMode model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "settings", "global_policy_mode" ] []
         , body    = emptyBody
         , expect  = expectJson GetPolicyModeResult decodeGetPolicyMode
@@ -37,7 +37,7 @@ getGlobalGroupCompliance model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "compliance", "groups", model.groupId.value ] []
         , body    = emptyBody
         , expect  = expectJson GetGroupComplianceResult decodeGetGroupCompliance
@@ -53,7 +53,7 @@ getTargetedGroupCompliance model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "compliance", "groups", model.groupId.value, "target" ] []
         , body    = emptyBody
         , expect  = expectJson GetGroupComplianceResult decodeGetGroupCompliance

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/ApiCalls.elm
@@ -16,7 +16,7 @@ getRulesTree model relatedRules =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "rulesinternal", "relatedtree" ] [string "rules" (String.join "," (List.map (.value) relatedRules.value))]
         , body    = emptyBody
         , expect  = expectJson (GetRulesResult relatedRules) decodeGetRulesTree

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/ApiCalls.elm
@@ -1,7 +1,7 @@
 module Groups.ApiCalls exposing (..)
 
 import Url.Builder exposing (string, QueryParameter)
-import Http exposing (emptyBody, expectJson, request)
+import Http exposing (emptyBody, expectJson, request, header)
 
 import Groups.DataTypes exposing (..)
 import Groups.JsonDecoder exposing (..)
@@ -20,9 +20,8 @@ getGroupsCompliance keepGroups groupIds model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "compliance", "summary", "groups"] [string "groups" (String.join "," (List.map (.value) groupIds))]
-
         , body    = emptyBody
         , expect  = expectJson (GetGroupsComplianceResult keepGroups) decodeGetGroupsCompliance
         , timeout = Nothing
@@ -37,10 +36,10 @@ getGroupsTree model chainInitTable =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model ["groupsinternal", "categorytree"] []
         , body    = emptyBody
-        , expect  = expectJson (\r -> GetGroupsTreeResult r chainInitTable) decodeGetGroupsTree 
+        , expect  = expectJson (\r -> GetGroupsTreeResult r chainInitTable) decodeGetGroupsTree
         , timeout = Nothing
         , tracker = Nothing
         }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Hooks/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Hooks/ApiCalls.elm
@@ -23,7 +23,7 @@ getHooks model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [] []
         , body    = emptyBody
         , expect  = Detailed.expectJson GetHooksResult decodeGetHooks

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Node/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Node/ApiCalls.elm
@@ -22,7 +22,7 @@ getScoreDetails model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model ["nodes" , model.nodeId.value, "score" , "details"] []
         , body    = emptyBody
         , expect  = expectJson GetScoreDetails decodeGetDetails
@@ -39,7 +39,7 @@ getScoreInfo model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model url []
         , body    = emptyBody
         , expect  = expectJson GetScoreInfo decodeGetInfo

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/ApiCalls.elm
@@ -21,7 +21,7 @@ getPolicyMode model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "settings", "global_policy_mode" ] []
         , body    = emptyBody
         , expect  = expectJson GetPolicyModeResult decodeGetPolicyMode
@@ -38,7 +38,7 @@ getNodeCompliance model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model url []
         , body    = emptyBody
         , expect  = expectJson GetNodeComplianceResult decodeGetNodeCompliance

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ApiCalls.elm
@@ -20,7 +20,7 @@ getNodeProperties model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "displayInheritedProperties" ] []
         , body    = emptyBody
         , expect  = expectJson GetNodeProperties decoder
@@ -37,7 +37,7 @@ saveProperty properties model successMsg =
     req =
       request
         { method  = "POST"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [] []
         , body    = encodeProperty model properties "Add" |> jsonBody
         , expect  = expectJson (SaveProperty successMsg) decoder
@@ -55,7 +55,7 @@ deleteProperty property model =
     req =
       request
         { method  = "POST"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [] []
         , body    = encodeProperty model [property] "Delete" |> jsonBody
         , expect  = expectJson (SaveProperty successMsg) decoder

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/QuickSearch/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/QuickSearch/ApiCalls.elm
@@ -1,7 +1,7 @@
 module QuickSearch.ApiCalls exposing (..)
 
 
-import Http exposing (get)
+import Http exposing (request, header, emptyBody)
 import Http.Detailed as Detailed
 import Json.Decode exposing (at, list)
 import QuickSearch.Datatypes exposing (..)
@@ -23,9 +23,14 @@ getSearchResult : Model -> String -> Cmd Msg
 getSearchResult model search =
   let
     req =
-      get
-        { url     = getUrl model search
+      request
+        { method  = "GET"
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
+        , url     = getUrl model search
+        , body    = emptyBody
         , expect  = Detailed.expectJson GetResults (at ["data"] (list decoderResult))
+        , timeout = Nothing
+        , tracker = Nothing
         }
   in
     req

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ApiCalls.elm
@@ -3,7 +3,6 @@ module Rules.ApiCalls exposing (..)
 import Http exposing (..)
 import Time.Iso8601
 import Time.ZonedDateTime exposing (ZonedDateTime)
-import Url
 import Url.Builder exposing (QueryParameter, int, string)
 import Maybe.Extra exposing (isJust)
 import List.Extra exposing (find)
@@ -36,7 +35,7 @@ getRulesTree model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "rules" ,"tree" ] []
         , body    = emptyBody
         , expect  = expectJson GetRulesResult decodeGetRulesTree
@@ -52,7 +51,7 @@ getRuleChanges model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "changes" ] []
         , body    = emptyBody
         , expect  = expectJson GetRuleChanges decodeRuleChanges
@@ -69,7 +68,7 @@ getRepairedReports model ruleId start end =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "changes", ruleId.value ] [string "start" (Time.Iso8601.fromZonedDateTime start), string "end" (Time.Iso8601.fromZonedDateTime end) ]
         , body    = emptyBody
         , expect  = expectJson (GetRepairedReportsResult ruleId start end) decodeRepairedReports
@@ -87,7 +86,7 @@ getPolicyMode model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "settings", "global_policy_mode" ] []
         , body    = emptyBody
         , expect  = expectJson GetPolicyModeResult decodeGetPolicyMode
@@ -103,7 +102,7 @@ getCrSettings model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "settings" ] []
         , body    = emptyBody
         , expect  = expectJson GetChangeRequestSettings decodeGetChangeRequestSettings
@@ -119,7 +118,7 @@ getPendingChangeRequests model ruleId =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "changeRequests" ] [string "status" "open", string "ruleId" ruleId.value]
         , body    = emptyBody
         , expect  = expectJson GetPendingChangeRequests decodePendingChangeRequests
@@ -135,7 +134,7 @@ getGroupsTree model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model ["groups", "tree"] []
         , body    = emptyBody
         , expect  = expectJson GetGroupsTreeResult decodeGetGroupsTree
@@ -151,7 +150,7 @@ getTechniquesTree model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "directives", "tree" ] []
         , body    = emptyBody
         , expect  = expectJson GetTechniquesTreeResult decodeGetTechniquesTree
@@ -167,7 +166,7 @@ getRuleDetails model ruleId =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "rules" , ruleId.value ] []
         , body    = emptyBody
         , expect  = expectJson GetRuleDetailsResult decodeGetRuleDetails
@@ -184,7 +183,7 @@ getRulesCategoryDetails model catId =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model ["rules" , "categories", catId] []
         , body    = emptyBody
         , expect  = expectJson GetCategoryDetailsResult decodeGetCategoryDetails
@@ -200,7 +199,7 @@ getRuleNodesDirectives ruleId model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "rulesinternal", "nodesanddirectives", ruleId.value ] []
         , body    = emptyBody
         , expect  = expectJson ( GetRuleNodesDirectivesResult ruleId ) decodeRuleNodesDirective
@@ -216,7 +215,7 @@ getRulesCompliance model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "compliance", "rules"] [ int "level" 1 ]
         , body    = emptyBody
         , expect  = expectJson GetRulesComplianceResult decodeGetRulesCompliance
@@ -232,7 +231,7 @@ getRulesComplianceDetails ruleId model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "compliance", "rules", ruleId.value ] [ int "level" 10 ]
         , body    = emptyBody
         , expect  = expectJson (GetRuleComplianceResult ruleId) decodeGetRulesComplianceDetails
@@ -249,7 +248,7 @@ getNodesList model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model ["nodes"] []
         , body    = emptyBody
         , expect  = expectJson GetNodesList decodeGetNodesList
@@ -292,7 +291,7 @@ saveRuleDetails ruleDetails creation model =
     req =
       request
         { method  = method
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model url (changeRequestParameters model.ui.crSettings)
         , body    = encodeRuleDetails newRuleDetails |> jsonBody
         , expect  = expectJson (SaveRuleDetails unknwonTargetsMsg) decodeGetRuleDetails
@@ -309,7 +308,7 @@ saveDisableAction ruleDetails model =
     req =
       request
         { method  = "POST"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model ["rules", ruleDetails.id.value ] (changeRequestParameters model.ui.crSettings)
         , body    = encodeRuleDetails ruleDetails |> jsonBody
         , expect  = expectJson SaveDisableAction decodeGetRuleDetails
@@ -326,7 +325,7 @@ saveCategoryDetails category parentId creation model =
     req =
       request
         { method  = method
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model url []
         , body    = encodeCategoryDetails parentId category |> jsonBody
         , expect  = expectJson SaveCategoryResult decodeGetCategoryDetails
@@ -342,7 +341,7 @@ deleteRule rule model =
     req =
       request
         { method  = "DELETE"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model ["rules", rule.id.value ] []
         , body    = emptyBody
         , expect  = expectJson DeleteRule decodeDeleteRuleResponse
@@ -358,7 +357,7 @@ deleteCategory category model =
     req =
       request
         { method  = "DELETE"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model ["rules","categories", category.id] []
         , body    = emptyBody
         , expect  = expectJson DeleteCategory decodeDeleteCategoryResponse

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Score/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Score/ApiCalls.elm
@@ -22,7 +22,7 @@ getScore model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model url []
         , body    = emptyBody
         , expect  = expectJson GetScore decodeGetScore
@@ -41,7 +41,7 @@ getScoreDetails model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model url []
         , body    = emptyBody
         , expect  = expectJson GetScore decodeGetScore
@@ -58,7 +58,7 @@ getScoreInfo model =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model url []
         , body    = emptyBody
         , expect  = expectJson GetScoreInfo decodeGetInfo

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Tags/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Tags/ApiCalls.elm
@@ -24,7 +24,7 @@ getCompletionTags model completion =
     req =
       request
         { method  = "GET"
-        , headers = []
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model param []
         , body    = emptyBody
         , expect  = expectJson (GetCompletionTags completion) decodeCompletionTags

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/ApiCalls.elm
@@ -6,7 +6,7 @@ module UserManagement.ApiCalls exposing (..)
 -- API call to get the category tree
 
 import UserManagement.DataTypes exposing (AddUserForm, Model, Msg(..), UserAuth, UserInfoForm, Username)
-import Http exposing (emptyBody, expectJson, get, jsonBody, post, request)
+import Http exposing (emptyBody, expectJson, jsonBody, request, header)
 import Json.Decode as Decode
 import UserManagement.JsonDecoder exposing (decodeApiAddUserResult, decodeApiCurrentUsersConf, decodeApiDeleteUserResult, decodeApiReloadResult, decodeApiStatusResult, decodeApiUpdateUserInfoResult, decodeApiUpdateUserResult, decodeGetRoleApiResult)
 import UserManagement.JsonEncoder exposing (encodeAddUser, encodeUserAuth, encodeUserInfo)
@@ -21,9 +21,14 @@ getUsersConf : Model -> Cmd Msg
 getUsersConf model =
     let
         req =
-            get
-                { url = getUrl model "/usermanagement/users"
+            request
+                { method = "GET"
+                , headers = [header "X-Requested-With" "XMLHttpRequest"]
+                , url = getUrl model "/usermanagement/users"
+                , body = emptyBody
                 , expect = expectJson GetUserInfo decodeApiCurrentUsersConf
+                , timeout = Nothing
+                , tracker = Nothing
                 }
     in
     req
@@ -33,10 +38,14 @@ postReloadConf : Model -> Cmd Msg
 postReloadConf model =
     let
         req =
-            post
-                { url = getUrl model "/usermanagement/users/reload"
+            request
+                { method = "POST"
+                , headers = [header "X-Requested-With" "XMLHttpRequest"]
+                , url = getUrl model "/usermanagement/users/reload"
                 , body = emptyBody
                 , expect = expectJson PostReloadUserInfo decodeApiReloadResult
+                , timeout = Nothing
+                , tracker = Nothing
                 }
     in
     req
@@ -46,10 +55,14 @@ addUser : Model -> AddUserForm -> Cmd Msg
 addUser model userForm =
     let
         req =
-            post
-                { url = getUrl model "/usermanagement"
+            request
+                { method = "POST"
+                , headers = [header "X-Requested-With" "XMLHttpRequest"]
+                , url = getUrl model "/usermanagement"
                 , body = jsonBody (encodeAddUser userForm)
                 , expect = expectJson AddUser decodeApiAddUserResult
+                , timeout = Nothing
+                , tracker = Nothing
                 }
     in
     req
@@ -61,7 +74,7 @@ deleteUser username model =
         req =
             request
                 { method = "DELETE"
-                , headers = []
+                , headers = [header "X-Requested-With" "XMLHttpRequest"]
                 , url = getUrl model ("/usermanagement/" ++ username)
                 , body = emptyBody
                 , expect = expectJson DeleteUser decodeApiDeleteUserResult
@@ -76,10 +89,14 @@ updateUser : Model -> String -> UserAuth -> Cmd Msg
 updateUser model toUpdate userForm =
     let
         req =
-            post
-                { url = getUrl model ("/usermanagement/update/" ++ toUpdate)
+            request
+                { method = "POST"
+                , headers = [header "X-Requested-With" "XMLHttpRequest"]
+                , url = getUrl model ("/usermanagement/update/" ++ toUpdate)
                 , body = jsonBody (encodeUserAuth userForm)
                 , expect = expectJson UpdateUser decodeApiUpdateUserResult
+                , timeout = Nothing
+                , tracker = Nothing
                 }
     in
     req
@@ -89,10 +106,14 @@ updateUserInfo : Model -> String -> UserInfoForm -> Cmd Msg
 updateUserInfo model toUpdate userForm =
     let
         req =
-            post
-                { url = getUrl model ("/usermanagement/update/info/" ++ toUpdate)
+            request
+                { method = "POST"
+                , headers = [header "X-Requested-With" "XMLHttpRequest"]
+                , url = getUrl model ("/usermanagement/update/info/" ++ toUpdate)
                 , body = jsonBody (encodeUserInfo userForm)
                 , expect = expectJson UpdateUserInfo decodeApiUpdateUserInfoResult
+                , timeout = Nothing
+                , tracker = Nothing
                 }
     in
     req
@@ -104,7 +125,7 @@ activateUser model username =
         req =
             request
                 { method = "PUT"
-                , headers = []
+                , headers = [header "X-Requested-With" "XMLHttpRequest"]
                 , url = getUrl model ("/usermanagement/status/activate/" ++ username)
                 , body = emptyBody
                 , expect = expectJson UpdateUserStatus (Decode.map (\_ -> username) decodeApiStatusResult)
@@ -121,7 +142,7 @@ disableUser model username =
         req =
             request
                 { method = "PUT"
-                , headers = []
+                , headers = [header "X-Requested-With" "XMLHttpRequest"]
                 , url = getUrl model ("/usermanagement/status/disable/" ++ username)
                 , body = emptyBody
                 , expect = expectJson UpdateUserStatus (Decode.map (\_ -> username) decodeApiStatusResult)
@@ -136,9 +157,14 @@ getRoleConf : Model -> Cmd Msg
 getRoleConf model =
     let
         req =
-            get
-                { url = getUrl model "/usermanagement/roles"
+            request
+                { method = "GET"
+                , headers = [header "X-Requested-With" "XMLHttpRequest"]
+                , url = getUrl model "/usermanagement/roles"
+                , body = emptyBody
                 , expect = expectJson GetRoleConf decodeGetRoleApiResult
+                , timeout = Nothing
+                , tracker = Nothing
                 }
     in
     req

--- a/webapp/sources/rudder/rudder-web/src/main/resources/applicationContext-security.xml
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/applicationContext-security.xml
@@ -33,6 +33,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
 
+
 <beans:beans xmlns="http://www.springframework.org/schema/security"
   xmlns:beans="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -40,6 +41,8 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
 		http://www.springframework.org/schema/security
 		http://www.springframework.org/schema/security/spring-security.xsd">
+
+  <beans:bean id="restSecureAuthenticationFilter" class="bootstrap.liftweb.RestSecureAuthenticationFilter" />
 
 <!--    <global-method-security pre-post-annotations="enabled">-->
 <!--         AspectJ pointcut expression that locates our "post" method and applies security that way-->
@@ -56,6 +59,19 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <intercept-url pattern='/**' access="hasRole('ROLE_REMOTE')" />
       <custom-filter position="BASIC_AUTH_FILTER" ref="restAuthenticationFilter" />
       <csrf disabled="true"/>
+    </http>
+
+    <!-- same config as mainHttpSecurityFilters but applies to authenticated API calls (/secure/api/): they need a custom filter for CSRF mitigation -->
+    <http pattern="/secure/api/**" disable-url-rewriting="true"  entry-point-ref="restAuthenticationEntryPoint">
+        <intercept-url pattern="/**" access="isAuthenticated()" />
+        <custom-filter after="LAST" ref="restSecureAuthenticationFilter" />
+        <headers>
+            <xss-protection disabled="true"/>
+            <frame-options disabled="true"/>
+        </headers>
+
+        <csrf disabled="true"/>
+        <session-management session-fixation-protection="migrateSession" />
     </http>
 
     <http use-expressions="true" disable-url-rewriting="true" name="mainHttpSecurityFilters">

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -329,6 +329,9 @@ class AppConfigAuth extends ApplicationContextAware {
   @Bean def restAuthenticationFilter =
     new RestAuthenticationFilter(RudderConfig.roApiAccountRepository, rudderUserDetailsService, SYSTEM_API_ACL)
 
+  @Bean def restSecureAuthenticationFilter =
+    new RestSecureAuthenticationFilter()
+
   @Bean def restAuthenticationEntryPoint: AuthenticationEntryPoint = new AuthenticationEntryPoint() {
     override def commence(request: HttpServletRequest, response: HttpServletResponse, ex: AuthenticationException): Unit = {
       response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized")

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RestSecureAuthenticationFilter.java
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RestSecureAuthenticationFilter.java
@@ -1,0 +1,37 @@
+package bootstrap.liftweb;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Filter to check that X-Requested-With header is present and has the value
+ * XMLHttpRequest, to mitigate CSRF attacks.
+ */
+public class RestSecureAuthenticationFilter implements Filter {
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+		HttpServletRequest httpRequest = (HttpServletRequest) request;
+		HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+		String requestedWithHeader = httpRequest.getHeader("X-Requested-With");
+		if (requestedWithHeader == null || !requestedWithHeader.equals("XMLHttpRequest")) {
+			httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			httpResponse.getWriter().write("CSRF mitigation header missing or invalid.");
+			return;
+		}
+
+		chain.doFilter(request, response);
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+	}
+
+	@Override
+	public void destroy() {
+	}
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/24897

I chose to go with the same header used by jQuery.

Tested with:

```
# Internal API
<LocationMatch /rudder/secure/api/>
    <RequireAll>
        Require expr %{HTTP:X-Requested-With} == 'XMLHttpRequest'
    </RequireAll>
</LocationMatch>
```

in apache configuration. Still lacking the same in API auth code (I could not find where to add it). And we'll obviously have to do the same in the plugins.