### PR TITLE
Fixes #24930: Compliance score chart for vulnerabilities is all black with X

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/homePage.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/homePage.js
@@ -289,7 +289,8 @@ function doughnutChart (id,data,colors,hoverColors) {
       , events: ['click', 'mousemove']
       , onClick: (e, active, currentChart) => {
              if (active[0] !== undefined){
-              data = currentChart.data.labels[active[0].index]
+              // we have specific mapping of query filters for scores
+              data = (data.labelQueryFilters ?? currentChart.data.labels)[active[0].index]
               var query = {query:{select:"nodeAndPolicyServer",composition:"And"}};
               switch (id) {
                 case 'nodeOs':


### PR DESCRIPTION
https://issues.rudder.io/issues/24930

* Replace the black color (empty `""`) with gray (`#d8dde5`, same as the gray color for the gauge in the dashboard)
* Display `No ... score found` instead of `X` which is not very user-friendly. With chart.Js, it seems that the legend text is hard to customize, so need to map the label `No ... score found` back to the `X` label when building query filters when redirecting to nodes page...

**Screenshot :**  
![Screenshot from 2024-05-29 10-23-42](https://github.com/Normation/rudder/assets/65616064/92888509-8891-47e5-8363-9362206a64be)
