### PR TITLE
Fixes #26725: Reverting change in queue since it leads to CPU over use

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeStatusReportRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeStatusReportRepository.scala
@@ -37,7 +37,6 @@
 
 package com.normation.rudder.services.reports
 
-import cats.data.NonEmptyList
 import com.normation.errors.*
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.db.Doobie
@@ -224,7 +223,7 @@ class InMemoryNodeStatusReportStorage(storage: Ref[Map[NodeId, NodeStatusReport]
 /*
  * A JDBC implementation using the `NodeLastCompliance` table as backend
  */
-class JdbcNodeStatusReportStorage(doobie: Doobie, jdbcBatchSize: Int) extends NodeStatusReportStorage {
+class JdbcNodeStatusReportStorage(doobie: Doobie) extends NodeStatusReportStorage {
   import doobie.*
 
   override def getAll(): IOResult[Map[NodeId, NodeStatusReport]] = {
@@ -238,26 +237,18 @@ class JdbcNodeStatusReportStorage(doobie: Doobie, jdbcBatchSize: Int) extends No
 
   override def save(reports: Iterable[(NodeId, NodeStatusReport)]): IOResult[Unit] = {
     val t = DateTime.now()
-
-    def toRows(rs: Iterable[(NodeId, NodeStatusReport)]): Vector[(NodeId, DateTime, JNodeStatusReport)] = {
-      rs.map { case (a, b) => (a, t, JNodeStatusReport.from(b)) }.toVector
-    }
+    val rows: Vector[(NodeId, DateTime, JNodeStatusReport)] = reports.map {
+      case (a, b) => (a, t, JNodeStatusReport.from(b))
+    }.toVector
 
     val query = Update[(NodeId, DateTime, JNodeStatusReport)](
       """INSERT INTO NodeLastCompliance (nodeId, computationDateTime, details) VALUES (?,?,?)
         |  ON CONFLICT (nodeId) DO UPDATE
         |  SET computationDateTime = excluded.computationDateTime, details = excluded.details ;""".stripMargin
-    )
+    ).updateMany(rows)
 
-    // batch update, don't fail on first error
-    ZIO
-      .validate(reports.sliding(jdbcBatchSize).to(Iterable)) { rs =>
-        val rows = toRows(rs)
-        ComplianceLoggerPure.debug(s"Saving compliance state for ${rs.size} nodes in base") *>
-        transactIOResult(s"error when saving compliance for nodes")(xa => query.updateMany(rows).transact(xa))
-      }
-      .mapError(errs => Accumulated(NonEmptyList(errs.head, errs.tail)))
-      .unit
+    ComplianceLoggerPure.debug(s"Saving compliance state for ${reports.size} nodes in base") *>
+    transactIOResult(s"error when saving compliance for nodes")(xa => query.transact(xa)).unit
   }
 
   override def delete(nodes: Iterable[NodeId]): IOResult[Unit] = {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -195,7 +195,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
       y   = new TestFindNewStatusReports()
       r2 <- Ref.make(Chunk[NodeStatusReportUpdateHook]())
     } yield {
-      (x, y, new ComputeNodeStatusReportServiceImpl(nodeFactRepo, x, y, new DummyComplianceExpirationService(policy), r2, 3))
+      (x, y, new ComputeNodeStatusReportServiceImpl(x, y, new DummyComplianceExpirationService(policy), r2, 3))
     }).runNow
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -3193,13 +3193,12 @@ object RudderConfigInit {
     lazy val nodeStatusReportRepository: NodeStatusReportRepositoryImpl = {
       (for {
         x <- Ref.make(Map[NodeId, NodeStatusReport]())
-        s  = new JdbcNodeStatusReportStorage(doobie, RUDDER_JDBC_BATCH_MAX_SIZE)
+        s  = new JdbcNodeStatusReportStorage(doobie)
       } yield new NodeStatusReportRepositoryImpl(s, x)).runNow
     }
 
     lazy val computeNodeStatusReportService: ComputeNodeStatusReportService & HasNodeStatusReportUpdateHook = {
       new ComputeNodeStatusReportServiceImpl(
-        nodeFactRepository,
         nodeStatusReportRepository,
         findNewNodeStatusReports,
         new NodePropertyBasedComplianceExpirationService(


### PR DESCRIPTION
https://issues.rudder.io/issues/26725

The reason of the cpu load is that `queue.takeAll` is non blocking. Which is :exploding_head: 