### PR TITLE
Fixes #26447: Policy backup and plugins pages should not be available as read-only admin

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -831,7 +831,7 @@ class Boot extends Loggable {
         Menu("920-maintenance", <span>Maintenance</span>) / "secure" / "administration" / "maintenance"
           >> needPerms(Authz.Administration.Read),
         Menu("950-plugins", <span>Plugins</span>) / "secure" / "administration" / "pluginInformation"
-          >> needPerms(Authz.Administration.Read),
+          >> needPerms(Authz.Administration.Write),
         Menu("990-about", <span>About</span>) / "secure" / "administration" / "about"
           >> needPerms(Authz.Administration.Read)
       )

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -125,6 +125,7 @@ import com.normation.rudder.services.user.*
 import com.normation.rudder.services.workflows.*
 import com.normation.rudder.tenants.*
 import com.normation.rudder.users.*
+import com.normation.rudder.web.components.administration.PolicyBackup
 import com.normation.rudder.web.components.administration.RudderCompanyAccount
 import com.normation.rudder.web.model.*
 import com.normation.rudder.web.services.*
@@ -3564,6 +3565,7 @@ object RudderConfigInit {
     ////////////////////// Snippet plugins & extension register //////////////////////
     lazy val snippetExtensionRegister: SnippetExtensionRegister = new SnippetExtensionRegisterImpl()
     snippetExtensionRegister.register(new RudderCompanyAccount())
+    snippetExtensionRegister.register(new PolicyBackup())
 
     lazy val cachedNodeConfigurationService: CachedNodeConfigurationService = {
       val cached = new CachedNodeConfigurationService(findExpectedRepo, nodeFactRepository)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/administration/PolicyBackup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/administration/PolicyBackup.scala
@@ -1,6 +1,6 @@
 /*
  *************************************************************************************
- * Copyright 2024 Normation SAS
+ * Copyright 2025 Normation SAS
  *************************************************************************************
  *
  * This file is part of Rudder.
@@ -35,27 +35,34 @@
  *************************************************************************************
  */
 
-package com.normation.rudder.web.snippet.administration
+package com.normation.rudder.web.components.administration
 
-import com.normation.plugins.DefaultExtendableSnippet
+import com.normation.plugins.SnippetExtensionPoint
+import com.normation.rudder.AuthorizationType
+import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.ChooseTemplate
 import com.normation.rudder.web.snippet.TabUtils
-import net.liftweb.http.DispatchSnippet
-import scala.xml.*
+import com.normation.rudder.web.snippet.administration.Maintenance
+import scala.reflect.ClassTag
+import scala.xml.NodeSeq
 
-class Settings extends DispatchSnippet with DefaultExtendableSnippet[Settings] {
-  private def settingsTabContent(xml: NodeSeq) =
-    ChooseTemplate("templates-hidden" :: "components" :: "administration" :: "policyServerManagement" :: Nil, "component-body")
+class PolicyBackup()(implicit val ttag: ClassTag[Maintenance]) extends SnippetExtensionPoint[Maintenance] {
+  private val tabId = "policyBackupTab"
 
-  override def mainDispatch: Map[String, NodeSeq => NodeSeq] = {
-    Map(
-      "body"           -> identity,
-      "mainTabContent" -> settingsTabContent
-    )
+  private def template: NodeSeq =
+    ChooseTemplate("templates-hidden" :: "components" :: "administration" :: "policyBackup" :: Nil, "component-body")
+
+  override def compose(snippet: Maintenance): Map[String, NodeSeq => NodeSeq] = {
+    if (CurrentUser.checkRights(AuthorizationType.Administration.Write)) {
+      Map(
+        "body" -> {
+          (Maintenance.addTabMenu(tabId, "Policy Backup", TabUtils.ReplaceInTab("policyBackupTabMenu")) & Maintenance
+            .addTabContent(tabId, template, TabUtils.ReplaceInTab("policyBackupContent")))
+        }
+      )
+    } else {
+      Map.empty
+    }
   }
-}
 
-object Settings extends TabUtils {
-  override def tabMenuId:    String = "settingsTabMenu"
-  override def tabContentId: String = "settingsTabContent"
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/TabUtils.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/TabUtils.scala
@@ -1,0 +1,127 @@
+/*
+ *************************************************************************************
+ * Copyright 2024 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+package com.normation.rudder.web.snippet
+
+import net.liftweb.util.CssSel
+import net.liftweb.util.Helpers.*
+import scala.xml.*
+
+/**
+ * Helper for adding menu using our convention on DOM structure for menu item and content
+ */
+trait TabUtils {
+  import TabUtils.*
+
+  /**
+   * The HTML ID for the container for menu tabs.
+   * It should not start with "#".
+   */
+  def tabMenuId: String
+
+  /**
+   * The HTML ID for the container for menu contents.
+   * It should not start with "#".
+   */
+  def tabContentId: String
+
+  def addTabMenu(tabId: String, name: String, mode: AddTabMode): CssSel = {
+    mode(tabMenuId)(tabMenu(tabId, name))
+  }
+
+  def addTabContent(tabId: String, content: NodeSeq, mode: AddTabMode): CssSel = {
+    mode(tabContentId)(tabContent(tabId, content))
+  }
+
+  /**
+   * Create a new tab using a human name and a new tabId and content.
+   * Adds the tab with the name by default as the last tab, and and its content as last content. 
+   */
+  def addTab(tabId: String, name: String, content: NodeSeq, mode: AddTabMode = AppendTab): CssSel =
+    addTabMenu(tabId, name, mode) & addTabContent(tabId, content, mode)
+
+  private def tabMenu(tabId: String, name: String) = {
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" data-bs-toggle="tab" data-bs-target={
+      "#" + tabId
+    } type="button" role="tab" aria-controls={tabId}>{name}</button>
+    </li>
+  }
+
+  private def tabContent(tabId: String, content: NodeSeq): Elem = {
+    <div id={tabId} class="tab-pane">{content}</div>
+  }
+}
+
+object TabUtils {
+
+  /**
+   * Mode used for abstracting over liftweb selectors and apply content on 
+   * predefined tab selectors
+   */
+  sealed trait AddTabMode {
+    def apply(id: String)(content: NodeSeq): CssSel
+  }
+
+  /**
+   * Default exposed mode
+   */
+  case object AppendTab extends AddTabMode {
+    def apply(id: String)(content: NodeSeq) = s"#${id} *+" #> content
+  }
+
+  case object PrependTab extends AddTabMode {
+    def apply(id: String)(content: NodeSeq) = s"#${id} -*" #> content
+  }
+
+  /**
+   * Mode that can replace within a given selector.
+   * Useful when tabs have specific position (hence they need a special ID for replacement,
+   * so they can be used on e.g. span with id="myInner").
+   * You can define attributes, and class attributes will remain except for "d-none"
+   */
+  case class ReplaceInTab(replaceSel: String) extends AddTabMode {
+    def apply(id: String)(content: NodeSeq): CssSel = {
+      s"#${id}" #> (
+        s"#${replaceSel}" #> content
+      ) & (
+        s"#${id}" #> (
+          s"#${replaceSel} [class!]" #> "d-none"
+        )
+      )
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/Maintenance.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/Maintenance.scala
@@ -39,8 +39,8 @@ package com.normation.rudder.web.snippet.administration
 
 import com.normation.plugins.DefaultExtendableSnippet
 import com.normation.rudder.web.ChooseTemplate
+import com.normation.rudder.web.snippet.TabUtils
 import net.liftweb.http.DispatchSnippet
-import net.liftweb.util.CssSel
 import scala.xml.*
 
 class Maintenance extends DispatchSnippet with DefaultExtendableSnippet[Maintenance] {
@@ -51,22 +51,21 @@ class Maintenance extends DispatchSnippet with DefaultExtendableSnippet[Maintena
       "body"               -> identity,
       "healthCheckTab"     -> healthCheckTab,
       "reportsDatabaseTab" -> reportsDatabaseTab,
-      "policyBackupTab"    -> policyBackupTab,
       "hooksTab"           -> hooksTab,
       "techniqueTreeTab"   -> techniqueTreeTab
     )
   }
 }
 
-object Maintenance {
+object Maintenance extends TabUtils {
+  override def tabMenuId:    String = "maintenanceTabMenu"
+  override def tabContentId: String = "maintenanceTabContent"
+
   private def healthCheckTab(xml: NodeSeq) =
     ChooseTemplate("templates-hidden" :: "components" :: "administration" :: "healthcheck" :: Nil, "component-body")
 
   private def reportsDatabaseTab(xml: NodeSeq) =
     ChooseTemplate("templates-hidden" :: "components" :: "administration" :: "reportsDatabase" :: Nil, "component-body")
-
-  private def policyBackupTab(xml: NodeSeq) =
-    ChooseTemplate("templates-hidden" :: "components" :: "administration" :: "policyBackup" :: Nil, "component-body")
 
   private def hooksTab(xml: NodeSeq) =
     ChooseTemplate("templates-hidden" :: "components" :: "administration" :: "hooksManagement" :: Nil, "component-body")
@@ -77,19 +76,4 @@ object Maintenance {
       "component-body"
     )
   }
-
-  /*
-   * Create a new tab (the clickable header part).
-   * The id must not contain the `#`
-   */
-  def tabMenu(tabId: String, name: String) = Settings.tabMenu(tabId, name)
-
-  // an utility method that provides the correct cssSel to add a menu item
-  def addTabMenu(tabId: String, name: String): CssSel = Settings.addTabMenu(tabId, name)
-
-  def tabContent(tabId: String, content: NodeSeq): Elem = Settings.tabContent(tabId, content)
-
-  def addTabContent(tabId: String, content: NodeSeq): CssSel = Settings.addTabContent(tabId, content)
-
-  def addTab(tabId: String, name: String, content: NodeSeq): CssSel = Settings.addTab(tabId, name, content)
 }

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/administration/maintenance.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/administration/maintenance.html
@@ -25,11 +25,8 @@
               Reports database
             </button>
           </li>
-          <li class="nav-item" role="presentation">
-            <button class="nav-link" data-bs-toggle="tab" data-bs-target="#policyBackup" type="button" role="tab" aria-controls="policyBackup">
-              Policy backup
-            </button>
-          </li>
+          <span id="policyBackupTabMenu" class="d-none">
+          </span>
           <li class="nav-item" role="presentation">
             <button class="nav-link" data-bs-toggle="tab" data-bs-target="#hooks" type="button" role="tab" aria-controls="hooks">
               Hooks
@@ -53,9 +50,8 @@
                 <div id="reportsDatabase" class="tab-pane">
                   <div class="lift:administration.Maintenance.reportsDatabaseTab"></div>
                 </div>
-                <div id="policyBackup" class="tab-pane">
-                  <div class="lift:administration.Maintenance.policyBackupTab"></div>
-                </div>
+                <span id="policyBackupContent">
+                </span>
                 <div id="hooks" class="tab-pane">
                   <div class="lift:administration.Maintenance.hooksTab"></div>
                 </div>


### PR DESCRIPTION
https://issues.rudder.io/issues/26447

The tab system in `Settings` page needs to be refactored, as it is now needed in the `Maintenance` page.
Also the CSS selectors are not similar, we need to be able to insert the tab content at a specific place, instead of just appending it, so we need to specify modes within a `TabUtils`