### PR TITLE
Fixes #25691: Full archive export does not work anymore

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
@@ -856,3 +856,23 @@ function initBsTabs(){
 function copy(value) {
   navigator.clipboard.writeText(value).then(function(){ createInfoNotification("Copied to clipboard!") }, function() {createErrorNotification("Could not copy to clipboard")})
 }
+
+// to create blob of binary data and download it, see https://stackoverflow.com/a/37340749
+function base64ToArrayBuffer(base64) {
+  var binaryString = window.atob(base64);
+  var binaryLen = binaryString.length;
+  var bytes = new Uint8Array(binaryLen);
+  for (var i = 0; i < binaryLen; i++) {
+    var ascii = binaryString.charCodeAt(i);
+    bytes[i] = ascii;
+  }
+  return bytes;
+}
+function saveByteArray(downloadedFileName, contentType, byte) {
+  var blob = new Blob([byte], {type: contentType});
+  var link = document.createElement('a');
+  link.href = window.URL.createObjectURL(blob);
+  var fileName = downloadedFileName;
+  link.download = fileName;
+  link.click();
+}

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1091,6 +1091,7 @@ object RudderConfig extends Loggable {
   val dynGroupService:                     DynGroupService                            = rci.dynGroupService
   val eventListDisplayer:                  EventListDisplayer                         = rci.eventListDisplayer
   val eventLogApi:                         EventLogAPI                                = rci.eventLogApi
+  val systemApiService:                    SystemApiService11                         = rci.systemApiService
   val eventLogDeploymentService:           EventLogDeploymentService                  = rci.eventLogDeploymentService
   val eventLogDetailsService:              EventLogDetailsService                     = rci.eventLogDetailsService
   val eventLogRepository:                  EventLogRepository                         = rci.eventLogRepository
@@ -1286,6 +1287,7 @@ case class RudderServiceApi(
     restCompletion:                      RestCompletion,
     sharedFileApi:                       SharedFilesAPI,
     eventLogApi:                         EventLogAPI,
+    systemApiService:                    SystemApiService11,
     stringUuidGenerator:                 StringUuidGenerator,
     inventoryWatcher:                    InventoryFileWatcher,
     configService:                       ReadConfigService with UpdateConfigService,
@@ -3614,6 +3616,7 @@ object RudderConfigInit {
       restCompletion,
       sharedFileApi,
       eventLogApi,
+      systemApiService11,
       uuidGen,
       inventoryWatcher,
       configService,


### PR DESCRIPTION
https://issues.rudder.io/issues/25691

The problem is the same as #5941 : we can no longer redirect to a secure API endpoint since they need CSRF headers, so we need to execute AJAX to download the file content (the AJAX consists in saving the archive itself from the browser).
* In this PR the JS functions that do the download are put in global scope (`rudder.js`) they may be reused in more that one place in Rudder (and I checked btw that this one is the last case of redirect).
* The FS mappings for archive types (rules, directives, etc.) have been put in an attribute of an enum type, which helps avoiding the "String" API.
* Also the previous tests about this part were always testing an error because the test setup with commit ids of archive were causing a null pointer exception, I enforced the tests   