### PR TITLE
refactor: avoid implicit discard of values in ZIO

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/CleanupUsers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/CleanupUsers.scala
@@ -102,12 +102,14 @@ class CleanupUsers(
         .foldZIO(
           err => logger.error(s"Error when disabling user accounts inactive since '${disableInactive.render}': ${err.fullMsg}"),
           disabledUsers => {
-            ZIO.unless(disabledUsers.isEmpty)(
-              logger.warn(
-                s"Following users status changed to 'disabled' because they were inactive since '${disableInactive.render}': '${disabledUsers
-                    .mkString("', '")}'"
+            ZIO
+              .unless(disabledUsers.isEmpty)(
+                logger.warn(
+                  s"Following users status changed to 'disabled' because they were inactive since '${disableInactive.render}': '${disabledUsers
+                      .mkString("', '")}'"
+                )
               )
-            )
+              .unit
           }
         )
     _    <- userRepository
@@ -121,9 +123,11 @@ class CleanupUsers(
               .foldZIO(
                 err => logger.error(s"Error when deleting user accounts inactive since '${deleteInactive.render}': ${err.fullMsg}"),
                 deletedUsers => {
-                  ZIO.unless(deletedUsers.isEmpty)(
-                    logger.info(s"Following users status changed from 'disabled' to 'deleted': '${deletedUsers.mkString("', '")}'")
-                  )
+                  ZIO
+                    .unless(deletedUsers.isEmpty)(
+                      logger.info(s"Following users status changed from 'disabled' to 'deleted': '${deletedUsers.mkString("', '")}'")
+                    )
+                    .unit
                 }
               )
     _    <- userRepository
@@ -136,12 +140,14 @@ class CleanupUsers(
               .foldZIO(
                 err => logger.error(s"Error when purging user accounts deleted since '${purgeDeleted.render}': ${err.fullMsg}"),
                 purgedUsers => {
-                  ZIO.unless(purgedUsers.isEmpty)(
-                    logger.info(
-                      s"Users were purged from the database because they were configured to be purged ${purgeDeleted.render} after deletion. Users list is : '${purgedUsers
-                          .mkString("', '")}'"
+                  ZIO
+                    .unless(purgedUsers.isEmpty)(
+                      logger.info(
+                        s"Users were purged from the database because they were configured to be purged ${purgeDeleted.render} after deletion. Users list is : '${purgedUsers
+                            .mkString("', '")}'"
+                      )
                     )
-                  )
+                    .unit
                 }
               )
     dos   = d.minus(purgeSessions.toMillis)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/GitGC.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/GitGC.scala
@@ -93,6 +93,7 @@ class GitGC(
             .withPermit(IOResult.attempt {
               gitRepo.git.gc().setProgressMonitor(new LogProgressMonitor()).call
             })
+            .unit
             .catchAll(err => logger.error(s"Error when performing git-gc on ${gitRepo.rootDirectory.name}: ${err.fullMsg}"))
     t1 <- currentTimeMillis
     _  <- logger.info(s"git-gc performed on ${gitRepo.rootDirectory.name} in ${new Duration(t1 - t0).toString}")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeOldInventoryData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeOldInventoryData.scala
@@ -76,8 +76,8 @@ class PurgeOldInventoryData(
     t0 <- currentTimeMillis
     now = Instant.ofEpochMilli(t0)
     _  <- ZIO
-            .foreach(cleanDirectories) { dir =>
-              ZIO.foreach(dir.list.to(Iterable)) { f =>
+            .foreachDiscard(cleanDirectories) { dir =>
+              ZIO.foreachDiscard(dir.list.to(Iterable)) { f =>
                 isOlderThanMaxAge(f, maxAge.toSeconds, now).flatMap { older =>
                   if (older) {
                     InventoryProcessingLogger.info(
@@ -85,6 +85,7 @@ class PurgeOldInventoryData(
                     ) *>
                     IOResult
                       .attempt(f.delete())
+                      .unit
                       .catchAll(err => {
                         InventoryProcessingLogger
                           .error(s"Error while trying to clean old inventory file '${f.pathAsString}': ${err.fullMsg}")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JSONReportsHandler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JSONReportsHandler.scala
@@ -90,7 +90,7 @@ case class JSONReportsAnalyser(reportsRepository: ReportsRepository, propRepo: R
                         propRepo.updateReportHandlerLastId(highestId)
                       case Some(maxIdReport) =>
                         CampaignLogger.debug(s"Found ${reports.size} json reports, update parsed id to max id ${maxIdReport._1 + 1}") *>
-                        ZIO.foreach(reports)(r => handle(r._2)).catchAll(err => CampaignLogger.error(err.fullMsg)) *>
+                        ZIO.foreach(reports)(r => handle(r._2)).unit.catchAll(err => CampaignLogger.error(err.fullMsg)) *>
                         propRepo.updateReportHandlerLastId(maxIdReport._1 + 1)
                     }
       t4         <- currentTimeMillis

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactChangeEventCallback.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactChangeEventCallback.scala
@@ -372,10 +372,10 @@ class HistorizeNodeState(
       NodeLoggerPure.Delete.debug(s"  - delete fact about node '${nodeId.value}'") *>
       gitFactStorage
         .changeStatus(nodeId, RemovedInventory)
+        .unit
         .catchAll(err =>
           NodeLoggerPure.info(s"Error when trying to update fact when deleting node '${nodeId.value}': ${err.fullMsg}")
         )
-        .unit
     }
 
     change.event match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryFileWatcher.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryFileWatcher.scala
@@ -664,7 +664,7 @@ class ProcessFile(
              InventoryProcessingLogger.debug(s"Dealing with zip file '${file.name}'") *>
              IOResult.attempt {
                file.unGzipTo(dest)
-             }.catchAll { err => // if the gz file is corrupted, we still want to delete it in the next instruction, but log
+             }.unit.catchAll { err => // if the gz file is corrupted, we still want to delete it in the next instruction, but log
                InventoryProcessingLogger.error(
                  Chained(s"gz archive '${file.pathAsString}' is corrupted: deleting it.", err).fullMsg
                )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
@@ -448,8 +448,8 @@ class InventoryMover(
     IOResult
       .attempt(File(rejectPath).writeText(s"""${date}
                                              |${result.msg.replaceAll("; cause was:", "\ncause was:")}\n""".stripMargin))
-      .catchAll(err => InventoryProcessingLogger.error(s"Error when writing rejection log file ${rejectPath}: ${err.fullMsg}"))
       .unit
+      .catchAll(err => InventoryProcessingLogger.error(s"Error when writing rejection log file ${rejectPath}: ${err.fullMsg}"))
   }
 
   def moveFiles(inventory: File, signature: File, result: InventoryProcessStatus): UIO[Unit] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/RemoveNodeService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/RemoveNodeService.scala
@@ -505,8 +505,8 @@ class CloseNodeConfiguration(expectedReportsRepository: UpdateExpectedReportsRep
       _ <- NodeLoggerPure.Delete.debug(s"  - close expected reports for '${nodeId.value}'")
       _ <- expectedReportsRepository
              .closeNodeConfigurationsPure(nodeId)
-             .catchAll(err => NodeLoggerPure.Delete.error(s"Error when closing expected reports for node ${(nodeId, info).name}"))
              .unit
+             .catchAll(_ => NodeLoggerPure.Delete.error(s"Error when closing expected reports for node ${(nodeId, info).name}"))
       _ <- expectedReportsRepository.deleteNodeInfos(nodeId).catchAll(err => NodeLoggerPure.Delete.error(err.msg))
     } yield ()
   }


### PR DESCRIPTION
`UIO[Foo].catchAll(log).unit` resolves the value as Any whereas `UIO[Foo].unit.catchAll(log)` does not, we should use the latter.