### PR TITLE
Fixes #25429: When a mandatory variable has not value but a default one is configured, use it

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/VariableAndSection.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/VariableAndSection.scala
@@ -137,9 +137,9 @@ sealed trait Variable {
       res <- if (seq != null) {
                if (!this.spec.checked) {
                  Right(seq)
-               } else if (!this.spec.multivalued && values.lengthCompare(1) > 0) {
+               } else if (!this.spec.multivalued && seq.lengthCompare(1) > 0) {
                  Left(LoadTechniqueError.Variable("Wrong variable length for " + this.spec.name))
-               } else if (values.map(x => Variable.checkValue(this, x)).contains(false)) {
+               } else if (seq.map(x => Variable.checkValue(this, x)).contains(false)) {
                  Left(
                    LoadTechniqueError.Variable("Wrong variable value for " + this.spec.name)
                  ) // this should really not be thrown

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/VariableAndSection.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/VariableAndSection.scala
@@ -187,10 +187,10 @@ sealed trait Variable {
 
   protected def castValue(x: String, escape: String => String): PureResult[Any] = {
     // we don't want to check constraint on empty value
-    // when the variable is optionnal.
-    // But I'm not sure if I understand what is happening with a an optionnal
+    // when the variable is optional.
+    // But I'm not sure if I understand what is happening with a an optional
     // boolean, since we are returning a string in that case :/
-    if (this.spec.constraint.mayBeEmpty && x.isEmpty) Right("")
+    if (this.spec.constraint.mayBeEmpty && (x == null || x.isEmpty)) Right("")
     else spec.constraint.typeName.getFormatedValidated(x, spec.name, escape)
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
@@ -582,37 +582,56 @@ final case class BoundPolicyDraft(
    */
   def toPolicy(agent: AgentType): Either[String, Policy] = {
     PolicyTechnique.forAgent(technique, agent).flatMap { pt =>
-      expandedVars.values.collectFirst { case v if (!v.spec.constraint.mayBeEmpty && v.values.exists(_ == "")) => v } match {
-        case Some(v) =>
-          Left(
-            s"Error for policy for directive '${directiveName}' [${id.directiveId.debugString}] in rule '${ruleName}' [${id.ruleId.serialize}]: " +
-            s"a non optional value is missing for parameter '${v.spec.description}' [param ID: ${v.spec.name}]"
-          )
-        case None    =>
-          Right(
-            Policy(
-              id,
-              ruleName,
-              directiveName,
-              pt,
-              acceptationDate,
-              NonEmptyList.of(
-                PolicyVars(
-                  id,
-                  policyMode,
-                  expandedVars,
-                  originalVars,
-                  trackerVariable
-                )
-              ),
-              priority,
-              policyMode,
-              ruleOrder,
-              directiveOrder,
-              overrides
-            )
-          )
+      val checkedMandatoryValues: Either[Accumulated[RudderError], List[(ComponentId, Variable)]] = expandedVars.accumulatePure {
+        case (cid, variable) =>
+          // check if there is mandatory variable with missing/blank values
+          (variable.spec.constraint.mayBeEmpty, variable.values.exists(v => v == null || v.isBlank)) match {
+            case (false, true) =>
+              // first, if we have a default value, use that
+              variable.spec.constraint.default match {
+                case Some(d) =>
+                  variable
+                    .copyWithSavedValues(variable.values.map(v => if (v.isBlank) d else v))
+                    .map(v => (cid, v))
+                // else it's an error
+                case None    =>
+                  Left(
+                    Inconsistency(
+                      s"Error for policy for directive '${directiveName}' [${id.directiveId.debugString}] in rule '${ruleName}' [${id.ruleId.serialize}]: " +
+                      s"a non optional value is missing for parameter '${variable.spec.description}' [param ID: ${variable.spec.name}]"
+                    )
+                  )
+              }
+            case _             => Right((cid, variable))
+          }
       }
+
+      checkedMandatoryValues
+        .map(withDefaultVals => {
+          Policy(
+            id,
+            ruleName,
+            directiveName,
+            pt,
+            acceptationDate,
+            NonEmptyList.of(
+              PolicyVars(
+                id,
+                policyMode,
+                withDefaultVals.toMap,
+                originalVars,
+                trackerVariable
+              )
+            ),
+            priority,
+            policyMode,
+            ruleOrder,
+            directiveOrder,
+            overrides
+          )
+        })
+        .left
+        .map(_.deduplicate.msg)
     }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
@@ -1110,7 +1110,7 @@ class TestNodeConfiguration(
   lazy val clockVariables: Map[ComponentId, Variable] = {
     val spec = clockTechnique.getAllVariableSpecs.map(s => (s.name, s)).toMap
     Seq(
-      spec("CLOCK_FQDNNTP").toVariable(Seq("true")),
+      spec("CLOCK_FQDNNTP").toVariable(Seq("")), // testing mandatory value with default "true"
       spec("CLOCK_HWSYNC_ENABLE").toVariable(Seq("true")),
       spec("CLOCK_NTPSERVERS").toVariable(Seq("${rudder.param.ntpserver}")),
       spec("CLOCK_SYNCSCHED").toVariable(Seq("240")),

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PolicyAgregationTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PolicyAgregationTest.scala
@@ -127,7 +127,17 @@ class PolicyAgregationTest extends Specification {
   val technique3_2: Technique = technique3_1.copy(id = TechniqueId(TechniqueName("tech_3"), TechniqueVersionHelper("2.0")))
 
   def newPolicy(technique: Technique, id: String, varName: String, values: Seq[String]): BoundPolicyDraft = {
-    val v = InputVariable(InputVariableSpec("card", "description for " + varName, None, multivalued = true, id = None), values)
+    val v = InputVariable(
+      InputVariableSpec(
+        "card",
+        "description for " + varName,
+        None,
+        multivalued = true,
+        id = None,
+        constraint = Constraint(mayBeEmpty = true)
+      ),
+      values
+    )
     BoundPolicyDraft(
       id,
       ruleName = "rule name",


### PR DESCRIPTION
https://issues.rudder.io/issues/25429

This one use https://github.com/Normation/rudder/pull/5862

The main idea is that when we produce policy from a draft, we first try to assign default value to missing mandatory ones. 

This exposes a failing test that wasn't making sense: we have one test where we have null values for non-optionnal case. 
This test used to pass because we were only checking `v.values.exists(_ == "")` and not also for null values. I added "may be empty" for that test. 
(it should not change anything in real rudder, because we should never have a null value, and it is likely a scare from the past. Still, the test was false, the code was false, and the two problem were compensating each others)