### PR TITLE
Fixes #26429: Changing the system group category hierarchy breaks Rudder

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -1341,6 +1341,9 @@ class GroupApiService14(
     for {
       root      <- readGroup.getFullGroupLibrary().toBox
       category  <- Box(root.allCategories.get(id)) ?~! s"Cannot find Group category '${id.value}'"
+      _         <- if (category.isSystem)
+                     Failure(s"Could not update group category '${id.value}', cause is: system categories cannot be updated.")
+                   else Full(())
       oldParent <- Box(root.parentCategories.get(id)) ?~! s"Cannot find Group category '${id.value}' parent"
       parent     = restData.parent.getOrElse(oldParent.id)
       update     = restData.update(category)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
@@ -142,15 +142,14 @@ class NodeGroupCategoryForm(
 
     (
       "category-name" #> name
-      & "directive-name" #> name.toForm_!
-      & "directive-description" #> description.toForm_!
-      & "directive-container" #> container.toForm_!
+      & "directive-name" #> (if (_nodeGroupCategory.isSystem) name.readOnlyValue else name.toForm_!)
+      & "directive-description" #> (if (_nodeGroupCategory.isSystem) description.readOnlyValue else description.toForm_!)
+      & "directive-container" #> (if (_nodeGroupCategory.isSystem) container.readOnlyValue else container.toForm_!)
       & "directive-notifications" #> updateAndDisplayNotifications()
       & (if (_nodeGroupCategory.isSystem) {
            (
              "input [disabled]" #> "true"
-             & "textarea [disabled]" #> "true"
-             & "directive-save" #> SHtml.ajaxSubmit("Update", onSubmit _, ("class", "btn btn-success"))
+             & "directive-save" #> NodeSeq.Empty
              & "directive-delete" #> deleteButton
            )
          } else {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -405,7 +405,7 @@ class NodeGroupForm(
     & "group-container" #> groupContainer.readOnlyValue
     & "group-static" #> NodeSeq.Empty
     & "group-showgroup" #> NodeSeq.Empty
-    & "group-clone" #> group.map(systemGroupCloneButton).getOrElse(NodeSeq.Empty)
+    & "group-clone" #> systemGroupCloneButton()
     & "group-close" #>
     <button class="btn btn-default" onclick={
       s"""$$('#${htmlIdCategory}').trigger("group-close-detail")"""
@@ -449,7 +449,7 @@ class NodeGroupForm(
     }
   }
 
-  private def systemGroupCloneButton(group: NodeGroup) = {
+  private def systemGroupCloneButton() = {
     if (CurrentUser.checkRights(AuthorizationType.Group.Write)) {
       SHtml.ajaxButton(
         <span>Clone


### PR DESCRIPTION
https://issues.rudder.io/issues/26429

* Prevent API modification of system groups (as for deletion)
* Remove the button to save system groups and make all form fields readonly