### PR TITLE
Fixes #26354: Adding a property column to nodes list causes lines to double height thus screen shows 2 times less nodes

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeProperties/ViewUtils.elm
@@ -247,7 +247,7 @@ displayNodePropertyRow model =
                 _ -> "<h4 class='tags-tooltip-title'>" ++ pr ++ "</h4> <div class='tooltip-inner-content'>This property is managed by its provider ‘<b>" ++ pr ++ "</b>’ and can not be modified manually. Check Rudder’s settings to adjust this provider’s configuration.</div>"
             in
               (span
-              [ class "rudder-label label-provider label-sm bs-tooltip"
+              [ class "rudder-label label-provider label-sm bs-tooltip ms-1"
               , attribute "data-bs-toggle" "tooltip"
               , attribute "data-bs-placement" "right"
               , attribute "data-bs-trigger" "click"

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -1152,8 +1152,8 @@ function propertyFunction(value, inherited) { return function (nTd, sData, oData
       provider = $('<span class="rudder-label label-provider label-sm" data-bs-toggle="tooltip" data-bs-placement="right">inherited</span>')
       provider.attr('title', "This property is inherited from these group(s) or global parameter: <div>"+ property.hierarchy + "</div>.")
     }
-    var pre = $("<pre onclick='$(this).toggleClass(\"toggle\")' class='json-beautify show-more'></pre>").text(text);
-    $(nTd).prepend( pre ).prepend(provider)
+    var pre = $("<pre onclick='$(this).toggleClass(\"toggle\")' class='json-beautify show-more'></pre>").text(text).prepend(provider);
+    $(nTd).prepend( pre );
   }
 } }
 

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.css
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.css
@@ -357,7 +357,6 @@ td.listclose:after {
 .dataTables_paginate {
   float: right;
   text-align: right;
-  line-height:1;
 }
 .dataTables_paginate .fg-button {
   display: inline-block;

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.scss
@@ -124,7 +124,7 @@ pre.json-beautify, .content-wrapper pre.json-beautify{
   position: relative;
   margin-bottom: 0;
   padding: 7px 6px;
-  padding-right: 65px;
+  padding-right: 105px;
   white-space: pre-wrap;
   word-break: break-all;
   word-wrap: break-word;
@@ -680,10 +680,17 @@ pre.json-beautify code.elmsh {
   background-color: #1384BE;
 }
 
-.label-provider, .dataTable .rudder-label.label-sm.label-provider {
+.label-provider,
+.dataTable .rudder-label.label-sm.label-provider {
   padding:0 5px !important;
-  margin-top:4px;
-  margin-left: 6px;
+}
+.dataTable pre.json-beautify > .label-provider {
+  position: absolute;
+  top: 8px;
+  right: 25px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .label-provider + .tooltip .tooltip-inner {

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/nodes.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/nodes.html
@@ -9,7 +9,7 @@
         flex-basis : initial !important;
         flex: auto !important;
       }
-      #nodes tbody tr td .rudder-label.label-sm{
+      #nodes tbody tr td .rudder-label.label-sm:not(.label-provider){
         padding: 3px 24px !important;
         margin-right: 0;
         font-size: inherit;


### PR DESCRIPTION
https://issues.rudder.io/issues/26354

Now the ‘provider’ label is in absolute position, so has no impact on the display of the property value. Here is the result :
![properties-label](https://github.com/user-attachments/assets/d3dfe879-f293-4522-a3c0-a73783bdbbe6)

