### PR TITLE
Fixes #25892: Error when accepting 2 or more nodes

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/DBCommon.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/DBCommon.scala
@@ -160,7 +160,8 @@ trait DBCommon extends Specification with Loggable with BeforeAfterAll {
       properties.getProperty("jdbc.password"),
       // maxPoolSize MUST BE '1', else temp table disappear between the two connections in
       // really funny ways
-      1
+      1,
+      250.millis.asScala
     )
     config.datasource
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/GenerateCompliance.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/GenerateCompliance.scala
@@ -56,6 +56,7 @@ import java.nio.charset.StandardCharsets
 import java.util.Properties
 import javax.sql.DataSource
 import org.joda.time.DateTime
+import scala.concurrent.duration.DurationInt
 import scala.util.Random
 import zio.interop.catz.*
 
@@ -90,7 +91,8 @@ object GenerateCompliance {
       properties.getProperty("rudder.jdbc.url"),
       properties.getProperty("rudder.jdbc.username"),
       properties.getProperty("rudder.jdbc.password"),
-      properties.getProperty("rudder.jdbc.maxPoolSize").toInt
+      properties.getProperty("rudder.jdbc.maxPoolSize").toInt,
+      250.millis
     )
     config.datasource
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/25892

This PR replace #6045. It adds some more change in the LDAP pool ergonomics: 
- the main change is still `LDAP_CREATE_IF_NECESSARY` set to `false` which means that the max pool size is really the max pool size, and that yes we want a pool to reuse existing connections, seriously
- the minimum for pool size can be lower than 10. It could likely be even lower than 7, but it seems to work well, even in small servers, and up to big one (10k nodes). 
- add `LDAP_MINIMUM_AVAILABLE_CONNECTION_GOAL` for the number of min alive connexion. Set to 2, which should be OK everywhere. 
- `LDAP_MAX_WAIT_TIME` is the time code will wait for a connection from the pool. It was to 0, which is strange for a pool. Use `30 seconds` like in most pool. 
- deconnect and connect again connection after `LDAP_MAX_CONNECTION_AGE` = 30 minutes. I'm not sure it's necessary, but it's often seen as a good practice to refresh connections regularly. 
- in consequence, also set `LDAP_MIN_DISCONNECT_INTERVAL` which ensure that connection are not all refreshed at the same time, with a default interval of 5s. 
