### PR TITLE
Fixes #25762: Sometimes too long properties values move out actions buttons from window

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.scss
@@ -128,6 +128,7 @@ pre.json-beautify, .content-wrapper pre.json-beautify{
   white-space: pre-wrap;
   word-break: break-all;
   word-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 pre.json-beautify.toggle, .content-wrapper pre.json-beautify.toggle{
   height:auto;


### PR DESCRIPTION
https://issues.rudder.io/issues/25762

This bug only appears on Firefox, so I had to add a simple css rule to prevent it.

> Note: In contrast to [word-break](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break), overflow-wrap will only create a break if an entire word cannot be placed on its own line without overflowing.
https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap