### PR TITLE
Fixes #25663: Tooltips in nodes compliance are not displayed

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/ViewUtils.elm
@@ -48,15 +48,14 @@ badgePolicyMode globalPolicyMode policyMode =
         _ -> "Unknown policy mode"
 
   in
-    span [class ("treeGroupName tooltipable bs-tooltip rudder-label label-sm label-" ++ mode), attribute "data-toggle" "tooltip", attribute "data-placement" "bottom", attribute "data-container" "body", attribute "data-html" "true", attribute "data-original-title" (buildTooltipContent "Policy mode" msg)][]
-
+    span [class ("treeGroupName rudder-label label-sm label-" ++ mode), attribute "data-bs-toggle" "tooltip", attribute "data-bs-placement" "bottom", title (buildTooltipContent "Policy mode" msg)][]
 badgeSkipped : SkippedDetails -> Html Msg
 badgeSkipped { overridingRuleId, overridingRuleName } =
     let
         msg =
             "This directive is skipped because it is overridden by the rule <b>" ++ overridingRuleName ++ "</b> (with id " ++ overridingRuleId ++ ")."
     in
-    span [ class "treeGroupName tooltipable bs-tooltip rudder-label label-sm label-overriden", attribute "data-toggle" "tooltip", attribute "data-placement" "bottom", attribute "data-container" "body", attribute "data-html" "true", attribute "data-original-title" (buildTooltipContent "Skipped directive" msg) ] []
+    span [ class "treeGroupName rudder-label label-sm label-overriden", attribute "data-bs-toggle" "tooltip", attribute "data-bs-placement" "bottom", title (buildTooltipContent "Skipped directive" msg) ] []
 
 
 subItemOrder : ItemFun item subItem data ->  Model -> String -> (item -> item -> Order)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Nodecompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Nodecompliance.elm
@@ -108,7 +108,7 @@ update msg model =
         case res of
           Ok compliance ->
             ( { newModel | nodeCompliance = Just compliance }
-              , Cmd.none
+              , initTooltips ""
             )
           Err err ->
             processApiError "Getting node compliance" err newModel
@@ -116,7 +116,6 @@ update msg model =
 processApiError : String -> Error -> Model -> ( Model, Cmd Msg )
 processApiError apiName err model =
   let
-    modelUi = model.ui
     message =
       case err of
         Http.BadUrl url ->
@@ -136,6 +135,3 @@ processApiError apiName err model =
 
   in
     (model, errorNotification ("Error when "++apiName ++", details: \n" ++ message ) )
-
-getUrl : Model -> String
-getUrl model = model.contextPath ++ "/secure/configurationManager/directiveManagement"

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabContent.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabContent.elm
@@ -241,12 +241,10 @@ informationTab model details =
                           text ""
                         else
                           span
-                          [ class "bs-tooltip fa fa-question-circle icon-info"
-                          , attribute "data-toggle" "tooltip"
-                          , attribute "data-placement" "top"
-                          , attribute "data-container" "body"
-                          , attribute "data-html" "true"
-                          , attribute "data-original-title" (buildTooltipContent "Description" cr.description)
+                          [ class "fa fa-question-circle icon-info"
+                          , attribute "data-bs-toggle" "tooltip"
+                          , attribute "data-bs-placement" "top"
+                          , title (buildTooltipContent "System updates" (buildTooltipContent "Description" cr.description))
                           ][]
                     in
                       li[]


### PR DESCRIPTION
https://issues.rudder.io/issues/25663

The data-attributes used to generate tooltips did not use the bootstrap 5 syntax, and a call to initTooltips was missing.