### PR TITLE
Fixes #26119: All rule show up in directive compliance

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -631,6 +631,7 @@ class ComplianceAPIService(
                        } else {
                          Seq().succeed
                        }
+      ruleIds        = rules.map(_.id).toSet
       t2            <- currentTimeMillis
       _             <- TimingDebugLoggerPure.trace(s"getByDirectivesCompliance - getAllRules in ${t2 - t1} ms")
       nodeFacts     <- nodeFactRepos.getAll()
@@ -654,7 +655,12 @@ class ComplianceAPIService(
       globalPolicyMode <- getGlobalPolicyMode
 
       reportsByRule = reportsByNode.flatMap {
-                        case (_, status) => status.reports.get(PolicyTypeName.rudderBase).map(_.reports).getOrElse(Nil)
+                        case (_, status) =>
+                          status.reports
+                            .get(PolicyTypeName.rudderBase)
+                            .map(_.reports)
+                            .getOrElse(Set.empty)
+                            .filter(r => ruleIds.contains(r.ruleId))
                       }.groupBy(_.ruleId)
       t7           <- currentTimeMillis
       _            <- TimingDebugLoggerPure.trace(s"getByRulesCompliance - group reports by rules in ${t7 - t6} ms")
@@ -684,34 +690,43 @@ class ComplianceAPIService(
         directive <- directives
       } yield {
         // We will compute compliance for each rule for the current Directive
-        val rulesCompliance = for {
-          (ruleId, ruleReports) <- reportsByRule.toSeq
+        val rulesCompliance = reportsByRule
+          .flatMap[ByDirectiveByRuleCompliance] {
+            case (ruleId, ruleReports) =>
+              // We will filter rules that truly have directive reports
+              ruleReports.flatMap(ruleReport => ruleReport.directives.get(directive.id).map(ruleReport -> _)) match {
+                case Nil                  => Option.empty[ByDirectiveByRuleCompliance]
+                case ruleDirectiveReports =>
+                  // We will now gather our report by component for the current Directive
+                  val reportsByComponents = (for {
+                    ruleDirectiveReport          <- ruleDirectiveReports
+                    (ruleReport, directiveReport) = ruleDirectiveReport
+                    nodeId                        = ruleReport.nodeId
+                    component                    <- directiveReport.components
+                  } yield {
+                    (nodeId, component)
+                  }).groupBy(_._2.componentName).toSeq
 
-          // We will now gather our report by component for the current Directive
-          reportsByComponents = (for {
-                                  ruleReport       <- ruleReports
-                                  nodeId            = ruleReport.nodeId
-                                  directiveReports <- ruleReport.directives.get(directive.id).toList
-                                  component        <- directiveReports.components
-                                } yield {
-                                  (nodeId, component)
-                                }).groupBy(_._2.componentName).toSeq
+                  val componentsCompliance = reportsByComponents.flatMap {
+                    case (compName, reports) => components(nodeFacts)(compName, reports.toList)
+                  }
 
-        } yield {
-          val componentsCompliance = reportsByComponents.flatMap(c => components(nodeFacts)(c._1, c._2.toList))
+                  val ruleName          = rules.find(_.id == ruleId).map(_.name).getOrElse(s"Unknown rule (${ruleId.serialize})")
+                  val componentsDetails = if (computedLevel <= 3) Seq() else componentsCompliance
 
-          val ruleName          = rules.find(_.id == ruleId).map(_.name).getOrElse("")
-          val componentsDetails = if (computedLevel <= 3) Seq() else componentsCompliance
+                  Some(
+                    ByDirectiveByRuleCompliance(
+                      ruleId,
+                      ruleName,
+                      ComplianceLevel.sum(componentsCompliance.map(_.compliance)),
+                      policyModeByRules.get(ruleId).flatten,
+                      componentsDetails
+                    )
+                  )
+              }
+          }
+          .toSeq
 
-          ByDirectiveByRuleCompliance(
-            ruleId,
-            ruleName,
-            ComplianceLevel.sum(componentsCompliance.map(_.compliance)),
-            policyModeByRules.get(ruleId).flatten,
-            componentsDetails
-          )
-        }
-        // level = ComplianceLevel.sum(reportsByDir.map(_.compliance))
         ByDirectiveCompliance(
           directive.id,
           directive.name,
@@ -920,7 +935,7 @@ class ComplianceAPIService(
                           status.reports
                             .get(PolicyTypeName.rudderBase)
                             .map(_.reports)
-                            .getOrElse(Nil)
+                            .getOrElse(Set.empty)
                             .filter(r =>
                               (isGlobalCompliance || rules.keySet.contains(r.ruleId)) && currentGroupNodeIds.contains(r.nodeId)
                             )
@@ -1019,7 +1034,7 @@ class ComplianceAPIService(
           val reports  = status.reports
             .get(PolicyTypeName.rudderBase)
             .map(_.reports)
-            .getOrElse(Nil)
+            .getOrElse(Set.empty)
             .filter(r => isGlobalCompliance || rules.keySet.contains(r.ruleId))
             .toSeq
             .sortBy(_.ruleId.serialize)

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_compliance.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_compliance.yml
@@ -2312,3 +2312,59 @@ response:
         ]
       }
     }
+---
+description: Get a directive compliance
+method: GET
+url: /secure/api/compliance/directives/e9a1a909-2490-4fc9-95c3-9d0aa01717c9?level=3
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getDirectiveComplianceId",
+      "result" : "success",
+      "data" : {
+        "directiveCompliance" : {
+          "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+          "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+          "compliance" : 100.0,
+          "mode" : "full-compliance",
+          "policyMode" : "default",
+          "complianceDetails" : {
+            "successAlreadyOK" : 100.0
+          },
+          "rules" : [
+            {
+              "id" : "br1",
+              "name" : "R1",
+              "compliance" : 100.0,
+              "policyMode" : "enforce",
+              "complianceDetails" : {
+                "successAlreadyOK" : 100.0
+              },
+              "components" : []
+            },
+            {
+              "id" : "r1",
+              "name" : "R1",
+              "compliance" : 100.0,
+              "policyMode" : "enforce",
+              "complianceDetails" : {
+                "successAlreadyOK" : 100.0
+              },
+              "components" : []
+            },
+            {
+              "id" : "br4",
+              "name" : "R4",
+              "compliance" : 100.0,
+              "policyMode" : "enforce",
+              "complianceDetails" : {
+                "successAlreadyOK" : 100.0
+              },
+              "components" : []
+            }
+          ],
+          "nodes" : []
+        }
+      }
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -363,7 +363,11 @@ class MockCompliance(mockDirectives: MockDirectives) {
     def findDirectiveNodeStatusReports(
         nodeIds:            Set[NodeId],
         filterByDirectives: Set[DirectiveId]
-    )(implicit qc: QueryContext): IOResult[Map[NodeId, NodeStatusReport]] = ???
+    )(implicit qc: QueryContext): IOResult[Map[NodeId, NodeStatusReport]] = {
+      val filteredNodeReports = statusReports.view.filterKeys(nodeIds.contains(_)).toMap
+      ReportingService.filterReportsByDirectives(filteredNodeReports, filterByDirectives).succeed
+    }
+
     def findDirectiveRuleStatusReportsByRule(ruleId: RuleId)(implicit qc: QueryContext): IOResult[Map[NodeId, NodeStatusReport]] =
       ???
     def findNodeStatusReport(nodeId:            NodeId)(implicit qc: QueryContext): IOResult[NodeStatusReport] = ???


### PR DESCRIPTION
https://issues.rudder.io/issues/26119

The directive compliance reports are using rules compliance reports, but currently an empty list of rule reports is just flattened further down as a rule with 0 compliance.
It should instead be deduced from the `Option`, obtained when getting directive reports