### PR TITLE
Fixes #26336: Improve user interaction and displayed information on plugins management page 

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/elm.json
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/elm.json
@@ -30,6 +30,7 @@
             "elm-community/list-extra": "8.7.0",
             "elm-community/maybe-extra": "5.3.0",
             "elm-community/string-extra": "4.0.1",
+            "elm-explorations/test": "2.2.0",
             "hecrj/html-parser": "2.4.0",
             "isaacseymour/deprecated-time": "1.0.0",
             "jinjor/elm-debounce": "3.0.0",
@@ -59,12 +60,7 @@
         }
     },
     "test-dependencies": {
-        "direct": {
-            "elm-explorations/test": "2.1.2"
-        },
-        "indirect": {
-            "elm-community/basics-extra": "4.1.0",
-            "the-sett/elm-pretty-printer": "2.2.3"
-        }
+        "direct": {},
+        "indirect": {}
     }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Action.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Action.elm
@@ -1,0 +1,493 @@
+module Plugins.Action exposing
+    ( Action(..)
+    , ActionDisallowedResult(..)
+    , ActionModel(..)
+    , PluginActionResult
+    , PluginsAction(..)
+    , PluginsActionExplanation(..)
+    , actionText
+    , allSortedActionDisallowedResult
+    , explainDisallowedResult
+    , findPluginsAction
+    , initPluginsAction
+    , installUpgradeCount
+    , pluginAction
+    , successPluginsFromExplanation
+    )
+
+import Dict exposing (Dict)
+import List.Extra
+import Maybe.Extra
+import Ordering exposing (Ordering)
+import Plugins.PluginData exposing (..)
+import Set exposing (Set)
+import String.Extra
+
+
+{-| Summary of what an action was allowed to do, with optional disallowed with warning.
+It can be a useful description at any level.
+-}
+type Action
+    = ActionEnable
+    | ActionDisable
+    | ActionUninstall
+    | ActionInstall
+    | ActionUpgrade
+
+
+{-| Result computation on install status, activation status, and license status of a plugin.
+The license status cannot be changed, so it is just a limiting factor when associated with the others.
+The name is long and specific enough but also descriptive (it is a sentence), so that we can generate
+the message using the type.
+-}
+type ActionDisallowedResult
+    = PluginAlreadyUninstalled -- --    (InstallStatus ⊗ InstallStatus)
+    | PluginAlreadyEnabled -- --            (ActivationStatus ⊗ ActivationStatus)
+    | PluginAlreadyDisabled
+    | UninstalledPluginCannotBeEnabled
+    | UninstalledPluginCannotBeDisabled -- --       (InstallStatus ⊗ (ActivationStatus \ InstallStatus))
+    | IntegrationPluginCannotBeDisabled -- --       (PluginType ⊗ ActivationStatus)
+    | ExpiredLicensePreventPluginInstallation -- -- (LicenseStatus ⊗ InstallStatus)
+    | MissingLicensePreventPluginInstallation
+    | ExpiredLicensePreventPluginActivation -- --   (LicenseStatus ⊗ ActivationStatus)
+    | MissingLicensePreventPluginActivation
+
+
+
+-- We could add logic for when a plugin will restart, by defining results :
+-- e.g. uninstalling a disabled plugin
+-- We should just add such a result as a parameter to the associated result type below
+
+
+type ActionModel
+    = AllowedAction Action
+    | DisallowedAction ActionDisallowedResult
+
+
+{-| Action result for several plugins, merged and with exposed methods
+for creating and updating actions when plugins are updated.
+The model stores details that are handled internally as ActionModel.
+Instead we expose aggregated values :
+
+  - successCount is the filtered "AllowedAction" from details
+  - isActionDisabled = successCount == 0
+
+-}
+type PluginsAction
+    = PluginsAction PluginActionResult
+
+
+type alias PluginActionResult =
+    { successCount : Int
+    , isActionDisabled : Bool
+    , explanation : PluginsActionExplanation
+    }
+
+
+{-| Internally, it keeps all computed result for plugins, given an action
+-}
+type PluginsActionDetails
+    = PluginsActionDetails (Dict PluginId ActionModel)
+
+
+{-| We want to explain several cases, and we use several types,
+we also don't bother modeling non-empty collections as the type already explains it all
+(so, we are not modeling all edge cases of emptiness but only dispatching to the right case).
+
+The case of "upgrade" is specific because it is merged with the "install", so we need to consider all case where
+there could be upgrades, additionally to installs.
+
+So, either :
+
+  - we have no plugins/no triggered actions initally, so no exlanation
+  - all plugins action are allowed, given an action context (outside of this data, but it can be enabled, etc., except installed)
+  - all plugins actions are disallowed, plugins most likely have common reason to not be actionable, so we group them by error message
+  - some plugins actions are disallowed, a merged case for the two case above
+  - there are plugins install, and they are all allowed
+  - there are plugins install, but there is also some warning
+  - there are plugins upgrade, and they are all allowed
+  - there are plugins upgrade, but there is also some warning
+  - there are plugins install and upgrade, and they are all allowed
+  - there are plugins install and upgrade, but there is also some warning
+
+-}
+type PluginsActionExplanation
+    = PluginsActionNoExplanation
+    | PluginsActionExplainSuccess (Set PluginId)
+    | PluginsActionExplainErrors (List ( ActionDisallowedResult, Set PluginId ))
+    | PluginsActionExplainSuccessWarning { success : Set PluginId, warning : List ( ActionDisallowedResult, Set PluginId ) }
+    | PluginsActionExplainInstall (Set PluginId)
+    | PluginsActionExplainInstallWarning { install : Set PluginId, warning : List ( ActionDisallowedResult, Set PluginId ) }
+    | PluginsActionExplainUpgrade (Set PluginId)
+    | PluginsActionExplainUpgradeWarning { upgrade : Set PluginId, warning : List ( ActionDisallowedResult, Set PluginId ) }
+    | PluginsActionExplainInstallUpgrade { install : Set PluginId, upgrade : Set PluginId }
+    | PluginsActionExplainInstallUpgradeWarning { install : Set PluginId, upgrade : Set PluginId, warning : List ( ActionDisallowedResult, Set PluginId ) }
+
+
+initPluginsAction : PluginsAction
+initPluginsAction =
+    PluginsAction
+        { successCount = 0
+        , isActionDisabled = True
+        , explanation = PluginsActionNoExplanation
+        }
+
+
+pluginAction : ( PluginId, ActionModel ) -> PluginsAction
+pluginAction ( id, action ) =
+    let
+        ( count, isActionDisabled ) =
+            case action of
+                AllowedAction _ ->
+                    ( 1, False )
+
+                DisallowedAction _ ->
+                    ( 0, True )
+
+        details =
+            PluginsActionDetails (Dict.fromList [ ( id, action ) ])
+    in
+    PluginsAction
+        { successCount = count
+        , isActionDisabled = isActionDisabled
+        , explanation = explainPluginsAction details
+        }
+
+
+successPluginsFromExplanation : PluginsActionExplanation -> Set PluginId
+successPluginsFromExplanation x =
+    case x of
+        PluginsActionNoExplanation ->
+            Set.empty
+
+        PluginsActionExplainSuccess success ->
+            success
+
+        PluginsActionExplainErrors _ ->
+            Set.empty
+
+        PluginsActionExplainSuccessWarning { success } ->
+            success
+
+        PluginsActionExplainInstall success ->
+            success
+
+        PluginsActionExplainInstallWarning { install } ->
+            install
+
+        PluginsActionExplainUpgrade success ->
+            success
+
+        PluginsActionExplainUpgradeWarning { upgrade } ->
+            upgrade
+
+        PluginsActionExplainInstallUpgrade { install, upgrade } ->
+            Set.union install upgrade
+
+        PluginsActionExplainInstallUpgradeWarning { install, upgrade } ->
+            Set.union install upgrade
+
+
+{-| Is this input action an install ? An upgrade ? Both ?
+And how many of each ?
+-}
+installUpgradeCount : PluginsActionExplanation -> { install : Maybe Int, upgrade : Maybe Int }
+installUpgradeCount x =
+    let
+        ( i, u ) =
+            case x of
+                PluginsActionExplainInstall success ->
+                    ( Set.size success, 0 )
+
+                PluginsActionExplainInstallWarning { install } ->
+                    ( Set.size install, 0 )
+
+                PluginsActionExplainUpgrade success ->
+                    ( 0, Set.size success )
+
+                PluginsActionExplainUpgradeWarning { upgrade } ->
+                    ( 0, Set.size upgrade )
+
+                PluginsActionExplainInstallUpgrade { install, upgrade } ->
+                    ( Set.size install, Set.size upgrade )
+
+                PluginsActionExplainInstallUpgradeWarning { install, upgrade } ->
+                    ( Set.size install, Set.size upgrade )
+
+                _ ->
+                    ( 0, 0 )
+    in
+    { install = Just i |> Maybe.Extra.filter (\v -> v > 0)
+    , upgrade = Just u |> Maybe.Extra.filter (\v -> v > 0)
+    }
+
+
+{-| Aggregation state computation, keeping the details state and returning it.
+We do the aggregation on the new details, we do not bother deducing fields value from previous one.
+-}
+updatePluginAction : ( PluginId, ActionModel ) -> ( PluginsActionDetails, PluginsAction ) -> ( PluginsActionDetails, PluginsAction )
+updatePluginAction ( id, action ) ( PluginsActionDetails details, value ) =
+    let
+        ((PluginsActionDetails d) as updatedDetails) =
+            PluginsActionDetails (Dict.insert id action details)
+
+        newCount =
+            Dict.foldl
+                (\_ v n ->
+                    case v of
+                        AllowedAction _ ->
+                            n + 1
+
+                        DisallowedAction _ ->
+                            n
+                )
+                0
+                d
+
+        newDisabled =
+            newCount <= 0
+    in
+    ( updatedDetails
+    , PluginsAction
+        { successCount = newCount
+        , isActionDisabled = newDisabled
+        , explanation = explainPluginsAction updatedDetails
+        }
+    )
+
+
+initPluginDetails : PluginsActionDetails
+initPluginDetails =
+    PluginsActionDetails Dict.empty
+
+
+{-| Sorted lists of disallowed reasons, from least to most important
+-}
+allSortedActionDisallowedResult : List ActionDisallowedResult
+allSortedActionDisallowedResult =
+    [ PluginAlreadyUninstalled
+    , PluginAlreadyEnabled
+    , PluginAlreadyDisabled
+    , UninstalledPluginCannotBeEnabled
+    , UninstalledPluginCannotBeDisabled
+    , IntegrationPluginCannotBeDisabled
+    , ExpiredLicensePreventPluginInstallation
+    , MissingLicensePreventPluginInstallation
+    , ExpiredLicensePreventPluginActivation
+    , MissingLicensePreventPluginActivation
+    ]
+
+
+actionDisallowedResultOrdering : Ordering ActionDisallowedResult
+actionDisallowedResultOrdering =
+    Ordering.reverse <|
+        Ordering.explicit allSortedActionDisallowedResult
+
+
+explainPluginsAction : PluginsActionDetails -> PluginsActionExplanation
+explainPluginsAction (PluginsActionDetails details) =
+    let
+        ordering =
+            Ordering.byFieldWith actionDisallowedResultOrdering Tuple.first
+
+        ( ( success, install, upgrade ), warning ) =
+            details
+                |> Dict.toList
+                -- first partition by success to isolate warnings
+                |> List.partition
+                    (\( _, v ) ->
+                        case v of
+                            AllowedAction _ ->
+                                True
+
+                            DisallowedAction _ ->
+                                False
+                    )
+                |> Tuple.mapBoth
+                    (\allowed ->
+                        allowed
+                            |> List.foldl
+                                (\( p, a ) ->
+                                    \( s, i, u ) ->
+                                        case a of
+                                            AllowedAction ActionInstall ->
+                                                ( s, p :: i, u )
+
+                                            AllowedAction ActionUpgrade ->
+                                                ( s, i, p :: u )
+
+                                            _ ->
+                                                ( p :: s, i, u )
+                                )
+                                ( [], [], [] )
+                    )
+                    (\disallowed ->
+                        disallowed
+                            |> List.filterMap
+                                (\( p, a ) ->
+                                    case a of
+                                        DisallowedAction reason ->
+                                            Just ( reason, p )
+
+                                        AllowedAction _ ->
+                                            Nothing
+                                )
+                            |> List.sortWith ordering
+                            |> List.Extra.groupWhile (\a -> \b -> ordering a b == EQ)
+                            |> List.map (\( ( reason, plugin ), plugins ) -> ( reason, (plugin :: List.map Tuple.second plugins) |> Set.fromList ))
+                    )
+
+        nonEmptySet l =
+            if List.isEmpty l then
+                Nothing
+
+            else
+                Just (Set.fromList l)
+
+        nonEmptyList l =
+            if List.isEmpty l then
+                Nothing
+
+            else
+                Just l
+    in
+    case ( nonEmptySet success, ( nonEmptySet install, nonEmptySet upgrade ), nonEmptyList warning ) of
+        ( Nothing, ( Nothing, Nothing ), Nothing ) ->
+            PluginsActionNoExplanation
+
+        ( Just s, ( Nothing, Nothing ), Nothing ) ->
+            PluginsActionExplainSuccess s
+
+        ( Just s, ( Nothing, Nothing ), Just _ ) ->
+            PluginsActionExplainSuccessWarning { success = s, warning = warning }
+
+        ( _, ( Just s, Nothing ), Nothing ) ->
+            PluginsActionExplainInstall s
+
+        ( _, ( Just s, Nothing ), Just _ ) ->
+            PluginsActionExplainInstallWarning { install = s, warning = warning }
+
+        ( _, ( Nothing, Just upgr ), Nothing ) ->
+            PluginsActionExplainUpgrade upgr
+
+        ( _, ( Nothing, Just upgr ), Just _ ) ->
+            PluginsActionExplainUpgradeWarning { upgrade = upgr, warning = warning }
+
+        ( _, ( Just inst, Just upgr ), Nothing ) ->
+            PluginsActionExplainInstallUpgrade { install = inst, upgrade = upgr }
+
+        ( _, ( Just inst, Just upgr ), Just _ ) ->
+            PluginsActionExplainInstallUpgradeWarning { install = inst, upgrade = upgr, warning = warning }
+
+        ( Nothing, ( Nothing, Nothing ), Just errors ) ->
+            PluginsActionExplainErrors errors
+
+
+{-| Main exposed utility method to get all plugins actions from a given action on plugins
+-}
+findPluginsAction : Action -> Dict PluginId Plugin -> PluginsAction
+findPluginsAction action plugins =
+    plugins
+        |> Dict.map (\_ -> getActionResult action)
+        |> Dict.toList
+        |> List.foldl updatePluginAction ( initPluginDetails, initPluginsAction )
+        |> Tuple.second
+
+
+{-| The main business logic
+-}
+getActionResult : Action -> Plugin -> ActionModel
+getActionResult action { installStatus, pluginType, licenseStatus } =
+    case ( action, ( installStatus, pluginType, licenseStatus ) ) of
+        ( ActionInstall, ( _, _, ExpiredLicense _ ) ) ->
+            DisallowedAction ExpiredLicensePreventPluginInstallation
+
+        ( ActionInstall, ( _, _, MissingLicense _ ) ) ->
+            DisallowedAction MissingLicensePreventPluginInstallation
+
+        ( ActionEnable, ( _, _, ExpiredLicense _ ) ) ->
+            DisallowedAction ExpiredLicensePreventPluginActivation
+
+        ( ActionEnable, ( _, _, MissingLicense _ ) ) ->
+            DisallowedAction MissingLicensePreventPluginActivation
+
+        ( ActionDisable, ( Installed Enabled, Integration, _ ) ) ->
+            DisallowedAction IntegrationPluginCannotBeDisabled
+
+        ( ActionUninstall, ( Uninstalled, _, _ ) ) ->
+            DisallowedAction PluginAlreadyUninstalled
+
+        ( ActionEnable, ( Installed Enabled, _, _ ) ) ->
+            DisallowedAction PluginAlreadyEnabled
+
+        ( ActionEnable, ( Uninstalled, _, _ ) ) ->
+            DisallowedAction UninstalledPluginCannotBeEnabled
+
+        ( ActionDisable, ( Uninstalled, _, _ ) ) ->
+            DisallowedAction UninstalledPluginCannotBeDisabled
+
+        ( ActionInstall, ( Installed _, _, _ ) ) ->
+            AllowedAction ActionUpgrade
+
+        ( ActionDisable, ( Installed Enabled, _, _ ) ) ->
+            AllowedAction ActionDisable
+
+        ( ActionDisable, ( Installed Disabled, _, _ ) ) ->
+            DisallowedAction PluginAlreadyDisabled
+
+        _ ->
+            AllowedAction action
+
+
+actionText : Action -> String
+actionText action =
+    case action of
+        ActionInstall ->
+            "Install"
+
+        ActionUpgrade ->
+            "Upgrade"
+
+        ActionDisable ->
+            "Disable"
+
+        ActionEnable ->
+            "Enable"
+
+        ActionUninstall ->
+            "Uninstall"
+
+
+explainDisallowedResult : ActionDisallowedResult -> String
+explainDisallowedResult arg =
+    String.Extra.humanize <|
+        case arg of
+            PluginAlreadyUninstalled ->
+                "PluginAlreadyUninstalled"
+
+            PluginAlreadyEnabled ->
+                "PluginAlreadyEnabled"
+
+            PluginAlreadyDisabled ->
+                "PluginAlreadyDisabled"
+
+            UninstalledPluginCannotBeEnabled ->
+                "UninstalledPluginCannotBeEnabled"
+
+            UninstalledPluginCannotBeDisabled ->
+                "UninstalledPluginCannotBeDisabled"
+
+            IntegrationPluginCannotBeDisabled ->
+                "IntegrationPluginCannotBeDisabled"
+
+            ExpiredLicensePreventPluginInstallation ->
+                "ExpiredLicensePreventPluginInstallation"
+
+            MissingLicensePreventPluginInstallation ->
+                "MissingLicensePreventPluginInstallation"
+
+            ExpiredLicensePreventPluginActivation ->
+                "ExpiredLicensePreventPluginActivation"
+
+            MissingLicensePreventPluginActivation ->
+                "MissingLicensePreventPluginActivation"

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/ApiCalls.elm
@@ -3,8 +3,10 @@ module Plugins.ApiCalls exposing (..)
 import Http exposing (emptyBody, expectStringResponse, header, request)
 import Http.Detailed as Detailed
 import Plugins.DataTypes exposing (..)
