### PR TITLE
Fixes #25941: Spurious failing test for inherited properties rest API

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
@@ -1322,28 +1322,6 @@ response:
                   "mode" : "expire_immediately"
                 }
               }
-            },            
-            {
-              "name" : "someJson2",
-              "value" : "string",
-              "inheritMode" : "opa",
-              "provider" : "inherited",
-              "hierarchy" : [
-                {
-                  "kind" : "global",
-                  "value" : "string"
-                }
-              ],
-              "hierarchyStatus" : {
-                "hasChildTypeConflicts" : false,
-                "fullHierarchy" : [
-                  {
-                    "kind" : "global",
-                    "valueType" : "String"
-                  }
-                ]
-              },
-              "origval" : "string"
             },
             {
               "name" : "stringParam",

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestInheritedProperties.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestInheritedProperties.scala
@@ -48,7 +48,6 @@ import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.properties.GroupProperty
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.zio.*
-import net.liftweb.http.LiftRules
 import org.junit.runner.RunWith
 import zio.*
 import zio.test.*
@@ -65,9 +64,8 @@ class TestInheritedProperties extends ZIOSpecDefault {
 
   // nodeXX appears at several places
 
-  def yamlSourceDirectory:  String    = "api_inherited_prop"
-  def yamlDestTmpDirectory: File      = tmpApiTemplate
-  def liftRules:            LiftRules = restTestSetUp.liftRules
+  def yamlSourceDirectory:  String = "api_inherited_prop"
+  def yamlDestTmpDirectory: File   = tmpApiTemplate
 
   val transformations: Map[String, String => String] = Map()
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
@@ -85,7 +85,7 @@ class TestRestFromFileDef extends ZIOSpecDefault {
   tmpApiTemplate.createDirectories()
 
   override def spec: Spec[TestEnvironment with Scope, Any] = {
-    (suite("All REST tests defined in files") {
+    suite("All REST tests defined in files") {
 
       for {
         s <- TraitTestApiFromYamlFiles.doTest(
@@ -100,7 +100,7 @@ class TestRestFromFileDef extends ZIOSpecDefault {
                else ZIO.unit
              )
       } yield s
-    })
+    } @@ TestAspect.sequential // this is important so that modification done in files are always in the same order in the global env
   }
 
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
@@ -338,7 +338,7 @@ object TraitTestApiFromYamlFiles {
 
       limitToFiles:    List[String] = Nil,
       transformations: Map[String, String => String]
-  ) = {
+  ): UIO[List[Spec[Any, Throwable]]] = {
 
     ///// tests ////
     val restTest = new RestTest(liftRules)


### PR DESCRIPTION
https://issues.rudder.io/issues/25941

The current "test all files" REST test is not very user friendly because we only have one `restTestSetUp` for all tests. 
It's good for speed, because it means we only do one time the set up, which is quite long. 
But it also means that each file is bounded to others, and the test are not orthogonal at all. 
This means a dev has to think not only to the previous tests in the file (that's OK), but also to all other tests (which means each new test has an additionnal cost, when we want a constant, or reduced cost for adding tests). 

I can't do the change easily since it needs to change the API, and so it implies change in ALL plugins - so it's an other PR. But I think we will need to do it, even if it means one rest set-up by file. 

In the meantime, the "solution" is to for a sequential ordering of file, so AT LEAST the order are consistant between all environnements running tests, and so the sequence of change is the same .