### PR TITLE
Fixes #26707: Upgrade spring security dependency to correct CVE-2025-22228

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -443,8 +443,8 @@ limitations under the License.
     <commons-fileupload>2.0.0-M2</commons-fileupload>
     <commons-csv-version>1.11.0</commons-csv-version>
     <jgit-version>6.10.0.202406032230-r</jgit-version>
-    <spring-version>6.1.12</spring-version>
-    <spring-security-version>6.3.3</spring-security-version>
+    <spring-version>6.1.18</spring-version>
+    <spring-security-version>6.3.8</spring-security-version>
     <cglib-version>3.3.0</cglib-version>
     <asm-version>9.7</asm-version>
     <!-- Level of Java compatibility, here 1.8+ -->


### PR DESCRIPTION
https://issues.rudder.io/issues/26707

Upgrading spring/spring-security to last version where the CVE is corrected. 