### PR TITLE
Fixes #25430: Property sub-key is used in place of name for lookup

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/reports/execution/ReportsExecutionService.scala
@@ -153,7 +153,7 @@ class ReportsExecutionService(
                                case (nodeid, compliance) => (nodeid, UpdateCompliance(nodeid, compliance))
                              }.toSeq)
       _                   <- ReportLoggerPure.Cache.debug(
-                               s"Invalidated and updated compliance for nodes ${nodeWithCompliances.map(_._1.value).mkString(",")}"
+                               s"Invalidated and updated compliance for nodes: [${nodeWithCompliances.map(_._1.value).mkString(", ")}]"
                              )
       _                   <- complianceRepos.saveRunCompliance(nodeWithCompliances.values.toList) // unsure if here or in the queue
       _                   <- computeNodeStatusReportService.outDatedCompliance(new DateTime(startCompliance))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
@@ -184,7 +184,7 @@ class ComplianceJdbcRepository(
       Update[RunCompliance](queryCompliance).updateMany(runCompliances).void
     } else {
       logger
-        .debug(
+        .trace(
           s"Not persisting compliance details in table 'nodecompliance' because settings 'rudder_save_db_compliance_details' is undefined or false"
         )
         .pure[ConnectionIO]
@@ -196,7 +196,7 @@ class ComplianceJdbcRepository(
       Update[LEVELS](queryComplianceLevel).updateMany(nodeComplianceLevels)
     } else {
       logger
-        .debug(
+        .trace(
           s"Not persisting compliance levels in table 'nodecompliancelevels' because settings 'rudder_save_db_compliance_level' is false"
         )
         .pure[ConnectionIO]

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeStatusReportRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeStatusReportRepository.scala
@@ -161,17 +161,7 @@ class NodeStatusReportRepositoryImpl(
                              case Some(e) =>
                                e.runInfo.kind match {
                                  case RunAnalysisKind.ComputeCompliance => // keep existing compliance, change run info
-                                   Some(
-                                     (
-                                       id,
-                                       e.modify(_.runInfo.lastRunExpiration)
-                                         .setTo(report.runInfo.lastRunExpiration)
-                                         .modify(_.runInfo.lastRunDateTime)
-                                         .setTo(report.runInfo.lastRunDateTime)
-                                         .modify(_.runInfo.lastRunConfigId)
-                                         .setTo(report.runInfo.lastRunConfigId)
-                                     )
-                                   )
+                                   Some((id, e.modify(_.runInfo).setTo(report.runInfo)))
                                  case _                                 => // in any other case, change nothing but check if there's an actual change
                                    if (e == report) None else Some((id, e))
                                }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -1533,12 +1533,11 @@ class MockGlobalParam() {
 
   val rudderConfig: GlobalParameter = GlobalParameter
     .parse(
-      "rudder",
+      NodePropertyBasedComplianceExpirationService.PROP_NAME,
       GitVersion.DEFAULT_REV,
-      s"""{ "${NodePropertyBasedComplianceExpirationService.PROP_KEY}":
-         |  { "${NodePropertyBasedComplianceExpirationService.PROP_NAME}":
-         |    { "mode":"${NodeComplianceExpirationMode.ExpireImmediately}"}
-         | }}""".stripMargin,
+      s"""{ "${NodePropertyBasedComplianceExpirationService.PROP_SUB_NAME}":
+         |  { "mode":"${NodeComplianceExpirationMode.ExpireImmediately.entryName}"}
+         |}""".stripMargin,
       None,
       "rudder system config",
       Some(PropertyProvider.systemPropertyProvider)
@@ -1822,7 +1821,7 @@ z5VEb9yx2KikbWyChM1Akp82AV5BzqE80QIBIw==
     )
   )
 
-  val rootNodeFact = NodeFact.fromCompat(root, Right(FullInventory(rootInventory, None)), softwares.take(7), None)
+  val rootNodeFact: NodeFact = NodeFact.fromCompat(root, Right(FullInventory(rootInventory, None)), softwares.take(7), None)
 
   val node1Node: Node = Node(
     id1,

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -242,9 +242,8 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
 
     (n1 must beEqualTo(Map())) and
     (n2 must beEqualTo(finder.reports.filter(x => okId.contains(x._1)))) and
-    // second time, only expired are invalidate (8) ; excepted UnexpectedVersion (1) and
-    // non ExpiringStatus (NoExpectedConfig => 6
-    (finder.updated.size must beEqualTo(9 + 6))
+    // second time, only the node with changing status (pending and compute) are invalidated
+    (finder.updated.size must beEqualTo(9 + 2))
   }
 
   "When run are expired but we keep compliance, we keep compliance in repo" >> {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ComplianceExpirationServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ComplianceExpirationServiceTest.scala
@@ -39,10 +39,18 @@ package com.normation.rudder.services.reports
 
 import com.normation.errors.PureResult
 import com.normation.inventory.domain.NodeId
+import com.normation.rudder.MockGlobalParam
+import com.normation.rudder.MockNodeGroups
+import com.normation.rudder.MockNodes
 import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.domain.properties.PropertyProvider
 import com.normation.rudder.domain.reports.NodeComplianceExpiration
 import com.normation.rudder.domain.reports.NodeComplianceExpirationMode
+import com.normation.rudder.facts.nodes.ChangeContext
+import com.normation.rudder.facts.nodes.QueryContext
+import com.normation.rudder.services.reports.NodePropertyBasedComplianceExpirationService.PROP_SUB_NAME
+import com.normation.zio.*
+import com.softwaremill.quicklens.*
 import java.util.concurrent.TimeUnit
 import org.junit.runner.RunWith
 import org.specs2.mutable.*
@@ -54,6 +62,14 @@ import zio.*
  */
 @RunWith(classOf[JUnitRunner])
 class ComplianceExpirationServiceTest extends Specification {
+  implicit class ForceGetOpt[A](a: Option[A]) {
+    def force: A = {
+      a match {
+        case Some(v) => v
+        case None    => throw new RuntimeException(s"Can't extract a value from none in test")
+      }
+    }
+  }
 
   import NodePropertyBasedComplianceExpirationService.getPolicyFromProp
 
@@ -69,7 +85,7 @@ class ComplianceExpirationServiceTest extends Specification {
   val rudder_ok1:  NodeProperty = NodeProperty
     .parse(
       "rudder",
-      s"""{"${NodePropertyBasedComplianceExpirationService.PROP_NAME}": { "mode":"keep_last", "duration":"1 hour"}}""",
+      s"""{"${NodePropertyBasedComplianceExpirationService.PROP_SUB_NAME}": { "mode":"keep_last", "duration":"1 hour"}}""",
       None,
       Some(PropertyProvider.systemPropertyProvider)
     )
@@ -77,7 +93,7 @@ class ComplianceExpirationServiceTest extends Specification {
   val rudder_ok2:  NodeProperty = NodeProperty
     .parse(
       "rudder",
-      s"""{"${NodePropertyBasedComplianceExpirationService.PROP_NAME}": { "mode":"keep_last", "duration":"1 hour"}}""",
+      s"""{"${NodePropertyBasedComplianceExpirationService.PROP_SUB_NAME}": { "mode":"keep_last", "duration":"1 hour"}}""",
       None,
       None
     )
@@ -85,7 +101,7 @@ class ComplianceExpirationServiceTest extends Specification {
   val rudder_ok3:  NodeProperty = NodeProperty
     .parse(
       "rudder",
-      s"""{"${NodePropertyBasedComplianceExpirationService.PROP_NAME}": { "mode":"expire_immediately"}}""",
+      s"""{"${NodePropertyBasedComplianceExpirationService.PROP_SUB_NAME}": { "mode":"expire_immediately"}}""",
       None,
       None
     )
@@ -93,7 +109,7 @@ class ComplianceExpirationServiceTest extends Specification {
   val rudder_nok1: NodeProperty = NodeProperty
     .parse(
       "rudder",
-      s"""{ "bad": {"${NodePropertyBasedComplianceExpirationService.PROP_NAME}": { "mode": "keep_last", "duration":"1 hour"}}}""",
+      s"""{ "bad": {"${NodePropertyBasedComplianceExpirationService.PROP_SUB_NAME}": { "mode": "keep_last", "duration":"1 hour"}}}""",
       None,
       Some(PropertyProvider.systemPropertyProvider)
     )
@@ -103,34 +119,34 @@ class ComplianceExpirationServiceTest extends Specification {
   val rudder_nok3: NodeProperty = NodeProperty
     .parse(
       "not_rudder",
-      s"""{"${NodePropertyBasedComplianceExpirationService.PROP_NAME}": { "mode":"keep_last", "duration":"1 hour"}}""",
+      s"""{"${NodePropertyBasedComplianceExpirationService.PROP_SUB_NAME}": { "mode":"keep_last", "duration":"1 hour"}}""",
       None,
       Some(PropertyProvider.systemPropertyProvider)
     )
     .force
 
-  s"When ${NodePropertyBasedComplianceExpirationService.PROP_NAME} is set we should find it" >> {
+  s"When ${NodePropertyBasedComplianceExpirationService.PROP_SUB_NAME} is set we should find it" >> {
     val keep1h =
       NodeComplianceExpiration(NodeComplianceExpirationMode.KeepLast, Some(scala.concurrent.duration.Duration(1, TimeUnit.HOURS)))
 
     (getPolicyFromProp(
       Chunk(rudder_ok1),
       "rudder",
-      s"${NodePropertyBasedComplianceExpirationService.PROP_NAME}",
+      s"${NodePropertyBasedComplianceExpirationService.PROP_SUB_NAME}",
       NodeId("node1")
     ) must beEqualTo(
       keep1h
     )) and (getPolicyFromProp(
       Chunk(rudder_ok2),
       "rudder",
-      s"${NodePropertyBasedComplianceExpirationService.PROP_NAME}",
+      s"${NodePropertyBasedComplianceExpirationService.PROP_SUB_NAME}",
       NodeId("node1")
     ) must beEqualTo(
       keep1h
     )) and (getPolicyFromProp(
       Chunk(rudder_ok3),
       "rudder",
-      s"${NodePropertyBasedComplianceExpirationService.PROP_NAME}",
+      s"${NodePropertyBasedComplianceExpirationService.PROP_SUB_NAME}",
       NodeId("node1")
     ) must beEqualTo(
       NodeComplianceExpiration.default
@@ -142,11 +158,38 @@ class ComplianceExpirationServiceTest extends Specification {
     getPolicyFromProp(
       Chunk(rudder_nok1, rudder_nok2, rudder_nok3),
       "rudder",
-      s"${NodePropertyBasedComplianceExpirationService.PROP_NAME}",
+      s"${NodePropertyBasedComplianceExpirationService.PROP_SUB_NAME}",
       NodeId("node1")
     ) must beEqualTo(
       NodeComplianceExpiration.default
     )
 
+  }
+
+  "Find a property from the mock repos" >> {
+    // for correct init of propRepo, we need param, node and group
+    val mockNodes         = new MockNodes
+    val mockGroup         = new MockNodeGroups(mockNodes, new MockGlobalParam)
+    val expirationService = new NodePropertyBasedComplianceExpirationService(
+      mockNodes.propRepo,
+      NodePropertyBasedComplianceExpirationService.PROP_NAME,
+      PROP_SUB_NAME
+    )
+    val expirationPolicyProp: NodeProperty = NodeProperty
+      .parse("rudder", """{"compliance_expiration_policy" : { "mode":"keep_last", "duration":"1 hour"}}""", None, None)
+      .getOrElse(throw new RuntimeException(s"For test"))
+
+    val nodeId1: NodeId = NodeId("node1")
+    val res = (for {
+      n1 <- mockNodes.nodeFactRepo.get(nodeId1)(QueryContext.testQC)
+      up  = n1.force.modify(_.properties).using(ps => ps.appended(expirationPolicyProp))
+      _  <- mockNodes.nodeFactRepo.save(up)(ChangeContext.newForRudder())
+      _  <- mockGroup.propService.updateAll()
+      v  <- expirationService.getExpirationPolicy(List(nodeId1))
+    } yield v).runNow
+
+    res === Map(
+      nodeId1 -> NodeComplianceExpiration(NodeComplianceExpirationMode.KeepLast, Some(Duration(1, TimeUnit.HOURS).asScala))
+    )
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
@@ -148,10 +148,8 @@ response:
               {
                 "name" : "rudder",
                 "value" : {
-                  "rudder" : {
-                    "compliance_expiration_policy" : {
-                      "mode" : "ExpireImmediately"
-                    }
+                  "compliance_expiration_policy" : {
+                    "mode" : "expire_immediately"
                   }
                 },
                 "provider" : "inherited",
@@ -159,10 +157,8 @@ response:
                   {
                     "kind" : "global",
                     "value" : {
-                      "rudder" : {
-                        "compliance_expiration_policy" : {
-                          "mode" : "ExpireImmediately"
-                        }
+                      "compliance_expiration_policy" : {
+                        "mode" : "expire_immediately"
                       }
                     }
                   }
@@ -177,10 +173,8 @@ response:
                   ]
                 },
                 "origval" : {
-                  "rudder" : {
-                    "compliance_expiration_policy" : {
-                      "mode" : "ExpireImmediately"
-                    }
+                  "compliance_expiration_policy" : {
+                    "mode" : "expire_immediately"
                   }
                 }
               },
@@ -311,14 +305,12 @@ response:
               {
                 "name" : "rudder",
                 "value" : {
-                  "rudder" : {
-                    "compliance_expiration_policy" : {
-                      "mode" : "ExpireImmediately"
-                    }
+                  "compliance_expiration_policy" : {
+                    "mode" : "expire_immediately"
                   }
                 },
                 "provider" : "inherited",
-                "hierarchy" : "<p>from <b>Global Parameter</b>:<pre>{\n    \"rudder\" : {\n        \"compliance_expiration_policy\" : {\n            \"mode\" : \"ExpireImmediately\"\n        }\n    }\n}\n</pre></p>",
+                "hierarchy" : "<p>from <b>Global Parameter</b>:<pre>{\n    \"compliance_expiration_policy\" : {\n        \"mode\" : \"expire_immediately\"\n    }\n}\n</pre></p>",
                 "hierarchyStatus" : {
                   "hasChildTypeConflicts" : false,
                   "fullHierarchy" : [
@@ -329,10 +321,8 @@ response:
                   ]
                 },
                 "origval" : {
-                  "rudder" : {
-                    "compliance_expiration_policy" : {
-                      "mode" : "ExpireImmediately"
-                    }
+                  "compliance_expiration_policy" : {
+                    "mode" : "expire_immediately"
                   }
                 }
               },              {

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
@@ -1310,10 +1310,8 @@ response:
             {
               "name" : "rudder",
               "value" : {
-                "rudder" : {
-                  "compliance_expiration_policy" : {
-                    "mode" : "ExpireImmediately"
-                  }
+                "compliance_expiration_policy" : {
+                  "mode" : "expire_immediately"
                 }
               },
               "provider" : "inherited",
@@ -1321,10 +1319,8 @@ response:
                 {
                   "kind" : "global",
                   "value" : {
-                    "rudder" : {
-                      "compliance_expiration_policy" : {
-                        "mode" : "ExpireImmediately"
-                      }
+                    "compliance_expiration_policy" : {
+                      "mode" : "expire_immediately"
                     }
                   }
                 }
@@ -1339,10 +1335,8 @@ response:
                 ]
               },
               "origval" : {
-                "rudder" : {
-                  "compliance_expiration_policy" : {
-                    "mode" : "ExpireImmediately"
-                  }
+                "compliance_expiration_policy" : {
+                  "mode" : "expire_immediately"
                 }
               }
             },            

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_parameters.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_parameters.yml
@@ -79,10 +79,8 @@ response:
           {
             "id" : "rudder",
             "value" : {
-              "rudder" : {
-                "compliance_expiration_policy" : {
-                  "mode" : "ExpireImmediately"
-                }
+              "compliance_expiration_policy" : {
+                "mode" : "expire_immediately"
               }
             },
             "description" : "rudder system config",

--- a/webapp/sources/rudder/rudder-web/src/main/resources/logback.xml
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/logback.xml
@@ -311,17 +311,6 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
 
   <!--
-    Cache (nodes, compliance)
-    =========================
-    Information on cache, interesting for Rudder 3.0 and up
-    Set to debug or trace to have information.
-  -->
-  <logger name="com.normation.rudder.services.reports.CachedReportingServiceImpl" level="info" />
-  <logger name="com.normation.rudder.services.reports.CachedNodeChangesServiceImpl" level="info" />
-  <logger name="com.normation.rudder.services.nodes.NodeInfoServiceCachedImpl" level="info"/>
-
-
-  <!--
     For the following logger where "OPSLOG" is defined, will get the logs in both the
     webapp logs and file config in OPSLOG (by default, /var/log/rudder/core/rudder-webapp.log
 
@@ -355,6 +344,15 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     <appender-ref ref="OPSLOG" />
     <appender-ref ref="STDOUT" />
   </logger>
+
+
+  <!--
+    Cache (nodes, compliance)
+    =========================
+    Information on cache, interesting for Rudder 3.0 and up
+    Set to debug or trace to have information.
+  -->
+  <logger name="compliance" level="info" />
 
   <!--
     =================

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -3010,8 +3010,8 @@ object RudderConfigInit {
         findNewNodeStatusReports,
         new NodePropertyBasedComplianceExpirationService(
           propertiesRepository,
-          NodePropertyBasedComplianceExpirationService.PROP_KEY,
-          NodePropertyBasedComplianceExpirationService.PROP_NAME
+          NodePropertyBasedComplianceExpirationService.PROP_NAME,
+          NodePropertyBasedComplianceExpirationService.PROP_SUB_NAME
         ),
         Ref.make(Chunk[NodeStatusReportUpdateHook](new ScoreNodeStatusReportUpdateHook(scoreServiceManager))).runNow,
         RUDDER_JDBC_BATCH_MAX_SIZE
@@ -3361,7 +3361,6 @@ object RudderConfigInit {
     lazy val reportDisplayerImpl = new ReportDisplayer(
       roLdapRuleRepository,
       roLdapDirectiveRepository,
-      techniqueRepositoryImpl,
       nodeFactRepository,
       configService,
       logDisplayerImpl

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/action/LoadNodeComplianceCache.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/action/LoadNodeComplianceCache.scala
@@ -75,7 +75,7 @@ class LoadNodeComplianceCache(
                   loadFromDB()
                 } else {
                   BootstrapLogger.info(s"Table 'NodeLastCompliance' is empty, compute last compliance from last available runs") *>
-                  computeNewCompliane()
+                  computeNewCompliance()
                 }
     } yield ()).toBox match {
       case eb: EmptyBox =>
@@ -99,7 +99,7 @@ class LoadNodeComplianceCache(
   }
 
   // compute from last available runs, for example for migration
-  def computeNewCompliane(): IOResult[Unit] = {
+  def computeNewCompliance(): IOResult[Unit] = {
     for {
       nodeIds <- nodeFactRepository.getAll()(QueryContext.systemQC).map(_.keys)
       _       <- ReportLoggerPure.Repository.debug(s"Initialize node status reports for ${nodeIds.size} nodes")


### PR DESCRIPTION
https://issues.rudder.io/issues/25430

So, there was a lot of small things that got unaligned during the last changes. 
- I added a lot of ops logs that help understand what really happen on prod without a debugger on hand, 
- I renamed the PROP_KEY to PROP_NAME, because in rudder we use "property name" to mean the key (and so PROP_NAME becomes PROP_SUB_NAME)
- which lead to an error, I was looking for the property sub name in place of name to check the expiration policy, whiich was always empty (added a full integration test for that)
- I change the expiration date for computed `NoReportInInterval` in `ExecutionBatch` to never use "now", even when we don't know the date. Since we are persisting things in base now, we were continuously make the expiration date a bit latter, and so node with no reports were always OK if they had a grace duration congiured ; at each check, we were giving them a bit more time 
- there was a loop, because the semantic of what need to be chech for expiration changed: now, only good things need that, because only good things get altered with time and become worse. The bad status remains bad, they need an actual change of context (new run, new config)
- clean up a bit our default logback.xml 
Also, I tried to normalize date format by using only the human one for HTML view, and the rfc one for logs. 