### PR TITLE
Fixes #25238: rudderc is generating 0 bytes resources when output directory is the same as the input

### DIFF
--- a/policies/rudderc/src/lib.rs
+++ b/policies/rudderc/src/lib.rs
@@ -113,6 +113,10 @@ pub fn run(args: MainArgs) -> Result<()> {
         } => {
             let library = check_libraries(library)?;
             let actual_output = output.unwrap_or(target);
+            if actual_output.canonicalize()? == input.canonicalize()?.parent().unwrap() {
+                bail!("Output directory cannot be the same as the input directory");
+            }
+
             action::build(
                 library.as_slice(),
                 input,


### PR DESCRIPTION
https://issues.rudder.io/issues/25238