### PR TITLE
Fixes #26532: Menu color leads to unclarity of meaning

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/BootstrapMenu.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/BootstrapMenu.scala
@@ -68,7 +68,7 @@ class BootstrapMenu {
             <li class={style + "treeview treview-toggle"}>
               <a href="#">
                 {item.text}
-                <i class="fa fa-angle-left pull-right"></i>
+                <i class="fa fa-angle-right pull-right"></i>
               </a>
               <ul class="treeview-menu"> {
               for (kid <- kids) yield {

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-menu.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-menu.scss
@@ -41,7 +41,10 @@
 @import "../../node_modules/bootstrap/scss/variables";
 @import "../../node_modules/bootstrap/scss/mixins";
 
-$navbar-hover-color : #F4F4F4;
+$navbar-hover-color : $rudder-bg-light-gray;
+
+// VARIABLES
+$menu-width: 230px;
 
 .wrapper {
   min-height: 100%;
@@ -51,8 +54,8 @@ $navbar-hover-color : #F4F4F4;
 }
 .content-wrapper{
   transition: transform .3s ease-in-out,margin .3s ease-in-out;
-  background-color: #F8F9FC;
-  margin-left: 230px;
+  background-color: $rudder-bg-light-gray;
+  margin-left: $menu-width;
   min-height: 100%;
   z-index: 800;
 }
@@ -60,15 +63,13 @@ $navbar-hover-color : #F4F4F4;
   .content-wrapper{
     margin-left:0
   }
+  .sidebar-open .content-wrapper{
+    transform: translate($menu-width,0);
+  }
 }
 @media (min-width: 768px) {
   .sidebar-collapse .content-wrapper{
     margin-left:0
-  }
-}
-@media (max-width: 767px) {
-  .sidebar-open .content-wrapper{
-    transform: translate(230px,0)
   }
 }
 .fixed .main-header,
@@ -98,7 +99,7 @@ $navbar-hover-color : #F4F4F4;
 .main-header >.navbar {
   transition: margin-left .3s ease-in-out;
   margin-bottom: 0;
-  margin-left: 230px;
+  margin-left: $menu-width;
   border: none;
   height: 50px;
   border-radius: 0;
@@ -153,7 +154,7 @@ $navbar-hover-color : #F4F4F4;
   font-size: 20px;
   line-height: 50px;
   text-align: center;
-  width: 230px;
+  width: $menu-width;
   padding: 0 15px;
   font-weight: 300;
   overflow: hidden;
@@ -245,7 +246,7 @@ header.main-header .logo-lg img{
   left: 0;
   padding-top: 50px;
   min-height: 100%;
-  width: 230px;
+  width: $menu-width;
   z-index: 810;
   transition: transform .3s ease-in-out,width .3s ease-in-out;
   background-color: #041922;
@@ -257,12 +258,12 @@ header.main-header .logo-lg img{
 }
 @media (max-width: 767px) {
   .main-sidebar {
-    transform: translate(-230px,0)
+    transform: translate(-$menu-width,0)
   }
 }
 @media (min-width: 768px) {
   .sidebar-collapse .main-sidebar {
-    transform: translate(-230px,0)
+    transform: translate(-$menu-width,0)
   }
 }
 @media (max-width: 767px) {
@@ -300,14 +301,14 @@ header.main-header .logo-lg img{
   padding: 10px 25px 10px 15px;
   font-size: 12px
 }
-.sidebar-menu li>a > .fa-angle-left {
+.sidebar-menu li>a > .fa-angle-right {
   width: auto;
   height: auto;
   padding: 0;
   margin-right: 10px;
   margin-top: 3px
 }
-.sidebar-menu li.active>a > .fa-angle-left {
+.sidebar-menu li.active>a > .fa-angle-right {
   transform: rotate(-90deg)
 }
 .sidebar-menu li.active>.treeview-menu {
@@ -334,7 +335,7 @@ header.main-header .logo-lg img{
 .sidebar-menu .treeview-menu>li>a > .fa, .sidebar-menu .treeview-menu>li>a > .ion {
   width: 20px
 }
-.sidebar-menu .treeview-menu>li>a > .fa-angle-down,.sidebar-menu .treeview-menu>li>a > .fa-angle-left {
+.sidebar-menu .treeview-menu>li>a > .fa-angle-down,.sidebar-menu .treeview-menu>li>a > .fa-angle-right {
   width: auto
 }
 @media (min-width: 768px) {
@@ -769,7 +770,6 @@ header.main-header .logo-lg img{
 }
 .sidebar-menu>li.active>a, .sidebar-menu>li:hover>a {
   color: #fff;
-  background-color: #213640;
   border-left-color: #13beb7
 }
 .sidebar-menu>li.active>a>i, .sidebar-menu>li:hover>a>i {
@@ -845,11 +845,12 @@ header.main-header .logo-lg img{
   color:#556D77;
 }
 
-.sidebar-menu li.treeview.active>a > .fa-angle-left {
-  transform: rotate(90deg);
+.sidebar-menu li.treeview > a > .fa-angle-right {
+  transition-property : transform;
+  transition-duration : .2s;
 }
-.sidebar-menu li.treeview>a > .fa-angle-left {
-  transform: rotate(-90deg);
+.sidebar-menu li.treeview.active>a > .fa-angle-right {
+  transform: rotate(90deg);
 }
 
 .sidebar-menu>li.footer {


### PR DESCRIPTION
https://issues.rudder.io/issues/26532

- I removed the highlight color from the active parent section, which was confusing because it was lighter than all the other menu items
- I've rotated the arrows indicating the open/closed status of the menus by 90°, to be consistent with the other arrows on the pages ( right : closed, down: open)

Here is the result 
![menu-colors](https://github.com/user-attachments/assets/ad83d5e9-4f11-4a45-a9cf-a3a116fbc5ad)
:
