### PR TITLE
Fixes #25448: Group position on dashboard statistics  make no sens

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/index.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/index.html
@@ -28,6 +28,12 @@
                 </a>
               </li>
               <li class="list-group-item border-0 p-0">
+                <a href="/secure/nodeManager/groups" class="d-flex justify-content-between py-2 px-3">
+                  Groups
+                  <span class="badge"><div data-lift="HomePage.groups"></div></span>
+                </a>
+              </li>
+              <li class="list-group-item border-0 p-0">
                 <a href="/secure/configurationManager/ruleManagement" class="d-flex justify-content-between py-2 px-3">
                   Rules
                   <span class="badge"><div data-lift="HomePage.rules"></div></span>
@@ -37,12 +43,6 @@
                 <a href="/secure/configurationManager/directiveManagement" class="d-flex justify-content-between py-2 px-3">
                   Directives
                   <span class="badge"><div data-lift="HomePage.directives"></div></span>
-                </a>
-              </li>
-              <li class="list-group-item border-0 p-0">
-                <a href="/secure/nodeManager/groups" class="d-flex justify-content-between py-2 px-3">
-                  Groups
-                  <span class="badge"><div data-lift="HomePage.groups"></div></span>
                 </a>
               </li>
               <li class="list-group-item border-0 p-0">


### PR DESCRIPTION
https://issues.rudder.io/issues/25448

Just put group after nodes: 

![image](https://github.com/user-attachments/assets/5e810554-139f-4e60-9280-de701a29516e)
