### PR TITLE
Fixes #26439: Fix display of license information

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/PluginData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/PluginData.scala
@@ -208,7 +208,7 @@ sealed abstract class GlobalPluginsLicense[EndDate](
     ) {}
   }
 
-  private def isDefined = licensees.isDefined && startDate.isDefined && endDate.isDefined && maxNodes.isDefined
+  private def isDefined = licensees.isDefined || startDate.isDefined || endDate.isDefined || maxNodes.isDefined
 }
 
 object GlobalPluginsLicense {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/About.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/About.scala
@@ -104,7 +104,7 @@ object LicenseJson {
     Transformer
       .define[PluginLicense, LicenseJson]
       .withFieldRenamed(_.maxNodes, _.allowedNodesNumber)
-      .withFieldComputed(_.supportedVersions, x => s"[${x.minVersion},${x.maxVersion}]")
+      .withFieldComputed(_.supportedVersions, x => s"[${x.minVersion.value},${x.maxVersion.value}]")
       .buildTransformer
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_plugins.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_plugins.yml
@@ -34,7 +34,7 @@ response:
             "errors" : [
               {
                 "error" : "license.near.expiration.error",
-                "message" : "Plugin license near expiration"
+                "message" : "Plugin license near expiration (1 days left until 2025-01-10)"
               }
             ],
             "license" : {
@@ -146,7 +146,7 @@ response:
             "errors" : [
               {
                 "error" : "license.near.expiration.error",
-                "message" : "Plugin license near expiration"
+                "message" : "Plugin license near expiration (1 days left until 2025-01-10)"
               }
             ],
             "license" : {
@@ -242,7 +242,7 @@ response:
             "errors" : [
               {
                 "error" : "license.near.expiration.error",
-                "message" : "Plugin license near expiration"
+                "message" : "Plugin license near expiration (1 days left until 2025-01-10)"
               }
             ],
             "license" : {
@@ -338,7 +338,7 @@ response:
             "errors" : [
               {
                 "error" : "license.near.expiration.error",
-                "message" : "Plugin license near expiration"
+                "message" : "Plugin license near expiration (1 days left until 2025-01-10)"
               }
             ],
             "license" : {
@@ -434,7 +434,7 @@ response:
             "errors" : [
               {
                 "error" : "license.near.expiration.error",
-                "message" : "Plugin license near expiration"
+                "message" : "Plugin license near expiration (1 days left until 2025-01-10)"
               }
             ],
             "license" : {

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -1000,7 +1000,7 @@ class RestTestSetUp {
         ParseVersion.parse("2.4.1").getOrElse(throw new Exception("bad version in test")),
         ParseVersion.parse("8.3.0").getOrElse(throw new Exception("bad version in test")),
         PluginType.Webapp,
-        List(PluginError.LicenseNearExpirationError),
+        List(PluginError.LicenseNearExpirationError(1, ZonedDateTime.parse("2025-01-10T20:53:20Z"))),
         Some(
           PluginLicense(
             Licensee("test-licensee"),

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/View.elm
@@ -158,7 +158,11 @@ view model =
                             pluginRow plugin =
                               let
                                 license = case plugin.license of
-                                  Nothing -> []
+                                  Nothing -> [
+                                      td[][]
+                                    , td[][]
+                                    , td[][]
+                                    , td[][]]
                                   Just l -> [
                                       td[][text l.licensee]
                                     , td[][text ("from " ++ l.startDate ++ " to " ++ l.endDate)]

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -251,7 +251,7 @@ object PluginsInfo {
     PluginsMetadata.fromPlugins[ZonedDateTime](_plugins.values.toList.sortBy(_.name.value).map(_.transformInto[Plugin]))
   }
 
-  // we build plugins details without license information for the public plugins API
+  // plugins details for the public plugins API with a different mapping, more oriented towards API consumers
   def pluginJsonInfos: JsonPluginsDetails = {
     // to get global information we need the metadata computed from pluginInfos
     val license = pluginInfos.globalLicense.map(_.transformInto[JsonGlobalPluginLimits])

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPlugin.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPlugin.scala
@@ -141,12 +141,6 @@ final case class PluginName(value: String) {
 }
 
 object RudderPluginDef {
-  implicit val licenseTransformer:           Transformer[PluginLicense, JsonPluginLicense]   = {
-    Transformer
-      .define[PluginLicense, JsonPluginLicense]
-      .withFieldRenamed(_.others, _.additionalInfo)
-      .buildTransformer
-  }
   implicit val transformerJsonPluginDetails: Transformer[RudderPluginDef, JsonPluginDetails] = {
     Transformer
       .define[RudderPluginDef, JsonPluginDetails]
@@ -183,7 +177,7 @@ object RudderPluginDef {
       .define[RudderPluginDef, Plugin]
       .withFieldConst(_.pluginType, PluginType.Webapp)
       .withFieldConst(_.errors, List.empty)
-      .withFieldComputed(_.name, _.name.value)
+      .withFieldComputed(_.name, _.shortName) // the RudderPluginDef name is used in plugins themselves
       .withFieldComputed(_.description, _.description.toString())
       .withFieldComputed(_.version, p => Some(p.version.pluginVersion.toVersionStringNoEpoch))
       .withFieldComputed(_.pluginVersion, _.version.pluginVersion)

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/plugins/RudderPluginTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/plugins/RudderPluginTest.scala
@@ -60,6 +60,13 @@ class RudderPluginTest extends Specification {
     "automatically add a patch level (eq 0)" in {
       RudderPluginVersion.from("7.1-2.3") must_!= (RudderPluginVersion("7.1.0".toVersion, "2.3.0".toVersion))
     }
+    "understand complicated format with beta" in {
+      RudderPluginVersion
+        .from("8.3.0~beta1-SNAPSHOT-2.1-nightly") must_!= (RudderPluginVersion(
+        "7.0.0~beta1-SNAPSHOT".toVersion,
+        "2.1.0-nightly".toVersion
+      ))
+    }
     "understand complicated format with rc" in {
       RudderPluginVersion
         .from("7.0.0~rc2-SNAPSHOT-2.1-nightly") must_!= (RudderPluginVersion(


### PR DESCRIPTION
https://issues.rudder.io/issues/26439

* License errors now have a more informative message for the expiration of plugins
* The Rudder version may contain `SNAPSHOT`, but plugins may be built on either snapshot or non-snapshot version, so we need to adjust the error check to ignore this part
* There was a bug for the global license : the tests were not covering the case of combining a list of licenses, an empty `maxNodes` ended up zeroing the license :facepalm:
* In the About page there was a table display issue and the version types were stringified with case class names