### PR TITLE
Fixes #26887: Compatibility fixe for scala 3 in Rudder 9.0

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/services/provisioning/CheckInventoryDigest.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/services/provisioning/CheckInventoryDigest.scala
@@ -37,7 +37,6 @@
 package com.normation.inventory.services.provisioning
 
 import com.normation.errors.*
-import com.normation.errors.IOResult
 import com.normation.inventory.domain.*
 import java.io.InputStream
 import java.security.PublicKey

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionInventoryParser.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionInventoryParser.scala
@@ -41,7 +41,6 @@ import cats.data.NonEmptyList
 import com.normation.errors.*
 import com.normation.inventory.domain.*
 import com.normation.inventory.domain.InventoryError.Inconsistency
-import com.normation.inventory.domain.NodeTimezone
 import com.normation.inventory.domain.VmType.*
 import com.normation.inventory.services.provisioning.*
 import com.normation.utils.HostnameRegex

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/PreInventoryParserCheckConsistency.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/PreInventoryParserCheckConsistency.scala
@@ -39,7 +39,6 @@ package com.normation.inventory.provisioning
 package fusion
 
 import com.normation.errors.*
-import com.normation.errors.RudderError
 import com.normation.inventory.domain.InventoryError
 import com.normation.inventory.services.provisioning.*
 import com.normation.utils.NodeIdRegex

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/PreInventoryParserCheckInventoryAge.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/PreInventoryParserCheckInventoryAge.scala
@@ -43,7 +43,6 @@ import com.normation.inventory.services.provisioning.*
 import java.time.*
 import java.time.format.DateTimeFormatter
 import scala.xml.NodeSeq
