### PR TITLE
Fixes #24332: Technical logs are not loaded when visiting the tab - rudder 8.1

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/LogDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/LogDisplayer.scala
@@ -151,6 +151,7 @@ class LogDisplayer(
       """
       } else ""}
     createTechnicalLogsTable("${tableId}",[], "${S.contextPath}",function() {${refresh.toJsCmd}}, ${runDate.isEmpty});
+    ${refresh.toJsCmd}
     """) // JsRaw ok, escaped
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/24332

Data refresh needs to happen after the table and form are initialized (same as in [eventlogs](https://github.com/Normation/rudder/blob/be26d0144a78dd6d86f80b7bb57eec8d88d6a4c3/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/EventListDisplayer.scala#L135))