### PR TITLE
Fixes #25046: Some results of quicksearch cannot be opened 

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups.elm
@@ -8,6 +8,7 @@ import Http exposing (..)
 import GroupCompliance.ApiCalls exposing (..)
 import GroupCompliance.ViewUtils exposing (..)
 
+import GroupRelatedRules.DataTypes exposing (GroupId)
 import Groups.ApiCalls exposing (..)
 import Groups.DataTypes exposing (..)
 import Groups.Init exposing (init)
@@ -25,11 +26,13 @@ port adjustComplianceCols   : () -> Cmd msg
 port createGroupModal       : () -> Cmd msg
 port closeModal             : (() -> msg) -> Sub msg
 port loadGroupTable         : (() -> msg) -> Sub msg
+port readUrl                : (String -> msg) -> Sub msg
 
 subscriptions : Model -> Sub Msg
 subscriptions _ = Sub.batch
   [ closeModal (\_ -> CloseModal)
   , loadGroupTable (\_ -> LoadGroupTable)
+  , readUrl (\s -> OpenGroupDetails (GroupId s))
   ]
 
 main =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/QuickSearch/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/QuickSearch/View.elm
@@ -21,7 +21,7 @@ kindName k =
 viewItem: SearchResultItem -> Html Msg
 viewItem item =
   li [ class "list-group-item" ] [
-    a [href item.url, style "text-decoration" "none"] [
+    a [href item.url, style "text-decoration" "none", onClick Close] [
       span [] [ text item.name ]
     , div [ class "description" ] [ text item.desc ]
     ]

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
@@ -160,6 +160,22 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
     }
 
     JsRaw(s"""
+        // support loading another directive from change in URL hash while staying in page (e.g. from quicksearch result)
+        window.addEventListener('hashchange', function (e) {
+          var newHash = e.target.location.hash;
+          var splitHash = newHash.split("#");
+          if (splitHash.length > 0) {
+            var hashJson = decodeURIComponent(splitHash[1]);
+            try {
+              var hashJsonObj = JSON.parse(hashJson);
+              if ("directiveId" in hashJsonObj) {
+                // displayDetails needs stringified object
+                ${SHtml.ajaxCall(JsVar("hashJson"), displayDetails _)._2.toJsCmd};
+              }
+            } catch {}
+          }
+        });
+
         var directiveId = null;
         try {
           var directiveId = decodeURI(window.location.hash.substring(1)) ;

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
@@ -163,6 +163,19 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
                |    window.location.hash = JSON.stringify({[hashKey]: hashValue});
                |  }
                |});
+               |// support loading another group from change in URL hash while staying in page (e.g. from quicksearch result)
+               |window.addEventListener('hashchange', function (e) {
+               |  var newHash = e.target.location.hash;
+               |  var splitHash = newHash.split("#");
+               |  if (splitHash.length > 0) {
+               |    try {
+               |      var hashJsonObj = JSON.parse(decodeURIComponent(splitHash[1]));
+               |      if ("groupId" in hashJsonObj) {
+               |        app.ports.readUrl.send(hashJsonObj["groupId"]);
+               |      }
+               |    } catch {}
+               |  }
+               |});
                |app.ports.adjustComplianceCols.subscribe(function() {
                |  //call the equalize width function
                |  var group = $$(".compliance-col");


### PR DESCRIPTION
https://issues.rudder.io/issues/25046

When [changing the URL hash](https://stackoverflow.com/a/52809105) while navigating to the quicksearch result on the same page, we need to : 
* parse the URL for `{"directiveId":...}` in the directives page, which calls back existing method to display the directive
* parse the URL for `{"groupId":...}` in the groups page, which calls an Elm port to load the group

Also, in every case, when changing the URL from clicking a quicksearch result, we will no longer need the quicksearch so we can send the `Close` message