### PR TITLE
Fixes #25032:  Use Content-Security-Policy strict headers in utilities pages

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/EventListDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/EventListDisplayer.scala
@@ -39,6 +39,7 @@ package com.normation.rudder.web.services
 import com.normation.box.*
 import com.normation.eventlog.EventLog
 import com.normation.rudder.repository.*
+import com.normation.rudder.web.snippet.WithNonce
 import doobie.*
 import doobie.implicits.*
 import doobie.implicits.javasql.*
@@ -127,12 +128,12 @@ class EventListDisplayer(repos: EventLogRepository) extends Loggable {
 
     val refresh = AnonFunc(SHtml.ajaxInvoke(() => getLastEvents))
 
-    Script(OnLoad(JsRaw(s"""
+    WithNonce.scriptWithNonce(Script(OnLoad(JsRaw(s"""
      var refreshEventLogs = ${refresh.toJsCmd};
      initDatePickers("#filterLogs", ${AnonFunc("param", SHtml.ajaxCall(JsVar("param"), getEventsInterval)._2).toJsCmd});
      createEventLogTable('${gridName}',[], '${S.contextPath}', refreshEventLogs)
      refreshEventLogs();
-    """))) // JsRaw ok, escaped
+    """)))) // JsRaw ok, escaped
   }
 
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/WithEnabledCSP.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/WithEnabledCSP.scala
@@ -1,0 +1,23 @@
+package com.normation.rudder.web.snippet
+
+import net.liftweb.http.RequestVar
+import net.liftweb.http.StatefulSnippet
+import scala.xml.*
+
+object WithEnabledCSP extends StatefulSnippet {
+
+  /**
+    * Holder for state of strict CSP headers activation
+    */
+  private object enabled extends RequestVar[Boolean](false) {}
+
+  def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = _ => enable()
+
+  def enable(): NodeSeq => NodeSeq = {
+    enabled.setIfUnset(true)
+    identity
+  }
+
+  def isEnabled: Boolean = enabled.get
+
+}

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/Archives.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/Archives.scala
@@ -48,6 +48,7 @@ import com.normation.rudder.git.GitArchiveId
 import com.normation.rudder.git.GitCommitId
 import com.normation.rudder.repository.*
 import com.normation.rudder.users.CurrentUser
+import com.normation.rudder.web.snippet.WithNonce
 import com.normation.utils.DateFormaterService
 import net.liftweb.common.*
 import net.liftweb.http.*
@@ -383,24 +384,28 @@ class Archives extends DispatchSnippet with Loggable {
     } &
     ("#" + restoreButtonId) #> {
       (SHtml.ajaxSubmit(restoreButtonName, restore _, ("id" -> restoreButtonId), ("class", "btn btn-default")) ++
-      Script(
-        OnLoad(
-          JsRaw(
-            """enableIfNonEmpty("%s", "%s");$("#%s").prop("disabled",true);"""
-              .format(archiveDateSelectId, restoreButtonId, restoreButtonId)
-          ) // JsRaw ok, all const values of actionFormBuilder
-        )
+      WithNonce.scriptWithNonce(
+        Script(
+          OnLoad(
+            JsRaw(
+              """enableIfNonEmpty("%s", "%s");$("#%s").prop("disabled",true);"""
+                .format(archiveDateSelectId, restoreButtonId, restoreButtonId)
+            )
+          )
+        ) // JsRaw ok, all const values of actionFormBuilder
       )): NodeSeq
     } &
     ("#" + downloadButtonId) #> {
       (SHtml.ajaxSubmit(downloadButtonName, download _, ("id" -> downloadButtonId), ("class", "btn btn-default")) ++
-      Script(
-        OnLoad(
-          JsRaw(
-            """enableIfNonEmpty("%s", "%s");$("#%s").prop("disabled",true);"""
-              .format(archiveDateSelectId, downloadButtonId, downloadButtonId)
-          ) // JsRaw ok, all const values of actionFormBuilder
-        )
+      WithNonce.scriptWithNonce(
+        Script(
+          OnLoad(
+            JsRaw(
+              """enableIfNonEmpty("%s", "%s");$("#%s").prop("disabled",true);"""
+                .format(archiveDateSelectId, downloadButtonId, downloadButtonId)
+            )
+          )
+        ) // JsRaw ok, all const values of actionFormBuilder
       )): NodeSeq
     }
   }

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/utilities/archiveManagement.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/utilities/archiveManagement.html
@@ -1,4 +1,4 @@
-<lift:surround with="common-layout" at="content">
+<lift:surround data-lift="with-enabled-csp" with="common-layout" at="content">
 
 <head>
   <title>Rudder - Archives</title>
@@ -26,7 +26,7 @@
     }
   </style>
 
-  <script>
+  <script data-lift="with-nonce">
   //<![CDATA[
     function enableIfNonEmpty(selectId, buttonId) {
       $("#"+selectId).change(function () {

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/utilities/eventLogs.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/utilities/eventLogs.html
@@ -1,4 +1,4 @@
-<lift:surround with="common-layout" at="content">
+<lift:surround data-lift="with-enabled-csp" with="common-layout" at="content">
 
   <head_merge>
     <title>Rudder - Event logs</title>
@@ -69,7 +69,7 @@
       </div>
     </div>
   </div>
-  <script id="rollbackBlock" type="text/template">
+  <script data-lift="with-nonce" id="rollbackBlock" type="text/template">
     <div class='rollbackDisplay'>
       <fieldset class='rollbackFieldSet'>
         <legend>Rollback</legend>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/utilities/healthcheck.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/utilities/healthcheck.html
@@ -1,4 +1,4 @@
-<lift:surround with="common-layout" at="content">
+<lift:surround data-lift="with-enabled-csp" with="common-layout" at="content">
   <lift:authz role="administration_read">
     <div id="healthcheck-main">
         <head_merge>


### PR DESCRIPTION
https://issues.rudder.io/issues/25032

* :bulb: Replace the regex-based filtering of CSP headers, and use a lift directive instead : `data-lift="with-enabled-csp"` to include in every HTML page for which to enforce strict-CSP
* :hammer: Migrate scripts in Archives page
* :hammer: Migrate scripts in Event logs page
*  :hammer: Reuse the lift directive in the Healthcheck page