### PR TITLE
Fixes #25589: Lost manufacturer & serial for BIOS  between 7.3 and 8.0

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/MachineInventory.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/MachineInventory.scala
@@ -46,12 +46,14 @@ sealed trait PhysicalElement {
 }
 
 final case class Bios(
-    name:        String,
-    description: Option[String] = None,
-    version:     Option[Version] = None,
-    editor:      Option[SoftwareEditor] = None,
-    releaseDate: Option[DateTime] = None,
-    quantity:    Int = 1
+    name:         String,
+    description:  Option[String] = None,
+    version:      Option[Version] = None,
+    editor:       Option[SoftwareEditor] = None,
+    releaseDate:  Option[DateTime] = None,
+    manufacturer: Option[Manufacturer] = None,
+    serialNumber: Option[String] = None,
+    quantity:     Int = 1
 ) extends PhysicalElement
 
 final case class Controller(

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestReportParsing.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestReportParsing.scala
@@ -379,6 +379,25 @@ class TestInventoryParsing extends Specification with Loggable {
     }
   }
 
+  "Parsing BIOS" should {
+    "parse system manufacturer SMANUFACTURER" in {
+      val bios            = parseRun("fusion-inventories/alma.ocs").machine.bios
+      val sysManufacturer = bios.map(_.manufacturer).headOption
+      sysManufacturer match {
+        case Some(manufacturer) => manufacturer.map(_.name) === Some("innotek GmbH")
+        case None               => ko("Missing <SMANUFACTURER> from <BIOS> section in fusion-inventories/alma.ocs")
+      }
+    }
+    "parse system serial number SSN" in {
+      val bios   = parseRun("fusion-inventories/alma.ocs").machine.bios
+      val ssnOpt = bios.map(_.serialNumber).headOption
+      ssnOpt match {
+        case Some(ssn) => ssn === Some("be7c0c4f-5f27-6648-9adb-6cce2129061d")
+        case None      => ko("Missing <SSN> from <BIOS> section in fusion-inventories/alma.ocs")
+      }
+    }
+  }
+
   "if we ignore processes, we don't get any" >> {
     val ignoringParser = new FusionInventoryParser(new StringUuidGeneratorImpl, ignoreProcesses = true)
     val processes      =

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryMapper.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryMapper.scala
@@ -228,21 +228,23 @@ class InventoryMapper(
     e.setOpt(elt.editor, A_EDITOR, (x: SoftwareEditor) => x.name)
     e.setOpt(elt.releaseDate, A_RELEASE_DATE, (x: DateTime) => GeneralizedTime(x).toString)
     e.setOpt(elt.version, A_SOFT_VERSION, (x: Version) => x.value)
-
+    e.setOpt(elt.manufacturer, A_MANUFACTURER, (x: Manufacturer) => x.name)
+    e.setOpt(elt.serialNumber, A_SERIAL_NUMBER, (x: String) => x)
     e
   }
 
   def biosFromEntry(e: LDAPEntry): InventoryMappingPure[Bios] = {
     for {
-      name       <- e.required(A_BIOS_NAME)
-      desc        = e(A_DESCRIPTION)
-      quantity    = e.getAsInt(A_QUANTITY).getOrElse(1)
-      version     = e(A_SOFT_VERSION).map(v => new Version(v))
-      releaseDate = e.getAsGTime(A_RELEASE_DATE) map { _.dateTime }
-      editor      = e(A_EDITOR) map { x => new SoftwareEditor(x) }
-
+      name        <- e.required(A_BIOS_NAME)
+      desc         = e(A_DESCRIPTION)
+      quantity     = e.getAsInt(A_QUANTITY).getOrElse(1)
+      version      = e(A_SOFT_VERSION).map(v => new Version(v))
+      releaseDate  = e.getAsGTime(A_RELEASE_DATE) map { _.dateTime }
+      editor       = e(A_EDITOR) map { x => new SoftwareEditor(x) }
+      manufacturer = e(A_MANUFACTURER).map(m => new Manufacturer(m))
+      serialNumber = e(A_SERIAL_NUMBER)
     } yield {
-      Bios(name, desc, version, editor, releaseDate, quantity)
+      Bios(name, desc, version, editor, releaseDate, manufacturer, serialNumber, quantity)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/NodeDetailLevel.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/NodeDetailLevel.scala
@@ -515,12 +515,14 @@ object NodeDetailLevel {
           JNothing
         } else {
           val bios = machine.bios.map { bio =>
-            ("name"        -> bio.name) ~
-            ("editor"      -> bio.editor.map(_.name)) ~
-            ("version"     -> bio.version.map(_.value)) ~
-            ("quantity"    -> bio.quantity) ~
-            ("description" -> bio.description) ~
-            ("releaseDate" -> bio.releaseDate.map(DateFormaterService.getDisplayDate))
+            ("name"         -> bio.name) ~
+            ("editor"       -> bio.editor.map(_.name)) ~
+            ("version"      -> bio.version.map(_.value)) ~
+            ("manufacturer" -> bio.manufacturer.map(_.name)) ~
+            ("serialNumber" -> bio.serialNumber) ~
+            ("quantity"     -> bio.quantity) ~
+            ("description"  -> bio.description) ~
+            ("releaseDate"  -> bio.releaseDate.map(DateFormaterService.getDisplayDate))
           }.toList
           JArray(bios)
         }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
@@ -151,7 +151,9 @@ class NodeQueryCriteriaData(groupRepo: () => SubGroupComparatorRepository) {
         Criterion(A_QUANTITY, LongComparator, UnsupportedByNodeMinimalApi),
         Criterion(A_SOFT_VERSION, StringComparator, UnsupportedByNodeMinimalApi),
         Criterion(A_RELEASE_DATE, DateComparator, UnsupportedByNodeMinimalApi),
-        Criterion(A_EDITOR, StringComparator, UnsupportedByNodeMinimalApi)
+        Criterion(A_EDITOR, StringComparator, UnsupportedByNodeMinimalApi),
+        Criterion(A_MANUFACTURER, StringComparator, UnsupportedByNodeMinimalApi),
+        Criterion(A_SERIAL_NUMBER, StringComparator, UnsupportedByNodeMinimalApi)
       )
     ),
     ObjectCriterion(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -1178,6 +1178,8 @@ object DisplayNode extends Loggable {
       ("Name", { (x: Bios) => escapeHTML(x.name) }) ::
       ("Editor", { (x: Bios) => ?(x.editor.map(_.name)) }) ::
       ("Version", { (x: Bios) => ?(x.version.map(_.value)) }) ::
+      ("Manufacturer", { (x: Bios) => ?(x.manufacturer.map(_.name)) }) ::
+      ("Serial Number", { (x: Bios) => ?(x.serialNumber) }) ::
       ("Release date", { (x: Bios) => ?(x.releaseDate.map(DateFormaterService.getDisplayDate(_))) }) ::
       Nil
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/25589
I simply add a `Manufacturer` and `Serial number` field in the `BIOS` object, these fields were previously present in `HARDWARE` section of the inventory but was cleaned because it was not map to anything.
Since these values are optional, it should not break anything, I add the missing filters in criteria when creating group for the BIOS too

The main strategy was to add the missing value `Manufacturer` and `Serial number` and let the compiler do the work
