### PR TITLE
Fixes #25935: 

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/test/resources/test-users-wrong-hash.xml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/test-users-wrong-hash.xml
@@ -1,0 +1,4 @@
+<authentication hash="unsupportedHash" case-sensitivity="true">
+  <user name="user1" password="1234" permissions="user" tenants="zoneA" />
+  <user name="user2" password="a94a8fe5ccb19ba61c4c0873d391e987982fbbd3" permissions="read_only" />
+</authentication>

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/test-users-wrong-unsafe-hashes.xml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/test-users-wrong-unsafe-hashes.xml
@@ -1,0 +1,4 @@
+<authentication unsafe-hashes="fsale" hash="bcrypt" case-sensitivity="true">
+  <user name="user1" password="$2a$04$DpsSbx141dUoKPyOFmohz.h9AbXRUbvaKX.3vK70U2PzD.yGiEU5K" permissions="user" tenants="zoneA" />
+  <user name="user2" password="a94a8fe5ccb19ba61c4c0873d391e987982fbbd3" permissions="read_only" />
+</authentication>

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -919,9 +919,9 @@ class MockUserManagement(userInfos: List[UserInfo], userSessions: List[UserSessi
 
 object MockUserManagement {
   // Default mock with fake values and returning the temporary directory for cleanup
-  def apply(): (File, MockUserManagement) = {
+  def apply(resourceFile: String = "test-users.xml"): (File, MockUserManagement) = {
     val tmpDir = File.newTemporaryDirectory("rudder-users")
-    (tmpDir, new MockUserManagement(fakeUsers, fakeUserSessions, fakeUserFile(tmpDir)))
+    (tmpDir, new MockUserManagement(fakeUsers, fakeUserSessions, fakeUserFile(tmpDir, resourceFile)))
   }
 
   val fakeUsers:        List[UserInfo]    = {
@@ -989,9 +989,9 @@ object MockUserManagement {
   }
 
   // copy the resource file to a temporary directory
-  def fakeUserFile(tmpDir: File) = Resource
-    .asStream("test-users.xml")
+  def fakeUserFile(tmpDir: File, resourceFile: String) = Resource
+    .asStream(resourceFile)
     .map(IOUtils.toString(_, StandardCharsets.UTF_8))
-    .map(File(tmpDir, "test-users.xml").writeText(_))
-    .getOrElse(throw new Exception("Cannot find test-users.xml in test resources"))
+    .map(File(tmpDir, resourceFile).writeText(_))
+    .getOrElse(throw new Exception(s"Cannot find ${resourceFile} in test resources"))
 }

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestCheckUsersFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/migration/TestCheckUsersFile.scala
@@ -1,25 +1,20 @@
 package bootstrap.liftweb.checks.migration
 
-import com.normation.errors.IOResult
 import com.normation.rudder.MockUserManagement
-import com.normation.rudder.users.RudderPasswordEncoder.SecurityLevel
-import com.normation.rudder.users.UserFileSecurityLevelMigration
 import com.normation.zio.UnsafeRun
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-import org.specs2.specification.AfterAll
+import org.specs2.specification.core.AsExecution
 import scala.xml.Elem
 
 @RunWith(classOf[JUnitRunner])
-class TestCheckUsersFile extends Specification with AfterAll {
+class TestCheckUsersFile extends Specification {
   sequential
 
-  val (mockUserManagementTmpDir, mockUserManagement) = MockUserManagement()
-
-  val migration: UserFileSecurityLevelMigration = mockUserManagement.userService
-
-  val checkUsersFile: CheckUsersFile = new CheckUsersFile(migration)
+  val shaLegacyFile:           String = "test-users.xml"
+  val unknownHashFile:         String = "test-users-wrong-hash.xml"
+  val unknownUnsafeHashesFile: String = "test-users-wrong-unsafe-hashes.xml"
 
   "CheckUsersFile" should {
 
@@ -28,29 +23,53 @@ class TestCheckUsersFile extends Specification with AfterAll {
     def haveUnsafeHashes(unsafeHashes: Option[String]) =
       beEqualTo(unsafeHashes) ^^ ((_: Elem).attribute("unsafe-hashes").flatMap(_.headOption).map(_.text))
 
-    "start with a sha-1 hash and no unsafe-hashes" in {
-      val initialFile = IOResult.attempt(scala.xml.XML.load(migration.file.inputStream())).runNow
-
-      initialFile must (haveHash("sha-1") and haveUnsafeHashes(None))
+    "start with a sha-1 hash and no unsafe-hashes" in withMigrationCtx(shaLegacyFile) {
+      case (initialFile, _) =>
+        initialFile() must (haveHash("sha-1") and haveUnsafeHashes(None))
     }
 
-    "migrate legacy hash to bcrypt and enable unsafe-hashes" in {
-      val migratedFile = (checkUsersFile.allChecks(SecurityLevel.Legacy) *> IOResult.attempt(
-        scala.xml.XML.load(migration.file.inputStream())
-      )).runNow
+    "migrate legacy hash to bcrypt and enable unsafe-hashes" in withMigrationCtx(shaLegacyFile) {
+      case (getFile, checkUsersFile) =>
+        checkUsersFile.prog.runNow
 
-      migratedFile must (haveHash("bcrypt") and haveUnsafeHashes(Some("true")))
+        getFile() must (haveHash("bcrypt") and haveUnsafeHashes(Some("true")))
     }
 
-    "keep hash unchanged" in {
-      checkUsersFile.checks()
-      val sameMigratedFile =
-        IOResult.attempt(scala.xml.XML.load(migration.file.inputStream())).runNow
-      sameMigratedFile must (haveHash("bcrypt") and haveUnsafeHashes(Some("true")))
+    "keep hash unchanged" in withMigrationCtx(shaLegacyFile) {
+      case (getFile, checkUsersFile) =>
+        checkUsersFile.prog.runNow
+        getFile() must (haveHash("bcrypt") and haveUnsafeHashes(Some("true")))
+
+        // idempotent check
+        checkUsersFile.prog.runNow
+        getFile() must (haveHash("bcrypt") and haveUnsafeHashes(Some("true")))
+    }
+
+    "migrate unknown hash to bcrypt with unsafe-hashes set to false" in withMigrationCtx(unknownHashFile) {
+      case (getFile, checkUsersFile) =>
+        checkUsersFile.prog.runNow
+        getFile() must (haveHash("bcrypt") and haveUnsafeHashes(Some("false")))
+    }
+
+    "migrate non-boolean unsafe-hashes to false" in withMigrationCtx(unknownUnsafeHashesFile) {
+      case (getFile, checkUsersFile) =>
+        checkUsersFile.prog.runNow
+        getFile() must (haveHash("bcrypt") and haveUnsafeHashes(Some("false")))
     }
   }
 
-  override def afterAll(): Unit = {
+  private def withMigrationCtx[A: AsExecution](
+      resourceFile: String
+  )(block: (() => Elem, CheckUsersFile) => A): A = {
+
+    val (mockUserManagementTmpDir, mockUserManagement) = MockUserManagement(resourceFile = resourceFile)
+    val migration                                      = mockUserManagement.userService
+    val checkUsersFile                                 = new CheckUsersFile(migration)
+
+    val elem = () => scala.xml.XML.load(migration.file.inputStream())
+    val res  = block(elem, checkUsersFile)
+
     mockUserManagementTmpDir.delete()
+    res
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/25935

We now have to consider the errored/success value of the `unsafe-hashes` attribute in the boot check, so we need to refactor reading the attribute into a method, similarly to `hash`.
Then we read the attribute and when there is an error reading either of them, we `enforceModern` i.e. we use bcrypt and disallow unsafe hashes.

N.B. : this change only affects the boot check, later when we will want to apply the enforcing at every file reload, we should be backporting that in 8.1