### PR TITLE
Fixes #25156: rudder-package fails to parse old plugin version numbers, breaking the upgrade

### DIFF
--- a/relay/sources/rudder-package/src/versions.rs
+++ b/relay/sources/rudder-package/src/versions.rs
@@ -305,7 +305,10 @@ mod tests {
         assert_eq!(v.patch, e_patch);
         assert_eq!(v.mode, RudderVersionMode::from_str(e_mode).unwrap());
         assert_eq!(v.nightly.clone().unwrap_or("".to_string()), e_nightly);
-        assert_eq!(v.to_string(), raw);
+        let old_version = v.to_string() == format!("{raw}.0");
+        let new_version = v.to_string() == raw;
+        let display_ok = new_version || old_version;
+        assert!(display_ok);
     }
 
     #[rstest]

--- a/relay/sources/rudder-package/src/versions.rs
+++ b/relay/sources/rudder-package/src/versions.rs
@@ -156,13 +156,24 @@ impl FromStr for RudderVersion {
         // For old Rudder versions, we don't have the patch version. Assume it is 0.
         let re_old = Regex::new(r"^(?<major>\d+)\.(?<minor>\d+)(?<spec>.*)$")?;
 
-        let (major, minor, patch, spec): (u32, u32, u32, String) = if let Some(c) = re.captures(raw) {
-            (c["major"].parse()?, c["minor"].parse()?, c["patch"].parse()?, c["spec"].to_string())
-        } else { if let Some(c) = re_old.captures(raw) {
-            (c["major"].parse()?, c["minor"].parse()?, 0, c["spec"].to_string())
+        let (major, minor, patch, spec): (u32, u32, u32, String) = if let Some(c) = re.captures(raw)
+        {
+            (
+                c["major"].parse()?,
+                c["minor"].parse()?,
+                c["patch"].parse()?,
+                c["spec"].to_string(),
+            )
+        } else if let Some(c) = re_old.captures(raw) {
+            (
+                c["major"].parse()?,
+                c["minor"].parse()?,
+                0,
+                c["spec"].to_string(),
+            )
         } else {
             bail!("Unparsable Rudder version '{}'", raw)
-        }};
+        };
 
         // spec contains the version type, plus the nightly tag if relevant.
         let (raw_mode, nightly) = if spec.contains("~git") {


### PR DESCRIPTION
https://issues.rudder.io/issues/25156