### PR TITLE
Fixes #25637: Sometimes tests with lift actor fails

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompilationCache.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompilationCache.scala
@@ -76,7 +76,11 @@ case class EditorTechniqueError(
 
 sealed trait CompilationStatus
 case object CompilationStatusAllSuccess                                                    extends CompilationStatus
-case class CompilationStatusErrors(techniquesInError: NonEmptyChunk[EditorTechniqueError]) extends CompilationStatus
+case class CompilationStatusErrors(techniquesInError: NonEmptyChunk[EditorTechniqueError]) extends CompilationStatus {
+  def ++(other: CompilationStatusErrors): CompilationStatusErrors = CompilationStatusErrors(
+    this.techniquesInError ++ other.techniquesInError
+  )
+}
 
 /**
   * Get latest global techniques compilation results


### PR DESCRIPTION
https://issues.rudder.io/issues/25637

It's weird that it fails sometimes even within ZIO fibers, the `!` method in the lift mock actor has a synchronized lock on the mutable list of messages it receives...
Our common solution for these synchronization issues in tests is `eventually` 
BUT here it does seem to take much time, so using a lock is the fastest solution

**Edit : ** the test above did some change in the state of the cache so we need to take these into account, and make tests reproducible by making them "sequential"