### PR TITLE
Fixes #25652: Default settings for new nodes are not applied on a accepted node

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2603,6 +2603,13 @@ object RudderConfigInit {
       configService.node_accept_duplicated_hostname()
     )
 
+    lazy val defaultStateAndPolicyMode = new DefaultStateAndPolicyMode(
+      "accept_new_node:setup_default_settings",
+      nodeFactRepository,
+      configService.rudder_node_onaccept_default_policy_mode(),
+      configService.rudder_node_onaccept_default_state()
+    )
+
     // used in accept node to see & store inventories on acceptation
     lazy val inventoryHistoryLogRepository: InventoryHistoryLogRepository = {
       val fullInventoryFromLdapEntries: FullInventoryFromLdapEntries =
@@ -3016,7 +3023,7 @@ object RudderConfigInit {
 
       // the sequence of unit process to accept a new inventory
       val unitAcceptors = {
-        acceptHostnameAndIp ::
+        acceptHostnameAndIp :: defaultStateAndPolicyMode ::
         Nil
       }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/25652
There were missing logic to modify the node according to the default global setting for new node. I simply add a `unitAcceptors` that is not really a unit... That fetch the node and modify his policy mode and his state.
It's working, but it can be confusing since theses should me `unitAcceptors` and for pre accepting :grimacing: 

see @clarktsiory comments https://github.com/Normation/rudder/pull/5949#discussion_r1802652374