### PR TITLE
Fixes #24968: Upgrade to ZIO 2.1.2

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -486,7 +486,7 @@ limitations under the License.
     <fs2-version>3.10.2</fs2-version>
     <shapeless-version>2.3.12</shapeless-version>
     <cats-effect-version>3.5.4</cats-effect-version>
-    <dev-zio-version>2.0.22</dev-zio-version>
+    <dev-zio-version>2.1.12</dev-zio-version>
     <zio-cats-version>23.1.0.2</zio-cats-version> <!-- gives fs2 3.10.2, but doobie 1.0.0-RC5 is in 3.9.3 -->
     <zio-json-version>0.7.1</zio-json-version>
     <enumeratum-version>1.7.4</enumeratum-version>


### PR DESCRIPTION
https://issues.rudder.io/issues/24968


New try with last version and the old strategy that all `ResultIO.attempt` are blocking.
I *looks* like it works for everything on one core (compilation, test, policy generation and update, node inventory processing...) BUT I can't log in the webUI anymore. 

The spring trace look normal until a redirect to login page. I'm not sure why ZIO version impact that (idea is something around threadlocal context, but not sure what)

UPDATE: it now works. When dealing with SpringSecurity related code, it seems that we must be careful to now yield other thread with `IOResult.attempt` because then, we loose the `SecurityContext` (which, IIRC, is stored in a ThreadLocal value). 

I didn't found other occurence of that happening, but we're likely going to need a systematic look at what need to be blocking or not. 

So now, everything seems to work, and everything seems to be quick. We will need to check for thread number explosion, though. 