### PR TITLE
Fixes #26264: The refresh button from the nodes webpage change the list of nodes in the other tab

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -41,7 +41,6 @@ var recentChanges = {};
 var recentChangesCount = {};
 var inventories = {};
 var recentGraphs = {};
-var nodeIds = undefined;
 
 
 /* Create an array with the values of all the checkboxes in a column */
@@ -1192,13 +1191,13 @@ function callbackElement(oData, displayCompliance) {
   return elem;
 }
 
-function reloadTable(gridId, scores) {
+function reloadTable(gridId, nodeIds, scores) {
   var table = $('#'+gridId).DataTable();
   table.destroy();
-  createNodeTable(gridId, function(){reloadTable(gridId, scores)}, scores)
+  createNodeTable(gridId, nodeIds, function(){reloadTable(gridId, nodeIds, scores)}, scores)
 }
 
-function createNodeTable(gridId, refresh, scores) {
+function createNodeTable(gridId, nodeIds, refresh, scores) {
   var tableWrapper = "#" + gridId + "_wrapper"
   var allColumns = {
       "Node ID" :

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/SrvGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/SrvGrid.scala
@@ -115,9 +115,7 @@ class SrvGrid(
     val jsTableId  = StringEscapeUtils.escapeEcmaScript(tableId)
     val nodeIds    = nodes.map(nodes => JsArray(nodes.map(n => Str(n.id.value)).toList).toJsCmd).getOrElse("undefined")
     JsRaw(
-      s"""nodeIds = ${nodeIds};
-         | createNodeTable("${jsTableId}",function() {reloadTable("${jsTableId}", ${scoreNames.toJsCmd})}, ${scoreNames.toJsCmd});
-                   """.stripMargin
+      s"""createNodeTable("${jsTableId}", ${nodeIds},function() {reloadTable("${jsTableId}", ${nodeIds}, ${scoreNames.toJsCmd})}, ${scoreNames.toJsCmd});"""
     ) & (additionalJs.getOrElse(Noop)) // JsRaw ok, escaped
   }
 
@@ -137,8 +135,7 @@ class SrvGrid(
         }
 
         JsRaw(s"""
-          nodeIds = ${nodeIds}
-          reloadTable("${tableId}", ${scoreNames.toJsCmd});
+          reloadTable("${tableId}", ${nodeIds}, ${scoreNames.toJsCmd});
       """) // JsRaw ok, escaped
       }
     )


### PR DESCRIPTION
https://issues.rudder.io/issues/26264

The `nodeIds` variable is no longer a global variable. The table is always initialized with the right node ids now.