### PR TITLE
Fixes #25334: Node property usage search seems to be limited to 10 elements

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchDomain.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchDomain.scala
@@ -52,9 +52,7 @@ final case class Query(
 
     objectClass: Set[QSObject], // what object to look for ? If empty => result empty
 
-    attributes: Set[QSAttribute], // limit the search on which attributes ?
-
-    limit: Int
+    attributes: Set[QSAttribute] // limit the search on which attributes ?
 )
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchQueryParser.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchQueryParser.scala
@@ -88,18 +88,14 @@ object QSRegexQueryParser {
    * The funny part that for each token add the interpretation of the token
    * by composing interpretation function.
    */
-  def interprete(parsed: (QueryString, List[Parameter])): PureResult[Query] = {
+  def interprete(parsed: (QueryString, List[Filter])): PureResult[Query] = {
 
     parsed match {
-      case (EmptyQuery, _)          =>
+      case (EmptyQuery, _)           =>
         Left(Unexpected("No query string was found (the query is only composed of whitespaces and filters)"))
-      case (CharSeq(query), params) =>
-        val is    = params.collect { case FilterType(set) => set }.flatten
-        val in    = params.collect { case FilterAttr(set) => set }.flatten
-        val limit = params.collect { case Limit(int) => int }.headOption match {
-          case Some(v) => v
-          case None    => 10
-        }
+      case (CharSeq(query), filters) =>
+        val is = filters.collect { case FilterType(set) => set }.flatten
+        val in = filters.collect { case FilterAttr(set) => set }.flatten
 
         (for {
           o <- getObjects(is.toSet) chainError ("The 'is' filter(s) contain unknown value(s)")
@@ -117,8 +113,7 @@ object QSRegexQueryParser {
             if (objs.isEmpty) { QSObject.all }
             else { objs },
             if (attrs.isEmpty) { QSAttribute.all }
-            else { attrs },
-            limit
+            else { attrs }
           )
         })
     }
@@ -139,15 +134,10 @@ object QSRegexQueryParser {
   final case class CharSeq(s: String) extends QueryString
   case object EmptyQuery              extends QueryString
 
-  sealed trait Parameter                         extends Token
   // filters like in:rule,directive,names,descriptions
-  sealed trait Filter                            extends Parameter { def keys: Set[String] }
+  sealed trait Filter                            extends Token { def keys: Set[String] }
   final case class FilterAttr(keys: Set[String]) extends Filter
   final case class FilterType(keys: Set[String]) extends Filter
-  case class Limit(limit: Int)                   extends Parameter
-
-  // to define how many result we want -> limit:42
-  case object DefaultLimit extends Parameter
 
   //// parsing language
 
@@ -160,58 +150,50 @@ object QSRegexQueryParser {
    * - have a query string, which is in one piece, and is exactly parsed as it is (unicode, regex, etc)
    *   - in particular, regex must not be interpreted, because they are often use in groups
    */
-  type QF = (QueryString, List[Parameter])
+  type QF = (QueryString, List[Filter])
 
   /////
   ///// this is the entry point /////
   /////
 
-  private def all[A: P]: P[QF] = P(Start ~ (nominal | onlyParams) ~ End)
+  private def all[A: P]: P[QF] = P(Start ~ (nominal | onlyFilters) ~ End)
 
   /////
   ///// different structure of queries
   /////
 
   // degenerated case with only filters, no query string
-  private def onlyParams[A: P]: P[QF] = P(parameter.rep(1)) map { case f => (EmptyQuery, f.toList) }
+  private def onlyFilters[A: P]: P[QF] = P(filter.rep(1)) map { case f => (EmptyQuery, f.toList) }
 
   // nonimal case: zero of more filter, a query string, zero or more filter
-  private def nominal[A: P]: P[QF] = P(parameter.rep(0) ~/ (case0 | case1)) map {
-    case (f1, (q, f2)) => (check(q), f1.toList ::: f2)
+  private def nominal[A: P]: P[QF] = P(filter.rep(0) ~/ (case0 | case1)) map {
+    case (f1, (q, f2)) => (check(q), f1.toList ::: f2.toList)
   }
 
   // need the two following rules so that so the parsing is correctly done for filter in the end
-  private def case0[A: P]: P[QF] = P(queryInMiddle ~ parameter.rep(1)) map { case (q, f) => (check(q), f.toList) }
+  private def case0[A: P]: P[QF] = P(queryInMiddle ~ filter.rep(1)) map { case (q, f) => (check(q), f.toList) }
   private def case1[A: P]: P[QF] = P(queryAtEnd) map { case q => (check(q), Nil) }
 
   /////
   ///// simple elements: filters
   /////
 
-  private def parameter[A:  P]: P[Parameter] = P(limitRes | filter)
-  private def filter[A:     P]: P[Filter]    = P(filterAttr | filterType)
-  private def filterType[A: P]: P[Filter]    = P(IgnoreCase("is:") ~ filterKeys) map { FilterType.apply }
-  private def filterAttr[A: P]: P[Filter]    = P(IgnoreCase("in:") ~ filterKeys) map { FilterAttr.apply }
+  // deal with filters: they all start with "in:"
+  private def filter[A:     P]: P[Filter] = P(filterAttr | filterType)
+  private def filterType[A: P]: P[Filter] = P(IgnoreCase("is:") ~ filterKeys) map { FilterType.apply }
+  private def filterAttr[A: P]: P[Filter] = P(IgnoreCase("in:") ~ filterKeys) map { FilterAttr.apply }
 
   // the keys part
   private def filterKeys[A: P]: P[Set[String]] = P(filterKey.rep(sep = ",")) map { l => l.toSet }
   private def filterKey[A:  P]: P[String]      = P(CharsWhileIn("""\\-._a-zA-Z0-9""").!)
 
-  private def limitRes[A:   P]: P[Parameter] = P(IgnoreCase("limit:") ~ limitValue) map { Limit.apply }
-  private def limitValue[A: P]: P[Int]       = P(CharsWhileIn("""0-9""").rep(1).!.map(_.toInt))
   /////
   ///// simple elements: query string
   /////
 
   // we need to case, because regex are bad to look-ahead and see if there is still filter after. .+? necessary to stop at first filter
-  private def queryInMiddle[A: P]: P[QueryString] = P((!("in:" | "is:" | "limit:") ~ AnyChar).rep(1).!) map { x =>
-    CharSeq(x.trim)
-  }
-  private def queryAtEnd[A: P]: P[QueryString] = P(AnyChar.rep(1).!) map { x => CharSeq(x.trim) }
-
-  /////
-  ///// limit
-  /////
+  private def queryInMiddle[A: P]: P[QueryString] = P((!("in:" | "is:") ~ AnyChar).rep(1).!) map { x => CharSeq(x.trim) }
+  private def queryAtEnd[A:    P]: P[QueryString] = P(AnyChar.rep(1).!) map { x => CharSeq(x.trim) }
 
   /////
   ///// utility methods

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/quicksearch/QSRegexQueryParserTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/quicksearch/QSRegexQueryParserTest.scala
@@ -88,77 +88,49 @@ class QSRegexQueryParserTest extends Specification {
   "Simple queries" should {
     "give the exact same string, but trimed" in {
       val q = """ some node """
-      parse(q) must beRight(Query(q.trim, QSObject.all, QSAttribute.all, 10))
+      parse(q) must beRight(Query(q.trim, QSObject.all, QSAttribute.all))
     }
     "give the exact same string, but trimed, even with regexp" in {
       val q = """ some.node[0-9]+.foo """
-      parse(q) must beRight(Query(q.trim, QSObject.all, QSAttribute.all, 10))
+      parse(q) must beRight(Query(q.trim, QSObject.all, QSAttribute.all))
     }
     "give the exact same string, but trimed, even with part of rudder variable" in {
       val q = """ /foo/${rudder. """
-      parse(q) must beRight(Query(q.trim, QSObject.all, QSAttribute.all, 10))
+      parse(q) must beRight(Query(q.trim, QSObject.all, QSAttribute.all))
     }
   }
 
   "Queries with filter" should {
     "if only on object, give all attributes" in {
       parse(" Is:Directives is:RuLes here, the query") must beRight(
-        Query("here, the query", Set(Directive, Rule), QSAttribute.all, 10)
+        Query("here, the query", Set(Directive, Rule), QSAttribute.all)
       )
     }
 
     "if only on attributes, give all objects" in {
       parse(" iN:display_name here, the query in:Node_Id") must beRight(
-        Query("here, the query", QSObject.all, Set(NodeId, Name), 10)
+        Query("here, the query", QSObject.all, Set(NodeId, Name))
       )
     }
 
     "on both sides works" in {
       parse(" Is:Directive is:RuLes iN:display_Name here, the query in:Node_Id") must beRight(
-        Query("here, the query", Set(Directive, Rule), Set(NodeId, Name), 10)
+        Query("here, the query", Set(Directive, Rule), Set(NodeId, Name))
       )
     }
     "only at end works" in {
       parse(" here, the query is:node in:descriptions") must beRight(
-        Query("here, the query", Set(Node), Set(Description, LongDescription), 10)
+        Query("here, the query", Set(Node), Set(Description, LongDescription))
       )
     }
     "only at starts works" in {
       parse(" is:Directive is:RuLes in:display_Name here, the query ") must beRight(
-        Query("here, the query", Set(Directive, Rule), Set(Name), 10)
+        Query("here, the query", Set(Directive, Rule), Set(Name))
       )
     }
     "parse multiple filter comma separated" in {
       parse(" is:Directive,rules in:display_Name here, the query in:Node_Id,Rule_Id") must beRight(
-        Query("here, the query", Set(Directive, Rule), Set(NodeId, Name, RuleId), 10)
-      )
-    }
-    "parse multiple filter comma separated hu" in {
-      parse(" is:Directive,rules in:display_Name here, the query in:Node_Id,Rule_Id limit: 30") must beRight(
-        Query("here, the query", Set(Directive, Rule), Set(NodeId, Name, RuleId), 30)
-      )
-    }
-  }
-
-  "Queries with limit" should {
-    "absence give default limit value" in {
-      parse(" Is:Directives is:RuLes here, the query") must beRight(
-        Query("here, the query", Set(Directive, Rule), QSAttribute.all, 10)
-      )
-    }
-    "between filters works" in {
-      parse(" Is:Directive limit: 54 is:RuLes iN:display_Name here, the query in:Node_Id") must beRight(
-        Query("here, the query", Set(Directive, Rule), Set(NodeId, Name), 54)
-      )
-    }
-    "only at end works" in {
-      parse(" here, the query is:node in:descriptions limit:23") must beRight(
-        Query("here, the query", Set(Node), Set(Description, LongDescription), 23)
-      )
-    }
-    "only at starts works" in {
-      parse(" limit:12 is:Directive is:RuLes in:display_Name here, the query ") must beRight(
-        Query("here, the query", Set(Directive, Rule), Set(Name), 12)
+        Query("here, the query", Set(Directive, Rule), Set(NodeId, Name, RuleId))
       )
     }
   }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala
@@ -309,6 +309,10 @@ object OldInternalApiAuthz {
   }
 
   // for quick search
+  def withReadUser(user: AuthenticatedUser)(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
+    withPerm(user.checkRights(Configuration.Read) || user.checkRights(Node.Read), resp)
+  }
+
   def withReadUser(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
     withPerm(CurrentUser.checkRights(Configuration.Read) || CurrentUser.checkRights(Node.Read), resp)
   }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_quicksearch.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_quicksearch.yml
@@ -1,0 +1,140 @@
+description: Search all directives with default limit to 10
+method: GET
+url: /secure/api/quicksearch?value=is:directive dir
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "completeTagsValue",
+      "result" : "success",
+      "data" : [
+        {
+          "header" : {
+            "type" : "Directive",
+            "summary" : "10 found",
+            "numbers" : 10
+          },
+          "items" : [
+            {
+              "name" : "00. Generic Variable Def #2",
+              "type" : "directive",
+              "id" : "gvd-directive2",
+              "value" : "gvd-directive2",
+              "desc" : "ID: gvd-directive2",
+              "url" : "/secure/configurationManager/directiveManagement#{\"directiveId\":\"gvd-directive2\"}"
+            },
+            {
+              "name" : "10. Clock Configuration",
+              "type" : "directive",
+              "id" : "directive1",
+              "value" : "directive1",
+              "desc" : "ID: directive1",
+              "url" : "/secure/configurationManager/directiveManagement#{\"directiveId\":\"directive1\"}"
+            },
+            {
+              "name" : "99. Generic Variable Def #1",
+              "type" : "directive",
+              "id" : "gvd-directive1",
+              "value" : "gvd-directive1",
+              "desc" : "ID: gvd-directive1",
+              "url" : "/secure/configurationManager/directiveManagement#{\"directiveId\":\"gvd-directive1\"}"
+            },
+            {
+              "name" : "directive 16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+              "type" : "directive",
+              "id" : "16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+              "value" : "directive 16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+              "desc" : "Name: directive 16617aa8-1f02-4e4a-87b6-d0bcdfb4019f",
+              "url" : "/secure/configurationManager/directiveManagement#{\"directiveId\":\"16617aa8-1f02-4e4a-87b6-d0bcdfb4019f\"}"
+            },
+            {
+              "name" : "directive 16d86a56-93ef-49aa-86b7-0d10102e4ea9",
+              "type" : "directive",
+              "id" : "16d86a56-93ef-49aa-86b7-0d10102e4ea9",
+              "value" : "directive 16d86a56-93ef-49aa-86b7-0d10102e4ea9",
+              "desc" : "Name: directive 16d86a56-93ef-49aa-86b7-0d10102e4ea9",
+              "url" : "/secure/configurationManager/directiveManagement#{\"directiveId\":\"16d86a56-93ef-49aa-86b7-0d10102e4ea9\"}"
+            },
+            {
+              "name" : "directive 99f4ef91-537b-4e03-97bc-e65b447514cc",
+              "type" : "directive",
+              "id" : "99f4ef91-537b-4e03-97bc-e65b447514cc",
+              "value" : "directive 99f4ef91-537b-4e03-97bc-e65b447514cc",
+              "desc" : "Name: directive 99f4ef91-537b-4e03-97bc-e65b447514cc",
+              "url" : "/secure/configurationManager/directiveManagement#{\"directiveId\":\"99f4ef91-537b-4e03-97bc-e65b447514cc\"}"
+            },
+            {
+              "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+              "type" : "directive",
+              "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+              "value" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+              "desc" : "Name: directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+              "url" : "/secure/configurationManager/directiveManagement#{\"directiveId\":\"e9a1a909-2490-4fc9-95c3-9d0aa01717c9\"}"
+            },
+            {
+              "name" : "directive-copyGitFile",
+              "type" : "directive",
+              "id" : "directive-copyGitFile",
+              "value" : "directive-copyGitFile",
+              "desc" : "ID: directive-copyGitFile",
+              "url" : "/secure/configurationManager/directiveManagement#{\"directiveId\":\"directive-copyGitFile\"}"
+            },
+            {
+              "name" : "directive2",
+              "type" : "directive",
+              "id" : "directive2",
+              "value" : "directive2",
+              "desc" : "ID: directive2",
+              "url" : "/secure/configurationManager/directiveManagement#{\"directiveId\":\"directive2\"}"
+            },
+            {
+              "name" : "test_import_export_archive_directive",
+              "type" : "directive",
+              "id" : "test_import_export_archive_directive",
+              "value" : "test_import_export_archive_directive",
+              "desc" : "ID: test_import_export_archive_directive",
+              "url" : "/secure/configurationManager/directiveManagement#{\"directiveId\":\"test_import_export_archive_directive\"}"
+            }
+          ]
+        }
+      ]
+    }
+---
+description: Search directives with limit parameter
+method: GET
+url: /secure/api/quicksearch?limit=4&value=is:directive Generic Variable Def
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "completeTagsValue",
+      "result" : "success",
+      "data" : [
+        {
+          "header" : {
+            "type" : "Directive",
+            "summary" : "2 found",
+            "numbers" : 2
+          },
+          "items" : [
+            {
+              "name" : "00. Generic Variable Def #2",
+              "type" : "directive",
+              "id" : "gvd-directive2",
+              "value" : "00. Generic Variable Def #2",
+              "desc" : "Name: 00. Generic Variable Def #2",
+              "url" : "/secure/configurationManager/directiveManagement#{\"directiveId\":\"gvd-directive2\"}"
+            },
+            {
+              "name" : "99. Generic Variable Def #1",
+              "type" : "directive",
+              "id" : "gvd-directive1",
+              "value" : "99. Generic Variable Def #1",
+              "desc" : "Name: 99. Generic Variable Def #1",
+              "url" : "/secure/configurationManager/directiveManagement#{\"directiveId\":\"gvd-directive1\"}"
+            }
+          ]
+        }
+      ]
+    }
+comment: Searching by name change the "value" and "desc" to be the searched completion i.e. full name of the directives


### PR DESCRIPTION
https://issues.rudder.io/issues/25334

We want the `limit` to be passed as REST query parameter instead of `limit:x` backend search : for now the `Query` case class is passed to the quicksearch backend param to transform into low-level query (LDAP, etc.), but this information is not actually used in any backend.
We only do the `take(limit)` at last when all results from a backend have been returned.
So the changes here removes the support introduced in https://github.com/Normation/rudder/pull/5778 and adds the support of the query parameter in place.

API tests have been bootstrapped for the Quicksearch API, and it was useful to understand and snapshot the behavior of the search (will also be useful when moving from lift-json to zio-json later).

Now it sees the number of requested elements : 
![image](https://github.com/user-attachments/assets/18c34426-197b-4574-8f89-2dea8c39f3cf)
