### PR TITLE
Fixes #26918: Store agent-version as a dedicated field

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionInventoryParser.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/FusionInventoryParser.scala
@@ -361,6 +361,7 @@ class FusionInventoryParser(
    *     <POLICY_SERVER_HOSTNAME>127.0.0.1</POLICY_SERVER_HOSTNAME>
    *     <POLICY_SERVER_UUID>root</POLICY_SERVER_UUID>
    *   </AGENT>
+   *   <AGENT_VERSION>xxx</AGENT_VERSION> <!-- added in 8.3.1 -->
    *   <AGENT_CAPABILITIES>
    *     <AGENT_CAPABILITY>cfengine</AGENT_CAPABILITY>
    *     ...
@@ -385,7 +386,7 @@ class FusionInventoryParser(
 
     // as a temporary solution, we are getting information from packages
 
-    def findAgentVersion(software: Seq[Software], agentType: AgentType): Option[AgentVersion] = {
+    def findAgentVersionFromPackages(software: Seq[Software], agentType: AgentType): Option[AgentVersion] = {
       val agentSoftName = agentType.inventorySoftwareName.toLowerCase()
 
       software.filter(_.name.exists(_.toLowerCase().contains(agentSoftName))).toList.flatMap(_.version) match {
@@ -435,10 +436,13 @@ class FusionInventoryParser(
               case Some(cert) => Right(Certificate(cert))
               case None       => Left(Inconsistency("could not parse agent security token (tag AGENT_CERT), which is mandatory"))
             }
-          version        <-
-            findAgentVersion(inventory.applications, agentType).notOptionalPure(
-              s"Agent is not present in software list and so we can't get its version. This is not supported anymore."
-            )
+          version        <- optText(rudderXml \ "AGENT_VERSION") match {
+                              case Some(version) => Right(AgentVersion(version))
+                              case None          =>
+                                findAgentVersionFromPackages(inventory.applications, agentType).notOptionalPure(
+                                  s"Agent is not present in software list and so we can't get its version. This is not supported anymore."
+                                )
+                            }
         } yield {
           (AgentInfo(agentType, Some(version), securityToken, Set()), rootUser, policyServerId)
         }

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/resources/fusion-inventories/rudder-tag/linux-8-3-with-agent-version.ocs
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/resources/fusion-inventories/rudder-tag/linux-8-3-with-agent-version.ocs
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- standard agent tag as of rudder 8.3 -->
+<REQUEST>
+  <CONTENT>
+    <OPERATINGSYSTEM>
+      <ARCH>x86_64</ARCH>
+      <BOOT_TIME>2025-05-16 02:24:17</BOOT_TIME>
+      <DNS_DOMAIN>normation.com</DNS_DOMAIN>
+      <FQDN>rudder.normation.com</FQDN>
+      <FULL_NAME>Ubuntu 22.04.5 LTS</FULL_NAME>
+      <HOSTID>007f0102</HOSTID>
+      <KERNEL_NAME>linux</KERNEL_NAME>
+      <KERNEL_VERSION>5.15.0-126-generic</KERNEL_VERSION>
+      <NAME>Ubuntu</NAME>
+      <SSH_KEY>ssh-ed25519 xxxxx</SSH_KEY>
+      <TIMEZONE>
+        <NAME>UTC</NAME>
+        <OFFSET>+0000</OFFSET>
+      </TIMEZONE>
+      <VERSION>22.04</VERSION>
+    </OPERATINGSYSTEM>
+    <SOFTWARES>
+      <NAME>rudder-agent</NAME>
+      <VERSION>8.3.1-ubuntu22.04</VERSION>
+    </SOFTWARES>
+    <RUDDER>
+      <AGENT>
+        <AGENT_CERT>>-----BEGIN CERTIFICATE-----
+some_certificate_context
+-----END CERTIFICATE-----
+        </AGENT_CERT>
+        <AGENT_NAME>cfengine-community</AGENT_NAME>
+        <CFENGINE_KEY>-----BEGIN RSA PUBLIC KEY-----
+some_key_content
+-----END RSA PUBLIC KEY-----
+        </CFENGINE_KEY>
+        <OWNER>root</OWNER>
+        <POLICY_SERVER_HOSTNAME>127.0.0.1</POLICY_SERVER_HOSTNAME>
+        <POLICY_SERVER_UUID>root</POLICY_SERVER_UUID>
+      </AGENT>
+      <AGENT_CAPABILITIES></AGENT_CAPABILITIES>
+      <AGENT_VERSION>8.3.1</AGENT_VERSION>
+      <CUSTOM_PROPERTIES></CUSTOM_PROPERTIES>
+      <HOSTNAME>rudder</HOSTNAME>
+      <SERVER_ROLES></SERVER_ROLES>
+      <UUID>root</UUID>
+    </RUDDER>
+  </CONTENT>
+  <QUERY>INVENTORY</QUERY>
+  <DEVICEID>foo</DEVICEID>
+</REQUEST>

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/resources/fusion-inventories/rudder-tag/linux-8-3-without-agent-version.ocs
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/resources/fusion-inventories/rudder-tag/linux-8-3-without-agent-version.ocs
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- standard agent tag as of rudder 8.3 -->
+<REQUEST>
+  <CONTENT>
+    <OPERATINGSYSTEM>
+      <ARCH>x86_64</ARCH>
+      <BOOT_TIME>2025-05-16 02:24:17</BOOT_TIME>
+      <DNS_DOMAIN>normation.com</DNS_DOMAIN>
+      <FQDN>rudder.normation.com</FQDN>
+      <FULL_NAME>Ubuntu 22.04.5 LTS</FULL_NAME>
+      <HOSTID>007f0102</HOSTID>
+      <KERNEL_NAME>linux</KERNEL_NAME>
+      <KERNEL_VERSION>5.15.0-126-generic</KERNEL_VERSION>
+      <NAME>Ubuntu</NAME>
+      <SSH_KEY>ssh-ed25519 xxxxx</SSH_KEY>
+      <TIMEZONE>
+        <NAME>UTC</NAME>
+        <OFFSET>+0000</OFFSET>
+      </TIMEZONE>
+      <VERSION>22.04</VERSION>
+    </OPERATINGSYSTEM>
+    <SOFTWARES>
+      <NAME>rudder-agent</NAME>
+      <VERSION>8.3.1-ubuntu22.04</VERSION>
+    </SOFTWARES>
+    <RUDDER>
+      <AGENT>
+        <AGENT_CERT>>-----BEGIN CERTIFICATE-----
+some_certificate_context
+-----END CERTIFICATE-----
+        </AGENT_CERT>
+        <AGENT_NAME>cfengine-community</AGENT_NAME>
+        <CFENGINE_KEY>-----BEGIN RSA PUBLIC KEY-----
+some_key_content
+-----END RSA PUBLIC KEY-----
+        </CFENGINE_KEY>
+        <OWNER>root</OWNER>
+        <POLICY_SERVER_HOSTNAME>127.0.0.1</POLICY_SERVER_HOSTNAME>
+        <POLICY_SERVER_UUID>root</POLICY_SERVER_UUID>
+      </AGENT>
+      <AGENT_CAPABILITIES></AGENT_CAPABILITIES>
+      <CUSTOM_PROPERTIES></CUSTOM_PROPERTIES>
+      <HOSTNAME>rudder</HOSTNAME>
+      <SERVER_ROLES></SERVER_ROLES>
+      <UUID>root</UUID>
+    </RUDDER>
+  </CONTENT>
+  <QUERY>INVENTORY</QUERY>
+  <DEVICEID>foo</DEVICEID>
+</REQUEST>

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestReportParsing.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestReportParsing.scala
@@ -358,6 +358,19 @@ class TestInventoryParsing extends Specification with Loggable {
       )
     }
 
+    "Correctly parse the version from AGENT_VERSION when available" in {
+      val inventory = parseRun("fusion-inventories/rudder-tag/linux-8-3-with-agent-version.ocs")
+
+      inventory.node.agents.head.version === Some(AgentVersion("8.3.1"))
+
+    }
+    "Correctly revert to agent package version if AGENT_VERSION is missing" in {
+      val inventory = parseRun("fusion-inventories/rudder-tag/linux-8-3-without-agent-version.ocs")
+
+      inventory.node.agents.head.version === Some(AgentVersion("8.3.1-ubuntu22.04"))
+
+    }
+
   }
 
   "Parsing Processors" should {

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryMapper.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryMapper.scala
@@ -807,7 +807,7 @@ class InventoryMapper(
     root.setOpt(server.lastLoggedUserTime, A_LAST_LOGGED_USER_TIME, (x: DateTime) => GeneralizedTime(x).toString)
     root.setOpt(server.inventoryDate, A_INVENTORY_DATE, (x: DateTime) => GeneralizedTime(x).toString)
     root.setOpt(server.receiveDate, A_RECEIVE_DATE, (x: DateTime) => GeneralizedTime(x).toString)
-    root.resetValuesTo(A_AGENTS_NAME, server.agents.map(x => x.toJson)*)
+    root.resetValuesTo(A_AGENT_NAME, server.agents.map(x => x.toJson)*)
     root.resetValuesTo(A_SOFTWARE_DN, server.softwareIds.map(x => dit.SOFTWARE.SOFT.dn(x).toString)*)
     root.resetValuesTo(A_EV, server.environmentVariables.map(_.toJson)*)
     root.resetValuesTo(A_LIST_OF_IP, server.serverIps.distinct*)
@@ -1001,7 +1001,7 @@ class InventoryMapper(
       rootUser       <- entry.required(A_ROOT_USER).toIO
       policyServerId <- entry.required(A_POLICY_SERVER_UUID).toIO
       agentNames     <- ZIO
-                          .foreach(entry.valuesFor(A_AGENTS_NAME).toList) {
+                          .foreach(entry.valuesFor(A_AGENT_NAME).toList) {
                             case agent =>
                               agent.fromJson[AgentInfo].toIO.chainError(s"Error when parsing agent security token '${agent}'")
                           }

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/LDAPConstants.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/LDAPConstants.scala
@@ -57,7 +57,8 @@ object LDAPConstants {
   val A_HOSTNAME           = "nodeHostname"
   val A_ROOT_USER          = "localAdministratorAccountName"
   val A_DEF                = "definition"
-  val A_AGENTS_NAME        = "agentName"
+  val A_AGENT_NAME         = "agentName" // does not exist for real, needed for the query criteria
+  val A_AGENT_VERSION      = "agentVersion"
   val A_DESCRIPTION        = "description"
   val A_REV_ID             = "revision"
   val A_MODEL              = "model"
@@ -399,7 +400,7 @@ object LDAPConstants {
     may = Set(
       A_NAME,
       A_DESCRIPTION,
-      A_AGENTS_NAME,
+      A_AGENT_NAME,
       A_CONTAINER_DN,
       A_SOFTWARE_DN,
       A_ACCOUNT,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderLDAPConstants.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderLDAPConstants.scala
@@ -184,7 +184,7 @@ object RudderLDAPConstants extends Loggable {
   OC.createObjectClass(
     OC_POLICY_SERVER_NODE,
     sup = OC(OC_RUDDER_NODE),
-    must = Set(A_HOSTNAME, A_LIST_OF_IP, A_INVENTORY_DATE, A_ROOT_USER, A_AGENTS_NAME, A_NODE_POLICY_SERVER),
+    must = Set(A_HOSTNAME, A_LIST_OF_IP, A_INVENTORY_DATE, A_ROOT_USER, A_AGENT_NAME, A_NODE_POLICY_SERVER),
     may = Set(A_DESCRIPTION)
   )
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
@@ -698,9 +698,9 @@ case object AgentComparator extends LDAPCriterionType {
    * <4.1: AGENTS_NAME only contains the name of the agent (but a value that is different form the id, oldShortName)
    */
   private def filterAgent(agent: AgentType) = {
-    SUB(A_AGENTS_NAME, null, Array(s""""agentType":"${agent.id}""""), null) ::           // 4.2+
-    SUB(A_AGENTS_NAME, null, Array(s""""agentType":"${agent.oldShortName}""""), null) :: // 4.1
-    EQ(A_AGENTS_NAME, agent.oldShortName) ::                                             // 3.1 ( < 4.1 in fact)
+    SUB(A_AGENT_NAME, null, Array(s""""agentType":"${agent.id}""""), null) ::           // 4.2+
+    SUB(A_AGENT_NAME, null, Array(s""""agentType":"${agent.oldShortName}""""), null) :: // 4.1
+    EQ(A_AGENT_NAME, agent.oldShortName) ::                                             // 3.1 ( < 4.1 in fact)
     Nil
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
@@ -248,7 +248,9 @@ class NodeQueryCriteriaData(groupRepo: () => SubGroupComparatorRepository, insta
         Criterion(A_STATE, NodeStateComparator, NodeCriterionMatcherString(_.rudderSettings.state.name.wrap)),
         Criterion(A_OS_RAM, MemoryComparator, NodeCriterionMatcherMemory(_.ram.toChunk)),
         Criterion(A_OS_SWAP, MemoryComparator, UnsupportedByNodeMinimalApi),
-        Criterion(A_AGENTS_NAME, AgentComparator, AgentMatcher),
+        Criterion(A_AGENT_NAME, AgentComparator, AgentMatcher),
+        // agentVersion does not exist at LDAP level, it only works with the NodeFact matcher
+        Criterion(A_AGENT_VERSION, StringComparator, NodeCriterionMatcherString(_.rudderAgent.version.value.wrap)),
         Criterion(A_ACCOUNT, StringComparator, UnsupportedByNodeMinimalApi),
         Criterion(A_LIST_OF_IP, NodeIpListComparator, NodeCriterionMatcherIpaddress),
         Criterion(A_ROOT_USER, StringComparator, NodeCriterionMatcherString(_.rudderAgent.user.wrap)),

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPEntityMapper.scala
@@ -277,7 +277,7 @@ class LDAPEntityMapper(
   def parseAgentInfo(nodeId: NodeId, inventoryEntry: LDAPEntry): IOResult[(List[AgentInfo], KeyStatus)] = {
     for {
       agentsName <- {
-        val agents = inventoryEntry.valuesFor(A_AGENTS_NAME).toList
+        val agents = inventoryEntry.valuesFor(A_AGENT_NAME).toList
         ZIO.foreach(agents) { case agent => agent.fromJson[AgentInfo].toIO }
       }
       keyStatus  <- inventoryEntry(A_KEY_STATUS).map(KeyStatus(_)).getOrElse(Right(UndefinedKey)).toIO

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
@@ -130,7 +130,7 @@ class WoLDAPNodeRepository(
 
       (agents.toList, status)
     }
-    import com.normation.inventory.ldap.core.LDAPConstants.{A_KEY_STATUS, A_AGENTS_NAME}
+    import com.normation.inventory.ldap.core.LDAPConstants.{A_KEY_STATUS, A_AGENT_NAME}
     if (agentKey.isEmpty && agentKeyStatus.isEmpty) ZIO.unit
     else {
       nodeLibMutex.writeLock(for {
@@ -141,7 +141,7 @@ class WoLDAPNodeRepository(
                          }
         con           <- ldap
         existingEntry <- con
-                           .get(acceptedDit.NODES.NODE.dn(nodeId.value), A_KEY_STATUS :: A_AGENTS_NAME :: Nil: _*)
+                           .get(acceptedDit.NODES.NODE.dn(nodeId.value), A_KEY_STATUS :: A_AGENT_NAME :: Nil: _*)
                            .notOptional(
                              s"Cannot update node with id ${nodeId.value}: there is no node with that id"
                            )
@@ -156,7 +156,7 @@ class WoLDAPNodeRepository(
         result        <- if (agentsInfo == newInfo) LDIFNoopChangeRecord(dn).succeed
                          else {
                            val e = LDAPEntry(dn)
-                           e.addValues(A_AGENTS_NAME, newInfo._1.map(_.toJson)*)
+                           e.addValues(A_AGENT_NAME, newInfo._1.map(_.toJson)*)
                            e.addValues(A_KEY_STATUS, newInfo._2.value)
 
                            con.save(e).chainError(s"Error when saving node entry in repository: ${e}")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NodeInfoService.scala
@@ -90,7 +90,7 @@ object NodeInfoService {
       A_WIN_COMPANY,
       A_WIN_KEY,
       A_WIN_ID,
-      A_AGENTS_NAME,
+      A_AGENT_NAME,
       A_POLICY_SERVER_UUID,
       A_ROOT_USER,
       A_ARCH,

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -2371,7 +2371,7 @@ class MockNodes() {
             case A_STATE              => Right((n: NodeFact) => List(n.rudderSettings.state.name))
             case A_OS_RAM             => Right((n: NodeFact) => n.ram.map(_.size.toString).toList)
             case A_OS_SWAP            => Right((n: NodeFact) => n.swap.map(_.size.toString).toList)
-            case A_AGENTS_NAME        => Right((n: NodeFact) => List(n.rudderAgent.agentType.id))
+            case A_AGENT_NAME         => Right((n: NodeFact) => List(n.rudderAgent.agentType.id))
             case A_ACCOUNT            => Right((n: NodeFact) => n.accounts.toList)
             case A_LIST_OF_IP         => Right((n: NodeFact) => n.ipAddresses.map(_.inet).toList)
             case A_ROOT_USER          => Right((n: NodeFact) => List(n.rudderAgent.user))

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/homePage.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/homePage.js
@@ -309,13 +309,8 @@ function doughnutChart (id,data,colors,hoverColors) {
 
             case 'nodeAgents':
               jsonHashSearch.query.where = [
-                { objectType: "software"
-                , attribute : "cn"
-                , comparator: "regex"
-                , value     : "rudder-agent|Rudder [aA]gent \\(DSC\\)"
-                },
-                { objectType: "software"
-                , attribute : "softwareVersion"
+                { objectType: "node"
+                , attribute : "agentVersion"
                 , comparator: "regex"
                 , value     : "(\\d+:)?" + data.replace(/\./g, "(\.|~)") + ".*"
                 }

--- a/webapp/sources/rudder/rudder-web/src/main/resources/ldapObjectAndAttributes.properties
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/ldapObjectAndAttributes.properties
@@ -153,6 +153,7 @@ ldap.attr.publicKey = Public Key
 ldap.attr.ram = RAM
 ldap.attr.swap = Swap
 ldap.attr.agentName = Agent type
+ldap.attr.agentVersion = Agent version
 ldap.attr.state = Node State
 ldap.attr.localAdministratorAccountName = Administrator account
 ldap.attr.nodeHostname = Hostname

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -934,6 +934,10 @@ object DisplayNode extends Loggable {
           ("Total swap space (Swap)", StringEscapeUtils.escapeHtml4(sm.node.swap.map(_.toStringMo).getOrElse("-"))),
           ("System serial number", StringEscapeUtils.escapeHtml4(sm.machine.flatMap(x => x.systemSerialNumber).getOrElse("-"))),
           ("Agent type", StringEscapeUtils.escapeHtml4(sm.node.agents.headOption.map(_.agentType.displayName).getOrElse("-"))),
+          (
+            "Agent version",
+            StringEscapeUtils.escapeHtml4(sm.node.agents.headOption.flatMap(_.version.map(_.value)).getOrElse("-"))
+          ),
           ("Node state", StringEscapeUtils.escapeHtml4(getNodeState(node.rudderSettings.state))),
           ("Account(s)", displayAccounts(sm.node)),
           ("Administrator account", StringEscapeUtils.escapeHtml4(sm.node.main.rootUser)),


### PR DESCRIPTION
https://issues.rudder.io/issues/26918

# General arch

- We are already saving the agent version in a dedicated structure in LDAP in along with other agent info. 
- We already use the agent version information to build the dashboard donut. 

So that change only does:

- read the new tab `AGENT_VERSION` from XML inventory. If present, it use it for the persistance, else it reverts to the old method (full compatibility with previous agent version - there's a unit test added to ensure of that)
- change the query used when one clicks in the donut for a given agent version. 
- it also add the relevant code to add a "agent version" criteria, similar to "agent type" and that works only on `NodeFact`. 

# MISC
- there is a renaming from `A_AGENTS_NAME` to `A_AGENT_NAME` for consistency with `A_AGENT_VERSION` since we can have only one agent since Rudder 8.0. 
