### PR TITLE
Fixes #25311: Remove expected reports from NodeStatusReport

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
@@ -47,7 +47,6 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.*
-import com.normation.rudder.services.reports.RunAndConfigInfo
 import com.normation.zio.*
 import doobie.*
 import doobie.implicits.javasql.*
@@ -235,7 +234,7 @@ object Doobie {
   }
 
   /*
-   * Do not use that one for extraction, only to save NodeExpectedReports
+   * Do not use that one for extraction, only to save NodeStatusReport
    */
   implicit val SerializeNodeExpectedReportsWrite: Write[NodeExpectedReports] = {
     import ExpectedReportsSerialisation.*
@@ -266,7 +265,7 @@ object Doobie {
     Write[String].contramap(x => compactRender(x.toJson))
   }
 
-  implicit val ComplianceRunInfoComposite: Write[(RunAndConfigInfo, RunComplianceInfo)] = {
+  implicit val ComplianceRunInfoComposite: Write[(RunAnalysis, RunComplianceInfo)] = {
     import NodeStatusReportSerialization.*
     Write[String].contramap(_.toCompactJson)
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
@@ -47,6 +47,7 @@ import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.domain.reports.ReportType.*
 import com.normation.rudder.services.policies.NodeConfigData
+import com.normation.rudder.services.reports.NodeStatusReportInternal
 import com.normation.rudder.services.reports.Pending
 import org.joda.time.DateTime
 import org.junit.runner.RunWith
@@ -215,31 +216,33 @@ class StatusReportTest extends Specification {
 
   "Node status reports" should {
     val modesConfig = NodeConfigData.defaultModesConfig
-    val report      = NodeStatusReport.buildWith(
-      NodeId("n1"),
-      Pending(
-        NodeExpectedReports(
-          NodeId("n1"),
-          NodeConfigId("plop"),
-          DateTime.now(),
-          None,
-          modesConfig,
-          Nil,
-          List()
-        ), // TODO : correct that test
+    val report      = NodeStatusReportInternal
+      .buildWith(
+        NodeId("n1"),
+        Pending(
+          NodeExpectedReports(
+            NodeId("n1"),
+            NodeConfigId("plop"),
+            DateTime.now(),
+            None,
+            modesConfig,
+            Nil,
+            List()
+          ), // TODO : correct that test
 
-        None,
-        DateTime.now.plusMinutes(15)
-      ),
-      RunComplianceInfo.OK,
-      Nil,
-      parse("""
+          None,
+          DateTime.now.plusMinutes(15)
+        ),
+        RunComplianceInfo.OK,
+        Nil,
+        parse("""
        n1, r1, 0, d1, c0  , v0  , "", pending   , pending msg
        n1, r1, 0, d1, c1  , v1  , "", pending   , pending msg
        n1, r2, 0, d1, c0  , v0  , "", success   , pending msg
        n1, r3, 0, d1, c1  , v1  , "", error     , pending msg
     """).toSet
-    )
+      )
+      .toNodeStatusReport()
 
     "Correctly compute the compliance" in {
       report.compliance === ComplianceLevel(pending = 2, success = 1, error = 1)

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -119,6 +119,7 @@ import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.services.policies.NodeConfigData
 import com.normation.rudder.services.policies.PolicyId
 import com.normation.rudder.services.reports.ComputeCompliance
+import com.normation.rudder.services.reports.NodeStatusReportInternal
 import com.normation.rudder.services.reports.ReportingService
 import com.normation.rudder.services.servers.AllowedNetwork
 import com.normation.rudder.services.servers.PolicyServer
@@ -749,32 +750,34 @@ class MockCompliance(mockDirectives: MockDirectives) {
       ruleNodeReports: Set[RuleNodeStatusReport],
       overrides:       List[OverridenPolicy] = List.empty
   ): NodeStatusReport = {
-    NodeStatusReport.buildWith(
-      nodeId,
-      ComputeCompliance(
-        DateTime.parse("2023-01-01T00:00:00.000Z"),
-        NodeExpectedReports(
-          nodeId,
-          NodeConfigId(s"${nodeId.value}-config"),
+    NodeStatusReportInternal
+      .buildWith(
+        nodeId,
+        ComputeCompliance(
           DateTime.parse("2023-01-01T00:00:00.000Z"),
-          None,
-          NodeModeConfig(
-            GlobalComplianceMode(FullCompliance, 0),
+          NodeExpectedReports(
+            nodeId,
+            NodeConfigId(s"${nodeId.value}-config"),
+            DateTime.parse("2023-01-01T00:00:00.000Z"),
             None,
-            AgentRunInterval(None, 1, 0, 0, 0),
-            None,
-            GlobalPolicyMode(PolicyMode.Enforce, PolicyModeOverrides.Unoverridable),
-            None
+            NodeModeConfig(
+              GlobalComplianceMode(FullCompliance, 0),
+              None,
+              AgentRunInterval(None, 1, 0, 0, 0),
+              None,
+              GlobalPolicyMode(PolicyMode.Enforce, PolicyModeOverrides.Unoverridable),
+              None
+            ),
+            List.empty,
+            List.empty
           ),
-          List.empty,
-          List.empty
+          DateTime.parse("2024-01-01T00:00:00.000Z")
         ),
-        DateTime.parse("2024-01-01T00:00:00.000Z")
-      ),
-      RunComplianceInfo.OK,
-      overrides,
-      ruleNodeReports
-    )
+        RunComplianceInfo.OK,
+        overrides,
+        ruleNodeReports
+      )
+      .toNodeStatusReport()
   }
 
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/25311

Remove the big structure `NodeExpectedReports` that are kept in `NodeStatusReport`, in the `RunAndConfigInfo` part (ie the part where we keep information about the run, because we keep information about the run config information, ie config id and expected reports). Plus, current `RunAndConfigInfo` is too complexe for magnolia serialisation in any case. 

We don't need them appart for information about debugging/message that can be constructed without the whole structure. 

We also want to make the minimum changes and absoltly not touch at the compliance computation logic done in `ExcecutionBatch`. 

For that: 
- we duplicate the `NodeStatusReport` into a `NodeStatusReportInternal` so that nothing change in it, 
- that structure is translated into a newer, leaner `NodeStatusReport` where `RunAndConfigInfo` is replaced with a dumb case class `RunAnalysis`, easely serialisable, and not big ; the translation happens at the end of `ExecutionBatch#getNodeStatusReports` once we don't need the config info

```
final case class RunAnalysis(
    kind:                RunAnalysisKind,
    expectedConfigId:    Option[NodeConfigId],
    expectedConfigStart: Option[DateTime],
    expirationDateTime:  Option[DateTime],
    expiredSince:        Option[DateTime],
    lastRunDateTime:     Option[DateTime],
    lastRunConfigId:     Option[NodeConfigId],
    lastRunExpiration:   Option[DateTime]
)
```


The translation from old `RunAndConfigInfo` to corresponding `RunAnalysis` is done in each `RunAndConfigInfo` leaf case classes. I chose to keep the names of attributes in `RunAnalysis` instanciation to try to make it somehow readable. 

Then, it's "just" weaving the change everywhere, trying to not break the semantic of any of the optional values in `RunAnalysis`. 

Some part loose a bit of precision but avoid some duplication. For ex, we used to need to pattern match each case individially to build the debug log. Now, we just have one or two different ones, and build the string with `.fold("unknown")(...)` for each optional values. 

Tests pass, Rudder starts, but it will need real testing to check that it looks ok. 
