### PR TITLE
Fixes #25088: Remove unused methods in ReportingService

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -126,6 +126,14 @@ final class NodeStatusReport private (
 
   def systemCompliance: ComplianceLevel = getCompliance(PolicyTypeName.rudderSystem)
   def baseCompliance:   ComplianceLevel = getCompliance(PolicyTypeName.rudderBase)
+
+  def forPolicyType(t: PolicyTypeName): NodeStatusReport = {
+    val r = reports.get(t) match {
+      case Some(r) => Map((t, r))
+      case None    => Map.empty[PolicyTypeName, AggregatedStatusReport]
+    }
+    new NodeStatusReport(nodeId, runInfo, statusInfo, overrides, r)
+  }
 }
 
 object NodeStatusReport {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -185,7 +185,6 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
     def getSystemAndUserCompliance(
         optNodeIds: Option[Set[NodeId]]
     )(implicit qc: QueryContext): IOResult[(Map[NodeId, ComplianceLevel], Map[NodeId, ComplianceLevel])] = ???
-    def computeComplianceFromReports(reports: Map[NodeId, NodeStatusReport]): Option[(ComplianceLevel, Long)] = None
 
     override def batchSize: Int = 5000
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportingServiceTest.scala
@@ -79,7 +79,6 @@ import com.normation.rudder.services.reports.NodeChangesServiceImpl
 import com.normation.rudder.services.reports.NodeConfigurationService
 import com.normation.rudder.services.reports.NodeConfigurationServiceImpl
 import com.normation.rudder.services.reports.ReportingServiceImpl
-import com.normation.rudder.services.reports.UnexpectedReportInterpretation
 import com.normation.rudder.tenants.DefaultTenantService
 import com.normation.zio.*
 import com.softwaremill.quicklens.*
@@ -359,7 +358,6 @@ class ReportingServiceTest extends DBCommon with BoxSpecMatcher {
     nodeConfigService,
     () => compliance.succeed,
     () => GlobalPolicyMode(PolicyMode.Audit, PolicyModeOverrides.Always).succeed,
-    () => UnexpectedReportInterpretation(Set()).succeed,
     RUDDER_JDBC_BATCH_MAX_SIZE
   )
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -161,11 +161,10 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
     var updated: List[NodeId] = Nil
 
     override def defaultFindRuleNodeStatusReports: DefaultFindRuleNodeStatusReports = new DefaultFindRuleNodeStatusReports() {
-      override def confExpectedRepo:            FindExpectedReportRepository                   = ???
-      override def reportsRepository:           ReportsRepository                              = ???
-      override def agentRunRepository:          RoReportsExecutionRepository                   = ???
-      override def getGlobalComplianceMode:     () => IOResult[GlobalComplianceMode]           = ???
-      override def getUnexpectedInterpretation: () => IOResult[UnexpectedReportInterpretation] = ???
+      override def confExpectedRepo:        FindExpectedReportRepository         = ???
+      override def reportsRepository:       ReportsRepository                    = ???
+      override def agentRunRepository:      RoReportsExecutionRepository         = ???
+      override def getGlobalComplianceMode: () => IOResult[GlobalComplianceMode] = ???
       override def findDirectiveRuleStatusReportsByRule(ruleId: RuleId)(implicit
           qc: QueryContext
       ): IOResult[Map[NodeId, NodeStatusReport]] = ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -172,11 +172,10 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
       override def getSystemAndUserCompliance(
           optNodeIds: Option[Set[NodeId]]
       )(implicit qc: QueryContext): IOResult[(Map[NodeId, ComplianceLevel], Map[NodeId, ComplianceLevel])] = ???
-      override def computeComplianceFromReports(reports: Map[NodeId, NodeStatusReport]): Option[(ComplianceLevel, Long)] = ???
       override def getGlobalUserCompliance()(implicit qc: QueryContext): IOResult[Option[(ComplianceLevel, Long)]] = ???
-      override def findNodeStatusReport(nodeId:           NodeId)(implicit qc: QueryContext): IOResult[NodeStatusReport] = ???
-      override def findUserNodeStatusReport(nodeId:       NodeId)(implicit qc: QueryContext): IOResult[NodeStatusReport] = ???
-      override def findSystemNodeStatusReport(nodeId:     NodeId)(implicit qc: QueryContext): IOResult[NodeStatusReport] = ???
+      override def findNodeStatusReport(nodeId:       NodeId)(implicit qc: QueryContext): IOResult[NodeStatusReport] = ???
+      override def findUserNodeStatusReport(nodeId:   NodeId)(implicit qc: QueryContext): IOResult[NodeStatusReport] = ???
+      override def findSystemNodeStatusReport(nodeId: NodeId)(implicit qc: QueryContext): IOResult[NodeStatusReport] = ???
       override def nodeConfigService: NodeConfigurationService = ???
       override def jdbcMaxBatchSize:  Int                      = batchSize
       override def findRuleNodeStatusReports(nodeIds: Set[NodeId], ruleIds: Set[RuleId])(implicit
@@ -198,7 +197,6 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
     override def findNodeStatusReport(nodeId: NodeId)(implicit qc: QueryContext): IOResult[NodeStatusReport] = ???
     override def findUncomputedNodeStatusReports(): IOResult[Map[NodeId, NodeStatusReport]] = ???
     override def getUserNodeStatusReports()(implicit qc: QueryContext): IOResult[Map[NodeId, NodeStatusReport]] = ???
-    override def computeComplianceFromReports(reports:   Map[NodeId, NodeStatusReport]): Option[(ComplianceLevel, Long)] = ???
     override def getGlobalUserCompliance()(implicit qc:  QueryContext): IOResult[Option[(ComplianceLevel, Long)]] = ???
     override def findUserNodeStatusReport(nodeId:        NodeId)(implicit qc: QueryContext): IOResult[NodeStatusReport] = ???
     override def findSystemNodeStatusReport(nodeId:      NodeId)(implicit qc: QueryContext): IOResult[NodeStatusReport] = ???

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ComplianceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ComplianceTest.scala
@@ -249,7 +249,7 @@ class ComplianceTest extends Specification {
       // here, we assume "compute compliance", i.e we are only testing the compliance engine, not
       // the meta-analysis on run consistency (correct run, at the correct time, etc)
       val runinfo = ComputeCompliance(runTime, config, runTime)
-      val status  = ExecutionBatch.getNodeStatusReports(config.nodeId, runinfo, reports, UnexpectedReportInterpretation(Set()))
+      val status  = ExecutionBatch.getNodeStatusReports(config.nodeId, runinfo, reports)
 
       // we really have 26 (ie 18+8) values
       status.compliance must beEqualTo(ComplianceLevel(success = 18, notApplicable = 8))
@@ -271,7 +271,7 @@ class ComplianceTest extends Specification {
       // here, we assume "compute compliance", i.e we are only testing the compliance engine, not
       // the meta-analysis on run consistancy (correct run, at the correct time, etc)
       val runinfo = ComputeCompliance(runTime, config, runTime)
-      val status  = ExecutionBatch.getNodeStatusReports(config.nodeId, runinfo, reports, UnexpectedReportInterpretation(Set()))
+      val status  = ExecutionBatch.getNodeStatusReports(config.nodeId, runinfo, reports)
 
       // we really have 39 values in total
       status.compliance must beEqualTo(ComplianceLevel(success = 34, notApplicable = 5))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -58,7 +58,6 @@ import com.normation.rudder.reports.execution.AgentRunId
 import com.normation.rudder.reports.execution.AgentRunWithNodeConfig
 import com.normation.rudder.services.reports.ExecutionBatch.ComputeComplianceTimer
 import com.normation.rudder.services.reports.ExecutionBatch.MergeInfo
-import com.normation.rudder.services.reports.UnexpectedReportBehavior.UnboundVarValues
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.junit.runner.*
@@ -86,7 +85,6 @@ class ExecutionBatchTest extends Specification {
 
   import ReportType.*
 
-  val strictUnexpectedInterpretation: UnexpectedReportInterpretation = UnexpectedReportInterpretation(Set())
   val executionTimestamp = new DateTime()
 
   val globalPolicyMode: GlobalPolicyMode = GlobalPolicyMode(PolicyMode.Enforce, PolicyModeOverrides.Always)
@@ -107,7 +105,7 @@ class ExecutionBatchTest extends Specification {
       nbRules:         Int,
       nbDirectives:    Int,
       nbReportsPerDir: Int
-  ): (MergeInfo, IndexedSeq[ResultSuccessReport], NodeExpectedReports, NodeExpectedReports, UnexpectedReportInterpretation) = {
+  ): (MergeInfo, IndexedSeq[ResultSuccessReport], NodeExpectedReports, NodeExpectedReports) = {
     val ruleIds      = (1 to nbRules).map("rule_id_" + _ + nodeId).toSeq
     val directiveIds = (1 to nbDirectives).map("directive_id_" + _ + nodeId).toSeq
     val dirPerRule   = ruleIds.map(rule => (RuleId(rule), directiveIds.map(dir => DirectiveId(DirectiveUid(dir + "@@" + rule)))))
@@ -175,7 +173,7 @@ class ExecutionBatchTest extends Specification {
 
     val mergeInfo = MergeInfo(NodeId(nodeId), Some(now), Some(nodeConfigId), now.plus(100))
 
-    (mergeInfo, executionReports, nodeExpectedReport, nodeExpectedReport, strictUnexpectedInterpretation)
+    (mergeInfo, executionReports, nodeExpectedReport, nodeExpectedReport)
 
   }
 
@@ -220,7 +218,7 @@ class ExecutionBatchTest extends Specification {
       val info    = nodeExpectedReports(nodeId)
       val runInfo = ComputeCompliance(runTime, info, runTime.plusMinutes(5))
 
-      (nodeId, ExecutionBatch.getNodeStatusReports(nodeId, runInfo, reportsParam, strictUnexpectedInterpretation))
+      (nodeId, ExecutionBatch.getNodeStatusReports(nodeId, runInfo, reportsParam))
     })
 
     res.toMap
@@ -333,8 +331,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         mixedReports,
         ReportType.EnforceSuccess, // change only on enforce
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
     val withErrors  = ExecutionBatch
@@ -342,8 +339,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         allErrors,
         ReportType.EnforceSuccess, // change only on enforce
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
     val withSuccess = ExecutionBatch
@@ -351,8 +347,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         allSuccesses,
         ReportType.EnforceSuccess, // change only on enforce
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
 
@@ -547,8 +542,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         reports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
     val withBad  = ExecutionBatch
@@ -556,8 +550,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         badReports,
         Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
 
@@ -619,8 +612,7 @@ class ExecutionBatchTest extends Specification {
           expectedComponent,
           noAnswer,
           ReportType.NoAnswer,
-          PolicyMode.Enforce,
-          strictUnexpectedInterpretation
+          PolicyMode.Enforce
         )
         .head
       res.compliance === ComplianceLevel(noAnswer = 2)
@@ -631,8 +623,7 @@ class ExecutionBatchTest extends Specification {
           expectedComponent,
           missing,
           ReportType.Missing,
-          PolicyMode.Enforce,
-          strictUnexpectedInterpretation
+          PolicyMode.Enforce
         )
         .head
       res.compliance === ComplianceLevel(success = 1, missing = 1)
@@ -711,8 +702,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         reports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
     val withBad           = ExecutionBatch
@@ -720,8 +710,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         badReports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
 
@@ -829,8 +818,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         reports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
     val withBad  = ExecutionBatch
@@ -838,8 +826,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         badReports,
         Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
 
@@ -951,8 +938,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         reports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
     val withBad  = ExecutionBatch
@@ -960,8 +946,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         badReports,
         Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
 
@@ -1073,8 +1058,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         reports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
     val withBad  = ExecutionBatch
@@ -1082,8 +1066,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         badReports,
         Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
 
@@ -1198,8 +1181,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         reports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
     val withBad  = ExecutionBatch
@@ -1207,8 +1189,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         badReports,
         Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
 
@@ -1400,7 +1381,6 @@ class ExecutionBatchTest extends Specification {
         reports,
         mode,
         ruleExpectedReports,
-        strictUnexpectedInterpretation,
         new ComputeComplianceTimer()
       )
       .collect { case r => r.directives("policy") }
@@ -1410,7 +1390,6 @@ class ExecutionBatchTest extends Specification {
         badReports,
         mode,
         ruleExpectedReports,
-        strictUnexpectedInterpretation,
         new ComputeComplianceTimer()
       )
       .collect { case r => r.directives("policy") }
@@ -1580,7 +1559,6 @@ class ExecutionBatchTest extends Specification {
         reportsWithLoop,
         mode,
         ruleExpectedReports,
-        UnexpectedReportInterpretation(Set(UnboundVarValues)),
         new ComputeComplianceTimer()
       )
       .collect { case r => r.directives("policy") }
@@ -1726,7 +1704,6 @@ class ExecutionBatchTest extends Specification {
         reportsWithLoop,
         mode,
         ruleExpectedReports,
-        UnexpectedReportInterpretation(Set(UnboundVarValues)),
         new ComputeComplianceTimer()
       )
       .collect { case r => r.directives("policy") }
@@ -1944,7 +1921,6 @@ class ExecutionBatchTest extends Specification {
         reports,
         mode,
         ruleExpectedReports,
-        strictUnexpectedInterpretation,
         new ComputeComplianceTimer()
       )
       .collect { case r => r.directives("policy") }
@@ -1955,7 +1931,6 @@ class ExecutionBatchTest extends Specification {
         badReports,
         mode,
         ruleExpectedReports,
-        strictUnexpectedInterpretation,
         new ComputeComplianceTimer()
       )
       .collect { case r => r.directives("policy") }
@@ -2161,7 +2136,6 @@ class ExecutionBatchTest extends Specification {
         reports,
         mode,
         ruleExpectedReports,
-        strictUnexpectedInterpretation,
         new ComputeComplianceTimer()
       )
       .collect { case r => r.directives("policy") }
@@ -2172,7 +2146,6 @@ class ExecutionBatchTest extends Specification {
         badReports,
         mode,
         ruleExpectedReports,
-        strictUnexpectedInterpretation,
         new ComputeComplianceTimer()
       )
       .collect { case r => r.directives("policy") }
@@ -2303,8 +2276,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         reports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
     val withBad  = ExecutionBatch
@@ -2312,8 +2284,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         badReports,
         Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
 
@@ -2421,8 +2392,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         reports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
     val withBad  = ExecutionBatch
@@ -2430,8 +2400,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         badReports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
 
@@ -2551,8 +2520,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         reports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
     val withBad  = ExecutionBatch
@@ -2560,8 +2528,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         badReports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
 
@@ -2703,8 +2670,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         reports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
     val withBad  = ExecutionBatch
@@ -2712,8 +2678,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         badReports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
 
@@ -2850,7 +2815,6 @@ class ExecutionBatchTest extends Specification {
       reports,
       mode,
       ruleExpectedReports,
-      strictUnexpectedInterpretation,
       new ComputeComplianceTimer()
     )
 
@@ -3013,8 +2977,7 @@ class ExecutionBatchTest extends Specification {
           expectedComponent,
           duplicated,
           ReportType.Missing,
-          PolicyMode.Enforce,
-          strictUnexpectedInterpretation
+          PolicyMode.Enforce
         )
         .head
       res.compliance === ComplianceLevel(success = 1, unexpected = 2) // 2 unexpected because the whole "foo" becomes unexpected
@@ -3025,8 +2988,7 @@ class ExecutionBatchTest extends Specification {
           expectedComponent,
           duplicated,
           ReportType.Missing,
-          PolicyMode.Enforce,
-          UnexpectedReportInterpretation(Set())
+          PolicyMode.Enforce
         )
         .head
       res.compliance === ComplianceLevel(success = 1, unexpected = 2)
@@ -3037,8 +2999,7 @@ class ExecutionBatchTest extends Specification {
           expectedComponent,
           tooMuchDuplicated,
           ReportType.Missing,
-          PolicyMode.Enforce,
-          UnexpectedReportInterpretation(Set())
+          PolicyMode.Enforce
         )
         .head
       res.compliance === ComplianceLevel(success = 1, unexpected = 4)
@@ -3050,20 +3011,7 @@ class ExecutionBatchTest extends Specification {
           expectedComponent,
           unboundedVars,
           ReportType.Missing,
-          PolicyMode.Enforce,
-          strictUnexpectedInterpretation
-        )
-        .head
-      res.compliance === ComplianceLevel(success = 1, unexpected = 3)
-    }
-    "when on strict mode, out of bound vars are unexpected" in {
-      val res = ExecutionBatch
-        .checkExpectedComponentWithReports(
-          expectedComponent,
-          unboundedVars,
-          ReportType.Missing,
-          PolicyMode.Enforce,
-          UnexpectedReportInterpretation(Set(UnexpectedReportBehavior.UnboundVarValues))
+          PolicyMode.Enforce
         )
         .head
       res.compliance === ComplianceLevel(success = 4)
@@ -3106,8 +3054,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         reports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
 
@@ -3132,8 +3079,7 @@ class ExecutionBatchTest extends Specification {
         id:                 String,
         patterns:           Seq[(String, Seq[Kind])],
         reports:            Seq[(String, Kind)],
-        unexpectedNotValue: Seq[String] = Nil,
-        mode:               UnexpectedReportInterpretation = strictUnexpectedInterpretation
+        unexpectedNotValue: Seq[String] = Nil
     ) = {
 
       // expected components are the list of key for patterns
@@ -3188,8 +3134,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         resultReports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        mode
+        PolicyMode.Enforce
       )
       val t2     = System.currentTimeMillis - t1
 
@@ -3275,10 +3220,11 @@ class ExecutionBatchTest extends Specification {
       // , unexpectedNotValue = Seq("baz")
     )
 
+    // here, the var get all extra reports
     test(
       "one var and simple reports",
-      patterns = ("${sys.bla}", Seq(Unexpected, Unexpected)) :: ("bar", Seq(Success)) :: Nil,
-      reports = ("/var/cfengine", Repaired) :: ("/var/cfengine", Success) :: ("bar", Success) :: Nil
+      patterns = ("${sys.bla}", Seq(Success, Success)) :: ("bar", Seq(Success)) :: Nil,
+      reports = ("/var/cfengine", Success) :: ("/var/cfengine", Success) :: ("bar", Success) :: Nil
     )
 
     /*
@@ -3295,9 +3241,10 @@ class ExecutionBatchTest extends Specification {
       reports = ("/var/cfengine", Repaired) :: ("/var/cfengine", Success) :: Nil
     )
 
+    // the first var get extra reports
     test(
       "same patterns with unexpected",
-      patterns = ("${sys.bla}", Seq(Repaired)) :: ("${sys.foo}", Seq(Unexpected, Unexpected)) :: Nil,
+      patterns = ("${sys.bla}", Seq(Repaired)) :: ("${sys.foo}", Seq(Success, Success)) :: Nil,
       reports = ("/var/cfengine", Repaired) :: ("/var/cfengine", Success) :: ("/var/cfengine", Success) :: Nil
     )
 
@@ -4234,8 +4181,7 @@ class ExecutionBatchTest extends Specification {
         expectedComponent,
         reports,
         ReportType.Missing,
-        PolicyMode.Enforce,
-        strictUnexpectedInterpretation
+        PolicyMode.Enforce
       )
       .head
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
@@ -61,8 +61,6 @@ import com.normation.rudder.reports.ChangesOnly
 import com.normation.rudder.reports.ComplianceMode
 import com.normation.rudder.reports.FullCompliance
 import com.normation.rudder.services.policies.SendMetrics
-import com.normation.rudder.services.reports.UnexpectedReportBehavior
-import com.normation.rudder.services.reports.UnexpectedReportInterpretation
 import com.normation.rudder.services.servers.RelaySynchronizationMethod
 import com.normation.rudder.services.servers.RelaySynchronizationMethod.*
 import com.normation.rudder.services.workflows.WorkflowLevelService
@@ -195,11 +193,6 @@ trait ReadConfigService {
   def rudder_node_onaccept_default_state():       IOResult[NodeState]
 
   def node_accept_duplicated_hostname(): IOResult[Boolean]
-
-  /**
-   * What is the behavior to adopt regarding unexpected reports ?
-   */
-  def rudder_compliance_unexpected_report_interpretation(): IOResult[UnexpectedReportInterpretation]
 
   /**
    * For debugging / disabling some part of Rudder. Should not be exposed in UI
@@ -338,8 +331,6 @@ trait UpdateConfigService {
 
   def set_node_accept_duplicated_hostname(accept: Boolean): IOResult[Unit]
 
-  def set_rudder_compliance_unexpected_report_interpretation(mode: UnexpectedReportInterpretation): IOResult[Unit]
-
   def set_rudder_compute_changes(value:              Boolean): IOResult[Unit]
   def set_rudder_generation_compute_dyngroups(value: Boolean): IOResult[Unit]
   def set_rudder_save_db_compliance_levels(value:    Boolean): IOResult[Unit]
@@ -409,7 +400,6 @@ class GenericConfigService(
        rudder.featureSwitch.directiveScriptEngine=enabled
        rudder.node.onaccept.default.state=enabled
        rudder.node.onaccept.default.policyMode=default
-       rudder.compliance.unexpectedReportUnboundedVarValues=true
        rudder.compute.changes=true
        rudder.generation.compute.dyngroups=true
        rudder.save.db.compliance.levels=true
@@ -721,21 +711,6 @@ class GenericConfigService(
    */
   def node_accept_duplicated_hostname(): IOResult[Boolean] = get("node_accept_duplicated_hostname")
   def set_node_accept_duplicated_hostname(accept: Boolean): IOResult[Unit] = save("node_accept_duplicated_hostname", accept)
-
-  def rudder_compliance_unexpected_report_interpretation():                                         IOResult[UnexpectedReportInterpretation] = {
-    for {
-      iterators <- get[Boolean]("rudder_compliance_unexpectedReportUnboundedVarValues")
-    } yield {
-      UnexpectedReportInterpretation(
-        (if (iterators) Set(UnexpectedReportBehavior.UnboundVarValues) else Set())
-      )
-    }
-  }
-  def set_rudder_compliance_unexpected_report_interpretation(mode: UnexpectedReportInterpretation): IOResult[Unit]                           = {
-    for {
-      _ <- save("rudder_compliance_unexpectedReportUnboundedVarValues", mode.isSet(UnexpectedReportBehavior.UnboundVarValues))
-    } yield ()
-  }
 
   ///// debug / perf /////
   def rudder_compute_changes(): IOResult[Boolean] = get("rudder_compute_changes")

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -61,7 +61,6 @@ import com.normation.rudder.rest.RestUtils
 import com.normation.rudder.rest.SettingsApi as API
 import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.services.policies.SendMetrics
-import com.normation.rudder.services.reports.UnexpectedReportBehavior
 import com.normation.rudder.services.servers.AllowedNetwork
 import com.normation.rudder.services.servers.PolicyServerManagementService
 import com.normation.rudder.services.servers.RelaySynchronizationMethod
@@ -119,7 +118,6 @@ class SettingsApi(
     RestSendMetrics ::
     RestOnAcceptNodeState ::
     RestOnAcceptPolicyMode ::
-    RestChangeRequestUnexpectedUnboundVarValues ::
     RestComputeChanges ::
     RestGenerationComputeDynGroups ::
     RestPersistComplianceLevels ::
@@ -695,31 +693,6 @@ class SettingsApi(
     def get:                     IOResult[NodeState]                                       = configService.rudder_node_onaccept_default_state()
     def set:                     (NodeState, EventActor, Option[String]) => IOResult[Unit] = (value: NodeState, _, _) =>
       configService.set_rudder_node_onaccept_default_state(value)
-  }
-
-  trait RestChangeUnexpectedReportInterpretation extends RestBooleanSetting {
-    def prop: UnexpectedReportBehavior
-    def get:  ZIO[Any, RudderError, Boolean]                                       =
-      configService.rudder_compliance_unexpected_report_interpretation().map(_.isSet(prop))
-    def set:  (Boolean, EventActor, Option[String]) => ZIO[Any, RudderError, Unit] = (value: Boolean, _, _) => {
-      for {
-        config  <- configService.rudder_compliance_unexpected_report_interpretation()
-        newConf  = if (value) {
-                     config.set(prop)
-                   } else {
-                     config.unset(prop)
-                   }
-        updated <- configService.set_rudder_compliance_unexpected_report_interpretation(newConf)
-      } yield {
-        updated
-      }
-    }
-  }
-
-  case object RestChangeRequestUnexpectedUnboundVarValues extends RestChangeUnexpectedReportInterpretation {
-    val startPolicyGeneration = false
-    val key                   = "unexpected_unbound_var_values"
-    val prop: UnexpectedReportBehavior.UnboundVarValues.type = UnexpectedReportBehavior.UnboundVarValues
   }
 
   def startNewPolicyGeneration(actor: EventActor): Unit = {

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_settings.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_settings.yml
@@ -60,8 +60,7 @@ response:
           "rudder_setup_done":false,
           "run_frequency":5,
           "send_metrics":"not_defined",
-          "splay_time":4,
-          "unexpected_unbound_var_values":true
+          "splay_time":4
         }
       }
     }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -343,7 +343,7 @@ class MockCompliance(mockDirectives: MockDirectives) {
         qc: QueryContext
     ): IOResult[Map[NodeId, NodeStatusReport]] = {
       val filteredNodeReports = statusReports.view.filterKeys(nodeIds.contains(_)).toMap
-      filterReportsByRules(filteredNodeReports, filterByRules).succeed
+      ReportingService.filterReportsByRules(filteredNodeReports, filterByRules).succeed
     }
     // used in node details API
     def getSystemAndUserCompliance(
@@ -357,13 +357,8 @@ class MockCompliance(mockDirectives: MockDirectives) {
         filterByDirectives: Set[DirectiveId]
     )(implicit qc: QueryContext): IOResult[Map[NodeId, NodeStatusReport]] = ???
     def findUncomputedNodeStatusReports():                                               IOResult[Map[NodeId, NodeStatusReport]] = ???
-    def findRuleNodeCompliance(nodeIds: Set[NodeId], tag: PolicyTypeName, filterByRules: Set[RuleId])(implicit
-        qc: QueryContext
-    ): IOResult[Map[NodeId, ComplianceLevel]] = ???
     def findSystemAndUserRuleCompliances(
-        nodeIds:             Set[NodeId],
-        filterBySystemRules: Set[RuleId],
-        filterByUserRules:   Set[RuleId]
+        nodeIds: Set[NodeId]
     )(implicit qc: QueryContext): IOResult[(Map[NodeId, ComplianceLevel], Map[NodeId, ComplianceLevel])] = ???
     def findDirectiveRuleStatusReportsByRule(ruleId: RuleId)(implicit qc: QueryContext): IOResult[Map[NodeId, NodeStatusReport]] =
       ???
@@ -374,7 +369,6 @@ class MockCompliance(mockDirectives: MockDirectives) {
     def findStatusReportsForDirective(directiveId: DirectiveId)(implicit
         qc: QueryContext
     ): IOResult[Map[NodeId, NodeStatusReport]] = ???
-    def computeComplianceFromReports(reports:   Map[NodeId, NodeStatusReport]): Option[(ComplianceLevel, Long)] = ???
     def getGlobalUserCompliance()(implicit qc:  QueryContext): IOResult[Option[(ComplianceLevel, Long)]] = ???
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -3074,7 +3074,6 @@ object RudderConfigInit {
           cachedNodeConfigurationService,
           () => globalComplianceModeService.getGlobalComplianceMode,
           () => configService.rudder_global_policy_mode(),
-          () => configService.rudder_compliance_unexpected_report_interpretation(),
           RUDDER_JDBC_BATCH_MAX_SIZE
         ),
         nodeFactRepository,

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/administration/policyServerManagement.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/administration/policyServerManagement.html
@@ -194,67 +194,6 @@
             <div id="complianceMode" class="lift:administration.PropertiesManagement.complianceMode"></div>
 
             <div class="inner-portlet">
-              <h3 class="page-title">Reporting behavior</h3>
-              <div class="portlet-content">
-                <div class="lift:administration.PropertiesManagement.unexpectedReportInterpretation" id="unexpectedReportInterpretation">
-                  <form class="lift:form.ajax form-horizontal" >
-                    <div class="explanation-text">
-                      The following settings affect the interpretation given to some type of unexpected reports when computing compliance.
-                      This option will take effect when the next reports are received from a node or if you "clear caches" below.
-                    </div>
-                    <div class="explanation-text">
-                      <p><b>Unbounded reports by elements when a variable is used</b></p>
-                      <p>
-                        Rudder await exactly one compliance report for each configuration point of control. If it gets more than one,
-                        the leftover reports will be considered as unexpected. This is not what one want in the case where:
-                      <ul>
-                        <li>
-                          the point of control is parametrized by a variable,
-                        </li>
-                        <li>
-                          that variable is multivalued.
-                        </li>
-                      </ul>
-                      </p>
-                      <p>
-                        For example, if you build a technique in editor with the generic method "Variable iterator" to define a list of
-                        packages and you use the resulting variable in "Package present" generic method for the "name" parameter,
-                        it is normal and expected to get several compliance reports, one for each configuration value.
-                      </p>
-                      <p>
-                        That option allows to increase the number of expected reports to the number of configuration values and so
-                        it avoids to get and "unexpected" compliance in that case.
-                      </p>
-                      <p>
-                        Unless it is more important for you to get "unexpected" compliance than the actual compliance of each
-                        configuration value, you should check that option.
-                      </p>
-                    </div>
-                    <ul>
-                      <li class="rudder-form">
-                        <div class="input-group">
-                          <label class="input-group-text" for="unboundVarValues">
-                            <input id="unboundVarValues" type="checkbox">
-                            <label for="unboundVarValues" class="label-radio">
-                              <span class="ion ion-checkmark-round"></span>
-                            </label>
-                            <span class="ion ion-checkmark-round check-icon"></span>
-                          </label>
-                          <label class="form-control" for="unboundVarValues">
-                            Allows multiple reports for configuration based on a multivalued variable:
-                          </label>
-                        </div>
-                      </li>
-                    </ul>
-                    <lift:authz role="administration_write">
-                      <input type="submit" value="[save]" id="unexpectedReportInterpretationFormSubmit"/>
-                    </lift:authz>
-                  </form>
-                </div>
-              </div>
-            </div>
-
-            <div class="inner-portlet">
               <h3 class="page-title">Default settings for new nodes</h3>
               <div class="portlet-content">
                 <div class="lift:administration.PropertiesManagement.nodeOnAcceptDefaults" id="nodeOnAcceptDefaults">


### PR DESCRIPTION
https://issues.rudder.io/issues/25088

Some well needed cleaning in `ReportingService` (first step, other will follow): 

**Getting only user/system compliance**

A lot of code in reporting service is based on the pattern : 

``` 
rules <- getRules(system = false) // only user rules
compliance <- computeComplianceForNodes(limitToRules = rules.map(_.id))
```

Or the same thing for system rule, getting all rules then diffing. 
This is not needed anymore since we have now a `Map[PolicyTypeName, AggregatedStatusReport]` now in `NodeStatusReport`. 

**Class methods when they can be object ones**

`ReportingService` trait has several method that are not linked to service dependencies and can be moved to its companion object. 

**Unused methods/classes**

Some methods were just unused anywhere: `complianceByNode`, `systemComplianceByNode`, `NodeCompliance`, `NodeSystemCompliance`.