-import zio.*
 
 class PreInventoryParserCheckInventoryAge(maxBeforeNow: Duration, maxAfterNow: Duration) extends PreInventoryParser {
   override val name = "post_process_inventory:check_inventory_age"

--- a/webapp/sources/ldap-inventory/inventory-provisioning-core/src/main/scala/com/normation/inventory/ldap/provisioning/PreCommits.scala
+++ b/webapp/sources/ldap-inventory/inventory-provisioning-core/src/main/scala/com/normation/inventory/ldap/provisioning/PreCommits.scala
@@ -39,7 +39,6 @@ package com.normation.inventory.ldap.provisioning
 
 import com.normation.errors.*
 import com.normation.inventory.domain.*
-import com.normation.inventory.domain.Inventory
 import com.normation.inventory.services.provisioning.*
 import zio.syntax.*
 

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryMapper.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryMapper.scala
@@ -38,10 +38,8 @@
 package com.normation.inventory.ldap.core
 
 import com.normation.errors.*
-import com.normation.errors.RudderError
 import com.normation.inventory.domain.*
 import com.normation.inventory.domain.InetAddressUtils.*
-import com.normation.inventory.domain.NodeTimezone
 import com.normation.inventory.domain.VmType.*
 import com.normation.inventory.ldap.core.InventoryMappingResult.*
 import com.normation.inventory.ldap.core.InventoryMappingRudderError.*

--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -108,23 +108,6 @@ limitations under the License.
     </extensions>
     <plugins>
       <plugin>
-        <groupId>io.github.evis</groupId>
-        <artifactId>scalafix-maven-plugin_2.13</artifactId>
-        <version>0.1.8_0.11.0</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-rewrites_2.13</artifactId>
-            <version>0.1.5</version>
-          </dependency>
-          <dependency>
-            <groupId>ch.epfl.scala</groupId>
-            <artifactId>scala3-migrate-rules_2.13</artifactId>
-            <version>0.7.2</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
         <!-- Specify maven resources plugin version because to avoid this bug from plugin 3.2+ https://issues.apache.org/jira/browse/MRESOURCES-269
 	especially with maven 3.9 that uses version 3.3.0 of this plugin by default, see https://issues.rudder.io/issues/22403
 	-->
@@ -167,13 +150,6 @@ limitations under the License.
         <configuration>
           <scalaCompatVersion>${scala-binary-version}</scalaCompatVersion>
           <recompileMode>all</recompileMode>
-          <compilerPlugins>
-            <compilerPlugin>
-              <groupId>org.scalameta</groupId>
-              <artifactId>semanticdb-scalac_${scala-version}</artifactId>
-              <version>4.13.2</version>
-            </compilerPlugin>
-          </compilerPlugins>
           <args>
             <arg>-release:17</arg>
             <arg>-dependencyfile</arg>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/PluginService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/PluginService.scala
@@ -37,8 +37,6 @@
 package com.normation.plugins
 
 import com.normation.errors.*
-import com.normation.plugins.*
-import com.normation.plugins.PluginInstallStatus
 import zio.*
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -44,8 +44,6 @@ import com.normation.GitVersion.Revision
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.errors.*
-import com.normation.errors.PureResult
-import com.normation.errors.Unexpected
 import com.normation.inventory.domain.CertifiedKey
 import com.normation.inventory.domain.KeyStatus
 import com.normation.inventory.domain.NodeId

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -94,7 +94,6 @@ import org.joda.time.DateTime
 import zio.*
 import zio.Tag as _
 import zio.json.*
-import zio.json.DeriveJsonEncoder
 import zio.json.internal.Write
 import zio.syntax.*
 
@@ -1502,10 +1501,10 @@ object JsonResponseObjects {
    */
   sealed trait GlobalPropertyStatus extends PropertyStatus
   object GlobalPropertyStatus {
-    final case object GlobalPropertyOkStatus extends GlobalPropertyStatus {
+    case object GlobalPropertyOkStatus extends GlobalPropertyStatus {
       override def errorMessage: Option[String] = None
     }
-    final case class GlobalPropertyErrorStatus private[GlobalPropertyStatus] (override val errorMessage: Some[String])
+    case class GlobalPropertyErrorStatus private[GlobalPropertyStatus] (override val errorMessage: Some[String])
         extends GlobalPropertyStatus
 
     def fromResolvedNodeProperty(hierarchy: ResolvedNodePropertyHierarchy): GlobalPropertyStatus = hierarchy match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AsyncDeploymentActor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AsyncDeploymentActor.scala
@@ -38,9 +38,6 @@
 package com.normation.rudder.batch
 
 import com.normation.errors.*
-import com.normation.errors.IOResult
-import com.normation.errors.PureResult
-import com.normation.errors.Unexpected
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.EventLog
 import com.normation.eventlog.EventLogDetails

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/CampaignEventRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/CampaignEventRepository.scala
@@ -45,7 +45,6 @@ import doobie.Read
 import doobie.Write
 import doobie.implicits.*
 import doobie.implicits.javasql.*
-import doobie.implicits.toSqlInterpolator
 import org.joda.time.DateTime
 import zio.interop.catz.*
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JSONReportsHandler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JSONReportsHandler.scala
@@ -38,7 +38,6 @@
 package com.normation.rudder.campaigns
 
 import com.normation.errors.*
-import com.normation.errors.IOResult
 import com.normation.rudder.domain.reports.Reports
 import com.normation.rudder.repository.ReportsRepository
 import com.normation.rudder.repository.RudderPropertiesRepository

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JsonCampaignSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JsonCampaignSerializer.scala
@@ -38,8 +38,6 @@
 package com.normation.rudder.campaigns
 
 import com.normation.errors.*
-import com.normation.errors.Inconsistency
-import com.normation.errors.IOResult
 import com.normation.utils.DateFormaterService
 import org.joda.time.DateTime
 import zio.ZIO

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/eventlog/TechniqueEventLog.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/eventlog/TechniqueEventLog.scala
@@ -45,7 +45,6 @@ import com.normation.cfclerk.services.VersionAdded
 import com.normation.cfclerk.services.VersionDeleted
 import com.normation.cfclerk.services.VersionUpdated
 import com.normation.eventlog.*
-import com.normation.eventlog.EventLogDetails
 import com.normation.rudder.domain.Constants
 import scala.xml.*
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -55,7 +55,6 @@ import com.normation.rudder.services.policies.ParameterEntry
 import com.typesafe.config.*
 import enumeratum.*
 import net.liftweb.json.*
-import net.liftweb.json.JsonDSL.*
 import org.apache.commons.text.StringEscapeUtils
 import zio.Chunk
 import zio.NonEmptyChunk
@@ -740,12 +739,15 @@ object GenericProperty {
    * Implicit class to render properties to JSON
    */
   implicit class PropertyToJson(val x: GenericProperty[?]) extends AnyVal {
-    def toJsonObj: JObject = (
-      ("name"            -> x.name)
+    def toJsonObj: JObject = {
+      import net.liftweb.json.JsonDSL.*
+      (
+        ("name"          -> x.name)
         ~ ("value"       -> parse(x.value.render(ConfigRenderOptions.concise())))
         ~ ("provider"    -> x.provider.map(_.value))
         ~ ("inheritMode" -> x.inheritMode.map(_.value))
-    )
+      )
+    }
 
     def toData: String = x.config.root().render(ConfigRenderOptions.concise().setComments(true))
   }
@@ -758,6 +760,8 @@ object GenericProperty {
     }
 
     def toDataJson: JObject = {
+      import net.liftweb.json.JsonDSL.*
+
       props.map(x => JField(x.name, x.jsonValue)).toList.sortBy(_.name)
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -514,7 +514,6 @@ sealed trait ComponentStatusReport extends StatusReport with ComponentCompliance
   def withFilteredElement(predicate: ComponentValueStatusReport => Boolean): Option[ComponentStatusReport]
   def componentValues: List[ComponentValueStatusReport]
   def componentValues(v: String): List[ComponentValueStatusReport] = componentValues.filter(_.componentValue == v)
-  def status: ReportType
 }
 
 final case class BlockStatusReport(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
@@ -80,7 +80,6 @@ import net.liftweb.common.EmptyBox
 import net.liftweb.common.Full
 import net.liftweb.json.JsonAST
 import net.liftweb.json.JsonAST.*
-import net.liftweb.json.JsonAST.JValue
 import org.joda.time.DateTime
 import zio.*
 import zio.json.*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactStorage.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactStorage.scala
@@ -40,7 +40,6 @@ package com.normation.rudder.facts.nodes
 import NodeFactSerialisation.*
 import better.files.File
 import com.normation.errors.*
-import com.normation.errors.IOResult
 import com.normation.inventory.domain.*
 import com.normation.inventory.ldap.core.FullInventoryRepositoryImpl
 import com.normation.inventory.ldap.core.InventoryDitService

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryDigestServiceV1.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryDigestServiceV1.scala
@@ -37,7 +37,6 @@
 package com.normation.inventory.services.provisioning
 
 import com.normation.errors.*
-import com.normation.errors.IOResult
 import com.normation.inventory.domain.*
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import zio.syntax.*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryFileWatcher.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryFileWatcher.scala
@@ -42,7 +42,6 @@ import com.normation.box.IOManaged
 import com.normation.errors.*
 import com.normation.inventory.domain.InventoryProcessingLogger
 import com.normation.zio.*
-import com.normation.zio.ZioRuntime
 import java.io.FileNotFoundException
 import java.io.InputStream
 import java.nio.file

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
@@ -40,8 +40,6 @@ package com.normation.rudder.inventory
 import better.files.File
 import com.normation.box.IOManaged
 import com.normation.errors.*
-import com.normation.errors.Chained
-import com.normation.errors.IOResult
 import com.normation.inventory.domain.CertifiedKey
 import com.normation.inventory.domain.FullInventory
 import com.normation.inventory.domain.Inventory
@@ -62,7 +60,6 @@ import com.normation.rudder.hooks.PureHooksLogger
 import com.normation.rudder.hooks.RunHooks
 import com.normation.utils.DateFormaterService
 import com.normation.zio.*
-import com.normation.zio.ZioRuntime
 import java.io.InputStream
 import java.nio.file.NoSuchFileException
 import java.security.PublicKey as JavaSecPubKey

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/PostCommits.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/PostCommits.scala
@@ -40,7 +40,6 @@ package com.normation.rudder.inventory
 import com.normation.errors.*
 import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.*
-import com.normation.inventory.domain.Inventory
 import com.normation.inventory.services.provisioning.*
 import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/DeleteEditorTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/DeleteEditorTechnique.scala
@@ -46,7 +46,6 @@ import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.cfclerk.services.UpdateTechniqueLibrary
 import com.normation.errors.*
-import com.normation.errors.IOResult
 import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.Version
 import com.normation.rudder.domain.logger.ApplicationLogger

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/EditorTechniqueReader.scala
@@ -2,8 +2,6 @@ package com.normation.rudder.ncf
 
 import better.files.*
 import com.normation.errors.*
-import com.normation.errors.Inconsistency
-import com.normation.errors.IOResult
 import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.AgentType
 import com.normation.rudder.domain.eventlog.RudderEventActor

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
@@ -40,8 +40,6 @@ package com.normation.rudder.ncf
 import better.files.File
 import cats.implicits.*
 import com.normation.errors.*
-import com.normation.errors.IOResult
-import com.normation.errors.RudderError
 import com.normation.rudder.domain.logger.RuddercLogger
 import com.normation.rudder.hooks.Cmd
 import com.normation.rudder.hooks.CmdResult

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
@@ -43,7 +43,6 @@ import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.cfclerk.services.UpdateTechniqueLibrary
 import com.normation.errors.*
-import com.normation.errors.IOResult
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
 import com.normation.rudder.domain.logger.TechniqueWriterLoggerPure

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/yaml/YamlTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/yaml/YamlTechnique.scala
@@ -41,10 +41,6 @@ import com.normation.cfclerk.domain.LoadTechniqueError.Consistancy
 import com.normation.cfclerk.domain.ReportingLogic
 import com.normation.cfclerk.domain.ReportingLogic.WeightedReport
 import com.normation.errors.*
-import com.normation.errors.AccumulateErrors
-import com.normation.errors.Inconsistency
-import com.normation.errors.IOResult
-import com.normation.errors.PureResult
 import com.normation.inventory.domain.Version
 import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.ncf.*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/EventLogJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/EventLogJdbcRepository.scala
@@ -38,7 +38,6 @@
 package com.normation.rudder.repository.jdbc
 
 import cats.implicits.*
-import cats.syntax.list.catsSyntaxList
 import com.normation.NamedZioLogger
 import com.normation.errors.*
 import com.normation.eventlog.*
@@ -130,7 +129,7 @@ class EventLogJdbcRepository(
     val limit       = optLimit.map(l => " limit " + l).getOrElse("")
     val eventFilter = eventTypeFilter match {
       case Nil => ""
-      case seq => " and eventType in (" + seq.map(x => "?").mkString(",") + ")"
+      case seq => " and eventType in (" + seq.map(_ => "?").mkString(",") + ")"
     }
 
     val q = s"""

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ReportsJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ReportsJdbcRepository.scala
@@ -44,7 +44,6 @@ import com.normation.rudder.db.Doobie
 import com.normation.rudder.db.Doobie.*
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.*
-import com.normation.rudder.domain.reports.Reports
 import com.normation.rudder.reports.execution.AgentRun
 import com.normation.rudder.reports.execution.AgentRunId
 import com.normation.rudder.repository.ReportsRepository

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDirectiveRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDirectiveRepository.scala
@@ -1375,7 +1375,7 @@ class WoLDAPDirectiveRepository(
                     deleted      <- con.delete(activeTechnique.dn, recurse = false)
                     diff          = DeleteTechniqueDiff(oldTechnique)
                     loggedAction <- actionLogger.saveDeleteTechnique(modId, principal = actor, deleteDiff = diff, reason = reason)
-                    autoArchive  <- ZIO
+                    _            <- ZIO
                                       .when(autoExportOnModify && deleted.size > 0 && !oldTechnique.policyTypes.isSystem) {
                                         for {
                                           ptName   <- activeTechnique(A_TECHNIQUE_UUID) match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -63,9 +63,7 @@ import com.normation.rudder.domain.appconfig.RudderWebProperty
 import com.normation.rudder.domain.appconfig.RudderWebPropertyName
 import com.normation.rudder.domain.logger.ApplicationLogger
 import com.normation.rudder.domain.nodes.*
-import com.normation.rudder.domain.nodes.Node
 import com.normation.rudder.domain.policies.*
-import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.domain.properties.GenericProperty
 import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.properties.GroupProperty

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
@@ -70,7 +70,6 @@ import com.normation.rudder.domain.RudderLDAPConstants.OC_RUDDER_NODE_GROUP
 import com.normation.rudder.domain.RudderLDAPConstants.OC_SPECIAL_TARGET
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.policies.*
-import com.normation.rudder.domain.policies.GroupTarget
 import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.NodeFactRepository
 import com.normation.rudder.facts.nodes.QueryContext

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPParameterRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPParameterRepository.scala
@@ -53,7 +53,6 @@ import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.properties.ModifyGlobalParameterDiff
 import com.normation.rudder.domain.properties.PropertyProvider
 import com.normation.rudder.repository.*
-import com.normation.rudder.repository.EventLogRepository
 import com.normation.rudder.services.user.PersonIdentService
 import com.unboundid.ldif.LDIFChangeRecord
 import org.joda.time.DateTime

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/LDAPRuleCategoryRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/LDAPRuleCategoryRepository.scala
@@ -46,9 +46,6 @@ import com.normation.inventory.ldap.core.LDAPConstants.*
 import com.normation.ldap.ldif.LDIFNoopChangeRecord
 import com.normation.ldap.sdk.*
 import com.normation.ldap.sdk.BuildFilter.*
-import com.normation.ldap.sdk.LDAPConnectionProvider
-import com.normation.ldap.sdk.LDAPEntry
-import com.normation.ldap.sdk.RoLDAPConnection
 import com.normation.rudder.domain.RudderDit
 import com.normation.rudder.domain.RudderLDAPConstants.*
 import com.normation.rudder.repository.ldap.LDAPEntityMapper

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/ComplianceScore.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/ComplianceScore.scala
@@ -43,7 +43,7 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.reports.ComplianceSerializable
 import com.normation.rudder.score.ComplianceScore.scoreId
 import com.normation.rudder.score.ScoreValue.*
-import io.scalaland.chimney.syntax.TransformerOps
+import io.scalaland.chimney.syntax.*
 import zio.*
 import zio.json.*
 import zio.syntax.*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/ScoreRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/ScoreRepository.scala
@@ -46,7 +46,6 @@ import doobie.Meta
 import doobie.Read
 import doobie.Write
 import doobie.implicits.*
-import doobie.implicits.toSqlInterpolator
 import doobie.postgres.implicits.pgEnumString
 import doobie.util.invariant.InvalidEnum
 import zio.Ref

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
@@ -72,13 +72,11 @@ import com.normation.rudder.git.GitPath
 import com.normation.rudder.reports.*
 import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.services.marshalling.*
-import com.normation.rudder.services.marshalling.TestFileFormat
 import com.normation.rudder.services.queries.CmdbQueryParser
 import com.normation.utils.Control.traverse
 import com.typesafe.config.ConfigValue
 import net.liftweb.common.*
 import net.liftweb.common.Box.*
-import net.liftweb.util.Helpers.tryo
 import org.eclipse.jgit.lib.PersonIdent
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -62,7 +62,6 @@ import org.apache.commons.text.StringEscapeUtils
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import scala.xml.*
-import scala.xml.Text
 import zio.json.*
 
 trait EventLogFactory {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckNotificationService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckNotificationService.scala
@@ -37,7 +37,6 @@
 package com.normation.rudder.services.healthcheck
 import com.normation.zio.*
 import zio.*
-import zio.Ref
 
 class HealthcheckNotificationService(
     healthcheckService: HealthcheckService,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlSerialisationImpl.scala
@@ -75,15 +75,12 @@ import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.properties.ModifyToGlobalParameterDiff
 import com.normation.rudder.domain.secret.Secret
 import com.normation.rudder.domain.workflows.*
-import com.normation.rudder.domain.workflows.ChangeRequest
-import com.normation.rudder.domain.workflows.ConfigurationChangeRequest
 import com.normation.rudder.rule.category.RuleCategory
 import com.normation.rudder.services.marshalling.MarshallingUtil.createTrimedElem
 import net.liftweb.common.*
 import org.apache.commons.text.StringEscapeUtils
 import org.joda.time.format.ISODateTimeFormat
 import scala.xml.{Node as XNode, *}
-import scala.xml.NodeSeq
 import zio.json.*
 
 //serialize / deserialize tags

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -55,17 +55,6 @@ import com.normation.rudder.batch.SuccessStatus
 import com.normation.rudder.domain.Constants.*
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.policies.*
-import com.normation.rudder.domain.policies.ActiveTechnique
-import com.normation.rudder.domain.policies.ActiveTechniqueCategory
-import com.normation.rudder.domain.policies.ActiveTechniqueCategoryId
-import com.normation.rudder.domain.policies.ActiveTechniqueId
-import com.normation.rudder.domain.policies.Directive
-import com.normation.rudder.domain.policies.DirectiveUid
-import com.normation.rudder.domain.policies.PolicyMode
-import com.normation.rudder.domain.policies.Rule
-import com.normation.rudder.domain.policies.RuleId
-import com.normation.rudder.domain.policies.RuleTarget
-import com.normation.rudder.domain.policies.SectionVal
 import com.normation.rudder.domain.properties.AddGlobalParameterDiff
 import com.normation.rudder.domain.properties.DeleteGlobalParameterDiff
 import com.normation.rudder.domain.properties.GlobalParameter
@@ -76,9 +65,6 @@ import com.normation.rudder.domain.properties.PropertyProvider
 import com.normation.rudder.domain.properties.Visibility
 import com.normation.rudder.domain.secret.Secret
 import com.normation.rudder.domain.workflows.*
-import com.normation.rudder.domain.workflows.DirectiveChangeItem
-import com.normation.rudder.domain.workflows.DirectiveChanges
-import com.normation.rudder.domain.workflows.NodeGroupChanges
 import com.normation.rudder.facts.nodes.NodeSecurityContext
 import com.normation.rudder.rule.category.RuleCategory
 import com.normation.rudder.rule.category.RuleCategoryId
@@ -86,8 +72,6 @@ import com.normation.rudder.services.queries.CmdbQueryParser
 import com.normation.utils.Control.traverse
 import net.liftweb.common.*
 import net.liftweb.common.Box.*
-import net.liftweb.common.Failure
-import net.liftweb.util.Helpers.tryo
 import org.apache.commons.text.StringEscapeUtils
 import org.joda.time.format.ISODateTimeFormat
 import scala.util.Failure as Catch

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeStatusReportRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeStatusReportRepository.scala
@@ -49,7 +49,7 @@ import com.normation.rudder.domain.reports.NodeStatusReport
 import com.normation.rudder.domain.reports.RunAnalysisKind
 import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.QueryContext
-import com.softwaremill.quicklens.ModifyPimp
+import com.softwaremill.quicklens.*
 import doobie.*
 import doobie.implicits.*
 import org.joda.time.DateTime

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -375,8 +375,8 @@ class MockDirectives(mockTechniques: MockTechniques) {
      * in class TestNodeConfiguration
      */
 
-    val commonTechnique:                                                      Technique                        = techniqueRepos.unsafeGet(TechniqueId(TechniqueName("common"), TV("1.0")))
-    def commonVariables(nodeId: NodeId, allNodeInfos: Map[NodeId, NodeInfo]): Map[ComponentId, VariableSpec#V] = {
+    val commonTechnique:                                                      Technique                  = techniqueRepos.unsafeGet(TechniqueId(TechniqueName("common"), TV("1.0")))
+    def commonVariables(nodeId: NodeId, allNodeInfos: Map[NodeId, NodeInfo]): Map[ComponentId, Variable] = {
       commonTechnique.getAllVariableSpecs.collect {
         case (c @ ComponentId("OWNER", _, _), s)              => (c, s.toVariable(Seq(allNodeInfos(nodeId).localAdministratorAccountName)))
         case (c @ ComponentId("UUID", _, _), s)               => (c, s.toVariable(Seq(nodeId.value)))
@@ -386,7 +386,7 @@ class MockDirectives(mockTechniques: MockTechniques) {
         case (c @ ComponentId("ALLOWEDNETWORK", _, _), s)     => (c, s.toVariable(Seq("")))
       }
     }
-    val commonDirective:                                                      Directive                        = Directive(
+    val commonDirective:                                                      Directive                  = Directive(
       DirectiveId(DirectiveUid("common-root"), GitVersion.DEFAULT_REV),
       TV("1.0"),
       Map(

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/DBCommon.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/DBCommon.scala
@@ -57,11 +57,7 @@ import zio.interop.catz.*
  */
 trait DBCommon extends Specification with Loggable with BeforeAfterAll {
 
-  val now = DateTime.now
-
-  logger.info(
-    """Set JAVA property 'test.postgres' to false to ignore that test, for example from maven with: mvn -DargLine="-Dtest.postgres=false" test"""
-  )
+  lazy val now = DateTime.now
 
   lazy val doDatabaseConnection: Boolean = java.lang.System.getProperty("test.postgres", "").toLowerCase match {
     case "true" | "1" => true
@@ -107,7 +103,12 @@ trait DBCommon extends Specification with Loggable with BeforeAfterAll {
    */
   def sqlClean: String = ""
 
-  override def beforeAll(): Unit = initDb()
+  override def beforeAll(): Unit = {
+    logger.info(
+      """Set JAVA property 'test.postgres' to false to ignore that test, for example from maven with: mvn -DargLine="-Dtest.postgres=false" test"""
+    )
+    initDb()
+  }
   override def afterAll():  Unit = cleanDb()
 
   def initDb(): Unit = {
@@ -161,7 +162,7 @@ trait DBCommon extends Specification with Loggable with BeforeAfterAll {
     config.datasource
   }
 
-  lazy val doobie = new DoobieIO(dataSource)
+  final lazy val doobie = new DoobieIO(dataSource)
   def transacRun[T](query: Transactor[Task] => Task[T]): T = {
     doobie.transactRunEither(xa => query(xa)) match {
       case Right(x) => x

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/TestBlockCompliance.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/TestBlockCompliance.scala
@@ -61,7 +61,7 @@ class TestBlockCompliance extends Specification {
       override val componentName: String,
       override val reportsByNode: Map[NodeId, Seq[ReportType]]
   ) extends DummyComponentComplianceByNode {
-    override def allReports: List[ReportType] = reportsByNode.values.flatten.toList
+    override def allReports: List[ReportType] = reportsByNode.values.toList.flatten
     override def compliance: ComplianceLevel  = ComplianceLevel.compute(allReports)
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
@@ -70,7 +70,7 @@ import com.normation.rudder.services.policies.TestNodeConfiguration
 import com.normation.rudder.services.policies.write.PolicyWriterServiceImpl.filepaths
 import com.normation.templates.FillTemplatesService
 import com.normation.zio.*
-import com.softwaremill.quicklens.ModifyPimp
+import com.softwaremill.quicklens.*
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.util.regex.Pattern

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -4571,7 +4571,7 @@ class ExecutionBatchTest extends Specification {
       nodeStatus.reports(tag1).directives("policy2").compliance === ComplianceLevel(success = 2)
     }
     "have detailed rule report for policy1 of 100% for policy2 on tag2 and policy is not on that tag" in {
-      nodeStatus.reports(tag2).directives.get("policy1") must beEmpty and
+      nodeStatus.reports(tag2).directives.get("policy1") must beNone and
       nodeStatus.reports(tag2).directives("policy2").compliance === ComplianceLevel(success = 2)
     }
 
@@ -4730,7 +4730,7 @@ class ExecutionBatchTest extends Specification {
     "have rule report for policy1 empty and overridden" in {
       val policy1 = nodeStatus.reports(PolicyTypeName.rudderBase).directives.get("policy1")
 
-      policy1 must not(beEmpty)
+      policy1 must beSome
       policy1.get.compliance === ComplianceLevel() // it's overridden
       policy1.get.overridden === Some(overridingPolicyId.ruleId)
     }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/users/UserRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/users/UserRepositoryTest.scala
@@ -664,7 +664,7 @@ trait UserRepositoryTest extends Specification with Loggable {
       // we only purge deleted users
       (repo.delete(List("bob"), None, Nil, Some(UserStatus.Disabled), traceBobOidc) *>
       repo.purge(List("bob"), None, Nil, traceBobOidc)).runNow
-      repo.getAll().runNow must beLike(_.map(_.id) must not(contain("bob")))
+      repo.getAll().runNow must beLike(_.map(_.id) must not(contain[String]("bob")))
 
       repo.setExistingUsers(AUTH_PLUGIN_NAME_REMOTE, List("bob"), traceBobPurged).runNow
       repo.getAll().runNow.toUTC must containTheSameElementsAs(userInfosBobPurged)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/Section2FieldService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/Section2FieldService.scala
@@ -340,7 +340,6 @@ class Section2FieldService(val fieldFactory: DirectiveFieldFactory, val translat
     priority match {
       case LowDisplayPriority  => false
       case HighDisplayPriority => true
-      case _                   => true
     }
   }
 }

--- a/webapp/sources/rudder/rudder-templates/src/main/scala/com/normation/templates/FillTemplatesService.scala
+++ b/webapp/sources/rudder/rudder-templates/src/main/scala/com/normation/templates/FillTemplatesService.scala
@@ -46,7 +46,6 @@ import com.normation.NamedZioLogger
 import com.normation.errors.*
 import com.normation.stringtemplate.language.NormationAmpersandTemplateLexer
 import com.normation.zio.*
-import com.normation.zio.ZioRuntime
 import org.antlr.stringtemplate.StringTemplate
 import org.apache.commons.lang3.StringUtils
 import scala.collection.immutable.ArraySeq

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -490,11 +490,11 @@ object DisplayNode extends Loggable {
          |</div>""".stripMargin.replaceAll("\n", " ")
     }
 
-    val nodeStateIcon = (
-      <span class={
-        "node-state " ++ StringEscapeUtils.escapeHtml4(getNodeState(node.rudderSettings.state).toLowerCase).replaceAll(" ", "-")
-      }></span>
-    )
+    val nodeStateClasses: String =
+      "node-state " ++ StringEscapeUtils.escapeHtml4(getNodeState(node.rudderSettings.state).toLowerCase).replaceAll(" ", "-")
+    val nodeStateIcon = {
+      <span class={nodeStateClasses}></span>
+    }
 
     <div class="header-title">
     <div class={"os-logo " ++ sm.node.main.osDetails.os.name.toLowerCase()} data-bs-toggle="tooltip" title={osTooltip}></div>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/Login.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/Login.scala
@@ -3,11 +3,23 @@ package com.normation.rudder.web.snippet
 import bootstrap.liftweb.RudderConfig
 import com.normation.plugins.DefaultExtendableSnippet
 import net.liftweb.http.DispatchSnippet
+import scala.annotation.unused
 import scala.xml.NodeSeq
 
 class Login extends DispatchSnippet with DefaultExtendableSnippet[Login] {
 
   val userListProvider = RudderConfig.rudderUserListProvider
+  @unused
+  private val script   = {
+    """window.setTimeout('location.reload()', 10000);
+      |$('.btn-clipboard').click(function(){
+      |  navigator.clipboard.writeText("rudder server create-user -u " ).then(function(){
+      |    $('.btn-clipboard').attr("title","Copied to clipboard!");
+      |    $('.btn-cmd-user .fa-clipboard').attr('class', 'fas fa-check') ;
+      |  }, function() {})
+      |} );""".stripMargin
+  }
+
   def mainDispatch: Map[String, NodeSeq => NodeSeq] = Map(
     "display" -> { (authForm: NodeSeq) =>
       if (userListProvider.authConfig.users.isEmpty) {
@@ -36,13 +48,7 @@ class Login extends DispatchSnippet with DefaultExtendableSnippet[Login] {
               </div>
               <script type="text/javascript">
                 // <![CDATA[
-                window.setTimeout('location.reload()', 10000);
-                $('.btn-clipboard').click(function(){
-                  navigator.clipboard.writeText("rudder server create-user -u " ).then(function(){
-                    $('.btn-clipboard').attr("title","Copied to clipboard!");
-                    $('.btn-cmd-user .fa-clipboard').attr('class', 'fas fa-check') ;
-                  }, function() {})
-                } );
+                {script}
                 // ]]>
               </script>
             </div>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DatabaseManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DatabaseManagement.scala
@@ -119,7 +119,7 @@ class DatabaseManagement extends DispatchSnippet with Loggable {
     def displayInProgress(lastValue: Box[Option[DateTime]]): NodeSeq = {
       val date = displayDate(lastValue)
       if (inProgress) {
-        <span>Archiving is in progress, please wait (last known value: '{date}')</span>
+        <span>Archiving is in progress, please wait (last known value: "{date}")</span>
       } else {
         date
       }

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/snippet/HomePageTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/snippet/HomePageTest.scala
@@ -37,16 +37,13 @@
 
 package com.normation.rudder.web.snippet
 
-import org.junit.runner.RunWith
-import org.specs2.mutable.*
-import org.specs2.runner.JUnitRunner
+import zio.test.*
+import zio.test.Assertion.*
 
-@RunWith(classOf[JUnitRunner])
-class HomePageTest extends Specification {
+object HomePageTest extends ZIOSpecDefault {
 
-  "Agent version mapping must matches" >> {
-
-    val mapping = Map(
+  val spec = suite("Agent version mapping must matches")(
+    List(
       "6.0.8-xenial0"                  -> "6.0.8",
       "6.0.4.release-1.EL.7"           -> "6.0.4",
       "6.1.10"                         -> "6.1.10",
@@ -72,12 +69,11 @@ class HomePageTest extends Specification {
       "3.1.15.release-1.AIX.5.3"             -> "3.1.15",
       "6.0.1~rc1~git201502100126-lenny0"     -> "6.0.1.rc1.git201502100126",
       "not-init"                             -> "not" // well, not very interesting, but we had that at some point in rudder
-    )
-
-    def matcherVersion(pair: (String, String)) = HomePageUtils.formatAgentVersion(pair._1) must beEqualTo(pair._2)
-
-    mapping must contain(matcherVersion(_)).foreach
-
-  }
-
+    ).map {
+      case (version, expectation) =>
+        test(s"$version should equal $expectation") {
+          assert(HomePageUtils.formatAgentVersion(version))(equalTo(expectation))
+        }
+    }
+  )
 }

--- a/webapp/sources/utils/src/test/scala/com/normation/ZioCommonsTest.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/ZioCommonsTest.scala
@@ -27,10 +27,7 @@ package com.normation
 import _root_.zio.*
 import _root_.zio.syntax.*
 import com.normation.errors.*
-import com.normation.errors.IOResult
-import com.normation.errors.RudderError
 import com.normation.zio.*
-import com.normation.zio.ZioRuntime
 import net.liftweb.common.*
 import org.junit.runner.RunWith
 import org.specs2.mutable.*


### PR DESCRIPTION
https://issues.rudder.io/issues/26887

This is the backport of https://github.com/Normation/rudder/pull/6362 to branche 9.0 with a corresponding rudder issue. A pair of imports to correct, and (strangely) in type asycription that may be due to formating. 