### PR TITLE
Fixes #26022: Status should not be on error when there is technique compilator error on disable techniques

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1274,6 +1274,7 @@ object RudderConfig extends Loggable {
   val updateDynamicGroups:                 UpdateDynamicGroups                        = rci.updateDynamicGroups
   val updateDynamicGroupsService:          DynGroupUpdaterService                     = rci.updateDynamicGroupsService
   val updateTechniqueLibrary:              UpdateTechniqueLibrary                     = rci.updateTechniqueLibrary
+  val techniqueCompilationStatusService:   TechniqueCompilationStatusSyncService      = rci.techniqueCompilationStatusService
   val userPropertyService:                 UserPropertyService                        = rci.userPropertyService
   val userRepository:                      UserRepository                             = rci.userRepository
   val userService:                         UserService                                = rci.userService
@@ -1460,7 +1461,8 @@ case class RudderServiceApi(
     computeNodeStatusReportService:      ComputeNodeStatusReportService & HasNodeStatusReportUpdateHook,
     scoreRepository:                     ScoreRepository,
     propertiesRepository:                PropertiesRepository,
-    propertiesService:                   NodePropertiesService
+    propertiesService:                   NodePropertiesService,
+    techniqueCompilationStatusService:   TechniqueCompilationStatusSyncService
 )
 
 /*
@@ -1919,8 +1921,14 @@ object RudderConfigInit {
       techniqueCompiler
     )
 
+    lazy val techniqueStatusReaderService: ReadEditorTechniqueActiveStatus = new TechniqueActiveStatusService(
+      roDirectiveRepository
+    )
+
     lazy val techniqueCompilationCache: TechniqueCompilationStatusSyncService = {
-      val sync = TechniqueCompilationErrorsActorSync.make(asyncDeploymentAgent, techniqueCompilationStatusService).runNow
+      val sync = TechniqueCompilationErrorsActorSync
+        .make(asyncDeploymentAgent, techniqueCompilationStatusService, techniqueStatusReaderService)
+        .runNow
       techniqueRepositoryImpl.registerCallback(new SyncCompilationStatusOnTechniqueCallback("SyncCompilationStatus", 10000, sync))
       sync
     }
@@ -3839,7 +3847,8 @@ object RudderConfigInit {
       computeNodeStatusReportService,
       scoreRepository,
       propertiesRepository,
-      propertiesService
+      propertiesService,
+      techniqueCompilationCache
     )
 
     // start init effects

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
@@ -106,9 +106,10 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
   override def lowPriority: PartialFunction[Any, Unit] = {
     case msg: AsyncDeploymentActorCreateUpdate =>
       deploymentStatus = msg.deploymentStatus
-      compilationStatus = msg.compilationStatus
       nodeProperties = msg.nodeProperties
       groupProperties = msg.groupProperties
+      // we want to completely ignore rendering of disabled techniques, so we can directly adapt the received message
+      compilationStatus = CompilationStatus.ignoreDisabledTechniques(msg.compilationStatus)
       reRender()
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/26022

When the actor receives the message, we want to ignore disabled techniques, and only process the enabled one for display in the Lift frontend actor.
This adds the `status` field to the data in the cache, so that the frontend actor can ignore disabled one. This also means we have to "sync" the `status`, especially upon changing the status in the UI. The status is still looked up every time we "sync all techniques", so the API is also changed a bit to add the new `TechniqueActiveStatus` data type.  