### PR TITLE
Fixes #26325: Resolved properties conflicts still appear as errors in status 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -38,6 +38,7 @@
 package com.normation.rudder.domain.properties
 
 import cats.data.Ior
+import cats.kernel.Monoid
 import cats.kernel.Semigroup
 import cats.syntax.semigroup.*
 import com.normation.GitVersion
@@ -46,8 +47,8 @@ import com.normation.errors.*
 import com.normation.inventory.domain.CustomProperty
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.logger.ApplicationLogger
-import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.properties.GroupProp
 import com.normation.rudder.services.policies.ParameterEntry
 import com.typesafe.config.*
 import enumeratum.*
@@ -893,20 +894,24 @@ object CompareProperties {
  *   - name of the diff provider: group/target name, global parameter
  */
 sealed trait ParentProperty {
+  def kind:        String
   def displayName: String // human-readable information about the parent providing prop
   def value:       ConfigValue
 }
 
 object ParentProperty {
   final case class Node(name: String, id: NodeId, value: ConfigValue)       extends ParentProperty {
+    override def kind:        String = "Node"
     override def displayName: String = s"${name} (${id.value})"
   }
   final case class Group(name: String, id: NodeGroupId, value: ConfigValue) extends ParentProperty {
+    override def kind:        String = "Group"
     override def displayName: String = s"${name} (${id.serialize})"
   }
   // a global parameter has the same name as property so no need to be specific for name
   final case class Global(value: ConfigValue)                               extends ParentProperty {
     val displayName = "Global Parameter"
+    override def kind: String = displayName
   }
 
   // The hierarchy of node properties from top to bottom : Global, Group, Node
@@ -1055,8 +1060,8 @@ object NodePropertyError         {
       s"MissingParentGroup(groupId=${groupId.serialize},groupName=${groupName},parentGroupId=${parentGroupId})"
   }
   object MissingParentGroup {
-    def apply(group: NodeGroup, parentGroupId: String): MissingParentGroup =
-      MissingParentGroup(group.id, group.name, parentGroupId)
+    def apply(groupProp: GroupProp, parentGroupId: String): MissingParentGroup =
+      MissingParentGroup(groupProp.groupId, groupProp.groupName, parentGroupId)
   }
 
   // The message can be very broad or specific here, it is known from the DAG resolution
@@ -1068,20 +1073,32 @@ object NodePropertyError         {
   case class PropertyInheritanceConflicts(
       conflicts: Map[NodeProperty, NonEmptyChunk[List[ParentProperty]]]
   ) extends NodePropertySpecificError {
-    def message: String = propertiesErrors.values.map {
-      case (_, conflicting, error) =>
-        s"In hierarchy with ${conflicting.map(_.displayName).mkString(", ")} :\n${error}"
-    }.mkString("\n")
+    override def toString(): String = debugString
+
+    def message: String = {
+      conflicts.toList.map {
+        case (k, hierarchies) =>
+          val error = conflictMessage(k, hierarchies)
+          s"In hierarchy with ${hierarchies.map(_.map(_.displayName).mkString(", ")).mkString("{", "|", "}")} :\n${error}"
+      }.mkString("\n")
+    }
 
     def debugString: String = s"PropertyInheritanceConflicts([${conflicts.map {
         case (prop, c) =>
           prop.name + "->" + c
-            .map(_.map(_.displayName).mkString(",")) // H = G1 (g1-uuid), G2 (g2-uuid)
+            .map(_.map(p => s"${p.kind} ${p.displayName}").mkString(",")) // H = Group G1 (g1-uuid), Group G2 (g2-uuid)
             .mkString("{", "|", "}") // conflicting hierarchies : {HA|HB|...}
       }.mkString(",")}])"
 
     def ++(that: PropertyInheritanceConflicts): PropertyInheritanceConflicts = {
       PropertyInheritanceConflicts(conflicts ++ that.conflicts)
+    }
+
+    /**
+      * This method is useful when resolving conflicts
+      */
+    def resolve(propNames: Set[String]): PropertyInheritanceConflicts = {
+      copy(conflicts = conflicts.filterNot { case (k, _) => propNames.contains(k.name) })
     }
 
     // the map needs to be evaluated eagerly to get all property errors at once and atomic checks
@@ -1121,8 +1138,10 @@ object NodePropertyError         {
       )
     }
 
-    // semigroup is used when using combinators from the Ior datatype to accumulate conflicts
-    implicit val semigroup: Semigroup[PropertyInheritanceConflicts] = Semigroup.instance(_ ++ _)
+    val empty: PropertyInheritanceConflicts = PropertyInheritanceConflicts(Map.empty)
+
+    // monoid is used when using combinators from the Ior datatype to accumulate conflicts
+    implicit val monoid: Monoid[PropertyInheritanceConflicts] = Monoid.instance(empty, _ ++ _)
   }
 
   /**
@@ -1195,7 +1214,11 @@ object FailedNodePropertyHierarchy {
   /**
     * Constuctor needs to validate that properties in success does not intersect specific node property errors
     */
