### PR TITLE
Fixes #26244: License repository errors should result in different exit codes

### DIFF
--- a/relay/sources/rudder-package/src/main.rs
+++ b/relay/sources/rudder-package/src/main.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2023 Normation SAS
 
-use std::process;
+use std::process::ExitCode;
 
-fn main() {
-    if rudder_package::run().is_err() {
-        process::exit(1);
+fn main() -> ExitCode {
+    match rudder_package::run() {
+        Err(_) => ExitCode::FAILURE,
+        Ok(code) => code,
     }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/26244

The main can return an `ExitCode`, we only have to map it from the result of running the CLI : we intercept the repository errors and associate specific error codes depending on the HTTP error. For now the exit code are 2 and 3. 