### PR TITLE
Fixes #26411: Publish step for CI runs the tests when they already have previously run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -656,7 +656,8 @@ pipeline {
                                           options: [artifactsPublisher(disabled: true)]
                                 ) {
                                     // we need to use $MVN_COMMAND to get the settings file path
-                                    sh script: '$MVN_CMD --update-snapshots clean package deploy', label: "webapp deploy"
+                                    // we no longer need to execute tests
+                                    sh script: '$MVN_CMD -DskipTests --update-snapshots clean package deploy', label: "webapp deploy"
                                 }
                             }
                         }


### PR DESCRIPTION
https://issues.rudder.io/issues/26411

To still publish tests, without running them (https://stackoverflow.com/questions/24727536/maven-skip-tests)