### PR TITLE
Fixes #25350: no reports in campaign page even if the node sent the data

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JSONReportsHandler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JSONReportsHandler.scala
@@ -103,8 +103,21 @@ case class JSONReportsAnalyser(reportsRepository: ReportsRepository, propRepo: R
   /*
    * start the handler process. It will execute at provided intervals
    */
-  def start(interval: Duration): ZIO[Any, RudderError, Nothing] = {
-    loop.delay(interval).forever
+  def start(interval: Duration): UIO[Nothing] = {
+    CampaignLogger.info(s"Starting campaign report handler running every ${interval.render}") *>
+    loop
+      .catchAllCause(cause => {
+        cause.failureOrCause match {
+          case Left(err)             =>
+            CampaignLogger.error(s"An error occurred while handling campaign reports, error message: ${err.msg}") *>
+            CampaignLogger.debug(s"Campaign report handling error details: ${err.fullMsg}")
+          case Right(systemErrCause) =>
+            CampaignLogger.error(s"An error occurred within campaign reports handling system, restarting it, details in debug") *>
+            CampaignLogger.debug(s"Campaign report handling system error details: ${systemErrCause.toString}")
+        }
+      })
+      .delay(interval)
+      .forever
   }
 
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/25350

This replaces #5835 

There is no error handling on the `loop` block, so when it has defects (uncaught runtime errors the fiber just terminates).
We need to use `catchAllCause` instead of `catchAll` for that purpose to catch other possible runtime errors, this process is really meant to run forever and retried every 5 seconds if needed.