### PR TITLE
Fixes #24955: One user is created each case change even if case sensivity if false

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
@@ -265,11 +265,14 @@ object UserRepositoryUpdateOnFileReload {
     RudderAuthorizationFileReloadCallback(
       "update-pg-users-on-xml-file-reload",
       userList => {
-        userRepository.setExistingUsers(
-          DefaultAuthBackendProvider.FILE,
-          userList.users.keys.toList,
-          EventTrace(RudderEventActor, DateTime.now(), "Updating users because `rudder-users.xml` was reloaded")
-        )
+        userRepository
+          .setExistingUsers(
+            DefaultAuthBackendProvider.FILE,
+            userList.users.keys.toList,
+            EventTrace(RudderEventActor, DateTime.now(), "Updating users because `rudder-users.xml` was reloaded"),
+            userList.isCaseSensitive
+          )
+          .unit
       }
     )
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/24955

We need to only insert the user when it does not already exist with lowered id : 
```sql
INSERT INTO users (id, ...)
SELECT ?,...,?
WHERE NOT EXISTS (
  SELECT 1 from users WHERE LOWER(id) = LOWER(?)
)
```
is the query that does that conditional insertion.

The user are not created in that case, so we need also a `RETURNING` clause to get back inserted users and compare with requested ones, to log non-created users as warning. 