### PR TITLE
Fixes #25302: API documentation examples are not valid bash scripts

### DIFF
--- a/webapp/sources/api-doc/code_samples/curl/usermanagement/add.sh
+++ b/webapp/sources/api-doc/code_samples/curl/usermanagement/add.sh
@@ -1,5 +1,7 @@
-add.json:
-
+curl --header "X-API-Token: yourToken" \
+  --request POST https://rudder.example.com/rudder/api/latest/usermanagement \
+  --header "Content-type: application/json" \
+  --data @- <<EOF
 {
 	"isPreHashed" : false,
 	"username" : "johndoe",
@@ -11,6 +13,4 @@ add.json:
 		"phone" : "+1234"
 	}
 }
-
-curl --header "X-API-Token: yourToken" --request POST https://rudder.example.com/rudder/api/latest/usermanagement --header "Content-type: application/json" --data @add.json
-
+EOF

--- a/webapp/sources/api-doc/code_samples/curl/usermanagement/update-info.sh
+++ b/webapp/sources/api-doc/code_samples/curl/usermanagement/update-info.sh
@@ -1,5 +1,7 @@
-update-info.json:
-
+curl --header "X-API-Token: yourToken" \
+  --request PUT https://rudder.example.com/rudder/api/latest/usermanagement/info/johndoe \
+  --header "Content-type: application/json" \
+  --data @- <<EOF
 {
 	"name" : "John Doe",
   "email" : "john.doe@example.com",
@@ -7,6 +9,4 @@ update-info.json:
 		"phone" : "+1234"
 	}
 }
-
-curl --header "X-API-Token: yourToken" --request PUT https://rudder.example.com/rudder/api/latest/usermanagement/info/johndoe --header "Content-type: application/json" --data @update-info.json
-
+EOF

--- a/webapp/sources/api-doc/code_samples/curl/usermanagement/update.sh
+++ b/webapp/sources/api-doc/code_samples/curl/usermanagement/update.sh
@@ -1,11 +1,11 @@
-update.json:
-
+curl --header "X-API-Token: yourToken" \
+  --request PUT https://rudder.example.com/rudder/api/latest/usermanagement/johndoe \
+  --header "Content-type: application/json" \
+  --data @- <<EOF
 {
 	"isPreHashed" : false,
 	"username"    : "",
   "password"    : "Safer password",
 	"permissions" : ["user", "deployer", "inventory"]
 }
-
-curl --header "X-API-Token: yourToken" --request PUT https://rudder.example.com/rudder/api/latest/usermanagement/johndoe --header "Content-type: application/json" --data @update.json
-
+EOF


### PR DESCRIPTION
https://issues.rudder.io/issues/25302

The _.sh_ files need to be valid Bash scripts and using multiline curl arguments for the JSON data is a way to make it a valid command 