### PR TITLE
Fixes #26692: Remove semaphore and use a sliding queue for compliance invalidation

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ComputeNodeStatusReportService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ComputeNodeStatusReportService.scala
@@ -45,6 +45,7 @@ import com.normation.rudder.domain.logger.TimingDebugLoggerPure
 import com.normation.rudder.domain.reports.*
 import com.normation.rudder.domain.reports.NodeStatusReport
 import com.normation.rudder.facts.nodes.ChangeContext
+import com.normation.rudder.facts.nodes.NodeFactRepository
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.reports.ComplianceModeName
 import com.normation.rudder.reports.GlobalComplianceMode
@@ -150,6 +151,7 @@ class ScoreNodeStatusReportUpdateHook(scoreServiceManager: ScoreServiceManager) 
  *   and then, in case of success, the hooks accordingly.
  */
 class ComputeNodeStatusReportServiceImpl(
+    nodeRepo:                    NodeFactRepository,
     nsrRepo:                     NodeStatusReportRepository,
     findNewNodeStatusReports:    FindNewNodeStatusReports,
     complianceExpirationService: ComplianceExpirationService,
@@ -164,23 +166,32 @@ class ComputeNodeStatusReportServiceImpl(
 
   /**
    * The queue of invalidation request.
-   * The queue size is 1 and new request need to merge with existing request
-   * It's a List and not a Set, because we want to keep the precedence in
-   * invalidation request.
+   * The size is based on the number of nodes x 10, with a minimum of 1000.
+   *   The reasoning is that we can always live with a 1000 elements queue, and it will handle the
+   *   cases when Rudder is bootstrapped and nodes are added to it.
+   * The strategy is sliding, meaning that newer invalidation will be kept against older ones.
    */
-  private val invalidateComplianceRequest = Queue.dropping[Chunk[(NodeId, CacheComplianceQueueAction)]](1).runNow
+  private val invalidateComplianceRequest = {
+    implicit val qc = QueryContext.systemQC
+    for {
+      nbNodes <- nodeRepo.getAll().map(_.size)
+      size     = Math.max(1000, 10 * nbNodes)
+      queue   <- Queue.sliding[(NodeId, CacheComplianceQueueAction)](size)
+    } yield queue
+  }.runNow
 
   /**
-   * We need a semaphore to protect queue content merge-update
+   * Update logic. We take message from queue all in one time, and we sort/process them.
    */
-  private val invalidateMergeUpdateSemaphore = Semaphore.make(1).runNow
+  private val updateCacheFromRequest: IO[Nothing, Unit] = {
+    invalidateComplianceRequest.takeAll.flatMap(processComplianceInvalidationActions)
+  }
 
-  /**
-   * Update logic. We take message from queue one at a time, and process.
-   */
+  // start updating
+  updateCacheFromRequest.forever.forkDaemon.runNow
 
-  private val updateCacheFromRequest: IO[Nothing, Unit] = invalidateComplianceRequest.take.flatMap(invalidatedIds => {
-    ZIO.foreachDiscard(groupQueueActionByType(invalidatedIds.map(x => x._2)))(actions =>
+  private def processComplianceInvalidationActions(actions: Chunk[(NodeId, CacheComplianceQueueAction)]): UIO[Unit] = {
+    ZIO.foreachDiscard(groupQueueActionByType(actions.map(x => x._2)))(actions =>
       // several strategy:
       // * we have a compliance: yeah, put it in the cache
       // * new policy generation, a new nodeexpectedreports is available: compute compliance for last run of the node, based on this nodeexpectedreports
@@ -197,10 +208,8 @@ class ComputeNodeStatusReportServiceImpl(
         })
       }
     )
-  })
 
-  // start updating
-  updateCacheFromRequest.forever.forkDaemon.runNow
+  }
 
   /**
    * Do something with the action we received
@@ -248,7 +257,8 @@ class ComputeNodeStatusReportServiceImpl(
             } yield ()
 
           // need to compute compliance
-          case _                                            =>
+          case ExpiredCompliance(_) | ExpectedReportAction(InsertNodeInCache(_)) |
+              ExpectedReportAction(UpdateNodeConfiguration(_, _)) =>
             val impactedNodeIds = actions.map(x => x.nodeId)
             for {
               _ <- ZIO.foreach(impactedNodeIds.grouped(batchSize).to(Seq)) { updatedNodes =>
@@ -392,11 +402,7 @@ class ComputeNodeStatusReportServiceImpl(
         ReportLoggerPure.Cache.debug(
           s"Compliance cache: invalidation request for nodes with action: [${actions.map(_._1).map(_.value).mkString(",")}]"
         ) *>
-        invalidateMergeUpdateSemaphore.withPermit(for {
-          elements  <- invalidateComplianceRequest.takeAll
-          allActions = (elements.flatten ++ actions)
-          _         <- invalidateComplianceRequest.offer(allActions)
-        } yield ())
+        invalidateComplianceRequest.offerAll(actions)
       }
       .unit
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -195,7 +195,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
       y   = new TestFindNewStatusReports()
       r2 <- Ref.make(Chunk[NodeStatusReportUpdateHook]())
     } yield {
-      (x, y, new ComputeNodeStatusReportServiceImpl(x, y, new DummyComplianceExpirationService(policy), r2, 3))
+      (x, y, new ComputeNodeStatusReportServiceImpl(nodeFactRepo, x, y, new DummyComplianceExpirationService(policy), r2, 3))
     }).runNow
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -3193,12 +3193,13 @@ object RudderConfigInit {
     lazy val nodeStatusReportRepository: NodeStatusReportRepositoryImpl = {
       (for {
         x <- Ref.make(Map[NodeId, NodeStatusReport]())
-        s  = new JdbcNodeStatusReportStorage(doobie)
+        s  = new JdbcNodeStatusReportStorage(doobie, RUDDER_JDBC_BATCH_MAX_SIZE)
       } yield new NodeStatusReportRepositoryImpl(s, x)).runNow
     }
 
     lazy val computeNodeStatusReportService: ComputeNodeStatusReportService & HasNodeStatusReportUpdateHook = {
       new ComputeNodeStatusReportServiceImpl(
+        nodeFactRepository,
         nodeStatusReportRepository,
         findNewNodeStatusReports,
         new NodePropertyBasedComplianceExpirationService(


### PR DESCRIPTION
https://issues.rudder.io/issues/26692

# Sliding Queue of size nb nodes * 10

Since we have a queue containing a `Seq[T]` of size 1, it's the same a having a queue of `T` of size N. 

In the previous case, the inner `seq` was unbounded, leading to memory exhaustion in worst case. 
I chose a bounded queue to avoid that. It's sliding, ie keeping the most recent events and dropping the older one when full. 

The use of the queue as intented allows to remove the semaphor used up of it, since it's the whole of a queue to be able to add things atomically. 
It also remove a `takeAll` + `merge two array` from the hot path, likely removing some useless translation between collection. 

Then, on the down side, we do the same thing as before, just `takeAll` (getting a seq of T) in place of `take` (getting a seq of T). 

The sizing of the queue is chosen to `10*number of nodes` (with a minimum of 1000 to avoid the case where there is only 1 root node, and then 2000 are added in the next hour). 

# Batch save of lastCompliance

I also added a batch size of the same value as elsewhere (500 by default) for the method which save compliance in `NodeLastCompliance` table, since having very long connection with a lot of data might lead to some exhaustion of resources. 


Based on top of https://github.com/Normation/rudder/pull/6306

Impact: 

![image](https://github.com/user-attachments/assets/29d9d29c-c174-4f0c-adba-f5febd2086b7)
