### PR TITLE
Fixes #26278: Add foreach on blocks

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
@@ -151,11 +151,12 @@ type alias TechniqueParameter =
   }
 
 type alias TechniqueCategory =
-    { id : String
-    , name : String
-    , path : String
-    , subCategories : SubCategories
-    }
+  { id : String
+  , name : String
+  , path : String
+  , subCategories : SubCategories
+  }
+
 type SubCategories = SubCategories (List TechniqueCategory)
 
 allCategories t =
@@ -242,6 +243,7 @@ type alias MethodBlockUiInfo =
   , tab        : MethodBlockTab
   , validation : ValidationState BlockError
   , showChildDetails : Bool
+  , foreachUI  : ForeachUI
   }
 
 type alias TechniqueUiInfo =
@@ -261,8 +263,11 @@ type alias TechniqueEditInfo =
   ,  result : Result String ()
   }
 
-type MethodCallTab = CallParameters | CallConditions | Result | CallReporting | ForEach
-type MethodBlockTab = BlockConditions | BlockReporting | Children
+type UiInfo = CallUiInfo MethodCallUiInfo MethodCall  | BlockUiInfo MethodBlockUiInfo MethodBlock
+
+type MethodCallTab = CallParameters | CallConditions | Result | CallReporting | CallForEach
+
+type MethodBlockTab = BlockConditions | BlockReporting | Children  | BlockForEach
 type MethodCallMode = Opened | Closed
 type Tab = General | Parameters | Resources | Output | None
 type Mode = Introduction | TechniqueDetails Technique TechniqueState TechniqueUiInfo TechniqueEditInfo
@@ -286,12 +291,12 @@ type Msg =
   | CheckOutYaml CheckMode (Result (Http.Detailed.Error String) ( Http.Metadata, String ))
   | UIMethodAction CallId MethodCallUiInfo
   | UIBlockAction CallId MethodBlockUiInfo
-  | UpdateMethodAndUi  CallId MethodCallUiInfo MethodElem
+  | UpdateCallAndUi UiInfo
+  | MethodCallModified MethodElem (Maybe UiInfo)
   | RemoveMethod CallId
   | UpdateEdition TechniqueEditInfo
   | CloneElem  MethodElem CallId
   | MethodCallParameterModified MethodCall ParameterId String
-  | MethodCallModified MethodElem
   | TechniqueParameterModified ParameterId TechniqueParameter
   | TechniqueParameterRemoved ParameterId
   | TechniqueParameterAdded ParameterId

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewMethod.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewMethod.elm
@@ -1,9 +1,8 @@
 module Editor.ViewMethod exposing (..)
 
-import Set
 import Dict exposing (Dict)
 import Dict.Extra exposing (keepOnly)
-import Html exposing (..)
+import Set
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Json.Encode
@@ -16,12 +15,12 @@ import Dom exposing (..)
 import Json.Decode
 import VirtualDom
 
-import Rules.ViewUtils exposing (onCustomClick)
 import Editor.DataTypes exposing (..)
 import Editor.MethodConditions exposing (..)
 import Editor.MethodElemUtils exposing (..)
 import Editor.AgentValueParser exposing (..)
 import Editor.ViewMethodsList exposing (getTooltipContent)
+import Editor.ViewTabForeach exposing (..)
 
 
 --
@@ -61,15 +60,15 @@ parameterName param =
   String.replace "_" " " (String.Extra.toSentenceCase param.name.value)
 
 
-showParam: Model -> MethodCall -> ValidationState MethodCallParamError -> MethodParameter -> List CallParameter -> Html Msg
+showParam: Model -> MethodCall -> ValidationState MethodCallParamError -> MethodParameter -> List CallParameter -> Element Msg
 showParam model call state methodParam params =
   let
     displayedValue = List.Extra.find (.id >> (==) methodParam.name ) params |> Maybe.map (.value >> displayValue) |> Maybe.withDefault ""
     isMandatory =
       if methodParam.constraints.allowEmpty |> Maybe.withDefault False then
-        span [class "allow-empty"] [text ""]
+        element "span" |> addClass "allow-empty"
       else
-        span [class "mandatory-param"] [text " *"]
+        element "span" |> addClass "mandatory-param" |> appendText " *"
     errors = case state of
       InvalidState constraintErrors -> List.filterMap (\c -> case c of
                                                          ConstraintError err ->
@@ -80,36 +79,41 @@ showParam model call state methodParam params =
                                                 ) constraintErrors
       _ -> []
   in
