### PR TITLE
Fixes #25498: Hooks are not executed anymore from their directory

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunHooks.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunHooks.scala
@@ -246,11 +246,11 @@ object RunHooks {
     }
 
     /*
-     * We can not use Future.fold, because it execute all scripts
+     * We can not use Future.fold, because it executes all scripts
      * in parallel and then combine their results. Our semantic
-     * is execute script one after the other, combining at each
+     * is executed script one after the other, combining at each
      * step.
-     * But we still want the whole operation to be non-bloking.
+     * But we still want the whole operation to be non-blocking.
      */
     val runAllSeq = ZIO.foldLeft(hooks.hooksFile)(Ok("", ""): HookReturnCode) {
       case (previousCode, (nextHookName, timeouts)) =>
@@ -270,7 +270,7 @@ object RunHooks {
                      .warn(s"Hook is taking more than ${warnTimeout.render} to finish: ${cmdInfo}")
                      .delay(warnTimeout)
                      .fork
-              p <- RunNuCommand.run(Cmd(path, Nil, env.toMap))
+              p <- RunNuCommand.run(Cmd(path, Nil, env.toMap, Some(hooks.basePath)))
               r <- p.await.timeout(killTimeout).flatMap {
                      case Some(ok) =>
                        ok.succeed
@@ -289,7 +289,7 @@ object RunHooks {
 
     val cmdInfo = s"'${hooks.basePath}' with environment parameters: [${hookParameters.debugString}]"
     (for {
-      // cmdInfo is just for comments/log. We use "*" to synthetize
+      // cmdInfo is just for comments/log. We use "*" to synthesize
       _       <- PureHooksLogger.debug(s"Run hooks: ${cmdInfo}")
       _       <- PureHooksLogger.trace(s"Hook environment variables: ${envVariables.debugString}")
       time_0  <- currentTimeNanos
@@ -323,7 +323,7 @@ object RunHooks {
    * Only the files with prefix ".hook" are selected as hooks, all
    * other files will be ignored.
    *
-   * The hooks will be run in lexigraphically order, so that the
+   * The hooks will be run in lexicographical order, so that the
    * "standard" ordering of unix hooks (or init.d) with numbers
    * works as expected:
    *
@@ -436,7 +436,7 @@ object RunHooks {
                 }
             }
           }
-          .sortBy(_._1) // sort them alphanumericaly
+          .sortBy(_._1) // sort them alphanumerically
         Hooks(basePath, files)
       } else {
         HooksLogger.debug(s"Ignoring hook directory '${dir.getAbsolutePath}' because path does not exist")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechniqueReader.scala
@@ -147,7 +147,7 @@ class EditorTechniqueReaderImpl(
     // We want everything in configuration repository to belong to the "rudder" group
     val groupOwner    = "rudder"
 
-    val cmd = Cmd(ruddercCmd, ruddercParams ::: ruddercLibs, Map.empty)
+    val cmd = Cmd(ruddercCmd, ruddercParams ::: ruddercLibs, Map.empty, None)
     for {
       updateCmd <- RunNuCommand.run(cmd)
       res       <- updateCmd.await

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
@@ -352,7 +352,7 @@ class RuddercServiceImpl(
       ("--directory" :: techniquePath.pathAsString :: "build" :: Nil)
     }
 
-    Cmd(ruddercCmd, params, Map("NO_COLOR" -> "1"))
+    Cmd(ruddercCmd, params, Map("NO_COLOR" -> "1"), None)
   }
 
   def logReturnCode(result: RuddercResult): IOResult[Unit] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckService.scala
@@ -143,7 +143,7 @@ final class CheckFileDescriptorLimit(val nodeFactRepository: NodeFactRepository)
   def run:  IOResult[HealthcheckResult] = {
     // Check the soft limit.
     // That can be raise or lower by any user but cannot exceed the hard limit
-    val cmd = Cmd("/usr/bin/prlimit", "-n" :: "-o" :: "SOFT" :: "--noheadings" :: Nil, Map.empty)
+    val cmd = Cmd("/usr/bin/prlimit", "-n" :: "-o" :: "SOFT" :: "--noheadings" :: Nil, Map.empty, None)
     for {
       fdLimitCmd <- RunNuCommand.run(cmd)
       res        <- fdLimitCmd.await

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/WriteNodeCertificatesPem.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/WriteNodeCertificatesPem.scala
@@ -145,7 +145,7 @@ class WriteNodeCertificatesPemImpl(reloadScriptPath: Option[String]) extends Wri
           case cmdPath :: args =>
             for {
               promise <-
-                RunNuCommand.run(Cmd(cmdPath, args, Map()), Duration.fromNanos(5L * 60 * 1000 * 1000)) // error after 5 mins
+                RunNuCommand.run(Cmd(cmdPath, args, Map(), None), Duration.fromNanos(5L * 60 * 1000 * 1000)) // error after 5 mins
               result  <- promise.await
               _       <- ZIO.when(result.code != 0) {
                            Unexpected(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/system/DebugInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/system/DebugInfoService.scala
@@ -65,7 +65,7 @@ class DebugInfoServiceImpl extends DebugInfoService {
     val environment = java.lang.System.getenv.asScala.toMap
     val timeOut     = Duration(30, TimeUnit.SECONDS)
     val scriptPath  = "/opt/rudder/bin/rudder-debug-info"
-    val cmd         = Cmd(scriptPath, Nil, environment)
+    val cmd         = Cmd(scriptPath, Nil, environment, Some("/opt/rudder/bin/"))
     // Since the API is blocking, we want to wait for the result.
     logger.debug(s"Launching debug-info script (${scriptPath})") *>
     RunNuCommand.run(cmd, timeOut)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/RunNuCommandTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/RunNuCommandTest.scala
@@ -68,7 +68,7 @@ class RunNuCommandTest() extends Specification {
     "has only the environment variable explicitly defined" in {
       val prog = {
         for {
-          p <- RunNuCommand.run(Cmd("env", Nil, Map("PATH" -> PATH, "foo" -> "bar")))
+          p <- RunNuCommand.run(Cmd("env", Nil, Map("PATH" -> PATH, "foo" -> "bar"), None))
           c <- p.await.timeout(500.millis).notOptional("oups, timed out")
         } yield {
           s"return code=${c.code}\n" ++
@@ -85,7 +85,7 @@ class RunNuCommandTest() extends Specification {
       // (we have one more line because last line ends with a "\n"
       val prog = {
         for {
-          p <- RunNuCommand.run(Cmd("ls", "-1" :: "/proc/self/fd" :: Nil, Map("PATH" -> PATH)))
+          p <- RunNuCommand.run(Cmd("ls", "-1" :: "/proc/self/fd" :: Nil, Map("PATH" -> PATH), None))
           c <- p.await.timeout(500.millis).notOptional("oups, timed out")
         } yield {
           (c.code, c.stdout.split("\n").size)
@@ -103,7 +103,7 @@ class RunNuCommandTest() extends Specification {
 
       val prog = {
         for {
-          p <- RunNuCommand.run(Cmd("mkdir", "-p" :: file.getPath :: Nil, Map("PATH" -> PATH)))
+          p <- RunNuCommand.run(Cmd("mkdir", "-p" :: file.getPath :: Nil, Map("PATH" -> PATH), None))
           c <- p.await.timeout(500.millis).notOptional("oups, timed out")
         } yield {
           c.code


### PR DESCRIPTION
https://issues.rudder.io/issues/25498

So, it seems that at some point (perhaps on 2.x, but I didn't find info), `nuProcess` changed the semantic of the current working directory. 
At least, now we can set it, and we don't, and for hooks it seems to be better to set it to the hook directory. 
I also changed for the `debug` script info that is supposed to start a lot of thing from its directory, but I'm not sure it's really used. 
I didn't changed for other command calls like `rudderc`. 

With the change, a hook with PWD change from: 
```
[2024-09-19T15:45:35+02:00] exec hook at /home/fanf/java/workspaces/rudder-project/rudder/webapp/sources
```

To:

```
exec hook at /home/fanf/java/workspaces/rudder-project/rudder/webapp/sources/rudder/rudder-core/src/main/resources/hooks.d/node-inventory-received-pending
```

Where `/home/fanf/java/workspaces/rudder-project/rudder/webapp/sources` is the Intellij directory used as the base directory for the webapp, and the second path is the actual path where hooks are. 