### PR TITLE
Fixes #26483: Error when trying to add a node property when “Change audit logs” are mandatory

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -416,7 +416,8 @@ object JsonQueryObjects {
       properties: Option[List[NodeProperty]],
       policyMode: Option[Option[PolicyMode]],
       state:      Option[NodeState],
-      agentKey:   Option[JQAgentKey]
+      agentKey:   Option[JQAgentKey],
+      reason:     Option[String]
   ) {
     val keyInfo: (Option[SecurityToken], Option[KeyStatus]) = agentKey.map(_.toKeyInfo).getOrElse((None, None))
   }
@@ -897,8 +898,9 @@ class ZioJsonExtractor(queryParser: CmdbQueryParser with JsonQueryLexer) {
       policyMode <- params.parse2("policyMode", PolicyMode.parseDefault(_))
       state      <- params.parseString("state", NodeState.parse(_))
       agentKey   <- params.parse("agentKey", JsonDecoder[JQAgentKey])
+      reason      = params.optGet("reason")
     } yield {
-      JQUpdateNode(properties, policyMode, state, agentKey)
+      JQUpdateNode(properties, policyMode, state, agentKey, reason)
     }
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/26483

Fixing the `NodeApi` to take the `reason` in the JSON instead of reading request form params.
I left the validation of the reason length there, we will want to refactor it later, as it is being used also in the "Group categories API" in 8.2 (it has been migrated to zio-json in 8.3 so the check was lost)
 