### PR TITLE
Fixes #25120: Use node properties to decide how long compliance is valid

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/DebugComplianceLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/DebugComplianceLogger.scala
@@ -109,6 +109,14 @@ object ComplianceDebugLogger extends Logger {
         s"expected NodeConfigId: ${expectedConfigId.toLog}|" +
         s" last run: none available (or too old)"
 
+      case KeepLastCompliance(expectedConfigId, expirationDateTime, keepUntil, optLastRun) =>
+        val run = optLastRun match {
+          case Some(r) => s"nodeConfigId: ${r._2.nodeConfigId.value} received at ${r._1.toIsoStringNoMillis}"
+          case None    => "unknown"
+        }
+        s"expected NodeConfigId: ${expectedConfigId.toLog}|" +
+        s" last: ${run} ; expired at ${expirationDateTime.toIsoStringNoMillis} but will be kept until ${keepUntil.toIsoStringNoMillis}"
+
       case ReportsDisabledInInterval(expectedConfigId, _) =>
         s"expected NodeConfigId: ${expectedConfigId.toLog}|" +
         s" last run: none available (compliance mode is reports-disabled)]"
@@ -156,6 +164,7 @@ object ComplianceDebugLogger extends Logger {
       case _: Pending                   => "Pending"
       case _: ComputeCompliance         => "ComputeCompliance"
       case _: NoUserRulesDefined        => "NoUserRulesDefined"
+      case _: KeepLastCompliance        => "KeepLastCompliance"
     }
 
     def toLog: String = logName + ": " + logDetails

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/NodeComplianceExpiration.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/NodeComplianceExpiration.scala
@@ -1,0 +1,33 @@
+package com.normation.rudder.domain.reports
+
+import scala.concurrent.duration.Duration
+
+/*
+ * This file defines data structures to inform what we should display when a node compliance
+ * is expired (keep compliance for a longer time, etc)
+ */
+
+sealed trait NodeComplianceExpiration {
+  def id: String
+}
+
+object NodeComplianceExpiration {
+
+  /*
+   * Historical expiration based on a 2 agent run duration + a grace period.
+   * But if the node is in status `NoReportInInterval`, then display that
+   */
+  case object ExpireImmediately extends NodeComplianceExpiration {
+    val id = "expireImmediately"
+  }
+
+  /*
+   * Keep the last know compliance for given additional time.
+   * At some point, we will certainly make that property "by-policyType", but
+   * for now it is the same for all compliance (and it's ok since we are computed
+   * at the same time for now).
+   */
+  case class KeepLast(duration: Duration) extends NodeComplianceExpiration {
+    def id = "keepLast"
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
@@ -124,8 +124,10 @@ class ComplianceJdbcRepository(
        */
       reports.flatMap { r =>
         r.runInfo match {
-          // ignore case with no runs
-          case _: NoReportInInterval | NoRunNoExpectedReport | _: ReportsDisabledInInterval | _: NoUserRulesDefined => None
+          // ignore case with no runs or when compliance should be kept
+          case _: KeepLastCompliance | _: NoReportInInterval | NoRunNoExpectedReport | _: ReportsDisabledInInterval |
+              _: NoUserRulesDefined =>
+            None
 
           case x: Pending =>
             x.optLastRun match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ComplianceExpirationService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ComplianceExpirationService.scala
@@ -1,0 +1,120 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.services.reports
+
+import com.normation.errors.IOResult
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.logger.ComplianceLogger
+import com.normation.rudder.domain.properties.NodeProperty
+import com.normation.rudder.domain.reports.NodeComplianceExpiration
+import com.normation.rudder.facts.nodes.NodeFactRepository
+import com.normation.rudder.facts.nodes.QueryContext
+import com.typesafe.config.ConfigException
+import zio.Chunk
+import zio.syntax.*
+
+/**
+ * This service is in charge of getting the duration of compliance validity for a node when
+ * its status is no reports
+ */
+trait ComplianceExpirationService {
+
+  /**
+   * Get the expiration policy for the set of nodes given as parameter
+   */
+  def getExpirationPolicy(nodeIds: Iterable[NodeId]): IOResult[Map[NodeId, NodeComplianceExpiration]]
+
+}
+
+class DummyComplianceExpirationService(policy: NodeComplianceExpiration) extends ComplianceExpirationService {
+  override def getExpirationPolicy(nodeIds: Iterable[NodeId]): IOResult[Map[NodeId, NodeComplianceExpiration]] = {
+    nodeIds.map(id => (id, policy)).toMap.succeed
+  }
+}
+
+/*
+ * A version that uses node properties, but only direct one, not inherited ones
+ * (that's NOT what we want, but it's free. The inherited version need to be
+ * able to have a cache of computed node properties)
+ */
+class NodePropertyBasedComplianceExpirationService(factRepo: NodeFactRepository, propertyKey: String, propertyName: String)
+    extends ComplianceExpirationService {
+
+  override def getExpirationPolicy(nodeIds: Iterable[NodeId]): IOResult[Map[NodeId, NodeComplianceExpiration]] = {
+    val ids = nodeIds.toSet
+    factRepo
+      .getAll()(QueryContext.systemQC)
+      .map(_.collect {
+        case (id, fact) if (ids.contains(id)) =>
+          val p = NodePropertyBasedComplianceExpirationService.getPolicyFromProp(fact.properties, propertyKey, propertyName, id)
+          (id, p)
+      }.toMap)
+  }
+}
+
+object NodePropertyBasedComplianceExpirationService {
+  def getPolicy(p: NodeProperty, propKey: String, propName: String, debugId: NodeId): NodeComplianceExpiration = {
+    try {
+      // direct access to implementation details is so-so, but alternative force to go
+      // to json and is quite convoluted, and ConfigValue is horrible.
+      val v = p.config.getString("value." + propName)
+      NodeComplianceExpiration.KeepLast(scala.concurrent.duration.Duration(v))
+    } catch {
+      case ex: ConfigException       =>
+        ex.printStackTrace()
+        NodeComplianceExpiration.ExpireImmediately
+      case ex: NumberFormatException =>
+        ComplianceLogger.error(
+          s"Node with id '${debugId.value}' has the keep expired compliance property set (${propKey}.${propName}) but value can not be parsed: ${ex.getMessage}"
+        )
+        NodeComplianceExpiration.ExpireImmediately
+    }
+  }
+
+  def getPolicyFromProp(
+      properties: Chunk[NodeProperty],
+      propKey:    String,
+      propName:   String,
+      debugId:    NodeId
+  ): NodeComplianceExpiration = {
+    properties.find(_.name == propKey) match {
+      case Some(p) => getPolicy(p, propKey, propName, debugId)
+      case None    => NodeComplianceExpiration.ExpireImmediately
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeChangesService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeChangesService.scala
@@ -185,7 +185,7 @@ final case class ChangesCache(
 
 /**
  * A cached version of NodeChangeService that:
- * - get its config (interval lenght) and first results from an other service
+ * - get its config (interval length) and first results from an other service
  * - is able to update a cache from other
  */
 class CachedNodeChangesServiceImpl(
@@ -315,7 +315,9 @@ class CachedNodeChangesServiceImpl(
    * important than responsiveness.
    */
   def update(lowestId: Long, highestId: Long): Box[Unit] = {
-    addUpdate(ChangesUpdate.For(lowestId, highestId)).toBox
+    if (lowestId < highestId) {
+      addUpdate(ChangesUpdate.For(lowestId, highestId)).toBox
+    } else Full(())
   }
 
   def addUpdate(update: ChangesUpdate): IOResult[Unit] = {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
@@ -215,7 +215,7 @@ class StatusReportTest extends Specification {
 
   "Node status reports" should {
     val modesConfig = NodeConfigData.defaultModesConfig
-    val report      = NodeStatusReport(
+    val report      = NodeStatusReport.buildWith(
       NodeId("n1"),
       Pending(
         NodeExpectedReports(

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ComplianceExpirationServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ComplianceExpirationServiceTest.scala
@@ -1,0 +1,124 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.services.reports
+
+import com.normation.errors.PureResult
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.properties.NodeProperty
+import com.normation.rudder.domain.properties.PropertyProvider
+import com.normation.rudder.domain.reports.NodeComplianceExpiration
+import java.util.concurrent.TimeUnit
+import org.junit.runner.RunWith
+import org.specs2.mutable.*
+import org.specs2.runner.JUnitRunner
+import zio.*
+
+/*
+ * Test the cache behaviour
+ */
+@RunWith(classOf[JUnitRunner])
+class ComplianceExpirationServiceTest extends Specification {
+
+  import NodePropertyBasedComplianceExpirationService.getPolicyFromProp
+
+  implicit class ForceGet[A](r: PureResult[A]) {
+    def force = {
+      r match {
+        case Left(value)  => throw new IllegalArgumentException(s"Error in test: result is left: ${value}")
+        case Right(value) => value
+      }
+    }
+  }
+
+  val rudder_ok1:  NodeProperty = NodeProperty
+    .parse(
+      "rudder",
+      """{"keep_compliance_duration": "1 hour"}""",
+      None,
+      Some(PropertyProvider.systemPropertyProvider)
+    )
+    .force
+  val rudder_ok2:  NodeProperty = NodeProperty
+    .parse(
+      "rudder",
+      """{"keep_compliance_duration": "1 hour"}""",
+      None,
+      None
+    )
+    .force
+  val rudder_nok1: NodeProperty = NodeProperty
+    .parse(
+      "rudder",
+      """{ "bad": {"keep_compliance_duration": "1 hour"}}""",
+      None,
+      Some(PropertyProvider.systemPropertyProvider)
+    )
+    .force
+  val rudder_nok2: NodeProperty =
+    NodeProperty.parse("rudder", """{ "bad": "bad"}""", None, Some(PropertyProvider.systemPropertyProvider)).force
+  val rudder_nok3: NodeProperty = NodeProperty
+    .parse(
+      "not_rudder",
+      """{"keep_compliance_duration": "1 hour"}""",
+      None,
+      Some(PropertyProvider.systemPropertyProvider)
+    )
+    .force
+
+  "When keep_compliance_duration we should find it" >> {
+    val keep1h = NodeComplianceExpiration.KeepLast(scala.concurrent.duration.Duration(1, TimeUnit.HOURS))
+    (getPolicyFromProp(Chunk(rudder_ok1), "rudder", "keep_compliance_duration", NodeId("node1")) must beEqualTo(
+      keep1h
+    )) and (getPolicyFromProp(Chunk(rudder_ok2), "rudder", "keep_compliance_duration", NodeId("node1")) must beEqualTo(
+      keep1h
+    ))
+  }
+
+//  "Expire immediately in other cases " >> {
+//
+//    getPolicyFromProp(
+//      Chunk(rudder_nok1, rudder_nok2, rudder_nok3),
+//      "rudder",
+//      "keep_compliance_duration",
+//      NodeId("node1")
+//    ) must beEqualTo(
+//      NodeComplianceExpiration.ExpireImmediately
+//    )
+//
+//  }
+}

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -427,7 +427,7 @@ class ExecutionBatchTest extends Specification {
         )
       }
 
-      val res = ExecutionBatch.computeNodesRunInfo(runs, currentNodeConfigs, runInfo)(nodeId)
+      val res = ExecutionBatch.computeNodesRunInfo(runs, currentNodeConfigs, runInfo, DateTime.now())(nodeId)
 
       // here, the end date depend on run time, so we need to check by case
       res match {
@@ -460,7 +460,7 @@ class ExecutionBatchTest extends Specification {
         )
       }
 
-      val res = ExecutionBatch.computeNodesRunInfo(runs, currentNodeConfigs, runInfo)(nodeId)
+      val res = ExecutionBatch.computeNodesRunInfo(runs, currentNodeConfigs, runInfo, DateTime.now())(nodeId)
 
       res match {
         case NoReportInInterval(exp, t) => exp must beEqualTo(generatedExpectedReports)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ReportingServiceUtilsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ReportingServiceUtilsTest.scala
@@ -127,8 +127,14 @@ class ReportingServiceUtilsTest extends Specification {
    */
   "a rule can not overrides itself" in {
     val reports = List(
-      NodeStatusReport(node1, NoRunNoExpectedReport, RunComplianceInfo.OK, List(), Set(rnReport(node1, rule1, dir1))),
-      NodeStatusReport(node2, NoRunNoExpectedReport, RunComplianceInfo.OK, List(thisOverrideThatOn(rule2, rule1, dir1)), Set())
+      NodeStatusReport.buildWith(node1, NoRunNoExpectedReport, RunComplianceInfo.OK, List(), Set(rnReport(node1, rule1, dir1))),
+      NodeStatusReport.buildWith(
+        node2,
+        NoRunNoExpectedReport,
+        RunComplianceInfo.OK,
+        List(thisOverrideThatOn(rule2, rule1, dir1)),
+        Set()
+      )
     ).map(r => (r.nodeId, r)).toMap
 
     ReportingServiceUtils
@@ -143,7 +149,13 @@ class ReportingServiceUtilsTest extends Specification {
    */
   "only overridden leads to skip" in {
     val reports = List(
-      NodeStatusReport(node1, NoRunNoExpectedReport, RunComplianceInfo.OK, List(thisOverrideThatOn(rule2, rule1, dir1)), Set())
+      NodeStatusReport.buildWith(
+        node1,
+        NoRunNoExpectedReport,
+        RunComplianceInfo.OK,
+        List(thisOverrideThatOn(rule2, rule1, dir1)),
+        Set()
+      )
     ).map(r => (r.nodeId, r)).toMap
 
     ReportingServiceUtils
@@ -154,7 +166,13 @@ class ReportingServiceUtilsTest extends Specification {
   }
   "directives on other rules are not kept in overrides" in {
     val reports = List(
-      NodeStatusReport(node1, NoRunNoExpectedReport, RunComplianceInfo.OK, List(thisOverrideThatOn(rule2, rule3, dir1)), Set())
+      NodeStatusReport.buildWith(
+        node1,
+        NoRunNoExpectedReport,
+        RunComplianceInfo.OK,
+        List(thisOverrideThatOn(rule2, rule3, dir1)),
+        Set()
+      )
     ).map(r => (r.nodeId, r)).toMap
 
     ReportingServiceUtils
@@ -173,8 +191,8 @@ class ReportingServiceUtilsTest extends Specification {
    */
   "a rule not overridden on all nodes is not written overridden" in {
     val reports = List(
-      NodeStatusReport(node1, NoRunNoExpectedReport, RunComplianceInfo.OK, List(), Set(rnReport(node1, rule1, dir1))),
-      NodeStatusReport(
+      NodeStatusReport.buildWith(node1, NoRunNoExpectedReport, RunComplianceInfo.OK, List(), Set(rnReport(node1, rule1, dir1))),
+      NodeStatusReport.buildWith(
         node2,
         NoRunNoExpectedReport,
         RunComplianceInfo.OK,
@@ -202,7 +220,7 @@ class ReportingServiceUtilsTest extends Specification {
    */
   "a rule not overridden on all nodes is not written overriden" in {
     val reports = List(
-      NodeStatusReport(
+      NodeStatusReport.buildWith(
         node1,
         NoRunNoExpectedReport,
         RunComplianceInfo.OK,

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -745,7 +745,7 @@ class MockCompliance(mockDirectives: MockDirectives) {
       ruleNodeReports: Set[RuleNodeStatusReport],
       overrides:       List[OverridenPolicy] = List.empty
   ): NodeStatusReport = {
-    NodeStatusReport(
+    NodeStatusReport.buildWith(
       nodeId,
       ComputeCompliance(
         DateTime.parse("2023-01-01T00:00:00.000Z"),

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -3082,6 +3082,8 @@ object RudderConfigInit {
       nodeStatusReportRepository,
       nodeFactRepository,
       findNewNodeStatusReports,
+      new NodePropertyBasedComplianceExpirationService(nodeFactRepository, "rudder", "keep_compliance_duration"),
+      Ref.make(Chunk[NodeStatusReportUpdateHook](new ScoreNodeStatusReportUpdateHook(scoreServiceManager))).runNow,
       RUDDER_JDBC_BATCH_MAX_SIZE
     )
 
@@ -3479,8 +3481,7 @@ object RudderConfigInit {
         recentChangesService,
         computeNodeStatusReportService,
         findNewNodeStatusReports,
-        complianceRepositoryImpl,
-        scoreServiceManager
+        complianceRepositoryImpl
       )
     }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/25120

This PR add the possibility to delay node compliance expiration based on a settings given via a node property. 
It implements the bottom service `ComplianceExpirationService` on the schema.

The main changes are: 

- add a new `KeepLastCompliance` run info case 
- change nothin in `ExecutionBatch` - the analysis of weither we keep or not last compliance when we have a `NoReport` is done latter on and is not based on a run/expect report analysis (obviously)
- add the logic to check is a node is configured to keep compliance in `ComputeNodeStatusService` based on `{"rudder": { "keep_compliance_duration": "duration" }}` node property
- the duration format is the standard one for scala: an integer followed by an unit, ie something like `2 days` or `48 hours`
- in the repo, actually atomically do the check is a past compliance exists and should be kept. Return modified compliance so that `scoringService` can be plugged and update with the real changes. 
    - note: that means that we kind of reverted #5737 but normally, the condition to do so are now correct


Globally, things remain simple and well separated, it's rather nice. 
Some comments added in the code for noticeable things.

Current limits: 
- the property MUST BE  at node level. It does take into account inherited properties. This will be addressed in a latter PR (it will be the `ResolvedPropertiesCache` or something alike on the schema)
- there is no cold persistance. So when rudder reboot, all old compliance that can't be computed again (because the corresponding run is too old and was deleted) are lost. This will be addressed in a latter PR (it will be the NodeLastCompliance DB connexion on the left of the schema, perhaps with an additionnal StorageService layer in between)

![image](https://github.com/Normation/rudder/assets/44649/3df73231-1c80-4b07-be27-de3ee4e46144)
