### PR TITLE
Fixes #25669: 

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
@@ -69,8 +69,6 @@ import com.normation.rudder.services.workflows.WorkflowLevelService
 import com.normation.rudder.services.workflows.WorkflowUpdate
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import net.liftweb.common.EmptyBox
-import net.liftweb.common.Full
 import scala.concurrent.duration.Duration
 import zio.*
 import zio.syntax.*
@@ -551,10 +549,14 @@ class GenericConfigService(
    * A feature switch is defaulted to Disabled is parsing fails.
    */
   implicit private def toFeatureSwitch(p: RudderWebProperty): FeatureSwitch = FeatureSwitch.parse(p.value) match {
-    case Full(status) => status
-    case eb: EmptyBox =>
-      val e = eb ?~! s"Error when trying to parse property '${p.name.value}' with value '${p.value}' into a feature switch status"
-      logEffect.warn(e.messageChain)
+    case Right(status) => status
+    case Left(err)     =>
+      logEffect.warn(
+        Chained(
+          s"Error when trying to parse property '${p.name.value}' with value '${p.value}' into a feature switch status",
+          err
+        ).fullMsg
+      )
       FeatureSwitch.Disabled
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -1229,6 +1229,12 @@ sealed trait UserApi extends EnumEntry with EndpointSchema with InternalApi with
   override def dataContainer: Option[String] = None
 }
 object UserApi       extends Enum[UserApi] with ApiModuleProvider[UserApi]                 {
+  case object GetTokenFeatureStatus extends UserApi with ZeroParam with StartsAtVersion10 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Get the feature switch configuration for the user API token from the provider config"
+    val (action, path) = GET / "user" / "api" / "token" / "status"
+  }
+
   case object GetApiToken    extends UserApi with ZeroParam with StartsAtVersion10 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Get information about user personal UserApi token"

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
@@ -224,7 +224,7 @@ object AuthorizationApiMapping {
           TechniqueApi.UpdateTechnique.x :: SystemApi.PoliciesUpdate.x :: SystemApi.PoliciesRegenerate.x ::
           TechniqueApi.UpdateTechniques.x :: TechniqueApi.UpdateMethods.x :: Nil
 
-        case UserAccount.Read  => UserApi.GetApiToken.x :: Nil
+        case UserAccount.Read  => UserApi.GetApiToken.x :: UserApi.GetTokenFeatureStatus.x :: Nil
         case UserAccount.Write => UserApi.CreateApiToken.x :: UserApi.DeleteApiToken.x :: Nil
         case UserAccount.Edit  => UserApi.UpdateApiToken.x :: Nil
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -648,12 +648,12 @@ class SettingsApi(
     def toJson(value: FeatureSwitch): JValue = value.name
     def parseJson(json: JValue):   Box[FeatureSwitch] = {
       json match {
-        case JString(value) => FeatureSwitch.parse(value)
+        case JString(value) => FeatureSwitch.parse(value).toBox
         case x              => Failure("Invalid value " + x)
       }
     }
     def parseParam(param: String): Box[FeatureSwitch] = {
-      FeatureSwitch.parse(param)
+      FeatureSwitch.parse(param).toBox
     }
     val key = "enable_javascript_directives"
     def get: IOResult[FeatureSwitch]                                       = configService.rudder_featureSwitch_directiveScriptEngine()

--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -642,6 +642,20 @@ rudder.users.cleanup.sessions.purgeAfter=30 days
 rudder.auth.provider=file
 
 #
+# To disable access to the REST API using user-generated API token
+# via the api-authorizations plugin, you can use change this option to "disabled"
+#
+rudder.auth.userRestToken=enabled
+
+#
+# To disable access to the REST API using user-generated API token
+# via the api-authorizations plugin for users from a specific provider (declared in rudder.auth.provider),
+# you can use uncomment this property. You can also set it to "enabled"
+# (the default value is the one for rudder.auth.userRestToken).
+#
+#rudder.auth.oidc.userRestToken=disabled
+
+#
 # Inactivity timeout for user sessions
 #
 # The default value is 30 minutes.


### PR DESCRIPTION
https://issues.rudder.io/issues/25669

Adding a `rudder.auth.{provider}.disableRest` boolean option for each known provider passed to the `rudder.auth.provider` list : just read the configuration for the provider into our case class for provider properties, and keep compatibility with previous behavior by using the `false` value (meaning : DO NOT disable REST authentication for this provider)