### PR TITLE
Fixes #26169: License information and credentials management in plugins API

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/plugins/TestRudderPackageService.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/plugins/TestRudderPackageService.scala
@@ -1,0 +1,62 @@
+/*
+ *************************************************************************************
+ * Copyright 2025 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+package com.normation.plugins
+import com.normation.rudder.hooks.CmdResult
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class TestRudderPackageService extends Specification {
+
+  "RudderPackageService" should {
+    "handle credentials error" in {
+      val res = CmdResult(
+        1,
+        "",
+        "ERROR Received an HTTP 401 Unauthorized error when trying to get 8.2/rpkg.index. Please check your credentials in the configuration."
+      )
+      RudderPackageService.CredentialError.fromResult(res).aka("CredentialError from cmd result") must beSome(
+        beEqualTo(
+          RudderPackageService.CredentialError(
+            "Received an HTTP 401 Unauthorized error when trying to get 8.2/rpkg.index. Please check your credentials in the configuration."
+          )
+        )
+      )
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
@@ -266,7 +266,8 @@ trait StartsAtVersion16 extends EndpointSchema { val versions: ApiV.From = ApiV.
 trait StartsAtVersion17 extends EndpointSchema { val versions: ApiV.From = ApiV.From(17) } // Rudder 7.3
 trait StartsAtVersion18 extends EndpointSchema { val versions: ApiV.From = ApiV.From(18) } // Rudder 8.0
 trait StartsAtVersion19 extends EndpointSchema { val versions: ApiV.From = ApiV.From(19) } // Rudder 8.1
-trait StartsAtVersion20 extends EndpointSchema { val versions: ApiV.From = ApiV.From(20) }
+trait StartsAtVersion20 extends EndpointSchema { val versions: ApiV.From = ApiV.From(20) } // Rudder 8.2
+trait StartsAtVersion21 extends EndpointSchema { val versions: ApiV.From = ApiV.From(21) } // Rudder 8.3
 
 // utility extension trait to define the kind of API
 trait PublicApi   extends EndpointSchema { val kind: ApiKind.Public.type = ApiKind.Public     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -653,6 +653,7 @@ object PluginInternalApi       extends Enum[PluginInternalApi] with ApiModulePro
     val z: Int = implicitly[Line].value
     val description    = "List all plugins"
     val (action, path) = GET / "pluginsinternal"
+    override def dataContainer: Option[String] = None
   }
   case object InstallPlugins      extends PluginInternalApi with ZeroParam with StartsAtVersion21 with SortIndex {
     val z: Int = implicitly[Line].value

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -649,18 +649,30 @@ sealed trait PluginInternalApi extends EnumEntry with EndpointSchema with Intern
 }
 object PluginInternalApi       extends Enum[PluginInternalApi] with ApiModuleProvider[PluginInternalApi] {
 
-  case object ListPlugins extends PluginInternalApi with ZeroParam with StartsAtVersion20 with SortIndex {
+  case object ListPlugins         extends PluginInternalApi with ZeroParam with StartsAtVersion21 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    = "List all plugins"
     val (action, path) = GET / "pluginsinternal"
   }
-  // case object UpdatePluginsSettings extends PluginApi with ZeroParam with StartsAtVersion14 with SortIndex {
-  //   val z:                      Int            = implicitly[Line].value
-  //   override def dataContainer: Option[String] = None
-  //   val description    = "Update plugin system settings"
-  //   val (action, path) = POST / "plugins" / "settings"
-  // }
+  case object InstallPlugins      extends PluginInternalApi with ZeroParam with StartsAtVersion21 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Install plugins"
+    val (action, path) = POST / "pluginsinternal" / "install"
+    override def dataContainer: Option[String] = None
+  }
+  case object RemovePlugins       extends PluginInternalApi with ZeroParam with StartsAtVersion21 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Remove plugins"
+    val (action, path) = POST / "pluginsinternal" / "remove"
+    override def dataContainer: Option[String] = None
+  }
   def endpoints: List[PluginInternalApi] = values.toList.sortBy(_.z)
+  case object ChangePluginsStatus extends PluginInternalApi with OneParam with StartsAtVersion21 with SortIndex  {
+    val z: Int = implicitly[Line].value
+    val description    = "Change the status of plugins"
+    val (action, path) = POST / "pluginsinternal" / "{status}"
+    override def dataContainer: Option[String] = None
+  }
 
   def values = findValues
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/PluginInternalApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/PluginInternalApi.scala
@@ -38,6 +38,7 @@
 package com.normation.rudder.rest.lift
 
 import com.normation.errors.Inconsistency
+import com.normation.plugins.JsonPluginsSystemDetails
 import com.normation.plugins.PluginId
 import com.normation.plugins.PluginSettings
 import com.normation.plugins.PluginSystemService
@@ -49,6 +50,7 @@ import com.normation.rudder.rest.ApiPath
 import com.normation.rudder.rest.AuthzToken
 import com.normation.rudder.rest.PluginInternalApi as API
 import com.normation.rudder.rest.RudderJsonRequest.*
+import com.normation.rudder.rest.RudderJsonResponse
 import com.normation.rudder.rest.implicits.*
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
@@ -84,7 +86,8 @@ class PluginInternalApi(
         .list()
         .chainError("Could not get plugins list")
         .tapError(err => ApplicationLoggerPure.Plugin.error(err.fullMsg))
-        .toLiftResponseList(params, schema)
+        .map(_.left.map(c => RudderJsonResponse.UnauthorizedError(Some(c.fullMsg))).map(JsonPluginsSystemDetails.buildDetails))
+        .toLiftResponseOneEither[JsonPluginsSystemDetails](params, schema, None)
     }
 
   }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_plugins.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_plugins.yml
@@ -8,6 +8,14 @@ response:
       "action":"listPlugins",
       "result":"success",
       "data":{
+        "license" : {
+          "licensees" : [
+            "test-licensee"
+          ],
+          "startDate" : "2025-01-10T21:53:20+01:00",
+          "endDate" : "2025-01-10T21:53:20+01:00",
+          "maxNodes" : 1000000
+        },
         "plugins" : [
           {
             "id" : "auth-backends",
@@ -104,6 +112,14 @@ response:
       "action":"listPlugins",
       "result":"success",
       "data":{
+        "license" : {
+          "licensees" : [
+            "test-licensee"
+          ],
+          "startDate" : "2025-01-10T21:53:20+01:00",
+          "endDate" : "2025-01-10T21:53:20+01:00",
+          "maxNodes" : 1000000
+        },
         "plugins" : [
           {
             "id" : "auth-backends",
@@ -184,6 +200,14 @@ response:
       "action":"listPlugins",
       "result":"success",
       "data":{
+        "license" : {
+          "licensees" : [
+            "test-licensee"
+          ],
+          "startDate" : "2025-01-10T21:53:20+01:00",
+          "endDate" : "2025-01-10T21:53:20+01:00",
+          "maxNodes" : 1000000
+        },
         "plugins" : [
           {
             "id" : "auth-backends",
@@ -264,6 +288,14 @@ response:
       "action":"listPlugins",
       "result":"success",
       "data":{
+        "license" : {
+          "licensees" : [
+            "test-licensee"
+          ],
+          "startDate" : "2025-01-10T21:53:20+01:00",
+          "endDate" : "2025-01-10T21:53:20+01:00",
+          "maxNodes" : 1000000
+        },
         "plugins" : [
           {
             "id" : "auth-backends",
@@ -344,6 +376,14 @@ response:
       "action":"listPlugins",
       "result":"success",
       "data":{
+        "license" : {
+          "licensees" : [
+            "test-licensee"
+          ],
+          "startDate" : "2025-01-10T21:53:20+01:00",
+          "endDate" : "2025-01-10T21:53:20+01:00",
+          "maxNodes" : 1000000
+        },
         "plugins" : [
           {
             "id" : "auth-backends",

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_plugins.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_plugins.yml
@@ -1,0 +1,400 @@
+description: List all plugins
+method: GET
+url: /secure/api/pluginsinternal
+response:
+  code: 200
+  content: >-
+    {
+      "action":"listPlugins",
+      "result":"success",
+      "data":{
+        "plugins" : [
+          {
+            "id" : "auth-backends",
+            "name" : "authentication backends",
+            "description" : "Add new authentication backends",
+            "version" : "8.3.0-2.4.1",
+            "status" : "enabled",
+            "abiVersion" : "2.4.1",
+            "pluginType" : "webapp",
+            "errors" : [
+              {
+                "error" : "license.near.expiration.error",
+                "message" : "Plugin license near expiration"
+              }
+            ],
+            "license" : {
+              "licensee" : "test-licensee",
+              "softwareId" : "test-softwareId",
+              "minVersion" : "0.0.0-0.0.0",
+              "maxVersion" : "99.99.0-99.99.0",
+              "startDate" : "2025-01-10T20:53:20Z",
+              "endDate" : "2025-01-10T20:53:20Z",
+              "maxNodes" : 1000000,
+              "additionalInfo" : {}
+            }
+          },
+          {
+            "id" : "cve",
+            "name" : "cve",
+            "description" : "Manage known vulnerabilities in system components",
+            "version" : "8.3.0-2.10",
+            "status" : "enabled",
+            "abiVersion" : "2.10",
+            "pluginType" : "webapp",
+            "errors" : [
+              {
+                "error" : "license.needed.error",
+                "message" : "A license is needed for the plugin"
+              }
+            ]
+          },
+          {
+            "id" : "zabbix",
+            "name" : "zabbix",
+            "description" : "Integration with Zabbix (monitoring tool)",
+            "version" : "8.3.0-2.1",
+            "status" : "uninstalled",
+            "abiVersion" : "2.1",
+            "pluginType" : "integration",
+            "errors" : []
+          }
+        ]
+      }
+    }
+---
+description: Install plugins
+method: POST
+url: /secure/api/pluginsinternal/install
+headers:
+  - "Content-Type: application/json"
+body: >-
+  ["zabbix"]
+response:
+  code: 200
+  content: >-
+    {
+      "action":"installPlugins",
+      "result":"success"
+    }
+---
+description: Fail to parse unsafe plugin id to install
+method: POST
+url: /secure/api/pluginsinternal/install
+headers:
+  - "Content-Type: application/json"
+body: >-
+  ["auth-backends; cat /etc/shadow"]
+response:
+  code: 500
+  content: >-
+    {
+      "action":"installPlugins",
+      "result":"error",
+      "errorDetails":"Could not install plugins; cause was: Could not parse the list of plugins to install; cause was: Unexpected: [0](Invalid plugin ID: 'auth-backends; cat /etc/shadow'. Plugin ID must be alphanumeric with hyphens.)"
+    }
+---
+description: List all plugins after install
+method: GET
+url: /secure/api/pluginsinternal
+response:
+  code: 200
+  content: >-
+    {
+      "action":"listPlugins",
+      "result":"success",
+      "data":{
+        "plugins" : [
+          {
+            "id" : "auth-backends",
+            "name" : "authentication backends",
+            "description" : "Add new authentication backends",
+            "version" : "8.3.0-2.4.1",
+            "status" : "enabled",
+            "abiVersion" : "2.4.1",
+            "pluginType" : "webapp",
+            "errors" : [
+              {
+                "error" : "license.near.expiration.error",
+                "message" : "Plugin license near expiration"
+              }
+            ],
+            "license" : {
+              "licensee" : "test-licensee",
+              "softwareId" : "test-softwareId",
+              "minVersion" : "0.0.0-0.0.0",
+              "maxVersion" : "99.99.0-99.99.0",
+              "startDate" : "2025-01-10T20:53:20Z",
+              "endDate" : "2025-01-10T20:53:20Z",
+              "maxNodes" : 1000000,
+              "additionalInfo" : {}
+            }
+          },
+          {
+            "id" : "cve",
+            "name" : "cve",
+            "description" : "Manage known vulnerabilities in system components",
+            "version" : "8.3.0-2.10",
+            "status" : "enabled",
+            "abiVersion" : "2.10",
+            "pluginType" : "webapp",
+            "errors" : [
+              {
+                "error" : "license.needed.error",
+                "message" : "A license is needed for the plugin"
+              }
+            ]
+          },
+          {
+            "id" : "zabbix",
+            "name" : "zabbix",
+            "description" : "Integration with Zabbix (monitoring tool)",
+            "version" : "8.3.0-2.1",
+            "status" : "enabled",
+            "abiVersion" : "2.1",
+            "pluginType" : "integration",
+            "errors" : []
+          }
+        ]
+      }
+    }
+---
+description: Remove plugins after install
+method: POST
+url: /secure/api/pluginsinternal/remove
+headers:
+  - "Content-Type: application/json"
+body: >-
+  ["zabbix"]
+response:
+  code: 200
+  content: >-
+    {
+      "action":"removePlugins",
+      "result":"success"
+    }
+---
+description: List all plugins after remove
+method: GET
+url: /secure/api/pluginsinternal
+response:
+  code: 200
+  content: >-
+    {
+      "action":"listPlugins",
+      "result":"success",
+      "data":{
+        "plugins" : [
+          {
+            "id" : "auth-backends",
+            "name" : "authentication backends",
+            "description" : "Add new authentication backends",
+            "version" : "8.3.0-2.4.1",
+            "status" : "enabled",
+            "abiVersion" : "2.4.1",
+            "pluginType" : "webapp",
+            "errors" : [
+              {
+                "error" : "license.near.expiration.error",
+                "message" : "Plugin license near expiration"
+              }
+            ],
+            "license" : {
+              "licensee" : "test-licensee",
+              "softwareId" : "test-softwareId",
+              "minVersion" : "0.0.0-0.0.0",
+              "maxVersion" : "99.99.0-99.99.0",
+              "startDate" : "2025-01-10T20:53:20Z",
+              "endDate" : "2025-01-10T20:53:20Z",
+              "maxNodes" : 1000000,
+              "additionalInfo" : {}
+            }
+          },
+          {
+            "id" : "cve",
+            "name" : "cve",
+            "description" : "Manage known vulnerabilities in system components",
+            "version" : "8.3.0-2.10",
+            "status" : "enabled",
+            "abiVersion" : "2.10",
+            "pluginType" : "webapp",
+            "errors" : [
+              {
+                "error" : "license.needed.error",
+                "message" : "A license is needed for the plugin"
+              }
+            ]
+          },
+          {
+            "id" : "zabbix",
+            "name" : "zabbix",
+            "description" : "Integration with Zabbix (monitoring tool)",
+            "version" : "8.3.0-2.1",
+            "status" : "uninstalled",
+            "abiVersion" : "2.1",
+            "pluginType" : "integration",
+            "errors" : []
+          }
+        ]
+      }
+    }
+---
+description: Disable a plugin
+method: POST
+url: /secure/api/pluginsinternal/disable
+headers:
+  - "Content-Type: application/json"
+body: >-
+  ["auth-backends"]
+response:
+  code: 200
+  content: >-
+    {
+      "action":"changePluginsStatus",
+      "result":"success"
+    }
+---
+description: List all plugins after disable
+method: GET
+url: /secure/api/pluginsinternal
+response:
+  code: 200
+  content: >-
+    {
+      "action":"listPlugins",
+      "result":"success",
+      "data":{
+        "plugins" : [
+          {
+            "id" : "auth-backends",
+            "name" : "authentication backends",
+            "description" : "Add new authentication backends",
+            "version" : "8.3.0-2.4.1",
+            "status" : "disabled",
+            "abiVersion" : "2.4.1",
+            "pluginType" : "webapp",
+            "errors" : [
+              {
+                "error" : "license.near.expiration.error",
+                "message" : "Plugin license near expiration"
+              }
+            ],
+            "license" : {
+              "licensee" : "test-licensee",
+              "softwareId" : "test-softwareId",
+              "minVersion" : "0.0.0-0.0.0",
+              "maxVersion" : "99.99.0-99.99.0",
+              "startDate" : "2025-01-10T20:53:20Z",
+              "endDate" : "2025-01-10T20:53:20Z",
+              "maxNodes" : 1000000,
+              "additionalInfo" : {}
+            }
+          },
+          {
+            "id" : "cve",
+            "name" : "cve",
+            "description" : "Manage known vulnerabilities in system components",
+            "version" : "8.3.0-2.10",
+            "status" : "enabled",
+            "abiVersion" : "2.10",
+            "pluginType" : "webapp",
+            "errors" : [
+              {
+                "error" : "license.needed.error",
+                "message" : "A license is needed for the plugin"
+              }
+            ]
+          },
+          {
+            "id" : "zabbix",
+            "name" : "zabbix",
+            "description" : "Integration with Zabbix (monitoring tool)",
+            "version" : "8.3.0-2.1",
+            "status" : "uninstalled",
+            "abiVersion" : "2.1",
+            "pluginType" : "integration",
+            "errors" : []
+          }
+        ]
+      }
+    }
+---
+description: Enable a plugin
+method: POST
+url: /secure/api/pluginsinternal/enable
+headers:
+  - "Content-Type: application/json"
+body: >-
+  ["auth-backends"]
+response:
+  code: 200
+  content: >-
+    {
+      "action":"changePluginsStatus",
+      "result":"success"
+    }
+---
+description: List all plugins after enable
+method: GET
+url: /secure/api/pluginsinternal
+response:
+  code: 200
+  content: >-
+    {
+      "action":"listPlugins",
+      "result":"success",
+      "data":{
+        "plugins" : [
+          {
+            "id" : "auth-backends",
+            "name" : "authentication backends",
+            "description" : "Add new authentication backends",
+            "version" : "8.3.0-2.4.1",
+            "status" : "enabled",
+            "abiVersion" : "2.4.1",
+            "pluginType" : "webapp",
+            "errors" : [
+              {
+                "error" : "license.near.expiration.error",
+                "message" : "Plugin license near expiration"
+              }
+            ],
+            "license" : {
+              "licensee" : "test-licensee",
+              "softwareId" : "test-softwareId",
+              "minVersion" : "0.0.0-0.0.0",
+              "maxVersion" : "99.99.0-99.99.0",
+              "startDate" : "2025-01-10T20:53:20Z",
+              "endDate" : "2025-01-10T20:53:20Z",
+              "maxNodes" : 1000000,
+              "additionalInfo" : {}
+            }
+          },
+          {
+            "id" : "cve",
+            "name" : "cve",
+            "description" : "Manage known vulnerabilities in system components",
+            "version" : "8.3.0-2.10",
+            "status" : "enabled",
+            "abiVersion" : "2.10",
+            "pluginType" : "webapp",
+            "errors" : [
+              {
+                "error" : "license.needed.error",
+                "message" : "A license is needed for the plugin"
+              }
+            ]
+          },
+          {
+            "id" : "zabbix",
+            "name" : "zabbix",
+            "description" : "Integration with Zabbix (monitoring tool)",
+            "version" : "8.3.0-2.1",
+            "status" : "uninstalled",
+            "abiVersion" : "2.1",
+            "pluginType" : "integration",
+            "errors" : []
+          }
+        ]
+      }
+    }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/DataTypes.elm
@@ -13,7 +13,7 @@ type alias PluginInfo =
     , abiVersion : String
     , version : String
     , pluginType : PluginType
-    , errors: List PluginError
+    , errors : List PluginError
     , status : PluginStatus
     , license : Maybe LicenseInfo
     }
@@ -43,6 +43,7 @@ type alias PluginError =
     { error : String
     , message : String
     }
+
 
 type alias Model =
     { contextPath : String

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/JsonDecoder.elm
@@ -3,29 +3,30 @@ module Plugins.JsonDecoder exposing (..)
 import Json.Decode as D exposing (..)
 import Json.Decode.Pipeline exposing (optional, required)
 import Plugins.DataTypes exposing (..)
-import Time.TimeZone exposing (TimeZone)
-import Time.ZonedDateTime exposing (ZonedDateTime)
-import Time.TimeZones exposing (utc)
 import Time.Iso8601
 import Time.Iso8601ErrorMsg
+import Time.TimeZone exposing (TimeZone)
+import Time.TimeZones exposing (utc)
+import Time.ZonedDateTime exposing (ZonedDateTime)
 
 
 decodeGetPluginInfos : Decoder (List PluginInfo)
 decodeGetPluginInfos =
-  at [ "data", "plugins" ] (list decodePluginInfo)
+    at [ "data", "plugins" ] (list decodePluginInfo)
+
 
 decodePluginInfo : Decoder PluginInfo
 decodePluginInfo =
- D.succeed PluginInfo
-    |> required "id" string
-    |> required "name" string
-    |> required "description" string
-    |> required "abiVersion" string
-    |> required "version" string
-    |> required "pluginType" decodePluginType
-    |> required "errors" (list decodePluginError)
-    |> required "status" decodePluginStatus
-    |> optional "license" (maybe decodeLicenseInfo) Nothing
+    D.succeed PluginInfo
+        |> required "id" string
+        |> required "name" string
+        |> required "description" string
+        |> required "abiVersion" string
+        |> required "version" string
+        |> required "pluginType" decodePluginType
+        |> required "errors" (list decodePluginError)
+        |> required "status" decodePluginStatus
+        |> optional "license" (maybe decodeLicenseInfo) Nothing
 
 
 decodePluginType : Decoder PluginType
@@ -75,14 +76,23 @@ decodeLicenseInfo =
         |> required "endDate" decodeDateTime
 
 
+
 -- Defaults to UTC
+
+
 decodeDateTime : Decoder ZonedDateTime
 decodeDateTime =
-  andThen (\d ->
+    andThen
+        (\d ->
             case d of
-              Ok r -> succeed r
-              Err e -> fail (String.join "\n" <| List.map (Time.Iso8601ErrorMsg.renderText "" ) e)
-          ) (map (Time.Iso8601.toZonedDateTime utc) string)
+                Ok r ->
+                    succeed r
+
+                Err e ->
+                    fail (String.join "\n" <| List.map (Time.Iso8601ErrorMsg.renderText "") e)
+        )
+        (map (Time.Iso8601.toZonedDateTime utc) string)
+
 
 decodePluginError : Decoder PluginError
 decodePluginError =

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/PluginStatus.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/PluginStatus.scala
@@ -69,7 +69,7 @@ trait PluginStatus {
           case Some(i) => s"'${i.softwareId}' "
           case None    => ""
         }
-        ApplicationLoggerPure.Plugin.logEffect.warn(s"Plugin ${name}is disabled: ${reason}")
+        ApplicationLoggerPure.Plugin.logEffect.warn(s"Plugin ${name} is disabled: ${reason}")
         false
     }
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPlugin.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPlugin.scala
@@ -403,11 +403,18 @@ class PluginSystemServiceImpl(
     }
   }
 
-  override def install(plugins: Chunk[String]): IOResult[Unit] = ???
+  override def install(plugins: Chunk[PluginId]): IOResult[Unit] = {
+    // install all plugins, rudder package already handles installed ones
+    rudderPackageService.installPlugins(plugins.map(_.transformInto[String]))
+  }
 
-  override def remove(plugins: Chunk[String]): IOResult[Unit] = ???
+  override def remove(plugins: Chunk[PluginId]): IOResult[Unit] = {
+    rudderPackageService.removePlugins(plugins.map(_.transformInto[String]))
+  }
 
-  override def updateStatus(status: PluginSystemStatus, plugins: Chunk[String]): IOResult[Unit] = ???
+  override def updateStatus(status: PluginSystemStatus, plugins: Chunk[PluginId]): IOResult[Unit] = {
+    rudderPackageService.changePluginSystemStatus(status, plugins.map(_.transformInto[String]))
+  }
 
   private def unknownLicensee = RudderPackagePlugin.Licensee("unknown")
 

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/plugins/PluginSettingTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/plugins/PluginSettingTest.scala
@@ -1,0 +1,170 @@
+/*
+ *************************************************************************************
+ * Copyright 2025 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+package com.normation.plugins
+
+import com.normation.utils.ParseVersion
+import com.normation.utils.Version
+import org.joda.time.DateTime
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class PluginSettingTest extends Specification {
+
+  "PluginManagementError" should {
+    implicit val rudderVersion:    String  = "8.3.0"
+    // a valid one is the rudder version, override implicit in needed tests cases
+    implicit val pluginAbiVersion: Version =
+      ParseVersion.parse(rudderVersion).getOrElse(throw new Exception("bad version in test"))
+
+    "list errors from rudder package plugin" in {
+
+      "plugin without license" in {
+        val plugin = fakePlugin(
+          requiresLicense = false,
+          license = None
+        )
+
+        val errors = PluginManagementError.fromRudderPackagePlugin(plugin)
+        errors must beEmpty
+      }
+
+      "plugin with expired license" in {
+        val plugin = fakePlugin(
+          requiresLicense = false,
+          license = Some(
+            RudderPackagePlugin.LicenseInfo(
+              DateTime.now.minusMonths(2),
+              DateTime.now.minusMonths(1)
+            )
+          )
+        )
+
+        val errors = PluginManagementError.fromRudderPackagePlugin(plugin)
+        errors must containTheSameElementsAs(
+          List(
+            PluginManagementError.LicenseExpiredError
+          )
+        )
+      }
+
+      "plugin with license near expiration" in {
+        val plugin = fakePlugin(
+          requiresLicense = false,
+          license = Some(
+            RudderPackagePlugin.LicenseInfo(
+              DateTime.now.minusMonths(2),
+              DateTime.now.plusDays(1)
+            )
+          )
+        )
+
+        val errors = PluginManagementError.fromRudderPackagePlugin(plugin)
+        errors must containTheSameElementsAs(
+          List(
+            PluginManagementError.LicenseNearExpirationError
+          )
+        )
+      }
+
+      "plugin with ABI version error" in {
+        val plugin = fakePlugin(
+          requiresLicense = false,
+          license = None
+        )
+
+        val errors = PluginManagementError.fromRudderPackagePlugin(plugin)(
+          rudderVersion,
+          ParseVersion.parse("9.9.9").getOrElse(throw new Exception("bad version in test"))
+        )
+        errors must containTheSameElementsAs(
+          List(
+            PluginManagementError.RudderAbiVersionError(rudderVersion)
+          )
+        )
+      }
+
+      "plugin missing needed license" in {
+        val plugin = fakePlugin(
+          requiresLicense = true,
+          license = None
+        )
+
+        val errors = PluginManagementError.fromRudderPackagePlugin(plugin)
+        errors must containTheSameElementsAs(
+          List(
+            PluginManagementError.LicenseNeededError
+          )
+        )
+      }
+
+      "plugin with multiple errors" in {
+        val plugin = fakePlugin(
+          requiresLicense = true,
+          license = None
+        )
+
+        val errors = PluginManagementError.fromRudderPackagePlugin(plugin)(
+          rudderVersion,
+          ParseVersion.parse("9.9.9").getOrElse(throw new Exception("bad version in test"))
+        )
+        errors must containTheSameElementsAs(
+          List(
+            PluginManagementError.LicenseNeededError,
+            PluginManagementError.RudderAbiVersionError(rudderVersion)
+          )
+        )
+      }
+    }
+  }
+
+  private def fakePlugin(
+      requiresLicense: Boolean,
+      license:         Option[RudderPackagePlugin.LicenseInfo]
+  ) = RudderPackagePlugin(
+    "test",
+    version = None,
+    latestVersion = None,
+    installed = true,
+    enabled = true,
+    webappPlugin = true,
+    description = "Test plugin",
+    requiresLicense = requiresLicense,
+    license = license
+  )
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/26169

## :warning: Based on #6120

* Adds license information to the plugins API (see yml tests), by refactoring the existing structures 
* Adds credential management on the 'plugins list' endpoint : we need to handle the command-line error message, up to our API response, by adding utility methods to convert an Either with an error into a lift response.
