### PR TITLE
Fixes #26973: Rollback event log endpoint has the wrong HTTP method

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
@@ -254,7 +254,7 @@ class EventLogAPI(
           toJsonError(None, fail.msg) // we don't want to let the user know about SQL error
       })
 
-    case Get(id :: "details" :: "rollback" :: Nil, req) =>
+    case Post(id :: "details" :: "rollback" :: Nil, req) =>
       implicit val prettify: Boolean =
         restExtractor.extractBoolean("prettify")(req)(identity).getOrElse(Some(false)).getOrElse(false)
       implicit val action:   String  = "eventRollback"

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -2029,7 +2029,7 @@ function confirmRollback(id) {
   var radios = $('.radio-btn');
   var action = getRadioChecked(radios);
   $.ajax({
-    type: "GET",
+    type: "POST",
     url: contextPath + '/secure/api/eventlog/' + id + "/details/rollback?action=" + action ,
     contentType: "application/json; charset=utf-8",
     beforeSend: function() {


### PR DESCRIPTION
https://issues.rudder.io/issues/26973

The API is internal, we need to also change the JS that calls it (this has been migrated in upper version in https://github.com/Normation/rudder/pull/6073, so there needs to be an upmerge) 