### PR TITLE
Fixes #25332: When changing node properties the old table is sometimes still displayed

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -953,6 +953,7 @@ class RestTestSetUp {
     new GroupsInternalApi(groupInternalApiService),
     new NodeApi(
       zioJsonExtractor,
+      mockNodeGroups.propService,
       restDataSerializer,
       nodeApiService,
       userPropertyService,
@@ -962,6 +963,7 @@ class RestTestSetUp {
     ),
     new GroupsApi(
       mockNodeGroups.groupsRepo,
+      mockNodeGroups.propService,
       restExtractorService,
       zioJsonExtractor,
       uuidGen,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2067,6 +2067,7 @@ object RudderConfigInit {
         new ComplianceApi(restExtractorService, complianceAPIService, roDirectiveRepository),
         new GroupsApi(
           roLdapNodeGroupRepository,
+          propertiesService,
           restExtractorService,
           zioJsonExtractor,
           stringUuidGenerator,
@@ -2085,6 +2086,7 @@ object RudderConfigInit {
         ),
         new NodeApi(
           zioJsonExtractor,
+          propertiesService,
           restDataSerializer,
           nodeApiService,
           userPropertyService,


### PR DESCRIPTION
https://issues.rudder.io/issues/25332

Awaiting for the resolution of properties in the cache after a group update.
It is no big deal : this will benefit for the Rudder UI which queries the inherited properties, that are already resolved in the cache after the `updateAll()`