### PR TITLE
Fixes #26921: Improve drag'n drop ergonomics in the techniques editor

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewBlock.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewBlock.elm
@@ -597,7 +597,7 @@ showChildren model block ui techniqueUi parentId =
         ) (ui.mode == Closed && (not (List.isEmpty block.calls) ))
      |> appendChildConditional
         ( element "li"
-          |> addAttribute (id "no-methods")
+          |> addAttribute (class "no-methods")
           |> appendChildList
              [ element "i"
                |> addClass "fas fa-sign-in-alt"
@@ -611,15 +611,14 @@ showChildren model block ui techniqueUi parentId =
         ) (List.isEmpty block.calls)
      |> appendChildConditional
         ( element "li"
-          |> addAttribute (id "no-methods")
+          |> addClass"no-methods drop-zone"
           |> addStyle ("text-align", "center")
-          |> addClass (if (DragDrop.isCurrentDropTarget model.dnd (InBlock block)) then " drop-target" else  "")
+          |> addClassConditional "drop-target" (DragDrop.isCurrentDropTarget model.dnd (InBlock block))
           |> appendChild
              ( element "i"
                |> addClass "fas fa-sign-in-alt"
                |> addStyle ("transform", "rotate(90deg)")
              )
-          |> addStyle ("padding", "3px 15px")
           |> DragDrop.makeDroppable model.dnd (InBlock block) dragDropMessages
         ) ( case (List.isEmpty block.calls , DragDrop.currentlyDraggedObject model.dnd) of
             ( True , _    ) -> False
@@ -640,17 +639,11 @@ showChildren model block ui techniqueUi parentId =
                   base =     [ showMethodCall model methodUi techniqueUi (Just block.id) c ]
                   dropElem = AfterElem (Just block.id) (Call parentId c)
                   dropTarget =  element "li"
-                                |> addAttribute (id "no-methods")
-                                |> addStyle ("padding", "3px 15px")
+                                |> addClass "no-methods drop-zone"
                                 |> addStyle ("text-align", "center")
-                                |> addClass (if (DragDrop.isCurrentDropTarget model.dnd dropElem) then " drop-target" else  "")
+                                |> addClassConditional "drop-target" (DragDrop.isCurrentDropTarget model.dnd dropElem)
                                 |> DragDrop.makeDroppable model.dnd dropElem dragDropMessages
                                 |> addAttribute (hidden currentDragChild)
-                                |> appendChild
-                                   ( element "i"
-                                     |> addClass "fas fa-sign-in-alt"
-                                     |> addStyle ("transform", "rotate(90deg)")
-                                   )
                 in
                    List.reverse (dropTarget :: base)
               Block _ b ->

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewMethod.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewMethod.elm
@@ -168,6 +168,7 @@ checkConstraintOnParameter call constraint =
     checks = [ checkEmpty, checkWhiteSpace, checkMax, checkMin, checkRegex, notRegexCheck, checkSelect ] |> List.concat
   in
     if List.isEmpty checks then ValidState else InvalidState checks
+
 {-
   DISPLAY ONE METHOD EXTENDED
 -}

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
@@ -19,7 +19,6 @@ import Editor.ViewTechniqueList exposing (..)
 import Maybe.Extra
 import Json.Decode
 import Regex
-import String.Extra
 
 
 --
@@ -266,7 +265,7 @@ showTechnique model technique origin ui editInfo =
       |> addAttributeList [ id "methods", class "list-unstyled" ]
       |> appendChild
            ( element "li"
-             |> addAttribute (id "no-methods")
+             |> addAttribute (class "no-methods")
              |> appendChildList
                 [ element "i"
                   |> addClass "fas fa-sign-in-alt"
@@ -279,17 +278,11 @@ showTechnique model technique origin ui editInfo =
            )
       |> appendChildConditional
            ( element "li"
-             |> addAttribute (id "no-methods")
+             |> addClass "no-methods drop-zone"
              |> addStyle ("text-align", "center")
-             |> addClass (if (DragDrop.isCurrentDropTarget model.dnd StartList) then " drop-target" else "")
-             |> appendChild
-                ( element "i"
-                  |> addClass "fas fa-sign-in-alt"
-                  |> addStyle ("transform", "rotate(90deg)")
-                )
-             |> addStyle ("padding", "3px 15px")
+             |> addClassConditional "drop-target" (DragDrop.isCurrentDropTarget model.dnd StartList)
+             |> appendChild ( element "div" )
              |> DragDrop.makeDroppable model.dnd StartList dragDropMessages
-
            ) ( case DragDrop.currentlyDraggedObject model.dnd of
                  Nothing -> False
                  Just _ -> not (List.isEmpty technique.elems)
@@ -304,16 +297,12 @@ showTechnique model technique origin ui editInfo =
                                                        Just _ -> False
                   dropElem = AfterElem Nothing call
                   dropTarget =  element "li"
-                                   |> addAttribute (id "no-methods")
-                                   |> addStyle ("padding", "3px 15px")
+                                   |> addClass "no-methods drop-zone"
                                    |> addStyle ("text-align", "center")
-                                   |> addClass (if (DragDrop.isCurrentDropTarget model.dnd dropElem) then " drop-target" else  "")
+                                   |> addClassConditional "drop-target" (DragDrop.isCurrentDropTarget model.dnd dropElem)
                                    |> DragDrop.makeDroppable model.dnd dropElem dragDropMessages
-                                   |> appendChild
-                                      ( element "i"
-                                        |> addClass "fas fa-sign-in-alt"
-                                        |> addStyle ("transform", "rotate(90deg)")
-                                      )
+                                   |> appendChild ( element "div" )
+
                   base = if currentDrag then [] else [dropTarget]
                   elem =
                       case call of

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechnique.elm
@@ -281,7 +281,6 @@ showTechnique model technique origin ui editInfo =
              |> addClass "no-methods drop-zone"
              |> addStyle ("text-align", "center")
              |> addClassConditional "drop-target" (DragDrop.isCurrentDropTarget model.dnd StartList)
-             |> appendChild ( element "div" )
              |> DragDrop.makeDroppable model.dnd StartList dragDropMessages
            ) ( case DragDrop.currentlyDraggedObject model.dnd of
                  Nothing -> False
@@ -301,7 +300,6 @@ showTechnique model technique origin ui editInfo =
                                    |> addStyle ("text-align", "center")
                                    |> addClassConditional "drop-target" (DragDrop.isCurrentDropTarget model.dnd dropElem)
                                    |> DragDrop.makeDroppable model.dnd dropElem dragDropMessages
-                                   |> appendChild ( element "div" )
 
                   base = if currentDrag then [] else [dropTarget]
                   elem =

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.scss
@@ -365,7 +365,14 @@ ul.tabs-list > li > .badge.empty{
   background-color: #F8F9FC;
   flex: 1;
 }
-#no-methods{
+
+.no-methods {
+  position: relative;
+  padding: 0 !important;
+  height: 0;
+  margin: 0 !important;
+}
+.no-methods:first-child:last-child{
   padding: 15px;
   border: 2px dashed #d6deef;
   border-radius: 4px;
@@ -378,10 +385,70 @@ ul.tabs-list > li > .badge.empty{
   opacity: .6;
 }
 
-.drop-target{
+/*
+.drop-zone > div {
+  position: absolute;
+  width: 100%;
+  height: 10px;
+  background-color: #D6DEEF;
+  top: -15px;
+  opacity: .4;
+  border-radius: 20px;
+}
+*/
+$drop-zone-height: 20px;
+$drop-zone-marker-height : 6px;
+.drop-target:not(.no-methods),
+.drop-zone{
+  position : relative;
+  margin-top: -$drop-zone-height !important;
+  height: $drop-zone-height;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /*
+  & > div{
+      position: absolute;
+      height: 2px;
+      top: 0;
+      left: 0;
+      border-top: 20px solid #1295C3 !important;
+      opacity: 1 !important;
+      box-shadow: 0 0px 12px rgba(18, 149, 194, 0.2117647059);
+      opacity:1 !important;
+      box-shadow: 0 0px 12px #1295c236;
+  }
+  */
+  & > div {
+    position: absolute;
+    width: 100%;
+    height: $drop-zone-marker-height;
+    background-color: #D6DEEF;
+    opacity: .4;
+    border-radius: 10px;
+  }
+  &.drop-target > div{
+    opacity:1 !important;
+    background-color: #1295C3;
+    box-shadow: 0 0px 12px #1295c236;
+  }
+}
+.drop-target.no-methods{
   border-color: #1295c2 !important;
   opacity:1 !important;
   box-shadow: 0 0px 12px #1295c236;
+}
+
+.card-method.showMethodCall[hidden]{
+  display: block !important;
+  opacity: .4;
+  filter: brightness(95%);
+
+
+  & > .method[hidden]{
+    display: flex !important;
+  }
 }
 
 /* FILEMANAGER */
@@ -945,14 +1012,9 @@ ul.list-unstyled > li{
 .card-method:not(.active) .block-child .methods {
   padding-left: 15px;
 }
-
-#methods li.card-method:nth-child(2) {
-  margin-top: 10px;
-}
 .method {
   border-radius: 4px;
   display: flex;
-  transition: all 1s ease;
   max-height:100000px
 }
 .method-elmt {
@@ -1589,7 +1651,7 @@ ul li.hide-method {
 }
 .card-method {
   box-shadow: rgba(50, 50, 105, 0.15) 0px 2px 5px 0px, rgba(0, 0, 0, 0.05) 0px 1px 1px 0px;
-  transition: all 0.3s cubic-bezier(.25,.8,.25,1);
+  transition: box-shadow 0.3s cubic-bezier(.25,.8,.25,1);
   background-color: #fff;
   border-radius: 6px;
 }

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.scss
@@ -373,7 +373,7 @@ ul.tabs-list > li > .badge.empty{
   margin: 0 !important;
 }
 .no-methods:first-child:last-child{
-  padding: 15px;
+  padding: 15px !important;
   border: 2px dashed #d6deef;
   border-radius: 4px;
   color: #0519258c;
@@ -383,6 +383,7 @@ ul.tabs-list > li > .badge.empty{
   transition-duration: .5s;
   text-align:center;
   opacity: .6;
+  height: initial !important;
 }
 
 $drop-zone-height: 20px;

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.scss
@@ -385,17 +385,6 @@ ul.tabs-list > li > .badge.empty{
   opacity: .6;
 }
 
-/*
-.drop-zone > div {
-  position: absolute;
-  width: 100%;
-  height: 10px;
-  background-color: #D6DEEF;
-  top: -15px;
-  opacity: .4;
-  border-radius: 20px;
-}
-*/
 $drop-zone-height: 20px;
 $drop-zone-marker-height : 6px;
 .drop-target:not(.no-methods),
@@ -407,20 +396,8 @@ $drop-zone-marker-height : 6px;
   display: flex;
   align-items: center;
   justify-content: center;
-  /*
-  & > div{
-      position: absolute;
-      height: 2px;
-      top: 0;
-      left: 0;
-      border-top: 20px solid #1295C3 !important;
-      opacity: 1 !important;
-      box-shadow: 0 0px 12px rgba(18, 149, 194, 0.2117647059);
-      opacity:1 !important;
-      box-shadow: 0 0px 12px #1295c236;
-  }
-  */
-  & > div {
+  &:before {
+    content: "";
     position: absolute;
     width: 100%;
     height: $drop-zone-marker-height;
@@ -428,7 +405,7 @@ $drop-zone-marker-height : 6px;
     opacity: .4;
     border-radius: 10px;
   }
-  &.drop-target > div{
+  &.drop-target:before{
     opacity:1 !important;
     background-color: #1295C3;
     box-shadow: 0 0px 12px #1295c236;
@@ -444,7 +421,6 @@ $drop-zone-marker-height : 6px;
   display: block !important;
   opacity: .4;
   filter: brightness(95%);
-
 
   & > .method[hidden]{
     display: flex !important;


### PR DESCRIPTION
https://issues.rudder.io/issues/26921

Drag'n drop has undergone some changes:
- when a method is dragged, it remains visible (but greyed out)
- The appearance of drop zones no longer has an impact on the size of the list, so items remain in place when dragged and dropped.
- the appearance of the drop zones has therefore changed: it is no longer a zone delimited by a dotted border, but a separator that indicates the drop zones. This separator is highlighted when it becomes the target for the drop.
- The margins between methods and blocks have been reduced

I've also moved the info icon at the top right of the method to the method name badge, and removes the "method" label to free up space (not visible in the gif) : 
![image](https://github.com/user-attachments/assets/fbeb7358-b53a-4b5f-850d-d4370401adbe)

Thanks to these changes, it's now easier to move an element, and harder to do so by mistake

Here is a preview :
![dragndrop-improved](https://github.com/user-attachments/assets/512623c2-6c88-44eb-9c35-0fcc6f589ff2)
