### PR TITLE
Fixes #25649: Node with kept compliance should have the clock icon in node list

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -84,6 +84,7 @@ import com.normation.rudder.domain.queries.Query
 import com.normation.rudder.domain.queries.QueryReturnType
 import com.normation.rudder.domain.queries.ResultTransformation
 import com.normation.rudder.domain.reports.ComplianceLevel
+import com.normation.rudder.domain.reports.RunAnalysisKind
 import com.normation.rudder.domain.servers.Srv
 import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.rudder.facts.nodes.CoreNodeFact
@@ -581,6 +582,7 @@ object JsonResponseObjects {
       os:                      String,
       state:                   NodeState,
       compliance:              Option[JRNodeCompliance],
+      runAnalysisKind:         Option[RunAnalysisKind],
       systemError:             Boolean,
       ipAddresses:             Chunk[IpAddress],
       acceptanceDate:          String,         // display date
@@ -599,6 +601,7 @@ object JsonResponseObjects {
         inheritedProperties:    Chunk[NodePropertyHierarchy],
         softs:                  Chunk[domain.Software],
         compliance:             Option[JRNodeCompliance],
+        runAnalysisKind:        Option[RunAnalysisKind],
         systemCompliance:       Option[JRNodeSystemCompliance],
         score:                  GlobalScore
     ): Transformer[CoreNodeFact, JRNodeDetailTable] = {
@@ -637,6 +640,7 @@ object JsonResponseObjects {
           nf => DateFormaterService.getDisplayDate(nf.lastInventoryDate.getOrElse(nf.factProcessedDate))
         )
         .withFieldConst(_.compliance, compliance)
+        .withFieldConst(_.runAnalysisKind, runAnalysisKind)
         .withFieldConst(
           _.systemError,
           systemCompliance
@@ -2091,6 +2095,7 @@ trait RudderJsonEncoders {
 
   implicit val nodeDetailLevelEncoder: JsonEncoder[JRNodeDetailLevel] = DeriveJsonEncoder.gen[JRNodeDetailLevel]
 
+  implicit val runAnalysisKindEncoder:  JsonEncoder[RunAnalysisKind]   = JsonEncoder[String].contramap(_.entryName)
   implicit val jrNodeComplianceEncoder: JsonEncoder[JRNodeCompliance]  = JsonEncoder[ComplianceLevel].contramap(_.compliance)
   implicit val policyModeSerializer:    JsonEncoder[PolicyMode]        = JsonEncoder[String].contramap(_.name)
   implicit val jrGlobalScoreEncoder:    JsonEncoder[JRGlobalScore]     = DeriveJsonEncoder.gen[JRGlobalScore]

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
@@ -45,6 +45,7 @@ import com.normation.rudder.domain.policies.PolicyTypeName
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.ComplianceLevel
 import com.normation.rudder.domain.reports.NodeStatusReport
+import com.normation.rudder.domain.reports.NodeStatusReport.*
 import com.normation.rudder.facts.nodes.QueryContext
 
 /**
@@ -66,18 +67,6 @@ trait ReportingService {
       nodeIds:            Set[NodeId],
       filterByDirectives: Set[DirectiveId]
   )(implicit qc: QueryContext): IOResult[Map[NodeId, NodeStatusReport]]
-
-  /**
-   * Retrieve two sets of rule/node compliances level given the nodes Id.
-   * Optionally restrict the set to some rules if filterByRules is non empty (else,
-   * find node status reports for all rules)
-   *
-   * The first set is System compliance.
-   * The second set is User compliance.
-   */
-  def findSystemAndUserRuleCompliances(
-      nodeIds: Set[NodeId]
-  )(implicit qc: QueryContext): IOResult[(Map[NodeId, ComplianceLevel], Map[NodeId, ComplianceLevel])]
 
   /**
    * A specialised version of `findRuleNodeStatusReports` to find node status reports for a given rule.
@@ -111,7 +100,9 @@ trait ReportingService {
    */
   def getSystemAndUserCompliance(
       optNodeIds: Option[Set[NodeId]]
-  )(implicit qc: QueryContext): IOResult[(Map[NodeId, ComplianceLevel], Map[NodeId, ComplianceLevel])]
+  )(implicit
+      qc:         QueryContext
+  ): IOResult[SystemUserComplianceRun]
 
   /**
   * Get the global compliance, restricted to user defined rules/directives.

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -73,6 +73,7 @@ import com.normation.rudder.domain.properties.NodePropertySpecificError
 import com.normation.rudder.domain.properties.Visibility.Displayed
 import com.normation.rudder.domain.properties.Visibility.Hidden
 import com.normation.rudder.domain.queries.Query
+import com.normation.rudder.domain.reports.RunAnalysisKind
 import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.facts.nodes.NodeFact
@@ -1067,8 +1068,11 @@ class NodeApiService(
             implicit val inheritedProperties:    Chunk[NodePropertyHierarchy]   =
               Chunk.fromIterable(inheritedProp.get(n.id).getOrElse(Nil))
             implicit val softwares:              Chunk[Software]                = Chunk.fromIterable(softs.get(n.id).getOrElse(Nil))
-            implicit val nodeCompliance:         Option[JRNodeCompliance]       = compliance._2.get(n.id).map(JRNodeCompliance(_))
-            implicit val systemCompliance:       Option[JRNodeSystemCompliance] = compliance._1.get(n.id).map(JRNodeSystemCompliance(_))
+            implicit val nodeCompliance:         Option[JRNodeCompliance]       =
+              compliance.user.get(n.id).map { case (_, compliance) => JRNodeCompliance(compliance) }
+            implicit val runAnalysisKind:        Option[RunAnalysisKind]        = compliance.user.get(n.id).map { case (kind, _) => kind }
+            implicit val systemCompliance:       Option[JRNodeSystemCompliance] =
+              compliance.system.get(n.id).map(JRNodeSystemCompliance(_))
             implicit val score:                  GlobalScore                    = {
               scores
                 .get(n.id)

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -87,6 +87,7 @@ import com.normation.rudder.domain.reports.NodeConfigId
 import com.normation.rudder.domain.reports.NodeExpectedReports
 import com.normation.rudder.domain.reports.NodeModeConfig
 import com.normation.rudder.domain.reports.NodeStatusReport
+import com.normation.rudder.domain.reports.NodeStatusReport.*
 import com.normation.rudder.domain.reports.OverriddenPolicy
 import com.normation.rudder.domain.reports.ReportType
 import com.normation.rudder.domain.reports.RuleNodeStatusReport
@@ -353,17 +354,16 @@ class MockCompliance(mockDirectives: MockDirectives) {
     // used in node details API
     def getSystemAndUserCompliance(
         optNodeIds: Option[Set[NodeId]]
-    )(implicit qc: QueryContext): IOResult[(Map[NodeId, ComplianceLevel], Map[NodeId, ComplianceLevel])] = {
-      ZIO.succeed((Map.empty, Map.empty))
+    )(implicit
+        qc:         QueryContext
+    ): IOResult[SystemUserComplianceRun] = {
+      ZIO.succeed(SystemUserComplianceRun.empty)
     }
 
     def findDirectiveNodeStatusReports(
         nodeIds:            Set[NodeId],
         filterByDirectives: Set[DirectiveId]
     )(implicit qc: QueryContext): IOResult[Map[NodeId, NodeStatusReport]] = ???
-    def findSystemAndUserRuleCompliances(
-        nodeIds: Set[NodeId]
-    )(implicit qc: QueryContext): IOResult[(Map[NodeId, ComplianceLevel], Map[NodeId, ComplianceLevel])] = ???
     def findDirectiveRuleStatusReportsByRule(ruleId: RuleId)(implicit qc: QueryContext): IOResult[Map[NodeId, NodeStatusReport]] =
       ???
     def findNodeStatusReport(nodeId:            NodeId)(implicit qc: QueryContext): IOResult[NodeStatusReport] = ???

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -1338,9 +1338,13 @@ function createNodeTable(gridId, refresh, scores) {
       , "type" : "numeric"
       , "createdCell" : function (nTd, sData, oData, iRow, iCol) {
           var link = callbackElement(oData, true)
+          link.addClass("d-flex align-items-center")
           var complianceBar = "<span class='text-muted'>N/A</span>"
           if (oData.compliance !== undefined) {
-            complianceBar = $('<div id="compliance-bar-'+oData.id+'"></div>').append(buildComplianceBar(oData.compliance))
+            complianceBar = $('<div id="compliance-bar-'+oData.id+'" style="flex:0 0 100%;"></div>').append(buildComplianceBar(oData.compliance))
+            if (oData.runAnalysisKind !== undefined && oData.runAnalysisKind.toString().toLowerCase() == "keeplastcompliance") {
+              link.append('<span style="font-size:0.6rem;margin-right: 2px;margin-left: -13px;">🕔</span>')
+            }
           }
           link.append(complianceBar)
           $(nTd).empty();


### PR DESCRIPTION
https://issues.rudder.io/issues/25649

Add the `runAnalysisKind` field in our node details table API along with the compliance, also remove a duplicate unused method and use accessors for system and user compliance

So :
![image](https://github.com/user-attachments/assets/462cc5f9-42d3-4979-9aa0-26d0e4542a30)
