### PR TITLE
Fixes #25960: Remove unused and duplicate rest extractor lift-json methods

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/json/JsonExctractorUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/json/JsonExctractorUtils.scala
@@ -88,59 +88,44 @@ trait JsonExtractorUtils[A[_]] {
     }
   }
 
+  /*
+   * Still used in apiaccount/eventlog/group API, tags
+   */
   def extractJsonString[T](json: JValue, key: String, convertTo: String => Box[T] = boxedIdentity[String]): Box[A[T]] = {
     extractJson(json, key, convertTo, { case JString(value) => value })
   }
-  def extractJsonStringMultipleKeys[T](
-      json:      JValue,
-      keys:      List[String],
-      convertTo: String => Box[T] = boxedIdentity[String]
-  ): Box[A[T]] = {
-    extractJson(json, keys, convertTo, { case JString(value) => value })
-  }
 
+  /*
+   * Still used in apiaccount API
+   */
   def extractJsonBoolean[T](json: JValue, key: String, convertTo: Boolean => Box[T] = boxedIdentity[Boolean]): Box[A[T]] = {
     extractJson(json, key, convertTo, { case JBool(value) => value })
   }
 
+  /*
+   * Still used in eventlog API
+   */
   def extractJsonInt(json: JValue, key: String): Box[A[Int]] = {
     extractJsonBigInt(json, key, i => Full(i.toInt))
   }
 
+  /*
+   * Still used in eventlog API
+   */
   def extractJsonBigInt[T](json: JValue, key: String, convertTo: BigInt => Box[T] = boxedIdentity[BigInt]): Box[A[T]] = {
     extractJson(json, key, convertTo, { case JInt(value) => value })
   }
 
