### PR TITLE
Fixes #25296: User management table always shows additional 'no_rights' authorization

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
@@ -175,7 +175,10 @@ final case class JsonRights(
 }
 
 object JsonRights {
-  implicit val transformer: Transformer[Rights, JsonRights] = rights => JsonRights(rights.authorizationTypes.map(_.id))
+  implicit val transformer: Transformer[Rights, JsonRights] = {
+    case rights if rights == Rights.NoRights => JsonRights.empty
+    case rights                              => JsonRights(rights.authorizationTypes.map(_.id))
+  }
 
   // We don't want to send "no_rights" for now, as it is not yet handled back as an empty set of rights when updating a user
   val empty:     JsonRights = JsonRights(Set.empty)

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_usermanagement.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_usermanagement.yml
@@ -57,7 +57,7 @@ response:
               "rule_only",
               "user"
             ],
-            "customRights" : ["no_rights"],
+            "customRights" : [],
             "providers" : [
               "file"
             ],
@@ -93,7 +93,7 @@ response:
                 "roles" : [
                   "user"
                 ],
-                "customRights" : ["no_rights"]
+                "customRights" : []
               }
             },
             "tenants" : "zoneA"
@@ -127,7 +127,7 @@ response:
               "read_only",
               "rule_only"
             ],
-            "customRights" : ["no_rights"],
+            "customRights" : [],
             "providers" : [
               "file"
             ],
@@ -154,7 +154,7 @@ response:
                 "roles" : [
                   "read_only"
                 ],
-                "customRights" : ["no_rights"]
+                "customRights" : []
               }
             },
             "tenants" : "all",
@@ -179,9 +179,9 @@ response:
             "providersInfo" : {
               "manager" : {
                 "provider" : "manager",
-                "authz" : ["no_rights"],
+                "authz" : [],
                 "roles" : [],
-                "customRights" : ["no_rights"]
+                "customRights" : []
               }
             },
             "tenants" : "none"


### PR DESCRIPTION
https://issues.rudder.io/issues/25296

`Rights` constructor enforce the `NoRights` authorization when passed an empty list. But in JSON we only want an empty list.

Screenshot of result :

![image](https://github.com/user-attachments/assets/be3ee598-e9f5-4a8b-8f6c-9b4dc0431bb8)
