### PR TITLE
Fixes #26936: 

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestPreParsing.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestPreParsing.scala
@@ -38,13 +38,13 @@ package com.normation.inventory.provisioning.fusion
 
 import com.normation.errors.*
 import com.normation.inventory.services.provisioning.PreInventoryParser
+import com.normation.utils.XmlSafe
 import com.normation.zio.*
 import java.io.InputStream
 import org.junit.runner.*
 import org.specs2.mutable.*
 import org.specs2.runner.*
 import scala.xml.NodeSeq
-import scala.xml.XML
 import zio.*
 
 /**
@@ -59,7 +59,7 @@ class TestPreParsing extends Specification {
   implicit private class TestParser(pre: PreInventoryParser) {
 
     def fromXml(checkName: String, is: InputStream): IOResult[NodeSeq] = {
-      ZIO.attempt(XML.load(is)).mapError(SystemError("error in test", _))
+      ZIO.attempt(XmlSafe.load(is)).mapError(SystemError("error in test", _))
     }
 
     def check(checkRelativePath: String): Either[RudderError, NodeSeq] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/TechniqueCategory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/TechniqueCategory.scala
@@ -37,8 +37,11 @@
 
 package com.normation.cfclerk.domain
 
+import better.files.File
+import com.normation.errors.IOResult
 import com.normation.rudder.domain.policies.ActiveTechniqueCategory
 import com.normation.rudder.domain.policies.ActiveTechniqueCategoryId
+import com.normation.utils.XmlSafe
 import scala.collection.SortedSet
 import scala.xml.Elem
 import zio.json.*
@@ -75,6 +78,12 @@ object TechniqueCategoryMetadata {
         <description>{metadata.description}</description>
         {if (metadata.isSystem) <system>true</system> else xml.NodeSeq.Empty}
       </xml>
+    }
+  }
+
+  def parse(file: File, defaultName: String): IOResult[TechniqueCategoryMetadata] = {
+    IOResult.attempt(s"Error when parsing category descriptor for '${defaultName}' at '${file.pathAsString}'") {
+      parseXML(XmlSafe.loadFile(file.toJava), defaultName)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
@@ -49,6 +49,7 @@ import com.normation.rudder.git.GitFindUtils
 import com.normation.rudder.git.GitRepositoryProvider
 import com.normation.rudder.git.GitRevisionProvider
 import com.normation.rudder.repository.xml.TechniqueFiles
+import com.normation.utils.XmlSafe
 import com.normation.zio.*
 import java.io.File
 import java.io.FileNotFoundException
@@ -980,7 +981,7 @@ class GitTechniqueReader(
     ZIO.scoped(
       managedStream.flatMap(is => {
         ZIO.attempt {
-          XML.load(is)
+          XmlSafe.load(is)
         }.foldZIO(
           err =>
             err match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
@@ -49,6 +49,7 @@ import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.*
 import com.normation.rudder.domain.reports.JsonPostgresqlSerialization.JNodeStatusReport
+import com.normation.utils.XmlSafe
 import com.normation.zio.*
 import doobie.*
 import doobie.implicits.javasql.*
@@ -307,7 +308,7 @@ object Doobie {
     Meta.Advanced.many[Elem](
       NonEmptyList.of(SqlXml),
       NonEmptyList.of("xml"),
-      (rs, n) => XML.load(rs.getObject(n).asInstanceOf[SQLXML].getBinaryStream),
+      (rs, n) => XmlSafe.load(rs.getObject(n).asInstanceOf[SQLXML].getBinaryStream),
       (ps, n, e) => {
         val sqlXml = ps.getConnection.createSQLXML
         val osw    = new java.io.OutputStreamWriter(sqlXml.setBinaryStream())

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
@@ -71,6 +71,7 @@ import com.normation.rudder.ncf.TechniqueCompiler
 import com.normation.rudder.repository.*
 import com.normation.rudder.services.marshalling.*
 import com.normation.rudder.services.user.PersonIdentService
+import com.normation.utils.XmlSafe
 import java.io.File
 import java.io.FileNotFoundException
 import net.liftweb.common.*
@@ -78,7 +79,6 @@ import org.apache.commons.io.FileUtils
 import org.eclipse.jgit.lib.PersonIdent
 import scala.collection.mutable.Buffer
 import scala.xml.Source
-import scala.xml.XML
 import zio.*
 import zio.syntax.*
 
@@ -415,7 +415,7 @@ class TechniqueArchiverImpl(
       known      = resourcesStatus.map(f => (f.path, f)).toMap
       updated    = res.fileStatus.map(f => (f.path, f)).toMap
       fileStates = Chunk.fromIterable((known ++ updated).values)
-      metadata  <- IOResult.attempt(XML.load(Source.fromFile((techniquePath / TechniqueFiles.Generated.metadata).toJava)))
+      metadata  <- IOResult.attempt(XmlSafe.load(Source.fromFile((techniquePath / TechniqueFiles.Generated.metadata).toJava)))
       tech      <- techniqueParser.parseXml(metadata, techniqueId).toIO
       files      = getFilesToCommit(tech, techniqueGitPath, fileStates)
       ident     <- personIdentservice.getPersonIdentOrDefault(committer.name)
@@ -444,7 +444,7 @@ class TechniqueArchiverImpl(
         (for {
           // the file may not exist, which is not an error in that case
           existing <- IOResult.attempt {
-                        val elem = XML.load(Source.fromFile(categoryFile.toJava))
+                        val elem = XmlSafe.load(Source.fromFile(categoryFile.toJava))
                         Some(TechniqueCategoryMetadata.parseXML(elem, catId))
                       }.catchSome { case SystemError(_, _: FileNotFoundException) => None.succeed }
           _        <- if (existing.contains(metadata)) {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
@@ -61,6 +61,7 @@ import com.normation.rudder.services.policies.DependencyAndDeletionService
 import com.normation.rudder.services.queries.DynGroupUpdaterService
 import com.normation.utils.Control.*
 import com.normation.utils.StringUuidGenerator
+import com.normation.utils.XmlSafe
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 import net.liftweb.common.*
@@ -174,7 +175,7 @@ class CommitAndDeployChangeRequestServiceImpl(
           for {
             entry <- xmlSerialize(elem)
             is     = new ByteArrayInputStream(entry.toString.getBytes(StandardCharsets.UTF_8))
-            xml    = XML.load(is)
+            xml    = XmlSafe.load(is)
             elem  <- xmlUnserialize(xml)
           } yield {
             elem

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/SectionTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/SectionTest.scala
@@ -39,6 +39,7 @@ package com.normation.cfclerk.domain
 
 import com.normation.cfclerk.xmlparsers.*
 import com.normation.cfclerk.xmlparsers.CfclerkXmlConstants.*
+import com.normation.utils.XmlSafe
 import java.io.FileNotFoundException
 import org.junit.runner.*
 import org.specs2.mutable.*
@@ -189,7 +190,7 @@ class SectionTest extends Specification {
   private def readFile(fileName: String): Elem = {
     val doc = {
       try {
-        XML.load(ClassLoader.getSystemResourceAsStream(fileName))
+        XmlSafe.load(ClassLoader.getSystemResourceAsStream(fileName))
       } catch {
         case e: SAXParseException              => throw new Exception("Unexpected issue (unvalid xml?) with " + fileName)
         case e: java.net.MalformedURLException => throw new FileNotFoundException("%s file not found".format(fileName))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/TechniqueTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/TechniqueTest.scala
@@ -39,6 +39,7 @@ package com.normation.cfclerk.domain
 
 import com.normation.cfclerk.services.impl.SystemVariableSpecServiceImpl
 import com.normation.cfclerk.xmlparsers.*
+import com.normation.utils.XmlSafe
 import java.io.FileNotFoundException
 import org.junit.runner.*
 import org.specs2.mutable.*
@@ -144,7 +145,7 @@ class TechniqueTest extends Specification {
   private def readFile(fileName: String): Elem = {
     val doc = {
       try {
-        XML.load(ClassLoader.getSystemResourceAsStream(fileName))
+        XmlSafe.load(ClassLoader.getSystemResourceAsStream(fileName))
       } catch {
         case e: SAXParseException              => throw new Exception("Unexpected issue (unvalid xml?) with " + fileName)
         case e: java.net.MalformedURLException => throw new FileNotFoundException("%s file not found".format(fileName))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/VariableTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/VariableTest.scala
@@ -40,6 +40,7 @@ package com.normation.cfclerk.domain
 import com.normation.cfclerk.domain.HashAlgoConstraint.*
 import com.normation.cfclerk.xmlparsers.*
 import com.normation.rudder.services.policies.write.CFEngineAgentSpecificGeneration
+import com.normation.utils.XmlSafe
 import java.io.FileNotFoundException
 import org.joda.time.format.*
 import org.junit.runner.RunWith
@@ -95,7 +96,7 @@ class VariableTest extends Specification {
   val variables: mutable.Map[String, Variable] = {
     val doc = {
       try {
-        XML.load(ClassLoader.getSystemResourceAsStream("testVariable.xml"))
+        XmlSafe.load(ClassLoader.getSystemResourceAsStream("testVariable.xml"))
       } catch {
         case e: SAXParseException              => throw new Exception("Unexpected issue (unvalid xml?) with testVariable.xml ")
         case e: java.net.MalformedURLException => throw new FileNotFoundException("testVariable.xml file not found ")
@@ -133,7 +134,7 @@ class VariableTest extends Specification {
   "SYSTEM_VARIABLE tag" should {
     "lead to an exception" in {
       val sysvar = (for {
-        elt      <- (XML.load(ClassLoader.getSystemResourceAsStream("testSystemVariable.xml")) \\ "VARIABLES")
+        elt      <- (XmlSafe.load(ClassLoader.getSystemResourceAsStream("testSystemVariable.xml")) \\ "VARIABLES")
         specNode <- elt.nonEmptyChildren
         if (!specNode.isInstanceOf[Text])
       } yield {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/xmlparsers/ParseTechniqueTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/xmlparsers/ParseTechniqueTest.scala
@@ -43,6 +43,7 @@ import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersionHelper
 import com.normation.cfclerk.services.impl.SystemVariableSpecServiceImpl
 import com.normation.inventory.domain.AgentType
+import com.normation.utils.XmlSafe
 import java.io.FileNotFoundException
 import org.junit.runner.*
 import org.specs2.mutable.*
@@ -86,7 +87,7 @@ class ParseTechniqueTest extends Specification {
   private def readFile(fileName: String): Elem = {
     val doc = {
       try {
-        XML.load(ClassLoader.getSystemResourceAsStream(fileName))
+        XmlSafe.load(ClassLoader.getSystemResourceAsStream(fileName))
       } catch {
         case e: SAXParseException              => throw new Exception("Unexpected issue (unvalid xml?) with " + fileName)
         case e: java.net.MalformedURLException => throw new FileNotFoundException("%s file not found".format(fileName))

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
@@ -662,7 +662,7 @@ trait BuildHandler[REQ, RESP, T, P] {
               Some(() => {
                 // here we are allowed to do time-consuming side effects
                 // we do handle that request ! Now for actual handling;
-                // in all case an response, even if an error (so Some(() => Full(...)))
+                // in all case a response, even if an error (so Some(() => Full(...)))
                 logger.debug(s"Processing request: ${logReq(req)}")
                 logger.debug(logBody(req))
                 logger.debug(
@@ -683,7 +683,7 @@ trait BuildHandler[REQ, RESP, T, P] {
                                          .toUpperCase()} ${info.path.value}': ${error.msg}")
                                      error
                                    }
-                  // extract modul parameters from request
+                  // extract module parameters from request
                   params        <- api.getParam(req).leftMap { error =>
                                      logger.error(s"Error when extracting request parameters from '${info.action.name
                                          .toUpperCase()} ${info.path.value}': ${error.msg}")

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonResponse.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonResponse.scala
@@ -226,10 +226,13 @@ object RudderJsonResponse {
           .fold(
             err => {
               ApiLogger.ResponseError.info(err.fullMsg)
-              internalError(None, schema, err.fullMsg)
+
+              // here, we don't want to return stack trace, since it can be security vulnerability
+              internalError(None, schema, err.msg)
             },
             seq => successList(schema, seq.toList)
           )
+          .catchAllDefect(err => zio.ZIO.succeed(internalError(None, schema, err.getMessage)))
           .runNow
       }
       def toLiftResponseList(params: DefaultParams, schema: EndpointSchema)(implicit encoder: JsonEncoder[A]): LiftResponse = {
@@ -261,10 +264,13 @@ object RudderJsonResponse {
           .fold(
             err => {
               ApiLogger.ResponseError.info(err.fullMsg)
-              internalError(id.error, schema, err.fullMsg)
+
+              // here, we don't want to return stack trace, since it can be security vulnerability
+              internalError(id.error, schema, err.msg)
             },
             one => successOne(schema, one, id.success(one))
           )
+          .catchAllDefect(err => zio.ZIO.succeed(internalError(id.error, schema, err.getMessage)))
           .runNow
       }
       def toLiftResponseOne(params: DefaultParams, schema: EndpointSchema, id: Option[String])(implicit
@@ -288,13 +294,16 @@ object RudderJsonResponse {
           .fold(
             err => {
               ApiLogger.ResponseError.info(err.fullMsg)
-              internalError(None, errorSchema, err.fullMsg)
+
+              // here, we don't want to return stack trace, since it can be security vulnerability
+              internalError(None, errorSchema, err.msg)
             },
             one => {
               val (schema, x, id) = map(one)
               successOne(schema, x, id)
             }
           )
+          .catchAllDefect(err => zio.ZIO.succeed(internalError(None, errorSchema, err.getMessage)))
           .runNow
       }
     }
@@ -306,10 +315,13 @@ object RudderJsonResponse {
           .fold(
             err => {
               ApiLogger.ResponseError.info(err.fullMsg)
-              internalError(None, schema, err.fullMsg)
+
+              // here, we don't want to return stack trace, since it can be security vulnerability
+              internalError(None, schema, err.msg)
             },
             msg => successZero(schema, msg)
           )
+          .catchAllDefect(err => zio.ZIO.succeed(internalError(None, schema, err.getMessage)))
           .runNow
       }
       def toLiftResponseZero(params: DefaultParams, schema: EndpointSchema): LiftResponse = {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -111,6 +111,7 @@ import com.normation.rudder.rest.lift.ImportAnswer.*
 import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.services.queries.CmdbQueryParser
 import com.normation.utils.StringUuidGenerator
+import com.normation.utils.XmlSafe
 import com.normation.zio.*
 import enumeratum.*
 import io.scalaland.chimney.syntax.*
@@ -127,7 +128,6 @@ import net.liftweb.http.OutputStreamResponse
 import net.liftweb.http.Req
 import org.joda.time.DateTime
 import scala.util.matching.Regex
-import scala.xml.XML
 import zio.*
 import zio.json.*
 import zio.syntax.*
@@ -1098,7 +1098,7 @@ class ZipArchiveReaderImpl(
 
         case TechniqueType.Metadata.name =>
           for {
-            xml  <- IOResult.attempt(XML.load(new ByteArrayInputStream(content)))
+            xml  <- IOResult.attempt(XmlSafe.load(new ByteArrayInputStream(content)))
             tech <- techniqueParser.parseXml(xml, id).toIO
             _    <- optTech.update {
                       case None    => Some(TechniqueInfo(tech.id, tech.name, TechniqueType.Metadata))

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/LiftApiDispatcher.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/LiftApiDispatcher.scala
@@ -278,7 +278,7 @@ class LiftHandler(
 
 /*
  * some type machinery to be able to have an implementation for old RuleApi up to V13
- * and an other for API with zio_json in V14 (and choose processing based on that)
+ * and another for API with zio_json in V14 (and choose processing based on that)
  */
 final case class ChooseApi0[A <: LiftApiModule0](old: A, current: A) extends LiftApiModule0 {
   override val schema = current.schema

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
@@ -49,6 +49,7 @@ import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.facts.nodes.NodeSecurityContext
 import com.normation.rudder.rest.RoleApiMapping
 import com.normation.rudder.users.*
+import com.normation.utils.XmlSafe
 import com.normation.zio.*
 import enumeratum.*
 import java.io.InputStream
@@ -528,7 +529,7 @@ object UserFileProcessing {
 
   def readUserFile(resource: UserFile): IOResult[Elem] = {
     IOResult.attempt {
-      scala.xml.XML.load(resource.inputStream())
+      XmlSafe.load(resource.inputStream())
     }.mapError {
       // map a SAXParseException to a technical butmore user-friendly but error message
       case s @ SystemError(_, e: SAXParseException) =>

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_directives.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_directives.yml
@@ -214,7 +214,7 @@ response:
     {
       "action":"directiveDetails",
       "result":"error",
-      "errorDetails":"Inconsistency: Directive with id 'xxxxxxxx-2675-43b9-ab57-bfbab84346aa' was not found"
+      "errorDetails":"Directive with id 'xxxxxxxx-2675-43b9-ab57-bfbab84346aa' was not found"
     }
 ---
 description: List directives
@@ -1204,7 +1204,7 @@ response:
     {
       "action":"directiveDetails",
       "result":"error",
-      "errorDetails":"Inconsistency: Directive with id '1bc636c0-61b0-410c-0000-66bcfc95804d' was not found"
+      "errorDetails":"Directive with id '1bc636c0-61b0-410c-0000-66bcfc95804d' was not found"
     }
 ---
 description: Get Directive tree

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
@@ -379,7 +379,7 @@ response:
     {
       "action":"groupDetails",
       "result":"error",
-      "errorDetails":"Inconsistency: Group with id 'xxxxxxxx-2675-43b9-ab57-bfbab84346aa' was not found'"
+      "errorDetails":"Group with id 'xxxxxxxx-2675-43b9-ab57-bfbab84346aa' was not found'"
     }
 ---
 description: List groups
@@ -1551,7 +1551,7 @@ response:
     {
       "action" : "deleteGroup",
       "result" : "error",
-      "errorDetails" : "Inconsistency: Could not delete group 'all-nodes', cause is: system groups cannot be deleted."
+      "errorDetails" : "Could not delete group 'all-nodes', cause is: system groups cannot be deleted."
     }
 ---
 description: Create a node group category (JSON)

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_parameters.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_parameters.yml
@@ -51,7 +51,7 @@ response:
     {
       "action":"parameterDetails",
       "result":"error",
-      "errorDetails":"Inconsistency: Could not find Parameter xxxxxxxx"
+      "errorDetails":"Could not find Parameter xxxxxxxx"
     }
 ---
 description: List parameters (hiddenParam is not listed)

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_rules.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_rules.yml
@@ -38,7 +38,7 @@ response:
     {
       "action":"ruleDetails",
       "result":"error",
-      "errorDetails":"Inconsistency: Rule with id 'xxxxxxxx-2675-43b9-ab57-bfbab84346aa' was not found"
+      "errorDetails":"Rule with id 'xxxxxxxx-2675-43b9-ab57-bfbab84346aa' was not found"
     }
 ---
 description: List rules

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_techniques.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_techniques.yml
@@ -577,7 +577,7 @@ response:
     {
       "action":"listTechniqueDirectives",
       "result":"error",
-      "errorDetails":"Inconsistency: Version '3.0' of Technique 'genericVariableDefinition' does not exist"
+      "errorDetails":"Version '3.0' of Technique 'genericVariableDefinition' does not exist"
     }
 ---
 description: Try to get directive for a technique/bad version
@@ -589,5 +589,5 @@ response:
     {
       "action":"listTechniqueDirectives",
       "result":"error",
-      "errorDetails":"Inconsistency: Could not find list of directives based on 'packageManagement' technique, because we could not parse 'X.Y' as a valid technique version"
+      "errorDetails":"Could not find list of directives based on 'packageManagement' technique, because we could not parse 'X.Y' as a valid technique version"
     }

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/earlyconfig/db/TestCheckUsersFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/earlyconfig/db/TestCheckUsersFile.scala
@@ -2,6 +2,7 @@ package bootstrap.liftweb.checks.migration
 
 import bootstrap.liftweb.checks.earlyconfig.db.CheckUsersFile
 import com.normation.rudder.MockUserManagement
+import com.normation.utils.XmlSafe
 import com.normation.zio.UnsafeRun
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
@@ -67,7 +68,7 @@ class TestCheckUsersFile extends Specification {
     val migration                                      = mockUserManagement.userService
     val checkUsersFile                                 = new CheckUsersFile(migration)
 
-    val elem = () => scala.xml.XML.load(migration.file.inputStream())
+    val elem = () => XmlSafe.load(migration.file.inputStream())
     val res  = block(elem, checkUsersFile)
 
     mockUserManagementTmpDir.delete()

--- a/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/ZioCommons.scala
@@ -189,12 +189,13 @@ object errors {
   }
 
   final case class Accumulated[E <: RudderError](all: NonEmptyList[E]) extends RudderError {
-    implicit val ord: Order[E]       = new Order[E]() {
+    implicit val ord:     Order[E]       = new Order[E]() {
       override def compare(x: E, y: E): Int = String.CASE_INSENSITIVE_ORDER.compare(x.fullMsg, y.fullMsg)
     }
-    def msg:          String         = all.map(_.fullMsg).toList.mkString(" ; ")
+    override def fullMsg: String         = all.map(_.fullMsg).toList.mkString(" ; ")
+    override def msg:     String         = all.map(_.msg).toList.mkString(" ; ")
     // only unique error
-    def deduplicate:  Accumulated[E] = {
+    def deduplicate:      Accumulated[E] = {
       Accumulated(all.distinct)
     }
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/26936

Move safe `SAXParserFactory` into its own object in `utils`, and use it everywhere. 
Also, create an utility method for technique category parsing to avoid having user not going through the safe parser. 

Also change the returned message of API to avoid letting too much go out (remove stack trace of system error in particular, likely to get displayed when a vulnerability is probed)