### PR TITLE
Fixes #25275: Make plugin install log less verbose

### DIFF
--- a/relay/sources/rudder-package/src/archive.rs
+++ b/relay/sources/rudder-package/src/archive.rs
@@ -188,7 +188,7 @@ impl Rpkg {
     }
 
     pub fn install(&self, force: bool, db: &mut Database, webapp: &mut Webapp) -> Result<()> {
-        info!("Installing rpkg '{}'...", self.path.display());
+        debug!("Installing rpkg file '{}'...", self.path.display());
         let is_upgrade = self.is_installed(db);
         // Verify webapp compatibility
         if !webapp.version.is_compatible(&self.metadata.version) && !force {


### PR DESCRIPTION
https://issues.rudder.io/issues/25275

Current ouput:

```
 INFO Installing rudder-plugin-security-benchmarks-8.2.0~alpha2-1.0-nightly.rpkg
 INFO Installing rpkg 'rudder-plugin-security-benchmarks-8.2.0~alpha2-1.0-nightly.rpkg'...
```

This makes no sense.