### PR TITLE
Fixes #25527: List techniques with compilation failure in bar for generation status

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/StatusLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/StatusLogger.scala
@@ -1,0 +1,51 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+package com.normation.rudder.domain.logger
+
+import com.normation.NamedZioLogger
+
+/**
+ * Applicative pure logger for configuration status that may have vary in Rudder, 
+ * from success to errors in different configuration management parts of Rudder
+ */
+object StatusLoggerPure extends NamedZioLogger { parent =>
+  override def loggerName: String = "status"
+
+  object Techniques extends NamedZioLogger {
+    def loggerName: String = parent.loggerName + ".techniques"
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompilationCache.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompilationCache.scala
@@ -1,0 +1,224 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.ncf
+
+import com.normation.errors.IOResult
+import com.normation.inventory.domain.Version
+import com.normation.rudder.batch.UpdateCompilationStatus
+import com.normation.rudder.domain.logger.StatusLoggerPure
+import net.liftweb.common.SimpleActor
+import zio.*
+
+sealed trait CompilationResult
+object CompilationResult {
+  case object Success                extends CompilationResult
+  case class Error(errorMsg: String) extends CompilationResult
+}
+
+case class EditorTechniqueCompilationResult(
+    id:      BundleName,
+    version: Version,
+    name:    String,
+    result:  CompilationResult
+)
+
+object EditorTechniqueCompilationResult {
+  def from(technique: EditorTechnique, output: TechniqueCompilationOutput) = {
+    if (output.isError) {
+      EditorTechniqueCompilationResult(technique.id, technique.version, technique.name, CompilationResult.Error(output.stderr))
+    } else {
+      EditorTechniqueCompilationResult(technique.id, technique.version, technique.name, CompilationResult.Success)
+    }
+  }
+}
+
+case class EditorTechniqueError(
+    id:           BundleName,
+    version:      Version,
+    name:         String,
+    errorMessage: String
+)
+
+sealed trait CompilationStatus
+case object CompilationStatusAllSuccess                                                    extends CompilationStatus
+case class CompilationStatusErrors(techniquesInError: NonEmptyChunk[EditorTechniqueError]) extends CompilationStatus
+
+/**
+  * Get latest global techniques compilation results
+  */
+trait ReadEditorTechniqueCompilationResult {
+
+  def get(): IOResult[List[EditorTechniqueCompilationResult]]
+
+}
+
+/**
+  * Update technique compilation status from technique compilation output and technique info
+  */
+trait TechniqueCompilationStatusSyncService {
+  /*
+   * Given new editor technique compilation results, update current status and sync it with UI
+   */
+  def syncOne(result: EditorTechniqueCompilationResult): IOResult[Unit]
+
+  /*
+   * The whole process that lookup for compilation status and update everything
+   */
+  def getUpdateAndSync(): IOResult[Unit]
+}
+
+/**
+  * Service to read the latest technique compilation results using the editor techniques 
+  * and the compiler which has access to the output from the editor techniques 
+  */
+class TechniqueCompilationStatusService(
+    readTechniques:    EditorTechniqueReader,
+    techniqueCompiler: TechniqueCompiler
+) extends ReadEditorTechniqueCompilationResult {
+
+  override def get(): IOResult[List[EditorTechniqueCompilationResult]] = {
+    readTechniques.readTechniquesMetadataFile.flatMap {
+      // _._3 errors are not compilation errors but error on techniques, we ignore them for status
+      case (techniques, _, _) => {
+
+        val outputs = ZIO
+          .foreach(techniques) { technique =>
+            techniqueCompiler
+              .getCompilationOutput(technique)
+              .map {
+                case None         => // we don't have output only in case of successful compilation
+                  EditorTechniqueCompilationResult(technique.id, technique.version, technique.name, CompilationResult.Success)
+                case Some(output) =>
+                  EditorTechniqueCompilationResult.from(technique, output)
+              }
+          }
+
+        outputs <* StatusLoggerPure.Techniques.trace(
+          s"Get compilation status : read ${techniques.size} editor techniques to update compilation status with"
+        )
+
+      }
+    }
+  }
+
+}
+
+/**
+  * Technique compilation output needs to be saved in a cache (frequent reads, we don't want to get files on the FS every time).
+  *
+  * This cache is a simple in-memory one which only saves errors,
+  * so it saves only compilation output stderr message in case the compilation failed.
+  * It notifies the lift actor on update of the compilation status.
+  *
+  * It is used mainly to get errors in the Rudder UI, and is updated when API requests to update techniques are made,
+  * when technique library is reloaded
+  */
+class TechniqueCompilationErrorsActorSync(
+    actor:     SimpleActor[UpdateCompilationStatus],
+    reader:    ReadEditorTechniqueCompilationResult,
+    errorBase: Ref[Map[(BundleName, Version), EditorTechniqueError]]
+) extends TechniqueCompilationStatusSyncService {
+
+  /*
+   * Update the internal cache and build a Compilation status
+   */
+  private[ncf] def updateStatus(results: List[EditorTechniqueCompilationResult]): UIO[CompilationStatus] = {
+    errorBase.updateAndGet { m =>
+      results.foldLeft(m) {
+        case (current, EditorTechniqueCompilationResult(id, version, name, CompilationResult.Error(error))) =>
+          current + ((id, version) -> EditorTechniqueError(id, version, name, error))
+        case (current, EditorTechniqueCompilationResult(id, version, _, CompilationResult.Success))         =>
+          current - ((id, version))
+      }
+    }.map(m => getStatus(m.values))
+  }
+
+  /*
+   * Given new editor technique compilation results, update current status and sync it with UI
+   */
+  def syncOne(result: EditorTechniqueCompilationResult): IOResult[Unit] = {
+    for {
+      status <- updateStatus(List(result))
+      _      <- syncStatusWithUi(status)
+    } yield ()
+  }
+
+  /*
+   * The whole process that lookup for compilation status and update everything
+   */
+  def getUpdateAndSync(): IOResult[Unit] = {
+    (for {
+      results <- reader.get()
+      status  <- updateStatus(results)
+      _       <- syncStatusWithUi(status)
+    } yield status).flatMap {
+      case CompilationStatusAllSuccess => StatusLoggerPure.Techniques.info("All techniques have success compilation result")
+      case e: CompilationStatusErrors =>
+        val techniques = e.techniquesInError.map(t => s"${t.id.value}(v${t.version.value})").toList.mkString(",")
+        StatusLoggerPure.Techniques.warn(
+          s"Found ${e.techniquesInError.size} techniques with compilation errors : ${techniques}"
+        )
+    }
+  }
+
+  /*
+   * Push the changes to comet actor
+   */
+  private[ncf] def syncStatusWithUi(status: CompilationStatus): IOResult[Unit] = {
+    IOResult.attempt(actor ! UpdateCompilationStatus(status))
+  }
+
+  private def getStatus(errors: Iterable[EditorTechniqueError]): CompilationStatus = {
+    NonEmptyChunk.fromIterableOption(errors) match {
+      case None        => CompilationStatusAllSuccess
+      case Some(value) => CompilationStatusErrors(value)
+    }
+  }
+
+}
+
+object TechniqueCompilationErrorsActorSync {
+  def make(
+      actor:  SimpleActor[UpdateCompilationStatus],
+      reader: ReadEditorTechniqueCompilationResult
+  ): UIO[TechniqueCompilationErrorsActorSync] = {
+    Ref
+      .make(Map.empty[(BundleName, Version), EditorTechniqueError])
+      .map(new TechniqueCompilationErrorsActorSync(actor, reader, _))
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
@@ -405,7 +405,7 @@ class TechniqueArchiverImpl(
 
     (for {
       res       <- techniqueCompiler.migrateCompileIfNeeded(techniquePath)
-      _         <- ZIO.when(res.resultCode != 0) {
+      _         <- ZIO.when(res.isError) {
                      Unexpected(
                        s"Error when trying to compile technique '${techniquePath.pathAsString}'. Error details are " +
                        s"available in `compilation-output.yml` file in the same directory. Error message: '${res.msg}'"

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
@@ -73,9 +73,9 @@ import com.normation.rudder.domain.policies.PolicyMode.Enforce
 import com.normation.rudder.domain.policies.PolicyTypes
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.domain.workflows.ChangeRequest
-import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.hooks.CmdResult
 import com.normation.rudder.ncf.ParameterType.PlugableParameterTypeService
+import com.normation.rudder.ncf.TechniqueWriterImpl
 import com.normation.rudder.repository.CategoryWithActiveTechniques
 import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.rudder.repository.RoDirectiveRepository
@@ -553,29 +553,12 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
     _.path,
     basePath
   )
-  val writer   = new TechniqueWriterImpl(
-    TestTechniqueArchiver,
-    TestLibUpdater,
-    new DeleteEditorTechnique {
-      override def deleteTechnique(
-          techniqueName:    String,
-          techniqueVersion: String,
-          deleteDirective:  Boolean,
-          modId:            ModificationId,
-          committer:        QueryContext
-      ): IOResult[Unit] = {
-        ZIO.unit
-      }
-    },
-    compiler,
-    basePath
-  )
 
   val yamlPath: String = s"techniques/ncf_techniques/${technique.id.value}/${technique.version.value}/technique.yml"
 
   s"Preparing files for technique ${technique.name}" should {
     "Should write yaml file without problem" in {
-      writer.writeYaml(technique).either.runNow must beRight(yamlPath)
+      TechniqueWriterImpl.writeYaml(technique)(basePath).either.runNow must beRight(yamlPath)
     }
 
     "Should generate expected yaml content for our technique" in {
@@ -626,7 +609,7 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
   s"Preparing files for technique ${technique.id.value}" should {
 
     "Should write yaml file without problem" in {
-      writer.writeYaml(technique_any).either.runNow must beRight(techniquePath_yaml)
+      TechniqueWriterImpl.writeYaml(technique_any)(basePath).either.runNow must beRight(techniquePath_yaml)
     }
 
     "Should generate expected yaml content for our technique" in {
@@ -674,7 +657,7 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
 
   s"Preparing files for technique ${technique.id.value}" should {
     "Should write metadata file without problem" in {
-      writer.writeYaml(technique_var_cond).either.runNow must beRight(
+      TechniqueWriterImpl.writeYaml(technique_var_cond)(basePath).either.runNow must beRight(
         s"techniques/ncf_techniques/${techniquePath_var_cond_yaml}"
       )
     }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestTechniqueCompilationCache.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestTechniqueCompilationCache.scala
@@ -1,0 +1,213 @@
+/*
+ *************************************************************************************
+ * Copyright 2017 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.ncf
+
+import better.files.File
+import com.normation.errors.*
+import com.normation.inventory.domain.Version
+import com.normation.rudder.batch.UpdateCompilationStatus
+import com.normation.rudder.hooks.CmdResult
+import com.normation.zio.UnsafeRun
+import net.liftweb.actor.MockLiftActor
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import org.specs2.specification.BeforeAfterAll
+import zio.Chunk
+import zio.NonEmptyChunk
+import zio.ZIO
+import zio.syntax.*
+
+@RunWith(classOf[JUnitRunner])
+class TestTechniqueCompilationCache extends Specification with BeforeAfterAll {
+
+  /*
+   * Reading things
+   */
+  private val compilationDir = File.newTemporaryDirectory("rudder-test-technique-compilation-service")
+
+  private val technique1 = EditorTechnique(
+    BundleName("tech1"),
+    new Version("1.0"),
+    "technique 1",
+    "",
+    Nil,
+    "",
+    "",
+    Seq.empty,
+    Seq.empty,
+    Map.empty,
+    None
+  )
+
+  private val technique2 = technique1.copy(id = BundleName("tech2"), name = "technique 2")
+  private val technique3 = technique1.copy(id = BundleName("tech3"), name = "technique 3")
+
+  private val techniques = List(technique1, technique2, technique3)
+
+  private val editorTechniqueReader: EditorTechniqueReader = new EditorTechniqueReader {
+    override def readTechniquesMetadataFile
+        : IOResult[(List[EditorTechnique], Map[BundleName, GenericMethod], List[RudderError])] = {
+      (techniques, Map.empty[BundleName, GenericMethod], List.empty[RudderError]).succeed
+    }
+    override def getMethodsMetadata:        IOResult[Map[BundleName, GenericMethod]] = ???
+    override def updateMethodsMetadataFile: IOResult[CmdResult]                      = ???
+
+  }
+  private val techniqueCompiler:     TechniqueCompiler     = new TechniqueCompiler {
+
+    override def compileTechnique(technique: EditorTechnique): IOResult[TechniqueCompilationOutput] = {
+      fakeCompilationOutput
+        .apply(technique)
+        .succeed
+    }
+
+    override def getCompilationOutputFile(technique: EditorTechnique): File = {
+      compilationDir / s"${technique.id.value}"
+    }
+
+    override def getCompilationConfigFile(technique: EditorTechnique): File = ???
+
+  }
+
+  // the SUT
+  private val compilationStatusService: ReadEditorTechniqueCompilationResult = new TechniqueCompilationStatusService(
+    editorTechniqueReader,
+    techniqueCompiler
+  )
+
+  private val fakeCompilationOutput: PartialFunction[EditorTechnique, TechniqueCompilationOutput] = {
+    case technique if technique.id == technique1.id =>
+      TechniqueCompilationOutput(
+        TechniqueCompilerApp.Rudderc,
+        101,
+        Chunk.empty,
+        "err1",
+        "stdout",
+        "tech1 error"
+      )
+    case technique if technique.id == technique2.id =>
+      TechniqueCompilationOutput(
+        TechniqueCompilerApp.Rudderc,
+        0,
+        Chunk.empty,
+        "success",
+        "stdout",
+        ""
+      )
+    case technique if technique.id == technique3.id =>
+      TechniqueCompilationOutput(
+        TechniqueCompilerApp.Rudderc,
+        2,
+        Chunk.empty,
+        "err3",
+        "stdout",
+        "tech3 error"
+      )
+  }
+
+  // sync with actor
+  private val mockActor  = new MockLiftActor
+  private val writeCache = TechniqueCompilationErrorsActorSync.make(mockActor, compilationStatusService).runNow
+
+  // create output test files for each technique
+  override def beforeAll(): Unit = {
+    import TechniqueCompilationIO.*
+    import zio.json.yaml.*
+    ZIO
+      .foreach(techniques)(t => fakeCompilationOutput.apply(t).toYaml().toIO.map(compilationDir.createChild(t.id.value).write(_)))
+      .runNow
+  }
+
+  val expectedListOfOutputs: List[EditorTechniqueCompilationResult] = List(
+    EditorTechniqueCompilationResult(technique1.id, technique1.version, technique1.name, CompilationResult.Error("tech1 error")),
+    EditorTechniqueCompilationResult(technique2.id, technique2.version, technique2.name, CompilationResult.Success),
+    EditorTechniqueCompilationResult(technique3.id, technique3.version, technique3.name, CompilationResult.Error("tech3 error"))
+  )
+
+  override def afterAll(): Unit = {
+    compilationDir.delete()
+  }
+
+  "ReadEditorTechniqueCompilationResult" should {
+    "read with cumulated errors" in {
+      compilationStatusService.get().runNow must beEqualTo(expectedListOfOutputs)
+    }
+  }
+
+  "Error repository" should {
+    "Correctly build the status" in {
+      writeCache.updateStatus(expectedListOfOutputs).runNow must beEqualTo(
+        CompilationStatusErrors(
+          NonEmptyChunk(
+            EditorTechniqueError(
+              technique1.id,
+              technique1.version,
+              technique1.name,
+              "tech1 error"
+            ),
+            EditorTechniqueError(
+              technique3.id,
+              technique3.version,
+              technique3.name,
+              "tech3 error"
+            )
+          )
+        )
+      )
+    }
+
+    "sync with UI" in {
+      (writeCache.syncOne(expectedListOfOutputs.head) *> IOResult.attempt(
+        mockActor hasReceivedMessage_? (UpdateCompilationStatus(
+          CompilationStatusErrors(
+            NonEmptyChunk(
+              EditorTechniqueError(
+                technique1.id,
+                technique1.version,
+                technique1.name,
+                "tech1 error"
+              )
+            )
+          )
+        ))
+      )).runNow
+
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/resources/logback.xml
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/logback.xml
@@ -451,6 +451,13 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
   </logger>
 
   <!--
+    Log about configuration information for the status of some specific parts of Rudder
+  -->
+  <logger name="status" level="info">
+    <appender-ref ref="STDOUT" />
+  </logger>
+
+  <!--
       This logger allows to log information about reports, especially DB cleaning operation
   -->
   <logger name="report" level="info" additivity="false">

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/action/CheckTechniqueCompilationStatus.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/action/CheckTechniqueCompilationStatus.scala
@@ -1,0 +1,26 @@
+package bootstrap.liftweb.checks.action
+
+import bootstrap.liftweb.BootstrapChecks
+import bootstrap.liftweb.BootstrapLogger
+import com.normation.rudder.ncf.TechniqueCompilationStatusSyncService
+import com.normation.zio.UnsafeRun
+
+/**
+  * Reload the global technique compilation status at startup.
+  * It is done asynchronously because errors (e.g. on a yml file in the filesystem)
+  * are not supposed to prevent Rudder startup.
+  */
+class CheckTechniqueCompilationStatus(
+    techniqueCompilationStatusService: TechniqueCompilationStatusSyncService
+) extends BootstrapChecks {
+
+  override def description: String = "Check for technique compilation errors"
+
+  override def checks(): Unit = {
+    techniqueCompilationStatusService
+      .getUpdateAndSync()
+      .catchAll(err => BootstrapLogger.error(s"Error when trying to check technique compilation errors: ${err.fullMsg}"))
+      .forkDaemon
+      .runNow
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/MigrateJsonTechniquesToYaml.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/MigrateJsonTechniquesToYaml.scala
@@ -58,10 +58,11 @@ import zio.*
  * Controlled by presence of flag file /opt/rudder/etc/force_ncf_technique_update
  */
 class MigrateJsonTechniquesToYaml(
-    techniqueWriter:   TechniqueWriter,
-    uuidGen:           StringUuidGenerator,
-    techLibUpdate:     UpdateTechniqueLibrary,
-    rootConfigRepoDir: String
+    techniqueWriter:                   TechniqueWriter,
+    uuidGen:                           StringUuidGenerator,
+    techLibUpdate:                     UpdateTechniqueLibrary,
+    techniqueCompilationStatusService: ReadEditorTechniqueCompilationResult,
+    rootConfigRepoDir:                 String
 ) extends BootstrapChecks {
 
   object TechniqueMigrationLogger extends NamedZioLogger {
@@ -139,6 +140,8 @@ class MigrateJsonTechniquesToYaml(
                           )
                           .toIO
                           .chainError(s"An error occurred during techniques update after update of all techniques from the editor")
+      // Update compilation status after every library change
+      _              <- techniqueCompilationStatusService.get().unless(libUpdate.isEmpty)
 
     } yield ()
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/25527

* Create a `TechniqueCompilationStatusService` that **reloads** the global compilation status : 
  * it is done every 5 minutes by default (`rudder.batch.techniqueLibrary.updateInterval` property)
  * it is reloaded at startup with a new bootstrap check
  * it is updated on individual techniques after every update of a techniques from a REST API call
* We call the lift actor that is responsible for updating the UI directly in the method that uploads the status that is computed from a cache. The architecture is a bit weird, but it prevents having to manually call the actor at every place which is also weird (call an UI actor in a REST API method ?). Later we would be exposing the status information in a dedicated endpoint so that we no longer need a stateful actor in our layers. 

The architecture of components looks like this : 
```mermaid
graph LR
   subgraph Technique_hooks
     CheckTechniqueCompilationStatus
     CheckTechniqueLibrary
     MigrateJsonTechniquesToYaml
   end
   Technique_hooks --get()-->TCSS
   
	 subgraph Techniques_core
     TCSS[TechniqueCompilationStatusService] --update--> TCEC[TechniqueCompilationErrorsCache]
   end
   TCEC --. ! UpdateCompilationStatus--> ADA
   
   subgraph Actors
     ADA((AsyncDeploymentActor)) --. ! AsyncDeploymentActorCreateUpdate--> AD((AsyncDeployment))
   end
   
   AD --> UI(UI)
```


UI : 
![Peek 2024-09-30 12-02](https://github.com/user-attachments/assets/9c8e0de2-d88f-4ced-885f-548af78a9cc8)
