### PR TITLE
Fixes #25203: The pending nodes API now returns array of arrays of nodes instead of an array of nodes

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -429,7 +429,7 @@ class NodeApi(
           nodeApiService.changeNodeStatus(List(NodeId(id)), status.status.transformInto[NodeStatusAction], Some(req.remoteAddr))
       } yield {
         res
-      }).chainError("Error when changing Node status").toLiftResponseOne(params, schema, _ => Some(id))
+      }).chainError("Error when changing Node status").toLiftResponseList(params, schema)
     }
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/25203
![image](https://github.com/user-attachments/assets/37335373-c878-47a6-9742-9cb2fcca01ed)