### PR TITLE
Fixes #26514: Change validation and global settings navigation menu got merged

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewUtils.elm
@@ -672,7 +672,12 @@ badgeSkipped { overridingRuleId, overridingRuleName } =
         msg =
             "This directive is skipped because it is overridden by the rule <b>" ++ overridingRuleName ++ "</b> (with id " ++ overridingRuleId ++ ")."
     in
-    span [ class "treeGroupName tooltipable bs-tooltip rudder-label label-sm label-overridden", attribute "data-toggle" "tooltip", attribute "data-placement" "bottom", attribute "data-container" "body", attribute "data-html" "true", attribute "data-original-title" (buildTooltipContent "Skipped directive" msg) ] []
+        span
+            [ class "treeGroupName rudder-label label-sm label-overridden"
+            , attribute "data-bs-toggle" "tooltip"
+            , attribute "data-bs-placement" "bottom"
+            , title (buildTooltipContent "Skipped directive" msg)
+            ] []
 
 
 

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
@@ -812,11 +812,12 @@ function navScroll(event, target, container){
   return false;
 }
 
-function buildScrollSpyNav(){
-    $("#navbar-scrollspy > ul").html("");
+function buildScrollSpyNav(navbarId, containerId){
+    const navbarUl = "#" + navbarId + " > ul";
+    $(navbarUl).html("");
     var linkText, tmp, link, listItem;
     var regex = /[^a-z0-9]/gmi
-    $(".page-title, .page-subtitle").each(function(){
+    $("#"+containerId).find(".page-title, .page-subtitle").each(function(){
       linkText = $(this).text();
       tmp      = linkText.replace(regex, "-");
       $(this).attr('id', tmp);
@@ -826,7 +827,7 @@ function buildScrollSpyNav(){
       var subClass = $(this).hasClass("page-subtitle") ? "subtitle" : ""
       link.attr("href","#"+tmp).text(linkText).addClass(subClass).on('click',function(event){navScroll(event, targetLink, ".main-details[data-bs-spy='scroll']")});
       listItem.addClass("nav-item").append(link);
-      $("#navbar-scrollspy > ul").append(listItem);
+      $(navbarUl).append(listItem);
     });
 }
 

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/administration/policyServerManagement.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/administration/policyServerManagement.html
@@ -634,7 +634,7 @@
   </div>
 
   <script>
-    buildScrollSpyNav();
+    buildScrollSpyNav("navbar-scrollspy", "generalSettingsTab");
   </script>
   </component-body>
 </xml:group>


### PR DESCRIPTION
https://issues.rudder.io/issues/26514

The `buildScrollSpyNav` function now takes 2 parameters: 
- the navbar identifier, so as not to override another navbar
- the identifier of the container that contains the titles linked to this menu