### PR TITLE
Fixes #26000: 

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SharedFilesApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SharedFilesApiTest.scala
@@ -37,15 +37,10 @@
 
 package com.normation.rudder.rest
 
-import better.files.*
 import com.normation.JsonSpecMatcher
 import com.normation.rudder.rest.internal.SharedFilesAPI
-import com.normation.rudder.rest.internal.SharedFilesAPI.*
-import com.normation.zio.ZioRuntime
 import net.liftweb.common.Full
 import net.liftweb.http.JsonResponse
-import org.joda.time.DateTime
-import org.joda.time.format.ISODateTimeFormat
 import org.junit.runner.*
 import org.specs2.mutable.*
 import org.specs2.runner.*
@@ -53,50 +48,8 @@ import org.specs2.runner.*
 @RunWith(classOf[JUnitRunner])
 class SharedFilesApiTest extends Specification with JsonSpecMatcher {
 
-  // Setup temporary test files
-  val tmp:      File = File(s"/tmp/rudder-test-shared-files/${DateTime.now.toString(ISODateTimeFormat.dateTime())}")
-  tmp.createDirectoryIfNotExists(createParents = true)
-  val folder1:  File = tmp / "folder1"
-  folder1.createDirectoryIfNotExists()
-  val file1:    File = folder1 / "file1"
-  file1.createFile()
-  val file2:    File = tmp / "file2"
-  file2.createFile()
-  val symlink1: File = tmp / "symlink1"
-  symlink1.symbolicLinkTo(File("/etc"))
-
   val restTestSetUp = RestTestSetUp.newEnv
   val restTest      = new RestTest(restTestSetUp.liftRules)
-
-  "sanitize valid path" >> {
-    val tail = "/file2"
-    val res  = ZioRuntime.unsafeRun(sanitizePath(tail, tmp))
-    res.toString() must beEqualTo(tmp.toString() + "/file2")
-  }
-
-  "sanitize valid path with .." >> {
-    val tail = "/dir/../file2"
-    val res  = ZioRuntime.unsafeRun(sanitizePath(tail, tmp))
-    res.toString() must beEqualTo(tmp.toString() + "/file2")
-  }
-
-  "sanitize non-existing valid path" >> {
-    val tail = "/file42"
-    val res  = ZioRuntime.unsafeRun(sanitizePath(tail, tmp))
-    res.toString() must beEqualTo(tmp.toString() + "/file42")
-  }
-
-  "sanitize does prevent for traversal" >> {
-    val tail = "/../../.."
-    val res  = ZioRuntime.unsafeRun(sanitizePath(tail, tmp).isFailure)
-    res must beTrue
-  }
-
-  "sanitize does not follow symlinks" >> {
-    val tail = "/symlink1"
-    val res  = ZioRuntime.unsafeRun(sanitizePath(tail, tmp).isFailure)
-    res must beTrue
-  }
 
   "Testing resourceExplorer" >> {
     "uploading file" in {

--- a/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
@@ -173,6 +173,11 @@ object errors {
   // a generic error to tell "there is some (business logic related) Inconsistency"
   final case class Inconsistency(msg: String) extends RudderError
 
+  // a specialised subtype of error to indicate that the error is caused by security concern
+  trait SecurityError extends RudderError {
+    override def fullMsg: String = s"SecurityError: ${msg}"
+  }
+
   trait BaseChainError[E <: RudderError] extends RudderError {
     def cause: E
     def hint:  String

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/FileUtils.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/FileUtils.scala
@@ -1,0 +1,97 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.utils
+
+import better.files.File
+import com.normation.errors.IOResult
+import com.normation.errors.SecurityError
+import scala.annotation.tailrec
+import zio.ZIO
+import zio.syntax.*
+
+object FileUtils {
+
+  /**
+    * Our representation of error related to file handling and I/O
+    */
+  sealed trait FileError
+
+  object FileError {
+
+    /**
+      * Subcase of error for the logic of handling a file, which should be within a contained path to avoid path traversal.
+      * It is an important security error.
+      */
+    case class OutsideBaseDir(filename: Option[String], realPath: File) extends FileError with SecurityError {
+      override def msg: String = s"Unauthorized access to file ${filename.getOrElse("without name")} (real path: ${realPath})"
+    }
+
+  }
+
+  import FileError.*
+
+  def sanitizePath(baseFolder: File, child: String): IOResult[Either[OutsideBaseDir, File]] = {
+    sanitizePath(baseFolder, List(child))
+  }
+
+  def sanitizePath(baseFolder: File, path: List[String]): IOResult[Either[OutsideBaseDir, File]] = {
+
+    @tailrec def recPath(file: File, children: List[String]): File = {
+      // Actually canonifies the path
+      children match {
+        case Nil           =>
+          file
+        case child :: next =>
+          recPath(file / child.dropWhile(_.equals('/')), next)
+      }
+    }
+
+    val filePath = recPath(baseFolder, path)
+    // We also want to resolve symlinks before checking, let's resort to Java's `toRealPath`
+    for {
+      fileExists <- IOResult.attempt(filePath.exists())
+      realPath    = if (fileExists) File(filePath.toJava.toPath.toRealPath()) else filePath
+      withinBase <-
+        ZIO.whenZIO(IOResult.attempt(baseFolder.contains(realPath, strict = false))) { // `false` means we allow access to the base directory itself
+          realPath.succeed
+        }
+    } yield {
+      withinBase.toRight(OutsideBaseDir(filePath.nameOption, realPath))
+    }
+  }
+}

--- a/webapp/sources/utils/src/test/scala/com/normation/utils/FileUtilsTest.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/utils/FileUtilsTest.scala
@@ -1,0 +1,108 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+package com.normation.utils
+
+import better.files.File
+import better.files.File.root
+import com.normation.errors.SecurityError
+import com.normation.utils.FileUtils.*
+import com.normation.zio.ZioRuntime
+import org.joda.time.DateTime
+import org.joda.time.format.ISODateTimeFormat
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class FileUtilsTest extends Specification {
+  import FileError.*
+
+  // Setup temporary test files
+  val tmp:      File = File(s"/tmp/rudder-test-shared-files/${DateTime.now.toString(ISODateTimeFormat.dateTime())}")
+  tmp.createDirectoryIfNotExists(createParents = true)
+  val folder1:  File = tmp / "folder1"
+  folder1.createDirectoryIfNotExists()
+  val file1:    File = folder1 / "file1"
+  file1.createFile()
+  val file2:    File = tmp / "file2"
+  file2.createFile()
+  val symlink1: File = tmp / "symlink1"
+  symlink1.symbolicLinkTo(File("/etc"))
+
+  "sanitize valid path" >> {
+    val tail = "/file2"
+    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail))
+    res.map(_.pathAsString) must beRight(beEqualTo(tmp.toString() + "/file2"))
+  }
+
+  "sanitize valid path with .." >> {
+    val tail = "/dir/../file2"
+    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail))
+    res.map(_.pathAsString) must beRight(beEqualTo(tmp.toString() + "/file2"))
+  }
+
+  "sanitize a split path" >> {
+    val tail = "/dir" :: ".." :: "file2" :: Nil
+    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail))
+    res.map(_.pathAsString) must beRight(beEqualTo(tmp.toString() + "/file2"))
+  }
+
+  "sanitize non-existing valid path" >> {
+    val tail = "/file42"
+    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail))
+    res.map(_.pathAsString) must beRight(beEqualTo(tmp.toString() + "/file42"))
+  }
+
+  "sanitize does prevent for traversal" >> {
+    val tail = "/../../.."
+    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail))
+    (res must beLeft(beAnInstanceOf[SecurityError])) and (res must beLeft(OutsideBaseDir(None, root)))
+  }
+
+  "sanitize also prevents a split path" >> {
+    val tail = ".." :: ".." :: ".." :: Nil
+    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail))
+    (res must beLeft(beAnInstanceOf[SecurityError])) and (res must beLeft(OutsideBaseDir(None, root)))
+  }
+
+  "sanitize does not follow symlinks" >> {
+    val tail = "/symlink1"
+    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail))
+    (res must beLeft(beAnInstanceOf[SecurityError])) and (res must beLeft(OutsideBaseDir(Some("symlink1"), root / "etc")))
+  }
+
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/26000
Make a `sanitizePath` util method in a new file utils namespace object. In the long term we may want to add other errors related to file handling (permissions,size), and also other security errors.
So we should have base types, and the returned error should be part of the return type.