### PR TITLE
Fixes #25978: CustomProperties (inventory properties) are not always correctly retrieved from inventory

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/TenantService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/tenants/TenantService.scala
@@ -118,7 +118,7 @@ object DefaultTenantService {
 
 /*
  *  _tenantsEnabled is accessed in a lot of hot path, we prefer not to encapsulate it into a Ref.
- * We still put its modification behind a eval.
+ * We still put its modification behind an eval.
  */
 class DefaultTenantService(private var _tenantsEnabled: Boolean, val tenantIds: Ref[Set[TenantId]]) extends TenantService {
 


### PR DESCRIPTION
https://issues.rudder.io/issues/25978

We were not correctly mapping back attributes from NodeInventory to Node in the case where we were retrieving both node and inventory info from storage. 

Rebased on top of #6063 which is around the same problems