### PR TITLE
Fixes #26261: The "Save" button disappears from the group webpage if the group name is too long

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
@@ -162,6 +162,7 @@ ul {
   padding: 0;
   margin: 0;
   font-size: 26px;
+  word-break: break-word;
 }
 .rudder-template .header-title h1 > .rudder-label.label-sm {
   position: relative;


### PR DESCRIPTION
https://issues.rudder.io/issues/26261