### PR TITLE
Fixes #25786: Add timezone field in campaign schedule

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JsonCampaignSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JsonCampaignSerializer.scala
@@ -125,6 +125,7 @@ object CampaignSerializer {
   implicit val statusInfoEncoder:       JsonEncoder[CampaignStatus]          = DeriveJsonEncoder.gen
   implicit val time:                    JsonEncoder[Time]                    = DeriveJsonEncoder.gen
   implicit val dayTime:                 JsonEncoder[DayTime]                 = DeriveJsonEncoder.gen
+  implicit val timezone:                JsonEncoder[ScheduleTimeZone]        = JsonEncoder[String].contramap(_.id)
   implicit val scheduleEncoder:         JsonEncoder[CampaignSchedule]        = DeriveJsonEncoder.gen
   implicit val campaignInfoEncoder:     JsonEncoder[CampaignInfo]            = DeriveJsonEncoder.gen
   implicit val idDecoder:               JsonDecoder[CampaignId]              = JsonDecoder[String].map(s => CampaignId(s))
@@ -162,6 +163,7 @@ object CampaignSerializer {
   implicit val statusInfoDecoder:   JsonDecoder[CampaignStatus]   = DeriveJsonDecoder.gen
   implicit val timeDecoder:         JsonDecoder[Time]             = DeriveJsonDecoder.gen
   implicit val dayTimeDecoder:      JsonDecoder[DayTime]          = DeriveJsonDecoder.gen
+  implicit val timezoneDecoder:     JsonDecoder[ScheduleTimeZone] = JsonDecoder[String].mapOrFail(ScheduleTimeZone.parse)
   implicit val scheduleDecoder:     JsonDecoder[CampaignSchedule] = DeriveJsonDecoder.gen
   implicit val campaignTypeDecoder: JsonDecoder[CampaignType]     = JsonDecoder[String].map(CampaignType.apply)
   implicit val campaignInfoDecoder: JsonDecoder[CampaignInfo]     = DeriveJsonDecoder.gen

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -76,6 +76,7 @@ import com.normation.rudder.campaigns.MainCampaignService
 import com.normation.rudder.campaigns.Monday
 import com.normation.rudder.campaigns.Running
 import com.normation.rudder.campaigns.Scheduled
+import com.normation.rudder.campaigns.ScheduleTimeZone
 import com.normation.rudder.campaigns.WeeklySchedule
 import com.normation.rudder.configuration.ConfigurationRepositoryImpl
 import com.normation.rudder.configuration.DirectiveRevisionRepository
@@ -3031,7 +3032,8 @@ final case class DumbCampaign(info: CampaignInfo, details: DumbCampaignDetails) 
   val campaignType: CampaignType = DumbCampaignType
   val version = 1
   def copyWithId(newId: CampaignId): Campaign = this.copy(info = info.copy(id = newId))
-
+  def setScheduleTimeZone(newScheduleTimeZone: ScheduleTimeZone): Campaign =
+    this.modify(_.info.schedule).using(_.atTimeZone(newScheduleTimeZone))
 }
 
 class MockCampaign() {
@@ -3045,7 +3047,7 @@ class MockCampaign() {
       "first campaign",
       "a test campaign present when rudder boot",
       Enabled,
-      WeeklySchedule(DayTime(Monday, 3, 42), DayTime(Monday, 4, 42))
+      WeeklySchedule(DayTime(Monday, 3, 42), DayTime(Monday, 4, 42), None)
     ),
     DumbCampaignDetails("campaign #0")
   )

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/campaign/CampaignSchedulerTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/campaign/CampaignSchedulerTest.scala
@@ -37,113 +37,105 @@
 
 package com.normation.rudder.campaign
 
-import com.normation.rudder.campaigns.DayTime
-import com.normation.rudder.campaigns.First
-import com.normation.rudder.campaigns.Last
-import com.normation.rudder.campaigns.MainCampaignScheduler
-import com.normation.rudder.campaigns.Monday
-import com.normation.rudder.campaigns.MonthlySchedule
-import com.normation.rudder.campaigns.Second
-import com.normation.rudder.campaigns.SecondLast
-import com.normation.rudder.campaigns.Sunday
-import com.normation.rudder.campaigns.Third
-import com.normation.zio.*
+import com.normation.errors.*
+import com.normation.rudder.campaigns.*
+import com.normation.rudder.campaigns.WeeklySchedule
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
+import org.joda.time.format.ISODateTimeFormat
 import org.junit.runner.RunWith
+import org.specs2.matcher.Matcher
 import org.specs2.mutable.*
 import org.specs2.runner.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class CampaignSchedulerTest extends Specification {
 
-  val now: DateTime = DateTime.now()
+  val now:       DateTime     = DateTime.now().withZone(DateTimeZone.UTC)
+  val defaultTz: DateTimeZone = DateTimeZone.getDefault()
+
   "A monthly campaign schedule set during december" should {
 
     // With bug, it was 2023/01/05 12:00 and end on 2023/01/09 18:00 instead of both date on 02/01/2023
     "Give a correct date in january for first occurrence" in {
       val s = MainCampaignScheduler
         .nextCampaignDate(
-          MonthlySchedule(First, DayTime(Monday, 9, 27), DayTime(Monday, 13, 37)),
+          MonthlySchedule(First, DayTime(Monday, 9, 27), DayTime(Monday, 13, 37), Some(ScheduleTimeZone("UTC"))),
           now.withYear(2022).withMonthOfYear(12).withDayOfMonth(7)
         )
-        .runNow
-      s must beSome(
-        (
-          now
-            .withYear(2023)
-            .withMonthOfYear(1)
-            .withDayOfMonth(2)
-            .withHourOfDay(9)
-            .withMinuteOfHour(27)
-            .withSecondOfMinute(0)
-            .withMillisOfSecond(0),
-          now
-            .withYear(2023)
-            .withMonthOfYear(1)
-            .withDayOfMonth(2)
-            .withHourOfDay(13)
-            .withMinuteOfHour(37)
-            .withSecondOfMinute(0)
-            .withMillisOfSecond(0)
-        )
+
+      s must haveSchedule(
+        now
+          .withYear(2023)
+          .withMonthOfYear(1)
+          .withDayOfMonth(2)
+          .withHourOfDay(9)
+          .withMinuteOfHour(27)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0),
+        now
+          .withYear(2023)
+          .withMonthOfYear(1)
+          .withDayOfMonth(2)
+          .withHourOfDay(13)
+          .withMinuteOfHour(37)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0)
       )
+
     }
 
     "Give a correct date in january for Second occurrence" in {
       val s = MainCampaignScheduler
         .nextCampaignDate(
-          MonthlySchedule(Second, DayTime(Monday, 9, 27), DayTime(Monday, 13, 37)),
+          MonthlySchedule(Second, DayTime(Monday, 9, 27), DayTime(Monday, 13, 37), Some(ScheduleTimeZone("UTC"))),
           now.withYear(2022).withMonthOfYear(12).withDayOfMonth(14)
         )
-        .runNow
-      s must beSome(
-        (
-          now
-            .withYear(2023)
-            .withMonthOfYear(1)
-            .withDayOfMonth(9)
-            .withHourOfDay(9)
-            .withMinuteOfHour(27)
-            .withSecondOfMinute(0)
-            .withMillisOfSecond(0),
-          now
-            .withYear(2023)
-            .withMonthOfYear(1)
-            .withDayOfMonth(9)
-            .withHourOfDay(13)
-            .withMinuteOfHour(37)
-            .withSecondOfMinute(0)
-            .withMillisOfSecond(0)
-        )
+
+      s must haveSchedule(
+        now
+          .withYear(2023)
+          .withMonthOfYear(1)
+          .withDayOfMonth(9)
+          .withHourOfDay(9)
+          .withMinuteOfHour(27)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0),
+        now
+          .withYear(2023)
+          .withMonthOfYear(1)
+          .withDayOfMonth(9)
+          .withHourOfDay(13)
+          .withMinuteOfHour(37)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0)
       )
     }
 
     "Give a correct date in january for third occurrence" in {
       val s = MainCampaignScheduler
         .nextCampaignDate(
-          MonthlySchedule(Third, DayTime(Monday, 9, 27), DayTime(Monday, 13, 37)),
+          MonthlySchedule(Third, DayTime(Monday, 9, 27), DayTime(Monday, 13, 37), Some(ScheduleTimeZone("UTC"))),
           now.withYear(2022).withMonthOfYear(12).withDayOfMonth(21)
         )
-        .runNow
-      s must beSome(
-        (
-          now
-            .withYear(2023)
-            .withMonthOfYear(1)
-            .withDayOfMonth(16)
-            .withHourOfDay(9)
-            .withMinuteOfHour(27)
-            .withSecondOfMinute(0)
-            .withMillisOfSecond(0),
-          now
-            .withYear(2023)
-            .withMonthOfYear(1)
-            .withDayOfMonth(16)
-            .withHourOfDay(13)
-            .withMinuteOfHour(37)
-            .withSecondOfMinute(0)
-            .withMillisOfSecond(0)
-        )
+
+      s must haveSchedule(
+        now
+          .withYear(2023)
+          .withMonthOfYear(1)
+          .withDayOfMonth(16)
+          .withHourOfDay(9)
+          .withMinuteOfHour(27)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0),
+        now
+          .withYear(2023)
+          .withMonthOfYear(1)
+          .withDayOfMonth(16)
+          .withHourOfDay(13)
+          .withMinuteOfHour(37)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0)
       )
     }
 
