### PR TITLE
Fixes #25903: Refactor API tokens after clear-text removal

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/DataStructures.scala
@@ -72,8 +72,9 @@ final case class ApiAccountName(value: String) extends AnyVal
  * All tokens are 32 alphanumeric characters, optionally
  * followed by a "-system" suffix, indicating a system token.
  *
+ * Use the [[exposeSecret()]] method to retrieve the held value
  */
-final case class ApiTokenSecret(private val secret: String) {
+final class ApiTokenSecret private (secret: String) {
   // Avoid printing the value in logs, regardless of token type
   override def toString: String = "[REDACTED ApiTokenSecret]"
 
@@ -95,9 +96,11 @@ final case class ApiTokenSecret(private val secret: String) {
 object ApiTokenSecret {
   private val tokenSize = 32
 
+  def apply(secret: String) = new ApiTokenSecret(secret)
+
   def generate(tokenGenerator: TokenGenerator, suffix: String = ""): ApiTokenSecret = {
     val completeSuffix = if (suffix.isEmpty) "" else "-" + suffix
-    ApiTokenSecret(tokenGenerator.newToken(tokenSize) + completeSuffix)
+    new ApiTokenSecret(tokenGenerator.newToken(tokenSize) + completeSuffix)
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/TokenGenerator.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/TokenGenerator.scala
@@ -40,7 +40,7 @@ import java.security.SecureRandom
 import scala.util.Random
 
 /**
- * Generate random string usable as token
+ * Generate a random string usable as secret (token, password, etc.)
  */
 trait TokenGenerator {
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
@@ -41,19 +41,24 @@ import com.normation.cfclerk.domain.*
 import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.api.ApiAccount
+import com.normation.rudder.api.ApiAccountId
+import com.normation.rudder.api.ApiAccountKind
 import com.normation.rudder.api.ApiAccountKind.PublicApi as PublicApiAccount
 import com.normation.rudder.api.ApiAccountKind.System
 import com.normation.rudder.api.ApiAccountKind.User
+import com.normation.rudder.api.ApiAccountName
 import com.normation.rudder.api.ApiAuthorization.ACL
 import com.normation.rudder.api.ApiAuthorization.None as NoAccess
 import com.normation.rudder.api.ApiAuthorization.RO
 import com.normation.rudder.api.ApiAuthorization.RW
 import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.api.NewApiAccount
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.domain.properties.*
 import com.normation.rudder.domain.queries.Query
 import com.normation.rudder.domain.workflows.*
+import com.normation.rudder.facts.nodes.NodeSecurityContext
 import com.normation.rudder.repository.FullActiveTechnique
 import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.rule.category.RuleCategory
@@ -67,6 +72,7 @@ import com.normation.utils.DateFormaterService
 import net.liftweb.common.*
 import net.liftweb.json.*
 import net.liftweb.json.JsonDSL.*
+import org.joda.time.DateTime
 import zio.json.ast.Json
 import zio.json.ast.Json.Str
 
@@ -605,33 +611,76 @@ object ApiAccountSerialisation {
 
   implicit val formats: Formats = DefaultFormats
 
+  def toJsonPartial(
+      kind:                ApiAccountKind,
+      id:                  ApiAccountId,
+      name:                ApiAccountName,
+      description:         String,
+      tokenGenerationDate: DateTime,
+      creationDate:        DateTime,
+      isEnabled:           Boolean,
+      tenants:             NodeSecurityContext
+  ): JObject = {
+    val (expirationDate, authzType, acl): (Option[String], Option[String], Option[List[JsonApiAcl]]) = {
+      kind match {
+        case User | System                           => (None, None, None)
+        case PublicApiAccount(authz, expirationDate) =>
+          val acl = authz match {
+            case NoAccess | RO | RW => None
+            case ACL(acls)          => Some(acls.flatMap(x => x.actions.map(a => JsonApiAcl(x.path.value, a.name))))
+          }
+          (expirationDate.map(DateFormaterService.getDisplayDateTimePicker), Some(authz.kind.name), acl)
+      }
+    }
+
+    ("id"                    -> id.value) ~
+    ("name"                  -> name.value) ~
+    ("tokenGenerationDate"   -> DateFormaterService.serialize(tokenGenerationDate)) ~
+    ("kind"                  -> kind.kind.name) ~
+    ("description"           -> description) ~
+    ("creationDate"          -> DateFormaterService.serialize(creationDate)) ~
+    ("enabled"               -> isEnabled) ~
+    ("expirationDate"        -> expirationDate) ~
+    ("expirationDateDefined" -> expirationDate.isDefined) ~
+    ("authorizationType"     -> authzType) ~
+    ("acl"                   -> acl.map(x => Extraction.decompose(x))) ~
+    ("tenants"               -> tenants.serialize)
+  }
+
   implicit class Json(val account: ApiAccount) extends AnyVal {
     def toJson: JObject = {
-      val (expirationDate, authzType, acl): (Option[String], Option[String], Option[List[JsonApiAcl]]) = {
-        account.kind match {
-          case User | System                           => (None, None, None)
-          case PublicApiAccount(authz, expirationDate) =>
-            val acl = authz match {
-              case NoAccess | RO | RW => None
-              case ACL(acls)          => Some(acls.flatMap(x => x.actions.map(a => JsonApiAcl(x.path.value, a.name))))
-            }
-            (expirationDate.map(DateFormaterService.getDisplayDateTimePicker), Some(authz.kind.name), acl)
-        }
-      }
+      toJsonPartial(
+        account.kind,
+        account.id,
+        account.name,
+        account.description,
+        account.tokenGenerationDate,
+        account.creationDate,
+        account.isEnabled,
+        account.tenants
+      ) ~
+      ("token" -> account.token.map(_.version().toString))
+    }
+  }
+}
 
-      ("id"                    -> account.id.value) ~
-      ("name"                  -> account.name.value) ~
-      ("token"                 -> account.token.map(_.value)) ~
-      ("tokenGenerationDate"   -> DateFormaterService.serialize(account.tokenGenerationDate)) ~
-      ("kind"                  -> account.kind.kind.name) ~
-      ("description"           -> account.description) ~
-      ("creationDate"          -> DateFormaterService.serialize(account.creationDate)) ~
-      ("enabled"               -> account.isEnabled) ~
-      ("expirationDate"        -> expirationDate) ~
-      ("expirationDateDefined" -> expirationDate.isDefined) ~
-      ("authorizationType"     -> authzType) ~
-      ("acl"                   -> acl.map(x => Extraction.decompose(x))) ~
-      ("tenants"               -> account.tenants.serialize)
+object NewApiAccountSerialisation {
+
+  implicit val formats: Formats = DefaultFormats
+
+  implicit class NewJson(val account: NewApiAccount) extends AnyVal {
+    def toJson: JObject = {
+      ApiAccountSerialisation.toJsonPartial(
+        account.kind,
+        account.id,
+        account.name,
+        account.description,
+        account.tokenGenerationDate,
+        account.creationDate,
+        account.isEnabled,
+        account.tenants
+      ) ~
+      ("token" -> account.token.map(_.exposeSecret()))
     }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
@@ -589,7 +589,7 @@ class LDAPDiffMapper(
                                 }
                               case A_API_TOKEN                   =>
                                 nonNull(diff, mod.getOptValueDefault("")) { (d, value) =>
-                                  d.copy(modToken = Some(SimpleDiff(oldAccount.token.map(_.value).getOrElse(""), value)))
+                                  d.copy(modToken = Some(SimpleDiff(oldAccount.token.flatMap(_.exposeHash()).getOrElse(""), value)))
                                 }
                               case A_DESCRIPTION                 =>
                                 nonNull(diff, mod.getOptValueDefault("")) { (d, value) =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -954,7 +954,7 @@ class LDAPEntityMapper(
       for {
         id                    <- e.required(A_API_UUID).map(ApiAccountId(_))
         name                  <- e.required(A_NAME).map(ApiAccountName(_))
-        token                  = e(A_API_TOKEN).map(ApiToken(_))
+        token                  = e(A_API_TOKEN).map(ApiTokenHash.fromHashValue(_))
         creationDatetime      <- e.requiredAs[GeneralizedTime](_.getAsGTime, A_CREATION_DATETIME)
         tokenCreationDatetime <- e.requiredAs[GeneralizedTime](_.getAsGTime, A_API_TOKEN_CREATION_DATETIME)
         isEnabled              = e.getAsBoolean(A_IS_ENABLED).getOrElse(false)
@@ -1050,8 +1050,8 @@ class LDAPEntityMapper(
     mod.resetValuesTo(A_API_UUID, principal.id.value)
     mod.resetValuesTo(A_NAME, principal.name.value)
     mod.resetValuesTo(A_CREATION_DATETIME, GeneralizedTime(principal.creationDate).toString)
-    principal.token match {
-      case Some(value) => mod.resetValuesTo(A_API_TOKEN, value.value)
+    principal.token.flatMap(_.exposeHash()) match {
+      case Some(value) => mod.resetValuesTo(A_API_TOKEN, value)
       case None        => mod.deleteAttribute(A_API_TOKEN)
     }
     mod.resetValuesTo(A_API_TOKEN_CREATION_DATETIME, GeneralizedTime(principal.tokenGenerationDate).toString)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
@@ -536,7 +536,7 @@ class APIAccountSerialisationImpl(xmlVersion: String) extends APIAccountSerialis
       (
         <id>{account.id.value}</id>
        <name>{account.name.value}</name>
-       <token>{account.token.getOrElse("")}</token>
+       <token>{account.token.flatMap(_.exposeHash()).getOrElse("")}</token>
        <description>{account.description}</description>
        <isEnabled>{account.isEnabled}</isEnabled>
        <creationDate>{account.creationDate.toString(ISODateTimeFormat.dateTime)}</creationDate>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -878,7 +878,7 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
         ApiAccountId(id),
         kind,
         ApiAccountName(name),
-        if (token.strip().isEmpty) None else Some(ApiToken(token)),
+        Some(ApiTokenHash.fromHashValue(token)),
         description,
         isEnabled,
         creationDate,

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/api/ApiTokenTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/api/ApiTokenTest.scala
@@ -41,21 +41,91 @@ import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
+final class TestTokenGenerator extends TokenGenerator {
+  override def newToken(size: Int): String = "a" * size
+}
+
 @RunWith(classOf[JUnitRunner])
 class TestApiToken extends Specification {
 
   "API tokens" should {
-    "be hidden in strings" in {
-      val token = ApiToken("UBeJJbm1tPDwILWVHXqBdgmIm3s4xjtY")
-      token.toString() must beEqualTo("[REDACTED ApiToken]")
+    "be generated from generator" in {
+      val token = ApiTokenSecret.generate(new TestTokenGenerator)
+      token.exposeSecret() must beEqualTo("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
     }
-    "be partly hidden in controled exposure" in {
-      val token          = ApiToken("UBeJJbm1tPDwILWVHXqBdgmIm3s4xjtY")
-      token.exposeSecretBeginning must beEqualTo("UBeJ[SHORTENED ApiToken]")
-      val shortToken     = ApiToken("test")
-      shortToken.exposeSecretBeginning must beEqualTo("test[SHORTENED ApiToken]")
-      val veryShortToken = ApiToken("t")
-      veryShortToken.exposeSecretBeginning must beEqualTo("t[SHORTENED ApiToken]")
+    "be generated with suffix" in {
+      val token = ApiTokenSecret.generate(new TestTokenGenerator, "end")
+      token.exposeSecret() must beEqualTo("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-end")
+    }
+    "be hidden in strings" in {
+      val token = ApiTokenSecret("UBeJJbm1tPDwILWVHXqBdgmIm3s4xjtY")
+      token.toString() must beEqualTo("[REDACTED ApiTokenSecret]")
+    }
+    "be partly hidden in controlled exposure" in {
+      val token          = ApiTokenSecret("UBeJJbm1tPDwILWVHXqBdgmIm3s4xjtY")
+      token.exposeSecretBeginning must beEqualTo("UBeJ[SHORTENED ApiTokenSecret]")
+      val shortToken     = ApiTokenSecret("test")
+      shortToken.exposeSecretBeginning must beEqualTo("test[SHORTENED ApiTokenSecret]")
+      val veryShortToken = ApiTokenSecret("t")
+      veryShortToken.exposeSecretBeginning must beEqualTo("t[SHORTENED ApiTokenSecret]")
+    }
+    "be hashed" in {
+      val token = ApiTokenSecret("UBeJJbm1tPDwILWVHXqBdgmIm3s4xjtY")
+      token.toHash() must beEqualTo(
+        ApiTokenHash.fromHashValue(
+          "v2:100caab9f3996edb04119ad4b2647b45150b10f75007b86bd82cdd0b7a9b009e2d5327115b3153bc4dc31bbbc775c6257f63f64a31f3c2d3924f11e8d24855bc"
+        )
+      )
+    }
+  }
+
+  "Hashed API tokens" should {
+    "be hidden in strings" in {
+      val token = ApiTokenSecret.generate(new TestTokenGenerator)
+      val hash  = token.toHash()
+      hash.toString() must beEqualTo("[REDACTED ApiTokenHash]")
+    }
+
+    "be compared correctly when identical" in {
+      val hash   = "v2:UBeJJbm1tPDwILWVHXqBdgmIm3s4xjtY"
+      val token1 = ApiTokenHash.fromHashValue(hash)
+      val token2 = ApiTokenHash.fromHashValue(hash)
+      token1.equalsToken(token1) must beTrue
+      token1.equalsToken(token2) must beTrue
+    }
+
+    "be compared correctly when different" in {
+      val hash   = "v2:UBeJJbm1tPDwILWVHXqBdgmIm3s4xjtY"
+      val token1 = ApiTokenHash.fromHashValue(hash)
+      val token2 = ApiTokenHash.fromHashValue(hash + "z")
+      token1.equalsToken(token2) must beFalse
+    }
+
+    "be compared correctly when different and empty" in {
+      val hash   = "v2:UBeJJbm1tPDwILWVHXqBdgmIm3s4xjtY"
+      val token1 = ApiTokenHash.fromHashValue(hash)
+      val token2 = ApiTokenHash.fromHashValue("")
+      token1.equalsToken(token2) must beFalse
+    }
+
+    "have correct version 1" in {
+      val token = ApiTokenHash.fromHashValue("UBeJJbm1tPDwILWVHXqBdgmIm3s4xjtY")
+      token.version() must beEqualTo(1)
+    }
+
+    "have correct version 2" in {
+      val token = ApiTokenHash.fromHashValue("v2:UBeJJbm1tPDwILWVHXqBdgmIm3s4xjtY")
+      token.version() must beEqualTo(2)
+    }
+
+    "have correct version 2 with empty hash" in {
+      val token = ApiTokenHash.fromHashValue("v2:")
+      token.version() must beEqualTo(2)
+    }
+
+    "not recognize version 3" in {
+      val token = ApiTokenHash.fromHashValue("v3:UBeJJbm1tPDwILWVHXqBdgmIm3s4xjtY")
+      token.version() must beEqualTo(1)
     }
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/User.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/User.scala
@@ -123,7 +123,9 @@ case class RudderUserDetail(
 
   override val (getUsername, getPassword, getAuthorities) = account match {
     case RudderAccount.User(login, password) => (login, password, RudderAuthType.User.grantedAuthorities)
-    case RudderAccount.Api(api)              => (api.name.value, api.token.map(_.value).getOrElse(""), RudderAuthType.Api.grantedAuthorities)
+    // We can default to "" as this value is ot used for authentication.
+    case RudderAccount.Api(api)              =>
+      (api.name.value, api.token.flatMap(_.exposeHash()).getOrElse(""), RudderAuthType.Api.grantedAuthorities)
   }
   override val isAccountNonExpired                        = true
   override val isAccountNonLocked                         = true

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -1326,7 +1326,7 @@ class EventLogDetailsGenerator(
   private def apiAccountDetails(xml: NodeSeq, apiAccount: ApiAccount) = (
     "#id" #> apiAccount.id.value &
       "#name" #> apiAccount.name.value &
-      "#token" #> apiAccount.token.map(_.value).getOrElse("") &
+      "#token" #> apiAccount.token.flatMap(_.exposeHash()).getOrElse("") &
       "#description" #> apiAccount.description &
       "#isEnabled" #> apiAccount.isEnabled &
       "#creationDate" #> DateFormaterService.getDisplayDate(apiAccount.creationDate) &

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -81,7 +81,7 @@ import com.normation.rudder.rest.RoleApiMapping
 import com.normation.rudder.rest.data.ApiAccountDetails
 import com.normation.rudder.rest.data.ApiAccountMapping
 import com.normation.rudder.rest.data.ClearTextSecret
-import com.normation.rudder.rest.data.NewApiAccount
+import com.normation.rudder.rest.data.NewRestApiAccount
 import com.normation.rudder.rest.data.UpdateApiAccount
 import com.normation.rudder.rest.lift.ApiAccountApiService
 import com.normation.rudder.rest.lift.ComplianceAPIService
@@ -983,7 +983,7 @@ class MockApiAccountService() {
         ApiAccountId("system-token"),
         ApiAccountKind.System, // must be filtered out
         ApiAccountName("system"),
-        Some(ApiToken("v2:system-hashed-token")),
+        Some(ApiTokenHash.fromHashValue("v2:system-hashed-token")),
         "system",
         isEnabled = true,
         creationDate = accountCreationDate,
@@ -995,7 +995,7 @@ class MockApiAccountService() {
         ApiAccountId("user1"),
         ApiAccountKind.PublicApi(ApiAuthorization.RW, None),
         ApiAccountName("user one"),
-        Some(ApiToken("v2:some-hashed-token")),
+        Some(ApiTokenHash.fromHashValue("v2:some-hashed-token")),
         "number one user",
         isEnabled = true,
         creationDate = accountCreationDate,
@@ -1010,7 +1010,7 @@ class MockApiAccountService() {
           Some(accountExpireDate)
         ),
         ApiAccountName("user2"),
-        Some(ApiToken("v2:some-hashed-token")),
+        Some(ApiTokenHash.fromHashValue("v2:some-hashed-token")),
         "number one user",
         isEnabled = true,
         creationDate = accountCreationDate,
@@ -1039,7 +1039,7 @@ class MockApiAccountService() {
         case h :: t => (ClearTextSecret(h), t)
       }
 
-      def generateToken(secret: ClearTextSecret): IOResult[ApiToken] = ApiToken("token-" + secret.value).succeed
+      def generateToken(secret: ClearTextSecret): IOResult[ApiTokenHash] = ApiTokenHash.disabled().succeed
 
       new ApiAccountMapping(creationDate, generateId, generateSecret, generateToken)
     }
@@ -1059,7 +1059,7 @@ class MockApiAccountService() {
       accounts.get.map(_.get(id).map(_.transformInto[ApiAccountDetails.Public]))
     }
 
-    override def saveAccount(data: NewApiAccount): IOResult[ApiAccountDetails] = {
+    override def saveAccount(data: NewRestApiAccount): IOResult[ApiAccountDetails] = {
       for {
         pair  <- mapper.fromNewApiAccount(data)
         (a, s) = pair

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts.elm
@@ -2,6 +2,7 @@ module Accounts exposing (..)
 
 import Accounts.ApiCalls exposing (..)
 import Accounts.DataTypes as TenantMode exposing (..)
+import Accounts.DataTypes as Token exposing (..)
 import Accounts.DatePickerUtils exposing (..)
 import Accounts.Init exposing (..)
 import Accounts.JsonDecoder exposing (decodeErrorDetails)
@@ -88,7 +89,7 @@ update msg model =
                 editAccount =
                     case modalState of
                         NewAccount ->
-                            Just (Account "" "" "" "rw" "" True "" "" Nothing (ExpireAtDate expDate) Nothing TenantMode.AllAccess Nothing)
+                            Just (Account "" "" "" "rw" "" True "" Token.Hashed Nothing (ExpireAtDate expDate) Nothing TenantMode.AllAccess Nothing)
 
                         EditAccount a ->
                             Just a
@@ -145,7 +146,7 @@ update msg model =
                 (modalState, action) =
                     case ui.modalState of
                         NewAccount ->
-                            ( CopyToken account.token
+                            ( CopyToken (exposeToken account.token)
                             , "created"
                             )
 
@@ -175,7 +176,7 @@ update msg model =
                             )
 
                         Regenerate ->
-                            ( CopyToken account.token
+                            ( CopyToken (exposeToken account.token)
                             , "regenerated token of"
                             )
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/DataTypes.elm
@@ -40,6 +40,10 @@ type TenantMode
     | NoAccess -- special "-" permission giving access to no object, whatever the tenant or its absence
     | ByTenants --give access to object in any of the listed tenants
 
+type Token
+    = New String 
+    | Hashed
+    | ClearText
 
 type alias DatePickerInfo =
     { currentTime : Posix
@@ -71,7 +75,7 @@ type alias Account =
     , kind : String
     , enabled : Bool
     , creationDate : String
-    , token : String
+    , token : Token
     , tokenGenerationDate : Maybe String
     , expirationPolicy: ExpirationPolicy
     , acl : Maybe (List AccessControl)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/View.elm
@@ -2,20 +2,20 @@ module Accounts.View exposing (..)
 
 import Accounts.ApiCalls exposing (..)
 import Accounts.DataTypes exposing (..)
+import Accounts.DataTypes as Token exposing (..)
 import Accounts.ViewModals exposing (..)
 import Accounts.ViewUtils exposing (..)
 import Html exposing (..)
 import Html.Attributes exposing (attribute, class, disabled, href, placeholder, selected, type_, value)
 import Html.Events exposing (onClick, onInput)
 import List
-import String
 
 
 view : Model -> Html Msg
 view model =
     let
         hasClearTextTokens =
-            List.any (\a -> String.length a.token > 0) model.accounts
+            List.any (\a -> a.token == Token.ClearText) model.accounts
     in
     div [ class "rudder-template" ]
         [ div [ class "one-col" ]
@@ -41,9 +41,8 @@ view model =
                                 [ if hasClearTextTokens then
                                     div [ class "alert alert-warning" ]
                                         [ i [ class "fa fa-exclamation-triangle" ] []
-                                        , text "You have API accounts with tokens generated on a previous Rudder versions, those for which the "
-                                        , text "beginning of the token value is displayed in the table. They are now deprecated, you should "
-                                        , text "re-generate or replace them for improved security."
+                                        , text "You have API accounts with tokens generated on an pre-8.1 Rudder versions."
+                                        , text "They are now disabled, you should re-generate or replace them."
                                         ]
 
                                   else

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewUtils.elm
@@ -50,7 +50,6 @@ searchField : DatePickerInfo -> Account -> List String
 searchField datePickerInfo a =
   List.append [ a.name
   , a.id
-  , a.token
   ] ( case a.expirationPolicy of
       ExpireAtDate d  -> [posixToString datePickerInfo d]
       NeverExpire -> []
@@ -80,10 +79,8 @@ generateLoadingList =
 displayAccountsTable : Model -> Html Msg
 displayAccountsTable model =
   let
-    hasClearTextTokens = List.any (\a -> (String.length a.token) > 0) model.accounts
-
-    trAccount : Account -> Bool -> Html Msg
-    trAccount a showTokens =
+    trAccount : Account -> Html Msg
+    trAccount a =
       let
         inputId = "toggle-" ++ a.id
         expirationDate = case a.expirationPolicy of
@@ -100,19 +97,7 @@ displayAccountsTable model =
         ]
         , td []
         [ span [class "token-txt"][ text a.id ] ]
-        , if showTokens then
-            if isEmpty a.token then
-                td [class "token"] [ span [class "token-txt"][ text "[hashed]" ] ]
-            else
-                td [class "token"]
-                [ span [class "token-txt"]
-                  [text (slice 0 5 a.token)]
-                  , span[class "fa hide-text"][]
-                , Html.a [ class "btn-goto clipboard", title "Copy to clipboard" , onClick (Copy a.token) ]
-                  [ i [class "ion ion-clipboard"][] ]
-                ]
-          else
-            td [class "date"][ text (cleanDate a.creationDate) ]
+        , td [class "date"][ text (cleanDate a.creationDate) ]
         , td [class "date"][ text expirationDate ]
         , td []
           [ button
@@ -153,10 +138,7 @@ displayAccountsTable model =
       [ tr [class "head"]
         [ th [class (thClass tableFilters Name    ), onClick (UpdateFilters {filters | tableFilters = (sortTable tableFilters Name    )})][ text "Account name"    ]
         , th [class (thClass tableFilters Id      ), onClick (UpdateFilters {filters | tableFilters = (sortTable tableFilters Id      )})][ text "Account id"           ]
-        , if hasClearTextTokens then
-            th [][ text "Token" ]
-          else
-            th [class (thClass tableFilters CreDate ), onClick (UpdateFilters {filters | tableFilters = (sortTable tableFilters CreDate )})][ text "Creation date" ]
+        , th [class (thClass tableFilters CreDate ), onClick (UpdateFilters {filters | tableFilters = (sortTable tableFilters CreDate )})][ text "Creation date" ]
         , th [class (thClass tableFilters ExpDate ), onClick (UpdateFilters {filters | tableFilters = (sortTable tableFilters ExpDate )})][ text "Expiration date" ]
         , th [][ text "Actions" ]
         ]
@@ -168,10 +150,10 @@ displayAccountsTable model =
         ]
       else if List.isEmpty filteredAccounts then
         [ tr[]
-          [ td[class "empty", colspan 4][i [class"fa fa-exclamation-triangle"][], text "No api accounts match your filters"] ]
+          [ td[class "empty", colspan 4][i [class"fa fa-exclamation-triangle"][], text "No API accounts match your filters"] ]
         ]
       else
-        List.map (\a -> trAccount a hasClearTextTokens) filteredAccounts
+        List.map (\a -> trAccount a) filteredAccounts
       )
     ]
 
@@ -223,3 +205,9 @@ htmlEscape s =
     |> String.replace "\"" "&quot;"
     |> String.replace "'" "&#x27;"
     |> String.replace "\\" "&#x2F;"
+
+exposeToken : Token -> String
+exposeToken t = 
+  case t of
+    New s -> s
+    _ -> ""

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/action/TestCreateSystemToken.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/action/TestCreateSystemToken.scala
@@ -38,7 +38,7 @@
 package bootstrap.liftweb.checks.endconfig.action
 
 import better.files.File
-import com.normation.rudder.api.ApiToken
+import com.normation.rudder.api.ApiTokenSecret
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -47,11 +47,11 @@ import org.specs2.runner.JUnitRunner
 class TestCreateSystemToken extends Specification {
 
   private val token    = "ohhcRCnPiRP67CuuxKDVMuig0AQqjKVo-system"
-  private val apiToken = ApiToken(token)
+  private val apiToken = ApiTokenSecret(token)
 
   "When writing the system tokens, we" should {
     "generate proper header and token files" in File.temporaryDirectory("rudder-test-system-token-") { tmpDir =>
-      val check = new CreateSystemToken(Some(apiToken), tmpDir, "x-api-token")
+      val check = new CreateSystemToken(apiToken, tmpDir, "x-api-token")
       check.checks()
 
       val tokenFile = tmpDir / CreateSystemToken.tokenFile


### PR DESCRIPTION
https://issues.rudder.io/issues/25903

A similar change needs to be done in the api-authorizations plugins for user tokens.

## Backend

* Since #6030 the old tokens are not usable anymore, this pull request takes advantage of this to refactor this part.

### Data types

Split the `ApiToken` type, which used to contain both clear-text and hashed values into two separate types to prevent confusions and prevent misusage as much as possible:

* `ApiTokenSecret`: The token value, to be sent to the creator and not stored on the server
* `ApiTokenHash`: The token hash, as stored (either in LDAP or memory)
  * Make no effort to prepare for a v3 (appart from storage), it would only be needed in case sha2 is not considered safe anymore. Future changes to the API access would likely be for something quite different (OAUTH/JWT/...), with a different architecture.

Also modifying the account types:

* `ApiAccount` now contains a `ApiTokenHash`
* A new `NewApiAccount` is created, to be used after creation, and contains a `ApiTokenSecret`

Notes:
* The system token now also uses a hash, and the clear text value is not kept after the token files creation.
* Make the access to the secret and hash values explicit with `expose()` methods (and make the value private)

### Usage

The JSON serialization of the accounts, used by the API tokens Web interface, is modified:

* For new accounts, the token value is sent
* For existing account, the token hash version only is sent

## Frontend

* Display the list of unsupported tokens along with a global warning
* Hide the enable/disable button for unsupported tokens (as it could not be actionnable)

![image](https://github.com/user-attachments/assets/7a81cd30-2bcf-421c-ac18-783ec927895b)
