### PR TITLE
Fixes #25604: Reporting type should be focus-worst instead of worst-case-percent

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/VariableAndSectionSpec.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/VariableAndSectionSpec.scala
@@ -490,17 +490,17 @@ object DisplayPriority {
  * - `weighted`
  *    compliance value will be the weighted contribution of all direct sub-elements
  * - `worst case (weight = 1)`
- *    compliance value will have the same level as the worst case, and will have weight 1
+ *    compliance value will have the same level as the worst case in all elements in the sub-tree, and will have weight 1
  * - `worst case (weight = sum all)`
- *    compliance value will have the same level as the worst case, and will have weight equals
+ *    compliance value will have the same level as the worst case in all elements in the sub-tree, and will have weight equals
  *    to the sum of weight of all sub components.
- * - `worst case by percent`
- *    compliance value will have the same level as the worst case with the least compliance percent
+ * - `focus worst`
+ *    compliance value will have the same level as the worst case with the least compliance percent of direct subelements
  *
  * Illustration :
  *
  *
- * BLOCK                                          FOCUS ON C1                        WEIGHTED                     WORST-1 on B1                    WORST-SUM on B1              WORST-PERCENT on BLOCK
+ * BLOCK                                          FOCUS ON C1                        WEIGHTED                     WORST-1 on B1                    WORST-SUM on B1               FOCUS-WORST on BLOCK
  * |                                                     |                               |                                |                                |                                |
  * +-- B1                                                |                               |                    +-----------------------+        +-----------------------+        +-----------------------+
  * |   |                                                 |                               |                    | B1 worst      = 1E    |        | B1 worst      = 1E    |        | B1 weighted   = 2S-1E |
@@ -546,8 +546,8 @@ object ReportingLogic {
   case object WorstReportWeightedSum             extends WorstReportWeightedReportingLogic {
     val value = "worst-case-weighted-sum"
   }
-  case object WorstReportByPercent               extends WorstReportReportingLogic         {
-    val value = "worst-case-percent"
+  case object FocusWorst                         extends WorstReportReportingLogic         {
+    val value = "focus-worst"
   }
 
   case object WeightedReport extends ReportingLogic {
@@ -558,7 +558,7 @@ object ReportingLogic {
     value.toLowerCase match {
       case WorstReportWeightedOne.value => Right(WorstReportWeightedOne)
       case WorstReportWeightedSum.value => Right(WorstReportWeightedSum)
-      case WorstReportByPercent.value   => Right(WorstReportByPercent)
+      case FocusWorst.value             => Right(FocusWorst)
       case WeightedReport.value         => Right(WeightedReport)
       case s"${FocusReport.key}:${a}"   => Right(FocusReport(a))
       case FocusReport.key              => Right(FocusReport(defaultFocusKey))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -364,7 +364,7 @@ final case class BlockStatusReport(
           case WorstReportWeightedSum => allReports
         }
         ComplianceLevel.compute(kept)
-      case WorstReportByPercent =>
+      case FocusWorst =>
         // Get reports of sub-components to find the worst by percent
         val allReports = subComponents.map {
           case b: BlockStatusReport =>
@@ -398,9 +398,9 @@ final case class BlockStatusReport(
 
   def status: ReportType = {
     reportingLogic match {
-      case WorstReportByPercent | WorstReportWeightedOne | WorstReportWeightedSum | WeightedReport =>
+      case FocusWorst | WorstReportWeightedOne | WorstReportWeightedSum | WeightedReport =>
         ReportType.getWorseType(subComponents.map(_.status))
-      case FocusReport(component)                                                                  =>
+      case FocusReport(component)                                                        =>
         ReportType.getWorseType(findChildren(component).map(_.status))
     }
   }
@@ -436,7 +436,7 @@ final case class ValueStatusReport(
 /**
  * Merge component status reports.
  * We assign a arbitrary preponderance order for reporting logic mode:
- * WorstReportWeightedOne > WorstReportWeightedSum > WorstReportByPercent > WeightedReport > FocusReport
+ * WorstReportWeightedOne > WorstReportWeightedSum > FocusWorst > WeightedReport > FocusReport
  * In the case of two focus, the focust for first component is kept.
  */
 object ComponentStatusReport extends Loggable {
@@ -464,7 +464,7 @@ object ComponentStatusReport extends Loggable {
                 (a, b) match {
                   case (WorstReportWeightedOne, _) | (_, WorstReportWeightedOne) => WorstReportWeightedOne
                   case (WorstReportWeightedSum, _) | (_, WorstReportWeightedSum) => WorstReportWeightedSum
-                  case (WorstReportByPercent, _) | (_, WorstReportByPercent)     => WorstReportByPercent
+                  case (FocusWorst, _) | (_, FocusWorst)                         => FocusWorst
                   case (WeightedReport, _) | (_, WeightedReport)                 => WeightedReport
                   case (FocusReport(a), _)                                       => FocusReport(a)
                 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/yaml/YamlTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/yaml/YamlTechnique.scala
@@ -244,12 +244,12 @@ object YamlTechniqueSerializer {
     def toReporting(logic: ReportingLogic): Reporting = {
       import ReportingLogic.*
       logic match {
-        case FocusReport(component)                                                                  =>
+        case FocusReport(component)                                                        =>
           Reporting(
             FocusReport.key,
             Some(component)
           )
-        case WeightedReport | WorstReportByPercent | WorstReportWeightedOne | WorstReportWeightedSum =>
+        case WeightedReport | FocusWorst | WorstReportWeightedOne | WorstReportWeightedSum =>
           Reporting(logic.value, None)
       }
     }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -2261,7 +2261,7 @@ class ExecutionBatchTest extends Specification {
 
     val expectedComponent        = BlockExpectedReport(
       "blockRoot",
-      ReportingLogic.WorstReportByPercent,
+      ReportingLogic.FocusWorst,
       BlockExpectedReport(
         "block1",
         ReportingLogic.WeightedReport,
@@ -2422,7 +2422,7 @@ class ExecutionBatchTest extends Specification {
 
     val expectedComponent        = BlockExpectedReport(
       "blockRoot",
-      ReportingLogic.WorstReportByPercent,
+      ReportingLogic.FocusWorst,
       BlockExpectedReport(
         "block1",
         ReportingLogic.WorstReportWeightedSum,

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
@@ -90,7 +90,7 @@ type alias Technique =
 type MethodElem = Call (Maybe CallId) MethodCall | Block (Maybe CallId) MethodBlock
 
 
-type WorstReportKind = WorstReportWeightedOne | WorstReportWeightedSum | WorstReportByPercent
+type WorstReportKind = WorstReportWeightedOne | WorstReportWeightedSum | FocusWorst
 
 type ReportingLogic = WorstReport WorstReportKind | WeightedReport | FocusReport String
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/JsonDecoder.elm
@@ -65,7 +65,7 @@ decodeCompositionRule =
         case v of
           "worst-case-weighted-sum" -> succeed (WorstReport WorstReportWeightedSum)
           "worst-case-weighted-one" -> succeed (WorstReport WorstReportWeightedOne)
-          "worst-case-percent"      -> succeed (WorstReport WorstReportByPercent)
+          "focus-worst"             -> succeed (WorstReport FocusWorst)
           "weighted"                -> succeed WeightedReport
           "focus"                   -> succeed (FocusReport "")
           value                     ->

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/JsonEncoder.elm
@@ -139,8 +139,8 @@ encodeCompositionRule composition =
        string "worst-case-weighted-sum"
     (WorstReport WorstReportWeightedOne) ->
        string "worst-case-weighted-one"
-    (WorstReport WorstReportByPercent) ->
-       string "worst-case-percent"
+    (WorstReport FocusWorst) ->
+       string "focus-worst"
     WeightedReport ->
       string "weighted"
     FocusReport value ->

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewBlock.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewBlock.elm
@@ -271,13 +271,13 @@ showBlockTab model parentId block uiInfo techniqueUi =
         labelWorst = \weight -> case weight of
                          WorstReportWeightedOne -> "Use a weight of '1' for component"
                          WorstReportWeightedSum -> "Use sum of sub-components for weight"
-                         WorstReportByPercent -> "Use the compliance percent of sub-components"
+                         FocusWorst -> "Focus on the child with worst compliance"
 
         liWorst = \weight -> element "li"
                     |> addActionStopAndPrevent ("click", MethodCallModified (Block parentId {block | reportingLogic = (WorstReport weight) }))
                     |> appendChild (element "a" |> addClass "dropdown-item" |> appendText (labelWorst weight))
 
-        availableWorst = List.map liWorst [ WorstReportWeightedOne, WorstReportWeightedSum, WorstReportByPercent]
+        availableWorst = List.map liWorst [FocusWorst, WorstReportWeightedOne, WorstReportWeightedSum]
       in
          element "div"
            |> appendChildList


### PR DESCRIPTION
https://issues.rudder.io/issues/25604

Based on https://github.com/Normation/rudder/pull/5913 and expects changes from https://github.com/Normation/rudder/pull/5914

This is a change to have a better name by considering existing semantics, so we need to change the name of the type in our model.
Also :

* Change the serialized value :warning: existing techniques will need to be replaced by changing yml with `sed -ie "s/worst-case-percent/focus-worst/"` technique.yml` then reloading the technique
* Update Elm to support the new value, add a new text with the better description
* Update the ASCII doc

Resulting UI : 
![Screenshot from 2024-10-04 09-59-21](https://github.com/user-attachments/assets/9062a027-c78d-462a-b5a1-d95444d5fba6)
