### PR TITLE
Fixes #25351: Windows KB don't show up in the inventory anymore

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-repository/src/test/resources/ldap-data/inventory-sample-data.ldif
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/test/resources/ldap-data/inventory-sample-data.ldif
@@ -27,6 +27,13 @@ cn: Software 3
 softwareVersion: 3.0-rc
 description: Third software, unreferenced
 
+dn: softwareId=soft3,ou=Software,ou=Inventories,cn=rudder-configuration
+softwareId: soft3
+objectClass: software
+objectClass: top
+cn: Software 4
+description: Fourth software, without version
+
 ###################################################################################################
 # Nodes #
 ###################################################################################################
@@ -199,6 +206,7 @@ nodeId: node7
 container: machineId=machine2,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
 cn: has everything
 software: softwareId=soft0,ou=Software,ou=Inventories,cn=rudder-configuration
+software: softwareId=soft3,ou=Software,ou=Inventories,cn=rudder-configuration
 localAdministratorAccountName: root
 agentName: {"agentType":"cfengine-community","version":"7.0.0","securityToken":{"value":"-----BEGIN CERTIFICATE-----\nMIIGOzCCBCOgAwIBAgIUFuBN6KMpOKFR61wrZInttrkbrjUwDQYJKoZIhvcNAQEL\nBQAwZTEtMCsGA1UEAwwkZjkxYjc1MTMtZTYyYi00Y2ZhLTg3NDItMzFiZDA5ZjZh\nYTRlMTQwMgYKCZImiZPyLGQBAQwkZjkxYjc1MTMtZTYyYi00Y2ZhLTg3NDItMzFi\nZDA5ZjZhYTRlMB4XDTIyMDEyNjE2MjI1MloXDTMyMDEyNDE2MjI1MlowZTEtMCsG\nA1UEAwwkZjkxYjc1MTMtZTYyYi00Y2ZhLTg3NDItMzFiZDA5ZjZhYTRlMTQwMgYK\nCZImiZPyLGQBAQwkZjkxYjc1MTMtZTYyYi00Y2ZhLTg3NDItMzFiZDA5ZjZhYTRl\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA21YjUjBICqWVny8QHxSn\nknzclapqqe+ghyj+kayk7tZDiPTfLkOLmEIipofBMRIBDMdVy4rRLKi+BY5L9h+T\nC70ycM+iaf2EC/UcNXBjg9B6T8O9TU8MS8E+0WjUUCLBbg4fkMaGZJaQfXq0GQwm\nGnLQ4BgOpnpgv5bgPtgMsUz5ZIVusmbkR2TUjLP7kB5gdhitWfHR/xhsMoTQy+nN\nZmK/HF+CcSeeUCXcPtB2qksYMC7zQsqgTRaK9pBqJjWhpI+jcIBoMDfdU+XZjK6K\nh/5d3DUXsIWplCdd7a3Kj0CjK7VaNOp57AAhylUOUVmh3p9/LeFVbYHkRkth1HXF\n+ULBZ2QinuTOqyaTKgYTaxgqlQWH5WpH6ws2ZxFwgnWZ9Iuo4lIiLAiC34keDSGz\nYU/MRv8wckFeETaHRDkLvKu0mVjw1X/+nJyFRmb81DAvqY+aiIOjG6fbnPpzwKD+\nQnqPXzwCAJPn38OeL/1fdGJoaRSyAZFYY1a/0HdwyKH+MiTFA/JHBDM7ORS45iFq\ndeZld+lbk76jFiv6ahA4DCYcGYBPVt+UV3FraDpJOL5134NSuQZLsrwFHAYGa3Et\nrTv/6bkFZC6P8MIrQh2JjqC2adfzc+vBhULz6zpr+G6/GvGnKKhzHSwI7I4JqdSB\n8fa+rJ4+uoVN5jufE0FJpdUCAwEAAaOB4jCB3zAMBgNVHRMEBTADAQH/MB0GA1Ud\nDgQWBBTUV+TmtrbuWwjAIX8bcX+JtP01GTCBogYDVR0jBIGaMIGXgBTUV+Tmtrbu\nWwjAIX8bcX+JtP01GaFppGcwZTEtMCsGA1UEAwwkZjkxYjc1MTMtZTYyYi00Y2Zh\nLTg3NDItMzFiZDA5ZjZhYTRlMTQwMgYKCZImiZPyLGQBAQwkZjkxYjc1MTMtZTYy\nYi00Y2ZhLTg3NDItMzFiZDA5ZjZhYTRlghQW4E3ooyk4oVHrXCtkie22uRuuNTAL\nBgNVHQ8EBAMCArwwDQYJKoZIhvcNAQELBQADggIBACTTu5U8ZXsxAnhtcznbQGMm\nvHzDk6HXSNG1OvLFi2kUm1J2Q4+Tnw9QLJ+J5NnpO9/Dz8URPFZuEtuvt3gGoExJ\n3rkx14+OxZeQML7R555eotv8XZT+W66N2nuwU6TRTPRYCuqcMukE++FsnG3sr3Pf\npJEOwyUWGLtQj08SnLrkzc/rXfPxNWBOd22yf6sYxI/uAddi/qfqqdhRXAf2D/5r\nEjbdoJQTgCz8EznTfm7o0hrGvbkeGJF7rUNZQVK3ncEOt4uQOX/ltN4PgAfWyw+0\n9S5pw/LG4PAHv8HJzIwDijCYtPtRjM9xblPkZ6yV+QaU3ZxmfX2PU/Jutah/OkI3\nIFzrjVsjYJfO75ZgruSdBmnqvNM/sxsw6cW2jZE7cjv5o4m28RzdK56zTpupLyKz\nYBeze56EtqsWxr+Ee5wKC6oS4CUp/QdkFCnAPUiYtkCuMfivrBVTAs3EyngyEPRI\nA4+qoGBfkWPTYgY71b6Emt5wc7PpMpfsBTKQDRche87zx7huKWdjFrKapKAkZ3Hw\napuy6Liu4M7R2BzoMMOH7/azAqtuRJAHcci8Y5K7SRnRnDnqQekwLPTQS0dTxPGt\nWmmC/QN1NPGHnEgkyQ+ePk0k5zUMHuIQDJIodpQh5JRW36qUxoyYpaWUmzzC56yT\nmMqkcelZGWpzrFO0mijZ\n-----END CERTIFICATE-----","type":"certificate"},"capabilities":["acl","cfengine","curl","http_reporting","jq","xml","yaml"]}
 policyServerId:root-policy-server

