### PR TITLE
Fixes #26779: Archive “download as zip” creates backup with wrong name (but right contents)

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
@@ -89,6 +89,7 @@ import net.liftweb.json.JsonDSL.*
 import org.eclipse.jgit.lib.PersonIdent
 import org.eclipse.jgit.revwalk.RevWalk
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.format.DateTimeFormatterBuilder
 import zio.*
@@ -888,7 +889,7 @@ class SystemApiService11(
           200
         )
       case Left(error)                                   =>
-        val fail = Chained("Error has occured while getting debug script result", error)
+        val fail = Chained("Error has occurred while getting debug script result", error)
         toJsonError(None, "debug script" -> s"An Error occurred: ${fail.fullMsg}")
     }
   }
@@ -1419,10 +1420,10 @@ private[rest] object SystemApi {
   val archiveDateFormat = new DateTimeFormatterBuilder()
     .append(DateTimeFormat.forPattern("YYYY-MM-dd"))
     .appendLiteral('T')
-    .append(DateTimeFormat.forPattern("hhmmss"))
+    .append(DateTimeFormat.forPattern("HHmmss'Z'")) // we want only utc here to avoid getting + or other strange char in URI
     .toFormatter
 
   def getArchiveName(archiveType: ArchiveType, date: DateTime): String =
-    s"rudder-conf-${archiveType.entryName}-${archiveDateFormat.print(date)}.zip"
+    s"rudder-conf-${archiveType.entryName}-${archiveDateFormat.print(date.toDateTime(DateTimeZone.UTC))}.zip"
 
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SystemApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SystemApiTest.scala
@@ -186,7 +186,7 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   val archive1: JObject = JObject(
     List(
       JField("id", "path"),
-      JField("date", "1970-01-01T010000"),
+      JField("date", "1970-01-01T010000Z"),
       JField("committer", "test-user"),
       JField("gitCommit", "6d6b2ceb46adeecd845ad0c0812fee07e2727104")
     )


### PR DESCRIPTION
https://issues.rudder.io/issues/26779

Bad `hh` in place of  `HH`. Plus normalize toward iso and utc

![image](https://github.com/user-attachments/assets/75437c93-7516-427f-b169-2e008d8ab2b8)
