### PR TITLE
Fixes #26297: Update zio and zio-json to take benefits of perf improvments

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -487,9 +487,9 @@ limitations under the License.
     <fs2-version>3.10.2</fs2-version>
     <shapeless-version>2.3.12</shapeless-version>
     <cats-effect-version>3.5.5</cats-effect-version>
-    <dev-zio-version>2.1.12</dev-zio-version>
+    <dev-zio-version>2.1.14</dev-zio-version>
     <zio-cats-version>23.1.0.3</zio-cats-version> <!-- gives fs2 3.10.2, but doobie 1.0.0-RC5 is in 3.9.3 -->
-    <zio-json-version>0.7.3</zio-json-version>
+    <zio-json-version>0.7.14</zio-json-version>
     <enumeratum-version>1.7.5</enumeratum-version>
 
     <!--


### PR DESCRIPTION
https://issues.rudder.io/issues/26297

The relevant release notes are:
- zio: https://github.com/zio/zio/releases/tag/v2.1.14
- zio-json: [a lot](https://github.com/zio/zio-json/releases), but in particular https://github.com/zio/zio-json/releases/tag/v0.7.14 corrects a bug that was introduced in 0.7.7 and was impacting us regarding decoder for `Optional[A]`, caught in our unit tests.