### PR TITLE
Fixes #26703: Make AggregatedStatusReport correct wrt equals

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -381,6 +381,22 @@ final class AggregatedStatusReport private (
       })
     )
   }
+
+  /*
+   * equals/hashCode are needed because we compare objects with equality in
+   * NodeStatusReportRepositoryImpl.
+   * And because we're in scala, it's extremely surprising to have a broken equals anyway.
+   */
+  override def hashCode(): Int = {
+    reports.hashCode() + 47
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case other: AggregatedStatusReport => this.reports == other.reports
+      case _ => false
+    }
+  }
 }
 
 object AggregatedStatusReport {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeStatusReportRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeStatusReportRepository.scala
@@ -105,6 +105,9 @@ trait NodeStatusReportStorage {
 
 object NodeStatusReportRepositoryImpl {
 
+  /*
+   * Create a repo from a datastore, initially loading data from it.
+   */
   def makeAndInit(storage: NodeStatusReportStorage): IOResult[NodeStatusReportRepositoryImpl] = {
     for {
       reports <- storage.getAll()
@@ -177,7 +180,8 @@ class NodeStatusReportRepositoryImpl(
                          // in other case, just update what is in cache if it's actually different
                          case _                                  =>
                            m.get(id) match {
-                             case Some(e) => if (e == report) None else Some((id, report))
+                             case Some(e) =>
+                               if (e == report) None else Some((id, report))
                              case None    => Some((id, report))
                            }
                        }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/NodeStatusReportRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/NodeStatusReportRepositoryTest.scala
@@ -1,0 +1,193 @@
+/*
+ *************************************************************************************
+ * Copyright 2025 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.services.reports
+
+import com.normation.errors.IOResult
+import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.policies.PolicyTypeName
+import com.normation.rudder.domain.policies.RuleId
+import com.normation.rudder.domain.policies.RuleUid
+import com.normation.rudder.domain.reports.NodeConfigId
+import com.normation.rudder.domain.reports.NodeExpectedReports
+import com.normation.rudder.domain.reports.NodeStatusReport
+import com.normation.rudder.domain.reports.RuleNodeStatusReport
+import com.normation.rudder.domain.reports.RunAnalysisKind
+import com.normation.rudder.domain.reports.RunComplianceInfo
+import com.normation.rudder.facts.nodes.ChangeContext
+import com.normation.rudder.facts.nodes.CoreNodeFact
+import com.normation.rudder.services.policies.NodeConfigData
+import com.normation.zio.*
+import com.softwaremill.quicklens.*
+import org.joda.time.DateTime
+import org.junit.runner.RunWith
+import org.specs2.mutable.*
+import org.specs2.runner.JUnitRunner
+import zio.*
+
+/*
+ * Test about the NodeStatusReportRepository, in particular:
+ * - behavior with missing reports,
+ * - behavior with keepLast
+ */
+@RunWith(classOf[JUnitRunner])
+class NodeStatusReportRepositoryTest extends Specification {
+
+  val expiration: DateTime = DateTime.now()
+  val beginDate:  DateTime = expiration.minusMinutes(10) // report generation time
+  val expired:    DateTime = expiration.minusMinutes(5)
+  val stillOk:    DateTime = expiration.plusMinutes(5)
+
+  // build one node by kind of reports, expired or not
+  def buildNode(id: String): (NodeId, CoreNodeFact) = {
+    (NodeId(id), NodeConfigData.fact1.modify(_.id).setTo(NodeId(id)))
+  }
+
+  def nsr(id: String, info: RunAndConfigInfo, bootstrapRules: Boolean = false): NodeStatusReport = {
+    val rules = if (bootstrapRules) {
+      Set(RuleNodeStatusReport(NodeId(id), RuleId(RuleUid("initRule")), PolicyTypeName.rudderBase, None, None, Map(), expiration))
+    } else Set.empty[RuleNodeStatusReport]
+    NodeStatusReportInternal.buildWith(NodeId(id), info, RunComplianceInfo.OK, Nil, rules).toNodeStatusReport()
+  }
+
+  // a list of node, one node by type of reports, in a triplet:
+  // (node, expired report, still ok report)
+  def expected(id: String, endDate: Option[DateTime]): NodeExpectedReports =
+    NodeExpectedReports(NodeId(id), NodeConfigId(id), beginDate, endDate, null, Nil, Nil)
+
+  def initReportEachKind(endDate: Option[DateTime], runDate: DateTime): List[(NodeId, NodeStatusReport)] = {
+    def buildOne(id: String)(f: NodeExpectedReports => RunAndConfigInfo) = {
+      val e = expected(id, endDate)
+      (NodeId(id), nsr(id, f(e), bootstrapRules = true))
+    }
+    List(
+      buildOne("nrner")(_ => NoRunNoExpectedReport),
+      buildOne("ner")(x => NoExpectedReport(runDate, None)),
+      buildOne("nurd")(x => NoUserRulesDefined(runDate, x, x.nodeConfigId, Some(x), expiration)),
+      buildOne("nrii")(x => NoReportInInterval(x, expiration)),
+      buildOne("klc")(x => KeepLastCompliance(x, expiration.minusMinutes(10), expiration, None)),
+      buildOne("rdii")(x => ReportsDisabledInInterval(x, expiration)),
+      buildOne("p")(x => Pending(x, None, expiration)),
+      buildOne("uv")(x => UnexpectedVersion(runDate, Some(x), expiration, x, expiration, expiration)),
+      buildOne("unv")(x => UnexpectedNoVersion(runDate, NodeConfigId("x"), expiration, x, expiration, expiration)),
+      buildOne("uuv")(x => UnexpectedUnknownVersion(runDate, NodeConfigId("x"), x, expiration, expiration)),
+      buildOne("cc")(x => ComputeCompliance(runDate, x, expiration))
+    )
+  }
+
+  class Counter(s: NodeStatusReportStorage) extends NodeStatusReportStorage {
+    val counters: Ref[Map[NodeId, Int]] = Ref.make(Map[NodeId, Int]()).runNow
+
+    // utility methods for tests
+    def getCount(id: String): Int = counters.get.runNow.getOrElse(NodeId(id), 0)
+    def get(id: String): NodeStatusReport =
+      s.getAll().map(_.getOrElse(NodeId(id), throw new RuntimeException(s"Id '${id}' is not present in storage"))).runNow
+
+    override def getAll(): IOResult[Map[NodeId, NodeStatusReport]] = {
+      s.getAll()
+    }
+
+    override def save(reports: Iterable[(NodeId, NodeStatusReport)]): IOResult[Unit] = {
+      for {
+        _ <- counters.update(m => m ++ reports.map { case (id, _) => (id, m.getOrElse(id, 0) + 1) })
+        _ <- s.save(reports)
+      } yield ()
+    }
+
+    override def delete(nodes: Iterable[NodeId]): IOResult[Unit] = {
+      s.delete(nodes)
+    }
+  }
+
+  def initServices(moreReports: NodeStatusReport*): (Counter, NodeStatusReportRepository) = {
+    val n = initReportEachKind(None, expiration)
+    (for {
+      x <- Ref.make((n ++ moreReports.map(x => (x.nodeId, x))).toMap)
+      s  = new Counter(new InMemoryNodeStatusReportStorage(x))
+    } yield (s, new NodeStatusReportRepositoryImpl(s, x))).runNow
+  }
+
+  "If we save exactly the same reports, no storage is done at all" >> {
+
+    val (counter, repo) = initServices()
+    implicit val cc     = ChangeContext.newForRudder()
+
+    val counters = (for {
+      rs <- counter.getAll()
+      _  <- repo.saveNodeStatusReports(rs)
+      c  <- counter.counters.get
+    } yield c).runNow
+
+    counters must beEmpty
+  }
+
+  "If we change runDate, 5 kind of reports are impacted" >> {
+
+    val (counter, repo) = initServices()
+    implicit val cc     = ChangeContext.newForRudder()
+    val newReports      = initReportEachKind(None, expiration.plusMinutes(5))
+
+    val counters = (for {
+      _ <- repo.saveNodeStatusReports(newReports)
+      c <- counter.counters.get
+    } yield c).runNow.map(x => (x._1.value, x._2))
+
+    counters must containTheSameElementsAs(
+      ("ner", 1) :: ("nurd", 1) :: ("uv", 1) :: ("uuv", 1) :: ("unv", 1) :: ("cc", 1) :: Nil
+    )
+  }
+
+  "A Pending or a ComputeCompliance which becomes missing is missing when no keep compliance" >> {
+
+    // generate a missing but with "keep last" flag set
+    def missing(id: String) = {
+      val x = expected(id, None)
+      nsr(id, NoReportInInterval(x, expiration)).modify(_.runInfo.kind).setTo(RunAnalysisKind.KeepLastCompliance)
+    }
+
+    val (counter, repo) = initServices()
+    implicit val cc     = ChangeContext.newForRudder()
+
+    repo.saveNodeStatusReports((missing("p") :: Nil).map(x => (x.nodeId, x))).runNow
+
+    // we have one modification because we changed kind from pending to "keep"
+    counter.getCount("p") === 1
+    // but we kept the existing report with some report (vs missing which has no rule status reports)
+    counter.get("p").reports must not(beEmpty)
+  }
+
+}

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -3191,6 +3191,13 @@ object RudderConfigInit {
 
     // we need to expose impl at that level to call `.init()` in bootstrap checks
     lazy val nodeStatusReportRepository: NodeStatusReportRepositoryImpl = {
+      /*
+       * We added the table in Rudder 8.2, and so for migration, we need a bit of
+       * logic to check if we init compliance from table or from runs, see: LoadNodeComplianceCache.
+       * And so, we are for initing it to empty here.
+       * In Rudder 9.0, we will be able to remove the bootstrap check and just use
+       * `NodeStatusReportRepositoryImpl.make`.
+       */
       (for {
         x <- Ref.make(Map[NodeId, NodeStatusReport]())
         s  = new JdbcNodeStatusReportStorage(doobie)
@@ -3211,8 +3218,8 @@ object RudderConfigInit {
       )
     }
 
-    // to avoid a StackOverflowError, we set the compliance cache once it'z ready,
-    // and can construct the nodeconfigurationservice without the comlpince cache
+    // to avoid a StackOverflowError, we set the compliance cache once it's ready,
+    // and can construct the nodeConfigurationService without the compliance cache
     cachedNodeConfigurationService.addHook(computeNodeStatusReportService)
 
     lazy val reportingService: ReportingService = new ReportingServiceImpl2(nodeStatusReportRepository)


### PR DESCRIPTION
https://issues.rudder.io/issues/26703

So, the culprit is `AggregatedStatusReport` which is a `final class` but not `case`. 
It means that that part of the code in `NodeStatusReportRepositoryImpl` always yield false (since `e` and `report` are built from different paths, their `AggregatedStatusReport` are different objects): 

```
                           m.get(id) match {
                             case Some(e) =>
                               if (e == report) {
                                 None
                               } else {
                                 Some((id, report))
                               }
```

So, for *each* checks, we get "it's a new report", so we *always* save it in database. The performance impact must be *huge*.

This is corrected by adding an equals/hashcode, as it must be done. 

Found with the dumbest unit test possible, *sigh*. 
