### PR TITLE
Fixes #26413: Ignore policies lib tests with qa-tests --shell

### DIFF
--- a/qa-test
+++ b/qa-test
@@ -5,7 +5,7 @@ set -ex
 test_shell()
 {
   mkdir -p .shellcheck
-  find . \( -path ./.git -prune -o -path "policies/lib/tests" -prune -o -path "*node_modules/*" -prune -o -path "*/10_ncf_internals/modules/*" -prune -o -path "*target/*" -prune \) -o -type f -exec grep -Eq '^#!(.*/|.*env +)(sh|bash|ksh)' {} \; -print |
+  find . \( -path ./.git -prune -o -path "*/policies/lib/tests/*" -prune -o -path "*node_modules/*" -prune -o -path "*/10_ncf_internals/modules/*" -prune -o -path "*target/*" -prune \) -o -type f -exec grep -Eq '^#!(.*/|.*env +)(sh|bash|ksh)' {} \; -print |
     while IFS="" read -r file
     do
       # collect all warnings


### PR DESCRIPTION
https://issues.rudder.io/issues/26413

`./qa-test` works since https://github.com/Normation/rudder/pull/6189/files, 
but `./qa-test --shell` has the wrong pattern, it misses the `*/` and `/*` 