### PR TITLE
Fixes #25479: Users cleanup configuration is too strict on disabled users

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
@@ -65,6 +65,10 @@ object ApplicationLoggerPure extends NamedZioLogger {
     def loggerName: String = parent.loggerName + ".plugin"
   }
 
+  object Auth extends NamedZioLogger {
+    def loggerName: String = parent.loggerName + ".authentication"
+  }
+
   object Authz extends NamedZioLogger {
     def loggerName: String = parent.loggerName + ".authorization"
   }

--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -598,22 +598,24 @@ rudder.batch.storeAgentRunTimes.updateInterval=5
 #
 rudder.users.cleanup.cron=0 17 1 * * ?
 
-# Other clean-up format are duration. You can use human format with unit: 'ms' 'milliseconds' up to 'days'
+# Other clean-up format are duration. You can use human format with unit: 'days', 'months'.
+# The value 'never' is also supported and when used the duration will be infinite (and the action is never executed).
+# Details on the duration format here: https://scala-lang.org/api/3.x/scala/concurrent/duration/Duration$.html#apply-537.
 # For users:
-# - when an user didn't logged-in for a certain period of time, its account can be disabled or/and
-#   deleted. If the user never logged-in, then the account create date is used.
-rudder.users.cleanup.account.disableAfterLastLogin=60 days
+# - when a user have not logged in for a certain period of time, its account can be marked as disabled.
+# - when the user account is already disabled and the user did not log in for some time, the account can marked as deleted.
+rudder.users.cleanup.account.disableAfterLastLogin=90 days
 rudder.users.cleanup.account.deleteAfterLastLogin=120 days
 
 # - when an user is deleted (for example removed from `rudder-user.xml` file), then the user information,
 #   like status changes, are not purged immediately (typically to be able to do post-deletion accountability).
 #   After some time, you will likely need to purge these information nonetheless.
-#   If that parameter is set to '0' then users are purged immediately on deletion. We do not advice to do that.
+#   If that parameter is set to '0' then users are purged immediately on deletion. We do not advise to do that.
 rudder.users.cleanup.purgeDeletedAfter=30 days
 
 # For sessions:
-# - user session information (log-in time, permissions for the sessions, log-out, etc) need to be purge after
-#   some time, too.
+# - user session information (log-in time, permissions for the sessions, log-out, etc) need to be purged after
+#   some time too.
 rudder.users.cleanup.sessions.purgeAfter=30 days
 
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1087,7 +1087,7 @@ object RudderParsedProperties {
     case Right(opt) => opt
   }
   val RUDDER_USERS_CLEAN_LAST_LOGIN_DISABLE: Duration         =
-    parseDuration("rudder.users.cleanup.account.disableAfterLastLogin", 60.days)
+    parseDuration("rudder.users.cleanup.account.disableAfterLastLogin", 90.days)
   val RUDDER_USERS_CLEAN_LAST_LOGIN_DELETE:  Duration         =
     parseDuration("rudder.users.cleanup.account.deleteAfterLastLogin", 120.days)
   val RUDDER_USERS_CLEAN_DELETED_PURGE:      Duration         = parseDuration("rudder.users.cleanup.purgeDeletedAfter", 30.days)
@@ -1095,7 +1095,11 @@ object RudderParsedProperties {
 
   def parseDuration(propName: String, default: Duration): Duration = {
     try {
-      Duration.fromScala(scala.concurrent.duration.Duration(config.getString(propName)))
+      val configValue = config.getString(propName)
+      configValue.toLowerCase match {
+        case "never" => Duration.Infinity
+        case _       => Duration.fromScala(scala.concurrent.duration.Duration(configValue))
+      }
     } catch {
       case ex: ConfigException       => // default
         default
@@ -1603,6 +1607,7 @@ object RudderConfigInit {
     // batch for cleaning users
     lazy val userCleanupBatch: CleanupUsers   = new CleanupUsers(
       userRepository,
+      IOResult.attempt(rudderUserListProvider.authConfig.users.filter(!_._2.isAdmin).keys.toList),
       RUDDER_USERS_CLEAN_CRON,
       RUDDER_USERS_CLEAN_LAST_LOGIN_DISABLE,
       RUDDER_USERS_CLEAN_LAST_LOGIN_DELETE,


### PR DESCRIPTION
https://issues.rudder.io/issues/25479

* Add an appropriate log with the `application.authentication` name and use it in the `CleanupUsers` file
* Improve logs globally : add some missing logs (for disable/purged) and use `zio.Duration#render` to display the date
* Only apply deletion of inactive only on disabled users

As for the properties file :
* Allow to parse "never" as `zio.Duration.Infinity`, when used in the config the existing logic of the code is still valid (eventually the code is disabling/deletion is never run)
* Improve the comments and update default to `90 days` for `disableAfterLastLogin`