### PR TITLE
Fixes #25404: Allow MPL-2.0 license in cargo checks

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,7 @@ allow = [
     "Unicode-DFS-2016",
     "BSD-3-Clause",
     "BSL-1.0",
+    "MPL-2.0",
 ]
 
 [advisories]


### PR DESCRIPTION
https://issues.rudder.io/issues/25404