### PR TITLE
Fixes #26438: Parent produces errors on stderr and a global error status for the event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,6 +962,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror",
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,6 +1158,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "gag"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a713bee13966e9fbffdf7193af71d54a6b35a0bb34997cd6c9519ebeb5005972"
+dependencies = [
+ "filedescriptor",
+ "tempfile",
 ]
 
 [[package]]
@@ -2778,7 +2799,9 @@ dependencies = [
  "chrono",
  "cli-table",
  "fnv",
+ "gag",
  "gumdrop",
+ "libc",
  "log 0.4.22",
  "memfile",
  "pretty_assertions",

--- a/policies/module-types/system-updates/Cargo.toml
+++ b/policies/module-types/system-updates/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 [dependencies]
 anyhow = "1"
 cli-table = "0.4"
+gag = "1"
 gumdrop = "0.8.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -35,3 +36,4 @@ apt = ["dep:rust-apt", "dep:memfile"]
 rudder_commons_test = { path = "../../rudder-commons-test" }
 tempfile = "3"
 pretty_assertions = "1"
+libc = "0.2.164"

--- a/policies/module-types/system-updates/src/package_manager/apt.rs
+++ b/policies/module-types/system-updates/src/package_manager/apt.rs
@@ -17,6 +17,7 @@ use crate::{
     },
 };
 use anyhow::{anyhow, Context, Result};
+use gag::Gag;
 use memfile::MemFile;
 use regex::Regex;
 #[cfg(not(debug_assertions))]
@@ -293,8 +294,12 @@ impl LinuxPackageManager for AptPackageManager {
             let mem_file_install = MemFile::create_default("upgrade-install").unwrap();
             let mut install_progress = InstallProgress::fd(mem_file_install.as_raw_fd());
 
+            // Before making calls to the package manager, we need to silence stdout.
+            // APT writes on it, and it breaks CFEngine's protocol.
+            let print_gag_out = Gag::stdout().expect("Failed to silence stdout");
             let mut res_commit =
                 Self::apt_errors_to_output(c.commit(&mut acquire_progress, &mut install_progress));
+            drop(print_gag_out);
 
             let acquire_out = RudderAptAcquireProgress::read_mem_file(mem_file_acquire);
             res_commit.stdout(acquire_out);


### PR DESCRIPTION
https://issues.rudder.io/issues/26438

The problem here is that APT (actually dpkg) writes to stdout which breaks CFEngine's protocl. stdout is then closed, hence the pile of broken pipe errors.

Let's just silence apt, we already collect everything we need through other channels.