### PR TITLE
Fixes #26639: Global properties are unfolded in weird way 

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.scss
@@ -1,6 +1,6 @@
 /*
 *************************************************************************************
-* Copyright 2024 Normation SAS
+* Copyright 2025 Normation SAS
 *************************************************************************************
 *
 * This file is part of Rudder.
@@ -401,6 +401,17 @@ table .innerDetails li{
   background-color: #fff;
   margin: 0 !important;
 }
+
+tr.parametersDescription {
+  background-color: #F8F9FC !important;
+  height: 30px;
+  border-top: 1px solid #d6deef !important;
+
+  .parametersDescriptionDetails {
+    padding:15px;
+  }
+}
+
 /* </TBODY></TR></TD> */
 
 /* <WRAPPER BOTTOM> */

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-directives.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-directives.scss
@@ -344,16 +344,6 @@ table.directiveGroupDef, table.directiveVarDef, table.directiveSectionDef {
   font-weight:bold;
 }
 
-tr.parametersDescription {
-  background-color: #F8F9FC !important;
-  height: 30px;
-  border-top: 1px solid #d6deef !important;
-}
-
-.parametersDescriptionDetails {
-  padding:15px;
-}
-
 /* === OVERRIDE TEMPLATE === */
 .main-header.no-header,
 .main-header.no-header + .main-navbar{


### PR DESCRIPTION
https://issues.rudder.io/issues/26639

The css rules that define the height of these table lines have been moved to the wrong scss file. Now it looks like before:
![global-properties-result](https://github.com/user-attachments/assets/5f36b942-91a1-4b02-b0b5-2c22d26ff6d7)