-import Plugins.JsonDecoder exposing (decodeGetPluginsInfo)
+import Plugins.JsonDecoder exposing (decodeGetPluginMetadata)
 import Plugins.JsonEncoder exposing (encodePluginIds)
+import Plugins.PluginData exposing (..)
+import Set exposing (Set)
 
 
 getUrl : Model -> String -> String
@@ -32,13 +34,13 @@ getPluginInfos model =
         , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
         , url = getUrl model "/pluginsinternal"
         , body = emptyBody
-        , expect = Detailed.expectJson ApiGetPlugins decodeGetPluginsInfo
+        , expect = Detailed.expectJson ApiGetPlugins decodeGetPluginMetadata
         , timeout = Nothing
         , tracker = Nothing
         }
 
 
-installPlugins : List PluginId -> Model -> Cmd Msg
+installPlugins : Set PluginId -> Model -> Cmd Msg
 installPlugins plugins model =
     request
         { method = "POST"
@@ -51,7 +53,7 @@ installPlugins plugins model =
         }
 
 
-removePlugins : List PluginId -> Model -> Cmd Msg
+removePlugins : Set PluginId -> Model -> Cmd Msg
 removePlugins plugins model =
     request
         { method = "POST"
@@ -64,7 +66,7 @@ removePlugins plugins model =
         }
 
 
-changePluginStatus : RequestType -> List PluginId -> Model -> Cmd Msg
+changePluginStatus : RequestType -> Set PluginId -> Model -> Cmd Msg
 changePluginStatus requestType plugins model =
     request
         { method = "POST"
@@ -77,20 +79,20 @@ changePluginStatus requestType plugins model =
         }
 
 
-requestTypeAction : RequestType -> Model -> Cmd Msg
-requestTypeAction t model =
+requestTypeAction : RequestType -> Model -> Set PluginId -> Cmd Msg
+requestTypeAction t model selected =
     case t of
         Install ->
-            installPlugins model.ui.selected model
+            installPlugins selected model
 
         Uninstall ->
-            removePlugins model.ui.selected model
+            removePlugins selected model
 
         Enable ->
-            changePluginStatus Enable model.ui.selected model
+            changePluginStatus Enable selected model
 
         Disable ->
-            changePluginStatus Disable model.ui.selected model
+            changePluginStatus Disable selected model
 
         UpdateIndex ->
             updateIndex model

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/DataTypes.elm
@@ -1,109 +1,80 @@
 module Plugins.DataTypes exposing (..)
 
-import Bytes exposing (Bytes)
+import Dict exposing (Dict)
 import Http
 import Http.Detailed
 import Json.Encode exposing (Value)
 import List.Extra
+import Maybe.Extra
 import Ordering exposing (Ordering)
-import Time.ZonedDateTime exposing (ZonedDateTime)
-
-
-type alias PluginsInfo =
-    { license : Maybe LicenseGlobalInfo
-    , plugins : List PluginInfo
-    }
-
-
-type alias LicenseGlobalInfo =
-    { licensees : Maybe (List String)
-    , startDate : Maybe ZonedDateTime
-    , endDates : Maybe (List DateCount)
-    , maxNodes : Maybe Int
-    }
-
-
-type alias DateCount =
-    { date : ZonedDateTime
-    , count : Int
-    }
-
-
-type alias PluginInfo =
-    { id : PluginId
-    , name : String
-    , description : String
-    , abiVersion : String
-    , pluginVersion : String
-    , version : String
-    , pluginType : PluginType
-    , errors : List PluginError
-    , status : PluginStatus
-    , license : Maybe LicenseInfo
-    }
-
-
-type alias PluginId =
-    String
-
-
-type PluginType
-    = Webapp
-    | Integration
-
-
-type PluginStatus
-    = Enabled
-    | Disabled
-    | Uninstalled
-
-
-type alias LicenseInfo =
-    { licensee : String
-    , allowedNodesNumber : Int
-    , supportedVersions : String
-    , startDate : ZonedDateTime
-    , endDate : ZonedDateTime
-    }
-
-
-type alias PluginError =
-    { error : String
-    , message : String
-    }
+import Plugins.Action exposing (..)
+import Plugins.PluginData exposing (..)
+import Plugins.Select exposing (..)
+import Set exposing (Set)
+import Time exposing (Posix)
 
 
 type alias UI =
     { loading : Bool
-    , selected : List PluginId
-    , modalState : ModalState
     , view : PluginsView
     }
 
 
+type alias PluginsViewModel =
+    { plugins : Dict PluginId Plugin
+    , modalState : ModalState
+    , filters : Filters
+    , selected : Selected
+    , installAction : PluginsAction
+    , enableAction : PluginsAction
+    , disableAction : PluginsAction
+    , uninstallAction : PluginsAction
+    }
+
+
 type PluginsView
-    = ViewPluginsList
-    | ViewSettingsError ( String, String ) -- message, details
+    = ViewPluginsList PluginsViewModel
+    | ViewActionError ( String, String ) PluginsViewModel -- (message, details)
+    | ViewSettingError ( String, String )
 
 
 type ModalState
-    = OpenModal RequestType
+    = OpenModal ModalAction PluginsActionExplanation
+    | ErrorModal ModalAction
     | NoModal
+
+
+type ModalAction
+    = ModalInstallUpgrade
+    | ModalActionEnable
+    | ModalActionDisable
+    | ModalActionUninstall
+
+
+type alias Filters =
+    { search : String
+    , pluginType : FilterByPluginType
+    , installStatus : FilterByInstallStatus
+    }
+
+
+type FilterByPluginType
+    = FilterByPluginType PluginType
+    | FilterByAllPluginType
+
+
+type FilterByInstallStatus
+    = FilterByInstallStatus InstallStatus
+    | FilterByAllInstallStatus
 
 
 type alias Model =
     { contextPath : String
-    , license : Maybe LicenseGlobalInfo
-    , plugins : List PluginInfo
+    , license : Maybe LicenseGlobal
+    , plugins : Dict PluginId Plugin
+    , now : Posix
     , ui : UI
     }
-
-
-type Select
-    = SelectOne PluginId
-    | UnselectOne PluginId
-    | SelectAll
-    | UnselectAll
 
 
 type RequestType
@@ -116,14 +87,257 @@ type RequestType
 
 type Msg
     = CallApi (Model -> Cmd Msg)
-    | RequestApi RequestType
-    | ApiGetPlugins (Result (Http.Detailed.Error String) ( Http.Metadata, PluginsInfo ))
+    | RequestApi RequestType (Set PluginId)
+    | ApiGetPlugins (Result (Http.Detailed.Error String) ( Http.Metadata, PluginMetadata ))
     | ApiPostPlugins RequestType (Result (Http.Detailed.Error String) ())
     | SetModalState ModalState
+    | ResetPluginListFromModal PluginsViewModel
     | ReloadPage
     | Copy String
     | CopyJson Value
     | CheckSelection Select
