### PR TITLE
Fixes #25982: Disable metrics pop-up and form

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
@@ -141,7 +141,6 @@ class SystemVariableServiceImpl(
 
     getModifiedFilesTtl:      () => Box[Int],
     getCfengineOutputsTtl:    () => Box[Int],
-    getSendMetrics:           () => Box[Option[SendMetrics]],
     getReportProtocolDefault: () => Box[AgentReportingProtocol]
 ) extends SystemVariableService with Loggable {
 
@@ -188,15 +187,8 @@ class SystemVariableServiceImpl(
 
     val varServerVersion = systemVariableSpecService.get("SERVER_VERSION").toVariable(Seq(serverVersion))
 
-    import SendMetrics.*
-    val sendMetricsValue = getSendMetrics().getOrElse(None) match {
-      case None                  => "no"
-      case Some(NoMetrics)       => "no"
-      case Some(MinimalMetrics)  => "minimal"
-      case Some(CompleteMetrics) => "complete"
-    }
-
-    val varSendMetrics = systemVariableSpecService.get("SEND_METRICS").toVariable(Seq(sendMetricsValue))
+    // always disable send metrics - see https://issues.rudder.io/issues/25982
+    val varSendMetrics = systemVariableSpecService.get("SEND_METRICS").toVariable(Seq("no"))
 
     logger.trace("Global system variables done")
     val vars = {
@@ -225,7 +217,7 @@ class SystemVariableServiceImpl(
   // for this method to work properly
 
   // The global system variables are computed before (in the method up there), and
-  // can be overriden by some node specific parameters (especially, the schedule for
+  // can be overridden by some node specific parameters (especially, the schedule for
   // policy servers)
   def getSystemVariables(
       nodeInfo:              CoreNodeFact,

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -350,7 +350,6 @@ class MockTechniques(configurationRepositoryRoot: File, mockGit: MockGitConfigRe
 
     getModifiedFilesTtl = () => Full(30),
     getCfengineOutputsTtl = () => Full(7),
-    getSendMetrics = () => Full(None),
     getReportProtocolDefault = () => Full(AgentReportingHTTPS)
   )
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
@@ -832,7 +832,6 @@ class TestNodeConfiguration(
 
     getModifiedFilesTtl = () => Full(30),
     getCfengineOutputsTtl = () => Full(7),
-    getSendMetrics = () => Full(None),
     getReportProtocolDefault = () => Full(AgentReportingHTTPS)
   )
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -3032,7 +3032,6 @@ object RudderConfigInit {
       () => configService.relay_server_syncsharedfiles().toBox,
       () => configService.cfengine_modified_files_ttl().toBox,
       () => configService.cfengine_outputs_ttl().toBox,
-      () => configService.send_server_metrics().toBox,
       () => configService.rudder_report_protocol_default().toBox
     )
     lazy val rudderCf3PromisesFileWriterService = new PolicyWriterServiceImpl(

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/administration/policyServerManagement.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/administration/policyServerManagement.html
@@ -630,8 +630,8 @@
               </div>
             </div>
 
-            <div class="inner-portlet">
-              <h3 class="page-title">Usage survey</h3>
+            <div class="inner-portlet d-none">
+              <h3>Usage survey</h3>
               <div class="portlet-content">
                 <div class="lift:administration.PropertiesManagement.sendMetricsConfiguration" id="sendMetrics">
                   <div class="explanation-text">
@@ -667,7 +667,6 @@
                       </lift:authz>
                     </div>
                   </form>
-
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
https://issues.rudder.io/issues/25982

Only hide the menu part, plus ensure that the system variable always get "no" - but keep the config service, API, etc logic so that it's easy to reinstanciate in 8.3. 

It looks like the pop-up logic was removed and not replaced in bb01e23b8eb48962e37bef93894fc2517b08dcd4 
The pop-up code still exists, it can be clean-up in Rudder 8.3 along with the script etc. 