### PR TITLE
Fixes #24937: Query in get pending node API doesn't match anything

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/NodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/NodeFactQueryProcessor.scala
@@ -153,7 +153,13 @@ class NodeFactQueryProcessor(
         s"Checking a query with 0 criterium will always lead to 0 nodes: ${query}"
       ) *> Set.empty[NodeId].succeed
     } else {
-      processPure(query).map(nodeFacts => nodeIds.map(_.toSet).getOrElse(Set.empty).intersect(nodeFacts.map(_.id).toSet))
+      nodeIds match {
+        case None      =>
+          processPure(query).map(nodeFacts => nodeFacts.map(_.id).toSet)
+        case Some(ids) =>
+          processPure(query).map(nodeFacts => ids.toSet.intersect(nodeFacts.map(_.id).toSet))
+      }
+
     }
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/24937

My initial though was that the query was not translated correctly in LDAP, but it quickly that was not the problem thanks to @clarktsiory with the trace logs we figure it out that the query was finding the node in the logs
`ubuntu22.rudder.local` is the hostname of my pending node in my example
```
2024-05-28 17:24:05+0200 DEBUG query.node-fact.metrics - Analyse query in 1 ms
2024-05-28 17:24:05+0200 DEBUG query.node-fact - (only matches node and relay) && ([node.nodeHostname eq ubuntu22.rudder.local])
2024-05-28 17:24:05+0200 DEBUG query.node-fact -   --'ubuntu22.rudder.local' (76b87d59-479a-4e1c-9c02-582df36d02b8)--
2024-05-28 17:24:05+0200 TRACE query.node-fact -     [true] for only matches node and relay on 'Node'
2024-05-28 17:24:05+0200 TRACE query.node-fact -     [true] for 'eq ubuntu22.rudder.local' on [ubuntu22.rudder.local]
2024-05-28 17:24:05+0200 DEBUG query.node-fact -   = [true] on 'ubuntu22.rudder.local' (76b87d59-479a-4e1c-9c02-582df36d02b8)
2024-05-28 17:24:05+0200 DEBUG query.node-fact.metrics - Run query in 1 ms
2024-05-28 17:24:05+0200 DEBUG query.node-fact - Found 1 results
2024-05-28 17:24:05+0200 TRACE query.node-fact - Matching nodes: '76b87d59-479a-4e1c-9c02-582df36d02b8'
2024-05-28 17:24:06+0200 DEBUG com.normation.rudder.services.reports.NodeChangesServiceImpl - Get all changes on all rules
2024-05-28 17:24:06+0200 DEBUG com.normation.rudder.repository.jdbc.ReportsJdbcRepository - Fetching all changes for intervals 2024-05-25T12:00:00.000+02:00/2024-05-25T18:00:00.000+02:00,2024-05-25T18:00:00.000+02:00/2024-05-26T00:00:00.000+02:00,2024-05-26T00:00:00.000+02:00/2024-05-26T06:00:00.000+02:00,2024-05-26T06:00:00.000+02:00/2024-05-26T12:00:00.000+02:00,2024-05-26T12:00:00.000+02:00/2024-05-26T18:00:00.000+02:00,2024-05-26T18:00:00.000+02:00/2024-05-27T00:00:00.000+02:00,2024-05-27T00:00:00.000+02:00/2024-05-27T06:00:00.000+02:00,2024-05-27T06:00:00.000+02:00/2024-05-27T12:00:00.000+02:00,2024-05-27T12:00:00.000+02:00/2024-05-27T18:00:00.000+02:00,2024-05-27T18:00:00.000+02:00/2024-05-28T00:00:00.000+02:00,2024-05-28T00:00:00.000+02:00/2024-05-28T06:00:00.000+02:00,2024-05-28T06:00:00.000+02:00/2024-05-28T12:00:00.000+02:00,2024-05-28T12:00:00.000+02:00/2024-05-28T18:00:00.000+02:00
2024-05-28 17:24:06+0200 DEBUG com.normation.rudder.repository.jdbc.ReportsJdbcRepository - Fetched all changes in intervals in 36 ms
2024-05-28 17:24:06+0200 DEBUG com.normation.rudder.services.reports.NodeChangesServiceImpl - Fetched all changes for all rules in 40 ms
```

We figure it out that the problem was the `Option[Seq[NodeId]]` set to `Node` in https://github.com/Normation/rudder/blob/8f3b3c0c07ea755342114d46c48b151cf3ecefff/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala#L1421
According to the documentation, this is the set of `NodeId` on which we run the query
https://github.com/Normation/rudder/blob/8f3b3c0c07ea755342114d46c48b151cf3ecefff/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/QueryProcessor.scala#L70
But the empty set is filtering the result here
https://github.com/Normation/rudder/blob/8f3b3c0c07ea755342114d46c48b151cf3ecefff/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/NodeFactQueryProcessor.scala#L156

This `check` method doesn't seem to be dedicated for pending nodes, we have a class that does seem to suit exactly what we want to do, but I don't know why it was here but left unused, maybe I don't get something. But using the` check` method of that class seems to fix the problem
https://github.com/Normation/rudder/blob/8f3b3c0c07ea755342114d46c48b151cf3ecefff/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala#L217