### PR TITLE
Fixes #25830: Bad postgresql time conversion for event log cleaning in 8.1

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeOldInventoryData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeOldInventoryData.scala
@@ -119,9 +119,11 @@ class PurgeOldInventoryData(
 
     val deleteDeleted = (for {
       ids <- inventoryHistory.deleteFactIfDeleteEventBefore(now.minus(deleteLogDeleted.toMillis))
-      _   <- InventoryProcessingLogger.info(
-               s"Deleted historical pending inventory information of nodes: '${ids.map(_.value).mkString("', '")}'"
-             )
+      _   <- InventoryProcessingLogger
+               .info(
+                 s"Deleted historical pending inventory information of nodes: '${ids.map(_.value).mkString("', '")}'"
+               )
+               .unless(ids.isEmpty)
     } yield ()).catchAll { err =>
       InventoryProcessingLogger.error(
         s"Error when deleting historical pending inventory information for deleted nodes: ${err.fullMsg}"

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/InventoryHistoryJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/InventoryHistoryJdbcRepository.scala
@@ -186,10 +186,10 @@ class InventoryHistoryJdbcRepository(
     transactIOResult(s"error when deleting acceptation information for node '${id.value}'")(xa => q.update.run.transact(xa)).unit
   }
 
-  // delete all facts which have a delete event older then given data
+  // delete all facts which have a delete event older than given data
   def deleteFactIfDeleteEventBefore(date: DateTime): IOResult[Vector[NodeId]] = {
     val q = sql"""delete from nodefacts
-           where to_timestamp(deleteEvent->>'date', 'YYYY-MM-DDTHH:MI:SS.MS') < ${date}
+           where to_timestamp(deleteEvent->>'date', 'YYYY-MM-DDTHH:MI:SS"Z"') < ${date}
            returning nodeid"""
 
     transactIOResult(
@@ -204,7 +204,7 @@ class InventoryHistoryJdbcRepository(
   // would have been good for logs
   def deleteFactCreatedBefore(date: DateTime): IOResult[Vector[NodeId]] = {
     val q = sql"""delete from nodefacts
-         where to_timestamp(acceptRefuseEvent->>'date', 'YYYY-MM-DDTHH:MI:SS.MS') < ${date}
+         where to_timestamp(acceptRefuseEvent->>'date', 'YYYY-MM-DDTHH:MI:SS"Z"') < ${date}
          returning nodeid"""
 
     transactIOResult(


### PR DESCRIPTION
https://issues.rudder.io/issues/25830

The format has always been serialized as ISO8601 (see the Joda date serializer), the bug was in fact in : 
https://github.com/Normation/rudder/pull/5034