### PR TITLE
Fixes #26194: Patch management campaigns on CentOS 7 end in error

### DIFF
--- a/policies/module-types/system-updates/src/package_manager/zypper.rs
+++ b/policies/module-types/system-updates/src/package_manager/zypper.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 use anyhow::Result;
 
 use crate::output::{CommandBehavior, CommandCapture};
+use crate::package_manager::PackageManager;
 use crate::{
     campaign::FullCampaignType,
     output::ResultOutput,
@@ -135,7 +136,7 @@ impl LinuxPackageManager for ZypperPackageManager {
         let (r, o, e) = (res.inner, res.stdout, res.stderr);
         let res = match r {
             Ok(_) => {
-                let services = o.iter().map(|s| s.trim().to_string()).collect();
+                let services = PackageManager::parse_services(&o);
                 Ok(services)
             }
             Err(e) => Err(e),


### PR DESCRIPTION
https://issues.rudder.io/issues/26194

No idea about the root cause, hard to reproduce. Let's try this.