### PR TITLE
Fixes #25314: Reload users file when user is disabled or activated upmerge in 8.2

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
@@ -489,7 +489,8 @@ class UserManagementApiImpl(
                             DateTime.now,
                             "User current disabled status set to 'active' by user management API"
                           )
-                          userRepo.setActive(List(user.id), eventTrace).as(JsonStatus(UserStatus.Active))
+                          (userRepo.setActive(List(user.id), eventTrace) *> userService.reloadPure())
+                            .as(JsonStatus(UserStatus.Active))
                         }
                         case UserStatus.Deleted  =>
                           Inconsistency(s"User '$id' cannot be activated because the user is currently deleted").fail
@@ -521,7 +522,8 @@ class UserManagementApiImpl(
                             DateTime.now,
                             "User current active status set to 'disabled' by user management API"
                           )
-                          userRepo.disable(List(user.id), None, List.empty, eventTrace).as(JsonStatus(UserStatus.Disabled))
+                          (userRepo.disable(List(user.id), None, List.empty, eventTrace) *> userService.reloadPure())
+                            .as(JsonStatus(UserStatus.Disabled))
                         }
                         case UserStatus.Deleted  =>
                           Inconsistency(s"User '$id' cannot be disabled because the user is currently deleted").fail

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -849,6 +849,7 @@ class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSessi
       userInfos.find(_.id == userId).succeed
     }
 
+    override def getStatuses(userIds: List[String]): IOResult[Map[String, UserStatus]] = ???
   }
 
   val usersInputStream: () => InputStream = () => IOUtils.toInputStream(usersConfigFile.contentAsString, StandardCharsets.UTF_8)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -266,7 +266,7 @@ class AppConfigAuth extends ApplicationContextAware {
     )
     rudderUserListProvider.registerCallback(checkUsersFileCallback)
 
-    val updatePasswordEncoder  = RudderAuthorizationFileReloadCallback(
+    val updatePasswordEncoder = RudderAuthorizationFileReloadCallback(
       "update-password-encoder",
       (c: ValidatedUserList) => effectUioUnit(provider.setPasswordEncoder(c.encoder))
     )

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/UserSessionInvalidationFilter.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/UserSessionInvalidationFilter.scala
@@ -36,9 +36,12 @@
  */
 package bootstrap.liftweb
 
+import com.normation.rudder.users.FileUserDetailListProvider
+import com.normation.rudder.users.RudderAuthorizationFileReloadCallback
 import com.normation.rudder.users.RudderUserDetail
 import com.normation.rudder.users.UserRepository
 import com.normation.rudder.users.UserStatus
+import com.normation.rudder.users.ValidatedUserList
 import com.normation.zio.UnsafeRun
 import java.io.IOException
 import javax.servlet.FilterChain


### PR DESCRIPTION
https://issues.rudder.io/issues/25314

Includes the diff as in https://github.com/Normation/rudder-plugins/pull/744 but in Rudder,
and upmerge of https://github.com/Normation/rudder/pull/5816 in 8.2 (due to moving user-management in Rudder, some users classes have different namespaces)