### PR TITLE
Fixes #25219: Cache for node properties and hierarchies

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -847,7 +847,7 @@ sealed trait ParentProperty {
 }
 
 /**
- * A node property with its ohneritance/overriding context.
+ * A node property with its inheritance/overriding context.
  */
 final case class NodePropertyHierarchy(prop: NodeProperty, hierarchy: List[ParentProperty])
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/NodeComplianceExpiration.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/NodeComplianceExpiration.scala
@@ -1,25 +1,25 @@
 package com.normation.rudder.domain.reports
 
+import enumeratum.Enum
+import enumeratum.EnumEntry
 import scala.concurrent.duration.Duration
+import zio.json.*
 
 /*
  * This file defines data structures to inform what we should display when a node compliance
  * is expired (keep compliance for a longer time, etc)
  */
 
-sealed trait NodeComplianceExpiration {
-  def id: String
-}
+sealed abstract class NodeComplianceExpirationMode(override val entryName: String) extends EnumEntry
 
-object NodeComplianceExpiration {
+object NodeComplianceExpirationMode extends Enum[NodeComplianceExpirationMode] {
 
   /*
    * Historical expiration based on a 2 agent run duration + a grace period.
    * But if the node is in status `NoReportInInterval`, then display that
    */
-  case object ExpireImmediately extends NodeComplianceExpiration {
-    val id = "expireImmediately"
-  }
+  // snake case because it's the convention chosen in "rudder" global property
+  case object ExpireImmediately extends NodeComplianceExpirationMode("expire_immediately")
 
   /*
    * Keep the last know compliance for given additional time.
@@ -27,7 +27,33 @@ object NodeComplianceExpiration {
    * for now it is the same for all compliance (and it's ok since we are computed
    * at the same time for now).
    */
-  case class KeepLast(duration: Duration) extends NodeComplianceExpiration {
-    def id = "keepLast"
+  // snake case because it's the convention chosen in "rudder" global property
+  case object KeepLast extends NodeComplianceExpirationMode("keep_last")
+
+  override def values: IndexedSeq[NodeComplianceExpirationMode] = findValues
+
+  implicit val decoderNodeComplianceExpirationMode: JsonDecoder[NodeComplianceExpirationMode] = {
+    JsonDecoder.string.mapOrFail(s => {
+      NodeComplianceExpirationMode
+        .withNameInsensitiveEither(s)
+        .left
+        .map(_ => s"Can not parse '${s}' as node compliance expiration mode")
+    })
   }
+}
+
+case class NodeComplianceExpiration(mode: NodeComplianceExpirationMode, duration: Option[Duration])
+
+object NodeComplianceExpiration {
+  val default: NodeComplianceExpiration = NodeComplianceExpiration(NodeComplianceExpirationMode.ExpireImmediately, None)
+
+  implicit val decoderDuration: JsonDecoder[Duration] = JsonDecoder[String].mapOrFail(s => {
+    try {
+      Right(Duration(s))
+    } catch {
+      case ex: Throwable => Left(s"Error decoding node compliance keep last duration: ${ex.getMessage}")
+    }
+  })
+
+  implicit val decoderNodeComplianceExpiration: JsonDecoder[NodeComplianceExpiration] = DeriveJsonDecoder.gen
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/NodePropertiesService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/NodePropertiesService.scala
@@ -1,0 +1,82 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.properties
+
+import com.normation.errors.*
+import com.normation.rudder.facts.nodes.NodeFactRepository
+import com.normation.rudder.facts.nodes.QueryContext
+import com.normation.rudder.repository.RoNodeGroupRepository
+import com.normation.rudder.repository.RoParameterRepository
+import zio.*
+
+/*
+ * This file contains a cache/in-memory repository for inherited node properties, ie the result
+ * of the computation of a property from the node, group and global context.
+ */
+
+trait NodePropertiesService {
+
+  /*
+   * Update all property hierarchy
+   */
+  def updateAll(): IOResult[Unit]
+
+}
+
+class NodePropertiesServiceImpl(
+    globalPropsRepo:       RoParameterRepository,
+    roNodeGroupRepository: RoNodeGroupRepository,
+    nodeFactRepository:    NodeFactRepository,
+    propertiesRepository:  PropertiesRepository
+) extends NodePropertiesService {
+  override def updateAll(): IOResult[Unit] = {
+    for {
+      params       <- globalPropsRepo.getAllGlobalParameters().map(_.map(x => (x.name, x)).toMap)
+      groups       <- roNodeGroupRepository.getFullGroupLibrary()
+      nodes        <- nodeFactRepository.getAll()(QueryContext.systemQC).map(_.values)
+      mergedGroups <- ZIO.foreach(groups.allGroups.keys) { gid =>
+                        MergeNodeProperties.forGroup(gid, groups.allGroups, params).toIO.map(p => (gid, p))
+                      }
+      mergedNodes  <- ZIO.foreach(nodes)(n =>
+                        MergeNodeProperties.forNode(n, groups.getTarget(n).values.toList, params).toIO.map(p => (n.id, p))
+                      )
+      _            <- propertiesRepository.saveNodeProps(mergedNodes.toMap)
+      _            <- propertiesRepository.saveGroupProps(mergedGroups.toMap)
+    } yield ()
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/PropertiesRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/PropertiesRepository.scala
@@ -1,0 +1,180 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.properties
+
+import com.normation.errors.IOResult
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.properties.NodePropertyHierarchy
+import com.normation.rudder.facts.nodes.NodeFactRepository
+import com.normation.rudder.facts.nodes.QueryContext
+import zio.*
+
+/*
+ * This file contains a cache/in-memory repository for inherited node properties, ie the result
+ * of the computation of a property from the node, group and global context.
+ */
+
+trait PropertiesRepository {
+
+  def getAllNodeProps()(implicit qc: QueryContext): IOResult[Map[NodeId, Chunk[NodePropertyHierarchy]]]
+
+  /*
+   * Get all properties for node with given ID
+   */
+  def getNodeProps(nodeId: NodeId)(implicit qc: QueryContext): IOResult[Option[Chunk[NodePropertyHierarchy]]]
+
+  /*
+   * Get a given property for a given node
+   */
+  def getNodesProp(nodeIds: Set[NodeId], propName: String)(implicit
+      qc: QueryContext
+  ): IOResult[Map[NodeId, NodePropertyHierarchy]]
+
+  /*
+   * Save updated properties for nodes.
+   * The chunk is considered to be all of the node properties, so previous
+   * properties not in the new chunk will be deleted.
+   */
+  def saveNodeProps(props: Map[NodeId, Chunk[NodePropertyHierarchy]]): IOResult[Unit]
+
+  /*
+   * Delete all properties for a node
+   */
+  def deleteNode(nodeId: NodeId): IOResult[Unit]
+
+  /*
+   * Get all properties for node with given ID
+   */
+  def getGroupProps(groupId: NodeGroupId): IOResult[Option[Chunk[NodePropertyHierarchy]]]
+
+  /*
+   * Get a given property for a given node
+   */
+  def getGroupProp(groupId: NodeGroupId, propName: String): IOResult[Option[NodePropertyHierarchy]]
+
+  /*
+   * Save updated properties for nodes.
+   * The chunk is considered to be all of the node properties, so previous
+   * properties not in the new chunk will be deleted.
+   */
+  def saveGroupProps(props: Map[NodeGroupId, Chunk[NodePropertyHierarchy]]): IOResult[Unit]
+
+  /*
+   * Delete all properties for a node
+   */
+  def deleteGroup(groupId: NodeGroupId): IOResult[Unit]
+}
+
+object InMemoryPropertiesRepository {
+  def make(nodeFactRepo: NodeFactRepository): IOResult[InMemoryPropertiesRepository] = {
+    for {
+      nodes  <- Ref.make(Map.empty[NodeId, Chunk[NodePropertyHierarchy]])
+      groups <- Ref.make(Map.empty[NodeGroupId, Chunk[NodePropertyHierarchy]])
+    } yield {
+      new InMemoryPropertiesRepository(nodeFactRepo, nodes, groups)
+    }
+  }
+}
+
+class InMemoryPropertiesRepository(
+    nodeFactRepository: NodeFactRepository,
+    nodeProps:          Ref[Map[NodeId, Chunk[NodePropertyHierarchy]]],
+    groupProps:         Ref[Map[NodeGroupId, Chunk[NodePropertyHierarchy]]]
+) extends PropertiesRepository {
+
+  override def getAllNodeProps()(implicit qc: QueryContext): IOResult[Map[NodeId, Chunk[NodePropertyHierarchy]]] = {
+    // we need core node fact to filter access
+    for {
+      ids   <- nodeFactRepository.getAll().map(_.keySet)
+      props <- nodeProps.get
+    } yield {
+      props.filter { case (id, _) => ids.contains(id) }
+    }
+  }
+
+  override def getNodeProps(nodeId: NodeId)(implicit qc: QueryContext): IOResult[Option[Chunk[NodePropertyHierarchy]]] = {
+    for {
+      // needed to check access to node
+      _     <- nodeFactRepository.get(nodeId)
+      props <- nodeProps.get
+    } yield {
+      props.get(nodeId)
+    }
+  }
+
+  override def getNodesProp(nodeIds: Set[NodeId], propName: String)(implicit
+      qc: QueryContext
+  ): IOResult[Map[NodeId, NodePropertyHierarchy]] = {
+    for {
+      // needed to check access to node
+      ids   <- nodeFactRepository.getAll().map(_.keySet)
+      props <- nodeProps.get
+    } yield {
+      val view = ids.intersect(nodeIds)
+      props.collect {
+        case (id, ps) if view.contains(id) =>
+          ps.find(_.prop.name == propName).map(p => (id, p))
+      }.flatten.toMap
+    }
+  }
+
+  override def saveNodeProps(props: Map[NodeId, Chunk[NodePropertyHierarchy]]): IOResult[Unit] = {
+    nodeProps.set(props)
+  }
+
+  override def deleteNode(nodeId: NodeId): IOResult[Unit] = {
+    nodeProps.update(_.removed(nodeId))
+  }
+
+  override def getGroupProps(groupId: NodeGroupId): IOResult[Option[Chunk[NodePropertyHierarchy]]] = {
+    groupProps.get.map(_.get(groupId))
+  }
+
+  override def getGroupProp(groupId: NodeGroupId, propName: String): IOResult[Option[NodePropertyHierarchy]] = {
+    groupProps.get.map(_.get(groupId).flatMap(_.find(_.prop.name == propName)))
+  }
+
+  override def saveGroupProps(props: Map[NodeGroupId, Chunk[NodePropertyHierarchy]]): IOResult[Unit] = {
+    groupProps.set(props)
+  }
+
+  override def deleteGroup(groupId: NodeGroupId): IOResult[Unit] = {
+    groupProps.update(_.removed(groupId))
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ComputeNodeStatusReportService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ComputeNodeStatusReportService.scala
@@ -304,7 +304,7 @@ class ComputeNodeStatusReportServiceImpl(
           r.runInfo match {
             case NoReportInInterval(conf, expiration) =>
               expirationPolicy.get(id) match {
-                case Some(NodeComplianceExpiration.KeepLast(d)) =>
+                case Some(NodeComplianceExpiration(NodeComplianceExpirationMode.KeepLast, Some(d))) =>
                   val keepUntil = expiration.plus(d.toMillis)
                   if (now.isBefore(keepUntil)) {
                     (id, r.modify(_.runInfo).setTo(KeepLastCompliance(conf, expiration, keepUntil, None)))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
@@ -58,6 +58,7 @@ import com.normation.rudder.domain.policies.PolicyTypes
 import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
+import com.normation.rudder.domain.properties.NodePropertyHierarchy
 import com.normation.rudder.domain.reports.NodeModeConfig
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.repository.FullActiveTechnique
@@ -73,6 +74,7 @@ import org.specs2.runner.*
 import scala.collection.MapView
 import scala.collection.SortedMap
 import scala.concurrent.duration.*
+import zio.Chunk
 
 /*
  * This class test the JsEngine. 6.0
@@ -185,6 +187,8 @@ class TestBuildNodeConfiguration extends Specification {
   val jsTimeout: FiniteDuration = FiniteDuration(5, "minutes")
   val generationContinueOnError = false
 
+  val inheritedProps: Map[NodeId, Chunk[NodePropertyHierarchy]] = Map()
+
   // you can debug detail timing by setting "TRACE" level below:
   org.slf4j.LoggerFactory
     .getLogger("policy.generation")
@@ -206,6 +210,7 @@ class TestBuildNodeConfiguration extends Specification {
         .getNodeContexts(
           allNodes.keySet.toSet,
           allNodes,
+          inheritedProps,
           groupLib,
           Nil,
           data.globalAgentRun,

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.services.reports
 import com.normation.errors.IOResult
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.reports.NodeComplianceExpiration
+import com.normation.rudder.domain.reports.NodeComplianceExpirationMode
 import com.normation.rudder.domain.reports.NodeConfigId
 import com.normation.rudder.domain.reports.NodeExpectedReports
 import com.normation.rudder.domain.reports.NodeStatusReport
@@ -189,7 +190,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
    * rule1/dir1 is applied on node1 and node2 and is both here (node1) and skipped (node2)
    */
   "When a value is expired, it is added to compliance repos" >> {
-    val (repo, finder, computer) = newServices(NodeComplianceExpiration.ExpireImmediately)
+    val (repo, finder, computer) = newServices(NodeComplianceExpiration.default)
     val id                       = NodeId("n1")
     finder.reports = nodes.collect { case (n, a, _) if (n._1 == id) => (n._1, a) }.toMap
 
@@ -207,7 +208,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
   }
 
   "Cache should return expired compliance but also ask for renew" >> {
-    val (repo, finder, computer) = newServices(NodeComplianceExpiration.ExpireImmediately)
+    val (repo, finder, computer) = newServices(NodeComplianceExpiration.default)
     finder.reports = nodes.map { case (n, a, _) => (n._1, a) }.toMap
 
     // node not in cache, empty, returns nothing
@@ -237,7 +238,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
 
   "When run are expired but we keep compliance, we keep compliance in repo" >> {
     val grace                    = scala.concurrent.duration.Duration("1h")
-    val (repo, finder, computer) = newServices(NodeComplianceExpiration.KeepLast(grace))
+    val (repo, finder, computer) = newServices(NodeComplianceExpiration(NodeComplianceExpirationMode.KeepLast, Some(grace)))
 
     val longExpired = expired.minusMinutes(30)
     val initReport  = nodes.collect {
@@ -265,7 +266,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
   }
 
   "Cache should not return ask for renew of up to date components" >> {
-    val (repo, finder, computer) = newServices(NodeComplianceExpiration.ExpireImmediately)
+    val (repo, finder, computer) = newServices(NodeComplianceExpiration.default)
     finder.reports = nodes.map { case (n, _, b) => (n._1, b) }.toMap
 
     // node not in cache, empty, returns nothing

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
@@ -481,7 +481,7 @@ class ParameterApiService14(
   }
 
   def listParameters(): IOResult[Seq[JRGlobalParameter]] = {
-    readParameter.getAllGlobalParameters().map(_.map(JRGlobalParameter.fromGlobalParameter(_, None)))
+    readParameter.getAllGlobalParameters().map(_.sortBy(_.name).map(JRGlobalParameter.fromGlobalParameter(_, None)))
   }
 
   def parameterDetails(id: String): IOResult[JRGlobalParameter] = {

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
@@ -146,6 +146,45 @@ response:
                 "origval":"some string"
               },
               {
+                "name" : "rudder",
+                "value" : {
+                  "rudder" : {
+                    "compliance_expiration_policy" : {
+                      "mode" : "ExpireImmediately"
+                    }
+                  }
+                },
+                "provider" : "inherited",
+                "hierarchy" : [
+                  {
+                    "kind" : "global",
+                    "value" : {
+                      "rudder" : {
+                        "compliance_expiration_policy" : {
+                          "mode" : "ExpireImmediately"
+                        }
+                      }
+                    }
+                  }
+                ],
+                "hierarchyStatus" : {
+                  "hasChildTypeConflicts" : false,
+                  "fullHierarchy" : [
+                    {
+                      "kind" : "global",
+                      "valueType" : "Object"
+                    }
+                  ]
+                },
+                "origval" : {
+                  "rudder" : {
+                    "compliance_expiration_policy" : {
+                      "mode" : "ExpireImmediately"
+                    }
+                  }
+                }
+              },
+              {
                 "name":"stringParam",
                 "value":"stringsome string",
                 "inheritMode":"map",
@@ -206,7 +245,7 @@ response:
       }
     }
 ---
-description: Get a group inherited properties in JSON
+description: Get a group inherited properties with hierarchy HTML
 method: GET
 url: /secure/api/groups/0000f5d3-8c61-4d20-88a7-bb947705ba8a/displayInheritedProperties
 response:
@@ -270,6 +309,33 @@ response:
                 "origval":"some string"
               },
               {
+                "name" : "rudder",
+                "value" : {
+                  "rudder" : {
+                    "compliance_expiration_policy" : {
+                      "mode" : "ExpireImmediately"
+                    }
+                  }
+                },
+                "provider" : "inherited",
+                "hierarchy" : "<p>from <b>Global Parameter</b>:<pre>{\n    \"rudder\" : {\n        \"compliance_expiration_policy\" : {\n            \"mode\" : \"ExpireImmediately\"\n        }\n    }\n}\n</pre></p>",
+                "hierarchyStatus" : {
+                  "hasChildTypeConflicts" : false,
+                  "fullHierarchy" : [
+                    {
+                      "kind" : "global",
+                      "valueType" : "Object"
+                    }
+                  ]
+                },
+                "origval" : {
+                  "rudder" : {
+                    "compliance_expiration_policy" : {
+                      "mode" : "ExpireImmediately"
+                    }
+                  }
+                }
+              },              {
                 "name":"stringParam",
                 "value":"stringsome string",
                 "inheritMode":"map",

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
@@ -1303,6 +1303,45 @@ response:
               "origval" : "some string"
             },
             {
+              "name" : "rudder",
+              "value" : {
+                "rudder" : {
+                  "compliance_expiration_policy" : {
+                    "mode" : "ExpireImmediately"
+                  }
+                }
+              },
+              "provider" : "inherited",
+              "hierarchy" : [
+                {
+                  "kind" : "global",
+                  "value" : {
+                    "rudder" : {
+                      "compliance_expiration_policy" : {
+                        "mode" : "ExpireImmediately"
+                      }
+                    }
+                  }
+                }
+              ],
+              "hierarchyStatus" : {
+                "hasChildTypeConflicts" : false,
+                "fullHierarchy" : [
+                  {
+                    "kind" : "global",
+                    "valueType" : "Object"
+                  }
+                ]
+              },
+              "origval" : {
+                "rudder" : {
+                  "compliance_expiration_policy" : {
+                    "mode" : "ExpireImmediately"
+                  }
+                }
+              }
+            },            
+            {
               "name" : "someJson2",
               "value" : "string",
               "inheritMode" : "opa",

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_parameters.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_parameters.yml
@@ -45,11 +45,6 @@ response:
       "data":{
         "parameters":[
           {
-            "id":"stringParam",
-            "value":"some string",
-            "description":"a simple string param"
-          },
-          {
             "id":"jsonParam",
             "value":{"array":[1,3,2], "json":{"var1":"val1","var2":"val2"}, "string":"a string"},
             "description":"a simple string param"
@@ -59,6 +54,23 @@ response:
             "value":"some string",
             "description":"a simple string param",
             "inheritMode":"opa"
+          },
+          {
+            "id" : "rudder",
+            "value" : {
+              "rudder" : {
+                "compliance_expiration_policy" : {
+                  "mode" : "ExpireImmediately"
+                }
+              }
+            },
+            "description" : "rudder system config",
+            "provider" : "system"
+          },
+          {
+            "id":"stringParam",
+            "value":"some string",
+            "description":"a simple string param"
           },
           {
             "id":"systemParam",

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -963,10 +963,10 @@ class Boot extends Loggable {
     // release guard for promise generation awaiting end of boot
     RudderConfig.policyGenerationBootGuard.succeed(()).runNow
 
-  }
+    // Run a health check
+    RudderConfig.healthcheckNotificationService.init
 
-  // Run a health check
-  RudderConfig.healthcheckNotificationService.init
+  }
 
   private def addPluginsMenuTo(plugins: List[RudderPluginDef], menus: List[Menu]): List[Menu] = {
     // return the updated siteMap


### PR DESCRIPTION
https://issues.rudder.io/issues/25219

This PR add a `PropertiesRepository` that stores the computed/resolved `GroupProperties` and `NodeProperties`. 

The repository is very simple: it is just an pure in-memory one, back by a pair of `Ref[Map[objId,  Chunk[NodePropertyHierarchy]]`.
It is used in place of interactive inheritance computation in group/node API that get inherited props, and in policy generation. 
The part is policy generation is the riskiest change. Moreover, I think we are changing a bit the way things are done, because we use to do: 
- interpolate global props, 
- do inheritance resolution for node props with the result, 
- interpolate resolved node props. 

Now, we directly get inherited props and interpolate that. I *think* it's the same, and no tests show that it's different, but I'm sure our tests would exhibite the kind of case where a problem can happen, which would be something leading to interpolated global props not being overridden in the same way that non interpolated ones. 

The repository is only update at two moment thanks to the action of `NodePropertiesService.updateAll()`: 
- when rudder starts to get initial values, 
- after dynamic group computation. 

I *think* it should be enough, since global properties, group properties, and node properties change all lead to a dyn group computation, but that's point will need to be toroughtly tested. 

For tests, I needed to add callback for global prop change and node change, because we don't have a real dyngroup update mocked-up. 

I also moved things related to property inheritance/overriding into a new package: `com.normation.rudder.properties`. I didn't move the `General/Global/Group/NodeProperty` class declaration into it, because it would have mean a massive refactoring, and it would have totally killed the understandability of that one, with repercussion on plugins etc. 
