### PR TITLE
Fixes #26114: Add campaign API documentation for CSV reporting endpoints

### DIFF
--- a/webapp/sources/api-doc/code_samples/curl/systemUpdate/report.sh
+++ b/webapp/sources/api-doc/code_samples/curl/systemUpdate/report.sh
@@ -1,0 +1,1 @@
+curl --silent --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/systemUpdate/events/0076a379-f32d-4732-9e91-33ab219d8fde/reports'

--- a/webapp/sources/api-doc/code_samples/curl/systemUpdate/summaryReport.sh
+++ b/webapp/sources/api-doc/code_samples/curl/systemUpdate/summaryReport.sh
@@ -1,0 +1,1 @@
+curl --silent --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/systemUpdate/events/0076a379-f32d-4732-9e91-33ab219d8fde/summaryReport'

--- a/webapp/sources/api-doc/openapi.src.yml
+++ b/webapp/sources/api-doc/openapi.src.yml
@@ -355,6 +355,10 @@ paths:
     $ref: paths/systemUpdate/detailedResult.yml
   "/systemUpdate/events/{id}/result":
     $ref: paths/systemUpdate/eventResult.yml
+  "/systemUpdate/events/{id}/report":
+    $ref: paths/systemUpdate/report.yml
+  "/systemUpdate/events/{id}/summaryReport":
+    $ref: paths/systemUpdate/summaryReport.yml
   "/systemUpdate/campaign/{id}/history":
     $ref: paths/systemUpdate/campaignHistory.yml
   "/openscap/report/{nodeId}":

--- a/webapp/sources/api-doc/paths/systemUpdate/report.yml
+++ b/webapp/sources/api-doc/paths/systemUpdate/report.yml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2025 Normation SAS
+get:
+  summary: Get report of campaign
+  description: Get a detailed CSV report of a system update result
+  operationId: getSystemUpdateResultReport
+  parameters:
+    - $ref: ../../components/parameters/campaign-event-id-path.yml
+  responses:
+    "200":
+      description: CSV report for campaign detailed result
+      content:
+        text/plain:
+          schema:
+            type: string
+          example: |
+            "Node Name","Campaign Name","Campaign Result","Execution date","Updated package","Package update status","Previous version","Current version"
+            "node1.localhost","campaign1","Success","2024-12-30T10:00:00.000Z","vim","Updated","9.1.0765","9.1.0787"
+  tags:
+    - 🧩 System update campaigns
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/systemUpdate/report.sh

--- a/webapp/sources/api-doc/paths/systemUpdate/summaryReport.yml
+++ b/webapp/sources/api-doc/paths/systemUpdate/summaryReport.yml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2025 Normation SAS
+get:
+  summary: Get summary report of campaign
+  description: Get a summarized CSV report of a system update result
+  operationId: getSystemUpdateSummaryReport
+  parameters:
+    - $ref: ../../components/parameters/campaign-event-id-path.yml
+  responses:
+    "200":
+      description: CSV report for campaign result
+      content:
+        text/plain:
+          schema:
+            type: string
+          example: |
+            "Node Name","Campaign Name","Campaign Result","Operating system name","Operating system service pack","Execution date","Updated packages"
+            "node1","campaign1","Success","Debian 12","None","2024-12-30T10:00:00.000Z","123"
+  tags:
+    - 🧩 System update campaigns
+  x-codeSamples:
+    - lang: curl
+      source:
+        $ref: ../../code_samples/curl/systemUpdate/summaryReport.sh


### PR DESCRIPTION
https://issues.rudder.io/issues/26114

OpenAPI documentation for the two endpoints added in https://github.com/Normation/rudder-plugins-private/pull/882, they return `text/plain` content type