### PR TITLE
Fixes #26633: License error in plugins should link to settings at licence tab

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/View.elm
@@ -461,7 +461,7 @@ displaySettingError contextPath message details =
     in
     div [ class "callout-fade callout-warning overflow-scroll" ]
         [ p [] [ i [ class "fa fa-warning" ] [], text message ]
-        , p [] [ a [ target "_blank", href (contextPath ++ "/secure/administration/settings") ] [ text "Open Rudder licence settings", i [ class "fa fa-external-link ms-1" ] [] ] ]
+        , p [] [ a [ target "_blank", href (contextPath ++ "/secure/administration/settings#welcomeSetupTab") ] [ text "Open Rudder licence settings", i [ class "fa fa-external-link ms-1" ] [] ] ]
         , p []
             [ button [ class "btn btn-primary me-1", onClick (CallApi updateIndex) ] [ i [ class "fa fa-refresh me-1" ] [], text "Refresh plugins" ]
             , seeDetailsBtnHtml


### PR DESCRIPTION
https://issues.rudder.io/issues/26633

Follows the renaming of the tab to "License", and of the tab ID to `welcomeSetupTab` in https://github.com/Normation/rudder/pull/6310