### PR TITLE
Fixes #26710: There is no indication that the rule page is loading compliance

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRulesTable.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRulesTable.elm
@@ -1,6 +1,6 @@
 module Rules.ViewRulesTable exposing (..)
 
-import Html exposing (Html, text,  tr, td, i, span)
+import Html exposing (Html, text,  tr, td, i, span, div)
 import Html.Attributes exposing (class, colspan, attribute, title)
 import Html.Events exposing (onClick)
 import List
@@ -85,7 +85,7 @@ buildRulesTable model rules =
           case getRuleCompliance model r.id of
             Just co ->
               buildComplianceBar defaultComplianceFilter co.complianceDetails
-            Nothing -> text "No report"
+            Nothing -> div[class "skeleton-loading"][span[][]]
 
         changes = text (String.fromFloat (countRecentChanges r.id model.changes))
 

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
@@ -1176,7 +1176,8 @@ ul {
 .rudder-template ul.skeleton-loading li > span,
 .rudder-template .table-container.skeleton-loading .table-filter .form-group > span,
 .rudder-template .table-container.skeleton-loading td > span,
-.rudder-template .table-container.skeleton-loading th > span{
+.rudder-template .table-container.skeleton-loading th > span,
+.rudder-template .skeleton-loading > span{
   display: inline-block;
   background-color: #f1f2f5;
   height: 24px;
@@ -1185,14 +1186,16 @@ ul {
 }
 .rudder-template .table-container.skeleton-loading .table-filter .form-group > span,
 .rudder-template .table-container.skeleton-loading td > span,
-.rudder-template .table-container.skeleton-loading th > span{
+.rudder-template .table-container.skeleton-loading th > span,
+.rudder-template .skeleton-loading > span{
   display: block;
 }
 .rudder-template ul.skeleton-loading li > i:before,
 .rudder-template ul.skeleton-loading li > span:before,
 .rudder-template .table-container.skeleton-loading .table-filter .form-group > span:before,
 .rudder-template .table-container.skeleton-loading td > span:before,
-.rudder-template .table-container.skeleton-loading th > span:before{
+.rudder-template .table-container.skeleton-loading th > span:before,
+.rudder-template .skeleton-loading > span:before{
   content: '';
   display: block;
   position: absolute;
@@ -1214,7 +1217,8 @@ ul {
 }
 .rudder-template .table-container.skeleton-loading .table-filter .form-group > span,
 .rudder-template .table-container.skeleton-loading td > span,
-.rudder-template .table-container.skeleton-loading th > span{
+.rudder-template .table-container.skeleton-loading th > span,
+.rudder-template .skeleton-loading > span{
   border-radius: 24px;
 }
 .rudder-template .table-container.skeleton-loading td > span,
@@ -1222,6 +1226,10 @@ ul {
   width: 50%;
   height: 20px;
   min-width: 25%;
+}
+.rudder-template .skeleton-loading > span{
+  width: 100%;
+  height: 20px;
 }
 .rudder-template ul.skeleton-loading > ul{
   padding: 0 0 0 50px;


### PR DESCRIPTION
https://issues.rudder.io/issues/26710

I've replaced the “No report” text with a loading animation :
![compliance-loading](https://github.com/user-attachments/assets/1100885c-8c51-4d18-b28d-9adbed8af00f)


