### PR TITLE
Fixes #25635: Chunk appending when resolving node ids from union target can be optimized

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
@@ -339,7 +339,7 @@ object RuleTarget extends Loggable {
       case TargetUnion(targets) =>
         val nodeSets = targets.map(t => getNodeIdsChunkRec(Chunk(t), allNodes, groups))
         // Compute the union of the sets of Nodes
-        val union    = nodeSets.foldLeft(Chunk[NodeId]()) { case (currentUnion, nodes) => currentUnion.concat(nodes) }
+        val union    = nodeSets.foldLeft(Chunk[NodeId]()) { case (currentUnion, nodes) => currentUnion ++ nodes }
         Right(union)
 
       case TargetExclusion(included, excluded) =>


### PR DESCRIPTION
https://issues.rudder.io/issues/25635

`++` is specialized for Chunk, `concat` is on Iterable