### PR TITLE
Fixes #26898: Prepare EventActor serialization for scala3

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserSerializationTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserSerializationTest.scala
@@ -1,5 +1,6 @@
 package com.normation.rudder.rest.users
 
+import com.normation.eventlog.EventActor
 import com.normation.rudder.users.*
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
@@ -44,6 +45,20 @@ class UserSerializationTest extends Specification {
       )
 
       JsonUser("user", None, None, Json.Obj(), UserStatus.Active, providersInfo, "", None, None) must beEqualTo(expected)
+    }
+  }
+
+  "EventActor" should {
+    "serialize as a case class" in {
+      UserSerialization.codecEventActor.encoder.encodeJson(EventActor("foo")).toString must beEqualTo("""{"name":"foo"}""")
+    }
+    "have isomorphic serialization" in {
+
+      val input = EventActor("foo")
+      def encode(input: EventActor) = UserSerialization.codecEventActor.encoder.encodeJson(input).toString
+      def decode(json:  String)     = UserSerialization.codecEventActor.decoder.decodeJson(json)
+
+      decode(encode(input)) must beRight(input)
     }
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/26898

This is a backport of https://github.com/Normation/rudder/pull/6367 to Rudder 8.2. 