### PR TITLE
Fixes #25067: 

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
@@ -583,7 +583,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
     Replace(htmlId_policyConf, showDirectiveDetails()) &
     JsRaw(s"""
         this.window.location.hash = "#" + JSON.stringify(${json})
-        sessionStorage.removeItem('tags-${directiveId.uid.value}');
+        sessionStorage.removeItem('tags-${StringEscapeUtils.escapeEcmaScript(directiveId.uid.value)}');
       """.stripMargin) &
     After(TimeSpan(0), JsRaw("""removeBsTooltips();createTooltip();""")) // OnLoad or JsRaw createTooltip does not work ...
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/25067

This escape has been forgotten when escaping directive ids from the user input