### PR TITLE
Fixes #25123: Authentication happens twice with same session id

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderProviderManagerUtil.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderProviderManagerUtil.scala
@@ -1,0 +1,55 @@
+package bootstrap.liftweb
+
+import com.normation.errors.Inconsistency
+import com.normation.errors.IOResult
+import com.normation.rudder.domain.logger.ApplicationLoggerPure
+import com.normation.rudder.users.RudderUserDetail
+import com.normation.rudder.users.SessionId
+import com.normation.rudder.users.UserRepository
+import com.normation.zio.UnsafeRun
+import org.joda.time.DateTime
+import org.springframework.web.context.request.RequestAttributes
+import org.springframework.web.context.request.ServletRequestAttributes
+import zio.syntax.*
+
+/**
+ * Scala (ZIO, etc.) method calls used in RudderProviderManager.java, but needing additional transformations
+ */
+object RudderProviderManagerUtil {
+  def logStartSession(
+      userRepository:    UserRepository,
+      details:           RudderUserDetail,
+      sessionId:         SessionId,
+      provider:          String,
+      requestAttributes: RequestAttributes
+  ): Unit = {
+    userRepository
+      .logStartSession(
+        details.getUsername,
+        com.normation.rudder.Role.toDisplayNames(details.roles),
+        com.normation.rudder.Rights
+          .combineAll(details.roles.toList.map(_.rights))
+          .authorizationTypes
+          .toList
+          .map(_.id),
+        details.nodePerms.value,
+        sessionId,
+        provider,
+        DateTime.now
+      )
+      .catchSome {
+        case Inconsistency(msg) =>
+          requestAttributes match {
+            case requestAttrs: ServletRequestAttributes =>
+              IOResult.attempt(requestAttrs.getRequest().getSession(false).invalidate())
+            case _ =>
+              // There is nothing we can do to change the user session programmatically, user will have to change session id manually
+              ApplicationLoggerPure.warn(
+                "Rudder does not know how to handle the current authentication request using " + requestAttributes.getClass.getName + ". Please retry to log in after clearing the browser cache."
+              ) *>
+              Inconsistency("Refused authentication: " + msg).fail
+          }
+      }
+      .runNow
+  }
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/25123

We just ignore the `insert` in that case, but it then needs to be done at the last operation of the database transaction because a sql error interrupts the whole transaction (hence the change of order).
Doobie provides a nice API for SQL errors, we just use it to log a user-friendly warning.