### PR TITLE
Fixes #26861: Migration from Box to ZIO : Refactor XmlUnserialisation 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/ApplicationLogger.scala
@@ -222,6 +222,10 @@ object ChangeRequestLogger extends Logger {
   override protected def _logger: slf4j.Logger = LoggerFactory.getLogger("changeRequest")
 }
 
+object ChangeRequestLoggerPure extends NamedZioLogger {
+  override def loggerName: String = "changeRequest"
+}
+
 /**
  * Logger used for historization of object names by `HistorizationService`
  */

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
@@ -363,7 +363,7 @@ class EventLogDetailsServiceImpl(
         if (crXml.attribute("changeType").map(_.text) == Some(changeType)) Full("OK")
         else Failure("Rule attribute does not have changeType=%s: ".format(changeType) + entry)
       }
-      rule            <- crUnserialiser.unserialise(crXml)
+      rule            <- crUnserialiser.unserialise(crXml).toBox
     } yield {
       rule
     }
@@ -382,7 +382,7 @@ class EventLogDetailsServiceImpl(
         if (directiveXml.attribute("changeType").map(_.text) == Some(changeType)) Full("OK")
         else Failure("Directive attribute does not have changeType=%s: ".format(changeType) + entry)
       }
-      unserialised    <- piUnserialiser.unserialise(directiveXml)
+      unserialised    <- piUnserialiser.unserialise(directiveXml).toBox
     } yield {
       unserialised
     }
@@ -424,7 +424,7 @@ class EventLogDetailsServiceImpl(
       techniqueVersion <-
         getFromTo[TechniqueVersion]((directive \ "techniqueVersion").headOption, v => TechniqueVersion.parse(v.text).toBox)
       parameters       <-
-        getFromTo[SectionVal]((directive \ "parameters").headOption, parameter => piUnserialiser.parseSectionVal(parameter))
+        getFromTo[SectionVal]((directive \ "parameters").headOption, parameter => piUnserialiser.parseSectionVal(parameter).toBox)
       shortDescription <- getFromToString((directive \ "shortDescription").headOption)
       longDescription  <- getFromToString((directive \ "longDescription").headOption)
       priority         <- getFromTo[Int]((directive \ "priority").headOption, x => tryo(x.text.toInt))
@@ -520,7 +520,7 @@ class EventLogDetailsServiceImpl(
         if (groupXml.attribute("changeType").map(_.text) == Some(changeType)) Full("OK")
         else Failure("nodeGroup attribute does not have changeType=%s: ".format(changeType) + entry)
       }
-      group           <- groupUnserialiser.unserialise(groupXml)
+      group           <- groupUnserialiser.unserialise(groupXml).toBox
     } yield {
       group
     }
@@ -822,7 +822,7 @@ class EventLogDetailsServiceImpl(
         if (globalParam.attribute("changeType").map(_.text) == Some(changeType)) Full("OK")
         else Failure(s"Global Parameter attribute does not have changeType=${changeType} in ${entry}")
       }
-      globalParameter <- globalParameterUnserialisation.unserialise(globalParam)
+      globalParameter <- globalParameterUnserialisation.unserialise(globalParam).toBox
     } yield {
       globalParameter
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/TestFileFormat.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/TestFileFormat.scala
@@ -37,6 +37,8 @@
 
 package com.normation.rudder.services.marshalling
 
+import com.normation.errors.Inconsistency
+import com.normation.errors.PureResult
 import com.normation.rudder.domain.Constants
 import net.liftweb.common.*
 import scala.xml.Node
@@ -46,5 +48,10 @@ object TestFileFormat {
   def apply(xml: Node, fileFormat: String = Constants.XML_CURRENT_FILE_FORMAT.toString): Box[String] = {
     if (xml.attribute("fileFormat").map(_.text) == Some(fileFormat)) Full("OK")
     else Failure("Bad fileFormat (expecting %s): %s".format(fileFormat, xml))
+  }
+
+  def check(xml: Node, fileFormat: String = Constants.XML_CURRENT_FILE_FORMAT.toString): PureResult[Unit] = {
+    if (xml.attribute("fileFormat").map(_.text) == Some(fileFormat)) Right(())
+    else Left(Inconsistency(s"Bad fileFormat (expecting ${fileFormat}): ${xml}"))
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisation.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisation.scala
@@ -38,6 +38,7 @@
 package com.normation.rudder.services.marshalling
 
 import com.normation.cfclerk.domain.TechniqueName
+import com.normation.errors.PureResult
 import com.normation.rudder.api.ApiAccount
 import com.normation.rudder.batch.CurrentDeploymentStatus
 import com.normation.rudder.domain.nodes.NodeGroup
@@ -110,7 +111,7 @@ trait NodeGroupCategoryUnserialisation {
         <isSystem>{cat.isSystem}</isSystem>
       </nodeGroupCategory>
    */
-  def unserialise(xml: XNode): Box[NodeGroupCategory]
+  def unserialise(xml: XNode): PureResult[NodeGroupCategory]
 }
 
 /**
@@ -135,7 +136,7 @@ trait NodeGroupUnserialisation {
        </nodeIds>
      </nodeGroup>
    */
-  def unserialise(xml: XNode): Box[NodeGroup]
+  def unserialise(xml: XNode): PureResult[NodeGroup]
 }
 
 /**
@@ -161,7 +162,7 @@ trait RuleUnserialisation {
         <isSystem>{rule.isSystem}</isSystem>
       </rule>
    */
-  def unserialise(xml: XNode): Box[Rule]
+  def unserialise(xml: XNode): PureResult[Rule]
 }
 
 /**
@@ -178,7 +179,7 @@ trait RuleCategoryUnserialisation {
         <isSystem>{ngc.isSystem}</isSystem>
       </ruleCategory>
    */
-  def unserialise(xml: XNode): Box[RuleCategory]
+  def unserialise(xml: XNode): PureResult[RuleCategory]
 }
 
 /**
@@ -259,7 +260,7 @@ trait DirectiveUnserialisation {
        </section>
      </directive>
    */
-  def unserialise(xml: XNode): Box[(TechniqueName, Directive, SectionVal)]
+  def unserialise(xml: XNode): PureResult[(TechniqueName, Directive, SectionVal)]
 
   /**
    * A section val look like:
@@ -282,7 +283,7 @@ trait DirectiveUnserialisation {
    *
    * We await for a node that contains an unique <section>
    */
-  def parseSectionVal(xml: NodeSeq): Box[SectionVal]
+  def parseSectionVal(xml: NodeSeq): PureResult[SectionVal]
 }
 
 /**
@@ -300,7 +301,7 @@ trait GlobalParameterUnserialisation {
        <overridable>{param.overridable}</overridable>
      </globalParameter>
    */
-  def unserialise(xml: XNode): Box[GlobalParameter]
+  def unserialise(xml: XNode): PureResult[GlobalParameter]
 }
 
 /**
@@ -412,9 +413,9 @@ trait ChangeRequestChangesUnserialisation {
         </globalParameters>
       </changeRequest>
    */
