### PR TITLE
Fixes #25095: Dashboard information are not updated when deleting a node

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -140,7 +140,7 @@ object HomePage {
     }
   }
 
-  object nodeFacts extends SessionVar[MapView[NodeId, CoreNodeFact]](initNodeInfos()(CurrentUser.queryContext))
+  object nodeFacts extends RequestVar[MapView[NodeId, CoreNodeFact]](initNodeInfos()(CurrentUser.queryContext))
 }
 
 class HomePage extends StatefulSnippet {


### PR DESCRIPTION
https://issues.rudder.io/issues/25095

Indeed, if it is a `SessionVar`, nodes updates only get displayed the same as when logging in.
Previously, there has not been any `Var`, the node info was always requested anyway, it should be fetched from cache so it should not cause performance issues here   