### PR TITLE
Fixes #26801: Add a "all" keyword for archives export

### DIFF
--- a/webapp/sources/api-doc/code_samples/curl/archives/import.sh
+++ b/webapp/sources/api-doc/code_samples/curl/archives/import.sh
@@ -1,1 +1,1 @@
-curl --header "X-API-Token: yourToken" -X POST https://rudder.example.com/rudder/api/latest/archives/import --form "archive=@my-archive-file.zip" --form "merge=keep-rule-groups"
+curl --header "X-API-Token: yourToken" -X POST https://rudder.example.com/rudder/api/latest/archives/import --form "archive=@my-archive-file.zip" --form "merge=keep-rule-targets"

--- a/webapp/sources/api-doc/paths/archives/export.yml
+++ b/webapp/sources/api-doc/paths/archives/export.yml
@@ -11,7 +11,9 @@ get:
         type: array
         items:
           type: string
-      description: IDs (optionally with revision, '+' need to be escaped as '%2B') of rules to include
+      description: >-
+        IDs (optionally with revision, '+' need to be escaped as '%2B') of rules to include. 
+        The special key-word 'all' can be use to mean "all non-system rules"
       style: form
       explode: false
       examples:
@@ -27,7 +29,9 @@ get:
         type: array
         items:
           type: string
-      description: IDs (optionally with revision, '+' need to be escaped as '%2B') of directives to include
+      description: >- 
+        IDs (optionally with revision, '+' need to be escaped as '%2B') of directives to include
+        The special key-word 'all' can be use to mean "all non-system directives"
       style: form
       explode: false
       examples:
@@ -43,13 +47,15 @@ get:
         type: array
         items:
           type: string
-      description: IDs, ie technique name/technique version (optionally with revision, '+' need to be escaped as '%2B') of techniques to include
+      description: >-
+        IDs, ie technique name/technique version (optionally with revision, '+' need to be escaped as '%2B') of techniques to include
+        The special key-word 'all' can be use to mean "all non-system techniques"
       style: form
       explode: false
       examples:
         oneId:
           summary: Example of a single ID
-          value: [fileContent/3.0] 
+          value: [fileContent/3.0]
         multipleIds:
           summary: Example of multiple IDs, some with revisions
           value: [userManagement/6.3, fileContent/3.0%2B35177d0823791a374de9e16a6ab27e6466fbc8c2]
@@ -59,7 +65,9 @@ get:
         type: array
         items:
           type: string
-      description: IDs (optionally with revision, '+' need to be escaped as '%2B') of groups to include
+      description: >- 
+        IDs (optionally with revision, '+' need to be escaped as '%2B') of groups to include
+        The special key-word 'all' can be use to mean "all non-system groups"
       style: form
       explode: false
       examples:
@@ -73,11 +81,11 @@ get:
       name: include
       schema:
         type: array
-        items: 
+        items:
           type: string
-          enum: 
+          enum:
             - all (default)
-            - none 
+            - none
             - directives
             - techniques
             - groups
@@ -90,7 +98,7 @@ get:
       examples:
         none:
           summary: Do not include dependencies
-          value: [none] 
+          value: [none]
         directivesAndGroups:
           summary: Include directives and groups, but no techniques
           value: [directives, groups]

--- a/webapp/sources/api-doc/paths/archives/import.yml
+++ b/webapp/sources/api-doc/paths/archives/import.yml
@@ -16,10 +16,14 @@ post:
               description: The ZIP archive file containing policies in a conventional layout and serialization format
             merge:
               type: string
-              description: Optional merge algo of the import. Default `override-all` means what is in the archive is the new reality. `keep-rule-groups` will keep existing target definition for existing rules (ignore archive value).
+              description: >-
+                Optional merge algo of the import. Default `override-all` means what is in the archive is the new reality. 
+                `keep-rule-targets` will keep existing target definition for existing rules (ignore archive value).
+                `ignore-source-targets` is like `keep-rule-targets` but in addition sets an empty target for new rules.
               enum:
                 - override-all
-                - keep-rule-groups
+                - keep-rule-targets
+                - ignore-source-targets
   responses:
     "200":
       description: Archive imported

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -60,6 +60,7 @@ import com.normation.rudder.apidata.JsonResponseObjects.JRRule
 import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
