### PR TITLE
Fixes #26167: Make API authentication pluggable

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -444,8 +444,8 @@ limitations under the License.
     <commons-fileupload>2.0.0-M2</commons-fileupload>
     <commons-csv-version>1.12.0</commons-csv-version>
     <jgit-version>7.0.0.202409031743-r</jgit-version>
-    <spring-version>6.1.14</spring-version>
-    <spring-security-version>6.3.4</spring-security-version>
+    <spring-version>6.1.16</spring-version>
+    <spring-security-version>6.3.6</spring-security-version>
     <cglib-version>3.3.0</cglib-version>
     <asm-version>9.7.1</asm-version>
     <!-- Level of Java compatibility, here 1.8+ -->

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
@@ -255,7 +255,7 @@ class RoleApiMapping(mapper: AuthorizationApiMapping) {
   // get the access control list from the user rights.
   // Always succeeds,
   def getApiAclFromRights(rights: Rights): List[ApiAclElement] = {
-    // we have two shortbreakers, no rights and all rigts
+    // we have two shortbreakers, no rights and all rights
     if (rights.authorizationTypes.contains(AuthorizationType.NoRights)) {
       Nil
     } else if (rights.authorizationTypes.contains(AuthorizationType.AnyRights)) {

--- a/webapp/sources/rudder/rudder-web/src/main/resources/applicationContext-security.xml
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/applicationContext-security.xml
@@ -51,12 +51,13 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 <!--    </global-method-security>-->
     <beans:bean id="userSessionInvalidationFilter" class="bootstrap.liftweb.UserSessionInvalidationFilter" />
 
+
     <http pattern="/style/**" security="none"/>
     <http pattern="/images/**" security="none"/>
     <http pattern="/javascript/**" security="none"/>
     <http pattern="/cache-**" security="none"/>
 
-    <http pattern="/api/**" create-session="stateless" entry-point-ref="restAuthenticationEntryPoint">
+    <http pattern="/api/**" create-session="stateless" entry-point-ref="restAuthenticationEntryPoint" name="publicApiSecurityFilter">
       <intercept-url pattern='/**' access="hasRole('ROLE_REMOTE')" />
       <custom-filter position="BASIC_AUTH_FILTER" ref="restAuthenticationFilter" />
       <csrf disabled="true"/>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderProviderManager.java
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderProviderManager.java
@@ -112,6 +112,15 @@ public class RudderProviderManager implements org.springframework.security.authe
 
 		for (AuthenticationProvider provider : getProviders()) {
 			if (!provider.supports(toTest)) {
+                if(logger.isTraceEnabled()) {
+                    StringBuilder msg = new StringBuilder("Rudder authentication for ");
+                    msg.append(authentication.getClass().getName()).append(" can not be done with ");
+                    msg.append(provider.getClass().getName());
+                    if(provider instanceof RudderAuthenticationProvider) {
+                        msg.append(": ").append(((RudderAuthenticationProvider)provider).name());
+                    }
+                    logger.trace(msg.toString());
+                }
 				continue;
 			}
 
@@ -193,15 +202,20 @@ public class RudderProviderManager implements org.springframework.security.authe
                         }
                     }
 
+                    if(logger.isInfoEnabled()) {
+                        StringBuilder msg = new StringBuilder("Rudder authentication attempt for principal '")
+                                .append(principal)
+                                .append("' with backend '")
+                                .append(p.name())
+                                .append("': ")
+                                .append(authenticated? "success":"failure" + ((lastException==null)?"":": "+lastException.getMessage()));
 
-                    String msg = "Rudder authentication attempt for principal '" +principal+
-                            "' with backend '"+p.name()+"': " + (authenticated? "success":"failure");
-
-                    // we don't want to log info about "rootAdmin" backend
-                    if(p.name() == "rootAdmin") {
-                        logger.debug(msg);
-                    } else {
-                        logger.info(msg);
+                        // we don't want to log info about "rootAdmin" backend
+                        if(p.name() == "rootAdmin") {
+                            logger.debug(msg.toString());
+                        } else {
+                            logger.info(msg.toString());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
https://issues.rudder.io/issues/26167

The only meaningful changes are: 
- adde a `name` to the http security filter for API, so that it can be referenced in the plugin, 
- make the current Rudder API filter, `RestAuthenticationFilter`, just pass the request away when the authentication is already done

Other changes are new logger/trying to make msg construction clearer. 
Look a the change with `?w=1` . 