### PR TITLE
Fixes #24907: The list of plugin in info API is always empty

### DIFF
--- a/webapp/sources/utils/src/main/scala/zio/syntax.scala
+++ b/webapp/sources/utils/src/main/scala/zio/syntax.scala
@@ -5,7 +5,7 @@ import zio.IO
  * .fail and .succeed were removed in RC18
  */
 object syntax {
-  implicit class ToZio[A](a: A) {
+  implicit class ToZio[A](a: => A) {
     def fail:    IO[A, Nothing]       = ZIO.fail(a)
     def succeed: ZIO[Any, Nothing, A] = ZIO.succeed(a)
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/24907

So, at some point `ZIO` changed implementation of `ZIO.succeed` to make its parameter call by name, which was not reflected in our syntax add-on, which means that we were capturing the result of the computation and not a real effect. 