### PR TITLE
Fixes #26444: Update cargo auditable for Rust 2024

### DIFF
--- a/rust.makefile
+++ b/rust.makefile
@@ -18,7 +18,7 @@ version:
 # https://matklad.github.io/2021/09/04/fast-rust-builds.html#ci-workflow
 build: CARGO_INCREMENTAL=0
 build: version
-	cargo install --locked cargo-auditable@0.6.4
+	cargo install --locked cargo-auditable@0.6.6
 	cargo auditable build --features=${CARGO_FEATURES} --release --locked --jobs 2
 
 dev-doc:


### PR DESCRIPTION
https://issues.rudder.io/issues/26444