### PR TITLE
Fixes #25974: Link to node is missing for modified nodes

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -133,7 +133,10 @@ class EventLogDetailsGenerator(
 
     def nodeDesc(x: EventLog, actionName: NodeSeq) = {
       val id   = (x.details \\ "node" \ "id").text
-      val name = (x.details \\ "node" \ "hostname").text
+      val name = (x.details \\ "node" \ "hostname").text.strip() match {
+        case "" => id
+        case x  => x
+      }
       Text("Node ") ++ {
         if ((id.size < 1) || (actionName == Text(" deleted"))) Text(name)
         else <a href={nodeLink(NodeId(id))} onclick="noBubble(event);">{name}</a> ++ actionName


### PR DESCRIPTION
https://issues.rudder.io/issues/25974

The whole thing feels broken (the id should be in the event somewhere mandatory for ex). 
But at least, we need to check if the `name` is not empty and have a fallback.

![image](https://github.com/user-attachments/assets/bbd68a7d-296c-48b4-9f86-41d6988bfe8d)
