### PR TITLE
Fixes #25513: worst report by percentage seems to be non fonctionnal

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -2358,7 +2358,128 @@ class ExecutionBatchTest extends Specification {
     "Return the worst Block" in { // b1 is the worst subComponent with 33% error
       statusReports.head.compliance === ComplianceLevel(error = 1, repaired = 2)
     }
+  }
 
+  // same as above with b1 being in worst-sum instead of weighted, so overall we should have errors and 0%
+  "Sub block with reporting 'worst case by percent' with case" should {
+    val reports = Seq[ResultReports](
+      new ResultErrorReport(
+        executionTimestamp,
+        "cr",
+        "policy",
+        "nodeId",
+        "report_id12",
+        "component1",
+        "b1c1",
+        executionTimestamp,
+        "message"
+      ),
+      new ResultRepairedReport(
+        executionTimestamp,
+        "cr",
+        "policy",
+        "nodeId",
+        "report_id12",
+        "component2",
+        "b1c2",
+        executionTimestamp,
+        "message"
+      ),
+      new ResultRepairedReport(
+        executionTimestamp,
+        "cr",
+        "policy",
+        "nodeId",
+        "report_id12",
+        "component3",
+        "b1c3",
+        executionTimestamp,
+        "message"
+      ),
+      new ResultSuccessReport(
+        executionTimestamp,
+        "cr",
+        "policy",
+        "nodeId",
+        "report_id12",
+        "component1",
+        "b2c1",
+        executionTimestamp,
+        "message"
+      ),
+      new ResultRepairedReport(
+        executionTimestamp,
+        "cr",
+        "policy",
+        "nodeId",
+        "report_id12",
+        "component1",
+        "b3c1",
+        executionTimestamp,
+        "message"
+      )
+    )
+
+    val expectedComponent        = BlockExpectedReport(
+      "blockRoot",
+      ReportingLogic.WorstReportByPercent,
+      BlockExpectedReport(
+        "block1",
+        ReportingLogic.WorstReportWeightedSum,
+        new ValueExpectedReport(
+          "component1",
+          ExpectedValueMatch("b1c1", "b1c1") :: Nil
+        ) :: new ValueExpectedReport(
+          "component2",
+          ExpectedValueMatch("b1c2", "b1c2") :: Nil
+        ) :: new ValueExpectedReport(
+          "component3",
+          ExpectedValueMatch("b1c3", "b1c3") :: Nil
+        ) :: Nil,
+        None
+      ) :: BlockExpectedReport(
+        "block2",
+        ReportingLogic.WeightedReport,
+        new ValueExpectedReport(
+          "component1",
+          ExpectedValueMatch("b2c1", "b2c1") :: Nil
+        ) :: Nil,
+        None
+      ) :: BlockExpectedReport(
+        "block3",
+        ReportingLogic.WeightedReport,
+        new ValueExpectedReport(
+          "component1",
+          ExpectedValueMatch("b3c1", "b3c1") :: Nil
+        ) :: Nil,
+        None
+      ) :: Nil,
+      None
+    )
+    val directiveExpectedReports = {
+      DirectiveExpectedReports(
+        DirectiveId(DirectiveUid("policy")),
+        None,
+        PolicyTypes.rudderBase,
+        components = expectedComponent :: Nil
+      )
+    }
+    val ruleExpectedReports      = RuleExpectedReports(RuleId("cr"), directiveExpectedReports :: Nil)
+    val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now())
+
+    val statusReports = ExecutionBatch
+      .getComplianceForRule(
+        mergeInfo,
+        reports,
+        mode,
+        ruleExpectedReports,
+        new ComputeComplianceTimer()
+      )
+      .collect { case r => r.directives("policy") }
+
+    "Return the worst Block" in { // b1 is the worst subComponent with sum of 3
+      statusReports.head.compliance === ComplianceLevel(error = 3)
+    }
   }
 
   "A block, with Sum reporting logic" should {


### PR DESCRIPTION
https://issues.rudder.io/issues/25513

It was not using real percentage of direct sub-components but of all the nested components for blocks :sweat_smile:...
 
The final result : 
![Screenshot from 2024-10-03 17-04-26](https://github.com/user-attachments/assets/3fa7d274-5152-4a4d-99f6-ede075d928a7)
