### PR TITLE
Fixes #25008: When node compliance right is missing, we don't want a red error pop-up

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
@@ -178,6 +178,8 @@ object AuthorizationApiMapping {
           NodeApi.NodeInheritedProperties.x :: NodeApi.NodeDisplayInheritedProperties.x :: NodeApi.NodeDetailsTable.x ::
           NodeApi.PendingNodeDetails.x :: NodeApi.NodeDetailsSoftware.x :: NodeApi.NodeDetailsProperty.x ::
           NodeApi.GetNodesStatus.x :: InventoryApi.QueueInformation.x ::
+          // this compliance is more about how rudder works on that node, it's not really "compliance"
+          ComplianceApi.GetNodeSystemCompliance.x ::
           // node read also allows to read some settings
           AuthzForApi.withValues(SettingsApi.GetSetting, AclPathSegment.Segment("global_policy_mode") :: Nil) ::
           AuthzForApi.withValues(SettingsApi.GetSetting, AclPathSegment.Segment("global_policy_mode_overridable") :: Nil) ::

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -43,6 +43,7 @@ import com.normation.box.*
 import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.inventory.domain.AgentType
 import com.normation.inventory.domain.NodeId
+import com.normation.rudder.AuthorizationType
 import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.domain.policies.PolicyMode
@@ -51,6 +52,7 @@ import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.rudder.repository.RoDirectiveRepository
 import com.normation.rudder.repository.RoRuleRepository
 import com.normation.rudder.services.reports.*
+import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.ChooseTemplate
 import com.normation.rudder.web.model.JsNodeId
 import net.liftweb.common.*
@@ -509,25 +511,34 @@ class ReportDisplayer(
       withCompliance: Boolean,
       onlySystem:     Boolean
   ): NodeSeq = {
-    <div id="nodecompliance-app"></div> ++
-    Script(JsRaw(s"""
-                    |var main = document.getElementById("nodecompliance-app")
-                    |var initValues = {
-                    |  nodeId : "${node.id.value}",
-                    |  contextPath : contextPath,
-                    |  onlySystem: ${onlySystem}
-                    |};
-                    |var app = Elm.Nodecompliance.init({node: main, flags: initValues});
-                    |app.ports.errorNotification.subscribe(function(str) {
-                    |  createErrorNotification(str)
-                    |});
-                    |// Initialize tooltips
-                    |app.ports.initTooltips.subscribe(function(msg) {
-                    |  setTimeout(function(){
-                    |    $$('.bs-tooltip').bsTooltip();
-                    |  }, 800);
-                    |});
-                    |""".stripMargin))
+    // system compliance is not compliance, it's about how rudder works for that node, so linked to node perm
+    if (onlySystem || CurrentUser.checkRights(AuthorizationType.Compliance.Read)) {
+      <div id="nodecompliance-app"></div> ++
+      Script(JsRaw(s"""
+                      |var main = document.getElementById("nodecompliance-app")
+                      |var initValues = {
+                      |  nodeId : "${node.id.value}",
+                      |  contextPath : contextPath,
+                      |  onlySystem: ${onlySystem}
+                      |};
+                      |var app = Elm.Nodecompliance.init({node: main, flags: initValues});
+                      |app.ports.errorNotification.subscribe(function(str) {
+                      |  createErrorNotification(str)
+                      |});
+                      |// Initialize tooltips
+                      |app.ports.initTooltips.subscribe(function(msg) {
+                      |  setTimeout(function(){
+                      |    $$('.bs-tooltip').bsTooltip();
+                      |  }, 800);
+                      |});
+                      |""".stripMargin))
+    } else {
+      <div class="alert alert-warning">
+        <p></p>
+        <p>You don't have enough rights to see compliance details.</p>
+        <p></p>
+      </div>
+    }
   }
 
   // this method cannot return an IOResult, as it uses S.


### PR DESCRIPTION
https://issues.rudder.io/issues/25008

So, when someone does not have the compliance rights, we want to display a nice message in place of the red frightening pop-up. 
Still, we want that someone with the `node_read` right is able to see the "system status" tab, since that compliance is not really compliance, it's just "how rudder is working on that node" - so totally what `node_read` should give access to. 

So with the correction and a `node_all` right, you now get: 

For compliance: 
![image](https://github.com/Normation/rudder/assets/44649/10705002-b073-4d10-8fa5-bf171943a9fc)

For system status:
(same as before)
![image](https://github.com/Normation/rudder/assets/44649/527ed3d5-6192-486a-9efa-f81fae1bd82d)

Code is just an added "if" and a new API right for the system status case. 