### PR TITLE
Fixes #24899: API v19 documentation is missing in 8.1

### DIFF
--- a/webapp/sources/api-doc/introduction.md
+++ b/webapp/sources/api-doc/introduction.md
@@ -166,6 +166,14 @@ period of time to allow migration from previous versions.
         <li>Improve the structure of `/settings/allowed_networks` output</li>
       </ul></td>
     </tr>
+    <tr>
+      <td class="code">19</td>
+      <td class="code">8.1</td>
+      <td><ul>
+        <li>Multi-tenants</li>
+        <li>Scores list</li>
+      </ul></td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
https://issues.rudder.io/issues/24899

New API definitions since v19 : 
![Screenshot from 2024-06-05 17-32-33](https://github.com/Normation/rudder/assets/65616064/ad6084c0-964a-4d0e-9095-db20b1ed27d8)

Both set of endpoints for tenants are listed under `Multi-tenants` section in the existing API doc 