### PR TITLE
Fixes #26599: Rudder 8.3 Beta 2 : Missing Score pie charts on dashboard

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -190,7 +190,8 @@ class HomePage extends StatefulSnippet {
 
   def getAllCompliance(): NodeSeq = {
     // this needs to be outside of the zio for-comprehension context to see the right node facts
-    val nodes = HomePage.nodeFacts.get.keys.toSet
+    val nodes       = HomePage.nodeFacts.get.keys.toSet
+    implicit val qc = CurrentUser.queryContext
 
     (for {
       n2                <- currentTimeMillis
@@ -199,7 +200,7 @@ class HomePage extends StatefulSnippet {
       _                  = TimingDebugLogger.trace(s"Get rules: ${n3 - n2}ms")
       // reports contains the reports for user rules, used in the donut
       reports           <-
-        reportingService.findRuleNodeStatusReports(nodes, userRules)(CurrentUser.queryContext)
+        reportingService.findRuleNodeStatusReports(nodes, userRules)
       n4                <- currentTimeMillis
       _                  = TimingDebugLogger.trace(s"Compute Rule Node status reports for all nodes: ${n4 - n3}ms")
       // global compliance is a unique number, used in the top right hand size, based on
@@ -222,7 +223,7 @@ class HomePage extends StatefulSnippet {
       n5                <- currentTimeMillis
       _                 <- TimingDebugLoggerPure.trace(s"Compute global compliance in: ${n5 - n4}ms")
       _                 <- TimingDebugLoggerPure.debug(s"Compute compliance: ${n5 - n2}ms")
-      scores            <- scoreService.getAll()(CurrentUser.queryContext)
+      scores            <- scoreService.getAll()
       existingScore     <- scoreService.getAvailableScore()
     } yield {
 


### PR DESCRIPTION
https://issues.rudder.io/issues/26599

The call `scoreService.getAll()` faces the same issue as in #6274 when it calls `nodeFactsRepo.getAll()` : it sees empty nodes when inside the for-yield, but when initialized early it sees the correct list of nodes

**EDIT:**
the `CurrentUser.queryContext` is a also an access of `RequestVar` which is impure state, it needs to be done early oustide of the for-comprehension