### PR TITLE
Fixes #25868: Don't configure a broken Rudder account by default

### DIFF
--- a/relay/sources/rudder-package/tools/rudder-pkg.conf
+++ b/relay/sources/rudder-package/tools/rudder-pkg.conf
@@ -1,7 +1,9 @@
 [Rudder]
-url = https://download.rudder.io/plugins
-username = username
-password = password
-proxy_url = 
-proxy_user = 
-proxy_password = 
+# The default values are commented below
+# 
+#url = https://download.rudder.io/plugins
+#username =
+#password =
+#proxy_url = 
+#proxy_user = 
+#proxy_password = 


### PR DESCRIPTION
https://issues.rudder.io/issues/25868