### PR TITLE
Fixes #26479: Bad "OnSuccess" delay in log

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AsyncDeploymentActor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AsyncDeploymentActor.scala
@@ -555,7 +555,7 @@ final class AsyncDeploymentActor(
         _ <- PolicyGenerationLoggerPure.manager.trace("Policy updater Agent: start to update policies")
         d <- delay
         _ <- ZIO.when(d.toMillis > 0) {
-               PolicyGenerationLoggerPure.manager.debug(s"Policy generation will start in ${delay.toString}")
+               PolicyGenerationLoggerPure.manager.info(s"Policy generation will start in ${d.toString}")
              }
         _ <- (for {
                _   <- PolicyGenerationLoggerPure.manager.debug(s"Policy generation starts now!")


### PR DESCRIPTION
https://issues.rudder.io/issues/26479

Use the actual duration and not the ZIO promise on it. 
Plus that log is important enough to be in `info`, not just debug