### PR TITLE
Fixes #24968: Upgrade to ZIO 2.1.11

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -486,7 +486,7 @@ limitations under the License.
     <fs2-version>3.10.2</fs2-version>
     <shapeless-version>2.3.12</shapeless-version>
     <cats-effect-version>3.5.4</cats-effect-version>
-    <dev-zio-version>2.0.22</dev-zio-version>
+    <dev-zio-version>2.1.11</dev-zio-version>
     <zio-cats-version>23.1.0.2</zio-cats-version> <!-- gives fs2 3.10.2, but doobie 1.0.0-RC5 is in 3.9.3 -->
     <zio-json-version>0.7.1</zio-json-version>
     <enumeratum-version>1.7.4</enumeratum-version>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
@@ -255,7 +255,6 @@ class PolicyWriterServiceImpl(
 ) extends PolicyWriterService {
   import com.normation.rudder.services.policies.write.PolicyWriterServiceImpl.*
 
-  val clock        = ZioRuntime.environment
   val timingLogger = PolicyGenerationLoggerPure.timing
 
   val hookGlobalWarnTimeout: Duration = 60.seconds // max time before warning for executing all hooks

--- a/webapp/sources/utils/src/test/scala/com/normation/ZioCommonsTest.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/ZioCommonsTest.scala
@@ -322,7 +322,7 @@ object TestJavaLockWithZio {
  * This test show that without a fork, execution is purely mono-fiber and sequential.
  */
 object TestZioSemantic {
-  val rt = ZioRuntime.internal
+  def rt(implicit unsafe: Unsafe) = ZioRuntime.internal
   trait LOG {
     def apply(s: String): UIO[Unit]
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/24968
[ ] TODO: use EagerShiftBack
It seems to work when disabling test runs with the `Runtime.enableAutoBlockingExecutor`, but in tests there are memory errors : 
```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.028 sec
Running com.normation.rudder.services.queries.TestStringQueryParser
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 sec
Running com.normation.rudder.services.queries.TestNodeFactQueryProcessor
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f37e82f2000, 16384, 0) failed; error='Not enough space' (errno=12)
#
# There is insufficient memory for the Java Runtime Environment to continue.
# Native memory allocation (mmap) failed to map 16384 bytes. Error detail: committing reserved memory.
# An error report file with more information is saved as:
# /home/clarkenciel/IdeaProjects/rudder/webapp/sources/rudder/rudder-core/hs_err_pid23970.log
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f37e81f2000, 16384, 0) failed; error='Not enough space' (errno=12)
[thread 58859 also had an error]
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f37e80f2000, 16384, 0) failed; error='Not enough space' (errno=12)
[thread 58860 also had an error]
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f37e7ff2000, 16384, 0) failed; error='Not enough space' (errno=12)
[thread 58861 also had an error]
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f37e7ef2000, 16384, 0) failed; error='Not enough space' (errno=12)
[thread 58862 also had an error]
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f37e7df2000, 16384, 0) failed; error='Not enough space' (errno=12)
[thread 58863 also had an error]
[thread 58864 also had an error]
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f37e7cf2000, 16384, 0) failed; error='Not enough space' (errno=12)
[36.910s][warning][os,thread] Failed to start thread "Unknown thread" - pthread_create failed (EAGAIN) for attributes: stacksize: 1024k, guardsize: 0k, detached.
[thread 58865 also had an error]
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f37e7bf2000, 16384, 0) failed; error='Not enough space' (errno=12)
[36.910s][warning][os,thread] Failed to start the native thread for java.lang.Thread "ZScheduler-Worker-18"
java.lang.OutOfMemoryError: unable to create native thread: possibly out of memory or process/resource limits reached
        at java.base/java.lang.Thread.start0(Native Method)
        at java.base/java.lang.Thread.start(Thread.java:809)
        at zio.internal.ZScheduler.<init>(ZScheduler.scala:52)
        at zio.RuntimePlatformSpecific.$anonfun$enableAutoBlockingExecutor$1(RuntimePlatformSpecific.scala:59)
        at zio.ZLayer.$anonfun$scope$17(ZLayer.scala:431)
        at zio.ZLayer$MemoMap$$anon$25.$anonfun$getOrElseMemoize$17(ZLayer.scala:1986)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1077)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1162)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1097)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1067)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1067)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1162)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1162)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1097)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1162)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1067)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1162)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1097)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1067)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1067)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1162)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1067)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1067)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1162)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1097)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1162)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1067)
        at zio.internal.FiberRuntime.evaluateEffect(FiberRuntime.scala:413)
        at zio.internal.FiberRuntime.start(FiberRuntime.scala:1393)
        at zio.Runtime$UnsafeAPIV1.runOrFork(Runtime.scala:160)
        at zio.Runtime$UnsafeAPIV1.run(Runtime.scala:133)
        at zio.Runtime$unsafe$.fromLayer(Runtime.scala:309)
        at com.normation.zio$ZioRuntime$.$anonfun$unsafeRun$1(ZioCommons.scala:444)
        at zio.Unsafe$.unsafe(Unsafe.scala:37)
        at com.normation.zio$ZioRuntime$.unsafeRun(ZioCommons.scala:442)
        at com.normation.ldap.listener.InMemoryDsConnectionProvider.semaphore(InMemoryDsConnectionProvider.scala:57)
        at com.normation.ldap.sdk.OneConnectionProvider.getInternalConnection(LDAPConnectionProvider.scala:204)
        at com.normation.ldap.sdk.OneConnectionProvider.getInternalConnection$(LDAPConnectionProvider.scala:203)
        at com.normation.ldap.listener.InMemoryDsConnectionProvider.getInternalConnection(InMemoryDsConnectionProvider.scala:37)
        at com.normation.ldap.sdk.LDAPConnectionProvider.$anonfun$withCon$1(LDAPConnectionProvider.scala:117)
        at zio.ZIO$ReleaseExit.$anonfun$apply$21(ZIO.scala:5555)
        at zio.ZIO$.$anonfun$interruptionMasked$1(ZIO.scala:3940)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1162)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1097)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1067)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1097)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1097)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1097)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1162)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1097)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1162)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1067)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1067)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1162)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1097)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1162)
        at zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1162)
        at zio.internal.FiberRuntime.evaluateEffect(FiberRuntime.scala:413)
        at zio.internal.FiberRuntime.evaluateMessageWhileSuspended(FiberRuntime.scala:489)
        at zio.internal.FiberRuntime.drainQueueOnCurrentThread(FiberRuntime.scala:250)
        at zio.internal.FiberRuntime.run(FiberRuntime.scala:138)
        at zio.internal.ZScheduler$$anon$3.run(ZScheduler.scala:380)
[36.911s][warning][os,thread] Failed to start thread "Unknown thread" - pthread_create failed (EAGAIN) for attributes: stacksize: 1024k, guardsize: 0k, detached.
[36.911s][warning][os,thread] Failed to start the native thread for java.lang.Thread "Thread-154"
[thread 23986 also had an error]
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f42c7600000, 65536, 1) failed; error='Not enough space' (errno=12)
```