### PR TITLE
Fixes #25478: Normalize authentication logs

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
@@ -68,14 +68,6 @@ object ApplicationLoggerPure extends NamedZioLogger {
   object Auth extends NamedZioLogger {
     def loggerName: String = parent.loggerName + ".authentication"
   }
-
-  object Authz extends NamedZioLogger {
-    def loggerName: String = parent.loggerName + ".authorization"
-  }
-
-  object User extends NamedZioLogger {
-    def loggerName = parent.loggerName + ".user"
-  }
 }
 
 object ApiLogger extends Logger {

--- a/webapp/sources/rudder/rudder-web/src/main/resources/logback.xml
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/logback.xml
@@ -416,6 +416,12 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     <appender-ref ref="STDOUT" />
   </logger>
 
+  <!--
+    Log information about user authentication and user-related access to Rudder 
+    (rights, session, user management in general).
+  -->
+  <!-- Uncomment to have precise log about user management and authentication -->
+  <!-- <logger name="application.authentication" level="debug"/> -->
 
   <!--
     Schechuled Jobs

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderProviderManager.java
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderProviderManager.java
@@ -16,11 +16,9 @@
 
 package bootstrap.liftweb;
 
-import com.normation.rudder.AuthorizationType;
-import com.normation.rudder.domain.logger.ApplicationLogger;
 import com.normation.rudder.users.*;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -51,7 +49,7 @@ public class RudderProviderManager implements org.springframework.security.authe
 	// ~ Static fields/initializers
 	// =====================================================================================
 
-	private static final Log logger = LogFactory.getLog("org.springframework.security.RudderProviderManager");
+	private static final Logger logger = LoggerFactory.getLogger("application.authentication");
 
 	// ~ Instance fields
 	// ================================================================================================
@@ -174,13 +172,13 @@ public class RudderProviderManager implements org.springframework.security.authe
 										if (requestAttributes instanceof ServletRequestAttributes) {
 											sessionId = requestAttributes.getSessionId();
 										} else {
-											ApplicationLogger.warn(() -> "Rudder does not know how to get sessionId on this authentication using " + requestAttributes.getClass().getName() + ". It could happen when previous session has not been closed properly. Please retry to log in after clearing the browser cache.");
+											logger.warn("Rudder does not know how to get sessionId on this authentication using " + requestAttributes.getClass().getName() + ". It could happen when previous session has not been closed properly. Please retry to log in after clearing the browser cache.");
 											throw new IllegalStateException("Unknown request attributes type for session id retrieval: " + requestAttributes.getClass().getName() + ", aborting authentication");
 										}
 									}
                                 } else {
                                   final String className = result.getDetails().getClass().getName();
-                                  ApplicationLogger.warn(() -> "Rudder does not know how to get sessionId from '"+className+"'. Please report to developers that message");
+                                  logger.warn("Rudder does not know how to get sessionId from '"+className+"'. Please report to developers that message");
                                   sessionId = Integer.toHexString(result.getDetails().hashCode());
                                 }
 								// Authentication under the same session id may have already been attempted, to prevent session fixation, refuse authentication and renew login session
@@ -203,7 +201,7 @@ public class RudderProviderManager implements org.springframework.security.authe
                     if(p.name() == "rootAdmin") {
                         logger.debug(msg);
                     } else {
-                        ApplicationLogger.info(() -> msg);
+                        logger.info(msg);
                     }
                 }
             }
