### PR TITLE
Fixes #26064: Group query select attribute has different name in create and update payload

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -271,13 +271,13 @@ object JsonQueryObjects {
   }
 
   final case class JQStringQuery(
-      returnType:  Option[QueryReturnType],
+      select:      Option[QueryReturnType],
       composition: Option[String],
       transform:   Option[String],
       where:       Option[List[StringCriterionLine]]
   ) {
     def toQueryString: StringQuery =
-      StringQuery(returnType.getOrElse(NodeReturnType), composition, transform, where.getOrElse(Nil))
+      StringQuery(select.getOrElse(NodeReturnType), composition, transform, where.getOrElse(Nil))
   }
 
   final case class GroupPatch(
@@ -418,7 +418,8 @@ trait RudderJsonDecoders {
   // Rest group
   implicit val nodeGroupCategoryIdDecoder:      JsonDecoder[NodeGroupCategoryId] = JsonDecoder[String].map(NodeGroupCategoryId.apply)
   implicit val queryStringCriterionLineDecoder: JsonDecoder[StringCriterionLine] = DeriveJsonDecoder.gen
-  implicit val queryReturnTypeDecoder:          JsonDecoder[QueryReturnType]     = DeriveJsonDecoder.gen
+  implicit val queryReturnTypeDecoder:          JsonDecoder[QueryReturnType]     =
+    JsonDecoder[String].mapOrFail(QueryReturnType.apply(_).left.map(_.fullMsg))
   implicit val queryDecoder:                    JsonDecoder[StringQuery]         = DeriveJsonDecoder.gen[JQStringQuery].map(_.toQueryString)
   implicit val groupPropertyDecoder:            JsonDecoder[JQGroupProperty]     = DeriveJsonDecoder.gen
   implicit val groupPropertyDecoder2:           JsonDecoder[GroupProperty]       = JsonDecoder[JQGroupProperty].map(_.toGroupProperty)

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
@@ -1050,6 +1050,78 @@ response:
       }
     }
 ---
+description: Update a node group query
+method: POST
+url: /api/latest/groups/00000000-cb9d-4f7b-abda-ca38c5d643ea
+headers:
+  - "Content-Type: application/json"
+body: >-
+  {
+    "id": "00000000-cb9d-4f7b-abda-ca38c5d643ea",
+    "query": {
+      "select": "nodeAndPolicyServer",
+      "composition": "and",
+      "transform": "invert",
+      "where":[
+        {
+          "objectType": "node",
+          "attribute": "nodeId",
+          "comparator": "eq",
+          "value": "11111111-cb9d-4f7b-abda-ca38c5d643ea"
+        }
+      ]
+    }
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action":"updateGroup",
+      "id":"00000000-cb9d-4f7b-abda-ca38c5d643ea",
+      "result":"success",
+      "data":{
+        "groups":[
+          {
+            "id":"00000000-cb9d-4f7b-abda-ca38c5d643ea",
+            "displayName":"clone from api of debian group",
+            "description":"Some long description",
+            "category":"GroupRoot",
+            "query": {
+              "select": "nodeAndPolicyServer",
+              "composition": "and",
+              "transform": "invert",
+              "where":[
+                {
+                  "objectType": "node",
+                  "attribute": "nodeId",
+                  "comparator": "eq",
+                  "value": "11111111-cb9d-4f7b-abda-ca38c5d643ea"
+                }
+              ]
+            },
+            "nodeIds":[],
+            "dynamic":true,
+            "enabled":true,
+            "groupClass":[
+              "group_00000000_cb9d_4f7b_abda_ca38c5d643ea",
+              "group_clone_from_api_of_debian_group"
+            ],
+            "properties":[
+              {
+                "name":"os",
+                "value":{
+                  "name":"debian",
+                  "nickname":"Buster"
+                }
+              }
+            ],
+            "target":"group:00000000-cb9d-4f7b-abda-ca38c5d643ea",
+            "system":false
+          }
+        ]
+      }
+    }
+---
 description: Move a node group to a new category
 method: POST
 url: /api/latest/groups/3fa29229-1a4b-4fd6-9edd-af114289fc9a


### PR DESCRIPTION
https://issues.rudder.io/issues/26064

This is breaking but the previous case was actually not what was in [the documentation](https://docs.rudder.io/api/v/20/#tag/Groups/operation/createGroup) : the previous `returnType` needed to be the default zio-json sealed trait payload with the type discriminator as key : `"returnType":{"NodeAndRootServerReturnType":""}`.