### PR TITLE
Fixes #26455: Changes for scala 3 migration - branch 8.3

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -120,7 +120,7 @@ limitations under the License.
           <dependency>
             <groupId>ch.epfl.scala</groupId>
             <artifactId>scala3-migrate-rules_2.13</artifactId>
-            <version>0.7.1</version>
+            <version>0.7.2</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -433,42 +433,42 @@ limitations under the License.
     <scala-xml-version>1.3.0</scala-xml-version>
     <lift-version>4.0.0-M1</lift-version>
     <slf4j-version>2.0.16</slf4j-version>
-    <logback-version>1.5.12</logback-version>
+    <logback-version>1.5.17</logback-version>
     <janino-version>3.1.12</janino-version>
     <jodatime-version>2.13.0</jodatime-version>
     <jodaconvert-version>3.0.1</jodaconvert-version>
-    <commons-io-version>2.17.0</commons-io-version>
+    <commons-io-version>2.18.0</commons-io-version>
     <commons-lang-version>3.17.0</commons-lang-version>
-    <commons-text-version>1.12.0</commons-text-version>
-    <commons-codec-version>1.17.1</commons-codec-version>
+    <commons-text-version>1.13.0</commons-text-version>
+    <commons-codec-version>1.18.0</commons-codec-version>
     <commons-fileupload>2.0.0-M2</commons-fileupload>
     <commons-csv-version>1.12.0</commons-csv-version>
     <jgit-version>7.0.0.202409031743-r</jgit-version>
-    <spring-version>6.1.16</spring-version>
-    <spring-security-version>6.3.6</spring-security-version>
+    <spring-version>6.1.17</spring-version>
+    <spring-security-version>6.3.7</spring-security-version>
     <cglib-version>3.3.0</cglib-version>
     <asm-version>9.7.1</asm-version>
     <!-- Level of Java compatibility, here 1.8+ -->
     <bouncycastle-compat>jdk18on</bouncycastle-compat>
-    <bouncycastle-version>1.79</bouncycastle-version>
+    <bouncycastle-version>1.80</bouncycastle-version>
     <better-files-version>3.9.2</better-files-version>
     <sourcecode-version>0.4.2</sourcecode-version>
-    <quicklens-version>1.9.9</quicklens-version>
-    <hikaricp-version>6.0.0</hikaricp-version>
+    <quicklens-version>1.9.12</quicklens-version>
+    <hikaricp-version>6.2.1</hikaricp-version>
     <nuprocess-version>3.0.0</nuprocess-version>
-    <postgresql-version>42.7.4</postgresql-version>
+    <postgresql-version>42.7.5</postgresql-version>
     <json-path-version>2.9.0</json-path-version>
     <json-smart-version>2.5.1</json-smart-version>
     <scalaj-version>2.4.2</scalaj-version>
-    <unboundid-version>7.0.1</unboundid-version>
+    <unboundid-version>7.0.2</unboundid-version>
     <fastparse-version>3.1.1</fastparse-version>
     <config-version>1.4.3</config-version>
     <caffeine-version>3.1.8</caffeine-version>
     <jgrapht-version>1.5.2</jgrapht-version>
     <reflections-version>0.10.2</reflections-version>
-    <graalvm-version>24.1.1</graalvm-version>
-    <chimney-version>1.6.0</chimney-version>
-    <cron4s-version>0.7.0</cron4s-version>
+    <graalvm-version>24.1.2</graalvm-version>
+    <chimney-version>1.7.3</chimney-version>
+    <cron4s-version>0.8.2</cron4s-version>
     <ipaddress-version>5.5.1</ipaddress-version>
     <snakeyaml-version>2.3</snakeyaml-version>
 
@@ -487,9 +487,9 @@ limitations under the License.
     <fs2-version>3.10.2</fs2-version>
     <shapeless-version>2.3.12</shapeless-version>
     <cats-effect-version>3.5.5</cats-effect-version>
-    <dev-zio-version>2.1.14</dev-zio-version>
+    <dev-zio-version>2.1.16</dev-zio-version>
     <zio-cats-version>23.1.0.3</zio-cats-version> <!-- gives fs2 3.10.2, but doobie 1.0.0-RC5 is in 3.9.3 -->
