### PR TITLE
Fixes #26842: User management page no longer displays individual authorizations

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/View.elm
@@ -720,10 +720,10 @@ displayRights user roles =
                     ]
 
     in
-    if List.isEmpty userRoles then
+    if List.isEmpty userRoles && List.isEmpty tooltipAuths then
         span [ class "empty" ] [ text "No rights found" ]
     else
-        span [ class "list-auths" ] (List.append userRoles tooltipAuths)
+        span [ class "list-auths" ] (userRoles ++ tooltipAuths)
 
 displayProviders : Model -> User -> Html Msg
 displayProviders model user =


### PR DESCRIPTION
https://issues.rudder.io/issues/26842

The condition to not display was just too broad.
The result could be improved later, for a few single custom authorizations, we should display each authorization in grey : 
![image](https://github.com/user-attachments/assets/438912c8-0366-4be3-abeb-eb5ed6cdf5db)
