### PR TITLE
Fixes #24942: Properties tab in groups has no content after a save

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
@@ -213,12 +213,15 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
             redirect match {
               case Left((newGroup, newParentId)) =>
                 refreshGroupLib()
-                val newPanel = GroupForm(newGroup, newParentId)
                 refreshTree(htmlTreeNodeId(newGroup.fold(_.target, _.id.serialize))) &
-                refreshRightPanel(newPanel)
+                showGroupSection(newGroup, newParentId)
               case Right(crId)                   =>
                 linkUtil.redirectToChangeRequestLink(crId)
             }
+          },
+          () => {
+            // On failure, the NodeGroupForm replaces the DOM, and we need to still be initialize the group properties Elm app
+            showGroupProperties(group, parentCatId)
           }
         )
 
@@ -468,12 +471,16 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
   private[this] def fullDisplayCategory(category: FullNodeGroupCategory) = displayCategory(category.toNodeGroupCategory)
 
   private[this] def showGroupSection(g: Either[NonGroupRuleTarget, NodeGroup], parentCategoryId: NodeGroupCategoryId) = {
+    refreshRightPanel(GroupForm(g, parentCategoryId)) &
+    showGroupProperties(g, parentCategoryId)
+  }
+
+  private[this] def showGroupProperties(g: Either[NonGroupRuleTarget, NodeGroup], parentCategoryId: NodeGroupCategoryId) = {
     val value = g.fold(_.target, _.id.serialize)
     val js    = g match {
       case Left(_)  => s"'target':'${value}'"
       case Right(_) => s"'groupId':'${value}'"
     }
-    refreshRightPanel(GroupForm(g, parentCategoryId)) &
     JsRaw(s"""
              |jQuery('#ajaxItemContainer').show();
              |var groupId = JSON.stringify({${js}});


### PR DESCRIPTION
https://issues.rudder.io/issues/24942

The problem was that the Elm app is not mounted when a refresh of the whole DOM occurs on the server side (it leaves the `<div id="nodeproperties-app"></div>` as is).

We just forgot to initialize the app each time it occurs : on success or failure of the node group form update.