### PR TITLE
Fixes #25980: Migrate Group category API endpoints to zio-json

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/json/JsonExctractorUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/json/JsonExctractorUtils.scala
@@ -89,7 +89,7 @@ trait JsonExtractorUtils[A[_]] {
   }
 
   /*
-   * Still used in apiaccount/eventlog/group API, tags
+   * Still used in apiaccount/eventlog API, tags
    */
   def extractJsonString[T](json: JValue, key: String, convertTo: String => Box[T] = boxedIdentity[String]): Box[A[T]] = {
     extractJson(json, key, convertTo, { case JString(value) => value })

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -213,7 +213,7 @@ object ComplianceApi       extends Enum[ComplianceApi] with ApiModuleProvider[Co
 }
 
 sealed trait GroupApi extends EnumEntry with EndpointSchema with SortIndex    {
-  override def dataContainer: Some[String] = Some("groups")
+  override def dataContainer: Option[String] = Some("groups")
 }
 object GroupApi       extends Enum[GroupApi] with ApiModuleProvider[GroupApi] {
   // API v2
@@ -231,6 +231,7 @@ object GroupApi       extends Enum[GroupApi] with ApiModuleProvider[GroupApi] {
     val z: Int = implicitly[Line].value
     val description    = "List all group categories and group in a tree format"
     val (action, path) = GET / "groups" / "tree"
+    override def dataContainer: None.type = None
   }
   case object GroupDetails             extends GroupApi with GeneralApi with OneParam with StartsAtVersion2 with SortIndex  {
     val z: Int = implicitly[Line].value
@@ -271,25 +272,25 @@ object GroupApi       extends Enum[GroupApi] with ApiModuleProvider[GroupApi] {
     val z: Int = implicitly[Line].value
     val description    = "Get information about the given group category"
     val (action, path) = GET / "groups" / "categories" / "{id}"
-    override def dataContainer: Some[String] = Some("groupCategories")
+    override def dataContainer: None.type = None
   }
   case object DeleteGroupCategory extends GroupApi with GeneralApi with OneParam with StartsAtVersion6 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Delete given group category"
     val (action, path) = DELETE / "groups" / "categories" / "{id}"
-    override def dataContainer: Some[String] = Some("groupCategories")
+    override def dataContainer: None.type = None
   }
   case object UpdateGroupCategory extends GroupApi with GeneralApi with OneParam with StartsAtVersion6 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Update information for given group category"
     val (action, path) = POST / "groups" / "categories" / "{id}"
-    override def dataContainer: Some[String] = Some("groupCategories")
+    override def dataContainer: None.type = None
   }
   case object CreateGroupCategory extends GroupApi with GeneralApi with ZeroParam with StartsAtVersion6 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "Create a new group category"
     val (action, path) = PUT / "groups" / "categories"
-    override def dataContainer: Some[String] = Some("groupCategories")
+    override def dataContainer: None.type = None
   }
 
   def endpoints: List[GroupApi] = values.toList.sortBy(_.z)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -47,7 +47,6 @@ import com.normation.rudder.api.ApiAuthorization as ApiAuthz
 import com.normation.rudder.api.ApiAuthorizationKind
 import com.normation.rudder.api.HttpAction
 import com.normation.rudder.config.UserPropertyService
-import com.normation.rudder.domain.nodes.NodeGroupCategoryId
 import com.normation.rudder.domain.reports.CompliancePrecision
 import com.normation.rudder.facts.nodes.NodeSecurityContext
 import com.normation.rudder.ncf.ParameterType.ParameterTypeService
