### PR TITLE
Fixes #25371: Incorrect display of compliance in newly created rules

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabContent.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabContent.elm
@@ -83,7 +83,7 @@ informationTab model details =
       case getRuleCompliance model rule.id of
        Just co ->
           buildComplianceBar defaultComplianceFilter co.complianceDetails
-       Nothing -> text "No report"
+       Nothing -> div [class "text-muted"] [ text "No data available" ]
     rightCol =
       if isNewRule then
         div [class "callout-fade callout-info"]


### PR DESCRIPTION
https://issues.rudder.io/issues/25371

The display is identical to the other rules which have no compliance.

![no-compliance](https://github.com/user-attachments/assets/50b01b0f-c4e4-4ed8-a828-5784175bc01d)
