### PR TITLE
Fixes #26338: Prettify About page

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/View.elm
@@ -1,6 +1,6 @@
 module About.View exposing (..)
 
-import Html exposing (Html, div, text, h1, h4, span, p, label, i, a, button, table, thead, tbody, td, th, tr)
+import Html exposing (Html, div, pre, text, h1, h4, span, p, label, i, a, button, table, thead, tbody, td, th, tr)
 import Html.Attributes exposing (class, title, type_)
 import Html.Events exposing (onClick)
 import Json.Encode exposing (Value, list, object)
@@ -47,15 +47,27 @@ view model =
 
             Just info ->
                 let
-                    rowTxtInfo : String -> String -> Html Msg
-                    rowTxtInfo title val =
-                        div[class "mb-1"]
-                            [ div[class "info"]
-                                [ label[][text title]
-                                , span[][text val]
-                                , btnCopy val
+                    rowTxtInfo : String -> String -> Bool -> Html Msg
+                    rowTxtInfo title val isCode =
+                        let
+                            element = if isCode then pre else span
+                            (value, btn) =
+                                if String.isEmpty val then
+                                    ( i[class "text-secondary"][text "No data available"]
+                                    , text ""
+                                    )
+                                else
+                                    ( element[][text val]
+                                    , btnCopy val
+                                    )
+                        in
+                            div[class "mb-1"]
+                                [ div[class "info"]
+                                    [ label[][text title]
+                                    , value
+                                    , btn
+                                    ]
                                 ]
-                            ]
 
                     rowNbInfo : String -> Int -> Html Msg
                     rowNbInfo title val =
@@ -63,7 +75,7 @@ view model =
                             str = String.fromInt val
                         in
                         div[class "mb-1"]
-                            [ div[class "info"]
+                            [ div[class "info align-items-center"]
                                 [ label[][text title]
                                 , span[class "ms-0 badge fs-6"][text str]
                                 , btnCopy str
@@ -216,9 +228,9 @@ view model =
                             , btnCopyJson "rudder" (encodeRudderInfo info.rudderInfo)
                             ]
                         , div[]
-                            [ rowTxtInfo "Version" info.rudderInfo.version
-                            , rowTxtInfo "Build" info.rudderInfo.buildTime
-                            , rowTxtInfo "Instance ID" info.rudderInfo.instanceId
+                            [ rowTxtInfo "Version" info.rudderInfo.version False
+                            , rowTxtInfo "Build" info.rudderInfo.buildTime False
+                            , rowTxtInfo "Instance ID" info.rudderInfo.instanceId False
                             , relaysList info.rudderInfo.relays model.ui
                             ]
                         ]
@@ -228,10 +240,10 @@ view model =
                             , btnCopyJson "system" (encodeSystemInfo info.system)
                             ]
                         , div[]
-                            [ rowTxtInfo "Operating system name" info.system.os.name
-                            , rowTxtInfo "Operating system version" info.system.os.version
-                            , rowTxtInfo "JVM version" info.system.jvm.version
-                            , rowTxtInfo "Launch options" info.system.jvm.cmd
+                            [ rowTxtInfo "Operating system name" info.system.os.name False
+                            , rowTxtInfo "Operating system version" info.system.os.version False
+                            , rowTxtInfo "JVM version" info.system.jvm.version False
+                            , rowTxtInfo "Launch options" info.system.jvm.cmd True
                             ]
                         ]
                     , div[class "mb-4"]

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-about.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-about.scss
@@ -39,8 +39,11 @@ $col-label-width: 200px;
 $margin-label : 10px;
 
 .info-container{
+  background: #fff;
+
   h4, label{
       width: $col-label-width;
+      min-width: $col-label-width;
       text-align: right;
   }
   label {
@@ -57,7 +60,6 @@ $margin-label : 10px;
   }
   .info{
     display: inline-flex;
-    align-items: center;
     position: relative;
     padding-right: 30px;
 
@@ -71,6 +73,19 @@ $margin-label : 10px;
       margin-left: 0;
       position: absolute;
       right: 0;
+      top: calc(50% - 15px);
+    }
+
+    pre {
+      white-space: normal;
+      background-color: rgb(248, 249, 252);
+      padding: 4px;
+      border-radius: 8px;
+      border: 1px solid rgb(214, 222, 239);
+      height: 100px;
+      max-height: 300px;
+      resize: vertical;
+      overflow: auto;
     }
   }
   h4 > .btn-goto.clipboard{


### PR DESCRIPTION
https://issues.rudder.io/issues/26338

- When there is an empty value, it is replaced by a grey text ‘No data available’, and there is no longer a copy-to-clipboard button in this case.

- The "Launch options" value can now be resized and scrolled, and cannot exceed a certain maximum height so that it doesn't take up too much vertical space

![about-2](https://github.com/user-attachments/assets/900e6e5b-a7e5-4e52-914c-dff07132d05d)