+    | UpdateFilters Filters
+    | Now Posix
+
+
+initFilters : Filters
+initFilters =
+    { search = ""
+    , pluginType = FilterByAllPluginType
+    , installStatus = FilterByAllInstallStatus
+    }
+
+
+processSelect : Select -> Model -> Model
+processSelect s model =
+    model |> updatePluginsViewModel (select s model.plugins)
+
+
+setView : PluginsView -> Model -> Model
+setView view =
+    updateView (\_ -> view)
+
+
+updateView : (PluginsView -> PluginsView) -> Model -> Model
+updateView f ({ ui } as model) =
+    model |> setUI { ui | view = f ui.view }
+
+
+applyFilters : Filters -> Dict PluginId Plugin -> PluginsViewModel -> PluginsViewModel
+applyFilters ({ search, installStatus, pluginType } as filters) initialPlugins model =
+    let
+        onSearch { id, name, description } =
+            [ id, name, description ]
+                |> List.map String.toLower
+                |> List.Extra.find (String.contains (String.toLower search))
+                |> Maybe.Extra.isJust
+
+        onInstallStatus p =
+            case installStatus of
+                FilterByAllInstallStatus ->
+                    True
+
+                FilterByInstallStatus s ->
+                    p.installStatus == s
+
+        onPluginType p =
+            case pluginType of
+                FilterByAllPluginType ->
+                    True
+
+                FilterByPluginType t ->
+                    p.pluginType == t
+
+        plugins =
+            initialPlugins
+                |> Dict.filter
+                    (\_ ->
+                        \p ->
+                            onInstallStatus p && onPluginType p && onSearch p
+                    )
+    in
+    { model
+        | filters = filters
+        , plugins = plugins
+    }
+
+
+updatePluginsViewModel : (PluginsViewModel -> PluginsViewModel) -> Model -> Model
+updatePluginsViewModel f ({ ui } as model) =
+    model
+        |> setUI
+            { ui
+                | view =
+                    case ui.view of
+                        ViewPluginsList plugins ->
+                            ViewPluginsList <| f plugins
+
+                        _ ->
+                            ui.view
+            }
+
+
+setPluginsView : Dict PluginId Plugin -> PluginsViewModel -> PluginsViewModel
+setPluginsView plugins model =
+    setNotSelectablePlugins plugins
+        { model
+            | plugins = plugins
+        }
+
+
+processPlugins : List Plugin -> Model -> Model
+processPlugins plugins =
+    let
+        d =
+            pluginsFromList plugins
+    in
+    setPlugins d >> updatePluginsViewModel (setPluginsView d)
+
+
+pluginsFromList : List Plugin -> Dict PluginId Plugin
+pluginsFromList plugins =
+    plugins |> List.map (\p -> ( p.id, p )) |> Dict.fromList
+
+
+setPlugins : Dict PluginId Plugin -> Model -> Model
+setPlugins plugins model =
+    { model | plugins = plugins }
+
+
+setModalState : ModalState -> PluginsViewModel -> PluginsViewModel
+setModalState modalState model =
+    { model | modalState = modalState }
+
+
+processFilters : Filters -> Model -> Model
+processFilters filters model =
+    updatePluginsViewModel (applyFilters filters model.plugins) model
+
+
+setLicense : Maybe LicenseGlobal -> Model -> Model
+setLicense license model =
+    { model | license = license }
+
+
+setUI : UI -> Model -> Model
+setUI ui model =
+    { model | ui = ui }
+
+
+setSettingsError : ( String, String ) -> Model -> Model
+setSettingsError error model =
+    let
+        updateError ui =
+            { ui | view = ViewSettingError error, loading = False }
+    in
+    { model | ui = updateError model.ui }
+
+
+setActionError : ( String, String ) -> Model -> Model
+setActionError error ({ ui } as model) =
+    case ui.view of
+        ViewPluginsList ({ modalState } as pluginViewModel) ->
+            case modalState of
+                OpenModal action _ ->
+                    model |> setUI { ui | view = ViewActionError error { pluginViewModel | modalState = ErrorModal action }, loading = False }
+
+                _ ->
+                    model
+
+        ViewActionError _ ({ modalState } as pluginViewModel) ->
+            case modalState of
+                ErrorModal _ ->
+                    -- modal should be left open
+                    model |> setUI { ui | view = ViewActionError error pluginViewModel, loading = False }
+
+                _ ->
+                    model
+
+        ViewSettingError _ ->
+            model
+
+
+noGlobalLicense : LicenseGlobal
+noGlobalLicense =
+    { licensees = Nothing
+    , startDate = Nothing
+    , endDates = Nothing
+    , maxNodes = Nothing
+    }
+
+
+statusOrdering : Ordering InstallStatus
+statusOrdering =
+    Ordering.explicit [ Installed Enabled, Installed Disabled, Uninstalled ]
+
+
+pluginDefaultOrdering : Ordering Plugin
+pluginDefaultOrdering =
+    Ordering.byFieldWith statusOrdering .installStatus
+        |> Ordering.breakTiesWith (Ordering.byField .name)
+
+
+updateUI : (UI -> UI) -> Model -> Model
+updateUI f =
+    \model -> { model | ui = f model.ui }
+
+
+setLoading : Bool -> Model -> Model
+setLoading value =
+    updateUI (\ui -> { ui | loading = value })
+
+
+actionRequestType : ModalAction -> RequestType
+actionRequestType action =
+    case action of
+        ModalInstallUpgrade ->
+            Install
+
+        ModalActionEnable ->
+            Enable
+
+        ModalActionDisable ->
+            Disable
+
+        ModalActionUninstall ->
+            Uninstall
+
+
+actionToModal : Action -> ModalAction
+actionToModal action =
+    case action of
+        ActionInstall ->
+            ModalInstallUpgrade
+
+        ActionUpgrade ->
+            ModalInstallUpgrade
+
+        ActionEnable ->
+            ModalActionEnable
+
+        ActionDisable ->
+            ModalActionDisable
+
+        ActionUninstall ->
+            ModalActionUninstall
+
+
+{-| Used for modal name / title, so it is a human name
+-}
+modalActionText : ModalAction -> String
+modalActionText action =
+    case action of
+        ModalInstallUpgrade ->
+            "Install/Upgrade"
+
+        ModalActionEnable ->
+            "Enable"
+
+        ModalActionDisable ->
+            "Disable"
+
+        ModalActionUninstall ->
+            "Uninstall"
 
 
 requestTypeText : RequestType -> String
@@ -143,69 +357,3 @@ requestTypeText t =
 
         UpdateIndex ->
             "update index"
-
-
-processSelect : Select -> Model -> Model
-processSelect select model =
-    let
-        ui =
-            model.ui
-
-        withUiSelection s =
-            { ui | selected = s }
-
-        withSelection s =
-            { model | ui = withUiSelection s }
-
-        selected =
-            ui.selected
-
-        allPlugins =
-            List.map .id model.plugins
-    in
-    case select of
-        SelectOne id ->
-            withSelection (id :: selected)
-
-        UnselectOne id ->
-            withSelection (List.Extra.remove id selected)
-
-        SelectAll ->
-            withSelection allPlugins
-
-        UnselectAll ->
-            withSelection []
-
-
-withSettingsError : ( String, String ) -> Model -> Model
-withSettingsError error model =
-    let
-        updateError ui =
-            { ui | view = ViewSettingsError error }
-    in
-    { model | ui = updateError model.ui }
-
-
-noGlobalLicense : LicenseGlobalInfo
-noGlobalLicense =
-    { licensees = Nothing
-    , startDate = Nothing
-    , endDates = Nothing
-    , maxNodes = Nothing
-    }
-
-
-pluginStatusOrdering : Ordering PluginStatus
-pluginStatusOrdering =
-    Ordering.explicit [ Enabled, Disabled, Uninstalled ]
-
-
-pluginDefaultOrdering : Ordering PluginInfo
-pluginDefaultOrdering =
-    Ordering.byFieldWith pluginStatusOrdering .status
-        |> Ordering.breakTiesWith (Ordering.byField .name)
-
-
-withLoading : Bool -> Model -> Model
-withLoading value model =
-    { model | ui = (\ui -> { ui | loading = value }) model.ui }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Init.elm
@@ -1,7 +1,12 @@
 module Plugins.Init exposing (..)
 
+import Dict
+import Plugins.Action exposing (initPluginsAction)
 import Plugins.ApiCalls exposing (getPluginInfos)
 import Plugins.DataTypes exposing (..)
+import Plugins.Select exposing (noSelected)
+import Task
+import Time exposing (millisToPosix)
 
 
 subscriptions : Model -> Sub Msg
@@ -12,12 +17,37 @@ subscriptions model =
 init : { contextPath : String } -> ( Model, Cmd Msg )
 init flags =
     let
+        initUI : UI
         initUI =
-            UI True [] NoModal ViewPluginsList
+            { loading = True, view = ViewPluginsList initPluginsViewModel }
 
+        initModel : Model
         initModel =
-            Model flags.contextPath Nothing [] initUI
+            { contextPath = flags.contextPath
+            , license = Nothing
+            , now = millisToPosix 0
+            , plugins = Dict.empty
+            , ui = initUI
+            }
     in
     ( initModel
-    , getPluginInfos initModel
+    , Cmd.batch [ getInitTime, getPluginInfos initModel ]
     )
+
+
+getInitTime : Cmd Msg
+getInitTime =
+    Time.now |> Task.perform Now
+
+
+initPluginsViewModel : PluginsViewModel
+initPluginsViewModel =
+    { plugins = Dict.empty
+    , selected = noSelected
+    , modalState = NoModal
+    , filters = initFilters
+    , installAction = initPluginsAction
+    , enableAction = initPluginsAction
+    , disableAction = initPluginsAction
+    , uninstallAction = initPluginsAction
+    }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/JsonEncoder.elm
@@ -1,9 +1,10 @@
 module Plugins.JsonEncoder exposing (..)
 
 import Json.Encode exposing (..)
-import Plugins.DataTypes exposing (..)
+import Plugins.PluginData exposing (PluginId)
+import Set exposing (Set)
 
 
-encodePluginIds : List PluginId -> Value
+encodePluginIds : Set PluginId -> Value
 encodePluginIds =
