### PR TITLE
Fixes #26590: Make tabs accessible by URL

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -1180,13 +1180,13 @@ function propertyFunction(value, inherited) { return function (nTd, sData, oData
 function callbackElement(oData, displayCompliance) {
   var elem = $("<a></a>");
   if("callback" in oData) {
-      elem.click(function(e) {
-        oData.callback(displayCompliance);
-        e.stopPropagation();
-      });
-      elem.attr("href","javascript://");
+    elem.click(function(e) {
+      oData.callback(displayCompliance);
+      e.stopPropagation();
+    });
   } else {
-      elem.attr("href",contextPath+'/secure/nodeManager/node/'+oData.id+'?displayCompliance='+displayCompliance);
+    let complianceTab = displayCompliance ? "#node_reports" : "";
+    elem.attr("href", contextPath + '/secure/nodeManager/node/' + oData.id + complianceTab);
   }
   return elem;
 }

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
@@ -431,9 +431,9 @@ function parseSearchHash(queryCallback) {
 }
 
 function updateHashString(key, value) {
-  var hash = parseURLHash();
+  const hash = parseURLHash();
   hash[key] = value;
-  var baseUrl = window.location.href.split('#')[0];
+  const baseUrl = window.location.href.split('#')[0];
   window.location.replace(baseUrl + '#' + JSON.stringify(hash));
 }
 
@@ -912,21 +912,22 @@ function hideBsModal(modalName){
   if(modal === null || modal === undefined) return false;
   modal.hide();
 }
-function initBsTabs(){
-  var triggerTabList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tab"]'));
+function initBsTabs(isJsonHash = false){
+  const triggerTabList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tab"]'));
   triggerTabList.forEach(function (triggerEl) {
-    var tabTrigger = new bootstrap.Tab(triggerEl);
+    const tabTrigger = new bootstrap.Tab(triggerEl);
+
     triggerEl.addEventListener('click', function (event) {
-      tabTrigger.show();
       event.preventDefault();
+      tabTrigger.show();
 
-      // TODO: improve that
-      let newHash = this.getAttribute("data-bs-target");
+      const newHash = this.getAttribute("data-bs-target");
 
-      //window.location.hash = newHash;
-      //location.replace(newHash);
-      history.replaceState(undefined, undefined, newHash)
-
+      if (isJsonHash) {
+        updateHashString("tab",newHash);
+      }else{
+        history.replaceState(undefined, undefined, newHash);
+      }
       return false;
     });
   });
@@ -949,12 +950,25 @@ function waitForElement(selector) {
 }
 
 function initAndCheckTabs(){
-  initBsTabs();
-  if (window.location.hash === "") return false;
-  var tabSelector = '[data-bs-target="' + window.location.hash + '"]';
+  const isNodePage = window.location.pathname.includes("nodeManager/nodes");
+
+  initBsTabs(isNodePage);
+  let hash = window.location.hash;
+
+  // If the anchor corresponds to a tab ID then this tab is opened automatically,
+  // else nothing happens
+  if (hash === "") return false;
+
+  // An exception is made for the for the Nodes page,
+  // which uses the anchor to store the search query AND the tab ID in a json object.
+  if (isNodePage) {
+    let tab = parseURLHash().tab;
+    if (tab === undefined) return false;
+    hash = tab;
+  }
+  const tabSelector = '[data-bs-target="' + hash + '"]';
   waitForElement(tabSelector).then((tab) => {
     bootstrap.Tab.getInstance(tab).show();
-    //$(tabSelector).click();
   });
 }
 

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
@@ -921,7 +921,11 @@ function initBsTabs(){
       event.preventDefault();
 
       // TODO: improve that
-      window.location.hash = this.getAttribute("data-bs-target");
+      let newHash = this.getAttribute("data-bs-target");
+
+      //window.location.hash = newHash;
+      //location.replace(newHash);
+      history.replaceState(undefined, undefined, newHash)
 
       return false;
     });
@@ -950,6 +954,7 @@ function initAndCheckTabs(){
   var tabSelector = '[data-bs-target="' + window.location.hash + '"]';
   waitForElement(tabSelector).then((tab) => {
     bootstrap.Tab.getInstance(tab).show();
+    //$(tabSelector).click();
   });
 }
 

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
@@ -375,6 +375,8 @@ $(document).ready(function() {
   sidebarControl();
   // Init tooltips
   initBsTooltips();
+  // Init and check tab states
+  initAndCheckTabs();
 
   // Hide any open tooltips when the anywhere else in the body is clicked
   $('body').on('click', function (e) {
@@ -915,10 +917,40 @@ function initBsTabs(){
   triggerTabList.forEach(function (triggerEl) {
     var tabTrigger = new bootstrap.Tab(triggerEl);
     triggerEl.addEventListener('click', function (event) {
-      event.preventDefault()
-      tabTrigger.show()
+      tabTrigger.show();
+      event.preventDefault();
+
+      // TODO: improve that
+      window.location.hash = this.getAttribute("data-bs-target");
+
+      return false;
     });
-});
+  });
+}
+
+function waitForElement(selector) {
+  return new Promise((resolve) => {
+    const observer = new MutationObserver((mutations, observer) => {
+      const element = document.querySelector(selector);
+      if (element) {
+        observer.disconnect();
+        resolve(element);
+      }
+    });
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  });
+}
+
+function initAndCheckTabs(){
+  initBsTabs();
+  if (window.location.hash === "") return false;
+  var tabSelector = '[data-bs-target="' + window.location.hash + '"]';
+  waitForElement(tabSelector).then((tab) => {
+    bootstrap.Tab.getInstance(tab).show();
+  });
 }
 
 function copy(value) {

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/administration/settings.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/administration/settings.html
@@ -5,32 +5,33 @@
   </head>
 
   <div data-lift="administration.Settings.body">
-  <div class="rudder-template">
-    <div class="one-col">
-      <div class="main-header">
-        <div class="header-title">
-          <h1>
-            <span>Settings</span>
-          </h1>
+    <div class="rudder-template">
+      <div class="one-col">
+        <div class="main-header">
+          <div class="header-title">
+            <h1>
+              <span>Settings</span>
+            </h1>
+          </div>
         </div>
-      </div>
-      <div class="main-navbar">
-        <ul id="settingsTabMenu" class="nav nav-underline">
-          <li class="nav-item" role="presentation">
-            <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#generalSettingsTab" type="button" role="tab" aria-controls="generalSettingsTab" aria-selected="true">
-              General settings
-            </button>
-          </li>
-        </ul>
-      </div>
-      <div>
-        <div class="one-col-main">
-          <div class="template-main">
-            <div class="main-container">
-              <div class="main-details">
-                <div id="settingsTabContent" class="tab-content">
-                  <div id="generalSettingsTab" class="tab-pane active">
-                    <div class="lift:administration.Settings.mainTabContent"></div>
+        <div class="main-navbar">
+          <ul id="settingsTabMenu" class="nav nav-underline">
+            <li class="nav-item" role="presentation">
+              <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#generalSettingsTab" type="button" role="tab" aria-controls="generalSettingsTab" aria-selected="true">
+                General settings
+              </button>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div class="one-col-main">
+            <div class="template-main">
+              <div class="main-container">
+                <div class="main-details">
+                  <div id="settingsTabContent" class="tab-content">
+                    <div id="generalSettingsTab" class="tab-pane active">
+                      <div class="lift:administration.Settings.mainTabContent"></div>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -39,6 +40,5 @@
         </div>
       </div>
     </div>
-  </div>
   </div>
 </lift:surround>

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/nodes.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/nodeManager/nodes.html
@@ -41,26 +41,22 @@
           <div class="template-main">
             <div class="main-container">
               <div class="main-details">
-                <div class="main-container">
-                  <div class="main-details">
-                    <div class="tab-content">
-                      <div id="node_list" class="tab-pane active">
-                        <div class="table-container">
-                          <div data-lift="node.Nodes.table"></div>
+                <div class="tab-content">
+                  <div id="node_list" class="tab-pane active">
+                    <div class="table-container">
+                      <div data-lift="node.Nodes.table"></div>
+                    </div>
+                  </div>
+                  <div id="node_search" class="tab-pane">
+                      <div data-lift="node.SearchNodes.head"></div>
+                      <div id="query-search-content">
+                      <div class="inner-portlet-content">
+                        <div id="SearchNodes">
+                          <div data-lift="node.SearchNodes.showQuery"></div>
                         </div>
-                      </div>
-                      <div id="node_search" class="tab-pane">
-                          <div data-lift="node.SearchNodes.head"></div>
-                          <div id="query-search-content">
-                          <div class="inner-portlet-content">
-                            <div id="SearchNodes">
-                              <div data-lift="node.SearchNodes.showQuery"></div>
-                            </div>
-                            <lift:authz role="group_write">
-                              <div data-lift="node.SearchNodes.createGroup"></div>
-                            </lift:authz>
-                          </div>
-                        </div>
+                        <lift:authz role="group_write">
+                          <div data-lift="node.SearchNodes.createGroup"></div>
+                        </lift:authz>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
https://issues.rudder.io/issues/26590

We can now access tabs directly using an anchor in the url!

- When pages load, if an anchor is used that matches the ID of a tab on the page, then that tab will automatically be opened.
- This anchor is updated when the user changes tab, meaning that when the page is reloaded, the user is redirected to the last open tab.
- If the anchor does not correspond to any tab on the page, then nothing happens.
- :information_source: There is one exception: the Nodes page. This page already uses the anchor to store search data, so the tab id is stored in the anchor's json object.
 - :warning: This navigation system is not yet functional in Elm applications (such as Rules, Groups, Techniques...).
 

**Example below :arrow_down: :** the URL contains the anchor `#reportsDatabase`, which corresponds to the id of the “Reports database” tab. The user can directly access this tab via the URL `/rudder/secure/administration/maintenance#reportsDatabase`, and if he refreshes the page he will automatically return to this tab.

![nav-tab-url](https://github.com/user-attachments/assets/59f0c086-8c47-4e9b-a821-724dc0c952a5)


**Next steps :**
- Store tab navigation in history
- Improve node tab names (example: *#node_reports* **⇒** *#tab_compliance*)
- Remove node compliance tab redirection logic that uses the URL parameter `?displayCompliance=True/False`.
- Remove the use of href in the navigation menu of the Hooks page to avoid conflicts
- In node compliance tables, the link 🖊️ should redirect to the compliance tab
- Add redirection `secure/nodeManager/searchNodes#...` ⇒ `secure/nodeManager/nodes#...`