### PR TITLE
Fixes #26428: rudder-pkg reports a success when installing a plugin even if the postinst plugin script was in error

### DIFF
--- a/relay/sources/rudder-package/src/plugin.rs
+++ b/relay/sources/rudder-package/src/plugin.rs
@@ -137,7 +137,12 @@ impl Metadata {
         let mut writer = BufWriter::new(file);
         let _ = serde_json::to_writer_pretty(&mut writer, &r);
         if !r.output.status.success() {
-            debug!("Package script execution return unexpected exit code.");
+            bail!(
+                "Package script '{}' for plugin '{}' returned '{}'",
+                script,
+                self.short_name(),
+                r.output.status
+            );
         }
         Ok(())
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/26428