### PR TITLE
Fixes #25962: Authorize global parameter names that are not alpha numeric only 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -52,7 +52,6 @@ import com.normation.rudder.properties.GroupProp
 import com.normation.rudder.services.policies.ParameterEntry
 import com.typesafe.config.*
 import enumeratum.*
-import java.util.regex.Pattern
 import net.liftweb.json.*
 import net.liftweb.json.JsonDSL.*
 import org.apache.commons.text.StringEscapeUtils
@@ -286,12 +285,7 @@ object GenericProperty {
   val PROVIDER     = "provider"
   val DESCRIPTION  = "description"
   val INHERIT_MODE = "inheritMode" // options: inheritance mode
-  val VISIBILITY   = "visibility"  // optional, if missing Visibility.default is used.
-
-  /**
-   * Property name must matches that pattern
-   */
-  val patternName: Pattern = Pattern.compile("""[\-a-zA-Z0-9_]+""")
+  val VISIBILITY   = "visibility"  // optional, if missing Visibility.default
 
   def getMode(config: Config):                            Option[InheritMode] = {
     if (config.hasPath(INHERIT_MODE)) {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
@@ -219,6 +219,13 @@ final case class ParameterEntry(
     escapedValue:  String,
     agentType:     AgentType
 ) {
+
+  val escapedParameterName = parameterName.replaceAll("""[^\p{Alnum}_]""", "_")
+  // returns the escaped name of the parameter
+  def getEscapedParameterName(): String = {
+    escapedParameterName
+  }
+
   // returns the name of the parameter
   def getParameterName(): String = {
     parameterName

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestExtractorService.scala
@@ -193,11 +193,7 @@ final case class RestExtractorService(
 
   private def toParameterName(value: String): Box[String] = {
     toMinimalSizeString(1)(value) match {
-      case Full(value) =>
-        if (GenericProperty.patternName.matcher(value).matches)
-          Full(value)
-        else Failure(s"Parameter Name should be respect the following regex : ${GenericProperty.patternName.pattern()}")
-
+      case Full(value) => Full(value)
       case eb: EmptyBox => eb ?~! "Parameter Name should not be empty"
     }
   }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
@@ -502,12 +502,8 @@ class ParameterApiService14(
     val baseParameter = GlobalParameter.apply("", GitVersion.DEFAULT_REV, "".toConfigValue, None, "", None)
     val parameter     = restParameter.updateParameter(baseParameter)
     val diff          = AddGlobalParameterDiff(parameter)
-    val p             = GenericProperty.patternName // pattern for parameter ID
     for {
-      _   <- restParameter.id.checkMandatory(
-               v => p.matcher(v).matches(),
-               v => s"'id' is mandatory and must match pattern '${p.pattern()}' but was: '${v}'"
-             )
+      _   <- restParameter.id.notOptional(s"'id' is mandatory but was empty")
       cr   = GlobalParamChangeRequest(GlobalParamModAction.Create, None)
       res <- createChangeRequest(diff, parameter, cr, params, actor).toIO
     } yield res

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
@@ -60,7 +60,6 @@ import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.model.*
 import com.typesafe.config.ConfigValue
 import com.typesafe.config.ConfigValueType
-import java.util.regex.Pattern
 import net.liftweb.common.*
 import net.liftweb.http.*
 import net.liftweb.http.DispatchSnippet
@@ -225,7 +224,6 @@ class CreateOrUpdateGlobalParameterPopup(
   }
 
   ////////////////////////// fields for form ////////////////////////
-  private val patternName = Pattern.compile("[a-zA-Z0-9_]+");
 
   private val parameterName = new WBTextField("Name", change.previousGlobalParam.map(_.name).getOrElse("")) {
     override def setFilter      = notNull _ :: trim _ :: Nil
@@ -235,8 +233,7 @@ class CreateOrUpdateGlobalParameterPopup(
       case None        => super.inputField
     }) % ("onkeydown" -> "return processKey(event , 'createParameterSaveButton')") % ("tabindex" -> "1")
     override def validations    = {
-      valMinLen(1, "The name must not be empty") _ ::
-      valRegex(patternName, "The name can contain only letters, digits and underscore") _ :: Nil
+      valMinLen(1, "The name must not be empty") _ :: Nil
     }
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/25962

The idea is to bring make global properties (parameters) follow the same character restriction than group/node properties. 
Today, they have fewer chars allowed which means that we can create node or group properties that can't have a global default. 

This change doesn't affect any existing global properties because it only extends the set of allowed character, none of the existing ones are removed. 

The escaped string must be used in any cfengine-related code which want to refer to the parameter, like in https://github.com/Normation/rudder-techniques/pull/1868

:warning: We don't expose the escaped name to user in the UI or wherever easy, because actually we don't want user to refer directly to that parameter, we want them to use the `${node.properties[]}` syntax with the non-escaped name, and the other direct syntax will be removed in Rudder 9.0.