### PR TITLE
Fixes #26136: Add instance ID in group search criteria

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
@@ -61,6 +61,7 @@ import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.facts.nodes.NodeFact
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.repository.RoNodeGroupRepository
+import com.normation.rudder.services.servers.InstanceIdService
 import com.normation.utils.DateFormaterService
 import java.util.function.Predicate
 import java.util.regex.Pattern
@@ -91,7 +92,7 @@ class DefaultSubGroupComparatorRepository(repo: RoNodeGroupRepository) extends S
 }
 
 // groupRepo must be `=> ` to avoid cyclic dep
-class NodeQueryCriteriaData(groupRepo: () => SubGroupComparatorRepository) {
+class NodeQueryCriteriaData(groupRepo: () => SubGroupComparatorRepository, instanceIdService: InstanceIdService) {
 
   implicit class IterableToChunk[A](it: Iterable[A]) {
     def toChunk: Chunk[A] = Chunk.fromIterable(it)
@@ -256,7 +257,9 @@ class NodeQueryCriteriaData(groupRepo: () => SubGroupComparatorRepository) {
           A_POLICY_SERVER_UUID,
           StringComparator,
           NodeCriterionMatcherString(_.rudderSettings.policyServerId.value.wrap)
-        )
+        ),
+        // this one is not an LDAP constant but a global value in the application memory space
+        Criterion("instanceId", InstanceIdComparator(instanceIdService.instanceId), UnsupportedByNodeMinimalApi)
       )
     ),
     ObjectCriterion(

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -3084,7 +3084,8 @@ class MockLdapQueryParsing(mockGit: MockGitConfigRepo, mockNodeGroups: MockNodeG
   val inventoryDitService: InventoryDitService =
     new InventoryDitServiceImpl(pendingNodesDitImpl, acceptedNodesDitImpl, removedNodesDitImpl)
   val getSubGroupChoices = new DefaultSubGroupComparatorRepository(mockNodeGroups.groupsRepo)
-  val nodeQueryData      = new NodeQueryCriteriaData(() => getSubGroupChoices)
+  val instanceIdService  = new InstanceIdService(InstanceId("test-instance-id"))
+  val nodeQueryData      = new NodeQueryCriteriaData(() => getSubGroupChoices, instanceIdService)
   val ditQueryDataImpl   = new DitQueryData(acceptedNodesDitImpl, nodeDit, rudderDit, nodeQueryData)
   val queryParser        = CmdbQueryParser.jsonStrictParser(ditQueryDataImpl.criteriaMap.toMap)
 

--- a/webapp/sources/rudder/rudder-web/src/main/resources/ldapObjectAndAttributes.properties
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/ldapObjectAndAttributes.properties
@@ -156,6 +156,7 @@ ldap.attr.localAdministratorAccountName = Administrator account
 ldap.attr.nodeHostname = Hostname
 ldap.attr.inventoryDate = Last inventory date
 ldap.attr.policyServerId = Policy Server ID
+ldap.attr.instanceId = Instance ID
 ldap.attr.releaseDate = Release date
 ldap.attr.licenseExpirationDate = License expiration date
 ldap.attr.licenseName = License

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1315,6 +1315,7 @@ object RudderConfig extends Loggable {
   val updateTechniqueLibrary:              UpdateTechniqueLibrary                     = rci.updateTechniqueLibrary
   val techniqueCompilationStatusService:   TechniqueCompilationStatusSyncService      = rci.techniqueCompilationStatusService
   val userPropertyService:                 UserPropertyService                        = rci.userPropertyService
+  val instanceIdService:                   InstanceIdService                          = rci.instanceIdService
   val userRepository:                      UserRepository                             = rci.userRepository
   val userService:                         UserService                                = rci.userService
   val woApiAccountRepository:              WoApiAccountRepository                     = rci.woApiAccountRepository
@@ -2442,7 +2443,7 @@ object RudderConfigInit {
      * than the accepted ones.
      */
     lazy val getSubGroupChoices = new DefaultSubGroupComparatorRepository(roLdapNodeGroupRepository)
-    lazy val nodeQueryData      = new NodeQueryCriteriaData(() => getSubGroupChoices)
+    lazy val nodeQueryData      = new NodeQueryCriteriaData(() => getSubGroupChoices, instanceIdService)
     lazy val ditQueryDataImpl   = new DitQueryData(acceptedNodesDitImpl, nodeDit, rudderDit, nodeQueryData)
     lazy val queryParser        = CmdbQueryParser.jsonStrictParser(Map.empty[String, ObjectCriterion] ++ ditQueryDataImpl.criteriaMap)
     lazy val queryRawParser     = CmdbQueryParser.jsonRawParser(Map.empty[String, ObjectCriterion] ++ ditQueryDataImpl.criteriaMap)
@@ -3643,7 +3644,7 @@ object RudderConfigInit {
             pendingNodesDitImpl,
             nodeDit,
             rudderDit,
-            new NodeQueryCriteriaData(() => subGroup)
+            new NodeQueryCriteriaData(() => subGroup, instanceIdService)
           ),
           ldapEntityMapper
         )

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
@@ -925,7 +925,19 @@ object SearchNodeComponent {
               attrs*
             )
         }
-      case _                                          => AsForm.default
+
+      case InstanceIdComparator(instanceId) =>
+        AsForm {
+          case (value, func, attrs) =>
+            // empty value is not allowed so the input is filled with the current instance ID as default
+            val defaultOrValue = if (value.isEmpty) instanceId.value else value
+            SHtml.text(
+              defaultOrValue,
+              func,
+              attrs*
+            )
+        }
+      case _                                => AsForm.default
     }
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/26136

Adding an "Instance ID" criterion in groups : 

![image](https://github.com/user-attachments/assets/cb672243-24b3-4bf7-8313-ca16f0fdf2ab)

This criterion needs to be handled differently from other criterion :  
* the value that needs to be searched for comes from the application, `InstanceIdService`, and not from node facts (LDAP) attributes
* when combined with other criterion, if it does not match, it should short-circuit any other LDAP criterion comparison (to avoid doing LDAP search), to do so we introduce the absorption property in the boolean algebra 
* and finally in the UI, it needs to be filled by default (i.e. when the value is still empty) with the current instance ID