### PR TITLE
Fixes #25439: Static rudderc builds are failing due to missing tracing import

### DIFF
--- a/policies/rudderc/src/lib.rs
+++ b/policies/rudderc/src/lib.rs
@@ -10,7 +10,6 @@ use std::{
 use anyhow::bail;
 use anyhow::{anyhow, Context, Result};
 use rudder_cli::custom_panic_hook_ignore_sigpipe;
-#[cfg(not(feature = "embedded-lib"))]
 use tracing::debug;
 use tracing::error;
 


### PR DESCRIPTION
https://issues.rudder.io/issues/25439