### PR TITLE
Fixes #25348: Deleting CVE group is possible even if it is a system group

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -86,6 +86,7 @@ import com.normation.rudder.domain.RudderDit
 import com.normation.rudder.domain.archives.ParameterArchiveId
 import com.normation.rudder.domain.archives.RuleArchiveId
 import com.normation.rudder.domain.nodes.*
+import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.domain.properties.AddGlobalParameterDiff
 import com.normation.rudder.domain.properties.DeleteGlobalParameterDiff
@@ -2857,6 +2858,22 @@ class MockNodeGroups(nodesRepo: MockNodes) {
         subCategories = Nil,
         targetInfos = List(groupsTargetInfos.head), // that g0 id:0000f5d3-8c61-4d20-88a7-bb947705ba8
         isSystem = false
+      ),
+      FullNodeGroupCategory(
+        NodeGroupCategoryId("system-category1"),
+        name = "system category 1",
+        description = "a system group category",
+        subCategories = Nil,
+        targetInfos = List.empty,
+        isSystem = true
+      ),
+      FullNodeGroupCategory(
+        NodeGroupCategoryId("category-to-be-deleted"),
+        name = "a category to be deleted",
+        description = "no life",
+        subCategories = Nil,
+        targetInfos = List.empty,
+        isSystem = false
       )
     ),
     List(
@@ -2879,6 +2896,26 @@ class MockNodeGroups(nodesRepo: MockNodes) {
         description = "Liste de l'ensemble de serveurs cassés à réparer",
         isEnabled = true,
         isSystem = false
+      ),
+      FullRuleTargetInfo(
+        FullGroupTarget(
+          GroupTarget(NodeGroupId(NodeGroupUid("all-nodes"))),
+          NodeGroup(
+            NodeGroupId(NodeGroupUid("all-nodes")),
+            name = "All nodes",
+            description = "All nodes known by Rudder (including Rudder policy servers)",
+            properties = Nil,
+            query = None,
+            isDynamic = false,
+            serverList = MockNodes.nodeIds,
+            _isEnabled = true,
+            isSystem = true
+          )
+        ),
+        name = "System groups",
+        description = "system groups that cannot be deleted",
+        isEnabled = true,
+        isSystem = true
       ),
       FullRuleTargetInfo(
         FullOtherTarget(PolicyServerTarget(NodeId("root"))),

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -961,11 +961,16 @@ class GroupApiService2(
     val actor             = RestUtils.getActor(req)
 
     NodeGroupId.parse(sid).toIO.flatMap(readGroup.getNodeGroup).toBox match {
-      case Full((group, _)) =>
-        val deleteGroupDiff = DeleteNodeGroupDiff(group)
-        implicit val cc: ChangeContext =
-          ChangeContext(ModificationId(uuidGen.newUuid), actor, new DateTime(), None, None, qc.nodePerms)
-        createChangeRequestAndAnswer(sid, deleteGroupDiff, group, Some(group), None, actor, req, DGModAction.Delete, apiVersion)
+      case Full((group, cat)) =>
+        val deletionError = s"Could not delete group '${sid}', cause is: system groups cannot be deleted."
+        if (group.isSystem) {
+          toJsonError(Some(sid), deletionError)
+        } else {
+          val deleteGroupDiff = DeleteNodeGroupDiff(group)
+          implicit val cc: ChangeContext =
+            ChangeContext(ModificationId(uuidGen.newUuid), actor, new DateTime(), None, None, qc.nodePerms)
+          createChangeRequestAndAnswer(sid, deleteGroupDiff, group, Some(group), None, actor, req, DGModAction.Delete, apiVersion)
+        }
 
       case eb: EmptyBox =>
         val fail    = eb ?~ (s"Could not find Group ${sid}")
@@ -1032,6 +1037,9 @@ class GroupApiService6(
     for {
       root     <- readGroup.getFullGroupLibrary().toBox
       category <- Box(root.allCategories.get(id)) ?~! s"Cannot find Group category '${id.value}'"
+      _        <- if (category.isSystem)
+                    Failure(s"Could not delete group category '${id.value}', cause is: system categories cannot be deleted.")
+                  else Full(())
       parent   <- Box(root.parentCategories.get(id)) ?~! s"Cannot find Groupl category '${id.value}' parent"
       _        <- writeGroup.delete(id, modId, actor, reason).toBox
     } yield {
@@ -1246,17 +1254,24 @@ class GroupApiService14(
   }
 
   def deleteGroup(id: NodeGroupId, params: DefaultParams, actor: EventActor)(implicit qc: QueryContext): IOResult[JRGroup] = {
-    readGroup.getNodeGroupOpt(id).flatMap {
-      case Some((group, cat)) =>
-        val deleteGroupDiff = DeleteNodeGroupDiff(group)
-        val change          = NodeGroupChangeRequest(DGModAction.Delete, group, Some(cat), Some(group))
-        implicit val cc: ChangeContext =
-          ChangeContext(ModificationId(uuidGen.newUuid), actor, new DateTime(), None, None, qc.nodePerms)
-        createChangeRequest(deleteGroupDiff, change, params, actor).toIO
+    val error = Inconsistency(s"Could not delete group '${id.serialize}', cause is: system groups cannot be deleted.")
+    readGroup
+      .getNodeGroupOpt(id)
+      // error should be thrown when group is system
+      .reject {
+        case Some((group, _)) if group.isSystem => error
+      }
+      .flatMap {
+        case Some((group, cat)) =>
+          val deleteGroupDiff = DeleteNodeGroupDiff(group)
+          val change          = NodeGroupChangeRequest(DGModAction.Delete, group, Some(cat), Some(group))
+          implicit val cc: ChangeContext =
+            ChangeContext(ModificationId(uuidGen.newUuid), actor, new DateTime(), None, None, qc.nodePerms)
+          createChangeRequest(deleteGroupDiff, change, params, actor).toIO
 
-      case None =>
-        JRGroup.empty(id.serialize).succeed
-    }
+        case None =>
+          JRGroup.empty(id.serialize).succeed
+      }
   }
 
   def updateGroup(restGroup: JQGroup, params: DefaultParams, actor: EventActor)(implicit qc: QueryContext): IOResult[JRGroup] = {
@@ -1300,6 +1315,9 @@ class GroupApiService14(
     for {
       root     <- readGroup.getFullGroupLibrary().toBox
       category <- Box(root.allCategories.get(id)) ?~! s"Cannot find Group category '${id.value}'"
+      _        <- if (category.isSystem)
+                    Failure(s"Could not delete group category '${id.value}', cause is: system categories cannot be deleted.")
+                  else Full(())
       parent   <- Box(root.parentCategories.get(id)) ?~! s"Cannot find Groupl category '${id.value}' parent"
       _        <- writeGroup.delete(id, modId, actor, reason).toBox
     } yield {

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
@@ -491,11 +491,38 @@ response:
             "properties":[],
             "target":"group:a-group-for-root-only",
             "system":false
+          },
+          {
+            "id" : "all-nodes",
+            "displayName" : "All nodes",
+            "description" : "All nodes known by Rudder(including Rudder policy servers)",
+            "category" : "GroupRoot",
+            "nodeIds" : [
+              "0",
+              "1",
+              "10",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9"
+            ],
+            "dynamic" : false,
+            "enabled" : true,
+            "groupClass" : [
+              "group_all_nodes",
+              "group_all_nodes"
+            ],
+            "properties" : [],
+            "target" : "group:all-nodes",
+            "system" : true
           }
         ]
       }
     }
----
 description: Create a node group (JSON)
 method: PUT
 url: /api/latest/groups
@@ -1278,6 +1305,47 @@ response:
       }
     }
 ---
+description: Delete a non-existing group with success
+method: DELETE
+url: /api/latest/groups/a-non-existing-group
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "deleteGroup",
+      "id" : "a-non-existing-group",
+      "result" : "success",
+      "data" : {
+        "groups" : [
+          {
+            "id" : "a-non-existing-group",
+            "displayName" : "",
+            "description" : "",
+            "category" : "",
+            "nodeIds" : [],
+            "dynamic" : false,
+            "enabled" : false,
+            "groupClass" : [],
+            "properties" : [],
+            "target" : "",
+            "system" : false
+          }
+        ]
+      }
+    }
+---
+description: Delete a system group with error
+method: DELETE
+url: /api/latest/groups/all-nodes
+response:
+  code: 500
+  content: >-
+    {
+      "action" : "deleteGroup",
+      "result" : "error",
+      "errorDetails" : "Inconsistency: Could not delete group 'all-nodes', cause is: system groups cannot be deleted."
+    }
+---
 description: Create a node group category (JSON)
 method: PUT
 url: /api/latest/groups/categories
@@ -1402,6 +1470,42 @@ response:
             "targets":[]
           }
       }
