### PR TITLE
Fixes #26335: Port RestApiAccount api endpoint to zio-json 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/RestDataSerializer.scala
@@ -599,7 +599,7 @@ final case class RestDataSerializerImpl(
  * Between front and backend, we exchange a JsonAcl list, where JsonAcl are *just*
  * one path and one verb. The grouping is done in extractor
  */
-final case class JsonApiAcl(path: String, verb: String)
+final private case class JsonApiAcl(path: String, verb: String)
 
 object ApiAccountSerialisation {
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RoleApiMapping.scala
@@ -90,7 +90,7 @@ object AuthorizationApiMapping {
   }
 
   /*
-   * A default mapping for "only 'all rights' (ie admin) can access it
+   * A default mapping for "only 'all rights' (ie admin) can access it"
    */
   case object OnlyAdmin extends AuthorizationApiMapping {
     override def mapAuthorization(authz: AuthorizationType): List[ApiAclElement] = Nil

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/ApiAccount.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/ApiAccount.scala
@@ -1,0 +1,476 @@
+/*
+ *************************************************************************************
+ * Copyright 2025 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.rest.data
+
+import cats.implicits.*
+import com.normation.errors.IOResult
+import com.normation.rudder.api.AclPath
+import com.normation.rudder.api.ApiAccount
+import com.normation.rudder.api.ApiAccountId
+import com.normation.rudder.api.ApiAccountKind
+import com.normation.rudder.api.ApiAccountKind.PublicApi
+import com.normation.rudder.api.ApiAccountName
+import com.normation.rudder.api.ApiAccountType
+import com.normation.rudder.api.ApiAclElement
+import com.normation.rudder.api.ApiAuthorization
+import com.normation.rudder.api.ApiAuthorizationKind
+import com.normation.rudder.api.ApiToken
+import com.normation.rudder.api.HttpAction
+import com.normation.rudder.facts.nodes.NodeSecurityContext
+import com.normation.rudder.rest.data.NewApiAccount.transformNewApiAccount
+import com.normation.utils.DateFormaterService.DateTimeCodecs
+import com.softwaremill.quicklens.*
+import enumeratum.Enum
+import enumeratum.EnumEntry
+import io.scalaland.chimney.*
+import io.scalaland.chimney.syntax.*
+import java.time.ZonedDateTime
+import org.joda.time.DateTime
+import zio.json.*
+import zio.json.internal.Write
+import zio.syntax.*
+
+/*
+ * Data for API accounts.
+ * We are a bit more careful about what is sent because we don't ever want to send
+ * back Token by API apart when generated.
+ * Same, data creation and update is a bit different for API account.
+ */
+
+/**
+ * Account status: enabled or not
+ */
+sealed trait ApiAccountStatus extends EnumEntry with EnumEntry.Lowercase
+object ApiAccountStatus       extends Enum[ApiAccountStatus] {
+  case object Enabled  extends ApiAccountStatus
+  case object Disabled extends ApiAccountStatus
+
+  override def values: IndexedSeq[ApiAccountStatus] = findValues
+
+  implicit val codecApiAccountStatus: JsonCodec[ApiAccountStatus] = new JsonCodec[ApiAccountStatus](
+    JsonEncoder.string.contramap(_.entryName),
+    JsonDecoder.string.mapOrFail(withNameInsensitiveEither(_).left.map(_.getMessage()))
+  )
+}
+
+/**
+ * Token state: deleted, generated
+ */
+sealed trait ApiTokenState extends EnumEntry with EnumEntry.Lowercase
+object ApiTokenState       extends Enum[ApiTokenState] {
+  case object Missing   extends ApiTokenState
+  case object Generated extends ApiTokenState
+
+  override def values: IndexedSeq[ApiTokenState] = findValues
+
+  implicit val codecApiTokenState: JsonCodec[ApiTokenState] = new JsonCodec[ApiTokenState](
+    JsonEncoder.string.contramap(_.entryName),
+    JsonDecoder.string.mapOrFail(withNameInsensitiveEither(_).left.map(_.getMessage()))
+  )
+}
+
+sealed trait ApiAccountExpirationPolicy extends EnumEntry with EnumEntry.Lowercase
+object ApiAccountExpirationPolicy       extends Enum[ApiAccountExpirationPolicy] {
+
+  case object Never      extends ApiAccountExpirationPolicy
+  case object AtDateTime extends ApiAccountExpirationPolicy {
+    override def entryName: String = "datetime"
+  }
+
+  override def values: IndexedSeq[ApiAccountExpirationPolicy] = findValues
+
+  implicit val codecApiTokenExpirationPolicy: JsonCodec[ApiAccountExpirationPolicy] = new JsonCodec[ApiAccountExpirationPolicy](
+    JsonEncoder.string.contramap(_.entryName),
+    JsonDecoder.string.mapOrFail(withNameInsensitiveEither(_).left.map(_.getMessage()))
+  )
+}
+
+// Output DATA
+
+/**
+ * ACL
+ * Between front and backend, we exchange a JsonAcl list, where JsonAcl are *just*
+ * one path and one verb. The grouping is done in extractor.
+ * The objects are sorted by verb.
+ */
+final case class JsonApiPerm(path: String, verb: String)
+object JsonApiPerm {
+
+  /**
+   * Enforce that permissions are sorted by path first, then by verb
+   */
+  def from(acls: List[ApiAclElement]): List[JsonApiPerm] =
+    acls.flatMap(acl => acl.actions.map(a => JsonApiPerm(acl.path.value, a.name)).toList).sorted
+
+  implicit private val ordering: Ordering[JsonApiPerm] =
+    Ordering[String].on[JsonApiPerm](_.path).orElse(Ordering[String].on[JsonApiPerm](_.verb))
+}
+
+// default codecs for API accounts
+trait ApiAccountCodecs extends DateTimeCodecs {
+
+  implicit val accountIdEncoder:            JsonEncoder[ApiAccountId]         = JsonEncoder.string.contramap(_.value)
+  implicit val decoderApiAccountId:         JsonDecoder[ApiAccountId]         =
+    JsonDecoder.string.mapOrFail(ApiAccountId.parse(_).left.map(_.fullMsg))
+  implicit val accountNameEncoder:          JsonEncoder[ApiAccountName]       = JsonEncoder.string.contramap(_.value)
+  implicit val decoderApiAccountName:       JsonDecoder[ApiAccountName]       = JsonDecoder.string.map(ApiAccountName.apply)
+  implicit val accountTypeEncoder:          JsonEncoder[ApiAccountType]       = JsonEncoder.string.contramap(_.name)
+  implicit val decoderApiAccountType:       JsonDecoder[ApiAccountType]       =
+    JsonDecoder.string.mapOrFail(ApiAccountType.parse(_).left.map(_.fullMsg))
+  implicit val authorizationTypeEncoder:    JsonEncoder[ApiAuthorizationKind] = JsonEncoder.string.contramap(_.name)
+  implicit val decoderApiAuthorizationKind: JsonDecoder[ApiAuthorizationKind] =
+    JsonDecoder.string.mapOrFail(ApiAuthorizationKind.parse)
+  implicit val aclPermCodec:                JsonCodec[JsonApiPerm]            = DeriveJsonCodec.gen[JsonApiPerm]
+  // for acl, we decode into our business object to check for validity ASAP
+  implicit val decoderAcl:                  JsonDecoder[List[ApiAclElement]]  = JsonDecoder[List[JsonApiPerm]].mapOrFail {
+    _.traverse {
+      case JsonApiPerm(path, verb) =>
+        for {
+          p <- AclPath.parse(path)
+          v <- HttpAction.parse(verb)
+        } yield (p, v)
+    }.map(_.groupBy(_._1).toList.map {
+      case (p, seq) =>
+        ApiAclElement(p, seq.map(_._2).toSet)
+    })
+  }
+  implicit val encoderNodeSecurityContext:  JsonEncoder[NodeSecurityContext]  = JsonEncoder.string.contramap(_.serialize)
+  implicit val decoderNodeSecurityContext:  JsonDecoder[NodeSecurityContext]  =
+    JsonDecoder.string.mapOrFail(s => NodeSecurityContext.parse(Some(s)).left.map(_.fullMsg))
+}
+
+sealed trait ApiAccountDetails {
+  def id:                  ApiAccountId
+  def name:                ApiAccountName               // used in event log to know who did actions.
+  def description:         String
+  def status:              ApiAccountStatus
+  def creationDate:        ZonedDateTime
+  def expirationPolicy:    ApiAccountExpirationPolicy   // this is expiration for the whole account
+  def expirationDate:      Option[ZonedDateTime]        // this is expiration for the whole account
+  def tokenState:          ApiTokenState
+  def tokenGenerationDate: Option[ZonedDateTime]
+  def tenants:             NodeSecurityContext
+  def authorizationType:   Option[ApiAuthorizationKind] // ApiAuthorization.kind
+  def acl:                 Option[List[JsonApiPerm]]
+}
+
+final case class ClearTextSecret(value: String)
+
+object ApiAccountDetails extends ApiAccountCodecs {
+
+  /**
+   * General data structure about a public API account details. Some notes:
+   * - kind is not returned (only public accounts are returned here)
+   * - token value is never returned here, in place token info is returned:
+   *   - a token can not be generated for the account
+   *   - if it is, then we also return the generation date,
+   *   - a generated token has an expiration policy,
+   *   - if it is generated and it expires, we return the expiration date
+   */
+  final case class Public(
+      id:                  ApiAccountId,
+      name:                ApiAccountName,
+      description:         String,
+      status:              ApiAccountStatus,
+      creationDate:        ZonedDateTime,
+      expirationPolicy:    ApiAccountExpirationPolicy,
+      expirationDate:      Option[ZonedDateTime],
+      tokenState:          ApiTokenState,
+      tokenGenerationDate: Option[ZonedDateTime],
+      tenants:             NodeSecurityContext,
+      authorizationType:   Option[ApiAuthorizationKind],
+      acl:                 Option[List[JsonApiPerm]]
+  ) extends ApiAccountDetails
+
+  final case class WithToken(
+      id:                  ApiAccountId,
+      name:                ApiAccountName,
+      description:         String,
+      status:              ApiAccountStatus,
+      creationDate:        ZonedDateTime,
+      expirationPolicy:    ApiAccountExpirationPolicy,
+      expirationDate:      Option[ZonedDateTime],
+      tokenState:          ApiTokenState,
+      tokenGenerationDate: Option[ZonedDateTime],
+      token:               ClearTextSecret,
+      tenants:             NodeSecurityContext,
+      authorizationType:   Option[ApiAuthorizationKind],
+      acl:                 Option[List[JsonApiPerm]]
+  ) extends ApiAccountDetails
+
+  // only encode, no decoder for that
+  implicit val encoderClearTextSecret:            JsonEncoder[ClearTextSecret]                       = JsonEncoder.string.contramap(_.value)
+  implicit val encoderApiAccountDetailsPublic:    JsonEncoder[ApiAccountDetails.Public]              = DeriveJsonEncoder.gen
+  implicit val encoderApiAccountDetailsWithToken: JsonEncoder[ApiAccountDetails.WithToken]           = DeriveJsonEncoder.gen
+  implicit val encoderApiAccountDetails:          JsonEncoder[ApiAccountDetails]                     = new JsonEncoder[ApiAccountDetails] {
+    override def unsafeEncode(a: ApiAccountDetails, indent: Option[Int], out: Write): Unit = {
+      a match {
+        case x: ApiAccountDetails.Public    => encoderApiAccountDetailsPublic.unsafeEncode(x, indent, out)
+        case x: ApiAccountDetails.WithToken => encoderApiAccountDetailsWithToken.unsafeEncode(x, indent, out)
+      }
+    }
+  }
+  implicit val transformApiAccountKindExpDT:      Transformer[ApiAccountKind, Option[ZonedDateTime]] = {
+    case ApiAccountKind.System | ApiAccountKind.User => None
+    case PublicApi(_, expirationDate)                => expirationDate.map(_.transformInto[ZonedDateTime])
+  }
+
+  implicit val transformApiAccountKindExpPol: Transformer[ApiAccountKind, ApiAccountExpirationPolicy] = {
+    case PublicApi(_, expirationDate) if (expirationDate.isDefined) => ApiAccountExpirationPolicy.AtDateTime
+    case _                                                          => ApiAccountExpirationPolicy.Never
+  }
+
+  implicit val transformApiAclElement: Transformer[List[ApiAclElement], List[JsonApiPerm]] = JsonApiPerm.from _
+
+  // authorization name is only defined for public API
+  implicit val transformApiAccountKindAuthz: Transformer[ApiAccountKind, Option[ApiAuthorizationKind]] = {
+    case ApiAccountKind.System | ApiAccountKind.User => None
+    case PublicApi(authz, _)                         => Some(authz.kind)
+  }
+
+  // ACLs are only defined for authorization kind = ACLs (and we ungroup path on each verb)
+  implicit val transformApiAccountKindAcl: Transformer[ApiAccountKind, Option[List[JsonApiPerm]]] = {
+    case PublicApi(ApiAuthorization.ACL(list), _) => Some(list.transformInto[List[JsonApiPerm]])
+    case _                                        => None
+  }
+
+  private def transformApiAccountDetails[A <: ApiAccountDetails] = Transformer
+    .define[ApiAccount, A]
+    .withFieldComputed(_.status, x => if (x.isEnabled) ApiAccountStatus.Enabled else ApiAccountStatus.Disabled)
+    .withFieldComputed(_.expirationPolicy, _.kind.transformInto[ApiAccountExpirationPolicy])
+    .withFieldComputed(_.expirationDate, _.kind.transformInto[Option[ZonedDateTime]])
+    .withFieldComputed(_.tokenState, x => if (x.token.isEmpty) ApiTokenState.Missing else ApiTokenState.Generated)
+    .withFieldComputed(_.authorizationType, _.kind.transformInto[Option[ApiAuthorizationKind]])
+    .withFieldComputed(_.acl, _.kind.transformInto[Option[List[JsonApiPerm]]])
+
+  implicit val transformPublicApi: Transformer[ApiAccount, ApiAccountDetails.Public] = {
+    transformApiAccountDetails[ApiAccountDetails.Public]
+      .withFieldComputed(_.tokenGenerationDate, x => x.token.map(_ => x.tokenGenerationDate.transformInto[ZonedDateTime]))
+      .buildTransformer
+  }
+
+  def transformWithTokenApi(secret: ClearTextSecret): Transformer[ApiAccount, ApiAccountDetails.WithToken] = {
+    transformApiAccountDetails[ApiAccountDetails.WithToken]
+      .withFieldConst(_.token, secret)
+      .buildTransformer
+  }
+}
+
+// Input DATA
+
+/**
+ * Things that changed since 8.3 :
+ * - no more `oldId` supported
+ * - boolean "enabled" is replaced with a status "enabled/disabled"
+ * - there is an explicit expirationPolicy in place of expirationDateDefined
+ * - expirationDate is an option
+ */
+final case class NewApiAccount(
+    id:                Option[ApiAccountId],
+    name:              ApiAccountName, // used in event log to know who did actions.
+    description:       Option[String],
+    status:            ApiAccountStatus,
+    tenants:           NodeSecurityContext,
+    generateToken:     Option[Boolean],
+    expirationPolicy:  Option[ApiAccountExpirationPolicy],
+    expirationDate:    Option[ZonedDateTime],
+    authorizationType: Option[ApiAuthorizationKind],
+    acl:               Option[List[ApiAclElement]]
+)
+
+/**
+ * This is the object where lies most of the logic that interprets an API account input
+ */
+object NewApiAccount extends ApiAccountCodecs {
+  implicit val decoderNewApiAccount: JsonDecoder[NewApiAccount] = DeriveJsonDecoder.gen
+
+  // build transformer with dependencies
+  def transformNewApiAccount(
+      d:  DateTime,
+      id: ApiAccountId,
+      t:  Option[ApiToken]
+  ): Transformer[NewApiAccount, ApiAccount] = {
+    Transformer
+      .define[NewApiAccount, ApiAccount]
+      .withFieldConst(_.id, id)
+      .withFieldComputed(
+        _.kind,
+        x => {
+          ApiAccountMapping
+            .apiKind(x.authorizationType.getOrElse(ApiAuthorizationKind.None), x.acl, d, x.expirationPolicy, x.expirationDate)
+        }
+      )
+      .withFieldComputed(_.description, _.description.getOrElse(""))
+      .withFieldConst(_.token, t)
+      .withFieldComputed(_.isEnabled, _.status == ApiAccountStatus.Enabled)
+      .withFieldConst(_.creationDate, d)
+      .withFieldConst(_.tokenGenerationDate, d) // should be optional no?
+      .buildTransformer
+  }
+}
+
+final case class UpdateApiAccount(
+    name:              Option[ApiAccountName],
+    description:       Option[String],
+    status:            Option[ApiAccountStatus],
+    tenants:           Option[NodeSecurityContext],
+    expirationPolicy:  Option[ApiAccountExpirationPolicy],
+    expirationDate:    Option[ZonedDateTime],
+    authorizationType: Option[ApiAuthorizationKind],
+    acl:               Option[List[ApiAclElement]]
+)
+
+object UpdateApiAccount extends ApiAccountCodecs {
+  implicit val decoderUpdateApiAccount: JsonDecoder[UpdateApiAccount] = DeriveJsonDecoder.gen
+}
+
+/**
+ * Transformation service for the part with effects / injection
+ * of other needed services
+ */
+class ApiAccountMapping(
+    creationDate:   IOResult[DateTime],
+    generateId:     IOResult[ApiAccountId],
+    generateSecret: IOResult[ClearTextSecret],
+    createToken:    ClearTextSecret => IOResult[ApiToken]
+) extends DateTimeCodecs {
+
+  /**
+   * Create a new ApiAccount and optionally return the secret used for the token
+   */
+  def fromNewApiAccount(newApiAccount: NewApiAccount): IOResult[(ApiAccount, Option[ClearTextSecret])] = {
+    for {
+      id     <- newApiAccount.id match {
+                  case Some(x) => x.succeed
+                  case None    => generateId
+                }
+      secret <- if (newApiAccount.generateToken.getOrElse(true)) generateSecret.map(Some.apply) else None.succeed
+      token  <- secret match {
+                  case Some(s) => createToken(s).map(Some.apply)
+                  case None    => None.succeed
+                }
+      d      <- creationDate
+    } yield (transformNewApiAccount(d, id, token).transform(newApiAccount), secret)
+  }
+
+  /**
+   * Update an ApiAccount from Rest data
+   */
+  def update(account: ApiAccount, up: UpdateApiAccount): ApiAccount = {
+    account
+      .modify(_.name)
+      .setToIfDefined(up.name)
+      .modify(_.isEnabled)
+      .setToIfDefined(up.status.map(_ == ApiAccountStatus.Enabled))
+      .modify(_.tenants)
+      .setToIfDefined(up.tenants)
+      .modify(_.kind)
+      .using {
+        case ApiAccountKind.PublicApi(a, e) =>
+          val authz = up.authorizationType.map(x => ApiAccountMapping.authz(x, up.acl))
+          val exp   = {
+            // if we go from "never" to "datetime" without a date, now + 1 month
+            (e, up.expirationPolicy, up.expirationDate) match {
+              case (None, None, None)                                        => None
+              case (_, Some(ApiAccountExpirationPolicy.Never), _)            => None
+              case (_, _, Some(d))                                           => Some(d.transformInto[DateTime])
+              case (None, Some(ApiAccountExpirationPolicy.AtDateTime), None) => Some(DateTime.now())
+              case (Some(e), _, None)                                        => Some(e)
+            }
+          }
+          ApiAccountKind.PublicApi(authz.getOrElse(a), exp)
+        case x                              => x
+      }
+  }
+
+  def updateToken(account: ApiAccount): IOResult[(ApiAccount, ClearTextSecret)] = {
+    for {
+      s <- generateSecret
+      t <- createToken(s)
+      n <- creationDate
+    } yield {
+      val a = account.modify(_.token).setTo(Some(t)).modify(_.tokenGenerationDate).setTo(n)
+      (a, s)
+    }
+  }
+
+  def toDetailsWithSecret(account: ApiAccount, secret: ClearTextSecret): ApiAccountDetails.WithToken = {
+    ApiAccountDetails.transformWithTokenApi(secret).transform(account)
+  }
+
+}
+
+object ApiAccountMapping extends DateTimeCodecs {
+
+  // from an API authz kind and acl, build the public API
+  def authz(k: ApiAuthorizationKind, acl: Option[List[ApiAclElement]]): ApiAuthorization = {
+    k match {
+      case ApiAuthorizationKind.None => ApiAuthorization.None
+      case ApiAuthorizationKind.RO   => ApiAuthorization.RO
+      case ApiAuthorizationKind.RW   => ApiAuthorization.RW
+      case ApiAuthorizationKind.ACL  =>
+        acl match {
+          case None       => ApiAuthorization.ACL(Nil)
+          case Some(list) => ApiAuthorization.ACL(list)
+        }
+    }
+  }
+
+  // if expiration policy is missing, it's datetime by default
+  // if expiration date is missing, it's one month ahead by default
+  def exp(now: DateTime, policy: Option[ApiAccountExpirationPolicy], date: Option[ZonedDateTime]): Option[DateTime] = {
+    policy match {
+      case Some(ApiAccountExpirationPolicy.Never) => None
+      case _                                      =>
+        date match {
+          case Some(d) => Some(d.transformInto[DateTime])
+          case None    => Some(now.plusMonths(1))
+        }
+    }
+  }
+
+  def apiKind(
+      a:       ApiAuthorizationKind,
+      acl:     Option[List[ApiAclElement]],
+      now:     DateTime,
+      expPol:  Option[ApiAccountExpirationPolicy],
+      expDate: Option[ZonedDateTime]
+  ): ApiAccountKind.PublicApi = {
+    ApiAccountKind.PublicApi(authz(a, acl), exp(now, expPol, expDate))
+  }
+}

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestApiAccounts.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestApiAccounts.scala
@@ -72,10 +72,10 @@ class RestApiAccounts(
 
   // used in ApiAccounts snippet to get the context path
   // of that service
-  val relativePath: List[String] = "secure" :: "apiaccounts" :: Nil
+  val relativePath: List[String] = "oldapiaccounttoremove" :: Nil
 
   serve {
-    case Get("secure" :: "apiaccounts" :: Nil, req) =>
+    case Get("oldapiaccounttoremove" :: Nil, req) =>
       implicit val prettify: Boolean = restExtractor
         .extractBoolean("prettify")(req)(identity)
         .getOrElse(Some(false))
@@ -119,7 +119,7 @@ class RestApiAccounts(
 
       })
 
-    case "secure" :: "apiaccounts" :: Nil JsonPut body -> req =>
+    case "oldapiaccounttoremove" :: Nil JsonPut body -> req =>
       implicit val prettify: Boolean = restExtractor
         .extractBoolean("prettify")(req)(identity)
         .getOrElse(Some(false))
@@ -198,7 +198,7 @@ class RestApiAccounts(
           toJsonError(None, "No Json data sent")
       })
 
-    case "secure" :: "apiaccounts" :: tokenId :: Nil JsonPost body -> req =>
+    case "oldapiaccounttoremove" :: tokenId :: Nil JsonPost body -> req =>
       val apiTokenId = ApiAccountId(tokenId)
       implicit val prettify: Boolean = restExtractor
         .extractBoolean("prettify")(req)(identity)
@@ -235,7 +235,7 @@ class RestApiAccounts(
           toJsonError(None, "No Json data sent")
       })
 
-    case Delete("secure" :: "apiaccounts" :: tokenId :: Nil, req) =>
+    case Delete("oldapiaccounttoremove" :: tokenId :: Nil, req) =>
       val apiTokenId = ApiAccountId(tokenId)
       implicit val prettify: Boolean = restExtractor
         .extractBoolean("prettify")(req)(identity)
@@ -267,7 +267,7 @@ class RestApiAccounts(
           toJsonError(None, s"Could not delete account ${tokenId} cause: ${err.fullMsg}")
       })
 
-    case Post("secure" :: "apiaccounts" :: tokenId :: "regenerate" :: Nil, req) =>
+    case Post("oldapiaccounttoremove" :: tokenId :: "regenerate" :: Nil, req) =>
       val apiTokenId = ApiAccountId(tokenId)
       implicit val prettify: Boolean = restExtractor
         .extractBoolean("prettify")(req)(identity)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ApiAccountApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ApiAccountApi.scala
@@ -1,0 +1,226 @@
+/*
+ *************************************************************************************
+ * Copyright 2025 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.rest.lift
+
+import com.normation.errors.*
+import com.normation.eventlog.ModificationId
+import com.normation.rudder.api.*
+import com.normation.rudder.apidata.ZioJsonExtractor
+import com.normation.rudder.domain.logger.ApiLoggerPure
+import com.normation.rudder.rest.*
+import com.normation.rudder.rest.ApiAccounts as API
+import com.normation.rudder.rest.data.*
+import com.normation.rudder.rest.implicits.*
+import com.normation.rudder.users.UserService
+import com.normation.utils.StringUuidGenerator
+import io.scalaland.chimney.syntax.*
+import net.liftweb.http.*
+import org.joda.time.DateTime
+import zio.syntax.*
+
+/*
+ * API account management with API.
+ */
+class ApiAccountApi(
+    service: ApiAccountApiService
+) extends LiftApiModuleProvider[API] {
+
+  def schemas: ApiModuleProvider[API] = API
+
+  def getLiftEndpoints(): List[LiftApiModule] = {
+    API.endpoints.map {
+      case API.GetAllAccounts  => GetAllAccounts
+      case API.GetAccount      => GetAccount
+      case API.CreateAccount   => CreateAccount
+      case API.UpdateAccount   => UpdateAccount
+      case API.RegenerateToken => RegenerateToken
+      case API.DeleteAccount   => DeleteAccount
+    }
+  }
+
+  // utility method to check that the string for ID is a valid account ID.
+  def toId(s: String): IOResult[ApiAccountId] = ApiAccountId.parse(s).toIO
+
+  /*
+   * Return only public API accounts
+   */
+  object GetAllAccounts extends LiftApiModule0 {
+    val schema: API.GetAllAccounts.type = API.GetAllAccounts
+
+    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      service.getAccounts().toLiftResponseList(params, schema)
+    }
+  }
+
+  object GetAccount extends LiftApiModule {
+    val schema: API.GetAccount.type = API.GetAccount
+
+    def process(v: ApiVersion, path: ApiPath, s: String, req: Req, params: DefaultParams, t: AuthzToken): LiftResponse = {
+      (for {
+        id <- toId(s)
+        r  <- service.getAccount(id)
+      } yield r).toLiftResponseOne(params, schema, Some(s))
+    }
+  }
+
+  object CreateAccount extends LiftApiModule0 {
+    val schema: API.CreateAccount.type = API.CreateAccount
+
+    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+      (for {
+        account <- ZioJsonExtractor.parseJson[NewApiAccount](req).toIO
+        res     <- service.saveAccount(account)
+      } yield res).toLiftResponseOne(params, schema, x => Some(x.id.value))
+    }
+  }
+
+  object UpdateAccount extends LiftApiModule {
+    val schema: API.UpdateAccount.type = API.UpdateAccount
+
+    def process(v: ApiVersion, path: ApiPath, s: String, req: Req, params: DefaultParams, t: AuthzToken): LiftResponse = {
+      (for {
+        id      <- toId(s)
+        account <- ZioJsonExtractor.parseJson[UpdateApiAccount](req).toIO
+        res     <- service.updateAccount(id, account)
+      } yield res).toLiftResponseOne(params, schema, x => Some(x.id.value))
+    }
+  }
+
+  object RegenerateToken extends LiftApiModule {
+    val schema: API.RegenerateToken.type = API.RegenerateToken
+
+    def process(v: ApiVersion, path: ApiPath, s: String, req: Req, params: DefaultParams, t: AuthzToken): LiftResponse = {
+      (for {
+        id <- toId(s)
+        r  <- service.regenerateToken(id)
+      } yield r).toLiftResponseOne(params, schema, Some(s))
+    }
+  }
+
+  object DeleteAccount extends LiftApiModule {
+    val schema: API.DeleteAccount.type = API.DeleteAccount
+
+    def process(v: ApiVersion, path: ApiPath, s: String, req: Req, params: DefaultParams, t: AuthzToken): LiftResponse = {
+      (for {
+        id <- toId(s)
+        r  <- service.deleteAccount(id)
+      } yield r).toLiftResponseOne(params, schema, Some(s))
+    }
+  }
+}
+
+trait ApiAccountApiService {
+  def getAccounts(): IOResult[List[ApiAccountDetails.Public]]
+  def getAccount(id:       ApiAccountId): IOResult[Option[ApiAccountDetails.Public]]
+  def saveAccount(account: NewApiAccount): IOResult[ApiAccountDetails]
+  def updateAccount(id:    ApiAccountId, data: UpdateApiAccount): IOResult[ApiAccountDetails.Public]
+  def regenerateToken(id:  ApiAccountId): IOResult[ApiAccountDetails]
+  def deleteAccount(id:    ApiAccountId): IOResult[Option[ApiAccountDetails.Public]]
+}
+
+class ApiAccountApiServiceV1(
+    readApi:        RoApiAccountRepository,
+    writeApi:       WoApiAccountRepository,
+    tokenGenerator: TokenGenerator,
+    uuidGen:        StringUuidGenerator,
+    userService:    UserService
+) extends ApiAccountApiService {
+  // mapping from/to rest data
+  private val mapper = {
+    val getNow         = DateTime.now().succeed
+    val generateId     = ApiAccountId(uuidGen.newUuid).succeed
+    val generateSecret = ClearTextSecret(ApiToken.generate_secret(tokenGenerator)).succeed
+    def generateToken(secret: ClearTextSecret): IOResult[ApiToken] = ApiToken(ApiToken.hash(secret.value)).succeed
+
+    new ApiAccountMapping(getNow, generateId, generateSecret, generateToken)
+  }
+
+  override def getAccounts(): IOResult[List[ApiAccountDetails.Public]] = {
+    readApi.getAllStandardAccounts.map(_.toList.map(_.transformInto[ApiAccountDetails.Public]))
+  }
+
+  override def getAccount(id: ApiAccountId): IOResult[Option[ApiAccountDetails.Public]] = {
+    readApi.getById(id).flatMap {
+      case None                                                                  =>
+        None.succeed
+      case Some(account) if (account.kind.kind.name == ApiAccountType.PublicApi) =>
+        Some(account.transformInto[ApiAccountDetails.Public]).succeed
+      case Some(x)                                                               =>
+        ApiLoggerPure.warn(s"Access to API account with ID '${id.value}' is not authorized via API") *>
+        None.succeed
+    }
+  }
+
+  override def saveAccount(data: NewApiAccount): IOResult[ApiAccountDetails] = {
+    for {
+      pair <- mapper.fromNewApiAccount(data)
+      _    <- writeApi.save(pair._1, ModificationId(uuidGen.newUuid), userService.getCurrentUser.actor)
+    } yield {
+      pair._2 match {
+        case Some(s) => mapper.toDetailsWithSecret(pair._1, s)
+        case None    => pair._1.transformInto[ApiAccountDetails.Public]
+      }
+    }
+  }
+
+  override def updateAccount(id: ApiAccountId, data: UpdateApiAccount): IOResult[ApiAccountDetails.Public] = {
+    for {
+      a <- readApi.getById(id).notOptional(s"API account with ID '${id.value}' was not found")
+      up = mapper.update(a, data)
+      _ <- writeApi.save(up, ModificationId(uuidGen.newUuid), userService.getCurrentUser.actor)
+    } yield up.transformInto[ApiAccountDetails.Public]
+  }
+
+  override def regenerateToken(id: ApiAccountId): IOResult[ApiAccountDetails] = {
+    for {
+      a    <- readApi.getById(id).notOptional(s"API account with ID '${id.value}' was not found")
+      pair <- mapper.updateToken(a)
+      _    <- writeApi.save(pair._1, ModificationId(uuidGen.newUuid), userService.getCurrentUser.actor)
+    } yield mapper.toDetailsWithSecret.tupled(pair)
+  }
+
+  override def deleteAccount(id: ApiAccountId): IOResult[Option[ApiAccountDetails.Public]] = {
+    for {
+      opt <- readApi.getById(id)
+      _   <- opt match {
+               case None    => None.succeed
+               case Some(_) => writeApi.delete(id, ModificationId(uuidGen.newUuid), userService.getCurrentUser.actor)
+             }
+    } yield opt.map(_.transformInto[ApiAccountDetails.Public])
+  }
+}

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_accounts.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_accounts.yml
@@ -1,0 +1,293 @@
+description: Get all API accounts
+method: GET
+url: /api/apiaccounts
+response:
+  code: 200
+  content: >-
+    {
+      "action":"getAllAccounts",
+      "result":"success",
+      "data" : {
+        "accounts" : [
+          {
+            "id" : "user1",
+            "name" : "user one",
+            "description" : "number one user",
+            "status" : "enabled",
+            "creationDate" : "2025-02-12T10:55:00Z",
+            "expirationPolicy" : "never",
+            "tokenState" : "generated",
+            "tokenGenerationDate" : "2025-02-12T10:55:00Z",
+            "tenants" : "*",
+            "authorizationType" : "rw"
+          },
+          {
+            "id" : "user2",
+            "name" : "user2",
+            "description" : "number one user",
+            "status" : "enabled",
+            "creationDate" : "2025-02-12T10:55:00Z",
+            "expirationPolicy" : "datetime",
+            "expirationDate" : "2025-08-12T00:00:00Z",
+            "tokenState" : "generated",
+            "tokenGenerationDate" : "2025-02-12T10:55:00Z",
+            "tenants" : "zone1",
+            "authorizationType" : "acl",
+            "acl" : [
+              {
+                "path" : "some/endpoint/*",
+                "verb" : "get"
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Get one API accounts
+method: GET
+url: /api/apiaccounts/user1
+response:
+  code: 200
+  content: >-
+    {
+      "action":"getAccount",
+      "id" : "user1",
+      "result":"success",
+      "data" : {
+        "accounts" : [
+          {
+            "id" : "user1",
+            "name" : "user one",
+            "description" : "number one user",
+            "status" : "enabled",
+            "creationDate" : "2025-02-12T10:55:00Z",
+            "expirationPolicy" : "never",
+            "tokenState" : "generated",
+            "tokenGenerationDate" : "2025-02-12T10:55:00Z",
+            "tenants" : "*",
+            "authorizationType" : "rw"
+          }
+        ]
+      }
+    }
+---
+description: Get one API accounts - bad ID
+method: GET
+url: /api/apiaccounts/user+1
+response:
+  code: 500
+  content: >-
+    {
+      "action":"getAccount",
+      "id" : "user+1",
+      "result" : "error",
+      "errorDetails" : "Inconsistency: 'user+1' is not a valid API account ID, only [a-zA-Z0-9_-]+ is allowed"
+    }
+---
+description: Create a new API account (no ID provided, token generated, default exp)
+method: POST
+url: /secure/api/apiaccounts
+headers:
+  - "Content-Type: application/json"
+body: >-
+    {
+      "name":"account 1",
+      "description":"account 1 description",
+      "expirationPolicy": "datetime",
+      "status": "enabled",
+      "generateToken":true,
+      "tenants":"*",
+      "authorizationType":"acl",
+      "acl":[
+        {
+          "path":"rules/tree",
+          "verb":"get"
+        },
+        {
+          "path":"rules/categories/*",
+          "verb":"get"
+        },
+        {
+          "path":"compliance/*",
+          "verb":"get"
+        }
+      ]
+    }
+response:
+  code: 200
+  content: >-
+    {
+      "action":"createAccount",
+      "id":"144ce2af-57d6-4e92-bdc1-1fdf2d88c2b1",
+      "result":"success",
+      "data":{
+        "accounts":[
+          {
+            "id":"144ce2af-57d6-4e92-bdc1-1fdf2d88c2b1",
+            "name":"account 1",
+            "description":"account 1 description",
+            "status": "enabled",
+            "creationDate": "2025-02-10T16:37:19Z",
+            "expirationPolicy": "datetime",
+            "expirationDate":"2025-03-10T16:37:19Z",
+            "tokenState" : "generated",
+            "tokenGenerationDate":"2025-02-10T16:37:19Z",
+            "token":"t1-ca5a50899d25cd3ff148350843a9d435",
+            "tenants":"*",
+            "authorizationType":"acl",
+            "acl":[
+              {
+                "path":"compliance/*",
+                "verb":"get"
+              },
+              {
+                "path":"rules/categories/*",
+                "verb":"get"
+              },
+              {
+                "path":"rules/tree",
+                "verb":"get"
+              }
+            ]
+          }
+        ]
+      }
+    }
+---
+description: Create a new API account (no ID provided, no token generated)
+method: POST
+url: /secure/api/apiaccounts
+headers:
+  - "Content-Type: application/json"
+body: >-
+    {
+      "name":"account 2",
+      "description":"this is a demo account with only compliance and rules (GET) access",
+      "expirationDate":"2025-05-22T17:35:00Z",
+      "status": "disabled",
+      "generateToken":false,
+      "tenants":"-",
+      "authorizationType":"none"
+    }
+response:
+  code: 200
+  content: >-
+    {
+      "action":"createAccount",
+      "id":"e16114be-94ee-497f-8d17-7b258c8e5624",
+      "result":"success",
+      "data":{
+        "accounts":[
+          {
+            "id":"e16114be-94ee-497f-8d17-7b258c8e5624",
+            "name":"account 2",
+            "description":"this is a demo account with only compliance and rules (GET) access",
+            "status": "disabled",
+            "creationDate": "2025-02-10T16:37:19Z",
+            "expirationPolicy": "datetime",
+            "expirationDate":"2025-05-22T17:35:00Z",
+            "tokenState":"missing",
+            "tenants":"-",
+            "authorizationType":"none"
+          }
+        ]
+      }
+    }
+---
+description: Regenerate a token for a given api account
+method: POST
+url: /secure/api/apiaccounts/e16114be-94ee-497f-8d17-7b258c8e5624/regenerate
+headers:
+  - "Content-Type: application/json"
+response:
+  code: 200
+  content: >-
+    {
+      "action":"regenerateToken",
+      "id":"e16114be-94ee-497f-8d17-7b258c8e5624",
+      "result":"success",
+      "data":{
+        "accounts":[
+          {
+            "id":"e16114be-94ee-497f-8d17-7b258c8e5624",
+            "name":"account 2",
+            "description":"this is a demo account with only compliance and rules (GET) access",
+            "status": "disabled",
+            "creationDate": "2025-02-10T16:37:19Z",
+            "expirationPolicy": "datetime",
+            "expirationDate":"2025-05-22T17:35:00Z",
+            "tokenState":"generated",
+            "tokenGenerationDate":"2025-02-10T16:37:19Z",
+            "token":"t2-29d5c3cdca39bd7ba81e7e0f88084689",
+            "tenants":"-",
+            "authorizationType":"none"
+          }
+        ]
+      }
+    }
+---
+description: Update an API account - token not displayed
+method: POST
+url: /secure/api/apiaccounts/e16114be-94ee-497f-8d17-7b258c8e5624
+headers:
+  - "Content-Type: application/json"
+body: >-
+    {
+      "name":"account 2 updated",
+      "status": "enabled"
+    }
+response:
+  code: 200
+  content: >-
+    {
+      "action":"updateAccount",
+      "id":"e16114be-94ee-497f-8d17-7b258c8e5624",
+      "result":"success",
+      "data":{
+        "accounts":[
+          {
+            "id":"e16114be-94ee-497f-8d17-7b258c8e5624",
+            "name":"account 2 updated",
+            "description":"this is a demo account with only compliance and rules (GET) access",
+            "status": "enabled",
+            "creationDate": "2025-02-10T16:37:19Z",
+            "expirationPolicy": "datetime",
+            "expirationDate":"2025-05-22T17:35:00Z",
+            "tokenState":"generated",
+            "tokenGenerationDate":"2025-02-10T16:37:19Z",
+            "tenants":"-",
+            "authorizationType":"none"
+          }
+        ]
+      }
+    }
+---
+description: Delete an api account
+method: DELETE
+url: /secure/api/apiaccounts/e16114be-94ee-497f-8d17-7b258c8e5624
+response:
+  code: 200
+  content: >-
+    {
+      "action":"deleteAccount",
+      "id":"e16114be-94ee-497f-8d17-7b258c8e5624",
+      "result":"success",
+      "data":{
+        "accounts":[
+          {
+            "id":"e16114be-94ee-497f-8d17-7b258c8e5624",
+            "name":"account 2 updated",
+            "description":"this is a demo account with only compliance and rules (GET) access",
+            "status": "enabled",
+            "creationDate": "2025-02-10T16:37:19Z",
+            "expirationPolicy": "datetime",
+            "expirationDate":"2025-05-22T17:35:00Z",
+            "tokenState":"generated",
+            "tokenGenerationDate":"2025-02-10T16:37:19Z",
+            "tenants":"-",
+            "authorizationType":"none"
+          }
+        ]
+      }
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/data/ApiAccountTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/data/ApiAccountTest.scala
@@ -1,0 +1,119 @@
+/*
+ *************************************************************************************
+ * Copyright 2025 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.rest.data
+
+import com.normation.rudder.api.*
+import com.normation.utils.DateFormaterService.DateTimeCodecs
+import com.normation.zio.*
+import io.scalaland.chimney.syntax.*
+import java.time.ZonedDateTime
+import org.joda.time.DateTime
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+import zio.syntax.*
+
+@RunWith(classOf[JUnitRunner])
+class ApiAccountTest extends Specification with DateTimeCodecs {
+
+  private val now       = DateTime.parse("2025-02-10T10:10:10Z")
+  private val accountId = ApiAccountId("account1")
+  private val token     = ApiToken("token1")
+
+  // test transformer with fixed id generation, fix token id, fixe date now
+  private val mapper = new ApiAccountMapping(
+    now.succeed,
+    accountId.succeed,
+    ClearTextSecret(token.value).succeed,
+    s => ApiToken(s.value).succeed
+  )
+
+  "New account with the minimal of data get a new id and are limited to one month" >> {
+    val data = NewApiAccount(
+      None,
+      ApiAccountName("a1"),
+      None,
+      ApiAccountStatus.Disabled,
+      com.normation.rudder.facts.nodes.NodeSecurityContext.None,
+      None,
+      None,
+      None,
+      None,
+      None
+    )
+
+    val (account, _) = mapper.fromNewApiAccount(data).runNow
+
+    account.id === accountId
+    account.token === Some(token)
+    account.kind match {
+      case ApiAccountKind.PublicApi(_, expirationDate) =>
+        expirationDate === Some(now.plusMonths(1))
+      case x                                           => ko(s"The account type should not be '${x}'")
+    }
+    account.isEnabled === false
+  }
+
+  "If we fix expiration and account ID, they are fixed" >> {
+    val id         = ApiAccountId("defined-id")
+    val expiration = now.plusYears(1).transformInto[ZonedDateTime]
+
+    val data = NewApiAccount(
+      Some(id),
+      ApiAccountName("a2"),
+      None,
+      ApiAccountStatus.Disabled,
+      com.normation.rudder.facts.nodes.NodeSecurityContext.None,
+      None,
+      None,
+      Some(expiration),
+      None,
+      None
+    )
+
+    val (account, _) = mapper.fromNewApiAccount(data).runNow
+
+    account.id === id
+    account.token === Some(token)
+    account.kind match {
+      case ApiAccountKind.PublicApi(_, expirationDate) =>
+        expirationDate === Some(expiration.transformInto[DateTime])
+      case x                                           => ko(s"The account type should not be '${x}'")
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ApiCalls.elm
@@ -15,7 +15,7 @@ import Accounts.JsonEncoder exposing (..)
 
 getUrl: Model -> List String -> List QueryParameter -> String
 getUrl m url p=
-  Url.Builder.relative (m.contextPath :: "secure" :: url) p
+  Url.Builder.relative (m.contextPath :: "secure" :: "api" :: url) p
 
 getAccounts : Model -> Cmd Msg
 getAccounts model =
@@ -37,7 +37,7 @@ saveAccount : Account -> Model -> Cmd Msg
 saveAccount account model =
   let
     (method, url) = case model.ui.modalState of
-      NewAccount -> ("PUT",["apiaccounts"])
+      NewAccount -> ("POST",["apiaccounts"])
       _ -> ("POST", ["apiaccounts", account.id])
     req =
       request

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/DatePickerUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/DatePickerUtils.elm
@@ -7,6 +7,14 @@ import List.Extra exposing (getAt)
 import Date exposing (fromIsoString)
 
 import Accounts.DataTypes exposing (..)
+import String.Extra
+import Time.Iso8601
+import Time.DateTime exposing (DateTime)
+import Time.DateTime as DateTime
+import Time.Iso8601ErrorMsg
+import Time.Extra exposing (toOffset)
+import Time exposing (posixToMillis)
+import Time exposing (millisToPosix)
 
 
 isDateBeforeToday : Posix -> Posix -> Bool
@@ -104,36 +112,12 @@ getDateString datePickerInfo pickedTime =
     Nothing ->
       ""
 
-stringToPosix : DatePickerInfo -> String -> Maybe Posix
-stringToPosix datePickerInfo str =
--- Format : YYYY-MM-dd HH:mm
-  let
-    dateTimeString = String.split " " str
-    dateString = getAt 0 dateTimeString
-    timeString = getAt 1 dateTimeString
-  in
-    case (dateString, timeString) of
-      ( Just d, Just t) ->
-        let
-          date = fromIsoString d
-          decomposeTime = String.split ":" t
-          hourStr  = getAt 0 decomposeTime
-          minStr   = getAt 1 decomposeTime
-        in
-          case (date, hourStr, minStr) of
-            (Ok dd, Just strH, Just strM) -> case (String.toInt strH, String.toInt strM) of
-              (Just h, Just m) -> Just (partsToPosix datePickerInfo.zone (Parts (Date.year dd) (Date.month dd) (Date.day dd) h m 0 0))
-              _ -> Nothing
-            _ -> Nothing
-      _ -> Nothing
-
 posixToString : DatePickerInfo -> Posix -> String
 posixToString datePickerInfo p =
   (posixToDateString datePickerInfo.zone p ++ " " ++ posixToTimeString datePickerInfo.zone p)
 
 checkIfExpired : DatePickerInfo -> Account -> Bool
 checkIfExpired datePickerInfo account =
-  case (account.expirationDateDefined, account.expirationDate) of
-    ( False , _       ) -> False
-    ( True  , Nothing ) -> False
-    ( True  , Just p  ) -> isDateBeforeToday datePickerInfo.currentTime p
+  case account.expirationPolicy of
+    ExpireAtDate p -> isDateBeforeToday datePickerInfo.currentTime p
+    NeverExpire -> False

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/Init.elm
@@ -66,7 +66,7 @@ subscriptions model =
         ]
 
 
-init : { contextPath : String, hasWriteRights : Bool } -> ( Model, Cmd Msg )
+init : { contextPath : String, hasWriteRights : Bool, aclPluginEnabled:Bool, tenantsPluginEnabled: Bool } -> ( Model, Cmd Msg )
 init flags =
     let
         initDatePicker =
@@ -78,11 +78,25 @@ init flags =
             UI initFilters NoModal False True initDatePicker False False
 
         initModel =
-            Model flags.contextPath initUi [] False False Nothing
+            Model flags.contextPath initUi [] flags.aclPluginEnabled flags.tenantsPluginEnabled Nothing
+
+        initAclPlugin =
+            if flags.aclPluginEnabled && not initUi.pluginAclInit then
+                initAcl ""
+            else
+                Cmd.none
+
+        initTenantsPlugin =
+            if flags.tenantsPluginEnabled && not initUi.pluginTenantsInit then
+                initTenants ""
+            else
+                Cmd.none
 
         initActions =
             [ Task.perform Tick Time.now
             , Task.perform AdjustTimeZone Time.here
+            , initAclPlugin
+            , initTenantsPlugin
             ]
     in
     ( initModel, Cmd.batch initActions )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/JsonEncoder.elm
@@ -1,20 +1,26 @@
 module Accounts.JsonEncoder exposing (..)
 
 import Accounts.DataTypes exposing (..)
-import Accounts.DatePickerUtils exposing (posixToString)
 import Json.Encode exposing (..)
+import Json.Encode.Extra exposing (maybe)
+import Maybe.Extra
+import String.Extra
+import Time exposing (Month(..), Posix, Zone)
+import Time.DateTime exposing (..)
+import Time.Extra
+import Time.Iso8601
 
 
 encodeAccount : DatePickerInfo -> Account -> Value
-encodeAccount datePickerInfo account =
+encodeAccount { zone } account =
     let
-        ( expirationDate, expirationDateDefined ) =
-            case account.expirationDate of
-                Just d ->
-                    ( [ ( "expirationDate", string (posixToString datePickerInfo d) ) ], account.expirationDateDefined )
+        ( expirationPolicy, expirationDate ) =
+            case account.expirationPolicy of
+                ExpireAtDate d ->
+                    ( "datetime", [ ( "expirationDate", string (posixToIso8601 zone d) ) ] )
 
-                Nothing ->
-                    ( [], False )
+                NeverExpire ->
+                    ( "never", [] )
 
         acl =
             case account.acl of
@@ -23,19 +29,26 @@ encodeAccount datePickerInfo account =
 
                 Nothing ->
                     []
+
+        status =
+            if account.enabled then
+                "enabled"
+
+            else
+                "disabled"
+
+        id =
+            String.Extra.nonEmpty account.id
     in
     object
-        ([ ( "id", string account.id )
+        ([ ( "id", maybe string id )
          , ( "name", string account.name )
          , ( "description", string account.description )
-         , ( "authorizationType", string account.authorisationType )
-         , ( "kind", string account.kind )
-         , ( "enabled", bool account.enabled )
-         , ( "creationDate", string account.creationDate )
-         , ( "token", string account.token )
-         , ( "tokenGenerationDate", string account.tokenGenerationDate )
-         , ( "expirationDateDefined", bool expirationDateDefined )
+         , ( "status", string status )
          , ( "tenants", string (encodeTenants account.tenantMode account.selectedTenants) )
+         , ( "generateToken", bool (Maybe.Extra.isNothing id) )
+         , ( "authorizationType", string account.authorisationType )
+         , ( "expirationPolicy", string expirationPolicy )
          ]
             |> List.append expirationDate
             |> List.append acl
@@ -82,3 +95,65 @@ encodeAccountTenants accountId tenants =
         [ ( "id", string accountId )
         , ( "tenants", list string tenants )
         ]
+
+
+{-| Take a zone into account when encoding to date to ISO8601 from a POSIX.
+We need to translate into parts, otherwise we would lose zone information.
+-}
+posixToIso8601 : Zone -> Posix -> String
+posixToIso8601 zone p =
+    let
+        { year, month, day, hour, minute, second, millisecond } =
+            Time.Extra.posixToParts zone p
+    in
+    Time.DateTime.fromPosix p
+        |> setYear year
+        |> setMonth (monthToInt month)
+        |> setDay day
+        |> setHour hour
+        |> setMinute minute
+        |> setSecond second
+        |> setMillisecond millisecond
+        |> Time.Iso8601.fromDateTime
+
+
+{-| Library does not expose this
+-}
+monthToInt : Month -> Int
+monthToInt m =
+    case m of
+        Jan ->
+            1
+
+        Feb ->
+            2
+
+        Mar ->
+            3
+
+        Apr ->
+            4
+
+        May ->
+            5
+
+        Jun ->
+            6
+
+        Jul ->
+            7
+
+        Aug ->
+            8
+
+        Sep ->
+            9
+
+        Oct ->
+            10
+
+        Nov ->
+            11
+
+        Dec ->
+            12

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ApiAccounts.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ApiAccounts.scala
@@ -56,7 +56,9 @@ class ApiAccounts extends DispatchSnippet with DefaultExtendableSnippet[ApiAccou
   )
 
   def render(xml: NodeSeq): NodeSeq = <head>{
-    Script(JsRaw(s"""var apiPath = "${S.contextPath + relativePath}"; """))
+    Script(JsRaw(s"""const apiPath = "${S.contextPath + relativePath}";
+                    |const aclPluginEnabled = ${RudderConfig.apiAuthorizationLevelService.aclEnabled};
+                    |const tenantsPluginEnabled = ${RudderConfig.tenantService.tenantsEnabled};""".stripMargin))
   }</head> // JsRaw ok, const
 
 }

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/access/apiManagement.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/access/apiManagement.html
@@ -22,10 +22,12 @@
     <script>
       var app;
       $(document).ready(function () {
-        var main = document.getElementById("accounts-app")
-        var initValues = {
-          contextPath: contextPath
-          , hasWriteRights: hasWriteRights
+        const main = document.getElementById("accounts-app")
+        const initValues = {
+            contextPath: contextPath,
+            hasWriteRights: hasWriteRights,
+            aclPluginEnabled: aclPluginEnabled,
+            tenantsPluginEnabled: tenantsPluginEnabled
         };
 
         app = Elm.Accounts.init({node: main, flags: initValues});


### PR DESCRIPTION
https://issues.rudder.io/issues/26335

WIP status at 2025-02-14

- The backend is working accordingly to what we want, API tests work
- I didn't clean-up things for now: in particular `RestApiAccounts` must be deleted (butI did clean-up things related to the old format)
- elm does not work, at least because elm side isn't able to decode rfc3339 datetime and is expected an other format for the date pickler. 
    - there will be some other inconsistencies, since the API input for update / regenerate token / create token have changed a bit
    - I don't know if there's other things not working since for now, it's blocked here. 


On the backend side, the most notable change are that we have different data structures for different action and return values. 
In particular: 
- create and update are different, since when creating we need to be able to optionnaly choose ID and generate or not a token, 
- there is a difference between action that can expose a token (create, regenerate) and the one that just query information to avoid displaying a token. There is also a difference between the `ClearTextSecret` and the `ApiToken` (hashed).