### PR TITLE
Fixes #25709: OpenAPI documentation is invalid with duplicate /nodes/pending endpoints

### DIFF
--- a/api-doc/build.py
+++ b/api-doc/build.py
@@ -25,6 +25,13 @@ templates = glob.glob(source + '/openapi*.src.yml')
 for template in templates:
     with open(template, 'r') as content_file:
         main = yaml.load(content_file.read(), Loader=yaml.FullLoader)
+
+        ################################################################################
+        # Lint doc using redocly (on split files to allow correct file reports)
+        if subprocess.call(['npx', 'redocly', 'lint', template]):
+            print('Linter failed on %s' % (template))
+            exit(1)
+
     version = main['info']['version']
     intro_file = main['info']['description']
 
@@ -40,17 +47,11 @@ for template in templates:
     # Dump target in target .yml file
     src_openapi_file = template.replace('.src', '')
     with open(src_openapi_file, 'w') as file:
-        documents = yaml.dump(main, file)
+        yaml.dump(main, file)
 
     target = '%s/%s/%s' % (target_dir, api, version)
 
     print('Built %s' % (src_openapi_file))
-
-    ################################################################################
-    # Lint doc using redocly (on split files to allow correct file reports)
-    if subprocess.call(['npx', 'redocly', 'lint', src_openapi_file]):
-        print('Linter failed on %s' % (src_openapi_file))
-        exit(1)
 
     ################################################################################
     # Build final OpenAPI spec files using redocly

--- a/api-doc/redocly.yml
+++ b/api-doc/redocly.yml
@@ -17,7 +17,7 @@ rules:
   no-invalid-media-type-examples:
     severity: 'error'
     allowAdditionalProperties: false
-  no-server-example.com: 'error'
+  no-server-example.com: 'warn' # we should migrate away from localhost as server url
   no-unused-components: 'error'
 
 theme:

--- a/webapp/sources/api-doc/openapi.src.yml
+++ b/webapp/sources/api-doc/openapi.src.yml
@@ -255,9 +255,10 @@ paths:
   "/nodes/status":
     $ref: paths/nodes/status.yml
   "/nodes/pending":
-    $ref: paths/nodes/pending-all.yml
-  "/nodes/pending":
-    $ref: paths/nodes/pending-update.yml
+    get:
+      $ref: paths/nodes/pending-all.yml
+    post:
+      $ref: paths/nodes/pending-update.yml
   "/nodes/{nodeId}":
     $ref: paths/nodes/id.yml
   "/nodes/pending/{nodeId}":

--- a/webapp/sources/api-doc/paths/nodes/pending-all.yml
+++ b/webapp/sources/api-doc/paths/nodes/pending-all.yml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: CC-BY-SA-2.0
 # SPDX-FileCopyrightText: 2013-2020 Normation SAS
-get:
   summary: List pending nodes
   description: Get information about the nodes pending acceptation
   operationId: listPendingNodes

--- a/webapp/sources/api-doc/paths/nodes/pending-update.yml
+++ b/webapp/sources/api-doc/paths/nodes/pending-update.yml
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: CC-BY-SA-2.0
 # SPDX-FileCopyrightText: 2013-2024 Normation SAS
-post:
   summary: Update pending nodes status
   description: Accept or refuse one or many pending nodes
   operationId: changePendingNodesStatus


### PR DESCRIPTION
https://issues.rudder.io/issues/25709

The linting of the openapi was misplaced, it should be done on split YAML files because loading them into a single `main` replaces duplicate keys silently (it is the behavior of the yaml loader from the Python library).

Also the `relay` could not build unless the [no-server-example-com](https://redocly.com/docs/cli/rules/no-server-example-com#no-server-example.com) rule is set to 'warn', we should at some point use another URL than _localhost_ for our examples.