### PR TITLE
Fixes #25191: RUSTSEC-2024-0357 vulnerability in openssl lib - 8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.62"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -1808,9 +1808,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.98"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",

--- a/deny.toml
+++ b/deny.toml
@@ -17,8 +17,6 @@ allow = [
 ignore = [
     # A DoS in h2
     "RUSTSEC-2024-0332",
-    # Fixed in 8.1 (upgrade pulls openssl3)
-    "RUSTSEC-2024-0357",
 ]
 
 [bans]


### PR DESCRIPTION
https://issues.rudder.io/issues/25191