### PR TITLE
Fixes #25705: search on event log must also search on event type

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
@@ -126,7 +126,7 @@ class EventLogAPI(
             None
           } else {
             val v = "%" + value + "%"
-            Some(fr" temp1.filter like ${v}")
+            Some(fr"(temp1.filter ilike ${v} OR temp1.eventtype ilike ${v})")
           }
         }
       }


### PR DESCRIPTION
https://issues.rudder.io/issues/25705

This part of query is within a larger set of condition, it needs parenthesis, and it knows that the `eventtype` column is there. Also we don't need to consider the exact case even for the user query (EventType is stored as PascalCase). 

The drawback of this is that the user should know the EventType. And we have no way of statically checking for known event types before applying the filter.