### PR TITLE
Fixes #24472: We should rework the targets rules page when we create a directive

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -2324,3 +2324,7 @@ function displayTags(element, tagsArray){
   $(element).append(tagsLabel);
 }
 
+function searchTargetRules(input) {
+    let table = new DataTable('#grid_rules_grid_zone');
+    table.search(input.value, false, true).draw();
+}

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleDisplayer.scala
@@ -233,13 +233,14 @@ class RuleDisplayer(
                 <div class="box-body">
                   <div class="row">
                     <div class="col-xs-12">
-                      <div id="showFiltersRules" ng-controller="filterTagCtrl" ng-init="initRule()" class="filters" ng-cloak="">
+                      <div id="showFiltersRules" class="filters">
                         <div>
                           <div class="filterTag">
                             <div class="input-group search-addon">
                               <label for="searchStr" class="input-group-addon search-addon"><span class="ion ion-search"></span></label>
-                              <input type="text" id="searchStr" class="input-sm form-control" placeholder="Filter" ng-model="strSearch" ng-keyup="filterGlobal(strSearch)"/>
+                              <input type="text" id="searchStr" class="input-sm form-control" placeholder="Filter" onkeyup="searchTargetRules(this)"/>
                             </div>
+                            <!--
                             <div class="form-group">
                               <label>Tags</label>
                               <div class="input-group">
@@ -286,6 +287,7 @@ class RuleDisplayer(
                                 </button>
                               </div>
                             </div>
+                            -->
                           </div>
                         </div>
                       </div>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateRulePopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateRulePopup.scala
@@ -238,9 +238,6 @@ class CreateOrCloneRulePopup(
       }
       createRule & JsRaw(s"""
         localStorage.setItem('Active_Rule_Tab', 1);
-        scope.$$apply(function(){
-          scope.filterGlobal(scope.searchStr);
-        });
       """.stripMargin)
     }
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/24472

I think this is the simplest solution for bringing the filters back on the target rules (starting with the search bar), while waiting for this interface to be completely rewritten in Elm.

I removed all the dead code linked to the angular application that managed the filters, and replaced it with a simple javascript function, adding an onkeyup event to the search input :

![target-rules-search](https://github.com/Normation/rudder/assets/9928447/4b84a8a8-dbb0-4fb5-bc78-d2317ac9774d)

