### PR TITLE
Fixes #25490: User cleanup actions are logged every time even there is no change 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/users/UserRepository.scala
@@ -708,11 +708,12 @@ class JdbcUserRepository(doobie: Doobie) extends UserRepository {
 
     transactIOResult(s"Error when purging user sessions older then: ${DateFormaterService.serialize(olderThan)}")(xa =>
       sql.update.run.transact(xa)
-    ).flatMap(deletedSessionCount => {
-      logger.info(
-        s"${deletedSessionCount} user sessions older than ${DateFormaterService.serialize(olderThan)} were deleted"
-      )
-    })
+    ).tapSome {
+      case deletedSessionCount if deletedSessionCount > 0 =>
+        logger.info(
+          s"${deletedSessionCount} user sessions older than ${DateFormaterService.serialize(olderThan)} were deleted"
+        )
+    }.unit
   }
 
   override def setExistingUsers(


### PR DESCRIPTION
https://issues.rudder.io/issues/25490

* `zio.Duration#render` was forgotten in https://github.com/Normation/rudder/pull/5880
* log conditionally when count is > 0 or list is non empty 