### PR TITLE
Fixes #26671: Confusing warning header on the plugin webpage

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_accounts.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_accounts.yml
@@ -10,13 +10,25 @@ response:
       "data" : {
         "accounts" : [
           {
+           "id" : "old1",
+           "name" : "old account",
+           "description" : "old account",
+           "status" : "disabled",
+           "creationDate" : "2025-02-12T10:55:00Z",
+           "expirationPolicy" : "never",
+           "tokenState" : "generatedv1",
+           "tokenGenerationDate" : "2025-02-12T10:55:00Z",
+           "tenants" : "*",
+           "authorizationType" : "rw"
+         },
+         {
             "id" : "user1",
             "name" : "user one",
             "description" : "number one user",
             "status" : "enabled",
             "creationDate" : "2025-02-12T10:55:00Z",
             "expirationPolicy" : "never",
-            "tokenState" : "generated",
+            "tokenState" : "generatedv2",
             "tokenGenerationDate" : "2025-02-12T10:55:00Z",
             "tenants" : "*",
             "authorizationType" : "rw"
@@ -29,7 +41,7 @@ response:
             "creationDate" : "2025-02-12T10:55:00Z",
             "expirationPolicy" : "datetime",
             "expirationDate" : "2025-08-12T00:00:00Z",
-            "tokenState" : "generated",
+            "tokenState" : "generatedv2",
             "tokenGenerationDate" : "2025-02-12T10:55:00Z",
             "tenants" : "zone1",
             "authorizationType" : "acl",
@@ -63,7 +75,7 @@ response:
             "status" : "enabled",
             "creationDate" : "2025-02-12T10:55:00Z",
             "expirationPolicy" : "never",
-            "tokenState" : "generated",
+            "tokenState" : "generatedv2",
             "tokenGenerationDate" : "2025-02-12T10:55:00Z",
             "tenants" : "*",
             "authorizationType" : "rw"
@@ -135,7 +147,7 @@ response:
             "creationDate": "2025-02-10T16:37:19Z",
             "expirationPolicy": "datetime",
             "expirationDate":"2025-03-10T16:37:19Z",
-            "tokenState" : "generated",
+            "tokenState" : "generatedv2",
             "tokenGenerationDate":"2025-02-10T16:37:19Z",
             "token":"t1-ca5a50899d25cd3ff148350843a9d435",
             "tenants":"*",
@@ -191,7 +203,7 @@ response:
             "creationDate": "2025-02-10T16:37:19Z",
             "expirationPolicy": "datetime",
             "expirationDate":"2025-05-22T17:35:00Z",
-            "tokenState":"missing",
+            "tokenState":"undef",
             "tenants":"-",
             "authorizationType":"none"
           }
@@ -246,7 +258,7 @@ response:
             "creationDate": "2025-02-10T16:37:19Z",
             "expirationPolicy": "datetime",
             "expirationDate":"2025-05-22T17:35:00Z",
-            "tokenState":"generated",
+            "tokenState":"generatedv2",
             "tokenGenerationDate":"2025-02-10T16:37:19Z",
             "token":"t2-29d5c3cdca39bd7ba81e7e0f88084689",
             "tenants":"-",
@@ -283,7 +295,7 @@ response:
             "creationDate": "2025-02-10T16:37:19Z",
             "expirationPolicy": "datetime",
             "expirationDate":"2025-05-22T17:35:00Z",
-            "tokenState":"generated",
+            "tokenState":"generatedv2",
             "tokenGenerationDate":"2025-02-10T16:37:19Z",
             "tenants":"-",
             "authorizationType":"none"
@@ -311,7 +323,7 @@ response:
             "creationDate": "2025-02-10T16:37:19Z",
             "expirationPolicy": "datetime",
             "expirationDate":"2025-05-22T17:35:00Z",
-            "tokenState":"generated",
+            "tokenState":"generatedv2",
             "tokenGenerationDate":"2025-02-10T16:37:19Z",
             "tenants":"-",
             "authorizationType":"none"

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts.elm
@@ -3,6 +3,7 @@ module Accounts exposing (..)
 import Accounts.ApiCalls exposing (..)
 import Accounts.DataTypes as TenantMode exposing (..)
 import Accounts.DataTypes as Token exposing (..)
+import Accounts.DataTypes as TokenState exposing (..)
 import Accounts.DatePickerUtils exposing (..)
 import Accounts.Init exposing (..)
 import Accounts.JsonDecoder exposing (decodeErrorDetails)
@@ -10,17 +11,10 @@ import Accounts.JsonEncoder exposing (encodeAccountTenants, encodeTokenAcl)
 import Accounts.View exposing (view)
 import Accounts.ViewUtils exposing (..)
 import Browser
-import Dict
-import Dict.Extra
-import Http exposing (..)
 import Http.Detailed as Detailed
-import Json.Encode exposing (..)
-import List.Extra
 import Random
 import Result
 import SingleDatePicker exposing (Settings, TimePickerVisibility(..), defaultSettings, defaultTimePickerSettings)
-import Task
-import Time exposing (Month(..), Posix, Zone)
 import Time.Extra as Time exposing (Interval(..), add)
 import UUID
 import Maybe.Extra
@@ -89,7 +83,7 @@ update msg model =
                 editAccount =
                     case modalState of
                         NewAccount ->
-                            Just (Account "" "" "" "rw" "" True "" Token.Hashed Nothing (ExpireAtDate expDate) Nothing TenantMode.AllAccess Nothing)
+                            Just (Account "" "" "" "rw" "" True "" TokenState.GeneratedV2 (Just Token.Hashed) Nothing (ExpireAtDate expDate) Nothing TenantMode.AllAccess Nothing)
 
                         EditAccount a ->
                             Just a

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ApiCalls.elm
@@ -3,7 +3,6 @@ module Accounts.ApiCalls exposing (..)
 import Http exposing (..)
 import Url.Builder exposing (QueryParameter)
 import Http.Detailed as Detailed
-
 import Accounts.DataTypes exposing (..)
 import Accounts.JsonDecoder exposing (..)
 import Accounts.JsonEncoder exposing (..)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/DataTypes.elm
@@ -5,10 +5,7 @@ import Http.Detailed
 import Json.Decode as D exposing (..)
 import SingleDatePicker exposing (DatePicker, Settings, TimePickerVisibility(..), defaultSettings, defaultTimePickerSettings)
 import Time exposing (Posix, Zone)
-
 import Ui.Datatable exposing (TableFilters)
-import Agentpolicymode.JsonEncoder exposing (policyModeToString)
-import Maybe.Extra
 
 
 --
@@ -40,6 +37,11 @@ type TenantMode
     = AllAccess -- special "*" permission giving access to objects in any/no tenants
     | NoAccess -- special "-" permission giving access to no object, whatever the tenant or its absence
     | ByTenants --give access to object in any of the listed tenants
+
+type TokenState
+    = Undef
+    | GeneratedV1
+    | GeneratedV2
 
 type Token
     = New String
@@ -76,7 +78,8 @@ type alias Account =
     , kind : String
     , enabled : Bool
     , creationDate : String
-    , token : Token
+    , tokenState: TokenState
+    , token : Maybe Token
     , tokenGenerationDate : Maybe String
     , expirationPolicy: ExpirationPolicy
     , acl : Maybe (List AccessControl)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/DatePickerUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/DatePickerUtils.elm
@@ -2,19 +2,9 @@ module Accounts.DatePickerUtils exposing (..)
 
 import SingleDatePicker exposing (Settings, TimePickerVisibility(..), defaultSettings, defaultTimePickerSettings)
 import Time exposing (Month(..), Posix, Zone)
-import Time.Extra as Time exposing (Interval(..), Parts, partsToPosix)
-import List.Extra exposing (getAt)
-import Date exposing (fromIsoString)
-
+import Time.Extra as Time exposing (Interval(..), Parts)
 import Accounts.DataTypes exposing (..)
-import String.Extra
-import Time.Iso8601
-import Time.DateTime exposing (DateTime)
-import Time.DateTime as DateTime
-import Time.Iso8601ErrorMsg
-import Time.Extra exposing (toOffset)
-import Time exposing (posixToMillis)
-import Time exposing (millisToPosix)
+import Accounts.DataTypes as TokenState exposing (..)
 
 
 isDateBeforeToday : Posix -> Posix -> Bool
@@ -121,3 +111,10 @@ checkIfExpired datePickerInfo account =
   case account.expirationPolicy of
     ExpireAtDate p -> isDateBeforeToday datePickerInfo.currentTime p
     NeverExpire -> False
+
+checkIfTokenV1 : Account -> Bool
+checkIfTokenV1 a =
+  case a.tokenState of
+    TokenState.GeneratedV1 -> True
+    TokenState.GeneratedV2 -> False
+    TokenState.Undef       -> False

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/View.elm
@@ -2,11 +2,11 @@ module Accounts.View exposing (..)
 
 import Accounts.ApiCalls exposing (..)
 import Accounts.DataTypes exposing (..)
-import Accounts.DataTypes as Token exposing (..)
+import Accounts.DataTypes as TokenState exposing (..)
 import Accounts.ViewModals exposing (..)
 import Accounts.ViewUtils exposing (..)
 import Html exposing (..)
-import Html.Attributes exposing (attribute, class, disabled, href, placeholder, selected, type_, value)
+import Html.Attributes exposing (class, disabled, href, placeholder, selected, type_, value)
 import Html.Events exposing (onClick, onInput)
 import List
 
@@ -15,7 +15,7 @@ view : Model -> Html Msg
 view model =
     let
         hasClearTextTokens =
-            List.any (\a -> a.token == Token.ClearText) model.accounts
+            List.any (\a -> a.tokenState == TokenState.GeneratedV1) model.accounts
     in
     div [ class "rudder-template" ]
         [ div [ class "one-col" ]
@@ -41,7 +41,7 @@ view model =
                                 [ if hasClearTextTokens then
                                     div [ class "alert alert-warning" ]
                                         [ i [ class "fa fa-exclamation-triangle" ] []
-                                        , text "You have API accounts with tokens generated on an pre-8.1 Rudder versions."
+                                        , text "You have API accounts with tokens generated on an pre-8.1 Rudder versions. "
                                         , text "They are now disabled, you should re-generate or replace them."
                                         ]
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewModals.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewModals.elm
@@ -6,11 +6,10 @@ import Accounts.DatePickerUtils exposing (..)
 import Accounts.JsonDecoder exposing (parseTenants)
 import Accounts.JsonEncoder exposing (encodeTenants)
 import Html exposing (..)
-import Html.Attributes exposing (attribute, checked, class, disabled, for, id, name, placeholder, selected, style, title, type_, value)
+import Html.Attributes exposing (checked, class, disabled, for, id, name, placeholder, selected, style, title, type_, value)
 import Html.Events exposing (onCheck, onClick, onInput)
 import SingleDatePicker exposing (Settings, TimePickerVisibility(..))
 import Time.Extra as Time exposing (Interval(..), add)
-import Maybe.Extra
 
 buildModal : String -> Html Msg -> Html Msg -> Html Msg
 buildModal modalTitle modalBody modalBtn =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewUtils.elm
@@ -5,12 +5,10 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onCheck)
 import List
 import NaturalOrdering as N exposing (compare)
-
 import Accounts.ApiCalls exposing (..)
 import Accounts.DataTypes exposing (..)
-import Accounts.DatePickerUtils exposing (posixToString, checkIfExpired)
-import String exposing (isEmpty, slice)
-
+import Accounts.DatePickerUtils exposing (checkIfExpired, checkIfTokenV1, posixToString)
+import String exposing (slice)
 import Ui.Datatable exposing (thClass, sortTable, SortOrder(..), filterSearch)
 import Maybe.Extra
 
@@ -97,6 +95,7 @@ displayAccountsTable model =
         , displayAccountDescription a
         , span [class "badge badge-grey"][ text (getAuthorisationType a.authorisationType) ]
         , (if checkIfExpired model.ui.datePickerInfo a then span[class "badge-expired"][] else text "")
+        , (if checkIfTokenV1 a then span[class "badge-disabled"][] else text "")
         ]
         , td []
         [ span [class "token-txt"][ text a.id ] ]
@@ -217,8 +216,8 @@ htmlEscape s =
     |> String.replace "'" "&#x27;"
     |> String.replace "\\" "&#x2F;"
 
-exposeToken : Token -> String
+exposeToken : Maybe Token -> String
 exposeToken t =
   case t of
-    New s -> s
-    _ -> ""
+    Just (New s) -> s
+    _            -> ""


### PR DESCRIPTION
https://issues.rudder.io/issues/26671

So, the main idea is to expose the token state and make the token optional in elm, to match backen semantic. The token state can be `undef`, `generatedV1` for old token, and `generatedV2` for new format. 

It prefred to enumerate all the state because if we do a v3, it's likely that we will need to change all the place and so I made them easy to find. 

That `tokenState` is transferred by API. 
Then, in elm, we just map that into the token account data structure, and I changed the check for the warning messge to look for token with a `GeneratedV1` token state. 
These token also get the `token-disabled` badge.

Finally, I added a check in the LDAP unserialisation method for the token version, so that we can disable `ApiAccount` right here, even if they were enabled on last save. 

I adapted the test to check that the `tokenState` is correct in API, and that new token are created with the correct state (they were not in tests :sweat: )

Resulting account management page with the warning: 
![image](https://github.com/user-attachments/assets/c9619d7f-68f5-4d36-ad9d-a2683cacb8a1)

And after token regeneration and enabling again the account: 
![image](https://github.com/user-attachments/assets/29f10919-06aa-4a36-86b8-fe6a67b22680)
