### PR TITLE
Fixes #26712: When directives are skipped, they are multiplied in the directive tab of the rule

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DataStructures.scala
@@ -279,7 +279,7 @@ final case class NodeConfiguration(
 
 /**
  * Unique identifier for the policy.
- * These is a general container that can be used to generate the different ID
+ * This is a general container that can be used to generate the different ID
  * used in rudder: the policyId as used in reports, the unique identifier
  * used to differentiate multi-version technique, etc.
  */
@@ -298,14 +298,14 @@ final case class PolicyId(ruleId: RuleId, directiveId: DirectiveId, techniqueVer
 
 /**
  * Until we have a unique identifier, we need to use another key to identify our components/Variable so that blocks
- * can identified  correctly when building expected reports. Since in this case several blocks can have the same
+ * can be identified  correctly when building expected reports. Since in this case several blocks can have the same
  * component name.
- * This will allow too prevent missing expected reports, because we were building a map with toMap, that only keep
+ * This will allow to prevent missing expected reports, because we were building a map with toMap, that only keep
  * one elem for a specific key. A component Id for now is composed of component name and a list of Parents
  * Section (and maybe blocks) that has lead to it.
  *
  * - since 7.1, with a reportId. The report id is optional since we don't have all techniques ported to
- *   use it: as of 7.1, only ncf techniques (from editor) got it, so we needed a transitionnal period.
+ *   use it: as of 7.1, only ncf techniques (from editor) got it, so we needed a transitional period.
  *
  */
 case class ComponentId(value: String, parents: List[String], reportId: Option[String])

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
@@ -51,6 +51,7 @@ import com.normation.rudder.domain.reports.ReportType.BadPolicyMode
 import com.normation.rudder.reports.*
 import com.normation.rudder.reports.execution.AgentRunId
 import com.normation.rudder.reports.execution.AgentRunWithNodeConfig
+import com.softwaremill.quicklens.*
 import io.scalaland.chimney.*
 import io.scalaland.chimney.syntax.*
 import java.util.regex.Pattern
@@ -441,8 +442,60 @@ object NodeStatusReportInternal {
           .map(r => s"${r.nodeId.value}:${r.ruleId.serialize}")
           .mkString("|")}"
     )
+
+    // overridden directives for existing rules could be done along the way in `buildRuleNodeStatusReport`
+    // but it complicates test and in any way we still need to deal with the case where a rule had all its
+    // directives overridden, and so it didn't appear anywhere yet. We must create it from scratch.
+    val ra                                          = runInfo.toRunAnalysis
+    val (reportWithOverridden, remainingOverridden) = reports.foldLeft((List.empty[RuleNodeStatusReport], overrides)) {
+      case ((all, os), next) =>
+        // check if some overridden directives belong to that rule
+        val overridden = os.collect {
+          case op if op.policy.ruleId == next.ruleId =>
+            (
+              op.policy.directiveId,
+              DirectiveStatusReport(
+                op.policy.directiveId,
+                PolicyTypes.rudderBase,
+                Some(op.overriddenBy.ruleId),
+                Nil
+              )
+            )
+        }.toMap
+
+        val nextOs         = os.filterNot(_.policy.ruleId == next.ruleId)
+        val withOverridden = next.modify(_.directives).using(_ ++ overridden)
+
+        (withOverridden :: all, nextOs)
+    }
+
+    // create rules with full overridden directives
+
+    val fullyOverridden = remainingOverridden.map { op =>
+      RuleNodeStatusReport(
+        nodeId,
+        op.policy.ruleId,
+        PolicyTypeName.rudderBase,
+        ra.lastRunDateTime,
+        ra.expectedConfigId,
+        Map(
+          op.policy.directiveId -> DirectiveStatusReport(
+            op.policy.directiveId,
+            PolicyTypes.rudderBase,
+            Some(op.overriddenBy.ruleId),
+            Nil
+          )
+        ),
+        ra.expirationDateTime.orElse(ra.lastRunExpiration).getOrElse(DateTime.now())
+      )
+    }
+
     // group map and aggregate
-    val aggregates = reports.groupBy(_.complianceTag).map { case (tag, reports) => (tag, AggregatedStatusReport(reports)) }
+    val aggregates = {
+      (reportWithOverridden ++ fullyOverridden).groupBy(_.complianceTag).map {
+        case (tag, reports) => (tag, AggregatedStatusReport(reports))
+      }
+    }
     NodeStatusReportInternal(nodeId, runInfo, statusInfo, overrides, aggregates)
   }
 }
