### PR TITLE
Fixes #25701: Search on RAM fails in node groups

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
@@ -219,6 +219,16 @@ class TestNodeFactQueryProcessor {
       s(1) :: Nil
     )
 
+    val q2_0_1 = TestQuery(
+      "q2_0_1",
+      parser("""
+      {  "select":"node", "where":[
+        { "objectType":"node", "attribute":"ram", "comparator":"gt", "value":"1kb" }
+      ] }
+      """).openOrThrowException("For tests"),
+      s(1) :: Nil
+    )
+
     val q2_0_ = TestQuery(
       "q2_0_",
       query = q2_0.query.copy(composition = Or),
@@ -257,7 +267,7 @@ class TestNodeFactQueryProcessor {
       q2_2.awaited
     )
 
-    testQueries(q2_0 :: q2_0_ :: q2_1 :: q2_1_ :: q2_2 :: q2_2_ :: Nil, doInternalQueryTest = true)
+    testQueries(q2_0 :: q2_0_1 :: q2_0_ :: q2_1 :: q2_1_ :: q2_2 :: q2_2_ :: Nil, doInternalQueryTest = true)
   }
 
   @Test def testMachineType(): Unit = {


### PR DESCRIPTION
https://issues.rudder.io/issues/25701

I forgot to create the `MemorySize` matcher for `CoreNodeFact` when I switched to `NodeFact` in 8.1. So it was obviously broken. 