-    list string
+    set string

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/PluginData.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/PluginData.elm
@@ -1,0 +1,222 @@
+module Plugins.PluginData exposing (..)
+
+import List.Extra
+import Maybe.Extra
+import Time.ZonedDateTime exposing (ZonedDateTime)
+
+
+type alias PluginId =
+    String
+
+
+type alias PluginMetadata =
+    { license : Maybe LicenseGlobal
+    , plugins : List Plugin
+    }
+
+
+type alias Plugin =
+    { id : PluginId
+    , name : String
+    , pluginType : PluginType
+    , installStatus : InstallStatus
+    , docLink : String
+    , description : String
+    , version : String
+    , licenseStatus : LicenseStatus
+    , abiVersionError : Maybe String
+    }
+
+
+type PluginType
+    = Webapp
+    | Integration
+
+
+type InstallStatus
+    = Installed ActivationStatus
+    | Uninstalled
+
+
+type ActivationStatus
+    = Enabled
+    | Disabled
+
+
+type alias PluginLicense =
+    { startDate : ZonedDateTime
+    , endDate : ZonedDateTime
+    }
+
+
+type LicenseStatus
+    = ValidLicense PluginLicense
+    | NearExpirationLicense String
+    | ExpiredLicense String
+    | MissingLicense String
+    | NoLicense
+
+
+{-| The API representation of the Plugin
+-}
+type alias PluginInfo =
+    { id : PluginId
+    , name : String
+    , description : String
+    , abiVersion : String
+    , pluginVersion : String
+    , version : String
+    , pluginType : PluginType
+    , errors : List PluginInfoError
+    , status : PluginStatus
+    , license : Maybe LicenseInfo
+    }
+
+
+type alias PluginsInfo =
+    { license : Maybe LicenseGlobal
+    , plugins : List PluginInfo
+    }
+
+
+type alias LicenseGlobal =
+    { licensees : Maybe (List String)
+    , startDate : Maybe ZonedDateTime
+    , endDates : Maybe (List DateCount)
+    , maxNodes : Maybe Int
+    }
+
+
+type alias DateCount =
+    { date : ZonedDateTime
+    , count : Int
+    }
+
+
+type PluginStatus
+    = StatusEnabled
+    | StatusDisabled
+    | StatusUninstalled
+
+
+type alias LicenseInfo =
+    { licensee : String
+    , allowedNodesNumber : Int
+    , supportedVersions : String
+    , startDate : ZonedDateTime
+    , endDate : ZonedDateTime
+    }
+
+
+type alias PluginInfoError =
+    { error : String
+    , message : String
+    }
+
+
+toPlugin : PluginInfo -> Plugin
+toPlugin { id, name, abiVersion, pluginType, description, status, pluginVersion, errors, license } =
+    { id = id
+    , name = name
+    , pluginType = pluginType
+    , installStatus = toInstallStatus status
+    , docLink = docLink { id = id, abiVersion = abiVersion }
+    , description = description
+    , version = pluginVersion
+    , licenseStatus = findLicenseStatus (Maybe.map toPluginLicense license) errors
+    , abiVersionError = findAbiVersionError errors
+    }
+
+
+findAbiVersionError : List PluginInfoError -> Maybe String
+findAbiVersionError =
+    List.Extra.findMap
+        (\{ error, message } ->
+            if error == "abi.version.error" then
+                Just message
+
+            else
+                Nothing
+        )
+
+
+findLicenseStatus : Maybe PluginLicense -> List PluginInfoError -> LicenseStatus
+findLicenseStatus license errors =
+    let
+        findErr err =
+            errors |> List.Extra.find (\{ error } -> error == err)
+    in
+    case ( license, ( findErr "license.needed.error", findErr "license.expired.error", findErr "license.near.expiration.error" ) ) of
+        -- ignore current license as API already handles the message according to license data
+        ( _, ( Just { message }, _, _ ) ) ->
+            MissingLicense message
+
+        ( _, ( _, Just { message }, _ ) ) ->
+            ExpiredLicense message
+
+        ( _, ( Nothing, _, Just { message } ) ) ->
+            NearExpirationLicense message
+
+        ( Just l, ( Nothing, Nothing, Nothing ) ) ->
+            ValidLicense l
+
+        ( Nothing, ( Nothing, Nothing, Nothing ) ) ->
+            NoLicense
+
+
+toInstallStatus : PluginStatus -> InstallStatus
+toInstallStatus p =
+    case p of
+        StatusEnabled ->
+            Installed Enabled
+
+        StatusDisabled ->
+            Installed Disabled
+
+        StatusUninstalled ->
+            Uninstalled
+
+
+toPluginLicense : LicenseInfo -> PluginLicense
+toPluginLicense { startDate, endDate } =
+    { startDate = startDate, endDate = endDate }
+
+
+{-| We need to infer the plugin ABI version with respects to main version
+i.e. minor version without the patch version and without the ~rc1, ~beta2, etc.
+-}
+docLink : { id : PluginId, abiVersion : String } -> String
+docLink { id, abiVersion } =
+    let
+        rudderVersion =
+            abiVersion
+                |> String.split "."
+                |> List.take 2
+                |> String.join "."
+    in
+    String.join "/" [ "https://docs.rudder.io/reference", rudderVersion, "plugins", id ++ ".html" ]
+
+
+setInstallStatus : InstallStatus -> Plugin -> Plugin
+setInstallStatus status plugin =
+    { plugin | installStatus = status }
+
+
+setPluginType : PluginType -> Plugin -> Plugin
+setPluginType pluginType plugin =
+    { plugin | pluginType = pluginType }
+
+
+setLicenseStatus : LicenseStatus -> Plugin -> Plugin
+setLicenseStatus license plugin =
+    { plugin | licenseStatus = license }
+
+
+pluginTypeText : PluginType -> String
+pluginTypeText arg =
+    case arg of
+        Webapp ->
+            "Webapp"
+
+        Integration ->
+            "Integration"

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Select.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Select.elm
@@ -1,0 +1,216 @@
+module Plugins.Select exposing
+    ( Select(..)
+    , Selected
+    , Selection(..)
+    , ViewModel
+    , getSelection
+    , isAllSelected
+    , noSelected
+    , select
+    , selectedCount
+    , setNotSelectablePlugins
+    )
+
+import Dict exposing (Dict)
+import Dict.Extra
+import Plugins.Action exposing (Action(..), PluginsAction, findPluginsAction)
+import Plugins.PluginData exposing (..)
+import Set exposing (Set)
+
+
+{-| The generic record type with interesting fields for selection and plugin actions
+-}
+type alias ViewModel a =
+    { a
+        | plugins : Dict PluginId Plugin
+        , selected : Selected
+        , installAction : PluginsAction
+        , enableAction : PluginsAction
+        , disableAction : PluginsAction
+        , uninstallAction : PluginsAction
+    }
+
+
+type Select
+    = SelectOne PluginId
+    | UnselectOne PluginId
+    | SelectAll (Set PluginId)
+    | UnselectAll
+
+
+{-| Opaque type with invariants defined in its manipulation
+(plugins have a unique selection which is only selectable)
+-}
+type Selected
+    = Selected (Dict PluginId Selection)
+
+
+{-| Local type for implementation for selected element
+We store only a Selection and non-selectable elements,
+non-selected ones are not in the dict
+-}
+type Selection
+    = Selection Bool
+    | NotSelectable
+
+
+{-| Main exposed setter, which enforces upon selection that actions are all updated
+-}
+select : Select -> Dict PluginId Plugin -> ViewModel a -> ViewModel a
+select sel allPlugins model =
+    model
+        |> updateSelected (toSelected sel)
+        |> updateInstallAction allPlugins
+        |> updateEnableAction allPlugins
+        |> updateDisableAction allPlugins
+        |> updateUninstallAction allPlugins
+
+
+{-| For initial selection : set plugins selection according to their selectability.
+We enforce that some plugins cannot be selected, depending on their attributes
+-}
+setNotSelectablePlugins : Dict PluginId Plugin -> ViewModel a -> ViewModel a
+setNotSelectablePlugins plugins model =
+    model
+        |> updateSelected (\_ -> findNotSelectablePlugins plugins)
+        |> updateInstallAction plugins
+        |> updateEnableAction plugins
+        |> updateDisableAction plugins
+        |> updateUninstallAction plugins
+
+
+{-| For initialization, when there isn't anything yet to even setup initial selection with
+-}
+noSelected : Selected
+noSelected =
+    Selected Dict.empty
+
+
+toSelected : Select -> Selected -> Selected
+toSelected s =
+    case s of
+        SelectOne id ->
+            transformSelected <| Dict.insert id (Selection True)
+
+        UnselectOne id ->
+            transformSelected <| Dict.remove id
+
+        SelectAll plugins ->
+            transformSelected <| \_ -> plugins |> Set.toList |> List.map (\p -> ( p, Selection True )) |> Dict.fromList
+
+        UnselectAll ->
+            transformSelected <| \_ -> Dict.empty
+
+
+updateSelected : (Selected -> Selected) -> ViewModel a -> ViewModel a
+updateSelected f ({ selected } as model) =
+    { model
+        | selected = f selected
+    }
+
+
+onlySelectedPlugins : Selected -> Dict PluginId a -> Dict PluginId a
+onlySelectedPlugins sel plugins =
+    plugins |> Dict.Extra.keepOnly (selectedSet sel)
+
+
+updateInstallAction : Dict PluginId Plugin -> ViewModel a -> ViewModel a
+updateInstallAction plugins ({ selected } as model) =
+    { model
+        | installAction = findPluginsAction ActionInstall (onlySelectedPlugins selected plugins)
+    }
+
+
+updateEnableAction : Dict PluginId Plugin -> ViewModel a -> ViewModel a
+updateEnableAction plugins ({ selected } as model) =
+    { model
+        | enableAction = findPluginsAction ActionEnable (onlySelectedPlugins selected plugins)
+    }
+
+
+updateDisableAction : Dict PluginId Plugin -> ViewModel a -> ViewModel a
+updateDisableAction plugins ({ selected } as model) =
+    { model
+        | disableAction = findPluginsAction ActionDisable (onlySelectedPlugins selected plugins)
+    }
+
+
+updateUninstallAction : Dict PluginId Plugin -> ViewModel a -> ViewModel a
+updateUninstallAction plugins ({ selected } as model) =
+    { model
+        | uninstallAction = findPluginsAction ActionUninstall (onlySelectedPlugins selected plugins)
+    }
+
+
+nonSelectable : Selected -> Dict PluginId Selection
+nonSelectable (Selected sel) =
+    sel |> Dict.filter (\_ -> \v -> v == NotSelectable)
+
+
+{-| Local helper function, guarantees that we cannot select non-selectable
+-}
+transformSelected : (Dict PluginId Selection -> Dict PluginId Selection) -> Selected -> Selected
+transformSelected f ((Selected d) as sel) =
+    Selected (Dict.union (nonSelectable sel) (f d))
+
+
+findNotSelectablePlugins : Dict PluginId Plugin -> Selected
+findNotSelectablePlugins plugins =
+    let
+        notSelectable { installStatus, licenseStatus } =
+            case ( installStatus, licenseStatus ) of
+                ( Uninstalled, ExpiredLicense _ ) ->
+                    Just NotSelectable
+
+                ( Uninstalled, MissingLicense _ ) ->
+                    Just NotSelectable
+
+                _ ->
+                    Nothing
+    in
+    plugins
+        |> Dict.Extra.filterMap (\_ -> notSelectable)
+        |> Selected
+
+
+isAllSelected : Selected -> Set PluginId -> Bool
+isAllSelected (Selected s) plugins =
+    Set.diff plugins (s |> Dict.keys |> Set.fromList)
+        |> Set.isEmpty
+
+
+getSelection : PluginId -> Selected -> Selection
+getSelection id (Selected sel) =
+    Dict.get id sel |> Maybe.withDefault (Selection False)
+
+
+selectedCount : Selected -> Int
+selectedCount (Selected sel) =
+    Dict.foldl
+        (\_ ->
+            \s ->
+                \acc ->
+                    case s of
+                        Selection True ->
+                            acc + 1
+
+                        _ ->
+                            acc
+        )
+        0
+        sel
+
+
+selectedSet : Selected -> Set PluginId
+selectedSet (Selected s) =
+    Dict.foldl
+        (\key selection keySet ->
+            case selection of
+                Selection True ->
+                    Set.insert key keySet
+
+                _ ->
+                    keySet
+        )
+        Set.empty
+        s

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Tests/PluginsTests.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Tests/PluginsTests.elm
@@ -1,0 +1,185 @@
+module Plugins.Tests.PluginsTests exposing (suite)
+
+import Dict
+import Expect exposing (..)
+import Fuzz exposing (..)
+import Plugins.Action exposing (..)
+import Plugins.DataTypes exposing (PluginsViewModel, pluginsFromList, setPluginsView)
+import Plugins.Init exposing (initPluginsViewModel)
+import Plugins.PluginData exposing (..)
+import Plugins.Select exposing (..)
+import Test exposing (..)
+import Time.Iso8601
+import Time.TimeZones exposing (utc)
+import Time.ZonedDateTime
+
+
+pluginFuzz : Fuzzer Plugin
+pluginFuzz =
+    constant Plugin
+        |> andMap string
+        |> andMap string
+        |> andMap pluginTypeFuzzer
+        |> andMap installStatusFuzzer
+        |> andMap string
+        |> andMap string
+        |> andMap string
+        |> andMap licenseStatusFuzzer
+        |> andMap (maybe string)
+
+
+licenseStatusFuzzer : Fuzzer LicenseStatus
+licenseStatusFuzzer =
+    oneOf
+        [ map ValidLicense pluginLicenseFuzzer
+        , map NearExpirationLicense string
+        , map ExpiredLicense string
+        , map MissingLicense string
+        , constant NoLicense
+        ]
+
+
+pluginLicenseFuzzer : Fuzzer PluginLicense
+pluginLicenseFuzzer =
+    map2 PluginLicense zonedDateTimeFuzzer zonedDateTimeFuzzer
+
+
+installStatusFuzzer : Fuzzer InstallStatus
+installStatusFuzzer =
+    oneOf [ map Installed activationStatusFuzzer, constant Uninstalled ]
+
+
+activationStatusFuzzer : Fuzzer ActivationStatus
+activationStatusFuzzer =
+    oneOf [ constant Enabled, constant Disabled ]
+
+
+pluginTypeFuzzer : Fuzzer PluginType
+pluginTypeFuzzer =
+    oneOf [ constant Webapp, constant Integration ]
+
+
+pluginErrorFuzzer : Fuzzer PluginInfoError
+pluginErrorFuzzer =
+    map2 PluginInfoError string string
+
+
+pluginStatusFuzzer : Fuzzer PluginStatus
+pluginStatusFuzzer =
+    oneOf [ constant StatusEnabled, constant StatusDisabled, constant StatusUninstalled ]
+
+
+licenseInfoFuzzer : Fuzzer LicenseInfo
+licenseInfoFuzzer =
+    map5 LicenseInfo string int string zonedDateTimeFuzzer zonedDateTimeFuzzer
+
+
+zonedDateTimeFuzzer : Fuzzer Time.ZonedDateTime.ZonedDateTime
+zonedDateTimeFuzzer =
+    constant (Time.Iso8601.toZonedDateTime utc "2025-02-12T10:12:14Z")
+        |> filterMap Result.toMaybe
+
+
+fuzzPluginExpectAction : String -> (PluginsViewModel -> PluginsAction) -> InstallStatus -> PluginType -> LicenseStatus -> (PluginId -> Select) -> (Plugin -> (PluginsAction -> Expectation)) -> Test
+fuzzPluginExpectAction msg toAction status pluginType license sel toExpectation =
+    fuzz pluginFuzz msg <|
+        \plugin ->
+            let
+                plugins =
+                    Dict.singleton plugin.id (plugin |> setPluginType pluginType |> setInstallStatus status |> setLicenseStatus license)
+
+                viewModel =
+                    initPluginsViewModel
+                        |> setPluginsView plugins
+                        |> select (sel plugin.id) plugins
+            in
+            viewModel |> toAction |> toExpectation plugin
+
+
+fuzzPlugin : String -> (PluginsViewModel -> PluginsAction) -> InstallStatus -> PluginType -> LicenseStatus -> (PluginId -> Select) -> ActionModel -> Test
+fuzzPlugin msg toAction status pluginType license sel singleActionResult =
+    fuzzPluginExpectAction msg toAction status pluginType license sel (\p -> Expect.equal <| pluginAction ( p.id, singleActionResult ))
+
+
+fuzzSelectValidLicensePlugin : String -> (PluginsViewModel -> PluginsAction) -> InstallStatus -> LicenseStatus -> Action -> Test
+fuzzSelectValidLicensePlugin msg toAction status license action =
+    fuzzPlugin msg toAction status Webapp license SelectOne (AllowedAction action)
+
+
+fuzzSelectValidPlugin : String -> (PluginsViewModel -> PluginsAction) -> InstallStatus -> Action -> Test
+fuzzSelectValidPlugin msg toAction status action =
+    fuzzSelectValidLicensePlugin msg toAction status NoLicense action
+
+
+suite =
+    describe "Plugins.module"
+        [ describe "select valid plugins"
+            [ -- install
+              fuzz (list pluginFuzz) "initialize install action" <|
+                \plugins -> initPluginsViewModel |> setPluginsView (pluginsFromList plugins) |> .installAction |> Expect.equal initPluginsAction
+            , fuzzSelectValidPlugin "allow installing uninstalled plugin" .installAction Uninstalled ActionInstall
+            , fuzzSelectValidPlugin "allow upgrading already installed (enabled)" .installAction (Installed Enabled) ActionUpgrade
+            , fuzzSelectValidPlugin "allow upgrading already installed (disabled)" .installAction (Installed Disabled) ActionUpgrade
+
+            -- enable
+            , fuzz (list pluginFuzz) "initialize enable action" <|
+                \plugins -> initPluginsViewModel |> setPluginsView (pluginsFromList plugins) |> .enableAction |> Expect.equal initPluginsAction
+            , fuzzSelectValidPlugin "allow enabling disabled plugin" .enableAction (Installed Disabled) ActionEnable
+
+            -- disable
+            , fuzz (list pluginFuzz) "initialize disable action" <|
+                \plugins -> initPluginsViewModel |> setPluginsView (pluginsFromList plugins) |> .disableAction |> Expect.equal initPluginsAction
+            , fuzzSelectValidPlugin "allow disabling enabled webapp plugin" .disableAction (Installed Enabled) ActionDisable
+
+            -- uninstall
+            , fuzz (list pluginFuzz) "initialize uninstall action" <|
+                \plugins -> initPluginsViewModel |> setPluginsView (pluginsFromList plugins) |> .disableAction |> Expect.equal initPluginsAction
+            , fuzzSelectValidPlugin "allow uninstalling enabled plugin" .uninstallAction (Installed Enabled) ActionUninstall
+            , fuzzSelectValidPlugin "allow uninstalling disabled plugin" .uninstallAction (Installed Disabled) ActionUninstall
+
+            -- license
+            , fuzzSelectValidLicensePlugin "allow disabling plugin with expired license" .disableAction (Installed Enabled) (ExpiredLicense "") ActionDisable
+            , fuzzSelectValidLicensePlugin "allow uninstalling plugin with expired license" .uninstallAction (Installed Disabled) (ExpiredLicense "") ActionUninstall
+            , fuzzSelectValidLicensePlugin "allow disabling plugin with no license" .disableAction (Installed Enabled) (MissingLicense "") ActionDisable
+            , fuzzSelectValidLicensePlugin "allow uninstalling plugin with no license" .uninstallAction (Installed Disabled) (MissingLicense "") ActionUninstall
+            ]
+        , describe "disallow selection" <| List.map testDisallowedResult allSortedActionDisallowedResult
+        ]
+
+
+{-| To ensure every error is mapped to a test
+-}
+testDisallowedResult : ActionDisallowedResult -> Test
+testDisallowedResult result =
+    case result of
+        PluginAlreadyUninstalled ->
+            fuzzPlugin "disallow uninstalling already uninstalled plugin" .uninstallAction Uninstalled Webapp NoLicense SelectOne (DisallowedAction PluginAlreadyUninstalled)
+
+        PluginAlreadyEnabled ->
+            fuzzPlugin "disallow enabling already enabled plugin" .enableAction (Installed Enabled) Webapp NoLicense SelectOne (DisallowedAction PluginAlreadyEnabled)
+
+        PluginAlreadyDisabled ->
+            fuzzPlugin "disallow disabling already disabled plugin" .disableAction (Installed Disabled) Webapp NoLicense SelectOne (DisallowedAction PluginAlreadyDisabled)
+
+        UninstalledPluginCannotBeEnabled ->
+            fuzzPlugin "disallow enabling uninstalled plugin" .enableAction Uninstalled Webapp NoLicense SelectOne (DisallowedAction UninstalledPluginCannotBeEnabled)
+
+        UninstalledPluginCannotBeDisabled ->
+            fuzzPlugin "disallow disabling uninstalled plugin" .disableAction Uninstalled Webapp NoLicense SelectOne (DisallowedAction UninstalledPluginCannotBeDisabled)
+
+        IntegrationPluginCannotBeDisabled ->
+            fuzzPlugin "disallow disabling integration plugin" .disableAction (Installed Enabled) Integration NoLicense SelectOne (DisallowedAction IntegrationPluginCannotBeDisabled)
+
+        ExpiredLicensePreventPluginActivation ->
+            fuzzPlugin "disallow enabling plugin with expired license" .enableAction (Installed Disabled) Webapp (ExpiredLicense "") SelectOne (DisallowedAction ExpiredLicensePreventPluginActivation)
+
+        MissingLicensePreventPluginActivation ->
+            fuzzPlugin "disallow enabling plugin with no license" .enableAction (Installed Disabled) Webapp (MissingLicense "") SelectOne (DisallowedAction MissingLicensePreventPluginActivation)
+
+        ExpiredLicensePreventPluginInstallation ->
+            -- plugin is non-selectable, selection prevents from selecting it
+            fuzzPluginExpectAction "disallow installing plugin with expired license" .installAction Uninstalled Webapp (ExpiredLicense "") SelectOne (\_ -> Expect.equal initPluginsAction)
+
+        MissingLicensePreventPluginInstallation ->
+            -- plugin is non-selectable, selection prevents from selecting it
+            fuzzPluginExpectAction "disallow installing plugin with no license" .installAction Uninstalled Webapp (MissingLicense "") SelectOne (\_ -> Expect.equal initPluginsAction)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/View.elm
@@ -1,18 +1,25 @@
 module Plugins.View exposing (..)
 
