### PR TITLE
Fixes #26944: 

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -339,27 +339,27 @@ class ArchiveApi(
         }
       }
 
-      def parseArchive(archive: FileParamHolder): IOResult[PolicyArchive] = {
-        val originalFilename = archive.fileName
-
+      def parseArchive(archive: FileParamHolder, name: String): IOResult[PolicyArchive] = {
         ZIO
           .acquireReleaseWith(IOResult.attempt(archive.fileStream))(is => effectUioUnit(is.close())) { is =>
-            ZipUtils.getZipEntries(originalFilename, is)
+            ZipUtils.getZipEntries(name, is)
           }
-          .flatMap(entries => zipArchiveReader.readPolicyItems(originalFilename, entries))
+          .flatMap(entries => zipArchiveReader.readPolicyItems(name, entries))
       }
 
       val prog = (req.uploadedFiles.find(_.name == FILE) match {
         case None      =>
           Unexpected(s"Missing uploaded file with parameter name '${FILE}'").fail
         case Some(zip) =>
+          val originalFilename = File(zip.fileName).name
+
           for {
-            _       <- ApplicationLoggerPure.Archive.info(s"Received a new policy archive '${zip.fileName}', processing")
+            _       <- ApplicationLoggerPure.Archive.info(s"Received a new policy archive '${originalFilename}', processing")
             merge   <- parseMergePolicy(req)
-            archive <- parseArchive(zip)
+            archive <- parseArchive(zip, originalFilename)
             _       <- checkArchiveService.check(archive)
             _       <- saveArchiveService.save(archive, merge)(authzToken.qc)
-            _       <- ApplicationLoggerPure.Archive.info(s"Uploaded archive '${zip.fileName}' processed successfully")
+            _       <- ApplicationLoggerPure.Archive.info(s"Uploaded archive '${originalFilename}' processed successfully")
           } yield JRArchiveImported(success = true)
       }).tapError(err => ApplicationLoggerPure.Archive.error(s"Error when processing uploaded archive: ${err.fullMsg}"))
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InventoryApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InventoryApi.scala
@@ -119,14 +119,17 @@ class InventoryApi(
       }
       def parseInventory(pretty: Boolean, inventoryFile: FileParamHolder, signatureFile: FileParamHolder): IOResult[String] = {
         // here, we are at the end of our world. Evaluate ZIO and see what happen.
-        val originalFilename  = inventoryFile.fileName
+        // do not take the whole path as it can lead to path traversal, just the filename
+        val originalFilename = File(inventoryFile.fileName).name
+        val sigFilename      = File(signatureFile.fileName).name
+
         // for the signature, we want:
         // - to assume the signature is for the given inventory, so make the name matches
         // - still keep the extension so that we do what is needed for compressed file. No extension == assume non compressed
         val signatureFilename = {
           // remove gz extension for sig name comparison
           val simpleOrig =
-            if (originalFilename.endsWith(".gz")) originalFilename.substring(0, originalFilename.size - 3) else originalFilename
+            if (sigFilename.endsWith(".gz")) sigFilename.substring(0, sigFilename.size - 3) else sigFilename
           if (signatureFile.fileName.startsWith(simpleOrig)) { // assume extension is ok
             signatureFile.fileName
           } else {


### PR DESCRIPTION
https://issues.rudder.io/issues/26944

We were using `filename` as the file name, and not a path, which it is really. So just use the real filename. 

Also changed for archive API, even if there not risk their since the file is never written, but if we change our way of doing things in the futur, I prefer to have that checked. 