+    }
+---
+description: Delete a group category
+method: DELETE
+url: /api/latest/groups/categories/category-to-be-deleted
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "deleteGroupCategory",
+      "id" : "category-to-be-deleted",
+      "result" : "success",
+      "data" : {
+        "groupCategories" : {
+          "id" : "category-to-be-deleted",
+          "name" : "a category to be deleted",
+          "description" : "no life",
+          "parent" : "GroupRoot",
+          "categories" : [],
+          "groups" : [],
+          "targets" : []
+        }
+      }
+    }
+---
+description: Delete a system group category
+method: DELETE
+url: /api/latest/groups/categories/system-category1
+response:
+  code: 500
+  content: >-
+    {
+      "action" : "deleteGroupCategory",
+      "id" : "system-category1",
+      "result" : "error",
+      "errorDetails" : "Could not delete Group category 'system-category1' <- Could not delete group category 'system-category1', cause is: system categories cannot be deleted."
     }
 ---
 description: Get minimal info on group category category1

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groupsinternal.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groupsinternal.yml
@@ -63,6 +63,14 @@ response:
               }
             ],
             "targets" : []
+          },
+          {
+            "id" : "system-category1",
+            "name" : "system category1",
+            "description" : "a system group category",
+            "categories" : [],
+            "groups" : [],
+            "targets" : []
           }
         ],
         "groups" : [
@@ -83,15 +91,6 @@ response:
             "dynamic" : false,
             "enabled" : true,
             "target" : "group:6666f5d3-8c61-4d20-88a7-bb947705ba8a"
-          },
-          {
-            "id" : "4444f5d3-8c61-4d20-88a7-bb947705ba8a",
-            "displayName" : "Odd nodes",
-            "description" : "",
-            "category" : "GroupRoot",
-            "dynamic" : false,
-            "enabled" : true,
-            "target" : "group:4444f5d3-8c61-4d20-88a7-bb947705ba8a"
           },
           {
             "id" : "3333f5d3-8c61-4d20-88a7-bb947705ba8a",
@@ -128,6 +127,24 @@ response:
             "dynamic" : true,
             "enabled" : true,
             "target" : "group:a-group-for-root-only"
+          },
+          {
+            "id" : "all-nodes",
+            "displayName" : "All nodes",
+            "description" : "All nodes known by Rudder(including Rudder policy servers)",
+            "category" : "GroupRoot",
+            "dynamic" : false,
+            "enabled" : true,
+            "target" : "group:all-nodes"
+          },
+          {
+            "id" : "4444f5d3-8c61-4d20-88a7-bb947705ba8a",
+            "displayName" : "Odd nodes",
+            "description" : "",
+            "category" : "GroupRoot",
+            "dynamic" : false,
+            "enabled" : true,
+            "target" : "group:4444f5d3-8c61-4d20-88a7-bb947705ba8a"
           },
           {
             "id" : "2222f5d3-8c61-4d20-88a7-bb947705ba8a",

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
@@ -181,11 +181,13 @@ class NodeGroupCategoryForm(
 
   /**
    * Delete button is only enabled is that category
-   * has zero child
+   * has zero child and is not a system category
    */
   private def deleteButton: NodeSeq = {
 
-    if (parentCategory.isDefined && _nodeGroupCategory.children.isEmpty && _nodeGroupCategory.items.isEmpty) {
+    if (
+      parentCategory.isDefined && !_nodeGroupCategory.isSystem && _nodeGroupCategory.children.isEmpty && _nodeGroupCategory.items.isEmpty
+    ) {
       val popupContent = {
         <div class="modal-dialog">
              <div class="modal-content">
@@ -218,7 +220,7 @@ class NodeGroupCategoryForm(
       )
     } else {
       (<span class="btn btn-danger disabled" data-bs-toggle="tooltip" data-bs-placement="bottom" title={
-        "<div><i class='fa fa-exclamation-triangle text-warning'></i>Only empty and non root categories can be deleted.</div>"
+        "<div><i class='fa fa-exclamation-triangle text-warning'></i>Only empty and user created categories can be deleted.</div>"
       }>Delete</span>) ++ Script(JsRaw("""initBsTooltips();""")) // JsRaw ok, const
     }
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/25348

We need to forbid the deletion of system groups and system group categories in the REST API (this PR adds the error handling and API tests for that).
However, in the UI we now want to allow cloning a system group which has a group target and an ID.

For the CVE groups, we now have them as system in https://github.com/Normation/rudder-plugins-private/pull/720, so we now redirect to CVE details page to delete them :
![Peek 2024-08-28 16-04](https://github.com/user-attachments/assets/18aa385c-c2db-4f30-a4dd-f423bedf82c9)


Illustration of the cloning part : 
![Peek 2024-08-28 16-06](https://github.com/user-attachments/assets/d16362f0-f12d-4952-be2e-ba6d0c88f91b)