-import Html exposing (Html, a, button, div, h1, h2, h3, i, input, label, li, p, pre, span, strong, table, tbody, td, text, tr, ul)
-import Html.Attributes exposing (attribute, checked, class, disabled, for, href, id, style, target, type_)
+import Dict exposing (Dict)
+import Html exposing (Html, a, button, div, em, h1, h2, h3, i, input, label, li, p, pre, span, strong, text, ul)
+import Html.Attributes exposing (attribute, autocomplete, checked, class, disabled, for, href, id, name, placeholder, style, target, title, type_, value)
 import Html.Attributes.Extra exposing (role)
-import Html.Events exposing (onCheck, onClick)
+import Html.Events exposing (onCheck, onClick, onInput)
 import List.Extra
 import Maybe.Extra
+import NaturalOrdering exposing (compareOn)
+import Ordering
+import Plugins.Action exposing (Action(..), PluginsAction(..), PluginsActionExplanation(..), actionText, explainDisallowedResult, installUpgradeCount, successPluginsFromExplanation)
 import Plugins.ApiCalls exposing (..)
 import Plugins.DataTypes exposing (..)
-import Plugins.JsonEncoder exposing (..)
+import Plugins.PluginData exposing (..)
+import Plugins.Select exposing (Select(..), Selected, Selection(..), getSelection, isAllSelected, noSelected, selectedCount)
+import Set exposing (Set)
 import String.Extra
 import Time.DateTime
 import Time.Iso8601
-import Time.ZonedDateTime
+import Time.TimeZones exposing (utc)
+import Time.ZonedDateTime as ZonedDateTime exposing (ZonedDateTime)
 
 
 view : Model -> Html Msg
