### PR TITLE
Fixes #25136: Nodes table sorting is not obvious and we need to guess the sort column and direction 

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -1336,7 +1336,6 @@ function createNodeTable(gridId, refresh, scores) {
       , "title": "Compliance"
       , "sSortDataType": "node-compliance"
       , "type" : "numeric"
-      , "class" : "tw-bs"
       , "createdCell" : function (nTd, sData, oData, iRow, iCol) {
           var link = callbackElement(oData, true)
           var complianceBar = "<span class='text-muted'>N/A</span>"

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.css
@@ -80,23 +80,27 @@
 /* </TABLE> */
 
 /* <THEAD> */
-.dataTable tr.head{
+.dataTable tr.head,
+.dataTables_scrollHead thead > tr {
   border-bottom : 1px solid #d6deef;
   font-size: 1.15em;
 }
 /* </THEAD> */
 
 /* <TH> */
-.dataTable tr.head th .DataTables_sort_wrapper {
+.dataTable tr.head th .DataTables_sort_wrapper,
+.dataTables_scrollHead thead > tr th .DataTables_sort_wrapper{
   top: 1px;
   position: relative;
   padding-right: 4px;
 }
-.dataTable tr.head th .DataTables_sort_wrapper .DataTables_sort_icon{
+.dataTable tr.head th .DataTables_sort_wrapper .DataTables_sort_icon,
+.dataTables_scrollHead thead > tr th .DataTables_sort_wrapper .DataTables_sort_icon{
   position: absolute;
 }
 
-.dataTable tr.head th{
+.dataTable tr.head th,
+.dataTables_scrollHead thead > tr th{
   padding: 10px 6px;
   outline: none !important;
   cursor: pointer;
@@ -104,17 +108,23 @@
 }
 .dataTable tr.head th.sorting,
 .dataTable tr.head th.sorting_asc,
-.dataTable tr.head th.sorting_desc{
+.dataTable tr.head th.sorting_desc,
+.dataTables_scrollHead thead > tr th.sorting,
+.dataTables_scrollHead thead > tr th.sorting_asc,
+.dataTables_scrollHead thead > tr th.sorting_desc{
   white-space: pre;
 }
-.dataTable tr.head th.sorting:after{
+.dataTable tr.head th.sorting:after,
+.dataTables_scrollHead thead > tr th.sorting:after{
   content: "";
   display: inline-block;
   min-width: 12px;
   margin-left: 6px;
 }
 .dataTable tr.head th.sorting_asc:after,
-.dataTable tr.head th.sorting_desc:after{
+.dataTable tr.head th.sorting_desc:after,
+.dataTables_scrollHead thead > tr th.sorting_asc:after,
+.dataTables_scrollHead thead > tr th.sorting_desc:after{
   display: inline-block;
   min-width: 12px;
   font-family: "Font Awesome 5 Free";
@@ -131,26 +141,34 @@
   position: relative;
   top: 1px;
 }
-.dataTable tr.head th.sorting_asc:after{
+.dataTable tr.head th.sorting_asc:after,
+.dataTables_scrollHead thead > tr th.sorting_asc:after{
   content: "\f0d8";
 }
-.dataTable tr.head th.sorting_desc:after{
+.dataTable tr.head th.sorting_desc:after,
+.dataTables_scrollHead thead > tr th.sorting_desc:after{
   content: "\f0d7";
 }
 .dataTable .dataTable tr.head th {
   padding: 4px 6px;
   font-size: 0.9em;
 }
-.dataTable tr.head th.sorting{
+.dataTable tr.head th.sorting,
+.dataTables_scrollHead thead > tr th.sorting{
   color: #738195;
 }
 .dataTable tr.head th.sorting.sorting_desc,
-.dataTable tr.head th.sorting.sorting_asc{
+.dataTable tr.head th.sorting.sorting_asc,
+.dataTables_scrollHead thead > tr th.sorting_asc,
+.dataTables_scrollHead thead > tr th.sorting_desc{
   color: #041922;
 }
 .dataTable tr.head th.sorting:hover,
 .dataTable tr.head th.sorting.sorting_desc:hover,
-.dataTable tr.head th.sorting.sorting_asc:hover{
+.dataTable tr.head th.sorting.sorting_asc:hover,
+.dataTables_scrollHead thead > tr th.sorting:hover,
+.dataTables_scrollHead thead > tr th.sorting_asc:hover,
+.dataTables_scrollHead thead > tr th.sorting_desc:hover{
   cursor: pointer;
   color: #0e5e9f;
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/25136

Because the columns in the node table are customisable and this table is still generated by datatable.js, the .head class cannot easily be added to the <tr> tag in the table header (without causing any side-effects). 

The simplest way is to apply the same css rule to this kind of table header

Now this header is identical to that of the other tables :
![header-node](https://github.com/user-attachments/assets/4c3eebb3-fa41-4f25-8e40-b4134683e230)
