### PR TITLE
Fixes #25387: Add JSON tests for software without versions in 8.2

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/resources/node-facts/node-930dccb0-5b06-4385-ab7a-80a7e56eb969-v2.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/node-facts/node-930dccb0-5b06-4385-ab7a-80a7e56eb969-v2.json
@@ -189,6 +189,10 @@
       "version": "3.118ubuntu5",
       "publisher": "Ubuntu",
       "sourceVersion": "3.118ubuntu5"
+    },
+    {
+      "name": "windows KB12345",
+      "publisher": "Windows"
     }
   ],
   "storages": [

--- a/webapp/sources/rudder/rudder-core/src/test/resources/node-facts/node-930dccb0-5b06-4385-ab7a-80a7e56eb969.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/node-facts/node-930dccb0-5b06-4385-ab7a-80a7e56eb969.json
@@ -188,6 +188,10 @@
       "version": "3.118ubuntu5",
       "publisher": "Ubuntu",
       "sourceVersion": "3.118ubuntu5"
+    },
+    {
+      "name": "windows KB12345",
+      "publisher": "Windows"
     }
   ],
   "storages": [


### PR DESCRIPTION
https://issues.rudder.io/issues/25387

There is a check that both files end up with the same final nodefact, it tests JSON decoders. The tests should pass because we should be able to decode a software without version this time