@@ -151,29 +143,27 @@ class CampaignSchedulerTest extends Specification {
     "Give a correct date in December for last occurrence" in {
       val s = MainCampaignScheduler
         .nextCampaignDate(
-          MonthlySchedule(Last, DayTime(Sunday, 9, 27), DayTime(Sunday, 13, 37)),
+          MonthlySchedule(Last, DayTime(Sunday, 9, 27), DayTime(Sunday, 13, 37), Some(ScheduleTimeZone("UTC"))),
           now.withYear(2022).withMonthOfYear(12).withDayOfMonth(7)
         )
-        .runNow
-      s must beSome(
-        (
-          now
-            .withYear(2022)
-            .withMonthOfYear(12)
-            .withDayOfMonth(25)
-            .withHourOfDay(9)
-            .withMinuteOfHour(27)
-            .withSecondOfMinute(0)
-            .withMillisOfSecond(0),
-          now
-            .withYear(2022)
-            .withMonthOfYear(12)
-            .withDayOfMonth(25)
-            .withHourOfDay(13)
-            .withMinuteOfHour(37)
-            .withSecondOfMinute(0)
-            .withMillisOfSecond(0)
-        )
+
+      s must haveSchedule(
+        now
+          .withYear(2022)
+          .withMonthOfYear(12)
+          .withDayOfMonth(25)
+          .withHourOfDay(9)
+          .withMinuteOfHour(27)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0),
+        now
+          .withYear(2022)
+          .withMonthOfYear(12)
+          .withDayOfMonth(25)
+          .withHourOfDay(13)
+          .withMinuteOfHour(37)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0)
       )
     }
 
