### PR TITLE
Fixes #25407: 

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/User.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/User.scala
@@ -117,6 +117,10 @@ case class RudderUserDetail(
   // merge roles rights
   val authz: Rights = Rights(roles.flatMap(_.rights.authorizationTypes))
 
+  val isAdmin: Boolean = {
+    (AuthorizationType.AnyRights +: AuthorizationType.Administration.values).exists(authz.authorizationTypes.contains)
+  }
+
   override val (getUsername, getPassword, getAuthorities) = account match {
     case RudderAccount.User(login, password) => (login, password, RudderAuthType.User.grantedAuthorities)
     case RudderAccount.Api(api)              => (api.name.value, api.token.value, RudderAuthType.Api.grantedAuthorities)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -657,10 +657,12 @@ class Boot extends Loggable {
         LiftSpringApplicationContext.springContext
           .getBean(classOf[UserSessionInvalidationFilter])
           .getUserSessionStatus()
-          .fold("")(r => s" because ${StringEscapeUtils.escapeHtml4(r)}")
+          .fold(". Please reload the page to sign in again.")(r =>
+            s" because ${StringEscapeUtils.escapeEcmaScript(r)}. Please reload the page and try to sign in again."
+          )
       }
       JsRaw(
-        s"isLoggedIn=false; createErrorNotification('You have been signed out${signOutReason}. Please reload the page to sign in again.');"
+        s"isLoggedIn=false; createErrorNotification('You have been signed out${signOutReason}');"
       ).cmd // JsRaw ok, escaped
     })
 


### PR DESCRIPTION
https://issues.rudder.io/issues/25407

We previously had a cache of user statuses only, that we processed upon every request (in the `doFilter`) because the status value is sufficient to guess if the user session should be invalidated.

But now, the state management is more complex, since we need to handle a *change* of password and rights, instead of their value alone. The diff would needs to be computed and processed before storing into the cache, hence another cache model with `ValidUser` and `InvalidUser` within the cache, the invalidity being declined into 3 different reasons : invalid status, password change and rights change.
Also, since multiple changes could occur at once, before the session of the user in question is checked, we need to process changes and guarantee to always keep the final invalid state with the most up-to-date field values (see the unit tests).

We also enforce that admin users (admin_write/edit and any_rights) are not affected and remain logged