### PR TITLE
Fixes #26417: Keep line breaks in reports

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ViewUtils.elm
@@ -74,8 +74,8 @@ valueCompliance complianceFilters =
   ItemFun
     (\ _ _ _ -> [])
     (\_ i -> i)
-    [ ("Value"   , .value   >> text, (\d1 d2 -> N.compare d1.value  d2.value))
-    , ("Messages", .reports >> List.filter (filterReports complianceFilters) >> List.map (\r -> Maybe.withDefault "" r.message) >> List.foldl (++) "\n"  >> text, (\d1 d2 -> N.compare d1.value d2.value) )
+    [ ("Value"   , .value   >> (\v -> div[class "value-container font-monospace"][text v]), (\d1 d2 -> N.compare d1.value  d2.value))
+    , ("Messages", .reports >> List.filter (filterReports complianceFilters) >> List.map (\r -> Maybe.withDefault "" r.message) >> List.foldl (++) "\n"  >> (\v -> div[class "value-container"][text v]), (\d1 d2 -> N.compare d1.value d2.value) )
     , ("Status"  , .reports >> List.filter (filterReports complianceFilters) >> buildComplianceReport, (\d1 d2 -> Basics.compare d1.value d2.value))
     ]
     .value
@@ -203,7 +203,7 @@ showComplianceDetails fun compliance parent openedRows model =
   let
     itemRows = List.map Tuple3.second (fun.rows)
     data = fun.data model compliance
-    detailsRows = List.map (\row -> td [class "ok"] [row data]) itemRows
+    detailsRows = List.map (\row -> td [] [row data]) itemRows
     id = fun.id compliance
     rowId = parent ++ "/" ++ id
     rowOpened = Dict.get rowId openedRows

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupCompliance/ViewUtils.elm
@@ -59,8 +59,8 @@ valueCompliance complianceFilters =
   ItemFun
     (\ _ _ _ -> [])
     (\_ i -> i)
-    [ ("Value"   , .value   >> text, (\d1 d2 -> N.compare d1.value  d2.value))
-    , ("Messages", .reports >> List.filter (filterReports complianceFilters) >> List.map (\r -> Maybe.withDefault "" r.message) >> List.foldl (++) "\n"  >> text, (\d1 d2 -> N.compare d1.value d2.value) )
+    [ ("Value"   , .value   >> (\v -> div[class "value-container font-monospace"][text v]), (\d1 d2 -> N.compare d1.value  d2.value))
+    , ("Messages", .reports >> List.filter (filterReports complianceFilters) >> List.map (\r -> Maybe.withDefault "" r.message) >> List.foldl (++) "\n"  >> (\v -> div[class "value-container"][text v]), (\d1 d2 -> N.compare d1.value d2.value) )
     , ("Status"  , .reports >> List.filter (filterReports complianceFilters) >> buildComplianceReport, (\d1 d2 -> Basics.compare d1.value d2.value))
     ]
     .value
@@ -212,7 +212,7 @@ showComplianceDetails fun compliance parent openedRows model =
   let
     itemRows = List.map Tuple3.second (fun.rows)
     data = fun.data model compliance
-    detailsRows = List.map (\row -> td [class "ok"] [row data]) itemRows
+    detailsRows = List.map (\row -> td [] [row data]) itemRows
     id = fun.id compliance
     rowId = parent ++ "/" ++ id
     rowOpened = Dict.get rowId openedRows

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/ViewUtils.elm
@@ -81,8 +81,8 @@ valueCompliance complianceFilters =
   ItemFun
     (\ _ _ _ -> [])
     (\_ i -> i)
-    [ ("Value"   , .value   >> text, (\d1 d2 -> N.compare d1.value  d2.value))
-    , ("Messages", .reports >> List.filter (filterReports complianceFilters) >> List.map (\r -> Maybe.withDefault "" r.message) >> List.foldl (++) "\n"  >> text, (\d1 d2 -> N.compare d1.value d2.value) )
+    [ ("Value"   , .value   >> (\v -> div[class "value-container font-monospace"][text v]), (\d1 d2 -> N.compare d1.value  d2.value))
+    , ("Messages", .reports >> List.filter (filterReports complianceFilters) >> List.map (\r -> Maybe.withDefault "" r.message) >> List.foldl (++) "\n"  >> (\v -> div[class "value-container"][text v]), (\d1 d2 -> N.compare d1.value d2.value) )
     , ("Status"  , .reports >> List.filter (filterReports complianceFilters) >> buildComplianceReport, (\d1 d2 -> Basics.compare d1.value d2.value))
     ]
     .value
@@ -191,7 +191,7 @@ showComplianceDetails fun compliance parent openedRows model =
   let
     itemRows = List.map Tuple3.second (fun.rows)
     data = fun.data model compliance
-    detailsRows = List.map (\row -> td [class "ok"] [row data]) itemRows
+    detailsRows = List.map (\row -> td [] [row data]) itemRows
     id = fun.id compliance
     rowId = parent ++ "/" ++ id
     rowOpened = Dict.get rowId openedRows

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.css
@@ -302,6 +302,19 @@ td.listclose:after {
 .dataTable > tbody > tr > td.details{
   padding: 0;
 }
+.dataTable > tbody > tr > td:has(> .value-container){
+  padding-top: 0;
+  padding-bottom: 0;
+}
+.dataTable > tbody > tr > td > .value-container {
+  padding: 6px 0;
+  white-space: pre-line;
+  max-height: 200px;
+  overflow: auto;
+}
+.dataTable > tbody > tr > td > .value-container.font-monospace {
+  font-size: .9em;
+}
 .dataTable > tbody > tr > td.listclose{
   position: relative;
 }

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
@@ -830,7 +830,7 @@ ul {
   padding-left: 15px;
 }
 .rudder-template .dataTable .report-compliance{
-  padding: 0;
+  padding: 0 !important;
 }
 .rudder-template .dataTable .report-compliance > div{
   display: flex;


### PR DESCRIPTION
https://issues.rudder.io/issues/26417

- I've removed the unused css class **.ok** applied on `<td>` element
- I've added a `div.value-container` to "Value" and "Message" cells, on which I've changed the way line breaks are handled, and I've applied a maximum height to it (a scroll bar appears when the content is too long).

![line-breaks](https://github.com/user-attachments/assets/5a227c37-d1d4-4e67-bb90-1337db837e6a)
