### PR TITLE
Fixes #25033: Do node delete table nodecompliance

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ExpectedReportsJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ExpectedReportsJdbcRepository.scala
@@ -469,17 +469,14 @@ class UpdateExpectedReportsJdbcRepository(
   override def deleteNodeCompliances(date: DateTime): Box[Int] = {
 
     val dateAt_0000 = date.toString("yyyy-MM-dd")
-    val d1          = s"delete from archivednodecompliance where coalesce(runtimestamp, '${dateAt_0000}') < '${dateAt_0000}'"
-    val d2          = s"delete from nodecompliance where coalesce(runtimestamp, '${dateAt_0000}') < '${dateAt_0000}'"
+    val d1          = s"delete from nodecompliance where coalesce(runtimestamp, '${dateAt_0000}') < '${dateAt_0000}'"
 
     logger.debug(s"""Deleting NodeCompliance with SQL query: [[
                     | ${d1}
-                    |]] and: [[
-                    | ${d2}
                     |]]""".stripMargin)
 
     (for {
-      i <- transactRunEither(xa => (d1 :: d2 :: Nil).traverse(q => Update0(q, None).run).transact(xa))
+      i <- transactRunEither(xa => (d1 :: Nil).traverse(q => Update0(q, None).run).transact(xa))
     } yield {
       i
     }) match {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/DeleteArchiveTables.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/DeleteArchiveTables.scala
@@ -58,7 +58,6 @@ class DeleteArchiveTables(
     "archivednodecompliance",
     "archivednodeconfigurations",
     "archivedruddersysevents",
-    "nodecompliance",
     "migrationeventlog"
   )
 


### PR DESCRIPTION
https://issues.rudder.io/issues/25033

Parent pr was not doing what it said it does:
- deleted `nodeCompliance` when it should not have, 
- kept some sql on deleted `archivedNodeCompliance` which will have lead to an exception