@@ -20,19 +27,15 @@ view model =
     div [ class "rudder-template" ]
         [ div [ class "one-col w-100" ]
             [ div [ class "main-header" ]
-                [ div [ class "header-title" ]
+                [ div [ class "header-title d-flex justify-content-baseline" ]
                     [ h1 []
                         [ span [] [ text "Plugins management" ]
                         ]
-                    ]
-                , div [ class "header-description" ]
-                    [ p []
-                        [ text "Plugins can extend Rudder’s base functionality to add extra features. Learn about available plugins on our "
-                        , a [ target "_blank", href "https://www.rudder.io/software/plugins/" ] [ text "website" ]
-                        , text " or directly "
-                        , a [ target "_blank", href "https://repository.rudder.io/plugins/" ] [ text "download free plugins" ]
-                        , text "."
-                        ]
+                    , if model.ui.loading then
+                        text ""
+
+                      else
+                        displayMainLicense model
                     ]
                 ]
             , div [ class "one-col-main" ]
@@ -48,48 +51,6 @@ view model =
         ]
 
 
-pluginStatusText : PluginStatus -> String
-pluginStatusText status =
-    case status of
-        Enabled ->
-            "Enabled"
-
-        Disabled ->
-            "Disabled"
-
-        Uninstalled ->
-            "Uninstalled"
-
-
-displayPluginLicense : Maybe LicenseInfo -> String
-displayPluginLicense l =
-    case l of
-        Just license ->
-            "Licensee: "
-                |> String.append license.licensee
-                |> String.append ", Allowed nodes: "
-                |> String.append (String.fromInt license.allowedNodesNumber)
-                |> String.append ", Supported versions: "
-                |> String.append license.supportedVersions
-                |> String.append ", Start date: "
-                |> String.append (Time.Iso8601.fromZonedDateTime license.startDate)
-                |> String.append ", End date: "
-                |> String.append (Time.Iso8601.fromZonedDateTime license.endDate)
-
-        Nothing ->
-            "No License"
-
-
-pluginTypeText : PluginType -> String
-pluginTypeText pluginType =
-    case pluginType of
-        Webapp ->
-            "Webapp"
-
-        Integration ->
-            "Integration"
-
-
 checkOne : PluginId -> Bool -> Msg
 checkOne id =
     CheckSelection
@@ -102,147 +63,352 @@ checkOne id =
            )
 
 
-checkAll : Bool -> Msg
-checkAll =
+checkAll : Set PluginId -> Bool -> Msg
+checkAll plugins =
     CheckSelection
         << (\check ->
                 if check then
-                    SelectAll
+                    SelectAll plugins
 
                 else
                     UnselectAll
            )
 
 
-actionButtons : Model -> List (Html Msg)
-actionButtons model =
-    [ button [ class "btn btn-primary me-1", onClick (CallApi updateIndex) ] [ i [ class "fa fa-refresh me-1" ] [], text "Check for updates" ]
-    , button [ class "btn btn-default mx-1", disabled <| List.isEmpty model.ui.selected, onClick (SetModalState (OpenModal Install)) ] [ text "Install", i [ class "fa fa-plus-circle ms-1" ] [] ]
-    , button [ class "btn btn-default mx-1", disabled <| List.isEmpty model.ui.selected, onClick (SetModalState (OpenModal Uninstall)) ] [ text "Uninstall", i [ class "fa fa-minus-circle ms-1" ] [] ]
-    , button [ class "btn btn-default mx-1", disabled <| List.isEmpty model.ui.selected, onClick (SetModalState (OpenModal Enable)) ] [ text "Enable", i [ class "fa fa-check-circle ms-1" ] [] ]
-    , button [ class "btn btn-default ms-1", disabled <| List.isEmpty model.ui.selected, onClick (SetModalState (OpenModal Disable)) ] [ text "Disable", i [ class "fa fa-ban ms-1" ] [] ]
+actionInstallUpgradeButton : PluginsActionExplanation -> Html Msg
+actionInstallUpgradeButton x =
+    let
+        { install, upgrade } =
+            installUpgradeCount x
+
+        installText =
+            text (actionText ActionInstall)
+                :: (install
+                        |> Maybe.map
+                            (\count ->
+                                [ em []
+                                    [ text <| "(" ++ String.fromInt count ++ ")" ]
+                                ]
+                            )
+                        |> Maybe.withDefault []
+                   )
+
+        upgradeText =
+            text (actionText ActionUpgrade)
+                :: (upgrade
+                        |> Maybe.map
+                            (\count ->
+                                [ em []
+                                    [ text <| "(" ++ String.fromInt count ++ ")" ]
+                                ]
+                            )
+                        |> Maybe.withDefault []
+                   )
+
+        disabledAttrs =
+            [ disabled (Maybe.Extra.isNothing install && Maybe.Extra.isNothing upgrade) ]
+    in
+    button
+        ([ class "btn btn-default mx-1"
+
+         -- we need action to be Install, since the Upgrade is just a user point-of-view
+         , onClick (SetModalState (OpenModal ModalInstallUpgrade x))
+         ]
+            ++ disabledAttrs
+        )
+        (installText ++ text " / " :: upgradeText ++ [ i [ class "fa fa-plus-circle ms-1" ] [] ])
+
+
+displaySelectAll : Int -> PluginsViewModel -> List (Html Msg)
+displaySelectAll totalCount { selected, plugins } =
+    let
+        pluginIds =
+            plugins |> Dict.keys |> Set.fromList
+
+        isSelectAll =
+            not (isAllSelected selected pluginIds)
+
+        selectText =
+            [ text
+                (if isSelectAll then
+                    "Select all  "
+
+                 else
+                    "Unselect all "
+                )
+            , em []
+                [ text <| "(" ++ String.fromInt (selectedCount selected) ++ "/" ++ String.fromInt totalCount ++ ")" ]
+            ]
+
+        disableButton =
+            Set.isEmpty pluginIds && selected == noSelected
+    in
+    if disableButton then
+        [ button [ class "btn btn-default", disabled True ]
+            (input [ id "select-plugins", type_ "checkbox", class "me-2", checked False ] []
+                :: selectText
+            )
+        ]
+
+    else
+        [ label [ class "btn btn-default", for "select-plugins" ]
+            -- We need a clone checkbox because bootstrap checkbox button hides it
+            (input [ id "clone-select-plugins", type_ "checkbox", class "me-2", checked (not isSelectAll), onCheck (checkAll pluginIds) ] []
+                :: selectText
+            )
+        , input [ id "select-plugins", type_ "checkbox", class "btn-check", checked (not isSelectAll), onCheck (checkAll pluginIds) ] []
+        ]
+
+
+displayFilters : Filters -> List (Html Msg)
+displayFilters filters =
+    [ div [ class "form-group" ]
+        [ input
+            [ class "form-control"
+            , type_ "text"
+            , value filters.search
+            , placeholder "Filter..."
+            , onInput
+                (\s ->
+                    UpdateFilters { filters | search = s }
+                )
+            ]
+            []
+        ]
+    , div [ class "form-group" ]
+        [ div [ class "btn-group", attribute "role" "group", attribute "aria-label" "Plugin Type Filter" ]
+            (pluginTypeRadioButtons filters)
+        ]
+    , div [ class "form-group" ]
+        [ div [ class "btn-group", attribute "role" "group", attribute "aria-label" "Install Status Filter" ]
+            (installStatusRadioButtons filters)
+        ]
     ]
 
 
-displayPluginsList : Model -> Html Msg
-displayPluginsList model =
-    if List.isEmpty model.plugins then
+pluginTypeRadioButtons : Filters -> List (Html Msg)
+pluginTypeRadioButtons filters =
+    [ ( "All types", FilterByAllPluginType )
+    , ( "Webapp", FilterByPluginType Webapp )
+    , ( "Integration", FilterByPluginType Integration )
+    ]
+        |> List.indexedMap (radioButton "pluginType" filters.pluginType (\s -> UpdateFilters { filters | pluginType = s }))
+        |> List.concat
+
+
+installStatusRadioButtons : Filters -> List (Html Msg)
+installStatusRadioButtons filters =
+    [ ( "All status", FilterByAllInstallStatus )
+    , ( "Enabled", FilterByInstallStatus (Installed Enabled) )
+    , ( "Disabled", FilterByInstallStatus (Installed Disabled) )
+    , ( "Uninstalled", FilterByInstallStatus Uninstalled )
+    ]
+        |> List.indexedMap
+            (radioButton "installStatus" filters.installStatus (\s -> UpdateFilters { filters | installStatus = s }))
+        |> List.concat
+
+
+radioButton : String -> a -> (a -> Msg) -> Int -> ( String, a ) -> List (Html Msg)
+radioButton groupName selected toMsg index ( labelText, value ) =
+    let
+        isChecked =
+            selected == value
+
+        inputId =
+            groupName ++ String.fromInt index
+    in
+    [ input
+        [ type_ "radio"
+        , class "btn-check"
+        , name groupName
+        , id inputId
+        , autocomplete False
+        , checked isChecked
+        , onClick (toMsg value)
+        ]
+        []
+    , label [ class "btn btn-outline-primary", Html.Attributes.for inputId ] [ text labelText ]
+    ]
+
+
+displayActionButtons : PluginsViewModel -> List (Html Msg)
+displayActionButtons { selected, installAction, uninstallAction, enableAction, disableAction } =
+    [ button [ class "btn btn-primary me-1", onClick (CallApi updateIndex) ] [ i [ class "fa fa-refresh me-1" ] [], text "Refresh plugins" ]
+    , actionInstallUpgradeButton ((\(PluginsAction { explanation }) -> explanation) installAction)
+    , actionButton ActionUninstall selected uninstallAction
+    , actionButton ActionEnable selected enableAction
+    , actionButton ActionDisable selected disableAction
+    ]
+
+
+actionButton : Action -> Selected -> PluginsAction -> Html Msg
+actionButton action selected (PluginsAction { successCount, isActionDisabled, explanation }) =
+    let
+        totalSelected =
+            String.fromInt <| selectedCount selected
+
+        onlyAllowedSelected =
+            String.fromInt successCount
+
+        byTotal =
+            if onlyAllowedSelected == totalSelected then
+                ""
+
+            else
+                "/" ++ totalSelected
+
+        count =
+            text (actionText action ++ " ")
+                :: (if isActionDisabled then
+                        []
+
+                    else
+                        [ em []
+                            [ text <|
+                                "("
+                                    ++ onlyAllowedSelected
+                                    ++ byTotal
+                                    ++ ")"
+                            ]
+                        ]
+                   )
+
+        disabledAttrs =
+            [ disabled isActionDisabled ]
+    in
+    button
+        ([ class "btn btn-default mx-1"
+         , onClick (SetModalState (OpenModal (actionToModal action) explanation))
+         ]
+            ++ disabledAttrs
+        )
+        (count ++ [ actionIcon action ])
+
+
+displayPluginsList : Dict PluginId Plugin -> PluginsViewModel -> Html Msg
+displayPluginsList plugins pluginsModel =
+    if Dict.isEmpty plugins then
         i [ class "text-secondary" ] [ text "There are no plugins available." ]
 
     else
-        pluginsSection model
+        displayPluginsSection (Dict.size plugins) pluginsModel
 
 
-pluginsSection : Model -> Html Msg
-pluginsSection model =
+displayPluginsSection : Int -> PluginsViewModel -> Html Msg
+displayPluginsSection totalCount pluginsModel =
     let
-        selected =
-            model.ui.selected
-
         plugins =
-            List.sortWith pluginDefaultOrdering model.plugins
+            pluginsModel.plugins |> Dict.toList |> List.map Tuple.second |> List.sortWith pluginDefaultOrdering
 
-        isSelectAll =
-            not (List.length plugins == List.length selected)
+        listContent =
+            div [ class "plugins-list" ]
+                (if List.isEmpty plugins then
+                    [ div [ class "plugins-list callout-fade callout-warning overflow-scroll" ]
+                        [ i [ class "fa fa-exclamation-triangle me-2" ] []
+                        , em [] [ text "No plugins match your filters" ]
+                        ]
+                    ]
 
-        selectText =
-            if isSelectAll then
-                "Select all"
-
-            else
-                "Unselect all"
-
-        selectHtml =
-            [ label [ class "btn btn-default", for "select-plugins" ]
-                -- We need a clone checkbox because bootstrap checkbox button hides it
-                [ input [ id "clone-select-plugins", type_ "checkbox", class "me-2", checked (not isSelectAll), onCheck checkAll ] []
-                , text selectText
-                ]
-            , input [ id "select-plugins", type_ "checkbox", class "btn-check", checked (not isSelectAll), onCheck checkAll ] []
-            ]
+                 else
+                    List.map (displayPlugin pluginsModel) plugins
+                )
     in
     div [ class "main-table" ]
         [ div [ class "table-container plugins-container" ]
             [ div [ class "dataTables_wrapper_top table-filter plugins-actions" ]
-                [ div [ class "start" ] selectHtml
-                , div [ class "end" ] (actionButtons model)
+                [ div [ class "plugins-actions-buttons" ]
+                    [ div [] (displaySelectAll totalCount pluginsModel)
+                    , div [] (displayActionButtons pluginsModel)
+                    ]
+                , div [ class "plugins-actions-filters" ]
+                    (displayFilters pluginsModel.filters)
                 ]
-            , h2 [ class "fs-5 p-3 m-0" ] [ text "Features" ]
-            , div [ class "plugins-list" ] (List.map (displayPlugin model) plugins)
+            , listContent
             ]
         ]
 
 
-displayGlobalLicense : LicenseGlobalInfo -> Html Msg
-displayGlobalLicense license =
+displayGlobalLicense : ZonedDateTime -> LicenseGlobal -> Html Msg
+displayGlobalLicense now license =
     let
         licensees =
             license.licensees |> Maybe.map (String.join ", ") |> Maybe.withDefault "-"
 
         dateOf =
-            Time.ZonedDateTime.toDateTime >> Time.DateTime.date >> Time.Iso8601.fromDate
+            ZonedDateTime.toDateTime >> Time.DateTime.date >> Time.Iso8601.fromDate
 
         -- dates needs to be aggregated by date part of datetime
-        aggregateDates : List DateCount -> List ( String, Int )
+        aggregateDates : List DateCount -> List ( ZonedDateTime, Int )
         aggregateDates dates =
             dates
                 |> List.sortBy (.date >> dateOf)
                 |> List.Extra.groupWhile (\x y -> dateOf (.date x) == dateOf (.date y))
-                |> List.map (\( d, ns ) -> ( dateOf d.date, d.count + (List.map .count >> List.sum) ns ))
+                |> List.map (\( d, ns ) -> ( d.date, d.count + (List.map .count >> List.sum) ns ))
+
+        isBeforeNow =
+            Ordering.greaterThanBy (compareOn dateOf)
+
+        isBeforeNextMonth zdt n =
+            isBeforeNow zdt (ZonedDateTime.addMonths 1 n)
+
+        cls d =
+            if isBeforeNow d now then
+                ""
+
+            else if isBeforeNextMonth d now then
+                "text-warning"
+
+            else
+                "text-danger"
 
         displayPluginDates ends =
-            String.join ", " (List.map (\( d, n ) -> d ++ " (" ++ String.Extra.pluralize " plugin)" " plugins)" n) ends)
+            List.intersperse (text ", ")
+                (List.map (\( d, n ) -> span [ class <| cls d ++ " d-inline-block" ] [ text <| dateOf d ++ " (" ++ String.Extra.pluralize " plugin)" " plugins)" n ]) ends)
 
         validityPeriod =
             case ( license.startDate, license.endDates ) of
                 ( Just start, Just ends ) ->
-                    "from " ++ dateOf start ++ " to " ++ displayPluginDates (aggregateDates ends)
+                    (text <| "from " ++ dateOf start ++ " to ") :: displayPluginDates (aggregateDates ends)
 
                 _ ->
-                    "-"
+                    [ text "-" ]
 
         nbNodes =
             license.maxNodes |> Maybe.map String.fromInt |> Maybe.withDefault "Unlimited"
     in
-    div [ class "main-license" ]
-        [ div [ attribute "data-plugin" "statusInformation", class "license-card" ]
-            [ div [ id "license-information", class "license-info" ]
-                [ h2 [ class "license-info-title" ] [ span [] [ text "License information" ], i [ class "license-icon ion ion-ribbon-b" ] [] ]
-                , p [ class "license-information-details" ] [ text "The following license information are provided" ]
-                , div [ class "license-information-details" ]
-                    [ table [ class "table-license" ]
-                        [ tbody []
-                            [ tr [] [ td [] [ text "Licensee:" ], td [] [ text licensees ] ]
-
-                            -- in individual plugin only
-                            -- , tr [] [ td [] [ text "Supported version:" ], td [] [ text "from 0.0.0-0.0.0 to 99.99.0-99.99.0" ] ]
-                            , tr [] [ td [] [ text "Validity period:" ], td [] [ text validityPeriod ] ]
-                            , tr [] [ td [] [ text "Allowed number of nodes:" ], td [] [ text nbNodes ] ]
-                            ]
-                        ]
-                    ]
-                ]
-            ]
+    ul []
+        [ li [ class "d-inline-block" ] [ span [ class "fw-normal" ] [ text "Licensee: " ], text licensees, text ", ", span [ class "fw-normal" ] [ text "Allowed number of nodes: " ], text nbNodes ]
+        , li [ class "d-inline-block" ] (span [ class "fw-normal" ] [ text "Validity period: " ] :: validityPeriod)
         ]
 
 
-displaySettingError : Model -> String -> String -> Html Msg
-displaySettingError model message details =
+displaySettingError : String -> String -> Maybe String -> Html Msg
+displaySettingError contextPath message details =
+    let
+        seeDetailsBtnHtml =
+            if Maybe.Extra.isJust details then
+                a [ class "btn btn-default", attribute "data-bs-toggle" "collapse", href "#collapseSettingsError", role "button", attribute "aria-expanded" "false", attribute "aria-controls" "collapseSettingsError" ]
+                    [ text "See details" ]
+
+            else
+                text ""
+
+        detailsCollapseHtml =
+            details
+                |> Maybe.map
+                    (\d ->
+                        div [ class "collapse", id "collapseSettingsError" ] [ div [ class "card card-body" ] [ pre [ class "command-output" ] [ text d ] ] ]
+                    )
+                |> Maybe.withDefault (text "")
+    in
     div [ class "callout-fade callout-warning overflow-scroll" ]
         [ p [] [ i [ class "fa fa-warning" ] [], text message ]
-        , p [] [ a [ target "_blank", href (model.contextPath ++ "/secure/administration/settings") ] [ text "Open Rudder account settings", i [ class "fa fa-external-link ms-1" ] [] ] ]
+        , p [] [ a [ target "_blank", href (contextPath ++ "/secure/administration/settings") ] [ text "Open Rudder account settings", i [ class "fa fa-external-link ms-1" ] [] ] ]
         , p []
             [ button [ class "btn btn-primary me-1", onClick (CallApi updateIndex) ] [ i [ class "fa fa-refresh me-1" ] [], text "Refresh plugins" ]
-            , a [ class "btn btn-default", attribute "data-bs-toggle" "collapse", href "#collapseSettingsError", role "button", attribute "aria-expanded" "false", attribute "aria-controls" "collapseSettingsError" ]
-                [ text "See details" ]
+            , seeDetailsBtnHtml
             ]
-        , div [ class "collapse", id "collapseSettingsError" ]
-            [ div [ class "card card-body" ]
-                [ pre [ class "command-output" ]
-                    [ text details
-                    ]
-                ]
-            ]
+        , detailsCollapseHtml
         ]
 
 
@@ -250,132 +416,169 @@ displayMainLicense : Model -> Html Msg
 displayMainLicense model =
     case model.license of
         Nothing ->
-            displaySettingError model "No license found. Please contact Rudder to get license or configure your access" ("Available plugins : [" ++ String.join ", " (List.map .id model.plugins) ++ "]")
+            displaySettingError model.contextPath "No license found. Please contact Rudder to get license or configure your access" Nothing
 
         Just license ->
             if license == noGlobalLicense then
-                displaySettingError model "Empty license found. Please contact Rudder to get license or configure your access" ("Available plugins : [" ++ String.join ", " (List.map .id model.plugins) ++ "]")
+                displaySettingError model.contextPath "Empty license found. Please contact Rudder to get license or configure your access" Nothing
 
             else
-                displayGlobalLicense license
+                displayGlobalLicense (ZonedDateTime.fromPosix utc model.now) license
 
 
 displayPluginView : Model -> List (Html Msg)
 displayPluginView model =
     case model.ui.view of
-        ViewSettingsError ( message, details ) ->
-            [ displaySettingError model message details ]
+        ViewSettingError ( message, details ) ->
+            [ displaySettingError model.contextPath message (Just details) ]
 
-        ViewPluginsList ->
-            [ displayMainLicense model
-            , displayPluginsList model
+        ViewActionError _ pluginsModel ->
+            -- error is already dislayed in modal
+            [ displayPluginsList model.plugins pluginsModel
+            ]
+
+        ViewPluginsList pluginsModel ->
+            [ displayPluginsList model.plugins pluginsModel
             ]
 
 
-findLicenseNeededError : List PluginError -> Maybe PluginError
-findLicenseNeededError =
-    List.Extra.find (\{ error } -> error == "license.needed.error")
-
-
-pluginBadge : PluginInfo -> List (Html msg)
+pluginBadge : Plugin -> List (Html msg)
 pluginBadge p =
-    case ( p.status, findLicenseNeededError p.errors ) of
-        ( Enabled, _ ) ->
-            [ div [ class "position-absolute top-0 end-0" ] [ span [ class "badge float-end bg-success" ] [ text "Installed" ] ] ]
+    case ( p.installStatus, p.licenseStatus ) of
+        ( Installed Disabled, _ ) ->
+            [ div [ class "position-absolute top-0 start-0" ] [ span [ class "badge float-start" ] [ text "Disabled" ] ] ]
 
-        ( _, Just _ ) ->
-            [ div [ class "position-absolute top-0 end-0" ] [ span [ class "badge float-end text-dark" ] [ i [ class "fa fa-info-circle me-1" ] [], text "Missing license" ] ] ]
+        ( _, MissingLicense _ ) ->
+            [ div [ class "position-absolute top-0 start-0" ] [ span [ class "badge float-start text-dark" ] [ i [ class "fa fa-info-circle me-1" ] [], text "No license" ] ] ]
 
-        ( Disabled, _ ) ->
-            [ div [ class "position-absolute top-0 end-0" ] [ span [ class "badge float-end" ] [ text "Disabled" ] ] ]
+        ( Installed Enabled, _ ) ->
+            [ div [ class "position-absolute top-0 start-0" ] [ span [ class "badge float-start bg-success" ] [ text "Installed" ] ] ]
 
         ( Uninstalled, _ ) ->
             []
 
 
-pluginCardBgClass : PluginInfo -> Maybe String
+pluginCardBgClass : Plugin -> Maybe String
 pluginCardBgClass p =
-    case ( p.status, findLicenseNeededError p.errors ) of
-        ( Disabled, _ ) ->
-            Just "plugin-card-disabled"
-
-        ( _, Just _ ) ->
+    case ( p.installStatus, p.licenseStatus ) of
+        ( _, MissingLicense _ ) ->
             Just "plugin-card-missing-license"
 
-        _ ->
-            Nothing
-
-
-pluginErrorCalloutClass : PluginError -> Maybe String
-pluginErrorCalloutClass err =
-    case err.error of
-        "license.near.expiration.error" ->
-            Just "warning"
-
-        "abi.version.error" ->
-            Just "warning"
-
-        "license.expired.error" ->
-            Just "danger"
+        ( Installed Disabled, _ ) ->
+            Just "plugin-card-disabled"
 
         _ ->
             Nothing
 
 
-pluginErrorCallouts : PluginInfo -> Maybe (List (Html msg))
-pluginErrorCallouts p =
-    p.errors
-        |> List.filterMap (\err -> pluginErrorCalloutClass err |> Maybe.map (\cls -> ( err, cls )))
-        |> List.map (\( err, cls ) -> div [ class ("callout-fade callout-" ++ cls) ] [ i [ class ("me-1 fa fa-" ++ cls) ] [], text err.message ])
-        |> (\e ->
-                if List.isEmpty e then
-                    Nothing
+pluginErrorCallouts : Plugin -> List (Html Msg)
+pluginErrorCallouts { licenseStatus, abiVersionError } =
+    case ( licenseStatus, abiVersionError ) of
+        ( ExpiredLicense message, _ ) ->
+            [ div [ class "callout-fade callout-danger" ] [ i [ class "me-1 fa fa-warning" ] [], text message ] ]
 
-                else
-                    Just e
-           )
+        ( MissingLicense message, _ ) ->
+            [ div [ class "callout-fade callout-danger" ] [ i [ class "me-1 fa fa-warning" ] [], text message ] ]
 
+        ( NearExpirationLicense message, _ ) ->
+            [ div [ class "callout-fade callout-warning" ] [ i [ class "me-1 fa fa-warning" ] [], text message ] ]
 
-pluginInputCheck : Model -> PluginInfo -> List (Html Msg)
-pluginInputCheck model p =
-    let
-        -- plugin cannot be selected
-        isDisabled =
-            Maybe.Extra.isJust <| findLicenseNeededError p.errors
-    in
-    if isDisabled then
-        [ input [ id p.id, type_ "checkbox", class "d-none", disabled True ] [], i [ class "fa fa-info-circle text-muted fs-5 mx-2" ] [] ]
+        ( _, Just message ) ->
+            [ div [ class "callout-fade callout-warning" ] [ i [ class "me-1 fa fa-warning" ] [], text message ] ]
 
-    else
-        [ input [ id p.id, type_ "checkbox", class "mx-2", checked (List.member p.id model.ui.selected), onCheck (checkOne p.id) ] [] ]
+        _ ->
+            []
 
 
-displayPlugin : Model -> PluginInfo -> Html Msg
-displayPlugin model p =
+pluginInputCheck : { a | id : PluginId } -> Selected -> List (Html Msg)
+pluginInputCheck p selected =
+    case getSelection p.id selected of
+        NotSelectable ->
+            [ input [ id p.id, type_ "checkbox", class "d-none", disabled True ] [], i [ class "fa fa-info-circle text-muted fs-5 mx-3" ] [] ]
+
+        Selection b ->
+            [ input [ id p.id, type_ "checkbox", class "mx-3", checked b, onCheck (checkOne p.id) ] [] ]
+
+
+displayPlugin : PluginsViewModel -> Plugin -> Html Msg
+displayPlugin pluginsModel p =
     div [ class <| "plugin-card card " ++ Maybe.withDefault "" (pluginCardBgClass p) ]
         [ div [ class "card-body" ]
             [ div [ class "form-check p-0 d-flex align-items-center" ]
-                (pluginInputCheck model p
-                    ++ label [ class "d-flex flex-column mx-2", for p.id ]
-                        [ div [ class "d-flex align-items-baseline" ]
-                            [ h3 [ class "plugin-name card-title" ] [ text p.name ]
-                            , span [ class "plugin-version ms-2" ] [ text ("v" ++ p.pluginVersion) ]
+                (pluginBadge p
+                    ++ pluginInputCheck p pluginsModel.selected
+                    ++ [ label [ class "d-flex flex-column mx-4", for p.id ]
+                            [ div [ class "d-flex align-items-baseline" ]
+                                [ h3 [ class "plugin-title card-title" ]
+                                    [ text p.description
+                                    , a [ class "link-dark text-decoration-underline link-underline link-offset-2 link-underline-opacity-0 link-underline-opacity-100-hover", target "_blank", href p.docLink ] [ i [ class "plugin-doc-icon fa fa-book me-2" ] [] ]
+                                    ]
+                                ]
+                            , div [ class "card-text" ]
+                                -- [badge](Webapp) - ID: branding - v2.1.0
+                                [ div [ class "plugin-technical-info" ]
+                                    [ span [ class <| "badge badge-type plugin-" ++ (String.Extra.decapitalize <| pluginTypeText p.pluginType) ] [ text <| pluginTypeText p.pluginType ]
+                                    , span [] [ text <| "ID: " ++ p.id ]
+                                    , span [ class "plugin-version" ] [ text <| "v" ++ p.version ]
+                                    ]
+                                , Maybe.withDefault (text "") <|
+                                    Maybe.map (div [ class "plugin-errors d-flex flex-column" ]) <|
+                                        Maybe.Extra.filter (\l -> List.length l > 0) <|
+                                            Just (pluginErrorCallouts p)
+                                ]
                             ]
-                        , div [ class "card-text" ]
-                            [ div [ class "plugin-description" ] [ text p.description ]
-                            , Maybe.withDefault (text "") <|
-                                Maybe.map (div [ class "plugin-errors d-flex flex-column" ]) <|
-                                    pluginErrorCallouts p
-                            ]
-                        ]
-                    :: pluginBadge p
+                       ]
                 )
+            ]
+        ]
+
+
+buildErrorModal : PluginsViewModel -> String -> ( String, String ) -> Html Msg
+buildErrorModal pluginsViewModel title ( message, details ) =
+    let
+        seeDetailsBtnHtml =
+            a
+                [ class "btn btn-default", attribute "data-bs-toggle" "collapse", href "#collapseSettingsError", role "button", attribute "aria-expanded" "false", attribute "aria-controls" "collapseSettingsError" ]
+                [ text "See details" ]
+
+        detailsCollapseHtml =
+            div [ class "collapse", id "collapseSettingsError" ] [ div [ class "card card-body" ] [ pre [ class "command-output" ] [ text details ] ] ]
+    in
+    div [ class "modal modal-plugins fade show", style "display" "block" ]
+        [ div [ class "modal-backdrop fade show", onClick (ResetPluginListFromModal pluginsViewModel) ] []
+        , div [ class "modal-dialog modal-dialog-scrollable" ]
+            [ div [ class "modal-content" ]
+                [ div [ class "modal-header" ]
+                    [ h2 [ class "fs-5 modal-title" ] [ text title ]
+                    , button [ type_ "button", class "btn-close", onClick (ResetPluginListFromModal pluginsViewModel) ] []
+                    ]
+                , div [ class "modal-body" ]
+                    [ div [ class "callout-fade callout-danger overflow-scroll" ]
+                        [ p [] [ i [ class "fa fa-warning" ] [], text message ]
+                        , seeDetailsBtnHtml
+                        , detailsCollapseHtml
+                        ]
+                    ]
+                , div [ class "modal-footer" ]
+                    [ button [ type_ "button", class "btn btn-default", onClick (ResetPluginListFromModal pluginsViewModel) ] [ text "Close" ]
+                    ]
+                ]
             ]
         ]
 
 
 buildModal : Bool -> String -> Html Msg -> Msg -> Html Msg
 buildModal loading title body saveAction =
+    let
+        submitButton =
+            if loading then
+                button [ type_ "button", class "btn btn-success", disabled True ]
+                    [ text "Restarting..." ]
+
+            else
+                button [ type_ "button", class "btn btn-success", onClick saveAction ]
+                    [ text "Confirm & Restart" ]
+    in
     div [ class "modal modal-plugins fade show", style "display" "block" ]
         [ div [ class "modal-backdrop fade show", onClick (SetModalState NoModal) ] []
         , div [ class "modal-dialog modal-dialog-scrollable" ]
@@ -388,44 +591,153 @@ buildModal loading title body saveAction =
                     [ body
                     ]
                 , div [ class "modal-footer" ]
-                    [ button [ type_ "button", class "btn btn-default", onClick (SetModalState NoModal) ] [ text "Close" ]
-                    , button [ type_ "button", class "btn btn-success", onClick saveAction ]
-                        (loadWithSpinner "spinner-grow spinner-grow-sm"
-                            loading
-                            (if loading then
-                                []
-
-                             else
-                                [ text "Confirm" ]
-                            )
-                        )
+                    [ button [ type_ "button", class "btn btn-default", onClick (SetModalState NoModal) ] [ text "Cancel" ]
+                    , submitButton
                     ]
                 ]
             ]
         ]
 
 
-modalTitle : RequestType -> String
-modalTitle requestType =
-    String.Extra.toSentenceCase (requestTypeText requestType) ++ " plugins"
+modalTitle : ModalAction -> String
+modalTitle action =
+    String.Extra.toSentenceCase (modalActionText action) ++ " plugins"
 
 
-modalBody : RequestType -> Model -> Html Msg
-modalBody requestType model =
-    div [ class "callout-fade callout-warning" ]
-        [ p [] [ i [ class "fa fa-warning me-2" ] [], strong [] [ text "Rudder may restart" ], text <| " to " ++ requestTypeText requestType ++ " " ++ String.Extra.pluralize "plugin" "plugins" (List.length model.ui.selected) ++ " :" ]
-        , ul [ class "list-group m-0" ] (List.map (\p -> li [ class "list-group-item" ] [ text p ]) model.ui.selected)
-        ]
+modalBody : ModalAction -> PluginsActionExplanation -> Dict PluginId Plugin -> Html Msg
+modalBody action explanation plugins =
+    let
+        doAction act =
+            String.Extra.decapitalize (modalActionText act)
+
+        pastAction act =
+            act
+                ++ (if String.endsWith "e" act then
+                        "d"
+
+                    else
+                        "ed"
+                   )
+
+        pluginListGroupItem p =
+            li [ class "list-group-item" ]
+                (case Dict.get p plugins of
+                    Just { id, description } ->
+                        [ text description
+                        , text " "
+                        , em [] [ text <| "(" ++ id ++ ")" ]
+                        ]
+
+                    Nothing ->
+                        [ text p
+                        ]
+                )
+
+        successHtml success =
+            div [ class "callout-fade callout-success" ]
+                [ ul [ class "list-group m-0" ] (success |> Set.toList |> List.map pluginListGroupItem)
+                ]
+
+        displaySuccess success actionText =
+            [ p [] [ strong [] [ text "Rudder will restart" ], text <| " to " ++ actionText ++ " " ++ String.Extra.pluralize "plugin" "plugins" (Set.size success) ++ " :" ]
+            , successHtml success
+            ]
+
+        displayError errors actionText =
+            [ p [] [ strong [] [ text <| "Following plugins cannot be " ++ pastAction actionText ++ " : " ] ]
+            , div [ class "callout-fade callout-warning plugin-action" ]
+                (errors
+                    |> List.map
+                        (\( error, ps ) ->
+                            div [ class "plugin-action-error" ]
+                                [ div [ class "px-1 mb-1 fw-bolder" ] [ text <| explainDisallowedResult error ]
+                                , ul [ class "list-group m-0" ] (ps |> Set.toList |> List.map pluginListGroupItem)
+                                ]
+                        )
+                )
+            ]
+
+        actionInstallText =
+            String.Extra.decapitalize (actionText ActionInstall)
+
+        actionUpgradeText =
+            String.Extra.decapitalize (actionText ActionUpgrade)
+
+        errorInstallUpgradeText =
+            "installed/upgrade"
+    in
+    case explanation of
+        PluginsActionNoExplanation ->
+            text ""
+
+        PluginsActionExplainSuccess success ->
+            div [] (displaySuccess success (doAction action))
+
+        PluginsActionExplainErrors errors ->
+            div [] (displayError errors (doAction action))
+
+        PluginsActionExplainSuccessWarning { success, warning } ->
+            div [] (displaySuccess success (doAction action) ++ displayError warning (doAction action))
+
+        PluginsActionExplainInstall success ->
+            div [] (displaySuccess success actionInstallText)
+
+        PluginsActionExplainInstallWarning { install, warning } ->
+            div [] (displaySuccess install actionInstallText ++ displayError warning actionInstallText)
+
+        PluginsActionExplainUpgrade success ->
+            div [] (displaySuccess success actionUpgradeText)
+
+        PluginsActionExplainUpgradeWarning { upgrade, warning } ->
+            div [] (displaySuccess upgrade actionUpgradeText ++ displayError warning errorInstallUpgradeText)
+
+        PluginsActionExplainInstallUpgrade { install, upgrade } ->
+            div [] (displaySuccess install actionInstallText ++ [ p [] [ text <| "and upgrade " ++ String.fromInt (Set.size upgrade) ++ " plugins :" ], successHtml upgrade ])
+
+        PluginsActionExplainInstallUpgradeWarning { install, upgrade, warning } ->
+            div [] (displaySuccess install actionInstallText ++ [ p [] [ text <| "and upgrade " ++ String.fromInt (Set.size upgrade) ++ " plugins :" ], successHtml upgrade ] ++ displayError warning errorInstallUpgradeText)
 
 
 displayModal : Model -> Html Msg
 displayModal model =
-    case model.ui.modalState of
-        NoModal ->
+    case model.ui.view of
+        ViewSettingError _ ->
             text ""
 
-        OpenModal requestType ->
-            buildModal model.ui.loading (modalTitle requestType) (modalBody requestType model) (RequestApi requestType)
+        ViewActionError errDetails pluginsModel ->
+            case pluginsModel.modalState of
+                ErrorModal action ->
+                    buildErrorModal pluginsModel (modalTitle action) errDetails
+
+                _ ->
+                    text ""
+
+        ViewPluginsList pluginsModel ->
+            case pluginsModel.modalState of
+                OpenModal action explanation ->
+                    buildModal model.ui.loading (modalTitle action) (modalBody action explanation pluginsModel.plugins) (RequestApi (actionRequestType action) (successPluginsFromExplanation explanation))
+
+                _ ->
+                    text ""
+
+
+actionIcon : Action -> Html Msg
+actionIcon action =
+    case action of
+        ActionInstall ->
+            i [ class "fa fa-plus-circle ms-1" ] [] 
+
+        ActionUpgrade ->
+            i [ class "fa fa-plus-circle ms-1" ] [] 
+
+        ActionEnable ->
+            i [ class "fa fa-check-circle ms-1" ] [] 
+
+        ActionDisable ->
+            i [ class "fa fa-ban ms-1" ] [] 
+
+        ActionUninstall ->
+            i [ class "fa fa-minus-circle ms-1" ] [] 
 
 
 loadWithSpinner : String -> Bool -> List (Html Msg) -> List (Html Msg)

--- a/webapp/sources/rudder/rudder-web/src/main/resources/load-page/rudder-loading.html
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/load-page/rudder-loading.html
@@ -184,7 +184,7 @@
       </h1>
     </div>
     <div class="logo">
-      <h2 class="loading">Rudder is currently loading, please wait</h2>
+      <h2 class="loading">Rudder is currently starting, please wait</h2>
       <h1>
         <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/PluginExpirationInfo.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/PluginExpirationInfo.scala
@@ -98,7 +98,7 @@ class PluginExpirationInfo extends DispatchSnippet with Loggable {
       data-bs-placement="bottom"
       title={tooltipContent}
       >
-        <a href="/secure/administration/plugins"><span class="fa fa-puzzle-piece"></span></a>
+        <a href="/secure/administration/pluginInformation"><span class="fa fa-puzzle-piece"></span></a>
       </li>
     }
     if (warnings.licenseError.nonEmpty || warnings.licenseExpired.nonEmpty) {

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/_rudder-variables.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/_rudder-variables.scss
@@ -56,6 +56,7 @@ $rudder-txt-link      : #1295C2;
 $rudder-bg-light-gray : #F8F9FC;
 $rudder-bg-gray       : #EEF1F9;
 $rudder-bg-dark-gray  : #E1E5EB;
+$rudder-bg-danger     : #F8D7DA;
 
 // --- BORDERS
 $rudder-border-color-default : #D6DEEF;

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-plugins.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-plugins.scss
@@ -111,11 +111,22 @@ $spinner-height-sm: $spinner-width-sm;
   }
 }
 
+.header-title {
+  & ul {
+    max-width: 30vw;
+    margin-bottom: 0;
+    text-align: right;
+    font-weight: 300;
+    font-style: italic;
+  }
+}
 
 .plugins-container {
   $default-font-size: 0.86em;
 
   & .plugins-actions {
+    display: flex;
+    flex-direction: column;
     border-bottom: 2px solid $rudder-border-color-default !important; // in combination with datatable classes
 
     & .btn {
@@ -123,16 +134,43 @@ $spinner-height-sm: $spinner-width-sm;
       border-radius: 0.3em;
       min-width: 4.8rem;
     }
+
+    & .plugins-actions-buttons {
+      width: 100%;
+      display: flex;
+      flex-wrap: nowrap;
+      justify-content: space-between;
+
+      & :first-child {
+        flex: 1 1 auto;
+      }
+
+      & :last-child {
+        flex: 0 1 auto;
+      }
+    }
+
+    & .plugins-actions-filters {
+      width: 100%;
+      display: flex;
+      margin-top: 0.4em;
+
+      & .form-group:not(:first-child) {
+        margin-left: 1em;
+      }
+    }
   }
 
   & .plugins-list {
     padding-left: 1rem;
     padding-right: 1rem;
 
-    & .plugin-card {
-      &:not(:first-child):not(:last-child) {
-        margin: 10px 0;
-      }
+    &.callout-warning {
+      margin: 10px 0;
+    }
+
+    & .plugin-card.card {
+      margin: 10px 0;
 
       &.plugin-card-disabled {
         background-color: $rudder-bg-light-gray;
@@ -146,51 +184,101 @@ $spinner-height-sm: $spinner-width-sm;
         }
       }
 
-      & .badge.float-end {
+      & .badge.float-start {
         font-size: $default-font-size;
-        border-top-left-radius: 0;
-        border-bottom-right-radius: 0;
+        border-top-right-radius: 0;
+        border-bottom-left-radius: 0;
         text-transform: uppercase;
         padding: 0.3rem 0.8rem;
         font-weight: 600;
+        margin: 0;
+      }
+
+      & .card-body {
+        margin-top: 1rem;
       }
 
       & .form-check label {
         cursor: pointer;
       }
 
-      & .card-text {
-        font-size: $default-font-size;
-      }
-
-      & .plugin-name {
+      & .plugin-title {
         font-size: 1rem;
         font-weight: 500;
+
+        & .plugin-doc-icon {
+          margin-left: 0.6rem;
+          color: #337ab7;
+          opacity: 0.8;
+          &:hover {
+            opacity: 1;
+          }
+        }
       }
 
-      & .plugin-description {
-        color: $rudder-txt-secondary;
-      }
+      & .card-text {
+        font-size: $default-font-size;
 
-      & .plugin-version {
-        font-size: 0.72rem;
-        font-weight: 300;
-      }
+        & .plugin-technical-info {
+          color: $rudder-txt-secondary;
 
-      & .plugin-errors {
-        $el-margin: 0.5rem;
+          & .badge.badge-type {
+            opacity: 0.75;
+            border-radius: 0.25rem;
 
-        margin-top: $el-margin;
-
-        & .callout-fade {
-          &:not(:last-child) {
-            margin-top: $el-margin;
-            margin-bottom: $el-margin;
+            &.plugin-webapp + &.plugin-integration{
+              background-color: #72829d;
+              font-weight: 600 !important;
+            }
           }
 
-          &:last-child {
-            margin-bottom: 0;
+          & .plugin-version {
+            &:before{
+              content: "-";
+              padding: 0 0.3rem;
+            }
           }
+        }
+
+        & .plugin-errors {
+          $el-margin: 0.5rem;
+
+          margin-top: $el-margin;
+
+          & .callout-fade {
+            &:not(:last-child) {
+              margin-top: $el-margin;
+              margin-bottom: $el-margin;
+            }
+
+            &:last-child {
+              margin-bottom: 0;
+            }
+
+            &.callout-danger {
+              background-color: $rudder-bg-danger;
+
+              & .fa.fa-warning {
+                color: #58151c;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+/* === MODAL === */
+.modal {
+  .modal-body {
+    .plugin-action.callout-fade {
+      .plugin-action-error {
+        &:not(:last-child) {
+          padding-bottom: 1em;
+        }
+        & .list-group li {
+          background: #f8f9fc;
         }
       }
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/26336

In terms of features, we need to know information about which selected plugins can be installed/enabled/disabled/uninstalled.
To better split this, there are two modules : 
* one which contains all the logic of install/enable,etc. : `Action.elm`
* another which makes the selection of allowed plugins : `Select.elm`
which only expose the needed datatypes (most of them are opaque), the mainly used functions are :  
```mermaid
graph LR
  Action --findPluginActions--> Select --select--> DataTypes
```
This model allows to define the action that are allowed/disallowed, then to apply them for selected plugins, and tests have been added for the `select` method on all cases for allowing/disallowing an action on a plugin.

At last, this information is used in aggregated format (count, group by errors/success), and displayed both in the filter bar and in the confirmation modal.

---
In addition to this splitting, the main changes in the existing codebase consist of : 
* modelling a separate type for the plugin parsed from the API JSON, and mapping it to the plugin type used for display
* modelling the view in the UI as a union type that represents it better, essentially the `ViewPluginsList` case with all the plugins, actions, selections and filters
* using setters to enforce invariants when changing fields together (e.g. selection needs to be reset with a new plugins list), minimize copy-paste and enforce code style
* minimizing data transformation in `View.elm`, there is already fewer logic because the model has changed to be closer to the actual data being displayed (e.g. license errors)

Additional minor changes for the final result include refactoring and adding SCSS :
 
![Peek 2025-02-25 10-44](https://github.com/user-attachments/assets/902e56f8-ff45-4662-945a-2814744ef121)
