### PR TITLE
Fixes #26449: Improve accessibility of filter, actions and errors on plugins page

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/plugins/cli/RudderPackageServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/plugins/cli/RudderPackageServiceTest.scala
@@ -53,7 +53,7 @@ class RudderPackageServiceTest extends Specification {
       val res = CmdResult(
         2,
         "",
-        "\u001b[31mERROR\u001b[0m Invalid credentials, please check your credentials in the configuration. (received HTTP 401)\n"
+        "ERROR Invalid credentials, please check your credentials in the configuration. (received HTTP 401)\n"
       )
       RudderPackageService.PluginSettingsError.fromResult(res).aka("PluginSettingsError from cmd result") must beRight(
         beSome(
@@ -67,7 +67,7 @@ class RudderPackageServiceTest extends Specification {
     }
     "handle unknown error code and message" in {
       RudderPackageService.PluginSettingsError.fromResult(
-        CmdResult(12345, "", "\u001b[31mERROR\u001b[0m Unknown error")
+        CmdResult(12345, "", "ERROR Unknown error")
       ) must beLeft(beLike[RudderError] { case err: Inconsistency => err.msg must contain("ERROR Unknown error") })
     }
   }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Init.elm
@@ -19,7 +19,7 @@ init flags =
     let
         initUI : UI
         initUI =
-            { loading = True, view = ViewPluginsList initPluginsViewModel }
+            { loading = True, view = { viewModel = initPluginsViewModel, error = Nothing, modalState = NoModal } }
 
         initModel : Model
         initModel =
@@ -44,7 +44,6 @@ initPluginsViewModel : PluginsViewModel
 initPluginsViewModel =
     { plugins = Dict.empty
     , selected = noSelected
-    , modalState = NoModal
     , filters = initFilters
     , installAction = initPluginsAction
     , enableAction = initPluginsAction

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Select.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Select.elm
@@ -8,6 +8,7 @@ module Plugins.Select exposing
     , noSelected
     , select
     , selectedCount
+    , selectedSet
     , setNotSelectablePlugins
     )
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Tests/PluginsTests.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Tests/PluginsTests.elm
@@ -4,7 +4,7 @@ import Dict
 import Expect exposing (..)
 import Fuzz exposing (..)
 import Plugins.Action exposing (..)
-import Plugins.DataTypes exposing (PluginsViewModel, pluginsFromList, setPluginsView)
+import Plugins.DataTypes exposing (PluginsViewModel, pluginsFromList, setViewModelPlugins)
 import Plugins.Init exposing (initPluginsViewModel)
 import Plugins.PluginData exposing (..)
 import Plugins.Select exposing (..)
@@ -90,7 +90,7 @@ fuzzPluginExpectAction msg toAction status pluginType license sel toExpectation 
 
                 viewModel =
                     initPluginsViewModel
-                        |> setPluginsView plugins
+                        |> setViewModelPlugins plugins
                         |> select (sel plugin.id) plugins
             in
             viewModel |> toAction |> toExpectation plugin
@@ -116,24 +116,24 @@ suite =
         [ describe "select valid plugins"
             [ -- install
               fuzz (list pluginFuzz) "initialize install action" <|
-                \plugins -> initPluginsViewModel |> setPluginsView (pluginsFromList plugins) |> .installAction |> Expect.equal initPluginsAction
+                \plugins -> initPluginsViewModel |> setViewModelPlugins (pluginsFromList plugins) |> .installAction |> Expect.equal initPluginsAction
             , fuzzSelectValidPlugin "allow installing uninstalled plugin" .installAction Uninstalled ActionInstall
             , fuzzSelectValidPlugin "allow upgrading already installed (enabled)" .installAction (Installed Enabled) ActionUpgrade
             , fuzzSelectValidPlugin "allow upgrading already installed (disabled)" .installAction (Installed Disabled) ActionUpgrade
 
             -- enable
             , fuzz (list pluginFuzz) "initialize enable action" <|
-                \plugins -> initPluginsViewModel |> setPluginsView (pluginsFromList plugins) |> .enableAction |> Expect.equal initPluginsAction
+                \plugins -> initPluginsViewModel |> setViewModelPlugins (pluginsFromList plugins) |> .enableAction |> Expect.equal initPluginsAction
             , fuzzSelectValidPlugin "allow enabling disabled plugin" .enableAction (Installed Disabled) ActionEnable
 
             -- disable
             , fuzz (list pluginFuzz) "initialize disable action" <|
-                \plugins -> initPluginsViewModel |> setPluginsView (pluginsFromList plugins) |> .disableAction |> Expect.equal initPluginsAction
+                \plugins -> initPluginsViewModel |> setViewModelPlugins (pluginsFromList plugins) |> .disableAction |> Expect.equal initPluginsAction
             , fuzzSelectValidPlugin "allow disabling enabled webapp plugin" .disableAction (Installed Enabled) ActionDisable
 
             -- uninstall
             , fuzz (list pluginFuzz) "initialize uninstall action" <|
-                \plugins -> initPluginsViewModel |> setPluginsView (pluginsFromList plugins) |> .disableAction |> Expect.equal initPluginsAction
+                \plugins -> initPluginsViewModel |> setViewModelPlugins (pluginsFromList plugins) |> .disableAction |> Expect.equal initPluginsAction
             , fuzzSelectValidPlugin "allow uninstalling enabled plugin" .uninstallAction (Installed Enabled) ActionUninstall
             , fuzzSelectValidPlugin "allow uninstalling disabled plugin" .uninstallAction (Installed Disabled) ActionUninstall
 

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-menu.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-menu.scss
@@ -422,8 +422,11 @@ header.main-header .logo-lg img{
   margin-top: -7px
 }
 
-.dropdown-menu>li>a > .fa, .dropdown-menu>li>a > .ion {
-  margin-right: 10px
+.dropdown-menu>li>a,
+.dropdown-menu>li>button {
+  & > .fa, & > .ion {
+    margin-right: 10px
+  }
 }
 
 .navbar-nav .notifications-menu>.dropdown-menu,

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-plugins.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-plugins.scss
@@ -112,22 +112,46 @@ $spinner-height-sm: $spinner-width-sm;
 }
 
 .header-title {
+  & > :first-child {
+    display: flex;
+    flex-direction: column;
+  }
+
   & ul {
     max-width: 30vw;
     margin-bottom: 0;
     text-align: right;
     font-weight: 300;
     font-style: italic;
+
+    & li {
+      width: 100%;
+    }
   }
 }
 
 .plugins-container {
   $default-font-size: 0.86em;
+  $main-details-lr-padding: 15px;
+  position: absolute;
+  top: 0;
+  right: $main-details-lr-padding;
+  left: $main-details-lr-padding;
+  bottom: 0;
 
   & .plugins-actions {
     display: flex;
-    flex-direction: column;
-    border-bottom: 2px solid $rudder-border-color-default !important; // in combination with datatable classes
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
+
+    // in combination with datatable classes
+    &.table-filter {
+      border-bottom: 2px solid $rudder-border-color-default !important;
+      padding-bottom: 10px !important;
+      border-top: 0 !important;
+      margin-top: 0 !important;
+    }
 
     & .btn {
       font-size: $default-font-size;
@@ -135,29 +159,42 @@ $spinner-height-sm: $spinner-width-sm;
       min-width: 4.8rem;
     }
 
-    & .plugins-actions-buttons {
-      width: 100%;
+    & .plugins-actions-filters {
       display: flex;
       flex-wrap: nowrap;
       justify-content: space-between;
 
       & :first-child {
-        flex: 1 1 auto;
+        flex: 0 0 160px;
       }
 
-      & :last-child {
-        flex: 0 1 auto;
+      & .plugins-actions-filters-search  {
+        flex: 0 0 20%;
+      }
+
+      & .plugins-actions-filters-radio {
+        opacity: 0.85;
+        display: flex;
+        justify-content: space-between;
+
+        & :first-child {
+          margin-right: 2em;
+        }
       }
     }
 
-    & .plugins-actions-filters {
-      width: 100%;
+    & .plugins-actions-buttons {
+      margin-left: auto;
+      overflow: visible;
       display: flex;
-      margin-top: 0.4em;
+      flex-wrap: nowrap;
+      justify-content: space-between;
+    }
 
-      & .form-group:not(:first-child) {
-        margin-left: 1em;
-      }
+    & .plugins-actions-warning {
+      width: 100%;
+      font-size: 12px;
+      margin-top: 0.5em;
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
@@ -242,61 +242,57 @@ ul {
   padding: 0;
 }
 .header-buttons .dropdown-menu > li > a,
-.gm-labels .dropdown-menu > li > a {
+.header-buttons .dropdown-menu > li > button,
+.gm-labels .dropdown-menu > li > a,
+.gm-labels .dropdown-menu > li > button {
   padding: 10px 14px;
   transition-duration: .2s;
   cursor: pointer;
   color: #738195;
   background-color: #fff;
+
+  &:hover{
+    color: #041922;
+    background-color: $rudder-bg-light-gray;
+  }
+  &.action-success {
+    color: $rudder-success;
+    &:hover {
+      color: #fff;
+      background-color: $rudder-success;
+      border-color: #109f9a;
+    }
+  }
+  &.action-primary {
+    color: #337ab7;
+    &:hover {
+      color: #fff;
+      background-color: #337ab7;
+      border-color: #2e6da4;
+    }
+  }
+  &.action-danger {
+    color: #DA291C;
+    &:hover {
+      color: #fff;
+      background-color: #DA291C;
+      border-color: #DA291C;
+    }
+  }
+  &.disabled,
+  &[disabled],
+  &:disabled {
+    opacity: .6;
+    cursor: not-allowed;
+  }
+  & > i {
+    margin-left: 6px;
+  }
+  &:first-child {
+    margin-left: 0;
+  }
 }
-.header-buttons .dropdown-menu > li > a:hover,
-.gm-labels .dropdown-menu > li > a:hover {
-  color: #041922;
-  background-color: $rudder-bg-light-gray;
-}
-.header-buttons .dropdown-menu > li > a.action-success,
-.gm-labels .dropdown-menu > li > a.action-success {
-  color: #13BEB7;
-}
-.header-buttons .dropdown-menu > li > a.action-success:hover,
-.gm-labels .dropdown-menu > li > a.action-success:hover {
-  color: #fff;
-  background-color: #13BEB7;
-  border-color: #109f9a;
-}
-.header-buttons .dropdown-menu > li > a.action-primary,
-.gm-labels .dropdown-menu > li > a.action-primary {
-  color: #337ab7;
-}
-.header-buttons .dropdown-menu > li > a.action-primary:hover,
-.gm-labels .dropdown-menu > li > a.action-primary:hover {
-  color: #fff;
-  background-color: #337ab7;
-  border-color: #2e6da4;
-}
-.header-buttons .dropdown-menu > li > a.action-danger,
-.gm-labels .dropdown-menu > li > a.action-danger {
-  color: #DA291C;
-}
-.header-buttons .dropdown-menu > li > a.action-danger:hover,
-.gm-labels .dropdown-menu > li > a.action-danger:hover {
-  color: #fff;
-  background-color: #DA291C;
-  border-color: #DA291C;
-}
-.header-buttons .dropdown-menu > li > a.disabled,
-.gm-labels .dropdown-menu > li > a.disabled {
-  opacity: .6;
-  cursor: not-allowed;
-}
-.header-buttons .dropdown-menu > li > a > i,
-.gm-labels .dropdown-menu > li > a > i {
-  margin-left: 6px;
-}
-.header-buttons .dropdown-menu > li > a > i:first-child,
-.gm-labels .dropdown-menu > li > a > i:first-child {
-  margin-left: 0;
-}
+
 .header-buttons .dropdown-menu .divider,
 .gm-labels .dropdown-menu .divider {
   margin: 0px;


### PR DESCRIPTION
https://issues.rudder.io/issues/26449

* Remove colors from API by adding NO_COLOR=1 environment variable
* Refactor the view errors, the previous union type for viewing plugins did not make sense : now we always have a list of plugins, and maybe a modal and an error aside from that.
* Changing the UI for the filter, and the top bar
* Adding several warnings : in the header when account is not found, below the filters : 
![image](https://github.com/user-attachments/assets/236feb69-682b-4d5f-91f4-24447e141347)
