### PR TITLE
Fixes #467: CSV export of server list (simple)

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -1178,6 +1178,7 @@ function reloadTable(gridId, scores) {
 }
 
 function createNodeTable(gridId, refresh, scores) {
+  var tableWrapper = "#" + gridId + "_wrapper"
   var allColumns = {
       "Node ID" :
       { "data": "id"
@@ -1368,7 +1369,7 @@ function createNodeTable(gridId, refresh, scores) {
   var allColumnsKeys =  Object.keys(allColumns)
 
   var isResizing = false,
-    hasHandle = $('#drag').length > 0,
+    hasHandle = $(tableWrapper + ' #drag').length > 0,
     offsetBottom = 250;
 
   $(function () {
@@ -1507,12 +1508,12 @@ function createNodeTable(gridId, refresh, scores) {
     , "drawCallback": function( oSettings ) {
         initBsTooltips();
       }
-    , "dom": ' <"dataTables_wrapper_top newFilter "<"#first_line_header" f <"dataTables_refresh"> <"#edit-columns">> <"#select-columns"> >rt<"dataTables_wrapper_bottom"lip>'
+    , "dom": ` <"dataTables_wrapper_top newFilter "<"#first_line_header" f <"dataTables_refresh"> <"#${gridId}_wrapper"> <"#edit-columns">> <"#select-columns"> >rt<"dataTables_wrapper_bottom"lip>`
   };
 
 
   createTable(gridId, [] , columns, params, contextPath, refresh, "nodes");
-  $("#first_line_header input").addClass("form-control")
+  $(tableWrapper + " #first_line_header input").addClass("form-control")
 
 
   function resetColumns()  {
@@ -1527,7 +1528,7 @@ function createNodeTable(gridId, refresh, scores) {
     columns = Array.from(defaultColumns);
     localStorage.setItem(cacheId, JSON.stringify(columns))
     createTable(gridId,data2, columns, params, contextPath, refresh, "nodes");
-    $("#first_line_header input").addClass("form-control")
+    $(tableWrapper + " #first_line_header input").addClass("form-control")
     columnSelect(true);
   }
 
@@ -1580,7 +1581,7 @@ function createNodeTable(gridId, refresh, scores) {
       delete params["ajax"];
       createTable(gridId,data2, columns, params, contextPath, refresh, "nodes");
     }
-    $("#first_line_header input").addClass("form-control")
+    $(tableWrapper + " #first_line_header input").addClass("form-control")
     columnSelect(true);
   }
 
@@ -1600,7 +1601,7 @@ function createNodeTable(gridId, refresh, scores) {
     localStorage.setItem(cacheId, JSON.stringify(columns))
     delete params["ajax"];
     createTable(gridId,data2, columns, params, contextPath, refresh, "nodes");
-    $("#first_line_header input").addClass("form-control")
+    $(tableWrapper + " #first_line_header input").addClass("form-control")
     columnSelect(true);
   }
 
@@ -1616,10 +1617,10 @@ function createNodeTable(gridId, refresh, scores) {
     var textBtn    = editOpen ? confirmTxt : editTxt;
     var classBtn   = editOpen ? "btn-success" : "btn-default";
     var editColBtn = $("<button class='btn btn-icon " + classBtn + "' id='edit-col-btn'>" + textBtn + "</button>").click(function(){
-      $("#select-columns").toggle();
+      $(tableWrapper + " #select-columns").toggle();
       $(this).toggleClass("btn-success").toggleClass("btn-default").toggleHtml(confirmTxt, editTxt)
     });
-    $("#edit-columns").append(editColBtn)
+    $(tableWrapper + " #edit-columns").append(editColBtn)
     var select = "<div class='form-inline-flex'> <div> <select id='column-select' placeholder='Select column to add' class='form-select'>"
     for (var key in dynColumns) {
       value = dynColumns[key]
@@ -1631,8 +1632,8 @@ function createNodeTable(gridId, refresh, scores) {
       }
     }
     select += "</select></div><div><select id='selectScoreDetails' class='form-select'></select></div><div><input class='form-control' id='colValue' type='text'></div><label for='colCheckbox' class='input-group'><span class='input-group-text'><input id='colCheckbox' type='checkbox'></span><div class='form-control'>Show inherited properties</div></label><button id='add-column' class='btn btn-default btn-icon flex-shrink-0'>Add column <i class='fa fa-plus-circle'></i></button><button id='reset-columns' class='btn btn-default btn-icon flex-shrink-0'>Reset columns <i class='fa fa-rotate-left'></i></button></div>"
-    editOpen ? $("#select-columns").show() : $("#select-columns").hide()
-    $("#select-columns").html(select)
+    editOpen ? $(tableWrapper + " #select-columns").show() : $(tableWrapper + " #select-columns").hide()
+    $(tableWrapper + " #select-columns").html(select)
     var selectedColumns =""
     var colsContainer = $("<div class='column-tags-container'></div>")
     for (var key in columns) {
@@ -1642,44 +1643,44 @@ function createNodeTable(gridId, refresh, scores) {
       }
       colsContainer.append(elem)
     }
-    $("#select-columns").append(colsContainer)
+    $(tableWrapper + " #select-columns").append(colsContainer)
     if (dynColumns[0] != "Property" && dynColumns[0] !="Software" && dynColumns[0] !="Score details" ) {
-      $("#select-columns input").parent().hide()
-      $("#select-columns select#selectScoreDetails").hide()
-      $("#colCheckbox").parent().parent().hide()
+      $(tableWrapper + " #select-columns input").parent().hide()
+      $(tableWrapper + " #select-columns select#selectScoreDetails").hide()
+      $(tableWrapper + " #colCheckbox").parent().parent().hide()
     }
-    $("#select-columns select#column-select").change(function(e) {
+    $(tableWrapper + " #select-columns select#column-select").change(function(e) {
       if (this.value =="Property" || this.value =="Software"  ) {
-        $("#select-columns input").parent().show()
-        $("#select-columns select#selectScoreDetails").hide()
-        $("#select-columns input").attr('placeholder', this.value + " name" )
+        $(tableWrapper + " #select-columns input").parent().show()
+        $(tableWrapper + " #select-columns select#selectScoreDetails").hide()
+        $(tableWrapper + " #select-columns input").attr('placeholder', this.value + " name" )
         if (this.value == "Property" ) {
-          $("#colCheckbox").parent().parent().show()
+          $(tableWrapper + " #colCheckbox").parent().parent().show()
         } else {
-          $("#colCheckbox").parent().parent().hide()
+          $(tableWrapper + " #colCheckbox").parent().parent().hide()
         }
       } else if ( this.value =="Score details"){
-          $("#select-columns input").parent().hide()
+          $(tableWrapper + " #select-columns input").parent().hide()
           // Only add score that are not in table yet (first filter)
           var options = scores.filter((elem) => ! addedScore.includes(elem.id) ).map((elem) => "<option value='"+elem.id+"'>"+elem.name+"</option>")
-          $("#select-columns select#selectScoreDetails").html(options.join(''))
-          $("#select-columns select#selectScoreDetails").show()
-          $("#colCheckbox").parent().parent().hide()
+          $(tableWrapper + " #select-columns select#selectScoreDetails").html(options.join(''))
+          $(tableWrapper + " #select-columns select#selectScoreDetails").show()
+          $(tableWrapper + " #colCheckbox").parent().parent().hide()
         } else {
-        $("#select-columns input").parent().hide()
-        $("#select-columns select#selectScoreDetails").hide()
-        $("#colCheckbox").parent().parent().hide()
+        $(tableWrapper + " #select-columns input").parent().hide()
+        $(tableWrapper + " #select-columns select#selectScoreDetails").hide()
+        $(tableWrapper + " #colCheckbox").parent().parent().hide()
       }
     })
-    $("#select-columns div button#add-column").click(function(e) {
-      var column = $("#select-columns select").val()
-      var value = $("#select-columns input#colValue").val()
+    $(tableWrapper + " #select-columns div button#add-column").click(function(e) {
+      var column = $(tableWrapper + " #select-columns select").val()
+      var value = $(tableWrapper + " #select-columns input#colValue").val()
       if ( column =="Score details") {
-        value = $("#select-columns select#selectScoreDetails").val()
+        value = $(tableWrapper + " #select-columns select#selectScoreDetails").val()
       }
-      addColumn(column, value, $("#colCheckbox").prop("checked"))
+      addColumn(column, value, $(tableWrapper + " #colCheckbox").prop("checked"))
     })
-    $("#select-columns div button#reset-columns").click(function(e) {
+    $(tableWrapper + " #select-columns div button#reset-columns").click(function(e) {
       resetColumns()
     })
   }

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -57,6 +57,27 @@ const equalsCheck = (a, b) =>
     a.length === b.length &&
     a.every((v, i) => v === b[i]);
 
+// Shared config for DataTables Button CSV
+const csvButtonConfig = (filename) => ({
+  extend: 'csv',
+  className: 'btn btn-primary btn-export',
+  filename: filename,
+  text: 'Export',
+  exportOptions: {
+    customizeData: function (data) {
+      // export compliance percent
+      const complianceColumnIdx = data.header.findIndex(s => s.toLowerCase() === "compliance")
+      if (complianceColumnIdx >= 0) {
+        data.body.forEach((row, idx) => {
+          data.body[idx][complianceColumnIdx] = computeCompliancePercentFromString(row[complianceColumnIdx]).toString() + "%"
+        })
+      }
+      return data
+    }
+  }
+})
+
+
 /*
  * This function is used to resort a table after its sorting data were changed ( like sorting function below)
  */
@@ -1508,7 +1529,7 @@ function createNodeTable(gridId, refresh, scores) {
     , "drawCallback": function( oSettings ) {
         initBsTooltips();
       }
-    , "dom": ` <"dataTables_wrapper_top newFilter "<"#first_line_header" f <"dataTables_refresh"> <"#${gridId}_wrapper"> <"#edit-columns">> <"#select-columns"> >rt<"dataTables_wrapper_bottom"lip>`
+    , "dom": ` <"dataTables_wrapper_top newFilter "<"#first_line_header.d-flex" <"d-flex flex-fill" <"me-2" f> <"#edit-columns">> <"d-flex ms-auto my-auto" <"me-2" B> <"dataTables_refresh">>> <"#select-columns"> >rt<"dataTables_wrapper_bottom"lip>`
   };
 
 
@@ -2429,6 +2450,7 @@ function createTable(gridId,data,columns, customParams, contextPath, refresh, st
     , "lengthMenu": [ [10, 25, 50, 100, 500, 1000, -1], [10, 25, 50, 100, 500, 1000, "All"] ]
     , "pageLength": 25
     , "retrieve" : true
+    , "buttons": [ csvButtonConfig(gridId) ]
   };
   if (storageId !== undefined) {
     var storageParams = {

--- a/webapp/sources/rudder/rudder-web/src/main/package-lock.json
+++ b/webapp/sources/rudder/rudder-web/src/main/package-lock.json
@@ -11,6 +11,7 @@
         "datatables.net-fixedheader": "^3.3.2",
         "datatables.net-plugins": "^1.13.5",
         "datatables.net-rowgroup": "^1.3.1",
+        "datatables.net-buttons": "^1.7.1",
         "diff": "^5.1.0",
         "elm-review": "^2.12.0",
         "gaugeJS": "^1.3.7",
@@ -1261,6 +1262,15 @@
       "dependencies": {
         "@types/jquery": "^3.5.16",
         "datatables.net": "^1.13.2"
+      }
+    },
+    "node_modules/datatables.net-buttons": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/datatables.net-buttons/-/datatables.net-buttons-1.7.1.tgz",
+      "integrity": "sha512-D2OxZeR18jhSx+l0xcfAJzfUH7l3LHCu0e606fV7+v3hMhphOfljjZYLaiRmGiR9lqO/f5xE/w2a+OtG/QMavw==",
+      "dependencies": {
+        "datatables.net": "^1.10.15",
+        "jquery": ">=1.7"
       }
     },
     "node_modules/datatables.net-rowgroup": {

--- a/webapp/sources/rudder/rudder-web/src/main/package.json
+++ b/webapp/sources/rudder/rudder-web/src/main/package.json
@@ -6,6 +6,7 @@
     "datatables.net-fixedheader": "^3.3.2",
     "datatables.net-plugins": "^1.13.5",
     "datatables.net-rowgroup": "^1.3.1",
+    "datatables.net-buttons": "^1.7.1",
     "diff": "^5.1.0",
     "elm-review": "^2.12.0",
     "gaugeJS": "^1.3.7",

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.scss
@@ -1,3 +1,42 @@
+/*
+*************************************************************************************
+* Copyright 2024 Normation SAS
+*************************************************************************************
+*
+* This file is part of Rudder.
+*
+* Rudder is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* In accordance with the terms of section 7 (7. Additional Terms.) of
+* the GNU General Public License version 3, the copyright holders add
+* the following Additional permissions:
+* Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+* Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+* Public License version 3, when you create a Related Module, this
+* Related Module is not considered as a part of the work and may be
+* distributed under the license agreement of your choice.
+* A "Related Module" means a set of sources files including their
+* documentation that, without modification of the Source Code, enables
+* supplementary functions or services in addition to those offered by
+* the Software.
+*
+* Rudder is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+*
+*************************************************************************************
+*/
+// Modules
+@use 'rudder-variables' as *;
+
 .content-wrapper td, .content-wrapper th {
   padding: 4px 3px;
   line-height: 1.42857143;
@@ -39,6 +78,14 @@
 }
 .dataTables_refresh{
   float: right;
+}
+.dt-buttons button.btn-export{
+  &::after {
+    content: "\f0ce";
+    font-family: "Font Awesome 5 Free";
+    font-weight: 900;
+    margin-left: 5px;
+  }
 }
 .dataTables_filter label{
   margin-bottom: 0;

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/common-layout.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/common-layout.html
@@ -40,6 +40,8 @@
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/libs/jquery.dataTables.min.js"></script>
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/libs/dataTables.rowGroup.min.js"></script>
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/libs/dataTables.fixedHeader.min.js"></script>
+    <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/libs/dataTables.buttons.min.js"></script>
+    <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/libs/buttons.html5.min.js"></script>
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/libs/natural.js"></script>
 
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/libs/jquery-ui.min.js"></script>


### PR DESCRIPTION
https://issues.rudder.io/issues/467

## :warning:  Based on #6225 to avoid merge conflicts

Adding the `Export` button to every nodes table : 
* add the latest compatible [DataTable Buttons library)](https://cdn.datatables.net/buttons/1.7.1/)
* [options](https://datatables.net/reference/button/csv#Options) : 
  * customize the compliance export to only export the percent value
  * file name is the table grid ID 
* rework the [sDom](https://datatables.net/reference/option/dom) option for correct alignment, buttons is `B` 

![Screenshot from 2025-03-13 12-26-06](https://github.com/user-attachments/assets/f6f11901-c6a6-4c6e-ad6a-dd82a2e7fbf8)


N.B. : This can now be applied to any other table, just by adding `B` to the `dom`/`sDom`