### PR TITLE
Fixes #26328: Some more changes needed for scala 3 migrations

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/FullInventoryFromLdapEntriesImpl.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/FullInventoryFromLdapEntriesImpl.scala
@@ -42,7 +42,7 @@ import com.normation.inventory.domain.FullInventory
 import com.normation.ldap.sdk.LDAPEntry
 import com.normation.ldap.sdk.LDAPTree
 import scala.collection.mutable.Buffer
-import zio.syntax.*
+import zio.ZIO
 
 class FullInventoryFromLdapEntriesImpl(
     inventoryDitService: InventoryDitService,
@@ -66,10 +66,10 @@ class FullInventoryFromLdapEntriesImpl(
     }
 
     for {
-      nodeTree   <- LDAPTree(serverElts)
+      nodeTree   <- ZIO.fromEither(LDAPTree(serverElts))
       node       <- mapper.nodeFromTree(nodeTree)
-      optMachine <- if (machineElts.isEmpty) None.succeed
-                    else LDAPTree(machineElts).flatMap(t => mapper.machineFromTree(t).map(m => Some(m)))
+      optMachine <- if (machineElts.isEmpty) ZIO.none
+                    else ZIO.fromEither(LDAPTree(machineElts)).flatMap(mapper.machineFromTree).asSome
     } yield {
       FullInventory(node, optMachine)
     }

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/FullInventoryRepositoryImpl.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/FullInventoryRepositoryImpl.scala
@@ -443,14 +443,15 @@ class FullInventoryRepositoryImpl(
       resServer  <- con.saveTree(pair._1, deleteRemoved = true)
       // when pair._2 is non empty, process need to be saved apart for performance reasons
       _          <- pair._2 match {
-                      case None     => Seq().succeed
+                      case None     => ZIO.unit
                       case Some(ps) =>
                         con
                           .save(ps, removeMissingAttributes = false)
+                          .unit
                           .catchAll(err => { // we don't want to fail because we tried to compensate
                             InventoryProcessingLogger.error(
                               s"Couldn't update the processes for node ${inventory.node.main.id.value}, Error is: ${err.fullMsg}"
-                            ) *> Seq().succeed
+                            )
                           })
                     }
       resMachine <- inventory.machine match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountRepository.scala
@@ -243,7 +243,7 @@ final class WoLDAPApiAccountRepository(
                            if (e(A_API_UUID) == Some(principal.id.value)) {
                              Some(e).succeed
                            } else {
-                             LDAPRudderError.Consistancy(s"An account with the same name ${principal.name.value} exists").fail
+                             LDAPRudderError.Consistency(s"An account with the same name ${principal.name.value} exists").fail
                            }
                        }
         optPrevious <- ldap.get(rudderDit.API_ACCOUNTS.API_ACCOUNT.dn(principal.id))
@@ -293,7 +293,7 @@ final class WoLDAPApiAccountRepository(
     for {
       ldap         <- ldapConnexion
       entry        <- ldap.get(rudderDit.API_ACCOUNTS.API_ACCOUNT.dn(id)).flatMap {
-                        case None    => LDAPRudderError.Consistancy(s"Api Account with ID '${id.value}' is not present").fail
+                        case None    => LDAPRudderError.Consistency(s"Api Account with ID '${id.value}' is not present").fail
                         case Some(x) => x.succeed
                       }
       oldAccount   <- mapper.entry2ApiAccount(entry).toIO

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/CleanupUsers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/CleanupUsers.scala
@@ -102,12 +102,14 @@ class CleanupUsers(
         .foldZIO(
           err => logger.error(s"Error when disabling user accounts inactive since '${disableInactive.render}': ${err.fullMsg}"),
           disabledUsers => {
-            ZIO.unless(disabledUsers.isEmpty)(
-              logger.warn(
-                s"Following users status changed to 'disabled' because they were inactive since '${disableInactive.render}': '${disabledUsers
-                    .mkString("', '")}'"
+            ZIO
+              .unless(disabledUsers.isEmpty)(
+                logger.warn(
+                  s"Following users status changed to 'disabled' because they were inactive since '${disableInactive.render}': '${disabledUsers
+                      .mkString("', '")}'"
+                )
               )
-            )
+              .unit
           }
         )
     _    <- userRepository
@@ -121,9 +123,11 @@ class CleanupUsers(
               .foldZIO(
                 err => logger.error(s"Error when deleting user accounts inactive since '${deleteInactive.render}': ${err.fullMsg}"),
                 deletedUsers => {
-                  ZIO.unless(deletedUsers.isEmpty)(
-                    logger.info(s"Following users status changed from 'disabled' to 'deleted': '${deletedUsers.mkString("', '")}'")
-                  )
+                  ZIO
+                    .unless(deletedUsers.isEmpty)(
+                      logger.info(s"Following users status changed from 'disabled' to 'deleted': '${deletedUsers.mkString("', '")}'")
+                    )
+                    .unit
                 }
               )
     _    <- userRepository
@@ -136,12 +140,14 @@ class CleanupUsers(
               .foldZIO(
                 err => logger.error(s"Error when purging user accounts deleted since '${purgeDeleted.render}': ${err.fullMsg}"),
                 purgedUsers => {
-                  ZIO.unless(purgedUsers.isEmpty)(
-                    logger.info(
-                      s"Users were purged from the database because they were configured to be purged ${purgeDeleted.render} after deletion. Users list is : '${purgedUsers
-                          .mkString("', '")}'"
+                  ZIO
+                    .unless(purgedUsers.isEmpty)(
+                      logger.info(
+                        s"Users were purged from the database because they were configured to be purged ${purgeDeleted.render} after deletion. Users list is : '${purgedUsers
+                            .mkString("', '")}'"
+                      )
                     )
-                  )
+                    .unit
                 }
               )
     dos   = d.minus(purgeSessions.toMillis)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/GitGC.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/GitGC.scala
@@ -93,6 +93,7 @@ class GitGC(
             .withPermit(IOResult.attempt {
               gitRepo.git.gc().setProgressMonitor(new LogProgressMonitor()).call
             })
+            .unit
             .catchAll(err => logger.error(s"Error when performing git-gc on ${gitRepo.rootDirectory.name}: ${err.fullMsg}"))
     t1 <- currentTimeMillis
     _  <- logger.info(s"git-gc performed on ${gitRepo.rootDirectory.name} in ${new Duration(t1 - t0).toString}")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeOldInventoryData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeOldInventoryData.scala
@@ -76,8 +76,8 @@ class PurgeOldInventoryData(
     t0 <- currentTimeMillis
     now = Instant.ofEpochMilli(t0)
     _  <- ZIO
-            .foreach(cleanDirectories) { dir =>
-              ZIO.foreach(dir.list.to(Iterable)) { f =>
+            .foreachDiscard(cleanDirectories) { dir =>
+              ZIO.foreachDiscard(dir.list.to(Iterable)) { f =>
                 isOlderThanMaxAge(f, maxAge.toSeconds, now).flatMap { older =>
                   if (older) {
                     InventoryProcessingLogger.info(
@@ -85,6 +85,7 @@ class PurgeOldInventoryData(
                     ) *>
                     IOResult
                       .attempt(f.delete())
+                      .unit
                       .catchAll(err => {
                         InventoryProcessingLogger
                           .error(s"Error while trying to clean old inventory file '${f.pathAsString}': ${err.fullMsg}")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JSONReportsHandler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JSONReportsHandler.scala
@@ -90,7 +90,7 @@ case class JSONReportsAnalyser(reportsRepository: ReportsRepository, propRepo: R
                         propRepo.updateReportHandlerLastId(highestId)
                       case Some(maxIdReport) =>
                         CampaignLogger.debug(s"Found ${reports.size} json reports, update parsed id to max id ${maxIdReport._1 + 1}") *>
-                        ZIO.foreach(reports)(r => handle(r._2)).catchAll(err => CampaignLogger.error(err.fullMsg)) *>
+                        ZIO.foreach(reports)(r => handle(r._2)).unit.catchAll(err => CampaignLogger.error(err.fullMsg)) *>
                         propRepo.updateReportHandlerLastId(maxIdReport._1 + 1)
                     }
       t4         <- currentTimeMillis

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactChangeEventCallback.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactChangeEventCallback.scala
@@ -372,10 +372,10 @@ class HistorizeNodeState(
       NodeLoggerPure.Delete.debug(s"  - delete fact about node '${nodeId.value}'") *>
       gitFactStorage
         .changeStatus(nodeId, RemovedInventory)
+        .unit
         .catchAll(err =>
           NodeLoggerPure.info(s"Error when trying to update fact when deleting node '${nodeId.value}': ${err.fullMsg}")
         )
-        .unit
     }
 
     change.event match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryFileWatcher.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryFileWatcher.scala
@@ -664,7 +664,7 @@ class ProcessFile(
              InventoryProcessingLogger.debug(s"Dealing with zip file '${file.name}'") *>
              IOResult.attempt {
                file.unGzipTo(dest)
-             }.catchAll { err => // if the gz file is corrupted, we still want to delete it in the next instruction, but log
+             }.unit.catchAll { err => // if the gz file is corrupted, we still want to delete it in the next instruction, but log
                InventoryProcessingLogger.error(
                  Chained(s"gz archive '${file.pathAsString}' is corrupted: deleting it.", err).fullMsg
                )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
@@ -430,8 +430,8 @@ class InventoryMover(
     IOResult
       .attempt(File(rejectPath).writeText(s"""${date}
                                              |${result.msg.replaceAll("; cause was:", "\ncause was:")}\n""".stripMargin))
-      .catchAll(err => InventoryProcessingLogger.error(s"Error when writing rejection log file ${rejectPath}: ${err.fullMsg}"))
       .unit
+      .catchAll(err => InventoryProcessingLogger.error(s"Error when writing rejection log file ${rejectPath}: ${err.fullMsg}"))
   }
 
   def moveFiles(inventory: File, signature: File, result: InventoryProcessStatus): UIO[Unit] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDirectiveRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDirectiveRepository.scala
@@ -106,7 +106,7 @@ class RoLDAPDirectiveRepository(
           case 1 => Some(piEntries(0)).succeed
           case _ =>
             LDAPRudderError
-              .Consistancy(
+              .Consistency(
                 s"Error, the directory contains multiple occurrence of directive with id '${id.debugString}'. DN: ${piEntries.map(_.dn).mkString("; ")}"
               )
               .fail
@@ -533,7 +533,7 @@ class RoLDAPDirectiveRepository(
                       case 1 => Some(uptEntries(0)).succeed
                       case _ =>
                         LDAPRudderError
-                          .Consistancy(
+                          .Consistency(
                             s"Error, the directory contains multiple occurrence of active " +
                             s"technique with ID '${id}'. DNs involved: ${uptEntries.map(_.dn).mkString("; ")}"
                           )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/RemoveNodeService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/RemoveNodeService.scala
@@ -507,8 +507,8 @@ class CloseNodeConfiguration(expectedReportsRepository: UpdateExpectedReportsRep
       _ <- NodeLoggerPure.Delete.debug(s"  - close expected reports for '${nodeId.value}'")
       _ <- expectedReportsRepository
              .closeNodeConfigurationsPure(nodeId)
-             .catchAll(err => NodeLoggerPure.Delete.error(s"Error when closing expected reports for node ${(nodeId, info).name}"))
              .unit
+             .catchAll(_ => NodeLoggerPure.Delete.error(s"Error when closing expected reports for node ${(nodeId, info).name}"))
       _ <- expectedReportsRepository.deleteNodeInfos(nodeId).catchAll(err => NodeLoggerPure.Delete.error(err.msg))
     } yield ()
   }

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPConnection.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPConnection.scala
@@ -374,19 +374,21 @@ sealed class RoLDAPConnection(
   override def getTreeFilter(dn: DN, filter: Filter, attributes: String*): LDAPIOResult[Option[LDAPTree]] = {
     blocking {
       backed.search(dn.toString, Sub.toUnboundid, filter, attributes*)
-    } flatMap { all =>
-      if (all.getEntryCount() > 0) {
-        // build the tree
-        LDAPTree(all.getSearchEntries.asScala.map(x => LDAPEntry(x))).map(Some(_))
-      } else None.succeed
-    } catchAll { x =>
-      (x: @unchecked) match {
-        // a no such object error simply means that the required LDAP tree is not in the directory
-        case e: LDAPSearchException if (NO_SUCH_OBJECT == e.getResultCode) => None.succeed
-        case e: LDAPException                                              =>
-          LDAPRudderError.BackendException(s"Can not get tree '${dn.toString}': ${e.getDiagnosticMessage}", e).fail
-      }
-    }
+    }.refineToOrDie[LDAPException]
+      .foldZIO(
+        failure = {
+          // a no such object error simply means that the required LDAP tree is not in the directory
+          case e: LDAPSearchException if (NO_SUCH_OBJECT == e.getResultCode) => ZIO.none
+          case e: LDAPException                                              =>
+            LDAPRudderError.BackendException(s"Can not get tree '${dn.toString}': ${e.getDiagnosticMessage}", e).fail
+        },
+        all => {
+          if (all.getEntryCount() > 0) {
+            // build the tree
+            ZIO.fromEither(LDAPTree(all.getSearchEntries.asScala.map(x => LDAPEntry(x)))).asSome
+          } else ZIO.none
+        }
+      )
   }
 
 }

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPIOResult.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPIOResult.scala
@@ -43,7 +43,7 @@ object LDAPRudderError {
     override def fullMsg: String = s"${msg}; LDAP result was: ${result.getResultString}"
   }
 
-  final case class Consistancy(msg: String) extends LDAPRudderError
+  final case class Consistency(msg: String) extends LDAPRudderError
 
   // accumulated errors from multiple independent action
   final case class Accumulated(errors: NonEmptyList[RudderError]) extends LDAPRudderError {
@@ -65,13 +65,13 @@ object LDAPIOResult {
   implicit class StrictOption[T](opt: LDAPIOResult[Option[T]]) {
     def notOptional(msg: String): ZIO[Any, LDAPRudderError, T] = opt.flatMap(_ match {
       case Some(x) => x.succeed
-      case None    => LDAPRudderError.Consistancy(msg).fail
+      case None    => LDAPRudderError.Consistency(msg).fail
     })
   }
 
   // same than above for a Rudder error from a string
   implicit class ToFailureMsg(e: String) {
-    def fail: IO[LDAPRudderError.Consistancy, Nothing] = ZIO.fail(LDAPRudderError.Consistancy(e))
+    def fail: IO[LDAPRudderError.Consistency, Nothing] = ZIO.fail(LDAPRudderError.Consistency(e))
   }
 
   implicit class ValidatedToLdapError[T](res: ZIO[Any, NonEmptyList[LDAPRudderError], List[T]]) {
@@ -81,7 +81,7 @@ object LDAPIOResult {
   implicit class EitherToLdapError[T](res: Either[RudderError, T]) {
     def toLdapResult: LDAPIOResult[T] = {
       res match {
-        case Left(error) => LDAPRudderError.Consistancy(error.msg).fail
+        case Left(error) => LDAPRudderError.Consistency(error.msg).fail
         case Right(x)    => x.succeed
       }
     }

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPTree.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPTree.scala
@@ -23,15 +23,13 @@ package com.normation.ldap.sdk
 import cats.implicits.*
 import com.normation.ldap.ldif.ToLDIFRecords
 import com.normation.ldap.ldif.ToLDIFString
-import com.normation.ldap.sdk.LDAPIOResult.*
-import com.normation.ldap.sdk.LDAPRudderError.Consistancy
+import com.normation.ldap.sdk.LDAPRudderError.Consistency
 import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.RDN
 import com.unboundid.ldif.LDIFRecord
 import org.slf4j.Logger
 import scala.collection.mutable.Buffer
 import scala.collection.mutable.HashMap
-import zio.syntax.*
 
 /*
  * An LDAP tree of entries.
@@ -142,15 +140,15 @@ object LDAPTree {
    * All entries in the list safe one (the one that will become the root of the tree)
    * must have a direct parent in other entries.
    */
-  def apply(entries: Iterable[LDAPEntry]):                              LDAPIOResult[LDAPTree]                      = {
+  def apply(entries: Iterable[LDAPEntry]):                              Either[LDAPRudderError.Consistency, LDAPTree] = {
     if (null == entries || entries.isEmpty) {
-      LDAPRudderError.Consistancy(s"You can't create a Tree from an empty list of entries").fail
+      Left(LDAPRudderError.Consistency(s"You can't create a Tree from an empty list of entries"))
     }
     // verify that there is no duplicates
     else if (entries.map(_.dn).toSet.size != entries.size) {
       val s   = entries.map(_.dn).toSet
       val res = entries.map(_.dn).filter(x => !s.contains(x))
-      LDAPRudderError.Consistancy(s"Some entries have the same dn, what is forbiden: ${res.toString}").fail
+      Left(LDAPRudderError.Consistency(s"Some entries have the same dn, what is forbiden: ${res.toString}"))
     } else {
       val used = Buffer[DN]()
       /*
@@ -173,8 +171,8 @@ object LDAPTree {
 
       if (used.size < entries.size - 1) {
         val s = entries.map(_.dn).filter(x => !used.contains(x))
-        LDAPRudderError.Consistancy(s"Some entries have no parents: ${s.toString()}").fail
-      } else root.succeed
+        Left(LDAPRudderError.Consistency(s"Some entries have no parents: ${s.toString()}"))
+      } else Right(root)
     }
   }
   /*
@@ -184,10 +182,10 @@ object LDAPTree {
    * The comparison is strict, so that:
    * - if
    */
-  def diff(source: LDAPTree, target: LDAPTree, removeMissing: Boolean): Either[Consistancy, List[TreeModification]] = {
+  def diff(source: LDAPTree, target: LDAPTree, removeMissing: Boolean): Either[Consistency, List[TreeModification]]   = {
     if (source.root.dn != target.root.dn) {
       Left(
-        Consistancy(s"DN of the two LDAP tree's root are different: ${source.root.dn.toString()} <> ${target.root.dn.toString()}")
+        Consistency(s"DN of the two LDAP tree's root are different: ${source.root.dn.toString()} <> ${target.root.dn.toString()}")
       )
     } else {
       // modification on root

--- a/webapp/sources/scala-ldap/src/test/scala/com/normation/ldap/sdk/LDAPTreeTest.scala
+++ b/webapp/sources/scala-ldap/src/test/scala/com/normation/ldap/sdk/LDAPTreeTest.scala
@@ -20,7 +20,6 @@
 
 package com.normation.ldap.sdk
 
-import com.normation.zio.*
 import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.DN.NULL_DN
 import com.unboundid.ldap.sdk.RDN
@@ -74,7 +73,7 @@ class LDAPTreeTest extends Specification {
       LDAPEntry(new DN(rdn4, dn2))
     )
 
-    val optTree = ZioRuntime.unsafeRun(LDAPTree(entries).either)
+    val optTree = LDAPTree(entries)
     val tree    = optTree.getOrElse(throw new IllegalArgumentException("this is for test"))
     val mTree   = tree._children(rdn2)
 


### PR DESCRIPTION
https://issues.rudder.io/issues/26328

This is the backport (rebased) in 8.1 of several scala 3 related PR that were immediately portable: 
- https://github.com/Normation/rudder/pull/6148
- https://github.com/Normation/rudder/pull/6150
- https://github.com/Normation/rudder/pull/6146

Everything cleaning compile and tests pass. 

They are superseeded by that PR and can be closed once this one is merged. 