### PR TITLE
Fixes #25383: Worst report takes the worst component instead of block

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/yaml/YamlTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/yaml/YamlTechnique.scala
@@ -244,12 +244,13 @@ object YamlTechniqueSerializer {
     def toReporting(logic: ReportingLogic): Reporting = {
       import ReportingLogic.*
       logic match {
-        case FocusReport(component)                                           =>
+        case FocusReport(component)                                                                  =>
           Reporting(
             FocusReport.key,
             Some(component)
           )
-        case WeightedReport | WorstReportWeightedOne | WorstReportWeightedSum => Reporting(logic.value, None)
+        case WeightedReport | WorstReportByPercent | WorstReportWeightedOne | WorstReportWeightedSum =>
+          Reporting(logic.value, None)
       }
     }
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
@@ -91,7 +91,7 @@ type alias Technique =
 type MethodElem = Call (Maybe CallId) MethodCall | Block (Maybe CallId) MethodBlock
 
 
-type WorstReportKind = WorstReportWeightedOne | WorstReportWeightedSum
+type WorstReportKind = WorstReportWeightedOne | WorstReportWeightedSum | WorstReportByPercent
 
 type ReportingLogic = WorstReport WorstReportKind | WeightedReport | FocusReport String
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/JsonDecoder.elm
@@ -65,6 +65,7 @@ decodeCompositionRule =
         case v of
           "worst-case-weighted-sum" -> succeed (WorstReport WorstReportWeightedSum)
           "worst-case-weighted-one" -> succeed (WorstReport WorstReportWeightedOne)
+          "worst-case-percent"      -> succeed (WorstReport WorstReportByPercent)
           "weighted"                -> succeed WeightedReport
           "focus"                   -> succeed (FocusReport "")
           value                     ->

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/JsonEncoder.elm
@@ -139,6 +139,8 @@ encodeCompositionRule composition =
        string "worst-case-weighted-sum"
     (WorstReport WorstReportWeightedOne) ->
        string "worst-case-weighted-one"
+    (WorstReport WorstReportByPercent) ->
+       string "worst-case-percent"
     WeightedReport ->
       string "weighted"
     FocusReport value ->

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewBlock.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewBlock.elm
@@ -271,12 +271,13 @@ showBlockTab model parentId block uiInfo techniqueUi =
         labelWorst = \weight -> case weight of
                          WorstReportWeightedOne -> "Use a weight of '1' for component"
                          WorstReportWeightedSum -> "Use sum of sub-components for weight"
+                         WorstReportByPercent -> "Use the compliance percent of sub-components"
 
         liWorst = \weight -> element "li"
                     |> addActionStopAndPrevent ("click", MethodCallModified (Block parentId {block | reportingLogic = (WorstReport weight) }))
                     |> appendChild (element "a" |> addClass "dropdown-item" |> appendText (labelWorst weight))
 
-        availableWorst = List.map liWorst [ WorstReportWeightedOne, WorstReportWeightedSum]
+        availableWorst = List.map liWorst [ WorstReportWeightedOne, WorstReportWeightedSum, WorstReportByPercent]
       in
          element "div"
            |> appendChildList


### PR DESCRIPTION
https://issues.rudder.io/issues/25383

Adding a new worst reporting logic type "by percent" :
![image](https://github.com/user-attachments/assets/e1997d83-4d0e-4876-8d9f-e8d1983dfc96)

The reporting computation that results takes the worst with respect to computed compliance (using default compliance precision) : 
![Screenshot from 2024-09-05 16-44-58](https://github.com/user-attachments/assets/7e916827-8caf-48ff-8aa4-bdb3ed6694d2)
