### PR TITLE
Fixes #25368: Apply policy returns a json error when clicking on trigger agent

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -433,7 +433,7 @@ trait RudderJsonDecoders {
   implicit val deleteModeDecoder:   JsonDecoder[DeleteMode]   =
     JsonDecoder[String].mapOrFail(DeleteMode.withNameInsensitiveEither(_).left.map(_.getMessage()))
   implicit val jqDeleteModeDecoder: JsonDecoder[JQDeleteMode] = DeriveJsonDecoder.gen[JQDeleteMode]
-  implicit val classesDecoder:      JsonDecoder[JQClasses]    = DeriveJsonDecoder.gen[JQClasses]
+  implicit val classesDecoder:      JsonDecoder[JQClasses]    = DeriveJsonDecoder.gen[JQClasses].orElse((_, _) => JQClasses(None))
 
   implicit val nodeIdDecoder:             JsonDecoder[NodeId]                      = JsonDecoder[String].map(NodeId.apply)
   implicit val nodeStatusActionDecoder:   JsonDecoder[JQNodeStatusAction]          =

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestDataExtractorTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestDataExtractorTest.scala
@@ -166,4 +166,17 @@ class RestDataExtractorTest extends Specification {
         (ruleDecoder.decodeJson(json)) must beEqualTo(Right(expected))
     }
   }
+
+  "extract node Classes" >> {
+    val tests = List(
+      ("", JQClasses(None)),
+      ("""{"classes":[]}""", JQClasses(Some(List.empty))),
+      ("""{"classes":["class1"]}""", JQClasses(Some(List("class1"))))
+    )
+
+    Fragments.foreach(tests) {
+      case (json, expected) =>
+        (classesDecoder.decodeJson(json)) must beRight(expected)
+    }
+  }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/25368

The frontend has always posted an empty JSON body, but the current case class model expects at least a JSON object, not a "", so we get the infamous "Unexpected end of input". For simplicity and testability, any non-JSON object input should just be ignored with success.

This was not tested in the API yaml tests because the API response is bytes. We already have error cases for the API yaml tests though, except that the case of an empty string was never supposed to be an error :sweat_smile: 
