### PR TITLE
Fixes #25670: "Started since" time in status zone is not correct

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
@@ -66,6 +66,7 @@ import net.liftweb.http.js.JE.*
 import net.liftweb.http.js.JsCmds.*
 import org.apache.commons.text.StringEscapeUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeComparator
 import scala.util.matching.Regex
 import scala.xml.*
 
@@ -114,9 +115,19 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
   }
 
   private def displayTime(label: String, time: DateTime): NodeSeq = {
-    val t = time.toString("yyyy-MM-dd HH:mm:ssZ")
-    val d = DateFormaterService.getFormatedPeriod(time, DateTime.now)
-    <span>{s"${label} ${d} ago"}<div class="help-block"><em>↳ at {t}</em></div></span>
+    // display only the time when it's on the same day, and date if different one
+    val now       = DateTime.now()
+    val (t, help) = {
+      if (DateTimeComparator.getDateOnlyInstance().compare(time, now) == 0) {
+        (
+          time.toString("HH:mm:ss"),
+          s"on ${time.toString("yyyy-MM-dd")} (${DateFormaterService.getFormatedPeriod(time, now)} ago)"
+        )
+      } else {
+        (time.toString("yyyy-MM-dd HH:mm:ssZ"), s"${DateFormaterService.getFormatedPeriod(time, now)} ago")
+      }
+    }
+    <span>{s"${label} at ${t}"}<div class="help-block"><em>↳ {help} </em></div></span>
   }
   private def displayDate(label: String, time: DateTime): NodeSeq = {
     val t = time.toString("yyyy-MM-dd HH:mm:ssZ")


### PR DESCRIPTION
https://issues.rudder.io/issues/25670

Because the date can take too much space the date is moved to the "help" section when on the same day.
The duration is still not refreshed (that would require some JS code) 

![image](https://github.com/user-attachments/assets/fe61555c-c0ea-4482-aeac-0e07bc99e89c)