@@ -181,30 +171,618 @@ class CampaignSchedulerTest extends Specification {
     "Give a correct date in December for second last occurrence" in {
       val s = MainCampaignScheduler
         .nextCampaignDate(
-          MonthlySchedule(SecondLast, DayTime(Sunday, 9, 27), DayTime(Sunday, 13, 37)),
+          MonthlySchedule(SecondLast, DayTime(Sunday, 9, 27), DayTime(Sunday, 13, 37), Some(ScheduleTimeZone("UTC"))),
           now.withYear(2022).withMonthOfYear(12).withDayOfMonth(7)
         )
-        .runNow
-      s must beSome(
-        (
-          now
-            .withYear(2022)
-            .withMonthOfYear(12)
-            .withDayOfMonth(18)
-            .withHourOfDay(9)
-            .withMinuteOfHour(27)
-            .withSecondOfMinute(0)
-            .withMillisOfSecond(0),
-          now
-            .withYear(2022)
-            .withMonthOfYear(12)
-            .withDayOfMonth(18)
-            .withHourOfDay(13)
-            .withMinuteOfHour(37)
-            .withSecondOfMinute(0)
-            .withMillisOfSecond(0)
-        )
+
+      s must haveSchedule(
+        now
+          .withYear(2022)
+          .withMonthOfYear(12)
+          .withDayOfMonth(18)
+          .withHourOfDay(9)
+          .withMinuteOfHour(27)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0),
+        now
+          .withYear(2022)
+          .withMonthOfYear(12)
+          .withDayOfMonth(18)
+          .withHourOfDay(13)
+          .withMinuteOfHour(37)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0)
       )
     }
   }
