### PR TITLE
Fixes #26159: Unable to download technique resources

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Model.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Model.elm
@@ -8,6 +8,7 @@ import FileManager.Vec exposing (..)
 import Dict exposing (Dict)
 
 import Ui.Datatable exposing (TableFilters)
+import Bytes exposing (Bytes)
 
 type alias Flags =
   { api: String
@@ -84,6 +85,7 @@ type Msg
   | FileUpdate FileUpdateError
   | Name String
   | Download
+  | Downloaded FileMeta (Result Http.Error Bytes)
   | Cut
   | Paste
   | Delete

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Update.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/FileManager/Update.elm
@@ -136,9 +136,13 @@ update msg model = case msg of
       | showContextMenu = False
       }
       , Cmd.batch
-      <| map (File.Download.url << (++) (model.downloadsUrl  ++ "?action=download&path=" ++ (getDirPath model.dir)) << .name)
+      <| map (download model.downloadsUrl model.dir)
       <| filter (.type_ >> (/=) "dir") model.selected
     )
+  Downloaded fileMeta (Ok bytes) ->
+    (model, File.Download.bytes fileMeta.name fileMeta.type_ bytes)
+  Downloaded fileMeta (Err err) ->
+    (model, processApiError ("downloading file " ++ fileMeta.name) err)
   Cut -> ({ model | clipboardDir = (getDirPath model.dir), clipboardFiles = model.selected, showContextMenu = False }, Cmd.none)
   Paste -> if (getDirPath model.dir) == model.clipboardDir
     then ({ model | clipboardFiles = [], showContextMenu = False }, Cmd.none)


### PR DESCRIPTION
https://issues.rudder.io/issues/26159

The documentation of `File.Download.url` itself recommends to work with `File.Download.bytes` and AJAX when needing specific authorization to the server (in our case the CSRF headers), since the current one is just an `<a href="" target="_blank"/>`