### PR TITLE
Fixes #24988: Property inheritance of type array doesn't work

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -388,11 +388,11 @@ object GenericProperty {
    * Merge two properties. newProp values will win.
    * You should have check before that "name" and "provider" are OK.
    */
-  def mergeConfig(oldProp: Config, newProp: Config): Config = {
-    val mode           = (GenericProperty.getMode(oldProp), GenericProperty.getMode(newProp)) match {
+  def mergeConfig(oldProp: Config, newProp: Config)(implicit defaultInheritMode: Option[InheritMode]): Config = {
+    val mode           = ((GenericProperty.getMode(oldProp), GenericProperty.getMode(newProp)) match {
       case (mode, None) => mode
       case (_, mode)    => mode
-    }
+    }).orElse(defaultInheritMode)
     val otherThanValue = newProp
       .withValue(VALUE, ConfigValueFactory.fromAnyRef(""))
       .withFallback(oldProp.withValue(VALUE, ConfigValueFactory.fromAnyRef("")))


### PR DESCRIPTION
https://issues.rudder.io/issues/24988

When having an inheritance chain with more than 1 parent/child relationship, properties from child are being merged without really taking the global parameter inherit mode into account...

N.B. : This only fixes the inheritance when there is a global parameter along the chain. By default, the inherit mode for arrays is "override", so it makes sense 