-  div [class "form-group method-parameter"] [
-    label [ for "param-index" ] [
-      span [] [
-        text (String.Extra.toTitleCase methodParam.name.value)
-      , isMandatory
-      , text (" -")
-      , span [ class "badge badge-secondary ng-binding" ] [ text methodParam.type_ ]
-      ]
-    , small [] [ text ( " " ++ methodParam.description) ]
-    ]
-  , textarea  [
-        stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
-      , onFocus DisableDragDrop
-      , readonly (not model.hasWriteRights)
-      , name "param"
-      , class "form-control"
-      , rows  1
-      , value displayedValue
-      , onInput  (MethodCallParameterModified call methodParam.name)
-      -- to deactivate plugin "Grammarly" or "Language Tool" from
-      -- adding HTML that make disapear textarea (see  https://issues.rudder.io/issues/21172)
-      , attribute "data-gramm" "false"
-      , attribute "data-gramm_editor" "false"
-      , attribute "data-enable-grammarly" "false"
-      , spellcheck False
-      ] []
-  , if (not (List.isEmpty errors)) then ul [ class "list-unstyled" ]
-      (List.map (\e -> li [ class "text-danger" ] [ text e ]) errors)
-    else text ""
-  ]
+    element "div"
+      |> addClass "form-group method-parameter"
+      |> appendChildList
+        [ element "label"
+          |> addAttribute (for "param-index")
+          |> appendChildList
+            [ element "span"
+              |> appendChild (element "span" |> appendText (String.Extra.toTitleCase methodParam.name.value))
+              |> appendChild isMandatory
+              |> appendChild (element "span" |> appendText " -")
+              |> appendChild (element "span" |> addClass "badge badge-secondary ng-binding" |> appendText methodParam.type_)
+            , element "small" |> appendText (" " ++ methodParam.description)
+            ]
+        , element "textarea"
+          |> addAttributeList
+            [ stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+            , onFocus DisableDragDrop
+            , readonly (not model.hasWriteRights)
+            , name "param"
+            , class "form-control"
+            , rows  1
+            , value displayedValue
+            , onInput  (MethodCallParameterModified call methodParam.name)
+            -- to deactivate plugin "Grammarly" or "Language Tool" from
+            -- adding HTML that make disapear textarea (see  https://issues.rudder.io/issues/21172)
+            , attribute "data-gramm" "false"
+            , attribute "data-gramm_editor" "false"
+            , attribute "data-enable-grammarly" "false"
+            , spellcheck False
+            ]
+        ]
+      |> appendChildConditional ( element "ul"
+        |> addClass "list-unstyled"
+        |> appendChildList (errors |> List.map (\e -> element "li" |> addClass "text-danger" |> appendText e))
+      ) (not (List.isEmpty errors))
 
 accumulateValidationState: List (ValidationState a) -> ValidationState a -> ValidationState a
 accumulateValidationState validations base =
@@ -168,554 +172,388 @@ checkConstraintOnParameter call constraint =
   DISPLAY ONE METHOD EXTENDED
 -}
 
-showMethodTab: Model -> Method -> Maybe CallId ->  MethodCall -> MethodCallUiInfo -> Html Msg
-showMethodTab model method parentId call uiInfo=
+showMethodTab: Model -> Method -> Maybe CallId ->  MethodCall -> MethodCallUiInfo -> Element Msg
+showMethodTab model method parentId call uiInfo =
   case uiInfo.tab of
     CallReporting ->
-      div [ class "tab-parameters"] [
-        div [ class "form-group"] [
-          label [ for "disable_reporting", style "margin-right" "5px"] [ text "Disable reporting"]
-        , input [ readonly (not model.hasWriteRights), type_ "checkbox", name "disable_reporting", checked call.disableReporting,  onCheck  (\b -> MethodCallModified (Call parentId {call  | disableReporting = b }))] []
-        ]
-      ]
+      element "div"
+      |> addClass "tab-parameters"
+      |> appendChild ( element "div"
+        |> addClass "form-group"
+        |> appendChildList
+          [ element "label"
+            |> addAttribute (for "disable_reporting")
+            |> addClass "me-2"
+            |> appendText "Disable reporting"
+          , element "input"
+            |> addAttributeList
+              [ readonly (not model.hasWriteRights)
+              , type_ "checkbox"
+              , name "disable_reporting"
+              , checked call.disableReporting
+              , onCheck  (\b -> MethodCallModified (Call parentId {call  | disableReporting = b }) Nothing)
+              ]
+          ]
+      )
+
     CallParameters ->
-      div [ class "tab-parameters"] (List.map (\m  -> showParam model call uiInfo.validation m call.parameters )  method.parameters )
+      element "div" |> addClass "tab-parameters"
+       |> appendChildList (List.map (\m  -> showParam model call uiInfo.validation m call.parameters )  method.parameters )
+
     CallConditions ->
       let
         condition = call.condition
+
         errorOnConditionInput =
-          if(String.contains "\n" call.condition.advanced) then
-            ul [ class "list-unstyled" ] [ li [ class "text-danger" ] [ text "Return carriage is forbidden in condition" ] ]
-          else
-            div[][]
-        ubuntuLi = List.map (\ubuntuMinor ->
-                     let
-                       updatedCall = Call parentId { call | condition = {condition | os =  updateUbuntuMinor  ubuntuMinor condition.os } }
-                     in
-                       li [ onClick (MethodCallModified updatedCall) ] [ a [class "dropdown-item"] [ text (showUbuntuMinor ubuntuMinor) ] ]
-
-                   ) [All, ZeroFour, Ten]
-        updateConditonVersion = \f s ->
-                      let
-                        updatedCall = Call parentId { call | condition = {condition | os =  f  (String.toInt s) condition.os } }
-                      in
-                        MethodCallModified updatedCall
-      in
-      div [ class "tab-conditions"] [
-        div [class "form-group condition-form", id "os-form"] [
-          div [ class "form-inline" ] [
-            div [ class "form-group" ] [
-              label [ style "display" "inline-block", for ("OsCondition-" ++ call.id.value)]
-              [ text "Operating system: " ]
-            , div [ class "btn-group" ]
-              [ button [ class "btn btn-default dropdown-toggle", id ("OsCondition-" ++ call.id.value), attribute  "data-bs-toggle" "dropdown"
-                , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True)) ]
-                [ text ((osName condition.os) ++ " ")
-                , span [ class "caret" ] []
-                ]
-              , ul [ class "dropdown-menu" ]
-                 ( List.map (\os ->
-                     let
-                       updatedCondition = {condition | os = os }
-                     in
-                       li [ onClick (MethodCallModified (Call parentId {call | condition = updatedCondition })), class (osClass os) ] [ a [class "dropdown-item"] [ text (osName os) ] ] ) osList )
-              ]
-            , if (hasMajorMinorVersion condition.os || isUbuntu condition.os ) then
-                input [ readonly (not model.hasWriteRights)
-                      , value (Maybe.withDefault "" (Maybe.map String.fromInt (getMajorVersion condition.os) ))
-                      , onInput (updateConditonVersion updateMajorVersion)
-                      , type_ "number", style "display" "inline-block", style "width" "auto", style "margin-left" "5px"
-                      , style "margin-top" "0",  class "form-control", placeholder "Major version"
-                      , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
-                      ] []
-              else text ""
-            , if (hasMajorMinorVersion condition.os ) then
-                input [ readonly (not model.hasWriteRights)
-                      , value (Maybe.withDefault "" (Maybe.map String.fromInt (getMinorVersion condition.os) ))
-                      , onInput (updateConditonVersion updateMinorVersion)
-                      , type_ "number", style "display" "inline-block", style "width" "auto", class "form-control"
-                      , style "margin-left" "5px", style "margin-top" "0", placeholder "Minor version"
-                      , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
-                      ] []
-              else text ""
-           , if  ( isUbuntu condition.os ) then
-               div [ style  "margin-left" "5px", class "btn-group" ]
-                 [ button
-                   [ class "btn btn-default dropdown-toggle", id "ubuntuMinor" , attribute  "data-bs-toggle" "dropdown"
-                   , attribute  "aria-haspopup" "true", attribute "aria-expanded" "true"
-                   , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
-                   ]
-                   [ text  ((getUbuntuMinor condition.os) ++ " ")
-                   , span [ class"caret" ] []
-                   ]
-                 , ul [ class "dropdown-menu", attribute "aria-labelledby" "ubuntuMinor" ] ubuntuLi
-
-                 ]
-              else text ""
-
-
-            , if (hasVersion condition.os ) then
-                input [ readonly (not model.hasWriteRights)
-                      , value (Maybe.withDefault "" (Maybe.map String.fromInt (getVersion condition.os) ))
-                      , onInput  (updateConditonVersion updateVersion)
-                      , type_ "number", style "display" "inline-block", style "width" "auto"
-                      , class "form-control", style "margin-left" "5px", style "margin-top" "0", placeholder "Version"
-                      , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
-                      ] []
-              else text ""
-            , if (hasSP condition.os ) then
-                input [ readonly (not model.hasWriteRights)
-                      , value (Maybe.withDefault "" (Maybe.map String.fromInt (getSP condition.os) ))
-                      , onInput (updateConditonVersion updateSP)
-                      , type_ "number", style "display" "inline-block", style "width" "auto", class "form-control"
-                      , style "margin-left" "5px", style "margin-top" "0", placeholder "Service pack"
-                      , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
-                      ] []
-              else text ""
-            ]
-          ]
-        ]
-      , div [ class "form-group condition-form" ] [
-          label [ for "advanced"] [ text "Other conditions:" ]
-        , textarea [  readonly (not model.hasWriteRights)
-                   , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
-                   , onFocus DisableDragDrop
-                   , name "advanced"
-                   , class "form-control"
-                   , rows 1
-                   , id "advanced"
-                   , value condition.advanced
-                   , attribute "onkeypress" "if (event.keyCode == 13) alert('You pressed the return button.'); return false;"
-                   , onInput (\s ->
-                     let
-                       updatedCondition = {condition | advanced = s }
-                       updatedCall = Call parentId {call | condition = updatedCondition }
-                     in MethodCallModified updatedCall)
-                   -- to deactivate plugin "Grammarly" or "Language Tool" from
-                   -- adding HTML that make disapear textarea (see  https://issues.rudder.io/issues/21172)
-                   , attribute "data-gramm" "false"
-                   , attribute "data-gramm_editor" "false"
-                   , attribute "data-enable-grammarly" "false"
-                   , spellcheck False
-                   ] []
-        , errorOnConditionInput
-       ]
-      , div [ class "form-group condition-form" ] [
-          label [ for "class_context" ] [ text "Applied condition expression:" ]
-        , textarea [
-            readonly (not model.hasWriteRights)
-            , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
-            , onFocus DisableDragDrop
-            , name "class_context"
-            , class "form-control"
-            , rows 1
-            , id "class_context"
-            , value (conditionStr condition)
-            , readonly True
-            -- to deactivate plugin "Grammarly" or "Language Tool" from
-            -- adding HTML that make disapear textarea (see  https://issues.rudder.io/issues/21172)
-            , attribute "data-gramm" "false"
-            , attribute "data-gramm_editor" "false"
-            , attribute "data-enable-grammarly" "false"
-            , spellcheck False
-            ] []
-        , if String.length (conditionStr condition) > 2048 then
-            span [ class "text-danger" ] [text "Classes over 2048 characters are currently not supported." ]
-          else
-            text ""
-        ]
-      ]
-    Result     ->
-      let
-        classParameter = getClassParameter method
-        paramValue = call.parameters |> List.Extra.find (\c -> c.id == classParameter.name) |> Maybe.map (.value)  |> Maybe.withDefault [Value ""]
-      in
-      div [ class "tab-result" ] [
-        label [] [
-          small [] [ text "Result conditions defined by this method" ]
-        ]
-      , div [ class "form-horizontal editForm result-class" ] [
-          div [ class "input-group result-success" ] [
-            div [ class "input-group-text" ] [
-              text "Success"
-            ]
-          , input [ readonly True, type_ "text", class "form-control",  value (method.classPrefix ++ "_" ++ (canonify paramValue) ++ "_kept")
-                   , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True)) , stopPropagationOn "click" (Json.Decode.succeed (DisableDragDrop, True)) ] []
-          , button [ class "btn btn-outline-secondary clipboard", type_ "button", title "Copy to clipboard", onClick (Copy (method.classPrefix ++ "_" ++ (canonify paramValue) ++ "_kept")) ] [
-              i [ class "ion ion-clipboard" ] []
-            ]
-          ]
-        , div [ class "input-group result-repaired" ] [
-            div [ class "input-group-text" ] [
-              text "Repaired"
-            ]
-          , input [ readonly True, type_ "text", class "form-control",  value (method.classPrefix ++ "_" ++ (canonify paramValue) ++ "_repaired")
-                   , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True)) , stopPropagationOn "click" (Json.Decode.succeed (DisableDragDrop, True)) ] []
-          , button [ class "btn btn-outline-secondary clipboard", type_ "button" , title "Copy to clipboard" , onClick (Copy (method.classPrefix ++ "_" ++ (canonify paramValue) ++ "_repaired")) ] [
-              i [ class "ion ion-clipboard" ] []
-            ]
-          ]
-        , div [ class "input-group result-error" ] [
-            div [ class "input-group-text" ] [
-              text "Error"
-            ]
-          , input [ readonly True, type_ "text", class "form-control",  value (method.classPrefix ++ "_" ++ (canonify paramValue) ++ "_error")
-                   , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True)) , stopPropagationOn "click" (Json.Decode.succeed (DisableDragDrop, True)) ] []
-          , button [ class "btn btn-outline-secondary clipboard", type_ "button", title "Copy to clipboard", onClick (Copy (method.classPrefix ++ "_" ++ (canonify paramValue) ++ "_error")) ] [
-              i [ class "ion ion-clipboard" ] []
-            ]
-          ]
-        ]
-      ]
-    ForEach ->
-      let
-        foreachUI = uiInfo.foreachUI
-        newForeach = foreachUI.newForeach
-
-        newKeys : Bool -> List (Html Msg)
-        newKeys edit = newForeach.foreachKeys
-          |> List.reverse
-          |> List.map (\k ->
-            span[class ("d-inline-flex align-items-center me-2 mb-2" ++ if edit then " ps-2" else " p-2")]
-            [ text k
-            , ( if edit then
-              i[ class "fa fa-times p-2 cursorPointer", onCustomClick (UIMethodAction call.id {uiInfo | foreachUI = {foreachUI | newForeach = {newForeach | foreachKeys = (List.Extra.remove k newForeach.foreachKeys)}}}) ][]
-              else
-              text ""
+          element "ul"
+            |> addClass "list-unstyled"
+            |> appendChild ( element "li"
+              |> addClass "text-danger"
+              |> appendText "Return carriage is forbidden in condition"
             )
+
+        ubuntuLi = List.map (\ubuntuMinor ->
+          let
+            updatedCall = Call parentId { call | condition = {condition | os =  updateUbuntuMinor  ubuntuMinor condition.os } }
+          in
+            element "li"
+              |> addAction ("click", (MethodCallModified updatedCall Nothing))
+              |> appendChild (element "a"
+                |> addClass "dropdown-item"
+                |> appendText (showUbuntuMinor ubuntuMinor)
+              )
+          ) [All, ZeroFour, Ten]
+
+        updateConditonVersion = \f s ->
+          let
+            updatedCall = Call parentId { call | condition = {condition | os =  f  (String.toInt s) condition.os } }
+          in
+            MethodCallModified updatedCall Nothing
+      in
+      element "div"
+      |> addClass "tab-conditions"
+      |> appendChildList
+        [ element "div"
+          |> addClass "form-group condition-form"
+          |> addAttribute (id "os-form")
+          |> appendChild ( element "div"
+            |> addClass "form-inline"
+            |> appendChild ( element "div"
+              |> addClass "form-group"
+              |> appendChild ( element "label"
+                |> addClass "d-inline-block"
+                |> addAttribute (for ("OsCondition-" ++ call.id.value))
+                |> appendText "Operating system: "
+              )
+              |> appendChild ( element "div"
+                |> addClass "btn-group"
+                |> appendChildList
+                  [ element "button"
+                    |> addClass "btn btn-default dropdown-toggle"
+                    |> addAttributeList
+                      [ id ("OsCondition-" ++ call.id.value)
+                      , attribute "data-bs-toggle" "dropdown"
+                      , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+                      ]
+                    |> appendChildList
+                      [ element "span" |> appendText ((osName condition.os) ++ " ")
+                      , element "span" |> addClass "caret"
+                      ]
+                  , element "ul"
+                    |> addClass "dropdown-menu"
+                    |> appendChildList (List.map (\os ->
+                      let
+                        updatedCondition = {condition | os = os }
+                      in
+                        element "li"
+                        |> addAction ("click", (MethodCallModified (Call parentId {call | condition = updatedCondition }) Nothing))
+                        |> addClass (osClass os)
+                        |> appendChild ( element "a"
+                          |> addClass "dropdown-item"
+                          |> appendText (osName os)
+                        )
+                    ) osList )
+                  ]
+              )
+            )
+          )
+          |> appendChildConditional ( element "input"
+            |> addClass "form-control mt-0 ms-2 d-inline-block w-auto"
+            |> addAttributeList
+              [ readonly (not model.hasWriteRights)
+              , value (Maybe.withDefault "" (Maybe.map String.fromInt (getMajorVersion condition.os) ))
+              , onInput (updateConditonVersion updateMajorVersion)
+              , type_ "number"
+              , placeholder "Major version"
+              , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+              ]
+          ) (hasMajorMinorVersion condition.os || isUbuntu condition.os )
+
+          |> appendChildConditional ( element "input"
+            |> addClass "form-control mt-0 ms-2 d-inline-block w-auto"
+            |> addAttributeList
+              [ readonly (not model.hasWriteRights)
+              , value (Maybe.withDefault "" (Maybe.map String.fromInt (getMinorVersion condition.os) ))
+              , onInput (updateConditonVersion updateMinorVersion)
+              , type_ "number"
+              , placeholder "Minor version"
+              , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+              ]
+          ) (hasMajorMinorVersion condition.os )
+
+          |> appendChildConditional (element "div"
+            |> addClass "ms-2 btn-group"
+            |> appendChildList
+              [ element "button"
+                |> addClass "btn btn-default dropdown-toggle"
+                |> addAttributeList
+                  [ id "ubuntuMinor" , attribute  "data-bs-toggle" "dropdown"
+                  , attribute  "aria-haspopup" "true", attribute "aria-expanded" "true"
+                  , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+                  ]
+                |> appendChild (element "span" |> appendText ((getUbuntuMinor condition.os) ++ " "))
+                |> appendChild (element "span" |> addClass "caret")
+              , element "ul"
+                |> addClass "dropdown-menu"
+                |> addAttribute (attribute "aria-labelledby" "ubuntuMinor")
+                |> appendChildList ubuntuLi
+              ]
+          ) (isUbuntu condition.os)
+
+          |> appendChildConditional (element "input"
+            |> addClass "form-control ms-2 mt-0 d-inline-block w-auto"
+            |> addAttributeList
+            [ readonly (not model.hasWriteRights)
+            , value (Maybe.withDefault "" (Maybe.map String.fromInt (getVersion condition.os) ))
+            , onInput  (updateConditonVersion updateVersion)
+            , type_ "number"
+            , placeholder "Version"
+            , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
             ]
+          ) (hasVersion condition.os)
+
+          |> appendChildConditional ( element "input"
+            |> addClass "form-control ms-2 mt-0 d-inline-block w-auto"
+            |> addAttributeList
+              [ readonly (not model.hasWriteRights)
+              , value (Maybe.withDefault "" (Maybe.map String.fromInt (getSP condition.os) ))
+              , onInput (updateConditonVersion updateSP)
+              , type_ "number"
+              , placeholder "Service pack"
+              , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+              ]
+          ) (hasSP condition.os)
+
+        , element "div"
+          |> addClass "form-group condition-form"
+          |> appendChild (element "label" |> addAttribute (for "advanced") |> appendText "Other conditions:")
+          |> appendChild ( element "textarea"
+            |> addClass "form-control"
+            |> addAttributeList
+              [ readonly (not model.hasWriteRights)
+              , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+              , onFocus DisableDragDrop
+              , name "advanced"
+              , rows 1
+              , id "advanced"
+              , value condition.advanced
+              , attribute "onkeypress" "if (event.keyCode == 13) alert('You pressed the return button.'); return false;"
+              , onInput (\s ->
+                let
+                  updatedCondition = {condition | advanced = s }
+                  updatedCall = Call parentId {call | condition = updatedCondition }
+                in MethodCallModified updatedCall Nothing
+              )
+              -- to deactivate plugin "Grammarly" or "Language Tool" from
+              -- adding HTML that make disapear textarea (see  https://issues.rudder.io/issues/21172)
+              , attribute "data-gramm" "false"
+              , attribute "data-gramm_editor" "false"
+              , attribute "data-enable-grammarly" "false"
+              , spellcheck False
+              ]
+          )
+          |> appendChildConditional errorOnConditionInput (String.contains "\n" call.condition.advanced)
+
+        , element "div"
+          |> addClass "form-group condition-form"
+          |> appendChild ( element "label" |> addAttribute (for "class_context") |> appendText "Applied condition expression:" )
+          |> appendChild ( element "textarea"
+            |> addClass "form-control"
+            |> addAttributeList
+              [ readonly (not model.hasWriteRights)
+              , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+              , onFocus DisableDragDrop
+              , name "class_context"
+              , rows 1
+              , id "class_context"
+              , value (conditionStr condition)
+              , readonly True
+              -- to deactivate plugin "Grammarly" or "Language Tool" from
+              -- adding HTML that make disapear textarea (see  https://issues.rudder.io/issues/21172)
+              , attribute "data-gramm" "false"
+              , attribute "data-gramm_editor" "false"
+              , attribute "data-enable-grammarly" "false"
+              , spellcheck False
+              ]
           )
 
-        tabContent =
-          let
-            infoMsg =
-              let
-                iteratorName = case call.foreachName of
-                  Just foreachName -> if String.isEmpty foreachName then "item" else foreachName
-                  Nothing -> "<iterator name>"
-              in
-                div[class "callout-fade callout-info"]
-                  [ div [class "marker"][span [class "fa fa-info-circle"][]]
-                  , div[]
-                    [ text "Use the iterator in the Name, Parameters and Conditions tabs with "
-                    , b[]
-                      [ code[class "cursorPointer py-2 me-1", onClick (Copy ("${" ++ iteratorName ++ "}.x"))]
-                        [ text "${"
-                        , (if Maybe.Extra.isJust call.foreachName then
-                          text iteratorName
-                          else
-                          i[][text iteratorName]
-                          )
-                        , text ".x}"
-                        , i [class "ion ion-clipboard ms-1"][]
-                        ]
-                      ]
-                    , text " where "
-                    , b[]
-                      [ code[]
-                        [ text "x"
-                        ]
-                      ]
-                    , text " is a key name."
-                    ]
-                  ]
-          in
-            case call.foreachName of
-              -- Creation
-              Nothing ->
-                let
-                  newItem = newForeach.foreachKeys
-                    |> List.map (\k -> (k, ""))
-                    |> Dict.fromList
+        , element "span"
+          |> appendChildConditional (element "span"
+            |> addClass "text-danger"
+            |> appendText "Classes over 2048 characters are currently not supported."
+          ) (String.length (conditionStr condition) > 2048)
+        ]
 
-                  newDefaultForeach = defaultNewForeach call.foreachName call.foreach
-                in
-                  div[class "d-flex row gx-3"]
-                    [ div[class "col-12 col-md-6"]
-                      [ div [class "form-group mb-3"]
-                        [ label [for "foreachName", class "form-label"]
-                          [ text "Iterator name"
-                          ]
-                        , input
-                          [ type_ "text"
-                          , class "form-control"
-                          , id "foreachName"
-                          , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
-                          , stopPropagationOn "click" (Json.Decode.succeed (DisableDragDrop, True))
-                          , onFocus DisableDragDrop
-                          , placeholder "item"
-                          , value newForeach.foreachName
-                          , onInput  (\s -> UIMethodAction call.id {uiInfo | foreachUI = {foreachUI | newForeach = {newForeach | foreachName = s}}})
-                          ]
-                          []
-                        ]
-                      , div [class "form-group"]
-                        [ label [for "foreachKeys", class "form-label"]
-                          [ text "Iterator keys"
-                          ]
-                        , div [class "input-group"]
-                          [ input
-                            [ type_ "text"
-                            , class "form-control"
-                            , id "foreachKeys"
-                            , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
-                            , onFocus DisableDragDrop
-                            , value newForeach.newKey
-                            , onInput  (\s -> UIMethodAction call.id {uiInfo | foreachUI = {foreachUI | newForeach = {newForeach | newKey = s}}})
-                            ][]
-                          , button
-                            [ class "btn btn-default"
-                            , type_ "button"
-                            , onCustomClick (UIMethodAction call.id {uiInfo | foreachUI = {foreachUI | newForeach = {newForeach | newKey = "", foreachKeys = (newForeach.newKey :: newForeach.foreachKeys)}}})
-                            , disabled (String.isEmpty newForeach.newKey)
-                            ]
-                            [ i[class "fa fa-plus-circle"][]
-                            ]
-                          ]
-                        ]
-                      , div [class "foreach-keys mt-2"] ( newKeys True )
-                      , div [class "mt-3"]
-                        [ button[class "btn btn-default me-3", onCustomClick (UIMethodAction call.id {uiInfo | foreachUI = {foreachUI | newForeach = newDefaultForeach}}) ]
-                          [ text "Reset"
-                          , i[class "fa fa-undo ms-1"][]
-                          ]
-                        , button
-                          [ class "btn btn-primary"
-                          , disabled (List.isEmpty newForeach.foreachKeys)
-                          , onCustomClick (UpdateMethodAndUi call.id {uiInfo | foreachUI = {foreachUI | newForeach = { newForeach | newItem = newItem}}} (Call (Just call.id) {call | foreachName = Just (if String.isEmpty newForeach.foreachName then "item" else newForeach.foreachName), foreach = Just [newItem]}))
-                          ]
-                          [ text "Add foreach"
-                          , i[class "fa fa-check ms-1"][]
-                          ]
-                        ]
-                    ]
-                  , div[class "col-12 col-md-6"]
-                    [ infoMsg ]
-                  ]
-              -- Edit
-              Just foreachName ->
-                let
-                  keys = Dict.keys newForeach.newItem
-
-                  header = keys
-                    |> List.map (\k -> th[][text k])
-
-                  foreachItems = case call.foreach of
-                    Just foreach ->
-                      foreach
-                        |> List.map (\f ->
-                          let
-                            values = keys
-                              |> List.map (\k ->
-                                let
-                                  val = case Dict.get k f of
-                                    Just v -> v
-                                    Nothing -> ""
-
-                                  updateForeachVal : String -> List (Dict String String) -> Dict String String -> Maybe (List (Dict String String))
-                                  updateForeachVal newVal list currentForeach =
-                                    Just (List.Extra.updateIf (\i -> i == currentForeach) (\i -> Dict.update k (always (Just newVal)) i) list)
-                                in
-                                  td[]
-                                    [ input
-                                      [ type_ "text"
-                                      , value val
-                                      , class "form-control input-sm"
-                                      , onInput(\s ->
-                                        (MethodCallModified (Call (Just call.id) {call | foreach = (updateForeachVal s foreach f) }))
-                                      )
-                                      ][]
-                                    ]
-                              )
-                            actionBtns =
-                              [ td[class "text-center"]
-                                [ button[type_ "button", class "btn btn-danger", disabled (List.length foreach <= 1), onCustomClick (MethodCallModified (Call (Just call.id) {call | foreach = Just (List.Extra.remove f foreach) }))]
-                                  [ i[class "fa fa-times"][]
-                                  ]
-                                ]
-                              ]
-                          in
-                            tr[class "item-foreach"] (List.append values actionBtns)
-                        )
-                    Nothing -> []
-
-                  newItemRow =
-                    let
-                      newValues = keys
-                        |> List.map (\k ->
-                          let
-                            val = case Dict.get k newForeach.newItem of
-                              Just v -> v
-                              Nothing -> ""
-                          in
-                            td[]
-                              [ input
-                                [ type_ "text"
-                                , class "form-control input-sm"
-                                , value val
-                                , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
-                                , onFocus DisableDragDrop
-                                , onInput (\s ->
-                                    UIMethodAction call.id {uiInfo | foreachUI = {foreachUI | newForeach = {newForeach | newItem = Dict.update k (always (Just s) ) newForeach.newItem }}}
-                                )
-                                ]
-                                []
-                              ]
-                        )
-                      actionBtns =
-                        let
-                          newItems = case call.foreach of
-                            Just f -> List.append f [newForeach.newItem]
-                            Nothing -> [newForeach.newItem]
-                          newItem = newForeach.newItem
-                            |> Dict.map (\k v -> "")
-                        in
-                          [ td[class "text-center"]
-                            [ button[type_ "button", class "btn btn-success" , onCustomClick (UpdateMethodAndUi call.id {uiInfo | foreachUI = {foreachUI | newForeach = { newForeach | newItem = newItem}}} (Call (Just call.id) {call | foreach = Just newItems}))]
-                              [ i[class "fa fa-plus-circle"][]
-                              ]
-                            ]
-                          ]
-                    in
-                      [ tr[class "item-foreach new"] (List.append newValues actionBtns) ]
-
-                  newForeachItems =
-                    case call.foreach of
-                      Nothing -> Nothing
-                      Just foreach ->
-                        let
-                          newKeysList = newForeach.foreachKeys
-                          updatedForeach =
-                            foreach
-                              |> List.Extra.updateIf (\f -> (Dict.keys f) |> List.any (\k -> List.Extra.notMember k newKeysList) ) -- If an old key is not present anymore, remove it
-                                (\f -> f |> keepOnly (Set.fromList newKeysList) )
-                              |> List.Extra.updateIf (\f -> newKeysList |> List.any (\k -> List.Extra.notMember k (Dict.keys f)) ) -- If a new key is detected, insert it
-                                (\f ->
-                                  let
-                                    keysList  = Dict.keys f
-                                    currentList = Dict.toList f
-                                    newList = newKeysList
-                                      |> List.Extra.filterNot (\k -> List.member k keysList)
-                                      |> List.map (\k -> (k, ""))
-                                  in
-                                    currentList
-                                      |> List.append newList
-                                      |> Dict.fromList
-                                )
-                        in
-                          Just updatedForeach
-
-                  foreachNameLabel =
-                    if String.isEmpty foreachName then
-                      i[][text "item"]
-                    else
-                      text foreachName
-
-                  updatedNewItem =
-                    newForeach.foreachKeys
-                      |> List.map (\k -> (k, ""))
-                      |> Dict.fromList
-                in
-                  div[class "d-flex row gx-3"]
-                  [ div[class "col-12 col-md-6"]
-                    [ div [class "row mb-3 form-group"]
-                      [ label [for "foreachName", class "col-auto col-form-label"]
-                        [ text "Iterator name: " ]
-                      , div [class "col d-flex align-items-center"]
-                        ( if foreachUI.editName then
-                          [ div [class "input-group"]
-                            [ input
-                              [ type_ "text"
-                              , class "form-control"
-                              , id "foreachName"
-                              , placeholder "item"
-                              , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
-                              , onFocus DisableDragDrop
-                              , value newForeach.foreachName
-                              , onInput (\s -> UIMethodAction call.id {uiInfo | foreachUI = {foreachUI | newForeach = {newForeach | foreachName = s}}})
-                              ][]
-                            , button
-                              [ class "btn btn-default"
-                              , type_ "button"
-                              , onCustomClick (UpdateMethodAndUi call.id {uiInfo | foreachUI = {foreachUI | editName = False}} (Call (Just call.id) {call | foreachName = Just (newForeach.foreachName) }))
-                              ]
-                              [ i[class "fa fa-check"][]
-                              ]
-                            ]
-                          ]
-                        else
-                          [ foreachNameLabel
-                          , i[class "fa fa-edit ms-2", onCustomClick (UIMethodAction call.id {uiInfo | foreachUI = {foreachUI | newForeach = {newForeach | foreachName = (Maybe.withDefault "" call.foreachName)}, editName = True}})][]
-                          ]
-                        )
-                      ]
-                    , div[class "row mb-3 form-group"]
-                      [ label [for "foreachKeys", class "col-auto col-form-label"]
-                          [ text "Iterator keys:"
-                          ]
-                        , ( if foreachUI.editKeys then
-                          div[class "col d-flex"]
-                            [ div[class "d-flex row w-100"]
-                              [ div [class "input-group group-key"]
-                                [ input
-                                  [ type_ "text"
-                                  , class "form-control"
-                                  , id "foreachKeys"
-                                  , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
-                                  , onFocus DisableDragDrop
-                                  , value newForeach.newKey
-                                  , onInput  (\s -> UIMethodAction call.id {uiInfo | foreachUI = {foreachUI | newForeach = {newForeach | newKey = s}}})
-                                  ][]
-                                , button
-                                  [ class "btn btn-default"
-                                  , type_ "button"
-                                  , onCustomClick (UIMethodAction call.id {uiInfo | foreachUI = {foreachUI | newForeach = {newForeach | newKey = "", foreachKeys = (newForeach.newKey :: newForeach.foreachKeys)}}})
-                                  , disabled (String.isEmpty newForeach.newKey)
-                                  ]
-                                  [ i[class "fa fa-plus-circle"][]
-                                  ]
-                                  , button
-                                    [ class "btn btn-default ms-2"
-                                    , type_ "button"
-                                    , onCustomClick (UpdateMethodAndUi call.id {uiInfo | foreachUI = {foreachUI | editKeys = False, newForeach = {newForeach | newItem = updatedNewItem}}} (Call (Just call.id) {call | foreach = newForeachItems }))
-                                    , disabled (List.isEmpty newForeach.foreachKeys)
-                                    ]
-                                    [ i[class "fa fa-check"][]
-                                    ]
-                                ]
-                              , div [class "foreach-keys mt-2 mb-3"] ( newKeys True )
-                              ]
-                            ]
-                          else
-                          div[class "col d-flex align-items-center foreach-keys"]
-                            ( List.append (newKeys False) [i[class "fa fa-edit ms-2", onCustomClick (UIMethodAction call.id {uiInfo | foreachUI = {foreachUI | editKeys = True}})][]]
-                            )
-                          )
-                      ]
-                    , div[class "table-foreach-container"]
-                      [ table[class "table table-bordered table-foreach mb-0"]
-                        [ thead[]
-                          [ tr[] (List.append header [th[][text "Action"]])
-                          ]
-                        , tbody[] (List.append foreachItems newItemRow)
-                        ]
-                      ]
-                    , button [class "btn btn-danger mt-2"
-                      , onCustomClick (UpdateMethodAndUi call.id {uiInfo | foreachUI = {foreachUI | newForeach = (defaultNewForeach Nothing Nothing)}} (Call (Just call.id) {call | foreachName = Nothing, foreach = Nothing }))]
-                      [ text "Remove iterator"
-                      , i[class "fa fa-times ms-1"][]
-                      ]
-                    ]
-                  , div[class "col-12 col-md-6"]
-                    [ infoMsg
-                    ]
-                  ]
+    Result ->
+      let
+        classParameter = getClassParameter method
+        paramValue = call.parameters |> List.Extra.find (\c -> c.id == classParameter.name) |> Maybe.map (.value) |> Maybe.withDefault [Value ""]
       in
-        div [ class "tab-result" ]
-          [ tabContent
-          ]
+        element "div"
+          |> addClass "tab-result"
+          |> appendChildList
+            [ element "label"
+              |> appendChild (element "small" |> appendText "Result conditions defined by this method")
+            , element "div"
+              |> addClass "form-horizontal editForm result-class"
+              |> appendChildList
+                [ element "div"
+                  |> addClass "input-group result-success"
+                  |> appendChildList
+                    [ element "div"
+                      |> addClass "input-group-text"
+                      |> appendText "Success"
+                    , element "input"
+                      |> addClass "form-control"
+                      |> addAttributeList
+                        [ readonly True
+                        , type_ "text"
+                        , value (method.classPrefix ++ "_" ++ (canonify paramValue) ++ "_kept")
+                        , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+                        , stopPropagationOn "click" (Json.Decode.succeed (DisableDragDrop, True))
+                        ]
+                    , element "button"
+                       |> addClass "btn btn-outline-secondary clipboard"
+                       |> addAttributeList
+                         [ type_ "button"
+                         , title "Copy to clipboard"
+                         ]
+                       |> addAction ("click", (Copy (method.classPrefix ++ "_" ++ (canonify paramValue) ++ "_kept")))
+                       |> appendChild (element "i" |> addClass "ion ion-clipboard")
+                    ]
 
-methodDetail: Method -> MethodCall -> Maybe CallId -> MethodCallUiInfo -> Model -> Html Msg
+                , element "div"
+                  |> addClass "input-group result-repaired"
+                  |> appendChildList
+                    [ element "div"
+                      |> addClass "input-group-text"
+                      |> appendText "Repaired"
+                    , element "input"
+                      |> addClass "form-control"
+                      |> addAttributeList
+                        [ readonly True
+                        , type_ "text"
+                        , value (method.classPrefix ++ "_" ++ (canonify paramValue) ++ "_repaired")
+                        , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+                        , stopPropagationOn "click" (Json.Decode.succeed (DisableDragDrop, True))
+                        ]
+                    , element "button"
+                       |> addClass "btn btn-outline-secondary clipboard"
+                       |> addAttributeList
+                         [ type_ "button"
+                         , title "Copy to clipboard"
+                         ]
+                       |> addAction ("click", (Copy (method.classPrefix ++ "_" ++ (canonify paramValue) ++ "_repaired")))
+                       |> appendChild (element "i" |> addClass "ion ion-clipboard")
+                    ]
+
+                , element "div"
+                  |> addClass "input-group result-error"
+                  |> appendChildList
+                    [ element "div"
+                      |> addClass "input-group-text"
+                      |> appendText "Error"
+                    , element "input"
+                      |> addClass "form-control"
+                      |> addAttributeList
+                        [ readonly True
+                        , type_ "text"
+                        , value (method.classPrefix ++ "_" ++ (canonify paramValue) ++ "_error")
+                        , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+                        , stopPropagationOn "click" (Json.Decode.succeed (DisableDragDrop, True))
+                        ]
+                    , element "button"
+                       |> addClass "btn btn-outline-secondary clipboard"
+                       |> addAttributeList
+                         [ type_ "button"
+                         , title "Copy to clipboard"
+                         ]
+                       |> addAction ("click", (Copy (method.classPrefix ++ "_" ++ (canonify paramValue) ++ "_error")))
+                       |> appendChild (element "i" |> addClass "ion ion-clipboard")
+                    ]
+
+                ]
+
+            , element "div"
+              |> addClass "form-horizontal editForm result-class"
+              |> appendChildList
+                [ element "div"
+                  |> addClass "input-group result-repaired"
+                  |> appendChild (element "div"
+                    |> addClass "input-group-text"
+                    |> appendText "Repaired"
+                  )
+                , element "input"
+                  |> addClass "form-control"
+                  |> addAttributeList
+                    [ readonly True
+                    , type_ "text"
+                    , value (method.classPrefix ++ "_" ++ (canonify paramValue) ++ "_repaired")
+                    , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+                    , stopPropagationOn "click" (Json.Decode.succeed (DisableDragDrop, True))
+                    ]
+                , element "button"
+                   |> addClass "btn btn-outline-secondary clipboard"
+                   |> addAttributeList
+                     [ type_ "button"
+                     , title "Copy to clipboard"
+                     ]
+                   |> addAction ("click", (Copy (method.classPrefix ++ "_" ++ (canonify paramValue) ++ "_repaired")))
+                   |> appendChild (element "i" |> addClass "ion ion-clipboard")
+                ]
+
+            , element "div"
+              |> addClass "form-horizontal editForm result-class"
+              |> appendChildList
+                [ element "div"
+                  |> addClass "input-group result-error"
+                  |> appendChild (element "div"
+                    |> addClass "input-group-text"
+                    |> appendText "Error"
+                  )
+                , element "input"
+                  |> addClass "form-control"
+                  |> addAttributeList
+                    [ readonly True
+                    , type_ "text"
+                    , value (method.classPrefix ++ "_" ++ (canonify paramValue) ++ "_error")
+                    , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+                    , stopPropagationOn "click" (Json.Decode.succeed (DisableDragDrop, True))
+                    ]
+                , element "button"
+                   |> addClass "btn btn-outline-secondary clipboard"
+                   |> addAttributeList
+                     [ type_ "button"
+                     , title "Copy to clipboard"
+                     ]
+                   |> addAction ("click", (Copy (method.classPrefix ++ "_" ++ (canonify paramValue) ++ "_error")))
+                   |> appendChild (element "i" |> addClass "ion ion-clipboard")
+                ]
+            ]
+    CallForEach ->
+      displayTabForeach (CallUiInfo uiInfo call)
+
+methodDetail: Method -> MethodCall -> Maybe CallId -> MethodCallUiInfo -> Model -> Element Msg
 methodDetail method call parentId ui model =
   let
     activeClass = (\c -> if c == ui.tab then "active" else "" )
@@ -730,25 +568,45 @@ methodDetail method call parentId ui model =
         )
 
   in
-  div [ class "method-details" ] [
-    div [] [
-      ul [ class "tabs-list"] [
-        li [ class (activeClass CallParameters),  stopPropagationOn "mousedown" (Json.Decode.succeed  (UIMethodAction call.id {ui | tab = CallParameters}, True)) ] [text "Parameters"] -- click select param tabs, class active if selected
-      , li [ class (activeClass CallConditions),stopPropagationOn "mousedown" (Json.Decode.succeed  (UIMethodAction call.id {ui | tab = CallConditions}, True)) ] [text "Conditions"]
-      , li [ class (activeClass Result), stopPropagationOn "mousedown" (Json.Decode.succeed  (UIMethodAction call.id {ui | tab = Result}, True))] [text "Result conditions"]
-      , li [ class (activeClass CallReporting), stopPropagationOn "mousedown" (Json.Decode.succeed  (UIMethodAction call.id {ui | tab = CallReporting}, True)) ] [text "Reporting"]
-      , li [ class (activeClass ForEach), stopPropagationOn "mousedown" (Json.Decode.succeed  (UIMethodAction call.id {ui | tab = ForEach}, True)) ]
-        [ text "Foreach"
-        , span[class ("badge" ++ foreachClass)]
-          [ text nbForeach
-          , i[class "fa fa-retweet ms-1"][]
-          ]
-        ]
-      ]
-    , div [ class "tabs" ] [ (showMethodTab model method parentId call ui) ]
-    ]
-  ]
-
+    element "div"
+      |> addClass "method-details"
+      |> appendChild ( element "div"
+        |> appendChild ( element "ul"
+          |> addClass "tabs-list"
+          |> appendChildList
+            [ element "li"
+              |> addClass (activeClass CallParameters)
+              |> addAttribute (stopPropagationOn "mousedown" (Json.Decode.succeed  (UIMethodAction call.id {ui | tab = CallParameters}, True)))
+              |> appendText "Parameters"
+            , element "li"
+              |> addClass (activeClass CallConditions)
+              |> addAttribute (stopPropagationOn "mousedown" (Json.Decode.succeed  (UIMethodAction call.id {ui | tab = CallConditions}, True)))
+              |> appendText "Conditions"
+            , element "li"
+              |> addClass (activeClass Result)
+              |> addAttribute (stopPropagationOn "mousedown" (Json.Decode.succeed  (UIMethodAction call.id {ui | tab = Result}, True)))
+              |> appendText "Result conditions"
+            , element "li"
+              |> addClass (activeClass CallReporting)
+              |> addAttribute (stopPropagationOn "mousedown" (Json.Decode.succeed  (UIMethodAction call.id {ui | tab = CallReporting}, True)))
+              |> appendText "Reporting"
+            , element "li"
+              |> addClass (activeClass CallForEach)
+              |> addAttribute (stopPropagationOn "mousedown" (Json.Decode.succeed  (UIMethodAction call.id {ui | tab = CallForEach}, True)))
+              |> appendChildList
+                [ element "span" |> appendText "Foreach"
+                , element "span"
+                  |> addClass ("badge" ++ foreachClass)
+                  |> appendChild (element "span" |> appendText nbForeach)
+                  |> appendChild (element "i" |> addClass "fa fa-retweet ms-1")
+                ]
+            ]
+        )
+        |> appendChild ( element "div"
+          |> addClass "tabs"
+          |> appendChild (showMethodTab model method parentId call ui)
+        )
+      )
 
 showMethodCall: Model -> MethodCallUiInfo -> TechniqueUiInfo -> Maybe CallId ->  MethodCall -> Element Msg
 showMethodCall model ui tui parentId call =
@@ -837,21 +695,7 @@ callBody model ui techniqueUi call pid =
                      , title "Show documentation"
                      ]
                   |> appendChild docIcon
-{--
-, div [ class "method-details-footer"] [
-          case method.documentation of
-            Just _ ->
-              let
-                classes = "btn btn-sm btn-primary " ++
-                          if List.member method.id model.methodsUI.docsOpen then "doc-opened" else ""
-              in
-                button [ class classes, type_ "button", onClick (ShowDoc call.methodName) ] [
-                  text "Show docs "
-                , i [ class "fa fa-book"] []
-                ]
-            Nothing -> text ""
-        ]
---}
+
     condition = element "div"
                 |> addClass "method-condition flex-form"
                 |> addClassConditional "d-none" (call.condition.os == Nothing && call.condition.advanced == "")
@@ -878,36 +722,6 @@ callBody model ui techniqueUi call pid =
           Just Audit -> "label-audit"
           Just Enforce -> "label-enforce"
 
-    appendForeachLabel =
-      let
-        nbForeach = case call.foreach of
-          Just foreach -> String.fromInt (List.length foreach) --TODO : To improve
-          Nothing -> "0"
-
-        labelTxt = case call.foreachName of
-          Nothing -> ""
-          Just f  -> "foreach ${" ++ f ++ ".x}"
-
-      in
-        appendChildConditional
-          ( element "div"
-            |> addClass ("gm-label rudder-label gm-foreach d-inline-flex ps-0 overflow-hidden")
-            |> appendChild
-              ( element "span"
-                |> addClass "counter px-1 me-1"
-                |> appendText nbForeach
-                |> appendChild
-                  ( element "i"
-                    |> addClass "fa fa-retweet ms-1"
-                  )
-              )
-            |> appendChild
-              ( element "span"
-                |> appendText labelTxt
-              )
-          )
-          ( Maybe.Extra.isJust call.foreachName )
-
     appendLeftLabels = appendChild
                          ( element "div"
                            |> addClass ("gm-labels left")
@@ -921,7 +735,7 @@ callBody model ui techniqueUi call pid =
                                 |> addClass ("gm-label rudder-label gm-label-name " ++ methodNameLabelClass)
                                 |> appendText method.name
                               )
-                           |> appendForeachLabel
+                           |> foreachLabel call.foreachName call.foreach
                          )
     appendRightLabels = appendChild
       ( case ui.mode of
@@ -955,21 +769,21 @@ callBody model ui techniqueUi call pid =
                                   element "li"
                                    |> appendChild
                                       (element "a"
-                                        |> addAction ("click",  MethodCallModified (Call pid {call  | policyMode = Nothing }) )
+                                        |> addAction ("click",  MethodCallModified (Call pid {call  | policyMode = Nothing }) Nothing )
                                         |> addClass "dropdown-item"
                                         |> appendText "None"
                                       )
                                  , element "li"
                                    |> appendChild
                                       (element "a"
-                                        |> addAction ("click",  MethodCallModified (Call pid {call  | policyMode = Just Audit }) )
+                                        |> addAction ("click",  MethodCallModified (Call pid {call  | policyMode = Just Audit }) Nothing )
                                         |> addClass "dropdown-item"
                                         |> appendText "Audit"
                                       )
                                  , element "li"
                                    |> appendChild
                                       (element "a"
-                                        |> addAction ("click",  MethodCallModified (Call pid {call  | policyMode = Just Enforce }) )
+                                        |> addAction ("click",  MethodCallModified (Call pid {call  | policyMode = Just Enforce }) Nothing )
                                         |> addClass "dropdown-item"
                                         |> appendText "Enforce"
                                       )
@@ -991,7 +805,7 @@ callBody model ui techniqueUi call pid =
                                              |> appendText "Name"
                                            , element "input"
                                              |> addAttributeList [ readonly (not model.hasWriteRights), stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True)), onFocus DisableDragDrop, type_ "text", name "component", style "width" "100%", class "form-control", value call.component,  placeholder "A friendly name for this component" ]
-                                             |> addInputHandler  (\s -> MethodCallModified (Call pid {call  | component = s }))
+                                             |> addInputHandler  (\s -> MethodCallModified (Call pid {call  | component = s }) Nothing)
                                            ]
                                        )
                                 )
