### PR TITLE
Fixes #25155: Resources upload over 8 MB show error in log and not in UI

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala
@@ -48,6 +48,7 @@ import com.normation.rudder.api.ApiAuthorization as ApiAuthz
 import com.normation.rudder.api.HttpAction
 import com.normation.rudder.domain.logger.ApiLogger
 import com.normation.rudder.facts.nodes.QueryContext
+import com.normation.rudder.users.AuthenticatedUser
 import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.users.RudderAccount
 import com.normation.rudder.users.UserService
@@ -314,5 +315,11 @@ object OldInternalApiAuthz {
 
   def withWriteConfig(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
     withPerm(CurrentUser.checkRights(Configuration.Write) || CurrentUser.checkRights(Configuration.Edit), resp)
+  }
+
+  def withWriteConfig(
+      user: AuthenticatedUser
+  )(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
+    withPerm(user.checkRights(Configuration.Write) || user.checkRights(Configuration.Edit), resp)
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_sharedfiles.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_sharedfiles.yml
@@ -1,0 +1,45 @@
+description: List files
+method: POST
+url: /secure/api/resourceExplorer/draft/09533e85-37ae-431e-b9bb-87666aeecf6b/1.0
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+      "action": "list",
+      "path": "/"
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "result": []
+    }
+---
+description: Upload files
+method: POST
+url: /secure/api/resourceExplorer/draft/09533e85-37ae-431e-b9bb-87666aeecf6b/1.0
+headers:
+  - "Content-Type: application/x-www-form-urlencoded"
+body:
+params:
+  destination: "/"
+  file: "file content is not detected in yml tests, see SharedAPITest"
+response:
+  code: 500
+  content: >-
+    {
+      "success": false,
+      "error": "Missing file to copy to /"
+    }
+---
+# TODO: Many other actions to test !
+description: Upload file without payload
+method: POST
+url: /secure/api/resourceExplorer/draft/09533e85-37ae-431e-b9bb-87666aeecf6b/1.0
+response:
+  code: 500
+  content: >-
+    {
+      "success": false,
+      "error": "An error occurred while looking into directory <- 'action' is not defined in json data"
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -107,6 +107,7 @@ import com.normation.rudder.rest.internal.GroupInternalApiService
 import com.normation.rudder.rest.internal.GroupsInternalApi
 import com.normation.rudder.rest.internal.RuleInternalApiService
 import com.normation.rudder.rest.internal.RulesInternalApi
+import com.normation.rudder.rest.internal.SharedFilesAPI
 import com.normation.rudder.rest.lift.*
 import com.normation.rudder.rest.v1.RestStatus
 import com.normation.rudder.rule.category.RuleCategoryService
@@ -474,6 +475,13 @@ class RestTestSetUp {
   val restDataSerializer: RestDataSerializerImpl = RestDataSerializerImpl(
     mockTechniques.techniqueRepo,
     null // diffService
+  )
+
+  val sharedFilesApi = new SharedFilesAPI(
+    restExtractorService,
+    userService,
+    "unknown-shared-folder-path",
+    mockGitRepo.configurationRepositoryRoot.pathAsString
   )
 
   // TODO
@@ -963,6 +971,7 @@ class RestTestSetUp {
   val (rudderApi, liftRules) = TraitTestApiFromYamlFiles.buildLiftRules(apiModules, apiVersions, Some(userService))
 
   liftRules.statelessDispatch.append(RestStatus)
+  liftRules.statelessDispatch.append(sharedFilesApi)
 
   val baseTempDirectory = mockGitRepo.abstractRoot
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Action.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Action.elm
@@ -1,10 +1,11 @@
 module FileManager.Action exposing (..)
 
 import File exposing (File)
-import Json.Decode as Decode exposing (andThen, fail, succeed)
+import Json.Decode as Decode exposing (andThen, bool, fail, maybe, succeed)
 import Json.Decode exposing (Decoder)
+import Http.Detailed
 import Http exposing (Body, emptyBody, expectJson, header, request, stringBody)
-import Json.Decode.Pipeline exposing (required)
+import Json.Decode.Pipeline exposing (required, optional)
 import Json.Encode
 import List exposing ( map)
 import List.Extra
@@ -13,7 +14,7 @@ import String exposing (dropLeft)
 import Url.Builder exposing (string, toQuery, QueryParameter)
 
 import FileManager.Model exposing (..)
-import FileManager.Util exposing (getDirPath, processApiError)
+import FileManager.Util exposing (getDirPath)
 
 get :  String -> Decoder a -> (Result Http.Error a -> msg) -> Cmd msg
 get url decoder handler =
@@ -46,7 +47,7 @@ upload api dir file =
     , headers = []
     , url = api
     , body = Http.multipartBody [ Http.stringPart "destination" dir, Http.filePart "file" file ]
-    , expect = Http.expectWhatever Uploaded
+    , expect = Http.Detailed.expectJson Uploaded decoderUploadResponse
     , timeout = Nothing
     , tracker = Just "upload"
     }
@@ -201,3 +202,9 @@ handleFileUpdate : Result Http.Error a -> Msg
 handleFileUpdate r = case r of
   Ok _ -> EnvMsg (Refresh (Ok ()))
   Err e -> FileUpdate (FileUpdateHttpError e)
+
+decoderUploadResponse : Decoder UploadResponse
+decoderUploadResponse =
+  succeed UploadResponse
+    |> required "success" bool
+    |> optional "error" (maybe Decode.string) Nothing

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Model.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Model.elm
@@ -3,6 +3,7 @@ module FileManager.Model exposing (..)
 import Browser.Dom exposing (Element)
 import File exposing (File)
 import Http exposing (Error)
+import Http.Detailed
 import FileManager.Vec exposing (..)
 import Dict exposing (Dict)
 
@@ -83,7 +84,7 @@ type Msg
   | GotFiles File (List File)
   | Progress Http.Progress
   | Cancel
-  | Uploaded (Result Http.Error ())
+  | Uploaded (Result (Http.Detailed.Error String) (Http.Metadata, UploadResponse))
   | OpenNameDialog DialogAction
   | CloseNameDialog
   | ConfirmNameDialog
@@ -114,3 +115,7 @@ type EnvMsg
 
 type DialogAction = Rename FileMeta String | NewFile String | NewDir String | Edit String String | Closed
 type FileUpdateError = FileValidationError String | FileUpdateHttpError Http.Error
+type alias UploadResponse =
+  { success : Bool
+  , error : Maybe String
+  }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -473,7 +473,8 @@ class Boot extends Loggable {
     LiftRules.ajaxEnd = Full(() => LiftRules.jsArtifacts.hide("ajax-loader").cmd)
     LiftRules.ajaxPostTimeout = 30000
 
-    LiftRules.maxMimeFileSize = 10 * 1024 * 1024
+    // Same as default LiftRules.maxMimeSize
+    LiftRules.maxMimeFileSize = 8 * 1024 * 1024
 
     // We don't want to reload the page
     LiftRules.redirectAsyncOnSessionLoss = false;

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2235,7 +2235,8 @@ object RudderConfigInit {
     }
 
     // Internal APIs
-    lazy val sharedFileApi     = new SharedFilesAPI(restExtractorService, RUDDER_DIR_SHARED_FILES_FOLDER, RUDDER_GIT_ROOT_CONFIG_REPO)
+    lazy val sharedFileApi     =
+      new SharedFilesAPI(restExtractorService, userService, RUDDER_DIR_SHARED_FILES_FOLDER, RUDDER_GIT_ROOT_CONFIG_REPO)
     lazy val eventLogApi       = new EventLogAPI(eventLogRepository, restExtractorService, eventLogDetailsGenerator, personIdentService)
     lazy val asyncWorkflowInfo = new AsyncWorkflowInfo
     lazy val configService: ReadConfigService with UpdateConfigService = {


### PR DESCRIPTION
https://issues.rudder.io/issues/25155

The core of it is about error handling, but most of changes is about bootstraping tests for this API (to also help future zio-json migration), and testing this feature.

Example in Chrome (in Firefox, the client behavior makes it that we receive a browser `NS_ERROR_NET_RESET` error code which maps to a network error in Elm, so we need to also add the message just in case) : 
 
![image](https://github.com/user-attachments/assets/51aab515-2d18-4b7c-b031-cabacf2b0070)

