### PR TITLE
Fixes #25555: 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/DataStructures.scala
@@ -60,6 +60,9 @@ final case class ApiAccountName(value: String) extends AnyVal
 /**
  * The actual authentication token.
  *
+ * TODO: Once support for plain text tokens is dropped, make separate types for plain and hashed tokens.
+         Current situation is confusing, and hence a bit risky.
+ *
  * There are two versions of tokens:
  *
  * * v1: 32 alphanumeric characters stored as clear text
@@ -78,7 +81,13 @@ final case class ApiAccountName(value: String) extends AnyVal
  */
 case class ApiToken(value: String) extends AnyVal {
   // Avoid printing the value in logs, regardless of token type
-  override def toString: String = s"[REDACTED ApiToken]"
+  override def toString: String = "[REDACTED ApiToken]"
+
+  // For cases we need to print a part of the plain token for debug.
+  // Show the first 4 chars: enough to disambiguate, and preserves 166 bits of randomness.
+  def exposeSecretBeginning: String = {
+    value.take(4) + "[SHORTENED ApiToken]"
+  }
 
   def isHashed: Boolean = {
     value.startsWith(prefixV2)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/api/ApiTokenTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/api/ApiTokenTest.scala
@@ -1,0 +1,61 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.api
+
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class TestApiToken extends Specification {
+
+  "API tokens" should {
+    "be hidden in strings" in {
+      val token = ApiToken("UBeJJbm1tPDwILWVHXqBdgmIm3s4xjtY")
+      token.toString() must beEqualTo("[REDACTED ApiToken]")
+    }
+    "be partly hidden in controled exposure" in {
+      val token          = ApiToken("UBeJJbm1tPDwILWVHXqBdgmIm3s4xjtY")
+      token.exposeSecretBeginning must beEqualTo("UBeJ[SHORTENED ApiToken]")
+      val shortToken     = ApiToken("test")
+      shortToken.exposeSecretBeginning must beEqualTo("test[SHORTENED ApiToken]")
+      val veryShortToken = ApiToken("t")
+      veryShortToken.exposeSecretBeginning must beEqualTo("t[SHORTENED ApiToken]")
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -793,7 +793,11 @@ class RestAuthenticationFilter(
                   failsAuthentication(httpRequest, httpResponse, err)
 
                 case Right(None) =>
-                  failsAuthentication(httpRequest, httpResponse, Inconsistency(s"No registered token '${token}'"))
+                  failsAuthentication(
+                    httpRequest,
+                    httpResponse,
+                    Inconsistency(s"No registered token '${apiToken.exposeSecretBeginning}'")
+                  )
 
                 case Right(Some(principal)) =>
                   if (principal.isEnabled) {


### PR DESCRIPTION
https://issues.rudder.io/issues/25555

The problem was that the log message used the raw token and not the typed `ApiToken` (which has a custom `toString`). But it is useful to be able to identify an unknown token, and we can afford to lose a bit of randomness.