### PR TITLE
Fixes #25592: Add node property errors in inherited properties API

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/NodeGroupRepository.scala
@@ -199,6 +199,17 @@ final case class FullNodeGroupCategory(
     }
   }
 
+  /**
+   * Given a nodeId, get all the strict groups targets where it belongs to.
+   */
+  def getGroupTarget(node: CoreNodeFact): Map[RuleTarget, FullGroupTarget] = {
+    allTargets.collect {
+      case (t, FullRuleTargetInfo(groupTarget: FullGroupTarget, _, _, _, _))
+          if groupTarget.nodeGroup.serverList.contains(node.id) =>
+        t -> groupTarget
+    }
+  }
+
 }
 
 trait RoNodeGroupRepository {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/properties/PropertiesRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/properties/PropertiesRepositoryTest.scala
@@ -1,0 +1,93 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.domain.properties
+
+import com.normation.rudder.MockNodes
+import com.normation.rudder.facts.nodes.QueryContext
+import com.normation.rudder.properties.InMemoryPropertiesRepository
+import com.normation.zio.UnsafeRun
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import zio.Chunk
+
+@RunWith(classOf[JUnitRunner])
+class PropertiesRepositoryTest extends Specification {
+  sequential
+
+  private val mockNodes    = new MockNodes()
+  private val nodeFactRepo = mockNodes.nodeFactRepo
+  private val repo         = InMemoryPropertiesRepository.make(nodeFactRepo).runNow
+
+  implicit private val qc: QueryContext = QueryContext.testQC
+
+  "PropertiesRepository" should {
+    // node1 has empty properties
+    // node2 has some properties
+    val resolvedNode2 = SuccessNodePropertyHierarchy(
+      Chunk.from(
+        MockNodes.node2Node.properties.map(NodePropertyHierarchy(_, List.empty))
+      )
+    )
+    val initialProps  = Map(
+      MockNodes.node1.id -> ResolvedNodePropertyHierarchy.empty,
+      MockNodes.node2.id -> resolvedNode2
+    )
+    "save node properties" in {
+      (repo.saveNodeProps(initialProps) *> repo.getAllNodeProps()).runNow must containTheSameElementsAs(initialProps.toList)
+    }
+
+    "get node properties on several nodes for a property" in {
+      // node1 without the property is ommited from the result
+      val expected = resolvedNode2.resolved.filter(_.prop.name == "simpleString").map(MockNodes.node2.id -> _)
+      repo.getNodesProp(Set(MockNodes.node1.id, MockNodes.node2.id), "simpleString").runNow must containTheSameElementsAs(
+        expected
+      )
+    }
+
+    "get node properties on several nodes for a property with resolution errors" in {
+      // if node2 has failed resolution of properties
+      val props = initialProps
+        .updated(MockNodes.node2.id, FailedNodePropertyHierarchy(Chunk.empty, NodePropertyError.DAGError("A DAGError")))
+      (repo.saveNodeProps(props) *> repo.getNodesProp(
+        Set(MockNodes.node1.id, MockNodes.node2.id),
+        "simpleString"
+      )).runNow must beEmpty
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestBuildNodeConfiguration.scala
@@ -58,7 +58,7 @@ import com.normation.rudder.domain.policies.PolicyTypes
 import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
-import com.normation.rudder.domain.properties.NodePropertyHierarchy
+import com.normation.rudder.domain.properties.ResolvedNodePropertyHierarchy
 import com.normation.rudder.domain.reports.NodeModeConfig
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.repository.FullActiveTechnique
@@ -74,7 +74,6 @@ import org.specs2.runner.*
 import scala.collection.MapView
 import scala.collection.SortedMap
 import scala.concurrent.duration.*
-import zio.Chunk
 
 /*
  * This class test the JsEngine. 6.0
@@ -191,7 +190,7 @@ class TestBuildNodeConfiguration extends Specification {
   val jsTimeout: FiniteDuration = FiniteDuration(5, "minutes")
   val generationContinueOnError = false
 
-  val inheritedProps: Map[NodeId, Chunk[NodePropertyHierarchy]] = Map()
+  val inheritedProps: Map[NodeId, ResolvedNodePropertyHierarchy] = Map()
 
   // you can debug detail timing by setting "TRACE" level below:
   org.slf4j.LoggerFactory

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
@@ -264,7 +264,7 @@ response:
                 },
                 "provider":"overridden",
                 "hierarchy" : "<p>from <b>Global Parameter</b>:<pre>{\n    \"array\" : [\n        1,\n        3,\n        2\n    ],\n    \"json\" : {\n        \"var1\" : \"val1\",\n        \"var2\" : \"val2\"\n    },\n    \"string\" : \"a string\"\n}\n</pre></p><p>from <b>this group (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>{\n    \"array\" : [\n        5,\n        6\n    ],\n    \"group\" : \"string\",\n    \"json\" : {\n        \"g1\" : \"g1\"\n    }\n}\n</pre></p>",
-                  "hierarchyStatus":{
+                "hierarchyStatus":{
                   "hasChildTypeConflicts":false,
                   "fullHierarchy":[
                     {

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -73,7 +73,7 @@ import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleTarget
 import com.normation.rudder.domain.properties.GlobalParameter
-import com.normation.rudder.domain.properties.NodePropertyHierarchy
+import com.normation.rudder.domain.properties.ResolvedNodePropertyHierarchy
 import com.normation.rudder.domain.reports.NodeConfigId
 import com.normation.rudder.domain.reports.NodeExpectedReports
 import com.normation.rudder.domain.reports.NodeModeConfig
@@ -339,17 +339,17 @@ class RestTestSetUp {
     override def writeCertificatesPem(allNodeInfos: MapView[NodeId, CoreNodeFact]): Unit = ???
     override def triggerNodeGroupUpdate(): Box[Unit] = ???
     override def beforeDeploymentSync(generationTime: DateTime): Box[Unit] = ???
-    override def HOOKS_D:                     String                                              = ???
-    override def HOOKS_IGNORE_SUFFIXES:       List[String]                                        = ???
-    override def UPDATED_NODE_IDS_PATH:       String                                              = ???
-    override def GENERATION_FAILURE_MSG_PATH: String                                              = ???
+    override def HOOKS_D:                     String                                               = ???
+    override def HOOKS_IGNORE_SUFFIXES:       List[String]                                         = ???
+    override def UPDATED_NODE_IDS_PATH:       String                                               = ???
+    override def GENERATION_FAILURE_MSG_PATH: String                                               = ???
     override def getAppliedRuleIds(
         rules:        Seq[Rule],
         groupLib:     FullNodeGroupCategory,
         directiveLib: FullActiveTechniqueCategory,
         allNodeInfos: MapView[NodeId, Boolean]
     ): Set[RuleId] = ???
-    override def findDependantRules():        Box[Seq[Rule]]                                      = ???
+    override def findDependantRules():        Box[Seq[Rule]]                                       = ???
     override def buildRuleVals(
         activesRules: Set[RuleId],
         rules:        Seq[Rule],
@@ -357,20 +357,20 @@ class RestTestSetUp {
         groupLib:     FullNodeGroupCategory,
         allNodeInfos: MapView[NodeId, Boolean]
     ): Box[Seq[RuleVal]] = ???
-    override def getNodeProperties:           IOResult[Map[NodeId, Chunk[NodePropertyHierarchy]]] = {
+    override def getNodeProperties:           IOResult[Map[NodeId, ResolvedNodePropertyHierarchy]] = {
       ???
     }
     override def getNodeContexts(
         nodeIds:              Set[NodeId],
         allNodeInfos:         MapView[NodeId, CoreNodeFact],
-        inheritedProps:       Map[NodeId, Chunk[NodePropertyHierarchy]],
+        inheritedProps:       Map[NodeId, ResolvedNodePropertyHierarchy],
         allGroups:            FullNodeGroupCategory,
         globalParameters:     List[GlobalParameter],
         globalAgentRun:       AgentRunInterval,
         globalComplianceMode: ComplianceMode,
         globalPolicyMode:     GlobalPolicyMode
     ): Box[NodesContextResult] = ???
-    override def getFilteredTechnique():      Map[NodeId, List[TechniqueName]]                    = ???
+    override def getFilteredTechnique():      Map[NodeId, List[TechniqueName]]                     = ???
     override def buildNodeConfigurations(
         activeNodeIds:             Set[NodeId],
         ruleVals:                  Seq[RuleVal],
@@ -384,7 +384,7 @@ class RestTestSetUp {
         generationContinueOnError: Boolean
     ): Box[NodeConfigurations] = ???
     override def forgetOtherNodeConfigurationState(keep: Set[NodeId]): Box[Set[NodeId]] = ???
-    override def getNodeConfigurationHash():  Box[Map[NodeId, NodeConfigurationHash]]             = ???
+    override def getNodeConfigurationHash():  Box[Map[NodeId, NodeConfigurationHash]]              = ???
     override def getNodesConfigVersion(
         allNodeConfigs: Map[NodeId, NodeConfiguration],
         hashes:         Map[NodeId, NodeConfigurationHash],


### PR DESCRIPTION
https://issues.rudder.io/issues/25592

**Domain :**
* Change the data that is stored in the cache i.e. the resolved node properties (for both node and group properties), it may now contain errors, the model is oriented towards keeping success values despite errors, a model around and based on `Ior` from cats is used for the combinators as there does not seem to be a convenient ZIO equivalent. The ADT in the model is still the mainly used one : `ResolvedNodePropertyHierarchy`
* Errors have previously been into the "Left" channel of `PureResult[A] = Either[RudderError, A]` for all errors that could happen on groups, but now we need to know if the error is specific to a property of not, if so we need to accumulate errors in the left channel with `Ior`, so we bring it in with a new `NodePropertyError` ADT to get an `Ior[NodePropertyError, A]` instead
* This structure is converted to `ResolvedNodePropertyHierarchy`, which is exactly the type of what is stored in the cache

**API :**
* Change the Node and Group APIs to have an `errorMessage` at root level of the `displayInheritedProperties` API,
* At the level of the `hierarchyStatus` for a property, we also need to indicate an `errorMessage` if the property is conflicting because the group structure has conflict when overriding properties
* Having conflicting child type is also an error case and has been genericized into the current model of `InheritedPropertyStatus`

N.B. : adding API tests for conflicts is complicated for now, but we have it in a PR that needs to be upmerged : https://github.com/Normation/rudder/pull/5860, in which we will add the error message