### PR TITLE
Fixes #25377: Upgrade Rudder core to lift4 and spring 6

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -422,6 +422,7 @@ limitations under the License.
     <rudder-major-version>8.2</rudder-major-version>
     <rudder-version>8.2.0~alpha2-SNAPSHOT</rudder-version>
 
+    <servlet-version>5.0.0</servlet-version>
     <scala-version>2.13.12</scala-version>
     <scala-binary-version>2.13</scala-binary-version>
     <!-- lift force us to remain with 1.3.0 because of
@@ -430,7 +431,7 @@ limitations under the License.
          upgrade without much care and correcting how we parse XML doc (xml
          parser option - see https://github.com/scala/scala-xml/releases/tag/v2.1.0 -->
     <scala-xml-version>1.3.0</scala-xml-version>
-    <lift-version>3.5.0</lift-version>
+    <lift-version>4.0.0-alpha01</lift-version>
     <slf4j-version>2.0.13</slf4j-version>
     <logback-version>1.5.6</logback-version>
     <jodatime-version>2.12.7</jodatime-version>
@@ -439,11 +440,11 @@ limitations under the License.
     <commons-lang-version>3.15.0</commons-lang-version>
     <commons-text-version>1.12.0</commons-text-version>
     <commons-codec-version>1.17.0</commons-codec-version> <!-- can't update to 1.17.1 because of md5 requiring a non-empty salt prefix -->
-    <commons-fileupload>1.5</commons-fileupload>
+    <commons-fileupload>2.0.0-M2</commons-fileupload>
     <commons-csv-version>1.11.0</commons-csv-version>
     <jgit-version>6.10.0.202406032230-r</jgit-version>
-    <spring-version>5.3.37</spring-version>
-    <spring-security-version>5.8.13</spring-security-version>
+    <spring-version>6.1.12</spring-version>
+    <spring-security-version>6.3.3</spring-security-version>
     <cglib-version>3.3.0</cglib-version>
     <asm-version>9.7</asm-version>
     <!-- Level of Java compatibility, here 1.8+ -->
@@ -524,6 +525,12 @@ limitations under the License.
         We need to enforce version of all components of scala, else maven takes the oldest from transitive dep.
         It seems to be because scala has them "compatible"
        -->
+      <dependency>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>${servlet-version}</version>
+        <scope>provided</scope>
+      </dependency>
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-library</artifactId>

--- a/webapp/sources/rudder/rudder-rest/pom.xml
+++ b/webapp/sources/rudder/rudder-rest/pom.xml
@@ -110,15 +110,13 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <version>${rudder-version}</version>
     </dependency>
     <dependency>
-      <groupId>commons-fileupload</groupId>
-      <artifactId>commons-fileupload</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-fileupload2-jakarta-servlet5</artifactId>
       <version>${commons-fileupload}</version>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
-      <scope>provided</scope>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
 
     <!-- it seems to not be resolved, don't know why - lift-json -->

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/SharedFilesAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/SharedFilesAPI.scala
@@ -67,7 +67,7 @@ import net.liftweb.json.JsonAST.JNull
 import net.liftweb.json.JsonAST.JObject
 import net.liftweb.json.JsonAST.JString
 import net.liftweb.json.JsonAST.JValue
-import org.apache.commons.fileupload.FileUploadBase.SizeLimitExceededException
+import org.apache.commons.fileupload2.core.FileUploadSizeException
 import org.joda.time.DateTime
 import org.joda.time.Instant
 import scala.jdk.CollectionConverters.*
@@ -482,9 +482,9 @@ class SharedFilesAPI(
         }.recover {
           // Lift uses apache file upload under the hood and this file exception can happen because of LiftRules.maxMimeSize.
           // The value should be approximately matching MAX_FILE_SIZE, if it is not the case then change either of them.
-          case ex: SizeLimitExceededException => {
+          case ex: FileUploadSizeException => {
             // This is rounded to MB which is the order of magnitude of file upload limit
-            val allowedSizeMb: Long = ex.getPermittedSize / 1024 / 1024
+            val allowedSizeMb: Long = ex.getPermitted / 1024 / 1024
             errorResponse(s"File exceeds the maximum upload size of ${allowedSizeMb}MB", code = 413)
           }
         }

--- a/webapp/sources/rudder/rudder-web/pom.xml
+++ b/webapp/sources/rudder/rudder-web/pom.xml
@@ -220,10 +220,8 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
-      <scope>provided</scope>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
 
     <dependency>

--- a/webapp/sources/rudder/rudder-web/src/main/resources/applicationContext-security.xml
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/applicationContext-security.xml
@@ -75,17 +75,17 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
         <session-management session-fixation-protection="migrateSession" />
     </http>
 
-    <http use-expressions="true" disable-url-rewriting="true" name="mainHttpSecurityFilters">
+    <http use-expressions="true" disable-url-rewriting="true" name="mainHttpSecurityFilters" security-context-explicit-save="false">
         <headers>
             <xss-protection disabled="true"/>
             <frame-options disabled="true"/>
         </headers>
 
         <csrf disabled="true"/>
-        <session-management session-fixation-protection="migrateSession">
+        <session-management session-fixation-protection="migrateSession" authentication-strategy-explicit-invocation="false">
           <!--
             One can control the maximum concurrent session to have in parallel.
-            Unfortunatly, it seems to be unbeliebely hard to make it a configurable property.
+            Unfortunately, it seems to be unbelievably hard to make it a configurable property.
             One can add the control if wanted by uncommenting the line below.
           -->
           <!--

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -52,14 +52,14 @@ import com.normation.zio.*
 import com.softwaremill.quicklens.*
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigException
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.FilterConfig
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import java.util.Collection
-import javax.servlet.Filter
-import javax.servlet.FilterChain
-import javax.servlet.FilterConfig
-import javax.servlet.ServletRequest
-import javax.servlet.ServletResponse
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
 import net.liftweb.common.*
 import org.joda.time.DateTime
 import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer
@@ -674,7 +674,7 @@ class AuthBackendProvidersManager() extends DynamicRudderProviderManager {
 
 /**
  * Our rest filter, we just look for X-API-Token and
- * ckeck if a token exists with that value.
+ * check if a token exists with that value.
  * For Account with type "user", we need to also check
  * for the user and update REST token ACL with that knowledge
  */
@@ -684,8 +684,8 @@ class RestAuthenticationFilter(
     systemApiAcl:       ApiAuthorization,
     apiTokenHeaderName: String = "X-API-Token"
 ) extends Filter with Loggable {
-  def destroy(): Unit = {}
-  def init(config: FilterConfig): Unit = {}
+  override def destroy(): Unit = {}
+  override def init(config: FilterConfig): Unit = {}
 
   private val not_authenticated_api = List(
     "/api/status"

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/BootstrapChecks.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/BootstrapChecks.scala
@@ -38,7 +38,7 @@
 package bootstrap.liftweb
 
 import com.normation.NamedZioLogger
-import javax.servlet.UnavailableException
+import jakarta.servlet.UnavailableException
 import org.joda.time.Duration
 import org.joda.time.format.PeriodFormatter
 import org.joda.time.format.PeriodFormatterBuilder

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/LiftInitContextListener.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/LiftInitContextListener.scala
@@ -42,9 +42,9 @@ import com.normation.errors.SystemError
 import com.normation.rudder.domain.logger.ApplicationLogger
 import com.normation.zio.*
 import com.typesafe.config.ConfigException
+import jakarta.servlet.ServletContextEvent
 import java.io.File
 import java.net.URL
-import javax.servlet.ServletContextEvent
 import net.liftweb.common.*
 import org.springframework.core.io.ClassPathResource as CPResource
 import org.springframework.core.io.FileSystemResource as FSResource
@@ -86,7 +86,7 @@ class LiftInitContextListener extends ContextLoaderListener {
             config.getPath
           )
         )
-        throw new javax.servlet.UnavailableException("Configuration file not found: %s".format(config.getPath))
+        throw new jakarta.servlet.UnavailableException("Configuration file not found: %s".format(config.getPath))
       }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/LiftSpringSecurityFilter.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/LiftSpringSecurityFilter.scala
@@ -39,20 +39,21 @@ package bootstrap.liftweb
 
 import com.normation.rudder.domain.logger.ApplicationLogger
 import com.normation.spring.SecurityFilter
-import javax.servlet.FilterChain
-import javax.servlet.ServletRequest
-import javax.servlet.ServletResponse
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpHeaders
 import org.springframework.security.web.firewall.RequestRejectedException
+import org.springframework.web.context.WebApplicationContext
 
 /**
  * Our Spring security filter, only redefined to override the way
  * the Spring Application context is accessed
  */
 class LiftSpringSecurityFilter extends SecurityFilter {
-  override def webApplicationContext = LiftSpringApplicationContext.springContext
+  override def webApplicationContext: WebApplicationContext = LiftSpringApplicationContext.springContext
 
   override def doFilter(request: ServletRequest, response: ServletResponse, filterChain: FilterChain): Unit = {
     try {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RestSecureAuthenticationFilter.java
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RestSecureAuthenticationFilter.java
@@ -1,8 +1,8 @@
 package bootstrap.liftweb;
 
-import javax.servlet.*;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -307,7 +307,7 @@ object RudderProperties {
         ApplicationLogger.error(
           s"Can not find configuration file specified by JVM property '${JVM_CONFIG_FILE_KEY}': '${config.getPath}' ; abort"
         )
-        throw new javax.servlet.UnavailableException(s"Configuration file not found: ${config.getPath}")
+        throw new jakarta.servlet.UnavailableException(s"Configuration file not found: ${config.getPath}")
       }
   }
 
@@ -1522,7 +1522,7 @@ object RudderConfigInit {
         case Left(err)       =>
           ApplicationLogger.error(err.fullMsg)
           // make the application not available
-          throw new javax.servlet.UnavailableException(s"Error when trying to parse Rudder users file, aborting.")
+          throw new jakarta.servlet.UnavailableException(s"Error when trying to parse Rudder users file, aborting.")
       }
     }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/UserSessionInvalidationFilter.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/UserSessionInvalidationFilter.scala
@@ -46,11 +46,11 @@ import com.normation.rudder.users.UserRepository
 import com.normation.rudder.users.UserStatus
 import com.normation.rudder.users.ValidatedUserList
 import com.normation.zio.UnsafeRun
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import java.io.IOException
-import javax.servlet.FilterChain
-import javax.servlet.ServletException
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.filter.OncePerRequestFilter
 import zio.*
@@ -58,7 +58,7 @@ import zio.syntax.*
 
 /**
  * A filter that invalidates sessions of non-active users.
- * It has a local cache of user statuses that are updated from the actual database values, 
+ * It has a local cache of user statuses that are updated from the actual database values,
  * only when the users file is reloaded (using the RudderAuthorizationFileReloadCallback).
  */
 class UserSessionInvalidationFilter(userRepository: UserRepository, userDetailListProvider: FileUserDetailListProvider)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/action/LoadNodeComplianceCache.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/action/LoadNodeComplianceCache.scala
@@ -46,7 +46,7 @@ import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.services.reports.CacheComplianceQueueAction.ExpectedReportAction
 import com.normation.rudder.services.reports.CacheExpectedReportAction.InsertNodeInCache
 import com.normation.rudder.services.reports.ComputeNodeStatusReportService
-import javax.servlet.UnavailableException
+import jakarta.servlet.UnavailableException
 import net.liftweb.common.EmptyBox
 
 /**

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/consistency/CheckConnections.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/consistency/CheckConnections.scala
@@ -43,7 +43,7 @@ import com.normation.box.*
 import com.normation.ldap.sdk.LDAPConnectionProvider
 import com.normation.ldap.sdk.RwLDAPConnection
 import com.normation.rudder.repository.jdbc.RudderDatasourceProvider
-import javax.servlet.UnavailableException
+import jakarta.servlet.UnavailableException
 import net.liftweb.common.*
 
 /**

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/consistency/CheckDIT.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/consistency/CheckDIT.scala
@@ -47,7 +47,7 @@ import com.normation.ldap.sdk.RwLDAPConnection
 import com.normation.rudder.domain.RudderDit
 import com.normation.zio.*
 import com.unboundid.ldap.sdk.DN
-import javax.servlet.UnavailableException
+import jakarta.servlet.UnavailableException
 import net.liftweb.common.*
 import zio.*
 import zio.syntax.*

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/consistency/CloseOpenUserSessions.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/consistency/CloseOpenUserSessions.scala
@@ -41,7 +41,7 @@ import bootstrap.liftweb.BootstrapChecks
 import bootstrap.liftweb.BootstrapLogger
 import com.normation.rudder.users.*
 import com.normation.zio.*
-import javax.servlet.UnavailableException
+import jakarta.servlet.UnavailableException
 import org.joda.time.DateTime
 
 /**


### PR DESCRIPTION
https://issues.rudder.io/issues/25377

The update is rather simple once you know what must be done for Spring:

For the servlet part: 
- update the version of lift, spring to the new ones
- use the dependency to `jakarta` servlet 
- change all occurence of `javax.servlet` to `jakarta.servlet`
- update the dependency for commons fileupload to the version 2 for jakarta servlet5 and adapt corresponding namespaces

For Spring Security changes related to the migration from 5 to 6
- enable the SecurityContextPersistenceFilter with `authentication-strategy-explicit-invocation="false"`
- disable the need to explicitly persist in code the security context with `security-context-explicit-save="false"`

It's in draft because we will need a release of lift, in our repos to check this one. 
