### PR TITLE
Fixes #25934: Search is not able to parse new format

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
@@ -614,7 +614,8 @@ final case class NodeCriterionMatcherMemory(extractor: CoreNodeFact => Chunk[Mem
 final case class NodeCriterionMatcherDate(extractorNode: CoreNodeFact => Chunk[DateTime])
     extends NodeCriterionOrderedValueMatcher[DateTime] {
   val parseDate: String => Option[DateTime] = (s: String) =>
-    DateFormaterService.parseDate(s).toOption.orElse(Try(DateTimeFormat.forPattern("dd/MM/YYYY").parseDateTime(s)).toOption)
+    DateFormaterService.parseDateOnly(s).toOption.orElse(Try(DateTimeFormat.forPattern("dd/MM/YYYY").parseDateTime(s)).toOption)
+
   // we need to accept both ISO format and old dd/MM/YYYY format for compatibility
   // also, we discard the time, only keep date
 

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/DateFormaterService.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/DateFormaterService.scala
@@ -105,6 +105,14 @@ object DateFormaterService {
     }
   }
 
+  def parseDateOnly(date: String): PureResult[DateTime] = {
+    try {
+      Right(ISODateTimeFormat.date().parseDateTime(date))
+    } catch {
+      case NonFatal(ex) => Left(Inconsistency(s"String '${date}' can't be parsed as an ISO date: ${ex.getMessage}"))
+    }
+  }
+
   def parseDateZDT(date: String): PureResult[ZonedDateTime] = {
     try {
       Right(ZonedDateTime.parse(date, java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME))


### PR DESCRIPTION
https://issues.rudder.io/issues/25934

We tried to parse a `Date` with a `DateTime` parser, which fails. The naming of method is bad and should be change (but it needs to be changed everywhere at once to avoid compilation error in plugins, likely using a deprecation stub for forward). 

Add missing unit tests to check both old and new format consistency. 