### PR TITLE
Fixes #25476: API don't include acceptedSince information

### DIFF
--- a/webapp/sources/api-doc/components/schemas/node-full.yml
+++ b/webapp/sources/api-doc/components/schemas/node-full.yml
@@ -57,6 +57,11 @@ properties:
     format: date
     example: "2020-02-29T14:48:28Z"
     description: "Date and time of the latest run, if one is available (node time). Up to API v11, format was: \"YYYY-MM-dd HH:mm\""
+  acceptanceDate:
+    type: string
+    example: "2020-02-29T10:11:32Z"
+    format: date
+    description: "Date and time of the acceptance of the node into Rudder."
   lastInventoryDate:
     type: string
     example: "2020-02-29T10:11:32Z"
@@ -333,6 +338,22 @@ properties:
         type: string
         description: Local user account used by the agent
         example: root
+      scheduleOverride:
+        type: object
+        description: Node agent run specific run schedule
+        properties:
+          runInterval:
+            type: string
+            description: duration of run interval, formatted with a time unit
+            example: "20 min"
+          firstRun:
+            type: string
+            description: time of the first run in HH:mm format
+            example: 00:11
+          splayTime:
+            type: string
+            description: duration of the configured splay time with a time unit
+            example: 7 min
   memories:
     type: array
     description: Memory slots

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
@@ -56,7 +56,7 @@ import com.normation.rudder.domain.properties.*
 import com.normation.rudder.domain.queries.Query
 import com.normation.rudder.domain.servers.Srv
 import com.normation.rudder.domain.workflows.*
-import com.normation.rudder.facts.nodes.SecurityTag
+import com.normation.rudder.facts.nodes.MinimalNodeFactInterface
 import com.normation.rudder.repository.FullActiveTechnique
 import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.rule.category.RuleCategory
@@ -125,7 +125,7 @@ trait RestDataSerializer {
       optRunDate:  Option[DateTime],
       inventory:   Option[FullInventory],
       software:    Seq[Software],
-      optTenant:   Option[SecurityTag],
+      cnf:         MinimalNodeFactInterface,
       detailLevel: NodeDetailLevel
   ): JValue
 
@@ -173,10 +173,10 @@ final case class RestDataSerializerImpl(
       optRunDate:  Option[DateTime],
       inventory:   Option[FullInventory],
       software:    Seq[Software],
-      optTenant:   Option[SecurityTag],
+      cnf:         MinimalNodeFactInterface,
       detailLevel: NodeDetailLevel
   ): JValue = {
-    detailLevel.toJson(nodeInfo, status, optRunDate, inventory, software, optTenant)
+    detailLevel.toJson(nodeInfo, status, optRunDate, inventory, software, cnf)
   }
 
   def serializeInventory(inventory: FullInventory, status: String): JValue = {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -1359,14 +1359,22 @@ class NodeApiService(
                            inventory = x.toFullInventory
                            software  = x.software.toList.map(_.toSoftware)
                          } yield {
-                           Some((x.toNodeInfo, runs, inventory, software, x.rudderSettings.security))
+                           Some((x.toNodeInfo, runs, inventory, software, x))
                          }
                      }
     } yield {
       nodeInfo.map {
-        case (node, runs, inventory, software, optTenant) =>
+        case (node, runs, inventory, software, cnf) =>
           val runDate = runs.get(nodeId).flatMap(_.map(_.agentRunId.date))
-          restSerializer.serializeInventory(node, state, runDate, Some(inventory), software, optTenant, detailLevel)
+          restSerializer.serializeInventory(
+            node,
+            state,
+            runDate,
+            Some(inventory),
+            software,
+            cnf,
+            detailLevel
+          )
       }
     }
   }
@@ -1442,7 +1450,7 @@ class NodeApiService(
           runDate,
           inventories.get(nodeId),
           software.getOrElse(nodeId, Seq()),
-          nodeFact.rudderSettings.security,
+          nodeFact,
           detailLevel
         )
       }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
@@ -54,6 +54,7 @@ response:
               "192.168.0.10"
             ],
             "description":"",
+            "acceptanceDate" : "2021-01-30T01:20:00+01:00",
             "lastInventoryDate":"2021-01-30T01:20:00+01:00",
             "policyServerId":"root",
             "managementTechnology":[


### PR DESCRIPTION
https://issues.rudder.io/issues/25476

Add the `acceptanceDate` (when the node was accepted in Rudder) in the default pool of node details properties. 

Add `scheduleOverride` in the `managementTechnologyDetails` with details of the overridden values. 
It's in details, and only for the overriding case, because it was simpler technically to do so (and upmerge will be complicated), it doesn't seem to be asked a lot, and it will be possible to later add the run schedule in a more general section if we want (and in 8.2 and up, it will be easier to do so). 

I used `nodeFact` since we have it in 8.2, but in any cases, the upmerge will be interesting. 