### PR TITLE
Fixes #25369: Add an optional visibility attribute on node property 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -63,6 +63,7 @@ import com.normation.rudder.domain.properties.InheritMode
 import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.domain.properties.PatchProperty
 import com.normation.rudder.domain.properties.PropertyProvider
+import com.normation.rudder.domain.properties.Visibility.Hidden
 import com.normation.rudder.domain.queries.NodeReturnType
 import com.normation.rudder.domain.queries.Query
 import com.normation.rudder.domain.queries.QueryReturnType
@@ -368,11 +369,17 @@ object JsonQueryObjects {
 
     def updateGroup(group: NodeGroup, queryParser: CmdbQueryParser): PureResult[NodeGroup] = {
       for {
-        q <- query match {
-               case None    => Right(None)
-               case Some(x) => queryParser.parse(x).toPureResult.map(Some(_))
-             }
-        p <- CompareProperties.updateProperties(group.properties, properties)
+        q        <- query match {
+                      case None    => Right(None)
+                      case Some(x) => queryParser.parse(x).toPureResult.map(Some(_))
+                    }
+        // when properties come from REST, we add hidden properties since the user should not change them.
+        // Still, if the user redefines a hidden property by using the same name, we keep the user one.
+        propNames = properties.getOrElse(Nil).map(_.name).toSet
+        p        <- CompareProperties.updateProperties(
+                      group.properties,
+                      properties.map(_ ::: group.properties.filter(p => p.visibility == Hidden && !propNames.contains(p.name)))
+                    )
       } yield {
         group.patchUsing(
           GroupPatch(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -73,6 +73,7 @@ import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.domain.properties.NodePropertyHierarchy
 import com.normation.rudder.domain.properties.ParentProperty
 import com.normation.rudder.domain.properties.PropertyProvider
+import com.normation.rudder.domain.properties.Visibility.Displayed
 import com.normation.rudder.domain.queries.CriterionLine
 import com.normation.rudder.domain.queries.Query
 import com.normation.rudder.domain.queries.QueryReturnType
@@ -339,7 +340,9 @@ object JsonResponseObjects {
         )
         .withFieldComputed(
           _.properties,
-          levelField("properties")(Chunk.fromIterable(nodeInfo.properties.sortBy(_.name).map(JRProperty.fromNodeProp)))
+          levelField("properties")(
+            Chunk.fromIterable(nodeInfo.properties.filter(_.visibility == Displayed).sortBy(_.name).map(JRProperty.fromNodeProp))
+          )
         )
         .withFieldComputed(_.policyMode, levelField("policyMode")(nodeInfo.policyMode.map(_.name).getOrElse("default")))
         .withFieldComputed(_.timezone, levelField(_)("timezone")(nodeInfo.timezone))
@@ -1476,7 +1479,7 @@ object JsonResponseObjects {
         .withFieldComputed(_.query, _.query.map(JRQuery.fromQuery(_)))
         .withFieldComputed(_.nodeIds, _.serverList.toList.map(_.value).sorted)
         .withFieldComputed(_.groupClass, x => List(x.id.serialize, x.name).map(RuleTarget.toCFEngineClassName _).sorted)
-        .withFieldComputed(_.properties, _.properties.map(JRProperty.fromGroupProp(_)))
+        .withFieldComputed(_.properties, _.properties.filter(_.visibility == Displayed).map(JRProperty.fromGroupProp(_)))
         .withFieldComputed(_.target, x => GroupTarget(x.id).target)
         .withFieldComputed(_.system, _.isSystem)
         .transform

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/MergeNodeProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/MergeNodeProperties.scala
@@ -129,7 +129,7 @@ object GroupProp {
         (
           p.name,
           NodePropertyHierarchy(
-            NodeProperty(p.config).withProvider(INHERITANCE_PROVIDER),
+            NodeProperty(p.config).withProvider(INHERITANCE_PROVIDER).withVisibility(p.visibility),
             ParentProperty.Group(g.groupName, g.groupId, p.value) :: Nil
           ) -> globalInheritMode
         )
@@ -450,6 +450,7 @@ object MergeNodeProperties {
                          v.inheritMode,
                          Some(INHERITANCE_PROVIDER),
                          None,
+                         Some(v.visibility),
                          ConfigParseOptions.defaults().setOriginDescription(s"Global parameter '${n}'")
                        )
                        (n, NodePropertyHierarchy(NodeProperty(config), ParentProperty.Global(v.value) :: Nil) -> v.inheritMode)

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-default-install/properties.d/properties.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-default-install/properties.d/properties.json
@@ -1,3 +1,5 @@
 {
-  "properties":{}
+  "properties":{
+    "hidden":"hiddenValue"
+  }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-one-multipolicy/properties.d/properties.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-one-multipolicy/properties.d/properties.json
@@ -1,3 +1,5 @@
 {
-  "properties":{}
+  "properties":{
+    "hidden":"hiddenValue"
+  }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-two-directives/properties.d/properties.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-two-directives/properties.d/properties.json
@@ -1,3 +1,5 @@
 {
-  "properties":{}
+  "properties":{
+    "hidden":"hiddenValue"
+  }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
@@ -379,7 +379,8 @@ class TestMergeGroupProperties extends Specification {
     def beMerged(configValue: ConfigValue, mode: Option[InheritMode], globalProperty: Option[ConfigValue]) = {
       (haveLength[List[NodePropertyHierarchy]](1)) and
       (beEqualTo(
-        GenericProperty.toConfig("foo", GitVersion.DEFAULT_REV, configValue, mode, Some(PropertyProvider("inherited")), None)
+        GenericProperty
+          .toConfig("foo", GitVersion.DEFAULT_REV, configValue, mode, Some(PropertyProvider("inherited")), None, None)
       ) ^^ { (l: List[NodePropertyHierarchy]) => l.head.prop.config }) and
       (beEqualTo(globalProperty match {
         case Some(prop) => List(c, p2, p1).toH3("foo", prop).hierarchy

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -54,6 +54,7 @@ import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.properties.NodePropertyHierarchy
+import com.normation.rudder.domain.properties.Visibility.Displayed
 import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.NodeFactRepository
 import com.normation.rudder.facts.nodes.QueryContext
@@ -1376,20 +1377,21 @@ class GroupApiService14(
                                 s"Inherited properties for node '${nodeFact.id.value}' were not found while it's contained into group '${groupId.serialize}''"
                               )
                               .map { childProperties =>
-                                parentProperties.map { p =>
-                                  val matchingChildProperties = childProperties.collect {
-                                    case cp if cp.prop.name == p.prop.name => cp.hierarchy
-                                  }.toList
+                                parentProperties.collect {
+                                  case p if p.prop.visibility == Displayed =>
+                                    val matchingChildProperties = childProperties.collect {
+                                      case cp if cp.prop.name == p.prop.name => cp.hierarchy
+                                    }.toList
 
-                                  val hasConflicts = MergeNodeProperties
-                                    .checkValueTypes(matchingChildProperties.map(NodePropertyHierarchy(p.prop, _)))
-                                    .isLeft
+                                    val hasConflicts = MergeNodeProperties
+                                      .checkValueTypes(matchingChildProperties.map(NodePropertyHierarchy(p.prop, _)))
+                                      .isLeft
 
-                                  (
-                                    p,
-                                    matchingChildProperties.flatten,
-                                    hasConflicts
-                                  )
+                                    (
+                                      p,
+                                      matchingChildProperties.flatten,
+                                      hasConflicts
+                                    )
                                 }
                               }
                           }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
@@ -481,7 +481,9 @@ class ParameterApiService14(
   }
 
   def listParameters(): IOResult[Seq[JRGlobalParameter]] = {
-    readParameter.getAllGlobalParameters().map(_.sortBy(_.name).map(JRGlobalParameter.fromGlobalParameter(_, None)))
+    readParameter
+      .getAllGlobalParameters()
+      .map(_.filter(_.visibility == Visibility.Displayed).sortBy(_.name).map(JRGlobalParameter.fromGlobalParameter(_, None)))
   }
 
   def parameterDetails(id: String): IOResult[JRGlobalParameter] = {

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
@@ -765,7 +765,12 @@ response:
                 "nodeKind" : "node"
               }
             ],
-            "properties" : [],
+            "properties" : [
+              {
+                "name" : "simpleString",
+                "value" : "string value"
+              }
+            ],
             "policyMode" : "enforce",
             "timezone" : {
               "name" : "UTC",

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_parameters.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_parameters.yml
@@ -20,6 +20,27 @@ response:
       }
     }
 ---
+description: Get a hidden parameter directly (absent from list)
+method: GET
+url: /api/latest/parameters/hiddenParam
+response:
+  code: 200
+  content: >-
+    {
+      "action":"parameterDetails",
+      "id":"hiddenParam",
+      "result":"success",
+      "data":{
+        "parameters":[
+          {
+            "id":"hiddenParam",
+            "value":"hidden value",
+            "description":"a hidden param"
+          }
+        ]
+      }
+    }
+---
 description: Get a missing parameter
 method: GET
 url: /api/latest/parameters/xxxxxxxx
@@ -33,7 +54,7 @@ response:
       "errorDetails":"Inconsistency: Could not find Parameter xxxxxxxx"
     }
 ---
-description: List parameters
+description: List parameters (hiddenParam is not listed)
 method: GET
 url: /api/latest/parameters
 response:

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
@@ -54,6 +54,7 @@ import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
+import com.normation.rudder.domain.properties.Visibility.Displayed
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.git.ZipUtils
 import com.normation.rudder.ncf.ResourceFile
@@ -572,7 +573,8 @@ class ArchiveApiTest extends Specification with AfterAll with Loggable {
       val (group, _) = restTestSetUp.mockNodeGroups.groupsRepo
         .getNodeGroup(NodeGroupId(NodeGroupUid("0000f5d3-8c61-4d20-88a7-bb947705ba8a")))
         .runNow
-      group.copy(description = "a new description")
+      // hidden properties are not copied in archive
+      group.copy(description = "a new description").copy(properties = group.properties.filter(_.visibility == Displayed))
     }
     val rule1 = restTestSetUp.mockRules.ruleRepo
       .getOpt(RuleId(RuleUid("rule1")))


### PR DESCRIPTION
https://issues.rudder.io/issues/25369

This PR add a new `visibility` attribute on properties (global, group, node) that can be either `hidden` or `displayed` (default value). 
That attribute direct the fact that a property is returned or not in API/UI/Archive. Even if `hidden`, a property will still be used for policy generation and transferred to node `properties.d/prorperties.json` file. 

That attribute is inherited, so that if the `benchmark_rsc01` property is defined at global level as `hidden`, then it is also `hidden` when inherited in groups or nodes. 

From a code point of view, it's just one more key in the config value for a properties. 
Contrary to other cases, I choose to never have the default value (`displayed`) stored. The semantic is "if the `visibility` key is not here, then its the default value". So when we update, we actually remove the property. It looks cleaner, perhaps we could do that with other property with a clear default value (provider for ex). 

The other change in code are rather simple:
- most of the PR is about testing the different case of filtering own or inherited properties,
- the actual changes for GET are adding a `filter(visibility == Displayed)` when we transform group/node properties to json for API
- for PUT we put back group/node hidden properties in addition to user provided one. If the user use a property with the same name than a hidden one, then the user property overrides the hidden one. 
