### PR TITLE
Fixes #25091: Add VARIABLE_NAME to technique so that we can use valid parameter name in techniques

### DIFF
--- a/policies/rudderc/src/backends/metadata.rs
+++ b/policies/rudderc/src/backends/metadata.rs
@@ -96,6 +96,7 @@ impl From<Parameter> for Input {
 
         Self {
             name: p.id.to_string().to_uppercase(),
+            variable_name: p.name.clone(),
             description: p.description.unwrap_or(p.name),
             long_description: p.documentation,
             constraint: Constraint {
@@ -135,6 +136,7 @@ impl From<Parameter> for SelectOne {
 
         Self {
             name: p.name.clone(),
+            variable_name: p.name.clone(),
             description: p.description.unwrap_or(p.name),
             long_description: p.documentation,
             item: items,
@@ -375,11 +377,12 @@ struct SectionInput {
 struct Input {
     // actually, the id
     name: String,
+    #[serde(rename = "VARIABLENAME")]
     // actually, the name
+    variable_name: String,
     description: String,
     #[serde(rename = "LONGDESCRIPTION")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    // actually, the description
     long_description: Option<String>,
     constraint: Constraint,
 }
@@ -389,11 +392,12 @@ struct Input {
 struct SelectOne {
     // actually, the id
     name: String,
+    #[serde(rename = "VARIABLENAME")]
     // actually, the name
+    variable_name: String,
     description: String,
     #[serde(rename = "LONGDESCRIPTION")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    // actually, the description
     long_description: Option<String>,
     item: Vec<SelectItem>,
     constraint: Constraint,
@@ -518,6 +522,7 @@ mod tests {
                         name: "Technique parameters".to_string(),
                         section: vec![InputType::Input(Input {
                             name: "server".to_string(),
+                            variable_name: "My_parameter".to_string(),
                             description: "My parameter".to_string(),
                             long_description: Some("My interesting parameter".to_string()),
                             constraint: Constraint {

--- a/policies/rudderc/tests/cases/general/escaping/metadata.xml
+++ b/policies/rudderc/tests/cases/general/escaping/metadata.xml
@@ -29,6 +29,7 @@
     <SECTION name="Technique parameters">
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C27E</NAME>
+        <VARIABLENAME>server</VARIABLENAME>
         <DESCRIPTION>server</DESCRIPTION>
         <LONGDESCRIPTION>${sys.host} . | / ${sys.${host}} &apos; &apos;&apos; &apos;&apos;&apos; $ $$ &quot; &quot;&quot; \ \\😋aà3
 	</LONGDESCRIPTION>

--- a/policies/rudderc/tests/cases/general/form/metadata.xml
+++ b/policies/rudderc/tests/cases/general/form/metadata.xml
@@ -27,6 +27,7 @@
     <SECTION name="Technique parameters">
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C27A</NAME>
+        <VARIABLENAME>server_a</VARIABLENAME>
         <DESCRIPTION>description</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>textarea</TYPE>
@@ -34,6 +35,7 @@
       </INPUT>
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C27B</NAME>
+        <VARIABLENAME>server_b</VARIABLENAME>
         <DESCRIPTION>The server hostname</DESCRIPTION>
         <LONGDESCRIPTION>This is markdown</LONGDESCRIPTION>
         <CONSTRAINT>
@@ -46,6 +48,7 @@
       </INPUT>
       <SELECT1>
         <NAME>server_c</NAME>
+        <VARIABLENAME>server_c</VARIABLENAME>
         <DESCRIPTION>The package name</DESCRIPTION>
         <ITEM>
           <LABEL>htop</LABEL>
@@ -61,6 +64,7 @@
       </SELECT1>
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C27D</NAME>
+        <VARIABLENAME>server_d</VARIABLENAME>
         <DESCRIPTION>server_d</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>mail</TYPE>
@@ -68,6 +72,7 @@
       </INPUT>
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C27E</NAME>
+        <VARIABLENAME>server_e</VARIABLENAME>
         <DESCRIPTION>server_e</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>boolean</TYPE>
@@ -75,6 +80,7 @@
       </INPUT>
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C27F</NAME>
+        <VARIABLENAME>server_f</VARIABLENAME>
         <DESCRIPTION>server_f</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>password</TYPE>
@@ -83,6 +89,7 @@
       </INPUT>
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C271</NAME>
+        <VARIABLENAME>server_g</VARIABLENAME>
         <DESCRIPTION>server_g</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>password</TYPE>
@@ -91,6 +98,7 @@
       </INPUT>
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C272</NAME>
+        <VARIABLENAME>server_h</VARIABLENAME>
         <DESCRIPTION>server_h</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>perm</TYPE>
@@ -98,6 +106,7 @@
       </INPUT>
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C273</NAME>
+        <VARIABLENAME>server_i</VARIABLENAME>
         <DESCRIPTION>server_i</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>size-gb</TYPE>
@@ -105,6 +114,7 @@
       </INPUT>
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C274</NAME>
+        <VARIABLENAME>server_j</VARIABLENAME>
         <DESCRIPTION>server_j</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>textarea</TYPE>
@@ -112,6 +122,7 @@
       </INPUT>
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C275</NAME>
+        <VARIABLENAME>server_k</VARIABLENAME>
         <DESCRIPTION>server_k</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>ipv6</TYPE>
@@ -119,6 +130,7 @@
       </INPUT>
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C276</NAME>
+        <VARIABLENAME>server_l</VARIABLENAME>
         <DESCRIPTION>server_l</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>textarea</TYPE>
@@ -126,6 +138,7 @@
       </INPUT>
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C277</NAME>
+        <VARIABLENAME>server_m</VARIABLENAME>
         <DESCRIPTION>server_m</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>integer</TYPE>
@@ -134,6 +147,7 @@
       </INPUT>
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C278</NAME>
+        <VARIABLENAME>server_n</VARIABLENAME>
         <DESCRIPTION>server_n</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>textarea</TYPE>

--- a/policies/rudderc/tests/cases/general/ntp/metadata.xml
+++ b/policies/rudderc/tests/cases/general/ntp/metadata.xml
@@ -44,6 +44,7 @@
     <SECTION name="Technique parameters">
       <INPUT>
         <NAME>3439BBB0-D8F1-4C43-95A9-0C56BFB8C27E</NAME>
+        <VARIABLENAME>server</VARIABLENAME>
         <DESCRIPTION>The server hostname</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>textarea</TYPE>

--- a/policies/rudderc/tests/cases/general/param_in_condition/metadata.xml
+++ b/policies/rudderc/tests/cases/general/param_in_condition/metadata.xml
@@ -27,6 +27,7 @@
     <SECTION name="Technique parameters">
       <INPUT>
         <NAME>2F415DC5-9F9E-4FBE-B836-8960AF613EC9</NAME>
+        <VARIABLENAME>file</VARIABLENAME>
         <DESCRIPTION>file</DESCRIPTION>
         <CONSTRAINT>
           <TYPE>textarea</TYPE>

--- a/policies/rudderc/tests/metadata/serialized.xml
+++ b/policies/rudderc/tests/metadata/serialized.xml
@@ -36,6 +36,7 @@
       <SECTION name="Technique parameters">
         <INPUT>
           <NAME>server</NAME>
+          <VARIABLENAME>My_parameter</VARIABLENAME>
           <DESCRIPTION>My parameter</DESCRIPTION>
           <LONGDESCRIPTION>My interesting parameter</LONGDESCRIPTION>
           <CONSTRAINT>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/VariableAndSectionSpec.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/VariableAndSectionSpec.scala
@@ -179,6 +179,7 @@ sealed trait VariableSpec {
   type V <: Variable // type of variable linked to that variable spec
 
   def name:            String
+  def variableName:    Option[String]
   def description:     String
   def longDescription: String
 
@@ -218,6 +219,7 @@ sealed trait VariableSpec {
 final case class SystemVariableSpec(
     override val name:   String,
     val description:     String,
+    variableName:        Option[String] = None,
     val longDescription: String = "",
     val valueslabels:    Seq[ValueLabel] = Seq(),
     val multivalued:     Boolean, // we expect that by default the variable will be checked
@@ -248,10 +250,10 @@ final case class TrackerVariableSpec(
   override type T = TrackerVariableSpec
   override type V = TrackerVariable
 
-  override val name:        String = TRACKINGKEY
-  override val description: String = "Variable which kept information about the policy"
-
-  override val checked: Boolean = false
+  override val name:         String         = TRACKINGKEY
+  override val description:  String         = "Variable which kept information about the policy"
+  override val variableName: Option[String] = None
+  override val checked:      Boolean        = false
 
   val constraint: Constraint = Constraint()
 
@@ -284,6 +286,7 @@ trait ValueLabelVariableSpec extends SectionVariableSpec {
 final case class SelectVariableSpec(
     override val name:   String,
     val description:     String,
+    variableName:        Option[String],
     val longDescription: String = "",
     val valueslabels:    Seq[ValueLabel] = Seq(),
     val multivalued:     Boolean = false, // we expect that by default the variable will be checked
@@ -305,6 +308,7 @@ final case class SelectVariableSpec(
 final case class SelectOneVariableSpec(
     override val name:   String,
     val description:     String,
+    variableName:        Option[String],
     val longDescription: String = "",
     val valueslabels:    Seq[ValueLabel] = Seq(),
     val multivalued:     Boolean = false, // we expect that by default the variable will be checked
@@ -326,12 +330,13 @@ final case class SelectOneVariableSpec(
  * won't be able to change them.
  */
 final case class PredefinedValuesVariableSpec(
-    override val name: String,
-    val description:   String, // The list of predefined values, provided
+    override val name:   String,
+    val description:     String,         // The list of predefined values, provided
     // directly in the variable spec
     // that list can not be empty (but Scala does not have a NonEmptyList type)
     // Values are ordered.
 
+    variableName:        Option[String],
     val providedValues:  (String, Seq[String]),
     val longDescription: String = "",
     val multivalued:     Boolean = true, // we expect that by default the variable will be checked
@@ -357,6 +362,7 @@ final case class PredefinedValuesVariableSpec(
 final case class InputVariableSpec(
     override val name:   String,
     val description:     String,
+    variableName:        Option[String],
     val longDescription: String = "",
     val multivalued:     Boolean = false, // we expect that by default the variable will be checked
 
@@ -391,6 +397,7 @@ object SectionVariableSpec {
       varName:         String,
       description:     String,
       markerName:      String,
+      variableName:    Option[String],
       longDescription: String = "",
       valueslabels:    Seq[ValueLabel],
       multivalued:     Boolean = false,
@@ -402,11 +409,31 @@ object SectionVariableSpec {
 
     markerName match {
       case INPUT       =>
-        InputVariableSpec(varName, description, longDescription, multivalued, checked, constraint, id)
+        InputVariableSpec(varName, description, variableName, longDescription, multivalued, checked, constraint, id)
       case SELECT      =>
-        SelectVariableSpec(varName, description, longDescription, valueslabels, multivalued, checked, constraint, id)
+        SelectVariableSpec(
+          varName,
+          description,
+          variableName,
+          longDescription,
+          valueslabels,
+          multivalued,
+          checked,
+          constraint,
+          id
+        )
       case SELECT1     =>
-        SelectOneVariableSpec(varName, description, longDescription, valueslabels, multivalued, checked, constraint, id)
+        SelectOneVariableSpec(
+          varName,
+          description,
+          variableName,
+          longDescription,
+          valueslabels,
+          multivalued,
+          checked,
+          constraint,
+          id
+        )
       case REPORT_KEYS =>
         if (providedValues.isEmpty) {
           throw EmptyReportKeysValue(varName)
@@ -414,6 +441,7 @@ object SectionVariableSpec {
           PredefinedValuesVariableSpec(
             varName,
             description,
+            variableName,
             (providedValues.head, providedValues.tail),
             longDescription,
             multivalued,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/CfclerkXmlConstants.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/CfclerkXmlConstants.scala
@@ -110,6 +110,7 @@ object CfclerkXmlConstants {
   val VAR_NAME                        = "NAME"
   val VAR_DESCRIPTION                 = "DESCRIPTION"
   val VAR_LONG_DESCRIPTION            = "LONGDESCRIPTION"
+  val VAR_VARIABLE_NAME               = "VARIABLENAME"
   val VAR_IS_UNIQUE_VARIABLE          = "UNIQUEVARIABLE"
   val VAR_IS_MULTIVALUED              = "MULTIVALUED"
   val VAR_CONSTRAINT                  = "CONSTRAINT"

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/VariableSpecParser.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/VariableSpecParser.scala
@@ -152,6 +152,7 @@ class VariableSpecParser extends Loggable {
             varName = reportKeysVariableName(parentSectionName),
             description = s"Expected Report key names for component ${parentSectionName}",
             markerName = markerName,
+            variableName = None,
             longDescription = "",
             valueslabels = Nil,
             multivalued = true,
@@ -190,6 +191,12 @@ class VariableSpecParser extends Loggable {
                 )
               }
             }
+            variableName   <- (elt \ VAR_VARIABLE_NAME).toList match {
+                                case varName :: Nil => Right(Some(varName.text))
+                                case Nil            => Right(None)
+                                case _              => Left(LoadTechniqueError.Consistancy(s"Only one <${VAR_VARIABLE_NAME}> is authorized"))
+
+                              }
             multiValued     = getUniqueNodeText(elt, VAR_IS_MULTIVALUED, "false").toLowerCase match {
                                 case "true" => true
                                 case _      => false
@@ -206,6 +213,7 @@ class VariableSpecParser extends Loggable {
                 varName = name,
                 description = desc,
                 markerName = markerName,
+                variableName = variableName,
                 longDescription = longDescription,
                 valueslabels = items,
                 multivalued = multiValued,
@@ -309,6 +317,7 @@ class VariableSpecParser extends Loggable {
         varName = s"${parentName}_${postfix}",
         description = s"This password field value is derived from input value from ${parentName}",
         markerName = INPUT,
+        variableName = None,
         constraint = Constraint(vtype, defaultValue, mayBeEmpty, Set()),
         valueslabels = Nil,
         providedValues = Nil,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
@@ -660,6 +660,7 @@ class WebappTechniqueCompiler(
       //     name       |   description
       <INPUT>
         <NAME>{parameter.id.value.toUpperCase()}</NAME>
+        <VARIABLENAME>{parameter.name}</VARIABLENAME>
         <DESCRIPTION>{parameter.description.getOrElse(parameter.name)}</DESCRIPTION>
         <LONGDESCRIPTION>{parameter.documentation.getOrElse("")}</LONGDESCRIPTION>
         <CONSTRAINT>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/BuildBundleSequence.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/BuildBundleSequence.scala
@@ -117,14 +117,15 @@ object BuildBundleSequence {
   // (double quote is the default, and simple quote are used mostly for JSON)
   sealed trait BundleParam {
     def quote(agentEscape: String => String): String
-    def name:  String
-    def value: String
+    def name:         String
+    def value:        String
+    def variableName: Option[String]
   }
   object BundleParam       {
-    final case class SimpleQuote(value: String, name: String) extends BundleParam {
+    final case class SimpleQuote(value: String, name: String, variableName: Option[String]) extends BundleParam {
       def quote(agentEscape: String => String): String = "'" + value + "'"
     }
-    final case class DoubleQuote(value: String, name: String) extends BundleParam {
+    final case class DoubleQuote(value: String, name: String, variableName: Option[String]) extends BundleParam {
       def quote(agentEscape: String => String): String = "\"" + agentEscape(value) + "\""
     }
   }
@@ -151,8 +152,10 @@ object BuildBundleSequence {
         case (false, PolicyMode.Enforce) => enforce
       }
     }
-    val audit:                                                 Bundle = Bundle.apply(None, BundleName("""set_dry_run_mode"""), BundleParam.DoubleQuote("true", "mode") :: Nil)
-    val enforce:                                               Bundle = Bundle.apply(None, BundleName("""set_dry_run_mode"""), BundleParam.DoubleQuote("false", "mode") :: Nil)
+    val audit:                                                 Bundle =
+      Bundle.apply(None, BundleName("""set_dry_run_mode"""), BundleParam.DoubleQuote("true", "mode", None) :: Nil)
+    val enforce:                                               Bundle =
+      Bundle.apply(None, BundleName("""set_dry_run_mode"""), BundleParam.DoubleQuote("false", "mode", None) :: Nil)
   }
 
   /*
@@ -193,12 +196,12 @@ object BuildBundleSequence {
             None,
             BundleName("rudder_reporting_context_v4"),
             List(
-              (id.directiveId.serialize, "directiveId"),
-              (id.ruleId.serialize, "ruleId"),
-              (techniqueId.name.value, "techniqueName"),
-              ("", "component"),
-              ("", "value"),
-              (id.directiveId.serialize ++ id.ruleId.serialize, "report_id")
+              (id.directiveId.serialize, "directiveId", None),
+              (id.ruleId.serialize, "ruleId", None),
+              (techniqueId.name.value, "techniqueName", None),
+              ("", "component", None),
+              ("", "value", None),
+              (id.directiveId.serialize ++ id.ruleId.serialize, "report_id", None)
             ).map((BundleParam.DoubleQuote.apply _).tupled)
           ) :: Nil
       }
@@ -380,11 +383,13 @@ class BuildBundleSequence(
                 //      N/A       |        N/A      |    value = values.get(variable.name) = values.get(parameter.id)
                 // We would definitely be happier if we add a way to describe them as Rudder technique parameter and not as variable
 
-                (varId, varName) <-
-                  policy.technique.rootSection.copyWithoutSystemVars.getAllVariables.map(v => (v.name, v.description))
+                (varId, varName, variableName) <-
+                  policy.technique.rootSection.copyWithoutSystemVars.getAllVariables.map(v =>
+                    (v.name, v.description, v.variableName)
+                  )
               } yield {
                 val value = policy.expandedVars.get(varId).map(_.values.headOption.getOrElse("")).getOrElse("")
-                BundleParam.DoubleQuote(value, varName)
+                BundleParam.DoubleQuote(value, varName, variableName)
               }
             case TechniqueGenerationMode.MergeDirectives | TechniqueGenerationMode.MultipleDirectives =>
               Nil
@@ -572,7 +577,7 @@ object CfengineBundleVariables {
       case RunHook.Kind.Post => "post-run-hook"
     }
     import BundleParam.*
-    (promiser, Bundle(None, BundleName(hook.bundle), List(SimpleQuote(hook.jsonParam, "hook_param"))) :: Nil)
+    (promiser, Bundle(None, BundleName(hook.bundle), List(SimpleQuote(hook.jsonParam, "hook_param", None))) :: Nil)
   }
 
   /*

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/testing_variables_in_conditions/1.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/testing_variables_in_conditions/1.0/metadata.xml
@@ -37,6 +37,7 @@
     <SECTION name="Technique parameters">
       <INPUT>
         <NAME>40E3A5AB-0812-4A60-96F3-251BE8CEDF43</NAME>
+        <VARIABLENAME>my_custom_condition</VARIABLENAME>
         <DESCRIPTION>my custom condition</DESCRIPTION>
         <LONGDESCRIPTION></LONGDESCRIPTION>
         <CONSTRAINT>

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/1.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/1.0/metadata.xml
@@ -33,6 +33,7 @@
     <SECTION name="Technique parameters">
       <INPUT>
         <NAME>PACKAGE_VERSION</NAME>
+        <VARIABLENAME>version</VARIABLENAME>
         <DESCRIPTION>package version</DESCRIPTION>
         <LONGDESCRIPTION>Package version to install</LONGDESCRIPTION>
         <CONSTRAINT>

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/2.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_any/2.0/metadata.xml
@@ -33,6 +33,7 @@
     <SECTION name="Technique parameters">
       <INPUT>
         <NAME>PACKAGE_VERSION</NAME>
+        <VARIABLENAME>version</VARIABLENAME>
         <DESCRIPTION>package version</DESCRIPTION>
         <LONGDESCRIPTION>Package version to install</LONGDESCRIPTION>
         <CONSTRAINT>

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/technique_by_Rudder/1.0/metadata.xml
@@ -59,6 +59,7 @@
     <SECTION name="Technique parameters">
       <INPUT>
         <NAME>1AAACD71-C2D5-482C-BCFF-5EEE6F8DA9C2</NAME>
+        <VARIABLENAME>technique_parameter</VARIABLENAME>
         <DESCRIPTION>technique parameter</DESCRIPTION>
         <LONGDESCRIPTION> a long description, with line 
  break within</LONGDESCRIPTION>

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/VariableTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/VariableTest.scala
@@ -63,12 +63,13 @@ class VariableTest extends Specification {
 
   val nbVariables = 28
 
-  val refName        = "name"
-  val refDescription = "description"
-  val refValue       = "value"
-  val dateValue      = "2010-01-16T12:00:00.000+01:00"
-  val listValue      = "value1;value2"
-  val defaultValue   = "default_value"
+  val refName         = "name"
+  val refDescription  = "description"
+  val refValue        = "value"
+  val refVariableName = Some("variable_name")
+  val dateValue       = "2010-01-16T12:00:00.000+01:00"
+  val listValue       = "value1;value2"
+  val defaultValue    = "default_value"
 
   val rawValue  = """This is a test \ " \\ """
   val escapedTo = """This is a test \\ \" \\\\ """
@@ -168,14 +169,14 @@ class VariableTest extends Specification {
   ///////////////// generic tests about variable construction, do not use files /////////////////
 
   "Unsetted Variable" should {
-    implicit val variable = InputVariable(InputVariableSpec(refName, refDescription, id = None), Seq())
+    implicit val variable = InputVariable(InputVariableSpec(refName, refDescription, refVariableName, id = None), Seq())
     haveName()
     haveDescription()
   }
 
   "Variable" should {
-    val v                 = InputVariable(InputVariableSpec(refName, refDescription, id = None), Seq())
-    implicit val variable = v.copyWithSavedValue(refValue).orThrow
+    val v = InputVariable(InputVariableSpec(refName, refDescription, refVariableName, id = None), Seq())
+    implicit val variable: InputVariable = v.copyWithSavedValue(refValue).orThrow
 
     haveName()
     haveDescription()
@@ -183,8 +184,9 @@ class VariableTest extends Specification {
   }
 
   "Multivalued variable" should {
-    val variable   = InputVariable(InputVariableSpec(refName, refDescription, multivalued = true, id = None), Seq())
-    implicit val v = variable.copyWithSavedValues(listValue.split(";").toSeq).orThrow
+    val variable =
+      InputVariable(InputVariableSpec(refName, refDescription, refVariableName, multivalued = true, id = None), Seq())
+    implicit val v: InputVariable = variable.copyWithSavedValues(listValue.split(";").toSeq).orThrow
 
     haveName()
     haveDescription()
@@ -192,8 +194,9 @@ class VariableTest extends Specification {
   }
 
   "Select variable" should {
-    val variable   = SelectVariable(SelectVariableSpec(refName, refDescription, valueslabels = refItem, id = None), Seq())
-    implicit val v = variable.copyWithSavedValue(refValue).orThrow
+    val variable =
+      SelectVariable(SelectVariableSpec(refName, refDescription, refVariableName, valueslabels = refItem, id = None), Seq())
+    implicit val v: SelectVariable = variable.copyWithSavedValue(refValue).orThrow
 
     haveName()
     haveDescription()
@@ -201,8 +204,8 @@ class VariableTest extends Specification {
   }
 
   "Input variable" should {
-    val variable   = InputVariable(InputVariableSpec(refName, refDescription, id = None), Seq())
-    implicit val v = variable.copyWithSavedValue(refValue).orThrow
+    val variable = InputVariable(InputVariableSpec(refName, refDescription, refVariableName, id = None), Seq())
+    implicit val v: InputVariable = variable.copyWithSavedValue(refValue).orThrow
 
     haveName()
     haveDescription()
@@ -210,8 +213,8 @@ class VariableTest extends Specification {
   }
 
   "Nulled variable" should {
-    val variable   = InputVariable(InputVariableSpec(refName, refDescription, id = None), Seq())
-    implicit val v = variable.copyWithSavedValue(null).orThrow
+    val variable = InputVariable(InputVariableSpec(refName, refDescription, refVariableName, id = None), Seq())
+    implicit val v: InputVariable = variable.copyWithSavedValue(null).orThrow
 
     haveName()
     haveDescription()
@@ -219,8 +222,8 @@ class VariableTest extends Specification {
   }
 
   "Valid variable" should {
-    val variable   = InputVariable(InputVariableSpec(refName, refDescription, id = None), Seq())
-    implicit val v = variable.copyWithSavedValue(refValue).orThrow
+    val variable = InputVariable(InputVariableSpec(refName, refDescription, refVariableName, id = None), Seq())
+    implicit val v: InputVariable = variable.copyWithSavedValue(refValue).orThrow
 
     haveName()
     haveDescription()
@@ -228,8 +231,12 @@ class VariableTest extends Specification {
   }
 
   "Boolean variable" should {
-    val variable =
-      InputVariable(InputVariableSpec(refName, refDescription, constraint = Constraint(BooleanVType), id = None), Seq())
+    val variable = {
+      InputVariable(
+        InputVariableSpec(refName, refDescription, refVariableName, constraint = Constraint(BooleanVType), id = None),
+        Seq()
+      )
+    }
 
     implicit val v = variable.copyWithSavedValue("true").orThrow
     haveName()
@@ -238,8 +245,12 @@ class VariableTest extends Specification {
   }
 
   "Boolean variable" should {
-    val variable =
-      InputVariable(InputVariableSpec(refName, refDescription, constraint = Constraint(BooleanVType), id = None), Seq())
+    val variable = {
+      InputVariable(
+        InputVariableSpec(refName, refDescription, refVariableName, constraint = Constraint(BooleanVType), id = None),
+        Seq()
+      )
+    }
 
     implicit val v = variable.copyWithSavedValue("false").orThrow
     haveValue(false)
@@ -247,7 +258,7 @@ class VariableTest extends Specification {
 
   "Invalid variable" should {
     implicit val variable =
-      new SelectVariable(SelectVariableSpec(refName, refDescription, valueslabels = refItem, id = None), Seq())
+      new SelectVariable(SelectVariableSpec(refName, refDescription, refVariableName, valueslabels = refItem, id = None), Seq())
 
     "throw a VariableException" in {
       variable.copyWithSavedValue(unvalidValue) must beLeft[LoadTechniqueError]

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/DummyTechniqueRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/DummyTechniqueRepository.scala
@@ -56,15 +56,15 @@ class DummyTechniqueRepository(policies: Seq[Technique] = Seq()) extends Techniq
     "",
     agentCfg("one"),
     TrackerVariableSpec(id = None),
-    SectionSpec(name = "root", children = Seq(InputVariableSpec("$variable1", "a variable1", id = None))),
+    SectionSpec(name = "root", children = Seq(InputVariableSpec("$variable1", "a variable1", None, id = None))),
     None
   )
 
   val sections: SectionSpec = SectionSpec(
     name = "root",
     children = Seq(
-      InputVariableSpec("$variable2", "a variable2", multivalued = true, id = None),
-      InputVariableSpec("$variable22", "a variable22", id = None)
+      InputVariableSpec("$variable2", "a variable2", Some("var_name"), multivalued = true, id = None),
+      InputVariableSpec("$variable22", "a variable22", None, id = None)
     )
   )
   val policy2:  Technique   = Technique(
@@ -78,7 +78,7 @@ class DummyTechniqueRepository(policies: Seq[Technique] = Seq()) extends Techniq
   )
 
   val sections3: SectionSpec =
-    SectionSpec(name = "root", children = Seq(InputVariableSpec("$variable3", "a variable3", id = None)))
+    SectionSpec(name = "root", children = Seq(InputVariableSpec("$variable3", "a variable3", None, id = None)))
   val policy3:   Technique   = Technique(
     TechniqueId(TechniqueName("policy3"), TechniqueVersionHelper("1.0")),
     "policy3",
@@ -90,7 +90,7 @@ class DummyTechniqueRepository(policies: Seq[Technique] = Seq()) extends Techniq
   )
 
   val sections4: SectionSpec =
-    SectionSpec(name = "root", children = Seq(InputVariableSpec("$variable4", "an variable4", id = None)))
+    SectionSpec(name = "root", children = Seq(InputVariableSpec("$variable4", "an variable4", Some("var_name_4"), id = None)))
   val policy4:   Technique   = Technique(
     TechniqueId(TechniqueName("policy4"), TechniqueVersionHelper("1.0")),
     "policy4",
@@ -101,7 +101,7 @@ class DummyTechniqueRepository(policies: Seq[Technique] = Seq()) extends Techniq
     None
   )
 
-  val sectionsFoo: SectionSpec = SectionSpec(name = "root", children = Seq(InputVariableSpec("$bar", "bar", id = None)))
+  val sectionsFoo: SectionSpec = SectionSpec(name = "root", children = Seq(InputVariableSpec("$bar", "bar", None, id = None)))
   val foo:         Technique   = Technique(
     TechniqueId(TechniqueName("foo"), TechniqueVersionHelper("1.0")),
     "foo",

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/SectionValTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/SectionValTest.scala
@@ -61,6 +61,7 @@ class SectionValTest extends Specification with Loggable {
         children = InputVariableSpec(
           name = "var1",
           description = "",
+          variableName = None,
           id = None
         ) ::
           Nil
@@ -141,30 +142,30 @@ class SectionValTest extends Specification with Loggable {
       name = "root",
       children = SectionSpec(
         name = "sec0",
-        children = InputVariableSpec(name = "var0", description = "", id = None) ::
+        children = InputVariableSpec(name = "var0", description = "", variableName = Some("variable_name0"), id = None) ::
           Nil
       ) ::
         SectionSpec(
           name = "sec1",
           isMultivalued = true,
-          children = InputVariableSpec(name = "var1", description = "", id = None) ::
+          children = InputVariableSpec(name = "var1", description = "", variableName = None, id = None) ::
             SectionSpec(
               name = "sec2",
-              children = InputVariableSpec(name = "var2", description = "", id = None) ::
+              children = InputVariableSpec(name = "var2", description = "", variableName = None, id = None) ::
                 Nil
             ) ::
             Nil
         ) ::
         SectionSpec(
           name = "sec3",
-          children = InputVariableSpec(name = "var3", description = "", id = None) ::
+          children = InputVariableSpec(name = "var3", description = "", variableName = None, id = None) ::
             SectionSpec(
               name = "sec4",
               isMultivalued = true,
-              children = InputVariableSpec(name = "var4", description = "", id = None) ::
+              children = InputVariableSpec(name = "var4", description = "", variableName = None, id = None) ::
                 SectionSpec(
                   name = "sec5",
-                  children = InputVariableSpec(name = "var5", description = "", id = None) ::
+                  children = InputVariableSpec(name = "var5", description = "", variableName = None, id = None) ::
                     Nil
                 ) ::
                 Nil

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeExpectedReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeExpectedReportTest.scala
@@ -82,10 +82,10 @@ class NodeExpectedReportTest extends Specification {
   // a technique with a var non multi-valued and a mutivalued section with 2 components
   // a non multivalued var
   def tvar(x: String):  SectionVariableSpec =
-    SectionVariableSpec(s"var_${x}", "", "INPUT", valueslabels = Nil, providedValues = Nil, id = None)
+    SectionVariableSpec(s"var_${x}", "", "INPUT", None, valueslabels = Nil, providedValues = Nil, id = None)
   // a multivalued var
   def tmvar(x: String): SectionVariableSpec =
-    SectionVariableSpec(s"m_var_${x}", "", "INPUT", multivalued = true, valueslabels = Nil, providedValues = Nil, id = None)
+    SectionVariableSpec(s"m_var_${x}", "", "INPUT", None, multivalued = true, valueslabels = Nil, providedValues = Nil, id = None)
 
   // return the couple of (var name, var with value)
   def v(x: String, values: String*):  (ComponentId, SectionVariableSpec#V) = {
@@ -427,6 +427,7 @@ class NodeExpectedReportTest extends Specification {
         "expectedReportKey " + componentKey,
         "",
         "REPORTKEYS",
+        None,
         valueslabels = Nil,
         providedValues = Seq(value),
         id = None

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
@@ -89,6 +89,7 @@ class RuleValServiceTest extends Specification {
     PredefinedValuesVariableSpec(
       reportKeysVariableName(name),
       "description",
+      None,
       providedValues,
       id = None
     )

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestJsEngine.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestJsEngine.scala
@@ -67,7 +67,7 @@ import zio.syntax.*
 class TestJsEngine extends Specification {
 
   val hashPrefix = "test"
-  val variableSpec: InputVariableSpec = InputVariableSpec(hashPrefix, "", id = None)
+  val variableSpec: InputVariableSpec = InputVariableSpec(hashPrefix, "", None, id = None)
 
   val noscriptVariable:     InputVariable = variableSpec.toVariable(Seq("simple ${rudder} value"))
   val get4scriptVariable:   InputVariable = variableSpec.toVariable(Seq(s"${JsEngine.EVALJS} 2+2"))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestNodeAndGlobalParameterLookup.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestNodeAndGlobalParameterLookup.scala
@@ -166,30 +166,30 @@ class TestNodeAndGlobalParameterLookup extends Specification {
   catch { case ex: Exception => JString(s) }
 
   // two variables
-  val var1:              InputVariable = InputVariableSpec("var1", "", id = None).toVariable(Seq("== ${rudder.param.foo} =="))
+  val var1:              InputVariable = InputVariableSpec("var1", "", None, id = None).toVariable(Seq("== ${rudder.param.foo} =="))
   val var1_double:       InputVariable =
-    InputVariableSpec("var1_double", "", id = None).toVariable(Seq("== ${rudder.param.foo}${rudder.param.bar} =="))
-  val var1_double_space: InputVariable = InputVariableSpec("var1_double_space", "", id = None).toVariable(
+    InputVariableSpec("var1_double", "", None, id = None).toVariable(Seq("== ${rudder.param.foo}${rudder.param.bar} =="))
+  val var1_double_space: InputVariable = InputVariableSpec("var1_double_space", "", None, id = None).toVariable(
     Seq("== ${rudder.param.foo} contains ${rudder.param.bar} ==")
   )
 
   val pathCaseInsensitive: InputVariable =
-    InputVariableSpec("pathCaseInsensitive", "", id = None).toVariable(Seq("== ${RudDer.paRam.foo} =="))
+    InputVariableSpec("pathCaseInsensitive", "", None, id = None).toVariable(Seq("== ${RudDer.paRam.foo} =="))
 
   val paramNameCaseSensitive: InputVariable =
-    InputVariableSpec("paramNameCaseSensitive", "", id = None).toVariable(Seq("== ${rudder.param.Foo} =="))
+    InputVariableSpec("paramNameCaseSensitive", "", None, id = None).toVariable(Seq("== ${rudder.param.Foo} =="))
 
   val recurVariable: InputVariable =
-    InputVariableSpec("recurParam", "", id = None).toVariable(Seq("== ${rudder.param.recurToFoo} =="))
+    InputVariableSpec("recurParam", "", None, id = None).toVariable(Seq("== ${rudder.param.recurToFoo} =="))
 
-  val dangerVariable: InputVariable = InputVariableSpec("danger", "", id = None).toVariable(Seq("${rudder.param.danger}"))
+  val dangerVariable: InputVariable = InputVariableSpec("danger", "", None, id = None).toVariable(Seq("${rudder.param.danger}"))
 
   val multilineInputVariable:    InputVariable =
-    InputVariableSpec("multiInput", "", id = None).toVariable(Seq("=\r= \n${rudder.param.foo} =\n="))
+    InputVariableSpec("multiInput", "", None, id = None).toVariable(Seq("=\r= \n${rudder.param.foo} =\n="))
   val multilineNodePropVariable: InputVariable =
-    InputVariableSpec("multiNodeProp", "", id = None).toVariable(Seq("=\r= \n${node.properties[datacenter][Europe]} =\n="))
+    InputVariableSpec("multiNodeProp", "", None, id = None).toVariable(Seq("=\r= \n${node.properties[datacenter][Europe]} =\n="))
 
-  val var2: InputVariable = InputVariableSpec("var1", "", multivalued = true, id = None).toVariable(
+  val var2: InputVariable = InputVariableSpec("var1", "", None, multivalued = true, id = None).toVariable(
     Seq(
       "a${rudder.node.id})",
       "=${rudder.node.hostname}/",
@@ -200,9 +200,9 @@ class TestNodeAndGlobalParameterLookup extends Specification {
     )
   )
 
-  val badEmptyRudder: InputVariable = InputVariableSpec("empty", "", id = None).toVariable(Seq("== ${rudder.} =="))
-  val badUnclosed:    InputVariable = InputVariableSpec("empty", "", id = None).toVariable(Seq("== ${rudder.param.foo =="))
-  val badUnknown:     InputVariable = InputVariableSpec("empty", "", id = None).toVariable(Seq("== ${rudder.foo} =="))
+  val badEmptyRudder: InputVariable = InputVariableSpec("empty", "", None, id = None).toVariable(Seq("== ${rudder.} =="))
+  val badUnclosed:    InputVariable = InputVariableSpec("empty", "", None, id = None).toVariable(Seq("== ${rudder.param.foo =="))
+  val badUnknown:     InputVariable = InputVariableSpec("empty", "", None, id = None).toVariable(Seq("== ${rudder.foo} =="))
 
   val fooParam:   ParameterForConfiguration = ParameterForConfiguration("foo", "fooValue")
   val barParam:   ParameterForConfiguration = ParameterForConfiguration("bar", "barValue")

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PolicyAgregationTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PolicyAgregationTest.scala
@@ -127,7 +127,7 @@ class PolicyAgregationTest extends Specification {
   val technique3_2: Technique = technique3_1.copy(id = TechniqueId(TechniqueName("tech_3"), TechniqueVersionHelper("2.0")))
 
   def newPolicy(technique: Technique, id: String, varName: String, values: Seq[String]): BoundPolicyDraft = {
-    val v = InputVariable(InputVariableSpec("card", "description for " + varName, multivalued = true, id = None), values)
+    val v = InputVariable(InputVariableSpec("card", "description for " + varName, None, multivalued = true, id = None), values)
     BoundPolicyDraft(
       id,
       "rule name",

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/Section2FieldServiceTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/Section2FieldServiceTest.scala
@@ -145,9 +145,9 @@ class Section2FieldServiceTest extends Specification {
   }
 
   def allVars(): Seq[SectionVariableSpec] = {
-    SelectVariableSpec("select", "selectDesc", id = None) ::
-    SelectOneVariableSpec("selectOne", "selectOneDesc", id = None) ::
-    InputVariableSpec("input", "inputDesc", id = None) ::
+    SelectVariableSpec("select", "selectDesc", Some("a_var_name"), id = None) ::
+    SelectOneVariableSpec("selectOne", "selectOneDesc", None, id = None) ::
+    InputVariableSpec("input", "inputDesc", None, id = None) ::
     Nil
   }
 
@@ -162,12 +162,12 @@ class Section2FieldServiceTest extends Specification {
     def createRootSectionSpec: SectionSpec = {
       val innerMultSect    = SectionSpec("innerMultSect", isMultivalued = true, children = allVars())
       val innerSect        = SectionSpec("innerSect", children = allVars())
-      val selectInMultSect = SelectVariableSpec("selectInMultSect", "selectInMultSectDesc", id = None)
+      val selectInMultSect = SelectVariableSpec("selectInMultSect", "selectInMultSectDesc", None, id = None)
 
       val childrenMultSect = Seq(innerMultSect, innerSect, selectInMultSect)
       val multSect         = SectionSpec("multSect", isMultivalued = true, children = childrenMultSect)
 
-      val inputInRoot = InputVariableSpec("inputInRoot", "inputInRootDesc", id = None)
+      val inputInRoot = InputVariableSpec("inputInRoot", "inputInRootDesc", None, id = None)
 
       val rootSect = SectionSpec("rootSect", children = Seq(inputInRoot, multSect))
       rootSect


### PR DESCRIPTION
https://issues.rudder.io/issues/25091

Add a `VARIABLENAME` metadata parameter that is used only for power geneation (paramter names). 
It hold the technque editor parameter "parameter name", ie a normalized name with only alpha-num and `_` chars. 
This what `NAME` used to be in metadata.xml, but it was change to an UUID at some point so that the technique editor can retrieve parameters.  