### PR TITLE
Fixes #26584: License information not displayed on “About” page

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/DataTypes.elm
@@ -52,7 +52,8 @@ type alias LicenseInfo =
     { licensee : String
     , startDate : String
     , endDate : String
-    , allowedNodesNumber : Int
+    , allowedNodesNumber : Maybe Int
+    , supportedVersions : String
     }
 
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/JsonDecoder.elm
@@ -64,7 +64,7 @@ decodeNodesInfo =
 decodePluginInfo : Decoder PluginInfo
 decodePluginInfo =
   D.succeed PluginInfo
-    |> required "name" ( string |> andThen (\name -> succeed (String.replace "rudder-plugins-" "" name)) )
+    |> required "name" string
     |> required "version" string
     |> required "abiVersion" string
     |> optional "license" (D.maybe decodeLicenseInfo) Nothing
@@ -75,4 +75,5 @@ decodeLicenseInfo =
     |> required "licensee" string
     |> required "startDate" string
     |> required "endDate" string
-    |> required "allowedNodesNumber" int
+    |> optional "allowedNodesNumber" (D.maybe int) Nothing
+    |> required "supportedVersions" string

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/JsonEncoder.elm
@@ -67,7 +67,8 @@ encodeLicenseInfo licenseInfo =
         [ ( "licensee", string li.licensee )
         , ( "startDate", string li.startDate )
         , ( "endDate", string li.endDate )
-        , ( "allowedNodesNumber", int li.allowedNodesNumber )
+        , ( "allowedNodesNumber", Maybe.map int li.allowedNodesNumber |> Maybe.withDefault null )
+        , ( "supportedVersions", string li.supportedVersions )
         ]
 
 encodeAboutInfo : AboutInfo -> Value

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/View.elm
@@ -166,7 +166,7 @@ view model =
                                         Just l ->
                                             [ td[][text l.licensee]
                                             , td[][text ("from " ++ l.startDate ++ " to " ++ l.endDate)]
-                                            , td[][text (String.fromInt l.allowedNodesNumber)]
+                                            , td[][text (l.allowedNodesNumber |> Maybe.map String.fromInt |> Maybe.withDefault "Unlimited")]
                                             ]
                                 in
                                     tr[]


### PR DESCRIPTION
https://issues.rudder.io/issues/26584

The parsing of the license always ended up as `Nothing` because in case of unlimited number of nodes, the API returns `null`.
The model needs to be changed to be the same as in the API

**EDIT:** re-add license `supportedVersion` for copying it to the clipboard as it has been deleted in #6273