### PR TITLE
Fixes #26747: Number of “nodes in audit mode” wrong on "About" page

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/About/View.elm
@@ -255,6 +255,7 @@ view model =
                         , div[]
                             [ rowNbInfo "Nodes in audit mode" info.nodes.audit
                             , rowNbInfo "Nodes in enforce mode" info.nodes.enforce
+                            , rowNbInfo "Nodes in mixed mode" info.nodes.mixed
                             , rowNbInfo "Enabled nodes" info.nodes.enabled
                             , rowNbInfo "Disabled nodes" info.nodes.disabled
                             , rowNbInfo "Total" info.nodes.total


### PR DESCRIPTION
https://issues.rudder.io/issues/26747

We were just not displaying node in mixed mode info.