### PR TITLE
Fixes #24976: Tenants column in user-management should depend on plugin activation

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
@@ -53,6 +53,7 @@ import com.normation.rudder.facts.nodes.NodeSecurityContext
 import com.normation.rudder.rest.*
 import com.normation.rudder.rest.EndpointSchema.syntax.*
 import com.normation.rudder.rest.implicits.*
+import com.normation.rudder.tenants.TenantService
 import com.normation.rudder.users.EventTrace
 import com.normation.rudder.users.FileUserDetailListProvider
 import com.normation.rudder.users.JsonAddedUser
@@ -196,6 +197,7 @@ class UserManagementApiImpl(
     userService:               FileUserDetailListProvider,
     userManagementService:     UserManagementService,
     roleApiMapping:            RoleApiMapping,
+    tenantsService:            TenantService,
     getProviderRoleExtensions: () => Map[String, ProviderRoleExtension],
     getAuthBackendsProviders:  () => Set[String]
 ) extends LiftApiModuleProvider[UserManagementApi] {
@@ -568,7 +570,7 @@ class UserManagementApiImpl(
     val roleListOverride       = providerRoleExtensions.values.max
     val providersProperties    = providerRoleExtensions.view.mapValues(_.transformInto[JsonProviderProperty]).toMap
 
-    JsonAuthConfig(roleListOverride, getAuthBackendsProviders(), providersProperties, users)
+    JsonAuthConfig(roleListOverride, getAuthBackendsProviders(), providersProperties, users, tenantsService.tenantsEnabled)
   }
 
   private def transformUser(

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
@@ -146,6 +146,7 @@ final case class JsonAuthConfig(
     authenticationBackends: Set[String],
     providerProperties:     Map[String, JsonProviderProperty],
     users:                  List[JsonUser],
+    tenantsEnabled:         Boolean,
     digest:                 PasswordEncoderType = PasswordEncoderType.DEFAULT // default value
 )
 

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_usermanagement.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_usermanagement.yml
@@ -187,6 +187,7 @@ response:
             "tenants" : "none"
           }
         ],
+        "tenantsEnabled" : false,
         "digest" : "BCRYPT"
       }
     }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -45,6 +45,7 @@ import com.normation.appconfig.ModifyGlobalPropertyInfo
 import com.normation.cfclerk.domain.TechniqueVersionHelper
 import com.normation.errors
 import com.normation.errors.IOResult
+import com.normation.errors.IOStream
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.FullInventory
@@ -93,6 +94,7 @@ import com.normation.rudder.domain.reports.RunComplianceInfo
 import com.normation.rudder.domain.reports.ValueStatusReport
 import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.CoreNodeFact
+import com.normation.rudder.facts.nodes.MinimalNodeFactInterface
 import com.normation.rudder.facts.nodes.NodeFact
 import com.normation.rudder.facts.nodes.NodeFactChangeEventCallback
 import com.normation.rudder.facts.nodes.NodeFactChangeEventCC
@@ -124,6 +126,8 @@ import com.normation.rudder.services.servers.PolicyServerManagementService
 import com.normation.rudder.services.servers.PolicyServers
 import com.normation.rudder.services.servers.PolicyServersUpdateCommand
 import com.normation.rudder.services.workflows.WorkflowLevelService
+import com.normation.rudder.tenants.TenantId
+import com.normation.rudder.tenants.TenantService
 import com.normation.rudder.users.EventTrace
 import com.normation.rudder.users.FileUserDetailListProvider
 import com.normation.rudder.users.PasswordEncoderDispatcher
@@ -872,6 +876,28 @@ class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSessi
 
   val providerRoleExtension: Map[String, ProviderRoleExtension] = Map("file" -> ProviderRoleExtension.WithOverride)
   val authBackendProviders:  Set[String]                        = Set("file")
