### PR TITLE
Fixes #24865: User management should display tenants, last and previous session

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/User.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/User.scala
@@ -120,7 +120,9 @@ case class UserSession(
     tenants:      Option[String],
     endDate:      Option[DateTime],
     endCause:     Option[String]
-)
+) {
+  def isOpen: Boolean = endDate.isEmpty
+}
 
 object UserSerialization {
   implicit val codecUserStatus:    JsonCodec[UserStatus]    = new JsonCodec[UserStatus](

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
@@ -334,7 +334,7 @@ class InMemoryUserRepository(userBase: Ref[Map[String, UserInfo]], sessionBase: 
 
   override def getLastPreviousLogin(userId: String, closedSessionsOnly: Boolean = true): IOResult[Option[UserSession]] = {
     // sessions are sorted oldest first, for find is ok
-    sessionBase.get.map(_.find(s => s.userId == userId && s.endDate.isDefined))
+    sessionBase.get.map(_.find(s => s.userId == userId && (!closedSessionsOnly || s.endDate.isDefined)))
   }
 
   override def deleteOldSessions(olderThan: DateTime): IOResult[Unit] = {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
@@ -227,7 +227,9 @@ final case class JsonUser(
     customRights:                    JsonRights,
     providers:                       List[String],
     providersInfo:                   Map[String, JsonProviderInfo],
-    lastLogin:                       Option[DateTime]
+    tenants:                         String,
+    lastLogin:                       Option[DateTime],
+    previousLogin:                   Option[DateTime]
 ) {
   def merge(providerInfo: JsonProviderInfo): JsonUser = {
     JsonUser(
@@ -237,7 +239,9 @@ final case class JsonUser(
       otherInfo,
       status,
       providersInfo + (providerInfo.provider -> providerInfo),
-      lastLogin
+      tenants,
+      lastLogin,
+      previousLogin
     )
   }
 
@@ -245,7 +249,7 @@ final case class JsonUser(
     * Only add the provider info but do not take it into account in roles and rights
     */
   def addProviderInfo(providerInfo: JsonProviderInfo): JsonUser = {
-    // The list is not ordered so we can just append
+    // TODO: The list is not ordered so we can just append
     copy(providers = providers :+ providerInfo.provider, providersInfo = providersInfo + (providerInfo.provider -> providerInfo))
   }
 
@@ -281,7 +285,9 @@ object JsonUser {
       otherInfo:     Json.Obj,
       status:        UserStatus,
       providersInfo: Map[String, JsonProviderInfo],
-      lastLogin:     Option[DateTime]
+      tenants:       String,
+      lastLogin:     Option[DateTime],
+      previousLogin: Option[DateTime]
   ): JsonUser = {
     JsonUser(
       username,
@@ -295,7 +301,9 @@ object JsonUser {
       JsonRights.empty,
       providersInfo.keys.toList,
       providersInfo,
-      lastLogin
+      tenants,
+      lastLogin,
+      previousLogin
     )
   }
   def anyRights(
@@ -305,7 +313,9 @@ object JsonUser {
       otherInfo:     Json.Obj,
       status:        UserStatus,
       providersInfo: Map[String, JsonProviderInfo],
-      lastLogin:     Option[DateTime]
+      tenants:       String,
+      lastLogin:     Option[DateTime],
+      previousLogin: Option[DateTime]
   ): JsonUser = {
     JsonUser(
       username,
@@ -319,7 +329,9 @@ object JsonUser {
       JsonRights.empty,
       providersInfo.keys.toList,
       providersInfo,
-      lastLogin
+      tenants,
+      lastLogin,
+      previousLogin
     )
   }
 
@@ -331,7 +343,9 @@ object JsonUser {
       otherInfo:     Json.Obj,
       status:        UserStatus,
       providersInfo: Map[String, JsonProviderInfo],
-      lastLogin:     Option[DateTime]
+      tenants:       String,
+      lastLogin:     Option[DateTime],
+      previousLogin: Option[DateTime]
   ): JsonUser = {
     val authz        = providersInfo.values.map(_.authz).foldLeft(JsonRights.empty)(_ ++ _)
     val roles        = providersInfo.values.map(_.roles).foldLeft(JsonRoles.empty)(_ ++ _)
@@ -349,7 +363,9 @@ object JsonUser {
       customRights,
       providersInfo.keys.toList,
       providersInfo,
-      lastLogin
+      tenants,
+      lastLogin,
+      previousLogin
     )
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_usermanagement.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_usermanagement.yml
@@ -96,7 +96,8 @@ response:
                 ],
                 "customRights" : ["no_rights"]
               }
-            }
+            },
+            "tenants" : "zoneA"
           },
           {
             "login" : "user2",
@@ -157,7 +158,9 @@ response:
                 "customRights" : ["no_rights"]
               }
             },
-            "lastLogin" : "2024-02-29T00:00:00Z"
+            "tenants" : "all",
+            "lastLogin" : "2024-02-29T00:00:00Z",
+            "previousLogin" : "2024-02-28T12:34:00Z"
           },
           {
             "login" : "user3",
@@ -181,7 +184,8 @@ response:
                 "roles" : [],
                 "customRights" : ["no_rights"]
               }
-            }
+            },
+            "tenants" : "none"
           }
         ]
       }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/test-users.xml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/test-users.xml
