### PR TITLE
Fixes #26046: Migrate compliance status from lift-json to zio-json

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -467,7 +467,7 @@ limitations under the License.
     <jgrapht-version>1.5.2</jgrapht-version>
     <reflections-version>0.10.2</reflections-version>
     <graalvm-version>24.1.1</graalvm-version>
-    <chimney-version>1.5.0</chimney-version>
+    <chimney-version>1.6.0</chimney-version>
     <cron4s-version>0.7.0</cron4s-version>
     <ipaddress-version>5.5.1</ipaddress-version>
     <snakeyaml-version>2.3</snakeyaml-version>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
@@ -57,6 +57,7 @@ import doobie.util.log.ExecFailure
 import doobie.util.log.LogEvent
 import doobie.util.log.ProcessingFailure
 import doobie.util.transactor
+import io.scalaland.chimney.syntax.*
 import java.sql.SQLXML
 import javax.sql.DataSource
 import net.liftweb.common.*
@@ -279,15 +280,16 @@ object Doobie {
     }
   }
 
+  /*
+   * The 4 following ones are used in udder-core/src/main/scala/com/normation/rudder/repository/jdbc/ComplianceRepository.scala
+   */
   implicit val CompliancePercentWrite: Write[CompliancePercent] = {
-    import ComplianceLevelSerialisation.*
-    import net.liftweb.json.*
-    Write[String].contramap(x => compactRender(x.toJson))
+    Write[String].contramap(x => x.transformInto[ComplianceSerializable].toJson)
   }
 
   implicit val ComplianceRunInfoComposite: Write[(RunAnalysis, RunComplianceInfo)] = {
     import NodeStatusReportSerialization.*
-    Write[String].contramap(_.toCompactJson)
+    Write[String].contramap(runToJson)
   }
 
   implicit val AggregatedStatusReportComposite: Write[AggregatedStatusReport] = {
@@ -297,7 +299,7 @@ object Doobie {
 
   implicit val SetRuleNodeStatusReportComposite: Write[Set[RuleNodeStatusReport]] = {
     import NodeStatusReportSerialization.*
-    Write[String].contramap(_.toCompactJson)
+    Write[String].contramap(ruleNodeStatusReportToJson)
   }
 
   import doobie.enumerated.JdbcType.SqlXml

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/json/JsonExctractorUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/json/JsonExctractorUtils.scala
@@ -39,7 +39,6 @@ package com.normation.rudder.repository.json
 
 import cats.*
 import cats.implicits.*
-import com.normation.rudder.domain.policies.JsonTagExtractor
 import com.normation.utils.Control.*
 import net.liftweb.common.*
 import net.liftweb.json.*
@@ -133,7 +132,7 @@ trait JsonExtractorUtils[A[_]] {
   }
 }
 
-trait DataExtractor[T[_]] extends JsonTagExtractor[T]
+trait DataExtractor[T[_]] extends JsonExtractorUtils[T]
 object DataExtractor {
 
   object OptionnalJson extends DataExtractor[Option] {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
@@ -58,7 +58,6 @@ import com.normation.rudder.domain.properties.GroupProperty
 import com.normation.rudder.domain.properties.InheritMode
 import com.normation.rudder.domain.properties.ModifyGlobalParameterDiff
 import com.normation.rudder.domain.properties.PropertyProvider
-import com.normation.rudder.repository.json.DataExtractor
 import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.services.queries.*
 import com.unboundid.ldap.sdk.DN
@@ -174,12 +173,9 @@ class LDAPDiffMapper(
                          case A_SERIALIZED_TAGS  =>
                            for {
                              d    <- diff
-                             tags <- mod.getOptValue() match {
-                                       case Some(v) => DataExtractor.CompleteJson.unserializeTags(v).map(_.tags).toPureResult
-                                       case None    => Right(Set[Tag]())
-                                     }
+                             tags <- Tags.parse(mod.getOptValue())
                            } yield {
-                             d.copy(modTags = Some(SimpleDiff(oldCr.tags.tags, tags)))
+                             d.copy(modTags = Some(SimpleDiff(oldCr.tags.tags, tags.tags)))
                            }
                          case x                  => Left(Err.UnexpectedObject("Unknown diff attribute: " + x))
                        }
@@ -336,10 +332,7 @@ class LDAPDiffMapper(
                            case A_SERIALIZED_TAGS     =>
                              for {
                                d    <- diff
-                               tags <- mod.getOptValue() match {
-                                         case Some(v) => DataExtractor.CompleteJson.unserializeTags(v).toPureResult
-                                         case None    => Right(Tags(Set()))
-                                       }
+                               tags <- Tags.parse(mod.getOptValue())
                              } yield {
                                d.copy(modTags = Some(SimpleDiff(oldPi.tags, tags)))
                              }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -72,6 +72,7 @@ import org.apache.commons.text.StringEscapeUtils
 import scala.xml.*
 import zio.ZIO
 import zio.json.*
+import zio.json.ast.*
 import zio.syntax.*
 
 object NodeGroupForm {
@@ -276,8 +277,8 @@ class NodeGroupForm(
     _.name
   )
 
-  private def showComplianceForGroup(progressBarSelector: String, optComplianceArray: Option[JsArray]) = {
-    val complianceHtml = optComplianceArray.map(js => s"buildComplianceBar(${js.toJsCmd})").getOrElse("\"No report\"")
+  private def showComplianceForGroup(progressBarSelector: String, optComplianceArray: Option[Json.Arr]) = {
+    val complianceHtml = optComplianceArray.map(js => s"buildComplianceBar(${js.toJson})").getOrElse("\"No report\"")
     Script(JsRaw(s"""$$("${progressBarSelector}").html(${complianceHtml});"""))
   }
 
@@ -489,7 +490,7 @@ class NodeGroupForm(
     intro ++ tabProperties
   }
 
-  private def loadComplianceBar(isGlobalCompliance: Boolean): Option[JsArray] = {
+  private def loadComplianceBar(isGlobalCompliance: Boolean): Option[Json.Arr] = {
     val target = nodeGroup match {
       case Left(value)  => value
       case Right(value) => GroupTarget(value.id)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TagsEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TagsEditForm.scala
@@ -1,8 +1,7 @@
 package com.normation.rudder.web.components
 
-import com.normation.rudder.domain.policies.JsonTagSerialisation
+import com.normation.box.*
 import com.normation.rudder.domain.policies.Tags
-import com.normation.rudder.repository.json.DataExtractor.CompleteJson
 import com.normation.rudder.web.ChooseTemplate
 import net.liftweb.common.*
 import net.liftweb.http.SHtml
@@ -12,15 +11,16 @@ import net.liftweb.util.CssSel
 import net.liftweb.util.Helpers.*
 import org.apache.commons.text.StringEscapeUtils
 import scala.xml.NodeSeq
+import zio.json.*
 
 class TagsEditForm(tags: Tags, objectId: String) extends Loggable {
 
   val templatePath: List[String] = List("templates-hidden", "components", "ComponentTags")
   def tagsTemplate: NodeSeq      = ChooseTemplate(templatePath, "tag-form")
 
-  val jsTags: String = net.liftweb.json.compactRender(JsonTagSerialisation.serializeTags(tags))
+  val jsTags: String = tags.toJson
 
-  def parseResult(s: String): Box[Tags] = CompleteJson.unserializeTags(s)
+  def parseResult(s: String): Box[Tags] = s.fromJson[Tags].toBox
 
   def tagsForm(controllerId: String, appId: String, update: Box[Tags] => Unit, isRule: Boolean): NodeSeq = {
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/AsyncComplianceService.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/AsyncComplianceService.scala
@@ -159,7 +159,7 @@ class AsyncComplianceService(
               for { (key, optCompliance) <- compliances } yield {
                 val value             = kind.value(key)
                 val displayCompliance = optCompliance
-                  .map(_.toJsArray.toJsCmd)
+                  .map(_.toJsArray.toJson)
                   .getOrElse("""'<div class="text-muted text-center">no data available</div>'""")
                 s"${kind.jsContainer}['${value}'] = ${displayCompliance};"
               }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -68,6 +68,7 @@ import net.liftweb.http.js.JE.*
 import net.liftweb.http.js.JsCmds.*
 import scala.collection.MapView
 import scala.xml.*
+import zio.json.*
 
 case class ScoreChart(scoreValue: ScoreValue, value: Int, noScoreLegend: Option[String]) {
   import com.normation.rudder.score.ScoreValue.*
@@ -322,7 +323,7 @@ class HomePage extends StatefulSnippet {
           import com.normation.rudder.domain.reports.ComplianceLevelSerialisation.*
           (bar.copy(pending = 0).toJsArray, value)
         case None               =>
-          (JsArray(Nil), -1L)
+          (ast.Json.Arr(), -1L)
       }
 
       val n4 = System.currentTimeMillis
@@ -330,7 +331,7 @@ class HomePage extends StatefulSnippet {
 
       Script(OnLoad(JsRaw(s"""
         homePage(
-            ${complianceBar.toJsCmd}
+            ${complianceBar.toJson}
           , ${globalCompliance}
           , ${data.toJsCmd}
           , ${pendingNodes.toJsCmd}

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/ComplianceLineTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/ComplianceLineTest.scala
@@ -56,6 +56,7 @@ import org.specs2.mutable.*
 import org.specs2.runner.JUnitRunner
 import scala.collection.MapView
 import scala.util.Random
+import zio.json.*
 
 @RunWith(classOf[JUnitRunner])
 class ComplianceLineTest extends Specification with JsonSpecMatcher {
@@ -66,8 +67,10 @@ class ComplianceLineTest extends Specification with JsonSpecMatcher {
   val nodes:       MapView[NodeId, CoreNodeFact] = mockCompliance.nodeFactRepo.getAll().runNow
   val directives:  FullActiveTechniqueCategory   = mockDirectives.directiveRepo.getFullDirectiveLibrary().runNow
 
-  val stableRandom = new Random(42)
-  def freshName(): String = stableRandom.nextLong().toString
+  implicit object StableRandom extends ProvideNextName {
+    val stableRandom = new Random(42)
+    override def nextName: String = stableRandom.nextLong().toString
+  }
 
   "compliance lines serialisation" >> {
     val nodeId = NodeId("n1")
@@ -83,8 +86,7 @@ class ComplianceLineTest extends Specification with JsonSpecMatcher {
         GlobalPolicyMode(Enforce, PolicyModeOverrides.Always),
         true
       )
-      .json(freshName _)
-      .toJsCmd
+      .toJson
 
     lines must equalsJsonSemantic(
       """[
@@ -125,14 +127,14 @@ class ComplianceLineTest extends Specification with JsonSpecMatcher {
         |                "compliance":[[0,0.0],[0,0.0], [1, 100.0], [0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0]
         |                ],
         |                "compliancePercent":100.0,
-        |                "jsid":"-5025562857975149833"
+        |                "jsid":"-5843495416241995736"
         |              }
         |            ],
         |            "noExpand":false,
-        |            "jsid":"-5843495416241995736"
+        |            "jsid":"5111195811822994797"
         |          }
         |        ],
-        |        "jsid":"5694868678511409995",
+        |        "jsid":"-1782466964123969572",
         |        "isSystem":false,
         |        "policyMode":"audit",
         |        "explanation":"The <i><b>Node</b></i> is configured to <b class=\"text-Enforce\">enforce</b> but is overridden to <b>audit</b> by this <i><b>Directive</b></i>. ",
@@ -144,7 +146,7 @@ class ComplianceLineTest extends Specification with JsonSpecMatcher {
         |        ]
         |      }
         |    ],
-        |    "jsid":"5111195811822994797",
+        |    "jsid":"5086654115216342560",
         |    "isSystem":false,
         |    "policyMode":"audit",
         |    "explanation":"The <i><b>Node</b></i> is configured to <b class=\"text-Enforce\">enforce</b> but is overridden to <b>audit</b> by all <i><b>Directives</b></i>. ",
@@ -187,21 +189,21 @@ class ComplianceLineTest extends Specification with JsonSpecMatcher {
         |                "compliance":[[0,0.0],[0,0.0],[0,0.0], [1, 100.0], [0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0]
         |                ],
         |                "compliancePercent":100.0,
-        |                "jsid":"-6169532649852302182"
+        |                "jsid":"-4004755535478349341"
         |              }
         |            ],
         |            "noExpand":false,
-        |            "jsid":"-1782466964123969572"
+        |            "jsid":"8051837266862454915"
         |          }
         |        ],
-        |        "jsid":"6802844026563419272",
+        |        "jsid":"7130900098642117381",
         |        "isSystem":false,
         |        "policyMode":"enforce",
         |        "explanation":"<b>Enforce</b> is forced by this <i><b>Node</b></i> mode",
         |        "tags":[]
         |      }
         |    ],
-        |    "jsid":"5086654115216342560",
+        |    "jsid":"-7482923245497525943",
         |    "isSystem":false,
         |    "policyMode":"enforce",
         |    "explanation":"<b>enforce</b> mode is forced by this <i><b>Node</b></i>",
@@ -244,21 +246,21 @@ class ComplianceLineTest extends Specification with JsonSpecMatcher {
         |                "compliance":[[0,0.0],[0,0.0],[0,0.0],[0,0.0], [1, 100.0], [0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0],[0,0.0]
         |                ],
         |                "compliancePercent":0.0,
-        |                "jsid":"8552898714322622292"
+        |                "jsid":"-3210362905434573697"
         |              }
         |            ],
         |            "noExpand":false,
-        |            "jsid":"-4004755535478349341"
+        |            "jsid":"-7610621359446545191"
         |          }
         |        ],
-        |        "jsid":"-1488139573943419793",
+        |        "jsid":"-7912908803613548926",
         |        "isSystem":false,
         |        "policyMode":"enforce",
         |        "explanation":"<b>Enforce</b> is forced by this <i><b>Node</b></i> mode",
         |        "tags":[]
         |      }
         |    ],
-        |    "jsid":"8051837266862454915",
+        |    "jsid":"-4565385657661118002",
         |    "isSystem":false,
         |    "policyMode":"enforce",
         |    "explanation":"<b>enforce</b> mode is forced by this <i><b>Node</b></i>",


### PR DESCRIPTION
https://issues.rudder.io/issues/26046

Main change: 

- upgrade to chimney 1.6.0 so that we can avoid `...withFieldComputed(_.a, _.aa.transformInto[AA])` and just use `.withFieldRenamed(_.a, _.aa)` given a transformer `A` to `AA` in scope
- `Tags` needed to be migrated. Only encode is needed at that point, which was created with an intermediate `JsonTag` that is not exposed so that we can keep `Tags` in Json objects in place of `JValue`. 
- where the Json Lift objects were used directly, I mapped to the corresponding `zio.json.ast` objects
- I introduced a `OptPosNum` type for compliance and compliance percent serialization. It's an `Option[Numeric]` (so that it works with int and float, but some quirks because js/java/scala) and so can be eliminated in the json when not present. 
- the json object `ComplianceSerializable` and `ComplianceLevelSerialisation` have their fields with the correct naming and order. There's a lot of chimney to map to/from the corresponding business objects. 
- I did on more time the encoding for `AggregatedStatusReport` (it already existed in a more compact fashion for database, now with full name - and IIRC, there's some other little differences)

:warning:  For now, we don't migrate `RuleLine`, because it's an horror mixing json and full js. And perhaps we can just delete it at some point. 

I think other things are rather automatics. 
Not a lot of `net.liftweb.json` removed, but still some more, especially in `rudder-core`. 