### PR TITLE
Fixes #25945: Add and Remove/deprecate API for Rudder 8.3

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/CampaignApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/CampaignApi.scala
@@ -19,7 +19,6 @@ import com.normation.rudder.rest.ApiPath
 import com.normation.rudder.rest.AuthzToken
 import com.normation.rudder.rest.CampaignApi as API
 import com.normation.rudder.rest.OneParam
-import com.normation.rudder.rest.RestExtractorService
 import com.normation.rudder.rest.implicits.*
 import com.normation.utils.DateFormaterService
 import com.normation.utils.StringUuidGenerator
@@ -36,28 +35,26 @@ class CampaignApi(
     campaignSerializer:      CampaignSerializer,
     campaignEventRepository: CampaignEventRepository,
     mainCampaignService:     MainCampaignService,
-    restExtractorService:    RestExtractorService,
     stringUuidGenerator:     StringUuidGenerator
 ) extends LiftApiModuleProvider[API] {
 
   def schemas: ApiModuleProvider[API] = API
 
   def getLiftEndpoints(): List[LiftApiModule] = {
-    API.endpoints.map(e => {
-      e match {
-        case API.SaveCampaign              => SaveCampaign
-        case API.ScheduleCampaign          => ScheduleCampaign
-        case API.SaveCampaignEvent         => SaveCampaignEvent
-        case API.GetCampaignEventDetails   => GetCampaignEventDetails
-        case API.GetCampaignEvents         => GetCampaignEvents
-        case API.GetCampaignDetails        => GetCampaignDetails
-        case API.GetCampaignEventsForModel => GetAllEventsForCampaign
-        case API.GetCampaigns              => GetCampaigns
-        case API.DeleteCampaign            => DeleteCampaign
-        case API.DeleteCampaignEvent       => DeleteCampaignEvent
-      }
-    })
+    API.endpoints.map {
+      case API.SaveCampaign              => SaveCampaign
+      case API.ScheduleCampaign          => ScheduleCampaign
+      case API.SaveCampaignEvent         => SaveCampaignEvent
+      case API.GetCampaignEventDetails   => GetCampaignEventDetails
+      case API.GetCampaignEvents         => GetCampaignEvents
+      case API.GetCampaignDetails        => GetCampaignDetails
+      case API.GetCampaignEventsForModel => GetAllEventsForCampaign
+      case API.GetCampaigns              => GetCampaigns
+      case API.DeleteCampaign            => DeleteCampaign
+      case API.DeleteCampaignEvent       => DeleteCampaignEvent
+    }
   }
+
   object GetCampaigns extends LiftApiModule0 {
     val schema: API.GetCampaigns.type = API.GetCampaigns
 
@@ -79,6 +76,7 @@ class CampaignApi(
 
     }
   }
+
   object GetCampaignDetails extends LiftApiModule {
     val schema: OneParam = API.GetCampaignDetails
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -110,30 +110,26 @@ class ComplianceApi(
 
   /*
    * The actual builder for the compliance API.
-   * Depends of authz method and supported version.
+   * Depends on authz method and supported version.
    *
    * It's quite verbose, but it's the only way I found to
    * get the exhaustivity check and be sure that ALL
    * endpoints are processed.
    */
   def getLiftEndpoints(): List[LiftApiModule] = {
-    API.endpoints
-      .map(e => {
-        e match {
-          case API.GetRulesCompliance             => GetRules
-          case API.GetRulesComplianceId           => GetRuleId
-          case API.GetNodesCompliance             => GetNodes
-          case API.GetNodeSystemCompliance        => GetNodeSystemCompliance
-          case API.GetNodeComplianceId            => GetNodeId
-          case API.GetGlobalCompliance            => GetGlobal
-          case API.GetDirectiveComplianceId       => GetDirectiveId
-          case API.GetDirectivesCompliance        => GetDirectives
-          case API.GetNodeGroupComplianceSummary  => GetNodeGroupSummary
-          case API.GetNodeGroupComplianceId       => GetNodeGroupId
-          case API.GetNodeGroupComplianceTargetId => GetNodeGroupTargetId
-        }
-      })
-      .toList
+    API.endpoints.map {
+      case API.GetRulesCompliance             => GetRules
+      case API.GetRulesComplianceId           => GetRuleId
+      case API.GetNodesCompliance             => GetNodes
+      case API.GetNodeSystemCompliance        => GetNodeSystemCompliance
+      case API.GetNodeComplianceId            => GetNodeId
+      case API.GetGlobalCompliance            => GetGlobal
+      case API.GetDirectiveComplianceId       => GetDirectiveId
+      case API.GetDirectivesCompliance        => GetDirectives
+      case API.GetNodeGroupComplianceSummary  => GetNodeGroupSummary
+      case API.GetNodeGroupComplianceId       => GetNodeGroupId
+      case API.GetNodeGroupComplianceTargetId => GetNodeGroupTargetId
+    }
   }
 
   object GetRules extends LiftApiModule0 {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
@@ -64,7 +64,6 @@ import com.normation.rudder.domain.policies.Directive
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.ModifyToDirectiveDiff
-import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.repository.FullActiveTechniqueCategory
@@ -90,7 +89,6 @@ import com.softwaremill.quicklens.*
 import net.liftweb.common.*
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
-import net.liftweb.json.JsonAST.JValue
 import org.joda.time.DateTime
 import zio.*
 import zio.syntax.*
@@ -105,12 +103,6 @@ class DirectiveApi(
   private val dataName = "directives"
 
   def schemas: ApiModuleProvider[API] = API
-
-  def response(function: Box[JValue], req: Req, errorMessage: String, id: Option[String])(implicit
-      action: String
-  ): LiftResponse = {
-    RestUtils.response(restExtractorService, dataName, id)(function, req, errorMessage)
-  }
 
   type ActionType = RestUtils.ActionType
   def actionResponse(function: Box[ActionType], req: Req, errorMessage: String, id: Option[String], actor: EventActor)(implicit
@@ -310,8 +302,6 @@ class DirectiveApiService14(
     restDataSerializer:   RestDataSerializer,
     techniqueRepository:  TechniqueRepository
 ) {
-
-  def serialize: (Technique, Directive, Option[ChangeRequestId]) => JValue = restDataSerializer.serializeDirective _
 
   def directiveTree(includeSystem: Boolean): IOResult[JRDirectiveTreeCategory] = {
     def filterSystem(cat: FullActiveTechniqueCategory): FullActiveTechniqueCategory = {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/HookApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/HookApi.scala
@@ -23,11 +23,7 @@ class HookApi(
 
   override def getLiftEndpoints(): List[LiftApiModule] = {
 
-    API.endpoints.map(e => {
-      e match {
-        case API.GetHooks => GetHooks
-      }
-    })
+    API.endpoints.map { case API.GetHooks => GetHooks }
   }
 
   object GetHooks extends LiftApiModule0 {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InfoApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InfoApi.scala
@@ -59,15 +59,11 @@ class InfoApi(
   def schemas: ApiModuleProvider[API] = API
 
   def getLiftEndpoints(): List[LiftApiModule] = {
-    API.endpoints
-      .map(e => {
-        e match {
-          case API.ApiGeneralInformations => ApiGeneralInformations
-          case API.ApiSubInformations     => ApiSubInformations
-          case API.ApiInformations        => ApiInformations
-        }
-      })
-      .toList
+    API.endpoints.map {
+      case API.ApiGeneralInformations => ApiGeneralInformations
+      case API.ApiSubInformations     => ApiSubInformations
+      case API.ApiInformations        => ApiInformations
+    }
   }
 
   private case class EndpointInfo(

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InventoryApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InventoryApi.scala
@@ -67,17 +67,13 @@ class InventoryApi(
   def schemas: ApiModuleProvider[API] = API
 
   def getLiftEndpoints(): List[LiftApiModule] = {
-    API.endpoints
-      .map(e => {
-        e match {
-          case API.QueueInformation   => QueueInformation
-          case API.UploadInventory    => UploadInventory
-          case API.FileWatcherStart   => FileWatcherStart
-          case API.FileWatcherStop    => FileWatcherStop
-          case API.FileWatcherRestart => FileWatcherRestart
-        }
-      })
-      .toList
+    API.endpoints.map {
+      case API.QueueInformation   => QueueInformation
+      case API.UploadInventory    => UploadInventory
+      case API.FileWatcherStart   => FileWatcherStart
+      case API.FileWatcherStop    => FileWatcherStop
+      case API.FileWatcherRestart => FileWatcherRestart
+    }
   }
 
   object QueueInformation extends LiftApiModule0 {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/LiftApiDispatcher.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/LiftApiDispatcher.scala
@@ -276,42 +276,9 @@ class LiftHandler(
   }
 }
 
-/*
- * some type machinery to be able to have an implementation for old RuleApi up to V13
- * and an other for API with zio_json in V14 (and choose processing based on that)
- */
-final case class ChooseApi0[A <: LiftApiModule0](old: A, current: A) extends LiftApiModule0 {
-  override val schema = current.schema
-  override def process0(
-      version:    ApiVersion,
-      path:       ApiPath,
-      req:        Req,
-      params:     DefaultParams,
-      authzToken: AuthzToken
-  ): LiftResponse = {
-    if (version.value < 14) old.process0(version, path, req, params, authzToken)
-    else current.process0(version, path, req, params, authzToken)
-  }
-}
-trait LiftApiModuleN[R]                                              extends LiftApiModule  {
+trait LiftApiModuleN[R] extends LiftApiModule {
   type Aux[a] = EndpointSchema { type RESOURCES = a }
   override val schema: Aux[R]
-}
-
-final case class ChooseApiN[R](old: LiftApiModuleN[R], current: LiftApiModuleN[R]) extends LiftApiModule {
-  override val schema: EndpointSchema = old.schema
-  override def process(
-      version:    ApiVersion,
-      path:       ApiPath,
-      _resources: schema.RESOURCES,
-      req:        Req,
-      params:     DefaultParams,
-      authzToken: AuthzToken
-  ): LiftResponse = {
-    val resources = _resources.asInstanceOf[R]
-    if (version.value < 14) old.process(version, path, resources, req, params, authzToken)
-    else current.process(version, path, resources, req, params, authzToken)
-  }
 }
 
 /*

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -168,31 +168,28 @@ class NodeApi(
   def schemas: ApiModuleProvider[API] = API
 
   def getLiftEndpoints(): List[LiftApiModule] = {
-    API.endpoints.map(e => {
-
-      e match {
-        case API.ListPendingNodes               => ListPendingNodes
-        case API.NodeDetails                    => NodeDetails
-        case API.NodeInheritedProperties        => NodeInheritedProperties
-        case API.NodeDisplayInheritedProperties => NodeDisplayInheritedProperties
-        case API.PendingNodeDetails             => PendingNodeDetails
-        case API.DeleteNode                     => DeleteNode
-        case API.ChangePendingNodeStatus        => ChangePendingNodeStatus
-        case API.ChangePendingNodeStatus2       => ChangePendingNodeStatus2
-        case API.ApplyPolicyAllNodes            => ApplyPolicyAllNodes
-        case API.UpdateNode                     => UpdateNode
-        case API.ListAcceptedNodes              => ListAcceptedNodes
-        case API.ApplyPolicy                    => ApplyPolicy
-        case API.GetNodesStatus                 => GetNodesStatus
-        case API.NodeDetailsTable               => NodeDetailsTable
-        case API.NodeDetailsSoftware            => NodeDetailsSoftware
-        case API.NodeDetailsProperty            => NodeDetailsProperty
-        case API.CreateNodes                    => CreateNodes
-        case API.NodeGlobalScore                => GetNodeGlobalScore
-        case API.NodeScoreDetails               => GetNodeScoreDetails
-        case API.NodeScoreDetail                => GetNodeScoreDetail
-      }
-    })
+    API.endpoints.map {
+      case API.ListPendingNodes               => ListPendingNodes
+      case API.NodeDetails                    => NodeDetails
+      case API.NodeInheritedProperties        => NodeInheritedProperties
+      case API.NodeDisplayInheritedProperties => NodeDisplayInheritedProperties
+      case API.PendingNodeDetails             => PendingNodeDetails
+      case API.DeleteNode                     => DeleteNode
+      case API.ChangePendingNodeStatus        => ChangePendingNodeStatus
+      case API.ChangePendingNodeStatus2       => ChangePendingNodeStatus2
+      case API.ApplyPolicyAllNodes            => ApplyPolicyAllNodes
+      case API.UpdateNode                     => UpdateNode
+      case API.ListAcceptedNodes              => ListAcceptedNodes
+      case API.ApplyPolicy                    => ApplyPolicy
+      case API.GetNodesStatus                 => GetNodesStatus
+      case API.NodeDetailsTable               => NodeDetailsTable
+      case API.NodeDetailsSoftware            => NodeDetailsSoftware
+      case API.NodeDetailsProperty            => NodeDetailsProperty
+      case API.CreateNodes                    => CreateNodes
+      case API.NodeGlobalScore                => GetNodeGlobalScore
+      case API.NodeScoreDetails               => GetNodeScoreDetails
+      case API.NodeScoreDetail                => GetNodeScoreDetail
+    }
   }
 
   /*

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/PluginApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/PluginApi.scala
@@ -66,12 +66,10 @@ class PluginApi(
   def schemas: ApiModuleProvider[API] = API
 
   def getLiftEndpoints(): List[LiftApiModule] = {
-    API.endpoints.map { e =>
-      e match {
-        case API.GetPluginsInfo        => GetPluginInfo
-        case API.GetPluginsSettings    => GetPluginSettings
-        case API.UpdatePluginsSettings => UpdatePluginSettings
-      }
+    API.endpoints.map {
+      case API.GetPluginsInfo        => GetPluginInfo
+      case API.GetPluginsSettings    => GetPluginSettings
+      case API.UpdatePluginsSettings => UpdatePluginSettings
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -72,7 +72,6 @@ import com.normation.utils.StringUuidGenerator
 import net.liftweb.common.Box
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
-import net.liftweb.json.*
 import org.joda.time.DateTime
 import scala.collection.MapView
 import zio.*
@@ -86,10 +85,6 @@ class RuleApi(
 ) extends LiftApiModuleProvider[API] {
 
   import RestUtils.*
-
-  def response(function: Box[JValue], req: Req, errorMessage: String, dataName: String)(implicit action: String): LiftResponse = {
-    RestUtils.response(restExtractorService, dataName, None)(function, req, errorMessage)
-  }
 
   def actionResponse(
       function:     Box[ActionType],

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ScoreApiImpl.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ScoreApiImpl.scala
@@ -16,7 +16,7 @@ class ScoreApiImpl(restExtractorService: RestExtractorService, scoreService: Sco
   def schemas: ApiModuleProvider[API] = API
 
   override def getLiftEndpoints(): List[LiftApiModule] = {
-    GetScoreList :: Nil
+    API.endpoints.map { case ScoreApi.GetScoreList => GetScoreList }
   }
 
   object GetScoreList extends LiftApiModule0 {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
@@ -106,50 +106,48 @@ class SystemApi(
 
   override def getLiftEndpoints(): List[LiftApiModule] = {
 
-    API.endpoints.map(e => {
-      e match {
-        case API.Info                           => Info
-        case API.Status                         => Status
-        case API.DebugInfo                      => DebugInfo
-        case API.TechniquesReload               => TechniquesReload
-        case API.DyngroupsReload                => DyngroupsReload
-        case API.ReloadAll                      => ReloadAll
-        case API.PoliciesUpdate                 => PoliciesUpdate
-        case API.PoliciesRegenerate             => PoliciesRegenerate
-        case API.ArchivesGroupsList             => ArchivesGroupsList
-        case API.ArchivesDirectivesList         => ArchivesDirectivesList
-        case API.ArchivesRulesList              => ArchivesRulesList
-        case API.ArchivesParametersList         => ArchivesParametersList
-        case API.ArchivesFullList               => ArchivesFullList
-        case API.RestoreGroupsLatestArchive     => RestoreGroupsLatestArchive
-        case API.RestoreDirectivesLatestArchive => RestoreDirectivesLatestArchive
-        case API.RestoreRulesLatestArchive      => RestoreRulesLatestArchive
-        case API.RestoreParametersLatestArchive => RestoreParametersLatestArchive
-        case API.RestoreFullLatestArchive       => RestoreFullLatestArchive
-        case API.RestoreGroupsLatestCommit      => RestoreGroupsLatestCommit
-        case API.RestoreDirectivesLatestCommit  => RestoreDirectivesLatestCommit
-        case API.RestoreRulesLatestCommit       => RestoreRulesLatestCommit
-        case API.RestoreParametersLatestCommit  => RestoreParametersLatestCommit
-        case API.RestoreFullLatestCommit        => RestoreFullLatestCommit
-        case API.ArchiveGroups                  => ArchiveGroups
-        case API.ArchiveDirectives              => ArchiveDirectives
-        case API.ArchiveRules                   => ArchiveRules
-        case API.ArchiveParameters              => ArchiveParameters
-        case API.ArchiveFull                    => ArchiveAll
-        case API.ArchiveGroupDateRestore        => ArchiveGroupDateRestore
-        case API.ArchiveDirectiveDateRestore    => ArchiveDirectiveDateRestore
-        case API.ArchiveRuleDateRestore         => ArchiveRuleDateRestore
-        case API.ArchiveParameterDateRestore    => ArchiveParameterDateRestore
-        case API.ArchiveFullDateRestore         => ArchiveFullDateRestore
-        case API.GetGroupsZipArchive            => GetGroupsZipArchive
-        case API.GetDirectivesZipArchive        => GetDirectivesZipArchive
-        case API.GetRulesZipArchive             => GetRulesZipArchive
-        case API.GetParametersZipArchive        => GetParametersZipArchive
-        case API.GetAllZipArchive               => GetAllZipArchive
-        case API.GetHealthcheckResult           => GetHealthcheckResult
-        case API.PurgeSoftware                  => PurgeSoftware
-      }
-    })
+    API.endpoints.map {
+      case API.Info                           => Info
+      case API.Status                         => Status
+      case API.DebugInfo                      => DebugInfo
+      case API.TechniquesReload               => TechniquesReload
+      case API.DyngroupsReload                => DyngroupsReload
+      case API.ReloadAll                      => ReloadAll
+      case API.PoliciesUpdate                 => PoliciesUpdate
+      case API.PoliciesRegenerate             => PoliciesRegenerate
+      case API.ArchivesGroupsList             => ArchivesGroupsList
+      case API.ArchivesDirectivesList         => ArchivesDirectivesList
+      case API.ArchivesRulesList              => ArchivesRulesList
+      case API.ArchivesParametersList         => ArchivesParametersList
+      case API.ArchivesFullList               => ArchivesFullList
+      case API.RestoreGroupsLatestArchive     => RestoreGroupsLatestArchive
+      case API.RestoreDirectivesLatestArchive => RestoreDirectivesLatestArchive
+      case API.RestoreRulesLatestArchive      => RestoreRulesLatestArchive
+      case API.RestoreParametersLatestArchive => RestoreParametersLatestArchive
+      case API.RestoreFullLatestArchive       => RestoreFullLatestArchive
+      case API.RestoreGroupsLatestCommit      => RestoreGroupsLatestCommit
+      case API.RestoreDirectivesLatestCommit  => RestoreDirectivesLatestCommit
+      case API.RestoreRulesLatestCommit       => RestoreRulesLatestCommit
+      case API.RestoreParametersLatestCommit  => RestoreParametersLatestCommit
+      case API.RestoreFullLatestCommit        => RestoreFullLatestCommit
+      case API.ArchiveGroups                  => ArchiveGroups
+      case API.ArchiveDirectives              => ArchiveDirectives
+      case API.ArchiveRules                   => ArchiveRules
+      case API.ArchiveParameters              => ArchiveParameters
+      case API.ArchiveFull                    => ArchiveAll
+      case API.ArchiveGroupDateRestore        => ArchiveGroupDateRestore
+      case API.ArchiveDirectiveDateRestore    => ArchiveDirectiveDateRestore
+      case API.ArchiveRuleDateRestore         => ArchiveRuleDateRestore
+      case API.ArchiveParameterDateRestore    => ArchiveParameterDateRestore
+      case API.ArchiveFullDateRestore         => ArchiveFullDateRestore
+      case API.GetGroupsZipArchive            => GetGroupsZipArchive
+      case API.GetDirectivesZipArchive        => GetDirectivesZipArchive
+      case API.GetRulesZipArchive             => GetRulesZipArchive
+      case API.GetParametersZipArchive        => GetParametersZipArchive
+      case API.GetAllZipArchive               => GetAllZipArchive
+      case API.GetHealthcheckResult           => GetHealthcheckResult
+      case API.PurgeSoftware                  => PurgeSoftware
+    }
   }
 
   object Info extends LiftApiModule0 {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
@@ -196,7 +196,6 @@ class UserManagementApiImpl(
     userRepo:                  UserRepository,
     userService:               FileUserDetailListProvider,
     userManagementService:     UserManagementService,
-    roleApiMapping:            RoleApiMapping,
     tenantsService:            TenantService,
     getProviderRoleExtensions: () => Map[String, ProviderRoleExtension],
     getAuthBackendsProviders:  () => Set[String]
@@ -218,7 +217,7 @@ class UserManagementApiImpl(
       case UserManagementApi.DisableUser     => DisableUser
       case UserManagementApi.RoleCoverage    => RoleCoverage
       case UserManagementApi.GetRoles        => GetRoles
-    }.toList
+    }
   }
 
   /*

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -658,23 +658,8 @@ class RestTestSetUp {
     null
   )
 
-  val ruleApiService2 = new RuleApiService2(
-    mockRules.ruleRepo,
-    mockRules.ruleRepo,
-    uuidGen,
-    asyncDeploymentAgent,
-    workflowLevelService,
-    restExtractorService,
-    restDataSerializer
-  )
+  val ruleCategoryService = new RuleCategoryService()
 
-  val ruleCategoryService     = new RuleCategoryService()
-  val ruleApiService6         = new RuleApiService6(
-    mockRules.ruleCategoryRepo,
-    mockRules.ruleRepo,
-    mockRules.ruleCategoryRepo,
-    restDataSerializer
-  )
   val ruleApiService14        = new RuleApiService14(
     mockRules.ruleRepo,
     mockRules.ruleRepo,
@@ -698,7 +683,7 @@ class RestTestSetUp {
   )
   val groupInternalApiService = new GroupInternalApiService(mockNodeGroups.groupsRepo)
 
-  val fieldFactory:         DirectiveFieldFactory = new DirectiveFieldFactory {
+  val fieldFactory: DirectiveFieldFactory = new DirectiveFieldFactory {
     override def forType(fieldType: VariableSpec, id: String): DirectiveField = default(id)
     override def default(withId: String): DirectiveField = new DirectiveField {
       self => type ValueType = String
@@ -723,19 +708,6 @@ class RestTestSetUp {
     mockConfigRepo.configurationRepository,
     new Section2FieldService(fieldFactory, Translator.defaultTranslators)
   )
-  val directiveApiService2: DirectiveApiService2  = {
-    new DirectiveApiService2(
-      mockDirectives.directiveRepo,
-      mockDirectives.directiveRepo,
-      uuidGen,
-      asyncDeploymentAgent,
-      workflowLevelService,
-      restExtractorService,
-      directiveEditorService,
-      restDataSerializer,
-      mockTechniques.techniqueRepo
-    )
-  }
 
   val directiveApiService14: DirectiveApiService14 = {
     new DirectiveApiService14(
@@ -750,11 +722,6 @@ class RestTestSetUp {
       mockTechniques.techniqueRepo
     )
   }
-
-  val techniqueAPIService6 = new TechniqueAPIService6(
-    mockDirectives.directiveRepo,
-    restDataSerializer
-  )
 
   val techniqueAPIService14 = new TechniqueAPIService14(
     mockDirectives.directiveRepo,
@@ -840,33 +807,13 @@ class RestTestSetUp {
     }
   }
 
-  val parameterApiService2  = new ParameterApiService2(
-    mockParameters.paramsRepo,
-    mockParameters.paramsRepo,
-    uuidGen,
-    workflowLevelService,
-    restExtractorService,
-    restDataSerializer
-  )
   val parameterApiService14 = new ParameterApiService14(
-    mockParameters.paramsRepo,
     mockParameters.paramsRepo,
     uuidGen,
     workflowLevelService
   )
 
-  val groupService2               = new GroupApiService2(
-    mockNodeGroups.groupsRepo,
-    mockNodeGroups.groupsRepo,
-    uuidGen,
-    asyncDeploymentAgent,
-    workflowLevelService,
-    restExtractorService,
-    mockNodes.queryProcessor,
-    restDataSerializer
-  )
-  val groupService6               = new GroupApiService6(mockNodeGroups.groupsRepo, mockNodeGroups.groupsRepo, restDataSerializer)
-  val groupService14              = new GroupApiService14(
+  val groupService14 = new GroupApiService14(
     mockNodes.nodeFactRepo,
     mockNodeGroups.groupsRepo,
     mockNodeGroups.groupsRepo,
@@ -879,7 +826,6 @@ class RestTestSetUp {
     mockNodes.queryProcessor,
     restDataSerializer
   )
-  val groupApiInheritedProperties = new GroupApiInheritedProperties(mockNodes.propRepo)
   val ncfTechniqueWriter:  TechniqueWriter       = null
   val ncfTechniqueReader:  EditorTechniqueReader = null
   val techniqueRepository: TechniqueRepository   = null
@@ -923,15 +869,14 @@ class RestTestSetUp {
     val translator = new CampaignSerializer()
     translator.addJsonTranslater(mockCampaign.dumbCampaignTranslator)
     import mockCampaign.*
-    val api        = new CampaignApi(repo, translator, dumbCampaignEventRepository, mainCampaignService, restExtractorService, uuidGen)
+    val api        = new CampaignApi(repo, translator, dumbCampaignEventRepository, mainCampaignService, uuidGen)
   }
 
   val apiModules: List[LiftApiModuleProvider[? <: EndpointSchema with SortIndex]] = List(
     systemApi,
-    new ParameterApi(restExtractorService, zioJsonExtractor, parameterApiService2, parameterApiService14),
+    new ParameterApi(zioJsonExtractor, parameterApiService14),
     new TechniqueApi(
       restExtractorService,
-      techniqueAPIService6,
       techniqueAPIService14,
       ncfTechniqueWriter,
       ncfTechniqueReader,
@@ -942,14 +887,12 @@ class RestTestSetUp {
       mockGitRepo.configurationRepositoryRoot.pathAsString
     ),
     new DirectiveApi(
-      mockDirectives.directiveRepo,
       restExtractorService,
       zioJsonExtractor,
       uuidGen,
-      directiveApiService2,
       directiveApiService14
     ),
-    new RuleApi(restExtractorService, zioJsonExtractor, ruleApiService2, ruleApiService6, ruleApiService14, uuidGen),
+    new RuleApi(restExtractorService, zioJsonExtractor, ruleApiService14, uuidGen),
     new RulesInternalApi(ruleInternalApiService, ruleApiService14),
     new GroupsInternalApi(groupInternalApiService),
     new NodeApi(
@@ -963,15 +906,11 @@ class RestTestSetUp {
       DeleteMode.Erase
     ),
     new GroupsApi(
-      mockNodeGroups.groupsRepo,
       mockNodeGroups.propService,
       restExtractorService,
       zioJsonExtractor,
       uuidGen,
-      groupService2,
-      groupService6,
-      groupService14,
-      groupApiInheritedProperties
+      groupService14
     ),
     new SettingsApi(
       restExtractorService,
@@ -992,7 +931,6 @@ class RestTestSetUp {
       mockUserManagement.userRepo,
       mockUserManagement.userService,
       mockUserManagement.userManagementService,
-      new RoleApiMapping(new ExtensibleAuthorizationApiMapping(AuthorizationApiMapping.Core :: Nil)),
       mockUserManagement.tenantsService,
       () => mockUserManagement.providerRoleExtension,
       () => mockUserManagement.authBackendProviders

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1577,26 +1577,6 @@ object RudderConfigInit {
     )
     lazy val restCompletion  = new RestCompletion(new RestCompletionService(roDirectiveRepository, roRuleRepository))
 
-    lazy val ruleApiService2 = {
-      new RuleApiService2(
-        roRuleRepository,
-        woRuleRepository,
-        uuidGen,
-        asyncDeploymentAgent,
-        workflowLevelService,
-        restExtractorService,
-        restDataSerializer
-      )
-    }
-
-    lazy val ruleApiService6  = {
-      new RuleApiService6(
-        roRuleCategoryRepository,
-        roRuleRepository,
-        woRuleCategoryRepository,
-        restDataSerializer
-      )
-    }
     lazy val ruleApiService13 = {
       new RuleApiService14(
         roRuleRepository,
@@ -1615,20 +1595,6 @@ object RudderConfigInit {
       )
     }
 
-    lazy val directiveApiService2 = {
-      new DirectiveApiService2(
-        roDirectiveRepository,
-        woDirectiveRepository,
-        uuidGen,
-        asyncDeploymentAgent,
-        workflowLevelService,
-        restExtractorService,
-        directiveEditorService,
-        restDataSerializer,
-        techniqueRepositoryImpl
-      )
-    }
-
     lazy val directiveApiService14 = {
       new DirectiveApiService14(
         roDirectiveRepository,
@@ -1643,13 +1609,6 @@ object RudderConfigInit {
       )
     }
 
-    lazy val techniqueApiService6 = {
-      new TechniqueAPIService6(
-        roDirectiveRepository,
-        restDataSerializer
-      )
-    }
-
     lazy val techniqueApiService14 = {
       new TechniqueAPIService14(
         roDirectiveRepository,
@@ -1658,27 +1617,6 @@ object RudderConfigInit {
         techniqueSerializer,
         restDataSerializer,
         techniqueCompiler
-      )
-    }
-
-    lazy val groupApiService2 = {
-      new GroupApiService2(
-        roNodeGroupRepository,
-        woNodeGroupRepository,
-        uuidGen,
-        asyncDeploymentAgent,
-        workflowLevelService,
-        restExtractorService,
-        queryProcessor,
-        restDataSerializer
-      )
-    }
-
-    lazy val groupApiService6 = {
-      new GroupApiService6(
-        roNodeGroupRepository,
-        woNodeGroupRepository,
-        restDataSerializer
       )
     }
 
@@ -1719,20 +1657,9 @@ object RudderConfigInit {
       scoreService
     )
 
-    lazy val parameterApiService2  = {
-      new ParameterApiService2(
-        roLDAPParameterRepository,
-        woLDAPParameterRepository,
-        uuidGen,
-        workflowLevelService,
-        restExtractorService,
-        restDataSerializer
-      )
-    }
     lazy val parameterApiService14 = {
       new ParameterApiService14(
         roLDAPParameterRepository,
-        woLDAPParameterRepository,
         uuidGen,
         workflowLevelService
       )
@@ -2044,13 +1971,10 @@ object RudderConfigInit {
      * - 5.2.5: 16
      */
     lazy val ApiVersions: List[ApiVersion] = {
-      ApiVersion(14, deprecated = true) ::  // rudder 7.0
-      ApiVersion(15, deprecated = true) ::  // rudder 7.1 - system update on node details
-      ApiVersion(16, deprecated = true) ::  // rudder 7.2 - create node api, import/export archive, hooks & campaigns internal API
-      ApiVersion(17, deprecated = true) ::  // rudder 7.3 - directive compliance, campaign API is public
-      ApiVersion(18, deprecated = false) :: // rudder 8.0 - allowed network
-      ApiVersion(19, deprecated = false) :: // rudder 8.1 - (score), tenants
+      ApiVersion(18, deprecated = true) ::  // rudder 8.0 - allowed network
+      ApiVersion(19, deprecated = true) ::  // rudder 8.1 - (score), tenants
       ApiVersion(20, deprecated = false) :: // rudder 8.2 - zio-json
+      ApiVersion(21, deprecated = false) :: // rudder 8.3 - zio-json
       Nil
     }
 
@@ -2061,36 +1985,28 @@ object RudderConfigInit {
     lazy val rudderApi           = {
       import com.normation.rudder.rest.lift.*
 
-      val nodeInheritedProperties  = new NodeApiInheritedProperties(propertiesRepository)
-      val groupInheritedProperties = new GroupApiInheritedProperties(propertiesRepository)
+      val nodeInheritedProperties = new NodeApiInheritedProperties(propertiesRepository)
 
       val campaignApi = new lift.CampaignApi(
         campaignRepo,
         campaignSerializer,
         campaignEventRepo,
         mainCampaignService,
-        restExtractorService,
         stringUuidGenerator
       )
       val modules     = List(
         new ComplianceApi(restExtractorService, complianceAPIService, roDirectiveRepository),
         new GroupsApi(
-          roLdapNodeGroupRepository,
           propertiesService,
           restExtractorService,
           zioJsonExtractor,
           stringUuidGenerator,
-          groupApiService2,
-          groupApiService6,
-          groupApiService14,
-          groupInheritedProperties
+          groupApiService14
         ),
         new DirectiveApi(
-          roDirectiveRepository,
           restExtractorService,
           zioJsonExtractor,
           stringUuidGenerator,
-          directiveApiService2,
           directiveApiService14
         ),
         new NodeApi(
@@ -2103,7 +2019,7 @@ object RudderConfigInit {
           uuidGen,
           DeleteMode.Erase // only supported mode for Rudder 8.0
         ),
-        new ParameterApi(restExtractorService, zioJsonExtractor, parameterApiService2, parameterApiService14),
+        new ParameterApi(zioJsonExtractor, parameterApiService14),
         new SettingsApi(
           restExtractorService,
           configService,
@@ -2114,7 +2030,6 @@ object RudderConfigInit {
         ),
         new TechniqueApi(
           restExtractorService,
-          techniqueApiService6,
           techniqueApiService14,
           ncfTechniqueWriter,
           ncfTechniqueReader,
@@ -2127,8 +2042,6 @@ object RudderConfigInit {
         new RuleApi(
           restExtractorService,
           zioJsonExtractor,
-          ruleApiService2,
-          ruleApiService6,
           ruleApiService13,
           stringUuidGenerator
         ),
@@ -2149,7 +2062,6 @@ object RudderConfigInit {
             passwordEncoderDispatcher,
             UserFileProcessing.getUserResourceFile()
           ),
-          roleApiMapping,
           tenantService,
           () => authenticationProviders.getProviderProperties().view.mapValues(_.providerRoleExtension).toMap,
           () => authenticationProviders.getConfiguredProviders().map(_.name).toSet


### PR DESCRIPTION
https://issues.rudder.io/issues/25945

Based on #6023 to takes benefits from already migration Lift stuff. 

Along with the deletion of old api version, I did a clean-up of our existing APIs on 3 points: 
- 1/ normalize pattern matching of API implementation, 
- 2/ remove pre-v14 API alternative (seriously)
- 3/ clean-up all unused services or class parameters I could find. 

# 1/ Normalize pattern matching of API implementation

We have a rule of pattern-matching the API declared endpoints so that we're sure no implementation is missing, since we can't enforce that point by types (at least I never found a reasonnable way to do it). We had quite a few ways of doing it, I normalized with the shortest form, which also seems the clearest for that reason (and of course keep the exhautivness check): 

```
class UserManagementApiImpl(...) extends LiftApiModuleProvider[UserManagementApi] {
  override def schemas: ApiModuleProvider[UserManagementApi] = UserManagementApi

  override def getLiftEndpoints(): List[LiftApiModule] = {
    UserManagementApi.endpoints.map {
      case UserManagementApi.GetUserInfo     => GetUserInfo
      case UserManagementApi.ReloadUsersConf => ReloadUsersConf
      case UserManagementApi.AddUser         => AddUser
      ....
    }
  }
```

# 2/ remove pre-v14 API

In several API, we still had the alternative for pre-/post-zio introduction in v14. I removed that it. Concerned API: 
- rules
- parameters
- directives
- groups
- techniques

I also renamed the "xxxxV14" in "xxxx", because V14 isn't very telling anymore (but it's well that API implementation that I kept). 

In the same step, it removes most usage of `lift-json` in these API. 

# 3/ remove unused class parameters in API

Following step 2, but also because we missed some unused class parameters in the past, we had a lot of injected dependencies via class parameters which were not used anymore in API class. I cleaned-up all I saw. 