### PR TITLE
Fixes #25894: Migrate CmdbQuery to zio-json

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -64,9 +64,9 @@ import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.domain.properties.PatchProperty
 import com.normation.rudder.domain.properties.PropertyProvider
 import com.normation.rudder.domain.properties.Visibility.Hidden
-import com.normation.rudder.domain.queries.NodeReturnType
 import com.normation.rudder.domain.queries.Query
 import com.normation.rudder.domain.queries.QueryReturnType
+import com.normation.rudder.domain.queries.QueryReturnType.NodeReturnType
 import com.normation.rudder.rule.category.RuleCategory
 import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.services.policies.PropertyParser

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
@@ -182,7 +182,8 @@ final case class RestDataSerializerImpl(
   }
 
   override def serializeGroup(group: NodeGroup, cat: Option[NodeGroupCategoryId], crId: Option[ChangeRequestId]): JValue = {
-    val query = group.query.map(query => query.toJSON)
+    import zio.json.*
+    val query = group.query.map(query => parse(query.toJson))
     (
       ("changeRequestId" -> crId.map(_.value.toString))
       ~ ("id"            -> group.id.serialize)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderDit.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderDit.scala
@@ -407,7 +407,7 @@ class RudderDit(val BASE_DN: DN) extends AbstractDit {
       query match {
         case None    => // No query to add. Maybe we'd like to enforce that it is not activated
         case Some(q) =>
-          mod.resetValuesTo(A_QUERY_NODE_GROUP, q.toJSONString)
+          mod.resetValuesTo(A_QUERY_NODE_GROUP, q.toJson)
       }
       mod
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeGroup.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeGroup.scala
@@ -41,7 +41,7 @@ import com.normation.GitVersion
 import com.normation.GitVersion.Revision
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.properties.GroupProperty
-import com.normation.rudder.domain.queries.And
+import com.normation.rudder.domain.queries.CriterionComposition.And
 import com.normation.rudder.domain.queries.CriterionLine
 import com.normation.rudder.domain.queries.Query
 import com.normation.rudder.domain.queries.SubGroupComparator

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/MergeNodeProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/MergeNodeProperties.scala
@@ -148,7 +148,7 @@ object GroupProp {
           GroupProp(
             group.properties,
             group.id,
-            And,
+            CriterionComposition.And,
             ResultTransformation.Identity,
             group.isDynamic,
             Nil, // terminal leaf
@@ -165,9 +165,10 @@ object GroupProp {
             q.criteria.flatMap {
               // we are only interested in subgroup criterion with AND, and we want to
               // keep order for overriding priority.
-              case CriterionLine(_, a, _, value) if (q.composition == And && a.cType.isInstanceOf[SubGroupComparator]) =>
+              case CriterionLine(_, a, _, value)
+                  if (q.composition == CriterionComposition.And && a.cType.isInstanceOf[SubGroupComparator]) =>
                 Some(value)
-              case _                                                                                                   => None
+              case _ => None
             },
             group.name
           )
@@ -308,9 +309,9 @@ object MergeNodeProperties {
    *   In that case, properties are merged according to the merge function.
    *
    * We know that we have all groups/subgroups in which the node is here.
-   * 
-   * The IOR chaining is necessary to recover partially from successful values 
-   * and still accumulate errors. It will be the responsibility of caller 
+   *
+   * The IOR chaining is necessary to recover partially from successful values
+   * and still accumulate errors. It will be the responsibility of caller
    * to discard or not the success part.
    */
   def checkPropertyMerge(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -63,6 +63,7 @@ import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import scala.xml.*
 import scala.xml.Text
+import zio.json.*
 
 trait EventLogFactory {
 
@@ -636,7 +637,7 @@ class EventLogFactoryImpl(
           SimpleDiff.toXml[Option[Query]](<query/>, x) { t =>
             t match {
               case None    => <none/>
-              case Some(y) => Text(y.toJSONString)
+              case Some(y) => Text(y.toJson)
             }
           }
         }) ++

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
@@ -248,7 +248,7 @@ class NodeGroupSerialisationImpl(xmlVersion: String) extends NodeGroupSerialisat
       <id>{group.id.withDefaultRev.serialize}</id>
         <displayName>{group.name}</displayName>
         <description>{group.description}</description>
-        <query>{group.query.map(_.toJSONString).getOrElse("")}</query>
+        <query>{group.query.map(_.toJson).getOrElse("")}</query>
         <isDynamic>{group.isDynamic}</isDynamic>
         <nodeIds>{
         if (group.isDynamic) {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NewNodeManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NewNodeManager.scala
@@ -46,12 +46,12 @@ import com.normation.inventory.ldap.core.LDAPConstants.*
 import com.normation.rudder.domain.logger.NodeLoggerPure
 import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.domain.policies.PolicyMode
+import com.normation.rudder.domain.queries.CriterionComposition.Or
 import com.normation.rudder.domain.queries.CriterionLine
 import com.normation.rudder.domain.queries.DitQueryData
 import com.normation.rudder.domain.queries.Equals
-import com.normation.rudder.domain.queries.NodeReturnType
-import com.normation.rudder.domain.queries.Or
 import com.normation.rudder.domain.queries.Query
+import com.normation.rudder.domain.queries.QueryReturnType.NodeReturnType
 import com.normation.rudder.domain.queries.ResultTransformation
 import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.CoreNodeFact

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/CmdbQueryParser.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/CmdbQueryParser.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.services.queries
 import cats.implicits.*
 import com.normation.box.*
 import com.normation.rudder.domain.queries.*
+import com.normation.rudder.domain.queries.QueryReturnType.*
 import com.normation.rudder.services.queries.CmdbQueryParser.*
 import com.normation.utils.Control.traverse
 import net.liftweb.common.*
@@ -108,7 +109,7 @@ trait DefaultStringQueryParser extends StringQueryParser {
 
     for {
       comp  <- query.composition match {
-                 case None    => Full(And)
+                 case None    => Full(CriterionComposition.And)
                  case Some(s) =>
                    CriterionComposition.parse(s) match {
                      case Some(x) => Full(x)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupService.scala
@@ -317,7 +317,7 @@ class CheckPendingNodeInDynGroups(
         blocked: List[DynGroup],
         done:    List[(NodeGroupId, Set[NodeId])]
     ): IOResult[List[(NodeGroupId, Set[NodeId])]] = {
-      import com.normation.rudder.domain.queries.And as CAnd
+      import com.normation.rudder.domain.queries.CriterionComposition.And as CAnd
 
       NodeLogger.PendingNode.Policies.trace("TODO   :" + todo.debugString)
       NodeLogger.PendingNode.Policies.trace("BLOCKED:" + blocked.debugString)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
@@ -50,6 +50,7 @@ import com.normation.ldap.sdk.syntax.*
 import com.normation.rudder.domain.*
 import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.queries.*
+import com.normation.rudder.domain.queries.CriterionComposition.*
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.repository.ldap.LDAPEntityMapper
 import com.normation.zio.currentTimeMillis

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/NodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/NodeFactQueryProcessor.scala
@@ -214,7 +214,7 @@ class NodeFactQueryProcessor(
    * - LdapQuery (we want to have all lines of that kind grouped in a new query)
    */
   def analyzeQuery(query: Query)(implicit qc: QueryContext): IOResult[NodeFactMatcher] = {
-    val group = if (query.composition == And) GroupAnd else GroupOr
+    val group = if (query.composition == CriterionComposition.And) GroupAnd else GroupOr
 
     // we need a better pattern matching (extensible would be better) in place of `isInstanceOf`
     // we prefer coreNodeFact matcher on top of LDAP, since the former is quick in cache, the latter needs IO
@@ -251,8 +251,10 @@ class NodeFactQueryProcessor(
       // inverse now if needed, because we don't want to return root if not asked *even* when inverse is present
       val inv = if (query.transform == ResultTransformation.Invert) group.inverse(lineResult) else lineResult
       // finally, filter out root if need
-      val res =
-        if (query.returnType == NodeAndRootServerReturnType) inv else GroupAnd.compose(NodeFactMatcher.nodeAndRelayMatcher, inv)
+      val res = {
+        if (query.returnType == QueryReturnType.NodeAndRootServerReturnType) inv
+        else GroupAnd.compose(NodeFactMatcher.nodeAndRelayMatcher, inv)
+      }
       res
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/PolicyServerManagementService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/servers/PolicyServerManagementService.scala
@@ -69,14 +69,14 @@ import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.domain.policies.Tags
 import com.normation.rudder.domain.queries.AgentComparator
-import com.normation.rudder.domain.queries.And
 import com.normation.rudder.domain.queries.Criterion
+import com.normation.rudder.domain.queries.CriterionComposition.And
 import com.normation.rudder.domain.queries.CriterionLine
 import com.normation.rudder.domain.queries.Equals
-import com.normation.rudder.domain.queries.NodeAndRootServerReturnType
 import com.normation.rudder.domain.queries.NodeCriterionMatcherString
 import com.normation.rudder.domain.queries.ObjectCriterion
 import com.normation.rudder.domain.queries.Query
+import com.normation.rudder.domain.queries.QueryReturnType.NodeAndRootServerReturnType
 import com.normation.rudder.domain.queries.ResultTransformation
 import com.normation.rudder.domain.queries.StringComparator
 import com.normation.rudder.repository.EventLogRepository

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -2312,9 +2312,9 @@ class MockNodes() {
         byLine <- lines.traverse(filterForLine(_, nodes))
       } yield {
         combine match {
-          case And =>
+          case CriterionComposition.And =>
             (nodes :: byLine).reduce((a, b) => a.intersect(b))
-          case Or  =>
+          case CriterionComposition.Or  =>
             (Nil :: byLine).reduce((a, b) => a ++ b)
         }
       }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestCoreNodeFactInventory.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestCoreNodeFactInventory.scala
@@ -46,8 +46,8 @@ import com.normation.inventory.ldap.core.InventoryDit
 import com.normation.inventory.ldap.core.ReadOnlySoftwareDAOImpl
 import com.normation.rudder.domain.Constants
 import com.normation.rudder.domain.nodes.MachineInfo
-import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.domain.nodes.NodeState
+import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.tenants.DefaultTenantService
 import com.normation.rudder.tenants.TenantId
 import com.normation.utils.DateFormaterService

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/marshalling/TestXmlUnserialisation.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/marshalling/TestXmlUnserialisation.scala
@@ -162,7 +162,7 @@ class TestXmlUnserialisation extends Specification with BoxSpecMatcher {
           "xml" -> "hack:<img src=\"https://hackme.net/h.jpg\"/>"
         )
       ),
-      Some(Query(NodeReturnType, And, Identity, List())),
+      Some(Query(QueryReturnType.NodeReturnType, CriterionComposition.And, Identity, List())),
       isDynamic = true,
       serverList = Set(),
       _isEnabled = true

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
@@ -57,6 +57,8 @@ import com.normation.rudder.domain.properties.ParentProperty
 import com.normation.rudder.domain.properties.PropertyProvider
 import com.normation.rudder.domain.properties.SuccessNodePropertyHierarchy
 import com.normation.rudder.domain.queries.*
+import com.normation.rudder.domain.queries.CriterionComposition.*
+import com.normation.rudder.domain.queries.QueryReturnType.*
 import com.normation.rudder.domain.queries.ResultTransformation.*
 import com.normation.rudder.facts.nodes.NodeFact
 import com.normation.rudder.properties.GroupProp

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestJsonQueryLexing.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestJsonQueryLexing.scala
@@ -37,7 +37,7 @@
 
 package com.normation.rudder.services.queries
 
-import com.normation.rudder.domain.queries.NodeReturnType
+import com.normation.rudder.domain.queries.QueryReturnType.NodeReturnType
 import net.liftweb.common.*
 import org.junit.*
 import org.junit.Assert.*

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
@@ -31,7 +31,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
- *
+ *import com.normation.rudder.domain.queries.
  *************************************************************************************
  */
 
@@ -45,6 +45,7 @@ import com.normation.rudder.domain.RudderDit
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.queries.*
+import com.normation.rudder.domain.queries.CriterionComposition.*
 import com.normation.rudder.facts.nodes.*
 import com.normation.rudder.tenants.DefaultTenantService
 import com.normation.zio.*

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestPendingNodePolicies.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestPendingNodePolicies.scala
@@ -46,14 +46,14 @@ import com.normation.rudder.domain.RudderLDAPConstants.A_NODE_GROUP_UUID
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.nodes.NodeGroupUid
-import com.normation.rudder.domain.queries.And
 import com.normation.rudder.domain.queries.Criterion
+import com.normation.rudder.domain.queries.CriterionComposition.And
+import com.normation.rudder.domain.queries.CriterionComposition.Or
 import com.normation.rudder.domain.queries.CriterionLine
 import com.normation.rudder.domain.queries.Equals
 import com.normation.rudder.domain.queries.ExactStringComparator
 import com.normation.rudder.domain.queries.NodeCriterionMatcherString
 import com.normation.rudder.domain.queries.ObjectCriterion
-import com.normation.rudder.domain.queries.Or
 import com.normation.rudder.domain.queries.Query
 import com.normation.rudder.domain.queries.ResultTransformation.*
 import com.normation.rudder.domain.queries.StringComparator

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestStringQueryParser.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestStringQueryParser.scala
@@ -38,6 +38,8 @@
 package com.normation.rudder.services.queries
 
 import com.normation.rudder.domain.queries.*
+import com.normation.rudder.domain.queries.CriterionComposition.*
+import com.normation.rudder.domain.queries.QueryReturnType.*
 import com.normation.rudder.domain.queries.ResultTransformation.*
 import net.liftweb.common.*
 import org.junit.*

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -65,9 +65,9 @@ import com.normation.rudder.domain.properties.GroupProperty
 import com.normation.rudder.domain.properties.InheritMode
 import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.domain.properties.PropertyProvider
-import com.normation.rudder.domain.queries.NodeReturnType
 import com.normation.rudder.domain.queries.Query
 import com.normation.rudder.domain.queries.QueryReturnType
+import com.normation.rudder.domain.queries.QueryReturnType.NodeReturnType
 import com.normation.rudder.domain.reports.CompliancePrecision
 import com.normation.rudder.domain.workflows.*
 import com.normation.rudder.facts.nodes.NodeSecurityContext

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -82,6 +82,7 @@ import scala.util.Random
 import scala.util.Success
 import scala.util.Try
 import scala.xml.*
+import zio.json.*
 
 class EventLogDetailsGenerator(
     logDetailsService:   EventLogDetailsService,
@@ -493,7 +494,7 @@ class EventLogDetailsGenerator(
                           val mapOptionQuery = (opt: Option[Query]) => {
                             opt match {
                               case None    => Text("None")
-                              case Some(q) => Text(q.toJSONString)
+                              case Some(q) => Text(q.toJson)
                             }
                           }
 
@@ -1287,7 +1288,7 @@ class EventLogDetailsGenerator(
       "#shortDescription" #> group.description &
       "#query" #> (group.query match {
         case None    => Text("None")
-        case Some(q) => Text(q.toJSONString)
+        case Some(q) => Text(q.toJson)
       }) &
       "#isDynamic" #> group.isDynamic &
       "#nodes" #> ({

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
@@ -46,10 +46,11 @@ import com.normation.inventory.ldap.core.LDAPConstants.*
 import com.normation.rudder.domain.RudderLDAPConstants.A_NODE_PROPERTY
 import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.domain.queries.*
-import com.normation.rudder.domain.queries.And
 import com.normation.rudder.domain.queries.CriterionComposition
+import com.normation.rudder.domain.queries.CriterionComposition.And
+import com.normation.rudder.domain.queries.CriterionComposition.Or
 import com.normation.rudder.domain.queries.CriterionLine
-import com.normation.rudder.domain.queries.Or
+import com.normation.rudder.domain.queries.QueryReturnType.*
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.users.CurrentUser

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/SearchNodes.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/SearchNodes.scala
@@ -62,6 +62,7 @@ import net.liftweb.http.js.JsCmds.*
 import scala.xml.Elem
 import scala.xml.NodeSeq
 import scala.xml.NodeSeq.seqToNodeSeq
+import zio.json.*
 
 /**
  *
@@ -246,7 +247,7 @@ class SearchNodes extends StatefulSnippet with Loggable {
   private def updateQueryHash(button: Boolean, query: Option[Query]): JsCmd = {
     query match {
       case Some(q) =>
-        JsRaw(s"updateHashString('query', ${q.toJSONString})") // JsRaw ok, escaped
+        JsRaw(s"updateHashString('query', ${q.toJson})") // JsRaw ok, escaped
       case None    => Noop
     }
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/25894

In the same vein as #6020, #6021, #6022, etc

In this one, a part of the refactoring is about putting ADT values in the companion object of the sealed root. 
It also needs to use an intermediary for `CriterionLine` and chimney mapping from it because that case class is just too complicated for the simple encoding only we want. If one day we build a full codec, we will be able to delete `JsonCriterionLine` and the plumbing around. 

A needed to `liftjson.parse(query.toJson)` in group serialization because it awaits a `JValue`. It's not a problem, it will be removed once we have migrated group API. 
