### PR TITLE
Fixes #25579: System variable can be empty early on the generation process

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
@@ -616,9 +616,10 @@ final case class BoundPolicyDraft(
                                            )
                                          }
                                          // check if there is mandatory variable with missing/blank values
+                                         // NOTE : it's OK that system variables are not filled here yet
                                          (
-                                           variable.spec.constraint.mayBeEmpty,
-                                           variable.values.exists(v => v == null || v.isEmpty)
+                                           variable.spec.constraint.mayBeEmpty || variable.spec.isSystem,
+                                           variable.values.isEmpty || variable.values.exists(v => v == null || v.isEmpty)
                                          ) match {
                                            // simple case: it's optional, we don't care if empty or not.
                                            case (true, _) => Right((cid, variable))
@@ -651,7 +652,8 @@ final case class BoundPolicyDraft(
         // add missing if possible
         added                 <- missing.accumulatePure {
                                    case (_, (cid, spec)) =>
-                                     (spec.constraint.mayBeEmpty, spec.constraint.default) match {
+                                     // if mayBeEmpty or if it's a system variable, just add it - empty.
+                                     (spec.constraint.mayBeEmpty || spec.isSystem, spec.constraint.default) match {
                                        case (true, _)        => Right((cid, spec.toVariable()))
                                        case (false, Some(d)) => Right((cid, spec.toVariable(Seq(d))))
                                        case (false, None)    =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PrepareTemplateVariables.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PrepareTemplateVariables.scala
@@ -353,11 +353,8 @@ class PrepareTemplateVariablesImpl(
       systemVars:           Map[String, Variable]
   ): IOResult[Seq[STVariable]] = {
 
-    // we want to check that all technique variables are correctly provided.
-    // we can't do it when we built node configuration because some (system variable at least (note: but only? If so, we could just check
-    // them here, not everything).
-
-    ZIO.foreach(policy.trackerVariable :: (systemVars.values ++ policy.expandedVars.values).toList)(v =>
+    // here, we want to be sure to get the system variable that were late defined in priority.
+    ZIO.foreach(policy.trackerVariable :: (policy.expandedVars ++ systemVars).values.toList)(v =>
       stVariableFromVariable(v, agentVariableHandler, agentNodeProps.nodeId, policy.technique.id)
     )
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/25579

So, our management of system variable is not very good. We need to idenfy the one that are late bound and allow only these one to be void, but that's a big change. So for now, we are just relaxing the check on system var. It's ok, we never have a failure because of that for system var (which would be a bug) if we don't add/remove system var or change their generation. We will need to correct it in next patch, though.