### PR TITLE
Fixes #25742: Add LDAP synchronous mode config param

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -87,6 +87,10 @@ ldap.port=389
 ldap.authdn=cn=manager,cn=rudder-configuration
 ldap.maxPoolSize=2
 
+# By default, Rudder use a synchronous mode for LDAP connection. Before 8.1.8, it used to be async.
+# You can revert to async by using 'false'
+ldap.useSynchronousMode = true
+
 #
 # Password used to connect to the OpenLDAP server.
 # On a standard Rudder installation, the password is managed in

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -467,6 +467,17 @@ object RudderParsedProperties {
         2
     }
   }
+  val LDAP_USE_SYNC_MODE:                Boolean        = {
+    try {
+      config.getBoolean("ldap.useSynchronousMode")
+    } catch {
+      case ex: ConfigException =>
+        ApplicationLogger.info(
+          "Property 'ldap.useSynchronousMode' is missing or empty in rudder.configFile. Default to true."
+        )
+        true
+    }
+  }
   val LDAP_CACHE_NODE_INFO_MIN_INTERVAL: Duration       = {
     val x = {
       try {
@@ -2559,7 +2570,8 @@ object RudderConfigInit {
         port = LDAP_PORT,
         authDn = LDAP_AUTHDN,
         authPw = LDAP_AUTHPW,
-        poolSize = LDAP_MAX_POOL_SIZE
+        poolSize = LDAP_MAX_POOL_SIZE,
+        useSynchronousMode = LDAP_USE_SYNC_MODE
       )
     }
     lazy val roLDAPConnectionProvider = roLdap
@@ -2569,7 +2581,8 @@ object RudderConfigInit {
         port = LDAP_PORT,
         authDn = LDAP_AUTHDN,
         authPw = LDAP_AUTHPW,
-        poolSize = LDAP_MAX_POOL_SIZE
+        poolSize = LDAP_MAX_POOL_SIZE,
+        useSynchronousMode = LDAP_USE_SYNC_MODE
       )
     }
 

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/listener/InMemoryDsConnectionProvider.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/listener/InMemoryDsConnectionProvider.scala
@@ -26,6 +26,7 @@ import com.normation.ldap.sdk.syntax.UnboundidLDAPConnection
 import com.normation.zio.*
 import com.unboundid.ldap.listener.InMemoryDirectoryServer
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig
+import com.unboundid.ldap.sdk.LDAPConnectionOptions
 import com.unboundid.ldap.sdk.schema.Schema
 import zio.*
 
@@ -53,9 +54,10 @@ class InMemoryDsConnectionProvider[CON <: RoLDAPConnection](
   bootstrapLDIFPaths foreach { path => server.importFromLDIF(false, path) }
   server.startListening
 
-  override def toConnectionString: String           = "in-memory-ldap-connection"
-  override def semaphore:          Semaphore        = ZioRuntime.unsafeRun(Semaphore.make(1))
-  override val connection:         Ref[Option[CON]] = ZioRuntime.unsafeRun(Ref.make(Option.empty[CON]))
+  override def toConnectionString: String                                         = "in-memory-ldap-connection"
+  override def semaphore:          Semaphore                                      = ZioRuntime.unsafeRun(Semaphore.make(1))
+  override def customizeOption:    LDAPConnectionOptions => LDAPConnectionOptions = identity
+  override val connection:         Ref[Option[CON]]                               = ZioRuntime.unsafeRun(Ref.make(Option.empty[CON]))
 
   override def newUnboundidConnection: UnboundidLDAPConnection = server.getConnection
 


### PR DESCRIPTION
https://issues.rudder.io/issues/25742

Make LDAP request synchronous by default (configurable via a rudder properties parameter). 
This make async request impossible (ie when we query LDAP with a listener and then asked for answers), but we don't use any of them (AFAIK). 
Making request synchronous make the pool usage more predictable, error more clearly linked to the request leading to them, and general enhance performance. 
See https://ldapwiki.com/wiki/Wiki.jsp?page=Tips%20using%20UnboundID%20LDAP%20SDK#section-Tips+using+UnboundID+LDAP+SDK-LDAPConnectionPoolsAndGetConnection

Also add options to: 
- release the connection to the pool as early as possible in case of error, 
- use information from our LDAP Schema and don't try to refresh them (since in Rudder, the schema doesn't change without a restart of Rudder)