### PR TITLE
Fixes #26078: Fix API yaml tests on groups and remove restriction to event log

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
@@ -1917,20 +1917,15 @@ response:
               "description" : "Some long description",
               "category" : "GroupRoot",
               "query" : {
-                "select" : "node",
+                "select" : "nodeAndPolicyServer",
                 "composition" : "and",
+                "transform" : "invert",
                 "where" : [
                   {
                     "objectType" : "node",
-                    "attribute" : "osName",
+                    "attribute" : "nodeId",
                     "comparator" : "eq",
-                    "value" : "Debian"
-                  },
-                  {
-                    "objectType" : "node",
-                    "attribute" : "osVersion",
-                    "comparator" : "regex",
-                    "value" : "10\\..*"
+                    "value" : "11111111-cb9d-4f7b-abda-ca38c5d643ea"
                   }
                 ]
               },

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
@@ -92,7 +92,7 @@ class TestRestFromFileDef extends ZIOSpecDefault {
                yamlSourceDirectory,
                yamlDestTmpDirectory,
                restTestSetUp.liftRules,
-               List("api_eventlogs.yml"),
+               Nil,
                transformations
              )
         _ <- effectUioUnit(


### PR DESCRIPTION
https://issues.rudder.io/issues/26078

Some group updates from https://github.com/Normation/rudder/pull/6083 have impact on master branch