@@ -1064,14 +878,14 @@ callBody model ui techniqueUi call pid =
                                         ]
                     ]
                )
-            |> appendChild condition-- (call.condition.os /= Nothing || call.condition.advanced /= "")
+            |> appendChild condition -- (call.condition.os /= Nothing || call.condition.advanced /= "")
             |> appendChild methodName
             --|> appendChild methodNameId
             |> appendChildConditional methodContent (ui.mode == Closed)
             |> appendChildConditional
                         ( element "div"
                           |> addClass "method-details"
-                          |> appendNode (methodDetail method call pid ui model )
+                          |> appendChild (methodDetail method call pid ui model )
                           |> addAttribute (VirtualDom.property "draggable" (Json.Encode.bool (techniqueUi.enableDragDrop == Just call.id)))
 
                         ) (ui.mode == Opened)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTabForeach.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTabForeach.elm
@@ -1,0 +1,521 @@
+module Editor.ViewTabForeach exposing (..)
+
+
+import Json.Decode
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
+import Dom exposing (..)
+import Set
+import Dict exposing (Dict)
+import Dict.Extra exposing (keepOnly)
+import List.Extra
+import Maybe.Extra
+
+import Rules.ViewUtils exposing (onCustomClick)
+import Editor.DataTypes exposing (..)
+import Editor.MethodElemUtils exposing (..)
+
+
+foreachLabel : Maybe String -> Maybe (List (Dict String String)) -> Element msg -> Element msg
+foreachLabel foreachName foreach =
+  let
+    nbForeach = case foreach of
+      Just f -> String.fromInt (List.length f)
+      Nothing -> "0"
+
+    labelTxt = case foreachName of
+      Nothing -> ""
+      Just f  -> "foreach ${" ++ f ++ ".x}"
+  in
+    appendChildConditional
+      ( element "div"
+        |> addClass ("gm-label rudder-label gm-foreach d-inline-flex ps-0 overflow-hidden")
+        |> appendChild
+          ( element "span"
+            |> addClass "counter px-1 me-1"
+            |> appendText nbForeach
+            |> appendChild
+              ( element "i"
+                |> addClass "fa fa-retweet ms-1"
+              )
+          )
+        |> appendChild
+          ( element "span"
+            |> appendText labelTxt
+          )
+      )
+      ( Maybe.Extra.isJust foreachName )
+
+type alias UpdateUIMsg =
+  { addNewKey           : Msg
+  , removeKey           : String -> Msg
+  , updateNewForeach    : String -> Msg
+  , updateNewForeachKey : String -> Msg
+  , resetNewForeach     : Msg
+  , updateNewItem       : String -> String -> Msg
+  , editForeachName     : Msg
+  , editForeachKeys     : Msg
+  }
+
+type alias UpdateMsg =
+  { addForeach          : Msg
+  , addNewItem          : Msg
+  , saveNewForeach      : Msg
+  , saveEditKeys        : Msg
+  , removeForeach       : Msg
+  }
+
+type alias CallForeach a = { a | foreachName : Maybe String, foreach : Maybe (List (Dict String String)) } -- a = MethodCall OR MethodBlock
+
+getUIMessages : ForeachUI -> ( ForeachUI -> Msg ) -> CallForeach a -> UpdateUIMsg
+getUIMessages f toMsg call =
+  let
+    newF = f.newForeach
+  in
+    { removeKey             = \k -> toMsg { f | newForeach = {newF | foreachKeys = (List.Extra.remove k newF.foreachKeys)} }
+    , updateNewForeach      = \s -> toMsg { f | newForeach = {newF | foreachName = s}}
+    , updateNewForeachKey   = \s -> toMsg { f | newForeach = {newF | newKey = s}}
+    , addNewKey             = toMsg { f | newForeach = {newF | newKey = "", foreachKeys = (newF.newKey :: newF.foreachKeys)}}
+    , resetNewForeach       = toMsg { f | newForeach = (defaultNewForeach call.foreachName call.foreach)}
+    , updateNewItem         = \k -> \s -> toMsg { f | newForeach = {newF | newItem = Dict.update k (always (Just s) ) newF.newItem }}
+    , editForeachName       = toMsg { f | newForeach = {newF | foreachName = (Maybe.withDefault "" call.foreachName)}, editName = True}
+    , editForeachKeys       = toMsg { f | editKeys = True }
+    }
+
+getUpdateMessages : ForeachUI -> CallForeach a -> (ForeachUI -> CallForeach a -> Msg) -> UpdateMsg
+getUpdateMessages foreachUI call toMsg =
+  let
+    newForeach = foreachUI.newForeach
+    foreach = call.foreach
+
+    newItems = case foreach of
+      Just f -> List.append f [newForeach.newItem]
+      Nothing -> [newForeach.newItem]
+
+    newItem = newForeach.foreachKeys
+      |> List.map (\k -> (k, ""))
+      |> Dict.fromList
+
+    newForeachItems =
+      case foreach of
+        Nothing -> Nothing
+        Just items ->
+          let
+            newKeysList = newForeach.foreachKeys
+            updatedForeach =
+              items
+                |> List.Extra.updateIf (\f -> (Dict.keys f) |> List.any (\k -> List.Extra.notMember k newKeysList) ) -- If an old key is not present anymore, remove it
+                  (\f -> f |> keepOnly (Set.fromList newKeysList) )
+                |> List.Extra.updateIf (\f -> newKeysList |> List.any (\k -> List.Extra.notMember k (Dict.keys f)) ) -- If a new key is detected, insert it
+                  (\f ->
+                    let
+                      keysList  = Dict.keys f
+                      currentList = Dict.toList f
+                      newList = newKeysList
+                        |> List.Extra.filterNot (\k -> List.member k keysList)
+                        |> List.map (\k -> (k, ""))
+                    in
+                      currentList
+                        |> List.append newList
+                        |> Dict.fromList
+                  )
+          in
+            Just updatedForeach
+  in
+    { addForeach     = toMsg { foreachUI | newForeach = { newForeach | newItem = newItem}} ( {call | foreachName = Just (if String.isEmpty newForeach.foreachName then "item" else newForeach.foreachName), foreach = Just [newItem]})
+    , addNewItem     = toMsg { foreachUI | newForeach = { newForeach | newItem = newItem}} ( {call | foreach = Just newItems})
+    , saveNewForeach = toMsg { foreachUI | editName = False} ( {call | foreachName = Just (newForeach.foreachName) })
+    , saveEditKeys   = toMsg { foreachUI | editKeys = False, newForeach = {newForeach | newItem = newItem}} ( {call | foreach = newForeachItems })
+    , removeForeach  = toMsg { foreachUI | newForeach = (defaultNewForeach Nothing Nothing)} ( {call | foreachName = Nothing, foreach = Nothing })
+    }
+
+displayTabForeach : UiInfo -> Element Msg
+displayTabForeach uiInfo =
+  let
+
+    {callId, foreachName, foreach, updateForeach, foreachUI, updateUIMsg, updateMsg} = case uiInfo of
+      CallUiInfo methodCallUiInfo call ->
+        { callId = call.id
+        , foreachName = call.foreachName
+        , foreach = call.foreach
+        , updateForeach = \maybeForeach -> (Call  (Just call.id) {call | foreach = maybeForeach})
+        , foreachUI = methodCallUiInfo.foreachUI
+        , updateUIMsg = getUIMessages methodCallUiInfo.foreachUI (\fUI -> UIMethodAction call.id {methodCallUiInfo | foreachUI = fUI}) call -- (\c -> (Call (Just call.id) {call | foreachName = c.foreachName, foreach = c.foreach}))
+        , updateMsg = getUpdateMessages methodCallUiInfo.foreachUI call (\fUI c -> UpdateCallAndUi (CallUiInfo {methodCallUiInfo | foreachUI = fUI} {call | foreachName = c.foreachName, foreach = c.foreach} ))
+        }
+
+      BlockUiInfo methodBlockUiInfo call ->
+        { callId = call.id
+        , foreachName = call.foreachName
+        , foreach = call.foreach
+        , updateForeach = \maybeForeach -> (Block (Just call.id) {call | foreach = maybeForeach})
+        , foreachUI = methodBlockUiInfo.foreachUI
+        , updateUIMsg = getUIMessages methodBlockUiInfo.foreachUI (\fUI -> UIBlockAction call.id {methodBlockUiInfo | foreachUI = fUI}) call -- (\c -> (Block (Just call.id) {call | foreachName = c.foreachName, foreach = c.foreach}))
+        , updateMsg = getUpdateMessages methodBlockUiInfo.foreachUI call (\fUI c -> UpdateCallAndUi (BlockUiInfo {methodBlockUiInfo | foreachUI = fUI} {call | foreachName = c.foreachName, foreach = c.foreach} ))
+        }
+
+    { removeKey, updateNewForeach, updateNewForeachKey, addNewKey, resetNewForeach, updateNewItem, editForeachName, editForeachKeys } = updateUIMsg
+    { addForeach, addNewItem, saveNewForeach, saveEditKeys, removeForeach } = updateMsg
+
+    newForeach = foreachUI.newForeach
+
+    newKeys : Bool -> List (Element Msg)
+    newKeys edit = newForeach.foreachKeys
+      |> List.reverse
+      |> List.map (\k ->
+        element "span"
+          |> addClass "d-inline-flex align-items-center me-2 mb-2"
+          |> addClassConditional "ps-2" edit
+          |> addClassConditional "p-2" (not edit)
+          |> appendText k
+          |> appendChildConditional
+            ( element "i"
+              |> addClass "fa fa-times p-2 cursorPointer"
+              |> addActionStopAndPrevent ("click", removeKey k)
+            ) edit
+      )
+
+    tabContent =
+      let
+        infoMsg =
+          let
+            iteratorName = case foreachName of
+              Just name -> if String.isEmpty name then "item" else name
+              Nothing -> "<iterator name>"
+          in
+            element "div"
+              |> addClass "callout-fade callout-info"
+              |> appendChildList
+                [ element "div" |> addClass "marker" |> appendChild (element "span" |> addClass "fa fa-info-circle")
+                , element "div"
+                  |> appendChildList
+                    [ element "span" |> appendText "Use the iterator in the Name, Parameters and Conditions tabs with "
+                    , element "b"
+                      |> appendChild (element "code"
+                        |> addClass "cursorPointer py-2 me-1"
+                        |> addAction ("click", Copy ("${" ++ iteratorName ++ "}.x"))
+                        |> appendChild (element "span" |> appendText "${")
+                        |> appendChildConditional (element "span" |> appendText iteratorName) (Maybe.Extra.isJust foreachName)
+                        |> appendChildConditional (element "i" |> appendText iteratorName) (Maybe.Extra.isNothing foreachName)
+                        |> appendChild (element "span" |> appendText ".x}")
+                        |> appendChild (element "i" |> addClass "ion ion-clipboard ms-1")
+                      )
+                    , element "span" |> appendText " where "
+                    , element "b" |> appendChild ( element "code" |> appendText "x" )
+                    , element "span" |> appendText " is a key name."
+                    ]
+                ]
+      in
+        case foreachName of
+          -- Creation
+          Nothing ->
+            element "div"
+              |> addClass "d-flex row gx-3"
+              |> appendChildList
+                [ element "div"
+                  |> addClass "col-12 col-md-6"
+                  |> appendChildList
+                    [ element "div"
+                      |> addClass "form-group mb-3"
+                      |> appendChildList
+                        [ element "label"
+                          |> addClass "form-label"
+                          |> addAttribute (for "foreachName")
+                          |> appendText "Iterator name"
+                        , element "input"
+                          |> addAttributeList
+                            [ type_ "text"
+                            , class "form-control"
+                            , id "foreachName"
+                            , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+                            , stopPropagationOn "click" (Json.Decode.succeed (DisableDragDrop, True))
+                            , onFocus DisableDragDrop
+                            , placeholder "item"
+                            , value newForeach.foreachName
+                            ]
+                          |> addInputHandler  (\s -> updateNewForeach s)
+                        ]
+                    , element "div"
+                      |> addClass "form-group"
+                      |> appendChildList
+                        [ element "label"
+                          |> addClass "form-label"
+                          |> addAttribute (for "foreachKeys")
+                          |> appendText "Iterator keys"
+                        , element "div"
+                          |> addClass "input-group"
+                          |> appendChildList
+                            [ element "input"
+                              |> addAttributeList
+                                [ type_ "text"
+                                , class "form-control"
+                                , id "foreachKeys"
+                                , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+                                , stopPropagationOn "click" (Json.Decode.succeed (DisableDragDrop, True))
+                                , onFocus DisableDragDrop
+                                , value newForeach.newKey
+                                ]
+                              |> addInputHandler (\s -> updateNewForeachKey s)
+                            , element "button"
+                              |> addAttributeList
+                                [ class "btn btn-default"
+                                , type_ "button"
+                                , disabled (String.isEmpty newForeach.newKey)
+                                , onCustomClick addNewKey
+                                ]
+                              |> appendChild (
+                                element "i"
+                                |> addClass "fa fa-plus-circle"
+                              )
+                            ]
+                        ]
+                    , element "div"
+                      |> addClass "foreach-keys mt-2"
+                      |> appendChildList (newKeys True)
+                    , element "div"
+                      |> addClass "mt-3"
+                      |> appendChildList
+                        [ element "button"
+                          |> addAttributeList
+                            [ class "btn btn-default me-3"
+                            , type_ "button"
+                            , onCustomClick resetNewForeach
+                            ]
+                          |> appendText "Reset"
+                          |> appendChild (element "i" |> addClass "fa fa-undo ms-1")
+                        , element "button"
+                          |> addAttributeList
+                            [ class "btn btn-primary"
+                            , type_ "button"
+                            , disabled (List.isEmpty newForeach.foreachKeys)
+                            , onCustomClick addForeach
+                            ]
+                          |> appendText "Add foreach"
+                          |> appendChild (element "i" |> addClass "fa fa-check ms-1")
+                        ]
+                    ]
+                , element "div"
+                  |> addClass "col-12 col-md-6"
+                  |> appendChild infoMsg
+                ]
+
+          -- Edit
+          Just name ->
+            let
+              keys = Dict.keys newForeach.newItem
+
+              header = keys
+                |> List.map (\k -> element "th" |> appendText k)
+
+              foreachItems = case foreach of
+                Just items ->
+                  items
+                    |> List.map (\f ->
+                      let
+                        values = keys
+                          |> List.map (\k ->
+                            let
+                              val = case Dict.get k f of
+                                Just v -> v
+                                Nothing -> ""
+
+                              updateForeachVal : String -> List (Dict String String) -> Dict String String -> Maybe (List (Dict String String))
+                              updateForeachVal newVal list currentForeach =
+                                Just (List.Extra.updateIf (\i -> i == currentForeach) (\i -> Dict.update k (always (Just newVal)) i) list)
+                            in
+                              element "td"
+                              |> appendChild ( element "input"
+                                |> addAttributeList
+                                  [ type_ "text"
+                                  , value val
+                                  , class "form-control input-sm"
+                                  ]
+                                |> addInputHandler  (\s -> MethodCallModified (updateForeach (updateForeachVal s items f)) Nothing)
+                              )
+                          )
+                        actionBtns =
+                          [ element "td"
+                            |> addClass "text-center"
+                            |> appendChild (
+                              element "button"
+                              |> addAttributeList
+                                [ type_ "button"
+                                , class "btn btn-danger"
+                                , disabled (List.length items <= 1)
+                                , onCustomClick (MethodCallModified (updateForeach (Just (List.Extra.remove f items))) Nothing)
+                                ]
+                              |> appendChild (element "i" |> addClass "fa fa-times")
+                            )
+                          ]
+                      in
+                        element "tr"
+                        |> addClass "item-foreach"
+                        |> appendChildList (List.append values actionBtns)
+                    )
+                Nothing -> []
+
+              newItemRow =
+                let
+                  newValues = keys
+                    |> List.map (\k ->
+                      let
+                        val = case Dict.get k newForeach.newItem of
+                          Just v -> v
+                          Nothing -> ""
+                      in
+                        element "td"
+                        |> appendChild ( element "input"
+                          |> addAttributeList
+                            [ type_ "text"
+                            , class "form-control input-sm"
+                            , value val
+                            , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+                            , onFocus DisableDragDrop
+                            ]
+                          |> addInputHandler  (\s -> updateNewItem k s)
+                        )
+                    )
+                  actionBtns =
+                    [ element "td"
+                      |> addClass "text-center"
+                      |> appendChild (element "button"
+                        |> addAttributeList
+                          [ type_ "button"
+                          , class "btn btn-success"
+                          , onCustomClick addNewItem
+                          ]
+                        |> appendChild (element "i" |> addClass "fa fa-plus-circle")
+                      )
+                    ]
+                in
+                  [ element "tr" |> addClass "item-foreach new" |> appendChildList (List.append newValues actionBtns) ]
+
+              foreachNameLabel =
+                if String.isEmpty name then
+                  element "i" |> appendText "item"
+                else
+                  element "span" |> appendText name
+            in
+              element "div"
+              |> addClass "d-flex row gx-3"
+              |> appendChildList
+                [ element "div"
+                  |> addClass "col-12 col-md-6"
+                  |> appendChildList
+                    [ element "div"
+                      |> addClass "row mb-3 form-group"
+                      |> appendChildList
+                        [ element "label"
+                          |> addAttribute (for "foreachName")
+                          |> addClass "col-auto col-form-label"
+                          |> appendText "Iterator name "
+                        , element "div"
+                          |> addClass "col d-flex align-items-center"
+                          |> appendChildListConditional
+                            [ element "div"
+                              |> addClass "input-group"
+                              |> appendChildList
+                                [ element "input"
+                                  |> addAttributeList
+                                    [ type_ "text"
+                                    , class "form-control"
+                                    , id "foreachName"
+                                    , placeholder "item"
+                                    , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+                                    , onFocus DisableDragDrop
+                                    , value newForeach.foreachName
+                                    ]
+                                  |> addInputHandler  (\s -> updateNewForeach s)
+                                , element "button"
+                                  |> addClass "btn btn-default"
+                                  |> addAttributeList
+                                    [ type_ "button"
+                                    , onCustomClick saveNewForeach
+                                    ]
+                                  |> appendChild (element "i" |> addClass "fa fa-check")
+                                ]
+                            ] foreachUI.editName
+                          |> appendChildListConditional
+                            [ foreachNameLabel
+                            , element "i" |> addClass "fa fa-edit ms-2" |> addActionStopAndPrevent ("click", editForeachName)
+                            ] (not foreachUI.editName)
+
+                        ]
+                    , element "div"
+                      |> addClass "row mb-3 form-group"
+                      |> appendChild ( element "label"
+                        |> addAttribute (for "foreachKeys")
+                        |> addClass "col-auto col-form-label"
+                        |> appendText "Iterator keys "
+                      )
+                      |> appendChildConditional ( element "div"
+                        |> addClass "col d-flex"
+                        |> appendChild ( element "div"
+                          |> addClass "d-flex row w-100"
+                          |> appendChildList
+                            [ element "div"
+                              |> addClass "input-group group-key"
+                              |> appendChildList
+                                [ element "input"
+                                  |> addAttributeList
+                                    [ type_ "text"
+                                    , class "form-control"
+                                    , id "foreachKeys"
+                                    , stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+                                    , onFocus DisableDragDrop
+                                    , value newForeach.newKey
+                                    ]
+                                  |> addInputHandler (\s -> updateNewForeachKey s)
+                                , element "button"
+                                  |> addClass "btn btn-default"
+                                  |> addAttributeList
+                                    [ type_ "button"
+                                    , disabled (String.isEmpty newForeach.newKey)
+                                    ]
+                                  |> addActionStopAndPrevent ("click", addNewKey)
+                                  |> appendChild (element "i" |> addClass "fa fa-plus-circle")
+                                , element "button"
+                                  |> addClass "btn btn-default ms-2"
+                                  |> addAttributeList
+                                    [ type_ "button"
+                                    , disabled (List.isEmpty newForeach.foreachKeys)
+                                    ]
+                                  |> addActionStopAndPrevent ("click", saveEditKeys)
+                                  |> appendChild (element "i" |> addClass "fa fa-check")
+                                ]
+                          , element "div" |> addClass "foreach-keys mt-2 mb-3" |> appendChildList (newKeys True)
+                          ]
+                        )
+                      ) foreachUI.editKeys
+                      |> appendChildConditional ( element "div"
+                        |> addClass "col d-flex align-items-center foreach-keys"
+                        |> appendChildList ( List.append
+                          (newKeys False)
+                          [ (element "i" |> addClass "fa fa-edit ms-2" |> addActionStopAndPrevent ("click" , editForeachKeys)) ]
+                        )
+                      ) (not foreachUI.editKeys)
+
+                    , element "div"
+                      |> addClass "table-foreach-container"
+                      |> appendChild (element "table"
+                        |> addClass "table table-bordered table-foreach mb-0"
+                        |> appendChildList
+                          [ element "thead" |> appendChild (element "tr" |> appendChildList (List.append header [element "th" |> appendText "Action"] ))
+                          , element "tbody" |> appendChildList (List.append foreachItems newItemRow)
+                          ]
+                      )
+
+                    , element "button"
+                      |> addClass "btn btn-danger mt-2"
+                      |> addActionStopAndPrevent ("click", removeForeach)
+                      |> appendText "Remove iterator"
+                      |> appendChild (element "i" |> addClass "fa fa-times ms-1")
+                    ]
+                , element "div"
+                  |> addClass "col-12 col-md-6"
+                  |> appendChild infoMsg
+                ]
+  in
+    element "div"
+      |> addClass "form-group"
+      |> appendChild tabContent

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
@@ -323,7 +323,7 @@ showTechnique model technique origin ui editInfo =
                            showMethodCall model methodUi ui parentId c
                        Block parentId b ->
                          let
-                           methodUi = Maybe.withDefault (MethodBlockUiInfo Closed Children ValidState True) (Dict.get b.id.value ui.blockUI)
+                           methodUi = Maybe.withDefault (MethodBlockUiInfo Closed Children ValidState True (ForeachUI False False (defaultNewForeach b.foreachName b.foreach))) (Dict.get b.id.value ui.blockUI)
                          in
                            showMethodBlock model ui methodUi parentId b
                 in


### PR DESCRIPTION
https://issues.rudder.io/issues/26278

This PR brings the loops feature to the blocks.

- All the code that manages the display of loops has been placed in a new file, `ViewTabForeach.elm`

- In ViewMethod.elm, `showParam`, `showMethodTab` functions now return an `Element Msg` instead of an `Html Msg` (as in ViewBlock.elm). This way, the code used to display the loops tab and the label is the same for methods and blocks