### PR TITLE
Fixes #26061: Number of techniques shows 0 when I have several techniques. They have been imported.

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -150,6 +150,7 @@ class HomePage extends StatefulSnippet {
   private val reportingService = RudderConfig.reportingService
   private val roRuleRepo       = RudderConfig.roRuleRepository
   private val scoreService     = RudderConfig.rci.scoreService
+  private val directiveRepo    = RudderConfig.roDirectiveRepository
 
   override val dispatch: DispatchIt = {
     case "pendingNodes"       => pendingNodes
@@ -436,9 +437,14 @@ class HomePage extends StatefulSnippet {
   }.toBox
 
   private def countAllTechniques(): Box[Int] = {
-    ldap.flatMap { con =>
-      con.searchSub(rudderDit.ACTIVE_TECHNIQUES_LIB.dn, AND(IS(OC_ACTIVE_TECHNIQUE), EQ(A_IS_SYSTEM, FALSE.toLDAPString)), "1.1")
-    }.map(x => x.size)
+    // for techniques, we can't easily rely on LDAP attribute, because we can have a mix of isSystem/policyType.
+    // So just use the repo.
+    directiveRepo
+      .getFullDirectiveLibrary()
+      .map(_.allActiveTechniques.collect {
+        // here, we only want to count one technique whatever the number of versions, but only the ones enabled and of type "base"
+        case (_, at) if at.policyTypes.isBase && at.isEnabled => Math.min(1, at.techniques.count(_._2.policyTypes.isBase))
+      }.sum)
   }.toBox
 
   private def countAllGroups(): Box[Int] = {


### PR DESCRIPTION
https://issues.rudder.io/issues/26061

So, for `directives` and `techniques`, we want to display only non-system items. So we used to use the LDAP filter `'(&(objectClass=activeTechnique)(isSystem=FALSE))'` which says : "look for entries with the attribute `objectClass` set to `activeTechnique` and the attribute `isSystem` set to `FALSE`. Which *needs* both attribute to be defined at the given value. 

But `isSystem` is optional and along the way, we lost the habits to set it to `false` when it's the case, because it's the default semantic. So we have `activeTechnique`s without the attribute actually set to `FALSE`. 

All that is due to the fact that we added `policyType` at LDAP level, but we are doing Smart Things at the repository level to make update transparent - at least for things that don't query LDAP directly. 
 
So the solution is to just use the scala layer of things for the count. 