### PR TITLE
Fixes #26206: Directive will not be displayed when clicking on a technique then on directive in tree

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
@@ -886,10 +886,10 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
   private def onClickActiveTechnique(fullActiveTechnique: FullActiveTechnique): JsCmd = {
     currentTechnique = fullActiveTechnique.newestAvailableTechnique.map(fat => (fullActiveTechnique, fat.id.version))
     currentDirectiveSettingForm.set(Empty)
-    // Update UI
+    // Update UI and reset hash location : we do not have hash for techniques, see https://issues.rudder.io/issues/26206
     Replace(html_techniqueDetails, techniqueDetails.applyAgain()) &
     Replace(htmlId_policyConf, showDirectiveDetails()) &
-    JsRaw("""initBsTooltips();""") // JsRaw ok, const
+    JsRaw("""this.window.location.hash = ""; initBsTooltips();""".stripMargin) // JsRaw ok, const
   }
 
   private def onClickTechnique(id: ActiveTechniqueId): JsCmd = {


### PR DESCRIPTION
https://issues.rudder.io/issues/26206

As we don't display techniques based on the window hash, we can just set the hash to empty when clicked (it may leave `#` but it is not an issue, and does not seem to refresh the page, even on the load testing machine)