### PR TITLE
Fixes #26059: Create a new ‘About’ page for easy access to technical information

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/metrics/HistorizeNodeCountService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/metrics/HistorizeNodeCountService.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.metrics
 import better.files.*
 import com.normation.errors.*
 import com.normation.rudder.domain.logger.ScheduledJobLoggerPure
+import com.normation.rudder.domain.nodes.NodeState.Ignored
 import com.normation.rudder.domain.reports.ComplianceLevel
 import com.normation.rudder.facts.nodes.NodeFactRepository
 import com.normation.rudder.facts.nodes.QueryContext
@@ -151,7 +152,7 @@ class FetchDataServiceImpl(nodeFactRepo: NodeFactRepository, reportingService: R
       }
     }
 
-    (for {
+    for {
       accepted   <- nodeFactRepo.getAll()(QueryContext.systemQC, SelectNodeStatus.Accepted)
       pending    <- nodeFactRepo.getAll()(QueryContext.systemQC, SelectNodeStatus.Pending)
       compliance <- reportingService.getUserNodeStatusReports()(QueryContext.systemQC)
@@ -162,9 +163,10 @@ class FetchDataServiceImpl(nodeFactRepo: NodeFactRepository, reportingService: R
         accepted.size,
         modes.getOrElse(Mode.Audit, 0),
         modes.getOrElse(Mode.Enforce, 0),
-        modes.getOrElse(Mode.Mixed, 0)
+        modes.getOrElse(Mode.Mixed, 0),
+        accepted.count { case (_, n) => n.rudderSettings.state == Ignored }
       )
-    })
+    }
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/metrics/SystemInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/metrics/SystemInfoService.scala
@@ -1,0 +1,53 @@
+/*
+ *************************************************************************************
+ * Copyright 2025 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.metrics
+
+import com.normation.errors.IOResult
+
+/*
+ * A service that get public & private system info
+ */
+trait SystemInfoService {
+
+  def getPublicInfo(): IOResult[PublicSystemInfo]
+
+  def getPrivateInfo(): IOResult[PrivateSystemInfo]
+
+  def getAll(): IOResult[SystemInfo]
+
+}

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/metrics/NodeCountHistorizationTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/metrics/NodeCountHistorizationTest.scala
@@ -100,12 +100,12 @@ class NodeCountHistorizationTest extends Specification with BeforeAfter {
     val t2    = 1000L.millis          // go to 2020-03-20 3:49:37
     val prog  = {
       for {
-        refMetrics <- Ref.make(FrequentNodeMetrics(1, 2, 3, 4, 5))
+        refMetrics <- Ref.make(FrequentNodeMetrics(1, 2, 3, 4, 5, 6))
         _          <- ZIO.sleep(t1).fork
         _          <- TestClock.adjust(t1)
         service    <- makeService(rootDir, refMetrics)
         commit     <- service.fetchDataAndLog("initialize logs")
-        _          <- refMetrics.set(FrequentNodeMetrics(35, 46, 57, 68, 79))
+        _          <- refMetrics.set(FrequentNodeMetrics(35, 46, 57, 68, 79, 3))
         _          <- ZIO.sleep(t2).fork
         _          <- TestClock.adjust(t2)
         commit     <- service.fetchDataAndLog("A second one")
@@ -117,8 +117,8 @@ class NodeCountHistorizationTest extends Specification with BeforeAfter {
     val lines = File(rootDir, "nodes-2020-03").lines(StandardCharsets.UTF_8).toVector
 
     (lines.size must beEqualTo(3)) and (
-      (lines(1) must beEqualTo(""""2020-03-20T03:49:36Z";"1";"2";"3";"4";"5"""")) and
-      (lines(2) must beEqualTo(""""2020-03-20T03:49:37Z";"35";"46";"57";"68";"79""""))
+      (lines(1) must beEqualTo(""""2020-03-20T03:49:36Z";"1";"2";"3";"4";"5";"6"""")) and
+      (lines(2) must beEqualTo(""""2020-03-20T03:49:37Z";"35";"46";"57";"68";"79";"3""""))
     )
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/About.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/About.scala
@@ -1,0 +1,215 @@
+/*
+ *************************************************************************************
+ * Copyright 2025 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.rest.data
+
+import com.normation.inventory.domain.OsDetails
+import com.normation.plugins.JsonPluginDetails
+import com.normation.plugins.PluginLicenseInfo
+import com.normation.rudder.metrics.*
+import com.normation.utils.DateFormaterService.*
+import io.scalaland.chimney.*
+import io.scalaland.chimney.syntax.*
+import java.time.ZonedDateTime
+import zio.json.*
+import zio.json.internal.Write
+
+/*
+ * Translation from system info to the Json About structure
+ */
+case class RelayJson(uuid: String, hostname: String, managedNodes: Int)
+object RelayJson {
+  implicit val encoderRelayJson: JsonEncoder[RelayJson] = DeriveJsonEncoder.gen
+}
+
+case class OsJson(name: String, version: String)
+
+object OsJson {
+  implicit val transformOsDetails: Transformer[OsDetails, OsJson] = {
+    Transformer
+      .define[OsDetails, OsJson]
+      .withFieldComputed(_.name, _.fullName)
+      .withFieldComputed(_.version, _.version.value)
+      .buildTransformer
+  }
+
+  implicit val encoderOsJson: JsonEncoder[OsJson] = DeriveJsonEncoder.gen
+}
+
+case class JvmJson(version: String, cmd: String)
+object JvmJson     {
+  implicit val transformJvmInfo: Transformer[JvmInfo, JvmJson] =
+    Transformer.derive[JvmInfo, JvmJson]
+
+  implicit val encoderJvmJson: JsonEncoder[JvmJson] = DeriveJsonEncoder.gen
+}
+case class NodesJson(total: Int, audit: Int, enforce: Int, mixed: Int, enabled: Int, disabled: Int)
+object NodesJson   {
+  implicit val transformNodesInfo: Transformer[FrequentNodeMetrics, NodesJson] = {
+    Transformer
+      .define[FrequentNodeMetrics, NodesJson]
+      .withFieldRenamed(_.accepted, _.total)
+      .withFieldRenamed(_.modeAudit, _.audit)
+      .withFieldRenamed(_.modeEnforce, _.enforce)
+      .withFieldRenamed(_.modeMixed, _.mixed)
+      .withFieldComputed(_.enabled, x => x.accepted - x.disabled)
+      .buildTransformer
+  }
+
+  implicit val encoderNodesJson: JsonEncoder[NodesJson] = DeriveJsonEncoder.gen
+}
+case class LicenseJson(
+    licensee:           String,
+    startDate:          ZonedDateTime,
+    endDate:            ZonedDateTime,
+    allowedNodesNumber: Option[Int],
+    supportedVersions:  String
+)
+object LicenseJson {
+  implicit val transformPluginLicenseInfo: Transformer[PluginLicenseInfo, LicenseJson] = {
+    Transformer
+      .define[PluginLicenseInfo, LicenseJson]
+      .withFieldComputed(_.startDate, _.startDate.toJava)
+      .withFieldComputed(_.endDate, _.endDate.toJava)
+      .withFieldRenamed(_.maxNodes, _.allowedNodesNumber)
+      .withFieldComputed(_.supportedVersions, x => s"[${x.minVersion},${x.maxVersion}]")
+      .buildTransformer
+  }
+
+  implicit val encoderLicenseJson: JsonEncoder[LicenseJson] = DeriveJsonEncoder.gen
+}
+
+case class PluginJson(id: String, name: String, version: String, abiVersion: String, license: Option[LicenseJson])
+object PluginJson {
+  implicit val transformJsonPluginDetails: Transformer[JsonPluginDetails, PluginJson] = {
+    Transformer
+      .define[JsonPluginDetails, PluginJson]
+      .withFieldComputed(_.abiVersion, _.version)
+      .buildTransformer
+  }
+
+  implicit val encoderPluginJson: JsonEncoder[PluginJson] = DeriveJsonEncoder.gen
+}
+
+case class SystemJson(os: OsJson, jvm: JvmJson)
+
+object SystemJson             {
+  implicit val transformSystemInfo: Transformer[SystemInfo, SystemJson] = {
+    Transformer
+      .define[SystemInfo, SystemJson]
+      .withFieldComputed(_.os, _.public.os.transformInto[OsJson])
+      .withFieldComputed(_.jvm, _.public.jvm.transformInto[JvmJson])
+      .buildTransformer
+  }
+
+  implicit val encoderSystemJson: JsonEncoder[SystemJson] = DeriveJsonEncoder.gen
+}
+
+case class AboutRudderInfoJsonV20(
+    @jsonField("major-version") majorVersion: String,
+    @jsonField("full-version") version:       String,
+    @jsonField("build-time") buildTime:       String
+)
+object AboutRudderInfoJsonV20 {
+  implicit val transformSystemInfo: Transformer[SystemInfo, AboutRudderInfoJsonV20] = {
+    Transformer
+      .define[SystemInfo, AboutRudderInfoJsonV20]
+      .withFieldComputed(_.majorVersion, _.public.rudderMajorVersion)
+      .withFieldComputed(_.version, _.public.rudderVersion)
+      .withFieldComputed(_.buildTime, _.public.buildTime)
+      .buildTransformer
+  }
+
+  implicit val encoderAboutRudderInfoJsonV20: JsonEncoder[AboutRudderInfoJsonV20] = DeriveJsonEncoder.gen
+}
+
+case class RudderJson(
+    version:    String,
+    buildTime:  String,
+    instanceId: String,
+    relays:     List[RelayJson]
+)
+
+object RudderJson {
+  implicit val transformSystemInfo: Transformer[SystemInfo, RudderJson] = {
+    Transformer
+      .define[SystemInfo, RudderJson]
+      .withFieldComputed(_.version, _.public.rudderVersion)
+      .withFieldComputed(_.buildTime, _.public.buildTime)
+      .withFieldComputed(_.instanceId, _.priv.instanceId.value)
+      .withFieldComputed(_.relays, _.priv.relays.map(r => RelayJson(r.id.value, r.hostname, r.managedNodes)))
+      .buildTransformer
+  }
+
+  implicit val encoderRudderJson: JsonEncoder[RudderJson] = DeriveJsonEncoder.gen
+}
+
+sealed trait SystemInfoJson
+
+object SystemInfoJson {
+
+  case class AboutInfoJsonV20(rudder: AboutRudderInfoJsonV20) extends SystemInfoJson
+  // version for Rudder 8.3
+  case class AboutInfoJsonV21(
+      rudder:  RudderJson,
+      system:  SystemJson,
+      nodes:   NodesJson,
+      plugins: List[PluginJson]
+  ) extends SystemInfoJson
+
+  implicit val transformSystemInfo: Transformer[SystemInfo, AboutInfoJsonV21] = {
+    Transformer
+      .define[SystemInfo, AboutInfoJsonV21]
+      .withFieldComputed(_.rudder, _.transformInto[RudderJson])
+      .withFieldComputed(_.system, _.transformInto[SystemJson])
+      .withFieldComputed(_.nodes, _.public.nodes.transformInto[NodesJson])
+      .withFieldComputed(_.plugins, _.priv.plugins.toList.map(_.transformInto[PluginJson]))
+      .buildTransformer
+  }
+
+  implicit val encoderAboutInfoJsonV20: JsonEncoder[AboutInfoJsonV20] = DeriveJsonEncoder.gen
+  implicit val encoderAboutInfoJsonV21: JsonEncoder[AboutInfoJsonV21] = DeriveJsonEncoder.gen
+
+  implicit val encoderSystemInfoJson: JsonEncoder[SystemInfoJson] = new JsonEncoder[SystemInfoJson] {
+    override def unsafeEncode(a: SystemInfoJson, indent: Option[Int], out: Write): Unit = {
+      a match {
+        case x: AboutInfoJsonV20 => encoderAboutInfoJsonV20.unsafeEncode(x, indent, out)
+        case x: AboutInfoJsonV21 => encoderAboutInfoJsonV21.unsafeEncode(x, indent, out)
+      }
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_system.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_system.yml
@@ -1,0 +1,70 @@
+---
+description: Get system info for Rudder prior to Rudder 8.3 (API V20)
+method: GET
+url: /api/20/system/info
+response:
+  code: 200
+  content: >-
+    {
+      "action":"info",
+      "result":"success",
+      "data":{
+        "rudder" : {
+          "major-version" : "8.3",
+          "full-version" : "8.3.0",
+          "build-time" : "2025-01-05T21:53:20+01:00"
+        }
+      }
+    }
+---
+description: Get system info for Rudder 8.3 (API V21)
+method: GET
+url: /api/latest/system/info
+response:
+  code: 200
+  content: >-
+    {
+      "action":"info",
+      "result":"success",
+      "data":{
+        "rudder" : {
+          "version" : "8.3.0",
+          "buildTime" : "2025-01-05T21:53:20+01:00",
+          "instanceId" : "c2180fd6-36e1-41d9-ad27-b71ff49eef68",
+          "relays" : [
+            {
+              "uuid" : "ac189019-6f8d-47ca-9f3a-ad66c338ce50",
+              "hostname" : "relay0.rudder.io",
+              "managedNodes" : 342
+            }
+          ]
+        },
+        "system" : {
+          "os" : {
+            "name" : "Rocky Linux release 8.10 (Green Obsidian)",
+            "version" : "8.10"
+          },
+          "jvm" : {
+            "version" : "21.0.32",
+            "cmd" : "java -Dblablabla rudder"
+          }
+        },
+        "nodes" : {
+            "total" : 233,
+            "audit" : 144,
+            "enforce" : 178,
+            "mixed" : 42,
+            "enabled" : 207,
+            "disabled" : 26
+          },
+          "plugins" : [
+            {
+              "id" : "rudder-plugin-auth-backends",
+              "name" : "authentication backends",
+              "version" : "8.3.0-2.4.1",
+              "abiVersion" : "8.3.0-2.4.1"
+            }
+          ]
+        }
+      }
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SystemApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SystemApiTest.scala
@@ -74,27 +74,6 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
     }
   }
 
-  "Testing system API info" should {
-    "match the response defined below" in {
-
-      implicit val action   = "getSystemInfo"
-      implicit val prettify = false
-
-      val response = toJsonResponse(
-        None,
-        ("rudder"           -> (
-          ("major-version"  -> "5.0")
-          ~ ("full-version" -> "5.0.0")
-          ~ ("build-time"   -> "some time")
-        ))
-      )
-
-      restTest.testGET("/api/latest/system/info") { req =>
-        restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
-      }
-    }
-  }
-
   "Testing system API status" should {
     "match the response defined below" in {
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/About.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/About.elm
@@ -1,0 +1,109 @@
+port module About exposing (update)
+
+import Browser
+import Result
+import Json.Decode exposing (Value)
+import Http.Detailed as Detailed
+
+import About.DataTypes exposing (..)
+import About.Init exposing (init, subscriptions) -- fakeData
+import About.View exposing (view)
+import List exposing (drop, head)
+import String exposing (join, split)
+import Json.Decode exposing (..)
+
+--
+-- Port for interacting with external JS
+--
+
+port errorNotification : String -> Cmd msg
+port copy : String -> Cmd msg
+port copyJson : Value -> Cmd msg
+
+main =
+  Browser.element
+    { init = init
+    , view = view
+    , update = update
+    , subscriptions = subscriptions
+    }
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        ApiGetAboutInfo res ->
+            let
+                ui = model.ui
+                newModel = {model | ui = {ui | loading = False}}
+            in
+                case res of
+                    Ok (_, info) ->
+                        ({newModel | info = Just info}, Cmd.none)
+                    Err err ->
+                      processApiError "Error while fetching information" err model
+        Copy s ->
+            ( model, copy s )
+
+        CopyJson value ->
+            (model, copyJson value)
+
+        UpdateUI newUI ->
+            ({model | ui = newUI}, Cmd.none)
+
+
+processApiError : String -> Detailed.Error String -> Model -> ( Model, Cmd Msg )
+processApiError msg err model =
+    let
+        modelUi =
+            model.ui
+
+        message =
+            case err of
+                Detailed.BadUrl url ->
+                    "The URL " ++ url ++ " was invalid"
+
+                Detailed.Timeout ->
+                    "Unable to reach the server, try again"
+
+                Detailed.NetworkError ->
+                    "Unable to reach the server, check your network connection"
+
+                Detailed.BadStatus metadata body ->
+                    let
+                        ( title, errors ) =
+                            decodeErrorDetails body
+                    in
+                    title ++ "\n" ++ errors
+
+                Detailed.BadBody metadata body m ->
+                    m
+    in
+    ( model , errorNotification (msg ++ ", details: \n" ++ message) )
+
+
+decodeErrorDetails : String -> ( String, String )
+decodeErrorDetails json =
+    let
+        errorMsg =
+            decodeString (Json.Decode.at [ "errorDetails" ] string) json
+
+        msg =
+            case errorMsg of
+                Ok s ->
+                    s
+
+                Err e ->
+                    "fail to process errorDetails"
+
+        errors =
+            split "<-" msg
+
+        title =
+            head errors
+    in
+    case title of
+        Nothing ->
+            ( "", "" )
+
+        Just s ->
+            ( s, join " \n " (drop 1 (List.map (\err -> "\t ‣ " ++ err) errors)) )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/ApiCalls.elm
@@ -1,0 +1,25 @@
+module About.ApiCalls exposing (..)
+
+import Http exposing (emptyBody, expectJson, header, request)
+import Http.Detailed as Detailed
+
+import About.DataTypes exposing (..)
+import About.JsonDecoder exposing (decodeApiGetAboutInfo)
+
+
+getUrl: Model -> String -> String
+getUrl m url =
+  m.contextPath ++ "/secure/api" ++ url
+
+apiGetAboutInfo : Model -> Cmd Msg
+apiGetAboutInfo model =
+  request
+    { method          = "GET"
+    , headers         = [header "X-Requested-With" "XMLHttpRequest"]
+    , url             = getUrl model "/system/info"
+    , body            = emptyBody
+    , expect          = Detailed.expectJson ApiGetAboutInfo decodeApiGetAboutInfo
+    , timeout         = Nothing
+    , tracker         = Nothing
+    }
+--}

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/DataTypes.elm
@@ -1,0 +1,84 @@
+module About.DataTypes exposing (..)
+
+import Http exposing (Error)
+import Http.Detailed
+import Json.Encode exposing (Value)
+
+type alias RudderInfo =
+    { version   : String
+    , buildTime : String
+    , instanceId: String
+    , relays    : List Relay
+    }
+
+type alias Relay =
+    { uuid : String
+    , hostname : String
+    , managedNodes : Int
+    }
+
+type alias SystemInfo =
+    { os : OperatingSystem
+    , jvm: JvmInfo
+    }
+
+type alias OperatingSystem =
+    { name : String
+    , version : String
+    }
+
+type alias JvmInfo =
+    { version : String
+    , cmd : String
+    }
+
+type alias NodesInfo =
+    { total : Int
+    , audit : Int
+    , enforce : Int
+    , mixed : Int
+    , enabled : Int
+    , disabled : Int
+    }
+
+type alias PluginInfo =
+    { id : String
+    , name : String
+    , version : String
+    , abiVersion : String
+    , license    : Maybe LicenseInfo
+    }
+
+type alias LicenseInfo =
+    { licensee : String
+    , startDate : String
+    , endDate : String
+    , allowedNodesNumber : Int
+    , supportedVersions : String
+    }
+
+
+type alias AboutInfo =
+    { rudderInfo : RudderInfo
+    , system : SystemInfo
+    , nodes : NodesInfo
+    , plugins : List PluginInfo
+    }
+
+type alias Model =
+    { contextPath : String
+    , info : Maybe AboutInfo
+    , ui : UI
+    }
+
+type alias UI =
+    { loading : Bool
+    , showRelays : Bool
+    , showPlugins : Bool
+    }
+
+type Msg
+  = ApiGetAboutInfo (Result (Http.Detailed.Error String) ( Http.Metadata, AboutInfo ))
+  | Copy String
+  | CopyJson Value
+  | UpdateUI UI

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/Init.elm
@@ -1,0 +1,43 @@
+module About.Init exposing (..)
+
+import About.DataTypes exposing (..)
+import About.ApiCalls exposing (apiGetAboutInfo)
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.none
+
+init : { contextPath : String } -> ( Model, Cmd Msg )
+init flags =
+    let
+      initModel = Model flags.contextPath Nothing (UI True True True)
+    in
+      ( initModel
+      , apiGetAboutInfo initModel
+      )
+{--
+fakeData : AboutInfo
+fakeData =
+    let
+        relaysList =
+            [ (Relay "0123-4567-8901-2345" "relay1" 96)
+            , (Relay "4567-8901-2345-6789" "relay2" 202)
+            , (Relay "8901-2345-6789-0123" "relay3" 29)
+            ]
+
+        rudderInfo = RudderInfo "8.3.0" "build-1" "d40076ff-6a7d-4887-b1a9-6c99c4b25e29" relaysList
+
+        os = OperatingSystem "Ubuntu" "24.04"
+        jvm = JvmInfo "9.0" "lauchOptions -X -R --param1 --param2 --param3 --param4 --param5"
+        system = SystemInfo os jvm
+
+        nodes = NodesInfo 1000 600 400 900 100
+
+        license = LicenseInfo "Demo Normation" "01-01-2024" "01-01-2025" 9999 "8.3.0"
+        plugins =
+            [ PluginInfo "branding" "Branding" "2.0.0" "8.3.0" license
+            ]
+    in
+        AboutInfo rudderInfo system nodes plugins
+--}

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/JsonDecoder.elm
@@ -1,0 +1,80 @@
+module About.JsonDecoder exposing (..)
+
+import Json.Decode as D exposing (..)
+import Json.Decode.Pipeline exposing (required, optional)
+
+import About.DataTypes exposing (..)
+
+
+decodeApiGetAboutInfo : Decoder AboutInfo
+decodeApiGetAboutInfo =
+  at [ "data" ] decodeAboutInfo
+
+decodeAboutInfo : Decoder AboutInfo
+decodeAboutInfo =
+  D.succeed AboutInfo
+    |> required "rudder" decodeRudderInfo
+    |> required "system" decodeSystemInfo
+    |> required "nodes" decodeNodesInfo
+    |> required "plugins" (list decodePluginInfo)
+
+decodeRudderInfo : Decoder RudderInfo
+decodeRudderInfo =
+  D.succeed RudderInfo
+    |> required "version" string
+    |> required "buildTime" string
+    |> required "instanceId" string
+    |> required "relays" (list decodeRelay)
+
+decodeRelay : Decoder Relay
+decodeRelay =
+  D.succeed Relay
+    |> required "uuid" string
+    |> required "hostname" string
+    |> required "managedNodes" int
+
+decodeSystemInfo : Decoder SystemInfo
+decodeSystemInfo =
+  D.succeed SystemInfo
+    |> required "os" decodeOperatingSystem
+    |> required "jvm" decodeJvm
+
+decodeOperatingSystem : Decoder OperatingSystem
+decodeOperatingSystem =
+  D.succeed OperatingSystem
+    |> required "name" string
+    |> required "version" string
+
+decodeJvm : Decoder JvmInfo
+decodeJvm =
+  D.succeed JvmInfo
+    |> required "version" string
+    |> required "cmd" string
+
+decodeNodesInfo : Decoder NodesInfo
+decodeNodesInfo =
+  D.succeed NodesInfo
+    |> required "total" int
+    |> required "audit" int
+    |> required "mixed" int
+    |> required "enforce" int
+    |> required "enabled" int
+    |> required "disabled" int
+
+decodePluginInfo : Decoder PluginInfo
+decodePluginInfo =
+  D.succeed PluginInfo
+    |> required "id" string
+    |> required "name" string
+    |> required "version" string
+    |> required "abiVersion" string
+    |> optional "license" (D.maybe decodeLicenseInfo) Nothing
+
+decodeLicenseInfo : Decoder LicenseInfo
+decodeLicenseInfo =
+  D.succeed LicenseInfo
+    |> required "licensee" string
+    |> required "startDate" string
+    |> required "endDate" string
+    |> required "allowedNodesNumber" int
+    |> required "supportedVersions" string

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/JsonEncoder.elm
@@ -1,0 +1,82 @@
+module About.JsonEncoder exposing (..)
+
+import About.DataTypes exposing (..)
+import Json.Encode exposing (..)
+
+encodeRudderInfo : RudderInfo -> Value
+encodeRudderInfo rudderInfo =
+    object
+        [ ( "version", string rudderInfo.version )
+        , ( "buildTime", string rudderInfo.buildTime )
+        , ( "instanceId", string rudderInfo.instanceId )
+        , ( "relays", (list encodeRelay) rudderInfo.relays )
+        ]
+
+encodeRelay : Relay -> Value
+encodeRelay relay =
+    object
+        [ ( "uuid", string relay.uuid )
+        , ( "hostname", string relay.hostname )
+        , ( "managedNodes", int relay.managedNodes )
+        ]
+
+encodeSystemInfo : SystemInfo -> Value
+encodeSystemInfo systemInfo =
+    object
+        [ ( "os", encodeOs systemInfo.os )
+        , ( "jvm", encodeJvm systemInfo.jvm )
+        ]
+
+encodeOs : OperatingSystem -> Value
+encodeOs os =
+    object
+        [ ( "name", string os.name )
+        , ( "version", string os.version )
+        ]
+encodeJvm : JvmInfo -> Value
+encodeJvm jvm =
+    object
+        [ ( "version", string jvm.version )
+        , ( "cmd", string jvm.cmd )
+        ]
+
+encodeNodesInfo : NodesInfo -> Value
+encodeNodesInfo nodesInfo =
+    object
+        [ ( "total", int nodesInfo.total )
+        , ( "audit", int nodesInfo.audit )
+        , ( "enforce", int nodesInfo.enforce )
+        , ( "enabled", int nodesInfo.enabled )
+        , ( "disabled", int nodesInfo.disabled )
+        ]
+
+encodePluginInfo : PluginInfo -> Value
+encodePluginInfo pluginInfo =
+    object
+        [ ( "id", string pluginInfo.id )
+        , ( "name", string pluginInfo.name )
+        , ( "version", string pluginInfo.version )
+        , ( "abiVersion", string pluginInfo.abiVersion )
+        , ( "license", encodeLicenseInfo pluginInfo.license )
+        ]
+
+encodeLicenseInfo : Maybe LicenseInfo -> Value
+encodeLicenseInfo licenseInfo =
+  case licenseInfo of
+    Nothing -> null
+    Just li ->  object
+        [ ( "licensee", string li.licensee )
+        , ( "startDate", string li.startDate )
+        , ( "endDate", string li.endDate )
+        , ( "allowedNodesNumber", int li.allowedNodesNumber )
+        , ( "supportedVersions", string li.supportedVersions )
+        ]
+
+encodeAboutInfo : AboutInfo -> Value
+encodeAboutInfo aboutInfo =
+    object
+        [ ( "rudder", encodeRudderInfo aboutInfo.rudderInfo )
+        , ( "system", encodeSystemInfo aboutInfo.system )
+        , ( "nodes", encodeNodesInfo aboutInfo.nodes )
+        , ( "plugins", (list encodePluginInfo) aboutInfo.plugins )
+        ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/View.elm
@@ -1,0 +1,283 @@
+module About.View exposing (..)
+
+import Html exposing (Html, div, text, h1, h4, span, p, label, i, a, button, table, thead, tbody, td, th, tr)
+import Html.Attributes exposing (class, title, type_)
+import Html.Events exposing (onClick)
+import Json.Encode exposing (Value, list, object)
+
+import About.DataTypes exposing (..)
+import About.JsonEncoder exposing (..)
+
+
+view : Model -> Html Msg
+view model =
+    let
+        (copyBtn, content) =
+            case model.info of
+            Nothing ->
+                ( text ""
+                , if model.ui.loading then
+                    let
+                        fakeSection : Int -> Html Msg
+                        fakeSection i =
+                            div[class "mb-2"]
+                                ( p [class "placeholder-wave"]
+                                    [ span [class "placeholder bg-secondary rounded placeholder-lg col-2"][]
+                                    ]
+                                :: List.repeat i (
+                                    p [class "placeholder-glow"]
+                                        [ span [class "placeholder bg-secondary rounded col-1"][]
+                                        ]
+                                    )
+                                )
+
+                    in
+                    [ fakeSection 4
+                    , fakeSection 4
+                    , fakeSection 5
+                    , fakeSection 3
+                    ]
+                else
+                    [ div [class "alert alert-danger d-flex align-items-center"]
+                        [ i[class "fa fa-warning"][]
+                        , text "Error while fetching information."
+                        ]
+                    ]
+                )
+
+            Just info ->
+                let
+                    rowTxtInfo : String -> String -> Html Msg
+                    rowTxtInfo title val =
+                        div[class "mb-1"]
+                            [ div[class "info"]
+                                [ label[][text title]
+                                , span[][text val]
+                                , btnCopy val
+                                ]
+                            ]
+
+                    rowNbInfo : String -> Int -> Html Msg
+                    rowNbInfo title val =
+                        let
+                            str = String.fromInt val
+                        in
+                        div[class "mb-1"]
+                            [ div[class "info"]
+                                [ label[][text title]
+                                , span[class "ms-0 badge fs-6"][text str]
+                                , btnCopy str
+                                ]
+                            ]
+
+                    btnCopy : String -> Html Msg
+                    btnCopy value =
+                        a [ class "btn-goto always clipboard", title "Copy to clipboard" , onClick (Copy value) ]
+                            [ i [class "ion ion-clipboard"][]
+                            ]
+
+                    btnCopyJson : String -> Value -> Html Msg
+                    btnCopyJson key val =
+                        let
+                            obj = object
+                                [ ( key, val ) ]
+                        in
+                            a [ class "btn-goto always clipboard", title "Copy to clipboard" , onClick (CopyJson obj) ]
+                                [ i [class "ion ion-clipboard"][]
+                                ]
+
+                    relaysList : List Relay -> UI -> Html Msg
+                    relaysList relays ui =
+                        let
+                            showList = ui.showRelays
+                            relayRow : Relay -> Html Msg
+                            relayRow relay =
+                                tr[]
+                                [ td[][text relay.hostname]
+                                , td[][text relay.uuid]
+                                , td[][text (String.fromInt relay.managedNodes)]
+                                ]
+
+                            nbRelays = String.fromInt (List.length relays)
+                        in
+                            div[class "mb-1"]
+                                [ div[class "info"]
+                                    ( if List.isEmpty relays then
+                                    [ label[]
+                                        [ text "Relays"
+                                        ]
+                                    , i [class "text-secondary"][text "There are no managed relays"]
+                                    ]
+                                    else
+                                        [ label[]
+                                            [ text "Relays"
+                                            ]
+                                        , span[class "ms-0 me-2 badge fs-6"][text nbRelays]
+                                        , button[class "btn btn-sm btn-default", onClick (UpdateUI {ui | showRelays = not showList})]
+                                            [ text ((if showList then "Hide" else "Show") ++ " list")
+                                            ]
+                                        , btnCopyJson "relays" (list encodeRelay relays)
+                                        ]
+                                    )
+                                , ( if List.isEmpty relays then
+                                        text ""
+                                    else
+                                        div[class (if showList then "d-flex " else "d-none")]
+                                            [ table[class "dataTable mt-1"]
+                                                [ thead[]
+                                                    [ tr[class "head"]
+                                                        [ th[][text "Hostname"]
+                                                        , th[][text "ID"]
+                                                        , th[][text "Managed nodes"]
+                                                        ]
+                                                    ]
+                                                , tbody[]
+                                                    (relays |> List.sortBy .hostname |> List.map relayRow)
+                                                ]
+                                            ]
+                                    )
+                                ]
+
+                    pluginsList : List PluginInfo -> UI -> Html Msg
+                    pluginsList plugins ui =
+                        let
+                            showList = ui.showPlugins
+                            pluginRow : PluginInfo -> Html Msg
+                            pluginRow plugin =
+                              let
+                                license = case plugin.license of
+                                  Nothing -> []
+                                  Just l -> [
+                                      td[][text l.licensee]
+                                    , td[][text ("from " ++ l.startDate ++ " to " ++ l.endDate)]
+                                    , td[][text (String.fromInt l.allowedNodesNumber)]
+                                    , td[][text l.supportedVersions]]
+                              in
+                                tr[]
+                                ([ td[][text plugin.id]
+                                , td[][text plugin.name]
+                                , td[][text plugin.version]
+                                , td[][text plugin.abiVersion]
+                                ] ++ license)
+
+                            nbPlugins = String.fromInt (List.length plugins)
+                        in
+                            div[class "mb-1"]
+                                [ div[class "info"]
+                                    ( if List.isEmpty plugins then
+                                    [ label[]
+                                        [ text "Plugins"
+                                        ]
+                                    , i [class "text-secondary"][text "No plugins installed"]
+                                    ]
+                                    else
+                                        [ label[]
+                                            [ text "Plugins"
+                                            ]
+                                        , span[class "ms-0 me-2 badge fs-6"][text nbPlugins]
+                                        , button[class "btn btn-sm btn-default", onClick (UpdateUI {ui | showPlugins = not showList})]
+                                            [ text ((if showList then "Hide" else "Show") ++ " list")
+                                            ]
+                                        , btnCopyJson "plugins" (list encodePluginInfo plugins)
+                                        ]
+                                    )
+                                , ( if List.isEmpty plugins then
+                                        text ""
+                                    else
+                                        div[class (if showList then "d-flex " else "d-none")]
+                                            [ table[class "dataTable mt-1"]
+                                                [ thead[]
+                                                    [ tr[class "head"]
+                                                        [ th[][text "ID"]
+                                                        , th[][text "Name"]
+                                                        , th[][text "Version"]
+                                                        , th[][text "ABI version"]
+                                                        , th[][text "Licensee"]
+                                                        , th[][text "Validity period"]
+                                                        , th[][text "Node limit"]
+                                                        , th[][text "Supported versions"]
+                                                        ]
+                                                    ]
+                                                , tbody[]
+                                                    (plugins |> List.sortBy .id |> List.map pluginRow)
+                                                ]
+                                            ]
+                                    )
+                                ]
+
+                in
+                    ( button [class "btn btn-primary", type_ "button", onClick (CopyJson (encodeAboutInfo info))]
+                        [ text "Copy all to clipboard"
+                        , i [class "ms-2 ion ion-clipboard"][]
+                        ]
+                    , [ div[class "mb-4"]
+                        [ h4[]
+                            [ text "Rudder info"
+                            , btnCopyJson "rudder" (encodeRudderInfo info.rudderInfo)
+                            ]
+                        , div[]
+                            [ rowTxtInfo "Version" info.rudderInfo.version
+                            , rowTxtInfo "Build" info.rudderInfo.buildTime
+                            , rowTxtInfo "Instance ID" info.rudderInfo.instanceId
+                            , relaysList info.rudderInfo.relays model.ui
+                            ]
+                        ]
+                    , div[class "mb-4"]
+                        [ h4[]
+                            [ text "System"
+                            , btnCopyJson "system" (encodeSystemInfo info.system)
+                            ]
+                        , div[]
+                            [ rowTxtInfo "Operating system name" info.system.os.name
+                            , rowTxtInfo "Operating system version" info.system.os.version
+                            , rowTxtInfo "JVM version" info.system.jvm.version
+                            , rowTxtInfo "Launch options" info.system.jvm.cmd
+                            ]
+                        ]
+                    , div[class "mb-4"]
+                        [ h4[]
+                            [ text "Managed nodes"
+                            , btnCopyJson "nodes" (encodeNodesInfo info.nodes)
+                            ]
+                        , div[]
+                            [ rowNbInfo "Nodes in audit mode" info.nodes.audit
+                            , rowNbInfo "Nodes in enforce mode" info.nodes.enforce
+                            , rowNbInfo "Enabled nodes" info.nodes.enabled
+                            , rowNbInfo "Disabled nodes" info.nodes.disabled
+                            , rowNbInfo "Total" info.nodes.total
+                            ]
+                        ]
+                    , div[class "mb-4"]
+                        [ h4[]
+                            [ text "Plugins"
+                            , btnCopyJson "plugins" (list encodePluginInfo info.plugins)
+                            ]
+                        , div[]
+                            [ pluginsList info.plugins model.ui
+                            ]
+                        ]
+                    ]
+                    )
+    in
+        div[ class "rudder-template"]
+            [ div[ class "one-col w-100"]
+                [ div[ class "main-header"]
+                    [ div[ class "header-title"]
+                        [ h1[]
+                            [ span[] [text "About"]
+                            ]
+                        , div[class "header-buttons"]
+                            [ copyBtn
+                            ]
+                        ]
+                    , div [class "header-description"]
+                        [ p[][text "This page contains useful information about the Rudder server and instance."]
+                        ]
+                    ]
+                , div[ class "one-col-main overflow-auto h-100"]
+                    [ div [class "d-flex flex-column info-container p-3 pb-5 w-100 h-100 overflow-auto"]
+                        [ div [class "col-12 col-xl-10"] (content)
+                        ]
+                    ]
+                ]
+            ]

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -244,7 +244,7 @@ object PluginsInfo {
     }
   }
 
-  def plugins = _plugins
+  def plugins: Map[PluginName, RudderPluginDef] = _plugins
 
   def pluginInfos: JsonPluginsDetails = {
     JsonPluginsDetails.buildDetails(_plugins.values.toList.sortBy(_.name.value).map(_.toJsonPluginDetails))
@@ -825,6 +825,8 @@ class Boot extends Loggable {
         Menu("920-maintenance", <span>Maintenance</span>) / "secure" / "administration" / "maintenance"
           >> needPerms(Authz.Administration.Read),
         Menu("950-plugins", <span>Plugins</span>) / "secure" / "administration" / "pluginInformation"
+          >> needPerms(Authz.Administration.Read),
+        Menu("990-about", <span>About</span>) / "secure" / "administration" / "about"
           >> needPerms(Authz.Administration.Read)
       )
     }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/metrics/SystemInfoServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/metrics/SystemInfoServiceImpl.scala
@@ -1,0 +1,128 @@
+/*
+ *************************************************************************************
+ * Copyright 2025 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package bootstrap.liftweb.metrics
+
+import bootstrap.liftweb.PluginsInfo
+import com.normation.errors.Inconsistency
+import com.normation.errors.IOResult
+import com.normation.errors.PureResult
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.Constants
+import com.normation.rudder.facts.nodes.CoreNodeFact
+import com.normation.rudder.facts.nodes.NodeFactRepository
+import com.normation.rudder.facts.nodes.QueryContext
+import com.normation.rudder.metrics.FetchDataService
+import com.normation.rudder.metrics.JvmInfo
+import com.normation.rudder.metrics.PrivateSystemInfo
+import com.normation.rudder.metrics.PublicSystemInfo
+import com.normation.rudder.metrics.RelayInfo
+import com.normation.rudder.metrics.SystemInfo
+import com.normation.rudder.metrics.SystemInfoService
+import com.normation.rudder.services.servers.InstanceIdService
+import com.normation.rudder.services.servers.PolicyServerManagementService
+import scala.collection.MapView
+
+class SystemInfoServiceImpl(
+    getNodeMetrics:      FetchDataService,
+    nodeFactRepository:  NodeFactRepository,
+    instanceIdService:   InstanceIdService,
+    policyServerService: PolicyServerManagementService
+) extends SystemInfoService {
+  // properties from version.properties file,
+  val (
+    rudderMajorVersion,
+    rudderFullVersion,
+    builtTimestamp
+  ) = {
+    val p = new java.util.Properties
+    p.load(this.getClass.getClassLoader.getResourceAsStream("version.properties"))
+    def checkProp(p: java.util.Properties, x: String): PureResult[String] = p.getProperty(x) match {
+      case null => Left(Inconsistency(s"The system property '${x}' is missing from 'version.properties'"))
+      case s    => Right(s)
+    }
+    (
+      checkProp(p, "rudder-major-version"),
+      checkProp(p, "rudder-full-version"),
+      checkProp(p, "build-timestamp")
+    )
+  }
+
+  override def getPublicInfo(): IOResult[PublicSystemInfo] = {
+    for {
+      mv  <- rudderMajorVersion.toIO
+      fv  <- rudderFullVersion.toIO
+      bt  <- builtTimestamp.toIO
+      r   <-
+        nodeFactRepository.get(Constants.ROOT_POLICY_SERVER_ID)(QueryContext.systemQC).notOptional(s"The root server is missing!")
+      jvmN = System.getProperty("java.vm.name")
+      jvmV = System.getProperty("java.vm.version")
+      cmd <- IOResult
+               .attempt(ProcessHandle.current().info().commandLine())
+               .map(_.orElseGet(() => "rudder process command line not available"))
+      m   <- getNodeMetrics.getFrequentNodeMetric()
+    } yield PublicSystemInfo(mv, fv, bt, r.os, JvmInfo(jvmN, jvmV, cmd), m)
+  }
+
+  private def relayInfo(relays: List[NodeId], nodes: MapView[NodeId, CoreNodeFact]): List[RelayInfo] = {
+    val sums = nodes.groupMapReduce(p => p._2.rudderSettings.policyServerId)(_ => 1)(_ + _)
+
+    relays.map(id => RelayInfo(id, nodes.get(id).map(_.fqdn).getOrElse("no hostname information"), sums.getOrElse(id, 0)))
+  }
+
+  override def getPrivateInfo(): IOResult[PrivateSystemInfo] = {
+    for {
+      servers <- policyServerService.getPolicyServers()
+      nodes   <- nodeFactRepository.getAll()(QueryContext.systemQC)
+    } yield {
+      val pi = PluginsInfo.pluginInfos
+      PrivateSystemInfo(
+        instanceIdService.instanceId,
+        relayInfo(servers.relays.map(_.id), nodes),
+        pi.globalLimits,
+        pi.details
+      )
+    }
+  }
+
+  override def getAll(): IOResult[SystemInfo] = {
+    for {
+      priv <- getPrivateInfo()
+      pub  <- getPublicInfo()
+    } yield SystemInfo(priv, pub)
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-about.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-about.scss
@@ -1,0 +1,83 @@
+/*
+*************************************************************************************
+* Copyright 2024 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+
+$col-label-width: 200px;
+$margin-label : 10px;
+
+.info-container{
+  h4, label{
+      width: $col-label-width;
+      text-align: right;
+  }
+  label {
+    color: #738195;
+    margin-right: $margin-label;
+
+    &:after{
+      content : ":";
+    }
+  }
+  div:hover > .btn-goto.clipboard,
+  h4:hover > .btn-goto.clipboard{
+    opacity: 1;
+  }
+  .info{
+    display: inline-flex;
+    align-items: center;
+    position: relative;
+    padding-right: 30px;
+
+    .badge{
+      height: fit-content;
+    }
+
+    .btn-goto.clipboard {
+      padding: 0 9px;
+      font-size: 20px;
+      margin-left: 0;
+      position: absolute;
+      right: 0;
+    }
+  }
+  h4 > .btn-goto.clipboard{
+    margin-right: -30px;
+  }
+  .dataTable{
+    background-color: #fff;
+    margin-left: $col-label-width + $margin-label;
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/administration/about.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/administration/about.html
@@ -1,0 +1,29 @@
+<lift:surround with="common-layout" at="content">
+    <head_merge>
+        <title>About</title>
+        <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-about.css" media="screen">
+        <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-about.js"></script>
+    </head_merge>
+
+    <div id="about"></div>
+
+    <script>
+        $(document).ready(function () {
+          var main = document.getElementById("about")
+          var initValues = {
+            contextPath : contextPath
+          };
+          var app  = Elm.About.init({node: main, flags: initValues});
+          app.ports.errorNotification.subscribe(function(message) {
+            createErrorNotification(message);
+          });
+          app.ports.copy.subscribe(function(str) {
+            copy(str);
+          });
+          app.ports.copyJson.subscribe(function(value) {
+            let str = JSON.stringify(value, null, 2);
+            copy(str);
+          });
+        })
+    </script>
+</lift:surround>

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/DateFormaterService.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/DateFormaterService.scala
@@ -56,7 +56,9 @@ import zio.json.*
 object DateFormaterService {
 
   implicit class JodaTimeToJava(d: DateTime) {
-    def toJava: ZonedDateTime = ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli(d.getMillis), ZoneId.of(d.getZone.getID))
+    // see https://stackoverflow.com/a/47753227 - read other solution and the comment in them, too
+    def toJava: ZonedDateTime =
+      ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli(d.getMillis), ZoneId.of(d.getZone.getID, ZoneId.SHORT_IDS))
   }
 
   object json {


### PR DESCRIPTION
https://issues.rudder.io/issues/26059

This PR superseeds https://github.com/Normation/rudder/pull/6102

It adds a `SystemInfoService` and two data structures: 
- `PrivateSystemInfo` contains data that can lead to server identification (like `InstanceId`) and should never be pushed in public/sharable metrics
- `PublicSystemInfo` has only sharable data like node counts, jvm info, etc. 

These data are mapped to a JSON equivalent data structure used for the `About` page: `SystemInfoJson`. 
Since we already have a `system/info` page that gives some info (just rudder version and build time for now), I chose to extends it. For backward compatibility, the old data is kept for API version < 20. 

Not finished, remains: 
- [x] incorporate changes requested from https://github.com/Normation/rudder/pull/6102
- [x] replicate changes from the JSON structure to client side (some names and property variation)
- [x] adapt endpoints / elm decoders / data and UI 