@@ -76,31 +75,6 @@ final case class RestExtractorService(
 ) extends Loggable {
 
   import com.normation.rudder.repository.json.DataExtractor.OptionnalJson.*
-  /*
-   * Params Extractors
-   */
-
-  private def extractOneValue[T](params: Map[String, List[String]], key: String)(
-      to: (String) => Box[T] = ((value: String) => Full(value))
-  ) = {
-    params.get(key) match {
-      case None               => Full(None)
-      case Some(value :: Nil) => to(value).map(Some(_))
-      case _                  => Failure(s"updateRule should contain only one value for $key")
-    }
-  }
-
-  private def toMinimalSizeString(minimalSize: Int)(value: String): Box[String] = {
-    if (value.size >= minimalSize) {
-      Full(value)
-    } else {
-      Failure(s"$value must be at least have a ${minimalSize} character size")
-    }
-  }
-
-  private def toNodeGroupCategoryId(value: String): Box[NodeGroupCategoryId] = {
-    Full(NodeGroupCategoryId(value))
-  }
 
   private def toApiAccountId(value: String): Box[ApiAccountId] = {
     Full(ApiAccountId(value))
@@ -108,21 +82,6 @@ final case class RestExtractorService(
 
   private def toApiAccountName(value: String): Box[ApiAccountName] = {
     Full(ApiAccountName(value))
-  }
-
-  /*
-   * Still used in group API
-   */
-  def extractGroupCategory(params: Map[String, List[String]]): Box[RestGroupCategory] = {
-
-    for {
-      id          <- extractOneValue(params, "id")(toNodeGroupCategoryId)
-      name        <- extractOneValue(params, "name")(toMinimalSizeString(3))
-      description <- extractOneValue(params, "description")()
-      parent      <- extractOneValue(params, "parent")(toNodeGroupCategoryId)
-    } yield {
-      RestGroupCategory(id, name, description, parent)
-    }
   }
 
   /*
@@ -154,17 +113,6 @@ final case class RestExtractorService(
           Some(level)
         }
 
-    }
-  }
-
-  def extractGroupCategory(json: JValue): Box[RestGroupCategory] = {
-    for {
-      id          <- extractJsonString(json, "id", toNodeGroupCategoryId)
-      name        <- extractJsonString(json, "name", toMinimalSizeString(3))
-      description <- extractJsonString(json, "description")
-      parent      <- extractJsonString(json, "parent", toNodeGroupCategoryId)
-    } yield {
-      RestGroupCategory(id, name, description, parent)
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/RestData.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/RestData.scala
@@ -59,11 +59,9 @@ import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.domain.properties.PropertyProvider
 import com.normation.rudder.domain.queries.Query
 import com.normation.rudder.domain.workflows.ChangeRequestInfo
-import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.rule.category.*
 import com.typesafe.config.ConfigValue
 import io.scalaland.chimney.Transformer
-import net.liftweb.common.*
 
 final case class APIChangeRequestInfo(
     name:        Option[String],
@@ -91,42 +89,6 @@ final case class RestRuleCategory(
       name = updateName,
       description = updateDescription
     )
-  }
-}
-
-final case class RestGroupCategory(
-    id:          Option[NodeGroupCategoryId] = None,
-    name:        Option[String] = None,
-    description: Option[String] = None,
-    parent:      Option[NodeGroupCategoryId] = None
-) {
-
-  def update(category: FullNodeGroupCategory): FullNodeGroupCategory = {
-    val updateId          = id.getOrElse(category.id)
-    val updateName        = name.getOrElse(category.name)
-    val updateDescription = description.getOrElse(category.description)
-    category.copy(
-      id = updateId,
-      name = updateName,
-      description = updateDescription
-    )
-  }
-
-  def create(defaultId: () => NodeGroupCategoryId): Box[FullNodeGroupCategory] = {
-    name match {
-      case Some(name) =>
-        Full(
-          FullNodeGroupCategory(
-            id.getOrElse(defaultId()),
-            name,
-            description.getOrElse(""),
-            Nil,
-            Nil
-          )
-        )
-      case None       =>
-        Failure("Could not create group Category, cause: name is not defined")
-    }
   }
 }
 

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
@@ -1536,6 +1536,65 @@ response:
       }
     }
 ---
+description: Fail to update group category name
+method: POST
+url: /api/latest/groups/categories/219b9c98-4c2f-44c9-aff5-95b4fc7c4ada
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "parent": "GroupRoot",
+    "name": "sh"
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action":"updateGroupCategory",
+      "id":"219b9c98-4c2f-44c9-aff5-95b4fc7c4ada",
+      "result" : "error",
+      "errorDetails" : "Could not update Group category '219b9c98-4c2f-44c9-aff5-95b4fc7c4ada'; cause was: Unexpected: (Group category name 'sh' must at least have a 3 character size)"
+    }
+---
+description: Fail to create a node group category without name
+method: PUT
+url: /api/latest/groups/categories
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "parent": "GroupRoot",
+    "id": "219b9c98-4c2f-44c9-aff5-95b4fc7c4ada"
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action":"createGroupCategory",
+      "result" : "error",
+      "errorDetails" : "Could not create group category; cause was: Inconsistency: Could not create group Category, cause: name is not defined"
+    }
+---
+description: Fail to create a node group category with name too short
+method: PUT
+url: /api/latest/groups/categories
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "parent": "GroupRoot",
+    "name": "sh",
+    "id": "219b9c98-4c2f-44c9-aff5-95b4fc7c4ada"
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action":"createGroupCategory",
+      "result" : "error",
+      "errorDetails" : "Could not create group category; cause was: Unexpected: (Group category name 'sh' must at least have a 3 character size)"
+    }
+---
 description: Delete a group category
 method: DELETE
 url: /api/latest/groups/categories/category-to-be-deleted
@@ -1569,7 +1628,7 @@ response:
       "action" : "deleteGroupCategory",
       "id" : "system-category1",
       "result" : "error",
-      "errorDetails" : "Could not delete Group category 'system-category1' <- Could not delete group category 'system-category1', cause is: system categories cannot be deleted."
+      "errorDetails" : "Could not delete Group category 'system-category1'; cause was: Inconsistency: Could not delete group category 'system-category1', cause is: system categories cannot be deleted."
     }
 ---
 description: Get minimal info on group category category1
@@ -1599,6 +1658,423 @@ response:
         }
       }
     }
+---
+description: List all group categories and group in a tree format
+method: GET
+url: /api/latest/groups/tree
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getGroupTree",
+      "result" : "success",
+      "data" : {
+        "groupCategories" : {
+          "id" : "GroupRoot",
+          "name" : "GroupRoot",
+          "description" : "root of group categories",
+          "parent" : "GroupRoot",
+          "categories" : [
+            {
+              "id" : "219b9c98-3d1e-44c9-0001-95b4fc7c4ada",
+              "name" : "category 2",
+              "description" : "",
+              "parent" : "GroupRoot",
+              "categories" : [],
+              "groups" : [],
+              "targets" : []
+            },
+            {
+              "id" : "219b9c98-3d1e-44c9-aff5-95b4fc7c4ada",
+              "name" : "category 2",
+              "description" : "",
+              "parent" : "GroupRoot",
+              "categories" : [],
+              "groups" : [],
+              "targets" : []
+            },
+            {
+              "id" : "category1",
+              "name" : "category 1",
+              "description" : "the first category",
+              "parent" : "GroupRoot",
+              "categories" : [
+                {
+                  "id" : "219b9c98-3d1e-44c9-0001-95b4fc7c4ada",
+                  "name" : "category 2 update",
+                  "description" : "category 2",
+                  "parent" : "category1",
+                  "categories" : [],
+                  "groups" : [],
+                  "targets" : []
+                },
+                {
+                  "id" : "219b9c98-3d1e-44c9-aff5-95b4fc7c4ada",
+                  "name" : "category 2 update",
+                  "description" : "category 2",
+                  "parent" : "category1",
+                  "categories" : [],
+                  "groups" : [],
+                  "targets" : []
+                }
+              ],
+              "groups" : [
+                {
+                  "id" : "0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "displayName" : "Real nodes",
+                  "description" : "",
+                  "category" : "category1",
+                  "query" : {
+                    "select" : "nodeAndPolicyServer",
+                    "composition" : "or",
+                    "where" : [
+                      {
+                        "objectType" : "node",
+                        "attribute" : "nodeId",
+                        "comparator" : "eq",
+                        "value" : "node1"
+                      },
+                      {
+                        "objectType" : "node",
+                        "attribute" : "nodeId",
+                        "comparator" : "eq",
+                        "value" : "node2"
+                      },
+                      {
+                        "objectType" : "node",
+                        "attribute" : "nodeId",
+                        "comparator" : "eq",
+                        "value" : "root"
+                      }
+                    ]
+                  },
+                  "nodeIds" : [
+                    "node1",
+                    "node2",
+                    "root"
+                  ],
+                  "dynamic" : false,
+                  "enabled" : true,
+                  "groupClass" : [
+                    "group_0000f5d3_8c61_4d20_88a7_bb947705ba8a",
+                    "group_real_nodes"
+                  ],
+                  "properties" : [
+                    {
+                      "name" : "stringParam",
+                      "value" : "string",
+                      "inheritMode" : "map",
+                      "provider" : "datasources"
+                    },
+                    {
+                      "name" : "jsonParam",
+                      "value" : {
+                        "array" : [
+                          5,
+                          6
+                        ],
+                        "group" : "string",
+                        "json" : {
+                          "g1" : "g1"
+                        }
+                      }
+                    }
+                  ],
+                  "target" : "group:0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "system" : false
+                }
+              ],
+              "targets" : []
+            },
+            {
+              "id" : "system-category1",
+              "name" : "system category 1",
+              "description" : "a system group category",
+              "parent" : "GroupRoot",
+              "categories" : [],
+              "groups" : [],
+              "targets" : []
+            }
+          ],
+          "groups" : [
+            {
+              "id" : "00000000-cb9d-4f7b-0001-ca38c5d643ea",
+              "displayName" : "clone from api of debian group",
+              "description" : "Some long description",
+              "category" : "GroupRoot",
+              "query" : {
+                "select" : "node",
+                "composition" : "and",
+                "where" : [
+                  {
+                    "objectType" : "node",
+                    "attribute" : "osName",
+                    "comparator" : "eq",
+                    "value" : "Debian"
+                  },
+                  {
+                    "objectType" : "node",
+                    "attribute" : "osVersion",
+                    "comparator" : "regex",
+                    "value" : "10\\..*"
+                  }
+                ]
+              },
+              "nodeIds" : [],
+              "dynamic" : true,
+              "enabled" : true,
+              "groupClass" : [
+                "group_00000000_cb9d_4f7b_0001_ca38c5d643ea",
+                "group_clone_from_api_of_debian_group"
+              ],
+              "properties" : [
+                {
+                  "name" : "os",
+                  "value" : {
+                    "name" : "debian",
+                    "nickname" : "Buster"
+                  }
+                }
+              ],
+              "target" : "group:00000000-cb9d-4f7b-0001-ca38c5d643ea",
+              "system" : false
+            },
+            {
+              "id" : "00000000-cb9d-4f7b-abda-ca38c5d643ea",
+              "displayName" : "clone from api of debian group",
+              "description" : "Some long description",
+              "category" : "GroupRoot",
+              "query" : {
+                "select" : "node",
+                "composition" : "and",
+                "where" : [
+                  {
+                    "objectType" : "node",
+                    "attribute" : "osName",
+                    "comparator" : "eq",
+                    "value" : "Debian"
+                  },
+                  {
+                    "objectType" : "node",
+                    "attribute" : "osVersion",
+                    "comparator" : "regex",
+                    "value" : "10\\..*"
+                  }
+                ]
+              },
+              "nodeIds" : [],
+              "dynamic" : true,
+              "enabled" : true,
+              "groupClass" : [
+                "group_00000000_cb9d_4f7b_abda_ca38c5d643ea",
+                "group_clone_from_api_of_debian_group"
+              ],
+              "properties" : [
+                {
+                  "name" : "os",
+                  "value" : {
+                    "name" : "debian",
+                    "nickname" : "Buster"
+                  }
+                }
+              ],
+              "target" : "group:00000000-cb9d-4f7b-abda-ca38c5d643ea",
+              "system" : false
+            },
+            {
+              "id" : "1111f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "displayName" : "Empty group",
+              "description" : "",
+              "category" : "GroupRoot",
+              "nodeIds" : [],
+              "dynamic" : false,
+              "enabled" : true,
+              "groupClass" : [
+                "group_1111f5d3_8c61_4d20_88a7_bb947705ba8a",
+                "group_empty_group"
+              ],
+              "properties" : [],
+              "target" : "group:1111f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "system" : false
+            },
+            {
+              "id" : "2222f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "displayName" : "only root",
+              "description" : "",
+              "category" : "GroupRoot",
+              "nodeIds" : [
+                "root"
+              ],
+              "dynamic" : false,
+              "enabled" : true,
+              "groupClass" : [
+                "group_2222f5d3_8c61_4d20_88a7_bb947705ba8a",
+                "group_only_root"
+              ],
+              "properties" : [],
+              "target" : "group:2222f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "system" : false
+            },
+            {
+              "id" : "3333f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "displayName" : "Even nodes",
+              "description" : "",
+              "category" : "GroupRoot",
+              "nodeIds" : [
+                "0",
+                "10",
+                "2",
+                "4",
+                "6",
+                "8"
+              ],
+              "dynamic" : false,
+              "enabled" : true,
+              "groupClass" : [
+                "group_3333f5d3_8c61_4d20_88a7_bb947705ba8a",
+                "group_even_nodes"
+              ],
+              "properties" : [],
+              "target" : "group:3333f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "system" : false
+            },
+            {
+              "id" : "4444f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "displayName" : "Odd nodes",
+              "description" : "",
+              "category" : "GroupRoot",
+              "nodeIds" : [
+                "1",
+                "3",
+                "5",
+                "7",
+                "9"
+              ],
+              "dynamic" : false,
+              "enabled" : true,
+              "groupClass" : [
+                "group_4444f5d3_8c61_4d20_88a7_bb947705ba8a",
+                "group_odd_nodes"
+              ],
+              "properties" : [],
+              "target" : "group:4444f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "system" : false
+            },
+            {
+              "id" : "5555f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "displayName" : "Nodes id divided by 3",
+              "description" : "",
+              "category" : "GroupRoot",
+              "nodeIds" : [
+                "0",
+                "3",
+                "6",
+                "9"
+              ],
+              "dynamic" : false,
+              "enabled" : true,
+              "groupClass" : [
+                "group_5555f5d3_8c61_4d20_88a7_bb947705ba8a",
+                "group_nodes_id_divided_by_3"
+              ],
+              "properties" : [],
+              "target" : "group:5555f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "system" : false
+            },
+            {
+              "id" : "6666f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "displayName" : "Nodes id divided by 5",
+              "description" : "",
+              "category" : "GroupRoot",
+              "nodeIds" : [
+                "0",
+                "10",
+                "5"
+              ],
+              "dynamic" : false,
+              "enabled" : true,
+              "groupClass" : [
+                "group_6666f5d3_8c61_4d20_88a7_bb947705ba8a",
+                "group_nodes_id_divided_by_5"
+              ],
+              "properties" : [],
+              "target" : "group:6666f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "system" : false
+            },
+            {
+              "id" : "a-group-for-root-only",
+              "displayName" : "Serveurs [€ðŋ] cassés",
+              "description" : "Liste de l'ensemble de serveurs cassés à réparer",
+              "category" : "GroupRoot",
+              "nodeIds" : [
+                "root"
+              ],
+              "dynamic" : true,
+              "enabled" : true,
+              "groupClass" : [
+                "group_a_group_for_root_only",
+                "group_serveurs_______casses"
+              ],
+              "properties" : [],
+              "target" : "group:a-group-for-root-only",
+              "system" : false
+            },
+            {
+              "id" : "all-nodes",
+              "displayName" : "All nodes",
+              "description" : "All nodes known by Rudder (including Rudder policy servers)",
+              "category" : "GroupRoot",
+              "nodeIds" : [
+                "0",
+                "1",
+                "10",
+                "2",
+                "3",
+                "4",
+                "5",
+                "6",
+                "7",
+                "8",
+                "9"
+              ],
+              "dynamic" : false,
+              "enabled" : true,
+              "groupClass" : [
+                "group_all_nodes",
+                "group_all_nodes"
+              ],
+              "properties" : [],
+              "target" : "group:all-nodes",
+              "system" : true
+            }
+          ],
+          "targets" : [
+            {
+              "id" : "policyServer:root",
+              "displayName" : "special:policyServer_root",
+              "description" : "The root policy server",
+              "enabled" : true,
+              "target" : "policyServer:root"
+            },
+            {
+              "id" : "special:all_exceptPolicyServers",
+              "displayName" : "special:all_exceptPolicyServers",
+              "description" : "All groups without policy servers",
+              "enabled" : true,
+              "target" : "special:all_exceptPolicyServers"
+            },
+            {
+              "id" : "special:all",
+              "displayName" : "special:all",
+              "description" : "All nodes",
+              "enabled" : true,
+              "target" : "special:all"
+            }
+          ]
+        }
+      }
+    }
+
 
 #
 # API GROUPSINTERNAL

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -918,7 +918,6 @@ class RestTestSetUp {
     ),
     new GroupsApi(
       mockNodeGroups.propService,
-      restExtractorService,
       zioJsonExtractor,
       uuidGen,
       userPropertyService,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2106,7 +2106,6 @@ object RudderConfigInit {
         new ComplianceApi(restExtractorService, complianceAPIService, roDirectiveRepository),
         new GroupsApi(
           propertiesService,
-          restExtractorService,
           zioJsonExtractor,
           stringUuidGenerator,
           userPropertyService,


### PR DESCRIPTION
https://issues.rudder.io/issues/25980

Migrating remaining lift-json endpoints in the GroupsApi file : endpoints for rule categories.
It ends up being very similar to the already migrated Rules categories API.
I added some tests for validation error (on the `name`) along the way, I removed what could be removed from the evil  `RestExtractorService`...