### PR TITLE
Fixes #25164: When agent version is missing in inventory, we get a security token error

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionInventoryParser.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionInventoryParser.scala
@@ -440,12 +440,13 @@ class FusionInventoryParser(
                 "could not parse agent security token (tag AGENT_CERT), which is mandatory"
               ).fail
           }
-
+        version        <-
+          findAgent(inventory.applications, agentType).notOptional(
+            s"Agent is not present in software list and so we can't get its version. This is not supported anymore"
+          )
       } yield {
 
-        val version = findAgent(inventory.applications, agentType)
-
-        Some((AgentInfo(agentType, version, securityToken, Set()), rootUser, policyServerId))
+        Some((AgentInfo(agentType, Some(version), securityToken, Set()), rootUser, policyServerId))
       }
 
       agent.catchAll { eb =>

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionInventoryParser.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionInventoryParser.scala
@@ -442,7 +442,7 @@ class FusionInventoryParser(
           }
         version        <-
           findAgent(inventory.applications, agentType).notOptional(
-            s"Agent is not present in software list and so we can't get its version. This is not supported anymore"
+            s"Agent is not present in software list and so we can't get its version. This is not supported anymore."
           )
       } yield {
 

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/resources/fusion-inventories/dsc-agent.ocs
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/resources/fusion-inventories/dsc-agent.ocs
@@ -389,6 +389,10 @@ QHjxOfVdBMBBXq0oHSUsOzf9rIxMlWQmCQyNDB6qD+bXZnAZp7j7
       <UUID>2C15A03F-782C-4970-AF45-7A75DFBA4F59</UUID>
     </RUDDER>
     <SOFTWARES>
+      <NAME>Rudder agent (DSC)</NAME>
+      <VERSION>8.1.0</VERSION>
+    </SOFTWARES>
+    <SOFTWARES>
       <ARCH>x86_64</ARCH>
       <FROM>registry</FROM>
       <GUID>FusionInventory-Agent</GUID>

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/resources/fusion-inventories/rudder-tag/minimal-one-agent.ocs
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/resources/fusion-inventories/rudder-tag/minimal-one-agent.ocs
@@ -8,6 +8,10 @@
       <NAME>Debian</NAME>
       <VERSION>5.0.8</VERSION>
     </OPERATINGSYSTEM>
+    <SOFTWARES>
+      <NAME>rudder-agent</NAME>
+      <VERSION>8.1.0</VERSION>
+    </SOFTWARES>
     <RUDDER>
       <AGENT>
         <AGENT_NAME>cfengine-community</AGENT_NAME>

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/resources/fusion-inventories/rudder-tag/minimal-two-agents-fails.ocs
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/resources/fusion-inventories/rudder-tag/minimal-two-agents-fails.ocs
@@ -26,6 +26,10 @@
        <HOSTNAME>debian-6-64.labo.normation.com</HOSTNAME>
       <UUID>b9a71482-5030-4699-984d-b03d28bbbf36</UUID>
     </RUDDER>
+    <SOFTWARES>
+      <NAME>rudder-agent</NAME>
+      <VERSION>8.1.0</VERSION>
+    </SOFTWARES>
   </CONTENT>
   <QUERY>INVENTORY</QUERY>
   <DEVICEID>foo</DEVICEID>

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/resources/fusion-inventories/rudder-tag/minimal-zero-agent.ocs
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/resources/fusion-inventories/rudder-tag/minimal-zero-agent.ocs
@@ -12,6 +12,10 @@
       <HOSTNAME>debian-6-64.labo.normation.com</HOSTNAME>
       <UUID>b9a71482-5030-4699-984d-b03d28bbbf36</UUID>
     </RUDDER>
+    <SOFTWARES>
+      <NAME>rudder-agent</NAME>
+      <VERSION>8.1.0</VERSION>
+    </SOFTWARES>
   </CONTENT>
   <QUERY>INVENTORY</QUERY>
   <DEVICEID>foo</DEVICEID>

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestReportParsing.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestReportParsing.scala
@@ -460,9 +460,9 @@ class TestInventoryParsing extends Specification with Loggable {
       version must beEqualTo(Some(AgentVersion("2.3.0.beta1~git-1")))
     }
 
-    "be unknown if rudder agent is missing" in {
-      val version = parseRun("fusion-inventories/rudder-tag/minimal-two-agents.ocs").node.agents(0).version
-      version must beEqualTo(None)
+    "lead to an error if missing (no software for agent)" in {
+      val agents = parseRun("fusion-inventories/rudder-tag/minimal-two-agents.ocs").node.agents
+      agents must beEmpty
     }
 
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
@@ -636,9 +636,15 @@ object NodeFact {
   }
 
   def agentFromInventory(node: NodeInventory): Option[RudderAgent] = {
-    node.agents.headOption.flatMap(a =>
-      a.version.map(v => RudderAgent(a.agentType, node.main.rootUser, v, a.securityToken, a.capabilities.toChunk))
-    )
+    node.agents.headOption.map { a =>
+      RudderAgent(
+        a.agentType,
+        node.main.rootUser,
+        a.version.getOrElse(AgentVersion("Missing version")),
+        a.securityToken,
+        a.capabilities.toChunk
+      )
+    }
   }
 
   def defaultRudderSettings(status: InventoryStatus): RudderSettings = {


### PR DESCRIPTION
https://issues.rudder.io/issues/25164

Check for missing agent version in parsing to get a correct error message. 

Relax a bit the check on node fact transformation to make it easier to spot that kind of problem. 


![image](https://github.com/user-attachments/assets/2283d8bd-1536-4230-b543-50d12e6f87a1)
