### PR TITLE
Fixes #26620: Renaming tab and parameter for licence info in setup page

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Onboarding/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Onboarding/DataTypes.elm
@@ -22,7 +22,7 @@ type MetricsState
   | Complete -}
 
 type alias AccountSettings =
-  { username      : Maybe String
+  { username      : Maybe String --- username == Licence ID
   , password      : Maybe String
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Onboarding/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Onboarding/View.elm
@@ -33,7 +33,7 @@ view model =
         titleSection =
           case s of
             Welcome          -> "Welcome"
-            Account _ _      -> "Account"
+            Account _ _      -> "Licence"
          {-   Metrics _ _      -> "Metrics" -}
             GettingStarted _ -> "Getting Started"
 
@@ -75,9 +75,9 @@ view model =
 
           Account s ac ->
             case s of
-              Completed -> ( completeClass , completeIcon , "Your account will be setup."  )
-              Warning   -> ( warningClass  , warningIcon  , "There is a problem with your account credentials."       )
-              _         -> ( defaultClass  , defaultIcon  , "No account has been linked yet to your Rudder installation." )
+              Completed -> ( completeClass , completeIcon , "Your licence will be setup."  )
+              Warning   -> ( warningClass  , warningIcon  , "There is a problem with your licence credentials."       )
+              _         -> ( defaultClass  , defaultIcon  , "No licence has been linked yet to your Rudder installation." )
 
          {-  Metrics s m  ->
             let
@@ -115,17 +115,17 @@ view model =
                 , span[] [text ". Welcome!"]
                 ]
               , div[ class "wizard-btn-group"]
-                [ button[class "btn btn-default", type_ "button", onClick (SaveAction)] [text "I will configure my Rudder later"]
-                , button[class "btn btn-success", type_ "button", onClick (ChangeActiveSection (model.activeSection+1))] [text "Let's configure my account"]
+                [ button[class "btn btn-default", type_ "button", onClick (SaveAction)] [text "I will configure my licence later"]
+                , button[class "btn btn-success", type_ "button", onClick (ChangeActiveSection (model.activeSection+1))] [text "Let's configure my licence"]
                 ]
               ]
 
             Account state settings ->
-              [ h3 [] [text "Account"]
-              , div[] [text "Configure your Rudder account for automated plugin download and upgrade."]
+              [ h3 [] [text "Licence"]
+              , div[] [text "Configure your Rudder licence to download plugins."]
               , form[ class "wizard-form", name "wizard-account"]
                 [ div [class "form-group"]
-                  [ label[] [text "Username"]
+                  [ label[] [text "Licence Id"]
                   , input[class "form-control sm-width", type_ "text"    , name "rudder-username", id "rudder-username", value (Maybe.withDefault "" settings.username), onInput (\str -> UpdateSection 1 (Account state { settings | username = if String.isEmpty str then Nothing else Just str } ))][]
                   ]
                 , div [class "form-group"]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/View.elm
@@ -461,7 +461,7 @@ displaySettingError contextPath message details =
     in
     div [ class "callout-fade callout-warning overflow-scroll" ]
         [ p [] [ i [ class "fa fa-warning" ] [], text message ]
-        , p [] [ a [ target "_blank", href (contextPath ++ "/secure/administration/settings") ] [ text "Open Rudder account settings", i [ class "fa fa-external-link ms-1" ] [] ] ]
+        , p [] [ a [ target "_blank", href (contextPath ++ "/secure/administration/settings") ] [ text "Open Rudder licence settings", i [ class "fa fa-external-link ms-1" ] [] ] ]
         , p []
             [ button [ class "btn btn-primary me-1", onClick (CallApi updateIndex) ] [ i [ class "fa fa-refresh me-1" ] [], text "Refresh plugins" ]
             , seeDetailsBtnHtml

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/administration/RudderCompanyAccount.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/administration/RudderCompanyAccount.scala
@@ -50,7 +50,7 @@ class RudderCompanyAccount()(implicit val ttag: ClassTag[Settings]) extends Snip
     ChooseTemplate("templates-hidden" :: "components" :: "administration" :: "setup" :: Nil, "component-body")
 
   override def compose(snippet: Settings): Map[String, NodeSeq => NodeSeq] = Map(
-    "body" -> Settings.addTab(tabId, "Rudder Account", template)
+    "body" -> Settings.addTab(tabId, "Licence", template)
   )
 
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/26620
It just a renaming of displayed info, variable naming etc was not done to prevent potential issue. 
Typically, in many places, we use `Account` for the `Licence Id` for variable naming or pattern matching, also used in API output, but I think that we don't want to change all of that, but let me know if you want to rename some object.