### PR TITLE
Fixes #25246: Unauthorized access to API should not be logged as error

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
@@ -663,7 +663,7 @@ trait BuildHandler[REQ, RESP, T, P] {
                 )
                 val response: RESP = (for {
                   token         <- authz.checkAuthz(endpoint, info.path).leftMap { error =>
-                                     logger.error(
+                                     logger.warn(
                                        s"Authorization error for '${info.action.name.toUpperCase()} ${info.path.value}': ${error.msg}"
                                      )
                                      error


### PR DESCRIPTION
https://issues.rudder.io/issues/25246