### PR TITLE
Fixes #26478: We do need shapeless version to keep dependency tree correct

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -483,6 +483,7 @@ limitations under the License.
     <ip4s-version>3.6.0</ip4s-version>
     <doobie-version>1.0.0-RC5</doobie-version>
     <fs2-version>3.10.2</fs2-version>
+    <shapeless-version>2.3.12</shapeless-version>
     <cats-effect-version>3.5.5</cats-effect-version>
     <dev-zio-version>2.1.16</dev-zio-version>
     <zio-cats-version>23.1.0.3</zio-cats-version> <!-- gives fs2 3.10.2, but doobie 1.0.0-RC5 is in 3.9.3 -->


### PR DESCRIPTION
https://issues.rudder.io/issues/26478