### PR TITLE
fix: simplify xml parsing syntax that is not supported in scala3 and …

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -270,25 +270,22 @@ class NodeGroupUnserialisationImpl(
       isSystem     <- (group \ "isSystem").headOption.flatMap(s =>
                         tryo(s.text.toBoolean)
                       ) ?~! ("Missing attribute 'isSystem' in entry type nodeGroup : " + entry)
-      properties   <- traverse((group \ "properties" \ "property").toList) {
-                        // format: off
-                        case <property>{p @ _*}</property> =>
-                        // format: on
-                          val name = (p \\ "name").text.trim
-                          if (name.trim.isEmpty) {
-                            Failure(s"Found unexpected xml under <properties> tag (name is blank): ${p}")
-                          } else {
-                            GroupProperty
-                              .parse(
-                                (p \\ "name").text.trim,
-                                ParseRev((p \\ "revision").text.trim),
-                                StringEscapeUtils.unescapeXml((p \\ "value").text.trim),
-                                (p \\ "inheritMode").headOption.flatMap(p => InheritMode.parseString(p.text.trim).toOption),
-                                (p \\ "provider").headOption.map(p => PropertyProvider(p.text.trim))
-                              )
-                              .toBox
-                          }
-                        case xml                           => Failure(s"Found unexpected xml under <properties> tag: ${xml}")
+      properties   <- traverse(group \ "properties" \ "property") { property =>
+                        val name = (property \\ "name").text.trim
+                        if (name.trim.isEmpty) {
+                          Failure(s"Found unexpected xml under <properties> tag (name is blank): $property")
+                        } else {
+                          GroupProperty
+                            .parse(
+                              name = (property \\ "name").text.trim,
+                              rev = ParseRev((property \\ "revision").text.trim),
+                              value = StringEscapeUtils.unescapeXml((property \\ "value").text.trim),
+                              mode =
+                                (property \\ "inheritMode").headOption.flatMap(p => InheritMode.parseString(p.text.trim).toOption),
+                              provider = (property \\ "provider").headOption.map(p => PropertyProvider(p.text.trim))
+                            )
+                            .toBox
+                        }
                       }
     } yield {
       NodeGroup(
@@ -806,7 +803,7 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
         actions <- e \@ "actions" match {
                      case "" => Failure("Missing required attribute 'actions' for element 'authz'")
                      case s  =>
-                       (s.split(",").map(_.trim).toList.filter(_.isEmpty).traverse(HttpAction.parse _)) match {
+                       (s.split(",").map(_.trim).toList.filter(_.nonEmpty).traverse(HttpAction.parse)) match {
                          case Left(s)  => Failure(s)
                          case Right(x) => Full(x)
                        }
@@ -859,11 +856,8 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
                             Full(ApiAuthorization.RO)
                           case Some(Text(text)) if text == ApiAuthorizationKind.RW.name =>
                             Full(ApiAuthorization.RW)
-                          // format: off
-                          case Some(<acl>{xml @ _*}</acl>) if (xml.nonEmpty) =>
-                          // format: on
-                            unserAcl(xml.head)
-                          // all other case: serialization pb => None
+                          case Some(node) if (node \ "acl").nonEmpty                    =>
+                            unserAcl((node \ "acl").head)
                           case _                                                        => Full(ApiAuthorization.None)
                         }
       accountType     = (apiAccount \ "kind").headOption.map(_.text) match {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/marshalling/TestXmlUnserialisation.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/marshalling/TestXmlUnserialisation.scala
@@ -6,6 +6,15 @@ import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersionHelper
 import com.normation.cfclerk.xmlparsers.SectionSpecParser
 import com.normation.cfclerk.xmlparsers.VariableSpecParser
+import com.normation.rudder.api.AclPath
+import com.normation.rudder.api.ApiAccount
+import com.normation.rudder.api.ApiAccountId
+import com.normation.rudder.api.ApiAccountKind
+import com.normation.rudder.api.ApiAccountName
+import com.normation.rudder.api.ApiAclElement
+import com.normation.rudder.api.ApiAuthorization
+import com.normation.rudder.api.ApiTokenHash
+import com.normation.rudder.api.HttpAction
 import com.normation.rudder.domain.nodes.NodeGroup
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.nodes.NodeGroupUid
@@ -17,11 +26,14 @@ import com.normation.rudder.domain.policies.Tags
 import com.normation.rudder.domain.properties.GroupProperty
 import com.normation.rudder.domain.queries.*
 import com.normation.rudder.domain.queries.ResultTransformation.*
+import com.normation.rudder.facts.nodes.NodeSecurityContext
 import com.normation.rudder.services.policies.TestNodeConfiguration
 import com.normation.rudder.services.queries.CmdbQueryParser
 import net.liftweb.common.Empty
 import net.liftweb.common.Failure
 import net.liftweb.common.Full
+import org.joda.time.DateTime
+import org.joda.time.format.ISODateTimeFormat
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -131,6 +143,60 @@ class TestXmlUnserialisation extends Specification with BoxSpecMatcher {
         case Full(_) => ok("unserialization was a success")
       }
     }
+  }
+
+  "be able to correctly unserialize an ApiAccount " in {
+    val serialized = <apiAccount fileFormat="6" changeType="add">
+      <id>c331c718-db0e-429e-b800-20b055ca6a67</id>
+      <name>Test account with some acl scala 3</name>
+      <token>
+        v2:449967a9c3a1cf25b6333fa531626e1a9375accf889dea3063b8707debde9f033535082a31de85c34c71d8be9b228f38e6cde467d6f3ba423d99437899bfb1d6
+      </token>
+      <description/>
+      <isEnabled>true</isEnabled>
+      <creationDate>2025-05-06T13:59:59.613+02:00</creationDate>
+      <tokenGenerationDate>2025-05-06T13:59:59.613+02:00</tokenGenerationDate>
+      <tenants>*</tenants>
+      <kind>public</kind>
+      <authorization>
+        <acl>
+          <authz actions="get" path="archives/export"/>
+          <authz actions="post" path="archives/import"/>
+          <authz actions="get,delete,post" path="apiaccounts/*"/>
+        </acl>
+      </authorization>
+      <expirationDate>2025-06-06T15:59:35.297+02:00</expirationDate>
+    </apiAccount>
+
+    val actual = new ApiAccountUnserialisationImpl().unserialise(serialized)
+
+    actual.map(_.copy(token = None)) must beEqualTo(
+      Full(
+        ApiAccount(
+          id = ApiAccountId("c331c718-db0e-429e-b800-20b055ca6a67"),
+          kind = ApiAccountKind.PublicApi(
+            authorizations = ApiAuthorization.ACL(
+              List(
+                ApiAclElement(actions = Set(HttpAction.GET), path = AclPath.parse("archives/export").toOption.get),
+                ApiAclElement(actions = Set(HttpAction.POST), path = AclPath.parse("archives/import").toOption.get),
+                ApiAclElement(
+                  actions = Set(HttpAction.GET, HttpAction.DELETE, HttpAction.POST),
+                  path = AclPath.parse("apiaccounts/*").toOption.get
+                )
+              )
+            ),
+            expirationDate = Some(ISODateTimeFormat.dateTime.parseDateTime("2025-06-06T15:59:35.297+02:00"))
+          ),
+          name = ApiAccountName("Test account with some acl scala 3"),
+          token = None,
+          description = "",
+          isEnabled = true,
+          creationDate = ISODateTimeFormat.dateTime.parseDateTime("2025-05-06T13:59:59.613+02:00"),
+          tokenGenerationDate = ISODateTimeFormat.dateTime.parseDateTime("2025-05-06T13:59:59.613+02:00"),
+          tenants = NodeSecurityContext.All
+        )
+      )
+    )
   }
 
   "group property ser/unser should be identity" >> {


### PR DESCRIPTION
…fix acl parsing

`case <property>{p @ _*}</property>` syntax is not working in scala3 any longer.
While rewriting the 2 usages in the codebase, I figured the authz parsing is broken.
So this is the test and the fix (s/isEmpty/nonEmpty).