### PR TITLE
Fixes #24863: when we have compliance right, the rule page shows a weird message

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
@@ -200,8 +200,11 @@ object AuthorizationApiMapping {
         case Rule.Read  =>
           RuleApi.ListRules.x :: RuleApi.RuleDetails.x :: RuleApi.GetRuleTree.x ::
           RuleApi.GetRuleCategoryDetails.x :: RuleInternalApi.GetRuleNodesAndDirectives.x ::
-          RuleInternalApi.GetGroupRelatedRules.x ::
-          Nil
+          AuthzForApi.withValues(SettingsApi.GetSetting, AclPathSegment.Segment("enable_change_message") :: Nil) ::
+          AuthzForApi.withValues(SettingsApi.GetSetting, AclPathSegment.Segment("enable_change_request") :: Nil) ::
+          AuthzForApi.withValues(SettingsApi.GetSetting, AclPathSegment.Segment("enable_self_deployment") :: Nil) ::
+          AuthzForApi.withValues(SettingsApi.GetSetting, AclPathSegment.Segment("enable_self_validation") :: Nil) ::
+          AuthzForApi.withValues(SettingsApi.GetSetting, AclPathSegment.Segment("enable_validate_all") :: Nil) :: Nil
         case Rule.Write =>
           RuleApi.CreateRule.x :: RuleApi.DeleteRule.x :: RuleApi.CreateRuleCategory.x ::
           RuleApi.DeleteRuleCategory.x :: RuleApi.LoadRuleRevisionForGeneration.x :: RuleApi.UnloadRuleRevisionForGeneration.x ::
@@ -225,7 +228,15 @@ object AuthorizationApiMapping {
         case UserAccount.Write => UserApi.CreateApiToken.x :: UserApi.DeleteApiToken.x :: Nil
         case UserAccount.Edit  => UserApi.UpdateApiToken.x :: Nil
 
-        case Validator.Read  => Nil // ChangeRequestApi.ListChangeRequests.x :: ChangeRequestApi.ChangeRequestsDetails.x :: Nil
+        case Validator.Read =>
+          AuthzForApi.withValues(SettingsApi.GetSetting, AclPathSegment.Segment("enable_change_message") :: Nil) ::
+          AuthzForApi.withValues(SettingsApi.GetSetting, AclPathSegment.Segment("mandatory_change_message") :: Nil) ::
+          AuthzForApi.withValues(SettingsApi.GetSetting, AclPathSegment.Segment("change_message_prompt") :: Nil) ::
+          AuthzForApi.withValues(SettingsApi.GetSetting, AclPathSegment.Segment("enable_change_request") :: Nil) ::
+          AuthzForApi.withValues(SettingsApi.GetSetting, AclPathSegment.Segment("enable_self_deployment") :: Nil) ::
+          AuthzForApi.withValues(SettingsApi.GetSetting, AclPathSegment.Segment("enable_self_validation") :: Nil) ::
+          AuthzForApi.withValues(SettingsApi.GetSetting, AclPathSegment.Segment("enable_validate_all") :: Nil) :: Nil
+
         case Validator.Write =>
           Nil // ChangeRequestApi.DeclineRequestsDetails.x :: ChangeRequestApi.AcceptRequestsDetails.x :: Nil
         case Validator.Edit  => Nil // ChangeRequestApi.UpdateRequestsDetails.x :: Nil

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ApiCalls.elm
@@ -11,7 +11,7 @@ import List.Extra exposing (find)
 import Rules.DataTypes exposing (..)
 import Rules.JsonDecoder exposing (..)
 import Rules.JsonEncoder exposing (..)
-import Rules.ChangeRequest exposing (changeRequestParameters, decodeGetChangeRequestSettings, decodePendingChangeRequests)
+import Rules.ChangeRequest exposing (changeRequestParameters, decodeGetChangeRequestSettings, decodeGetEnableChangeMsg, decodeGetEnableCr, decodeGetMandatoryMsg, decodeGetMsgPrompt, decodePendingChangeRequests)
 
 --
 -- This files contains all API calls for the Rules UI
@@ -97,22 +97,69 @@ getPolicyMode model =
   in
     req
 
-getCrSettings : Model -> Cmd Msg
-getCrSettings model =
+getCrSettingsEnabledMsg : Model -> Cmd Msg
+getCrSettingsEnabledMsg model =
   let
     req =
       request
         { method  = "GET"
         , headers = []
-        , url     = getUrl model [ "settings" ] []
+        , url     = getUrl model [ "settings",  "enable_change_message"] []
         , body    = emptyBody
-        , expect  = expectJson GetChangeRequestSettings decodeGetChangeRequestSettings
+        , expect  = expectJson GetEnableChangeMsg decodeGetEnableChangeMsg
         , timeout = Nothing
         , tracker = Nothing
         }
   in
     req
 
+getCrSettingsMandatoryMsg : Model -> Cmd Msg
+getCrSettingsMandatoryMsg model =
+  let
+    req =
+      request
+        { method  = "GET"
+        , headers = []
+        , url     = getUrl model [ "settings", "mandatory_change_message" ] []
+        , body    = emptyBody
+        , expect  = expectJson GetMandatoryMsg decodeGetMandatoryMsg
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+  in
+    req
+
+getCrSettingsChangeMsgPrompt : Model -> Cmd Msg
+getCrSettingsChangeMsgPrompt model =
+  let
+    req =
+      request
+        { method  = "GET"
+        , headers = []
+        , url     = getUrl model [ "settings", "change_message_prompt" ] []
+        , body    = emptyBody
+        , expect  = expectJson GetMsgPrompt decodeGetMsgPrompt
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+  in
+    req
+
+getCrSettingsEnableCr : Model -> Cmd Msg
+getCrSettingsEnableCr model =
+  let
+    req =
+      request
+        { method  = "GET"
+        , headers = []
+        , url     = getUrl model [ "settings", "enable_change_request" ] []
+        , body    = emptyBody
+        , expect  = expectJson GetEnableCr decodeGetEnableCr
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+  in
+    req
 getPendingChangeRequests : Model -> RuleId -> Cmd Msg
 getPendingChangeRequests model ruleId =
   let

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ChangeRequest.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ChangeRequest.elm
@@ -28,6 +28,27 @@ type alias ChangeRequestSettings =
   , collapsePending        : Bool
   }
 
+initCrSettings : ChangeRequestSettings
+initCrSettings =
+  ChangeRequestSettings False False "" False "" "" False [] False
+
+
+decodeGetEnableChangeMsg : Decoder Bool
+decodeGetEnableChangeMsg =
+  at ["data", "settings", "enable_change_message" ] bool
+
+decodeGetMandatoryMsg : Decoder Bool
+decodeGetMandatoryMsg =
+  at ["data", "settings", "mandatory_change_message" ] bool
+
+decodeGetMsgPrompt : Decoder String
+decodeGetMsgPrompt =
+  at ["data", "settings", "change_message_prompt" ] string
+
+decodeGetEnableCr : Decoder Bool
+decodeGetEnableCr =
+  at ["data", "settings", "enable_change_request" ] bool
+
 decodeGetChangeRequestSettings : Decoder ChangeRequestSettings
 decodeGetChangeRequestSettings =
   at ["data", "settings" ] decodeChangeRequestSettings

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
@@ -320,6 +320,7 @@ type alias UI =
     , complianceFilters : ComplianceFilters
     , modal : ModalState
     , hasWriteRights : Bool
+    , canReadChanqeRequest : Bool
     , loadingRules : Bool
     , isAllCatFold : Bool
     , saving : Bool
@@ -372,7 +373,10 @@ type Msg
     | CallApi Bool (Model -> Cmd Msg)
     | GetRuleDetailsResult (Result Error Rule)
     | GetPolicyModeResult (Result Error String)
-    | GetChangeRequestSettings (Result Error ChangeRequestSettings)
+    | GetEnableChangeMsg (Result Error Bool)
+    | GetMandatoryMsg (Result Error Bool)
+    | GetMsgPrompt (Result Error String)
+    | GetEnableCr (Result Error Bool)
     | GetPendingChangeRequests (Result Error (List ChangeRequest))
     | GetCategoryDetailsResult (Result Error (Category Rule))
     | GetRulesComplianceResult (Result Error (List RuleComplianceGlobal))

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/Init.elm
@@ -7,14 +7,22 @@ import Rules.DataTypes exposing (..)
 import Compliance.DataTypes exposing (..)
 import Compliance.Utils exposing (defaultComplianceFilter)
 
-init : { contextPath : String, hasWriteRights : Bool } -> ( Model, Cmd Msg )
+init : { contextPath : String, hasWriteRights : Bool, canReadChanqeRequest : Bool } -> ( Model, Cmd Msg )
 init flags =
   let
     initCategory = Category "" "" "" (SubCategories []) []
     initFilters  = Filters (TableFilters Name Asc "" []) (TreeFilters "" [] (Tag "" "") [])
-    initUI       = UI initFilters initFilters initFilters defaultComplianceFilter NoModal flags.hasWriteRights True False False Nothing
+    initUI       = UI initFilters initFilters initFilters (ComplianceFilters False False []) NoModal flags.hasWriteRights flags.canReadChanqeRequest True False False Nothing
     initModel    = Model flags.contextPath Loading "" initCategory initCategory initCategory Dict.empty Dict.empty Dict.empty Dict.empty initUI
 
+    listCRActions =
+      if flags.canReadChanqeRequest then
+        [ getCrSettingsEnableCr initModel
+        , getCrSettingsEnabledMsg initModel
+        , getCrSettingsMandatoryMsg initModel
+        , getCrSettingsChangeMsgPrompt initModel
+        ]
+      else []
     listInitActions =
       [ getPolicyMode      initModel
       , getNodesList       initModel
@@ -23,11 +31,10 @@ init flags =
       , getTechniquesTree  initModel
       , getRulesTree       initModel
       , getRuleChanges     initModel
-      , getCrSettings      initModel
       ]
 
   in
 
     ( initModel
-    , Cmd.batch listInitActions
+    , Cmd.batch (listInitActions ++  listCRActions)
     )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabContent.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabContent.elm
@@ -219,8 +219,8 @@ informationTab model details =
 
     pendingCrWarning = case model.ui.crSettings of
       Just settings ->
-        if settings.enableChangeRequest && not (List.isEmpty settings.pendingChangeRequests) then
-          div [class "col-md-12"]
+        if (settings.enableChangeRequest && not (List.isEmpty settings.pendingChangeRequests)) then
+          div [class "col-sm-12"]
           [ div[class ("callout-fade callout-info callout-cr" ++ if settings.collapsePending then " list-hidden" else ""), id "accordionCR"]
             [ p[]
               [ b[]

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/ruleManagement.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/ruleManagement.html
@@ -10,10 +10,16 @@
   <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-rules.js"></script>
   <script>
     var hasWriteRights = false;
+    var canReadChanqeRequest = false;
   </script>
   <lift:authz role="rule_write">
     <script>
       hasWriteRights = true;
+    </script>
+  </lift:authz>
+  <lift:authz role="validator_read">
+    <script>
+      canReadChanqeRequest = true;
     </script>
   </lift:authz>
   <script>
@@ -22,6 +28,7 @@
       var initValues = {
         contextPath    : contextPath
       , hasWriteRights : hasWriteRights
+      , canReadChanqeRequest : canReadChanqeRequest
       };
 
       var app = Elm.Rules.init({node: main, flags: initValues});


### PR DESCRIPTION
Retargeted from #5678 
https://issues.rudder.io/issues/24863

It seems like there is bigger issue under this one.

### Initial issue
The initial problem was that when we go to a rule page, in Elm we initialize the page by fetching many information of which change-request's information that required `administration_read` right.
```
enable_change_message
enable_change_request
enable_self_deployment
enable_self_validation
enable_validate_all
```

### Potential issue discovered
In the initialization of the Rule page, we check if change-request is enabled. This fetching is done through [settings API](https://docs.rudder.io/api/v/19/#tag/Settings/operation/getAllSettings) [GetAllSetings](https://github.com/Normation/rudder/blob/master/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala#L535) that required [adminstration_read right](https://github.com/Normation/rudder/blob/master/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala#L114)
The main problem with this PR and logic is that an user for example with `validator` role will not see any change-request on a rule, because he doesn't have the administration_read access, and we don't want to great him with admin read because it can see other settings that are only meant for admin users.
 
### Potential solution
One possibility would be to extract the change-request part of the `GetAllSetings` API to create something like `GetChangeRequestSettingds`, add appropriate rights to this in order for a `validator` (maybe other roles) user to retrieve this info

### How I solved the problem

I have added some API calls for the specific settings :
- enable_change_message
- mandatory_change_message
- change_message_prompt
- enable_change_request
- enable_self_deployment
- enable_self_validation
- enable_validate_all

`GET /settings/<setting_name>`
We trigger these API calls if the user have `validator_read` right

:warning: This fix should be well tested, the risks are :
- Hide the change request message even if the user as the right to see the CR message
- Disabled CR on a rule for a user, so he can modify the rule without generating a change-request

