### PR TITLE
LDAPConnection code doesn't compile with scala 3 rules

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/FullInventoryFromLdapEntriesImpl.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/FullInventoryFromLdapEntriesImpl.scala
@@ -42,7 +42,7 @@ import com.normation.inventory.domain.FullInventory
 import com.normation.ldap.sdk.LDAPEntry
 import com.normation.ldap.sdk.LDAPTree
 import scala.collection.mutable.Buffer
-import zio.syntax.*
+import zio.ZIO
 
 class FullInventoryFromLdapEntriesImpl(
     inventoryDitService: InventoryDitService,
@@ -66,10 +66,10 @@ class FullInventoryFromLdapEntriesImpl(
     }
 
     for {
-      nodeTree   <- LDAPTree(serverElts)
+      nodeTree   <- ZIO.fromEither(LDAPTree(serverElts))
       node       <- mapper.nodeFromTree(nodeTree)
-      optMachine <- if (machineElts.isEmpty) None.succeed
-                    else LDAPTree(machineElts).flatMap(t => mapper.machineFromTree(t).map(m => Some(m)))
+      optMachine <- if (machineElts.isEmpty) ZIO.none
+                    else ZIO.fromEither(LDAPTree(machineElts)).flatMap(mapper.machineFromTree).asSome
     } yield {
       FullInventory(node, optMachine)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountRepository.scala
@@ -226,7 +226,7 @@ final class WoLDAPApiAccountRepository(
                            if (e(A_API_UUID) == Some(principal.id.value)) {
                              Some(e).succeed
                            } else {
-                             LDAPRudderError.Consistancy(s"An account with the same name ${principal.name.value} exists").fail
+                             LDAPRudderError.Consistency(s"An account with the same name ${principal.name.value} exists").fail
                            }
                        }
         optPrevious <- ldap.get(rudderDit.API_ACCOUNTS.API_ACCOUNT.dn(principal.id))
@@ -276,7 +276,7 @@ final class WoLDAPApiAccountRepository(
     for {
       ldap         <- ldapConnexion
       entry        <- ldap.get(rudderDit.API_ACCOUNTS.API_ACCOUNT.dn(id)).flatMap {
-                        case None    => LDAPRudderError.Consistancy(s"Api Account with ID '${id.value}' is not present").fail
+                        case None    => LDAPRudderError.Consistency(s"Api Account with ID '${id.value}' is not present").fail
                         case Some(x) => x.succeed
                       }
       oldAccount   <- mapper.entry2ApiAccount(entry).toIO

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDirectiveRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDirectiveRepository.scala
@@ -106,7 +106,7 @@ class RoLDAPDirectiveRepository(
           case 1 => Some(piEntries(0)).succeed
           case _ =>
             LDAPRudderError
-              .Consistancy(
+              .Consistency(
                 s"Error, the directory contains multiple occurrence of directive with id '${id.debugString}'. DN: ${piEntries.map(_.dn).mkString("; ")}"
               )
               .fail
@@ -533,7 +533,7 @@ class RoLDAPDirectiveRepository(
                       case 1 => Some(uptEntries(0)).succeed
                       case _ =>
                         LDAPRudderError
-                          .Consistancy(
+                          .Consistency(
                             s"Error, the directory contains multiple occurrence of active " +
                             s"technique with ID '${id}'. DNs involved: ${uptEntries.map(_.dn).mkString("; ")}"
                           )

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPConnection.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPConnection.scala
@@ -377,8 +377,8 @@ sealed class RoLDAPConnection(
     } flatMap { all =>
       if (all.getEntryCount() > 0) {
         // build the tree
-        LDAPTree(all.getSearchEntries.asScala.map(x => LDAPEntry(x))).map(Some(_))
-      } else None.succeed
+        ZIO.fromEither(LDAPTree(all.getSearchEntries.asScala.map(x => LDAPEntry(x)))).asSome
+      } else ZIO.none
     } catchAll { x =>
       (x: @unchecked) match {
         // a no such object error simply means that the required LDAP tree is not in the directory

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPIOResult.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPIOResult.scala
@@ -43,7 +43,7 @@ object LDAPRudderError {
     override def fullMsg: String = s"${msg}; LDAP result was: ${result.getResultString}"
   }
 
-  final case class Consistancy(msg: String) extends LDAPRudderError
+  final case class Consistency(msg: String) extends LDAPRudderError
 
   // accumulated errors from multiple independent action
   final case class Accumulated(errors: NonEmptyList[RudderError]) extends LDAPRudderError {
@@ -65,13 +65,13 @@ object LDAPIOResult {
   implicit class StrictOption[T](opt: LDAPIOResult[Option[T]]) {
     def notOptional(msg: String): ZIO[Any, LDAPRudderError, T] = opt.flatMap(_ match {
       case Some(x) => x.succeed
-      case None    => LDAPRudderError.Consistancy(msg).fail
+      case None    => LDAPRudderError.Consistency(msg).fail
     })
   }
 
   // same than above for a Rudder error from a string
   implicit class ToFailureMsg(e: String) {
-    def fail: IO[LDAPRudderError.Consistancy, Nothing] = ZIO.fail(LDAPRudderError.Consistancy(e))
+    def fail: IO[LDAPRudderError.Consistency, Nothing] = ZIO.fail(LDAPRudderError.Consistency(e))
   }
 
   implicit class ValidatedToLdapError[T](res: ZIO[Any, NonEmptyList[LDAPRudderError], List[T]]) {
@@ -81,7 +81,7 @@ object LDAPIOResult {
   implicit class EitherToLdapError[T](res: Either[RudderError, T]) {
     def toLdapResult: LDAPIOResult[T] = {
       res match {
-        case Left(error) => LDAPRudderError.Consistancy(error.msg).fail
+        case Left(error) => LDAPRudderError.Consistency(error.msg).fail
         case Right(x)    => x.succeed
       }
     }

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPTree.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPTree.scala
@@ -24,7 +24,7 @@ import cats.implicits.*
 import com.normation.ldap.ldif.ToLDIFRecords
 import com.normation.ldap.ldif.ToLDIFString
 import com.normation.ldap.sdk.LDAPIOResult.*
-import com.normation.ldap.sdk.LDAPRudderError.Consistancy
+import com.normation.ldap.sdk.LDAPRudderError.Consistency
 import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.RDN
 import com.unboundid.ldif.LDIFRecord
@@ -144,13 +144,13 @@ object LDAPTree {
    */
   def apply(entries: Iterable[LDAPEntry]):                              LDAPIOResult[LDAPTree]                      = {
     if (null == entries || entries.isEmpty) {
-      LDAPRudderError.Consistancy(s"You can't create a Tree from an empty list of entries").fail
+      LDAPRudderError.Consistency(s"You can't create a Tree from an empty list of entries").fail
     }
     // verify that there is no duplicates
     else if (entries.map(_.dn).toSet.size != entries.size) {
       val s   = entries.map(_.dn).toSet
       val res = entries.map(_.dn).filter(x => !s.contains(x))
-      LDAPRudderError.Consistancy(s"Some entries have the same dn, what is forbiden: ${res.toString}").fail
+      LDAPRudderError.Consistency(s"Some entries have the same dn, what is forbiden: ${res.toString}").fail
     } else {
       val used = Buffer[DN]()
       /*
@@ -173,7 +173,7 @@ object LDAPTree {
 
       if (used.size < entries.size - 1) {
         val s = entries.map(_.dn).filter(x => !used.contains(x))
-        LDAPRudderError.Consistancy(s"Some entries have no parents: ${s.toString()}").fail
+        LDAPRudderError.Consistency(s"Some entries have no parents: ${s.toString()}").fail
       } else root.succeed
     }
   }
@@ -184,10 +184,10 @@ object LDAPTree {
    * The comparison is strict, so that:
    * - if
    */
-  def diff(source: LDAPTree, target: LDAPTree, removeMissing: Boolean): Either[Consistancy, List[TreeModification]] = {
+  def diff(source: LDAPTree, target: LDAPTree, removeMissing: Boolean): Either[Consistency, List[TreeModification]] = {
     if (source.root.dn != target.root.dn) {
       Left(
-        Consistancy(s"DN of the two LDAP tree's root are different: ${source.root.dn.toString()} <> ${target.root.dn.toString()}")
+        Consistency(s"DN of the two LDAP tree's root are different: ${source.root.dn.toString()} <> ${target.root.dn.toString()}")
       )
     } else {
       // modification on root

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPTree.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPTree.scala
@@ -140,7 +140,7 @@ object LDAPTree {
    * All entries in the list safe one (the one that will become the root of the tree)
    * must have a direct parent in other entries.
    */
-  def apply(entries: Iterable[LDAPEntry]):                              Either[LDAPRudderError, LDAPTree]           = {
+  def apply(entries: Iterable[LDAPEntry]):                              Either[LDAPRudderError.Consistency, LDAPTree] = {
     if (null == entries || entries.isEmpty) {
       Left(LDAPRudderError.Consistency(s"You can't create a Tree from an empty list of entries"))
     }
@@ -182,7 +182,7 @@ object LDAPTree {
    * The comparison is strict, so that:
    * - if
    */
-  def diff(source: LDAPTree, target: LDAPTree, removeMissing: Boolean): Either[Consistency, List[TreeModification]] = {
+  def diff(source: LDAPTree, target: LDAPTree, removeMissing: Boolean): Either[Consistency, List[TreeModification]]   = {
     if (source.root.dn != target.root.dn) {
       Left(
         Consistency(s"DN of the two LDAP tree's root are different: ${source.root.dn.toString()} <> ${target.root.dn.toString()}")

--- a/webapp/sources/scala-ldap/src/test/scala/com/normation/ldap/sdk/LDAPTreeTest.scala
+++ b/webapp/sources/scala-ldap/src/test/scala/com/normation/ldap/sdk/LDAPTreeTest.scala
@@ -20,7 +20,6 @@
 
 package com.normation.ldap.sdk
 
-import com.normation.zio.*
 import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.DN.NULL_DN
 import com.unboundid.ldap.sdk.RDN
@@ -74,7 +73,7 @@ class LDAPTreeTest extends Specification {
       LDAPEntry(new DN(rdn4, dn2))
     )
 
-    val optTree = ZioRuntime.unsafeRun(LDAPTree(entries).either)
+    val optTree = LDAPTree(entries)
     val tree    = optTree.getOrElse(throw new IllegalArgumentException("this is for test"))
     val mTree   = tree._children(rdn2)
 


### PR DESCRIPTION
In scala 3, with -Werror, an IO can't have Object on the error channel unless it's done on purpose.
In this case, it seems more a programming error than a deliberate decision.
