### PR TITLE
Fixes #26249: Technique can be created with technique ID starting with a forbidden character

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor.elm
@@ -26,7 +26,7 @@ import Editor.JsonDecoder exposing (decodeDraft, decodeErrorDetails, decodeTechn
 import Editor.MethodConditions exposing (..)
 import Editor.MethodElemUtils exposing (..)
 import Editor.ViewMethod exposing ( accumulateErrorConstraint )
-import Editor.ViewTechnique exposing ( view, checkTechniqueName, checkTechniqueId )
+import Editor.ViewTechnique exposing ( view, checkTechniqueUiState )
 import Editor.ViewTechniqueList exposing (allMethodCalls)
 
 
@@ -104,19 +104,19 @@ updatedStoreTechnique model =
                              (Dict.remove t.id.value model.drafts, clearDraft t.id.value)
                            else
                              let
-                               draft = Draft  t (Just origin) origin.id.value (Time.millisToPosix 0)
+                               draft = Draft  t (Just origin) origin.id (Time.millisToPosix 0)
                              in
-                               (Dict.insert draft.id draft model.drafts, Cmd.batch[initInputs "", clearTooltips "", storeDraft (encodeDraft draft)] )
+                               (Dict.insert draft.id.value draft model.drafts, Cmd.batch[initInputs "", clearTooltips "", storeDraft (encodeDraft draft)] )
             Creation id ->
               let
-               draft = Draft  t Nothing id.value (Time.millisToPosix 0)
+               draft = Draft  t Nothing id (Time.millisToPosix 0)
               in
-                (Dict.insert draft.id draft model.drafts, Cmd.batch[initInputs "", clearTooltips "", storeDraft (encodeDraft draft)] )
+                (Dict.insert draft.id.value draft model.drafts, Cmd.batch[initInputs "", clearTooltips "", storeDraft (encodeDraft draft)] )
             Clone _ _ id ->
               let
-               draft = Draft  t Nothing id.value (Time.millisToPosix 0)
+               draft = Draft  t Nothing id (Time.millisToPosix 0)
               in
-                (Dict.insert draft.id draft model.drafts, Cmd.batch[initInputs "", clearTooltips "", storeDraft (encodeDraft draft)] )
+                (Dict.insert draft.id.value draft model.drafts, Cmd.batch[initInputs "", clearTooltips "", storeDraft (encodeDraft draft)] )
       in
          ({ model | drafts = drafts }, action)
     _ -> (model, Cmd.batch[initInputs "", clearTooltips ""])
@@ -161,12 +161,15 @@ selectTechnique model technique =
         let
          st = case d.origin of
                    Just o -> Clone d.technique Nothing o.id
-                   Nothing -> Creation (TechniqueId d.id)
+                   Nothing -> Creation (TechniqueId d.id.value)
         in
         (d.technique, st, Cmd.none)
     callState = (Dict.fromList (List.map (\c -> (c.id.value, defaultMethodUiInfo)) (List.concatMap getAllCalls effectiveTechnique.elems)))
     blockState = (Dict.fromList (List.map (\c -> (c.id.value, defaultBlockUiInfo)) (List.concatMap getAllBlocks effectiveTechnique.elems)))
-    ui = TechniqueUiInfo General callState blockState [] False Unchanged Unchanged Nothing
+    defaultUi = TechniqueUiInfo General callState blockState [] False Unchanged Unchanged Nothing
+    -- Revalidate state when technique is a Draft
+    validateDraftUi s = checkTechniqueUiState state s (List.map techniqueCheckState model.techniques) defaultUi
+    ui = Either.unpack (\_ -> defaultUi) (draftCheckState >> validateDraftUi) technique
     editInfo = TechniqueEditInfo "" False (Ok ())
   in
     ({ model | mode = TechniqueDetails effectiveTechnique  state ui editInfo } )
@@ -290,7 +293,7 @@ update msg model =
           case model.mode of
             TechniqueDetails _ o ui editInfo ->
 
-              { model | mode = TechniqueDetails {technique | id = techniqueId} o {ui |  nameState = checkTechniqueName technique model, idState = checkTechniqueId o technique model } editInfo }
+              { model | mode = TechniqueDetails {technique | id = techniqueId} o (checkTechniqueUiState o (techniqueCheckState technique) (List.map techniqueCheckState model.techniques) ui) editInfo }
             _ -> model
       in
         updatedStoreTechnique newModel

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/DataTypes.elm
@@ -22,7 +22,9 @@ type alias CallId = {value : String}
 
 type alias ParameterId = {value : String}
 
-type alias Draft = { technique : Technique, origin : Maybe Technique, id : String, date : Posix}
+type alias DraftId = {value : String}
+
+type alias Draft = { technique : Technique, origin : Maybe Technique, id : DraftId, date : Posix}
 
 type AgentValue = Value String | Variable (List AgentValue)
 
@@ -149,6 +151,11 @@ allCategorieswithoutRoot m =
 
 type TechniqueState = Creation TechniqueId | Edit Technique | Clone Technique (Maybe TechniqueId) TechniqueId
 
+type alias TechniqueCheckState =
+  { id : TechniqueId
+  , name : String
+  }
+
 type ModalState = DeletionValidation Technique
 
 type DragElement = NewMethod Method | NewBlock | Move MethodElem
@@ -203,7 +210,7 @@ type MethodFilterState = FilterOpened | FilterClosed
 type ValidationState error = Unchanged | ValidState | InvalidState (List error)
 type TechniqueNameError = EmptyName | AlreadyTakenName
 type BlockError = EmptyComponent  | NoFocusError | ConditionError
-type TechniqueIdError = TooLongId | AlreadyTakenId | InvalidStartId
+type TechniqueIdError = TooLongId | AlreadyTakenId
 type MethodCallParamError = ConstraintError { id : ParameterId , message: String }
 type MethodCallConditionError = ReturnCarrigeForbidden
 
@@ -318,3 +325,11 @@ dragDropMessages =
   , dragEnded = MoveCanceled
   , dropped = MoveCompleted
   }