-  def extractJsonObj[T](json: JValue, key: String, jsonValueFun: JObject => Box[T]):                    Box[A[T]] = {
+  /*
+   * Still used in eventlog API
+   */
+  def extractJsonObj[T](json: JValue, key: String, jsonValueFun: JObject => Box[T]): Box[A[T]] = {
     extractJson(json, key, jsonValueFun, { case obj: JObject => obj })
   }
-  def extractJsonObjMultipleKeys[T](json: JValue, keys: List[String], jsonValueFun: JObject => Box[T]): Box[A[T]] = {
-    extractJson(json, keys, jsonValueFun, { case obj: JObject => obj })
-  }
 
-  def extractJsonListString[T](
-      json:      JValue,
-      key:       String,
-      convertTo: List[String] => Box[T] = boxedIdentity[List[String]]
-  ): Box[A[T]] = {
-    json \ key match {
-      case JArray(values) =>
-        (for {
-          strings   <- traverse(values) {
-                         _ match {
-                           case JString(s) => Full(s)
-                           case x          => Failure(s"Error extracting a string from json: '${x}'")
-                         }
-                       }
-          converted <- convertTo(strings.toList)
-        } yield {
-          converted
-        }).map(monad.pure(_))
-      case JNothing       => emptyValue(key) ?~! s"Array of string is empty"
-      case _              => Failure(s"Not a good value for parameter ${key}")
-    }
-  }
-
+  /*
+   * Still used in tags, eventlog/apiaccount API
+   */
   def extractJsonArray[T](json: JValue, key: String)(convertTo: JValue => Box[T]):        Box[A[List[T]]] = {
     val trueJson =
       if (key.isEmpty) json else json \ key
@@ -155,6 +140,9 @@ trait JsonExtractorUtils[A[_]] {
       case _              => Failure(s"Invalid json to extract a json array, current value is: ${compactRender(json)}")
     }
   }
+  /*
+   * Still used in tags, eventlog/apiaccount API
+   */
   def extractJsonArray[T](json: JValue, keys: List[String])(convertTo: JValue => Box[T]): Box[A[List[T]]] = {
     keys.map(k => extractJsonArray(json, k)(convertTo)).reduce[Box[A[List[T]]]] {
       case (Full(res), _)                 => Full(res)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
@@ -78,7 +78,6 @@ import scala.reflect.ClassTag
 import zio.Chunk
 import zio.NonEmptyChunk
 
-
 @RunWith(classOf[JUnitRunner])
 class TestMergeGroupProperties extends Specification {
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -37,15 +37,8 @@
 
 package com.normation.rudder.rest
 
-import com.normation.GitVersion
 import com.normation.box.*
-import com.normation.cfclerk.domain.Technique
-import com.normation.cfclerk.domain.TechniqueId
-import com.normation.cfclerk.domain.TechniqueName
-import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.cfclerk.services.TechniqueRepository
-import com.normation.errors.*
-import com.normation.inventory.domain.NodeId
 import com.normation.rudder.api.AclPath
 import com.normation.rudder.api.ApiAccountId
 import com.normation.rudder.api.ApiAccountName
@@ -53,44 +46,22 @@ import com.normation.rudder.api.ApiAclElement
 import com.normation.rudder.api.ApiAuthorization as ApiAuthz
 import com.normation.rudder.api.ApiAuthorizationKind
 import com.normation.rudder.api.HttpAction
+import com.normation.rudder.config.UserPropertyService
 import com.normation.rudder.domain.nodes.NodeGroupCategoryId
-import com.normation.rudder.domain.policies.*
-import com.normation.rudder.domain.policies.PolicyMode
-import com.normation.rudder.domain.properties.GenericProperty
-import com.normation.rudder.domain.properties.GroupProperty
-import com.normation.rudder.domain.properties.InheritMode
-import com.normation.rudder.domain.properties.NodeProperty
-import com.normation.rudder.domain.properties.PropertyProvider
-import com.normation.rudder.domain.queries.Query
-import com.normation.rudder.domain.queries.QueryReturnType
-import com.normation.rudder.domain.queries.QueryReturnType.NodeReturnType
 import com.normation.rudder.domain.reports.CompliancePrecision
-import com.normation.rudder.domain.workflows.*
 import com.normation.rudder.facts.nodes.NodeSecurityContext
 import com.normation.rudder.ncf.ParameterType.ParameterTypeService
 import com.normation.rudder.repository.*
 import com.normation.rudder.repository.json.DataExtractor.CompleteJson
 import com.normation.rudder.rest.data.*
-import com.normation.rudder.rule.category.RuleCategoryId
-import com.normation.rudder.services.policies.PropertyParser
 import com.normation.rudder.services.queries.CmdbQueryParser
-import com.normation.rudder.services.queries.CmdbQueryParser.*
 import com.normation.rudder.services.queries.JsonQueryLexer
-import com.normation.rudder.services.queries.StringCriterionLine
-import com.normation.rudder.services.queries.StringQuery
 import com.normation.rudder.services.workflows.WorkflowLevelService
-import com.normation.rudder.web.services.ReasonBehavior
-import com.normation.rudder.web.services.UserPropertyService
-import com.normation.utils.Control
-import com.normation.utils.Control.*
 import com.normation.utils.DateFormaterService
 import com.normation.utils.StringUuidGenerator
 import net.liftweb.common.*
-import net.liftweb.common.Box.option2Box
 import net.liftweb.http.Req
 import net.liftweb.json.*
-import net.liftweb.json.JObject
-import net.liftweb.json.JsonDSL.*
 
 final case class RestExtractorService(
     readRule:             RoRuleRepository,
@@ -119,60 +90,6 @@ final case class RestExtractorService(
     }
   }
 
-  private def extractList[T](params: Map[String, List[String]], key: String)(
-      to: (List[String]) => Box[T]
-  ): Box[Option[T]] = {
-    params.get(key) match {
-      case None       => Full(None)
-      case Some(list) => to(list).map(Some(_))
-    }
-  }
-
-  /*
-   * Convert value functions
-   */
-  private def toBoolean(value: String): Box[Boolean] = {
-    value match {
-      case "true"  => Full(true)
-      case "false" => Full(false)
-      case _       => Failure(s"value for boolean should be true or false instead of ${value}")
-    }
-  }
-
-  private[this] def toInt(value: String): Box[Int] = {
-    try {
-      Full(value.toInt)
-    } catch {
-      case _: java.lang.NumberFormatException => Failure(s"value for integer should be an integer instead of ${value}")
-    }
-  }
-
-  private def toQuery(value: String): Box[Query] = {
-    queryParser(value)
-  }
-
-  private def toQueryCriterion(value: String): Box[List[StringCriterionLine]] = {
-    JsonParser.parseOpt(value) match {
-      case None        => Failure("Could not parse 'select' cause in api query ")
-      case Some(value) =>
-        // Need to encapsulate this in a json Object, so it parse correctly
-        val json = (CRITERIA -> value)
-        queryParser.parseCriterionLine(json)
-    }
-  }
-
-  private def toQueryReturnType(value: String): Box[QueryReturnType] = {
-    QueryReturnType(value).toBox
-  }
-
-  private def toQueryComposition(value: String): Box[Option[String]] = {
-    Full(Some(value))
-  }
-
-  private def toQueryTransform(value: String): Box[Option[String]] = {
-    Full(if (value.isEmpty) None else Some(value))
-  }
-
   private def toMinimalSizeString(minimalSize: Int)(value: String): Box[String] = {
     if (value.size >= minimalSize) {
       Full(value)
@@ -181,37 +98,7 @@ final case class RestExtractorService(
     }
   }
 
-  private def toParameterName(value: String): Box[String] = {
-    toMinimalSizeString(1)(value) match {
-      case Full(value) =>
-        if (GenericProperty.patternName.matcher(value).matches)
-          Full(value)
-        else Failure(s"Parameter Name should be respect the following regex : ${GenericProperty.patternName.pattern()}")
-
-      case eb: EmptyBox => eb ?~! "Parameter Name should not be empty"
-    }
-  }
-
-  private def toDirectiveParam(value: String): Box[Map[String, Seq[String]]] = {
-    parseSectionVal(parse(value)).map(SectionVal.toMapVariables(_))
-  }
-
-  private def extractJsonDirectiveParam(json: JValue): Box[Option[Map[String, Seq[String]]]] = {
-    json \ "parameters" match {
-      case JObject(Nil) | JNothing => Full(None)
-      case x @ JObject(_)          => parseSectionVal(x).map(x => Some(SectionVal.toMapVariables(x)))
-      case _                       => Failure(s"The value for parameter 'parameters' is malformed.")
-    }
-  }
-
   private def toNodeGroupCategoryId(value: String): Box[NodeGroupCategoryId] = {
-    Full(NodeGroupCategoryId(value))
-  }
-  private def toRuleCategoryId(value: String):      Box[RuleCategoryId]      = {
-    Full(RuleCategoryId(value))
-  }
-
-  private def toGroupCategoryId(value: String): Box[NodeGroupCategoryId] = {
     Full(NodeGroupCategoryId(value))
   }
 
@@ -223,346 +110,9 @@ final case class RestExtractorService(
     Full(ApiAccountName(value))
   }
 
-  private def toWorkflowStatus(value: String): Box[Seq[WorkflowNodeId]] = {
-    val possiblestates = workflowLevelService.getWorkflowService().stepsValue
-    value.toLowerCase match {
-      case "open"   => Full(workflowLevelService.getWorkflowService().openSteps)
-      case "closed" => Full(workflowLevelService.getWorkflowService().closedSteps)
-      case "all"    => Full(possiblestates)
-      case value    =>
-        possiblestates.find(_.value.equalsIgnoreCase(value)) match {
-          case Some(state) => Full(Seq(state))
-          case None        => Failure(s"'${value}' is not a possible state for change requests")
-        }
-    }
-  }
-
-  private def toWorkflowTargetStatus(value: String): Box[WorkflowNodeId] = {
-    val possiblestates = workflowLevelService.getWorkflowService().stepsValue
-    possiblestates.find(_.value.equalsIgnoreCase(value)) match {
-      case Some(state) => Full(state)
-      case None        =>
-        Failure(
-          s"'${value}' is not a possible state for change requests, availabled values are: ${possiblestates.mkString("[ ", ", ", " ]")}"
-        )
-    }
-  }
-
   /*
-   * Converting ruletarget.
-   *
-   * We support two use cases, in both json and parameters mode:
-   * - simple rule target name (list of string) =>
-   *   converted into a list of included target
-   * - full-fledge include/exclude
-   *   converted into one composite target.
-   *
-   * For now, it is an error to give several include/exclude,
-   * as of Rudder 3.0, the UI does not know how to handle it.
-   *
-   * So in all case, the result is exactly ONE target.
+   * Still used in group API
    */
-  private def toRuleTarget(parameters: Map[String, List[String]], key: String): Box[Option[RuleTarget]] = {
-    parameters.get(key) match {
-      case Some(values) =>
-        traverse(values)(value => RuleTarget.unser(value)).flatMap(mergeTarget)
-      case None         => Full(None)
-    }
-  }
-
-  def toRuleTarget(json: JValue, key: String): Box[Option[RuleTarget]] = {
-    for {
-      targets <- traverse((json \\ key).children) { child =>
-                   child match {
-                     case JArray(values) =>
-                       traverse(values.children)(value => RuleTarget.unserJson(value)).flatMap(mergeTarget)
-                     case x              => RuleTarget.unserJson(x).map(Some(_))
-                   }
-                 }
-      merged  <- mergeTarget(targets.flatten)
-    } yield {
-      merged
-    }
-  }
-
-  private def mergeTarget(seq: Seq[RuleTarget]): Box[Option[RuleTarget]] = {
-    seq match {
-      case Seq()         => Full(None)
-      case head +: Seq() => Full(Some(head))
-      case several       =>
-        // if we have only simple target, build a composite including
-        if (several.exists(x => x.isInstanceOf[CompositeRuleTarget])) {
-          Failure(
-            "Composing several composite target with include/exclude is not supported now, please only one composite target."
-          )
-        } else {
-          Full(Some(RuleTarget.merge(several.toSet)))
-        }
-    }
-  }
-
-  /*
-   * Convert List Functions
-   */
-  private def convertListToDirectiveId(values: Seq[String]): Box[Set[DirectiveId]] = {
-    def toDirectiveId(value: String): Box[DirectiveId] = {
-      // TODO: parse value correctly
-      readDirective.getDirective(DirectiveUid(value)).notOptional(s"Directive '$value' not found").map(_.id).toBox
-    }
-    traverse(values)(toDirectiveId).map(_.toSet)
-  }
-
-  private def convertListToNodeId(values: List[String]): Box[List[NodeId]] = {
-    Full(values.map(NodeId(_)))
-  }
-
-  def parseSectionVal(root: JValue): Box[SectionVal] = {
-
-    def parseSectionName(section: JValue): Box[String] = {
-      section \ "name" match {
-        case JString(sectionName) => Full(sectionName)
-        case a                    =>
-          Failure(s"A section should be an object with a 'name' element, you got: ${net.liftweb.json.compactRender(section)}")
-      }
-    }
-
-    def parseSection(section: JValue): Box[(String, SectionVal)] = {
-      section \ "section" match {
-        case values: JObject => recValParseSection(values)
-        case _ =>
-          Failure(
-            s"A 'section' section should be an object containing a 'section' element (ie: { 'section' : ... }), you got: ${net.liftweb.json
-                .compactRender(section)}"
-          )
-      }
-
-    }
-
-    def parseSections(section: JValue): Box[Map[String, Seq[SectionVal]]] = {
-      section \ "sections" match {
-        case JNothing         => Full(Map())
-        case JArray(sections) => (traverse(sections.toSeq)(parseSection)).map(_.groupMap(_._1)(_._2))
-        case a                =>
-          Failure(
-            s"A 'sections' element in a section should either be empty (no child section), or an array of section element, you got: ${net.liftweb.json
-                .compactRender(a)}"
-          )
-      }
-    }
-
-    def parseVar(varSection: JValue):      Box[(String, String)]    = {
-      varSection \ "var" match {
-        case varObject: JObject =>
-          (varObject \ "name", varObject \ "value") match {
-            case (JString(varName), JString(varValue)) => Full((varName, varValue))
-            case _                                     =>
-              Failure(
-                s"A var object should be an object containing a 'name' and a 'value' element (ie: { 'name' : ..., 'value' : ... }), you got: ${net.liftweb.json
-                    .compactRender(varObject)}"
-              )
-          }
-        case _ =>
-          Failure(
-            s"A 'var' section should be an object containing a 'var' element, containing an object with a 'name' and 'value' element (ie: { 'var' : { 'name' : ..., 'value' : ... } }, you got: ${net.liftweb.json
-                .compactRender(varSection)}"
-          )
-      }
-    }
-    def parseSectionVars(section: JValue): Box[Map[String, String]] = {
-      section \ "vars" match {
-        case JNothing     => Full(Map())
-        case JArray(vars) => (traverse(vars)(parseVar)).map(_.toMap)
-        case a            =>
-          Failure(
-            s"A 'vars' element in a section should either be empty (no variable), or an array of var sections, you got: ${net.liftweb.json
-                .compactRender(a)}"
-          )
-      }
-    }
-
-    def recValParseSection(section: JValue): Box[(String, SectionVal)] = {
-      for {
-        sectionName <- parseSectionName(section)
-        vars        <- parseSectionVars(section)
-        sections    <- parseSections(section)
-      } yield {
-        (sectionName, SectionVal(sections, vars))
-      }
-    }
-
-    for {
-      (_, sectionVal) <- parseSection(root)
-    } yield {
-      sectionVal
-    }
-  }
-
-  /*
-   * Data extraction functions
-   */
-  def extractPrettify(params: Map[String, List[String]]): Boolean = {
-    extractOneValue(params, "prettify")(toBoolean).map(_.getOrElse(false)).getOrElse(false)
-  }
-
-  def extractReason(req: Req): Box[Option[String]] = {
-    import ReasonBehavior.*
-    userPropertyService.reasonsFieldBehavior match {
-      case Disabled => Full(None)
-      case mode     =>
-        val reason = extractString("reason")(req)(Full(_))
-        (mode: @unchecked) match {
-          case Mandatory =>
-            reason match {
-              case Full(None)                  => Failure("Reason field is mandatory and should be at least 5 characters long")
-              case Full(Some(v)) if v.size < 5 => Failure("Reason field should be at least 5 characters long")
-              case _                           => reason
-            }
-          case Optionnal => reason
-        }
-    }
-  }
-
-  def extractChangeRequestName(req: Req): Box[Option[String]] = {
-    extractString("changeRequestName")(req)(Full(_))
-  }
-
-  def extractChangeRequestDescription(req: Req): String = {
-    extractString("changeRequestDescription")(req)(Full(_)).getOrElse(None).getOrElse("")
-  }
-
-  def extractParameterName(params: Map[String, List[String]]): Box[String] = {
-    extractOneValue(params, "id")(toParameterName) match {
-      case Full(None)        => Failure("Parameter id should not be empty")
-      case Full(Some(value)) => Full(value)
-      case eb: EmptyBox => eb ?~ "Error while fetch parameter Name"
-    }
-  }
-
-  def extractWorkflowStatus(params: Map[String, List[String]]): Box[Seq[WorkflowNodeId]] = {
-    extractOneValue(params, "status")(toWorkflowStatus) match {
-      case Full(None)        => Full(workflowLevelService.getWorkflowService().openSteps)
-      case Full(Some(value)) => Full(value)
-      case eb: EmptyBox => eb ?~ "Error while fetching workflow status"
-    }
-  }
-
-  def extractWorkflowTargetStatus(params: Map[String, List[String]]): Box[WorkflowNodeId] = {
-    extractOneValue(params, "status")(toWorkflowTargetStatus) match {
-      case Full(Some(value)) => Full(value)
-      case Full(None)        => Failure("workflow status should not be empty")
-      case eb: EmptyBox => eb ?~ "Error while fetching workflow status"
-    }
-  }
-
-  def extractChangeRequestInfo(params: Map[String, List[String]]): Box[APIChangeRequestInfo] = {
-    def ident = (value: String) => Full(value)
-    for {
-      name        <- extractOneValue(params, "name")(ident)
-      description <- extractOneValue(params, "description")(ident)
-    } yield {
-      APIChangeRequestInfo(name, description)
-    }
-  }
-
-  def extractTechnique(optTechniqueName: Option[TechniqueName], opTechniqueVersion: Option[TechniqueVersion]): Box[Technique] = {
-    optTechniqueName match {
-      case Some(techniqueName) =>
-        opTechniqueVersion match {
-          case Some(version) =>
-            techniqueRepository.getTechniqueVersions(techniqueName).find(_ == version) match {
-              case Some(version) =>
-                techniqueRepository.get(TechniqueId(techniqueName, version)) match {
-                  case Some(technique) => Full(technique)
-                  case None            =>
-                    Failure(s" Technique '${techniqueName.value}' version '${version.serialize}' is not a valid Technique")
-                }
-              case None          => Failure(s" version '${version.serialize}' of Technique '${techniqueName.value}'  is not valid")
-            }
-          case None          =>
-            techniqueRepository.getLastTechniqueByName(techniqueName) match {
-              case Some(technique) => Full(technique)
-              case None            => Failure(s"Error while fetching last version of technique '${techniqueName.value}''")
-            }
-        }
-      case None                => Failure("techniqueName should not be empty")
-    }
-  }
-
-  def checkTechniqueVersion(
-      techniqueName:    TechniqueName,
-      techniqueVersion: Option[TechniqueVersion]
-  ): Box[Option[TechniqueVersion]] = {
-    techniqueVersion match {
-      case Some(version) =>
-        techniqueRepository.getTechniqueVersions(techniqueName).find(_ == version) match {
-          case Some(version) => Full(Some(version))
-          case None          => Failure(s" version '${version.serialize}' of technique '${techniqueName.value}' is not valid")
-        }
-      case None          => Full(None)
-    }
-  }
-
-  def extractNodeGroupCategoryId(params: Map[String, List[String]]): Box[NodeGroupCategoryId] = {
-    extractOneValue(params, "nodeGroupCategory")(toNodeGroupCategoryId) match {
-      case Full(Some(category)) => Full(category)
-      case Full(None)           => Failure("nodeGroupCategory cannot be empty")
-      case eb: EmptyBox => eb ?~ "error when deserializing node group category"
-    }
-  }
-
-  def toTag(s: String):                               Box[Tag]      = {
-    import Tag.*
-    val list  = s.split(":")
-    val name  = list.headOption.getOrElse(s)
-    val value = list.tail.headOption.getOrElse("")
-    Full(Tag(name, value))
-  }
-  def extractRule(params: Map[String, List[String]]): Box[RestRule] = {
-
-    for {
-      name             <- extractOneValue(params, "displayName")(toMinimalSizeString(3))
-      category         <- extractOneValue(params, "category")(toRuleCategoryId)
-      shortDescription <- extractOneValue(params, "shortDescription")()
-      longDescription  <- extractOneValue(params, "longDescription")()
-      enabled          <- extractOneValue(params, "enabled")(toBoolean)
-      directives       <- extractList(params, "directives")(convertListToDirectiveId)
-      target           <- toRuleTarget(params, "targets")
-      tagsList         <- extractList(params, "tags")(traverse(_)(toTag))
-      tags              = tagsList.map(t => Tags(t.toSet))
-    } yield {
-      RestRule(name, category, shortDescription, longDescription, directives, target.map(Set(_)), enabled, tags)
-    }
-  }
-
-  def extractRuleCategory(params: Map[String, List[String]]): Box[RestRuleCategory] = {
-
-    for {
-      name        <- extractOneValue(params, "name")(toMinimalSizeString(3))
-      description <- extractOneValue(params, "description")()
-      parent      <- extractOneValue(params, "parent")(toRuleCategoryId)
-      id          <- extractOneValue(params, "id")(toRuleCategoryId)
-    } yield {
-      RestRuleCategory(name, description, parent, id)
-    }
-  }
-
-  def extractGroup(params: Map[String, List[String]]): Box[RestGroup] = {
-    for {
-      id          <- extractOneValue(params, "id")()
-      name        <- extractOneValue(params, "displayName")(toMinimalSizeString(3))
-      description <- extractOneValue(params, "description")()
-      enabled     <- extractOneValue(params, "enabled")(toBoolean)
-      dynamic     <- extractOneValue(params, "dynamic")(toBoolean)
-      query       <- extractOneValue(params, "query")(toQuery)
-      _           <- if (query.map(_.criteria.size > 0).getOrElse(true)) Full("Query has at least one criteria")
-                     else Failure("Query should containt at least one criteria")
-      category    <- extractOneValue(params, "category")(toGroupCategoryId)
-      properties  <- extractGroupProperties(params)
-    } yield {
-      RestGroup(id, name, description, properties, query, dynamic, enabled, category)
-    }
-  }
-
   def extractGroupCategory(params: Map[String, List[String]]): Box[RestGroupCategory] = {
 
     for {
@@ -575,108 +125,9 @@ final case class RestExtractorService(
     }
   }
 
-  def extractParameter(params: Map[String, List[String]]): Box[RestParameter] = {
-    for {
-      description <- extractOneValue(params, "description")()
-      value       <- extractOneValue(params, "value")(s => GenericProperty.parseValue(s).toBox)
-    } yield {
-      RestParameter(value, description)
-    }
-  }
-
-  /*
-   * Looking for parameter: "properties=foo=bar"
-   * ==> set foo to bar; delete baz, set plop to plop.
-   * With that syntaxe, you can't choose override mode
-   */
-  def extractNodeProperties(params: Map[String, List[String]]):  Box[Option[List[NodeProperty]]]  = {
-    // properties coming from the API are always provider=rudder / mode=read-write
-    extractProperties(params, (k, v) => NodeProperty.parse(k, v, None, None))
-  }
-  def extractGroupProperties(params: Map[String, List[String]]): Box[Option[List[GroupProperty]]] = {
-    // properties coming from the API are always provider=rudder / mode=read-write
-    // TODO: parse revision correctly
-    extractProperties(params, (k, v) => GroupProperty.parse(k, GitVersion.DEFAULT_REV, v, None, None))
-  }
-
-  def extractProperties[A](params: Map[String, List[String]], make: (String, String) => PureResult[A]): Box[Option[List[A]]] = {
-    import cats.implicits.*
-    import com.normation.box.*
-
-    extractList(params, "properties") { props =>
-      (props.traverse { prop =>
-        val parts = prop.split('=')
-
-        for {
-          name <- PropertyParser.validPropertyName(parts(0))
-          prop <- if (parts.size == 1) make(name, "")
-                  else make(name, parts(1))
-        } yield {
-          prop
-        }
-      }).toBox
-    }
-  }
-
-  /*
-   * expecting json:
-   * { "properties": [
-   *    {"name":"foo" , "value":"bar"  }
-   * ,  {"name":"baz" , "value": ""    }
-   * ,  {"name":"plop", "value":"plop" }
-   * ] }
-   */
-
-  def extractNodeProperty(json: JValue): Box[NodeProperty] = {
-    ((json \ "name"), (json \ "value")) match {
-      case (JString(nameValue), value) =>
-        val provider    = (json \ "provider") match {
-          case JString(string) => Some(PropertyProvider(string))
-          // if not defined of not a string, use default
-          case _               => None
-        }
-        val inheritMode = (json \ "inheritMode") match {
-          case JString(string) => InheritMode.parseString(string).toOption
-          // if not defined of not a string, use default
-          case _               => None
-        }
-        (for {
-          _ <- PropertyParser.validPropertyName(nameValue)
-        } yield {
-          NodeProperty(nameValue, GenericProperty.fromJsonValue(value), inheritMode, provider)
-        }).toBox
-
-      case (a, b) =>
-        Failure(s"""Error when trying to parse new property: '${compactRender(
-            json
-          )}'. The awaited format is: {"name": string, "value": json}""")
-    }
-  }
-
-  def extractNodePropertiesrFromJSON(json: JValue): Box[RestNodeProperties] = {
-    import com.normation.utils.Control.traverse
-    for {
-      props <- json \ "properties" match {
-                 case JArray(props) => Full(props)
-                 case x             => Failure(s"""Error: the given parameter is not a JSON object with a 'properties' key""")
-               }
-      seq   <- traverse(props)(extractNodeProperty)
-    } yield {
-      RestNodeProperties(Some(seq))
-    }
-  }
-
-  def extractNodePropertiesFromJSON(json: JValue): Box[Option[List[NodeProperty]]] = {
-    import com.normation.utils.Control.traverse
-    json \ "properties" match {
-      case JArray(props) => traverse(props)(extractNodeProperty).map(x => Some(x.toList))
-      case JNothing      => Full(None)
-      case x             => Failure(s"""Error: the given parameter is not a JSON object with a 'properties' key""")
-    }
-  }
-
   /*
    * Looking for parameter: "level=2"
+   * Still used in compliance APIs
    */
   def extractComplianceLevel(params: Map[String, List[String]]):  Box[Option[Int]]                 = {
     params.get("level") match {
@@ -706,191 +157,6 @@ final case class RestExtractorService(
     }
   }
 
-  def extractRule(req: Req): Box[RestRule] = {
-    req.json match {
-      case Full(json) => extractRuleFromJSON(json)
-      case _          => extractRule(req.params)
-    }
-  }
-
-  def extractDirective(req: Req): Box[RestDirective] = {
-    req.json match {
-      case Full(json) => extractDirectiveFromJSON(json)
-      case _          => extractDirective(req.params)
-    }
-  }
-
-  def extractDirective(params: Map[String, List[String]]): Box[RestDirective] = {
-    for {
-      name             <- (
-                            extractOneValue(params, "name")(toMinimalSizeString(3)),
-                            extractOneValue(params, "displayName")(toMinimalSizeString(3))
-                          ) match {
-                            case (res @ Full(Some(name)), _) => res
-                            case (_, res @ Full(Some(name))) => res
-                            case (Full(None), Full(None))    => Full(None)
-                            case (eb: EmptyBox, _)           => eb
-                            case (_, eb: EmptyBox)           => eb
-                          }
-      shortDescription <- extractOneValue(params, "shortDescription")()
-      longDescription  <- extractOneValue(params, "longDescription")()
-      enabled          <- extractOneValue(params, "enabled")(toBoolean)
-      priority         <- extractOneValue(params, "priority")(toInt)
-      parameters       <- extractOneValue(params, "parameters")(toDirectiveParam)
-      techniqueName    <- extractOneValue(params, "techniqueName")(x => Full(TechniqueName(x)))
-      techniqueVersion <- extractOneValue(params, "techniqueVersion")(x => TechniqueVersion.parse(x).toBox)
-      policyMode       <- extractOneValue(params, "policyMode")(PolicyMode.parseDefault(_).toBox)
-      tagsList         <- extractList(params, "tags")(traverse(_)(toTag))
-      tags              = tagsList.map(t => Tags(t.toSet))
-    } yield {
-      RestDirective(
-        name,
-        shortDescription,
-        longDescription,
-        enabled,
-        parameters,
-        priority,
-        techniqueName,
-        techniqueVersion,
-        policyMode,
-        tags
-      )
-    }
-  }
-
-  def toTagJson(json: JValue): Box[Tag] = {
-    import Tag.*
-    json match {
-      case JObject(JField(name, JString(value)) :: Nil) => Full(Tag(name, value))
-      case _                                            => Failure("Not valid format for tags")
-    }
-  }
-
-  def extractRuleFromJSON(json: JValue): Box[RestRule] = {
-    for {
-      name             <- extractJsonString(json, "displayName", toMinimalSizeString(3))
-      category         <- extractJsonString(json, "category", toRuleCategoryId)
-      shortDescription <- extractJsonString(json, "shortDescription")
-      longDescription  <- extractJsonString(json, "longDescription")
-      directives       <- extractJsonListString(json, "directives", convertListToDirectiveId)
-      target           <- toRuleTarget(json, "targets")
-      enabled          <- extractJsonBoolean(json, "enabled")
-      tags             <- extractTagsFromJson(json \ "tags") ?~! "Error when extracting Rule tags"
-    } yield {
-      RestRule(name, category, shortDescription, longDescription, directives, target.map(Set(_)), enabled, tags)
-    }
-  }
-
-  def extractRuleCategory(json: JValue): Box[RestRuleCategory] = {
-    for {
-      name        <- extractJsonString(json, "name", toMinimalSizeString(3))
-      description <- extractJsonString(json, "description")
-      parent      <- extractJsonString(json, "parent", toRuleCategoryId)
-      id          <- extractJsonString(json, "id", toRuleCategoryId)
-    } yield {
-      RestRuleCategory(name, description, parent, id)
-    }
-  }
-
-  // this extractTagsFromJson is exclusively used when updating TAG in the POST API request. We want to extract tags as a List
-  // of {key1,value1 ... keyN,valueN}
-
-  private def extractTagsFromJson(value: JValue): Box[Option[Tags]] = {
-    implicit val formats = DefaultFormats
-    if (value == JNothing) Full(None) // missing tag in json means user doesn't want to update them
-    else {
-      for {
-        jobjects <- Box(value.extractOpt[List[JObject]]) ?~! s"Invalid JSON serialization for Tags ${value}"
-        // be careful, we need to use JObject.obj to get the list even if there is duplicated keys,
-        // which would be removed with JObject.values
-        pairs    <- Control.traverse(jobjects) { o =>
-                      Control.traverse(o.obj) {
-                        case JField(key, v) =>
-                          v match {
-                            case JString(s) if (s.nonEmpty) => Full((key, s))
-                            case _                          => Failure(s"Cannot parse value '${v}' as a valid tag value for tag with name '${key}'")
-
-                          }
-                      }
-                    }
-      } yield {
-        val tags = pairs.flatten
-        Some(Tags(tags.map { case (k, v) => Tag(TagName(k), TagValue(v)) }.toSet))
-      }
-    }
-  }
-
-  def extractDirectiveFromJSON(json: JValue): Box[RestDirective] = {
-    for {
-      name             <- (
-                            extractJsonString(json, "name", toMinimalSizeString(3)),
-                            extractJsonString(json, "displayName", toMinimalSizeString(3))
-                          ) match {
-                            case (res @ Full(Some(name)), _) => res
-                            case (_, res @ Full(Some(name))) => res
-                            case (Full(None), Full(None))    => Full(None)
-                            case (eb: EmptyBox, _)           => eb
-                            case (_, eb: EmptyBox)           => eb
-                          }
-      shortDescription <- extractJsonString(json, "shortDescription")
-      longDescription  <- extractJsonString(json, "longDescription")
-      enabled          <- extractJsonBoolean(json, "enabled")
-      priority         <- extractJsonInt(json, "priority")
-      parameters       <- extractJsonDirectiveParam(json)
-      techniqueName    <- extractJsonString(json, "techniqueName", x => Full(TechniqueName(x)))
-      techniqueVersion <- extractJsonString(json, "techniqueVersion", x => TechniqueVersion.parse(x).toBox)
-      policyMode       <- extractJsonString(json, "policyMode", PolicyMode.parseDefault(_).toBox)
-      tags             <- extractTagsFromJson(json \ "tags") ?~! "Error when extracting Directive tags"
-    } yield {
-      RestDirective(
-        name,
-        shortDescription,
-        longDescription,
-        enabled,
-        parameters,
-        priority,
-        techniqueName,
-        techniqueVersion,
-        policyMode,
-        tags
-      )
-    }
-  }
-
-  def extractGroupPropertiesFromJSON(json: JValue): Box[Option[Seq[GroupProperty]]] = {
-    import com.normation.utils.Control.traverse
-    json \ "properties" match {
-      case JArray(props) =>
-        traverse(props)(p => GroupProperty.unserializeLdapGroupProperty(GenericProperty.serializeJson(p)).toBox).map(Some(_))
-      case JNothing      => Full(None)
-      case x             => Failure(s"""Error: the given parameter is not a JSON object with a 'properties' key""")
-    }
-  }
-
-  def extractGroupFromJSON(json: JValue): Box[RestGroup] = {
-    for {
-      id          <- extractJsonString(json, "id")
-      name        <- extractJsonString(json, "displayName", toMinimalSizeString(3))
-      description <- extractJsonString(json, "description")
-      properties  <- extractGroupPropertiesFromJSON(json)
-      enabled     <- extractJsonBoolean(json, "enabled")
-      dynamic     <- extractJsonBoolean(json, "dynamic")
-      query       <- json \ "query" match {
-                       case JNothing    => Full(None)
-                       case stringQuery =>
-                         for {
-                           st <- queryParser.jsonParse(stringQuery)
-                           q  <- queryParser.parse(st)
-                           _  <- if (q.criteria.size > 0) Full("Query has at least one criteria")
-                                 else Failure("Query should containt at least one criteria")
-                         } yield Some(q)
-                     }
-      category    <- extractJsonString(json, "category", toGroupCategoryId)
-    } yield {
-      RestGroup(id, name, description, properties.map(_.toList), query, dynamic, enabled, category)
-    }
-  }
-
   def extractGroupCategory(json: JValue): Box[RestGroupCategory] = {
     for {
       id          <- extractJsonString(json, "id", toNodeGroupCategoryId)
@@ -899,31 +165,6 @@ final case class RestExtractorService(
       parent      <- extractJsonString(json, "parent", toNodeGroupCategoryId)
     } yield {
       RestGroupCategory(id, name, description, parent)
-    }
-  }
-
-  def extractParameterNameFromJSON(json: JValue): Box[String] = {
-    extractJsonString(json, "id", toParameterName) match {
-      case Full(None)        => Failure("Parameter id should not be empty")
-      case Full(Some(value)) => Full(value)
-      case eb: EmptyBox => eb ?~ "Error while fetch parameter Name"
-    }
-  }
-
-  def extractParameterFromJSON(json: JValue): Box[RestParameter] = {
-    for {
-      description <- extractJsonString(json, "description")
-      value       <- (json \ "value") match {
-                       case JNothing => Full(None)
-                       case x        => Full(Some(GenericProperty.fromJsonValue(x)))
-                     }
-      inheritMode <- (json \ "inheritMode") match {
-                       case JString(s) => InheritMode.parseString(s).map(x => Some(x)).toBox
-                       case JNothing   => Full(None)
-                       case x          => Failure("Can not parse inherit mode: " + x)
-                     }
-    } yield {
-      RestParameter(value, description, inheritMode)
     }
   }
 
@@ -981,41 +222,9 @@ final case class RestExtractorService(
     }
   }
 
-  def extractNodeIdsFromJson(json: JValue): Box[Option[List[NodeId]]] = {
-    extractJsonListString(json, "nodeId", convertListToNodeId)
-  }
-
-  def extractQuery(params: Map[String, List[String]]): Box[Option[Query]] = {
-    extractOneValue(params, "query")(toQuery) match {
-      case Full(None)  =>
-        extractOneValue(params, CRITERIA)(toQueryCriterion) match {
-          case Full(None)            => Full(None)
-          case Full(Some(Nil))       => Failure("Query should at least contain one criteria")
-          case Full(Some(criterion)) =>
-            for {
-              // Target defaults to NodeReturnType
-              optType   <- extractOneValue(params, TARGET)(toQueryReturnType)
-              returnType = optType.getOrElse(NodeReturnType)
-
-              // Composition defaults to None/And
-              optComposition <- extractOneValue(params, COMPOSITION)(toQueryComposition)
-              composition     = optComposition.getOrElse(None)
-              transform      <- extractOneValue(params, TRANSFORM)(toQueryTransform)
-
-              // Query may fail when parsing
-              stringQuery = StringQuery(returnType, composition, transform.flatten, criterion.toList)
-              query      <- queryParser.parse(stringQuery)
-            } yield {
-              Some(query)
-            }
-          case eb: EmptyBox => eb ?~! "error with query"
-        }
-      case Full(query) =>
-        Full(query)
-      case eb: EmptyBox => eb ?~! "error with query"
-    }
-  }
-
+  /*
+   * Still used in technique API
+   */
   def extractString[T](key: String)(req: Req)(fun: String => Box[T]): Box[Option[T]] = {
     req.json match {
       case Full(json) =>
@@ -1033,31 +242,9 @@ final case class RestExtractorService(
     }
   }
 
-  def extractInt[T](key: String)(req: Req)(fun: BigInt => Box[T]): Box[Option[T]] = {
-    req.json match {
-      case Full(json) =>
-        json \ key match {
-          case JInt(value) => fun(value).map(Some(_))
-          case JNothing    => Full(None)
-          case x           => Failure(s"Not a valid value for '${key}' parameter, current value is : ${x}")
-        }
-      case _          =>
-        req.params.get(key) match {
-          case None              => Full(None)
-          case Some(head :: Nil) =>
-            try {
-              fun(head.toLong).map(Some(_))
-            } catch {
-              case e: Throwable =>
-                Failure(
-                  s"Parsing request parameter '${key}' as an integer failed, current value is '${head}'. Error message is: '${e.getMessage}'."
-                )
-            }
-          case Some(list)        => Failure(s"${list.size} values defined for 'id' parameter, only one needs to be defined")
-        }
-    }
-  }
-
+  /*
+   * Still used in technique/eventlog/apiaccounts API
+   */
   def extractBoolean[T](key: String)(req: Req)(fun: Boolean => T): Box[Option[T]] = {
     req.json match {
       case Full(json) =>
@@ -1082,82 +269,6 @@ final case class RestExtractorService(
         }
     }
   }
-
-  def extractMap[T, U](key: String)(req: Req)(
-      keyFun:           String => T,
-      jsonValueFun:     JValue => U,
-      paramValueFun:    String => U,
-      paramMapSepartor: String
-  ): Box[Option[Map[T, U]]] = {
-    req.json match {
-      case Full(json) =>
-        json \ key match {
-          case JObject(fields) =>
-            val map: Map[T, U] = fields.map { case JField(fieldName, value) => (keyFun(fieldName), jsonValueFun(value)) }.toMap
-            Full(Some(map))
-          case JNothing        => Full(None)
-          case x               => Failure(s"Not a valid value for '${key}' parameter, current value is : ${x}")
-        }
-      case _          =>
-        req.params.get(key) match {
-          case None            => Full(None)
-          case Some(keyValues) =>
-            (bestEffort(keyValues) {
-              case keyValue =>
-                val splitted = keyValue.split(paramMapSepartor, 1).toList
-                splitted match {
-                  case key :: value :: Nil => Full((keyFun(key), paramValueFun(value)))
-                  case _                   => Failure("Could not split value")
-                }
-            }).map(values => Some(values.toMap))
-        }
-    }
-  }
-
-  def extractObj[T](key: String)(req: Req)(jsonValueFun: JObject => Box[T]): Box[Option[T]] = {
-    req.json match {
-      case Full(json) => extractJsonObj(json, key, jsonValueFun)
-      case _          =>
-        req.params.get(key) match {
-          case None               => Full(None)
-          case Some(value :: Nil) =>
-            parseOpt(value) match {
-              case Some(obj: JObject) => jsonValueFun(obj).map(Some(_))
-              case _                  => Failure(s"Not a valid value for '${key}' parameter, current value is : ${value}")
-            }
-          case Some(list)         => Failure(s"${list.size} values defined for '${key}' parameter, only one needs to be defined")
-        }
-    }
-  }
-
-  def extractList[T](key: String)(req: Req)(fun: String => Box[T]): Box[List[T]] = {
-    req.json match {
-      case Full(json) =>
-        json \ key match {
-          case JString(value) => fun(value).map(_ :: Nil)
-          case JArray(values) =>
-            com.normation.utils.Control
-              .bestEffort(values) { value =>
-                value match {
-                  case JString(value) => fun(value)
-                  case x              =>
-                    Failure(s"Not a valid value for '${key}' parameter, current value is : ${x}")
-                }
-
-              }
-              .map(_.toList)
-          case JNothing       => Full(Nil)
-          case x              => Failure(s"Not a valid value for '${key}' parameter, current value is : ${x}")
-        }
-      case _          =>
-        req.params.get(key) match {
-          case None       => Full(Nil)
-          case Some(list) => bestEffort(list)(fun(_)).map(_.toList)
-        }
-    }
-  }
-
-  def extractId[T](req: Req)(fun: String => Box[T]): Box[Option[T]] = extractString("id")(req)(fun)
 
   def extractComplianceFormat(params: Map[String, List[String]]): Box[ComplianceFormat] = {
     params.get("format") match {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
@@ -73,8 +73,6 @@ import com.normation.rudder.rest.*
 import com.normation.rudder.rest.ApiPath
 import com.normation.rudder.rest.AuthzToken
 import com.normation.rudder.rest.DirectiveApi as API
-import com.normation.rudder.rest.RestExtractorService
-import com.normation.rudder.rest.RestUtils
 import com.normation.rudder.rest.data.*
 import com.normation.rudder.rest.implicits.*
 import com.normation.rudder.services.workflows.ChangeRequestService
@@ -94,37 +92,12 @@ import zio.*
 import zio.syntax.*
 
 class DirectiveApi(
-    restExtractorService: RestExtractorService,
-    zioJsonExtractor:     ZioJsonExtractor,
-    uuidGen:              StringUuidGenerator,
-    service:              DirectiveApiService14
+    zioJsonExtractor: ZioJsonExtractor,
+    uuidGen:          StringUuidGenerator,
+    service:          DirectiveApiService14
 ) extends LiftApiModuleProvider[API] {
 
-  private val dataName = "directives"
-
   def schemas: ApiModuleProvider[API] = API
-
-  type ActionType = RestUtils.ActionType
-  def actionResponse(function: Box[ActionType], req: Req, errorMessage: String, id: Option[String], actor: EventActor)(implicit
-      action: String
-  ): LiftResponse = {
-    RestUtils.actionResponse2(restExtractorService, dataName, uuidGen, id)(function, req, errorMessage)(action, actor)
-  }
-
-  type WorkflowType = RestUtils.WorkflowType
-  def workflowResponse(
-      function:     Box[WorkflowType],
-      req:          Req,
-      errorMessage: String,
-      id:           Option[String],
-      defaultName:  String,
-      actor:        EventActor
-  )(implicit action: String): LiftResponse = {
-    RestUtils.workflowResponse2(restExtractorService, dataName, uuidGen, id)(function, req, errorMessage, defaultName)(
-      action,
-      actor
-    )
-  }
 
   def getLiftEndpoints(): List[LiftApiModule] = {
     API.endpoints.map {
@@ -149,7 +122,7 @@ class DirectiveApi(
     val schema:                                                                                                API.DirectiveTree.type = API.DirectiveTree
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse           = {
       (for {
-        includeSystem <- restExtractorService.extractBoolean("includeSystem")(req)(identity).toIO
+        includeSystem <- zioJsonExtractor.extractIncludeSystem(req).toIO
         res           <- service.directiveTree(includeSystem.getOrElse(false))
       } yield {
         res

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -59,8 +59,6 @@ import com.normation.rudder.repository.*
 import com.normation.rudder.rest.*
 import com.normation.rudder.rest.ApiPath
 import com.normation.rudder.rest.AuthzToken
-import com.normation.rudder.rest.RestExtractorService
-import com.normation.rudder.rest.RestUtils
 import com.normation.rudder.rest.RuleApi as API
 import com.normation.rudder.rest.implicits.*
 import com.normation.rudder.rule.category.*
@@ -69,7 +67,6 @@ import com.normation.rudder.services.policies.RuleApplicationStatusService
 import com.normation.rudder.services.workflows.*
 import com.normation.rudder.web.services.ComputePolicyMode
 import com.normation.utils.StringUuidGenerator
-import net.liftweb.common.Box
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
 import org.joda.time.DateTime
@@ -78,24 +75,10 @@ import zio.*
 import zio.syntax.*
 
 class RuleApi(
-    restExtractorService: RestExtractorService,
-    zioJsonExtractor:     ZioJsonExtractor,
-    service:              RuleApiService14,
-    uuidGen:              StringUuidGenerator
+    zioJsonExtractor: ZioJsonExtractor,
+    service:          RuleApiService14,
+    uuidGen:          StringUuidGenerator
 ) extends LiftApiModuleProvider[API] {
-
-  import RestUtils.*
-
-  def actionResponse(
-      function:     Box[ActionType],
-      req:          Req,
-      errorMessage: String,
-      id:           Option[String],
-      actor:        EventActor,
-      dataName:     String
-  )(implicit action: String): LiftResponse = {
-    RestUtils.actionResponse2(restExtractorService, dataName, uuidGen, id)(function, req, errorMessage)(action, actor)
-  }
 
   def schemas: ApiModuleProvider[API] = API
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -184,7 +184,8 @@ class SettingsApi(
 
       // sort settings alphanum
       RestUtils.response(restExtractorService, "settings", None)(Full(data.sortBy(_.name)), req, s"Could not settings")(
-        "getAllSettings"
+        "getAllSettings",
+        params.prettify
       )
     }
   }
@@ -202,7 +203,10 @@ class SettingsApi(
         JField(setting.key, value)
       }
       startNewPolicyGeneration(authzToken.qc.actor)
-      RestUtils.response(restExtractorService, "settings", None)(Full(data), req, s"Could not modfiy settings")("modifySettings")
+      RestUtils.response(restExtractorService, "settings", None)(Full(data), req, s"Could not modfiy settings")(
+        "modifySettings",
+        params.prettify
+      )
     }
   }
 
@@ -224,7 +228,8 @@ class SettingsApi(
         (key -> value)
       }
       RestUtils.response(restExtractorService, "settings", Some(key))(data, req, s"Could not get parameter '${key}'")(
-        "getSetting"
+        "getSetting",
+        params.prettify
       )
     }
   }
@@ -247,7 +252,8 @@ class SettingsApi(
         (key -> value)
       }
       RestUtils.response(restExtractorService, "settings", Some(key))(data, req, s"Could not modify parameter '${key}'")(
-        "modifySetting"
+        "modifySetting",
+        params.prettify
       )
     }
   }
@@ -693,7 +699,8 @@ class SettingsApi(
   }
 
   def response(function: Box[JValue], req: Req, errorMessage: String, id: Option[String])(implicit
-      action: String
+      action:   String,
+      prettify: Boolean
   ): LiftResponse = {
     RestUtils.response(restExtractorService, kind, id)(function, req, errorMessage)
   }
@@ -847,6 +854,7 @@ class SettingsApi(
     val restExtractor = restExtractorService
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
       implicit val action = "getAllAllowedNetworks"
+      implicit val prettify: Boolean = params.prettify
       RestUtils.response(restExtractorService, getRootNameForVersion(version), None)(
         getAllowedNetworks()(authzToken.qc).toBox,
         req,
@@ -868,7 +876,8 @@ class SettingsApi(
     ): LiftResponse = {
 
       implicit val action = "getAllowedNetworks"
-      val result          = for {
+      implicit val prettify: Boolean = params.prettify
+      val result = for {
         nodeInfo <- nodeFactRepo.get(NodeId(id))(authzToken.qc)
         isServer <- nodeInfo match {
                       case Some(info) if info.rudderSettings.isPolicyServer =>
@@ -909,6 +918,7 @@ class SettingsApi(
     ): LiftResponse = {
 
       implicit val action = "modifyAllowedNetworks"
+      implicit val prettify: Boolean = params.prettify
 
       def checkAllowedNetwork(v: String) = {
         val netWithoutSpaces = v.replaceAll("""\s""", "")
@@ -992,6 +1002,7 @@ class SettingsApi(
     ): LiftResponse = {
 
       implicit val action = "modifyDiffAllowedNetworks"
+      implicit val prettify: Boolean = params.prettify
 
       def checkAllowedNetwork(v: String) = {
         val netWithoutSpaces = v.replaceAll("""\s""", "")

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -59,6 +59,7 @@ import com.normation.rudder.apidata.ZioJsonExtractor
 import com.normation.rudder.batch.*
 import com.normation.rudder.batch.PolicyGenerationTrigger.AllGeneration
 import com.normation.rudder.campaigns.CampaignSerializer
+import com.normation.rudder.config.StatelessUserPropertyService
 import com.normation.rudder.domain.appconfig.FeatureSwitch
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
@@ -147,7 +148,6 @@ import com.normation.rudder.web.model.LinkUtil
 import com.normation.rudder.web.services.DirectiveEditorServiceImpl
 import com.normation.rudder.web.services.DirectiveFieldFactory
 import com.normation.rudder.web.services.Section2FieldService
-import com.normation.rudder.web.services.StatelessUserPropertyService
 import com.normation.rudder.web.services.Translator
 import com.normation.utils.StringUuidGeneratorImpl
 import com.normation.zio.*
@@ -757,7 +757,7 @@ class RestTestSetUp {
         null,
         mockNodes.newNodeManager,
         mockNodes.removeNodeService,
-        restExtractorService,
+        zioJsonExtractor,
         mockCompliance.reportingService(Map.empty),
         mockNodes.queryProcessor,
         null,
@@ -894,16 +894,16 @@ class RestTestSetUp {
       techniqueRepository,
       techniqueSerializer,
       uuidGen,
+      userPropertyService,
       resourceFileService,
       mockGitRepo.configurationRepositoryRoot.pathAsString
     ),
     new DirectiveApi(
-      restExtractorService,
       zioJsonExtractor,
       uuidGen,
       directiveApiService14
     ),
-    new RuleApi(restExtractorService, zioJsonExtractor, ruleApiService14, uuidGen),
+    new RuleApi(zioJsonExtractor, ruleApiService14, uuidGen),
     new RulesInternalApi(ruleInternalApiService, ruleApiService14),
     new GroupsInternalApi(groupInternalApiService),
     new NodeApi(
@@ -921,6 +921,7 @@ class RestTestSetUp {
       restExtractorService,
       zioJsonExtractor,
       uuidGen,
+      userPropertyService,
       groupService14
     ),
     new SettingsApi(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -61,6 +61,8 @@ import com.normation.rudder.api.*
 import com.normation.rudder.apidata.*
 import com.normation.rudder.batch.*
 import com.normation.rudder.campaigns.*
+import com.normation.rudder.config.StatelessUserPropertyService
+import com.normation.rudder.config.UserPropertyService
 import com.normation.rudder.configuration.*
 import com.normation.rudder.db.Doobie
 import com.normation.rudder.domain.*
@@ -1754,7 +1756,7 @@ object RudderConfigInit {
       acceptedNodesDit,
       newNodeManagerImpl,
       removeNodeServiceImpl,
-      restExtractorService,
+      zioJsonExtractor,
       reportingService,
       queryProcessor,
       inventoryQueryChecker,
@@ -2107,10 +2109,10 @@ object RudderConfigInit {
           restExtractorService,
           zioJsonExtractor,
           stringUuidGenerator,
+          userPropertyService,
           groupApiService14
         ),
         new DirectiveApi(
-          restExtractorService,
           zioJsonExtractor,
           stringUuidGenerator,
           directiveApiService14
@@ -2142,11 +2144,11 @@ object RudderConfigInit {
           techniqueRepository,
           techniqueSerializer,
           stringUuidGenerator,
+          userPropertyService,
           resourceFileService,
           RUDDER_GIT_ROOT_CONFIG_REPO
         ),
         new RuleApi(
-          restExtractorService,
           zioJsonExtractor,
           ruleApiService13,
           stringUuidGenerator
@@ -2420,7 +2422,7 @@ object RudderConfigInit {
       configService.rudder_ui_changeMessage_mandatory _,
       configService.rudder_ui_changeMessage_explanation _
     )
-    lazy val userPropertyService     = userPropertyServiceImpl
+    lazy val userPropertyService: UserPropertyService = userPropertyServiceImpl
 
     ////////////////////////////////////
     //  non success services

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueEditForm.scala
@@ -260,29 +260,29 @@ class TechniqueEditForm(
   }
 
   private val crReasons = {
-    import com.normation.rudder.web.services.ReasonBehavior.*
-    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
+    import com.normation.rudder.config.ReasonBehavior.*
+    userPropertyService.reasonsFieldBehavior match {
       case Disabled  => None
       case Mandatory => Some(buildReasonField(true, "px-1"))
-      case Optionnal => Some(buildReasonField(false, "px-1"))
+      case Optional  => Some(buildReasonField(false, "px-1"))
     }
   }
 
   private val crReasonsRemovePopup = {
-    import com.normation.rudder.web.services.ReasonBehavior.*
-    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
+    import com.normation.rudder.config.ReasonBehavior.*
+    userPropertyService.reasonsFieldBehavior match {
       case Disabled  => None
       case Mandatory => Some(buildReasonField(true, "px-1"))
-      case Optionnal => Some(buildReasonField(false, "px-1"))
+      case Optional  => Some(buildReasonField(false, "px-1"))
     }
   }
 
   private val crReasonsDisablePopup = {
-    import com.normation.rudder.web.services.ReasonBehavior.*
-    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
+    import com.normation.rudder.config.ReasonBehavior.*
+    userPropertyService.reasonsFieldBehavior match {
       case Disabled  => None
       case Mandatory => Some(buildReasonField(true, "px-1"))
-      case Optionnal => Some(buildReasonField(false, "px-1"))
+      case Optional  => Some(buildReasonField(false, "px-1"))
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
@@ -313,11 +313,11 @@ class CreateCategoryOrGroupPopup(
   }
 
   private val piReasons = {
-    import com.normation.rudder.web.services.ReasonBehavior.*
-    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
+    import com.normation.rudder.config.ReasonBehavior.*
+    userPropertyService.reasonsFieldBehavior match {
       case Disabled  => None
       case Mandatory => Some(buildReasonField(true, "px-1"))
-      case Optionnal => Some(buildReasonField(false, "px-1"))
+      case Optional  => Some(buildReasonField(false, "px-1"))
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneDirectivePopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneDirectivePopup.scala
@@ -125,11 +125,11 @@ class CreateCloneDirectivePopup(
   ///////////// fields for category settings ///////////////////
 
   private val reasons = {
-    import com.normation.rudder.web.services.ReasonBehavior.*
-    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
+    import com.normation.rudder.config.ReasonBehavior.*
+    userPropertyService.reasonsFieldBehavior match {
       case Disabled  => None
       case Mandatory => Some(buildReasonField(true, "px-1"))
-      case Optionnal => Some(buildReasonField(false, "px-1"))
+      case Optional  => Some(buildReasonField(false, "px-1"))
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
@@ -208,11 +208,11 @@ class CreateCloneGroupPopup(
   ///////////// fields for category settings ///////////////////
 
   private val groupReasons = {
-    import com.normation.rudder.web.services.ReasonBehavior.*
-    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
+    import com.normation.rudder.config.ReasonBehavior.*
+    userPropertyService.reasonsFieldBehavior match {
       case Disabled  => None
       case Mandatory => Some(buildReasonField(true, "px-1"))
-      case Optionnal => Some(buildReasonField(false, "px-1"))
+      case Optional  => Some(buildReasonField(false, "px-1"))
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
@@ -330,11 +330,11 @@ class CreateOrUpdateGlobalParameterPopup(
   val parameterOverridable = true
 
   private val paramReasons = {
-    import com.normation.rudder.web.services.ReasonBehavior.*
-    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
+    import com.normation.rudder.config.ReasonBehavior.*
+    userPropertyService.reasonsFieldBehavior match {
       case Disabled  => None
       case Mandatory => Some(buildReasonField(true, "px-1"))
-      case Optionnal => Some(buildReasonField(false, "px-1"))
+      case Optional  => Some(buildReasonField(false, "px-1"))
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateRulePopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateRulePopup.scala
@@ -133,11 +133,11 @@ class CreateOrCloneRulePopup(
   ///////////// fields for category settings ///////////////////
 
   private val reason = {
-    import com.normation.rudder.web.services.ReasonBehavior.*
-    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
+    import com.normation.rudder.config.ReasonBehavior.*
+    userPropertyService.reasonsFieldBehavior match {
       case Disabled  => None
       case Mandatory => Some(buildReasonField(true, "px-1"))
-      case Optionnal => Some(buildReasonField(false, "px-1"))
+      case Optional  => Some(buildReasonField(false, "px-1"))
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/GiveReasonPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/GiveReasonPopup.scala
@@ -41,6 +41,7 @@ import bootstrap.liftweb.RudderConfig
 import com.normation.box.*
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.eventlog.ModificationId
+import com.normation.rudder.config.ReasonBehavior.*
 import com.normation.rudder.domain.policies.ActiveTechniqueCategoryId
 import com.normation.rudder.domain.policies.ActiveTechniqueId
 import com.normation.rudder.domain.policies.PolicyTypes
@@ -48,7 +49,6 @@ import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.ChooseTemplate
 import com.normation.rudder.web.model.FormTracker
 import com.normation.rudder.web.model.WBTextAreaField
-import com.normation.rudder.web.services.ReasonBehavior.*
 import net.liftweb.common.*
 import net.liftweb.http.DispatchSnippet
 import net.liftweb.http.SHtml
@@ -104,10 +104,10 @@ class GiveReasonPopup(
 
 ///////////// fields for category settings ///////////////////
   private val crReasons = {
-    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
+    userPropertyService.reasonsFieldBehavior match {
       case Disabled  => None
       case Mandatory => Some(buildReasonField(true, "px-1"))
-      case Optionnal => Some(buildReasonField(false, "px-1"))
+      case Optional  => Some(buildReasonField(false, "px-1"))
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ModificationValidationPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ModificationValidationPopup.scala
@@ -258,11 +258,11 @@ class ModificationValidationPopup(
 
   // must be here because used in val popupWarningMessages
   private val crReasons = {
-    import com.normation.rudder.web.services.ReasonBehavior.*
-    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
+    import com.normation.rudder.config.ReasonBehavior.*
+    userPropertyService.reasonsFieldBehavior match {
       case Disabled  => None
       case Mandatory => Some(buildReasonField(true, "px-1"))
-      case Optionnal => Some(buildReasonField(false, "px-1"))
+      case Optional  => Some(buildReasonField(false, "px-1"))
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleModificationValidationPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleModificationValidationPopup.scala
@@ -168,11 +168,11 @@ class RuleModificationValidationPopup(
   ///////////// fields for category settings ///////////////////
 
   private val crReasons = {
-    import com.normation.rudder.web.services.ReasonBehavior.*
-    (userPropertyService.reasonsFieldBehavior: @unchecked) match {
+    import com.normation.rudder.config.ReasonBehavior.*
+    userPropertyService.reasonsFieldBehavior match {
       case Disabled  => None
       case Mandatory => Some(buildReasonField(true, "px-1"))
-      case Optionnal => Some(buildReasonField(false, "px-1"))
+      case Optional  => Some(buildReasonField(false, "px-1"))
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/TechniqueLibraryManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/TechniqueLibraryManagement.scala
@@ -42,6 +42,7 @@ import com.normation.box.*
 import com.normation.cfclerk.domain.*
 import com.normation.eventlog.ModificationId
 import com.normation.rudder.AuthorizationType
+import com.normation.rudder.config.ReasonBehavior.*
 import com.normation.rudder.domain.eventlog.RudderEventActor
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.users.CurrentUser
@@ -50,7 +51,6 @@ import com.normation.rudder.web.components.popup.CreateActiveTechniqueCategoryPo
 import com.normation.rudder.web.components.popup.GiveReasonPopup
 import com.normation.rudder.web.model.JsTreeNode
 import com.normation.rudder.web.services.AgentCompat
-import com.normation.rudder.web.services.ReasonBehavior.*
 import net.liftweb.common.*
 import net.liftweb.common.Box.box2Option
 import net.liftweb.common.Box.option2Box


### PR DESCRIPTION
https://issues.rudder.io/issues/25960

After #6042 a lot of lift-json methods in rest extractor are left unused : cleanup most of them, and mark the remaining one with a comment to know which API/serializer depends on it.

Along the way I replaced the old `extractPrettify` and `extractReason` in lift-json with the existing equivalent in zio-json (but it needed to move `UserPropertyService` in core), and migrate away from trivial usage == single line of lift-json, to remove as much methods as possible.

After this, remaining migrations that depend on the extractor utils/service are well-known : 
* Tags.scala
* Groups API
* Eventlogs API
* ApiAccounts API
* Technique API
* Compliance API
* Settings API
