### PR TITLE
Fixes #26106: Sometimes when we click on an element (technique or rule), the whole page reloads

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueList.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueList.elm
@@ -5,6 +5,7 @@ import Either exposing (Either(..))
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
+import Html.Events.Extra exposing (onClickPreventDefault)
 import List.Extra
 import Maybe.Extra
 import NaturalOrdering as N exposing (compare)
@@ -208,7 +209,7 @@ techniqueItem model technique =
 
     li [class "jstree-node jstree-leaf"]
           [ i[class "jstree-icon jstree-ocl"][]
-          , a[class ("jstree-anchor " ++ activeClass), href (model.contextPath ++ "/secure/configurationManager/techniqueEditor/technique/" ++ technique.id.value), onClick (SelectTechnique (Left technique))]
+          , a[class ("jstree-anchor " ++ activeClass), href (model.contextPath ++ "/secure/configurationManager/techniqueEditor/technique/" ++ technique.id.value), onClickPreventDefault (SelectTechnique (Left technique))]
             [ i [class "jstree-icon jstree-themeicon fa fa-cog jstree-themeicon-custom"][]
             , span [class "treeGroupName"]
               [ text technique.name  ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/GroupRelatedRules/View.elm
@@ -3,6 +3,7 @@ module GroupRelatedRules.View exposing (..)
 import Html exposing (..)
 import Html.Attributes exposing (checked, class, disabled, for, href, id, placeholder, type_, value)
 import Html.Events exposing (onClick, onInput)
+import Html.Events.Extra exposing (onClickPreventDefault)
 import List.Extra
 import NaturalOrdering as N
 import Maybe.Extra
@@ -30,7 +31,7 @@ view model =
       in
         li [class "jstree-node jstree-leaf"]
         [ i[class "jstree-icon jstree-ocl"][]
-        , a[class ("jstree-anchor"++classDisabled), href (getRuleLink model.contextPath item.id), onClick (GoTo (getRuleLink model.contextPath item.id))]
+        , a[class ("jstree-anchor"++classDisabled), href (getRuleLink model.contextPath item.id), onClickPreventDefault (GoTo (getRuleLink model.contextPath item.id))]
           [ i [class "jstree-icon jstree-themeicon fa fa-sitemap jstree-themeicon-custom"][]
           , span [class "treeGroupName"]
             [ badgeIncludedExcluded model item.id
@@ -79,7 +80,7 @@ view model =
               Just (
                 li[class ("jstree-node" ++ foldedClass model.ui.ruleTreeFilters item.id)]
                 [ i [class "jstree-icon jstree-ocl", onClick (UpdateRuleFilters (foldUnfoldCategory model.ui.ruleTreeFilters item.id))][]
-                , a [class ("jstree-anchor"), href (getRuleCategoryLink model.contextPath item.id), onClick (GoTo (getRuleCategoryLink model.contextPath item.id))]
+                , a [class ("jstree-anchor"), href (getRuleCategoryLink model.contextPath item.id), onClickPreventDefault (GoTo (getRuleCategoryLink model.contextPath item.id))]
                   [ i [class ("jstree-icon jstree-themeicon jstree-themeicon-custom" ++ icons)][]
                   , span [class ("treeGroupCategoryName " ++ missingCatClass ++ mainMissingCat)][text item.name]
                   ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Groups/View.elm
@@ -3,6 +3,7 @@ module Groups.View exposing (..)
 import Html exposing (..)
 import Html.Attributes exposing (attribute, class, href, id, placeholder, style, title, type_, value)
 import Html.Events exposing (onClick, onInput)
+import Html.Events.Extra exposing (onClickPreventDefault)
 import NaturalOrdering as N
 import List
 import String
@@ -34,7 +35,7 @@ view model =
       in
         li [class "jstree-node jstree-leaf"]
         [ i[class "jstree-icon jstree-ocl"][]
-        , a[class ("jstree-anchor"++classDisabled {- ++classFocus -}), href (getGroupLink model.contextPath item.id.value), onClick (OpenGroupDetails item.id)]
+        , a[class ("jstree-anchor"++classDisabled {- ++classFocus -}), href (getGroupLink model.contextPath item.id.value), onClickPreventDefault (OpenGroupDetails item.id)]
           [ i [class "jstree-icon jstree-themeicon fa fa-sitemap jstree-themeicon-custom"][]
           , span
             ((
@@ -82,7 +83,7 @@ view model =
               Just (
                 li[class ("jstree-node" ++ foldedClass model.ui.groupFilters.treeFilters item.id)]
                 [ i [class "jstree-icon jstree-ocl", onClick (UpdateGroupFilters (foldUnfoldCategory model.ui.groupFilters item.id))][]
-                , a [class ("jstree-anchor"{- ++ classFocus -}), onClick (OpenCategoryDetails item.id)]
+                , a [class ("jstree-anchor"{- ++ classFocus -}), onClickPreventDefault (OpenCategoryDetails item.id)]
                   [ i [class ("jstree-icon jstree-themeicon jstree-themeicon-custom" ++ icons)][]
                   , span [class "treeGroupCategoryName"][text item.name]
                   ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/View.elm
@@ -3,6 +3,7 @@ module Rules.View exposing (..)
 import Html exposing (..)
 import Html.Attributes exposing (checked, class, disabled, for, href, id, placeholder, style, tabindex, type_, value, attribute)
 import Html.Events exposing (onClick, onInput)
+import Html.Events.Extra exposing (onClickPreventDefault)
 import List
 import List.Extra
 import Maybe.Extra exposing (isNothing)
@@ -40,7 +41,7 @@ view model =
       in
         li [class "jstree-node jstree-leaf"]
         [ i[class "jstree-icon jstree-ocl"][]
-        , a[class ("jstree-anchor"++classDisabled++classFocus), href (model.contextPath ++ "/secure/configurationManager/ruleManagement/rule/" ++ item.id.value), onClick (OpenRuleDetails item.id True)]
+        , a[class ("jstree-anchor"++classDisabled++classFocus), href (model.contextPath ++ "/secure/configurationManager/ruleManagement/rule/" ++ item.id.value), onClickPreventDefault (OpenRuleDetails item.id True)]
           [ i [class "jstree-icon jstree-themeicon fa fa-sitemap jstree-themeicon-custom"][]
           , span [class "treeGroupName"]
             [ badgePolicyMode model.policyMode item.policyMode
@@ -94,7 +95,7 @@ view model =
               Just (
                 li[class ("jstree-node" ++ foldedClass model.ui.ruleFilters.treeFilters item.id)]
                 [ i [class "jstree-icon jstree-ocl", onClick (UpdateRuleFilters (foldUnfoldCategory model.ui.ruleFilters item.id))][]
-                , a [class ("jstree-anchor" ++ classFocus), href ("/rudder/secure/configurationManager/ruleManagement/ruleCategory/" ++ item.id), onClick (OpenCategoryDetails item.id True)]
+                , a [class ("jstree-anchor" ++ classFocus), href ("/rudder/secure/configurationManager/ruleManagement/ruleCategory/" ++ item.id), onClickPreventDefault (OpenCategoryDetails item.id True)]
                   [ i [class ("jstree-icon jstree-themeicon jstree-themeicon-custom" ++ icons)][]
                   , span [class ("treeGroupCategoryName " ++ missingCatClass ++ mainMissingCat)][text item.name]
                   ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabContent.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabContent.elm
@@ -22,6 +22,7 @@ import Compliance.DataTypes exposing (..)
 import Compliance.Utils exposing (displayComplianceFilters, filterDetailsByCompliance, defaultComplianceFilter)
 import Compliance.Html exposing (buildComplianceBar)
 import Ui.Datatable exposing (SortOrder(..), filterSearch, Category, getSubElems, getAllElems)
+import Html.Events.Extra exposing (onClickPreventDefault)
 
 
 --
@@ -561,7 +562,7 @@ directivesTab model details =
                 in
                   li [class ("jstree-node jstree-leaf directiveNode" ++ disabledClass)]
                   [ i [class "jstree-icon jstree-ocl"][]
-                  , a [class ("jstree-anchor" ++ selectedClass), onClick (addDirectives d.id)]
+                  , a [class ("jstree-anchor" ++ selectedClass), onClickPreventDefault (addDirectives d.id)]
                     [ badgePolicyMode model.policyMode d.policyMode
                     , unusedWarning
                     , span [class "item-name"][text d.displayName]
@@ -869,7 +870,7 @@ groupsTab model details =
           in
             li [class ("jstree-node jstree-leaf" ++ disabledClass)]
             [ i [class "jstree-icon jstree-ocl"][]
-            , a [class ("jstree-anchor" ++ includeClass), onClick (SelectGroup item.target True)]
+            , a [class ("jstree-anchor" ++ includeClass), onClickPreventDefault (SelectGroup item.target True)]
               [ i [class "jstree-icon jstree-themeicon fa fa-sitemap jstree-themeicon-custom"][]
               , span [class "item-name"][text item.name, (if item.dynamic then (small [class "greyscala"][text "- Dynamic"]) else (text ""))]
               , disabledLabel

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
@@ -227,13 +227,6 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
                |    initBsTooltips();
                |  }, 800);
                |});
-               |// The timeout aims to wait that the tree is fully loaded to
-               |// to prevent href to reload the page on click
-               |setTimeout(function(){
-               |  $$('.jstree-anchor').click(function (event) {
-               |    event.preventDefault();
-               |  });
-               |}, 950);
               """.stripMargin
           )
         )

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/ruleManagement.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/ruleManagement.html
@@ -75,14 +75,6 @@
           initBsTooltips();
         }, 800);
       });
-
-      // The timeout aims to wait that the tree is fully loaded to
-      // to prevent href to reload the page on click
-      setTimeout(function(){
-        $('.jstree-anchor').click(function (event) {
-          event.preventDefault();
-        });
-      }, 950);
     });
   </script>
 

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/techniqueEditor.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/techniqueEditor.html
@@ -164,14 +164,6 @@ $(document).ready(function(){
 
   initBsTooltips();
 
-  // The timeout aims to wait that the tree is fully loaded to
-  // to prevent href to reload the page on click
-  setTimeout(function(){
-    $('.jstree-anchor').click(function (event) {
-      event.preventDefault();
-    });
-  }, 950);
-
 });
 
 function scrollToMethod(target){


### PR DESCRIPTION
https://issues.rudder.io/issues/26106

Remove the `href` from links, because the browser could use it to reload the page, instead of running the `onClick` defined in Elm. 
We used the `href` to open in a new tab e.g. with a middle click. Now, as a replacement, we open a new tab using the `auxclick` event : https://developer.mozilla.org/en-US/docs/Web/API/Element/auxclick_event

This occurs in both rules and technique editor.

**EDIT:**
Simple fix : use [onClickPreventDefault](https://package.elm-lang.org/packages/elm-community/html-extra/3.4.0/Html-Events-Extra#onClickPreventDefault) instead of `onClick`