### PR TITLE
Fixes #26939: User management UI does not display when a user info is a complex JSON object

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/ApiCalls.elm
@@ -6,9 +6,9 @@ module UserManagement.ApiCalls exposing (..)
 -- API call to get the category tree
 
 import UserManagement.DataTypes exposing (AddUserForm, Model, Msg(..), UserAuth, UserInfoForm, Username)
-import Http exposing (emptyBody, expectJson, jsonBody, request, header)
+import Http exposing (emptyBody, expectJson, expectWhatever, jsonBody, request, header)
 import Json.Decode as Decode
-import UserManagement.JsonDecoder exposing (decodeApiAddUserResult, decodeApiCurrentUsersConf, decodeApiDeleteUserResult, decodeApiReloadResult, decodeApiStatusResult, decodeApiUpdateUserInfoResult, decodeApiUpdateUserResult, decodeGetRoleApiResult)
+import UserManagement.JsonDecoder exposing (decodeApiUpdateUserResult, decodeApiAddUserResult, decodeApiCurrentUsersConf, decodeApiDeleteUserResult, decodeApiReloadResult, decodeApiStatusResult, decodeGetRoleApiResult)
 import UserManagement.JsonEncoder exposing (encodeAddUser, encodeUserAuth, encodeUserInfo)
 
 
@@ -111,7 +111,7 @@ updateUserInfo model toUpdate userForm =
                 , headers = [header "X-Requested-With" "XMLHttpRequest"]
                 , url = getUrl model ("/usermanagement/update/info/" ++ toUpdate)
                 , body = jsonBody (encodeUserInfo userForm)
-                , expect = expectJson UpdateUserInfo decodeApiUpdateUserInfoResult
+                , expect = expectWhatever UpdateUserInfo
                 , timeout = Nothing
                 , tracker = Nothing
                 }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/Init.elm
@@ -14,7 +14,7 @@ init : { contextPath : String, userId : String } -> ( Model, Cmd Msg )
 init flags =
     let
         initUi = UI Closed False (TableFilters UserLogin Asc "")
-        initUserInfoForm = UserInfoForm "" "" Dict.empty
+        initUserInfoForm = UserInfoForm "" "" Dict.empty Dict.empty
         initUserForm = UserForm "" "" True False [] initUserInfoForm [] ValidInputs 
         initModel = Model flags.contextPath flags.userId "" False (fromList []) (fromList []) [] None initUserForm initUi [] Dict.empty
     in

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/JsonDecoder.elm
@@ -63,7 +63,7 @@ decodeUser =
         |> required "login" D.string
         |> optional "name" D.string ""
         |> optional "email" D.string ""
-        |> required "otherInfo" (D.dict D.string)
+        |> required "otherInfo" (D.dict D.value)
         |> required "status" decodeUserStatus
         |> required "authz" (D.list <| D.string)
         |> required "permissions" (D.list <| D.string)
@@ -100,21 +100,6 @@ decodeApiUpdateUserResult =
 decodeUpdateUser : Decoder String
 decodeUpdateUser =
     D.at [ "updatedUser" ] (D.at [ "username" ] D.string)
-
-decodeApiUpdateUserInfoResult : Decoder UserInfoForm
-decodeApiUpdateUserInfoResult =
-    D.at [ "data" ] decodeUpdateUserInfo
-
-decodeUpdateUserInfoResult : Decoder UserInfoForm
-decodeUpdateUserInfoResult =
-    D.at [ "updatedUser" ] decodeUpdateUserInfo
-
-decodeUpdateUserInfo : Decoder UserInfoForm
-decodeUpdateUserInfo =
-    D.succeed UserInfoForm
-        |> optional "name" D.string ""
-        |> optional "email" D.string ""
-        |> optional "otherInfo" (D.dict D.string) Dict.empty
 
 decodeApiDeleteUserResult : Decoder String
 decodeApiDeleteUserResult =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/JsonEncoder.elm
@@ -30,5 +30,5 @@ encodeUserInfo user =
     object
     [ ("name", string user.name)
     , ("email", string user.email)
-    , ("otherInfo", object (List.map (\(k, v) -> (k, string v)) (Dict.toList user.otherInfo)))
+    , ("otherInfo",  object (user.info |> Dict.toList |> List.map (\(k, v) -> (k, string v)) |> List.append (Dict.toList user.otherInfo)))
     ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/UserManagement/View.elm
@@ -13,6 +13,7 @@ import Maybe.Extra exposing (isJust)
 import Set
 import String exposing (isEmpty)
 import NaturalOrdering as N
+import Json.Encode exposing (encode)
 
 view : Model -> Html Msg
 view model =
@@ -347,12 +348,23 @@ displayUserInfo userForm allowSaveInfo =
                     div [ class "user-info-row user-info-other" ]
                         [ label [ for k ] [ text k ]
                         , div [ class "user-info-row-edit" ]
+                            [ input [ id k, class "form-control user-info-value", value (encode 0 v), disabled True ] []
+                            , button [ class "btn btn-default", onClick (RemoveUserOtherInfoField k) ] [ i [ class "fa fa-trash" ] [] ]
+                            ]
+                        ]
+                )
+                (Dict.toList userForm.userInfoForm.otherInfo)
+            ++ List.map
+                (\( k, v ) ->
+                    div [ class "user-info-row user-info-other" ]
+                        [ label [ for k ] [ text k ]
+                        , div [ class "user-info-row-edit" ]
                             [ input [ id k, class "form-control user-info-value", placeholder ("Enter value for field '" ++ k ++ "'"), onInput (ModifyUserInfoField k), value v ] []
                             , button [ class "btn btn-default", onClick (RemoveUserInfoField k) ] [ i [ class "fa fa-trash" ] [] ]
                             ]
                         ]
                 )
-                (Dict.toList userForm.userInfoForm.otherInfo)
+                (Dict.toList userForm.userInfoForm.info)
             ++ List.indexedMap
                 (\idx ( k, v ) ->
                     div [ class "user-info-row user-info-other" ]


### PR DESCRIPTION
https://issues.rudder.io/issues/26939

Using the `Decoder.dict Decoder.string` can result in a silent error when the JSON has non-string values.
It happens with the `otherInfo` field which is additional user information that can be updated from the API, as JSON.

In the UI, complex JSON objects (int, objects) are not supposed to be edited, and parsed as JSON, but string only.
So, we decode the `otherInfo` field as any JSON object instead, and split the key-values into ones that are editable as string, and others that are read-only JSON : 
 
![Screenshot from 2025-05-22 16-04-53](https://github.com/user-attachments/assets/156a7218-ad29-465c-b6c0-ab78d10d0043)