@@ -1,4 +1,4 @@
 <authentication hash="bcrypt" case-sensitivity="true">
-  <user name="user1" password="1234" permissions="user" />
+  <user name="user1" password="1234" permissions="user" tenants="zoneA" />
   <user name="user2" password="4321" permissions="read_only" />
 </authentication>

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -798,7 +798,7 @@ class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSessi
     override def closeAllOpenSession(endDate: DateTime, endCause: String): IOResult[Unit] = ???
 
     override def getLastPreviousLogin(userId: String, closedSessionsOnly: Boolean): IOResult[Option[UserSession]] = {
-      userSessions.find(_.userId == userId).succeed
+      userSessions.find(us => us.userId == userId && (!closedSessionsOnly || !us.isOpen)).succeed
     }
 
     override def deleteOldSessions(olderThan: DateTime): IOResult[Unit] = ???
@@ -926,13 +926,24 @@ object MockUserManagement {
     List(
       UserSession(
         "user2",
-        SessionId("s2"),
+        SessionId("s2-2"),
         DateTime.parse("2024-02-29T00:00:00Z"),
         "file",
         List.empty,
         List.empty,
         None,
         None,
+        None
+      ),
+      UserSession(
+        "user2",
+        SessionId("s2-1"),
+        DateTime.parse("2024-02-28T12:34:00Z"),
+        "file",
+        List.empty,
+        List.empty,
+        Some("a-previous-tenant-zone"),
+        Some(DateTime.parse("2024-02-28T12:34:00Z")),
         None
       )
     )

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserSerializationTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserSerializationTest.scala
@@ -6,7 +6,7 @@ import org.specs2.runner.JUnitRunner
 import zio.json.ast.Json
 
 @RunWith(classOf[JUnitRunner])
-class SerializationTest extends Specification {
+class UserSerializationTest extends Specification {
 
   "JsonUser" should {
     "use providers info" in {
@@ -37,10 +37,12 @@ class SerializationTest extends Specification {
         JsonRights(Set("custom_read")),
         List("provider1", "provider2"),
         providersInfo,
+        "",
+        None,
         None
       )
 
-      JsonUser("user", None, None, Json.Obj(), UserStatus.Active, providersInfo, None) must beEqualTo(expected)
+      JsonUser("user", None, None, Json.Obj(), UserStatus.Active, providersInfo, "", None, None) must beEqualTo(expected)
     }
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/DataTypes.elm
@@ -47,7 +47,9 @@ type alias User =
     , customRights : List String
     , providers : List String
     , providersInfo : ProvidersInfo
+    , tenants : String
     , lastLogin : Maybe String
+    , previousLogin : Maybe String
     }
 
 type UserStatus = 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/JsonDecoder.elm
@@ -70,7 +70,9 @@ decodeUser =
         |> required "customRights" (D.list <| D.string)
         |> required "providers" (D.list <| D.string)
         |> required "providersInfo" decodeProvidersInfo
+        |> required "tenants" D.string
         |> optional "lastLogin" (D.maybe D.string) Nothing
+        |> optional "previousLogin" (D.maybe D.string) Nothing
 
 decodeUserStatus : Decoder UserStatus
 decodeUserStatus =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/View.elm
@@ -498,13 +498,13 @@ displayRightPanel model user =
                 [ h2 [ class "title-username" ] (text user.login :: List.map (\x -> span [ class "providers" ] [ text x ]) user.providers)
                 , button [ class "btn btn-sm btn-outline-secondary", onClick DeactivatePanel ] [ text "Close" ]
                 , div [ class "user-last-login" ]
-                    [ case user.lastLogin of
+                    (case user.previousLogin of
                         Nothing ->
-                            em [] [ text "Never logged in" ]
+                            [ em [] [ text "Never logged in" ] ]
 
                         Just l ->
-                            em [] [ text ("Last login: " ++ String.replace "T" " " l) ]
-                    ]
+                            [ em [] [ text ("Previous login: " ++ String.replace "T" " " l) ] ]
+                    )
                 ]
              , displayPasswordBlock model (Just user)
              ]
@@ -714,10 +714,17 @@ displayProviders user =
       ( user.providers
           |> List.map (\p -> span[class "badge"][text p])
       )
+    
+displayTenants : User -> Html Msg
+displayTenants user =
+    case user.tenants of
+        "all"  -> span [class "empty"][text "all"]
+        "none" -> span [class "empty"][text "none"]
+        o      -> text o
 
-displayUserLastLogin : User -> Html Msg
-displayUserLastLogin user =
-    case user.lastLogin of
+displayUserPreviousLogin : User -> Html Msg
+displayUserPreviousLogin user =
+    case user.previousLogin of
         Nothing ->
             span[class "empty"][text "Never logged in"]
 
@@ -758,13 +765,11 @@ displayUsersTable model =
             else
                 text ""
             )
-            {-- TENANTS
             , td []
-                [ text ""
+                [ displayTenants user
                 ]
-            --}
             , td []
-                [ displayUserLastLogin user
+                [ displayUserPreviousLogin user
                 ]
             , td []
               [ button
@@ -805,7 +810,7 @@ displayUsersTable model =
         else
             text ""
         )
-        -- , th [class (thClass model.ui.tableFilters Tenants        ), onClick (UpdateTableFilters (sortTable filters Tenants        ))] [ text "Tenants"        ]
+        , th [class (thClass model.ui.tableFilters Tenants        ), onClick (UpdateTableFilters (sortTable filters Tenants        ))] [ text "Tenants"        ]
         , th [class (thClass model.ui.tableFilters PreviousLogin  ), onClick (UpdateTableFilters (sortTable filters PreviousLogin  ))] [ text "Previous login" ]
         , th [style "width" "220px"][ text "Actions" ]
         ]
@@ -904,9 +909,9 @@ getSortFunction model u1 u2 =
                   checkOrder (N.compare name1 name2)
           Rights        -> compareStringList u1.roles u2.roles
           Providers     -> compareStringList u1.providers u2.providers
-          Tenants       -> checkOrder (N.compare u1.name u2.name) -- TODO : Compare tenants list when it will be here
+          Tenants       -> checkOrder (N.compare u1.name u2.name)
           PreviousLogin ->
-              case (u1.lastLogin, u2.lastLogin) of
+              case (u1.previousLogin, u2.previousLogin) of
                   (Just _, Nothing)  -> LT
                   (Nothing, Just _)  -> GT
                   (Nothing, Nothing) -> EQ

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-user-management.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-user-management.scss
@@ -98,7 +98,8 @@
   margin-right: auto;
 }
 
-.role, .auth {
+.role,
+.auth {
   display: inline-block;
   font-size: 13px;
   border: none;
@@ -108,16 +109,21 @@
   margin: 0 5px;
   border-radius: 3px;
 }
+
 .role {
   background-color: #EFF4FF;
   color: #2557D6;
 }
+
 .auth {
   color: #738195;
   background-color: #E3E6ED;
 }
+
 .dataTable {
-  .role, .auth{
+
+  .role,
+  .auth {
     cursor: help;
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/24865

Change is both in the API and the UI :
* in the API : 
  * add `tenants` as a string, which is sourced from `users.xml` file or the _usersessions_ table. I had no choice but parse it as a regex since from the `tags:[...]` format is not the one we want to display in the table, so API value is either `all`, `none` or `zoneA, zoneB`
  * add `previousLogin`, to be distinguished from `lastLogin` which could be the "current login with still an open session"
* in the UI : 
  * display tenants as is, but consider `all` and `none` as special values 
  * use `previousLogin` everywhere instead of `lastLogin` because that's what we want to display wrt semantic of columns. We will use `lastLogin` information later to infer if the user is currently logged in, and display a green circle (when both dates are different) 