-  def unserialise(xml: XNode): Box[
+  def unserialise(xml: XNode): PureResult[
     (
-        Box[Map[DirectiveId, DirectiveChanges]],
+        Map[DirectiveId, DirectiveChanges],
         Map[NodeGroupId, NodeGroupChanges],
         Map[RuleId, RuleChanges],
         Map[String, GlobalParameterChanges]

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -37,6 +37,7 @@
 
 package com.normation.rudder.services.marshalling
 
+import cats.implicits.*
 import com.normation.GitVersion
 import com.normation.GitVersion.ParseRev
 import com.normation.box.*
@@ -45,6 +46,10 @@ import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.cfclerk.xmlparsers.SectionSpecParser
+import com.normation.errors.AccumulateErrors
+import com.normation.errors.Inconsistency
+import com.normation.errors.OptionToPureResult
+import com.normation.errors.PureResult
 import com.normation.eventlog.EventActor
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.api.*
@@ -72,6 +77,7 @@ import com.normation.rudder.services.queries.CmdbQueryParser
 import com.normation.utils.Control.traverse
 import net.liftweb.common.*
 import net.liftweb.common.Box.*
+import net.liftweb.util.Helpers.tryo
 import org.apache.commons.text.StringEscapeUtils
 import org.joda.time.format.ISODateTimeFormat
 import scala.util.Failure as Catch
@@ -92,22 +98,23 @@ final case class XmlUnserializerImpl(
 
 class DirectiveUnserialisationImpl extends DirectiveUnserialisation {
 
-  override def parseSectionVal(xml: NodeSeq): Box[SectionVal] = {
-    def recValParseSection(elt: XNode): Box[(String, SectionVal)] = {
-      if (elt.label != "section") Failure("Bad XML, awaiting a <section> and get: " + elt)
+  override def parseSectionVal(xml: NodeSeq): PureResult[SectionVal] = {
+    def recValParseSection(elt: XNode): PureResult[(String, SectionVal)] = {
+      if (elt.label != "section") Left(Inconsistency(s"Bad XML, expected a <section> but got: ${elt}"))
       else {
         for {
-          name     <- (elt \ "@name").headOption ?~! ("Missing required attribute 'name' for <section>: " + elt)
+          name     <- (elt \ "@name").headOption.notOptionalPure(s"Missing required attribute 'name' for <section>: ${elt}")
           // Seq( (var name , var value ) )
-          vars     <- traverse(elt \ "var") { xmlVar =>
+          vars     <- (elt \ "var").accumulatePure { xmlVar =>
                         for {
-                          n <- (xmlVar \ "@name").headOption ?~! ("Missing required attribute 'name' for <var>: " + xmlVar)
+                          n <-
+                            (xmlVar \ "@name").headOption.notOptionalPure(s"Missing required attribute 'name' for <var>: ${xmlVar}")
                         } yield {
                           (n.text, xmlVar.text)
                         }
                       }
           // Seq ( SectionVal )
-          sections <- traverse(elt \ "section")(sectionXml => recValParseSection(sectionXml))
+          sections <- (elt \ "section").accumulatePure(sectionXml => recValParseSection(sectionXml))
         } yield {
           val s = sections.groupBy { case (n, s) => n }.map { case (n, seq) => (n, seq.map { case (_, section) => section }) }
           (name.text, SectionVal(s, vars.toMap))
@@ -116,52 +123,38 @@ class DirectiveUnserialisationImpl extends DirectiveUnserialisation {
     }
 
     for {
-      root            <- (xml \ "section").toList match {
-                           case Nil         => Failure("Missing required tag <section> in: " + xml)
-                           case node :: Nil => Full(node)
-                           case x           => Failure("Found several <section> tag in XML, but only one root section is allowed: " + xml)
-                         }
-      (_, sectionVal) <- recValParseSection(root)
+      root         <- ((xml \ "section").toList match {
+                        case Nil         => Left(Inconsistency(s"Missing required tag <section> in: ${xml}"))
+                        case node :: Nil => Right(node)
+                        case x           => Left(Inconsistency(s"Found several <section> tag in XML, but only one root section is allowed: ${xml}"))
+                      }): PureResult[XNode]
+      parseSection <- recValParseSection(root)
     } yield {
-      sectionVal
+      parseSection._2
     }
   }
 
-  override def unserialise(xml: XNode): Box[(TechniqueName, Directive, SectionVal)] = {
-    for {
-      directive        <- {
-        if (xml.label == XML_TAG_DIRECTIVE) Full(xml)
-        else Failure("Entry type is not a <%s>: %s".format(XML_TAG_DIRECTIVE, xml))
-      }
-      fileFormatOk     <- TestFileFormat(directive)
-      sid              <- (directive \ "id").headOption.map(_.text) ?~! ("Missing attribute 'id' in entry type directive : " + xml)
-      id               <- DirectiveId.parse(sid).toBox
-      ptName           <- (directive \ "techniqueName").headOption.map(
-                            _.text
-                          ) ?~! ("Missing attribute 'techniqueName' in entry type directive : " + xml)
-      name             <- (directive \ "displayName").headOption.map(
-                            _.text.trim
-                          ) ?~! ("Missing attribute 'displayName' in entry type directive : " + xml)
-      techniqueVersion <- (directive \ "techniqueVersion").headOption.flatMap(x =>
-                            TechniqueVersion.parse(x.text).toBox
-                          ) ?~! ("Missing attribute 'techniqueVersion' in entry type directive : " + xml)
+  override def unserialise(xml: XNode): PureResult[(TechniqueName, Directive, SectionVal)] = {
+
+    import XmlUtils.*
+    implicit val entryType: XmlEntryType = XmlEntryType(XML_TAG_DIRECTIVE)
+
+    (for {
+      directive        <- checkEntry(xml)
+      _                <- TestFileFormat.check(directive)
+      sid              <- getAndTransformChild(directive, "id", _.text)
+      id               <- DirectiveId.parse(sid).leftMap(errMsg => Inconsistency(errMsg))
+      ptName           <- getAndTransformChild(directive, "techniqueName", _.text)
+      name             <- getAndTransformChild(directive, "displayName", _.text.trim)
+      techniqueVersion <- getChild(directive, "techniqueVersion")
+                            .flatMap(x => TechniqueVersion.parse(x.text).leftMap(errMsg => Inconsistency(errMsg)))
       sectionVal       <- parseSectionVal(directive)
-      shortDescription <- (directive \ "shortDescription").headOption.map(
-                            _.text
-                          ) ?~! ("Missing attribute 'shortDescription' in entry type directive : " + xml)
-      longDescription  <- (directive \ "longDescription").headOption.map(
-                            _.text
-                          ) ?~! ("Missing attribute 'longDescription' in entry type directive : " + xml)
-      isEnabled        <- (directive \ "isEnabled").headOption.flatMap(s =>
-                            tryo(s.text.toBoolean)
-                          ) ?~! ("Missing attribute 'isEnabled' in entry type directive : " + xml)
-      priority         <- (directive \ "priority").headOption.flatMap(s =>
-                            tryo(s.text.toInt)
-                          ) ?~! ("Missing or bad attribute 'priority' in entry type directive : " + xml)
-      isSystem         <- (directive \ "isSystem").headOption.flatMap(s =>
-                            tryo(s.text.toBoolean)
-                          ) ?~! ("Missing attribute 'isSystem' in entry type directive : " + xml)
-      policyMode        = (directive \ "policyMode").headOption.flatMap(s => PolicyMode.parse(s.text).toBox)
+      shortDescription <- getAndTransformChild(directive, "shortDescription", _.text)
+      longDescription  <- getAndTransformChild(directive, "longDescription", _.text)
+      isEnabled        <- getAndParseChild(directive, "isEnabled", s => s.text.toBooleanOption)
+      priority         <- getAndParseChild(directive, "priority", s => s.text.toIntOption)
+      isSystem         <- getAndParseChild(directive, "isSystem", s => s.text.toBooleanOption)
+      policyMode        = (directive \ "policyMode").headOption.flatMap(s => PolicyMode.parse(s.text).toOption)
       tags              = TagsXml.getTags(directive \ "tags")
     } yield {
       (
@@ -181,29 +174,24 @@ class DirectiveUnserialisationImpl extends DirectiveUnserialisation {
         ),
         sectionVal
       )
-    }
+    }).chainError(s"${entryType} unserialisation failed")
   }
 }
 
 class NodeGroupCategoryUnserialisationImpl extends NodeGroupCategoryUnserialisation {
 
-  def unserialise(entry: XNode): Box[NodeGroupCategory] = {
-    for {
-      category     <- {
-        if (entry.label == XML_TAG_NODE_GROUP_CATEGORY) Full(entry)
-        else Failure("Entry type is not a <%s>: %s".format(XML_TAG_NODE_GROUP_CATEGORY, entry))
-      }
-      fileFormatOk <- TestFileFormat(category)
-      id           <- (category \ "id").headOption.map(_.text) ?~! ("Missing attribute 'id' in entry type groupLibraryCategory : " + entry)
-      name         <- (category \ "displayName").headOption.map(
-                        _.text.trim
-                      ) ?~! ("Missing attribute 'displayName' in entry type groupLibraryCategory : " + entry)
-      description  <- (category \ "description").headOption.map(
-                        _.text
-                      ) ?~! ("Missing attribute 'description' in entry type groupLibraryCategory : " + entry)
-      isSystem     <- (category \ "isSystem").headOption.flatMap(s =>
-                        tryo(s.text.toBoolean)
-                      ) ?~! ("Missing attribute 'isSystem' in entry type groupLibraryCategory : " + entry)
+  import XmlUtils.*
+  implicit val entryType: XmlEntryType = XmlEntryType(XML_TAG_NODE_GROUP_CATEGORY)
+
+  def unserialise(entry: XNode): PureResult[NodeGroupCategory] = {
+
+    (for {
+      category    <- checkEntry(entry)
+      _           <- TestFileFormat.check(category)
+      id          <- getAndTransformChild(category, "id", _.text)
+      name        <- getAndTransformChild(category, "dispayName", _.text.trim)
+      description <- getAndTransformChild(category, "description", _.text)
+      isSystem    <- getAndParseChild(category, "isSystem", _.text.toBooleanOption)
     } yield {
       NodeGroupCategory(
         id = NodeGroupCategoryId(id),
@@ -213,64 +201,55 @@ class NodeGroupCategoryUnserialisationImpl extends NodeGroupCategoryUnserialisat
         children = Nil,
         isSystem = isSystem
       )
-    }
+    }).chainError(s"${entryType} unserialisation failed")
   }
 }
 
 class NodeGroupUnserialisationImpl(
     cmdbQueryParser: CmdbQueryParser
 ) extends NodeGroupUnserialisation {
-  def unserialise(entry: XNode): Box[NodeGroup] = {
-    for {
-      group        <- {
-        if (entry.label == XML_TAG_NODE_GROUP) Full(entry)
-        else Failure("Entry type is not a <%s>: %s".format(XML_TAG_NODE_GROUP, entry))
-      }
-      fileFormatOk <- TestFileFormat(group)
-      sid          <- (group \ "id").headOption.map(_.text) ?~! ("Missing attribute 'id' in entry type nodeGroup : " + entry)
-      id           <- NodeGroupId.parse(sid).toBox
-      name         <- (group \ "displayName").headOption.map(
-                        _.text.trim
-                      ) ?~! ("Missing attribute 'displayName' in entry type nodeGroup : " + entry)
-      description  <-
-        (group \ "description").headOption.map(_.text) ?~! ("Missing attribute 'description' in entry type nodeGroup : " + entry)
-      query        <- (group \ "query").headOption match {
-                        case None    => Full(None)
-                        case Some(s) =>
-                          if (s.text.isEmpty) Full(None)
-                          else cmdbQueryParser(s.text).map(Some(_))
-                      }
-      isDynamic    <- (group \ "isDynamic").headOption.flatMap(s =>
-                        tryo(s.text.toBoolean)
-                      ) ?~! ("Missing attribute 'isDynamic' in entry type nodeGroup : " + entry)
-      serverList    = if (isDynamic) {
-                        Set[NodeId]()
-                      } else {
-                        (group \ "nodeIds" \ "id").map(n => NodeId(n.text)).toSet
-                      }
-      isEnabled    <- (group \ "isEnabled").headOption.flatMap(s =>
-                        tryo(s.text.toBoolean)
-                      ) ?~! ("Missing attribute 'isEnabled' in entry type nodeGroup : " + entry)
-      isSystem     <- (group \ "isSystem").headOption.flatMap(s =>
-                        tryo(s.text.toBoolean)
-                      ) ?~! ("Missing attribute 'isSystem' in entry type nodeGroup : " + entry)
-      properties   <- traverse(group \ "properties" \ "property") { property =>
-                        val name = (property \\ "name").text.trim
-                        if (name.trim.isEmpty) {
-                          Failure(s"Found unexpected xml under <properties> tag (name is blank): $property")
-                        } else {
-                          GroupProperty
-                            .parse(
-                              name = (property \\ "name").text.trim,
-                              rev = ParseRev((property \\ "revision").text.trim),
-                              value = StringEscapeUtils.unescapeXml((property \\ "value").text.trim),
-                              mode =
-                                (property \\ "inheritMode").headOption.flatMap(p => InheritMode.parseString(p.text.trim).toOption),
-                              provider = (property \\ "provider").headOption.map(p => PropertyProvider(p.text.trim))
-                            )
-                            .toBox
-                        }
-                      }
+
+  import XmlUtils.*
+  implicit val entryType: XmlEntryType = XmlEntryType(XML_TAG_NODE_GROUP)
+
+  def unserialise(entry: XNode): PureResult[NodeGroup] = {
+    (for {
+      group       <- checkEntry(entry)
+      _           <- TestFileFormat.check(group)
+      sid         <- getAndTransformChild(group, "id", _.text)
+      id          <- NodeGroupId.parse(sid).leftMap(errMsg => Inconsistency(errMsg))
+      name        <- getAndTransformChild(group, "displayName", _.text.trim)
+      description <- getAndTransformChild(group, "description", _.text)
+      query       <- (group \ "query").headOption match {
+                       case None    => Right(None)
+                       case Some(s) =>
+                         if (s.text.isEmpty) Right(None)
+                         else cmdbQueryParser.applyPure(s.text).map(Some(_))
+                     }
+      isDynamic   <- getAndParseChild(group, "isDynamic", s => s.text.toBooleanOption)
+      serverList   = if (isDynamic) {
+                       Set[NodeId]()
+                     } else {
+                       (group \ "nodeIds" \ "id").map(n => NodeId(n.text)).toSet
+                     }
+      isEnabled   <- getAndParseChild(group, "isEnabled", s => s.text.toBooleanOption)
+      isSystem    <- getAndParseChild(group, "isSystem", s => s.text.toBooleanOption)
+      properties  <- (group \ "properties" \ "property").toList.accumulatePure { property =>
+                       val name = (property \\ "name").text.trim
+                       if (name.trim.isEmpty) {
+                         Left(Inconsistency(s"Found unexpected xml under <properties> tag (name is blank): $property"))
+                       } else {
+                         GroupProperty
+                           .parse(
+                             name = (property \\ "name").text.trim,
+                             rev = ParseRev((property \\ "revision").text.trim),
+                             value = StringEscapeUtils.unescapeXml((property \\ "value").text.trim),
+                             mode =
+                               (property \\ "inheritMode").headOption.flatMap(p => InheritMode.parseString(p.text.trim).toOption),
+                             provider = (property \\ "provider").headOption.map(p => PropertyProvider(p.text.trim))
+                           )
+                       }
+                     }
     } yield {
       NodeGroup(
         id = id,
@@ -283,38 +262,30 @@ class NodeGroupUnserialisationImpl(
         _isEnabled = isEnabled,
         isSystem = isSystem
       )
-    }
+    }).chainError(s"${entryType} unserialisation failed")
   }
 }
 
 class RuleUnserialisationImpl extends RuleUnserialisation {
-  def unserialise(entry: XNode): Box[Rule] = {
-    for {
-      rule             <- {
-        if (entry.label == XML_TAG_RULE) Full(entry)
-        else Failure("Entry type is not a <%s>: %s".format(XML_TAG_RULE, entry))
-      }
-      fileFormatOk     <- TestFileFormat(rule)
-      sid              <- (rule \ "id").headOption.map(_.text) ?~!
-                          ("Missing attribute 'id' in entry type rule: " + entry)
-      id               <- RuleId.parse(sid).toBox
-      category         <- (rule \ "category").headOption.map(n => RuleCategoryId(n.text)) ?~!
-                          ("Missing attribute 'category' in entry type rule: " + entry)
-      name             <- (rule \ "displayName").headOption.map(_.text.trim) ?~!
-                          ("Missing attribute 'displayName' in entry type rule: " + entry)
-      revision          = ParseRev((rule \ "revision").headOption.map(_.text.trim))
-      shortDescription <- (rule \ "shortDescription").headOption.map(_.text) ?~!
-                          ("Missing attribute 'shortDescription' in entry type rule: " + entry)
-      longDescription  <- (rule \ "longDescription").headOption.map(_.text) ?~!
-                          ("Missing attribute 'longDescription' in entry type rule: " + entry)
-      isEnabled        <- (rule \ "isEnabled").headOption.flatMap(s => tryo(s.text.toBoolean)) ?~!
-                          ("Missing attribute 'isEnabled' in entry type rule: " + entry)
-      isSystem         <- (rule \ "isSystem").headOption.flatMap(s => tryo(s.text.toBoolean)) ?~!
-                          ("Missing attribute 'isSystem' in entry type rule: " + entry)
-      targets          <- traverse((rule \ "targets" \ "target")) { t =>
-                            RuleTarget.unser(t.text)
-                          } ?~!
-                          ("Invalid attribute in 'target' entry: " + entry)
+
+  import XmlUtils.*
+  implicit val entryType: XmlEntryType = XmlEntryType(XML_TAG_RULE)
+
+  def unserialise(entry: XNode): PureResult[Rule] = {
+    (for {
+      rule             <- checkEntry(entry)
+      _                <- TestFileFormat.check(rule)
+      sid              <- getAndTransformChild(rule, "id", _.text)
+      id               <- RuleId.parse(sid).leftMap(errMsg => Inconsistency(errMsg))
+      category         <- getAndTransformChild(rule, "category", n => RuleCategoryId(n.text))
+      name             <- getAndTransformChild(rule, "displayName", _.text.trim)
+      shortDescription <- getAndTransformChild(rule, "shortDescription", _.text)
+      longDescription  <- getAndTransformChild(rule, "longDescription", _.text)
+      isEnabled        <- getAndParseChild(rule, "isEnabled", s => s.text.toBooleanOption)
+      isSystem         <- getAndParseChild(rule, "isSystem", s => s.text.toBooleanOption)
+      targets          <- (rule \ "targets" \ "target").accumulatePure { t =>
+                            RuleTarget.unser(t.text).notOptionalPure(s"Invalid attribute in 'target' entry: ${entry}")
+                          }
       directiveIds      = (rule \ "directiveIds" \ "id").map { n =>
                             DirectiveId(DirectiveUid(n.text), ParseRev((n \ "@revision").text))
                           }.toSet
@@ -333,29 +304,23 @@ class RuleUnserialisationImpl extends RuleUnserialisation {
         isSystem,
         tags
       )
-    }
+    }).chainError(s"${entryType} unserialisation failed")
   }
 }
 
 class RuleCategoryUnserialisationImpl extends RuleCategoryUnserialisation {
 
-  def unserialise(entry: XNode): Box[RuleCategory] = {
-    for {
-      category     <- {
-        if (entry.label == XML_TAG_RULE_CATEGORY) Full(entry)
-        else Failure("Entry type is not a <%s>: %s".format(XML_TAG_RULE_CATEGORY, entry))
-      }
-      fileFormatOk <- TestFileFormat(category)
-      id           <- (category \ "id").headOption.map(_.text) ?~! ("Missing attribute 'id' in entry type groupLibraryCategory : " + entry)
-      name         <- (category \ "displayName").headOption.map(
-                        _.text.trim
-                      ) ?~! ("Missing attribute 'displayName' in entry type groupLibraryCategory : " + entry)
-      description  <- (category \ "description").headOption.map(
-                        _.text
-                      ) ?~! ("Missing attribute 'description' in entry type groupLibraryCategory : " + entry)
-      isSystem     <- (category \ "isSystem").headOption.flatMap(s =>
-                        tryo(s.text.toBoolean)
-                      ) ?~! ("Missing attribute 'isSystem' in entry type groupLibraryCategory : " + entry)
+  import XmlUtils.*
+  implicit val entryType: XmlEntryType = XmlEntryType(XML_TAG_RULE_CATEGORY)
+
+  def unserialise(entry: XNode): PureResult[RuleCategory] = {
+    (for {
+      category    <- checkEntry(entry)
+      _           <- TestFileFormat.check(category)
+      id          <- getAndTransformChild(category, "id", _.text)
+      name        <- getAndTransformChild(category, "displayName", _.text.trim)
+      description <- getAndTransformChild(category, "description", _.text)
+      isSystem    <- getAndParseChild(category, "isSystem", s => s.text.toBooleanOption)
     } yield {
       RuleCategory(
         id = RuleCategoryId(id),
@@ -364,7 +329,7 @@ class RuleCategoryUnserialisationImpl extends RuleCategoryUnserialisation {
         childs = Nil,
         isSystem = isSystem
       )
-    }
+    }).chainError(s"${entryType} unserialisation failed")
   }
 }
 
@@ -372,21 +337,21 @@ class ActiveTechniqueCategoryUnserialisationImpl extends ActiveTechniqueCategory
 
   def unserialise(entry: XNode): Box[ActiveTechniqueCategory] = {
     for {
-      uptc         <- {
+      uptc        <- {
         if (entry.label == XML_TAG_ACTIVE_TECHNIQUE_CATEGORY) Full(entry)
-        else Failure("Entry type is not a <%s>: %s".format(XML_TAG_ACTIVE_TECHNIQUE_CATEGORY, entry))
+        else Failure(s"Entry type is not a ${XML_TAG_ACTIVE_TECHNIQUE_CATEGORY}: ${entry}")
       }
-      fileFormatOk <- TestFileFormat(uptc)
-      id           <- (uptc \ "id").headOption.map(_.text) ?~! ("Missing attribute 'id' in entry type policyLibraryCategory : " + entry)
-      name         <- (uptc \ "displayName").headOption.map(
-                        _.text
-                      ) ?~! ("Missing attribute 'displayName' in entry type policyLibraryCategory : " + entry)
-      description  <- (uptc \ "description").headOption.map(
-                        _.text
-                      ) ?~! ("Missing attribute 'description' in entry type policyLibraryCategory : " + entry)
-      isSystem     <- (uptc \ "isSystem").headOption.flatMap(s =>
-                        tryo(s.text.toBoolean)
-                      ) ?~! ("Missing attribute 'isSystem' in entry type policyLibraryCategory : " + entry)
+      _           <- TestFileFormat(uptc)
+      id          <- (uptc \ "id").headOption.map(_.text) ?~! s"Missing attribute 'id' in entry type policyLibraryCategory : ${entry}"
+      name        <- (uptc \ "displayName").headOption.map(
+                       _.text
+                     ) ?~! s"Missing attribute 'displayName' in entry type policyLibraryCategory : ${entry}"
+      description <- (uptc \ "description").headOption.map(
+                       _.text
+                     ) ?~! s"Missing attribute 'description' in entry type policyLibraryCategory : ${entry}"
+      isSystem    <- (uptc \ "isSystem").headOption.flatMap(s =>
+                       tryo(s.text.toBoolean)
+                     ) ?~! s"Missing attribute 'isSystem' in entry type policyLibraryCategory : ${entry}"
     } yield {
       ActiveTechniqueCategory(
         id = ActiveTechniqueCategoryId(id),
@@ -409,15 +374,15 @@ class ActiveTechniqueUnserialisationImpl extends ActiveTechniqueUnserialisation 
     for {
       activeTechnique  <- {
         if (entry.label == XML_TAG_ACTIVE_TECHNIQUE) Full(entry)
-        else Failure("Entry type is not a <%s>: ".format(XML_TAG_ACTIVE_TECHNIQUE, entry))
+        else Failure(s"Entry type is not a ${XML_TAG_ACTIVE_TECHNIQUE}: ${entry}")
       }
-      fileFormatOk     <- TestFileFormat(activeTechnique)
+      _                <- TestFileFormat(activeTechnique)
       id               <- (activeTechnique \ "id").headOption.map(
                             _.text
-                          ) ?~! ("Missing attribute 'id' in entry type policyLibraryTemplate : " + entry)
+                          ) ?~! (s"Missing attribute 'id' in entry type policyLibraryTemplate : ${entry}")
       ptName           <- (activeTechnique \ "techniqueName").headOption.map(
                             _.text
-                          ) ?~! ("Missing attribute 'displayName' in entry type policyLibraryTemplate : " + entry)
+                          ) ?~! (s"Missing attribute 'displayName' in entry type policyLibraryTemplate : ${entry}")
       policyTypes       = (activeTechnique \ "policyTypes").headOption
                             .flatMap(s => s.text.fromJson[PolicyTypes].toBox)
                             .getOrElse(
@@ -426,17 +391,15 @@ class ActiveTechniqueUnserialisationImpl extends ActiveTechniqueUnserialisation 
                             )
       isEnabled        <- (activeTechnique \ "isEnabled").headOption.flatMap(s =>
                             tryo(s.text.toBoolean)
-                          ) ?~! ("Missing attribute 'isEnabled' in entry type policyLibraryTemplate : " + entry)
+                          ) ?~! (s"Missing attribute 'isEnabled' in entry type policyLibraryTemplate : ${entry}")
       acceptationDates <- traverse(activeTechnique \ "versions" \ "version") { version =>
                             for {
                               ptVersionName   <-
                                 version
                                   .attribute("name")
-                                  .map(_.text) ?~! "Missing attribute 'name' for acceptation date in PT '%s' (%s): '%s'".format(
-                                  ptName,
-                                  id,
-                                  version
-                                )
+                                  .map(
+                                    _.text
+                                  ) ?~! s"Missing attribute 'name' for acceptation date in PT '${ptName}' (${id}): '${version}'"
                               ptVersion       <- TechniqueVersion
                                                    .parse(ptVersionName)
                                                    .toBox ?~! s"Error when trying to parse '${ptVersionName}' as a technique version."
@@ -449,7 +412,7 @@ class ActiveTechniqueUnserialisationImpl extends ActiveTechniqueUnserialisation 
         val map = acceptationDates.toMap
         if (map.size != acceptationDates.size) {
           Failure(
-            "There exists a duplicate polity template version in the acceptation date map: " + acceptationDates.mkString("; ")
+            s"There exists a duplicate polity template version in the acceptation date map: ${acceptationDates.mkString("; ")}"
           )
         } else Full(map)
       }
@@ -469,23 +432,25 @@ class ActiveTechniqueUnserialisationImpl extends ActiveTechniqueUnserialisation 
 class DeploymentStatusUnserialisationImpl extends DeploymentStatusUnserialisation {
   def unserialise(entry: XNode): Box[CurrentDeploymentStatus] = {
     for {
-      depStatus    <- {
+      depStatus <- {
         if (entry.label == XML_TAG_DEPLOYMENT_STATUS) Full(entry)
-        else Failure("Entry type is not a <%s>: %s".format(XML_TAG_DEPLOYMENT_STATUS, entry))
+        else Failure(s"Entry type is not a ${XML_TAG_DEPLOYMENT_STATUS}: ${entry}")
       }
-      fileFormatOk <- TestFileFormat(depStatus)
-      id           <- (depStatus \ "id").headOption.flatMap(s =>
-                        tryo(s.text.toLong)
-                      ) ?~! ("Missing attribute 'id' in entry type deploymentStatus : " + entry)
-      status       <-
-        (depStatus \ "status").headOption.map(_.text) ?~! ("Missing attribute 'status' in entry type deploymentStatus : " + entry)
+      _         <- TestFileFormat(depStatus)
+      id        <- (depStatus \ "id").headOption.flatMap(s =>
+                     tryo(s.text.toLong)
+                   ) ?~! (s"Missing attribute 'id' in entry type deploymentStatus : ${entry}")
+      status    <-
+        (depStatus \ "status").headOption.map(
+          _.text
+        ) ?~! (s"Missing attribute 'status' in entry type deploymentStatus : ${entry}")
 
       started      <- (depStatus \ "started").headOption.flatMap(s =>
                         tryo(ISODateTimeFormat.dateTimeParser.parseDateTime(s.text))
-                      ) ?~! ("Missing or bad attribute 'started' in entry type deploymentStatus : " + entry)
+                      ) ?~! (s"Missing or bad attribute 'started' in entry type deploymentStatus : ${entry}")
       ended        <- (depStatus \ "ended").headOption.flatMap(s =>
                         tryo(ISODateTimeFormat.dateTimeParser.parseDateTime(s.text))
-                      ) ?~! ("Missing or bad attribute 'ended' in entry type deploymentStatus : " + entry)
+                      ) ?~! (s"Missing or bad attribute 'ended' in entry type deploymentStatus : ${entry}")
       errorMessage <- (depStatus \ "errorMessage").headOption match {
                         case None    => Full(None)
                         case Some(s) =>
@@ -503,7 +468,7 @@ class DeploymentStatusUnserialisationImpl extends DeploymentStatusUnserialisatio
 }
 
 /**
- * That trait allow to unserialise change request changes from an XML file.
+ * That trait allows to unserialise change request changes from an XML file.
  *
  */
 class ChangeRequestChangesUnserialisationImpl(
@@ -514,99 +479,121 @@ class ChangeRequestChangesUnserialisationImpl(
     techRepo:                TechniqueRepository,
     sectionSpecUnserialiser: SectionSpecParser
 ) extends ChangeRequestChangesUnserialisation with Loggable {
-  def unserialise(xml: XNode): Box[
+
+  def unserialise(xml: XNode): PureResult[
     (
-        Box[Map[DirectiveId, DirectiveChanges]],
+        Map[DirectiveId, DirectiveChanges],
         Map[NodeGroupId, NodeGroupChanges],
         Map[RuleId, RuleChanges],
         Map[String, GlobalParameterChanges]
     )
   ] = {
-    def unserialiseNodeGroupChange(changeRequest: XNode): Box[Map[NodeGroupId, NodeGroupChanges]] = {
-      (for {
-        groupsNode <- (changeRequest \ "groups").headOption ?~! s"Missing child 'groups' in entry type changeRequest : ${xml}"
+
+    import XmlUtils.*
+    val changeRequestEntryType = XmlEntryType(XML_TAG_CHANGE_REQUEST)
+
+    def unserialiseNodeGroupChange(changeRequest: XNode): PureResult[Map[NodeGroupId, NodeGroupChanges]] = {
+
+      for {
+        groupsNode <- getChild(changeRequest, "groups")(changeRequestEntryType)
       } yield {
-        (groupsNode \ "group").iterator.flatMap { group =>
-          for {
-            sid          <- group.attribute("id").map(id => id.text) ?~!
-                            s"Missing attribute 'id' in entry type changeRequest group changes  : ${group}"
-            nodeGroupId  <- NodeGroupId.parse(sid).toBox
-            initialNode  <- (group \ "initialState").headOption
+
+        implicit val entryType: XmlEntryType = XmlEntryType("changeRequest group changes")
+
+        (groupsNode \ "group").accumulatePure { group =>
+          (for {
+
+            sid          <- getAttribute(group, "id")
+            nodeGroupId  <- NodeGroupId.parse(sid).leftMap(errMsg => Inconsistency(errMsg))
+            initialNode  <- getChild(group, "initialState")
             initialState <- (initialNode \ "nodeGroup").headOption match {
                               case Some(initialState) =>
                                 nodeGroupUnserialiser.unserialise(initialState) match {
-                                  case Full(group) => Full(Some(group))
-                                  case eb: EmptyBox => eb ?~! "could not unserialize group"
+                                  case Right(group) => Right(Some(group))
+                                  case Left(_)      => Left(Inconsistency("could not unserialize group"))
                                 }
-                              case None               => Full(None)
+                              case None               => Right(None)
+                            }
+            changeNode   <- getGrandchild(group, "firstChange", "change")
+            actor        <- getAndTransformChildRec(changeNode, "actor", actor => EventActor(actor.text))
+            date         <- getAndTransformChildRec(
+                              changeNode,
+                              "date",
+                              date => ISODateTimeFormat.dateTimeParser.parseDateTime(date.text)
+                            )
+            reason        = (changeNode \\ "reason").headOption.map(_.text)
+            diff         <- getAndParseChildRec(changeNode, "diff", _.attribute("action").headOption.map(_.text))
+            diffGroup    <- getChildRec(changeNode, "nodeGroup")
+            changeGroup  <- nodeGroupUnserialiser.unserialise(diffGroup)
+            change       <- diff match {
+                              case "add"      => Right(AddNodeGroupDiff(changeGroup))
+                              case "delete"   => Right(DeleteNodeGroupDiff(changeGroup))
+                              case "modifyTo" => Right(ModifyToNodeGroupDiff(changeGroup))
+                              case _          => Left(Inconsistency("should not happen"))
                             }
 
-            changeNode  <- (group \ "firstChange" \ "change").headOption
-            actor       <- (changeNode \\ "actor").headOption.map(actor => EventActor(actor.text))
-            date        <- (changeNode \\ "date").headOption.map(date => ISODateTimeFormat.dateTimeParser.parseDateTime(date.text))
-            reason       = (changeNode \\ "reason").headOption.map(_.text)
-            diff        <- (changeNode \\ "diff").headOption.flatMap(_.attribute("action").headOption.map(_.text))
-            diffGroup   <- (changeNode \\ "nodeGroup").headOption
-            changeGroup <- nodeGroupUnserialiser.unserialise(diffGroup)
-            change      <- diff match {
-                             case "add"      => Full(AddNodeGroupDiff(changeGroup))
-                             case "delete"   => Full(DeleteNodeGroupDiff(changeGroup))
-                             case "modifyTo" => Full(ModifyToNodeGroupDiff(changeGroup))
-                             case _          => Failure("should not happen")
-                           }
           } yield {
             val groupChange = NodeGroupChange(initialState, NodeGroupChangeItem(actor, date, reason, change), Seq())
 
             (nodeGroupId -> NodeGroupChanges(groupChange, Seq()))
-          }
-        }.toMap
-      })
+          }).chainError(s"${entryType} unserialisation failed")
+
+        } match {
+          case Left(err)  =>
+            logger.error(err.fullMsg)
+            Map.empty
+          case Right(res) => res.toMap
+        }
+      }
     }
 
-    def unserialiseDirectiveChange(changeRequest: XNode): Box[Map[DirectiveId, DirectiveChanges]] = {
-      (for {
-        directivesNode <-
-          (changeRequest \ "directives").headOption ?~! s"Missing child 'directives' in entry type changeRequest : ${xml}"
+    def unserialiseDirectiveChange(changeRequest: XNode): PureResult[Map[DirectiveId, DirectiveChanges]] = {
+
+      for {
+        directivesNode <- getChild(changeRequest, "directives")(changeRequestEntryType)
       } yield {
+
+        implicit val entryType: XmlEntryType = XmlEntryType("changeRequest directive changes")
+
         (directivesNode \ "directive").iterator.flatMap { directive =>
-          for {
-            directiveId  <- directive.attribute("id").flatMap(id => DirectiveId.parse(id.text).toBox) ?~!
-                            s"Missing attribute 'id' in entry type changeRequest directive changes  : ${directive}"
-            initialNode  <- (directive \ "initialState").headOption
-            initialState <- (initialNode \\ "directive").headOption match {
-                              case Some(initialState) =>
-                                directiveUnserialiser.unserialise(initialState) match {
-                                  case Full((techName, directive, _)) => Full(Some((techName, directive)))
-                                  case eb: EmptyBox => eb ?~! "could not unserialize directive"
-                                }
-                              case None               => Full(None)
-                            }
+          val res = (for {
 
-            changeNode    <- (directive \ "firstChange" \ "change").headOption
-            actor         <- (changeNode \\ "actor").headOption.map(actor => EventActor(actor.text))
-            date          <- (changeNode \\ "date").headOption.map(date => ISODateTimeFormat.dateTimeParser.parseDateTime(date.text))
-            reason         = (changeNode \\ "reason").headOption.map(_.text)
-            diff          <- (changeNode \\ "diff").headOption.flatMap(_.attribute("action").headOption.map(_.text))
-            diffDirective <- (changeNode \\ "directive").headOption
-
-            (techniqueName, changeDirective, _) <- directiveUnserialiser.unserialise(diffDirective)
-            change                              <- {
+            directiveId                        <- getAttribute(directive, "id")
+                                                    .flatMap(id => DirectiveId.parse(id).leftMap(errMsg => Inconsistency(errMsg)))
+            initialNode                        <- getChild(directive, "initialState")
+            initialState                       <- (initialNode \\ "directive").headOption match {
+                                                    case Some(initialState) =>
+                                                      directiveUnserialiser.unserialise(initialState) match {
+                                                        case Right((techniqueName, directive, _)) => Right(Some((techniqueName, directive)))
+                                                        case Left(_)                              => Left(Inconsistency("could not unserialize directive"))
+                                                      }
+                                                    case None               => Right(None)
+                                                  }
+            changeNode                         <- getGrandchild(directive, "firstChange", "change")
+            actor                              <- getAndTransformChildRec(changeNode, "actor", actor => EventActor(actor.text))
+            date                               <- getAndTransformChildRec(
+                                                    changeNode,
+                                                    "date",
+                                                    date => ISODateTimeFormat.dateTimeParser.parseDateTime(date.text)
+                                                  )
+            reason                              = (changeNode \\ "reason").headOption.map(_.text)
+            diff                               <- getAndParseChildRec(changeNode, "diff", _.attribute("action").headOption.map(_.text))
+            diffDirective                      <- getChildRec(changeNode, "directive")
+            directive                          <- directiveUnserialiser.unserialise(diffDirective)
+            (techniqueName, changeDirective, _) = directive
+            change                             <- {
               diff match {
-                case "add"      => Full(AddDirectiveDiff(techniqueName, changeDirective))
-                case "delete"   => Full(DeleteDirectiveDiff(techniqueName, changeDirective))
+                case "add"      => Right(AddDirectiveDiff(techniqueName, changeDirective))
+                case "delete"   => Right(DeleteDirectiveDiff(techniqueName, changeDirective))
                 case "modifyTo" =>
-                  (changeNode \\ "rootSection").headOption match {
-                    case Some(rsXml) =>
+                  getChildRec(changeNode, "rootSection")
+                    .flatMap(rsXml => {
                       val techId = TechniqueId(techniqueName, changeDirective.techniqueVersion)
                       sectionSpecUnserialiser
                         .parseSectionsInPolicy(rsXml, techId, techniqueName.value)
                         .map(rootSection => ModifyToDirectiveDiff(techniqueName, changeDirective, Some(rootSection)))
-                        .toBox
-                    case None        => Failure(s"Could not find rootSection node in ${changeNode}")
-
-                  }
-
-                case _ => Failure("should not happen")
+                    })
+                case _          => Left(Inconsistency("should not happen"))
               }
 
             }
@@ -622,145 +609,176 @@ class ChangeRequestChangesUnserialisationImpl(
             )
 
             (directiveId -> DirectiveChanges(directiveChange, Seq()))
+          }).chainError(s"${entryType} unserialisation failed")
+
+          // Compatibility : the errors are not included in the final result and will only be logged
+          res match {
+            case Left(err)  =>
+              logger.error(err.fullMsg)
+              None
+            case Right(res) => Some(res)
           }
+
         }.toMap
-      })
+      }
     }
 
-    def unserialiseRuleChange(changeRequest: XNode): Box[Map[RuleId, RuleChanges]] = {
-      (for {
-        rulesNode <- (changeRequest \ "rules").headOption ?~! s"Missing child 'rules' in entry type changeRequest : ${xml}"
+    def unserialiseRuleChange(changeRequest: XNode): PureResult[Map[RuleId, RuleChanges]] = {
+
+      for {
+        rulesNode <- getChild(changeRequest, "rules")(changeRequestEntryType)
       } yield {
 
+        implicit val entryType: XmlEntryType = XmlEntryType("changeRequest rule changes")
+
         (rulesNode \ "rule").iterator.flatMap { rule =>
-          for {
-            ruleId       <- rule.attribute("id").flatMap(id => RuleId.parse(id.text).toBox) ?~!
-                            s"Missing attribute 'id' in entry type changeRequest rule changes  : ${rule}"
-            initialRule  <- (rule \ "initialState").headOption
+          val res = (for {
+            ruleId       <- getAttribute(rule, "id")
+                              .flatMap(id => RuleId.parse(id).leftMap(errMsg => Inconsistency(errMsg)))
+            initialRule  <- getChild(rule, "initialState")
             initialState <- (initialRule \ "rule").headOption match {
                               case Some(initialState) =>
                                 ruleUnserialiser.unserialise(initialState) match {
-                                  case Full(rule) => Full(Some(rule))
-                                  case eb: EmptyBox => eb ?~! "could not unserialize rule"
+                                  case Right(rule) => Right(Some(rule))
+                                  case Left(_)     => Left(Inconsistency("could not unserialize rule"))
                                 }
-                              case None               => Full(None)
+                              case None               => Right(None)
                             }
-
-            changeRule <- (rule \ "firstChange" \ "change").headOption
-            actor      <- (changeRule \\ "actor").headOption.map(actor => EventActor(actor.text))
-            date       <- (changeRule \\ "date").headOption.map(date => ISODateTimeFormat.dateTimeParser.parseDateTime(date.text))
-            reason      = (changeRule \\ "reason").headOption.map(_.text)
-            diff       <- (changeRule \\ "diff").headOption.flatMap(_.attribute("action").headOption.map(_.text))
-            diffRule   <- (changeRule \\ "rule").headOption
-            changeRule <- ruleUnserialiser.unserialise(diffRule)
-            change     <- diff match {
-                            case "add"      => Full(AddRuleDiff(changeRule))
-                            case "delete"   => Full(DeleteRuleDiff(changeRule))
-                            case "modifyTo" => Full(ModifyToRuleDiff(changeRule))
-                            case _          => Failure("should not happen")
-                          }
+            changeRule   <- getGrandchild(rule, "firstChange", "change")
+            actor        <- getAndTransformChildRec(changeRule, "actor", actor => EventActor(actor.text))
+            date         <- getAndTransformChildRec(
+                              changeRule,
+                              "date",
+                              date => ISODateTimeFormat.dateTimeParser.parseDateTime(date.text)
+                            )
+            reason        = (changeRule \\ "reason").headOption.map(_.text)
+            diff         <- getAndParseChildRec(changeRule, "diff", _.attribute("action").headOption.map(_.text))
+            diffRule     <- getChildRec(changeRule, "rule")
+            changeRule   <- ruleUnserialiser.unserialise(diffRule)
+            change       <- diff match {
+                              case "add"      => Right(AddRuleDiff(changeRule))
+                              case "delete"   => Right(DeleteRuleDiff(changeRule))
+                              case "modifyTo" => Right(ModifyToRuleDiff(changeRule))
+                              case _          => Left(Inconsistency("should not happen"))
+                            }
           } yield {
             val ruleChange = RuleChange(initialState, RuleChangeItem(actor, date, reason, change), Seq())
 
             (ruleId -> RuleChanges(ruleChange, Seq()))
+          }).chainError(s"${entryType} unserialisation failed")
+
+          // Compatibility : the errors are not included in the final result and will only be logged
+          res match {
+            case Left(err)  =>
+              logger.error(err.fullMsg)
+              None
+            case Right(res) => Some(res)
           }
+
         }.toMap
-      })
+      }
     }
 
-    def unserialiseGlobalParameterChange(changeRequest: XNode): Box[Map[String, GlobalParameterChanges]] = {
-      (for {
-        paramsNode <-
-          (changeRequest \ "globalParameters").headOption ?~! s"Missing child 'globalParameters' in entry type changeRequest : ${xml}"
+    def unserialiseGlobalParameterChange(changeRequest: XNode): PureResult[Map[String, GlobalParameterChanges]] = {
+
+      for {
+        paramsNode <- getChild(changeRequest, "globalParameters")(changeRequestEntryType)
       } yield {
+
+        implicit val entryType: XmlEntryType = XmlEntryType("globalParameters Global Parameter changes")
+
         (paramsNode \ "globalParameter").iterator.flatMap { param =>
-          for {
-            paramName    <- param.attribute("name").map(_.text) ?~!
-                            s"Missing attribute 'name' in entry type globalParameters Global Parameter changes  : ${param}"
-            initialParam <- (param \ "initialState").headOption
+          val res = (for {
+            paramName    <- getAttribute(param, "name")
+            initialParam <- getChild(param, "initialState")
             initialState <- (initialParam \ "globalParameter").headOption match {
                               case Some(initialState) =>
                                 globalParamUnserialiser.unserialise(initialState) match {
-                                  case Full(rule) => Full(Some(rule))
-                                  case eb: EmptyBox => eb ?~! "could not unserialize global parameter"
+                                  case Right(param) => Right(Some(param))
+                                  case Left(_)      => Left(Inconsistency("could not unserialize global parameter"))
                                 }
-                              case None               => Full(None)
+                              case None               => Right(None)
+                            }
+            changeParam  <- getGrandchild(param, "firstChange", "change")
+            actor        <- getAndTransformChildRec(changeParam, "actor", actor => EventActor(actor.text))
+            date         <- getAndTransformChildRec(
+                              changeParam,
+                              "date",
+                              date => ISODateTimeFormat.dateTimeParser.parseDateTime(date.text)
+                            )
+            reason        = (changeParam \\ "reason").headOption.map(_.text)
+            diff         <- getAndParseChildRec(changeParam, "diff", _.attribute("action").headOption.map(_.text))
+            diffParam    <- getChildRec(changeParam, "globalParameter")
+            changeParam  <- globalParamUnserialiser.unserialise(diffParam)
+            change       <- diff match {
+                              case "add"      => Right(AddGlobalParameterDiff(changeParam))
+                              case "delete"   => Right(DeleteGlobalParameterDiff(changeParam))
+                              case "modifyTo" => Right(ModifyToGlobalParameterDiff(changeParam))
+                              case _          => Left(Inconsistency("should not happen"))
                             }
 
-            changeParam <- (param \ "firstChange" \ "change").headOption
-            actor       <- (changeParam \\ "actor").headOption.map(actor => EventActor(actor.text))
-            date        <- (changeParam \\ "date").headOption.map(date => ISODateTimeFormat.dateTimeParser.parseDateTime(date.text))
-            reason       = (changeParam \\ "reason").headOption.map(_.text)
-            diff        <- (changeParam \\ "diff").headOption.flatMap(_.attribute("action").headOption.map(_.text))
-            diffParam   <- (changeParam \\ "globalParameter").headOption
-            changeParam <- globalParamUnserialiser.unserialise(diffParam)
-            change      <- diff match {
-                             case "add"      => Full(AddGlobalParameterDiff(changeParam))
-                             case "delete"   => Full(DeleteGlobalParameterDiff(changeParam))
-                             case "modifyTo" => Full(ModifyToGlobalParameterDiff(changeParam))
-                             case _          => Failure("should not happen")
-                           }
           } yield {
             val paramChange = GlobalParameterChange(initialState, GlobalParameterChangeItem(actor, date, reason, change), Seq())
 
             (paramName -> GlobalParameterChanges(paramChange, Seq()))
+          }).chainError(s"${entryType} unserialisation failed")
+
+          // Compatibility : the errors are not included in the final result and will only be logged
+          res match {
+            case Left(err)  =>
+              logger.error(err.fullMsg)
+              None
+            case Right(res) => Some(res)
           }
+
         }.toMap
-      })
+      }
     }
 
-    for {
-      changeRequest <- {
-        if (xml.label == XML_TAG_CHANGE_REQUEST) Full(xml)
-        else Failure("Entry type is not a <%s>: ".format(XML_TAG_CHANGE_REQUEST, xml))
-      }
-      fileFormatOk  <- TestFileFormat(changeRequest)
+    (for {
+      changeRequest <- checkEntry(xml)(changeRequestEntryType)
+      _             <- TestFileFormat.check(changeRequest)
       groups        <- unserialiseNodeGroupChange(changeRequest)
-      directives     = {
+      directives    <- {
         Try {
           unserialiseDirectiveChange(changeRequest)
         } match {
           case Success(change) => change
           case Catch(e)        =>
-            Failure(s"Could not deserialize directives changes cause ${e.getMessage()}")
+            Left(Inconsistency(s"Could not deserialize directives changes cause ${e.getMessage()}"))
         }
       }
       rules         <- unserialiseRuleChange(changeRequest)
       params        <- unserialiseGlobalParameterChange(changeRequest)
     } yield {
       (directives, groups, rules, params)
-    }
+    }).chainError(s"${changeRequestEntryType} unserialisation failed")
   }
 
 }
 
 class GlobalParameterUnserialisationImpl extends GlobalParameterUnserialisation {
-  def unserialise(entry: XNode): Box[GlobalParameter] = {
-    for {
-      globalParam  <- {
-        if (entry.label == XML_TAG_GLOBAL_PARAMETER) Full(entry)
-        else Failure("Entry type is not a <%s>: %s".format(XML_TAG_GLOBAL_PARAMETER, entry))
-      }
-      fileFormatOk <- TestFileFormat(globalParam)
 
-      name        <-
-        (globalParam \ "name").headOption.map(_.text) ?~! ("Missing attribute 'name' in entry type globalParameter : " + entry)
-      value       <-
-        (globalParam \ "value").headOption.map(_.text) ?~! ("Missing attribute 'value' in entry type globalParameter : " + entry)
-      description <- (globalParam \ "description").headOption.map(
-                       _.text
-                     ) ?~! ("Missing attribute 'description' in entry type globalParameter : " + entry)
+  import XmlUtils.*
+  implicit val entryType: XmlEntryType = XmlEntryType(XML_TAG_GLOBAL_PARAMETER)
+
+  def unserialise(entry: XNode): PureResult[GlobalParameter] = {
+    (for {
+      globalParam <- checkEntry(entry)
+      _           <- TestFileFormat.check(globalParam)
+      name        <- getAndTransformChild(globalParam, "name", _.text)
+      value       <- getAndTransformChild(globalParam, "value", _.text)
+      description <- getAndTransformChild(globalParam, "description", _.text)
       provider     = (globalParam \ "provider").headOption.map(x => PropertyProvider(x.text))
       mode         = (globalParam \ "inheritMode").headOption.flatMap(x => InheritMode.parseString(x.text).toOption)
       visibility   = (globalParam \ "visibility").headOption
                        .flatMap(x => Visibility.withNameInsensitiveOption(x.text))
                        .getOrElse(Visibility.default)
       // TODO: no version in param for now
-      g           <- GlobalParameter.parse(name, GitVersion.DEFAULT_REV, value, mode, description, provider, visibility).toBox
+      g           <- GlobalParameter.parse(name, GitVersion.DEFAULT_REV, value, mode, description, provider, visibility)
     } yield {
       g // TODO: no version in param for now
-
-    }
+    }).chainError(s"${entryType} unserialisation failed")
   }
 }
 
@@ -773,7 +791,7 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
   //   <authz path="/foo/wiz/$waz", actions="get, post, patch"/>
   // </acl>
   private def unserAcl(entry: XNode): Box[ApiAuthorization.ACL] = {
-    // at that point, any error is an grave error: we don't want to
+    // at that point, any error is a grave error: we don't want to
     // mess up with authz
     import cats.implicits.*
 
@@ -804,35 +822,35 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
     for {
       apiAccount     <- {
         if (entry.label == XML_TAG_API_ACCOUNT) Full(entry)
-        else Failure("Entry type is not a <%s>: %s".format(XML_TAG_API_ACCOUNT, entry))
+        else Failure(s"Entry type is not a ${XML_TAG_API_ACCOUNT}: ${entry}")
       }
-      fileFormatOk   <- TestFileFormat(apiAccount)
-      id             <- (apiAccount \ "id").headOption.map(_.text) ?~! ("Missing attribute 'id' in entry type API Account : " + entry)
-      name           <- (apiAccount \ "name").headOption.map(_.text) ?~! ("Missing attribute 'name' in entry type API Account : " + entry)
+      _              <- TestFileFormat(apiAccount)
+      id             <- (apiAccount \ "id").headOption.map(_.text) ?~! (s"Missing attribute 'id' in entry type API Account : ${entry}")
+      name           <- (apiAccount \ "name").headOption.map(_.text) ?~! (s"Missing attribute 'name' in entry type API Account : ${entry}")
       token          <-
-        (apiAccount \ "token").headOption.map(_.text) ?~! ("Missing attribute 'token' in entry type API Account : " + entry)
+        (apiAccount \ "token").headOption.map(_.text) ?~! (s"Missing attribute 'token' in entry type API Account : ${entry}")
       description    <- (apiAccount \ "description").headOption.map(
                           _.text
-                        ) ?~! ("Missing attribute 'description' in entry type API Account : " + entry)
+                        ) ?~! (s"Missing attribute 'description' in entry type API Account : ${entry}")
       isEnabled      <- (apiAccount \ "isEnabled").headOption.flatMap(s =>
                           tryo(s.text.toBoolean)
-                        ) ?~! ("Missing attribute 'isEnabled' in entry type API Account : " + entry)
+                        ) ?~! (s"Missing attribute 'isEnabled' in entry type API Account : ${entry}")
       creationDate   <- (apiAccount \ "creationDate").headOption.flatMap(s =>
                           tryo(dateFormatter.parseDateTime(s.text))
-                        ) ?~! ("Missing attribute 'creationDate' in entry type API Account : " + entry)
+                        ) ?~! (s"Missing attribute 'creationDate' in entry type API Account : ${entry}")
       tokenGenDate   <- (apiAccount \ "tokenGenerationDate").headOption.flatMap(s =>
                           tryo(dateFormatter.parseDateTime(s.text))
-                        ) ?~! ("Missing attribute 'tokenGenerationDate' in entry type API Account : " + entry)
+                        ) ?~! (s"Missing attribute 'tokenGenerationDate' in entry type API Account : ${entry}")
       expirationDate <- (apiAccount \ "expirationDate").headOption match {
                           case None    => Full(None)
                           case Some(s) =>
                             tryo {
                               Some(dateFormatter.parseDateTime(s.text))
-                            } ?~! ("Bad date format for field 'expirationDate' in entry type API Account : " + entry)
+                            } ?~! (s"Bad date format for field 'expirationDate' in entry type API Account : ${entry}")
                         }
       authz          <- (apiAccount \ "authorization").headOption match {
                           case None =>
-                            // we are most likelly in a case where API ACL weren't implemented,
+                            // we are most likely in a case where API ACL weren't implemented,
                             // because the event was saved < Rudder 4.3. Use a "nil" ACL
                             Full(ApiAuthorization.None)
 
@@ -874,16 +892,139 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
 class SecretUnserialisationImpl extends SecretUnserialisation {
   def unserialise(entry: XNode): Box[Secret] = {
     for {
-      secret       <- {
+      secret      <- {
         if (entry.label == XML_TAG_SECRET) Full(entry)
-        else Failure("Entry type is not a <%s>: %s".format(XML_TAG_SECRET, entry))
+        else Failure(s"Entry type is not a ${XML_TAG_SECRET}: ${entry}")
       }
-      fileFormatOk <- TestFileFormat(secret)
-      name         <- (secret \ "name").headOption.map(_.text) ?~! ("Missing attribute 'name' in entry type secret : " + entry)
-      description  <-
-        (secret \ "description").headOption.map(_.text) ?~! ("Missing attribute 'description' in entry type secret : " + entry)
+      _           <- TestFileFormat(secret)
+      name        <- (secret \ "name").headOption.map(_.text) ?~! s"Missing attribute 'name' in entry type secret : ${entry}"
+      description <-
+        (secret \ "description").headOption.map(_.text) ?~! s"Missing attribute 'description' in entry type secret : ${entry}"
     } yield {
       Secret(name, "", description)
     }
   }
+}
+
+/**
+ * Util class that offers methods to look up a child node or attribute in a given node's direct children or full tree
+ * of descendants, and handles the related errors.
+ */
+object XmlUtils {
+
+  /* The entry type (i.e. XML node label) of the node(s) that are passed as argument.
+     It is used in case of an error when a child node or label is missing from the given node. */
+  case class XmlEntryType(value: String) extends AnyVal
+
+  private def missingChildErrMsg(label: String, entryType: XmlEntryType, entry: XNode): String = {
+    s"Missing child '${label}' in entry type ${entryType} : ${entry}"
+  }
+
+  private def missingChildErrMsgRec(label: String, entryType: XmlEntryType, entry: XNode): String = {
+    s"Missing child '${label}' in sequence and sub-sequences of entry type ${entryType} : ${entry}"
+  }
+
+  private def missingOrBadChildErrMsg(label: String, entryType: XmlEntryType, entry: XNode): String = {
+    s"Missing or bad child '${label}' in entry type ${entryType} : ${entry}"
+  }
+
+  private def missingOrBadChildErrMsgRec(label: String, entryType: XmlEntryType, entry: XNode): String = {
+    s"Missing or bad child '${label}' in sequence and sub-sequences of entry type ${entryType} : ${entry}"
+  }
+
+  private def missingAttributeErrMsg(attributeName: String, entryType: XmlEntryType, entry: XNode): String = {
+    s"Missing attribute '${attributeName}' in entry type ${entryType} : ${entry}"
+  }
+
+  def checkEntry(entry: XNode)(implicit entryType: XmlEntryType): PureResult[XNode] = {
+    if (entry.label == entryType.value) Right(entry)
+    else Left(Inconsistency(s"Entry type is not a ${entryType.value}: ${entry}"))
+  }
+
+  def getAttribute(entry: XNode, attributeName: String)(implicit entryType: XmlEntryType): PureResult[String] = {
+    entry.attribute(attributeName).map(id => id.text).notOptionalPure(missingAttributeErrMsg(attributeName, entryType, entry))
+  }
+
+  def getGrandchild(entry: XNode, label1: String, label2: String)(implicit entryType: XmlEntryType): PureResult[XNode] = {
+    (entry \ label1 \ label2).headOption
+      .notOptionalPure(s"Missing child '${label2}' in child '${label1}' in entry type ${entryType} : ${entry}")
+  }
+
+  /**
+   * Get the first child node of the given 'entry' node that has the given label.
+   */
+  def getChild(entry: XNode, label: String)(implicit entryType: XmlEntryType): PureResult[XNode] = {
+    (entry \ label).headOption
+      .notOptionalPure(missingChildErrMsg(label, entryType, entry))
+  }
+
+  /**
+   * Get the first child node of the given 'entry' node that has the given label.
+   * If it exists, apply the given transformation function f on the child node.
+   */
+  def getAndTransformChild[A](
+      entry: XNode,
+      label: String,
+      f:     XNode => A
+  )(implicit entryType: XmlEntryType): PureResult[A] = {
+    (entry \ label).headOption
+      .notOptionalPure(missingChildErrMsg(label, entryType, entry))
+      .map(f)
+  }
+
+  /**
+   * Get the first child node of the given 'entry' node that has the given label.
+   * If it exists, apply the given parsing function f on the child node.
+   * The parsing may fail, in which case this function will return a Left(RudderError) value.
+   */
+  def getAndParseChild[A](
+      entry: XNode,
+      label: String,
+      f:     XNode => Option[A]
+  )(implicit entryType: XmlEntryType): PureResult[A] = {
+    (entry \ label).headOption
+      .flatMap(f)
+      .notOptionalPure(missingOrBadChildErrMsg(label, entryType, entry))
+  }
+
+  /**
+   * Get the first descendant of the given 'entry' node that has the given label.
+   */
+  def getChildRec(
+      entry: XNode,
+      label: String
+  )(implicit entryType: XmlEntryType): PureResult[XNode] = {
+    (entry \\ label).headOption
+      .notOptionalPure(missingChildErrMsgRec(label, entryType, entry))
+  }
+
+  /**
+   * Get the first descendant of the given 'entry' node that has the given label.
+   * If it exists, apply the given transformation function f on the node.
+   */
+  def getAndTransformChildRec[A](
+      entry: XNode,
+      label: String,
+      f:     XNode => A
+  )(implicit entryType: XmlEntryType): PureResult[A] = {
+    (entry \\ label).headOption
+      .map(f)
+      .notOptionalPure(missingChildErrMsgRec(label, entryType, entry))
+  }
+
+  /**
+   * Get the first descendant of the given 'entry' node that has the given label.
+   * If it exists, apply the given parsing function f on the node.
+   * The parsing may fail, in which case this function will return a Left(RudderError) value.
+   */
+  def getAndParseChildRec[A](
+      entry: XNode,
+      label: String,
+      f:     XNode => Option[A]
+  )(implicit entryType: XmlEntryType): PureResult[A] = {
+    (entry \\ label).headOption
+      .flatMap(f)
+      .notOptionalPure(missingOrBadChildErrMsgRec(label, entryType, entry))
+  }
+
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
@@ -44,7 +44,7 @@ import com.normation.errors.*
 import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.domain.eventlog.RudderEventActor
-import com.normation.rudder.domain.logger.ChangeRequestLogger
+import com.normation.rudder.domain.logger.ChangeRequestLoggerPure
 import com.normation.rudder.domain.nodes.AddNodeGroupDiff
 import com.normation.rudder.domain.nodes.DeleteNodeGroupDiff
 import com.normation.rudder.domain.nodes.ModifyToNodeGroupDiff
@@ -66,6 +66,7 @@ import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 import net.liftweb.common.*
 import scala.xml.*
+import zio.syntax.ToZio
 
 /**
  * A service responsible to actually commit a change request,
@@ -115,34 +116,37 @@ class CommitAndDeployChangeRequestServiceImpl(
     updateDynamicGroups:   DynGroupUpdaterService
 ) extends CommitAndDeployChangeRequestService {
 
-  val logger = ChangeRequestLogger
+  private val logger = ChangeRequestLoggerPure
 
   def save(changeRequest: ChangeRequest)(implicit cc: ChangeContext): IOResult[ChangeRequest] = {
     implicit val qc: QueryContext = cc.toQuery
 
-    workflowEnabled().either.runNow match {
-      case Right(b) => if (b) logger.info(s"Saving and deploying change request ${changeRequest.id.value}")
-      case _        => ()
-    }
-
     for {
-      (config, trigger) <- changeRequest match {
-                             case config: ConfigurationChangeRequest =>
-                               if (!isMergeableConfigurationChangeRequest(config)) {
-                                 ChangeRequestLogger.info(
-                                   s"Merging change request #${config.id.value} while configurations have diverged: ${config.info.name}: ${config.info.description}"
-                                 )
-                               }
-                               saveConfigurationChangeRequest(config).map(config -> _)
-                             case x => Failure("We don't know how to deploy change request like this one: " + x)
-                           }
+      _                <- workflowEnabled()
+                            .tap(workflowEnabled => {
+                              if (workflowEnabled) logger.info(s"Saving and deploying change request ${changeRequest.id.value}")
+                              else ().succeed
+                            })
+      res              <- changeRequest match {
+                            case config: ConfigurationChangeRequest =>
+                              if (!isMergeableConfigurationChangeRequest(config)) {
+                                logger.info(
+                                  s"Merging change request #${config.id.value} while configurations have diverged: ${config.info.name}: ${config.info.description}"
+                                )
+                              }
+                              saveConfigurationChangeRequest(config).map(config -> _).toIO
+
+                            case x =>
+                              Inconsistency("We don't know how to deploy change request like this one: " + x).fail
+                          }
+      (config, trigger) = res
     } yield {
       if (trigger) {
         asyncDeploymentAgent ! AutomaticStartDeployment(cc.modId, RudderEventActor)
       }
       ChangeRequest.setModId(config, cc.modId)
     }
-  }.toIO
+  }
 
   def isMergeable(changeRequest: ChangeRequest)(implicit qc: QueryContext): Boolean = {
     changeRequest match {
@@ -162,15 +166,15 @@ class CommitAndDeployChangeRequestServiceImpl(
       // Logging function
       def failureMessage(elem:     T): String
       // Find Current value from initial value
-      def getCurrentValue(initial: T): Box[T]
+      def getCurrentValue(initial: T): IOResult[T]
       // Function that validates that the change request is still valid
       def compareMethod(initial:   T, current: T): Boolean
       // How to serialize the data into XML
-      def xmlSerialize(elem:       T): Box[Node]
+      def xmlSerialize(elem:       T): PureResult[Node]
       // How to unserialize XML into the datatype
-      def xmlUnserialize(xml:      Node): Box[T]
+      def xmlUnserialize(xml:      Node): PureResult[T]
       // Transform date from LDAP to XML then transform it back to data using the XML parser
-      def normalizeData(elem: T): Box[T] = {
+      def normalizeData(elem: T): PureResult[T] = {
         try {
           for {
             entry <- xmlSerialize(elem)
@@ -181,23 +185,23 @@ class CommitAndDeployChangeRequestServiceImpl(
             elem
           }
         } catch {
-          case e: Exception => Failure(s"could not verify xml cause is : ${e.getCause}")
+          case e: Exception => Left(Inconsistency(s"could not verify xml cause is : ${e.getCause}"))
         }
       }
 
       // Check if the change request is mergeable
-      def check(initialState: Option[T]): Box[String] = {
+      def check(initialState: Option[T]): IOResult[String] = {
         initialState match {
           case None          => // No initial state means creation of new elements, can't diverge
-            Full("OK")
+            "OK".succeed
           case Some(initial) =>
             for {
               current    <- getCurrentValue(initial)
-              normalized <- normalizeData(current)
+              normalized <- normalizeData(current).toIO
               check      <- if (compareMethod(initial, normalized)) {
-                              Full("OK")
+                              "OK".succeed
                             } else {
-                              Failure(s"${failureMessage(initial)} has diverged since change request creation")
+                              Inconsistency(s"${failureMessage(initial)} has diverged since change request creation").fail
                             }
             } yield {
               check
@@ -210,9 +214,9 @@ class CommitAndDeployChangeRequestServiceImpl(
 
     case object CheckRule extends CheckChanges[Rule] {
       def failureMessage(rule:   Rule) = s"Rule ${rule.name} (id: ${rule.id.serialize})"
-      def getCurrentValue(rule:  Rule) = roRuleRepository.get(rule.id).toBox
+      def getCurrentValue(rule:  Rule) = roRuleRepository.get(rule.id)
       def compareMethod(initial: Rule, current: Rule) = CheckDivergenceForMerge.compareRules(initial, current)
-      def xmlSerialize(rule:     Rule): Box[Node] = Full(xmlSerializer.rule.serialise(rule))
+      def xmlSerialize(rule:     Rule) = Right(xmlSerializer.rule.serialise(rule))
       def xmlUnserialize(xml:    Node) = xmlUnserializer.rule.unserialise(xml)
     }
 
@@ -223,14 +227,14 @@ class CommitAndDeployChangeRequestServiceImpl(
       val directiveContext                      = {
         // Option is None, if this is a Directive creation, but serialisation won't be used in this case (see check method)
         changes.changes.initialState match {
-          case Some((techniqueName, _, rootSection)) => Full((techniqueName, rootSection))
-          case None                                  => Failure("could not find directive context from initial state")
+          case Some((techniqueName, _, rootSection)) => Right((techniqueName, rootSection))
+          case None                                  => Left(Inconsistency("could not find directive context from initial state"))
         }
       }
       def failureMessage(directive: Directive) = s"Directive ${directive.name} (id: ${directive.id.serialize})"
-      def getCurrentValue(directive: Directive) = roDirectiveRepo.getDirective(directive.id.uid).toBox.flatMap {
-        case None      => Empty
-        case Some(dir) => Full(dir)
+      def getCurrentValue(directive: Directive) = roDirectiveRepo.getDirective(directive.id.uid).flatMap {
+        case None            => Inconsistency("could not get current value of directive from roDirectiveRepo : directive is absent").fail
+        case Some(directive) => directive.succeed
       }
       def compareMethod(initial: Directive, current: Directive) = CheckDivergenceForMerge.compareDirectives(initial, current)
       def xmlSerialize(directive: Directive)    = {
@@ -244,61 +248,59 @@ class CommitAndDeployChangeRequestServiceImpl(
 
     case object CheckGroup extends CheckChanges[NodeGroup] {
       def failureMessage(group:  NodeGroup) = s"Group ${group.name} (id: ${group.id.serialize})"
-      def getCurrentValue(group: NodeGroup) = roNodeGroupRepo.getNodeGroup(group.id).map(_._1).toBox
+      def getCurrentValue(group: NodeGroup) = roNodeGroupRepo.getNodeGroup(group.id).map(_._1)
       def compareMethod(initial: NodeGroup, current: NodeGroup) = CheckDivergenceForMerge.compareGroups(initial, current)
-      def xmlSerialize(group:    NodeGroup): Box[Node] = Full(xmlSerializer.group.serialise(group))
+      def xmlSerialize(group:    NodeGroup): PureResult[Node] = Right(xmlSerializer.group.serialise(group))
       def xmlUnserialize(xml:    Node) = xmlUnserializer.group.unserialise(xml)
     }
 
     case object CheckGlobalParameter extends CheckChanges[GlobalParameter] {
       def failureMessage(param: GlobalParameter) = s"Parameter ${param.name}"
       def getCurrentValue(param: GlobalParameter)                           =
-        roParameterRepository.getGlobalParameter(param.name).notOptional(s"Parameter '${param.name}' was not found").toBox
+        roParameterRepository.getGlobalParameter(param.name).notOptional(s"Parameter '${param.name}' was not found")
       def compareMethod(initial: GlobalParameter, current: GlobalParameter) =
         CheckDivergenceForMerge.compareGlobalParameter(initial, current)
-      def xmlSerialize(param: GlobalParameter): Box[Node] = Full(xmlSerializer.globalParam.serialise(param))
+      def xmlSerialize(param: GlobalParameter): PureResult[Node] = Right(xmlSerializer.globalParam.serialise(param))
       def xmlUnserialize(xml: Node) = xmlUnserializer.globalParam.unserialise(xml)
     }
 
     /*
      * check for all elem, stop on the first failing
      */
-    (for {
-      cond <- workflowEnabled()
-    } yield {
-      if (cond) {
-        (for {
-          directivesOk  <- traverse(changeRequest.directives.values.toSeq) { changes =>
-                             // Only check the directive for now
-                             CheckDirective(changes).check(changes.changes.initialState.map(_._2))
-                           }
-          groupsOk      <- traverse(changeRequest.nodeGroups.values.toSeq) { changes =>
-                             CheckGroup.check(changes.changes.initialState)
-                           }
-          rulesOk       <- traverse(changeRequest.rules.values.toSeq)(changes => CheckRule.check(changes.changes.initialState))
-          globalParamOk <- traverse(changeRequest.globalParams.values.toSeq) { changes =>
-                             CheckGlobalParameter.check(changes.changes.initialState)
-                           }
-        } yield {
-          directivesOk
-        }) match {
-          case Full(_) => true
-          case eb: EmptyBox =>
-            val e = eb ?~! "Can not merge change request"
-            logger.debug(e.messageChain)
-            e.rootExceptionCause.foreach(ex => logger.debug("Root exception was:", ex))
+
+    def isMergeable = {
+      (for {
+        directivesOk  <- changeRequest.directives.values.toSeq.accumulate { changes =>
+                           // Only check the directive for now
+                           CheckDirective(changes).check(changes.changes.initialState.map(_._2))
+                         }
+        groupsOk      <- changeRequest.nodeGroups.values.toSeq.accumulate(changes => CheckGroup.check(changes.changes.initialState))
+        rulesOk       <- changeRequest.rules.values.toSeq.accumulate(changes => CheckRule.check(changes.changes.initialState))
+        globalParamOk <- changeRequest.globalParams.values.toSeq.accumulate { changes =>
+                           CheckGlobalParameter.check(changes.changes.initialState)
+                         }
+      } yield {
+        directivesOk
+      }).chainError("Can not merge change request")
+        .tapError(err => logger.debug(err.fullMsg))
+        .chainError("An error occurred while checking whether change request is mergeable")
+        .fold(
+          err => {
+            logger.error(err.fullMsg)
             false
-        }
-      } else {
-        // If workflow are disabled, a change is always mergeable.
-        true
-      }
-    }).toBox match {
-      case Full(mergeable) => mergeable
-      case eb: EmptyBox =>
-        val fail = eb ?~ "An error occurred while checking the change request acceptance"
-        logger.error(fail.messageChain)
-        false
+          },
+          _ => true
+        )
+    }
+
+    (for {
+      cond        <- workflowEnabled()
+      isMergeable <- if (cond) isMergeable else true.succeed
+    } yield {
+      isMergeable
+    }).either.runNow match {
+      case Right(mergeable) => mergeable
+      case Left(_)          => false
     }
   }
 
@@ -525,7 +527,7 @@ object CheckDivergenceForMerge {
   }
 
   def debugLog(message: String)(implicit changeRequestId: Int): Unit = {
-    ChangeRequestLogger.debug(s"CR #${changeRequestId}: ${message}")
+    ChangeRequestLoggerPure.debug(s"CR #${changeRequestId}: ${message}")
   }
   /*
    * Comparison methods between Rules/directives/groups/global Param

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/marshalling/TestXmlUnserialisation.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/marshalling/TestXmlUnserialisation.scala
@@ -28,8 +28,6 @@ import com.normation.rudder.domain.queries.ResultTransformation.*
 import com.normation.rudder.facts.nodes.NodeSecurityContext
 import com.normation.rudder.services.policies.TestNodeConfiguration
 import com.normation.rudder.services.queries.CmdbQueryParser
-import net.liftweb.common.Empty
-import net.liftweb.common.Failure
 import net.liftweb.common.Full
 import org.joda.time.format.ISODateTimeFormat
 import org.junit.runner.RunWith
@@ -105,7 +103,7 @@ class TestXmlUnserialisation extends Specification with BoxSpecMatcher {
 
       val expected = (TechniqueName(techniqueName), directive, SectionVal(Map(), Map()))
 
-      unserialized mustFullEq (expected)
+      unserialized must beRight(expected)
     }
 
     "be able to correctly unserialize a change request" in {
@@ -132,14 +130,7 @@ class TestXmlUnserialisation extends Specification with BoxSpecMatcher {
         <globalParameters/>
       </changeRequest>
 
-      changeRequestChangesUnserialisation.unserialise(change) match {
-        case f: Failure =>
-          val msg = s"I wasn't expecting the failure: ${f.messageChain}"
-          f.rootExceptionCause.foreach(ex => ex.printStackTrace())
-          ko(msg)
-        case Empty => ko(s"Unexpected Empty!")
-        case Full(_) => ok("unserialization was a success")
-      }
+      changeRequestChangesUnserialisation.unserialise(change) must beRight
     }
   }
 
@@ -229,7 +220,7 @@ class TestXmlUnserialisation extends Specification with BoxSpecMatcher {
     val xml    = nodeGroupSerialisation.serialise(group)
     val group2 = nodeGroupUnserialisation.unserialise(xml)
 
-    group2 must beEqualTo(Full(group))
+    group2 must beRight(group)
   }
 
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/26861

This is part of the plan to remove the dependency to the lift library from Rudder and Rudder plugins.
This PR migrates the following classes in XmlUnserialisation : 
- DirectiveUnserialisationImpl
- NodeGroupCategoryUnserialisationImpl
- NodeGroupUnserialisationImpl
- RuleUnserialisationImpl
- RuleCategoryUnserialisationImpl
- GlobalParameterUnserialisationImpl
- ChangeRequestChangesUnserialisationImpl

This change also includes a new `XmlUtils` object, which offers methods to look up a specific child node or attribute of a given XML node, and the error handling that comes with it. XmlUtils may be used in order to migrate the remaining classes in XmlUnserialisation

This PR is part of the migration from Box to ZIO in change-validation, and is linked to the following PR in the Rudder plugins repository : https://github.com/Normation/rudder-plugins/pull/828