### PR TITLE
Fixes #26396: Test for instance ID is failing on Docker CI

### DIFF
--- a/policies/module-types/system-updates/src/hooks.rs
+++ b/policies/module-types/system-updates/src/hooks.rs
@@ -137,11 +137,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn geteuid_gets_an_id() {
-        assert!(geteuid() > 0);
-    }
-
-    #[test]
     fn test_hook_is_runnable() {
         let euid = geteuid();
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/servers/TestInstanceIdService.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/servers/TestInstanceIdService.scala
@@ -38,9 +38,7 @@ package com.normation.rudder.services.servers
 
 import better.files.File
 import better.files.File.Attributes
-import com.normation.errors.RudderError
 import com.normation.zio.UnsafeRun
-import java.nio.file.attribute.PosixFilePermissions
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -74,20 +72,22 @@ class TestInstanceIdService extends Specification {
         )
       }
 
-      "non-readable file" in File.temporaryFile(
-        "rudder-test-instance-id-",
-        "",
-        None,
-        List(PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("---------")))
-      ) { tmpFile =>
-        InstanceIdService
-          .make(tmpFile, null)
-          .either
-          .runNow must beLeft(
-          like[RudderError](_.fullMsg must startWith(s"Could not use file ${tmpFile.pathAsString} to read instance ID"))
-        )
+      // this test makes "files.exists()" check fail with an exception because of permission error
+      // but it does not work on every tmp folder (e.g. CI)
+      // "non-readable file" in File.temporaryFile(
+      //   "rudder-test-instance-id-",
+      //   "",
+      //   None,
+      //   List(PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("---------")))
+      // ) { tmpFile =>
+      //   InstanceIdService
+      //     .make(tmpFile, null)
+      //     .either
+      //     .runNow must beLeft(
+      //     like[RudderError](_.fullMsg must startWith(s"Could not use file ${tmpFile.pathAsString} to read instance ID"))
+      //   )
 
-      }
+      // }
     }
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/26396

Just comment the test as it is not critical one.
Also the geteuid in policies can fail, we can remove that one.