### PR TITLE
Fixes #24991: Fix Migrate rest test from yaml file to zio-test

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
@@ -1929,12 +1929,9 @@ object NodeFactSerialisation {
       // for compat before correction of https://issues.rudder.io/issues/24971, we need to keep
       // "physicalMachine". "virtualMachine" wasn't directly used
       val decoder: JsonDecoder[MachineType] = JsonDecoder.string.map {
-        case s =>
-          s.toLowerCase match {
-            case UnknownMachineType.kind                      => UnknownMachineType
-            case PhysicalMachineType.kind | "physicalMachine" => PhysicalMachineType
-            case x                                            => VirtualMachineType(VmType.parse(x).getOrElse(VmType.UnknownVmType))
-          }
+        case UnknownMachineType.kind                      => UnknownMachineType
+        case PhysicalMachineType.kind | "physicalMachine" => PhysicalMachineType
+        case x                                            => VirtualMachineType(VmType.parse(x).getOrElse(VmType.UnknownVmType))
       }
 
       JsonCodec(encoder, decoder)


### PR DESCRIPTION
https://issues.rudder.io/issues/24991

[The change](https://github.com/Normation/rudder/pull/5713/files#r1634555658) introduced a `toLowerCase` but I don't see any reason to add this compatibility, we parse the same JSON that we produced for nodefacts