### PR TITLE
Fixes #26023: Technique compilation errors doesn't seems to be reloaded when the technique is deleted

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueReloadingCallbacks.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueReloadingCallbacks.scala
@@ -48,6 +48,7 @@ import com.normation.eventlog.ModificationId
 import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.domain.eventlog.ReloadTechniqueLibrary
+import com.normation.rudder.ncf.TechniqueCompilationStatusSyncService
 import com.normation.rudder.repository.EventLogRepository
 import net.liftweb.common.*
 
@@ -103,5 +104,22 @@ class LogEventOnTechniqueReloadCallback(
       .chainError("Error when saving event log for techniques library reload")
       .unit
       .toBox
+  }
+}
+
+class SyncCompilationStatusOnTechniqueCallback(
+    override val name:                 String,
+    override val order:                Int,
+    techniqueCompilationStatusService: TechniqueCompilationStatusSyncService
+) extends TechniquesLibraryUpdateNotification with Loggable {
+  override def updatedTechniques(
+      gitRev:            String,
+      techniqueIds:      Map[TechniqueName, TechniquesLibraryUpdateType],
+      updatedCategories: Set[TechniqueCategoryModType],
+      modId:             ModificationId,
+      actor:             EventActor,
+      reason:            Option[String]
+  ): Box[Unit] = {
+    techniqueCompilationStatusService.getUpdateAndSync().toBox
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
@@ -685,7 +685,7 @@ class SystemApiService11(
       getActor(req),
       Some("Technique library reloaded from REST API")
     ) match {
-      case Full(x) => Right(JField("techniques", "Started"))
+      case Full(_) => Right(JField("techniques", "Started"))
       case eb: EmptyBox =>
         val e = eb ?~! "An error occurred when updating the Technique library from file system"
         logger.error(e.messageChain)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
@@ -366,8 +366,8 @@ class TechniqueApi(
                                             s"An error occurred while reading techniques when updating them: ${errors.map(_.msg).mkString("\n ->", "\n ->", "")}"
                                           )
                                         }
-        _                            <- ZIO.foreach(techniques)(t => techniqueWriter.writeTechnique(t, modId, authzToken.qc.actor))
-        json                         <- ZIO.foreach(techniques)(_.toJsonAST.toIO)
+        res                          <- techniqueWriter.writeTechniques(techniques, modId, authzToken.qc.actor)
+        json                         <- ZIO.foreach(res)(_.toJsonAST.toIO)
       } yield {
         json
       }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1919,8 +1919,11 @@ object RudderConfigInit {
       techniqueCompiler
     )
 
-    lazy val techniqueCompilationCache: TechniqueCompilationStatusSyncService =
-      TechniqueCompilationErrorsActorSync.make(asyncDeploymentAgent, techniqueCompilationStatusService).runNow
+    lazy val techniqueCompilationCache: TechniqueCompilationStatusSyncService = {
+      val sync = TechniqueCompilationErrorsActorSync.make(asyncDeploymentAgent, techniqueCompilationStatusService).runNow
+      techniqueRepositoryImpl.registerCallback(new SyncCompilationStatusOnTechniqueCallback("SyncCompilationStatus", 10000, sync))
+      sync
+    }
 
     lazy val ncfTechniqueWriter: TechniqueWriter = new TechniqueWriterImpl(
       techniqueArchiver,
@@ -1932,6 +1935,7 @@ object RudderConfigInit {
         woDirectiveRepository,
         techniqueRepository,
         workflowLevelService,
+        techniqueCompilationCache,
         RUDDER_GIT_ROOT_CONFIG_REPO
       ),
       techniqueCompiler,


### PR DESCRIPTION
https://issues.rudder.io/issues/26023

The cache update had the semantics of : 
> for each result, add the current result in the cache of error, or remove if it is a success

But this leaves stale results in the cache, what we need is : 
> reset the cache to the error results

We also need to include the status update in the system reload actions, and update all techniques after a public API reload of techniques.   