### PR TITLE
Fixes #26342: Roles parsing for custom plugin role may fail in tests

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
@@ -69,6 +69,7 @@ import zio.Chunk
 @nowarn("msg=a type was inferred to be `AnyVal`")
 @RunWith(classOf[JUnitRunner])
 class RudderUserDetailsTest extends Specification {
+  sequential
 
   implicit class ForceEither[A](iores: IOResult[A]) {
     def force: A = iores.either.runNow match {


### PR DESCRIPTION
https://issues.rudder.io/issues/26342

I tried to run the test locally but could not reproduce the error, this line only appears in the CI : `WARN  application.authentication - Role 'role-a2' reference unknown role 'plugin': 'plugin' will be ignored.`, due to the [custom role](https://github.com/Normation/rudder/blob/516eabbfcd0dc9f31b0bf4c8ae03b28d6a3fc994/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala#L156) being expected to exist. 

I searched for any mutable state but did not found out a place where it could be mutated at all...
Let's just hope that making tests sequential will prevent them from failing :crossed_fingers: 