-    <zio-json-version>0.7.14</zio-json-version>
+    <zio-json-version>0.7.36</zio-json-version>
     <enumeratum-version>1.7.5</enumeratum-version>
 
     <!--
@@ -571,11 +571,6 @@ limitations under the License.
         <groupId>org.tpolecat</groupId>
         <artifactId>doobie-core_${scala-binary-version}</artifactId>
         <version>${doobie-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.chuusai</groupId>
-        <artifactId>shapeless_${scala-binary-version}</artifactId>
-        <version>${shapeless-version}</version>
       </dependency>
       <dependency>
         <groupId>com.lihaoyi</groupId>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/PluginData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/PluginData.scala
@@ -78,7 +78,7 @@ final case class AbiVersion(value: Version) extends AnyVal
 final case class PluginVersion(value: Version) extends AnyVal
 
 /**
-  * Main datatype for a plugin object which enforces the errors 
+  * Main datatype for a plugin object which enforces the errors
   * that can be associated with the plugin (on license, version, ...).
   */
 final case class Plugin(
@@ -196,7 +196,7 @@ sealed abstract class GlobalPluginsLicense[EndDate](
   }
 
   private[GlobalPluginsLicense] def sortDistinctLicensees: GlobalPluginsLicense[EndDate] = {
-    withLicensees(licensees.map(_.sorted.distinct).flatMap(NonEmptyChunk.fromChunk))
+    withLicensees(licensees.map(_.sorted.distinct).flatMap(NonEmptyChunk.fromChunk(_)))
   }
 
   protected def withLicensees(licensees: Option[NonEmptyChunk[String]]): GlobalPluginsLicense[EndDate] = {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/VariableTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/VariableTest.scala
@@ -139,7 +139,8 @@ class VariableTest extends Specification {
       } yield {
         variableSpecParser.parseSectionVariableSpec("default section", specNode)
       })
-      (sysvar.size === 1) and (sysvar.head must beLeft[LoadTechniqueError])
+      sysvar.size === 1
+      sysvar.head must beLeft
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/HooksTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/HooksTest.scala
@@ -133,8 +133,8 @@ class HooksTest() extends Specification with AfterAll {
       1.second,
       500.millis
     )
-
-    (timeout must beEqualTo(HookTimeout(Some(6.seconds), Some(10.seconds)))) and (res must beEqualTo(Ok("", "")))
+    timeout must beEqualTo(HookTimeout(Some(6.seconds), Some(10.seconds)))
+    res must beEqualTo(Ok("", ""))
   }
 
 // This one is more for testing performance. I don't want to make it a test, because in

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/metrics/NodeCountHistorizationTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/metrics/NodeCountHistorizationTest.scala
@@ -116,10 +116,9 @@ class NodeCountHistorizationTest extends Specification with BeforeAfter {
     ZioRuntime.unsafeRun(prog.provideLayer(Scope.default >>> testEnvironment))
     val lines = File(rootDir, "nodes-2020-03").lines(StandardCharsets.UTF_8).toVector
 
-    (lines.size must beEqualTo(3)) and (
-      (lines(1) must beEqualTo(""""2020-03-20T03:49:36Z";"1";"2";"3";"4";"5";"6"""")) and
-      (lines(2) must beEqualTo(""""2020-03-20T03:49:37Z";"35";"46";"57";"68";"79";"3""""))
-    )
+    lines.size must beEqualTo(3)
+    lines(1) must beEqualTo(""""2020-03-20T03:49:36Z";"1";"2";"3";"4";"5";"6"""")
+    lines(2) must beEqualTo(""""2020-03-20T03:49:37Z";"35";"46";"57";"68";"79";"3"""")
   }
 
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestTechniqueCompilationCache.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestTechniqueCompilationCache.scala
@@ -236,7 +236,8 @@ class TestTechniqueCompilationCache extends Specification with BeforeAfterAll {
       (writeCache.syncOne(newError) *> // println(mockActor.messages.head).succeed *>
       msgLock.withPermit(
         (mockActor hasReceivedMessage_? UpdateCompilationStatus(expectedCompilationStatus ++ newErrorStatus)).succeed
-      )).runNow.aka("actor received message") must beTrue and (mockActor.messageCount must beEqualTo(1))
+      )).runNow.aka("actor received message") must beTrue
+      mockActor.messageCount must beEqualTo(1)
     }
 
     "update an existing technique in error" in {
@@ -307,14 +308,16 @@ class TestTechniqueCompilationCache extends Specification with BeforeAfterAll {
       (writeCache.syncTechniqueActiveStatus(newError.id) *>
       msgLock.withPermit(
         (mockActor hasReceivedMessage_? UpdateCompilationStatus(newErrorStatus)).succeed
-      )).runNow.aka("actor received message") must beTrue and (mockActor.messageCount must beEqualTo(2))
+      )).runNow.aka("actor received message") must beTrue
+      mockActor.messageCount must beEqualTo(2)
     }
 
     "unsync one" in {
       (writeCache.unsyncOne(newError.id -> newError.version) *>
       msgLock.withPermit(
         (mockActor hasReceivedMessage_? UpdateCompilationStatus(CompilationStatusAllSuccess)).succeed
-      )).runNow.aka("actor received message") must beTrue and (mockActor.messageCount must beEqualTo(3))
+      )).runNow.aka("actor received message") must beTrue
+      mockActor.messageCount must beEqualTo(3)
     }
 
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsTest.scala
@@ -213,8 +213,8 @@ class ReportsTest extends DBCommon {
 
       val checkInsert = transacRun(xa => sql"""select id from ruddersysevents""".query[Long].to[Vector].transact(xa)).size
 
-      (checkInsert must beEqualTo(14)) and
-      (res._1 must contain(exactly(expected*)))
+      checkInsert must beEqualTo(14)
+      res._1 must contain(exactly(expected*))
     }
 
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/score/ComplianceScoreEventHandlerTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/score/ComplianceScoreEventHandlerTest.scala
@@ -39,7 +39,6 @@ package com.normation.rudder.score
 
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.reports.CompliancePercent
-import com.normation.rudder.domain.reports.CompliancePrecision
 import org.junit.runner.RunWith
 import org.specs2.mutable.*
 import org.specs2.runner.JUnitRunner
@@ -66,9 +65,7 @@ class ComplianceScoreEventHandlerTest extends Specification {
     val n1    = NodeId("node1")
     val event = ComplianceScoreEvent(
       n1,
-      CompliancePercent(pending = 17, success = 33, repaired = 21, error = 14, 0, 0, noAnswer = 25, 0, 0, 0, 0, 0, 0, 0)(
-        CompliancePrecision.Level2
-      )
+      CompliancePercent(pending = 17, success = 33, repaired = 21, error = 14, 0, 0, noAnswer = 25, 0, 0, 0, 0, 0, 0, 0)
     )
 
     val result = {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
@@ -225,7 +225,7 @@ class RuleValServiceTest extends Specification {
           vars.get(ComponentId(reportKeysVariableName("component1"), "component1" :: "root section" :: Nil, None)) match {
             case None           => ko(s"Excepted variable variable_component1, but got nothing. The variables are ${variables}")
             case Some(variable) =>
-              variable.values.size === 3 and
+              variable.values.size === 3
               variable.values === Seq("variable_component1", "variable_component1one", "variable_component1two")
           }
       }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -236,10 +236,10 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
     // these one are not expired (but false)
     val okId = finder.reports.keySet
 
-    (n1 must beEqualTo(Map())) and
-    (n2 must beEqualTo(finder.reports.filter(x => okId.contains(x._1)))) and
+    n1 must beEqualTo(Map())
+    n2 must beEqualTo(finder.reports.filter(x => okId.contains(x._1)))
     // second time, only the node with changing status (pending and compute) are invalidated
-    (finder.updated.size must beEqualTo(9 + 2))
+    finder.updated.size must beEqualTo(9 + 2)
   }
 
   "When run are expired but we keep compliance, we keep compliance in repo" >> {
@@ -305,8 +305,8 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
     // let a chance for zio to exec again to find back expired
     Thread.sleep(1000)
 
-    (n1 must beEqualTo(Map())) and
-    (n2 must beEqualTo(finder.reports)) and
-    (finder.updated.size must beEqualTo(9)) // second time, only expired are invalidate: none here
+    n1 must beEqualTo(Map())
+    n2 must beEqualTo(finder.reports)
+    finder.updated.size must beEqualTo(9) // second time, only expired are invalidate: none here
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/servers/TestInstanceIdService.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/servers/TestInstanceIdService.scala
@@ -56,11 +56,10 @@ class TestInstanceIdService extends Specification {
     "make instance" in {
       "with non-existing file without creating the file" in {
         val file = File("/tmp/rudder-test-instance-id-not-exists")
-        (InstanceIdService.make(file, instanceIdGenerator).either.runNow must beRight(
+        InstanceIdService.make(file, instanceIdGenerator).either.runNow must beRight(
           beLike[InstanceIdService](_.instanceId must beEqualTo(instanceIdGenerator.newInstanceId))
-        )) and (
-          file.exists must beFalse
         )
+        file.exists must beFalse
       }
 
       "existing file" in File.temporaryFile("rudder-test-instance-id-", "", None, Attributes.default) { tmpFile =>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ApiAccountApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ApiAccountApi.scala
@@ -177,11 +177,11 @@ class ApiAccountApiServiceV1(
 
   override def getAccount(id: ApiAccountId): IOResult[Option[ApiAccountDetails.Public]] = {
     readApi.getById(id).flatMap {
-      case None                                                                  =>
+      case None                                                             =>
         None.succeed
-      case Some(account) if (account.kind.kind.name == ApiAccountType.PublicApi) =>
+      case Some(account) if (account.kind.kind == ApiAccountType.PublicApi) =>
         Some(account.transformInto[ApiAccountDetails.Public]).succeed
-      case Some(x)                                                               =>
+      case Some(x)                                                          =>
         ApiLoggerPure.warn(s"Access to API account with ID '${id.value}' is not authorized via API") *>
         None.succeed
     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
@@ -152,10 +152,10 @@ final case class JsonAuthConfig(
 
 final case class JsonProviderProperty(
     @jsonField("roleListOverride") providerRoleExtension: ProviderRoleExtension
-) extends AnyVal
+)
 object JsonProviderProperty {
-  implicit val transformer: Transformer[ProviderRoleExtension, JsonProviderProperty] =
-    Transformer.derive[ProviderRoleExtension, JsonProviderProperty]
+  implicit val transformer: Transformer[ProviderRoleExtension, JsonProviderProperty] = roleExtension =>
+    JsonProviderProperty(providerRoleExtension = roleExtension)
 }
 
 final case class JsonRoles(
@@ -412,7 +412,7 @@ object JsonInternalUserData {
 
 final case class JsonAddedUser(
     addedUser: JsonAddedUserData
-) extends AnyVal
+)
 object JsonAddedUser        {
   implicit val transformer: Transformer[JsonUserFormData, JsonAddedUser] = (u: JsonUserFormData) =>
     JsonAddedUser(u.transformInto[JsonAddedUserData])
@@ -420,7 +420,7 @@ object JsonAddedUser        {
 
 final case class JsonUpdatedUser(
     updatedUser: JsonInternalUserData
-) extends AnyVal
+)
 object JsonUpdatedUser      {
   implicit val transformer: Transformer[User, JsonUpdatedUser] = (u: User) =>
     JsonUpdatedUser(u.transformInto[JsonInternalUserData])
@@ -428,7 +428,7 @@ object JsonUpdatedUser      {
 
 final case class JsonUpdatedUserInfo(
     updatedUser: UpdateUserInfo
-) extends AnyVal
+)
 object JsonUpdatedUserInfo  {
   implicit val transformer: Transformer[UpdateUserInfo, JsonUpdatedUserInfo] =
     JsonUpdatedUserInfo(_)
@@ -440,7 +440,7 @@ final case class JsonUsername(
 
 final case class JsonDeletedUser(
     deletedUser: JsonUsername
-) extends AnyVal
+)
 object JsonDeletedUser      {
   implicit val usernameTransformer: Transformer[String, JsonUsername]    = JsonUsername(_)
   implicit val transformer:         Transformer[String, JsonDeletedUser] = (s: String) => JsonDeletedUser(s.transformInto[JsonUsername])
@@ -469,10 +469,10 @@ object JsonUserFormData {
 
 final case class JsonCoverage(
     coverage: JsonRoleCoverage
-) extends AnyVal
+)
 object JsonCoverage     {
   implicit val transformer: Transformer[(Set[Role], Set[Custom]), JsonCoverage] = (x: (Set[Role], Set[Custom])) =>
-    x.transformInto[JsonRoleCoverage].transformInto[JsonCoverage]
+    x.transformInto[JsonRoleCoverage].transformInto[JsonCoverage](coverage => JsonCoverage(coverage))
 }
 
 final case class JsonRoleCoverage(

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/CampaignApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/CampaignApiTest.scala
@@ -97,15 +97,16 @@ class CampaignApiTest extends Specification with AfterAll with Loggable with Jso
 //  org.slf4j.LoggerFactory.getLogger("campaign").asInstanceOf[ch.qos.logback.classic.Logger].setLevel(ch.qos.logback.classic.Level.TRACE)
 
   val c0json: String = {
-    """{"info":{
+    """{
+      |"campaignType":"dumb-campaign",
+      |"info":{
       |"id":"c0",
       |"name":"first campaign",
       |"description":"a test campaign present when rudder boot",
       |"status":{"value":"enabled"},
-      |"schedule":{"start":{"day":1,"hour":3,"minute":42},"end":{"day":1,"hour":4,"minute":42},"type":"weekly"}
+      |"schedule":{"type":"weekly","start":{"day":1,"hour":3,"minute":42},"end":{"day":1,"hour":4,"minute":42}}
       |},
       |"details":{"name":"campaign #0"},
-      |"campaignType":"dumb-campaign",
       |"version":1
       |}""".stripMargin.replaceAll("""\n""", "")
   }

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/migration/TestMigrateJsonTechniquesToYaml.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/migration/TestMigrateJsonTechniquesToYaml.scala
@@ -218,10 +218,10 @@ class TestMigrateJsonTechniquesToYaml extends Specification with ContentMatchers
 
   "There is only three techniques to migrate" >> {
     val res = migration.getAllTechniqueFiles(gitMock.configurationRepositoryRoot / "techniques").runNow
-    (res.size === 3) and
-    (res.map(_.parent.parent.name) must containTheSameElementsAs(
+    res.size === 3
+    res.map(_.parent.parent.name) must containTheSameElementsAs(
       List("technique_with_blocks", "technique_with_error", "technique_with_parameters")
-    ))
+    )
   }
 
   "After migration, the config repo matches what is expected" >> {

--- a/webapp/sources/scala-ldap/src/test/scala/com/normation/ldap/sdk/LoadDemoDataTest.scala
+++ b/webapp/sources/scala-ldap/src/test/scala/com/normation/ldap/sdk/LoadDemoDataTest.scala
@@ -97,7 +97,6 @@ class LoadDemoDataTest extends Specification {
       val dn        = new DN("ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration")
       val newParent = new DN("ou=Not Existing Place For Inventories,ou=Inventories,cn=rudder-configuration")
 
-      val res = ldap.newConnection.flatMap(_.move(dn, newParent)).either.runNow
       /*
        * Failure message is:
        * Can not move 'biosName=bios1,machineId=machine2,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration' to new parent
@@ -105,10 +104,8 @@ class LoadDemoDataTest extends Specification {
        * 'biosName=bios1,machineId=machine2,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration' because the parent for the new DN
        * 'biosName=bios1,machineId=machine-does-not-exists,ou=Machines,ou=Accepted Inventories,ou=Inventories,cn=rudder-configuration' does not exist.
        */
-      res must beAnInstanceOf[Left[LDAPRudderError, ?]] and (
-        ldap.newConnection.flatMap(_.exists(dn)).runNow must beTrue
-      )
-
+      ldap.newConnection.flatMap(_.move(dn, newParent)).either.runNow must beLeft
+      ldap.newConnection.flatMap(_.exists(dn)).runNow must beTrue
     }
 
     "Missing attribute is a grave message that should not be ignored (#10067)" in {


### PR DESCRIPTION
https://issues.rudder.io/issues/26455

This the backport to branch 8.3 of:
- https://github.com/Normation/rudder/pull/6147
- https://github.com/Normation/rudder/pull/6206
- https://github.com/Normation/rudder/pull/6208
- https://github.com/Normation/rudder/pull/6210
- https://github.com/Normation/rudder/pull/6212
- https://github.com/Normation/rudder/pull/6213

Plus some update of dependencies which were transparent and seemed without risk (no source change, all test pass, rudder starts, etc)