### PR TITLE
Fixes #26070: Add tests and clean-up JsDataLine structures

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/JsonSerializers.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/JsonSerializers.scala
@@ -160,10 +160,10 @@ trait InventoryJsonEncodersHumanized { self: InventoryCommonJsonEncoders with In
   }
   import PrivateHumanizedEncoders.*
 
-  // Bios needs to be overriden with the humanized Datetime encoder
+  // Bios needs to be overridden with the humanized Datetime encoder
   implicit override val encoderBios: JsonEncoder[Bios] = DeriveJsonEncoder.gen[Bios]
 
-  // any datastructure depending on an encoder of MemorySize will need to be overriden
+  // any datastructure depending on an encoder of MemorySize will need to be overridden
   implicit override val encoderMemorySize: JsonEncoder[MemorySize] = JsonEncoder[Long].contramap(MemorySize.sizeMb)
 
   implicit override val encoderFileSystem: JsonEncoder[FileSystem] = DeriveJsonEncoder.gen[FileSystem]

--- a/webapp/sources/rudder/rudder-core/src/main/resources/ldap/rudder.schema
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/ldap/rudder.schema
@@ -336,7 +336,7 @@ attributetype ( RudderAttributes:302
 # but we need to wait for rudder 7.0 before removing it
 attributetype ( RudderAttributes:303
   NAME 'overridable'
-  DESC 'Define if the parameter may be overriden'
+  DESC 'Define if the parameter may be overridden'
   EQUALITY booleanMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.7  )
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleApplicationStatus.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleApplicationStatus.scala
@@ -65,7 +65,7 @@ object ApplicationStatus {
       case PartiallyApplied(seq) =>
         val why = seq.map { case (at, d) => "Directive '" + d.name + "' disabled" }.mkString(", ")
         ("Partially applied", Some(why))
-      case x: NotAppliedStatus =>
+      case _: NotAppliedStatus =>
         val (status, disabledMessage) = {
           if ((!rule.isEnabled) && (!rule.isEnabledStatus)) {
             ("Disabled", Some("This rule is disabled. "))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -366,7 +366,7 @@ class LDAPEntityMapper(
   */
   def overrideProperties(nodeId: NodeId, existing: Seq[NodeProperty], inventory: List[NodeProperty]): List[NodeProperty] = {
     val customProperties = inventory.map(x => (x.name, x)).toMap
-    val overriden        = existing.map { current =>
+    val overridden       = existing.map { current =>
       customProperties.get(current.name) match {
         case None         => current
         case Some(custom) =>
@@ -386,9 +386,9 @@ class LDAPEntityMapper(
     }
 
     // now, filter remaining inventory properties (ie the one not already processed)
-    val alreadyDone = overriden.map(_.name).toSet
+    val alreadyDone = overridden.map(_.name).toSet
 
-    (overriden ++ inventory.filter(x => !alreadyDone.contains(x.name))).toList
+    (overridden ++ inventory.filter(x => !alreadyDone.contains(x.name))).toList
   }
 
   /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
@@ -408,7 +408,7 @@ final case class Policy(
     policyMode:          Option[PolicyMode],
     ruleOrder:           BundleOrder,
     directiveOrder:      BundleOrder,
-    overrides:           Set[PolicyId] // a set of other draft overriden by that one
+    overrides:           Set[PolicyId] // a set of other draft overridden by that one
 ) {
 
   // here, it is extremely important to keep sorted order
@@ -552,7 +552,7 @@ final case class BoundPolicyDraft(
     policyMode:      Option[PolicyMode],
     ruleOrder:       BundleOrder,
     directiveOrder:  BundleOrder,
-    overrides:       Set[PolicyId] // a set of other draft overriden by that one
+    overrides:       Set[PolicyId] // a set of other draft overridden by that one
 ) {
 
   /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -1680,8 +1680,8 @@ trait PromiseGeneration_setExpectedReports extends PromiseGenerationService {
     val updatedNodeIds = updatedNodes.keySet
     allNodeConfigurations.collect {
       case (nodeId, nodeConfig) if (updatedNodeIds.contains(nodeId)) =>
-        // overrides are in the reverse way, we need to transform them into OverridenPolicy
-        val overrides = nodeConfig.policies.flatMap(p => p.overrides.map(overriden => OverriddenPolicy(overriden, p.id)))
+        // overrides are in the reverse way, we need to transform them into OverriddenPolicy
+        val overrides = nodeConfig.policies.flatMap(p => p.overrides.map(overridden => OverriddenPolicy(overridden, p.id)))
 
         NodeExpectedReports(
           nodeId,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
@@ -1022,7 +1022,7 @@ class InternalLDAPQueryProcessor(
       // Compute in one go all data for a filter, fails if one filter fails to build
       q.criteria.traverse {
         case crit @ CriterionLine(ot, a, comp, value) =>
-          // objectType may be overriden in the attribute (for node state).
+          // objectType may be overridden in the attribute (for node state).
           val objectType = a.overrideObjectType.getOrElse(ot.objectType)
 
           // Validate that for each object type in criteria, we know it

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -69,6 +69,7 @@ import com.normation.rudder.domain.archives.RuleArchiveId
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.policies.*
+import com.normation.rudder.domain.policies.PolicyMode.Audit
 import com.normation.rudder.domain.properties.*
 import com.normation.rudder.domain.properties.GenericProperty.StringToConfigValue
 import com.normation.rudder.domain.properties.Visibility.Hidden
@@ -584,8 +585,8 @@ class MockDirectives(mockTechniques: MockTechniques) {
     /*
      * Test override order of generic-variable-definition.
      * We want to have to directive, directive1 and directive2.
-     * directive1 is the default value and must be overriden by value in directive 2, which means that directive2 value must be
-     * define after directive 1 value in generated "genericVariableDefinition.cf".
+     * directive1 is the default value and must be overridden by value in directive 2, which means that directive2 value must be
+     * defined after directive 1 value in generated "genericVariableDefinition.cf".
      * The semantic to achieve that is to use Priority: directive 1 has a higher (ie smaller int number) priority than directive 2.
      *
      * To be sure that we don't use rule/directive name order, we will make directive 2 sort name come before directive 1 sort name.
@@ -623,6 +624,27 @@ class MockDirectives(mockTechniques: MockTechniques) {
       10
     )
 
+    /*
+     * a directive for testing blocks
+     */
+    val DIRECTIVE_TECHNIQUE_WITH_BLOCKS = "directive-technique_with_blocks"
+    val techniqueWithBlocksTechnique: Technique =
+      techniqueRepos.unsafeGet(TechniqueId(TechniqueName("technique_with_blocks"), TV("1.0")))
+    val techniqueWithBlocksDirective: Directive = Directive(
+      DirectiveId(DirectiveUid("directive-techniqueWithBlocks"), GitVersion.DEFAULT_REV),
+      TV("1.0"),
+      Map(
+        ("path", Seq("/tmp/root2")),
+        ("command", Seq("/bin/true #root1"))
+      ),
+      "25. Testing blocks",
+      """a short "description' with quotes""",
+      Some(Audit),
+      "a documentation *with markdown*",
+      _isEnabled = true,
+      tags = Tags.fromMaps(List(Map("aTagName" -> "the tagName value")))
+    )
+
     val all = Map(
       (commonTechnique, commonDirective :: Nil),
       (inventoryTechnique, inventoryDirective :: Nil),
@@ -640,7 +662,8 @@ class MockDirectives(mockTechniques: MockTechniques) {
       (ncf1Technique, ncf1Directive :: Nil),
       (pkgTechnique, pkgDirective :: Nil),
       (archiveTechnique, archiveDirective :: Nil),
-      (rpmTechnique, rpmDirective :: Nil)
+      (rpmTechnique, rpmDirective :: Nil),
+      (techniqueWithBlocksTechnique, techniqueWithBlocksDirective :: Nil)
     )
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/PolicyModeTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/PolicyModeTest.scala
@@ -97,8 +97,8 @@ class PolicyModeTest extends Specification with Loggable {
      * Here we are testing the truth table for:
      * - global: audit, overidable
      * - node  : enforce, overiable
-     * - { d1 , d2 } in { audit, enforne, not overriden }
-     * (so when not overriden, the detault is enforce)
+     * - { d1 , d2 } in { audit, enforne, not overridden }
+     * (so when not overridden, the detault is enforce)
      */
 
     def mode(d1: Option[PolicyMode], d2: Option[PolicyMode]) = {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
@@ -1397,7 +1397,7 @@ class TestNodeConfiguration(
   /*
    * Test override order of generic-variable-definition.
    * We want to have to directive, directive1 and directive2.
-   * directive1 is the default value and must be overriden by value in directive 2, which means that directive2 value must be
+   * directive1 is the default value and must be overridden by value in directive 2, which means that directive2 value must be
    * define after directive 1 value in generated "genericVariableDefinition.cf".
    * The semantic to achieve that is to use Priority: directive 1 has a higher (ie smaller int number) priority than directive 2.
    *

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ReportingServiceUtilsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ReportingServiceUtilsTest.scala
@@ -88,7 +88,7 @@ class ReportingServiceUtilsTest extends Specification {
     OverriddenPolicy(
       PolicyId(overridden, directive, TechniqueVersionHelper("1.0")), // this one is
 
-      PolicyId(overrider, directive, TechniqueVersionHelper("1.0")) // overriden by that one
+      PolicyId(overrider, directive, TechniqueVersionHelper("1.0")) // overridden by that one
     )
   }
   // a case where two directive from the same unique technique are on two rules
@@ -154,7 +154,7 @@ class ReportingServiceUtilsTest extends Specification {
   }
 
   /*
-   * rule1/dir1 on node1 is overriden (and node has nothing) => skipped
+   * rule1/dir1 on node1 is overridden (and node has nothing) => skipped
    */
   "only overridden leads to skip" in {
     val reports = List(
@@ -235,7 +235,7 @@ class ReportingServiceUtilsTest extends Specification {
    * - 3 rules: rule1 has dir2, dir3 (skipped),  rule2 has all 3 (so dir1 ok, other skipped), rule3 has all 3 (skipped)
    * There is no duplication of reports.
    */
-  "a rule not overridden on all nodes is not written overriden" in {
+  "a rule not overridden on all nodes is not written overridden" in {
     val reports = List(
       NodeStatusReportInternal
         .buildWith(

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
@@ -244,7 +244,7 @@ final case class SkippedDetails(
     overridingRuleName: String
 )
 final case class DirectiveComplianceOverride(
-    overridenRuleId:  RuleId,
+    overriddenRuleId: RuleId,
     directiveId:      DirectiveId,
     directiveName:    String,
     overridingRuleId: RuleId
@@ -274,16 +274,16 @@ final case class DirectiveComplianceOverride(
 }
 
 object ComplianceOverrides {
-  def getOverridenDirective(
+  def getOverriddenDirective(
       overrides:  List[OverriddenPolicy],
       directives: Map[DirectiveId, (FullActiveTechnique, Directive)]
   ): List[DirectiveComplianceOverride] = {
     val overridesData = for {
       over               <- overrides
-      (_, overridenDir)  <- directives.get(over.policy.directiveId)
+      (_, overriddenDir) <- directives.get(over.policy.directiveId)
       (_, overridingDir) <- directives.get(over.overriddenBy.directiveId)
     } yield {
-      DirectiveComplianceOverride(over.policy.ruleId, over.policy.directiveId, overridenDir.name, over.overriddenBy.ruleId)
+      DirectiveComplianceOverride(over.policy.ruleId, over.policy.directiveId, overriddenDir.name, over.overriddenBy.ruleId)
 
     }
     overridesData.toList

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -1553,15 +1553,15 @@ class ComplianceAPIService(
   ): IOResult[MapView[RuleId, List[T]]] = {
     // make a map of directive overrides for each rule, to add to the directives of a rule
     val directiveOverridesByRules = initialRuleObjects.keys.map { ruleId =>
-      val overridenDirectives = ComplianceOverrides
-        .getOverridenDirective(
+      val overriddenDirectives = ComplianceOverrides
+        .getOverriddenDirective(
           ReportingServiceUtils.buildRuleStatusReport(ruleId, reports).overrides,
           directives
         )
-      ruleId -> overridenDirectives
+      ruleId -> overriddenDirectives
     }.toMap
 
-    // we need to fetch info for rules pulled from overriden directives of our rules
+    // we need to fetch info for rules pulled from overridden directives of our rules
 
     ZIO
       .foreach(

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/ComputePolicyMode.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/ComputePolicyMode.scala
@@ -105,14 +105,14 @@ object ComputePolicyMode {
       case (Some(Audit), Some(Enforce))   =>
         (
           Audit,
-          "The <i><b>Directive</b></i> is configured to <b class='text-Enforce'>enforce</b> but is overriden to <b>audit</b> by this <i><b>Node</b></i>. "
+          """The <i><b>Directive</b></i> is configured to <b class="text-Enforce">enforce</b> but is overridden to <b>audit</b> by this <i><b>Node</b></i>. """
         )
       case (None, Some(Audit))            =>
         (Audit, "<b>Audit</b> is forced by this <i><b>Directive</b></i> mode")
       case (Some(Enforce), Some(Audit))   =>
         (
           Audit,
-          "The <i><b>Node</b></i> is configured to <b class='text-Enforce'>enforce</b> but is overriden to <b>audit</b> by this <i><b>Directive</b></i>. "
+          """The <i><b>Node</b></i> is configured to <b class="text-Enforce">enforce</b> but is overridden to <b>audit</b> by this <i><b>Directive</b></i>. """
         )
     }
   }
@@ -182,7 +182,7 @@ object ComputePolicyMode {
                       case Some(Enforce) =>
                         (
                           Audit.name,
-                          s"The <i><b>${uniqueKind}</b></i> is configured to <b class='text-Enforce'>enforce</b> but is overriden to <b>audit</b> by all <i><b>${multipleKind}</b></i>. "
+                          s"""The <i><b>${uniqueKind}</b></i> is configured to <b class="text-Enforce">enforce</b> but is overridden to <b>audit</b> by all <i><b>${multipleKind}</b></i>. """
                         )
                       // Audit is treated above ... maybe we should not treat it in that sense and always provide a more precise message
                       case Some(Audit)   =>
@@ -200,7 +200,7 @@ object ComputePolicyMode {
                         // Audit is treated above ... maybe we should not treat it in that sense and always provide a more precise message
                         (
                           Audit.name,
-                          s"All <i><b>${multipleKind}</b></i> are configured to <b class='text-Enforce'>enforce</b> but is overriden to <b>audit</b> by the <i><b>${uniqueKind}</b></i>. "
+                          s"""All <i><b>${multipleKind}</b></i> are configured to <b class="text-Enforce">enforce</b> but is overridden to <b>audit</b> by the <i><b>${uniqueKind}</b></i>. """
                         )
                       case Some(Enforce) =>
                         (

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_compliance.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_compliance.yml
@@ -24,50 +24,22 @@ response:
                 "id" : "r1",
                 "name" : "R1",
                 "compliance" : 100.0,
-                "policyMode" : "enforce",
+                "policyMode" : "default",
                 "complianceDetails" : {
                   "successAlreadyOK" : 100.0
                 },
                 "directives" : [
                   {
-                    "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
-                    "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "id" : "directive-techniqueWithBlocks",
+                    "name" : "25. Testing blocks",
                     "compliance" : 100.0,
-                    "policyMode" : "default",
+                    "policyMode" : "audit",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
                     "components" : [
                       {
-                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n2",
-                        "compliance" : 100.0,
-                        "complianceDetails" : {
-                          "successAlreadyOK" : 100.0
-                        },
-                        "nodes" : [
-                          {
-                            "id" : "n2",
-                            "name" : "node1.localhost",
-                            "compliance" : 100.0,
-                            "policyMode" : "enforce",
-                            "complianceDetails" : {
-                              "successAlreadyOK" : 100.0
-                            },
-                            "values" : [
-                              {
-                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n2",
-                                "reports" : [
-                                  {
-                                    "status" : "successAlreadyOK"
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n1",
+                        "name" : "directive-techniqueWithBlocks-component-r1-n1",
                         "compliance" : 100.0,
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
@@ -83,7 +55,35 @@ response:
                             },
                             "values" : [
                               {
-                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n1",
+                                "value" : "directive-techniqueWithBlocks-component-value-r1-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name" : "directive-techniqueWithBlocks-component-r1-n2",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n2",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "policyMode" : "enforce",
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive-techniqueWithBlocks-component-value-r1-n2",
                                 "reports" : [
                                   {
                                     "status" : "successAlreadyOK"
@@ -244,29 +244,29 @@ response:
                     "id" : "r1",
                     "name" : "R1",
                     "compliance" : 100.0,
-                    "policyMode" : "enforce",
+                    "policyMode" : "audit",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
                     "directives" : [
                       {
-                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
-                        "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "id" : "directive-techniqueWithBlocks",
+                        "name" : "25. Testing blocks",
                         "compliance" : 100.0,
-                        "policyMode" : "default",
+                        "policyMode" : "audit",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
                         "components" : [
                           {
-                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n1",
+                            "name" : "directive-techniqueWithBlocks-component-r1-n1",
                             "compliance" : 100.0,
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
                             "values" : [
                               {
-                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n1",
+                                "value" : "directive-techniqueWithBlocks-component-value-r1-n1",
                                 "reports" : [
                                   {
                                     "status" : "successAlreadyOK"
@@ -374,29 +374,29 @@ response:
                     "id" : "r1",
                     "name" : "R1",
                     "compliance" : 100.0,
-                    "policyMode" : "enforce",
+                    "policyMode" : "audit",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
                     "directives" : [
                       {
-                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
-                        "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "id" : "directive-techniqueWithBlocks",
+                        "name" : "25. Testing blocks",
                         "compliance" : 100.0,
-                        "policyMode" : "default",
+                        "policyMode" : "audit",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
                         "components" : [
                           {
-                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n2",
+                            "name" : "directive-techniqueWithBlocks-component-r1-n2",
                             "compliance" : 100.0,
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
                             "values" : [
                               {
-                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n2",
+                                "value" : "directive-techniqueWithBlocks-component-value-r1-n2",
                                 "reports" : [
                                   {
                                     "status" : "successAlreadyOK"
@@ -470,61 +470,34 @@ response:
           {
             "id" : "g1",
             "name" : "G1",
-            "compliance" : 100.0,
+            "compliance" : 60.0,
             "mode" : "full-compliance",
             "complianceDetails" : {
-              "successAlreadyOK" : 66.67,
-              "successRepaired" : 33.33
+              "successAlreadyOK" : 40.0,
+              "error" : 40.0,
+              "successRepaired" : 20.0
             },
             "rules" : [
               {
                 "id" : "r1",
                 "name" : "R1",
                 "compliance" : 100.0,
-                "policyMode" : "enforce",
+                "policyMode" : "default",
                 "complianceDetails" : {
                   "successAlreadyOK" : 100.0
                 },
                 "directives" : [
                   {
-                    "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
-                    "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "id" : "directive-techniqueWithBlocks",
+                    "name" : "25. Testing blocks",
                     "compliance" : 100.0,
-                    "policyMode" : "default",
+                    "policyMode" : "audit",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
                     "components" : [
                       {
-                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n2",
-                        "compliance" : 100.0,
-                        "complianceDetails" : {
-                          "successAlreadyOK" : 100.0
-                        },
-                        "nodes" : [
-                          {
-                            "id" : "n2",
-                            "name" : "node1.localhost",
-                            "compliance" : 100.0,
-                            "policyMode" : "enforce",
-                            "complianceDetails" : {
-                              "successAlreadyOK" : 100.0
-                            },
-                            "values" : [
-                              {
-                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n2",
-                                "reports" : [
-                                  {
-                                    "status" : "successAlreadyOK"
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n1",
+                        "name" : "directive-techniqueWithBlocks-component-r1-n1",
                         "compliance" : 100.0,
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
@@ -540,7 +513,35 @@ response:
                             },
                             "values" : [
                               {
-                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n1",
+                                "value" : "directive-techniqueWithBlocks-component-value-r1-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "successAlreadyOK"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name" : "directive-techniqueWithBlocks-component-r1-n2",
+                        "compliance" : 100.0,
+                        "complianceDetails" : {
+                          "successAlreadyOK" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n2",
+                            "name" : "node1.localhost",
+                            "compliance" : 100.0,
+                            "policyMode" : "enforce",
+                            "complianceDetails" : {
+                              "successAlreadyOK" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive-techniqueWithBlocks-component-value-r1-n2",
                                 "reports" : [
                                   {
                                     "status" : "successAlreadyOK"
@@ -604,6 +605,84 @@ response:
                     ]
                   }
                 ]
+              },
+              {
+                "id" : "r3",
+                "name" : "R3",
+                "compliance" : 0.0,
+                "policyMode" : "enforce",
+                "complianceDetails" : {
+                  "error" : 100.0
+                },
+                "directives" : [
+                  {
+                    "id" : "directive2",
+                    "name" : "directive2",
+                    "compliance" : 0.0,
+                    "policyMode" : "default",
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "components" : [
+                      {
+                        "name" : "directive2-component-r3-n1",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n1",
+                            "name" : "node1.localhost",
+                            "compliance" : 0.0,
+                            "policyMode" : "enforce",
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-r3-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name" : "directive2-component-r3-n2",
+                        "compliance" : 0.0,
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "nodes" : [
+                          {
+                            "id" : "n2",
+                            "name" : "node1.localhost",
+                            "compliance" : 0.0,
+                            "policyMode" : "enforce",
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-r3-n2",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
             ],
             "nodes" : [
@@ -611,40 +690,41 @@ response:
                 "id" : "n1",
                 "name" : "node1.localhost",
                 "mode" : "full-compliance",
-                "compliance" : 100.0,
+                "compliance" : 66.66,
                 "policyMode" : "enforce",
                 "complianceDetails" : {
-                  "successAlreadyOK" : 50.0,
-                  "successRepaired" : 50.0
+                  "successAlreadyOK" : 33.33,
+                  "error" : 33.34,
+                  "successRepaired" : 33.33
                 },
                 "rules" : [
                   {
                     "id" : "r1",
                     "name" : "R1",
                     "compliance" : 100.0,
-                    "policyMode" : "enforce",
+                    "policyMode" : "audit",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
                     "directives" : [
                       {
-                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
-                        "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "id" : "directive-techniqueWithBlocks",
+                        "name" : "25. Testing blocks",
                         "compliance" : 100.0,
-                        "policyMode" : "default",
+                        "policyMode" : "audit",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
                         "components" : [
                           {
-                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n1",
+                            "name" : "directive-techniqueWithBlocks-component-r1-n1",
                             "compliance" : 100.0,
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
                             "values" : [
                               {
-                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n1",
+                                "value" : "directive-techniqueWithBlocks-component-value-r1-n1",
                                 "reports" : [
                                   {
                                     "status" : "successAlreadyOK"
@@ -695,6 +775,45 @@ response:
                         ]
                       }
                     ]
+                  },
+                  {
+                    "id" : "r3",
+                    "name" : "R3",
+                    "compliance" : 0.0,
+                    "policyMode" : "enforce",
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "directive2",
+                        "name" : "directive2",
+                        "compliance" : 0.0,
+                        "policyMode" : "default",
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "directive2-component-r3-n1",
+                            "compliance" : 0.0,
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-r3-n1",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ]
               },
@@ -702,39 +821,40 @@ response:
                 "id" : "n2",
                 "name" : "node1.localhost",
                 "mode" : "full-compliance",
-                "compliance" : 100.0,
+                "compliance" : 50.0,
                 "policyMode" : "enforce",
                 "complianceDetails" : {
-                  "successAlreadyOK" : 100.0
+                  "successAlreadyOK" : 50.0,
+                  "error" : 50.0
                 },
                 "rules" : [
                   {
                     "id" : "r1",
                     "name" : "R1",
                     "compliance" : 100.0,
-                    "policyMode" : "enforce",
+                    "policyMode" : "audit",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
                     "directives" : [
                       {
-                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
-                        "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "id" : "directive-techniqueWithBlocks",
+                        "name" : "25. Testing blocks",
                         "compliance" : 100.0,
-                        "policyMode" : "default",
+                        "policyMode" : "audit",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
                         "components" : [
                           {
-                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n2",
+                            "name" : "directive-techniqueWithBlocks-component-r1-n2",
                             "compliance" : 100.0,
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
                             "values" : [
                               {
-                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n2",
+                                "value" : "directive-techniqueWithBlocks-component-value-r1-n2",
                                 "reports" : [
                                   {
                                     "status" : "successAlreadyOK"
@@ -746,9 +866,48 @@ response:
                         ]
                       }
                     ]
+                  },
+                  {
+                    "id" : "r3",
+                    "name" : "R3",
+                    "compliance" : 0.0,
+                    "policyMode" : "enforce",
+                    "complianceDetails" : {
+                      "error" : 100.0
+                    },
+                    "directives" : [
+                      {
+                        "id" : "directive2",
+                        "name" : "directive2",
+                        "compliance" : 0.0,
+                        "policyMode" : "default",
+                        "complianceDetails" : {
+                          "error" : 100.0
+                        },
+                        "components" : [
+                          {
+                            "name" : "directive2-component-r3-n2",
+                            "compliance" : 0.0,
+                            "complianceDetails" : {
+                              "error" : 100.0
+                            },
+                            "values" : [
+                              {
+                                "value" : "directive2-component-value-r3-n2",
+                                "reports" : [
+                                  {
+                                    "status" : "error"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ]
-              }    
+              }
             ]
           }
         ]
@@ -781,22 +940,22 @@ response:
                 "id" : "r1",
                 "name" : "R1",
                 "compliance" : 100.0,
-                "policyMode" : "enforce",
+                "policyMode" : "default",
                 "complianceDetails" : {
                   "successAlreadyOK" : 100.0
                 },
                 "directives" : [
                   {
-                    "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
-                    "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "id" : "directive-techniqueWithBlocks",
+                    "name" : "25. Testing blocks",
                     "compliance" : 100.0,
-                    "policyMode" : "default",
+                    "policyMode" : "audit",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
                     "components" : [
                       {
-                        "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n1",
+                        "name" : "directive-techniqueWithBlocks-component-r1-n1",
                         "compliance" : 100.0,
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
@@ -812,7 +971,7 @@ response:
                             },
                             "values" : [
                               {
-                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n1",
+                                "value" : "directive-techniqueWithBlocks-component-value-r1-n1",
                                 "reports" : [
                                   {
                                     "status" : "successAlreadyOK"
@@ -945,29 +1104,29 @@ response:
                     "id" : "r1",
                     "name" : "R1",
                     "compliance" : 100.0,
-                    "policyMode" : "enforce",
+                    "policyMode" : "audit",
                     "complianceDetails" : {
                       "successAlreadyOK" : 100.0
                     },
                     "directives" : [
                       {
-                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
-                        "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "id" : "directive-techniqueWithBlocks",
+                        "name" : "25. Testing blocks",
                         "compliance" : 100.0,
-                        "policyMode" : "default",
+                        "policyMode" : "audit",
                         "complianceDetails" : {
                           "successAlreadyOK" : 100.0
                         },
                         "components" : [
                           {
-                            "name" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-r1-n1",
+                            "name" : "directive-techniqueWithBlocks-component-r1-n1",
                             "compliance" : 100.0,
                             "complianceDetails" : {
                               "successAlreadyOK" : 100.0
                             },
                             "values" : [
                               {
-                                "value" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9-component-value-r1-n1",
+                                "value" : "directive-techniqueWithBlocks-component-value-r1-n1",
                                 "reports" : [
                                   {
                                     "status" : "successAlreadyOK"

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_directives.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_directives.yml
@@ -293,6 +293,24 @@ response:
             ]
           },
           {
+            "id" : "directive-techniqueWithBlocks",
+            "displayName" : "25. Testing blocks",
+            "shortDescription" : "a short \"description' with quotes",
+            "longDescription" : "a documentation *with markdown*",
+            "techniqueName" : "technique_with_blocks",
+            "techniqueVersion" : "1.0",
+            "parameters":{"section":{"name":"sections","sections":[]}},
+            "priority" : 5,
+            "enabled" : true,
+            "system" : false,
+            "policyMode" : "audit",
+            "tags" : [
+              {
+                "aTagName" : "the tagName value"
+              }
+            ]
+          },
+          {
             "id":"directive1",
             "displayName":"10. Clock Configuration",
             "shortDescription":"",
@@ -2054,7 +2072,26 @@ response:
                   {
                     "id": "technique_with_blocks",
                     "name": "technique with blocks",
-                    "directives": []
+                    "directives": [
+                      {
+                        "id" : "directive-techniqueWithBlocks",
+                        "displayName" : "25. Testing blocks",
+                        "shortDescription" : "a short \"description' with quotes",
+                        "longDescription" : "a documentation *with markdown*",
+                        "techniqueName" : "technique_with_blocks",
+                        "techniqueVersion" : "1.0",
+                        "parameters" : { "section" : { "name" : "sections", "sections" : [] } },
+                        "priority" : 5,
+                        "enabled" : true,
+                        "system" : false,
+                        "policyMode" : "audit",
+                        "tags" : [
+                          {
+                            "aTagName" : "the tagName value"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "id": "test_import_export_archive",

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_quicksearch.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_quicksearch.yml
@@ -11,8 +11,8 @@ response:
         {
           "header" : {
             "type" : "Directive",
-            "summary" : "10 found",
-            "numbers" : 10
+            "summary" : "11 found, only displaying the first 10. Please refine your query.",
+            "numbers" : 11
           },
           "items" : [
             {
@@ -30,6 +30,14 @@ response:
               "value" : "directive1",
               "desc" : "ID: directive1",
               "url" : "/secure/configurationManager/directiveManagement#{\"directiveId\":\"directive1\"}"
+            },
+            {
+              "name" : "25. Testing blocks",
+              "type" : "directive",
+              "id" : "directive-techniqueWithBlocks",
+              "value" : "directive-techniqueWithBlocks",
+              "desc" : "ID: directive-techniqueWithBlocks",
+              "url" : "/secure/configurationManager/directiveManagement#{\"directiveId\":\"directive-techniqueWithBlocks\"}"
             },
             {
               "name" : "99. Generic Variable Def #1",
@@ -86,14 +94,6 @@ response:
               "value" : "directive2",
               "desc" : "ID: directive2",
               "url" : "/secure/configurationManager/directiveManagement#{\"directiveId\":\"directive2\"}"
-            },
-            {
-              "name" : "test_import_export_archive_directive",
-              "type" : "directive",
-              "id" : "test_import_export_archive_directive",
-              "value" : "test_import_export_archive_directive",
-              "desc" : "ID: test_import_export_archive_directive",
-              "url" : "/secure/configurationManager/directiveManagement#{\"directiveId\":\"test_import_export_archive_directive\"}"
             }
           ]
         }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -269,7 +269,7 @@ class MockCompliance(mockDirectives: MockDirectives) {
     def getAllNonSystemCategories(): IOResult[Seq[NodeGroupCategory]] = ???
   }
 
-  private object nodeFactRepo extends NodeFactRepository {
+  object nodeFactRepo extends NodeFactRepository {
     override def getAll()(implicit qc: QueryContext, status: SelectNodeStatus): IOResult[MapView[NodeId, CoreNodeFact]] = {
       val _                                           = (qc, status) // ignore "unused" warning
       def build(id: String, mode: Option[PolicyMode]) = {
@@ -387,7 +387,7 @@ class MockCompliance(mockDirectives: MockDirectives) {
     )
   }
 
-  private object simpleExample {
+  object simpleExample {
 
     /*
     Nodes N1 and N2,
@@ -402,7 +402,7 @@ class MockCompliance(mockDirectives: MockDirectives) {
       nodeId(1) -> simpleNodeStatusReport(
         nodeId(1),
         Set(
-          simpleRuleNodeStatusReport(nodeId(1), ruleId(1), directives.fileTemplateDirecive1.id, ReportType.EnforceSuccess),
+          simpleRuleNodeStatusReport(nodeId(1), ruleId(1), directives.techniqueWithBlocksDirective.id, ReportType.EnforceSuccess),
           simpleRuleNodeStatusReport(nodeId(1), ruleId(2), directives.fileTemplateVariables2.id, ReportType.EnforceRepaired),
           simpleRuleNodeStatusReport(nodeId(1), ruleId(3), directives.rpmDirective.id, ReportType.EnforceError)
         )
@@ -411,7 +411,7 @@ class MockCompliance(mockDirectives: MockDirectives) {
       nodeId(2) -> simpleNodeStatusReport(
         nodeId(2),
         Set(
-          simpleRuleNodeStatusReport(nodeId(2), ruleId(1), directives.fileTemplateDirecive1.id, ReportType.EnforceSuccess),
+          simpleRuleNodeStatusReport(nodeId(2), ruleId(1), directives.techniqueWithBlocksDirective.id, ReportType.EnforceSuccess),
           simpleRuleNodeStatusReport(nodeId(2), ruleId(3), directives.rpmDirective.id, ReportType.EnforceError)
         )
       )
@@ -455,7 +455,7 @@ class MockCompliance(mockDirectives: MockDirectives) {
       "R1",
       RuleCategoryId("rulecat1"),
       Set(GroupTarget(g1.id)),
-      Set(directives.fileTemplateDirecive1.id)
+      Set(directives.techniqueWithBlocksDirective.id)
     )
 
     val r2: Rule = Rule(
@@ -464,16 +464,16 @@ class MockCompliance(mockDirectives: MockDirectives) {
       RuleCategoryId("rulecat1"),
       Set(
         TargetExclusion(TargetIntersection(Set(GroupTarget(g1.id))), TargetIntersection(Set(GroupTarget(g2.id))))
-      ), // include G1 but not G2
-      Set(directives.fileTemplateDirecive1.id)
+      ), // include G1 but not G2, ie only node1
+      Set(directives.fileTemplateVariables2.id)
     )
 
     val r3: Rule = Rule(
       ruleId(3),
       "R3",
       RuleCategoryId("rulecat1"),
-      Set(GroupTarget(g2.id), GroupTarget(g3.id)),
-      Set(directives.fileTemplateDirecive1.id)
+      Set(GroupTarget(g1.id), GroupTarget(g3.id)),
+      Set(directives.rpmDirective.id)
     )
 
     val simpleCustomRules: List[Rule] = List(r1, r2, r3)
@@ -485,7 +485,7 @@ class MockCompliance(mockDirectives: MockDirectives) {
     private def nodeGroupId(id: Int): NodeGroupId = NodeGroupId(NodeGroupUid("g" + id))
   }
 
-  private object complexExample {
+  object complexExample {
 
     /*
     Nodes N1, N2, N3, N4, N5

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Agentpolicymode/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Agentpolicymode/View.elm
@@ -85,7 +85,7 @@ view model =
               [ text ( if model.selectedSettings.overridable then
                 "Make this setting a default only and allow overrides on a per-node or per-directive basis."
                 else
-                "This setting may not be overriden per-node or per-directive. All Rudder configuration rules will operate in this mode."
+                "This setting may not be overridden per-node or per-directive. All Rudder configuration rules will operate in this mode."
                 )
               ]
             ]
@@ -103,7 +103,7 @@ view model =
               ]
               , span [class "info-mode"]
                 [ text (case selectedMode of
-                  Default -> "This may be overriden on a per-Directive basis."
+                  Default -> "This may be overridden on a per-Directive basis."
                   Audit   -> "Directives will never be enforced on this node, regardless of their policy mode."
                   Enforce -> "All Directives will apply necessary changes on this node, except Directives with an Audit override setting."
                   _       -> ""

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/ViewUtils.elm
@@ -57,7 +57,7 @@ badgeSkipped { overridingRuleId, overridingRuleName } =
         msg =
             "This directive is skipped because it is overridden by the rule <b>" ++ overridingRuleName ++ "</b> (with id " ++ overridingRuleId ++ ")."
     in
-    span [ class "treeGroupName rudder-label label-sm label-overriden", attribute "data-bs-toggle" "tooltip", attribute "data-bs-placement" "bottom", title (buildTooltipContent "Skipped directive" msg) ] []
+    span [ class "treeGroupName rudder-label label-sm label-overridden", attribute "data-bs-toggle" "tooltip", attribute "data-bs-placement" "bottom", title (buildTooltipContent "Skipped directive" msg) ] []
 
 
 subItemOrder : ItemFun item subItem data ->  Model -> String -> (item -> item -> Order)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewUtils.elm
@@ -672,7 +672,7 @@ badgeSkipped { overridingRuleId, overridingRuleName } =
         msg =
             "This directive is skipped because it is overridden by the rule <b>" ++ overridingRuleName ++ "</b> (with id " ++ overridingRuleId ++ ")."
     in
-    span [ class "treeGroupName tooltipable bs-tooltip rudder-label label-sm label-overriden", attribute "data-toggle" "tooltip", attribute "data-placement" "bottom", attribute "data-container" "body", attribute "data-html" "true", attribute "data-original-title" (buildTooltipContent "Skipped directive" msg) ] []
+    span [ class "treeGroupName tooltipable bs-tooltip rudder-label label-sm label-overridden", attribute "data-toggle" "tooltip", attribute "data-placement" "bottom", attribute "data-container" "body", attribute "data-html" "true", attribute "data-original-title" (buildTooltipContent "Skipped directive" msg) ] []
 
 
 

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -2263,7 +2263,7 @@ function compliancePercentValue(compliances) {
   decomposedValues.sort(function(a,b){return b.dec - a.dec;});
   total = decomposedValues.reduce(function(a, b) {;return {val : (a.val + b.val)}; }, {val:0}).val;
 
-  //we can have total = 0 in the case of overriden directives. We don't want to loop until 100.
+  //we can have total = 0 in the case of overridden directives. We don't want to loop until 100.
   //in fact, that loop can't be ok if (100 - total) > decomposedValue.length
   diff = 100 - total;
 

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
@@ -435,11 +435,11 @@ function updateHashString(key, value) {
   window.location.replace(baseUrl + '#' + JSON.stringify(hash));
 }
 
-function directiveOverridenTooltip(explanation){
+function directiveOverriddenTooltip(explanation){
   var tooltip = "" +
     "<h4>Directive Skipped</h4>" +
-    "<div class='tooltip-content policy-mode overriden'>"+
-    "<p>This directive is skipped because it is overriden by an other one here.</p>"+
+    "<div class='tooltip-content policy-mode overridden'>"+
+    "<p>This directive is skipped because it is overridden by an other one here.</p>"+
     "<p>"+ explanation +"</p>"+
     "</div>";
   return tooltip;
@@ -472,8 +472,8 @@ function createBadgeAgentPolicyMode(elmnt, currentPolicyMode, explanation){
   var span = "<span class='rudder-label label-sm "+ labelType +"' data-bs-toggle='tooltip' data-bs-placement='top' title=''></span>";
   var badge = $(span).get(0);
   var tooltip = null;
-  if(currentPolicyMode == "overriden") {
-    tooltip = directiveOverridenTooltip(explanation);
+  if(currentPolicyMode == "overridden") {
+    tooltip = directiveOverriddenTooltip(explanation);
   } else {
     tooltip = policyModeTooltip(elmnt, policyMode, explanation);
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -612,8 +612,8 @@ object AuthBackendProviderProperties {
   }
 
   /**
-    * The default properties the ones handled in the config parsing to be the default values: 
-    * - a provider can provide roles and roles are not overriden accross different providers
+    * The default properties the ones handled in the config parsing to be the default values:
+    * - a provider can provide roles and roles are not overridden accross different providers
     * - the rest API token feature for users is allowed
     */
   def default: AuthBackendProviderProperties =

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/MigrateChangeValidationEnforceSchema.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/migration/MigrateChangeValidationEnforceSchema.scala
@@ -74,7 +74,7 @@ class MigrateChangeValidationEnforceSchema(
     sql"alter table $table alter column $column set not null".update
   }
 
-  // we need the table fragment to be the class method that can be overriden (e.g. for tests)
+  // we need the table fragment to be the class method that can be overridden (e.g. for tests)
   private def transactMigration(table: String, tableFragment: Fragment, column: String)(implicit
       xa: Transactor[Task]
   ): Task[Unit] = {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPlugin.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPlugin.scala
@@ -322,7 +322,7 @@ trait RudderPluginDef {
   /**
    * A list of config files to get properties from.
    * If some properties are defined in different config files,
-   * the will be overriden (the last in the sequence win).
+   * the will be overridden (the last in the sequence win).
    */
   def configFiles: Seq[ConfigResource]
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
@@ -581,7 +581,7 @@ class DirectiveEditForm(
       </div>
     case Unoverridable =>
       <p>
-        Currrent global settings do not allow this mode to be overriden on a per-directive bases. You may change this in <b>Settings</b>,
+        Currrent global settings do not allow this mode to be overridden on a per-directive bases. You may change this in <b>Settings</b>,
         or contact your Rudder administrator about this.
       </p>
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -474,7 +474,7 @@ class NodeGroupForm(
       <div class="info">
         <h4>Property inheritance and overriding in hierarchy</h4>
         <p>When a group is a subgroup of another one, it inherit all its properties. If it defines
-        a property with the same name than a parent, then that property value is overriden and
+        a property with the same name than a parent, then that property value is overridden and
         the subgroup value is used. A node can also define a property with the same name, and in
         that case its value will override any group's value for that property name.</p>
       </div>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/ShowNodeDetailsFromNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/ShowNodeDetailsFromNode.scala
@@ -291,7 +291,7 @@ class ShowNodeDetailsFromNode(
       "reportsDetails",
       "reportsGrid",
       RudderConfig.reportingService.findUserNodeStatusReport(_).toBox,
-      addOverriden = true,
+      addOverridden = true,
       onlySystem = false
     ) &
     "#systemStatus *" #> reportDisplayer.asyncDisplay(
@@ -300,7 +300,7 @@ class ShowNodeDetailsFromNode(
       "systemStatus",
       "systemStatusGrid",
       RudderConfig.reportingService.findSystemNodeStatusReport(_).toBox,
-      addOverriden = false,
+      addOverridden = false,
       onlySystem = true
     ) &
     "#nodeProperties *" #> DisplayNode.displayTabProperties(id, nodeFact, sm) &

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.scss
@@ -785,13 +785,13 @@ pre.json-beautify code.elmsh {
 .content-wrapper .rudder-label.label-error + .tooltip b, .content-wrapper .label-text.label-error:after, .content-wrapper .label-text.label-error  + .tooltip b, .text-Error{
   color: #DA291C;
 }
-.content-wrapper .rudder-label.label-overriden:before,.content-wrapper .label-text.label-overriden:after{
+.content-wrapper .rudder-label.label-overridden:before,.content-wrapper .label-text.label-overridden:after{
   content: "Skipped";
 }
-.content-wrapper .rudder-label.label-overriden{
+.content-wrapper .rudder-label.label-overridden{
   background-color: #eda800;
 }
-.content-wrapper .rudder-label.label-overriden + .tooltip b, .content-wrapper .label-text.label-overriden:after, .content-wrapper .label-text.label-overriden  + .tooltip b, .text-overriden {
+.content-wrapper .rudder-label.label-overridden + .tooltip b, .content-wrapper .label-text.label-overridden:after, .content-wrapper .label-text.label-overridden  + .tooltip b, .text-overridden {
   color: #eda800;
 }
 .content-wrapper .rudder-label.label-included:before,.content-wrapper .label-text.label-included:after{

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/parameterManagement.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/parameterManagement.html
@@ -80,7 +80,7 @@
                     <p>
                       Be careful to enter exactly <b>node.properties</b> (lower case) and your global property name with the
                       same case
-                      (global property keys are case sensitive). Also, remember that their value can be overriden by
+                      (global property keys are case sensitive). Also, remember that their value can be overridden by
                       group and node properties.
                     </p>
                   </div>

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/components/RuleLineTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/components/RuleLineTest.scala
@@ -1,0 +1,104 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.web.components
+
+import com.normation.rudder.MockGlobalParam
+import com.normation.rudder.MockNodeGroups
+import com.normation.rudder.MockNodes
+import com.normation.rudder.MockRules
+import com.normation.rudder.domain.policies.*
+import com.normation.rudder.rule.category.RuleCategoryId
+import com.normation.rudder.web.components.RuleGrid.*
+import net.liftweb.http.SHtml
+import net.liftweb.http.js.JE.*
+import net.liftweb.http.js.JE.AnonFunc
+import net.liftweb.http.js.JsCmds.*
+import org.junit.runner.RunWith
+import org.specs2.mutable.*
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class RuleLineTest extends Specification {
+
+  val mockRules  = new MockRules()
+  val mockNodes  = new MockNodes
+  val mockGroups = new MockNodeGroups(mockNodes, new MockGlobalParam)
+
+  import com.normation.utils.SimpleStatus.*
+
+  val callback: Rule => Option[AnonFunc] = (r: Rule) => {
+    val ajax = SHtml.makeAjaxCall(JsRaw("'" + "cb" + "=' + encodeURIComponent(" + RedirectTo(r.id.serialize).toJsCmd + ")"))
+    Some(AnonFunc("action", ajax))
+  }
+
+  def catName(id: RuleCategoryId): String = id.value match {
+    case "rootRuleCategory" => "root rule category"
+  }
+
+  "OKLine serialisation" >> {
+    val lines = List(
+      OKLine(
+        mockRules.rules.rpmRule,
+        "enabled",
+        "the mode is enabled",
+        nodeIsEmpty = false,
+        FullyApplied,
+        Seq(DirectiveStatus("vim", Enabled, Enabled)),
+        Set(mockGroups.groupsTargetInfos(2).toTargetInfo)
+      )
+    )
+
+    RuleGrid.getRulesData(lines, None, callback, catName).toJson.toJsCmd.replaceAll("\n", "") ===
+    """[{"name": "50. Deploy PLOP STACK", "id": "rule2", "description": "global config for all nodes",
+      | "applying": false, "category": "root rule category", "status": "In application", "trClass": "",
+      | "policyMode": "enabled", "explanation": "the mode is enabled", "tags": "{}", "tagsDisplayed": [],
+      | "callback": function(action) {lift.ajax('cb=' + encodeURIComponent(window.location = "rule2";), null, null, null);}
+      |}]""".stripMargin.replaceAll("\n", "")
+  }
+
+  "Error Line serialisation" >> {
+    val lines = List(ErrorLine(mockRules.rules.rpmRule, "enabled", "the mode is enabled", nodeIsEmpty = false))
+
+    RuleGrid.getRulesData(lines, None, callback, catName).toJson.toJsCmd.replaceAll("\n", "") ===
+    """[{"name": "50. Deploy PLOP STACK", "id": "rule2", "description": "global config for all nodes",
+      | "applying": false, "category": "root rule category", "status": "N/A", "trClass": " error",
+      | "policyMode": "enabled", "explanation": "the mode is enabled", "tags": "{}", "tagsDisplayed": [],
+      | "callback": function(action) {lift.ajax('cb=' + encodeURIComponent(window.location = "rule2";), null, null, null);}
+      |}]""".stripMargin.replaceAll("\n", "")
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/ComplianceLineTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/ComplianceLineTest.scala
@@ -1,0 +1,270 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.web.services
+
+import com.normation.JsonSpecMatcher
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.MockCompliance
+import com.normation.rudder.MockDirectives
+import com.normation.rudder.MockGitConfigRepo
+import com.normation.rudder.MockTechniques
+import com.normation.rudder.domain.policies.GlobalPolicyMode
+import com.normation.rudder.domain.policies.PolicyMode.Enforce
+import com.normation.rudder.domain.policies.PolicyModeOverrides
+import com.normation.rudder.domain.policies.PolicyTypeName
+import com.normation.rudder.facts.nodes.CoreNodeFact
+import com.normation.rudder.facts.nodes.QueryContext
+import com.normation.rudder.repository.FullActiveTechniqueCategory
+import com.normation.zio.*
+import org.junit.runner.RunWith
+import org.specs2.mutable.*
+import org.specs2.runner.JUnitRunner
+import scala.collection.MapView
+import scala.util.Random
+
+@RunWith(classOf[JUnitRunner])
+class ComplianceLineTest extends Specification with JsonSpecMatcher {
+
+  val mockDirectives = new MockDirectives(MockTechniques(new MockGitConfigRepo("")))
+  val mockCompliance = new MockCompliance(mockDirectives)
+  implicit val qc: QueryContext                  = QueryContext.testQC
+  val nodes:       MapView[NodeId, CoreNodeFact] = mockCompliance.nodeFactRepo.getAll().runNow
+  val directives:  FullActiveTechniqueCategory   = mockDirectives.directiveRepo.getFullDirectiveLibrary().runNow
+
+  val stableRandom = new Random(42)
+  def freshName(): String = stableRandom.nextLong().toString
+
+  "compliance lines serialisation" >> {
+    val nodeId = NodeId("n1")
+    val report = mockCompliance.simpleExample.simpleStatusReports(nodeId)
+    val lines  = ComplianceData
+      .getNodeByRuleComplianceDetails(
+        nodeId,
+        report,
+        PolicyTypeName.rudderBase,
+        nodes.toMap,
+        directives,
+        mockCompliance.simpleExample.simpleCustomRules,
+        GlobalPolicyMode(Enforce, PolicyModeOverrides.Always),
+        true
+      )
+      .json(freshName _)
+      .toJsCmd
+
+    lines must equalsJsonSemantic(
+      """[
+        |  {
+        |    "rule":"R1",
+        |    "compliance":[[0,0.0],[0,0.0], [1, 100.0], [0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0]
+        |    ],
+        |    "compliancePercent":100.0,
+        |    "id":"r1",
+        |    "details":[
+        |      {
+        |        "directive":"25. Testing blocks",
+        |        "id":"directive-techniqueWithBlocks",
+        |        "techniqueName":"technique with blocks",
+        |        "techniqueVersion":"1.0",
+        |        "compliance":[[0,0.0],[0,0.0], [1, 100.0], [0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0]
+        |        ],
+        |        "compliancePercent":100.0,
+        |        "details":[
+        |          {
+        |            "component":"directive-techniqueWithBlocks-component-r1-n1",
+        |            "unexpanded":"directive-techniqueWithBlocks-component-r1-n1",
+        |            "compliance":[[0,0.0],[0,0.0], [1, 100.0], [0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0]
+        |            ],
+        |            "compliancePercent":100.0,
+        |            "details":[
+        |              {
+        |                "value":"directive-techniqueWithBlocks-component-value-r1-n1",
+        |                "unexpanded":"directive-techniqueWithBlocks-component-value-r1-n1",
+        |                "status":"Success",
+        |                "statusClass":"Success",
+        |                "messages":[
+        |                  {
+        |                    "status":"Success",
+        |                    "value":""
+        |                  }
+        |                ],
+        |                "compliance":[[0,0.0],[0,0.0], [1, 100.0], [0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0]
+        |                ],
+        |                "compliancePercent":100.0,
+        |                "jsid":"-5025562857975149833"
+        |              }
+        |            ],
+        |            "noExpand":false,
+        |            "jsid":"-5843495416241995736"
+        |          }
+        |        ],
+        |        "jsid":"5694868678511409995",
+        |        "isSystem":false,
+        |        "policyMode":"audit",
+        |        "explanation":"The <i><b>Node</b></i> is configured to <b class=\"text-Enforce\">enforce</b> but is overridden to <b>audit</b> by this <i><b>Directive</b></i>. ",
+        |        "tags":[
+        |          {
+        |            "key":"aTagName",
+        |            "value":"the tagName value"
+        |          }
+        |        ]
+        |      }
+        |    ],
+        |    "jsid":"5111195811822994797",
+        |    "isSystem":false,
+        |    "policyMode":"audit",
+        |    "explanation":"The <i><b>Node</b></i> is configured to <b class=\"text-Enforce\">enforce</b> but is overridden to <b>audit</b> by all <i><b>Directives</b></i>. ",
+        |    "tags":[]
+        |  },
+        |  {
+        |    "rule":"R2",
+        |    "compliance":[[0,0.0],[0,0.0],[0,0.0], [1, 100.0], [0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0]
+        |    ],
+        |    "compliancePercent":100.0,
+        |    "id":"r2",
+        |    "details":[
+        |      {
+        |        "directive":"directive 99f4ef91-537b-4e03-97bc-e65b447514cc",
+        |        "id":"99f4ef91-537b-4e03-97bc-e65b447514cc",
+        |        "techniqueName":"File content (from remote template)",
+        |        "techniqueVersion":"1.0",
+        |        "compliance":[[0,0.0],[0,0.0],[0,0.0], [1, 100.0], [0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0]
+        |        ],
+        |        "compliancePercent":100.0,
+        |        "details":[
+        |          {
+        |            "component":"99f4ef91-537b-4e03-97bc-e65b447514cc-component-r2-n1",
+        |            "unexpanded":"99f4ef91-537b-4e03-97bc-e65b447514cc-component-r2-n1",
+        |            "compliance":[[0,0.0],[0,0.0],[0,0.0], [1, 100.0], [0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0]
+        |            ],
+        |            "compliancePercent":100.0,
+        |            "details":[
+        |              {
+        |                "value":"99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-r2-n1",
+        |                "unexpanded":"99f4ef91-537b-4e03-97bc-e65b447514cc-component-value-r2-n1",
+        |                "status":"Repaired",
+        |                "statusClass":"Repaired",
+        |                "messages":[
+        |                  {
+        |                    "status":"Repaired",
+        |                    "value":""
+        |                  }
+        |                ],
+        |                "compliance":[[0,0.0],[0,0.0],[0,0.0], [1, 100.0], [0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0]
+        |                ],
+        |                "compliancePercent":100.0,
+        |                "jsid":"-6169532649852302182"
+        |              }
+        |            ],
+        |            "noExpand":false,
+        |            "jsid":"-1782466964123969572"
+        |          }
+        |        ],
+        |        "jsid":"6802844026563419272",
+        |        "isSystem":false,
+        |        "policyMode":"enforce",
+        |        "explanation":"<b>Enforce</b> is forced by this <i><b>Node</b></i> mode",
+        |        "tags":[]
+        |      }
+        |    ],
+        |    "jsid":"5086654115216342560",
+        |    "isSystem":false,
+        |    "policyMode":"enforce",
+        |    "explanation":"<b>enforce</b> mode is forced by this <i><b>Node</b></i>",
+        |    "tags":[]
+        |  },
+        |  {
+        |    "rule":"R3",
+        |    "compliance":[[0,0.0],[0,0.0],[0,0.0],[0,0.0], [1, 100.0], [0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0]
+        |    ],
+        |    "compliancePercent":0.0,
+        |    "id":"r3",
+        |    "details":[
+        |      {
+        |        "directive":"directive2",
+        |        "id":"directive2",
+        |        "techniqueName":"Packages (RHEL/CentOS/SuSE/RPM)",
+        |        "techniqueVersion":"7.0",
+        |        "compliance":[[0,0.0],[0,0.0],[0,0.0],[0,0.0], [1, 100.0], [0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0]
+        |        ],
+        |        "compliancePercent":0.0,
+        |        "details":[
+        |          {
+        |            "component":"directive2-component-r3-n1",
+        |            "unexpanded":"directive2-component-r3-n1",
+        |            "compliance":[[0,0.0],[0,0.0],[0,0.0],[0,0.0], [1, 100.0], [0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0]
+        |            ],
+        |            "compliancePercent":0.0,
+        |            "details":[
+        |              {
+        |                "value":"directive2-component-value-r3-n1",
+        |                "unexpanded":"directive2-component-value-r3-n1",
+        |                "status":"Error",
+        |                "statusClass":"Error",
+        |                "messages":[
+        |                  {
+        |                    "status":"Error",
+        |                    "value":""
+        |                  }
+        |                ],
+        |                "compliance":[[0,0.0],[0,0.0],[0,0.0],[0,0.0], [1, 100.0], [0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0]
+        |                ],
+        |                "compliancePercent":0.0,
+        |                "jsid":"8552898714322622292"
+        |              }
+        |            ],
+        |            "noExpand":false,
+        |            "jsid":"-4004755535478349341"
+        |          }
+        |        ],
+        |        "jsid":"-1488139573943419793",
+        |        "isSystem":false,
+        |        "policyMode":"enforce",
+        |        "explanation":"<b>Enforce</b> is forced by this <i><b>Node</b></i> mode",
+        |        "tags":[]
+        |      }
+        |    ],
+        |    "jsid":"8051837266862454915",
+        |    "isSystem":false,
+        |    "policyMode":"enforce",
+        |    "explanation":"<b>enforce</b> mode is forced by this <i><b>Node</b></i>",
+        |    "tags":[]
+        |  }
+        |]""".stripMargin
+    )
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/ReportLineTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/ReportLineTest.scala
@@ -1,0 +1,136 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.web.services
+
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.policies.*
+import com.normation.rudder.domain.reports.*
+import com.normation.rudder.web.services.ReportLineTest.*
+import com.normation.utils.DateFormaterService
+import net.liftweb.common.Full
+import org.joda.time.DateTime
+import org.junit.runner.RunWith
+import org.specs2.mutable.*
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ReportLineTest extends Specification {
+
+  "report lines serialisation" >> {
+
+    val executionTimestamp = DateTime.parse("2024-12-14T14:47:53Z", DateFormaterService.rfcDateformat)
+
+    val reports = Seq[ResultReports](
+      TestResultReport(
+        executionTimestamp,
+        "cr",
+        "policy",
+        "nodeId",
+        "report_id12",
+        "component",
+        "foo",
+        "message"
+      ).toRE,
+      TestResultReport(
+        executionTimestamp,
+        "cr",
+        "policy",
+        "nodeId",
+        "report_id12",
+        "component",
+        "foo",
+        "message"
+      ).toAC,
+      TestResultReport(
+        executionTimestamp,
+        "cr",
+        "policy",
+        "nodeId",
+        "report_id12",
+        "component",
+        "bar",
+        "message"
+      ).toRS
+    )
+
+    def dirName(id: DirectiveId): Full[String] = id.serialize match {
+      case "policy" => Full("Directive name")
+    }
+
+    def ruleName(id: RuleId): Full[String] = id.serialize match {
+      case "cr" => Full("Rule name")
+    }
+
+    LogDisplayer.getReportsLineForNode(reports, dirName, ruleName).toJson.toJsCmd.strip() must beEqualTo(
+      """[{"executionDate": "2024-12-14 15:47:53+0100", "runDate": "2024-12-14 15:47:53+0100", "kind": "result", "status": "error", "ruleName": "Rule name", "directiveName": "Directive name", "component": "component", "value": "foo", "message": "message"},
+        | {"executionDate": "2024-12-14 15:47:53+0100", "runDate": "2024-12-14 15:47:53+0100", "kind": "audit", "status": "compliant", "ruleName": "Rule name", "directiveName": "Directive name", "component": "component", "value": "foo", "message": "message"},
+        | {"executionDate": "2024-12-14 15:47:53+0100", "runDate": "2024-12-14 15:47:53+0100", "kind": "result", "status": "success", "ruleName": "Rule name", "directiveName": "Directive name", "component": "component", "value": "bar", "message": "message"}
+        |]""".stripMargin.replaceAll("\n", "").strip()
+    )
+  }
+}
+
+object ReportLineTest {
+
+  private case class TestResultReport(
+      executionDate: DateTime,
+      ruleId:        String,
+      directiveId:   String,
+      nodeId:        String,
+      reportId:      String,
+      component:     String,
+      keyValue:      String,
+      message:       String
+  ) {
+    def toT: (DateTime, RuleId, DirectiveId, NodeId, String, String, String, DateTime, String) = (
+      executionDate,
+      RuleId(RuleUid(ruleId)),
+      DirectiveId(DirectiveUid(directiveId)),
+      NodeId(nodeId),
+      reportId,
+      component,
+      keyValue,
+      executionDate,
+      message
+    )
+
+    def toRS: ResultSuccessReport  = ResultSuccessReport.tupled.apply(toT)
+    def toRE: ResultErrorReport    = ResultErrorReport.tupled.apply(toT)
+    def toAC: AuditCompliantReport = AuditCompliantReport.tupled.apply(toT)
+  }
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/26070

We want to get ride of `JsDataLine` and `JsDataTable` structure. 

This PR: 
- add an util class, `SimpleStatus` (`Enabled`, `Disabled`) that could (should) be used each time we have a `isEnabled: Boolean` parameter. 
- correct all `overriden` into `overridden` (that adds quite a lot of noise, it should have been done in an other PR)
- remove dead code around `ComplianceData` and other structures using `JsDataLine` - there was a lot
- in `JsTableData`, transform the `def json: JObject` into a `def json(freshName: () => String): JObject` so that we can define the "next fresh name" in tests,
- refactor some code to make clearer that we just want to test the serialization of `XXXLine`, not all the surrounding logic. I didn't do it for `ComplianceData`, it would have been too much. 
- change the compliance mock serivice to use a technique with a block, because that wasn't tested (and change the billions API tests impacted)

Generaly, there is a big mismatch in these objects between business logic and presentation / serialisation. 
There is *a ton* of business code that should be tested here, and don't reuse existing services. This is a first step in a more disciplined direction. 