### PR TITLE
Fixes #26286: InstanceId check must be in early bootstrap checks

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/CheckPostgreConnection.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/CheckPostgreConnection.scala
@@ -56,7 +56,7 @@ class CheckPostgreConnection(
   override def checks(): Unit = {
 
     def FAIL(msg: String) = {
-      BootstrapLogger.logEffect.error(msg)
+      BootstrapLogger.Early.DB.logEffect.error(msg)
       throw new UnavailableException(msg)
     }
 
@@ -67,7 +67,7 @@ class CheckPostgreConnection(
       case e: Exception => FAIL("Can not open connection to PostgreSQL database server")
     }
 
-    BootstrapLogger.logEffect.info("PostgreSQL connection is OK")
+    BootstrapLogger.Early.DB.logEffect.info("PostgreSQL connection is OK")
   }
 
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/CheckTableReportsExecutionTz.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/CheckTableReportsExecutionTz.scala
@@ -77,7 +77,9 @@ class CheckTableReportsExecutionTz(
     // Actually run the migration async to avoid blocking for that.
     // There is no need to have it sync.
     migrationProg(reportsExecution)
-      .catchAll(err => BootstrapLogger.error(s"Error when trying to add time zone to ReportsExecution table: ${err.fullMsg}"))
+      .catchAll(err =>
+        BootstrapLogger.Early.DB.error(s"Error when trying to add time zone to ReportsExecution table: ${err.fullMsg}")
+      )
       .forkDaemon
       .runNow
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/CheckTableScore.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/CheckTableScore.scala
@@ -91,7 +91,10 @@ class CheckTableScore(
 
     // Actually run the migration async to avoid blocking for that.
     // There is no need to have it sync.
-    prog.catchAll(err => BootstrapLogger.error(s"Error when trying to create score tables: ${err.fullMsg}")).forkDaemon.runNow
+    prog
+      .catchAll(err => BootstrapLogger.Early.DB.error(s"Error when trying to create score tables: ${err.fullMsg}"))
+      .forkDaemon
+      .runNow
   }
 
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/CheckTableUsers.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/CheckTableUsers.scala
@@ -130,7 +130,10 @@ class CheckTableUsers(
 
     // Actually run the migration async to avoid blocking for that.
     // There is no need to have it sync.
-    prog.catchAll(err => BootstrapLogger.error(s"Error when trying to create user tables: ${err.fullMsg}")).forkDaemon.runNow
+    prog
+      .catchAll(err => BootstrapLogger.Early.DB.error(s"Error when trying to create user tables: ${err.fullMsg}"))
+      .forkDaemon
+      .runNow
   }
 
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/CheckUsersFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/CheckUsersFile.scala
@@ -53,7 +53,7 @@ class CheckUsersFile(migration: UserFileSecurityLevelMigration) extends Bootstra
 
   override def checks(): Unit = {
     prog
-      .catchAll(err => BootstrapLogger.error(s"Error when trying to check users file: ${err.fullMsg}"))
+      .catchAll(err => BootstrapLogger.Early.DB.error(s"Error when trying to check users file: ${err.fullMsg}"))
       .forkDaemon
       .runNow
   }
@@ -71,12 +71,12 @@ class CheckUsersFile(migration: UserFileSecurityLevelMigration) extends Bootstra
                            allChecks(SecurityLevel.fromPasswordEncoderType(hash))
 
                          case (Left(unknownValue), _) =>
-                           BootstrapLogger.warn(
+                           BootstrapLogger.Early.DB.warn(
                              s"Error when reading users file hash in ${migration.file.name}, value '${unknownValue}' is unknown, falling back to secure authentication method"
                            ) *>
                            migration.enforceModern(userFile)
                          case (_, Left(unknownValue)) =>
-                           BootstrapLogger.warn(
+                           BootstrapLogger.Early.DB.warn(
                              s"Error when reading users file unsafe-hashes in ${migration.file.name}, value '${unknownValue}' is unknown, falling back to safe hashes"
                            ) *>
                            migration.enforceModern(userFile)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/CreateTableNodeFacts.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/CreateTableNodeFacts.scala
@@ -103,7 +103,10 @@ class CreateTableNodeFacts(
 
     // Actually run the migration async to avoid blocking for that.
     // There is no need to have it sync.
-    prog.catchAll(err => BootstrapLogger.error(s"Error when trying to create table NodeFacts: ${err.fullMsg}")).forkDaemon.runNow
+    prog
+      .catchAll(err => BootstrapLogger.Early.DB.error(s"Error when trying to create table NodeFacts: ${err.fullMsg}"))
+      .forkDaemon
+      .runNow
   }
 
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/DeleteArchiveTables.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/DeleteArchiveTables.scala
@@ -71,7 +71,7 @@ class DeleteArchiveTables(
     val sql = sql"""DROP TABLE IF EXISTS """ ++ Fragment.const0(table)
 
     transactIOResult(s"Error when deleting table '${table}'")(xa => sql.update.run.transact(xa)).unit.catchAll(err =>
-      BootstrapLogger.error(err.fullMsg)
+      BootstrapLogger.Early.DB.error(err.fullMsg)
     )
   }
 
@@ -79,7 +79,7 @@ class DeleteArchiveTables(
     val sql = sql"""DROP SEQUENCE IF EXISTS """ ++ Fragment.const0(sequence)
 
     transactIOResult(s"Error when deleting table '${sequence}'")(xa => sql.update.run.transact(xa)).unit.catchAll(err =>
-      BootstrapLogger.error(err.fullMsg)
+      BootstrapLogger.Early.DB.error(err.fullMsg)
     )
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/MigrateChangeValidationEnforceSchema.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/MigrateChangeValidationEnforceSchema.scala
@@ -83,7 +83,7 @@ class MigrateChangeValidationEnforceSchema(
       migrate <- isColumnNullable(table, column).transact(xa) // migrate when column is still nullable
       _       <- if (migrate) alterTableStatement(tableFragment, columnFragment).run.transact(xa)
                  else {
-                   BootstrapLogger.debug(
+                   BootstrapLogger.Early.DB.debug(
                      s"No need to migrate: have already previously migrated table ${table} column ${column} (${msg})"
                    )
                  }
@@ -104,12 +104,12 @@ class MigrateChangeValidationEnforceSchema(
       migrationEffect(_)
         .foldZIO(
           err =>
-            BootstrapLogger.error(
+            BootstrapLogger.Early.DB.error(
               s"Non-fatal error when trying to migrate ${msg}." +
               s"\nThis is a data check and it should not alter the behavior of Rudder." +
               s"\nPlease contact the development team with the following information to help resolving the issue : ${err.getMessage}"
             ),
-          _ => BootstrapLogger.info(s"Migrated ${msg}")
+          _ => BootstrapLogger.Early.DB.info(s"Migrated ${msg}")
         )
     ).forkDaemon
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/MigrateEventLogEnforceSchema.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/MigrateEventLogEnforceSchema.scala
@@ -111,7 +111,7 @@ class MigrateEventLogEnforceSchema(
             _       <- if (migrate) {
                          migrateColumnStatement(Fragment.const(colName), defaultValue).run.transact(xa)
                        } else {
-                         BootstrapLogger.debug(
+                         BootstrapLogger.Early.DB.debug(
                            s"No need to migrate: have already previously migrated table ${tableName} column ${colName} (${msg})"
                          )
                        }
@@ -126,12 +126,12 @@ class MigrateEventLogEnforceSchema(
       migrationEffect(_)
         .foldZIO(
           err =>
-            BootstrapLogger.error(
+            BootstrapLogger.Early.DB.error(
               s"Non-fatal error when trying to migrate ${msg}." +
               s"\nThis is a data check and it should not alter the behavior of Rudder." +
               s"\nPlease contact the development team with the following information to help resolving the issue : ${err.getMessage}"
             ),
-          _ => BootstrapLogger.info(s"Migrated ${msg}")
+          _ => BootstrapLogger.Early.DB.info(s"Migrated ${msg}")
         )
     ).forkDaemon
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/ldap/CheckLdapConnection.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/ldap/CheckLdapConnection.scala
@@ -59,7 +59,7 @@ class CheckLdapConnection(
   override def checks(): Unit = {
 
     def FAIL(msg: String) = {
-      BootstrapLogger.logEffect.error(msg)
+      BootstrapLogger.Early.LDAP.logEffect.error(msg)
       throw new UnavailableException(msg)
     }
 
@@ -69,7 +69,7 @@ class CheckLdapConnection(
       case _                         => // ok
     }
 
-    BootstrapLogger.logEffect.info("LDAP connection is OK")
+    BootstrapLogger.Early.LDAP.logEffect.info("LDAP connection is OK")
   }
 
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/action/CreateInstanceUuid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/action/CreateInstanceUuid.scala
@@ -61,7 +61,7 @@ class CreateInstanceUuid(file: File, instanceIdService: InstanceIdService) exten
           _ <- ApplicationLoggerPure.info(s"Server instance ID has been written into ${file.pathAsString}")
         } yield ()
       )
-      .chainError(s"An error occured when creating instance ID file at ${filePath}")
+      .chainError(s"An error occurred when creating instance ID file at ${filePath}")
       .tapError(err => BootstrapLogger.error(err.fullMsg))
       .runNow
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
@@ -115,7 +115,7 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
 
   private def displayTime(label: String, time: DateTime): NodeSeq = {
     // this is replaced by a dynamic JS timer, see updateDeploymentStart
-    val d = DateFormaterService.getFormatedPeriod(time, DateTime.now)
+    val d = DateFormaterService.getBroadlyFormatedPeriod(time, DateTime.now)
     <span>{label} <span id="deployment-start-interval">{d}</span> ago{displayHelpBlock(time)}</span>
   }
   private def displayDate(label: String, time: DateTime): NodeSeq = {
@@ -252,7 +252,7 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
             <li class="list-group-item"><a href="#" class="no-click"><span class={statusClass + " fa fa-clock-o"}></span>{
               dur
             } {
-              DateFormaterService.getFormatedPeriod(start, end)
+              DateFormaterService.getBroadlyFormatedPeriod(start, end)
             }</a></li>
           })
           .getOrElse(NodeSeq.Empty)


### PR DESCRIPTION
https://issues.rudder.io/issues/26286

It looks like it should have been a five minutes work and well, there was several tangeant in it: 
- I wanted to add an "exec once" bootchecks for instance id, so I rewrote check in zio
- which allows to simplify the exec timing part, with `.timed`, 
- we have a "formatPeriod" method that is extremely specific (it say "less than 1s") and so I renamed it to avoid confusion with strict formatting methods
- then I saw that actually, the formatter is for Joda, not Java, and (re, re)-discovered that there is no formatter for java.time.Duration, so wrote one so that it's done and we don't have to ask ourself again, 
- then, I discovered that I'm not able to find a single way to make a "zio exec once" if the "once" part is called with several runNow. I'm almost sure it used to work with promises (that's a bit of the goal of that tool), but impossible to make it work. Even tried the built-in memoize function, but it doesn't seems to survive runNow boundaries. Perhaps something to investigate more. 
- so finally I reverted to the old "do it once at instanciation" way. Works, not pretty. 

Also corrected several loggers to the new name, and typos. We could want to actually passe the sequence logger to the bootcheck, but it's a bigger refactoring since `Bootcheck` is just a trait, we need to make an abstract class with a constructor with the logger, of a default class, and change everywhere, including in CVE plugin. 

Now we have nice statup logs: 

```
2025-01-31 12:04:00+0100 INFO  org.eclipse.jetty.server.session.DefaultSessionIdManager - Session workerName=node0
2025-01-31 12:04:00+0100 INFO  application - Rudder starts with PID 224660 on 16 cores
2025-01-31 12:04:00+0100 INFO  application - Rudder application parameters are read from file defined by JVM property -Drudder.configFile: /home/fanf/java/workspaces/rudder-project/static-config/configuration-rudder-8.3.properties
2025-01-31 12:04:00+0100 INFO  application - -> files for overriding configuration parameters are read from directory /home/fanf/java/workspaces/rudder-project/static-config/configuration-rudder-8.3.properties.d (that path can be overridden with JVM property -Drudder.configDir)
....
2025-01-31 12:04:00+0100 INFO  application - Starting Rudder 8.3.0~alpha2-SNAPSHOT web application [build timestamp: 2025-01-30T12:59:32Z]
2025-01-31 12:04:00+0100 DEBUG application - Test if LDAP connection is active
2025-01-31 12:04:01+0100 INFO  bootchecks.early - Starting bootchecks for pre-LDAP/DB-connection checks
2025-01-31 12:04:01+0100 INFO  bootchecks.early - [#0] Check if server has the instance ID file, create it if does not exist
2025-01-31 12:04:01+0100 DEBUG bootchecks.early - [#0] Check if server has the instance ID file, create it if does not exist: OK in [2 ms]
2025-01-31 12:04:01+0100 INFO  git-repository - Automatic git-gc starts on fact-repository (schedule 'sec min h dayMonth month DayWeek': '0 42 3 * * ?')
2025-01-31 12:04:01+0100 INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
2025-01-31 12:04:01+0100 INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@64f32e9e
2025-01-31 12:04:01+0100 INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
2025-01-31 12:04:01+0100 INFO  bootchecks.early.db - Starting bootchecks for early PostgreSQL checks
2025-01-31 12:04:01+0100 INFO  bootchecks.early.db - [#0] Check PostgreSQL connection
2025-01-31 12:04:01+0100 INFO  bootchecks - PostgreSQL connection is OK
2025-01-31 12:04:01+0100 DEBUG bootchecks.early.db - [#0] Check PostgreSQL connection: OK in [1 ms]
2025-01-31 12:04:01+0100 INFO  bootchecks.early.db - [#1] Check if table 'NodeFacts' exists or create it
...
2025-01-31 12:04:01+0100 INFO  bootchecks.early.ldap - LDAP connection is OK
2025-01-31 12:04:01+0100 DEBUG bootchecks.early.ldap - [#0] Check LDAP connection: OK in [66 ms]
2025-01-31 12:04:01+0100 INFO  bootchecks.early.ldap - [#1] Check if system groups hasPolicyServer-root and all-nodes-with-cfengine-agent have the correct description and name
...
2025-01-31 12:04:03+0100 INFO  nodes - Nodes changes will be historized in Git in /var/rudder/fact-repository/nodes
...
2025-01-31 12:04:04+0100 INFO  application - Configure inventory processing with parallelism of '8'
...
2025-01-31 12:04:05+0100 INFO  application - List of registered properties:
2025-01-31 12:04:05+0100 INFO  application - registered property: file.separator="/"
...
2025-01-31 12:04:05+0100 INFO  application - registered property: ldap.authdn="cn=manager,cn=rudder-configuration"
2025-01-31 12:04:05+0100 INFO  application - registered property: ldap.authpw=**********
2025-01-31 12:04:05+0100 INFO  application - registered property: ldap.host="localhost"
...
2025-01-31 12:04:05+0100 INFO  application - registered property: waiting.inventory.queue.size="50"
2025-01-31 12:04:05+0100 INFO  application - Plugin's license directory: '/opt/rudder/etc/plugins/licenses/'
2025-01-31 12:04:05+0100 INFO  bootchecks - Starting bootchecks for post-service instantiation checks
2025-01-31 12:04:05+0100 INFO  bootchecks - [#0] Check if data from /var/rudder/inventories/historical are migrated
2025-01-31 12:04:05+0100 DEBUG bootchecks - [#0] Check if data from /var/rudder/inventories/historical are migrated: OK in [0 ms]
2025-01-31 12:04:05+0100 INFO  bootchecks - [#1] Check for force reload of Techniques library
2025-01-31 12:04:05+0100 INFO  bootchecks - Flag file '/opt/rudder/etc/force_technique_reload' does not exist, do not Technique library will not be reloaded
2025-01-31 12:04:05+0100 DEBUG bootchecks - [#1] Check for force reload of Techniques library: OK in [0 ms]
2025-01-31 12:04:05+0100 INFO  bootchecks - [#2] Check for technique compilation errors
2025-01-31 12:04:05+0100 DEBUG bootchecks - [#2] Check for technique compilation errors: OK in [1 ms]
2025-01-31 12:04:05+0100 INFO  bootchecks - Migrating '0' old inventory accept/refuse facts to 'NodeFacts' database table
2025-01-31 12:04:05+0100 INFO  bootchecks - [#3] Check mandatory DIT entries
...
2025-01-31 12:04:05+0100 INFO  bootchecks - [#7] Check existence of at least one archive of the configuration
```