--- a/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestInventory.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestInventory.scala
@@ -454,14 +454,14 @@ class TestInventory extends Specification {
   }
 
   "Softwares" should {
-    "Find 2 software referenced by nodes with the repository" in {
+    "Find 3 software referenced by nodes with the repository" in {
       val softwares = readOnlySoftware.getSoftwaresForAllNodes().testRun
-      softwares.map(_.size) must beRight(2)
+      softwares.map(_.size) must beRight(3)
     }
 
-    "Find 3 software in ou=software with the repository" in {
+    "Find 4 software in ou=software with the repository" in {
       val softwares = readOnlySoftware.getAllSoftwareIds().testRun
-      softwares.map(_.size) must beRight(3)
+      softwares.map(_.size) must beRight(4)
     }
 
     "Purge one unreferenced software with the SoftwareService" in {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
@@ -165,7 +165,7 @@ final case class VolumeGroup(
 
 final case class SoftwareFact(
     name:               String,
-    version:            SVersion,
+    version:            Option[SVersion],
     arch:               Option[String] = None,
     size:               Option[Long] = None,
     from:               Option[String] = None,
@@ -187,7 +187,7 @@ object SoftwareFact {
       SoftwareUuid(""), // here, we don't know the uuid. We need a way to mark that it's not valid and don't risk using a bad one
       Some(sf.name),
       None,
-      Some(sf.version),
+      sf.version,
       sf.publisher.map(SoftwareEditor.apply),
       None,
       sf.licenseName.map(l => License(l, sf.licenseDescription, sf.productId, sf.productKey, sf.oem, sf.expirationDate)),
@@ -442,10 +442,9 @@ object NodeFact {
   implicit class SoftwareToFact(s: Software)                         {
     def toFact: Option[SoftwareFact] = for {
       n <- s.name
-      v <- s.version
     } yield SoftwareFact(
       n,
-      v,
+      s.version,
       None,
       None,
       None,

--- a/webapp/sources/rudder/rudder-core/src/test/resources/ldap-data/inventory-sample-data.ldif
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/ldap-data/inventory-sample-data.ldif
@@ -219,6 +219,13 @@ cn: Software 1
 softwareVersion: 2.0-rc
 description: Second software
 
+dn: softwareId=soft3,ou=Software,ou=Inventories,cn=rudder-configuration
+softwareId: soft3
+objectClass: software
+objectClass: top
+cn: Software 4
+description: Fourth software, without version
+
 ###################################################################################################
 # Nodes #
 ###################################################################################################
@@ -424,6 +431,7 @@ nodeId: node7
 container: machineId=machine3,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration
 cn: has everything
 software: softwareId=soft0,ou=Software,ou=Inventories,cn=rudder-configuration
+software: softwareId=soft3,ou=Software,ou=Inventories,cn=rudder-configuration
 localAdministratorAccountName: root
 agentName: {"agentType":"cfengine-community","version":"8.0.0","securityToken":{"value":"-----BEGIN CERTIFICATE-----\nMIIFTjCCAzagAwIBAgIUfa0+S+CyJahRzuwNNOFLNQQjIH8wDQYJKoZIhvcNAQEL\nBQAwFzEVMBMGCgmSJomT8ixkAQEMBW5vZGU3MB4XDTI0MDMwMTExMDIxM1oXDTM0\nMDIyNzExMDIxM1owFzEVMBMGCgmSJomT8ixkAQEMBW5vZGU3MIICIjANBgkqhkiG\n9w0BAQEFAAOCAg8AMIICCgKCAgEAsmBUYI1A5vqkOTCW24m/mQhBaRu4WaAUXDAr\nArdIAAMN0KyHhEXP1/X32Flw90E0VjtUH4P+DYLBozXYWhJrUxdWLyn3TRSbv3Kr\npXoCWhMhMp8OK2s/mG+rfiMpTXIwaMhPnBaJFNV3c+bkijGAMHtFjl3+leXJvNZ7\nw3bIg4cA3e77kz7EWMyqxOUvvLMyY6wpd03ahe/By+iLgtOkgUwl9hMqMU8tJeaz\nNIeUporsHk5rrk8bSf6Mxxdknm43Sk6oflnueNCIUFdd4rS2JLieMugsTh8n/oH+\nk29ZyirE3ikhftmZ3vY8GQ3IcIzaXwiAOGnCKcze79zVx5jmOTGSZitGZaU/cZc6\nLjzEp+ZDmE8caVIksiA+hIlaZeBXNHB+YRv/gV1Rbt7kS1am+XUZJSfVFf+99YqE\nlZ5p0hqJsczkBb2RuMxWxxsWO3pesPUNCuL/yaeggTIp7eK06tQWi1EfXr40ctrf\noimbzMAKNBpRKWruL7652SlF75Usaq+PaPi1TtqYQjLRZmbpr+IR4uMeKnEMIZPw\n3dLDKBV6d71XkTAalCmcJU+fgYrRmgz1dEnaZDIXY+f+fYR15hsFpDrZ0avHgkzJ\nca/nT/rKeX7136BttxVSbZaTU9hnmjAvl+v0BF+JUWPQ3VPTcrmyUNAICt8xdVae\nuo1tsvkCAwEAAaOBkTCBjjAMBgNVHRMEBTADAQH/MB0GA1UdDgQWBBSRG0uHQRIA\ngl91YqzSjaeaw+F7PDBSBgNVHSMESzBJgBSRG0uHQRIAgl91YqzSjaeaw+F7PKEb\npBkwFzEVMBMGCgmSJomT8ixkAQEMBW5vZGU3ghR9rT5L4LIlqFHO7A004Us1BCMg\nfzALBgNVHQ8EBAMCArwwDQYJKoZIhvcNAQELBQADggIBABR2vTH/6WlqjaTZ/hQc\nB+crqRlFimqCiVTRdX6qfkt0tLX2dK6scHNTBT04ORLjLTAn0KbcOUz3k6i0mIqB\nnG5UjqCFEQR+i2V4Hz7aK6+7LBQuwXWRhDhvO5xMn7MxjvP0LGgNf5iiA4r/N22L\nEMc1prDESIOGmWdKg9XlfLxd877R2d8/3hXyT82Y2uJHO25b53skj4pbUOWLsGSw\nd4FBNnWqM+7Hbg2v9xFvmtfs2G2Inqk4Xjtjnj8qkVk3ft6KzClUIMXGXQ8QqaRp\nYPkTJm5g2UBYDiguD/tlz3VmbsNYU6fkap7DKqhttbaseIx1zDwdAv4jtVOWDyjx\nWq4b7pljYiczfRa84X/9v1x05pT3raELy5udY+Pxmnz+hOXOM+jY5bzSKS24b8rS\n5Sklmutm0IdflMKd5vNrXd9yPFLu3QzN50ArzHHXczwBLgjaMlZsPAp1wITlqM7+\nWCjy3qM5/KgAjH3L24MPTq23o9PokBVh1NH7lesZqgJPgsj+OG7FMQDvKzg7ytrs\nQlIDF1c8Ko+9/RrnRVAS8C4GZOqbmMmfJjMp09GBz2d0ixlTusF6m6iwfIVMf/nI\nP/V0D7STRiV62cfnZ3e0w8kIeZwWAgXI7RMHJU3skLyurUu8yxkp635IQyzQsW2A\nYo7t7O7fxjqD9yVI2QfkERZ7\n-----END CERTIFICATE-----\n","type":"certificate"},"capabilities":["acl","cfengine","curl","http_reporting","jq","xml","yaml"]}
 policyServerId:root-policy-server

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestCoreNodeFactInventory.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestCoreNodeFactInventory.scala
@@ -223,7 +223,7 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
   sequential
 
   // node7 has the following inventory info:
-  // - one software
+  // - two softwares
   // - one mount point
   // - machine2 (physical)
   // - a bios
@@ -291,8 +291,10 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
           Some(MemorySize(803838361699L))
         )
       ) and
-      (node.software.size === 1) and
-      (node.software.head === SoftwareFact("Software 0", new Version("1.0.0"))) and
+      (node.software.size === 2) and
+      (node.software must containTheSameElementsAs(
+        List(SoftwareFact("Software 0", Some(new Version("1.0.0"))), SoftwareFact("Software 4", None))
+      )) and
       (node7UndefinedElements(node) must contain((x: Chunk[?]) => x must beEmpty).foreach)
 
     }
@@ -317,8 +319,10 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
       (node.bios.size === 0) and
       (node.machine === MachineInfo(machineId, VirtualMachineType(VmType.VMWare), None, None)) and // we always get that
       (node.fileSystems.size === 0) and
-      (node.software.size === 1) and
-      (node.software.head === SoftwareFact("Software 0", new Version("1.0.0"))) and
+      (node.software.size === 2) and
+      (node.software must containTheSameElementsAs(
+        List(SoftwareFact("Software 0", Some(new Version("1.0.0"))), SoftwareFact("Software 4", None))
+      )) and
       (node7UndefinedElements(node) must contain((x: Chunk[?]) => x must beEmpty).foreach)
     }
 
@@ -507,7 +511,7 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
 
       val updated = node
         .modify(_.software)
-        .using(_.appended(SoftwareFact("s2", new Version("1.2"))))
+        .using(_.appended(SoftwareFact("s2", Some(new Version("1.2")))))
         .modify(_.environmentVariables)
         .using(_.appended(("envVAR", "envVALUE")))
         .modify(_.networks)
@@ -550,7 +554,7 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
 
       val updated = node
         .modify(_.software)
-        .using(_.appended(SoftwareFact("s3", new Version("1.3"))))
+        .using(_.appended(SoftwareFact("s3", Some(new Version("1.3")))))
         .modify(_.environmentVariables)
         .using(_.appended(("bad", "bad")))
         .modify(_.networks)


### PR DESCRIPTION
https://issues.rudder.io/issues/25351

Previous inventory class before introduction of `SoftwareFact` already sees the version as optional.
Just add the option, make it compile and add a test to get the software from ldap (we will likely need to see how tests in 8.2 behave, there are many of them and for json).