### PR TITLE
Fixes #26017: Migrate old internal EventLog APIs to zio-json

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
@@ -233,6 +233,10 @@ object GitArchiveLoggerPure extends NamedZioLogger {
   override def loggerName: String = "git-policy-archive"
 }
 
+object EventLogsLoggerPure extends NamedZioLogger {
+  def loggerName = "eventlogs"
+}
+
 object ConfigurationLoggerPure extends NamedZioLogger {
   def loggerName = "configuration"
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/json/JsonExctractorUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/json/JsonExctractorUtils.scala
@@ -89,7 +89,7 @@ trait JsonExtractorUtils[A[_]] {
   }
 
   /*
-   * Still used in apiaccount/eventlog API, tags
+   * Still used in apiaccount API, tags
    */
   def extractJsonString[T](json: JValue, key: String, convertTo: String => Box[T] = boxedIdentity[String]): Box[A[T]] = {
     extractJson(json, key, convertTo, { case JString(value) => value })
@@ -103,28 +103,7 @@ trait JsonExtractorUtils[A[_]] {
   }
 
   /*
-   * Still used in eventlog API
-   */
-  def extractJsonInt(json: JValue, key: String): Box[A[Int]] = {
-    extractJsonBigInt(json, key, i => Full(i.toInt))
-  }
-
-  /*
-   * Still used in eventlog API
-   */
-  def extractJsonBigInt[T](json: JValue, key: String, convertTo: BigInt => Box[T] = boxedIdentity[BigInt]): Box[A[T]] = {
-    extractJson(json, key, convertTo, { case JInt(value) => value })
-  }
-
-  /*
-   * Still used in eventlog API
-   */
-  def extractJsonObj[T](json: JValue, key: String, jsonValueFun: JObject => Box[T]): Box[A[T]] = {
-    extractJson(json, key, jsonValueFun, { case obj: JObject => obj })
-  }
-
-  /*
-   * Still used in tags, eventlog/apiaccount API
+   * Still used in tags, apiaccount API
    */
   def extractJsonArray[T](json: JValue, key: String)(convertTo: JValue => Box[T]):        Box[A[List[T]]] = {
     val trueJson =
@@ -141,7 +120,7 @@ trait JsonExtractorUtils[A[_]] {
     }
   }
   /*
-   * Still used in tags, eventlog/apiaccount API
+   * Still used in tags, apiaccount API
    */
   def extractJsonArray[T](json: JValue, keys: List[String])(convertTo: JValue => Box[T]): Box[A[List[T]]] = {
     keys.map(k => extractJsonArray(json, k)(convertTo)).reduce[Box[A[List[T]]]] {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala
@@ -295,10 +295,7 @@ object OldInternalApiAuthz {
     }
   }
 
-  def withReadAdmin(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
-    withPerm(CurrentUser.checkRights(Administration.Read), resp)
-  }
-
+  // Still used in RestApiAccounts
   def withWriteAdmin(resp: => LiftResponse)(implicit action: String, prettify: Boolean): LiftResponse = {
     withPerm(CurrentUser.checkRights(Administration.Write) || CurrentUser.checkRights(Administration.Edit), resp)
   }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -212,6 +212,34 @@ object ComplianceApi       extends Enum[ComplianceApi] with ApiModuleProvider[Co
   def values = findValues
 }
 
+sealed trait EventLogApi extends EnumEntry with EndpointSchema with SortIndex {
+  override def dataContainer: Option[String] = None
+}
+
+object EventLogApi extends Enum[EventLogApi] with ApiModuleProvider[EventLogApi] {
+  case object GetEventLogs extends EventLogApi with InternalApi with ZeroParam with StartsAtVersion2 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Get event logs based on filters"
+    val (action, path) = POST / "eventlog"
+  }
+
+  case object GetEventLogDetails extends EventLogApi with InternalApi with OneParam with StartsAtVersion2 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Get details of a specific event log"
+    val (action, path) = GET / "eventlog" / "{id}" / "details"
+  }
+
+  case object RollbackEventLog extends EventLogApi with InternalApi with OneParam with StartsAtVersion2 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Rollback a specific event log"
+    val (action, path) = GET / "eventlog" / "{id}" / "details" / "rollback"
+  }
+
+  def endpoints: List[EventLogApi] = values.toList.sortBy(_.z)
+
+  def values = findValues
+}
+
 sealed trait GroupApi extends EnumEntry with EndpointSchema with SortIndex    {
   override def dataContainer: Option[String] = Some("groups")
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -191,7 +191,7 @@ final case class RestExtractorService(
   }
 
   /*
-   * Still used in technique/eventlog/apiaccounts API
+   * Still used in technique/apiaccounts API
    */
   def extractBoolean[T](key: String)(req: Req)(fun: Boolean => T): Box[Option[T]] = {
     req.json match {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
@@ -111,7 +111,7 @@ object AuthorizationApiMapping {
         // Administration is Rudder setting
 
         case Administration.Read  =>
-          SettingsApi.GetAllSettings.x :: SettingsApi.GetSetting.x :: SystemApi.ArchivesDirectivesList.x ::
+          EventLogApi.GetEventLogs.x :: EventLogApi.GetEventLogDetails.x :: SettingsApi.GetAllSettings.x :: SettingsApi.GetSetting.x :: SystemApi.ArchivesDirectivesList.x ::
           SystemApi.ArchivesFullList.x :: SystemApi.ArchivesGroupsList.x :: SystemApi.ArchivesRulesList.x ::
           SystemApi.GetAllZipArchive.x :: SystemApi.GetDirectivesZipArchive.x :: SystemApi.GetGroupsZipArchive.x ::
           SystemApi.GetRulesZipArchive.x :: SystemApi.Info.x :: SystemApi.Status.x :: SystemApi.ArchivesParametersList.x ::
@@ -120,7 +120,7 @@ object AuthorizationApiMapping {
             _.x
           )
         case Administration.Write =>
-          PluginApi.UpdatePluginsSettings.x :: SettingsApi.ModifySettings.x :: SettingsApi.ModifySetting.x ::
+          EventLogApi.RollbackEventLog.x :: PluginApi.UpdatePluginsSettings.x :: SettingsApi.ModifySettings.x :: SettingsApi.ModifySetting.x ::
           InventoryApi.FileWatcherRestart.x :: InventoryApi.FileWatcherStart.x :: InventoryApi.FileWatcherStop.x ::
           NodeApi.CreateNodes.x :: SystemApi.endpoints.map(_.x)
         case Administration.Edit  =>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/EventLog.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/EventLog.scala
@@ -1,0 +1,229 @@
+/*
+ *************************************************************************************
+ * Copyright 2019 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+package com.normation.rudder.rest.data
+
+import com.normation.eventlog.EventActor
+import com.normation.eventlog.EventLog
+import com.normation.eventlog.EventLogType
+import com.normation.rudder.web.services.EventLogDetailsGenerator
+import com.normation.utils.DateFormaterService
+import doobie.util.Write
+import enumeratum.Enum
+import enumeratum.EnumEntry.Lowercase
+import enumeratum.EnumEntry.Uppercase
+import io.scalaland.chimney.Transformer
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import org.joda.time.DateTime
+import scala.xml.NodeSeq
+import zio.Chunk
+import zio.json.*
+
+/**
+  * Representation of an event log in the Rest API.
+  * This is data in the table of event logs
+  */
+final case class RestEventLog(
+    id:                              Option[Int],
+    @jsonField("date") creationDate: DateTime,
+    actor:                           EventActor,
+    @jsonField("type") eventType:    String,
+    description:                     NodeSeq,
+    hasDetails:                      Boolean
+)
+
+object RestEventLog {
+
+  // We still have Joda DateTime because we map an event log field using chimney
+  implicit val datetimeEncoder:    JsonEncoder[DateTime]     = JsonEncoder[String].contramap(DateFormaterService.getDisplayDate)
+  implicit val eventActorEncoder:  JsonEncoder[EventActor]   = JsonEncoder[String].contramap(_.name)
+  implicit val descriptionEncoder: JsonEncoder[NodeSeq]      = JsonEncoder[String].contramap(_.toString())
+  implicit val encoder:            JsonEncoder[RestEventLog] = DeriveJsonEncoder.gen[RestEventLog]
+
+  // For localization we need to transform eventType using translation, passing liftweb.S is not so elegant
+  // so we need a conversion (poke at Scala 3's Conversion)
+  implicit def transformer(implicit
+      translateEventType: EventLogType => String,
+      eventLogDetail:     EventLogDetailsGenerator
+  ): Transformer[EventLog, RestEventLog] = {
+    Transformer
+      .define[EventLog, RestEventLog]
+      .enableMethodAccessors // because source is a trait
+      .withFieldComputed(
+        _.actor,
+        _.principal
+      )
+      .withFieldComputed(
+        _.eventType,
+        e => translateEventType(e.eventType)
+      )
+      .withFieldComputed(
+        _.description,
+        eventLogDetail.displayDescription(_)
+      )
+      .withFieldComputed(
+        _.hasDetails,
+        _.details != <entry></entry>
+      )
+      .buildTransformer
+  }
+}
+
+/**
+  * Response data from the event log API : 
+  * - success has non-empty "data"
+  * - error has "error" message
+  */
+sealed trait RestEventLogResponse {
+  def draw:            Int
+  def recordsTotal:    Long
+  def recordsFiltered: Long
+}
+final case class RestEventLogSuccess(
+    draw:            Int,
+    recordsTotal:    Long,
+    recordsFiltered: Long,
+    data:            Seq[RestEventLog]
+) extends RestEventLogResponse
+object RestEventLogSuccess        {
+  implicit val encoder: JsonEncoder[RestEventLogSuccess] = DeriveJsonEncoder.gen[RestEventLogSuccess]
+}
+
+final case class RestEventLogError private[data] (
+    draw:            Int = 0,
+    recordsTotal:    Long = 0,
+    recordsFiltered: Long = 0,
+    data:            String = "",
+    error:           String
+) extends RestEventLogResponse
+
+object RestEventLogError {
+  implicit val encoder: JsonEncoder[RestEventLogError] = DeriveJsonEncoder.gen[RestEventLogError]
+
+  def apply(errorMessage: String): RestEventLogError = RestEventLogError(error = errorMessage)
+}
+
+final case class RestEventLogFilter(
+    draw:      Int,
+    start:     Int,
+    length:    Int,
+    search:    Option[RestEventLogFilter.Search],
+    startDate: Option[LocalDateTime],
+    endDate:   Option[LocalDateTime],
+    order:     Chunk[RestEventLogFilter.Order]
+)
+
+object RestEventLogFilter {
+
+  final case class Search(value: String)
+  object Search {
+    implicit val decoder: JsonDecoder[Search] = DeriveJsonDecoder.gen[Search]
+  }
+
+  // columns and direction are directly used for database query
+  // the case does not really matter for the parsing and serialization, we use the old one
+
+  sealed abstract class Column(val id: Int) extends Lowercase
+  object Column                             extends Enum[Column]    {
+    case object ID           extends Column(0)
+    case object CreationDate extends Column(1)
+    case object Principal    extends Column(2)
+    case object EventType    extends Column(3)
+
+    override def values: IndexedSeq[Column] = findValues
+
+    def fromId(id: Int): Either[String, Column] = {
+      values
+        .find(_.id == id)
+        .toRight(s"Not a valid column id : ${id}, columns are ${values.map(c => s"${c.id}=${c.entryName}").mkString(",")}")
+    }
+
+    implicit val decoder: JsonDecoder[Column] = JsonDecoder[Int].mapOrFail(fromId)
+    implicit val write:   Write[Column]       = Write[String].contramap(_.entryName)
+  }
+  sealed trait Direction                    extends Uppercase
+  object Direction                          extends Enum[Direction] {
+    case object Desc extends Direction
+    case object Asc  extends Direction
+
+    override def values: IndexedSeq[Direction] = findValues
+
+    def parse(s: String): Either[String, Direction] =
+      withNameInsensitiveEither(s).left.map(e => s"not a valid sorting order: ${e.notFoundName}")
+    implicit val decoder: JsonDecoder[Direction]    = JsonDecoder[String].mapOrFail(parse(_))
+  }
+  final case class Order(column: Column, dir: Direction)
+  object Order {
+    implicit val decoder: JsonDecoder[Order] = DeriveJsonDecoder.gen[Order]
+  }
+
+  implicit val localDateTimeDecoder: JsonDecoder[LocalDateTime] = {
+    val format = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+    JsonDecoder[String].map(LocalDateTime.parse(_, format))
+  }
+
+  implicit val decoder: JsonDecoder[RestEventLogFilter] = DeriveJsonDecoder.gen[RestEventLogFilter]
+}
+
+final case class RestEventLogDetails(
+    id:          String,
+    content:     NodeSeq,
+    canRollback: Boolean
+)
+object RestEventLogDetails {
+  implicit val contentEncoder: JsonEncoder[NodeSeq]             = JsonEncoder[String].contramap(_.toString())
+  implicit val encoder:        JsonEncoder[RestEventLogDetails] = DeriveJsonEncoder.gen[RestEventLogDetails]
+}
+
+final case class RestEventLogRollback(
+    action: RestEventLogRollback.Action,
+    id:     String
+)
+
+object RestEventLogRollback {
+  sealed trait Action extends Lowercase
+  object Action       extends Enum[Action] {
+    case object After  extends Action
+    case object Before extends Action
+
+    override def values: IndexedSeq[Action] = findValues
+
+    implicit val encoder: JsonEncoder[Action] = JsonEncoder[String].contramap(_.entryName)
+  }
+
+  implicit val encoder: JsonEncoder[RestEventLogRollback] = DeriveJsonEncoder.gen[RestEventLogRollback]
+}

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_eventlogs.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_eventlogs.yml
@@ -1,0 +1,288 @@
+description: Get event logs with valid filters
+method: POST
+url: /secure/api/eventlog
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "draw": 5,
+    "columns": [
+      {
+        "data": "id",
+        "name": "",
+        "searchable": true,
+        "orderable": true,
+        "search": {
+          "value": "",
+          "regex": false
+        }
+      },
+      {
+        "data": "date",
+        "name": "",
+        "searchable": true,
+        "orderable": true,
+        "search": {
+          "value": "",
+          "regex": false
+        }
+      },
+      {
+        "data": "actor",
+        "name": "",
+        "searchable": true,
+        "orderable": true,
+        "search": {
+          "value": "",
+          "regex": false
+        }
+      },
+      {
+        "data": "type",
+        "name": "",
+        "searchable": true,
+        "orderable": true,
+        "search": {
+          "value": "",
+          "regex": false
+        }
+      },
+      {
+        "data": "description",
+        "name": "",
+        "searchable": true,
+        "orderable": false,
+        "search": {
+          "value": "",
+          "regex": false
+        }
+      }
+    ],
+    "order": [
+      {
+        "column": 0,
+        "dir": "desc"
+      }
+    ],
+    "start": 0,
+    "length": 25,
+    "search": {
+      "value": "",
+      "regex": false
+    },
+    "startDate": "2024-12-04 15:31:15",
+    "endDate": "2024-12-04 15:30:54"
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "draw" : 5,
+      "recordsTotal" : 0,
+      "recordsFiltered" : 0,
+      "data" : [
+        {
+          "id" : 42,
+          "date" : "2024-12-04 15:30:10+0100",
+          "actor" : "test",
+          "type" : "NodeGroupModified",
+          "description" : "Group ",
+          "hasDetails" : true
+        }
+      ]
+    }
+---
+description: Get event logs with invalid column value
+method: POST
+url: /secure/api/eventlog
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "draw": 5,
+    "columns": [
+      {
+        "data": "id",
+        "name": "",
+        "searchable": true,
+        "orderable": true,
+        "search": {
+          "value": "",
+          "regex": false
+        }
+      }
+    ],
+    "order": [
+      {
+        "column": -1,
+        "dir": "desc"
+      }
+    ],
+    "start": 0,
+    "length": 25,
+    "search": {
+      "value": "",
+      "regex": false
+    },
+    "startDate": "2024-12-04 15:31:15",
+    "endDate": "2024-12-04 15:30:54"
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "draw" : 0,
+      "recordsTotal" : 0,
+      "recordsFiltered" : 0,
+      "data" : "",
+      "error" : "Error when fetching event logs; cause was: Unexpected: .order[0].column(Not a valid column id : -1, columns are 0=id,1=creationdate,2=principal,3=eventtype)"
+    }
+---
+description: Get event logs with invalid direction value
+method: POST
+url: /secure/api/eventlog
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "draw": 5,
+    "columns": [
+      {
+        "data": "id",
+        "name": "",
+        "searchable": true,
+        "orderable": true,
+        "search": {
+          "value": "",
+          "regex": false
+        }
+      }
+    ],
+    "order": [
+      {
+        "column": 1,
+        "dir": "d"
+      }
+    ],
+    "start": 0,
+    "length": 25,
+    "search": {
+      "value": "",
+      "regex": false
+    },
+    "startDate": "2024-12-04 15:31:15",
+    "endDate": "2024-12-04 15:30:54"
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "draw" : 0,
+      "recordsTotal" : 0,
+      "recordsFiltered" : 0,
+      "data" : "",
+      "error" : "Error when fetching event logs; cause was: Unexpected: .order[0].dir(not a valid sorting order: d)"
+    }
+---
+description: Get event logs with missing order direction
+method: POST
+url: /secure/api/eventlog
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "draw": 5,
+    "columns": [
+      {
+        "data": "id",
+        "name": "",
+        "searchable": true,
+        "orderable": true,
+        "search": {
+          "value": "",
+          "regex": false
+        }
+      }
+    ],
+    "order": [
+      {
+        "column": 1
+      }
+    ],
+    "start": 0,
+    "length": 25,
+    "search": {
+      "value": "",
+      "regex": false
+    },
+    "startDate": "2024-12-04 15:31:15",
+    "endDate": "2024-12-04 15:30:54"
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "draw" : 0,
+      "recordsTotal" : 0,
+      "recordsFiltered" : 0,
+      "data" : "",
+      "error" : "Error when fetching event logs; cause was: Unexpected: .order[0].dir(missing)"
+    }
+---
+description: Get details of a specific event log
+method: GET
+url: /secure/api/eventlog/1/details
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getEventLogDetails",
+      "result" : "success",
+      "data" : {
+        "id" : "1",
+        "content" : "<div class=\"py-2 flex-fill\">\n        \n          <div class=\"evloglmargin\">\n            <h5>Details for that node were not in a recognized format.\n              Raw data are displayed next:</h5><button id=\"showParameters42\" class=\"btn btn-default showParameters\">\n              <b class=\"action\">Show</b>\n              raw technical details\n            </button><pre id=\"showParametersInfo42\" style=\"display:none;\" class=\"technical-details\">&lt;test/&gt;\n</pre>\n          </div>\n        \n      </div>",
+        "canRollback" : true
+      }
+    }
+---
+description: Rollback a specific event log after
+method: GET
+url: /secure/api/eventlog/1/details/rollback?action=after
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "rollbackEventLog",
+      "result" : "success",
+      "data" : {
+        "action" : "after",
+        "id" : "1"
+      }
+    }
+---
+description: Rollback a specific event log with multiple action
+method: GET
+url: /secure/api/eventlog/1/details/rollback?action=some&action=other
+response:
+  code: 500
+  content: >-
+    {
+      "action" : "rollbackEventLog",
+      "result" : "error",
+      "errorDetails" : "Error when performing eventlog's rollback with id '1'; cause was: Inconsistency: Only one action is excepted, 2 found in request : some,other"
+    }
+
+
+---
+description: Rollback a specific event log with invalid action
+method: GET
+url: /secure/api/eventlog/1/details/rollback?action=unknown
+response:
+  code: 500
+  content: >-
+    {
+      "action" : "rollbackEventLog",
+      "result" : "error",
+      "errorDetails" : "Error when performing eventlog's rollback with id '1'; cause was: Inconsistency: Unknown rollback's action : unknown"
+    }
+

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
@@ -92,7 +92,7 @@ class TestRestFromFileDef extends ZIOSpecDefault {
                yamlSourceDirectory,
                yamlDestTmpDirectory,
                restTestSetUp.liftRules,
-               Nil,
+               List("api_eventlogs.yml"),
                transformations
              )
         _ <- effectUioUnit(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -521,7 +521,6 @@ class Boot extends Loggable {
     LiftRules.statelessDispatch.append(RudderConfig.restQuicksearch)
     LiftRules.statelessDispatch.append(RudderConfig.restCompletion)
     LiftRules.statelessDispatch.append(RudderConfig.sharedFileApi)
-    LiftRules.statelessDispatch.append(RudderConfig.eventLogApi)
     // REST API (all public/internal API)
     // we need to add "info" API here to have all used API (even plugins)
     val infoApi = {


### PR DESCRIPTION
https://issues.rudder.io/issues/26017

This is the migration of an old internal API : the one for event logs with 3 endpoints.
API YAML tests were added for all endpoints, and the only complexity apart from adding tests is to ensure that the json model are translated correctly in existing doobie queries.

The API endpoints schema were migrated as is, even though they may be changed (`GET /eventlog/id/details/rollback?action=before` is a really weird one, hopefully it's only for internal use in the JS ajax client)