### PR TITLE
Fixes #25508: No system status in 8.2

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Node.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Node.scala
@@ -46,20 +46,8 @@ import net.liftweb.http.S
 import net.liftweb.http.StatefulSnippet
 
 /**
- *
- * Snippet that handle the "searchNodes" page.
- *
- * Two main feature:
- * - diplay details of a node
- * - search for nodes based on a query
- *
- * Node details are ALWAYS load via Ajax (see parseHashtag method).
- * Hashtag modification are detected with the hashchange" events,
- * supported since ie8/ff3.6/chrome5/safari5 - as to say,
- * immemorial times (see http://caniuse.com/hashchange for details)
- *
+ * Snippet that handle the "node details" (/node/uuid) page.
  */
-
 class NodeDetails extends StatefulSnippet with Loggable {
 
   private val getFullGroupLibrary = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _


### PR DESCRIPTION
https://issues.rudder.io/issues/25508

So, the problem was the hardoced "policyTypeName == user" in the middle of the second algo. I replaced the boolean "onlySystem" by the policyTypeName, up to the first caller, and use it in place of the hardcoded value.

I'm not sure why we do such complicated things for getting compliance for the node (in the case of only one node), since we do have its `NodeReportStatus` with all the rules under it. But this is beyond the scope of that change. 