### PR TITLE
Fixes #26207: Plugin management operations need confirmation popup and license error info

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/PluginSettings.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/PluginSettings.scala
@@ -39,6 +39,8 @@ package com.normation.plugins
 
 import better.files.File
 import com.normation.errors.*
+import com.normation.plugins.PluginSystemStatus.Disabled
+import com.normation.plugins.PluginSystemStatus.Enabled
 import com.normation.plugins.RudderPackageService.*
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.hooks.Cmd
@@ -660,7 +662,11 @@ class RudderPackageCmdService(configCmdLine: String) extends RudderPackageServic
   }
 
   override def changePluginSystemStatus(status: PluginSystemStatus, plugins: Chunk[String]): IOResult[Unit] = {
-    runCmdOrFail(status.value :: plugins.toList)(
+    val action = status match {
+      case Enabled  => "enable"
+      case Disabled => "disable"
+    }
+    runCmdOrFail(action :: plugins.toList)(
       s"An error occurred while changin plugin status to ${status.value}"
     ).unit
   }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/elm.json
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/elm.json
@@ -36,6 +36,7 @@
             "justinmimbs/date": "4.1.0",
             "justinmimbs/time-extra": "1.2.0",
             "jzxhuang/http-extras": "2.1.0",
+            "matthewsj/elm-ordering": "2.0.0",
             "mcordova47/elm-natural-ordering": "1.1.0",
             "mercurymedia/elm-datetime-picker": "8.0.1",
             "pablen/toasty": "1.2.0",

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins.elm
@@ -63,6 +63,9 @@ update msg model =
                 Err err ->
                     processApiErrorBytes "Error while fetching information" err model
 
+        SetModalState modalState ->
+            ( { model | ui = (\ui -> { ui | modalState = modalState }) model.ui }, Cmd.none )
+
         Copy s ->
             ( model, copy s )
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/ApiCalls.elm
@@ -62,3 +62,19 @@ changePluginStatus requestType plugins model =
         , timeout = Nothing
         , tracker = Nothing
         }
+
+
+requestTypeAction : RequestType -> Model -> Cmd Msg
+requestTypeAction t model =
+    case t of
+        Install ->
+            installPlugins model.ui.selected model
+
+        Uninstall ->
+            removePlugins model.ui.selected model
+
+        Enable ->
+            changePluginStatus Enable model.ui.selected model
+
+        Disable ->
+            changePluginStatus Disable model.ui.selected model

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/DataTypes.elm
@@ -5,6 +5,7 @@ import Http
 import Http.Detailed
 import Json.Encode exposing (Value)
 import List.Extra
+import Ordering exposing (Ordering)
 import Time.ZonedDateTime exposing (ZonedDateTime)
 
 
@@ -68,8 +69,14 @@ type alias PluginError =
 
 type alias UI =
     { selected : List PluginId
+    , modalState : ModalState
     , settingsError : Maybe ( String, String ) -- message, details
     }
+
+
+type ModalState
+    = OpenModal RequestType
+    | NoModal
 
 
 type alias Model =
@@ -98,6 +105,7 @@ type Msg
     = CallApi (Model -> Cmd Msg)
     | ApiGetPlugins (Result (Http.Detailed.Error String) ( Http.Metadata, PluginsInfo ))
     | ApiPostPlugins (Result (Http.Detailed.Error Bytes) RequestType)
+    | SetModalState ModalState
     | Copy String
     | CopyJson Value
     | CheckSelection Select
@@ -171,3 +179,14 @@ noGlobalLicense =
     , endDate = Nothing
     , maxNodes = Nothing
     }
+
+
+pluginStatusOrdering : Ordering PluginStatus
+pluginStatusOrdering =
+    Ordering.explicit [ Enabled, Disabled, Uninstalled ]
+
+
+pluginDefaultOrdering : Ordering PluginInfo
+pluginDefaultOrdering =
+    Ordering.byFieldWith pluginStatusOrdering .status
+        |> Ordering.breakTiesWith (Ordering.byField .name)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Init.elm
@@ -13,7 +13,7 @@ init : { contextPath : String } -> ( Model, Cmd Msg )
 init flags =
     let
         initUI =
-            UI [] Nothing
+            UI [] NoModal Nothing
 
         initModel =
             Model flags.contextPath noGlobalLicense [] initUI

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-plugins.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-plugins.scss
@@ -108,11 +108,13 @@
 
 
 .plugins-container {
+  $default-font-size: 0.86em;
+
   & .plugins-actions {
-    border-bottom: 2px solid #d6deef !important; // in combination with datatable classes
+    border-bottom: 2px solid $rudder-border-color-default !important; // in combination with datatable classes
 
     & .btn {
-      font-size: 0.8em;
+      font-size: $default-font-size;
       border-radius: 0.3em;
       min-width: 4.8rem;
     }
@@ -127,19 +129,33 @@
         margin: 10px 0;
       }
 
-      &.plugin-card-missing-license {
+      &.plugin-card-disabled {
         background-color: $rudder-bg-light-gray;
       }
 
+      &.plugin-card-missing-license {
+        opacity: 95%;
+
+        & .badge.float-end {
+          background-color: #D6DEEF;
+        }
+      }
+
       & .badge.float-end {
+        font-size: $default-font-size;
         border-top-left-radius: 0;
         border-bottom-right-radius: 0;
         text-transform: uppercase;
-        padding: 0.3rem 0.6rem;
+        padding: 0.3rem 0.8rem;
+        font-weight: 600;
       }
 
       & .form-check label {
         cursor: pointer;
+      }
+
+      & .card-text {
+        font-size: $default-font-size;
       }
 
       & .plugin-name {
@@ -148,7 +164,6 @@
       }
 
       & .plugin-description {
-        font-size: 0.8rem;
         color: $rudder-txt-secondary;
       }
 
@@ -158,12 +173,14 @@
       }
 
       & .plugin-errors {
-        margin-top: 0.5rem;
+        $el-margin: 0.5rem;
+
+        margin-top: $el-margin;
 
         & .callout-fade {
           &:not(:last-child) {
-            margin-top: 0.5rem;
-            margin-bottom: 0.5rem;
+            margin-top: $el-margin;
+            margin-bottom: $el-margin;
           }
 
           &:last-child {


### PR DESCRIPTION
https://issues.rudder.io/issues/26207

Adding modals to confirm actions on plugins :
![image](https://github.com/user-attachments/assets/f1ec9445-9b35-4f26-8f83-259bd421d69c)

Fixing also some other problems :
* in case of missing license, the plugin is not supposed to be selected 
* disable and enable action were not working due to the command being "enabled/disabled" instead of "enable/disable"
* sorting the plugins by their status, then by alphabetical order, using the [elm-ordering](https://package.elm-lang.org/packages/matthewsj/elm-ordering/latest/) lib which is very handy for that
* minor SCSS adjustments 

