### PR TITLE
Fixes #25610: Display properties errors in nodes and groups page

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ApiCalls.elm
@@ -14,17 +14,17 @@ getUrl: Model -> List String -> List QueryParameter -> String
 getUrl m url p=
   Url.Builder.relative (m.contextPath :: "secure" :: "api"  :: (m.objectType ++ "s") :: m.nodeId :: url) p
 
-getNodeProperties : Model -> Cmd Msg
-getNodeProperties model =
-  let
-    decoder = if model.objectType == "node" then decodeGetProperties else decodeGetGroupProperties
+getInheritedProperties : Model -> Cmd Msg
+getInheritedProperties model =
+  let 
+    decoder = if model.objectType == "node" then decodeGetInheritedProperties else decodeGetGroupInheritedProperties
     req =
       request
         { method  = "GET"
         , headers = [header "X-Requested-With" "XMLHttpRequest"]
         , url     = getUrl model [ "displayInheritedProperties" ] []
         , body    = emptyBody
-        , expect  = expectJson GetNodeProperties decoder
+        , expect  = expectJson GetInheritedProperties decoder
         , timeout = Nothing
         , tracker = Nothing
         }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/DataTypes.elm
@@ -34,6 +34,11 @@ type alias EditProperty =
 
 type ValueFormat = JsonFormat | StringFormat
 
+type alias InheritedProperties = 
+  { properties : List Property
+  , errorMessage : Maybe String
+  }
+
 type alias Property =
   { name      : String
   , value     : Value
@@ -46,6 +51,7 @@ type alias Property =
 type alias HierarchyStatus =
   { hasChildTypeConflicts : Bool
   , fullHierarchy : List ParentProperty
+  , errorMessage : Maybe String
   }
 
 type alias ParentGlobalProperty = { valueType : String }
@@ -99,6 +105,7 @@ type alias Model =
   , properties       : List Property
   , newProperty      : EditProperty
   , ui               : UI
+  , errorMessage     : Maybe String
   }
 
 getPageMax : TablePagination -> Int
@@ -133,7 +140,7 @@ type Msg
   | Copy String
   | CallApi (Model -> Cmd Msg)
   | SaveProperty String (Result Error (List Property))
-  | GetNodeProperties (Result Error (List Property))
+  | GetInheritedProperties (Result Error InheritedProperties)
   | FindPropertyUsage String (Result Error (List SearchResult))
   | UpdateNewProperty EditProperty
   | UpdateProperty String EditProperty

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/Init.elm
@@ -3,15 +3,15 @@ module NodeProperties.Init exposing (..)
 import Dict exposing (Dict)
 
 import NodeProperties.DataTypes exposing (..)
-import NodeProperties.ApiCalls exposing (getNodeProperties)
+import NodeProperties.ApiCalls exposing (getInheritedProperties)
 
 init : { contextPath : String, hasNodeWrite : Bool, hasNodeRead : Bool, nodeId : String, objectType : String} -> ( Model, Cmd Msg )
 init flags =
   let
     pagination = TablePagination 1 1 10 0
     initUi = UI flags.hasNodeWrite flags.hasNodeRead True NoModal Dict.empty [] (TableFiltersOnProperty Name Asc "") (TableFiltersOnUsage Name NodeProperties.DataTypes.Asc "" Directives pagination)
-    initModel = Model flags.contextPath flags.nodeId flags.objectType [] (EditProperty "" "" StringFormat True True False) initUi
+    initModel = Model flags.contextPath flags.nodeId flags.objectType [] (EditProperty "" "" StringFormat True True False) initUi Nothing
   in
     ( initModel
-    , getNodeProperties initModel
+    , getInheritedProperties initModel
     )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/JsonDecoder.elm
@@ -7,20 +7,31 @@ import NodeProperties.DataTypes exposing (..)
 
 
 -- GENERAL
-decodeGetProperties =
-  at [ "data" ] (index 0 decodeProperties)
+decodeGetInheritedProperties : Decoder InheritedProperties
+decodeGetInheritedProperties =
+  at [ "data" ] (index 0 decodeInheritedProperties)
 
-decodeGetGroupProperties =
-  at [ "data", "groups" ] (index 0 decodeProperties)
+decodeGetGroupInheritedProperties : Decoder InheritedProperties
+decodeGetGroupInheritedProperties =
+  at [ "data", "groups" ] (index 0 decodeInheritedProperties)
 
