### PR TITLE
Fixes #26680: When the menu is collapsed, category titles have a transparent background.

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-menu.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-menu.scss
@@ -158,7 +158,7 @@ $menu-width: 230px;
   padding: 0 15px;
   font-weight: 300;
   overflow: hidden;
-  background-color: #041922;
+  background-color: $rudder-txt-primary;
   position: relative;
   z-index: 9999;
 }
@@ -249,7 +249,7 @@ header.main-header .logo-lg img{
   width: $menu-width;
   z-index: 810;
   transition: transform .3s ease-in-out,width .3s ease-in-out;
-  background-color: #041922;
+  background-color: $rudder-txt-primary;
 }
 @media (max-width: 767px) {
   .main-sidebar {
@@ -742,7 +742,7 @@ header.main-header .logo-lg img{
 }
 .main-header .navbar .sidebar-toggle:hover {
   background-color: $navbar-hover-color;
-  color: #041922;
+  color: $rudder-txt-primary;
 }
 @media (max-width: 767px) {
   .main-header .navbar .dropdown-menu li.divider {
@@ -770,10 +770,11 @@ header.main-header .logo-lg img{
 }
 .sidebar-menu>li.active>a, .sidebar-menu>li:hover>a {
   color: #fff;
-  border-left-color: #13beb7
+  background-color: $rudder-txt-primary;
+  border-left-color: $rudder-success
 }
 .sidebar-menu>li.active>a>i, .sidebar-menu>li:hover>a>i {
-  color: #13beb7
+  color: $rudder-success
 }
 .sidebar-menu>li>.treeview-menu {
   margin: 0;
@@ -823,9 +824,9 @@ header.main-header .logo-lg img{
 }
 .treeview-menu>li>a .fa {
   visibility:hidden;
-  color: #13beb7;
+  color: $rudder-success;
   position:relative;
-  color: #13beb7;
+  color: $rudder-success;
   left:-2px;
 }
 .treeview-menu>li>a.active .fa {
@@ -855,7 +856,7 @@ header.main-header .logo-lg img{
 
 .sidebar-menu>li.footer {
   color: #fff;
-  background: #041922;
+  background: $rudder-txt-primary;
   margin-top: auto;
   animation: squeeze .3s ease-in-out forwards;
 }
@@ -942,7 +943,7 @@ header.main-header .logo-lg img{
   text-decoration: none !important;
 }
 .navbar .navbar-nav li.notifications-menu> a:hover{
-  color: #041922;
+  color: $rudder-txt-primary;
 }
 .navbar-nav li.dropdown {
   height: 50px;
@@ -969,7 +970,7 @@ header.main-header .logo-lg img{
       cursor: pointer;
 
       &:hover{
-        color: #041922;
+        color: $rudder-txt-primary;
       }
     }
   }
@@ -1024,7 +1025,7 @@ header.main-header .logo-lg img{
 
 .navbar-nav .notifications-menu>.dropdown-menu > li > a > .fa{
   width: 30px;
-  color: #041922;
+  color: $rudder-txt-primary;
   opacity: 0.4;
 }
 .navbar-nav .notifications-menu>.dropdown-menu > li > a > .fa.text-succes{
@@ -1048,7 +1049,7 @@ header.main-header .logo-lg img{
 .navbar-nav .notifications-menu>.dropdown-menu > li > a:hover.text-success,
 .navbar-nav .notifications-menu>.dropdown-menu > li > a:focus.text-success,
 .navbar-nav .notifications-menu>.dropdown-menu > li > a:visited.text-success{
-  color: #13BEB7 !important;
+  color: $rudder-success !important;
 }
 .navbar-nav .notifications-menu>.dropdown-menu > li > a.text-danger,
 .navbar-nav .notifications-menu>.dropdown-menu > li > a:hover.text-danger,
@@ -1141,7 +1142,7 @@ header.main-header .logo-lg img{
 .navbar .navbar-nav li.notifications-menu.bg-ok a:active #generation-status,
 .navbar .navbar-nav li.notifications-menu.bg-ok a:focus  #generation-status,
 .navbar .navbar-nav li.notifications-menu.bg-ok.open     #generation-status{
-  color: #13BEB7;
+  color: $rudder-success;
 }
 .navbar .navbar-nav li.notifications-menu.bg-ok #generation-status > span:after{
   content: "\f00c";
@@ -1181,7 +1182,7 @@ header.main-header .logo-lg img{
 }
 /* ---- */
 #generation-status.label-success{
-  background-color: #13BEB7 !important;
+  background-color: $rudder-success !important;
 }
 .label-neutral{
   background-color: #ABACAC !important;

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-menu.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-menu.scss
@@ -329,8 +329,9 @@ header.main-header .logo-lg img{
 }
 .sidebar-menu .treeview-menu>li>a {
   padding: 5px 5px 5px 15px;
-  display: block;
-  font-size: 14px
+  display: flex;
+  align-items: baseline;
+  font-size: 14px;
 }
 .sidebar-menu .treeview-menu>li>a > .fa, .sidebar-menu .treeview-menu>li>a > .ion {
   width: 20px
@@ -341,12 +342,12 @@ header.main-header .logo-lg img{
 @media (min-width: 768px) {
   .sidebar-mini.sidebar-collapse .content-wrapper{
     margin-left:50px!important;
-    z-index: 840
+    z-index: 1040
   }
   .sidebar-mini.sidebar-collapse .main-sidebar {
     transform: translate(0,0);
     width: 50px!important;
-    z-index: 850
+    z-index: 1050
   }
   .sidebar-mini.sidebar-collapse .sidebar-menu>li {
     position: relative


### PR DESCRIPTION
https://issues.rudder.io/issues/26680

Here is the result (I also replaced some color codes with the corresponding scss variable) :
![Capture d’écran du 2025-04-03 18-14-27](https://github.com/user-attachments/assets/9a1a9eb1-b033-4ba0-a887-0a969138dfa4)

