### PR TITLE
Fixes #25693: Software update campaign does not work on SLES 15

### DIFF
--- a/policies/module-types/system-updates/src/package_manager/zypper.rs
+++ b/policies/module-types/system-updates/src/package_manager/zypper.rs
@@ -69,7 +69,7 @@ impl LinuxPackageManager for ZypperPackageManager {
 
     fn upgrade(&mut self, packages: Vec<PackageSpec>) -> ResultOutput<()> {
         let mut c = Command::new("zypper");
-        c.arg("--non-interactive").arg("--name").arg("update");
+        c.arg("--non-interactive").arg("update");
         c.args(packages.into_iter().map(Self::package_spec_as_argument));
         let res_update = ResultOutput::command(c);
         res_update.clear_ok()


### PR DESCRIPTION
https://issues.rudder.io/issues/25693