### PR TITLE
Fixes #26399: Hooks documentation link redirects to non-existing page

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Hooks/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Hooks/View.elm
@@ -22,7 +22,7 @@ view model =
         [ p[][text "This page shows you the current hooks used in Rudder."]
         , p[][
             text "For more information, please consult the"
-          , a [href "/rudder-doc/reference/7.2/usage/advanced_configuration_management.html#_server_event_hooks"][text " documentation."]
+          , a [href "/rudder-doc/reference/current/usage/advanced_configuration_management.html#_server_event_hooks"][text " documentation."]
           ]
         ]
       ]


### PR DESCRIPTION
https://issues.rudder.io/issues/26399