@@ -884,32 +937,18 @@ object ExecutionBatch extends Loggable {
       agentExecutionReports: Seq[Reports]
   ): NodeStatusReport = {
 
-    // UnexpectedVersion are always called for only one node
-    // The status can't merge, as the merge group by nodeconfigid, and unexpected and missing have, by construct, different configId
-    def buildUnexpectedVersion(
-        runTime:            DateTime,
-        runVersion:         Option[NodeConfigIdInfo],
-        runExpiration:      DateTime,
-        expectedConfig:     NodeExpectedReports,
-        expectedExpiration: DateTime,
-        nodeStatusReports:  Seq[ResultReports]
-    ): Set[RuleNodeStatusReport] = {
-      // we have 2 separate status: the missing and the expected, so two different RuleNodeStatusReport that will never merge
-      // all expected missing
-      buildRuleNodeStatusReport(
-        MergeInfo(nodeId, Some(runTime), Some(expectedConfig.nodeConfigId), expectedExpiration),
-        expectedConfig,
-        ReportType.Missing
-      ).toSet ++
-      buildUnexpectedReports(MergeInfo(nodeId, Some(runTime), runVersion.map(_.configId), runExpiration), nodeStatusReports)
-    }
-
     // only interesting reports: for that node, with a status
     val nodeStatusReports = agentExecutionReports.collect { case r: ResultReports if (r.nodeId == nodeId) => r }
 
     ComplianceDebugLogger.node(nodeId).debug(s"Computing compliance for node ${nodeId.value} with: [${runInfo.toLog}]")
 
-    val t1                    = System.currentTimeMillis
+    val t1        = System.currentTimeMillis
+    val overrides = runInfo match {
+      case x: ExpectedConfigAvailable => x.expectedConfig.overrides
+      case x: LastRunAvailable        => x.lastRunConfigInfo.map(_.overrides).getOrElse(Nil).toList
+      case _ => Nil
+    }
+
     val ruleNodeStatusReports = runInfo match {
 
       case ReportsDisabledInInterval(expectedConfig, _) =>
@@ -921,7 +960,8 @@ object ExecutionBatch extends Loggable {
           // always be the same.
           MergeInfo(nodeId, None, Some(expectedConfig.nodeConfigId), END_OF_TIME),
           expectedConfig,
-          ReportType.Disabled
+          ReportType.Disabled,
+          overrides
         )
 
       case ComputeCompliance(lastRunDateTime, expectedConfig, expirationTime) =>
@@ -934,7 +974,8 @@ object ExecutionBatch extends Loggable {
           MergeInfo(nodeId, Some(lastRunDateTime), Some(expectedConfig.nodeConfigId), expirationTime),
           nodeStatusReports,
           expectedConfig,
-          expectedConfig
+          expectedConfig,
+          overrides
         )
 
       case Pending(expectedConfig, optLastRun, expirationTime) =>
@@ -947,7 +988,8 @@ object ExecutionBatch extends Loggable {
             buildRuleNodeStatusReport(
               MergeInfo(nodeId, None, Some(expectedConfig.nodeConfigId), expirationTime),
               expectedConfig,
-              ReportType.Pending
+              ReportType.Pending,
+              overrides
             )
 
           case Some((runTime, runConfig)) =>
@@ -967,7 +1009,8 @@ object ExecutionBatch extends Loggable {
               MergeInfo(nodeId, Some(runTime), Some(expectedConfig.nodeConfigId), expirationTime),
               nodeStatusReports,
               runConfig,
-              expectedConfig
+              expectedConfig,
+              overrides
             )
         }
 
@@ -980,7 +1023,8 @@ object ExecutionBatch extends Loggable {
           // at expiration, and store that the nodes were not answering
           MergeInfo(nodeId, None, Some(expectedConfig.nodeConfigId), expirationTime),
           expectedConfig,
-          ReportType.NoAnswer
+          ReportType.NoAnswer,
+          overrides
         )
 
       case KeepLastCompliance(expectedConfig, expirationTime, keepUntil, optLastRun) =>
@@ -994,7 +1038,8 @@ object ExecutionBatch extends Loggable {
           // at expiration, and store that the nodes were not answering
           MergeInfo(nodeId, None, Some(expectedConfig.nodeConfigId), expirationTime),
           expectedConfig,
-          ReportType.NoAnswer
+          ReportType.NoAnswer,
+          overrides
         )
 
       case UnexpectedVersion(runTime, Some(runConfig), runExpiration, expectedConfig, expectedExpiration, _) =>
@@ -1004,12 +1049,14 @@ object ExecutionBatch extends Loggable {
             s"Received a run at ${runTime} for node '${nodeId.value}' with configId '${runConfig.nodeConfigId.value}' but that node should be sending reports for configId ${expectedConfig.nodeConfigId.value}"
           )
         buildUnexpectedVersion(
+          nodeId,
           runTime,
           Some(runConfig.configInfo),
           runExpiration,
           expectedConfig,
           expectedExpiration,
-          nodeStatusReports
+          nodeStatusReports,
+          overrides
         )
 
       case UnexpectedNoVersion(
@@ -1025,7 +1072,16 @@ object ExecutionBatch extends Loggable {
           .warn(
             s"Received a run at ${runTime} for node '${nodeId.value}' without any configId but that node should be sending reports for configId ${expectedConfig.nodeConfigId.value}"
           )
-        buildUnexpectedVersion(runTime, None, runExpiration, expectedConfig, expectedExpiration, nodeStatusReports)
+        buildUnexpectedVersion(
+          nodeId,
+          runTime,
+          None,
+          runExpiration,
+          expectedConfig,
+          expectedExpiration,
+          nodeStatusReports,
+          overrides
+        )
 
       case UnexpectedUnknownVersion(
             runTime,
@@ -1039,7 +1095,7 @@ object ExecutionBatch extends Loggable {
           .warn(
             s"Received a run at ${runTime} for node '${nodeId.value}' configId '${runId.value}' which is not known by Rudder, and that node should be sending reports for configId ${expectedConfig.nodeConfigId.value}."
           )
-        buildUnexpectedVersion(runTime, None, runTime, expectedConfig, expectedExpiration, nodeStatusReports)
+        buildUnexpectedVersion(nodeId, runTime, None, runTime, expectedConfig, expectedExpiration, nodeStatusReports, overrides)
 
       case NoUserRulesDefined(runTime, expectedConfig, runId, _, _) => // same as unextected, different log
         val expectedExpiration = expectedConfig.beginDate.plus(expectedConfig.agentRun.interval.plus(GRACE_TIME_PENDING))
@@ -1048,7 +1104,7 @@ object ExecutionBatch extends Loggable {
           .warn(
             s"Received a run at ${runTime} for node '${nodeId.value}' configId '${runId.value}' which is not known by Rudder, and that node should be sending reports for configId ${expectedConfig.nodeConfigId.value}"
           )
-        buildUnexpectedVersion(runTime, None, runTime, expectedConfig, expectedExpiration, nodeStatusReports)
+        buildUnexpectedVersion(nodeId, runTime, None, runTime, expectedConfig, expectedExpiration, nodeStatusReports, overrides)
 
       case NoExpectedReport(runTime, optConfigId) =>
         // these reports where not expected
@@ -1057,7 +1113,7 @@ object ExecutionBatch extends Loggable {
           .warn(
             s"Node '${nodeId.value}' sent reports for run at '${runInfo}' (with ${optConfigId.map(x => s" configuration ID: '${x.value}'").getOrElse(" no configuration ID")}). No expected configuration matches these reports."
           )
-        buildUnexpectedReports(MergeInfo(nodeId, Some(runTime), optConfigId, END_OF_TIME), nodeStatusReports)
+        buildUnexpectedReports(MergeInfo(nodeId, Some(runTime), optConfigId, END_OF_TIME), nodeStatusReports, overrides)
 
       case NoRunNoExpectedReport =>
         /*
@@ -1105,12 +1161,6 @@ object ExecutionBatch extends Loggable {
     val t3     = System.currentTimeMillis
     TimingDebugLogger.trace(s"Compliance: computing policy status for ${nodeId}: ${t3 - t2}ms")
 
-    val overrides = runInfo match {
-      case x: ExpectedConfigAvailable => x.expectedConfig.overrides
-      case x: LastRunAvailable        => x.lastRunConfigInfo.map(_.overrides).getOrElse(Nil).toList
-      case _ => Nil
-    }
-
     NodeStatusReportInternal.buildWith(nodeId, runInfo, status, overrides, ruleNodeStatusReports.toSet).toNodeStatusReport()
   }
 
@@ -1137,7 +1187,8 @@ object ExecutionBatch extends Loggable {
       reportsForThatNodeRule: Seq[ResultReports],
       modes:                  NodeModeConfig,
       ruleExpectedReports:    RuleExpectedReports,
-      timer:                  ComputeComplianceTimer
+      timer:                  ComputeComplianceTimer,
+      overrides:              List[OverriddenPolicy]
   ): List[RuleNodeStatusReport] = {
 
     // An effective expected component contains only the component path from the root component to a unique Value
@@ -1206,7 +1257,8 @@ object ExecutionBatch extends Loggable {
     // unexpected contains the one with unexpected key and all non matching serial/version
     val unexpected = (if (okKeys.size != reportKeys.size) {
                         buildUnexpectedDirectives(
-                          reports.filter(k => !expectedKeys.contains(k._1)).values.flatten.toSeq
+                          reports.filter(k => !expectedKeys.contains(k._1)).values.flatten.toSeq,
+                          overrides
                         )
                       } else {
                         Seq[DirectiveStatusReport]()
@@ -1222,6 +1274,7 @@ object ExecutionBatch extends Loggable {
           DirectiveStatusReport(
             directiveId,
             policyTypes,
+            getOverridden(ruleId, directiveId, overrides),
             expectedComponentsForDirective.flatMap {
               case ((directiveId, _, components), (policyMode, missingReportStatus)) =>
                 val filteredReports = reports.get(directiveId).getOrElse(Seq())
@@ -1259,6 +1312,33 @@ object ExecutionBatch extends Loggable {
     buildRuleNodeStatusReportFromDirective(mergeInfo, ruleId, directiveStatusReports.values)
   }
 
+  // UnexpectedVersion are always called for only one node
+  // The status can't merge, as the merge group by nodeconfigid, and unexpected and missing have, by construct, different configId
+  private[reports] def buildUnexpectedVersion(
+      nodeId:             NodeId,
+      runTime:            DateTime,
+      runVersion:         Option[NodeConfigIdInfo],
+      runExpiration:      DateTime,
+      expectedConfig:     NodeExpectedReports,
+      expectedExpiration: DateTime,
+      nodeStatusReports:  Seq[ResultReports],
+      overrides:          List[OverriddenPolicy]
+  ): Set[RuleNodeStatusReport] = {
+    // we have 2 separate status: the missing and the expected, so two different RuleNodeStatusReport that will never merge
+    // all expected missing
+    buildRuleNodeStatusReport(
+      MergeInfo(nodeId, Some(runTime), Some(expectedConfig.nodeConfigId), expectedExpiration),
+      expectedConfig,
+      ReportType.Missing,
+      overrides
+    ).toSet ++
+    buildUnexpectedReports(
+      MergeInfo(nodeId, Some(runTime), runVersion.map(_.configId), runExpiration),
+      nodeStatusReports,
+      overrides
+    )
+  }
+
   /*
    * from MergeInfo, ruleId and directive reports, build a Map[ComplianceTag, RuleNodeStatusReport]
    */
@@ -1294,7 +1374,8 @@ object ExecutionBatch extends Loggable {
       // for the correct run, for the correct version
 
       executionReports:  Seq[ResultReports],
-      lastRunNodeConfig: NodeExpectedReports
+      lastRunNodeConfig: NodeExpectedReports,
+      overrides:         List[OverriddenPolicy]
   ): Map[(RuleId, PolicyTypeName), RuleNodeStatusReport] = {
 
     val timer = new ComputeComplianceTimer()
@@ -1311,7 +1392,8 @@ object ExecutionBatch extends Loggable {
         reportsForThatNodeRule,
         lastRunNodeConfig.modes,
         ruleExpectedReport,
-        timer
+        timer,
+        overrides
       )
 
       ruleCompliance.map { c =>
@@ -1378,12 +1460,13 @@ object ExecutionBatch extends Loggable {
 
       executionReports:  Seq[ResultReports],
       lastRunNodeConfig: NodeExpectedReports,
-      currentConfig:     NodeExpectedReports
+      currentConfig:     NodeExpectedReports,
+      overrides:         List[OverriddenPolicy]
   ): Set[RuleNodeStatusReport] = {
 
     val t0 = System.currentTimeMillis()
 
-    val complianceForRun = getComplianceForRun(mergeInfo, executionReports, lastRunNodeConfig)
+    val complianceForRun = getComplianceForRun(mergeInfo, executionReports, lastRunNodeConfig, overrides)
 
     val t10 = System.currentTimeMillis()
 
@@ -1391,7 +1474,7 @@ object ExecutionBatch extends Loggable {
 
     // note: isn't there something specific to do for unexpected reports ? Keep them all ?
 
-    val currentRunReports = buildRuleNodeStatusReport(mergeInfo, currentConfig, ReportType.Pending)
+    val currentRunReports = buildRuleNodeStatusReport(mergeInfo, currentConfig, ReportType.Pending, overrides)
     val t11               = System.currentTimeMillis
 
     TimingDebugLogger.trace(s"Compliance: mergeCompareByRule - compute buildRuleNodeStatusReport: ${t11 - t10}ms")
@@ -1437,7 +1520,11 @@ object ExecutionBatch extends Loggable {
     (computed ::: newStatus).toSet
   }
 
-  private def buildUnexpectedReports(mergeInfo: MergeInfo, reports: Seq[Reports]): Set[RuleNodeStatusReport] = {
+  private def buildUnexpectedReports(
+      mergeInfo: MergeInfo,
+      reports:   Seq[Reports],
+      overrides: List[OverriddenPolicy]
+  ): Set[RuleNodeStatusReport] = {
     reports
       .groupBy(x => x.ruleId)
       .map {
@@ -1459,6 +1546,7 @@ object ExecutionBatch extends Loggable {
                     // since we don't know easily what directive lead to these unexpected reports,
                     // we assume "non system"
                     PolicyTypes.rudderBase,
+                    getOverridden(ruleId, directiveId, overrides),
                     reportsByDirectives.groupBy(_.component).toList.map {
                       case (component, reportsByComponents) =>
                         ValueStatusReport(
@@ -1490,12 +1578,13 @@ object ExecutionBatch extends Loggable {
   /**
    * Build unexpected reports for the given reports
    */
-  private def buildUnexpectedDirectives(reports: Seq[Reports]): Seq[DirectiveStatusReport] = {
+  private def buildUnexpectedDirectives(reports: Seq[Reports], overrides: List[OverriddenPolicy]): Seq[DirectiveStatusReport] = {
     reports.map { r =>
       DirectiveStatusReport(
         r.directiveId,
         // since we don't know for unexpected reports the directive kind easely, assume "non system"
         PolicyTypes.rudderBase,
+        getOverridden(r.ruleId, r.directiveId, overrides),
         ValueStatusReport(
           r.component,
           r.component,
@@ -1538,12 +1627,25 @@ object ExecutionBatch extends Loggable {
 
   }
 
+  /*
+   * Check if current directive in current rule is overridden in another rule given overridden policies
+   */
+  private[reports] def getOverridden(
+      currentRuleId:      RuleId,
+      currentDirectiveId: DirectiveId,
+      overrides:          List[OverriddenPolicy]
+  ): Option[RuleId] = {
+    overrides.collectFirst {
+      case o if (o.policy.ruleId == currentRuleId && o.policy.directiveId == currentDirectiveId) => o.overriddenBy.ruleId
+    }
+  }
+
   // by construct, NodeExpectedReports are correctly grouped by Rule/Directive/Component
   private[reports] def buildRuleNodeStatusReport(
       mergeInfo:       MergeInfo,
       expectedReports: NodeExpectedReports,
       status:          ReportType,
-      message:         String = ""
+      overrides:       List[OverriddenPolicy]
   ): List[RuleNodeStatusReport] = {
     expectedReports.ruleExpectedReports.flatMap {
       case RuleExpectedReports(ruleId, directives) =>
@@ -1551,10 +1653,10 @@ object ExecutionBatch extends Loggable {
           DirectiveStatusReport(
             d.directiveId,
             d.policyTypes,
+            getOverridden(ruleId, d.directiveId, overrides),
             d.components.map(c => componentExpectedReportToStatusReport(status, c))
           )
         }
-
         buildRuleNodeStatusReportFromDirective(mergeInfo, ruleId, reports)
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingService.scala
@@ -126,7 +126,7 @@ object ReportingService {
         val result = reports.view.mapValues {
           case status =>
             NodeStatusReport.filterByRules(status, ruleIds)
-        }.filter { case (_, v) => v.reports.nonEmpty || v.overrides.nonEmpty }
+        }.filter { case (_, v) => v.reports.nonEmpty }
         val n2     = System.currentTimeMillis
         TimingDebugLogger.trace(s"Filter Node Status Reports on ${ruleIds.size} in : ${n2 - n1}ms")
         result
@@ -145,7 +145,7 @@ object ReportingService {
         val result = reports.view.mapValues {
           case status =>
             NodeStatusReport.filterByDirectives(status, directiveIds)
-        }.filter { case (_, v) => v.reports.nonEmpty || v.overrides.nonEmpty }
+        }.filter { case (_, v) => v.reports.nonEmpty }
         val n2     = System.currentTimeMillis
         TimingDebugLogger.trace(s"Filter Node Status Reports on ${directiveIds.size} Directives in : ${n2 - n1}ms")
         result

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -45,7 +45,6 @@ import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.*
 import com.normation.rudder.domain.reports.NodeStatusReport
 import com.normation.rudder.domain.reports.NodeStatusReport.*
-import com.normation.rudder.domain.reports.RuleStatusReport
 import com.normation.rudder.facts.nodes.QueryContext
 import zio.{System as _, *}
 
@@ -58,21 +57,6 @@ object ReportingServiceUtils {
   val withLogError: ZIO[Any, Throwable, Nothing] =
     effect.flatMapError(exception => log(exception.getMessage) *> ZIO.succeed(exception))
 
-  /*
-   * Build rule status reports from node reports, deciding which directives should be "skipped"
-   */
-  def buildRuleStatusReport(ruleId: RuleId, nodeReports: Map[NodeId, NodeStatusReport]): RuleStatusReport = {
-    val toKeep     = nodeReports.values.flatMap(_.reports.flatMap(_._2.reports)).filter(_.ruleId == ruleId).toList
-    // we don't keep overrides for a directive which is already in "toKeep" or that don't target that rule
-    val toKeepDir  = toKeep.map(_.directives.keySet).toSet.flatten
-    val overrides  = nodeReports.values
-      .flatMap(_.overrides.filterNot(r => r.policy.ruleId != ruleId || toKeepDir.contains(r.policy.directiveId)))
-      .toList
-      .distinct
-    // and we must make overrides unique - ie, we don't keep overridden that are overridden by directive themselve in the overridden list
-    val overrides2 = overrides.filterNot(o => overrides.exists(_.policy == o.overriddenBy))
-    RuleStatusReport(ruleId, toKeep, overrides2)
-  }
 }
 
 /*

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
@@ -274,8 +274,7 @@ class StatusReportTest extends Specification {
        n2, r1, 0, d1, c0  , v0  , "", success   , pending msg
        n3, r1, 0, d1, c1  , v1  , "", error     , pending msg
        n4, r2, 0, d1, c0  , v0  , "", pending   , pending msg
-    """),
-      Nil
+    """)
     )
 
     "Filter out r2" in {
@@ -377,6 +376,7 @@ class StatusReportTest extends Specification {
                     DirectiveStatusReport(
                       d,
                       PolicyTypes.rudderBase,
+                      None,
                       List(
                         ValueStatusReport(
                           c,

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ReportingServiceUtilsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ReportingServiceUtilsTest.scala
@@ -52,6 +52,7 @@ import com.normation.rudder.domain.reports.RuleNodeStatusReport
 import com.normation.rudder.domain.reports.RuleStatusReport
 import com.normation.rudder.domain.reports.RunComplianceInfo
 import com.normation.rudder.services.policies.PolicyId
+import com.softwaremill.quicklens.*
 import org.joda.time.DateTime
 import org.junit.runner.*
 import org.specs2.matcher.MatchResult
@@ -77,10 +78,19 @@ class ReportingServiceUtilsTest extends Specification {
   val expiration = new DateTime(0) // not used
 
   val noOverrides = Nil
-  def dirReport(id: DirectiveId):                                         (DirectiveId, DirectiveStatusReport) =
-    (id, DirectiveStatusReport(id, PolicyTypes.rudderBase, Nil))
-  def rnReport(nodeId: NodeId, ruleId: RuleId, directives: DirectiveId*): RuleNodeStatusReport                 = {
-    RuleNodeStatusReport(nodeId, ruleId, PolicyTypeName.rudderBase, None, None, directives.map(dirReport _).toMap, expiration)
+  def dirReport(id: DirectiveId): (DirectiveId, DirectiveStatusReport) =
+    (id, DirectiveStatusReport(id, PolicyTypes.rudderBase, None, Nil))
+
+  def dirReportOv(id: (DirectiveId, Option[RuleId])): (DirectiveId, DirectiveStatusReport) =
+    (id._1, DirectiveStatusReport(id._1, PolicyTypes.rudderBase, id._2, Nil))
+
+  def rnReport(nodeId: NodeId, ruleId: RuleId, directives: DirectiveId*): RuleNodeStatusReport = {
+    RuleNodeStatusReport(nodeId, ruleId, PolicyTypeName.rudderBase, None, None, directives.map(dirReport).toMap, expiration)
+  }
+
+  // used to create report where directives are overridden by the Some(ruleX)
+  def rnReportOv(nodeId: NodeId, ruleId: RuleId, directives: (DirectiveId, Option[RuleId])*): RuleNodeStatusReport = {
+    RuleNodeStatusReport(nodeId, ruleId, PolicyTypeName.rudderBase, None, None, directives.map(dirReportOv).toMap, expiration)
   }
 
   // a case where the same directive is on two rules
@@ -88,9 +98,10 @@ class ReportingServiceUtilsTest extends Specification {
     OverriddenPolicy(
       PolicyId(overridden, directive, TechniqueVersionHelper("1.0")), // this one is
 
-      PolicyId(overrider, directive, TechniqueVersionHelper("1.0")) // overriden by that one
+      PolicyId(overrider, directive, TechniqueVersionHelper("1.0")) // overridden by that one
     )
   }
+
   // a case where two directive from the same unique technique are on two rules
   def thisOverrideThatOn2(
       overrider:  RuleId,
@@ -105,19 +116,20 @@ class ReportingServiceUtilsTest extends Specification {
     )
   }
 
-  // a matcher which compare two RuleNodeStatusReporst
+  // a matcher which compare two RuleNodeStatusRepost
   implicit class SameRuleReportMatcher(report1: RuleStatusReport) {
     def isSameReportAs(report2: RuleStatusReport): MatchResult[Equals] = {
-      (report1.forRule === report2.forRule) and
-      (report1.overrides === report2.overrides) and
+      (report1.forRule === report2.forRule)
       (report1.report.isSameReportAs(report2.report))
     }
   }
 
   // for aggregated status reports, we just compare directive list
   implicit class AggregatedReportMatcher(report1: AggregatedStatusReport) {
-    def isSameReportAs(report2: AggregatedStatusReport): MatchResult[Set[DirectiveId]] = {
-      report1.directives.keySet === report2.directives.keySet
+    def isSameReportAs(report2: AggregatedStatusReport): MatchResult[Set[RuleNodeStatusReport]] = {
+      report1.reports.modify(_.each.expirationDate).setTo(new DateTime(0)) === report2.reports
+        .modify(_.each.expirationDate)
+        .setTo(new DateTime(0))
     }
   }
 
@@ -146,15 +158,16 @@ class ReportingServiceUtilsTest extends Specification {
         .toNodeStatusReport()
     ).map(r => (r.nodeId, r)).toMap
 
-    ReportingServiceUtils
-      .buildRuleStatusReport(rule1, reports)
+    RuleStatusReport
+      .fromNodeStatusReports(rule1, reports)
       .isSameReportAs(
-        RuleStatusReport(rule1, List(rnReport(node1, rule1, dir1)), noOverrides)
+        // on node2, rule1/dir1 is marked overridden by rule2
+        RuleStatusReport(rule1, List(rnReport(node1, rule1, dir1), rnReportOv(node2, rule1, (dir1, Some(rule2)))))
       )
   }
 
   /*
-   * rule1/dir1 on node1 is overriden (and node has nothing) => skipped
+   * rule1/dir1 on node1 is overridden (and node has nothing) => skipped
    */
   "only overridden leads to skip" in {
     val reports = List(
@@ -169,12 +182,13 @@ class ReportingServiceUtilsTest extends Specification {
         .toNodeStatusReport()
     ).map(r => (r.nodeId, r)).toMap
 
-    ReportingServiceUtils
-      .buildRuleStatusReport(rule1, reports)
+    RuleStatusReport
+      .fromNodeStatusReports(rule1, reports)
       .isSameReportAs(
-        RuleStatusReport(rule1, List(), List(thisOverrideThatOn(rule2, rule1, dir1)))
+        RuleStatusReport(rule1, List(rnReportOv(node1, rule1, (dir1, Some(rule2)))))
       )
   }
+
   "directives on other rules are not kept in overrides" in {
     val reports = List(
       NodeStatusReportInternal
@@ -188,10 +202,10 @@ class ReportingServiceUtilsTest extends Specification {
         .toNodeStatusReport()
     ).map(r => (r.nodeId, r)).toMap
 
-    ReportingServiceUtils
-      .buildRuleStatusReport(rule1, reports)
+    RuleStatusReport
+      .fromNodeStatusReports(rule1, reports)
       .isSameReportAs(
-        RuleStatusReport(rule1, List(), List())
+        RuleStatusReport(rule1, List())
       )
   }
 
@@ -218,14 +232,14 @@ class ReportingServiceUtilsTest extends Specification {
         .toNodeStatusReport()
     ).map(r => (r.nodeId, r)).toMap
 
-    ReportingServiceUtils
-      .buildRuleStatusReport(rule1, reports)
+    RuleStatusReport
+      .fromNodeStatusReports(rule1, reports)
       .isSameReportAs(
-        RuleStatusReport(rule1, List(rnReport(node1, rule1, dir1)), noOverrides)
-      ) and ReportingServiceUtils
-      .buildRuleStatusReport(rule2, reports)
+        RuleStatusReport(rule1, List(rnReport(node1, rule1, dir1), rnReportOv(node2, rule1, (dir1, Some(rule2)))))
+      ) and RuleStatusReport
+      .fromNodeStatusReports(rule2, reports)
       .isSameReportAs(
-        RuleStatusReport(rule2, List(rnReport(node2, rule2, dir2)), noOverrides)
+        RuleStatusReport(rule2, List(rnReport(node2, rule2, dir2)))
       )
   }
 
@@ -235,7 +249,7 @@ class ReportingServiceUtilsTest extends Specification {
    * - 3 rules: rule1 has dir2, dir3 (skipped),  rule2 has all 3 (so dir1 ok, other skipped), rule3 has all 3 (skipped)
    * There is no duplication of reports.
    */
-  "a rule not overridden on all nodes is not written overriden" in {
+  "a rule not overridden on all nodes is not written overridden" in {
     val reports = List(
       NodeStatusReportInternal
         .buildWith(
@@ -248,7 +262,7 @@ class ReportingServiceUtilsTest extends Specification {
             thisOverrideThatOn2(rule2, dir1, rule1, dir3), // on rule2, both dir2 and dir3 are overridden by rule2/dir1
 
             thisOverrideThatOn2(rule2, dir1, rule2, dir2),
-            thisOverrideThatOn2(rule2, dir1, rule2, dir3), // on rule3, dir2, dir2 and dir3 are overridden by rule2/dir1
+            thisOverrideThatOn2(rule2, dir1, rule2, dir3), // on rule3, dir1, dir2 and dir3 are overridden by rule2/dir1
 
             thisOverrideThatOn2(rule2, dir1, rule3, dir1),
             thisOverrideThatOn2(rule2, dir1, rule3, dir2),
@@ -271,33 +285,29 @@ class ReportingServiceUtilsTest extends Specification {
         .toNodeStatusReport()
     ).map(r => (r.nodeId, r)).toMap
 
-    ReportingServiceUtils
-      .buildRuleStatusReport(rule1, reports)
+    RuleStatusReport
+      .fromNodeStatusReports(rule1, reports)
       .isSameReportAs(
         RuleStatusReport(
           rule1,
-          List(),
-          List(thisOverrideThatOn2(rule2, dir1, rule1, dir2), thisOverrideThatOn2(rule2, dir1, rule1, dir3))
+          // rule1 doesn't have dir1, but dir2 and dir3 are overridden
+          List(rnReportOv(node1, rule1, (dir2, Some(rule2)), (dir3, Some(rule2))))
         )
-      ) and ReportingServiceUtils
-      .buildRuleStatusReport(rule2, reports)
+      ) and RuleStatusReport
+      .fromNodeStatusReports(rule2, reports)
       .isSameReportAs(
         RuleStatusReport(
           rule2,
-          List(rnReport(node1, rule2, dir1)),
-          List(thisOverrideThatOn2(rule2, dir1, rule2, dir2), thisOverrideThatOn2(rule2, dir1, rule2, dir3))
+          // rule2/dir1 is the only not overridden case.
+          List(rnReport(node1, rule2, dir1), rnReportOv(node1, rule2, (dir2, Some(rule2)), (dir3, Some(rule2))))
         )
-      ) and ReportingServiceUtils
-      .buildRuleStatusReport(rule3, reports)
+      ) and RuleStatusReport
+      .fromNodeStatusReports(rule3, reports)
       .isSameReportAs(
         RuleStatusReport(
           rule3,
-          List(),
-          List(
-            thisOverrideThatOn2(rule2, dir1, rule3, dir1),
-            thisOverrideThatOn2(rule2, dir1, rule3, dir2),
-            thisOverrideThatOn2(rule2, dir1, rule3, dir3)
-          )
+          // on rule3, each of dir1, dir2 and dir3 are overridden by rule 2
+          List(rnReportOv(node1, rule3, (dir1, Some(rule2)), (dir2, Some(rule2)), (dir3, Some(rule2))))
         )
       )
   }

--- a/webapp/sources/rudder/rudder-rest/pom.xml
+++ b/webapp/sources/rudder/rudder-rest/pom.xml
@@ -160,5 +160,12 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
 
+    <!-- tool used to profile compliance perf in RunTestCompliance -->
+    <dependency>
+      <groupId>tools.profiler</groupId>
+      <artifactId>async-profiler</artifactId>
+      <version>4.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
@@ -42,14 +42,10 @@ import cats.data.NonEmptyList
 import cats.syntax.list.*
 import com.normation.cfclerk.domain.ReportingLogic
 import com.normation.inventory.domain.NodeId
-import com.normation.rudder.domain.policies.Directive
 import com.normation.rudder.domain.policies.DirectiveId
-import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.*
 import com.normation.rudder.reports.ComplianceModeName
-import com.normation.rudder.repository.FullActiveTechnique
-import com.normation.rudder.web.services.ComputePolicyMode
 import com.normation.rudder.web.services.ComputePolicyMode.ComputedPolicyMode
 import enumeratum.*
 import java.lang
@@ -109,11 +105,13 @@ final case class ByDirectiveCompliance(
 }
 
 final case class ByDirectiveByRuleCompliance(
-    id:         RuleId,
-    name:       String,
-    compliance: ComplianceLevel,
-    policyMode: ComputedPolicyMode,
-    components: Seq[ByRuleComponentCompliance]
+    id:             RuleId,
+    name:           String,
+    compliance:     ComplianceLevel,
+    // this one is a rule and has the skipped details because it is on an reversed hierarchy with directives
+    skippedDetails: Option[SkippedDetails],
+    policyMode:     ComputedPolicyMode,
+    components:     Seq[ByRuleComponentCompliance]
 )
 
 final case class ByDirectiveNodeCompliance(
@@ -159,11 +157,12 @@ final case class ByNodeGroupRuleCompliance(
 )
 
 final case class ByNodeGroupByRuleDirectiveCompliance(
-    id:         DirectiveId,
-    name:       String,
-    compliance: ComplianceLevel,
-    policyMode: ComputedPolicyMode,
-    components: Seq[ByRuleComponentCompliance]
+    id:             DirectiveId,
+    name:           String,
+    compliance:     ComplianceLevel,
+    skippedDetails: Option[SkippedDetails],
+    policyMode:     ComputedPolicyMode,
+    components:     Seq[ByRuleComponentCompliance]
 )
 
 final case class ByRuleDirectiveCompliance(
@@ -229,11 +228,12 @@ final case class GroupComponentCompliance(
 )
 
 final case class ByRuleByNodeByDirectiveCompliance(
-    id:         DirectiveId,
-    name:       String,
-    compliance: ComplianceLevel,
-    policyMode: ComputedPolicyMode,
-    components: Seq[ByRuleByNodeByDirectiveByComponentCompliance]
+    id:             DirectiveId,
+    name:           String,
+    compliance:     ComplianceLevel,
+    skippedDetails: Option[SkippedDetails],
+    policyMode:     ComputedPolicyMode,
+    components:     Seq[ByRuleByNodeByDirectiveByComponentCompliance]
 )
 
 sealed trait ByRuleByNodeByDirectiveByComponentCompliance extends ComponentCompliance {
@@ -265,62 +265,6 @@ final case class SkippedDetails(
     overridingRuleId:   RuleId,
     overridingRuleName: String
 )
-final case class DirectiveComplianceOverride(
-    overridenRuleId:  RuleId,
-    directiveId:      DirectiveId,
-    directiveName:    String,
-    overridingRuleId: RuleId
-) {
-  def toComplianceByRule(rules: Map[RuleId, Rule]): ByRuleDirectiveCompliance = {
-    val overridingRuleName = rules.get(overridingRuleId).map(_.name).getOrElse("unknown rule")
-    ByRuleDirectiveCompliance(
-      directiveId,
-      directiveName,
-      ComplianceLevel(),
-      Some(SkippedDetails(overridingRuleId, overridingRuleName)),
-      ComputePolicyMode.skipped(
-        s"This directive is skipped because it is overridden by the rule <b>${overridingRuleName}</b> (with id ${overridingRuleId.serialize})."
-      ),
-      Seq.empty
-    )
-  }
-
-  def toComplianceByNodeRule(rules: Map[RuleId, Rule]): ByNodeDirectiveCompliance = {
-    val overridingRuleName = rules.get(overridingRuleId).map(_.name).getOrElse("unknown rule")
-    ByNodeDirectiveCompliance(
-      directiveId,
-      directiveName,
-      ComplianceLevel(),
-      ComputePolicyMode.skipped(
-        s"This directive is skipped because it is overridden by the rule <b>${overridingRuleName}</b> (with id ${overridingRuleId.serialize})."
-      ),
-      Some(SkippedDetails(overridingRuleId, rules.get(overridingRuleId).map(_.name).getOrElse("unknown rule"))),
-      List.empty
-    )
-  }
-}
-
-object ComplianceOverrides {
-  def getOverridenDirective(
-      overrides:  List[OverriddenPolicy],
-      directives: Map[DirectiveId, (FullActiveTechnique, Directive)]
-  ): List[DirectiveComplianceOverride] = {
-    val overridesData = for {
-      over               <- overrides
-      (_, overridenDir)  <- directives.get(over.policy.directiveId)
-      (_, overridingDir) <- directives.get(over.overriddenBy.directiveId)
-    } yield {
-      DirectiveComplianceOverride(
-        over.policy.ruleId,
-        over.policy.directiveId,
-        overridenDir.name,
-        over.overriddenBy.ruleId
-      )
-
-    }
-    overridesData
-  }
-}
 
 object GroupComponentCompliance {
   // ordering that is required when creating sorted maps from cats strict groupByNel
@@ -390,13 +334,14 @@ object GroupComponentCompliance {
                             // All components were regrouped by nodes
                             case (nodeId, s) =>
                               val subs = s.map(_._2)
-                              // Rebuild a Directtive compliance for a Node
+                              // Rebuild a Directive compliance for a Node
                               (
                                 nodeId,
                                 ByRuleByNodeByDirectiveCompliance(
                                   d.id,
                                   d.name,
                                   ComplianceLevel.sum(subs.map(_.compliance)),
+                                  d.skippedDetails,
                                   d.policyMode,
                                   subs
                                 )
@@ -478,9 +423,8 @@ final case class ByNodeNodeCompliance(
  * - directiveCompliances: status for each directive, for that rule.
  */
 final case class ByNodeRuleCompliance(
-    id:   RuleId,
-    name: String, // compliance by directive (by nodes)
-
+    id:         RuleId,
+    name:       String, // compliance by directive (by nodes)
     compliance: ComplianceLevel,
     policyMode: ComputedPolicyMode,
     directives: Seq[ByNodeDirectiveCompliance]
@@ -490,17 +434,10 @@ final case class ByNodeDirectiveCompliance(
     id:             DirectiveId,
     name:           String,
     compliance:     ComplianceLevel,
-    policyMode:     ComputedPolicyMode,
     skippedDetails: Option[SkippedDetails],
+    policyMode:     ComputedPolicyMode,
     components:     List[ComponentStatusReport]
 )
-
-object ByNodeDirectiveCompliance {
-
-  def apply(d: DirectiveStatusReport, policyMode: ComputedPolicyMode, directiveName: String): ByNodeDirectiveCompliance = {
-    new ByNodeDirectiveCompliance(d.directiveId, directiveName, d.compliance, policyMode, None, d.components)
-  }
-}
 
 /*
  * These objects are only used to export compliance in CSV format, for example in directive screen.

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -64,7 +64,6 @@ import com.normation.rudder.domain.reports.ComplianceLevel
 import com.normation.rudder.domain.reports.CompliancePrecision
 import com.normation.rudder.domain.reports.ComponentStatusReport
 import com.normation.rudder.domain.reports.DirectiveStatusReport
-import com.normation.rudder.domain.reports.NodeStatusReport
 import com.normation.rudder.domain.reports.ValueStatusReport
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.facts.nodes.NodeFactRepository
@@ -81,7 +80,6 @@ import com.normation.rudder.rest.RestExtractorService
 import com.normation.rudder.rest.RestUtils.*
 import com.normation.rudder.rest.data.*
 import com.normation.rudder.services.reports.ReportingService
-import com.normation.rudder.services.reports.ReportingServiceUtils
 import com.normation.rudder.web.services.ComputePolicyMode
 import com.normation.rudder.web.services.ComputePolicyMode.ComputedPolicyMode
 import com.normation.zio.currentTimeMillis
@@ -699,20 +697,34 @@ class ComplianceAPIService(
 
                   // if rule cannot be found in "rules" it means the level prevent from returning rule details, so : no compliance
                   rules.find(_.id == ruleId).map { rule =>
-                    val nodeIds    = RoNodeGroupRepository
+                    val nodeIds = RoNodeGroupRepository
                       .getNodeIdsChunk(allGroups, rule.targets, nodeFacts.mapValues(_.rudderSettings.isPolicyServer))
                       .toSet
-                    val policyMode = getRulePolicyMode(
-                      rule,
-                      allDirectives,
-                      nodeIds.toSet,
-                      nodeFacts.mapValues(_.rudderSettings).toMap,
-                      globalPolicyMode
+
+                    def defaultMode                   = (
+                      None,
+                      getRulePolicyMode(
+                        rule,
+                        allDirectives,
+                        nodeIds,
+                        nodeFacts.mapValues(_.rudderSettings).toMap,
+                        globalPolicyMode
+                      )
                     )
+                    // if all directive on that rules are skipped, the rule is skipped too
+                    val (overrideDetails, policyMode) = if (ruleDirectiveReports.forall(_._2.overridden.nonEmpty)) {
+                      ruleDirectiveReports.collectFirst {
+                        case (_, DirectiveStatusReport(_, _, Some(rid), _)) =>
+                          val rname = rules.collectFirst { case r if r.id == rid => r.name }.getOrElse("unknown")
+                          (Some(SkippedDetails(rid, rname)), ComputePolicyMode.skippedBy(rid, rname))
+                      }.getOrElse(defaultMode)
+                    } else defaultMode
+
                     ByDirectiveByRuleCompliance(
                       ruleId,
                       rule.name,
                       ComplianceLevel.sum(componentsCompliance.map(_.compliance)),
+                      overrideDetails,
                       policyMode,
                       componentsDetails
                     )
@@ -749,6 +761,7 @@ class ComplianceAPIService(
     for {
       t1        <- currentTimeMillis
       allGroups <- nodeGroupRepo.getAllNodeIdsChunk()
+      allRules  <- rulesRepo.getAll()
       t2        <- currentTimeMillis
       _         <- TimingDebugLoggerPure.trace(s"getByRulesCompliance - nodeGroupRepo.getAllNodeIdsChunk in ${t2 - t1} ms")
 
@@ -778,10 +791,6 @@ class ComplianceAPIService(
       reportsByRule = reportsByNode.flatMap { case (_, status) => status.reports.flatMap(_._2.reports) }.groupBy(_.ruleId)
       t7            = System.currentTimeMillis()
       _            <- TimingDebugLoggerPure.trace(s"getByRulesCompliance - group reports by rules in ${t7 - t6} ms")
-
-      // make a map of directive overrides for each rule, to add to the directives of a rule
-      directivesOverrides <-
-        getDirectiveOverrides[ByRuleDirectiveCompliance](ruleObjects, reportsByNode, directives, _.toComplianceByRule(_))
 
       t8               <- currentTimeMillis
       _                <- TimingDebugLoggerPure.trace(s"getByRulesCompliance - get directive overrides and rules infos in ${t8 - t7} ms")
@@ -834,15 +843,19 @@ class ComplianceAPIService(
               case (directiveId, nodeDirectives) =>
                 val directive     = directives.get(directiveId)
                 val nodeModes     = nodeDirectives.map(_._1).flatMap(nodeFacts.get).map(_.rudderSettings.policyMode).toSet
-                val directiveMode =
-                  ComputePolicyMode.directiveModeOnRule(nodeModes, globalPolicyMode)(directive.flatMap(_._2.policyMode))
+                val overridden    = computeOverridingMode(directiveId, allRules, nodeDirectives)
+                val directiveMode = overridden match {
+                  case Some(x) => ComputePolicyMode.skippedBy(x.overridingRuleId, x.overridingRuleName)
+                  case None    =>
+                    ComputePolicyMode.directiveModeOnRule(nodeModes, globalPolicyMode)(directive.flatMap(_._2.policyMode))
+                }
                 ByRuleDirectiveCompliance(
                   directiveId,
                   directive.map(_._2.name).getOrElse("Unknown directive"),
                   ComplianceLevel.sum(
                     nodeDirectives.map(_._2.compliance)
                   ),
-                  None,
+                  overridden,
                   directiveMode, {
                     // here we want the compliance by components of the directive.
                     // if level is high enough, get all components and group by their name
@@ -863,7 +876,7 @@ class ComplianceAPIService(
       val t8            = System.currentTimeMillis()
       TimingDebugLoggerPure.logEffect.trace(s"getByRulesCompliance - Compute non empty rules in ${t8 - t7} ms")
 
-      // if any rules is in the list in parameter an not in the nonEmptyRules, then it means
+      // if any rules is in the list in parameter and not in the nonEmptyRules, then it means
       // there's no compliance for it, so it's empty
       // we need to set the ByRuleCompliance with a compliance of NoAnswer
       val rulesWithoutCompliance = ruleObjects.keySet -- reportsByRule.keySet
@@ -896,13 +909,31 @@ class ComplianceAPIService(
 
       // return the full list
       val singleRuleCompliance = nonEmptyRules ++ initializedCompliances
-      // add overrides to that result
-      val result               = singleRuleCompliance.map(r => r.copy(directives = r.directives ++ directivesOverrides(r.id)))
 
       val t10 = System.currentTimeMillis()
       TimingDebugLoggerPure.logEffect.trace(s"getByRulesCompliance - Compute result in ${t10 - t9} ms")
-      result
+      singleRuleCompliance
     }
+  }
+
+  /*
+   * For a set of directive status reports for the same directiveId, compute an aggregated "SkippedDetails" value.
+   * The rule is that you put it only if it's one ALL nodeId (meaning they are likely from the same target, and so
+   * the directive is skipped everywhere).
+   */
+  def computeOverridingMode(
+      id1:      DirectiveId,
+      allRules: Iterable[Rule],
+      reports:  Iterable[(NodeId, DirectiveStatusReport)]
+  ): Option[SkippedDetails] = {
+    if (reports.forall(_._2.overridden.isDefined)) {
+      // here, we COULD keep the list of all overriding rules/directives, but it's not don't
+      // to avoid risking duplicating "skipped" instance.
+      reports.collectFirst {
+        case (_, DirectiveStatusReport(id2, _, Some(ruleId), _)) if (id1 == id2) =>
+          SkippedDetails(ruleId, allRules.collectFirst { case r if r.id == ruleId => r.name }.getOrElse("unknown"))
+      }
+    } else None
   }
 
   private def getByNodeGroupCompliance(
@@ -970,20 +1001,33 @@ class ComplianceAPIService(
                   mode,
                   byDirectives.map {
                     case (directiveId, nodeDirectives) =>
-                      val directive     = allDirectives.get(directiveId).map(_._2)
-                      val directiveMode = ComputePolicyMode.directiveModeOnRule(
-                        nodeDirectives.map(_._1).toSet.map((n: NodeId) => nodeSettings.get(n).flatMap(_.policyMode)),
-                        globalMode
-                      )(
-                        directive.flatMap(_.policyMode)
+                      val directive                     = allDirectives.get(directiveId).map(_._2)
+                      def defaultMode                   = (
+                        None,
+                        ComputePolicyMode.directiveModeOnRule(
+                          nodeDirectives.map(_._1).toSet.map((n: NodeId) => nodeSettings.get(n).flatMap(_.policyMode)),
+                          globalMode
+                        )(
+                          directive.flatMap(_.policyMode)
+                        )
                       )
+                      val (overrideDetails, policyMode) = if (nodeDirectives.forall(_._2.overridden.nonEmpty)) {
+                        nodeDirectives.collectFirst {
+                          case (_, DirectiveStatusReport(_, _, Some(rid), _)) =>
+                            val rname = rules.get(rid).map(_._1.name)
+                            (
+                              Some(SkippedDetails(rid, rname.getOrElse("unknown"))),
+                              ComputePolicyMode.skippedBy(rid, r.name)
+                            )
+                        }.getOrElse(defaultMode)
+                      } else defaultMode
+
                       ByNodeGroupByRuleDirectiveCompliance(
                         directiveId,
                         directive.map(_.name).getOrElse("Unknown directive"),
-                        ComplianceLevel.sum(
-                          nodeDirectives.map(_._2.compliance)
-                        ),
-                        directiveMode,
+                        ComplianceLevel.sum(nodeDirectives.map(_._2.compliance)),
+                        overrideDetails,
+                        policyMode,
                         // here we want the compliance by components of the directive.
                         // if level is high enough, get all components and group by their name
                         {
@@ -1056,26 +1100,45 @@ class ComplianceAPIService(
             ComplianceLevel.sum(reports.map(_.compliance)),
             nodeMode,
             reports.map(r => {
+              val directives = r.directives.toSeq.map {
+                case (_, directiveReport) =>
+                  val d      = allDirectives.get(directiveReport.directiveId)
+                  val (p, o) = directiveReport.overridden match {
+                    case Some(overridingRuleId) =>
+                      val ruleName = rules.get(overridingRuleId).map(_._1.name).getOrElse("unknown")
+                      (
+                        ComputePolicyMode.skippedBy(overridingRuleId, ruleName),
+                        Some(SkippedDetails(overridingRuleId, ruleName))
+                      )
+                    case None                   =>
+                      (
+                        ComputePolicyMode
+                          .directiveModeOnNode(nodePolicyMode, globalMode)(
+                            d.flatMap(_._2.policyMode)
+                          ),
+                        None
+                      )
+                  }
+                  ByNodeDirectiveCompliance(
+                    directiveReport.directiveId,
+                    d.map(_._2.name).getOrElse("Unknown Directive"),
+                    directiveReport.compliance,
+                    o,
+                    p,
+                    directiveReport.components
+                  )
+              }
               ByNodeRuleCompliance(
                 r.ruleId,
                 rules.get(r.ruleId).map(_._1.name).getOrElse("Unknown rule"),
                 r.compliance,
-                ComputePolicyMode
-                  .ruleModeOnNode(nodePolicyMode, globalMode)(
-                    r.directives.flatMap(d => allDirectives.get(d._1).map(_._2.policyMode)).toSet
-                  ),
-                r.directives.toSeq.map {
-                  case (_, directiveReport) =>
-                    val d = allDirectives.get(directiveReport.directiveId)
-                    ByNodeDirectiveCompliance(
-                      directiveReport,
-                      ComputePolicyMode
-                        .directiveModeOnNode(nodePolicyMode, globalMode)(
-                          d.flatMap(_._2.policyMode)
-                        ),
-                      d.map(_._2.name).getOrElse("Unknown Directive")
-                    )
-                }
+                if (directives.forall(_.policyMode.isSkipped)) ComputePolicyMode.skipped(s"All directives on rule are skipped")
+                else
+                  ComputePolicyMode
+                    .ruleModeOnNode(nodePolicyMode, globalMode)(
+                      r.directives.flatMap(d => allDirectives.get(d._1).map(_._2.policyMode)).toSet
+                    ),
+                directives
               )
             })
           )
@@ -1371,13 +1434,17 @@ class ComplianceAPIService(
   }.toBox
 
   def getRulesCompliance(level: Option[Int])(implicit qc: QueryContext): Box[Seq[ByRuleRuleCompliance]] = {
+    getRulesCompliancePure(level).toBox
+  }
+
+  def getRulesCompliancePure(level: Option[Int])(implicit qc: QueryContext): IOResult[Seq[ByRuleRuleCompliance]] = {
     for {
       rules   <- rulesRepo.getAll()
       reports <- getByRulesCompliance(rules, level)
     } yield {
       reports
     }
-  }.toBox
+  }
 
   /**
    * Get the compliance for everything
@@ -1401,7 +1468,6 @@ class ComplianceAPIService(
       rules        <- if (PolicyTypeName.rudderSystem == policyType) getSystemRules() else getAllUserRules()
       ruleMap       = rules.map { case x => (x.id, x) }.toMap
       allGroups    <- nodeGroupRepo.getAllNodeIdsChunk()
-      groupLib     <- nodeGroupRepo.getFullGroupLibrary()
       directiveLib <- directiveRepo.getFullDirectiveLibrary().map(_.allDirectives)
       allNodeFacts <- nodeFactRepos.getAll()
       nodeFacts    <- onlyNode match {
@@ -1414,14 +1480,8 @@ class ComplianceAPIService(
                       }
       globalMode   <- getGlobalPolicyMode
       compliance   <- getGlobalComplianceMode
-      reports      <- reportingService
-                        .findRuleNodeStatusReports(
-                          nodeFacts.keySet.toSet,
-                          ruleMap.keySet
-                        )
+      reports      <- reportingService.findRuleNodeStatusReports(nodeFacts.keySet.toSet, ruleMap.keySet)
 
-      directiveOverrides <-
-        getDirectiveOverrides[ByNodeDirectiveCompliance](ruleMap, reports, directiveLib, _.toComplianceByNodeRule(_))
     } yield {
       // A map to access the node fqdn and settings
       val nodeInfos: Map[NodeId, (String, RudderSettings)] =
@@ -1481,11 +1541,11 @@ class ComplianceAPIService(
                           id,
                           directive.map(_._2.name).getOrElse("Unknown Directive"),
                           ComplianceLevel(noAnswer = 1),
-                          directiveMode,
                           None,
+                          directiveMode,
                           Nil
                         )
-                      }.toSeq ++ directiveOverrides.getOrElse(rule.id, Nil)
+                      }.toSeq
                     )
                 })
               )
@@ -1534,15 +1594,31 @@ class ComplianceAPIService(
                       rulePolicyMode,
                       r.directives.toSeq.map {
                         case (_, directiveReport) =>
+                          val (p, o) = directiveReport.overridden match {
+                            case Some(overridingRuleId) =>
+                              val ruleName = ruleMap.get(overridingRuleId).map(_.name).getOrElse("unknown")
+                              (
+                                ComputePolicyMode.skippedBy(overridingRuleId, ruleName),
+                                Some(SkippedDetails(overridingRuleId, ruleName))
+                              )
+                            case None                   =>
+                              (
+                                ComputePolicyMode
+                                  .directiveModeOnNode(nodeInfos.get(nodeId).flatMap(_._2.policyMode), globalMode)(
+                                    directiveLib.get(directiveReport.directiveId).flatMap(_._2.policyMode)
+                                  ),
+                                None
+                              )
+                          }
                           ByNodeDirectiveCompliance(
-                            directiveReport,
-                            ComputePolicyMode
-                              .directiveModeOnNode(nodeInfos.get(nodeId).flatMap(_._2.policyMode), globalMode)(
-                                directiveLib.get(directiveReport.directiveId).flatMap(_._2.policyMode)
-                              ),
-                            directiveLib.get(directiveReport.directiveId).map(_._2.name).getOrElse("Unknown Directive")
+                            directiveReport.directiveId,
+                            directiveLib.get(directiveReport.directiveId).map(_._2.name).getOrElse("Unknown Directive"),
+                            directiveReport.compliance,
+                            o,
+                            p,
+                            directiveReport.components
                           )
-                      } ++ directiveOverrides.getOrElse(r.ruleId, Nil)
+                      }
                     )
                 }
             )
@@ -1577,7 +1653,6 @@ class ComplianceAPIService(
     } yield {
       report
     }
-
   }
 
   def getNodesCompliance(policyTypeName: PolicyTypeName)(implicit qc: QueryContext): IOResult[Seq[ByNodeNodeCompliance]] = {
@@ -1598,32 +1673,5 @@ class ComplianceAPIService(
         nodeSettings.filter(!_._2.isPolicyServer).keySet
       case PolicyServerTarget(nodeId)   => Set(nodeId)
     }
-  }
-
-  private[this] def getDirectiveOverrides[T](
-      initialRuleObjects: Map[RuleId, Rule],
-      reports:            Map[NodeId, NodeStatusReport],
-      directives:         Map[DirectiveId, (FullActiveTechnique, Directive)],
-      overrideToTarget:   (DirectiveComplianceOverride, Map[RuleId, Rule]) => T
-  ): IOResult[MapView[RuleId, List[T]]] = {
-    // make a map of directive overrides for each rule, to add to the directives of a rule
-    val directiveOverridesByRules = initialRuleObjects.keys.map { ruleId =>
-      val overridenDirectives = ComplianceOverrides
-        .getOverridenDirective(
-          ReportingServiceUtils.buildRuleStatusReport(ruleId, reports).overrides,
-          directives
-        )
-      ruleId -> overridenDirectives
-    }.toMap
-
-    // we need to fetch info for rules pulled from overriden directives of our rules
-
-    ZIO
-      .foreach(
-        directiveOverridesByRules.values.toList
-          .flatMap(_.map(_.overridingRuleId))
-      )(rulesRepo.getOpt(_))
-      .map(rules => initialRuleObjects ++ rules.flatten.map(r => (r.id, r)).toMap)
-      .map(allRuleObjects => directiveOverridesByRules.view.mapValues(_.map(overrideToTarget(_, allRuleObjects))))
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_compliance.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_compliance.yml
@@ -2214,6 +2214,14 @@ response:
                         ]
                       }
                     ]
+                  },
+                  {
+                    "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "compliance" : 0.0,
+                    "policyMode" : "skipped",
+                    "complianceDetails" : {},
+                    "components" : []
                   }
                 ]
               }
@@ -2304,6 +2312,14 @@ response:
                             ]
                           }
                         ]
+                      },
+                      {
+                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "compliance" : 0.0,
+                        "policyMode" : "skipped",
+                        "complianceDetails" : {},
+                        "components" : []
                       }
                     ]
                   }
@@ -2394,6 +2410,14 @@ response:
                             ]
                           }
                         ]
+                      },
+                      {
+                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "compliance" : 0.0,
+                        "policyMode" : "skipped",
+                        "complianceDetails" : {},
+                        "components" : []
                       }
                     ]
                   }
@@ -2500,6 +2524,14 @@ response:
                         ]
                       }
                     ]
+                  },
+                  {
+                    "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                    "compliance" : 0.0,
+                    "policyMode" : "skipped",
+                    "complianceDetails" : {},
+                    "components" : []
                   }
                 ]
               }
@@ -2551,6 +2583,14 @@ response:
                             ]
                           }
                         ]
+                      },
+                      {
+                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "compliance" : 0.0,
+                        "policyMode" : "skipped",
+                        "complianceDetails" : {},
+                        "components" : []
                       }
                     ]
                   }
@@ -2602,6 +2642,14 @@ response:
                             ]
                           }
                         ]
+                      },
+                      {
+                        "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+                        "compliance" : 0.0,
+                        "policyMode" : "skipped",
+                        "complianceDetails" : {},
+                        "components" : []
                       }
                     ]
                   }
@@ -2652,6 +2700,14 @@ response:
               "complianceDetails" : {
                 "successAlreadyOK" : 100.0
               },
+              "components" : []
+            },
+            {
+              "id" : "br6",
+              "name" : "R6",
+              "compliance" : 0.0,
+              "policyMode" : "skipped",
+              "complianceDetails" : {},
               "components" : []
             },
             {
@@ -2904,18 +2960,6 @@ response:
                     ]
                   }
                 ]
-              },
-              {
-                "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
-                "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
-                "compliance" : 0.0,
-                "policyMode" : "skipped",
-                "complianceDetails" : {},
-                "skippedDetails" : {
-                  "overridingRuleId" : "br4",
-                  "overridingRuleName" : "R4"
-                },
-                "components" : []
               },
               {
                 "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
@@ -3738,18 +3782,6 @@ response:
                   ]
                 }
               ]
-            },
-            {
-              "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
-              "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
-              "compliance" : 0.0,
-              "policyMode" : "skipped",
-              "complianceDetails" : {},
-              "skippedDetails" : {
-                "overridingRuleId" : "br4",
-                "overridingRuleName" : "R4"
-              },
-              "components" : []
             },
             {
               "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
@@ -5196,6 +5228,14 @@ response:
                     ]
                   }
                 ]
+              },
+              {
+                "id" : "br6",
+                "name" : "R6",
+                "compliance" : 0.0,
+                "policyMode" : "skipped",
+                "complianceDetails" : {},
+                "components" : []
               },
               {
                 "id" : "br4",

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -753,6 +753,7 @@ class MockCompliance(mockDirectives: MockDirectives) {
         directiveId -> DirectiveStatusReport(
           directiveId,
           PolicyTypes.rudderBase,
+          None,
           List(
             ValueStatusReport(
               s"${directiveId.serialize}-component-${ruleId.serialize}-${nodeId.value}",

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RunComplianceComputation.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RunComplianceComputation.scala
@@ -1,0 +1,634 @@
+/*
+ *************************************************************************************
+ * Copyright 2025 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.rest
+
+import better.files.File
+import com.normation.cfclerk.domain.TechniqueVersionHelper
+import com.normation.errors
+import com.normation.errors.*
+import com.normation.eventlog.EventActor
+import com.normation.eventlog.ModificationId
+import com.normation.inventory.domain.FullInventory
+import com.normation.inventory.domain.InventoryStatus
+import com.normation.inventory.domain.NodeId
+import com.normation.inventory.domain.Software
+import com.normation.rudder.MockDirectives
+import com.normation.rudder.MockGitConfigRepo
+import com.normation.rudder.MockTechniques
+import com.normation.rudder.domain.archives.RuleArchiveId
+import com.normation.rudder.domain.nodes.*
+import com.normation.rudder.domain.policies.*
+import com.normation.rudder.domain.reports.*
+import com.normation.rudder.facts.nodes.*
+import com.normation.rudder.facts.nodes.ChangeContext
+import com.normation.rudder.facts.nodes.CoreNodeFact
+import com.normation.rudder.reports.AgentRunInterval
+import com.normation.rudder.reports.FullCompliance
+import com.normation.rudder.reports.GlobalComplianceMode
+import com.normation.rudder.repository.*
+import com.normation.rudder.rest.lift.*
+import com.normation.rudder.rule.category.RuleCategoryId
+import com.normation.rudder.services.policies.NodeConfigData
+import com.normation.rudder.services.policies.PolicyId
+import com.normation.rudder.services.reports.ComputeCompliance
+import com.normation.rudder.services.reports.InMemoryNodeStatusReportStorage
+import com.normation.rudder.services.reports.NodeStatusReportInternal
+import com.normation.rudder.services.reports.NodeStatusReportRepositoryImpl
+import com.normation.rudder.services.reports.ReportingService
+import com.normation.rudder.services.reports.ReportingServiceImpl2
+import com.normation.zio.*
+import org.joda.time.DateTime
+import scala.collection.MapView
+import scala.collection.immutable.SortedMap
+import zio.*
+import zio.syntax.*
+
+/*
+ * Run a compliance computation (the same that is given by API for rules,
+ * ie the same that is used when opening rules page).
+ * The number of nodes and rules is given as parameter of the set-up.
+ *
+ * The computation is instrumented by async-profiler: https://github.com/async-profiler/async-profiler
+ * And the result is written the `file` as a flamegraph.
+ */
+object RunTestCompliance {
+
+  // parameters of the run
+  val setUp = new SetUpCompliance(numNodes = 5000, numRules = 300)
+  // write result
+  val file  = "/tmp/test_compliance_computation/%p.html"
+
+  File(file).parent.createDirectories()
+
+  val cs       = setUp.complianceAPIService
+  val profiler = one.profiler.AsyncProfiler.getInstance();
+
+  def main(args: Array[String]): Unit = {
+    println(s"pid: ${new java.io.File("/proc/self").getCanonicalFile().getName()}")
+    println(s"events: ${profiler.execute("list")}")
+
+    // Parameter line for the profiler. here, we build a flamegraph based on CPU
+    // and default parameters. The flamegraph will be written in html in `file`.
+    // See https://github.com/async-profiler/async-profiler/blob/v4.0/src/arguments.cpp
+    // for more parameters. You can look for memory allocation, time spent in tree form, etc.
+    profiler.execute(s"start,event=cpu,tree,file=${file}")
+    println(s"computing compliance...")
+
+    // This is the actual thing we want to measure
+    /////////////// -- ///////////////
+    val (t, x) = cs.getRulesCompliancePure(Some(1))(QueryContext.systemQC).timed.runNow
+    /////////////// -- ///////////////
+
+    // it looks like if we want to be sure to have the file written, we must dump it before stop...
+    profiler.execute(s"dump,file=${file}")
+    profiler.execute("stop")
+    // and give some time to finish writing.
+    Thread.sleep(100)
+
+    println(s"Number rule compliance: ${x.size}")
+    x.sortBy(_.name).foreach(println)
+    println(s"Done in ********> ${t.render}")
+    java.lang.System.exit(0)
+  }
+}
+
+class SetUpCompliance(numNodes: Int, numRules: Int) {
+
+  private val mockGitRepo    = new MockGitConfigRepo("")
+  private val mockTechniques = MockTechniques(mockGitRepo)
+  private val mockDirectives = new MockDirectives(mockTechniques)
+  private val directives     = mockDirectives.directives
+
+  private val kindNodes = 6
+  private val nodeRange = (1 to numNodes).by(kindNodes)
+  private val kindRules = 6
+  private val ruleRange = (1 to numRules).by(kindRules)
+
+  private def nodeId(id:      Int): NodeId      = NodeId(f"bn${id}%04d")
+  private def ruleId(id:      Int): RuleId      = RuleId(RuleUid(f"br${id}%04d"))
+  private def nodeGroupId(id: Int): NodeGroupId = NodeGroupId(NodeGroupUid(f"bg${id}%04d"))
+
+  private def nodeGroupsRepo(nodeGroups: List[NodeGroup]) = new RoNodeGroupRepository {
+    val nodesByGroup: Map[NodeGroupId, Chunk[NodeId]] = nodeGroups.map(g => (g.id, Chunk.fromIterable(g.serverList))).toMap
+
+    override def getAllNodeIdsChunk(): IOResult[Map[NodeGroupId, Chunk[NodeId]]] = {
+      nodesByGroup.succeed
+    }
+
+    override def getNodeGroupOpt(
+        id: NodeGroupId
+    )(implicit qc: QueryContext): IOResult[Option[(NodeGroup, NodeGroupCategoryId)]] = {
+      nodeGroups.find(_.id == id).map((_, NodeGroupCategoryId("cat1"))).succeed
+    }
+
+    def getFullGroupLibrary(): IOResult[FullNodeGroupCategory] = {
+      FullNodeGroupCategory(
+        NodeGroupCategoryId("GroupRoot"),
+        name = "GroupRoot",
+        description = "root of group categories",
+        subCategories = Nil,
+        targetInfos = nodeGroups.map(g => {
+          FullRuleTargetInfo(FullGroupTarget(GroupTarget(g.id), g), g.name, g.description, g.isEnabled, g.isSystem)
+        }),
+        isSystem = true
+      ).succeed
+    }
+
+    def categoryExists(id:       NodeGroupCategoryId): IOResult[Boolean]           = ???
+    def getNodeGroupCategory(id: NodeGroupId):         IOResult[NodeGroupCategory] = ???
+    def getAll(): IOResult[Seq[NodeGroup]] = ???
+    def getAllByIds(ids: Seq[NodeGroupId]): IOResult[Seq[NodeGroup]] = ???
+    def getAllNodeIds(): IOResult[Map[NodeGroupId, Set[NodeId]]] = ???
+    def getGroupsByCategory(includeSystem: Boolean)(implicit
+        qc: QueryContext
+    ): IOResult[SortedMap[List[NodeGroupCategoryId], CategoryAndNodeGroup]] = ???
+    def findGroupWithAnyMember(nodeIds: Seq[NodeId]): IOResult[Seq[NodeGroupId]] = ???
+    def findGroupWithAllMember(nodeIds: Seq[NodeId]): IOResult[Seq[NodeGroupId]] = ???
+    def getRootCategory():     NodeGroupCategory                                                 = ???
+    def getRootCategoryPure(): IOResult[NodeGroupCategory]                                       = ???
+    def getCategoryHierarchy:  IOResult[SortedMap[List[NodeGroupCategoryId], NodeGroupCategory]] = ???
+    def getAllGroupCategories(includeSystem: Boolean):             IOResult[Seq[NodeGroupCategory]]  = ???
+    def getGroupCategory(id:                 NodeGroupCategoryId): IOResult[NodeGroupCategory]       = ???
+    def getParentGroupCategory(id:           NodeGroupCategoryId): IOResult[NodeGroupCategory]       = ???
+    def getParents_NodeGroupCategory(id:     NodeGroupCategoryId): IOResult[List[NodeGroupCategory]] = ???
+    def getAllNonSystemCategories(): IOResult[Seq[NodeGroupCategory]] = ???
+  }
+
+  object nodeFactRepo extends NodeFactRepository {
+    override def getAll()(implicit qc: QueryContext, status: SelectNodeStatus): IOResult[MapView[NodeId, CoreNodeFact]] = {
+      val _                                           = (qc, status) // ignore "unused" warning
+      def build(id: NodeId, mode: Option[PolicyMode]) = {
+        val nodeFact = NodeConfigData.fact1
+        nodeFact.copy(id = id, rudderSettings = nodeFact.rudderSettings.copy(policyMode = mode))
+      }
+      // build nodes 1 to 500
+      val nodes                                       = nodeRange.flatMap { i =>
+        Seq(
+          build(nodeId(i), Some(PolicyMode.Audit)),
+          build(nodeId(i + 1), Some(PolicyMode.Audit)),
+          build(nodeId(i + 2), Some(PolicyMode.Enforce)),
+          build(nodeId(i + 3), Some(PolicyMode.Enforce)),
+          build(nodeId(i + 4), Some(PolicyMode.Enforce))
+        )
+      }
+
+      nodes.map(n => (n.id, n)).toMap.view.succeed
+    }
+
+    def registerChangeCallbackAction(callback: NodeFactChangeEventCallback): IOResult[Unit] = ???
+    def getStatus(id:                          NodeId)(implicit qc:   QueryContext): IOResult[InventoryStatus] = ???
+    def get(nodeId:                            NodeId)(implicit qc:   QueryContext, status:    SelectNodeStatus): IOResult[Option[CoreNodeFact]]  = ???
+    def slowGet(
+        nodeId: NodeId
+    )(implicit qc: QueryContext, status: SelectNodeStatus, attrs: SelectFacts): IOResult[Option[NodeFact]] = ???
+    def getNodesBySoftwareName(softName:       String): IOResult[List[(NodeId, Software)]] = ???
+    def slowGetAll()(implicit qc:              QueryContext, status:  SelectNodeStatus, attrs: SelectFacts):      errors.IOStream[NodeFact]       = ???
+    def save(nodeFact:                         NodeFact)(implicit cc: ChangeContext, attrs:    SelectFacts):      IOResult[NodeFactChangeEventCC] = ???
+    def setSecurityTag(nodeId: NodeId, tag: Option[SecurityTag])(implicit cc: ChangeContext): IOResult[NodeFactChangeEventCC] =
+      ???
+    def updateInventory(inventory: FullInventory, software: Option[Iterable[Software]])(implicit
+        cc: ChangeContext
+    ): IOResult[NodeFactChangeEventCC] = ???
+    def changeStatus(nodeId: NodeId, into: InventoryStatus)(implicit cc: ChangeContext): IOResult[NodeFactChangeEventCC] = ???
+    def delete(nodeId: NodeId)(implicit cc: ChangeContext): IOResult[NodeFactChangeEventCC] = ???
+  }
+
+  // We want to ignore rules that are defined in `MockRules` because they may target all nodes and pollute our compliance tests
+  private def rulesRepo(rules: List[Rule]) = new RoRuleRepository with WoRuleRepository {
+    override def getOpt(ruleId: RuleId):         IOResult[Option[Rule]] = {
+      rules.find(_.id == ruleId).succeed
+    }
+    override def getAll(includeSystem: Boolean): IOResult[Seq[Rule]]    = {
+      rules.succeed
+    }
+
+    override def getIds(includeSystem:            Boolean): IOResult[Set[RuleId]] = ???
+    override def create(rule:                     Rule, modId:   ModificationId, actor: EventActor, reason: Option[String]): IOResult[AddRuleDiff] = ???
+    override def update(
+        rule:   Rule,
+        modId:  ModificationId,
+        actor:  EventActor,
+        reason: Option[String]
+    ): IOResult[Option[ModifyRuleDiff]] = ???
+    override def load(rule:                       Rule, modId:   ModificationId, actor: EventActor, reason: Option[String]): IOResult[Unit]        = ???
+    override def unload(ruleId:                   RuleId, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Unit]        = ???
+    override def updateSystem(
+        rule:   Rule,
+        modId:  ModificationId,
+        actor:  EventActor,
+        reason: Option[String]
+    ): IOResult[Option[ModifyRuleDiff]] = ???
+    override def delete(id: RuleId, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[DeleteRuleDiff] =
+      ???
+    override def deleteSystemRule(
+        id:     RuleId,
+        modId:  ModificationId,
+        actor:  EventActor,
+        reason: Option[String]
+    ): IOResult[DeleteRuleDiff] = ???
+    override def swapRules(newRules:              Seq[Rule]): IOResult[RuleArchiveId] = ???
+    override def deleteSavedRuleArchiveId(saveId: RuleArchiveId): IOResult[Unit] = ???
+  }
+
+  def reportingService(statusReports: Map[NodeId, NodeStatusReport]): ReportingService = {
+    val ref = Ref.make(statusReports).runNow
+    new ReportingServiceImpl2(new NodeStatusReportRepositoryImpl(new InMemoryNodeStatusReportStorage(ref), ref))
+  }
+
+  val complianceAPIService: ComplianceAPIService = {
+    import complexExample.*
+    buildComplianceService(
+      complexCustomRules,
+      complexCustomNodeGroups,
+      complexStatusReports
+    )
+  }
+
+  object complexExample {
+
+    /*
+    Nodes N1, N2, N3, N4, N5, N6 (and then modulo 6)
+
+    Groups G1 (with N1, N2), G2 (N3), G3 (N1), G4 (N4, N5, N6), G5 (N3, N4), G6(N5, N6)
+
+    Directives D1, D2, D3, D4, D5, D6
+
+    Rules
+
+    - R1, which applies D1 to G1
+    - R2, which applies D2 to G1 but not G2
+    - R3, which applies D3 to G2 and G3
+    - R4, which applies D4 to G4 and G5
+    - R5, which applies D5 to G6 but not G4 (so nothing)
+    - R6, which applies D4,D6 to G6 (so we will have skipped on D4)
+     */
+
+    val nodesG1 = nodeRange.flatMap(i => Seq(nodeId(i), nodeId(i + 1))).toSet
+//    println(s"nodes G1: " + nodesG1)
+    val g1: NodeGroup = NodeGroup(
+      nodeGroupId(1),
+      name = "G1",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = true,
+      serverList = nodesG1,
+      _isEnabled = true
+    )
+
+    val nodesG2 = nodeRange.flatMap(i => Seq(nodeId(i + 2))).toSet
+//    println(s"nodes G2: " + nodesG2)
+    val g2: NodeGroup = NodeGroup(
+      nodeGroupId(2),
+      name = "G2",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = true,
+      serverList = nodesG2,
+      _isEnabled = true
+    )
+
+    val nodesG3 = nodeRange.flatMap(i => Seq(nodeId(i))).toSet
+//    println(s"nodes G3: " + nodesG3)
+    val g3: NodeGroup = NodeGroup(
+      nodeGroupId(3),
+      name = "G3",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = true,
+      serverList = nodesG3,
+      _isEnabled = true
+    )
+
+    val nodesG4 = nodeRange.flatMap(i => Seq(nodeId(i + 3), nodeId(i + 4), nodeId(i + 5))).toSet
+//    println(s"nodes G4: " + nodesG4)
+    val g4: NodeGroup = NodeGroup(
+      nodeGroupId(4),
+      name = "G4",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = true,
+      serverList = nodesG4,
+      _isEnabled = true
+    )
+
+    val nodesG5 = nodeRange.flatMap(i => Seq(nodeId(i + 2), nodeId(i + 3))).toSet
+//    println(s"nodes G5: " + nodesG5)
+    val g5: NodeGroup = NodeGroup(
+      nodeGroupId(5),
+      name = "G5",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = true,
+      serverList = nodesG5,
+      _isEnabled = true
+    )
+
+    val nodesG6 = nodeRange.flatMap(i => Seq(nodeId(i + 4), nodeId(i + 5))).toSet
+//    println(s"nodes G6: " + nodesG6)
+    val g6: NodeGroup = NodeGroup(
+      nodeGroupId(6),
+      name = "G6",
+      description = "",
+      properties = Nil,
+      query = None,
+      isDynamic = true,
+      serverList = nodesG6,
+      _isEnabled = true
+    )
+
+    val d1 = directives.fileTemplateDirecive1
+    val d2 = directives.fileTemplateVariables2
+    val d3 = directives.rpmDirective
+    val d4 = directives.fileTemplateDirecive1
+    val d5 = directives.fileTemplateVariables2
+    val d6 = directives.copyGitFileDirective
+
+    val complexCustomRules: List[Rule] = ruleRange
+      .flatMap(i => {
+        List(
+          Rule( // br1 %6
+            ruleId(i),
+            f"R1-${i}%03d",
+            RuleCategoryId("rulecat1"),
+            Set(GroupTarget(g1.id)),
+            Set(d1.id)
+          ),
+          Rule( // br2 %6
+            ruleId(i + 1),
+            f"R2-${i + 1}%03d",
+            RuleCategoryId("rulecat1"),
+            Set(
+              TargetExclusion(TargetIntersection(Set(GroupTarget(g1.id))), TargetIntersection(Set(GroupTarget(g2.id))))
+            ),  // include G1 but not G2
+            Set(d2.id)
+          ),
+          Rule( // br3 %6
+            ruleId(i + 2),
+            f"R3-${i + 2}%03d",
+            RuleCategoryId("rulecat1"),
+            Set(GroupTarget(g2.id), GroupTarget(g3.id)),
+            Set(d3.id)
+          ),
+          Rule( // br4 %6
+            ruleId(i + 3),
+            f"R4-${i + 3}%03d",
+            RuleCategoryId("rulecat1"),
+            Set(GroupTarget(g4.id), GroupTarget(g5.id)),
+            Set(d4.id)
+          ),
+          Rule( // br5 %6
+            ruleId(i + 4),
+            f"R5-${i + 4}%03d",
+            RuleCategoryId("rulecat1"),
+            Set(
+              TargetExclusion(TargetIntersection(Set(GroupTarget(g6.id))), TargetIntersection(Set(GroupTarget(g4.id))))
+            ),  // include G6 but not G4 (no node at all)
+            Set(d5.id)
+          ),
+          Rule( // br6 %6
+            ruleId(i + 5),
+            f"R6-${i + 5}%03d",
+            RuleCategoryId("rulecat1"),
+            Set(GroupTarget(g6.id)),
+            Set(d4.id, d6.id)
+          )
+        )
+      })
+      .toList
+
+    val complexCustomNodeGroups: List[NodeGroup] = List(g1, g2, g3, g4, g5, g6)
+
+    val complexStatusReports: Map[NodeId, NodeStatusReport] = nodeRange.flatMap { i =>
+      Map(
+        // R1, R2, R3 apply on N1
+        nodeId(i)     -> simpleNodeStatusReport(
+          nodeId(i),
+          ruleRange.flatMap { j =>
+            List(
+              simpleRuleNodeStatusReport(nodeId(i), ruleId(j), d1.id, ReportType.EnforceSuccess),
+              simpleRuleNodeStatusReport(nodeId(i), ruleId(j + 1), d2.id, ReportType.EnforceRepaired),
+              simpleRuleNodeStatusReport(nodeId(i), ruleId(j + 2), d3.id, ReportType.EnforceError)
+            )
+          }.toSet
+        ),
+        // R1, R3, R4 apply on N2
+        nodeId(i + 1) -> simpleNodeStatusReport(
+          nodeId(i + 1),
+          ruleRange.flatMap { j =>
+            List(
+              simpleRuleNodeStatusReport(nodeId(i + 1), ruleId(j), d1.id, ReportType.EnforceSuccess),
+              simpleRuleNodeStatusReport(nodeId(i + 1), ruleId(j + 2), d3.id, ReportType.EnforceError),
+              simpleRuleNodeStatusReport(nodeId(i + 1), ruleId(j + 3), d4.id, ReportType.EnforceSuccess)
+            )
+          }.toSet
+        ),
+        // R4 applies on N3
+        nodeId(i + 2) -> simpleNodeStatusReport(
+          nodeId(i + 2),
+          ruleRange.flatMap { j =>
+            List(
+              simpleRuleNodeStatusReport(nodeId(i + 2), ruleId(j + 3), d4.id, ReportType.EnforceSuccess)
+            )
+          }.toSet
+        ),
+        // R4 applies D4 on N4
+        // R6 applies D6 on N4
+        nodeId(i + 3) -> simpleNodeStatusReport(
+          nodeId(i + 3),
+          ruleRange.flatMap { j =>
+            List(
+              simpleRuleNodeStatusReport(nodeId(i + 3), ruleId(j + 3), d4.id, ReportType.EnforceSuccess),
+              simpleRuleNodeStatusReport(nodeId(i + 3), ruleId(j + 5), d6.id, ReportType.EnforceSuccess)
+            )
+          }.toSet,
+          ruleRange.flatMap { j =>
+            List(
+              OverriddenPolicy(
+                PolicyId(ruleId(j + 5), d4.id, TechniqueVersionHelper("1.0")),
+                PolicyId(ruleId(j + 4), d4.id, TechniqueVersionHelper("1.0"))
+              ),
+              OverriddenPolicy(
+                PolicyId(ruleId(j + 5), d4.id, TechniqueVersionHelper("1.0")),
+                PolicyId(ruleId(j + 4), d4.id, TechniqueVersionHelper("1.0"))
+              )
+            )
+          }.toList
+        ),
+        // R4 applies D4 on N5
+        // R6 applies D6 on N5
+        nodeId(i + 4) -> simpleNodeStatusReport(
+          nodeId(i + 4),
+          ruleRange.flatMap { j =>
+            List(
+              simpleRuleNodeStatusReport(nodeId(i + 4), ruleId(j + 3), d4.id, ReportType.EnforceSuccess),
+              simpleRuleNodeStatusReport(nodeId(i + 4), ruleId(j + 5), d6.id, ReportType.EnforceSuccess)
+            )
+          }.toSet,
+          ruleRange.flatMap { j =>
+            List(
+              OverriddenPolicy(
+                PolicyId(ruleId(j + 5), d4.id, TechniqueVersionHelper("1.0")),
+                PolicyId(ruleId(j + 4), d4.id, TechniqueVersionHelper("1.0"))
+              ),
+              OverriddenPolicy(
+                PolicyId(ruleId(j + 5), d4.id, TechniqueVersionHelper("1.0")),
+                PolicyId(ruleId(j + 4), d4.id, TechniqueVersionHelper("1.0"))
+              )
+            )
+          }.toList
+        ),
+        // R5 targets nothing at all because no node is targeted
+        // R6 is skipped, there are some reports with 'overrides'
+        nodeId(i + 5) -> simpleNodeStatusReport(
+          nodeId(i + 5),
+          ruleRange.flatMap { j =>
+            List(
+              simpleRuleNodeStatusReport(nodeId(i + 5), ruleId(j + 3), d4.id, ReportType.NoAnswer),
+              simpleRuleNodeStatusReport(nodeId(i + 5), ruleId(j + 4), d4.id, ReportType.NoAnswer)
+            )
+          }.toSet,
+          ruleRange.flatMap { j =>
+            List(
+              OverriddenPolicy(
+                PolicyId(ruleId(j + 5), d4.id, TechniqueVersionHelper("1.0")),
+                PolicyId(ruleId(j + 4), d4.id, TechniqueVersionHelper("1.0"))
+              ),
+              OverriddenPolicy(
+                PolicyId(ruleId(j + 5), d4.id, TechniqueVersionHelper("1.0")),
+                PolicyId(ruleId(j + 4), d4.id, TechniqueVersionHelper("1.0"))
+              )
+            )
+          }.toList
+        )
+      )
+    }.toMap
+  }
+
+  private def buildComplianceService(
+      customRules:      List[Rule],
+      customNodeGroups: List[NodeGroup],
+      statusesReports:  Map[NodeId, NodeStatusReport]
+  ): ComplianceAPIService = {
+    new ComplianceAPIService(
+      rulesRepo(customRules),
+      nodeFactRepo,
+      nodeGroupsRepo(customNodeGroups),
+      reportingService(statusesReports),
+      mockDirectives.directiveRepo,
+      GlobalComplianceMode(FullCompliance, 0).succeed,
+      GlobalPolicyMode(PolicyMode.Enforce, PolicyModeOverrides.Always).succeed
+    )
+  }
+
+  private def simpleRuleNodeStatusReport(
+      nodeId:      NodeId,
+      ruleId:      RuleId,
+      directiveId: DirectiveId,
+      reportType:  ReportType
+  ): RuleNodeStatusReport = {
+    RuleNodeStatusReport(
+      nodeId,
+      ruleId,
+      PolicyTypeName.rudderBase,
+      None,
+      None,
+      Map(
+        directiveId -> DirectiveStatusReport(
+          directiveId,
+          PolicyTypes.rudderBase,
+          None,
+          List(
+            ValueStatusReport(
+              s"${directiveId.serialize}-component-${ruleId.serialize}-${nodeId.value}",
+              s"${directiveId.serialize}-component-${ruleId.serialize}-${nodeId.value}",
+              List(
+                ComponentValueStatusReport(
+                  s"${directiveId.serialize}-component-value-${ruleId.serialize}-${nodeId.value}",
+                  s"${directiveId.serialize}-component-value-${ruleId.serialize}-${nodeId.value}",
+                  s"report-${ruleId.serialize}-${nodeId.value}",
+                  List(MessageStatusReport(reportType, None))
+                )
+              )
+            )
+          )
+        )
+      ),
+      DateTime.parse("2100-01-01T00:00:00.000Z")
+    )
+  }
+
+  private def simpleNodeStatusReport(
+      nodeId:          NodeId,
+      ruleNodeReports: Set[RuleNodeStatusReport],
+      overrides:       List[OverriddenPolicy] = List.empty
+  ): NodeStatusReport = {
+    NodeStatusReportInternal
+      .buildWith(
+        nodeId,
+        ComputeCompliance(
+          DateTime.parse("2023-01-01T00:00:00.000Z"),
+          NodeExpectedReports(
+            nodeId,
+            NodeConfigId(s"${nodeId.value}-config"),
+            DateTime.parse("2023-01-01T00:00:00.000Z"),
+            None,
+            NodeModeConfig(
+              GlobalComplianceMode(FullCompliance, 0),
+              None,
+              AgentRunInterval(None, 1, 0, 0, 0),
+              None,
+              GlobalPolicyMode(PolicyMode.Enforce, PolicyModeOverrides.Unoverridable),
+              None
+            ),
+            List.empty,
+            List.empty
+          ),
+          DateTime.parse("2024-01-01T00:00:00.000Z")
+        ),
+        RunComplianceInfo.OK,
+        overrides,
+        ruleNodeReports
+      )
+      .toNodeStatusReport()
+  }
+}

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestDirectiveComplianceCsv.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestDirectiveComplianceCsv.scala
@@ -107,6 +107,7 @@ class TestDirectiveComplianceCsv extends Specification {
           RuleId(RuleUid("r1")),
           "Basic hardening on all systems",
           notUsed,
+          None,
           enforce,
           Seq(
             ByRuleBlockCompliance(

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/DataTypes.elm
@@ -26,6 +26,7 @@ type alias RuleCompliance value =
   { ruleId            : RuleId
   , name              : String
   , compliance        : Float
+  , policyMode        : String
   , complianceDetails : ComplianceDetails
   , components        : List (ComponentCompliance value)
   }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/JsonDecoder.elm
@@ -65,6 +65,7 @@ decodeRuleCompliance elem decoder =
     |> required "id"         (map RuleId string)
     |> required "name"       string
     |> required "compliance" float
+    |> required "policyMode"       string
     |> required "complianceDetails" decodeComplianceDetails
     |> required "components" (list (decodeComponentCompliance elem decoder ))
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/DirectiveCompliance/ViewUtils.elm
@@ -48,6 +48,11 @@ badgePolicyMode globalPolicyMode policyMode =
           This rule is applied on at least one node or directive that will <b style='color:#9bc832;'>enforce</b>
           one configuration, and at least one that will <b style='color:#3694d1;'>audit</b> them.
           """
+        "skipped"   ->
+          """
+          <div style='margin-bottom:5px;'>This rule is in <b style='color:#eda800;'>skipped</b> mode.</div>
+          This rule has all its directives skipped.
+          """
         _ -> "Unknown policy mode"
 
   in
@@ -170,7 +175,7 @@ byRuleCompliance model subFun complianceFilters =
       |> List.sortWith sortFunction
     )
     (\m i ->  i )
-    [ ("Rule", \i  -> span [] [ (badgePolicyMode model.policyMode (Maybe.map .policyMode model.directiveCompliance|> Maybe.withDefault "default")), text i.name , goToBtn (getRuleLink contextPath i.ruleId) ],  (\r1 r2 -> N.compare r1.name r2.name ))
+    [ ("Rule", \i  -> span [] [ (badgePolicyMode model.policyMode i.policyMode), text i.name , goToBtn (getRuleLink contextPath i.ruleId) ],  (\r1 r2 -> N.compare r1.name r2.name ))
     , ("Compliance", \i -> buildComplianceBar complianceFilters  i.complianceDetails,  (\(r1) (r2) -> Basics.compare r1.compliance r2.compliance ))
     ]
     (.ruleId >> .value)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/ShowNodeDetailsFromNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/ShowNodeDetailsFromNode.scala
@@ -291,7 +291,6 @@ class ShowNodeDetailsFromNode(
       "reportsDetails",
       "reportsGrid",
       RudderConfig.reportingService.findUserNodeStatusReport(_).toBox,
-      addOverriden = true,
       onlySystem = false
     ) &
     "#systemStatus *" #> reportDisplayer.asyncDisplay(
@@ -300,7 +299,6 @@ class ShowNodeDetailsFromNode(
       "systemStatus",
       "systemStatusGrid",
       RudderConfig.reportingService.findSystemNodeStatusReport(_).toBox,
-      addOverriden = false,
       onlySystem = true
     ) &
     "#nodeProperties *" #> DisplayNode.displayTabProperties(id, nodeFact, sm) &

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.scss
@@ -779,13 +779,15 @@ pre.json-beautify code.elmsh {
 .content-wrapper .rudder-label.label-error + .tooltip b, .content-wrapper .label-text.label-error:after, .content-wrapper .label-text.label-error  + .tooltip b, .text-Error{
   color: #DA291C;
 }
-.content-wrapper .rudder-label.label-overriden:before,.content-wrapper .label-text.label-overriden:after{
+.content-wrapper .rudder-label.label-overriden:before,.content-wrapper .label-text.label-overriden:after,
+.content-wrapper .rudder-label.label-skipped:before,.content-wrapper .label-text.label-skipped:after{
   content: "Skipped";
 }
-.content-wrapper .rudder-label.label-overriden{
+.content-wrapper .rudder-label.label-overriden,.content-wrapper .rudder-label.label-skipped{
   background-color: #eda800;
 }
-.content-wrapper .rudder-label.label-overriden + .tooltip b, .content-wrapper .label-text.label-overriden:after, .content-wrapper .label-text.label-overriden  + .tooltip b, .text-overriden {
+.content-wrapper .rudder-label.label-overriden + .tooltip b, .content-wrapper .label-text.label-overriden:after, .content-wrapper .label-text.label-overriden  + .tooltip b, .text-overriden ,
+.content-wrapper .rudder-label.label-skipped + .tooltip b, .content-wrapper .label-text.label-skipped:after, .content-wrapper .label-text.label-skipped  + .tooltip b, .text-skipped {
   color: #eda800;
 }
 .content-wrapper .rudder-label.label-included:before,.content-wrapper .label-text.label-included:after{


### PR DESCRIPTION
https://issues.rudder.io/issues/26712

So, this is a big, overdue clean-up of the skipped mess that organically growed during the years. 

It shoudl correct all `skipped` problem we got, including https://issues.rudder.io/issues/26712 and https://issues.rudder.io/issues/24843. 

It also lead to a MASSIVE performance improvent, that looks quadratic for number of node or number or rules, and lead to at least an order of magnitude quicker computation of compliance for rules. 


> Note: this PR is rather low risk since it only change the computation of skipped directives in API/UI. I thing that at worst, we get new problems with skipped directive. 

## Architecture: keep skipped directive in NodeStatusReport with an "overridden" info

The only idea is that we should really just keep the skipped directives in `NodeStatusReport` with a tag "I'm overridden by that rule`. It's really cheap to have the directive added at that point, and it's very cheap to derive what is skipped where if we have that information AT THE DIRECTIVE LEVEL. 

Onve we have that, since we do have real directive object (just with a marker), we: 
- don't have to try to add them latter on ,
- don't need to build complicated logic to retrieve what is overridden where. 

To do so, I chose to add a new attribute `overridden: Option[RuleId]` in `DirectiveStatusReport`. This has the benefits of being fully compatible with all the existing JSON for `NodeStatusReport` serialization and is simple. 

> Note: the saved `NodeStatusReport` in base will be false wrt to skipped directive. That will be corrected at the first generation, which will happen on restart. The only case I can think where it could lead a missing "skipped" info is for nodes in "keep compliance because the node is not responding". It looks OK. 

Its problem is that it's not very obvious that a directive is overridden with just that, and I explored two other options: 

- have two types, `DirectiveNodeStatus` and `OverriddenDirectiveNodeStatus` which is obvious and make possible JSON customization for the overridden part. But it would have lead to (even more) changes, and I feared breaking things a lot. 

- add a `PolicyMode`: `skipped`, since we latter have a `ComputedPolicyMode`. But it doesn't make sense in second though, since the policy mode is not computed in `NodeStatusReport`. It *could* make sense to do so, since we have all the information, and actually, it looks like something we want to do. But I believe it belongs to another refactoring where we move all the horrible logic in `ComplianceAPIService` into real business objects with the knowledge to map and remap compliance from a point of view of node, rule, directive, or group. This was a HUGE step I didn't want to take here. 

## Performance analysis

To understand what was happening, I used `async-profiler` in a dedicated autonomous test that can be run by hand in `RunComplianceComputation`. 

This is a really nice tool that helped me spot the big performance problem thanks to flamegraph. 

On a 5000 nodes / 300 rules tests, I got from 22 seconds to 2 seconds. On a 10k nodes / 500 rules, from several minutes to < 10 s. 

One big part of the graph just disappeared: 
![image](https://github.com/user-attachments/assets/65b4d0f6-4463-4b19-ad77-1e95ff12cccb)


## Consequences: 

- everything is simpler and just so much more logical
- `overrides: List[OverriddenPolicy]` disappear from `NodeStatusReport` and `RuleStatusReport`. 
- performance are EXTREMELLY improved. By order of magnitude. 

## Next/TODO in a futur PR

There is so much complicated logic in `complianceAPIService` and so little tests that there MUST be bugs there. 
The next big step is to clean that up: 
- isolated the logic for the different merge parts, which is the definition of business rules that need to be tested
- make the transformation pure
- call that new service from the existing one. 