### PR TITLE
Fixes #25822: Properties on newly created group are not initialized until policy generation or other group properties update

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -1093,6 +1093,7 @@ class GroupApiService14(
     readGroup:            RoNodeGroupRepository,
     writeGroup:           WoNodeGroupRepository,
     propertiesRepo:       PropertiesRepository,
+    propertiesService:    NodePropertiesService,
     uuidGen:              StringUuidGenerator,
     asyncDeploymentAgent: AsyncDeploymentActor,
     workflowLevelService: WorkflowLevelService,
@@ -1147,6 +1148,8 @@ class GroupApiService14(
         rootCat  <- readGroup.getRootCategoryPure()
         cat       = change.category.getOrElse(rootCat.id)
         saveDiff <- writeGroup.create(change.newGroup, cat, modId, actor, params.reason)
+        // after group creation, its properties should be computed and resolved
+        _        <- propertiesService.updateAll()
       } yield {
         if (saveDiff.needDeployment) {
           // Trigger a deployment only if it is needed

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -871,6 +871,7 @@ class RestTestSetUp {
     mockNodeGroups.groupsRepo,
     mockNodeGroups.groupsRepo,
     mockNodes.propRepo,
+    mockNodeGroups.propService,
     uuidGen,
     asyncDeploymentAgent,
     workflowLevelService,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1124,6 +1124,8 @@ object RudderConfig extends Loggable {
   val policyGenerationBootGuard:           zio.Promise[Nothing, Unit]                 = rci.policyGenerationBootGuard
   val policyServerManagementService:       PolicyServerManagementService              = rci.policyServerManagementService
   val propertyEngineService:               PropertyEngineService                      = rci.propertyEngineService
+  val propertiesRepository:                PropertiesRepository                       = rci.propertiesRepository
+  val propertiesService:                   NodePropertiesService                      = rci.propertiesService
   val purgeDeletedInventories:             PurgeDeletedInventories                    = rci.purgeDeletedInventories
   val purgeUnreferencedSoftwares:          PurgeUnreferencedSoftwares                 = rci.purgeUnreferencedSoftwares
   val readOnlySoftwareDAO:                 ReadOnlySoftwareDAO                        = rci.readOnlySoftwareDAO
@@ -1348,7 +1350,8 @@ case class RudderServiceApi(
     tenantService:                       TenantService,
     computeNodeStatusReportService:      ComputeNodeStatusReportService & HasNodeStatusReportUpdateHook,
     scoreRepository:                     ScoreRepository,
-    propertiesRepository:                PropertiesRepository
+    propertiesRepository:                PropertiesRepository,
+    propertiesService:                   NodePropertiesService
 )
 
 /*
@@ -1685,6 +1688,7 @@ object RudderConfigInit {
         roNodeGroupRepository,
         woNodeGroupRepository,
         propertiesRepository,
+        propertiesService,
         uuidGen,
         asyncDeploymentAgent,
         workflowLevelService,
@@ -3688,7 +3692,8 @@ object RudderConfigInit {
       tenantService,
       computeNodeStatusReportService,
       scoreRepository,
-      propertiesRepository
+      propertiesRepository,
+      propertiesService
     )
 
     // need to be done here to avoid cyclic dependencies

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
@@ -85,6 +85,7 @@ class CreateCategoryOrGroupPopup(
   )
 
   private val woNodeGroupRepository      = RudderConfig.woNodeGroupRepository
+  private val propertiesService          = RudderConfig.propertiesService
   private val categoryHierarchyDisplayer = RudderConfig.categoryHierarchyDisplayer
   private val uuidGen                    = RudderConfig.stringUuidGenerator
   private val userPropertyService        = RudderConfig.userPropertyService
@@ -290,6 +291,7 @@ class CreateCategoryOrGroupPopup(
             CurrentUser.actor,
             piReasons.map(_.get)
           )
+          .tap(_ => propertiesService.updateAll())
           .toBox match {
           case Full(x)          =>
             closePopup() &


### PR DESCRIPTION
https://issues.rudder.io/issues/25822

We need to call `propertiesService.updateAll()` to initialize the value of the properties of the group in the cache, the same way when a group properties are updated (same as in https://github.com/Normation/rudder/pull/5920/files).
We need to do this both in the UI and in the API to resolve the group properties hierarchy from global properties once it is created