+import com.normation.rudder.configuration.ActiveDirective
 import com.normation.rudder.configuration.ConfigurationRepository
 import com.normation.rudder.domain.appconfig.FeatureSwitch
 import com.normation.rudder.domain.logger.ApplicationLogger
@@ -68,14 +69,18 @@ import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupCategory
 import com.normation.rudder.domain.nodes.NodeGroupCategoryId
 import com.normation.rudder.domain.nodes.NodeGroupId
+import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.Directive
 import com.normation.rudder.domain.policies.DirectiveId
+import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.FullGroupTarget
 import com.normation.rudder.domain.policies.FullRuleTargetInfo
 import com.normation.rudder.domain.policies.GroupTarget
+import com.normation.rudder.domain.policies.PolicyTypes
 import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleTarget
+import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.git.ZipUtils
@@ -201,6 +206,14 @@ object MergePolicy                                                extends Enum[M
   }
 }
 
+// an object for the special ids for exporting all rules etc
+object SpecialExportAll {
+  val allRules:      RuleId      = RuleId(RuleUid("all"))
+  val allDirectives: DirectiveId = DirectiveId(DirectiveUid("all"))
+  val allGroups:     NodeGroupId = NodeGroupId(NodeGroupUid("all"))
+  val allTechniques: TechniqueId = TechniqueId(TechniqueName("all"), TechniqueVersion.V1_0)
+}
+
 class ArchiveApi(
     archiveBuilderService: ZipArchiveBuilderService,
     getArchiveName:        IOResult[String],
@@ -221,13 +234,13 @@ class ArchiveApi(
   }
 
   /*
-   * This API does not returns a standard JSON response, it returns a ZIP archive.
+   * This API does not return a standard JSON response, it returns a ZIP archive.
    */
   object ExportSimple extends LiftApiModule0 {
     val schema:                                                                                                API.ExportSimple.type = API.ExportSimple
     /*
      * Request format:
-     *   ../archives/export/rules=rule_ids&directives=dir_ids&techniques=tech_ids&groups=group_ids&include=scope
+     *   ../archives/export?rules=rule_ids&directives=dir_ids&techniques=tech_ids&groups=group_ids&include=scope
      * Where:
      * - rule_ids = xxxx-xxxx-xxx-xxx[,other ids]
      * - dir_ids = xxxx-xxxx-xxx-xxx[,other ids]
@@ -247,7 +260,10 @@ class ArchiveApi(
         ZIO.foreach(splitArg(req, "directives"))(DirectiveId.parse(_).toIO)
       }
       def parseTechniqueIds(req: Req):      IOResult[List[TechniqueId]]  = {
-        ZIO.foreach(splitArg(req, "techniques"))(TechniqueId.parse(_).toIO)
+        ZIO.foreach(splitArg(req, "techniques"))(t => {
+          if (t == "all") SpecialExportAll.allTechniques.succeed
+          else TechniqueId.parse(t).toIO
+        })
       }
       def parseGroupIds(req: Req):          IOResult[List[NodeGroupId]]  = {
         ZIO.foreach(splitArg(req, "groups"))(NodeGroupId.parse(_).toIO)
@@ -310,7 +326,7 @@ class ArchiveApi(
     /*
      * We expect a binary file in multipart/form-data, not in application/x-www-form-urlencodedcontent
      * You can get that in curl with:
-     * curl -k -X POST -H "X-API-TOKEN: ..." https://.../api/latest/archives/import --form "merge=keep-rule-groups" --form="archive=@my-archive.zip"
+     * curl -k -X POST -H "X-API-TOKEN: ..." https://.../api/latest/archives/import --form "merge=keep-rule-targets" --form="archive=@my-archive.zip"
      */
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
 
@@ -400,13 +416,14 @@ object JGroupCategory {
 
 object ZipArchiveBuilderService {
   // names of directories under the root directory of the archive
-  val RULES_DIR      = "rules"
-  val GROUPS_DIR     = "groups"
-  val DIRECTIVES_DIR = "directives"
-  val TECHNIQUES_DIR = "techniques"
+  val RULES_DIR:      String = "rules"
+  val GROUPS_DIR:     String = "groups"
+  val DIRECTIVES_DIR: String = "directives"
+  val TECHNIQUES_DIR: String = "techniques"
 
   val GROUP_CAT_FILENAME = "category.json"
   val RULE_CATS          = "rule-categories.json"
+
 }
 
 /**
@@ -424,7 +441,10 @@ class ZipArchiveBuilderService(
     fileArchiveNameService: FileArchiveNameService,
     configRepo:             ConfigurationRepository,
     techniqueRevisionRepo:  TechniqueRevisionRepository,
-    groupRepo:              RoNodeGroupRepository
+    groupRepo:              RoNodeGroupRepository,
+    ruleRepo:               RoRuleRepository,
+    directiveRepo:          RoDirectiveRepository,
+    techniqueRepo:          TechniqueRepository
 ) {
 
   import ZipArchiveBuilderService.*
@@ -695,7 +715,9 @@ class ZipArchiveBuilderService(
     // we need the file name without extension
     val GROUP_CAT_WITHOUT_EXT = GROUP_CAT_FILENAME.split("\\.")(0)
 
-    recFilter(ids, groupLib) match {
+    val allIds: Seq[NodeGroupId] = if (ids.contains(SpecialExportAll.allGroups)) groupLib.allGroups.keySet.toSeq else ids
+
+    recFilter(allIds, groupLib) match {
       case None      => if (ids.isEmpty) Nil.succeed else missingGroups(ids)
       case Some(cat) =>
         val missing = cat.allGroups.keySet -- ids
@@ -710,7 +732,7 @@ class ZipArchiveBuilderService(
    * Prepare the archive.
    * `rootDirName` is supposed to be normalized, no change will be done with it.
    * Any missing object will lead to an error.
-   * For each element, an human readable name derived from the object name is used when possible.
+   * For each element, a human-readable name derived from the object name is used when possible.
    *
    * System elements are not archived
    */
@@ -722,6 +744,7 @@ class ZipArchiveBuilderService(
       ruleIds:      Seq[RuleId],
       scopes:       Set[ArchiveScope]
   ): IOResult[Chunk[Zippable]] = {
+
     // normalize to no slash at end
     val root                 = rootDirName.strip().replaceAll("""/$""", "")
     import ArchiveScope.*
@@ -744,28 +767,31 @@ class ZipArchiveBuilderService(
       _               <- usedNames.update(_ + ((RULES_DIR, Set.empty[String])))
       rulesDirZip      = Zippable(rulesDir, None)
       ruleCatsRef     <- Ref.make(Set[RuleCategoryId]())
-      rulesZip        <- ZIO
-                           .foreach(ruleIds) { ruleId =>
+      rules           <- if (ruleIds.contains(SpecialExportAll.allRules)) ruleRepo.getAll(includeSytem = false)
+                         else {
+                           ZIO.foreach(ruleIds) { ruleId =>
                              configRepo
                                .getRule(ruleId)
                                .notOptional(s"Rule with id ${ruleId.serialize} was not found in Rudder")
-                               .flatMap { rule =>
-                                 if (rule.isSystem) None.succeed
-                                 else {
-                                   for {
-                                     _    <- depDirectiveIds.update(x => x ++ rule.directiveIds)
-                                     _    <- depGroupIds.update(x => x ++ RuleTarget.getNodeGroupIds(rule.targets))
-                                     json  = JRRule.fromRule(rule, None, None, None).toJsonPretty
-                                     name <- findName(rule.name, ".json", usedNames, RULES_DIR)
-                                     path  = rulesDir + "/" + name
-                                     _    <- ApplicationLoggerPure.Archive
-                                               .debug(s"Building archive '${rootDirName}': adding rule zippable: ${path}")
-                                     _    <- ruleCatsRef.update(_ + rule.categoryId)
-                                   } yield {
-                                     Some(Zippable(path, Some(getJsonZippableContent(json))))
-                                   }
-                                 }
+                           }
+                         }
+      rulesZip        <- ZIO
+                           .foreach(rules) { rule =>
+                             if (rule.isSystem) None.succeed
+                             else {
+                               for {
+                                 _    <- depDirectiveIds.update(x => x ++ rule.directiveIds)
+                                 _    <- depGroupIds.update(x => x ++ RuleTarget.getNodeGroupIds(rule.targets))
+                                 json  = JRRule.fromRule(rule, None, None, None).toJsonPretty
+                                 name <- findName(rule.name, ".json", usedNames, RULES_DIR)
+                                 path  = rulesDir + "/" + name
+                                 _    <- ApplicationLoggerPure.Archive
+                                           .debug(s"Building archive '${rootDirName}': adding rule zippable: ${path}")
+                                 _    <- ruleCatsRef.update(_ + rule.categoryId)
+                               } yield {
+                                 Some(Zippable(path, Some(getJsonZippableContent(json))))
                                }
+                             }
                            }
                            .map(_.flatten)
       ruleCats        <- ruleCatsRef.get
@@ -773,10 +799,12 @@ class ZipArchiveBuilderService(
       groupsDir        = root + "/" + GROUPS_DIR
       _               <- usedNames.update(_ + ((GROUPS_DIR, Set.empty[String])))
       groupsDirZip     = Zippable(groupsDir, None)
-      depGroups       <- if (includeDepGroups) depGroupIds.get else Nil.succeed
+      allGroupIDs     <- if (groupIds.contains(SpecialExportAll.allGroups))
+                           groupRepo.getAll().map(_.collect { case g if !g.isSystem => g.id })
+                         else (if (includeDepGroups) depGroupIds.get else Nil.succeed).map(_ ++ groupIds)
       groupLib        <- groupRepo.getFullGroupLibrary()
       groupDir         = root + "/" + GROUPS_DIR
-      groupsZip       <- getGroupLibZippable(groupIds ++ depGroups, groupDir, usedNames, rootDirName, groupLib)
+      groupsZip       <- getGroupLibZippable(allGroupIDs, groupDir, usedNames, rootDirName, groupLib)
       // directives need access to technique, but we don't want to look up several time the same one
       techniques      <- Ref.Synchronized.make(Map.empty[TechniqueId, (Chunk[TechniqueCategoryName], Technique)])
 
@@ -784,36 +812,47 @@ class ZipArchiveBuilderService(
       _               <- usedNames.update(_ + ((DIRECTIVES_DIR, Set.empty[String])))
       directivesDirZip = Zippable(directivesDir, None)
       depDirectives   <- if (includeDepDirectives) depDirectiveIds.get else Nil.succeed
+      directives      <- if (directiveIds.contains(SpecialExportAll.allDirectives)) {
+                           directiveRepo
+                             .getFullDirectiveLibrary()
+                             .map(_.allDirectives.collect {
+                               case (_, (fat, d)) if !d.isSystem => ActiveDirective(fat.toActiveTechnique(), d)
+                             })
+                         } else {
+                           ZIO
+                             .foreach(directiveIds ++ depDirectives) { directiveId =>
+                               configRepo
+                                 .getDirective(directiveId)
+                                 .notOptional(s"Directive with id ${directiveId.serialize} was not found in Rudder")
+                             }
+                         }
       directivesZip   <- ZIO
-                           .foreach(directiveIds ++ depDirectives) { directiveId =>
-                             configRepo
-                               .getDirective(directiveId)
-                               .notOptional(s"Directive with id ${directiveId.serialize} was not found in Rudder")
-                               .flatMap(ad => {
-                                 if (ad.directive.isSystem) None.succeed
-                                 else {
-                                   for {
-                                     tech <- getTechnique(
-                                               TechniqueId(ad.activeTechnique.techniqueName, ad.directive.techniqueVersion),
-                                               techniques
-                                             )
-                                     json  = JRDirective.fromDirective(tech._2, ad.directive, None).toJsonPretty
-                                     name <- findName(ad.directive.name, ".json", usedNames, DIRECTIVES_DIR)
-                                     path  = directivesDir + "/" + name
-                                     _    <- ApplicationLoggerPure.Archive
-                                               .debug(s"Building archive '${rootDirName}': adding directive zippable: ${path}")
-                                   } yield Some(Zippable(path, Some(getJsonZippableContent(json))))
-                                 }
-                               })
+                           .foreach(directives) { ad =>
+                             if (ad.directive.isSystem) None.succeed
+                             else {
+                               for {
+                                 tech <- getTechnique(
+                                           TechniqueId(ad.activeTechnique.techniqueName, ad.directive.techniqueVersion),
+                                           techniques
+                                         )
+                                 json  = JRDirective.fromDirective(tech._2, ad.directive, None).toJsonPretty
+                                 name <- findName(ad.directive.name, ".json", usedNames, DIRECTIVES_DIR)
+                                 path  = directivesDir + "/" + name
+                                 _    <- ApplicationLoggerPure.Archive
+                                           .debug(s"Building archive '${rootDirName}': adding directive zippable: ${path}")
+                               } yield Some(Zippable(path, Some(getJsonZippableContent(json))))
+                             }
                            }
                            .map(_.flatten)
       // Techniques don't need name normalization, their name is already normalized
       techniquesDir    = root + "/" + TECHNIQUES_DIR
       techniquesDirZip = Zippable(techniquesDir, None)
-      depTechniques   <- if (includeDepTechniques) techniques.get.map(_.keys) else Nil.succeed
-      allTech         <- ZIO.foreach(techniqueIds ++ depTechniques)(techniqueId => getTechnique(techniqueId, techniques))
+      allTechIds      <- if (techniqueIds.contains(SpecialExportAll.allTechniques))
+                           techniqueRepo.getAll().collect { case (id, t) if (t.policyTypes == PolicyTypes.rudderBase) => id }.succeed
+                         else (if (includeDepTechniques) techniques.get.map(_.keys) else Nil.succeed).map(_ ++ techniqueIds)
+      allTech         <- ZIO.foreach(allTechIds)(techniqueId => getTechnique(techniqueId, techniques))
       // start by zipping categories after having dedup them
-      techCats         = allTech.collect { case (c, t) => (c, t.id.version) }
+      techCats         = allTech.collect { case (c, t) => (c, t.id.version) }.toSeq
       techCatsZip     <- getTechniqueCategoryZippable(techniquesDir, techCats)
       techniquesZip   <- ZIO.foreach(allTech.filter(_._2.policyTypes.isBase)) {
                            case (cats, technique) =>
@@ -832,7 +871,7 @@ class ZipArchiveBuilderService(
         groupsDirZip,
         directivesDirZip,
         techniquesDirZip
-      ) ++ rulesZip ++ techCatsZip ++ techniquesZip.flatten ++ directivesZip ++ groupsZip
+      ) ++ ruleCatsZip ++ rulesZip ++ techCatsZip ++ techniquesZip.flatten ++ directivesZip ++ groupsZip
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -175,23 +175,29 @@ object ArchiveScope       extends Enum[ArchiveScope] {
   }
 }
 
-sealed trait MergePolicy extends EnumEntry         { def value: String }
-object MergePolicy       extends Enum[MergePolicy] {
+// explicitly using the entryName because it's an external API needing special care and grep-ability.
+sealed abstract class MergePolicy(override val entryName: String) extends EnumEntry
+object MergePolicy                                                extends Enum[MergePolicy] {
   // Default merge policy is "override everything", ie what is in the archive replace whatever exists in Rudder
-  case object OverrideAll    extends MergePolicy { val value = "override-all"     }
+  case object OverrideAll     extends MergePolicy("override-all")
   // A merge policy that will keep current groups for rule with an ID common with one of the archive
-  case object KeepRuleGroups extends MergePolicy { val value = "keep-rule-groups" }
+  case object KeepRuleTargets extends MergePolicy("keep-rule-targets")
+
+  // A merge policy that will always delete source groups of rule, and if rule exists, copy destination rule target (keep them)
+  case object IgnoreSourceTargets extends MergePolicy("ignore-source-targets")
 
   val values: IndexedSeq[MergePolicy] = findValues
 
+  override val extraNamesToValuesMap: Map[String, MergePolicy] = Map("keep-rule-groups" -> KeepRuleTargets)
+
   def parse(s: String): Either[String, MergePolicy] = {
-    values.find(_.value == s.toLowerCase.strip()) match {
-      case None    =>
-        Left(
-          s"Error: can not parse '${s}' as a merge policy for archive import. Accepted values are: ${values.mkString(", ")}"
-        )
-      case Some(x) => Right(x)
-    }
+    MergePolicy
+      .withNameInsensitiveEither(s)
+      .left
+      .map(err => {
+        s"Error: can not parse '${s}' as a merge policy for archive import. Accepted values are: ${values
+            .mkString(", ")}. Error was: ${err.getMessage()}"
+      })
   }
 }
 
@@ -1573,12 +1579,19 @@ class SaveArchiveServicebyRepo(
       x <- roRuleRepos.getOpt(r.id)
       _ <- x match {
              case Some(value) =>
-               // if merge policy is `keep-rule-groups`, update rule from archive with existing groups before saving
-               val ruleToSave = if (mergePolicy == MergePolicy.KeepRuleGroups) {
-                 r.copy(targets = value.targets)
-               } else r
+               // if merge policy asks for that, update rule from archive with existing groups before saving so
+               // that the rules use the actual groups meaning something in that instance.
+               val ruleToSave = {
+                 if (mergePolicy == MergePolicy.KeepRuleTargets || mergePolicy == MergePolicy.IgnoreSourceTargets) {
+                   r.copy(targets = value.targets)
+                 } else r
+               }
                woRuleRepos.update(ruleToSave, eventMetadata.modId, eventMetadata.actor, eventMetadata.msg)
-             case None        => woRuleRepos.create(r, eventMetadata.modId, eventMetadata.actor, eventMetadata.msg)
+             case None        =>
+               val ruleToSave = if (mergePolicy == MergePolicy.IgnoreSourceTargets) {
+                 r.copy(targets = Set())
+               } else r
+               woRuleRepos.create(ruleToSave, eventMetadata.modId, eventMetadata.actor, eventMetadata.msg)
            }
     } yield ()
   }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
@@ -343,7 +343,7 @@ class ArchiveApiTest extends Specification with AfterAll with Loggable {
       "archive",
       zipFile.name,
       zipFile.newInputStream.readAllBytes(),
-      Map(("merge", "keep-rule-groups"))
+      Map(("merge", "keep-rule-targets"))
     ) {
       case Full(LiftJsonResponse(res, _, 200)) =>
         restTestSetUp.archiveAPIModule.archiveSaver.base.get.runNow match {
@@ -482,6 +482,232 @@ class ArchiveApiTest extends Specification with AfterAll with Loggable {
           )
         )) and
         (children(testDir / s"${archiveName}/techniques").isEmpty must beTrue)
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+  "correctly build an archive with all rules (only)" in {
+
+    val archiveName = "archive-all-rules-no-dep"
+    restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+
+    restTest.testGETResponse(
+      "/api/latest/archives/export?rules=all&include=none"
+    ) {
+      case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+        val zipFile = testDir / s"${archiveName}.zip"
+        val zipOut  = new FileOutputStream(zipFile.toJava)
+        out(zipOut)
+        zipOut.close()
+        // unzip
+        ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+        children(testDir / s"${archiveName}/rules") must containTheSameElementsAs(
+          List(
+            "10__Global_configuration_for_all_nodes.json",
+            "50__Deploy_PLOP_STACK.json",
+            "50-rule-technique-ncf.json",
+            "60-rule-technique-std-lib.json",
+            "90-copy-git-file.json",
+            "99-rule-technique-std-lib.json"
+          )
+        )
+        children(testDir / s"${archiveName}/groups") must containTheSameElementsAs(Nil)
+        children(testDir / s"${archiveName}/directives") must containTheSameElementsAs(Nil)
+        children(testDir / s"${archiveName}/techniques") must containTheSameElementsAs(Nil)
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+  "correctly build an archive with all directives (only)" in {
+
+    val archiveName = "archive-all-directives-no-dep"
+    restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+
+    restTest.testGETResponse(
+      "/api/latest/archives/export?directives=all&include=none"
+    ) {
+      case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+        val zipFile = testDir / s"${archiveName}.zip"
+        val zipOut  = new FileOutputStream(zipFile.toJava)
+        out(zipOut)
+        zipOut.close()
+        // unzip
+        ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+        children(testDir / s"${archiveName}/rules") must containTheSameElementsAs(Nil)
+        children(testDir / s"${archiveName}/groups") must containTheSameElementsAs(Nil)
+        children(testDir / s"${archiveName}/directives") must containTheSameElementsAs(
+          List(
+            "00__Generic_Variable_Def__2.json",
+            "10__Clock_Configuration.json",
+            "99__Generic_Variable_Def__1.json",
+            "directive_16617aa8-1f02-4e4a-87b6-d0bcdfb4019f.json",
+            "directive_16d86a56-93ef-49aa-86b7-0d10102e4ea9.json",
+            "directive2.json",
+            "directive_99f4ef91-537b-4e03-97bc-e65b447514cc.json",
+            "directive-copyGitFile.json",
+            "directive_e9a1a909-2490-4fc9-95c3-9d0aa01717c9.json",
+            "test_import_export_archive_directive.json"
+          )
+        )
+        children(testDir / s"${archiveName}/techniques") must containTheSameElementsAs(Nil)
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+  "correctly build an archive with all techniques (only)" in {
+
+    val archiveName = "archive-all-techniques-no-dep"
+    restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+
+    restTest.testGETResponse(
+      "/api/latest/archives/export?techniques=all&include=none"
+    ) {
+      case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+        val zipFile = testDir / s"${archiveName}.zip"
+        val zipOut  = new FileOutputStream(zipFile.toJava)
+        out(zipOut)
+        zipOut.close()
+        // unzip
+        ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+        children(testDir / s"${archiveName}/rules") must containTheSameElementsAs(Nil)
+        children(testDir / s"${archiveName}/groups") must containTheSameElementsAs(Nil)
+        children(testDir / s"${archiveName}/directives") must containTheSameElementsAs(Nil)
+        children(testDir / s"${archiveName}/techniques") must containTheSameElementsAs(
+          List(
+            "applications",
+            "category.json",
+            "packageManagement",
+            "1.0",
+            "changelog",
+            "metadata.xml",
+            "packageManagement.st",
+            "rpmPackageInstallation",
+            "7.0",
+            "changelog",
+            "metadata.xml",
+            "rpmPackageInstallationData.st",
+            "rpmPackageInstallation.st",
+            "fileDistribution",
+            "category.json",
+            "copyGitFile",
+            "2.3",
+            "changelog",
+            "copyFileFromSharedFolder.ps1.st",
+            "copyFileFromSharedFolder.st",
+            "metadata.xml",
+            "fileTemplate",
+            "1.0",
+            "fileTemplate.ps1.st",
+            "fileTemplate.st",
+            "fileWithIdOnPath.txt",
+            "metadata.xml",
+            "tmlWithIdOnPath.st",
+            "ncf_techniques",
+            "a_simple_yaml_technique",
+            "1.0",
+            "resources",
+            "something.txt",
+            "technique.yml",
+            "category.json",
+            "Create_file",
+            "1.0",
+            "Create_file.ps1",
+            "expected_reports.csv",
+            "metadata.xml",
+            "rudder_reporting.st",
+            "technique_any",
+            "1.0",
+            "technique.yml",
+            "2.0",
+            "metadata.xml",
+            "technique.cf",
+            "technique.ps1",
+            "technique_by_Rudder",
+            "1.0",
+            "technique.yml",
+            "technique_with_blocks",
+            "1.0",
+            "metadata.xml",
+            "technique.cf",
+            "technique.json",
+            "technique.ps1",
+            "technique.rd",
+            "test_import_export_archive",
+            "1.0",
+            "metadata.xml",
+            "technique.cf",
+            "technique.json",
+            "technique.ps1",
+            "systemSettings",
+            "category.json",
+            "misc",
+            "category.json",
+            "clockConfiguration",
+            "3.0",
+            "changelog",
+            "clockConfiguration.st",
+            "metadata.xml",
+            "genericVariableDefinition",
+            "1.0",
+            "changelog",
+            "genericVariableDefinition.st",
+            "metadata.xml",
+            "2.0",
+            "changelog",
+            "genericVariableDefinition.st",
+            "metadata.xml",
+            "test_only",
+            "category.json",
+            "test_18205",
+            "1.0",
+            "metadata.xml",
+            "test_18205.st"
+          )
+        )
+
+      case err => ko(s"I got an error in test: ${err}")
+    }
+  }
+
+  "correctly build an archive with all groups (only)" in {
+
+    val archiveName = "archive-all-groups-no-dep"
+    restTestSetUp.archiveAPIModule.rootDirName.set(archiveName).runNow
+
+    restTest.testGETResponse(
+      "/api/latest/archives/export?groups=all&include=none"
+    ) {
+      case Full(OutputStreamResponse(out, _, _, _, 200)) =>
+        val zipFile = testDir / s"${archiveName}.zip"
+        val zipOut  = new FileOutputStream(zipFile.toJava)
+        out(zipOut)
+        zipOut.close()
+        // unzip
+        ZipUtils.unzip(new ZipFile(zipFile.toJava), zipFile.parent.toJava).runNow
+
+        children(testDir / s"${archiveName}/rules") must containTheSameElementsAs(Nil)
+        children(testDir / s"${archiveName}/groups") must containTheSameElementsAs(
+          List(
+            "category_1", // our children also list directories
+            "category.json",
+            "Real_nodes.json",
+            "Empty_group.json",
+            "Even_nodes.json",
+            "Nodes_id_divided_by_3.json",
+            "Nodes_id_divided_by_5.json",
+            "Odd_nodes.json",
+            "only_root.json",
+            "Serveurs_______casse_s.json"
+          )
+        )
+        children(testDir / s"${archiveName}/directives") must containTheSameElementsAs(Nil)
+        children(testDir / s"${archiveName}/techniques") must containTheSameElementsAs(Nil)
 
       case err => ko(s"I got an error in test: ${err}")
     }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
@@ -349,7 +349,7 @@ class ArchiveApiTest extends Specification with AfterAll with Loggable {
         restTestSetUp.archiveAPIModule.archiveSaver.base.get.runNow match {
           case None         => ko(s"No policies were saved")
           case Some((p, m)) =>
-            (m must beEqualTo(MergePolicy.KeepRuleGroups))
+            (m must beEqualTo(MergePolicy.KeepRuleTargets))
         }
 
       case err => ko(s"I got an error in test: ${err}")

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -892,7 +892,10 @@ class RestTestSetUp {
       new FileArchiveNameService(),
       mockConfigRepo.configurationRepository,
       mockTechniques.techniqueRevisionRepo,
-      mockNodeGroups.groupsRepo
+      mockNodeGroups.groupsRepo,
+      mockRules.ruleRepo,
+      mockDirectives.directiveRepo,
+      mockTechniques.techniqueRepo
     )
 
     // archive name in a Ref to make it simple to change in tests

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/lift/MergePolicySpec.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/lift/MergePolicySpec.scala
@@ -1,7 +1,6 @@
 package com.normation.rudder.rest.lift
 
-import com.normation.rudder.rest.lift.MergePolicy.KeepRuleGroups
-import com.normation.rudder.rest.lift.MergePolicy.OverrideAll
+import com.normation.rudder.rest.lift.MergePolicy.*
 import zio.test.*
 import zio.test.Assertion.*
 
@@ -12,7 +11,7 @@ object MergePolicySpec extends ZIOSpecDefault {
       assert(MergePolicy.parse("unsupported"))(
         isLeft(
           containsString(
-            Seq(KeepRuleGroups, OverrideAll).mkString(", ")
+            Seq(KeepRuleTargets, OverrideAll).mkString(", ")
           )
         )
       )

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserManagementServiceTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserManagementServiceTest.scala
@@ -1,7 +1,8 @@
-package com.normation.rudder.users
+package com.normation.rudder.rest.users
 
 import com.normation.rudder.AuthorizationType
 import com.normation.rudder.Role
+import com.normation.rudder.users.UserManagementService
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserSerializationTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserSerializationTest.scala
@@ -1,5 +1,6 @@
-package com.normation.rudder.users
+package com.normation.rudder.rest.users
 
+import com.normation.rudder.users.*
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2158,7 +2158,10 @@ object RudderConfigInit {
           new FileArchiveNameService(),
           configurationRepository,
           gitParseTechniqueLibrary,
-          roLdapNodeGroupRepository
+          roLdapNodeGroupRepository,
+          roRuleRepository,
+          roDirectiveRepository,
+          techniqueRepository
         )
       }
       // fixe archive name to make it simple to test


### PR DESCRIPTION
https://issues.rudder.io/issues/26801

Add the `all` keyword by making it a special item id. Then, when looking for things to zip, if there is an item with id `all`, get all corresponding ressources in place of the list of provided/dependent ids. 

Based on #5309 