### PR TITLE
Fixes #25322: Session could be null when checking user status

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/UserSessionInvalidationFilter.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/UserSessionInvalidationFilter.scala
@@ -36,6 +36,9 @@
  */
 package bootstrap.liftweb
 
+import com.normation.errors.IOResult
+import com.normation.errors.SystemError
+import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.users.RudderUserDetail
 import com.normation.rudder.users.UserRepository
 import com.normation.rudder.users.UserStatus
@@ -47,7 +50,8 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.filter.OncePerRequestFilter
-import zio.Ref
+import zio.*
+import zio.syntax.*
 
 /**
  * A filter that invalidates sessions of non-active users.
@@ -79,21 +83,46 @@ class UserSessionInvalidationFilter(userRepository: UserRepository, userDetailLi
   @throws[IOException]
   override def doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain): Unit = {
     val session = request.getSession(false)
-    val auth    = SecurityContextHolder.getContext.getAuthentication
-    if (auth != null) {
-      val userDetails = auth.getPrincipal
-      userDetails match { // we should only do session invalidation in specific cases : status is disabled/deleted, user is unknown
-        case user: RudderUserDetail =>
-          val status =
-            userStatuses.get.map(_.getOrElse(user.getUsername, UserStatus.Deleted)) // unknown user : falls back to deleted
+    if (session != null) { // else do nothing : not logged in
+      val auth = SecurityContextHolder.getContext.getAuthentication
+      if (auth != null) { // else not logged in
+        val userDetails = auth.getPrincipal
+        userDetails match { // we should only do session invalidation in specific cases : status is disabled/deleted, user is unknown
+          case user: RudderUserDetail =>
+            val status =
+              userStatuses.get.map(_.getOrElse(user.getUsername, UserStatus.Deleted)) // unknown user : falls back to deleted
 
-          status.runNow match {
-            case UserStatus.Disabled | UserStatus.Deleted => session.invalidate()
-            case _                                        => ()
-          }
-        case _ => ()
+            status.flatMap {
+              case status if status.in(UserStatus.Disabled, UserStatus.Deleted) =>
+                IOResult
+                  .attempt(session.invalidate())
+                  .foldZIO(
+                    {
+                      case SystemError(_, _: IllegalStateException) =>
+                        ApplicationLoggerPure.info(
+                          s"User session for user '${user.getUsername}' is already invalidated for user with status '${status.value}'"
+                        )
+                      case err                                      =>
+                        err
+                          .copy(msg = {
+                            s"User session for user '${user.getUsername}' could not be invalidated. " +
+                            s"Please contact Rudder developers with the following explanation : ${err.fullMsg}"
+                          })
+                          .fail
+                    },
+                    _ => {
+                      ApplicationLoggerPure.info(
+                        s"User session for user '${user.getUsername}' is invalidated because user has status '${status.value}'"
+                      )
+                    }
+                  )
+              case _                                                            =>
+                ZIO.unit
+            }
+          case _ => ()
+        }
       }
-    } // else do nothing : not logged in
+    }
 
     filterChain.doFilter(request, response)
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/25322

* Wrap the whole block with `if (session != null)`, we will avoid as much methods calls as possible because this is executed at every request
* Add error handling and actionability for the control flow of the session : 
  * invalidating the session may throw an exception when it is already invalidated (somehow from somewhere else in Rudder), just log it at info level
  * invalidating the session successfully should be traced in logs at info level 