### PR TITLE
Fixes #24882: Compliance doesn't show up at the top level in rudder 8.1.3~nightly

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Compliance/Utils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Compliance/Utils.elm
@@ -305,7 +305,7 @@ filterCompliance complianceDetails complianceFilters =
       ]
 
     statuses = if List.isEmpty complianceFilters.selectedStatus then
-                 allStatuses
+                 []
                else
                  if complianceFilters.showOnlyStatus then
                    List.filter (\s -> not (List.member s complianceFilters.selectedStatus )) allStatuses


### PR DESCRIPTION
https://issues.rudder.io/issues/24882

The list of status was the list of status to filter out, not the list of statuses to include. hence an empty list of filters was filterint out all statuses making and empty compliance bar