### PR TITLE
Fixes #25984: Add description/doc field to node settable by API

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -425,10 +425,11 @@ object JsonQueryObjects {
     }
   }
   final case class JQUpdateNode(
-      properties: Option[List[NodeProperty]],
-      policyMode: Option[Option[PolicyMode]],
-      state:      Option[NodeState],
-      agentKey:   Option[JQAgentKey]
+      properties:    Option[List[NodeProperty]],
+      policyMode:    Option[Option[PolicyMode]],
+      state:         Option[NodeState],
+      agentKey:      Option[JQAgentKey],
+      documentation: Option[String]
   ) {
     val keyInfo: (Option[SecurityToken], Option[KeyStatus]) = agentKey.map(_.toKeyInfo).getOrElse((None, None))
   }
@@ -927,8 +928,9 @@ class ZioJsonExtractor(queryParser: CmdbQueryParser with JsonQueryLexer) {
       policyMode <- params.parse2("policyMode", PolicyMode.parseDefault(_))
       state      <- params.parseString("state", NodeState.parse(_))
       agentKey   <- params.parse("agentKey", JsonDecoder[JQAgentKey])
+      doc         = params.optGet("documentation")
     } yield {
-      JQUpdateNode(properties, policyMode, state, agentKey)
+      JQUpdateNode(properties, policyMode, state, agentKey, doc)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -216,27 +216,23 @@ object JsonResponseObjects {
   )
 
   final case class JRUpdateNode(
-      id:         NodeId,
-      properties: Chunk[JRProperty], // sorted by name
-      policyMode: Option[PolicyMode],
-      state:      NodeState
+      id:            NodeId,
+      properties:    Chunk[JRProperty], // sorted by name
+      policyMode:    Option[PolicyMode],
+      state:         NodeState,
+      documentation: Option[String]
   )
   object JRUpdateNode       {
     implicit val transformer: Transformer[CoreNodeFact, JRUpdateNode] = {
       Transformer
         .define[CoreNodeFact, JRUpdateNode]
-        .withFieldComputed(
-          _.state,
-          _.rudderSettings.state
-        )
-        .withFieldComputed(
-          _.policyMode,
-          _.rudderSettings.policyMode
-        )
+        .withFieldComputed(_.state, _.rudderSettings.state)
+        .withFieldComputed(_.policyMode, _.rudderSettings.policyMode)
         .withFieldComputed(
           _.properties,
           _.properties.sortBy(_.name).map(JRProperty.fromNodeProp).transformInto[Chunk[JRProperty]]
         )
+        .withFieldComputed(_.documentation, _.documentation)
         .buildTransformer
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
@@ -139,14 +139,15 @@ object NodeState extends Enum[NodeState] {
  * For now, other simple properties are not handle.
  */
 final case class ModifyNodeDiff(
-    id:            NodeId,
-    modHeartbeat:  Option[SimpleDiff[Option[HeartbeatConfiguration]]],
-    modAgentRun:   Option[SimpleDiff[Option[AgentRunInterval]]],
-    modProperties: Option[SimpleDiff[List[NodeProperty]]],
-    modPolicyMode: Option[SimpleDiff[Option[PolicyMode]]],
-    modKeyValue:   Option[SimpleDiff[SecurityToken]],
-    modKeyStatus:  Option[SimpleDiff[KeyStatus]],
-    modNodeState:  Option[SimpleDiff[NodeState]]
+    id:               NodeId,
+    modHeartbeat:     Option[SimpleDiff[Option[HeartbeatConfiguration]]],
+    modAgentRun:      Option[SimpleDiff[Option[AgentRunInterval]]],
+    modProperties:    Option[SimpleDiff[List[NodeProperty]]],
+    modPolicyMode:    Option[SimpleDiff[Option[PolicyMode]]],
+    modKeyValue:      Option[SimpleDiff[SecurityToken]],
+    modKeyStatus:     Option[SimpleDiff[KeyStatus]],
+    modNodeState:     Option[SimpleDiff[NodeState]],
+    modDocumentation: Option[SimpleDiff[String]]
 )
 
 object ModifyNodeDiff {
@@ -197,7 +198,10 @@ object ModifyNodeDiff {
 
     val state = if (oldNode.state == newNode.state) None else Some(SimpleDiff(oldNode.state, newNode.state))
 
-    ModifyNodeDiff(newNode.id, heartbeat, agentRun, properties, policyMode, keyValue, keyStatus, state)
+    val documentation =
+      if (oldNode.description == newNode.description) None else Some(SimpleDiff(oldNode.description, newNode.description))
+
+    ModifyNodeDiff(newNode.id, heartbeat, agentRun, properties, policyMode, keyValue, keyStatus, state, documentation)
   }
 
   def keyInfo(
@@ -220,6 +224,6 @@ object ModifyNodeDiff {
       case Some(s) => if (s == oldStatus) None else Some(SimpleDiff(oldStatus, s))
     }
 
-    ModifyNodeDiff(nodeId, None, None, None, None, keyInfo, keyStatus, None)
+    ModifyNodeDiff(nodeId, None, None, None, None, keyInfo, keyStatus, None, None)
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
@@ -234,7 +234,7 @@ object MinimalNodeFactInterface {
     }
 
     eq(_.id) &&
-    eq(_.description) &&
+    eq(_.documentation) &&
     eq(_.fqdn) &&
     eq(_.os) &&
     eq(_.machine) &&
@@ -257,7 +257,7 @@ object MinimalNodeFactInterface {
   def toNode(node: MinimalNodeFactInterface): Node = Node(
     node.id,
     node.fqdn,
-    "", // description
+    node.documentation.getOrElse(""),
     node.rudderSettings.state,
     isSystem(node),
     isSystem((node)),
@@ -704,7 +704,7 @@ object NodeFact {
       case _ =>
         NodeFact(
           a.id,
-          a.description,
+          a.documentation,
           a.fqdn,
           a.os,
           a.machine,
@@ -843,7 +843,7 @@ object NodeFact {
   def updateNode(node: NodeFact, n: Node): NodeFact = {
     import com.softwaremill.quicklens.*
     node
-      .modify(_.description)
+      .modify(_.documentation)
       .setTo(Some(n.description))
       .modify(_.rudderSettings.state)
       .setTo(n.state)
@@ -871,7 +871,7 @@ object NodeFact {
     val pad     = "\n * "
     val ignored = new StringBuilder().append(pad).append("ignored: ")
     val sb      = new StringBuilder(s"""id:${diff(n1.id.value, n2.id.value)}
-                                  | * description:${diff(n1.description, n2.description)}
+                                  | * description:${diff(n1.documentation, n2.documentation)}
                                   | * fqdn:${diff(n1.fqdn, n2.fqdn)}
                                   | * os:${diff(n1.os, n2.os)}
                                   | * machine:${diff(n1.machine, n2.machine)}
@@ -915,7 +915,7 @@ object NodeFact {
 
 trait MinimalNodeFactInterface {
   def id:                NodeId
-  def description:       Option[String]
+  def documentation:     Option[String]
   def fqdn:              String
   def os:                OsDetails
   def machine:           MachineInfo
@@ -995,7 +995,7 @@ trait MinimalNodeFactInterface {
  */
 final case class CoreNodeFact(
     id:                NodeId,
-    description:       Option[String],
+    documentation:     Option[String],
     @jsonField("hostname")
     fqdn:              String,
     os:                OsDetails,
@@ -1018,8 +1018,8 @@ object CoreNodeFact {
   def updateNode(node: CoreNodeFact, n: Node): CoreNodeFact = {
     import com.softwaremill.quicklens.*
     node
-      .modify(_.description)
-      .setTo(Some(n.description))
+      .modify(_.documentation)
+      .setTo(if (n.description.isBlank) None else Some(n.description))
       .modify(_.rudderSettings.state)
       .setTo(n.state)
       .modify(_.rudderSettings.kind)
@@ -1040,7 +1040,7 @@ object CoreNodeFact {
       case _ =>
         CoreNodeFact(
           a.id,
-          a.description,
+          a.documentation,
           a.fqdn,
           a.os,
           a.machine,
@@ -1398,7 +1398,7 @@ object SelectFacts {
 
 final case class NodeFact(
     id:                NodeId,
-    description:       Option[String],
+    documentation:     Option[String],
     @jsonField("hostname")
     fqdn:              String,
     os:                OsDetails,
@@ -1461,7 +1461,7 @@ final case class NodeFact(
     val pad     = "\n * "
     val ignored = new StringBuilder().append(pad).append("ignored: ")
     val sb      = new StringBuilder(s"""id:${this.id.value}
-                                  | * description:${this.description}
+                                  | * documentation:${this.documentation}
                                   | * fqdn:${this.fqdn}
                                   | * os:${this.os}
                                   | * machine:${this.machine}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -1169,6 +1169,11 @@ class EventLogFactoryImpl(
           case None    => NodeSeq.Empty
           case Some(x) => SimpleDiff.toXml(<nodeState/>, x)(x => Text(x.name))
         }
+      }{
+        modifyDiff.modDocumentation match {
+          case None    => NodeSeq.Empty
+          case Some(x) => SimpleDiff.toXml(<description/>, x)(x => Text(x))
+        }
       }
       </node>)
     }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/eventlog/NodeEventLogFormatV6Test.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/eventlog/NodeEventLogFormatV6Test.scala
@@ -84,7 +84,8 @@ class NodeEventLogFormatV6Test extends Specification {
     modPolicyMode = None,
     modKeyValue = None,
     modKeyStatus = None,
-    modNodeState = None
+    modNodeState = None,
+    modDocumentation = None
   )
 
   val event_32_NodePropertiesModified: Elem = <entry><node changeType="modify" fileFormat="6">
@@ -123,7 +124,8 @@ class NodeEventLogFormatV6Test extends Specification {
     modPolicyMode = None,
     modKeyValue = None,
     modKeyStatus = None,
-    modNodeState = None
+    modNodeState = None,
+    modDocumentation = None
   )
 
   val event_32_NodeAgentRunPeriodModified: Elem = <entry><node changeType="modify" fileFormat="6">
@@ -147,7 +149,8 @@ class NodeEventLogFormatV6Test extends Specification {
     modPolicyMode = None,
     modKeyValue = None,
     modKeyStatus = None,
-    modNodeState = None
+    modNodeState = None,
+    modDocumentation = None
   )
 
   "Current EventTypeFactory" should {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -1039,6 +1039,8 @@ class EventLogDetailsGenerator(
                     mapComplexDiff(modDiff.modKeyStatus, <b>Key status</b>)(x => Text(x.value))
                   }{mapComplexDiff(modDiff.modKeyValue, <b>Key value</b>)(x => Text(x.key))}{reasonHtml}{
                     xmlParameters(event.id)
+                  }{
+                    mapComplexDiff(modDiff.modDocumentation, <b>Description</b>)(x => Text(x))
                   }
                   </div>
                 case e: EmptyBox =>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -634,6 +634,12 @@ object DisplayNode extends Loggable {
     }
           </div>
         </div>
+        <div class="rudder-info">
+          <h3>Documentation</h3>
+          <div class="markdown" id="nodeDocumentation">
+          </div>
+          {Script(OnLoad(JsRaw(s"generateMarkdown(${Str(nodeFact.documentation.getOrElse("")).toJsCmd}, '#nodeDocumentation')")))}
+        </div>
       </div>
       <div class="rudder-info">
         <h3>Rudder information</h3>


### PR DESCRIPTION
https://issues.rudder.io/issues/25984

Add a documentation field in node that can be set by API. 
This issue manage the backend, which is: 
- rename `description` to `documentation` in `NodeFact` because we want to support markdown and long format for that field, 
- extends API for updating node info to support that attribute, 
- manage change event for that field
- add a simple place in node details to display that field in markdown. That part will be need to be rework to be replaced by an editable part in an other issue. 

![image](https://github.com/user-attachments/assets/14abc4cd-c938-4be0-b4bf-8af3e3993e27)
