### PR TITLE
Fixes #25035: Process are not saved anymore in 8.1

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryMapper.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryMapper.scala
@@ -910,14 +910,19 @@ class InventoryMapper(
     tree
   }
 
+  // map process from node
+  def processesFromNode(node: NodeInventory): Seq[String] = {
+    // convert the processes
+    node.processes.map(x => Serialization.write(x))
+  }
+
   // Create the entry with only processes
   // we need to have a proper object class to avoid error
   // com.unboundid.ldap.sdk.LDAPException: no structural object class provide
-  def processesFromNode(node: NodeInventory): LDAPEntry = {
+  def entryWithProcessFromNode(node: NodeInventory): LDAPEntry = {
     val entry = createNodeModelFromServer(node)
-
     // convert the processes
-    entry.resetValuesTo(A_PROCESS, node.processes.map(x => Serialization.write(x))*)
+    entry.resetValuesTo(A_PROCESS, processesFromNode(node)*)
     entry
   }
 

--- a/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestInventory.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestInventory.scala
@@ -152,7 +152,7 @@ class TestInventory extends Specification {
   val inventoryMapper: InventoryMapper =
     new InventoryMapper(inventoryDitService, pendingNodesDitImpl, acceptedNodesDitImpl, removedNodesDitImpl)
 
-  val repo = new FullInventoryRepositoryImpl(inventoryDitService, inventoryMapper, ldap)
+  val repo = new FullInventoryRepositoryImpl(inventoryDitService, inventoryMapper, ldap, 5)
 
   val readOnlySoftware = new ReadOnlySoftwareDAOImpl(inventoryDitService, roLdap, inventoryMapper)
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/MockLdapFactStorage.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/MockLdapFactStorage.scala
@@ -134,7 +134,7 @@ class MockLdapFactStorage {
   val inventoryDitService: InventoryDitService = new InventoryDitServiceImpl(pendingDIT, acceptedDIT, removedDIT)
   val inventoryMapper             = new InventoryMapper(inventoryDitService, pendingDIT, acceptedDIT, removedDIT)
   val ldapMapper                  = new LDAPEntityMapper(rudderDit, nodeDit, acceptedDIT, null, inventoryMapper)
-  val ldapFullInventoryRepository = new FullInventoryRepositoryImpl(inventoryDitService, inventoryMapper, ldap)
+  val ldapFullInventoryRepository = new FullInventoryRepositoryImpl(inventoryDitService, inventoryMapper, ldap, 100)
   val softwareGet                 = new ReadOnlySoftwareDAOImpl(inventoryDitService, ldapRo, inventoryMapper)
   val softwareSave                = new NameAndVersionIdFinder("check_name_and_version", ldapRo, inventoryMapper, acceptedDIT)
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestCoreNodeFactInventory.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestCoreNodeFactInventory.scala
@@ -498,7 +498,7 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
       test(NodeId("node2")) and test(NodeId("node4"))
     }
 
-    "we can save a whole inventory and changing everything in storage, included software" >> {
+    "we can save a whole inventory and changing everything in storage, included software and processes" >> {
       factStorage.clearCallStack
       val node = factRepo
         .slowGet(node7id)(QueryContext.testQC, SelectNodeStatus.Accepted, SelectFacts.all)
@@ -514,6 +514,8 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
         .using(_.appended(Network("eth0")))
         .modify(_.slots)
         .using(_.appended(Slot("slot0")))
+        .modify(_.processes)
+        .using(_.appended(Process(4242, Some("process 4242 command line"))))
 
       factRepo.save(updated)(testChangeContext, SelectFacts.all).runNow
 
@@ -521,6 +523,9 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
       (mockLdapFactStorage.testServer
         .getEntry("nodeId=node7,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration")
         .getAttributeValue("environmentVariable") must beEqualTo("""{"name":"envVAR","value":"envVALUE"}""")) and
+      (mockLdapFactStorage.testServer
+        .getEntry("nodeId=node7,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration")
+        .getAttributeValue("process") must beEqualTo("""{"pid":4242,"commandName":"process 4242 command line"}""")) and
       (mockLdapFactStorage.testServer.entryExists(
         "networkInterface=eth0,nodeId=node7,ou=Nodes,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration"
       ) must beTrue) and

--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -262,6 +262,12 @@ inventory.parse.parallelization=2
 # In that case, node's processes will appear to be empty in node details.
 # Boolean, default to "false" (ie: processes are parsed and displayed)
 inventory.parse.ignore.processes=false
+#
+# In some case, <PROCESSES> cause performance problems in rudder web-app
+# and they are used so you can't ignore them. In that case, Rudder may need to
+# use a different LDAP write request just for them. This is the threshold number of processed
+# above which one dedicated request will be done just for processes.
+inventory.threshold.processes.isolatedWrite=1000
 
 #
 # You can keep exhaustive information about LDAP base modification

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -866,11 +866,19 @@ object RudderParsedProperties {
   }
 
   // don't parse some elements in inventories: processes
-  val INVENTORIES_IGNORE_PROCESSES: Boolean = {
+  val INVENTORIES_IGNORE_PROCESSES:                   Boolean = {
     try {
       config.getBoolean("inventory.parse.ignore.processes")
     } catch {
       case ex: ConfigException => false
+    }
+  }
+  // the limit above which processes need an individual LDAP write request
+  val INVENTORIES_THRESHOLD_PROCESSES_ISOLATED_WRITE: Int     = {
+    try {
+      config.getInt("inventory.threshold.processes.isolatedWrite")
+    } catch {
+      case ex: ConfigException => 1
     }
   }
 
@@ -3548,8 +3556,14 @@ object RudderConfigInit {
      * here goes deprecated services that we can't remove yet, for example because they are used for migration
      */
     object deprecated {
-      lazy val ldapFullInventoryRepository =
-        new FullInventoryRepositoryImpl(inventoryDitService, inventoryMapper, rwLdap)
+      lazy val ldapFullInventoryRepository = {
+        new FullInventoryRepositoryImpl(
+          inventoryDitService,
+          inventoryMapper,
+          rwLdap,
+          INVENTORIES_THRESHOLD_PROCESSES_ISOLATED_WRITE
+        )
+      }
 
       lazy val softwareInventoryDAO: ReadOnlySoftwareDAO =
         new ReadOnlySoftwareDAOImpl(inventoryDitService, roLdap, inventoryMapper)


### PR DESCRIPTION
https://issues.rudder.io/issues/25035

So, the problem is that #3899 changed the way processes were stored without changing it in `FullInventory.save`. 
So this was working for new inventories using the `DefaultInventoryAccept` workflow. 
But in 8.1, we changed the way node inventory are persisted to always use  `NodeFactStorage` and thus always using `FullInventoryRepo.save` which didn't have the logic to save processes. 

I added a configurable threshold to switch the behavior between one write request or two write request (many processess), since most of the time, it will be much more efficient to have only one write request. 
The threshold choice at 1000 is the result of a fair negociation with @VinceMacBuche.

~The property is hidden by default, because no user should have a need to know about it, ever. ~ added in `properties.sample`