### PR TITLE
Fixes #26602: User with "compliance" perm get error on group, directive pages

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.rest
 import cats.data.*
 import cats.implicits.*
 import com.normation.rudder.AuthorizationType
+import com.normation.rudder.api.ApiAclElement
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.api.HttpAction
 
@@ -230,6 +231,9 @@ trait EndpointSchema {
   // Nil means special `any_righs`, ie special admin role, is needed, so
   // that removing the last right effectively remove all permissions
   def authz: List[AuthorizationType]
+
+  // specific mapping of ACL that has access to some part of this endpoint
+  def otherAcls: Map[AuthorizationType, List[ApiAclElement]] = Map.empty
 }
 
 trait EndpointSchema0 extends EndpointSchema {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -38,6 +38,8 @@
 package com.normation.rudder.rest
 
 import com.normation.rudder.AuthorizationType
+import com.normation.rudder.api.AclPathSegment
+import com.normation.rudder.api.ApiAclElement
 import com.normation.rudder.api.HttpAction.*
 import com.normation.rudder.rest.EndpointSchema.syntax.*
 import enumeratum.*
@@ -679,6 +681,31 @@ object SettingsApi       extends Enum[SettingsApi] with ApiModuleProvider[Settin
     val description    = "Get information about given Rudder setting"
     val (action, path) = GET / "settings" / "{key}"
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Read :: Nil
+
+    // with some authorization, we can have access to given keys, as a singleton segment
+    override val otherAcls: Map[AuthorizationType, List[ApiAclElement]] = Map(
+      AuthorizationType.Node.Read      ->
+      (
+        AclPathSegment.Segment("global_policy_mode") ::
+        AclPathSegment.Segment("global_policy_mode_overridable") :: Nil
+      ).map(segment => AuthzForApi.withValues(this, List(segment))),
+      AuthorizationType.Rule.Read      -> (
+        AclPathSegment.Segment("enable_change_message") ::
+        AclPathSegment.Segment("enable_change_request") ::
+        AclPathSegment.Segment("enable_self_deployment") ::
+        AclPathSegment.Segment("enable_self_validation") ::
+        AclPathSegment.Segment("enable_validate_all") :: Nil
+      ).map(segment => AuthzForApi.withValues(this, List(segment))),
+      AuthorizationType.Validator.Read -> (
+        AclPathSegment.Segment("enable_change_message") ::
+        AclPathSegment.Segment("mandatory_change_message") ::
+        AclPathSegment.Segment("change_message_prompt") ::
+        AclPathSegment.Segment("enable_change_request") ::
+        AclPathSegment.Segment("enable_self_deployment") ::
+        AclPathSegment.Segment("enable_self_validation") ::
+        AclPathSegment.Segment("enable_validate_all") :: Nil
+      ).map(segment => AuthzForApi.withValues(this, List(segment)))
+    )
   }
   case object ModifySettings extends SettingsApi with ZeroParam with StartsAtVersion6 with SortIndex {
     val z: Int = implicitly[Line].value

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -828,7 +828,7 @@ class Boot extends Loggable {
 
     def administrationMenu = {
       (Menu(MenuUtils.administrationMenu, <i class="fa fa-gear"></i> ++ <span>Administration</span>: NodeSeq) /
-      "secure" / "administration" / "index" >> needPerms(Authz.Administration.Read, Authz.Technique.Read)).submenus(
+      "secure" / "administration" / "index" >> needPerms(Authz.Administration.Read)).submenus(
         Menu("910-settings", <span>Settings</span>) / "secure" / "administration" / "settings"
           >> needPerms(Authz.Administration.Read),
         Menu("920-maintenance", <span>Maintenance</span>) / "secure" / "administration" / "maintenance"

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/Index.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/Index.scala
@@ -50,13 +50,9 @@ class Index {
 
   def administration(xhtml: NodeSeq): NodeSeq = {
     if (CurrentUser.checkRights(AuthorizationType.Administration.Read)) {
-      S.redirectTo("policyServerManagement")
+      S.redirectTo("/secure/administration/settings")
     } else {
-      if (CurrentUser.checkRights(AuthorizationType.Technique.Read)) {
-        S.redirectTo("techniqueLibraryManagement")
-      } else {
-        S.redirectTo("/secure/index")
-      }
+      S.redirectTo("/secure/index")
     }
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/26602

Adding specific access to some settings keys, as they were removed [here](https://github.com/Normation/rudder/commit/ab5cc552a7d7d316a282c8ebd9d6aa7cf50a87e0#diff-29912d1fc9e0387f74c88c27c30606e2cb6bb89912d4dd63d2440d8f9d0fd292L203).
Endpoints need to declare that specific authorizations have access to some of its parts (segments, here in the Settings API : some _settings keys_)


Some cleaning has been made because the compliance has rights to see the "Administration" entry, because or the `technique_read` right : the right is removed in 8.2 in https://github.com/Normation/rudder/pull/6292, and in this PR the menu "Administration" can only be seen with `admin_read` 