### PR TITLE
Fixes #26243: Improve license errors handling in webapp

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunNuCommand.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunNuCommand.scala
@@ -82,7 +82,24 @@ import zio.syntax.*
 final case class Cmd(cmdPath: String, parameters: List[String], environment: Map[String, String], cwdPath: Option[String]) {
   def display: String = s"${cmdPath} ${parameters.mkString(" ")}"
 }
-final case class CmdResult(code: Int, stdout: String, stderr: String)
+final case class CmdResult(code: Int, stdout: String, stderr: String)                                                      {
+
+  /**
+    * Display the attributes of this result, by default each on a new line with indentation
+    */
+  def debugString(sep: String = "\n "): String = s"code: ${code}${sep}stderr: ${stderr}${sep}stdout: ${stdout}"
+
+  /**
+    * Strips the stdout and stderr of the result, may be useful when matching with a regex or for display purpose
+    */
+  def strip: CmdResult = transform(_.strip)
+
+  /**
+    * Apply some transformation (e.g. sanitizing on stdout and stderr)
+    */
+  def transform(f: String => String): CmdResult = copy(stdout = f(stdout), stderr = f(stderr))
+
+}
 
 object RunNuCommand {
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechniqueReader.scala
@@ -154,7 +154,7 @@ class EditorTechniqueReaderImpl(
       _         <-
         ZIO.when(res.code != 0)(
           Inconsistency(
-            s"An error occurred while updating generic methods library with command '${cmd.display}':\n code: ${res.code}\n stderr: ${res.stderr}\n stdout: ${res.stdout}"
+            s"An error occurred while updating generic methods library with command '${cmd.display}':\n ${res.debugString(sep = "\n ")}"
           ).fail
         )
       // write file

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckService.scala
@@ -149,7 +149,7 @@ final class CheckFileDescriptorLimit(val nodeFactRepository: NodeFactRepository)
       res        <- fdLimitCmd.await
       _          <- ZIO.when(res.code != 0) {
                       Inconsistency(
-                        s"An error occurred while getting file descriptor soft limit with command '${cmd.display}':\n code: ${res.code}\n stderr: ${res.stderr}\n stdout: ${res.stdout}"
+                        s"An error occurred while getting file descriptor soft limit with command '${cmd.display}':\n ${res.debugString(sep = "\n ")}"
                       ).fail
                     }
       limit      <- IOResult.attempt(res.stdout.trim.toLong)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/ApiCalls.elm
@@ -1,6 +1,6 @@
 module Plugins.ApiCalls exposing (..)
 
-import Http exposing (emptyBody, header, request)
+import Http exposing (emptyBody, expectStringResponse, header, request)
 import Http.Detailed as Detailed
 import Plugins.DataTypes exposing (..)
 import Plugins.JsonDecoder exposing (decodeGetPluginsInfo)
@@ -19,7 +19,7 @@ updateIndex model =
         , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
         , url = getUrl model "/pluginsinternal/update"
         , body = emptyBody
-        , expect = Detailed.expectWhatever <| ApiPostPlugins << Result.map (\_ -> UpdateIndex)
+        , expect = expectWhateverStringError <| ApiPostPlugins UpdateIndex
         , timeout = Nothing
         , tracker = Nothing
         }
@@ -45,7 +45,7 @@ installPlugins plugins model =
         , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
         , url = getUrl model "/pluginsinternal/install"
         , body = Http.jsonBody (encodePluginIds plugins)
-        , expect = Detailed.expectWhatever <| ApiPostPlugins << Result.map (\_ -> Install)
+        , expect = expectWhateverStringError <| ApiPostPlugins Install
         , timeout = Nothing
         , tracker = Nothing
         }
@@ -58,7 +58,7 @@ removePlugins plugins model =
         , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
         , url = getUrl model "/pluginsinternal/remove"
         , body = Http.jsonBody (encodePluginIds plugins)
-        , expect = Detailed.expectWhatever <| ApiPostPlugins << Result.map (\_ -> Uninstall)
+        , expect = expectWhateverStringError <| ApiPostPlugins Uninstall
         , timeout = Nothing
         , tracker = Nothing
         }
@@ -71,7 +71,7 @@ changePluginStatus requestType plugins model =
         , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
         , url = getUrl model ("/pluginsinternal/" ++ requestTypeText requestType)
         , body = Http.jsonBody (encodePluginIds plugins)
-        , expect = Detailed.expectWhatever <| ApiPostPlugins << Result.map (\_ -> requestType)
+        , expect = expectWhateverStringError <| ApiPostPlugins requestType
         , timeout = Nothing
         , tracker = Nothing
         }
@@ -94,3 +94,10 @@ requestTypeAction t model =
 
         UpdateIndex ->
             updateIndex model
+
+
+{-| Expect for a result that is ignored, but a BadStatus that needs to be read as String (e.g. JSON response from API)
+-}
+expectWhateverStringError : (Result (Detailed.Error String) () -> msg) -> Http.Expect msg
+expectWhateverStringError toMsg =
+    expectStringResponse (Result.map (\_ -> ()) >> toMsg) Detailed.responseToString

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Init.elm
@@ -13,7 +13,7 @@ init : { contextPath : String } -> ( Model, Cmd Msg )
 init flags =
     let
         initUI =
-            UI [] NoModal Nothing
+            UI True [] NoModal ViewPluginsList
 
         initModel =
             Model flags.contextPath Nothing [] initUI

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPlugin.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPlugin.scala
@@ -42,7 +42,7 @@ import bootstrap.liftweb.ConfigResource
 import bootstrap.liftweb.FileSystemResource
 import bootstrap.liftweb.RudderProperties
 import com.normation.errors.IOResult
-import com.normation.plugins.RudderPackageService.CredentialError
+import com.normation.plugins.RudderPackageService.PluginSettingsError
 import com.normation.rudder.domain.logger.ApplicationLogger
 import com.normation.rudder.rest.EndpointSchema
 import com.normation.rudder.rest.lift.LiftApiModuleProvider
@@ -370,7 +370,7 @@ class PluginSystemServiceImpl(
     pluginDefs:           => Map[PluginName, RudderPluginDef],
     rudderFullVersion:    String
 ) extends PluginSystemService {
-  override def updateIndex(): IOResult[Option[CredentialError]] = {
+  override def updateIndex(): IOResult[Option[PluginSettingsError]] = {
     rudderPackageService.update()
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-plugins.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-plugins.scss
@@ -41,6 +41,11 @@
 @import "../../node_modules/bootstrap/scss/variables";
 @import "../../node_modules/bootstrap/scss/mixins";
 
+// Limit the size of spinner in loading buttons
+$spinner-width-sm: 1.3rem;
+$spinner-height-sm: $spinner-width-sm;
+@import "../../node_modules/bootstrap/scss/spinners";
+
 .rudder-template .template-main {
   flex: auto !important;
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/26243

## :warning:  Based on #6135 

Several improvements, both in the displayed error information and the logic of error display while the list of plugin is showed :  

1. on the API-side : 
  - error propagation from [rudder-package](https://github.com/Normation/rudder/pull/6137), and add the response error types for yet other HTTP codes
  - error message cleaning : remove color from the rudder-package output

2. on the frontend-side : 
  - :bug:  `errorDetails` message was not read correctly, we should never read Bytes in Elm
  - disable buttons when there is no selection
  - after confirmation the server restarts (and returns 502/503 to the client) so we need a feedback : 

![Peek 2025-01-29 11-12](https://github.com/user-attachments/assets/b048a04f-e4a9-4fde-987b-a0915a755b59)