+
+  "A one shot schedule" should {
+    "correctly schedule" in {
+      val start = now.plusDays(1)
+      val end   = now.plusDays(2)
+
+      val res = MainCampaignScheduler.nextCampaignDate(OneShot(start, end), now)
+
+      res must haveSchedule(start, end)
+    }
+
+    "correctly schedule a run that ended in the past" in {
+      val start = now.minusDays(2)
+      val end   = now.minusDays(1)
+
+      val res = MainCampaignScheduler.nextCampaignDate(OneShot(start, end), now)
+
+      res must haveNoSchedule
+    }
+
+    "return error if start is equal or after end" in {
+      val start = now.plusDays(2)
+      val end   = now.plusDays(1)
+
+      val res      = MainCampaignScheduler.nextCampaignDate(OneShot(start, end), now)
+      val sameDate = MainCampaignScheduler.nextCampaignDate(OneShot(start, start), now)
+
+      val beError = beLeft[RudderError].like {
+        case Inconsistency(msg) => msg must startWith(s"Cannot schedule a one shot event")
+      }
+      (res must beError) and (sameDate must beError)
+    }
+
+    "correctly schedule a run with a different timezone from the server one" in {
+      val zone  = DateTimeZone.forOffsetHours(-7)
+      val start = now.plusDays(1).withZone(zone)
+      val end   = now.plusDays(2).withZone(zone)
+
+      val res = MainCampaignScheduler.nextCampaignDate(OneShot(start, end), now)
+
+      res must haveSchedule(start, end)
+    }
+
+    "correctly schedule a run by translating timezone" in {
+      // adding an negative offset that makes the start, end dates both be in the past
+      val zone  = DateTimeZone.forOffsetHours(7)
+      val start = now.plusHours(5).withZoneRetainFields(zone) // 2h before now
+      val end   = now.plusHours(6).withZoneRetainFields(zone) // 1h before now
+
+      val res =
+        MainCampaignScheduler.nextCampaignDate(OneShot(start, end), now)
+
+      res must haveNoSchedule
+    }
+  }
+
+  "A daily schedule" should {
+    val currentDate = DateTime.parse("2024-11-08T12:34:00Z")
+
+    // we would expect schedule with tz=None to be equivalent to default tz=+01:00
+    "correctly schedule" in {
+      "current day" in {
+        val start = Time(16, 30)
+        val end   = Time(20, 30)
+
+        val res = MainCampaignScheduler.nextCampaignDate(Daily(start, end, tz = None), currentDate)
+
+        val nextDate = currentDate.withHourOfDay(start.hour).withMinuteOfHour(start.minute).withZoneRetainFields(defaultTz)
+        res must haveSchedule(nextDate, nextDate.plusHours(4))
+      }
+
+      "next day when start day has already passed" in {
+        val start = Time(10, 30)
+        val end   = Time(14, 30)
+
+        val res = MainCampaignScheduler.nextCampaignDate(Daily(start, end, tz = None), currentDate)
+
+        val nextDay =
+          currentDate.plusDays(1).withHourOfDay(start.hour).withMinuteOfHour(start.minute).withZoneRetainFields(defaultTz)
+        res must haveSchedule(nextDay, nextDay.plusHours(4))
+      }
+
+      "next day when start day has already passed within the same hour" in {
+        val start = Time(12, 30)
+        val end   = Time(16, 30)
+
+        val res = MainCampaignScheduler.nextCampaignDate(Daily(start, end, tz = None), currentDate)
+
+        val nextDay =
+          currentDate.plusDays(1).withHourOfDay(start.hour).withMinuteOfHour(start.minute).withZoneRetainFields(defaultTz)
+        res must haveSchedule(nextDay, nextDay.plusHours(4))
+      }
+
+      "with overlap" in {
+        // overlap (start is passed, but end is not and is on the same day)
+        val start    = Time(20, 30)
+        val end      = Time(10, 30)
+        val schedule = Daily(start, end, tz = None)
+
+        val res = MainCampaignScheduler.nextCampaignDate(
+          schedule,
+          currentDate
+        )
+
+        val scheduleDate = currentDate
+          .withHourOfDay(start.hour)
+          .withMinuteOfHour(start.minute)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0)
+          .withZoneRetainFields(defaultTz)
+        res must haveSchedule(scheduleDate, scheduleDate.plusHours(14))
+      }
+
+      "with specific schedule timezone" in {
+        val scheduleTimeZone = DateTimeZone.forOffsetHours(6)
+        val start            = Time(19, 30)
+        val end              = Time(23, 30)
+        // 19h30 at +06:00 is 13h30 UTC so it's scheduled on same day
+        val schedule         = Daily(start, end, Some(ScheduleTimeZone(scheduleTimeZone.getID)))
+
+        val res = MainCampaignScheduler.nextCampaignDate(
+          schedule,
+          currentDate
+        )
+
+        val scheduleDate = currentDate
+          .withHourOfDay(start.hour)
+          .withMinuteOfHour(start.minute)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0)
+          .withZoneRetainFields(scheduleTimeZone)
+        res must haveSchedule(scheduleDate, scheduleDate.plusHours(4))
+      }
+
+      "with specific schedule timezone for next day" in {
+        // special case where the time zone being not the same as the default one makes it theoretically run on next day
+        // 10h30 at +06:00 is 04h30 UTC so it's scheduled on next day
+        val scheduleTimeZone = DateTimeZone.forOffsetHours(6)
+        val start            = Time(10, 30)
+        val end              = Time(14, 30)
+        val schedule         = Daily(start, end, Some(ScheduleTimeZone(scheduleTimeZone.getID)))
+
+        val res = MainCampaignScheduler.nextCampaignDate(
+          schedule,
+          currentDate
+        )
+
+        val scheduleDate = currentDate
+          .plusDays(1)
+          .withHourOfDay(start.hour)
+          .withMinuteOfHour(start.minute)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0)
+          .withZoneRetainFields(scheduleTimeZone)
+        res must haveSchedule(scheduleDate, scheduleDate.plusHours(4))
+      }
+
+      "with specific schedule timezone with overlap" in {
+        // overlap (start is passed, but end is not and is on the same day) : it needs to be scheduled on next day
+        // 16h30 at -06:00 is 22h30 UTC and 20h30 at -06:00 is 02h30 UTC on the next day
+        val scheduleTimeZone = DateTimeZone.forOffsetHours(-6)
+        val start            = Time(16, 30)
+        val end              = Time(20, 30)
+        val schedule         = Daily(start, end, Some(ScheduleTimeZone(scheduleTimeZone.getID)))
+
+        val res = MainCampaignScheduler.nextCampaignDate(
+          schedule,
+          currentDate
+        )
+
+        val scheduleDate = currentDate
+          .withHourOfDay(start.hour)
+          .withMinuteOfHour(start.minute)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0)
+          .withZoneRetainFields(scheduleTimeZone)
+        res must haveSchedule(scheduleDate, scheduleDate.plusHours(4))
+      }
+    }
+
+  }
+
+  "A weekly schedule" should {
+    // 2024-11-08 is a Friday
+    val currentDate = DateTime.parse("2024-11-08T12:34:00Z")
+
+    "correctly schedule" in {
+      "current week" in {
+        val start = DayTime(Friday, 16, 0)
+        val end   = DayTime(Saturday, 16, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(WeeklySchedule(start, end, tz = None), currentDate)
+
+        val nextDate = currentDate.withHourOfDay(start.hour).withMinuteOfHour(start.minute).withZoneRetainFields(defaultTz)
+        res must haveSchedule(nextDate, nextDate.plusDays(1))
+      }
+
+      "next week when time in week has already passed" in {
+        val start = DayTime(Monday, 16, 0)
+        val end   = DayTime(Tuesday, 16, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(WeeklySchedule(start, end, tz = None), currentDate)
+
+        val nextWeek = currentDate
+          .plusDays(3)
+          .withHourOfDay(start.hour)
+          .withMinuteOfHour(start.minute)
+          .withZoneRetainFields(defaultTz)
+        res must haveSchedule(nextWeek, nextWeek.plusDays(1))
+      }
+
+      "next week when time in week has already passed within the same hour" in {
+        val start = DayTime(Monday, 12, 0)
+        val end   = DayTime(Tuesday, 12, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(WeeklySchedule(start, end, tz = None), currentDate)
+
+        val nextWeek = currentDate
+          .plusDays(3)
+          .withHourOfDay(start.hour)
+          .withMinuteOfHour(start.minute)
+          .withZoneRetainFields(defaultTz)
+        res must haveSchedule(nextWeek, nextWeek.plusDays(1))
+      }
+
+      "with week overlap" in {
+        // week starts with Monday : the schedule should still be possible from previous week to the next one
+        val start = DayTime(Sunday, 12, 0)
+        val end   = DayTime(Monday, 12, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(WeeklySchedule(start, end, tz = None), currentDate)
+
+        val nextWeek = currentDate
+          .plusDays(2)
+          .withHourOfDay(start.hour)
+          .withMinuteOfHour(start.minute)
+          .withZoneRetainFields(defaultTz)
+        res must haveSchedule(nextWeek, nextWeek.plusDays(1))
+      }
+
+      "with specific schedule timezone" in {
+        val scheduleTimeZone = DateTimeZone.forOffsetHours(3)
+        val start            = DayTime(Friday, 16, 0)
+        val end              = DayTime(Saturday, 16, 0)
+        // 16h00 at +03:00 is 13h00 UTC so it's scheduled on same week (in fact on same day)
+        val schedule         = WeeklySchedule(start, end, Some(ScheduleTimeZone(scheduleTimeZone.getID)))
+
+        val res = MainCampaignScheduler.nextCampaignDate(
+          schedule,
+          currentDate
+        )
+
+        val scheduleDate = currentDate
+          .withHourOfDay(start.hour)
+          .withMinuteOfHour(start.minute)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0)
+          .withZoneRetainFields(scheduleTimeZone)
+        res must haveSchedule(scheduleDate, scheduleDate.plusDays(1))
+      }
+
+      "with specific schedule timezone for next week" in {
+        // special case where the time zone being not the same as the default one makes it theoretically run on next week (start is before current day)
+        val scheduleTimeZone = DateTimeZone.forOffsetHours(6)
+        val start            = DayTime(Friday, 16, 0)
+        val end              = DayTime(Saturday, 16, 0)
+        val schedule         = WeeklySchedule(start, end, Some(ScheduleTimeZone(scheduleTimeZone.getID)))
+
+        val res = MainCampaignScheduler.nextCampaignDate(
+          schedule,
+          currentDate
+        )
+
+        val scheduleDate = currentDate
+          .plusWeeks(1)
+          .withHourOfDay(start.hour)
+          .withMinuteOfHour(start.minute)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0)
+          .withZoneRetainFields(scheduleTimeZone)
+        res must haveSchedule(scheduleDate, scheduleDate.plusDays(1))
+      }
+
+      "with specific schedule timezone for the end of the week" in {
+        // special case where the time zone being not the same as the default one makes it theoretically run starting from next week
+        val scheduleTimeZone = DateTimeZone.forOffsetHours(-6)
+        val start            = DayTime(Sunday, 20, 0)
+        val end              = DayTime(Monday, 20, 0)
+        val schedule         = WeeklySchedule(start, end, Some(ScheduleTimeZone(scheduleTimeZone.getID)))
+
+        val res = MainCampaignScheduler.nextCampaignDate(
+          schedule,
+          currentDate
+        )
+
+        val scheduleDate = currentDate
+          .plusDays(2)
+          .withHourOfDay(start.hour)
+          .withMinuteOfHour(start.minute)
+          .withSecondOfMinute(0)
+          .withMillisOfSecond(0)
+          .withZoneRetainFields(scheduleTimeZone)
+        res must haveSchedule(scheduleDate, scheduleDate.plusDays(1))
+      }
+    }
+
+  }
+
+  "A monthly schedule" should {
+    "correctly schedule first week" in {
+      "first week in current week" in {
+        val currentDate = DateTime.parse("2024-11-04T11:11:00Z")
+        // monday 4th november, schedule for same week (same day)
+        val start       = DayTime(Monday, 16, 0)
+        val end         = DayTime(Wednesday, 16, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(MonthlySchedule(First, start, end, tz = None), currentDate)
+
+        val nextDate = {
+          currentDate
+            .withHourOfDay(start.hour)
+            .withMinuteOfHour(start.minute)
+            .withZoneRetainFields(defaultTz)
+        }
+        res must haveSchedule(nextDate, nextDate.plusDays(2))
+      }
+
+      "first week in next month" in {
+        val currentDate = DateTime.parse("2024-11-04T11:11:00Z")
+        // monday 4th november, schedule for same day but in the past : it should be next month
+        val start       = DayTime(Monday, 10, 0)
+        val end         = DayTime(Wednesday, 10, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(MonthlySchedule(First, start, end, tz = None), currentDate)
+
+        val nextDate = {
+          currentDate
+            .plusMonths(1)
+            .withDayOfWeek(start.day.value)
+            .withHourOfDay(start.hour)
+            .withMinuteOfHour(start.minute)
+            .withZoneRetainFields(defaultTz)
+        }
+        res must haveSchedule(nextDate, nextDate.plusDays(2))
+      }
+
+      "first week of the year from the previous year" in {
+        // edge case when year is not the same
+        val currentDate = DateTime.parse("2024-12-31T12:34:00Z")
+        // first of january is wednesday
+        val start       = DayTime(Wednesday, 16, 0)
+        val end         = DayTime(Friday, 16, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(MonthlySchedule(First, start, end, tz = None), currentDate)
+
+        val nextDate =
+          currentDate.plusDays(1).withHourOfDay(start.hour).withMinuteOfHour(start.minute).withZoneRetainFields(defaultTz)
+        res must haveSchedule(nextDate, nextDate.plusDays(2))
+      }
+    }
+
+    "correctly schedule second week" in {
+      "second week in current week" in {
+        val currentDate = DateTime.parse("2024-11-11T11:11:00Z")
+        // monday 11th november, schedule for same week (same day)
+        val start       = DayTime(Monday, 16, 0)
+        val end         = DayTime(Wednesday, 16, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(MonthlySchedule(Second, start, end, tz = None), currentDate)
+
+        val nextDate = {
+          currentDate
+            .withHourOfDay(start.hour)
+            .withMinuteOfHour(start.minute)
+            .withZoneRetainFields(defaultTz)
+        }
+        res must haveSchedule(nextDate, nextDate.plusDays(2))
+      }
+
+      "second week in next month" in {
+        val currentDate = DateTime.parse("2024-11-11T11:11:00Z")
+        // monday 11th november, schedule for same day but in the past : it should be next month
+        val start       = DayTime(Monday, 10, 0)
+        val end         = DayTime(Wednesday, 10, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(MonthlySchedule(Second, start, end, tz = None), currentDate)
+
+        val nextDate = {
+          currentDate
+            .plusMonths(1)
+            .withDayOfWeek(start.day.value)
+            .withHourOfDay(start.hour)
+            .withMinuteOfHour(start.minute)
+            .withZoneRetainFields(defaultTz)
+        }
+        res must haveSchedule(nextDate, nextDate.plusDays(2))
+      }
+
+      "second week of the year from the previous year" in {
+        val currentDate = DateTime.parse("2024-12-31T12:34:00Z")
+        // 8th of january is wednesday
+        val start       = DayTime(Wednesday, 16, 0)
+        val end         = DayTime(Friday, 16, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(MonthlySchedule(Second, start, end, tz = None), currentDate)
+
+        val nextDate =
+          currentDate.plusDays(8).withHourOfDay(start.hour).withMinuteOfHour(start.minute).withZoneRetainFields(defaultTz)
+        res must haveSchedule(nextDate, nextDate.plusDays(2))
+      }
+    }
+
+    "correctly schedule third week" in {
+      "third week in current week" in {
+        val currentDate = DateTime.parse("2024-11-18T11:11:00Z")
+        // monday 18th november, schedule for same week (same day)
+        val start       = DayTime(Monday, 16, 0)
+        val end         = DayTime(Wednesday, 16, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(MonthlySchedule(Third, start, end, tz = None), currentDate)
+
+        val nextDate = {
+          currentDate
+            .withHourOfDay(start.hour)
+            .withMinuteOfHour(start.minute)
+            .withZoneRetainFields(defaultTz)
+        }
+        res must haveSchedule(nextDate, nextDate.plusDays(2))
+      }
+
+      "third week in next month" in {
+        val currentDate = DateTime.parse("2024-11-18T11:11:00Z")
+        // monday 18th november, schedule for same day but in the past : it should be next month
+        val start       = DayTime(Monday, 10, 0)
+        val end         = DayTime(Wednesday, 10, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(MonthlySchedule(Third, start, end, tz = None), currentDate)
+
+        val nextDate = {
+          currentDate
+            .plusMonths(1)
+            .withDayOfWeek(start.day.value)
+            .withHourOfDay(start.hour)
+            .withMinuteOfHour(start.minute)
+            .withZoneRetainFields(defaultTz)
+        }
+        res must haveSchedule(nextDate, nextDate.plusDays(2))
+      }
+
+      "third week of the year from the previous year" in {
+        val currentDate = DateTime.parse("2024-12-31T12:34:00Z")
+        // 15th of january is wednesday
+        val start       = DayTime(Wednesday, 16, 0)
+        val end         = DayTime(Friday, 16, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(MonthlySchedule(Third, start, end, tz = None), currentDate)
+
+        val nextDate =
+          currentDate.plusDays(15).withHourOfDay(start.hour).withMinuteOfHour(start.minute).withZoneRetainFields(defaultTz)
+        res must haveSchedule(nextDate, nextDate.plusDays(2))
+      }
+    }
+
+    "correctly schedule second last week" in {
+      "second last week in current week" in {
+        val currentDate = DateTime.parse("2024-11-18T11:11:00Z")
+        // monday 18th november, schedule for second last week : it's on the same week so it's on the same day
+        val start       = DayTime(Monday, 16, 0)
+        val end         = DayTime(Wednesday, 16, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(MonthlySchedule(SecondLast, start, end, tz = None), currentDate)
+
+        val nextDate = {
+          currentDate
+            .withDayOfWeek(start.day.value)
+            .withHourOfDay(start.hour)
+            .withMinuteOfHour(start.minute)
+            .withZoneRetainFields(defaultTz)
+        }
+        res must haveSchedule(nextDate, nextDate.plusDays(2))
+      }
+
+      "second last week in next month" in {
+        val currentDate = DateTime.parse("2024-11-18T11:11:00Z")
+        // monday 18th november, schedule for same day but in the past : it should be next month
+        val start       = DayTime(Monday, 10, 0)
+        val end         = DayTime(Wednesday, 10, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(MonthlySchedule(SecondLast, start, end, tz = None), currentDate)
+
+        val nextDate = {
+          currentDate
+            .plusMonths(1)
+            // in december 2024 the second last monday of the month is yet one week after
+            .plusWeeks(1)
+            .withDayOfWeek(start.day.value)
+            .withHourOfDay(start.hour)
+            .withMinuteOfHour(start.minute)
+            .withZoneRetainFields(defaultTz)
+        }
+        res must haveSchedule(nextDate, nextDate.plusDays(2))
+      }
+
+      "second last week of the year from the previous year" in {
+        val currentDate = DateTime.parse("2024-12-31T12:34:00Z")
+        // 22nd of january is wednesday
+        val start       = DayTime(Wednesday, 16, 0)
+        val end         = DayTime(Friday, 16, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(MonthlySchedule(SecondLast, start, end, tz = None), currentDate)
+
+        val nextDate =
+          currentDate.plusDays(22).withHourOfDay(start.hour).withMinuteOfHour(start.minute).withZoneRetainFields(defaultTz)
+        res must haveSchedule(nextDate, nextDate.plusDays(2))
+      }
+    }
+
+    "correctly schedule last week" in {
+      "last week in current week" in {
+        val currentDate = DateTime.parse("2024-11-25T11:11:00Z")
+        // monday 25th november, schedule for last week
+        val start       = DayTime(Monday, 16, 0)
+        val end         = DayTime(Wednesday, 16, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(MonthlySchedule(Last, start, end, tz = None), currentDate)
+
+        val nextDate = {
+          currentDate
+            .withDayOfWeek(start.day.value)
+            .withHourOfDay(start.hour)
+            .withMinuteOfHour(start.minute)
+            .withZoneRetainFields(defaultTz)
+        }
+        res must haveSchedule(nextDate, nextDate.plusDays(2))
+      }
+
+      "last week in next month" in {
+        val currentDate = DateTime.parse("2024-11-25T11:11:00Z")
+        // monday 25th november, schedule for same day but in the past : it should be next month
+        val start       = DayTime(Monday, 10, 0)
+        val end         = DayTime(Wednesday, 10, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(MonthlySchedule(Last, start, end, tz = None), currentDate)
+
+        val nextDate = {
+          currentDate
+            .plusMonths(1)
+            // in december 2024 the last monday of the month is yet one week after
+            .plusWeeks(1)
+            .withDayOfWeek(start.day.value)
+            .withHourOfDay(start.hour)
+            .withMinuteOfHour(start.minute)
+            .withZoneRetainFields(defaultTz)
+        }
+        res must haveSchedule(nextDate, nextDate.plusDays(2))
+      }
+
+      "last week of the year from the previous year" in {
+        val currentDate = DateTime.parse("2024-12-31T12:34:00Z")
+        // 29th of january is wednesday
+        val start       = DayTime(Wednesday, 16, 0)
+        val end         = DayTime(Friday, 16, 0)
+
+        val res = MainCampaignScheduler.nextCampaignDate(MonthlySchedule(Last, start, end, tz = None), currentDate)
+
+        val nextDate =
+          currentDate.plusDays(29).withHourOfDay(start.hour).withMinuteOfHour(start.minute).withZoneRetainFields(defaultTz)
+        res must haveSchedule(nextDate, nextDate.plusDays(2))
+      }
+    }
+  }
+
+  // we need to compare ISO date time strings, specs2 seems to not detect equality with the timezone setup for each test
+  private val format = ISODateTimeFormat.dateTime()
+
+  private def haveScheduleStart(date: DateTime)            = {
+    beRight(beSome(be_===(date.toString(format)))) ^^ ((t: PureResult[Option[(DateTime, DateTime)]]) =>
+      t.map(_.map { case (start, _) => start.toString(format) })
+    )
+  }
+  private def haveScheduleEnd(date: DateTime)              = {
+    beRight(beSome(be_===(date.toString(format)))) ^^ ((t: PureResult[Option[(DateTime, DateTime)]]) =>
+      t.map(_.map { case (_, end) => end.toString(format) })
+    )
+  }
+  private def haveSchedule(start: DateTime, end: DateTime) = {
+    haveScheduleStart(start) and haveScheduleEnd(end)
+  }
+
+  private def haveNoSchedule: Matcher[PureResult[Option[(DateTime, DateTime)]]] = beRight(beNone)
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/CampaignApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/CampaignApiTest.scala
@@ -38,6 +38,7 @@
 package com.normation.rudder.rest
 
 import better.files.File
+import com.normation.JsonSpecMatcher
 import com.normation.rudder.campaigns.CampaignEvent
 import com.normation.rudder.campaigns.MainCampaignService
 import com.normation.rudder.campaigns.Scheduled
@@ -49,16 +50,21 @@ import net.liftweb.common.Full
 import net.liftweb.common.Loggable
 import org.apache.commons.io.FileUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import org.specs2.specification.AfterAll
 import scala.annotation.nowarn
 import zio.json.*
+import zio.json.ast.Json
+import zio.json.ast.JsonCursor
 
 @nowarn("msg=a type was inferred to be `\\w+`; this may indicate a programming error.")
 @RunWith(classOf[JUnitRunner])
-class CampaignApiTest extends Specification with AfterAll with Loggable {
+class CampaignApiTest extends Specification with AfterAll with Loggable with JsonSpecMatcher {
+
+  val tz = DateTimeZone.getDefault().getID()
 
   val restTestSetUp = RestTestSetUp.newEnv
   ZioRuntime.unsafeRun(MainCampaignService.start(restTestSetUp.mockCampaign.mainCampaignService))
@@ -77,6 +83,14 @@ class CampaignApiTest extends Specification with AfterAll with Loggable {
   }
 
   def children(f: File): List[String] = f.children.toList.map(_.name)
+
+  val tzCursor = {
+    JsonCursor.isObject >>>
+    JsonCursor.field("info") >>>
+    JsonCursor.isObject >>>
+    JsonCursor.field("schedule") >>>
+    JsonCursor.isObject
+  }
 
   // start service now, it takes sometime and is async, so we need to start it early to avoid flakiness
 
@@ -107,7 +121,25 @@ class CampaignApiTest extends Specification with AfterAll with Loggable {
 
       restTest.testGETResponse("/secure/api/campaigns") {
         case Full(LiftJsonResponse(JsonRudderApiResponse(_, _, _, Some(map), _), _, _)) =>
-          map.asInstanceOf[Map[String, List[zio.json.ast.Json]]]("campaigns").toJson must beEqualTo(resp)
+          map.asInstanceOf[Map[String, List[Json]]]("campaigns").toJson must equalsJson(resp)
+        case err                                                                        =>
+          ko(s"I got an error in test: ${err}")
+      }
+    }
+
+    "get one campaign with same schedule timezone when server timezone changes" in {
+      // MIGRATION to java-time WARNING !
+      // This may be specific to Joda, if java-time is implemented, the change in server timezone should be a different operation
+      DateTimeZone.setDefault(DateTimeZone.forID("Antarctica/South_Pole"))
+
+      val resp = s"""[$c0json]"""
+
+      restTest.testGETResponse("/secure/api/campaigns") {
+        case Full(LiftJsonResponse(JsonRudderApiResponse(_, _, _, Some(map), _), _, _)) =>
+          (map.asInstanceOf[Map[String, List[Json]]]("campaigns").toJson must equalsJsonSemantic(resp)) and {
+            DateTimeZone.setDefault(DateTimeZone.forID(tz))
+            DateTimeZone.getDefault().getID() must beEqualTo(tz)
+          }
         case err                                                                        =>
           ko(s"I got an error in test: ${err}")
       }
@@ -135,29 +167,96 @@ class CampaignApiTest extends Specification with AfterAll with Loggable {
       }
     }
 
-    "save one campaign" in {
+    val c1json = {
+      s"""{"info":{
+         |"id":"c1",
+         |"name":"second campaign",
+         |"description":"a test campaign present when rudder boot",
+         |"status":{"value":"enabled"},
+         |"schedule":{"start":{"day":1,"hour":3,"minute":42},"end":{"day":1,"hour":4,"minute":42},"tz":"${tz}","type":"weekly"}
+         |},
+         |"details":{"name":"campaign #0"},
+         |"campaignType":"dumb-campaign",
+         |"version":1
+         |}""".stripMargin.replaceAll("""\n""", "")
+    }
 
-      val c1json = {
-        """{"info":{
-          |"id":"c1",
-          |"name":"second campaign",
-          |"description":"a test campaign present when rudder boot",
-          |"status":{"value":"enabled"},
-          |"schedule":{"start":{"day":1,"hour":3,"minute":42},"end":{"day":1,"hour":4,"minute":42},"type":"weekly"}
-          |},
-          |"details":{"name":"campaign #0"},
-          |"campaignType":"dumb-campaign",
-          |"version":1
-          |}""".stripMargin.replaceAll("""\n""", "")
-      }
+    "save one campaign" in {
 
       val resp = s"""[$c1json]"""
 
       restTest.testPOSTResponse("/secure/api/campaigns", net.liftweb.json.parse(c1json)) {
         case Full(LiftJsonResponse(JsonRudderApiResponse(_, _, _, Some(map), _), _, _)) =>
-          map.asInstanceOf[Map[String, List[zio.json.ast.Json]]]("campaigns").toJson must beEqualTo(resp)
+          map.asInstanceOf[Map[String, List[Json]]]("campaigns").toJson must equalsJsonSemantic(resp)
         case err                                                                        =>
           ko(s"I got an error in test: ${err}")
+      }
+    }
+
+    "get the two existing campaigns" in {
+      val resp = s"[$c0json,$c1json]"
+      restTest.testGETResponse("/secure/api/campaigns") {
+        case Full(LiftJsonResponse(JsonRudderApiResponse(_, _, _, Some(map), _), _, _)) =>
+          map.asInstanceOf[Map[String, List[Json]]]("campaigns").toJson must equalsJsonSemantic(resp)
+        case err                                                                        =>
+          ko(s"I got an error in test: ${err}")
+      }
+    }
+
+    val c2json                     = {
+      s"""{"info":{
+         |"id":"c2",
+         |"name":"third campaign",
+         |"description":"a test campaign without explicit timezone",
+         |"status":{"value":"enabled"},
+         |"schedule":{"start":{"hour":1,"minute":23},"end":{"hour":3,"minute":21},"type":"daily"}
+         |},
+         |"details":{"name":"campaign #2"},
+         |"campaignType":"dumb-campaign",
+         |"version":1
+         |}""".stripMargin.replaceAll("""\n""", "")
+    }
+    def c2jsonTz(timeZone: String) = {
+      c2json
+        .fromJson[Json.Obj]
+        .flatMap(_.transformAt(tzCursor)(_.add("tz", Json.Str(timeZone))))
+        .fold(
+          err => throw new RuntimeException(s"c2jsonTz setup is failing in tests: ${err}"),
+          _.toJson
+        )
+    }
+
+    "save campaign without schedule timezone" in {
+      val resp = s"[${c2jsonTz(tz)}]"
+
+      restTest.testPOSTResponse("/secure/api/campaigns", net.liftweb.json.parse(c2json)) {
+        case Full(LiftJsonResponse(JsonRudderApiResponse(_, _, _, Some(map), _), _, _)) =>
+          map.asInstanceOf[Map[String, List[Json]]]("campaigns").toJson must equalsJsonSemantic(resp)
+        case err                                                                        =>
+          ko(s"I got an error in test: ${err}")
+      }
+    }
+
+    "save campaign with specific schedule timezone" in {
+      val jsonWithTz = c2jsonTz("Antarctica/South_Pole")
+      val resp       = s"[${jsonWithTz}]"
+
+      restTest.testPOSTResponse("/secure/api/campaigns", net.liftweb.json.parse(jsonWithTz)) {
+        case Full(LiftJsonResponse(JsonRudderApiResponse(_, _, _, Some(map), _), _, _)) =>
+          map.asInstanceOf[Map[String, List[Json]]]("campaigns").toJson must equalsJsonSemantic(resp)
+        case err                                                                        =>
+          ko(s"I got an error in test: ${err}")
+      }
+    }
+
+    "refuse to save a campaign with offset timezone" in {
+      val jsonWithTz = c2jsonTz("+01:00")
+
+      restTest.testPOSTResponse("/secure/api/campaigns", net.liftweb.json.parse(jsonWithTz)) {
+        case Full(LiftJsonResponse(JsonRudderApiResponse(_, _, _, _, Some(err)), _, _)) =>
+          err must contain("Error parsing schedule time zone, unknown IANA ID : '+01:00'")
+        case s                                                                          =>
+          ko(s"I got a success error in test but should be error : ${s}")
       }
     }
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/25786

Add `tz: Option[ScheduleTimeZone]` which is the ID of a IANA timezone (offsets are not supported). Also when saving a campaign the tz is the current server timezone. So, `None` means for old campaigns that no timezone was saved and the server one should be used when scheduling campaigns.  

A lot of unit tests were added, mostly to cover different cases for all schedules, and see that the variants with a timezone still work.