### PR TITLE
Fixes #25667: switching policy mode on a node from "Enforce" to anything else produce event log about properties

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactChangeEventCallback.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactChangeEventCallback.scala
@@ -53,7 +53,6 @@ import com.normation.rudder.domain.eventlog.InventoryLogDetails
 import com.normation.rudder.domain.eventlog.RefuseNodeEventLog
 import com.normation.rudder.domain.logger.NodeLoggerPure
 import com.normation.rudder.domain.nodes.ModifyNodeDiff
-import com.normation.rudder.facts.nodes.MinimalNodeFactInterface.toNode
 import com.normation.rudder.repository.CachedRepository
 import com.normation.rudder.repository.EventLogRepository
 import com.normation.rudder.services.nodes.history.impl.FactLogData
@@ -219,7 +218,7 @@ class EventLogsNodeFactChangeEventCallback(
         old:  MinimalNodeFactInterface,
         next: MinimalNodeFactInterface
     ): IOResult[Unit] = {
-      val diff = ModifyNodeDiff(toNode(old), toNode(next))
+      val diff = ModifyNodeDiff.fromFacts(old, next)
       eventLogRepository.saveModifyNode(cc.modId, cc.actor, diff, cc.message, cc.eventDate).unit
     }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/EventLogRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/EventLogRepository.scala
@@ -440,15 +440,17 @@ trait EventLogRepository {
       reason:     Option[String],
       eventDate:  DateTime
   ): IOResult[EventLog] = {
-    saveEventLog(
-      modId,
-      eventLogFactory.getModifyNodeFromDiff(
-        principal = principal,
-        modifyDiff = modifyDiff,
-        reason = reason,
-        creationDate = eventDate
-      )
-    )
+    for {
+      e <- saveEventLog(
+             modId,
+             eventLogFactory.getModifyNodeFromDiff(
+               principal = principal,
+               modifyDiff = modifyDiff,
+               reason = reason,
+               creationDate = eventDate
+             )
+           )
+    } yield e
   }
 
   def savePromoteToRelay(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
@@ -99,7 +99,7 @@ class WoLDAPNodeRepository(
         _             <- result match {
                            case LDIFNoopChangeRecord(_) => ZIO.unit
                            case _                       =>
-                             val diff = ModifyNodeDiff(oldNode, node)
+                             val diff = ModifyNodeDiff.compat(oldNode, node, None, None)
                              actionLogger.saveModifyNode(modId, actor, diff, reason, DateTime.now())
                          }
       } yield {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
@@ -171,7 +171,7 @@ trait EventLogDetailsService {
   // Global properties
   def getModifyGlobalPropertyDetails(xml: NodeSeq): Box[(RudderWebProperty, RudderWebProperty)]
 
-  // Node modifiction
+  // Node modification
   def getModifyNodeDetails(xml: NodeSeq): Box[ModifyNodeDiff]
 
   def getPromotedNodeToRelayDetails(xml: NodeSeq): Box[(NodeId, String)]
@@ -1096,6 +1096,7 @@ class EventLogDetailsServiceImpl(
                         (node \ "keyStatus").headOption,
                         x => KeyStatus.apply(x.text).map(Full(_)).getOrElse(Failure(s"Unrecognized agent key status '${x.text}'"))
                       )
+      nodeState    <- getFromTo[NodeState]((node \ "nodeState").headOption, x => NodeState.parse(x.text).toBox)
     } yield {
       ModifyNodeDiff(
         id,
@@ -1104,7 +1105,8 @@ class EventLogDetailsServiceImpl(
         properties,
         policyMode,
         agentKey,
-        keyStatus
+        keyStatus,
+        nodeState
       )
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -1163,6 +1163,11 @@ class EventLogFactoryImpl(
           case None    => NodeSeq.Empty
           case Some(x) => SimpleDiff.toXml(<keyStatus/>, x)(x => Text(x.value))
         }
+      }{
+        modifyDiff.modNodeState match {
+          case None    => NodeSeq.Empty
+          case Some(x) => SimpleDiff.toXml(<nodeState/>, x)(x => Text(x.name))
+        }
       }
       </node>)
     }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/eventlog/NodeEventLogFormatV6Test.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/eventlog/NodeEventLogFormatV6Test.scala
@@ -83,7 +83,8 @@ class NodeEventLogFormatV6Test extends Specification {
     modProperties = None,
     modPolicyMode = None,
     modKeyValue = None,
-    modKeyStatus = None
+    modKeyStatus = None,
+    modNodeState = None
   )
 
   val event_32_NodePropertiesModified: Elem = <entry><node changeType="modify" fileFormat="6">
@@ -121,7 +122,8 @@ class NodeEventLogFormatV6Test extends Specification {
     ),
     modPolicyMode = None,
     modKeyValue = None,
-    modKeyStatus = None
+    modKeyStatus = None,
+    modNodeState = None
   )
 
   val event_32_NodeAgentRunPeriodModified: Elem = <entry><node changeType="modify" fileFormat="6">
@@ -144,7 +146,8 @@ class NodeEventLogFormatV6Test extends Specification {
     modProperties = None,
     modPolicyMode = None,
     modKeyValue = None,
-    modKeyStatus = None
+    modKeyStatus = None,
+    modNodeState = None
   )
 
   "Current EventTypeFactory" should {


### PR DESCRIPTION
https://issues.rudder.io/issues/25667

I'm really not sure why there was properties info, I wasn't able to reproduce. But clearly, there was a lot of little things not correct: 
- no error reported in case of error of a node update callback, 
- missing node state change,
- missing display of several diff case, 
- added a title before diff of a node change to know what the diff is about
- simplify display. 

I'm not sure if it will correct the described bug, but at least now, I can cleanly display changes on policy mode and other things.
Policy mode / node state: 
![image](https://github.com/user-attachments/assets/b7c378c5-f9f6-4e4c-96e6-45aadabd0ce4)

Properties still working: 
![image](https://github.com/user-attachments/assets/6e60ad6f-336f-4993-8a94-76451ee58a26)
