### PR TITLE
Fixes #26292: Allow to choose api account ID on creation

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/resources/ldap/rudder.schema
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/ldap/rudder.schema
@@ -556,9 +556,9 @@ objectclass ( RudderObjectClasses:106
   SUP top
   STRUCTURAL
   MUST ( apiAccountId $ cn $ creationTimestamp $
-         apiToken $ apiTokenCreationTimestamp)
+         apiTokenCreationTimestamp)
   MAY ( description  $ isEnabled $ apiAccountKind $ apiTenant $
-        apiAuthorizationKind $ apiAcl $ expirationTimestamp ) )
+        apiToken $ apiAuthorizationKind $ apiAcl $ expirationTimestamp ) )
 
 #
 # Parameters

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/DataStructures.scala
@@ -348,13 +348,11 @@ object ApiAccountKind       {
  * An API principal
  */
 final case class ApiAccount(
-    id:   ApiAccountId,
-    kind: ApiAccountKind, // Authentication token. It is a mandatory value, and can't be ""
+    id:                  ApiAccountId,
+    kind:                ApiAccountKind,   // Authentication token. It is a mandatory value, and can't be ""
     // If a token should be revoked, use isEnabled = false.
-
-    name: ApiAccountName, // used in event log to know who did actions.
-
-    token:               ApiToken,
+    name:                ApiAccountName,   // used in event log to know who did actions.
+    token:               Option[ApiToken], // if none, then the token can't be used for authentication
     description:         String,
     isEnabled:           Boolean,
     creationDate:        DateTime,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
@@ -621,7 +621,7 @@ object ApiAccountSerialisation {
 
       ("id"                    -> account.id.value) ~
       ("name"                  -> account.name.value) ~
-      ("token"                 -> account.token.value) ~
+      ("token"                 -> account.token.map(_.value)) ~
       ("tokenGenerationDate"   -> DateFormaterService.serialize(account.tokenGenerationDate)) ~
       ("kind"                  -> account.kind.kind.name) ~
       ("description"           -> account.description) ~

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
@@ -589,7 +589,7 @@ class LDAPDiffMapper(
                                 }
                               case A_API_TOKEN                   =>
                                 nonNull(diff, mod.getOptValueDefault("")) { (d, value) =>
-                                  d.copy(modToken = Some(SimpleDiff(oldAccount.token.value, value)))
+                                  d.copy(modToken = Some(SimpleDiff(oldAccount.token.map(_.value).getOrElse(""), value)))
                                 }
                               case A_DESCRIPTION                 =>
                                 nonNull(diff, mod.getOptValueDefault("")) { (d, value) =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -954,7 +954,7 @@ class LDAPEntityMapper(
       for {
         id                    <- e.required(A_API_UUID).map(ApiAccountId(_))
         name                  <- e.required(A_NAME).map(ApiAccountName(_))
-        token                 <- e.required(A_API_TOKEN).map(ApiToken(_))
+        token                  = e(A_API_TOKEN).map(ApiToken(_))
         creationDatetime      <- e.requiredAs[GeneralizedTime](_.getAsGTime, A_CREATION_DATETIME)
         tokenCreationDatetime <- e.requiredAs[GeneralizedTime](_.getAsGTime, A_API_TOKEN_CREATION_DATETIME)
         isEnabled              = e.getAsBoolean(A_IS_ENABLED).getOrElse(false)
@@ -1050,7 +1050,10 @@ class LDAPEntityMapper(
     mod.resetValuesTo(A_API_UUID, principal.id.value)
     mod.resetValuesTo(A_NAME, principal.name.value)
     mod.resetValuesTo(A_CREATION_DATETIME, GeneralizedTime(principal.creationDate).toString)
-    mod.resetValuesTo(A_API_TOKEN, principal.token.value)
+    principal.token match {
+      case Some(value) => mod.resetValuesTo(A_API_TOKEN, value.value)
+      case None        => mod.deleteAttribute(A_API_TOKEN)
+    }
     mod.resetValuesTo(A_API_TOKEN_CREATION_DATETIME, GeneralizedTime(principal.tokenGenerationDate).toString)
     mod.resetValuesTo(A_DESCRIPTION, principal.description)
     mod.resetValuesTo(A_IS_ENABLED, principal.isEnabled.toLDAPString)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
@@ -536,7 +536,7 @@ class APIAccountSerialisationImpl(xmlVersion: String) extends APIAccountSerialis
       (
         <id>{account.id.value}</id>
        <name>{account.name.value}</name>
-       <token>{account.token.value}</token>
+       <token>{account.token.getOrElse("")}</token>
        <description>{account.description}</description>
        <isEnabled>{account.isEnabled}</isEnabled>
        <creationDate>{account.creationDate.toString(ISODateTimeFormat.dateTime)}</creationDate>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -878,7 +878,7 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
         ApiAccountId(id),
         kind,
         ApiAccountName(name),
-        ApiToken(token),
+        if (token.strip().isEmpty) None else Some(ApiToken(token)),
         description,
         isEnabled,
         creationDate,

--- a/webapp/sources/rudder/rudder-core/src/test/resources/ldap-data/schema/099-1-rudder.ldif
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/ldap-data/schema/099-1-rudder.ldif
@@ -439,9 +439,9 @@ objectClasses: ( 1.3.6.1.4.1.35061.2.2.106
   SUP top
   STRUCTURAL
   MUST ( apiAccountId $ cn $ creationTimestamp $
-  apiToken $ apiTokenCreationTimestamp)
-  MAY ( description  $ isEnabled $ apiAccountKind $
-  apiAuthorizationKind $ apiAcl $ expirationTimestamp ) )
+         apiTokenCreationTimestamp)
+  MAY ( description  $ isEnabled $ apiAccountKind $ apiTenant $
+        apiToken $ apiAuthorizationKind $ apiAcl $ expirationTimestamp ) )
 #
 # Parameters
 #

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -53,6 +53,7 @@ import com.normation.rudder.ncf.ParameterType.ParameterTypeService
 import com.normation.rudder.repository.*
 import com.normation.rudder.repository.json.DataExtractor.CompleteJson
 import com.normation.rudder.rest.data.*
+import com.normation.rudder.rest.internal.RestApiAccount
 import com.normation.rudder.services.queries.CmdbQueryParser
 import com.normation.rudder.services.queries.JsonQueryLexer
 import com.normation.rudder.services.workflows.WorkflowLevelService

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/GroupsInternalAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/GroupsInternalAPI.scala
@@ -1,3 +1,39 @@
+/*
+ *************************************************************************************
+ * Copyright 2019 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
 package com.normation.rudder.rest.internal
 
 import com.normation.errors.IOResult

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
@@ -1,3 +1,39 @@
+/*
+ *************************************************************************************
+ * Copyright 2021 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
 package com.normation.rudder.rest.internal
 
 import com.normation.errors.EitherToIoResult

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/User.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/User.scala
@@ -123,7 +123,7 @@ case class RudderUserDetail(
 
   override val (getUsername, getPassword, getAuthorities) = account match {
     case RudderAccount.User(login, password) => (login, password, RudderAuthType.User.grantedAuthorities)
-    case RudderAccount.Api(api)              => (api.name.value, api.token.value, RudderAuthType.Api.grantedAuthorities)
+    case RudderAccount.Api(api)              => (api.name.value, api.token.map(_.value).getOrElse(""), RudderAuthType.Api.grantedAuthorities)
   }
   override val isAccountNonExpired                        = true
   override val isAccountNonLocked                         = true

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -1326,7 +1326,7 @@ class EventLogDetailsGenerator(
   private def apiAccountDetails(xml: NodeSeq, apiAccount: ApiAccount) = (
     "#id" #> apiAccount.id.value &
       "#name" #> apiAccount.name.value &
-      "#token" #> apiAccount.token.value &
+      "#token" #> apiAccount.token.map(_.value).getOrElse("") &
       "#description" #> apiAccount.description &
       "#isEnabled" #> apiAccount.isEnabled &
       "#creationDate" #> DateFormaterService.getDisplayDate(apiAccount.creationDate) &

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/JsonDecoder.elm
@@ -26,7 +26,7 @@ decodeAccount datePickerInfo =
         |> required "kind" string
         |> required "enabled" bool
         |> required "creationDate" string
-        |> required "token" string
+        |> optional "token" string ""
         |> required "tokenGenerationDate" string
         |> required "expirationDateDefined" bool
         |> optional "expirationDate"

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewModals.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewModals.elm
@@ -149,6 +149,16 @@ displayModal model =
 
                           else
                               span [] [ text (": " ++ encodeTenants account.tenantMode account.selectedTenants) ]
+
+                      chooseId =
+                          case model.ui.modalState of
+                              NewAccount ->
+                                  div [ class "form-group" ]
+                                      [ label [ for "newAccount-id" ] [ text "Account ID" ]
+                                      , div [] [ span [ class "small fw-light"] [ text "By default, Rudder uses a generated UUID as account ID, but you can specify your own ID if needed. In that case, no token secret will be generated automatically."] ]
+                                      , input [ id "newAccount-id", placeholder "generated", class "form-control vresize float-none", value account.id, onInput (\s -> UpdateAccountForm { account | id = s }) ] []
+                                      ]
+                              _ -> text ""
                   in
                       div[]
                       [ form
@@ -181,6 +191,7 @@ displayModal model =
                               [ label [ for "newAccount-description" ] [ text "Description" ]
                               , textarea [ id "newAccount-description", class "form-control vresize float-none", value account.description, onInput (\s -> UpdateAccountForm { account | description = s }) ] []
                               ]
+                          , chooseId
                           , div [ class "form-group" ]
                               [ label [ for "newAccount-expiration", class "mb-1" ]
                                   [ text "Expiration date"
@@ -194,7 +205,6 @@ displayModal model =
                                       ]
                                   , if checkIfExpired model.ui.datePickerInfo account then
                                       span [ class "warning-info" ] [ i [ class "fa fa-warning" ] [], text " Expiration date has passed" ]
-
                                     else
                                       text ""
                                   ]
@@ -266,6 +276,16 @@ displayModal model =
                         ]
                     , button [ type_ "button", class ("btn btn-" ++ btnClass), onClick action ] [ text "Confirm" ]
                     )
+            CopyToken "" ->
+                ( "Account created without secret token"
+                , div []
+                    [ div [ class "alert alert-info" ]
+                        [ i [ class "fa fa-exclamation-triangle" ] []
+                        , text "This account doesn't have a token. You can create one with the refresh action"
+                        ]
+                    ]
+                , text ""
+                )
             CopyToken token ->
                 ( "Copy the token"
                 , div []

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewUtils.elm
@@ -113,13 +113,13 @@ displayAccountsTable model =
             td [class "date"][ text (cleanDate a.creationDate) ]
         , td [class "date"][ text expirationDate ]
         , td []
-          [ button 
+          [ button
             [ class "btn btn-default reload-token"
             , title ("Generated: " ++ (cleanDate a.tokenGenerationDate))
             , onClick (ToggleEditPopup (Confirm Regenerate a.name (CallApi (regenerateToken a))))
             ]
             [ span [class "fa fa-repeat"][] ]
-          , button 
+          , button
             [ class "btn btn-default"
             , onClick (ToggleEditPopup (EditAccount a))
             ]
@@ -132,7 +132,7 @@ displayAccountsTable model =
               , label [for inputId, class "toggle-disabled"][text "Disabled"]
               ]
             ]
-          , button 
+          , button
             [ class "btn btn-danger delete-button"
             , onClick (ToggleEditPopup (Confirm Delete a.name (CallApi (deleteAccount a))))
             ]

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -848,7 +848,7 @@ class RestAuthenticationFilter(
                   ), // un-authenticated APIv1 token certainly doesn't get any authz on v2 API
 
                   ApiAccountName(name),
-                  ApiToken(name),
+                  Some(ApiToken(name)),
                   "API Account for un-authenticated API",
                   isEnabled = true,
                   creationDate = new DateTime(0),
@@ -878,7 +878,7 @@ class RestAuthenticationFilter(
               // try to authenticate
               val apiToken      = ApiToken(token)
               val systemAccount = apiTokenRepository.getSystemAccount
-              if (systemAccount.token == apiToken) { // system token with super authz
+              if (systemAccount.token.contains(apiToken)) { // system token with super authz
                 authenticate(
                   RudderUserDetail(
                     RudderAccount.Api(systemAccount),

--- a/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/099-1-rudder.ldif
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/ldap-data/schema/099-1-rudder.ldif
@@ -432,9 +432,9 @@ objectClasses: ( 1.3.6.1.4.1.35061.2.2.106
   SUP top
   STRUCTURAL
   MUST ( apiAccountId $ cn $ creationTimestamp $
-  apiToken $ apiTokenCreationTimestamp)
-  MAY ( description  $ isEnabled $ apiAccountKind $
-  apiAuthorizationKind $ apiAcl $ expirationTimestamp ) )
+         apiTokenCreationTimestamp)
+  MAY ( description  $ isEnabled $ apiAccountKind $ apiTenant $
+        apiToken $ apiAuthorizationKind $ apiAcl $ expirationTimestamp ) )
 #
 # Parameters
 #

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/action/TestCreateSystemToken.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/action/TestCreateSystemToken.scala
@@ -51,7 +51,7 @@ class TestCreateSystemToken extends Specification {
 
   "When writing the system tokens, we" should {
     "generate proper header and token files" in File.temporaryDirectory("rudder-test-system-token-") { tmpDir =>
-      val check = new CreateSystemToken(apiToken, tmpDir, "x-api-token")
+      val check = new CreateSystemToken(Some(apiToken), tmpDir, "x-api-token")
       check.checks()
 
       val tokenFile = tmpDir / CreateSystemToken.tokenFile


### PR DESCRIPTION
https://issues.rudder.io/issues/26292

This PR allow user to choose an api account ID on creation. That allows to match third party token ID for example with an IdP providing OIDC opaque access beare token as done in https://github.com/Normation/rudder-plugins/pull/789. 

For this case, we dont' want to have a secret generated for these accounts. So if the user chose to specify an account ID, we don't generate a token secret. For that, we need to make the "secret" attribute of api account optional, which is a change in LDAP schema. This change is OK since we go from mandatory to optional. This was also the path followed in https://github.com/Normation/rudder/pull/6031. 

More cleaning and enhancement can be done in token secret mananement (signal that an account hasn't any token with a badge, allow to clean a secret without regenerating one, etc). But I would prefer to make these changes with  https://github.com/Normation/rudder/pull/6031 or a following PR in the same direction. 

![image](https://github.com/user-attachments/assets/7d4460fd-938a-48dc-88df-1fcf72230a73)
