### PR TITLE
Fixes #25488: Resource upload with file too big cause network error in firefox

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Util.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Util.elm
@@ -90,7 +90,7 @@ processApiDetailedError apiName decoder err =
         Detailed.Timeout ->
           formatApiNameMessage ("Unable to reach the server, try again")
         Detailed.NetworkError ->
-          formatApiNameMessage ("Unable to reach the server, check your network connection")
+          formatApiNameMessage ("You are trying to upload a file that exceeds the maximum upload size, or we are unable to reach the server, so please check your network connection.")
         Detailed.BadStatus metadata body ->
           case Json.Decode.decodeString decoder body of
             Ok { error } -> formatApiNameMessage (Maybe.withDefault "Unknown error" error)


### PR DESCRIPTION
https://issues.rudder.io/issues/25488

The error message was not in the right place in https://github.com/Normation/rudder/pull/5828