### PR TITLE
Fixes #25303: Database tests have non temporary DDL that prevents running them twice

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/DBCommon.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/DBCommon.scala
@@ -79,8 +79,14 @@ trait DBCommon extends Specification with Loggable with BeforeAfterAll {
    * everything is temporary
    */
   def sqlInit: String = {
-    val is      = this.getClass().getClassLoader().getResourceAsStream("reportsSchema.sql")
-    val sqlText = Source
+    val is              = this.getClass().getClassLoader().getResourceAsStream("reportsSchema.sql")
+    // This is a way to create and use all DDL under a schema, that will be dropped at the end of tests
+    val setTestNamepace = {
+      """
+        |SET search_path TO pg_temp
+        |""".stripMargin
+    }
+    val sqlText         = Source
       .fromInputStream(is)
       .getLines()
       .toSeq
@@ -88,15 +94,10 @@ trait DBCommon extends Specification with Loggable with BeforeAfterAll {
         val s = line.trim(); s.isEmpty || s.startsWith("/*") || s.startsWith("*")
       }
       .map(s => {
-        s
-          // using toLowerCase is safer, it will always replace create table by a temp one,
-          // but it also mean that we will not know when we won't be strict with ourselves
-          .toLowerCase
-          .replaceAll("create table", "create temp table")
-          .replaceAll("create sequence", "create temp sequence")
-          .replaceAll("alter database rudder", "alter database test")
+        // we work on a "test" database which needs to be created, and which is cleaned (see clean methods)
+        s.replaceAll("alter database rudder", "alter database test")
       })
-      .mkString("\n")
+      .mkString(s"${setTestNamepace};\n", "\n", "")
     is.close()
 
     sqlText
@@ -125,8 +126,12 @@ trait DBCommon extends Specification with Loggable with BeforeAfterAll {
     }
   }
 
-  def cleanDb(): Unit = {
-    if (sqlClean.trim.size > 0) doobie.transactRunEither(xa => Update0(sqlClean, None).run.transact(xa)) match {
+  final def cleanDb(): Unit = {
+    doobie.transactRunEither(xa => {
+      ZIO.when(sqlClean.trim.size > 0)(
+        Update0(sqlClean, None).run.transact(xa)
+      )
+    }) match {
       case Right(x) => ()
       case Left(ex) => throw ex
     }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsProgressTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsProgressTest.scala
@@ -84,7 +84,7 @@ class ReportsProgressTest extends DBCommon with BoxSpecMatcher {
   "Last logged id" should {
 
     "correctly insert at start" in {
-      (lastlogged.getReportLoggerLastId.mustEmpty()) and
+      (lastlogged.getReportLoggerLastId.mustFullEq(None)) and
       (lastlogged.updateReportLoggerLastId(43) mustFullEq (43)) and
       (lastlogged.getReportLoggerLastId mustFullEq (Some(43)))
     }

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateChangeValidationEnforceSchema.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateChangeValidationEnforceSchema.scala
@@ -63,19 +63,6 @@ class TestMigrateChangeValidationEnforceSchema extends DBCommon with IOChecker {
 
   override def transactor: Transactor[cats.effect.IO] = doobie.xaio
 
-  override def cleanDb(): Unit = {
-    doobie.transactRunEither(
-      sql"""
-        DROP TABLE IF EXISTS ${tempWorkflowTable};
-        DROP TABLE IF EXISTS ${tempCRTable};
-        DROP SEQUENCE IF EXISTS ChangeRequestId_temp;
-      """.update.run.transact(_)
-    ) match {
-      case Right(_) => ()
-      case Left(ex) => throw ex
-    }
-  }
-
   // The previous schema, with the renamed table for this test
   // We need to know for sure the initial state and the final state of the migrated table,
   // so we define and use the previous schema without conflicting with the current one (with all values renamed)
@@ -162,7 +149,6 @@ class TestMigrateChangeValidationEnforceSchema extends DBCommon with IOChecker {
 }
 
 object TestMigrateChangeValidationEnforceSchema {
-  // the tables are setup and tear down for the lifetime of this test execution
   private val tempCRTableName       = "changerequest_migratetest"
   private val tempCRTable           = fragment.Fragment.const(tempCRTableName)
   private val tempWorkflowTableName = "workflow_migratetest"

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateEventLogEnforceSchema.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestMigrateEventLogEnforceSchema.scala
@@ -70,21 +70,6 @@ class TestMigrateEventLogEnforceSchema extends DBCommon with IOChecker {
     }
   }
 
-  override def cleanDb(): Unit = {
-    doobie.transactRunEither(
-      sql"""
-        DROP TABLE IF EXISTS $tempTable;
-        DROP SEQUENCE IF EXISTS eventLogIdSeq_temp;
-        DROP INDEX IF EXISTS eventType_idx_temp;
-        DROP INDEX IF EXISTS creationDate_idx_temp;
-        DROP INDEX IF EXISTS eventlog_fileFormat_idx_temp;
-      """.update.run.transact(_)
-    ) match {
-      case Right(_) => ()
-      case Left(ex) => throw ex
-    }
-  }
-
   // The previous schema, with the renamed table for this test
   // We need to know for sure the initial state and the final state of the migrated table,
   // so we define and use the previous schema without conflicting with the current one (with all values renamed)


### PR DESCRIPTION
https://issues.rudder.io/issues/25303

There is no such `CREATE TEMP TYPE score` in PostgreSQL, even if there is `CREATE TEMP TABLE`.
The solution here is quite radical : use a [schema](https://www.postgresql.org/docs/current/ddl-schemas.html) for tests, all tables, sequence, etc. creation will be under the schema, and it could be dropped at the end of tests, along with any structure that was declared in tests because they are configured to be within the schema.

An alternative solution which could be harder to maintain as we add new Types, is to explicitly drop the Type.