### PR TITLE
Fixes #26688: Initial page after Rudder installation should be the license tab at welcome step

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/administration/RudderCompanyAccount.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/administration/RudderCompanyAccount.scala
@@ -44,7 +44,7 @@ import scala.reflect.ClassTag
 import scala.xml.NodeSeq
 
 class RudderCompanyAccount()(implicit val ttag: ClassTag[Settings]) extends SnippetExtensionPoint[Settings] {
-  private val tabId = "companyAccountTab"
+  private val tabId = "welcomeSetupTab"
 
   private def template: NodeSeq =
     ChooseTemplate("templates-hidden" :: "components" :: "administration" :: "setup" :: Nil, "component-body")

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-settings.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-settings.scss
@@ -4,7 +4,7 @@
   display: flex;
   height: 100%;
 }
-#companyAccountTab.show{
+#welcomeSetupTab.show{
   display: flex;
   width: 100%;
   & > div{


### PR DESCRIPTION
https://issues.rudder.io/issues/26688

* Evaluate Lift variables outside of ZIO context (similar to https://github.com/Normation/rudder/pull/6280)
* Rename the "company account" within the tab ID into something that looks more like onboarding : `welcomeSetupTab`