### PR TITLE
Fixes #26487: Global properties generated by security benchmarks are displayed on Global Properties GUI

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/resources/ldap/rudder.schema
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/ldap/rudder.schema
@@ -379,6 +379,13 @@ attributetype ( RudderAttributes:308
   SUBSTR caseIgnoreSubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
+attributetype ( RudderAttributes:309
+  NAME 'visibility'
+  DESC 'Visibility for properties and parameter'
+  EQUALITY caseExactMatch
+  SUBSTR caseIgnoreSubstringsMatch
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
 #### Nodes
 
 attributetype ( RudderAttributes:351
@@ -571,7 +578,7 @@ objectclass ( RudderObjectClasses:120
   STRUCTURAL
   MUST ( parameterName )
   MAY ( parameterValue $ description $ propertyProvider $
-        overridable $ inheritMode $ revision ) )
+        overridable $ inheritMode $ revision $ visibility ) )
 
 #
 # Application properties

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderLDAPConstants.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderLDAPConstants.scala
@@ -128,6 +128,7 @@ object RudderLDAPConstants extends Loggable {
   // property provider
   val A_PROPERTY_PROVIDER = "propertyProvider"
   val A_INHERIT_MODE      = "inheritMode"
+  val A_VISIBILITY        = "visibility"
 
   // node configuration hashes
   val A_NODE_CONFIG = "nodeConfig"

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -1282,9 +1282,12 @@ object GlobalParameter {
       value:       String,
       mode:        Option[InheritMode],
       description: String,
-      provider:    Option[PropertyProvider]
+      provider:    Option[PropertyProvider],
+      visibility:  Visibility
   ): PureResult[GlobalParameter] = {
-    GenericProperty.parseConfig(name, rev, value, mode, provider, Some(description), None).map(c => new GlobalParameter(c))
+    GenericProperty
+      .parseConfig(name, rev, value, mode, provider, Some(description), Some(visibility))
+      .map(c => new GlobalParameter(c))
   }
   def apply(
       name:        String,
@@ -1292,9 +1295,10 @@ object GlobalParameter {
       value:       ConfigValue,
       mode:        Option[InheritMode],
       description: String,
-      provider:    Option[PropertyProvider]
+      provider:    Option[PropertyProvider],
+      visibility:  Visibility
   ): GlobalParameter = {
-    new GlobalParameter(GenericProperty.toConfig(name, rev, value, mode, provider, Some(description), None))
+    new GlobalParameter(GenericProperty.toConfig(name, rev, value, mode, provider, Some(description), Some(visibility)))
   }
 
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -73,6 +73,7 @@ import com.normation.rudder.domain.properties.GroupProperty
 import com.normation.rudder.domain.properties.InheritMode
 import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.domain.properties.PropertyProvider
+import com.normation.rudder.domain.properties.Visibility
 import com.normation.rudder.facts.nodes.NodeSecurityContext
 import com.normation.rudder.facts.nodes.SecurityTag
 import com.normation.rudder.reports.*
@@ -1185,8 +1186,17 @@ class LDAPEntityMapper(
                         case None    => GitVersion.DEFAULT_REV
                         case Some(x) => x
                       }
+        visibility <- e(A_VISIBILITY) match {
+                        case None             => Right(Visibility.default)
+                        case Some(visibility) =>
+                          Visibility.withNameInsensitiveEither(visibility) match {
+                            case Left(err) =>
+                              Left(InventoryMappingRudderError.UnexpectedObject(err.getMessage()))
+                            case Right(x)  => Right(x)
+                          }
+                      }
       } yield {
-        GlobalParameter(name, rev, parsed, mode, description, provider)
+        GlobalParameter(name, rev, parsed, mode, description, provider, visibility)
       }
     } else {
       Left(
@@ -1205,6 +1215,7 @@ class LDAPEntityMapper(
     entry.resetValuesTo(A_DESCRIPTION, parameter.description)
     parameter.provider.foreach(p => entry.resetValuesTo(A_PROPERTY_PROVIDER, p.value))
     parameter.inheritMode.foreach(m => entry.resetValuesTo(A_INHERIT_MODE, m.value))
+    entry.resetValuesTo(A_VISIBILITY, parameter.visibility.entryName)
     entry
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -73,6 +73,7 @@ import com.normation.rudder.domain.properties.GroupProperty
 import com.normation.rudder.domain.properties.InheritMode
 import com.normation.rudder.domain.properties.ModifyToGlobalParameterDiff
 import com.normation.rudder.domain.properties.PropertyProvider
+import com.normation.rudder.domain.properties.Visibility
 import com.normation.rudder.domain.secret.Secret
 import com.normation.rudder.domain.workflows.*
 import com.normation.rudder.domain.workflows.DirectiveChangeItem
@@ -770,8 +771,11 @@ class GlobalParameterUnserialisationImpl extends GlobalParameterUnserialisation 
                      ) ?~! ("Missing attribute 'description' in entry type globalParameter : " + entry)
       provider     = (globalParam \ "provider").headOption.map(x => PropertyProvider(x.text))
       mode         = (globalParam \ "inheritMode").headOption.flatMap(x => InheritMode.parseString(x.text).toOption)
+      visibility   = (globalParam \ "visibility").headOption
+                       .flatMap(x => Visibility.withNameInsensitiveOption(x.text))
+                       .getOrElse(Visibility.default)
       // TODO: no version in param for now
-      g           <- GlobalParameter.parse(name, GitVersion.DEFAULT_REV, value, mode, description, provider).toBox
+      g           <- GlobalParameter.parse(name, GitVersion.DEFAULT_REV, value, mode, description, provider, visibility).toBox
     } yield {
       g // TODO: no version in param for now
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -1486,13 +1486,29 @@ class MockGlobalParam() {
     InheritMode(ObjectMode.Override, ArrayMode.Prepend, StringMode.Append)
   }
 
-  val stringParam: GlobalParameter =
-    GlobalParameter("stringParam", GitVersion.DEFAULT_REV, "some string".toConfigValue, None, "a simple string param", None)
+  val stringParam: GlobalParameter = {
+    GlobalParameter(
+      "stringParam",
+      GitVersion.DEFAULT_REV,
+      "some string".toConfigValue,
+      None,
+      "a simple string param",
+      None,
+      Visibility.default
+    )
+  }
 
   // an hidden parameter: skipped in listing, can be accessed directly or when displaying hidden is true.
   val hiddenParam: GlobalParameter = {
-    GlobalParameter("hiddenParam", GitVersion.DEFAULT_REV, "hidden value".toConfigValue, None, "a hidden param", None)
-      .withVisibility(Hidden)
+    GlobalParameter(
+      "hiddenParam",
+      GitVersion.DEFAULT_REV,
+      "hidden value".toConfigValue,
+      None,
+      "a hidden param",
+      None,
+      Visibility.Hidden
+    )
   }
 
   // json: the key will be sorted alpha-num by Config lib; array value order is kept.
@@ -1503,12 +1519,22 @@ class MockGlobalParam() {
       """{ "string":"a string", "array": [1, 3, 2], "json": { "var2":"val2", "var1":"val1"} }""",
       None,
       "a simple string param",
-      None
+      None,
+      Visibility.default
     )
     .getOrElse(throw new RuntimeException("error in mock jsonParam"))
 
-  val modeParam: GlobalParameter =
-    GlobalParameter("modeParam", GitVersion.DEFAULT_REV, "some string".toConfigValue, Some(mode), "a simple string param", None)
+  val modeParam: GlobalParameter = {
+    GlobalParameter(
+      "modeParam",
+      GitVersion.DEFAULT_REV,
+      "some string".toConfigValue,
+      Some(mode),
+      "a simple string param",
+      None,
+      Visibility.default
+    )
+  }
 
   val systemParam: GlobalParameter = GlobalParameter(
     "systemParam",
@@ -1516,7 +1542,8 @@ class MockGlobalParam() {
     "some string".toConfigValue,
     None,
     "a simple string param",
-    Some(PropertyProvider.systemPropertyProvider)
+    Some(PropertyProvider.systemPropertyProvider),
+    Visibility.default
   )
 
   val rudderConfig: GlobalParameter = GlobalParameter
@@ -1528,7 +1555,8 @@ class MockGlobalParam() {
          |}""".stripMargin,
       None,
       "rudder system config",
-      Some(PropertyProvider.systemPropertyProvider)
+      Some(PropertyProvider.systemPropertyProvider),
+      Visibility.default
     )
     .getOrElse(throw new RuntimeException("error in mock jsonParam"))
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/GlobalParamMigration61Test.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/GlobalParamMigration61Test.scala
@@ -49,6 +49,7 @@ import com.normation.rudder.domain.RudderDit
 import com.normation.rudder.domain.RudderLDAPConstants.*
 import com.normation.rudder.domain.properties.GenericProperty.*
 import com.normation.rudder.domain.properties.GlobalParameter
+import com.normation.rudder.domain.properties.Visibility
 import com.normation.rudder.services.queries.CmdbQueryParser
 import com.typesafe.config.ConfigValueType
 import com.unboundid.ldap.sdk.DN
@@ -99,7 +100,8 @@ class GlobalParamMigration61Test extends Specification {
     new LDAPEntityMapper(rudderDit, nodeDit, acceptedNodesDitImpl, cmdbQueryParser, inventoryMapper)
   }
 
-  val baseParam: GlobalParameter = GlobalParameter.parse("test", GitVersion.DEFAULT_REV, "", None, "", None).forceGet
+  val baseParam: GlobalParameter =
+    GlobalParameter.parse("test", GitVersion.DEFAULT_REV, "", None, "", None, Visibility.default).forceGet
 
   // attribute that used to be set in GlobalParameter entry before 6.1.
   def setIs6_0(e: LDAPEntry): Unit = {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
@@ -56,6 +56,7 @@ import com.normation.rudder.domain.properties.NodePropertyHierarchy
 import com.normation.rudder.domain.properties.ParentProperty
 import com.normation.rudder.domain.properties.PropertyProvider
 import com.normation.rudder.domain.properties.SuccessNodePropertyHierarchy
+import com.normation.rudder.domain.properties.Visibility
 import com.normation.rudder.domain.queries.*
 import com.normation.rudder.domain.queries.ResultTransformation.*
 import com.normation.rudder.facts.nodes.NodeFact
@@ -122,7 +123,7 @@ class TestMergeGroupProperties extends Specification {
       )
     }
     def toGP(name: String): GlobalParameter       = {
-      GlobalParameter(name, GitVersion.DEFAULT_REV, global, None, "", None)
+      GlobalParameter(name, GitVersion.DEFAULT_REV, global, None, "", None, Visibility.default)
     }
   }
   implicit class ToConfigValue(s: String)                         {
@@ -522,7 +523,8 @@ class TestMergeGroupProperties extends Specification {
               globalProperty,
               maaInheritMode,
               "",
-              None
+              None,
+              Visibility.default
             )
           )
         )
@@ -547,7 +549,8 @@ class TestMergeGroupProperties extends Specification {
               globalProperty,
               mpaInheritMode,
               "",
-              None
+              None,
+              Visibility.default
             )
           )
         )
@@ -657,7 +660,8 @@ class TestMergeGroupProperties extends Specification {
           GenericProperty.parseValue("""{"global":"global value", "override":"global"}""").forceGet,
           None,
           "",
-          None
+          None,
+          Visibility.default
         ))
       )
       val parent        = parent1

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
@@ -363,8 +363,11 @@ class ParameterApiService2(
     restParameter match {
       case Full(restParameter) =>
         import GenericProperty.*
-        val parameter =
-          restParameter.updateParameter(GlobalParameter(parameterName, GitVersion.DEFAULT_REV, "".toConfigValue, None, "", None))
+        val parameter = {
+          restParameter.updateParameter(
+            GlobalParameter(parameterName, GitVersion.DEFAULT_REV, "".toConfigValue, None, "", None, Visibility.default)
+          )
+        }
 
         val diff = AddGlobalParameterDiff(parameter)
         createChangeRequestAndAnswer(
@@ -499,7 +502,7 @@ class ParameterApiService14(
       qc: QueryContext
   ): IOResult[JRGlobalParameter] = {
     import GenericProperty.*
-    val baseParameter = GlobalParameter.apply("", GitVersion.DEFAULT_REV, "".toConfigValue, None, "", None)
+    val baseParameter = GlobalParameter.apply("", GitVersion.DEFAULT_REV, "".toConfigValue, None, "", None, Visibility.default)
     val parameter     = restParameter.updateParameter(baseParameter)
     val diff          = AddGlobalParameterDiff(parameter)
     for {

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestInheritedProperties.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestInheritedProperties.scala
@@ -46,6 +46,7 @@ import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.properties.GenericProperty.StringToConfigValue
 import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.properties.GroupProperty
+import com.normation.rudder.domain.properties.Visibility
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.zio.*
 import org.junit.runner.RunWith
@@ -71,8 +72,17 @@ class TestInheritedProperties extends ZIOSpecDefault {
 
   // there is some tests that need change in data model, that we don't want to have in all plugins.
   // For ex, the tests for inherited values
-  val badOverrideType: GlobalParameter =
-    GlobalParameter("badOverrideType", GitVersion.DEFAULT_REV, "a string".toConfigValue, None, "a string at first", None)
+  val badOverrideType: GlobalParameter = {
+    GlobalParameter(
+      "badOverrideType",
+      GitVersion.DEFAULT_REV,
+      "a string".toConfigValue,
+      None,
+      "a string at first",
+      None,
+      Visibility.default
+    )
+  }
   restTestSetUp.mockParameters.paramsRepo.paramsMap.update(m => m + (badOverrideType.name -> badOverrideType)).runNow
 
   val gProp: GroupProperty = GroupProperty

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/consistency/CheckRudderGlobalParameter.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/consistency/CheckRudderGlobalParameter.scala
@@ -50,6 +50,7 @@ import com.normation.rudder.domain.properties.GenericProperty
 import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.properties.InheritMode
 import com.normation.rudder.domain.properties.PropertyProvider
+import com.normation.rudder.domain.properties.Visibility
 import com.normation.rudder.repository.RoParameterRepository
 import com.normation.rudder.repository.WoParameterRepository
 import com.normation.utils.StringUuidGenerator
@@ -136,7 +137,8 @@ final private[checks] case class JsonParam(
     description: String,
     value:       JValue,
     inheritMode: Option[String],
-    provider:    Option[String]
+    provider:    Option[String],
+    visibility:  Option[String]
 ) {
   def toGlobalParam: GlobalParameter = {
     GlobalParameter(
@@ -145,7 +147,8 @@ final private[checks] case class JsonParam(
       GenericProperty.fromJsonValue(value),
       inheritMode.flatMap(InheritMode.parseString(_).toOption),
       description,
-      provider.map(PropertyProvider.apply)
+      provider.map(PropertyProvider.apply),
+      visibility.flatMap(Visibility.withNameInsensitiveOption).getOrElse(Visibility.default)
     )
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
@@ -49,6 +49,7 @@ import com.normation.rudder.domain.properties.GenericProperty
 import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.properties.InheritMode
 import com.normation.rudder.domain.properties.ModifyToGlobalParameterDiff
+import com.normation.rudder.domain.properties.Visibility
 import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.QueryContext
@@ -152,7 +153,8 @@ class CreateOrUpdateGlobalParameterPopup(
                      value,
                      InheritMode.parseString(parameterInheritMode.get).toOption,
                      parameterDescription.get,
-                     None
+                     None,
+                     Visibility.default
                    )
           diff  <- globalParamDiffFromAction(param)
           cr     = ChangeRequestService.createChangeRequestFromGlobalParameter(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/ParameterManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/ParameterManagement.scala
@@ -40,6 +40,7 @@ import bootstrap.liftweb.RudderConfig
 import com.normation.rudder.AuthorizationType
 import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.properties.PropertyProvider
+import com.normation.rudder.domain.properties.Visibility
 import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.services.workflows.GlobalParamChangeRequest
@@ -75,7 +76,7 @@ class ParameterManagement extends DispatchSnippet with Loggable {
     (for {
       seq <- roParameterService.getAllGlobalParameters()
     } yield {
-      seq
+      seq.filterNot(_.visibility == Visibility.Hidden)
     }) match {
       case Full((seq)) => displayGridParameters(seq, gridName)
       case eb: EmptyBox =>


### PR DESCRIPTION
https://issues.rudder.io/issues/26487