### PR TITLE
Fixes #26322: When several plugins are using the same menu, only the last one is displayed

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/PublicPlugin.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/PublicPlugin.scala
@@ -138,10 +138,9 @@ trait DefaultPluginDef extends RudderPluginDef {
 
     val updatedMenu = pluginMenuParent
       .foldRight(menus) {
-        // we need to always update the menu with the last provided to allow
-        // changing name based on presence of other plugins
+        // We need to ensure plugin name is managed correctly between plugins
         case (newParent, menu) =>
-          newParent :: menu.filterNot(_.loc.name == newParent.loc.name)
+          if (menu.exists(_.loc.name == newParent.loc.name)) menu else newParent :: menu
       }
       .sortBy(_.loc.name)
 


### PR DESCRIPTION
https://issues.rudder.io/issues/26322

If two plugins are setting the same menu, data that were already set are replaced because we are resetting the menu with the one from the new plugin 