### PR TITLE
Fixes #25073: 

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
@@ -63,6 +63,7 @@ import net.liftweb.http.js.JE.*
 import net.liftweb.http.js.JsCmds.*
 import net.liftweb.util.*
 import net.liftweb.util.Helpers.*
+import org.apache.commons.text.StringEscapeUtils
 import scala.xml.*
 
 object DirectiveEditForm {
@@ -356,7 +357,7 @@ class DirectiveEditForm(
                  |} );
                  |var main = document.getElementById("directiveComplianceApp")
                  |var initValues = {
-                 |  directiveId : "${directive.id.uid.value}",
+                 |  directiveId : "${StringEscapeUtils.escapeEcmaScript(directive.id.uid.value)}",
                  |  contextPath : contextPath
                  |};
                  |var app = Elm.Directivecompliance.init({node: main, flags: initValues});

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TagsEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TagsEditForm.scala
@@ -10,6 +10,7 @@ import net.liftweb.http.js.JE.*
 import net.liftweb.http.js.JsCmds.*
 import net.liftweb.util.CssSel
 import net.liftweb.util.Helpers.*
+import org.apache.commons.text.StringEscapeUtils
 import scala.xml.NodeSeq
 
 class TagsEditForm(tags: Tags, objectId: String) extends Loggable {
@@ -56,8 +57,8 @@ class TagsEditForm(tags: Tags, objectId: String) extends Loggable {
       }
       var scope = angular.element($$("#${controllerId}")).scope();
       scope.$$apply(function(){
-        scope.init(  ${jsTags}, "${filterId}" ,  ${isEditForm}, ${isRule}, "${objectId}");
+        scope.init(  ${jsTags}, "${filterId}" ,  ${isEditForm}, ${isRule}, "${StringEscapeUtils.escapeEcmaScript(objectId)}");
       });
-    """)))
+    """))) // JsRaw ok, escaped
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/25073

`Str(...).toJsCmd` does not escape all characters (like `'`, `)`, `}`, ...), so we need to use `StringEscapeUtils.escapeEcmaScript`