+decodeSaveProperties : Decoder (List Property)
 decodeSaveProperties =
   at [ "data" ] decodeProperties
 
+decodeSaveGroupProperties : Decoder (List Property)
 decodeSaveGroupProperties =
   at [ "data", "groups" ] (index 0 decodeProperties)
 
+decodeProperties : Decoder (List Property)
 decodeProperties =
   at [ "properties" ] (list decodeProperty)
+
+decodeInheritedProperties : Decoder InheritedProperties
+decodeInheritedProperties =
+  succeed InheritedProperties
+    |> required "properties" (list decodeProperty)
+    |> optional "errorMessage" (map Just string) Nothing
 
 decodeProperty : Decoder Property
 decodeProperty =
@@ -35,8 +46,9 @@ decodeProperty =
 decodeHierarchyStatus : Decoder HierarchyStatus
 decodeHierarchyStatus =
   succeed HierarchyStatus
-    |> required "hasChildTypeConflicts"      bool
-    |> required "fullHierarchy"     (list decodeParentProperty)
+    |> required "hasChildTypeConflicts" bool
+    |> required "fullHierarchy" (list decodeParentProperty)
+    |> optional "errorMessage" (map Just string) Nothing
 
 decodeParentProperty : Decoder ParentProperty
 decodeParentProperty =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/View.elm
@@ -8,7 +8,7 @@ import Html.Events exposing (onClick, onInput)
 
 import NodeProperties.DataTypes exposing (..)
 import NodeProperties.ViewUtils exposing (..)
-import NodeProperties.ApiCalls exposing (getNodeProperties)
+import NodeProperties.ApiCalls exposing (getInheritedProperties)
 
 
 view : Model -> Html Msg
@@ -31,13 +31,13 @@ view model =
     in
       div[]
       [ div [class "row", id "nodeProp"]
-        [ div [ class "col-sm-12" ] [
-            div [ class "alert alert-info" ] [
-                text "These are properties that can be used in directive inputs with the "
-              , b [ class "code" ] [ text "${node.properties[NAME]}" ]
-              , text " syntax."
-              ]
-          ]
+        [ div [ class "col-sm-12" ] 
+          (( div [ class "alert alert-info" ] 
+            [ text "These are properties that can be used in directive inputs with the "
+            , b [ class "code" ] [ text "${node.properties[NAME]}" ]
+            , text " syntax."
+            ]
+          ) :: (displayPropertiesError model))
         , ( if model.ui.hasNodeWrite then
           div[class "col-lg-7 col-md-8 col-xs-12 add-prop-form"]
           [ label[for "newPropName", class "fw-bold"][text "Add a new property:"]
@@ -95,7 +95,7 @@ view model =
         , div [class "col-sm-12 tab-table-content"]
           [ div [class "table-header"]
             [ input [type_ "text", placeholder "Filter", class "input-sm form-control", onInput (\s -> UpdateTableFiltersProperty {filters | filter = s})][]
-            , button [class "btn btn-default", onClick (CallApi getNodeProperties)] [ i [class "fa fa-refresh"][] ]
+            , button [class "btn btn-default", onClick (CallApi getInheritedProperties)] [ i [class "fa fa-refresh"][] ]
             ]
             , div [class "table-container"]
               [ table [class "no-footer dataTable", id "nodePropertiesTab"]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Nodeproperties.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Nodeproperties.elm
@@ -216,18 +216,18 @@ update msg model =
               }
           in
             ( newModel
-            , Cmd.batch [ initInputs "", initTooltips "" , successNotification successMsg, getNodeProperties newModel]
+            , Cmd.batch [ initInputs "", initTooltips "" , successNotification successMsg, getInheritedProperties newModel]
             )
         Err err ->
           processApiError "Saving node properties" err model
 
-    GetNodeProperties res ->
+    GetInheritedProperties res ->
       case  res of
-        Ok properties ->
+        Ok { properties, errorMessage } ->
           let
             modelUi  = model.ui
           in
-            ( { model | properties = properties, ui = { modelUi | loading = False } }
+            ( { model | properties = properties, ui = { modelUi | loading = False }, errorMessage = errorMessage }
               , Cmd.batch [initTooltips "", initInputs ""]
             )
         Err err ->


### PR DESCRIPTION
https://issues.rudder.io/issues/25610

PR based on #5910 API changes   

Just parse 
* the new `errorMessage` field at root of inherited properties API and display it as alert banner
* the new `errorMessage` field for each inherited property and display a warning for the corresponding property