+
+  object tenantsService extends TenantService {
+    override def tenantsEnabled: Boolean            = false
+    override def getTenants():   UIO[Set[TenantId]] = ???
+    override def updateTenants(ids:                             Set[TenantId]): IOResult[Unit] = ???
+    override def nodeFilter[A <: MinimalNodeFactInterface](opt: Option[A])(implicit qc:          QueryContext): UIO[Option[A]]     = ???
+    override def nodeFilterStream(s:                            IOStream[NodeFact])(implicit qc: QueryContext): IOStream[NodeFact] = ???
+    override def nodeFilterMapView(nodes: Ref[Map[NodeId, CoreNodeFact]])(implicit
+        qc: QueryContext
+    ): IOResult[MapView[NodeId, CoreNodeFact]] = ???
+    override def nodeGetMapView(nodes: Ref[Map[NodeId, CoreNodeFact]], nodeId: NodeId)(implicit
+        qc: QueryContext
+    ): IOResult[Option[CoreNodeFact]] = ???
+    override def manageUpdate[A](existing: Option[CoreNodeFact], updated: NodeFact, cc: ChangeContext)(
+        action: NodeFact => IOResult[A]
+    ): IOResult[A] = ???
+    override def checkDelete(
+        existing:         CoreNodeFact,
+        cc:               ChangeContext,
+        availableTenants: Set[TenantId]
+    ): Either[errors.RudderError, CoreNodeFact] = ???
+  }
 }
 
 object MockUserManagement {

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -963,6 +963,7 @@ class RestTestSetUp {
       mockUserManagement.userService,
       mockUserManagement.userManagementService,
       new RoleApiMapping(new ExtensibleAuthorizationApiMapping(AuthorizationApiMapping.Core :: Nil)),
+      mockUserManagement.tenantsService,
       () => mockUserManagement.providerRoleExtension,
       () => mockUserManagement.authBackendProviders
     )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement.elm
@@ -49,7 +49,7 @@ update msg model =
                         ui = model.ui
                         newUI = {ui | panelMode = newPanelMode} 
                         newModel =
-                            { model | roleListOverride = u.roleListOverride, users = users, ui = newUI, digest = u.digest, providers = (userProviders u.authenticationBackends), providersProperties = u.providersProperties}
+                            { model | roleListOverride = u.roleListOverride, users = users, ui = newUI, digest = u.digest, providers = (userProviders u.authenticationBackends), providersProperties = u.providersProperties, tenantsEnabled = u.tenantsEnabled }
 
                     in
                     ( newModel, getRoleConf model )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/DataTypes.elm
@@ -154,6 +154,7 @@ type alias UsersConf =
     , authenticationBackends: List String
     , providersProperties : Dict String ProviderProperties
     , users : List User
+    , tenantsEnabled : Bool
     }
 
 type PanelMode
@@ -180,6 +181,7 @@ type alias UserForm =
 type alias Model =
     { contextPath : String
     , digest: String
+    , tenantsEnabled : Bool
     , users: Users
     , roles: Roles
     , rolesConf : RoleConf  -- from API

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/Init.elm
@@ -16,7 +16,7 @@ init flags =
         initUi = UI Closed False (TableFilters UserLogin Asc "")
         initUserInfoForm = UserInfoForm "" "" Dict.empty
         initUserForm = UserForm "" "" True False [] initUserInfoForm [] ValidInputs 
-        initModel = Model flags.contextPath "" (fromList []) (fromList []) [] None initUserForm initUi [] Dict.empty
+        initModel = Model flags.contextPath "" False (fromList []) (fromList []) [] None initUserForm initUi [] Dict.empty
     in
     ( initModel
     , getUsersConf initModel
@@ -34,8 +34,7 @@ getErrorMessage e =
                 Http.BadStatus status ->
                     "Code " ++ String.fromInt status
 
-                Http.BadUrl str ->
-                    "Invalid API url"
+                Http.BadUrl str -> "Invalid API url"
 
                 Http.Timeout ->
                     "It took too long to get a response"

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/JsonDecoder.elm
@@ -27,6 +27,7 @@ decodeCurrentUsersConf =
         |> required "authenticationBackends" (D.list <| D.string)
         |> required "providerProperties" (D.dict decodeProviderProperties)
         |> required "users" (D.list <| decodeUser)
+        |> required "tenantsEnabled" D.bool
 
 decodeProviderProperties : Decoder ProviderProperties
 decodeProviderProperties =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/View.elm
@@ -765,9 +765,13 @@ displayUsersTable model =
             else
                 text ""
             )
-            , td []
+            , ( if model.tenantsEnabled then
+                td []
                 [ displayTenants user
                 ]
+            else
+                text ""
+            )
             , td []
                 [ displayUserPreviousLogin user
                 ]
@@ -810,7 +814,11 @@ displayUsersTable model =
         else
             text ""
         )
-        , th [class (thClass model.ui.tableFilters Tenants        ), onClick (UpdateTableFilters (sortTable filters Tenants        ))] [ text "Tenants"        ]
+        , ( if model.tenantsEnabled then
+            th [class (thClass model.ui.tableFilters Tenants        ), onClick (UpdateTableFilters (sortTable filters Tenants        ))] [ text "Tenants"        ]
+        else
+            text ""
+        )
         , th [class (thClass model.ui.tableFilters PreviousLogin  ), onClick (UpdateTableFilters (sortTable filters PreviousLogin  ))] [ text "Previous login" ]
         , th [style "width" "220px"][ text "Actions" ]
         ]

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2224,6 +2224,7 @@ object RudderConfigInit {
             UserFileProcessing.getUserResourceFile()
           ),
           roleApiMapping,
+          tenantService,
           () => authenticationProviders.getProviderProperties().view.mapValues(_.providerRoleExtension).toMap,
           () => authenticationProviders.getConfiguredProviders().map(_.name).toSet
         ),


### PR DESCRIPTION
https://issues.rudder.io/issues/24976

Change consists of adding the `tenantsEnabled` field in the API (the variable already exists), and conditionally displaying the table header and rows for the "Tenants" column based on a new boolean variable in the Elm model.