@@ -256,7 +254,7 @@ public class RudderProviderManager implements org.springframework.security.authe
 	// a version of the exception is thrown without stack trace to avoid having pages and pages of exception
     // in logs. Only keep information if debug mode is enabled.
 	private AuthenticationException cleanException(AuthenticationException t) {
-        if(ApplicationLogger.isDebugEnabled()) {
+        if(logger.isDebugEnabled()) {
             return t;
         } else {
             return new AuthenticationException(t.getMessage(), t.getCause()) {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderUserDetailsFile.scala
@@ -353,6 +353,8 @@ object UserFileProcessing {
   val JVM_AUTH_FILE_KEY      = "rudder.authFile"
   val DEFAULT_AUTH_FILE_NAME = "demo-rudder-users.xml"
 
+  private val logger = ApplicationLoggerPure.Auth
+
   // utility classes for a parsed custom role/user/everything before sanity check is done on them
   final case class ParsedRole(name: String, permissions: List[String])
   final case class ParsedUser(name: String, password: String, permissions: List[String], tenants: Option[List[String]])
@@ -366,7 +368,7 @@ object UserFileProcessing {
   def getUserResourceFile(): IOResult[UserFile] = {
     java.lang.System.getProperty(JVM_AUTH_FILE_KEY) match {
       case null | "" => // use default location in classpath
-        ApplicationLoggerPure.Authz.info(
+        logger.info(
           s"JVM property -D${JVM_AUTH_FILE_KEY} is not defined, using configuration file '${DEFAULT_AUTH_FILE_NAME}' in classpath"
         ) *>
         UserFile(
@@ -376,12 +378,12 @@ object UserFileProcessing {
       case x         => // so, it should be a full path, check it
         val config = new File(x)
         if (config.exists && config.canRead) {
-          ApplicationLoggerPure.Authz.info(
+          logger.info(
             s"Using configuration file defined by JVM property -D${JVM_AUTH_FILE_KEY} : ${config.getPath}"
           ) *>
           UserFile(config.getAbsolutePath, () => new FileInputStream(config)).succeed
         } else {
-          ApplicationLoggerPure.Authz.error(
+          logger.error(
             s"Can not find configuration file specified by JVM property ${JVM_AUTH_FILE_KEY}: ${config.getPath}; aborting"
           ) *> Unexpected(s"rudder-users configuration file not found at path: '${config.getPath}'").fail
         }
@@ -474,11 +476,11 @@ object UserFileProcessing {
         case "false" => false.succeed
         case str     =>
           (if (str.isEmpty) {
-             ApplicationLoggerPure.Authz.info(
+             logger.info(
                s"Case sensitivity: in file '${debugFileName}' parameter `case-sensitivity` is missing, set by default on `true`"
              )
            } else {
-             ApplicationLoggerPure.Authz.warn(
+             logger.warn(
                s"Case sensitivity: unknown case-sensitivity parameter `$str` in file '${debugFileName}', set by default on `true`"
              )
            }) *> true.succeed
@@ -518,7 +520,7 @@ object UserFileProcessing {
             UncheckedCustomRole(n, r)
           }) match {
             case Left(err)   =>
-              ApplicationLoggerPure.Authz
+              logger
                 .error(s"Role incorrectly defined in '${debugFileName}': ${err.fullMsg})") *> None.succeed
             case Right(role) =>
               Some(role).succeed
@@ -556,7 +558,7 @@ object UserFileProcessing {
                 Some(ParsedUser(name, p, permissions, tenants)).succeed
 
               case _ =>
-                ApplicationLoggerPure.Authz.error(
+                logger.error(
                   s"Ignore user line in authentication file '${debugFileName}', some required attribute is missing: ${node.toString}"
                 ) *> None.succeed
             }
@@ -583,7 +585,7 @@ object UserFileProcessing {
       extendedAuthz: Boolean
   ): UIO[List[Role]] = {
     if (!extendedAuthz && roles.nonEmpty) {
-      ApplicationLoggerPure.Authz.logEffect.warn(
+      logger.logEffect.warn(
         s"Custom roles are defined which is not supported without the User management plugin. " +
         s"These custom roles will be ignored: ${roles.map(_.name).mkString(", ")}"
       )
@@ -593,19 +595,19 @@ object UserFileProcessing {
         res <- RudderRoles.resolveCustomRoles(roles, knownRoles)
         _   <- ZIO.foreach(res.invalid) {
                  case (r, err) =>
-                   ApplicationLoggerPure.Authz.error(
+                   logger.error(
                      s"Error with custom role definition: custom role '${r.name}' is invalid and will be ignored: ${err}"
                    )
                }
         _   <- ZIO.foreach(res.validRoles) { r =>
                  r match {
                    case Role.NamedCustom(n, l) =>
-                     ApplicationLoggerPure.Authz.debug(
+                     logger.debug(
                        s"Custom role '${n}' defined as the union of roles: [${l.map(_.debugString).mkString(", ")}]"
                      )
                    // Should not happen, since there should be only custom roles, but to prevent warning here ...
                    case _                      =>
-                     ApplicationLoggerPure.Authz.debug(
+                     logger.debug(
                        s"Found role ${r.name}, in custom role definition, ignore this message"
                      )
                  }
@@ -631,13 +633,13 @@ object UserFileProcessing {
                  .toIO
                  .flatMap { // check for adequate plugin
                    case NodeSecurityContext.ByTenants(_) if (!TODO_MODULE_TENANTS_ENABLED) =>
-                     ApplicationLoggerPure.Authz.warn(
+                     logger.warn(
                        s"Tenants definition are only available with the corresponding plugin. To prevent unwanted right escalation, " +
                        s"user '${name}' will be restricted to no tenants"
                      ) *> NodeSecurityContext.None.succeed
                    case x                                                                  => x.succeed
                  }
-                 .catchAll(err => ApplicationLoggerPure.Authz.warn(err.fullMsg) *> NodeSecurityContext.None.succeed)
+                 .catchAll(err => logger.warn(err.fullMsg) *> NodeSecurityContext.None.succeed)
         rs  <-
           RudderRoles
             .parseRoles(roles)
@@ -648,13 +650,13 @@ object UserFileProcessing {
 
                 case rs =>
                   if (!extendedAuthz && rs.exists(_ != Role.Administrator)) {
-                    ApplicationLoggerPure.Authz.warn(
+                    logger.warn(
                       s"User '${name}' defined with authorizations different from 'administrator', which is not supported without the User management plugin. " +
                       s"To prevent problem, that user authorization is removed."
                     ) *> List(Role.NoRights).succeed
 
                   } else {
-                    ApplicationLoggerPure.Authz.debug(
+                    logger.debug(
                       s"User '${name}' defined with authorizations: ${rs.map(_.debugString).mkString(", ")}"
                     ) *> rs.succeed
                   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/CommonLayout.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/CommonLayout.scala
@@ -1,7 +1,7 @@
 package com.normation.rudder.web.snippet
 
 import com.normation.plugins.DefaultExtendableSnippet
-import com.normation.rudder.domain.logger.ApplicationLogger
+import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.users.CurrentUser
 import net.liftweb.http.DispatchSnippet
 import net.liftweb.http.js.JE.*
@@ -23,7 +23,7 @@ class CommonLayout extends DispatchSnippet with DefaultExtendableSnippet[CommonL
    */
   def init(xml: NodeSeq): NodeSeq = {
     CurrentUser.get match {
-      case None    => ApplicationLogger.warn("Authz.init called but user not authenticated")
+      case None    => ApplicationLoggerPure.Auth.logEffect.warn("Authz.init called but user not authenticated")
       case Some(_) => // expected
     }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/25478

Just removing `ApplicationLoggerPure.Authz` and `ApplicationLoggerPure.User` definitions, and replacing all usages by `ApplicationLoggerPure.Auth` to make it compile and use the `application.authentication` logger