### PR TITLE
Fixes #25189: RUSTSEC-2024-0357  vulnerability in openssl lib

### DIFF
--- a/relay/sources/relayd/deny.toml
+++ b/relay/sources/relayd/deny.toml
@@ -19,6 +19,8 @@ ignore = [
     # A DoS in h2
     "RUSTSEC-2023-0034",
     "RUSTSEC-2024-0332",
+    # Fixed in 8.1 (upgrade pulls openssl3)
+    "RUSTSEC-2024-0357",
 ]
 
 [bans]


### PR DESCRIPTION
https://issues.rudder.io/issues/25189