### PR TITLE
Fixes #25409: User identity does not show up in bar when user has last login

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/UserInformation.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/UserInformation.scala
@@ -67,7 +67,7 @@ class UserInformation extends DispatchSnippet with DefaultExtendableSnippet[User
       case Some(u) =>
         val displayName = userRepo.get(u.getUsername).runNow match {
           case None       => u.getUsername
-          case Some(info) => info.name.getOrElse(info.id)
+          case Some(info) => info.name.filter(_.strip.nonEmpty).getOrElse(info.id)
         }
 
         val roles       = s"User roles : ${Role.toDisplayNames(u.roles).mkString(", ")}"


### PR DESCRIPTION
https://issues.rudder.io/issues/25409

The name can be saved as an empty string, so we need to reject `Some("")` and display the _id_ instead