+
+
+techniqueCheckState : Technique -> TechniqueCheckState
+techniqueCheckState { id, name } = { id = id, name = name }
+
+
+draftCheckState : Draft -> TechniqueCheckState
+draftCheckState { id, technique } = { id = id, name = technique.name }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/JsonDecoder.elm
@@ -228,7 +228,7 @@ decodeDraft =
   maybe (succeed Draft
     |> required "technique" decodeTechnique
     |> optional "origin"  (maybe decodeTechnique) Nothing
-    |> required "id"  string
+    |> required "id"  (map DraftId string)
     |> required "date"  Iso8601.decoder)
 
 decodeErrorDetails : String -> (String, String)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/JsonEncoder.elm
@@ -13,7 +13,7 @@ encodeDraft draft =
   let
     standardData =  [
                      ("technique", encodeTechnique draft.technique)
-                     , ("id", string draft.id)
+                     , ("id", string draft.id.value)
                      , ("date", Iso8601.encode draft.date)
                      ]
     data = case draft.origin of

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
@@ -26,27 +26,34 @@ import String.Extra
 -- This file deals with the UI of one technique
 --
 
-checkTechniqueId origin technique model =
+checkTechniqueId: TechniqueState -> TechniqueCheckState -> List TechniqueCheckState -> ValidationState TechniqueIdError
+checkTechniqueId origin technique techniques =
   case origin of
     Edit _ -> ValidState
-    _ -> if (List.any (.id >> (==) technique.id) model.techniques) then
+    _ -> if (List.any (.id >> (==) technique.id) techniques) then
            InvalidState [ AlreadyTakenId ]
          else if String.length technique.id.value > 255 then
            InvalidState [ TooLongId ]
-         else if String.startsWith "_" technique.id.value then
-           InvalidState [ InvalidStartId ]
          else
            ValidState
 
-checkTechniqueName technique model =
+checkTechniqueName : TechniqueCheckState -> List TechniqueCheckState -> ValidationState TechniqueNameError
+checkTechniqueName technique techniques =
   if String.isEmpty technique.name then
    InvalidState [ EmptyName ]
   else
-   if List.any (.name >> (==) technique.name) (List.filter (.id >> (/=) technique.id ) model.techniques) then
+   if List.any (.name >> (==) technique.name) (List.filter (.id >> (/=) technique.id ) techniques) then
      InvalidState [ AlreadyTakenName ]
    else
      ValidState
 
+
+checkTechniqueUiState : TechniqueState -> TechniqueCheckState -> List TechniqueCheckState -> TechniqueUiInfo -> TechniqueUiInfo
+checkTechniqueUiState origin technique techniques ui =
+  { ui | idState = checkTechniqueId origin technique techniques, nameState = checkTechniqueName technique techniques }
+
+
+isValidState : ValidationState error -> Bool
 isValidState state =
   case state of
     Unchanged -> True

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueList.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueList.elm
@@ -151,12 +151,12 @@ draftsItem model draft =
   let
     activeClass = case model.mode of
                     TechniqueDetails _ (Clone _ _ id) _ _ ->
-                      if id.value == draft.id then
+                      if id.value == draft.id.value then
                          "jstree-clicked"
                       else
                         ""
                     TechniqueDetails _ (Creation id) _ _ ->
-                      if id.value == draft.id then
+                      if id.value == draft.id.value then
                          "jstree-clicked"
                       else
                         ""

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueTabs.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueTabs.elm
@@ -339,7 +339,6 @@ techniqueTab model technique creation ui =
                                                         \err -> case err of
                                                           TooLongId -> li [ class "text-danger col-md-8" ] [text "Technique IDs longer than 255 characters won't work on most filesystems." ]
                                                           AlreadyTakenId -> li [ class "text-danger col-md-8" ] [ text "Technique ID must be unique." ]
-                                                          InvalidStartId -> li [ class "text-danger col-md-8"] [ text "Technique ID should start with an alphanumeric character." ]
                                                       ) errors)
                              _ -> if String.length technique.id.value > 100 then
                                     span [ class "rudder-text-warning col-md-8 col-md-offset-3" ] [


### PR DESCRIPTION
https://issues.rudder.io/issues/26249

Upon selection, the whole UI state of the draft is not validated (name and ID), however it should because it may have been left into an invalid state. We just need to refactor the validation of the UI state and apply it upon a new draft selection.

We no longer need to prevent the ID from starting with `_`, it is not validated on the API and is supposed to be prefixed for CFEngine.
