### PR TITLE
Fixes #25650: Node in with no reports, pending and keep compliance lead to computation loop

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -131,7 +131,21 @@ final case class RunAnalysis(
     lastRunDateTime:     Option[DateTime],
     lastRunConfigId:     Option[NodeConfigId],
     lastRunExpiration:   Option[DateTime]
-)
+) {
+  def debugString: String = {
+    def d(o: Option[DateTime]): String = {
+      o.map(_.toString).getOrElse("N/A")
+    }
+
+    def i(o: Option[NodeConfigId]): String = {
+      o.map(_.value).getOrElse("no id")
+    }
+
+    s"[${kind.entryName}] expected CID: '${i(expectedConfigId)}'; expected start: '${d(expectedConfigStart)}'; " +
+    s"expired since: ${d(expiredSince)}; expiration: '${d(expirationDateTime)}'; last run: '${i(lastRunConfigId)}' " +
+    s"${d(lastRunDateTime)} -> ${d(lastRunExpiration)}]"
+  }
+}
 
 final case class NodeStatusReport(
     nodeId:     NodeId,


### PR DESCRIPTION
https://issues.rudder.io/issues/25650

In persistance, we need to cover all case of "expiring by themself" kind: we were missing `Pending`. So if a pending reached the database, then we were always updating it, always pushing ahead its expiration time. 

Other changes are just additionnal debug info, because I still wasn't able to find quickly what was done. 