### PR TITLE
Fixes #25499: Event log table default period of two hours is too short

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
@@ -673,13 +673,16 @@ function showHideRunLogs(scrollTarget, tabId, init, refresh) {
       }, 400);
 }
 
-function initDatePickers(id, action) {
-  var dateNow = new Date();
-  var twoHoursBefore = new Date();
-  twoHoursBefore.setHours(twoHoursBefore.getHours() - 2);
+/**
+ * Initialize a date picker fields with default 2 hours from now date range.
+ * You can specify a value that is greater than 24 for hours.
+ */
+function initDatePickers(id, action, endDate = new Date(), hours = 2) {
+  var startDate = new Date(endDate)
+  startDate.setHours(endDate.getHours() - hours);
   $(id + ' .pickStartInput, ' + id + ' .pickEndInput').datetimepicker({dateFormat:'yy-mm-dd', timeFormat: 'HH:mm:ss', timeInput: true});
-  $(".pickStartInput").datetimepicker("setDate", twoHoursBefore);
-  $(".pickEndInput").datetimepicker("setDate", dateNow);
+  $(".pickStartInput").datetimepicker("setDate", startDate);
+  $(".pickEndInput").datetimepicker("setDate", endDate);
   $(id+"Button").click(function () {
     var param = '{"start":"'+$(id +" .pickStartInput").val()+'", "end":"'+$(id +" .pickEndInput").val()+'"}'
     action(param)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/EventListDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/EventListDisplayer.scala
@@ -127,9 +127,15 @@ class EventListDisplayer(repos: EventLogRepository) extends Loggable {
 
     val refresh = AnonFunc(SHtml.ajaxInvoke(() => getLastEvents))
 
+    // Display 2 days of logs before now
+    val hoursBeforeNow = 48
+
     Script(OnLoad(JsRaw(s"""
      var refreshEventLogs = ${refresh.toJsCmd};
-     initDatePickers("#filterLogs", ${AnonFunc("param", SHtml.ajaxCall(JsVar("param"), getEventsInterval)._2).toJsCmd});
+     initDatePickers("#filterLogs", ${AnonFunc(
+        "param",
+        SHtml.ajaxCall(JsVar("param"), getEventsInterval)._2
+      ).toJsCmd}, new Date(), ${hoursBeforeNow});
      createEventLogTable('${gridName}',[], '${S.contextPath}', refreshEventLogs)
      refreshEventLogs();
     """))) // JsRaw ok, escaped


### PR DESCRIPTION
https://issues.rudder.io/issues/25499

Make the date picker initializers parameterizable with X hours before the end date (keep 2h from now by default which is used in technical logs). Then specify 48h for the event logs date pickers 