### PR TITLE
Fixes #26957: 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueWriter.scala
@@ -49,9 +49,9 @@ import com.normation.eventlog.ModificationId
 import com.normation.rudder.domain.logger.TechniqueWriterLoggerPure
 import com.normation.rudder.domain.logger.TimingDebugLoggerPure
 import com.normation.rudder.facts.nodes.QueryContext
-import com.normation.rudder.ncf.yaml.YamlTechniqueSerializer
 import com.normation.rudder.repository.xml.TechniqueArchiver
 import com.normation.rudder.repository.xml.TechniqueFiles
+import com.normation.utils.FileUtils
 import com.normation.zio.currentTimeMillis
 import java.nio.charset.StandardCharsets
 import zio.*
@@ -123,9 +123,9 @@ class TechniqueWriterImpl(
   ): IOResult[EditorTechnique] = {
     for {
       updated              <-
-        compileArchiveTechnique(technique, modId, committer, syncStatus = false) // sync is already0done in library update
+        compileArchiveTechnique(technique, modId, committer, syncStatus = false) // sync is already done in library update
       (updatedTechnique, _) = updated
-      libUpdate            <-
+      _                    <-
         techLibUpdate
           .update(modId, committer, Some(s"Update Technique library after creating files for ncf Technique ${technique.name}"))
           .toIO
@@ -184,7 +184,7 @@ class TechniqueWriterImpl(
       _                <- compilationStatusService.syncOne(compilationResult)
       time_3           <- currentTimeMillis
       id               <- TechniqueVersion.parse(technique.version.value).toIO.map(v => TechniqueId(TechniqueName(technique.id.value), v))
-      // resources files are missing the the "resources/" prefix
+      // resources files are missing the "resources/" prefix
       resources         = technique.resources.map(r => ResourceFile("resources/" + r.path, r.state))
       _                <- archiver.saveTechnique(
                             id,
@@ -214,15 +214,16 @@ object TechniqueWriterImpl {
     * Returns the relative path to the technique YAML file from the baseConfigRepo
     */
   private[ncf] def writeYaml(technique: EditorTechnique)(basePath: String): IOResult[String] = {
-    import YamlTechniqueSerializer.*
+    import com.normation.rudder.ncf.yaml.YamlTechniqueSerializer.*
 
     val metadataPath = s"${technique.path}/${TechniqueFiles.yaml}"
-    val path         = s"${basePath}/${metadataPath}"
+
     for {
+      path    <- FileUtils.sanitizePath(File(basePath), metadataPath)
       content <- technique.toYaml().toIO
       _       <- IOResult.attempt(s"An error occurred while creating yaml file for Technique '${technique.name}'") {
                    implicit val charSet = StandardCharsets.UTF_8
-                   val file             = File(path).createFileIfNotExists(true)
+                   val file             = path.createFileIfNotExists(createParents = true)
                    file.write(content)
                  }
     } yield {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/SharedFilesAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/SharedFilesAPI.scala
@@ -92,7 +92,7 @@ class SharedFilesAPI(
   private def checkPathAndContinue(path: String, baseFolder: File)(
       fun: File => IOResult[LiftResponse]
   ): IOResult[LiftResponse] = {
-    sanitizePath(baseFolder, path).flatMap(_.toIO).flatMap(fun)
+    sanitizePath(baseFolder, path).flatMap(fun)
   }
 
   def serialize(file: File):                           IOResult[JValue]       = {
@@ -305,23 +305,20 @@ class SharedFilesAPI(
                 uploadedFiles match {
                   case Nil         => errorResponse(s"Missing file to copy to ${dest}")
                   case file :: Nil =>
-                    sanitizePath(basePath, dest.replaceFirst("/", "") + '/' + file.fileName)
-                      .flatMap(_.toIO)
-                      .flatMap(path => {
-                        IOResult
-                          .attempt(s"Could not copy uploaded file to destination ${dest}")(for {
-                            in  <- file.fileStream.autoClosed
-                            out <- path.newOutputStream.autoClosed
-                          } yield {
-                            in.pipeTo(out)
-                          })
-                          .either
-                          .map {
-                            case Left(err) => errorResponse(err.fullMsg)
-                            case Right(_)  => basicSuccessResponse
-                          }
-                      })
-                      .runNow
+                    sanitizePath(basePath, dest.replaceFirst("/", "") + '/' + file.fileName).flatMap { path =>
+                      IOResult
+                        .attempt(s"Could not copy uploaded file to destination ${dest}")(for {
+                          in  <- file.fileStream.autoClosed
+                          out <- path.newOutputStream.autoClosed
+                        } yield {
+                          in.pipeTo(out)
+                        })
+                        .either
+                        .map {
+                          case Left(err) => errorResponse(err.fullMsg)
+                          case Right(_)  => basicSuccessResponse
+                        }
+                    }.runNow
                   case several     =>
                     errorResponse(
                       s"This API only support one uploaded file to copy to ${dest}, but ${several.size} were provided"
@@ -505,9 +502,8 @@ class SharedFilesAPI(
         req.path.partPath match {
           case "draft" :: techniqueId :: techniqueVersion :: _ =>
             val path = {
-              sanitizePath(File(configRepoPath), "workspace" :: techniqueId :: techniqueVersion :: "resources" :: Nil)
-                .flatMap(_.toIO)
-                .runNow
+              val base = File(configRepoPath)
+              checkSanitizedIsIn(base, base / "workspace" / techniqueId / techniqueVersion / "resources").runNow
             }
             path.createIfNotExists(asDirectory = true, createParents = true)
             val pf   = requestDispatch(path)
@@ -516,7 +512,7 @@ class SharedFilesAPI(
             val path = sanitizePath(
               File(configRepoPath),
               ("techniques" :: categories) :+ techniqueId :+ techniqueVersion :+ "resources"
-            ).flatMap(_.toIO).runNow
+            ).runNow
             path.createIfNotExists(true, true)
             val pf   = requestDispatch(path)
             pf.apply(req.withNewPath(req.path.drop(req.path.partPath.size)))

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
@@ -418,7 +418,8 @@ class TechniqueApi(
       val base = File(configRepoPath)
 
       for {
-        workspaceDir <- FileUtils.checkSanitizedIsIn(base, base / "workspace" / internalId / technique.version.value / "resources")
+        workspaceDir <-
+          FileUtils.checkSanitizedIsIn(base, base / "workspace" / internalId / technique.version.value / "resources")
         finalDir     <- FileUtils.checkSanitizedIsIn(
                           base,
                           base / "techniques" / technique.category / technique.id.value / technique.version.value / "resources"

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
@@ -60,6 +60,7 @@ import com.normation.rudder.rest.RestUtils.ActionType
 import com.normation.rudder.rest.RestUtils.response
 import com.normation.rudder.rest.implicits.*
 import com.normation.rudder.rest.lift.TechniqueApi.QueryFormat
+import com.normation.utils.FileUtils
 import com.normation.utils.ParseVersion
 import com.normation.utils.StringUuidGenerator
 import com.normation.utils.Version
@@ -412,24 +413,29 @@ class TechniqueApi(
 
     import techniqueSerializer.*
 
-    def moveRessources(technique: EditorTechnique, internalId: String): IO[SystemError, String] = {
-      val workspacePath = s"workspace/${internalId}/${technique.version.value}/resources"
-      val finalPath     = s"techniques/${technique.category}/${technique.id.value}/${technique.version.value}/resources"
+    private def moveRessources(technique: EditorTechnique, internalId: String): IOResult[Unit] = {
 
-      val workspaceDir = File(s"${configRepoPath}/${workspacePath}")
-      val finalDir     = File(s"${configRepoPath}/${finalPath}")
+      val base = File(configRepoPath)
 
-      IOResult.attempt("Error when moving resource file from workspace to final destination")(if (workspaceDir.exists) {
-        finalDir.createDirectoryIfNotExists(true)
-        workspaceDir.moveTo(finalDir)(File.CopyOptions.apply(true))
-        workspaceDir.parent.parent.delete()
-        "ok"
-      } else {
-        "ok"
-      })
+      for {
+        workspaceDir <- FileUtils.checkSanitizedIsIn(base, base / "workspace" / internalId / technique.version.value / "resources")
+        finalDir     <- FileUtils.checkSanitizedIsIn(
+                          base,
+                          base / "techniques" / technique.category / technique.id.value / technique.version.value / "resources"
+                        )
+        _            <- ZIO
+                          .whenZIO(IOResult.attempt(workspaceDir.exists)) {
+                            IOResult.attempt("Error when moving resource file from workspace to final destination") {
+                              finalDir.createDirectoryIfNotExists(true)
+                              workspaceDir.moveTo(finalDir)(File.CopyOptions.apply(true))
+                              workspaceDir.parent.parent.delete()
+                            }
+                          }
+                          .notOptional(s"Error: the workspace directory for techniques '${workspaceDir}' is missing")
+      } yield ()
     }
 
-    // Comparison on technique name and ID are not case sensitive
+    // Comparison on technique name and ID are not case-sensitive
     private def isTechniqueNameExist(techniqueName: String) = {
       val techniques = techniqueRepository.getAll()
       techniques.values.map(_.name.toLowerCase).toList.contains(techniqueName.toLowerCase)

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_techniques.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_techniques.yml
@@ -142,6 +142,31 @@ response:
       }
     }
 ---
+description: Get an error in attemp of path traversal
+method: PUT
+url: /api/latest/techniques
+body: >-
+  { "id": "",
+    "version":"1.0",
+    "name": "PoC",
+    "category":"../../../../../../../../tmp/traversal_poc_dir",
+    "calls":[],
+    "description":"Path Traversal PoC",
+    "documentation": "PoC details",
+    "parameters":[],        
+    "resources":[],
+    "tags":{},
+    "internalId":"c0cd1803-2264-4989-9915-8b24fd02fad4"
+  }
+response:
+  code: 500
+  content: >-
+    {
+      "action" : "createTechnique",
+      "result" : "error",
+      "errorDetails" : "Unauthorized access to file resources (real path: /tmp/traversal_poc_dir/1.0/resources)"
+    }
+---
 description: Get directives for one technique
 method: GET
 url: /api/latest/techniques/packageManagement/directives

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -40,10 +40,10 @@ package com.normation.rudder.rest
 import com.normation.box.*
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.VariableSpec
-import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.cfclerk.services.TechniquesLibraryUpdateNotification
 import com.normation.cfclerk.services.TechniquesLibraryUpdateType
 import com.normation.cfclerk.services.UpdateTechniqueLibrary
+import com.normation.errors
 import com.normation.errors.IOResult
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.EventLog
@@ -86,8 +86,13 @@ import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.git.GitArchiveId
 import com.normation.rudder.git.GitCommitId
 import com.normation.rudder.git.GitPath
+import com.normation.rudder.hooks.CmdResult
 import com.normation.rudder.hooks.HookEnvPairs
+import com.normation.rudder.ncf.BundleName
+import com.normation.rudder.ncf.EditorTechnique
 import com.normation.rudder.ncf.EditorTechniqueReader
+import com.normation.rudder.ncf.GenericMethod
+import com.normation.rudder.ncf.ParameterType.BasicParameterTypeService
 import com.normation.rudder.ncf.ResourceFileService
 import com.normation.rudder.ncf.TechniqueSerializer
 import com.normation.rudder.ncf.TechniqueWriter
@@ -881,9 +886,15 @@ class RestTestSetUp {
   )
   val groupApiInheritedProperties = new GroupApiInheritedProperties(mockNodes.propRepo)
   val ncfTechniqueWriter:  TechniqueWriter       = null
-  val ncfTechniqueReader:  EditorTechniqueReader = null
-  val techniqueRepository: TechniqueRepository   = null
-  val techniqueSerializer: TechniqueSerializer   = null
+  val ncfTechniqueReader:  EditorTechniqueReader = new EditorTechniqueReader {
+    def readTechniquesMetadataFile: IOResult[(List[EditorTechnique], Map[BundleName, GenericMethod], List[errors.RudderError])] =
+      (Nil, Map[BundleName, GenericMethod](), Nil).succeed
+
+    def getMethodsMetadata: IOResult[Map[BundleName, GenericMethod]] = Map[BundleName, GenericMethod]().succeed
+
+    def updateMethodsMetadataFile: IOResult[CmdResult] = CmdResult(0, "", "").succeed
+  }
+  val techniqueSerializer: TechniqueSerializer   = new TechniqueSerializer(new BasicParameterTypeService())
   val resourceFileService: ResourceFileService   = null
   val settingsService = new MockSettings(workflowLevelService, new AsyncWorkflowInfo())
 
@@ -938,7 +949,7 @@ class RestTestSetUp {
       techniqueAPIService14,
       ncfTechniqueWriter,
       ncfTechniqueReader,
-      techniqueRepository,
+      mockTechniques.techniqueRepo,
       techniqueSerializer,
       uuidGen,
       resourceFileService,

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/FileUtils.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/FileUtils.scala
@@ -65,11 +65,33 @@ object FileUtils {
 
   import FileError.*
 
-  def sanitizePath(baseFolder: File, child: String): IOResult[Either[OutsideBaseDir, File]] = {
-    sanitizePath(baseFolder, List(child))
+  /**
+   * Check that `file` is contained into `baseFolder` after normalization. Return the normalized File.
+   */
+  def checkSanitizedIsIn(baseFolder: File, file: File): IOResult[File] = {
+    // We also want to resolve symlinks before checking, let's resort to Java's `toRealPath`
+    for {
+      fileExists <- IOResult.attempt(file.exists())
+      realPath    = if (fileExists) File(file.path.toRealPath()) else file
+      // `false` means we allow access to the base directory itself
+      withinBase <- IOResult.attempt(baseFolder.contains(realPath, strict = false))
+      _          <- ZIO.when(!withinBase)(OutsideBaseDir(file.nameOption, realPath).fail)
+    } yield {
+      realPath
+    }
   }
 
-  def sanitizePath(baseFolder: File, path: List[String]): IOResult[Either[OutsideBaseDir, File]] = {
+  /**
+   * Returned a normalized-path file and also check that it's in given `baseFolder` after path normalization
+   */
+  def sanitizePath(baseFolder: File, subpath: String): IOResult[File] = {
+    sanitizePath(baseFolder, List(subpath))
+  }
+
+  /**
+   * Returned a normalized-path file and also check that it's in given `baseFolder` after path normalization
+   */
+  def sanitizePath(baseFolder: File, path: List[String]): IOResult[File] = {
 
     @tailrec def recPath(file: File, children: List[String]): File = {
       // Actually canonifies the path
@@ -82,16 +104,6 @@ object FileUtils {
     }
 
     val filePath = recPath(baseFolder, path)
-    // We also want to resolve symlinks before checking, let's resort to Java's `toRealPath`
-    for {
-      fileExists <- IOResult.attempt(filePath.exists())
-      realPath    = if (fileExists) File(filePath.toJava.toPath.toRealPath()) else filePath
-      withinBase <-
-        ZIO.whenZIO(IOResult.attempt(baseFolder.contains(realPath, strict = false))) { // `false` means we allow access to the base directory itself
-          realPath.succeed
-        }
-    } yield {
-      withinBase.toRight(OutsideBaseDir(filePath.nameOption, realPath))
-    }
+    checkSanitizedIsIn(baseFolder, filePath)
   }
 }

--- a/webapp/sources/utils/src/test/scala/com/normation/utils/FileUtilsTest.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/utils/FileUtilsTest.scala
@@ -65,43 +65,43 @@ class FileUtilsTest extends Specification {
 
   "sanitize valid path" >> {
     val tail = "/file2"
-    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail))
+    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail).either)
     res.map(_.pathAsString) must beRight(beEqualTo(tmp.toString() + "/file2"))
   }
 
   "sanitize valid path with .." >> {
     val tail = "/dir/../file2"
-    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail))
+    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail).either)
     res.map(_.pathAsString) must beRight(beEqualTo(tmp.toString() + "/file2"))
   }
 
   "sanitize a split path" >> {
     val tail = "/dir" :: ".." :: "file2" :: Nil
-    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail))
+    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail).either)
     res.map(_.pathAsString) must beRight(beEqualTo(tmp.toString() + "/file2"))
   }
 
   "sanitize non-existing valid path" >> {
     val tail = "/file42"
-    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail))
+    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail).either)
     res.map(_.pathAsString) must beRight(beEqualTo(tmp.toString() + "/file42"))
   }
 
   "sanitize does prevent for traversal" >> {
     val tail = "/../../.."
-    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail))
+    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail).either)
     (res must beLeft(beAnInstanceOf[SecurityError])) and (res must beLeft(OutsideBaseDir(None, root)))
   }
 
   "sanitize also prevents a split path" >> {
     val tail = ".." :: ".." :: ".." :: Nil
-    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail))
+    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail).either)
     (res must beLeft(beAnInstanceOf[SecurityError])) and (res must beLeft(OutsideBaseDir(None, root)))
   }
 
   "sanitize does not follow symlinks" >> {
     val tail = "/symlink1"
-    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail))
+    val res  = ZioRuntime.unsafeRun(sanitizePath(tmp, tail).either)
     (res must beLeft(beAnInstanceOf[SecurityError])) and (res must beLeft(OutsideBaseDir(Some("symlink1"), root / "etc")))
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/26957

Remove path trasversal in `TechniqueApi` creation. There's two place, in resources and in technique itself. 

That PR also rework a bit the `FileUtils` sanitization API: 
- change signature from `IOResult[Either[OutsideBaseDir, File]]` to `IOResult[File]` because we really don't want to treat an `OutsideBaseDir` as a potential ok result in the nominal case, and so it simplifies usage for nominal code,
- ass a `checkSanitizedIsIn(baseDir, path)` to add more flexibility in some case (it's just exposing what was internal before)