-  def apply(it: Iterable[NodePropertyHierarchy], error: NodePropertyError, contextMessage: String = "") = {
+  def apply(
+      it:             Iterable[NodePropertyHierarchy],
+      error:          NodePropertyError,
+      contextMessage: String = ""
+  ): FailedNodePropertyHierarchy = {
     val success = error match {
       case propErrors: NodePropertySpecificError =>
         it.filterNot(p => propErrors.propertiesErrors.keySet.contains(p.prop.name))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/MergeNodeProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/MergeNodeProperties.scala
@@ -55,6 +55,7 @@ import com.normation.rudder.domain.properties.GroupProperty
 import com.normation.rudder.domain.properties.InheritMode
 import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.domain.properties.NodePropertyError
+import com.normation.rudder.domain.properties.NodePropertyError.*
 import com.normation.rudder.domain.properties.NodePropertyHierarchy
 import com.normation.rudder.domain.properties.ParentProperty
 import com.normation.rudder.domain.properties.PropertyProvider
@@ -211,39 +212,40 @@ object MergeNodeProperties {
       allGroups:    Map[NodeGroupId, FullGroupTarget],
       globalParams: Map[String, GlobalParameter]
   ): ResolvedNodePropertyHierarchy = {
+    val groupProp     = group.nodeGroup.toGroupProp
+    val allGroupProps = allGroups.map { case (id, g) => (id.serialize, g.nodeGroup.toGroupProp) }
+
     // get parents till the top, recursively.
     // This can fail if a parent is missing from "all groups"
     def withParents(
-        currents:  List[FullGroupTarget],
-        allGroups: Map[String, FullGroupTarget], // key: serialized version of NodeGroupId, parent is a String
-        acc:       Map[NodeGroupId, FullGroupTarget]
-    ): Either[NodePropertyError.MissingParentGroup, Map[NodeGroupId, FullGroupTarget]] = {
-      import cats.implicits.*
+        currents:  List[GroupProp],
+        allGroups: Map[String, GroupProp], // key: serialized version of NodeGroupId, as parents of GroupProp is a List[String]
+        acc:       Map[NodeGroupId, GroupProp]
+    ): Either[NodePropertyError.MissingParentGroup, Map[NodeGroupId, GroupProp]] = {
       currents match {
         case Nil  => Right(acc)
         case list =>
-          list.foldLeft(Right(acc): Either[NodePropertyError.MissingParentGroup, Map[NodeGroupId, FullGroupTarget]]) {
-            case (optAcc, g) =>
+          list.foldLeft(Right(acc): Either[NodePropertyError.MissingParentGroup, Map[NodeGroupId, GroupProp]]) {
+            case (optAcc, prop) =>
               optAcc match {
                 case Left(err)  => Left(err)
                 case Right(acc) =>
-                  if (acc.isDefinedAt(g.nodeGroup.id)) Right(acc) // already done previously
+                  if (acc.isDefinedAt(prop.groupId)) Right(acc) // already done previously
                   else {
-                    val prop = g.nodeGroup.toGroupProp
                     for {
                       parents <- prop.parentGroups.traverse { parentId =>
                                    val parentExists = NodeGroupId.parse(parentId).map(acc.isDefinedAt(_)).getOrElse(false)
-                                   if (parentExists) Right(Nil)
+                                   if (parentExists) Right(None)
                                    else {
                                      allGroups.get(parentId) match {
                                        case None    =>
-                                         Left(NodePropertyError.MissingParentGroup(g.nodeGroup, parentId))
+                                         Left(NodePropertyError.MissingParentGroup(prop, parentId))
                                        case Some(p) =>
-                                         Right(p :: Nil)
+                                         Right(Some(p))
                                      }
                                    }
                                  }
-                      rec     <- withParents(parents.flatten, allGroups, acc + (g.nodeGroup.id -> g))
+                      rec     <- withParents(parents.flatten, allGroups, acc + (prop.groupId -> prop))
                     } yield {
                       rec
                     }
@@ -252,12 +254,73 @@ object MergeNodeProperties {
           }
       }
     }
+
+    // Group may resolve conflicting properties from parents, for some properties
+    // so we need to mark those as resolved, with the most prioritized parent (see https://issues.rudder.io/issues/26325)
+    def checkMergeGroupParent(otherProps: Map[NodeGroupId, GroupProp]): Ior[NodePropertyError, List[NodePropertyHierarchy]] = {
+      checkPropertyMerge(otherProps, globalParams) match {
+        case Ior.Right(b) => Ior.Right(b)
+        case withErr      =>
+          withErr.left match {
+            case Some(err: NodePropertyError.PropertyInheritanceConflicts) =>
+              // we need to remove resolved conflicting properties and transfer them to the success part
+              val resolved  = err.conflicts.toList.flatMap {
+                case (nodeProp, parentProps: NonEmptyChunk[List[ParentProperty]]) =>
+                  for {
+                    // reverse to get the parent which has the highest priority
+                    firstParent     <- groupProp.parentGroups.reverse.headOption
+                    parent          <- allGroupProps.get(firstParent)
+                    // we assume that there is a single property value for the same name (upstream we have List and not a Map)
+                    parentProp      <- parent.properties.find(_.name == nodeProp.name)
+                    // parentProps probably needs to be a NonEmptyChunk(VerticalPropTree[{node=(1),groups=(*),global=(1)}])
+                    // and what we want is a VerticalPropTree that has the parent group as its dominant group i.e. most prioritized groups, the last one
+                    // we probably want to have this natural subdivision, such that the Ordering[ParentProperty] will disappear, as it's explicitly : .node, .groups (already sorted), .global
+                    parentHierarchy <- parentProps.collectFirst {
+                                         case l
+                                             if l.reverse.collectFirst { case g: ParentProperty.Group => g }
+                                               .map(_.id)
+                                               .contains(parent.groupId) =>
+                                           l
+                                       }
+                  } yield {
+                    parentProp -> parentHierarchy
+                  }
+              }
+              val toResolve = resolved.map { case (parentProp, _) => parentProp.name }.toSet
+              val updated   = withErr.bimap(
+                {
+                  case err: NodePropertyError.PropertyInheritanceConflicts => err.resolve(toResolve)
+                  case err => err
+                },
+                _ ++ resolved.map {
+                  case (groupProp, hierarchy) =>
+                    // we always have a `NodeProperty`, instead of a `GroupProperty`
+                    // and the value is "inherited" from the parent
+                    NodePropertyHierarchy(
+                      NodeProperty(groupProp.config).withProvider(GroupProp.INHERITANCE_PROVIDER),
+                      hierarchy
+                    )
+                }
+              )
+              // it may happen that conflicts are empty, in which case it can be simplified to Ior.Right
+              updated match {
+                case Ior.Both(NodePropertyError.PropertyInheritanceConflicts.empty, r) => Ior.Right(r)
+                case Ior.Left(NodePropertyError.PropertyInheritanceConflicts.empty)    => Ior.Right(List.empty)
+                case other                                                             => other
+              }
+            case None | Some(_: NodePropertyError)                         => withErr
+          }
+      }
+    }
+
     val resolved = for {
       hierarchy   <-
-        // this fails with an empty list of property, maybe we should also ignore group parent errors, as with "sortGroups"
-        Ior.fromEither(withParents(group :: Nil, allGroups.map { case (id, group) => (id.serialize, group) }, Map()))
-      props        = (hierarchy - group.nodeGroup.id).map { case (groupId, target) => (groupId, target.nodeGroup.toGroupProp) }
-      hierarchies <- checkPropertyMerge(props, globalParams)
+        // this fails with an empty list of property, missing parents errors are short-circuiting, as they may be the cause of misconfiguration
+        Ior
+          .fromEither[NodePropertyError, Map[NodeGroupId, GroupProp]](withParents(groupProp :: Nil, allGroupProps, Map()))
+      otherProps   = hierarchy - group.nodeGroup.id
+      hierarchies <- checkMergeGroupParent(otherProps)
+
     } yield {
       val groupProps = group.nodeGroup.properties.map(g => (g.name, g)).toMap
       mergeDefault(group.nodeGroup.id.serialize, groupProps, hierarchies.map(h => (h.prop.name, h)).toMap).values
@@ -374,10 +437,9 @@ object MergeNodeProperties {
       // work on non empty chain for repeated append operations on the resulting hierarchy (due to cumulating both error and success)
       val grouped = propByTrees.groupByNec(_.prop.name)
 
-      // The right combinator that allows to use the semigroup structure of the error is the
       val validatedProps = grouped.toList.map {
         case (k, c) =>
-          val (h, more) = (c.head, c.tail)
+          val (h, more) = c.uncons
           if (more.forall(_.prop == h.prop)) { // if it's exactly the same property everywhere, it's ok
             Right(h)
           } else {
@@ -393,6 +455,7 @@ object MergeNodeProperties {
 
       // This is guaranteed to be at least a Both, since we start with a right one and we just add potential errors
       val initialValue = Ior.right[NodePropertyError.PropertyInheritanceConflicts, Chain[NodePropertyHierarchy]](Chain.empty)
+      // The right combinator that allows to use the semigroup structure of the error is the Ior data type
       validatedProps
         .foldLeft(initialValue) {
           case (acc, Left(c))  => acc.addLeft(c)


### PR DESCRIPTION
https://issues.rudder.io/issues/26325

The logic for overriding properties did not exist yet for groups : until now the specific case of a group defining the order of override of properties from its parents has always resulted in a conflict for the group.

We need to handle this case : to resolve the conflicts (on the left part) we look at the parent properties, and for a given property, we look at the most prioritized parent that defines it (and we leave it as a conflict if there isn't any).