### PR TITLE
Fixes #26974: The eventlog displaying of API account is missing information

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -95,7 +95,6 @@ import scala.util.Success
 import scala.util.Try
 import scala.xml.Node as XNode
 import scala.xml.NodeSeq
-import scala.xml.Text
 import zio.json.*
 
 final case class XmlUnserializerImpl(
@@ -794,10 +793,7 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
     import cats.implicits.*
 
     def parse(s: String): Box[List[HttpAction]] = {
-      (s.split(",").map(_.trim).toList.filter(_.nonEmpty).traverse(HttpAction.parse)) match {
-        case Left(e)  => Failure(e)
-        case Right(x) => Full(x)
-      }
+      (s.split(",").map(_.trim).toList.filter(_.nonEmpty).traverse(HttpAction.parse)).toBox
     }
 
     val authzs = traverse(entry \\ "authz") { e =>
@@ -864,17 +860,18 @@ class ApiAccountUnserialisationImpl extends ApiAccountUnserialisation {
                         }
       authz          <- (apiAccount \ "authorization").headOption match {
                           case None =>
-                            // we are most likelly in a case where API ACL weren't implemented,
+                            // we are most likely in a case where API ACL weren't implemented,
                             // because the event was saved < Rudder 4.3. Use a "nil" ACL
                             Full(ApiAuthorization.None)
 
-                          case Some(Text(text)) if text == ApiAuthorizationKind.RO.name =>
+                          case Some(x) if x.text == ApiAuthorizationKind.RO.name =>
                             Full(ApiAuthorization.RO)
-                          case Some(Text(text)) if text == ApiAuthorizationKind.RW.name =>
+                          case Some(x) if x.text == ApiAuthorizationKind.RW.name =>
                             Full(ApiAuthorization.RW)
-                          case Some(node) if (node \ "acl").nonEmpty                    =>
+                          case Some(node) if (node \ "acl").nonEmpty             =>
                             unserAcl((node \ "acl").head)
-                          case _                                                        => Full(ApiAuthorization.None)
+                          case _                                                 =>
+                            Full(ApiAuthorization.None)
                         }
       accountType     = (apiAccount \ "kind").headOption.map(_.text) match {
                           case None    => ApiAccountType.PublicApi

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/marshalling/TestXmlUnserialisation.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/marshalling/TestXmlUnserialisation.scala
@@ -144,6 +144,45 @@ class TestXmlUnserialisation extends Specification with BoxSpecMatcher {
     }
   }
 
+  "be able to correctly unserialize an ApiAccount with RW rights" in {
+    val serialized = <apiAccount fileFormat="6" changeType="add">
+      <id>c331c718-db0e-429e-b800-20b055ca6a67</id>
+      <name>Test account with some acl scala 3</name>
+      <token>
+        v2:449967a9c3a1cf25b6333fa531626e1a9375accf889dea3063b8707debde9f033535082a31de85c34c71d8be9b228f38e6cde467d6f3ba423d99437899bfb1d6
+      </token>
+      <description/>
+      <isEnabled>true</isEnabled>
+      <creationDate>2025-05-06T13:59:59.613+02:00</creationDate>
+      <tokenGenerationDate>2025-05-06T13:59:59.613+02:00</tokenGenerationDate>
+      <tenants>*</tenants>
+      <kind>public</kind>
+      <authorization>rw</authorization>
+      <expirationDate>2025-06-06T15:59:35.297+02:00</expirationDate>
+    </apiAccount>
+
+    val actual = new ApiAccountUnserialisationImpl().unserialise(serialized)
+
+    actual.map(_.copy(token = ApiToken(""))) must beEqualTo(
+      Full(
+        ApiAccount(
+          id = ApiAccountId("c331c718-db0e-429e-b800-20b055ca6a67"),
+          kind = ApiAccountKind.PublicApi(
+            authorizations = ApiAuthorization.RW,
+            expirationDate = Some(ISODateTimeFormat.dateTime.parseDateTime("2025-06-06T15:59:35.297+02:00"))
+          ),
+          name = ApiAccountName("Test account with some acl scala 3"),
+          token = ApiToken(""),
+          description = "",
+          isEnabled = true,
+          creationDate = ISODateTimeFormat.dateTime.parseDateTime("2025-05-06T13:59:59.613+02:00"),
+          tokenGenerationDate = ISODateTimeFormat.dateTime.parseDateTime("2025-05-06T13:59:59.613+02:00"),
+          tenants = NodeSecurityContext.All
+        )
+      )
+    )
+  }
+
   "be able to correctly unserialize an ApiAccount " in {
     val serialized = <apiAccount fileFormat="6" changeType="add">
       <id>c331c718-db0e-429e-b800-20b055ca6a67</id>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -1326,15 +1326,34 @@ class EventLogDetailsGenerator(
       "#description" #> globalParameter.description
   )(xml)
 
-  private def apiAccountDetails(xml: NodeSeq, apiAccount: ApiAccount) = (
-    "#id" #> apiAccount.id.value &
-      "#name" #> apiAccount.name.value &
-      "#token" #> apiAccount.token.value &
-      "#description" #> apiAccount.description &
-      "#isEnabled" #> apiAccount.isEnabled &
-      "#creationDate" #> DateFormaterService.getDisplayDate(apiAccount.creationDate) &
-      "#tokenGenerationDate" #> DateFormaterService.getDisplayDate(apiAccount.tokenGenerationDate)
-  )(xml)
+  private def apiAccountDetails(xml: NodeSeq, apiAccount: ApiAccount) = {
+    val (expiration, kind, authz) = apiAccount.kind match {
+      case ApiAccountKind.System                                    => ("N/A", "system", Text("N/A"))
+      case ApiAccountKind.User                                      => ("N/A", "user", Text("N/A"))
+      case ApiAccountKind.PublicApi(authorizations, expirationDate) =>
+        (
+          expirationDate.map(DateFormaterService.getDisplayDate).getOrElse("N/A"),
+          "API",
+          authorizations match {
+            case ApiAuthorization.None     => Text("none")
+            case ApiAuthorization.RW       => Text("read/write")
+            case ApiAuthorization.RO       => Text("read only")
+            case ApiAuthorization.ACL(acl) => <div> ACL <ul>{acl.map(x => <li>{x.display}</li>)}</ul></div>
+          }
+        )
+    }
+
+    ("#id" #> apiAccount.id.value &
+    "#name" #> apiAccount.name.value &
+    "#token" #> apiAccount.token.value &
+    "#description" #> apiAccount.description &
+    "#isEnabled" #> apiAccount.isEnabled &
+    "#creationDate" #> DateFormaterService.getDisplayDate(apiAccount.creationDate) &
+    "#tokenGenerationDate" #> DateFormaterService.getDisplayDate(apiAccount.tokenGenerationDate) &
+    "#expirationDate" #> expiration &
+    "#accountKind" #> kind &
+    "#authz" #> authz)(xml)
+  }
 
   private def mapSimpleDiffT[T](opt: Option[SimpleDiff[T]], t: T => String) = opt.map { diff =>
     ".diffOldValue *" #> t(diff.oldValue) &
@@ -1532,7 +1551,7 @@ class EventLogDetailsGenerator(
         <li><b>Token Generation date:&nbsp;</b><value id="tokenGenerationDate"/></li>
         <li><b>Token Expiration date:&nbsp;</b><value id="expirationDate"/></li>
         <li><b>Account Kind:&nbsp;</b><value id="accountKind"/></li>
-        <li><b>ACLs:&nbsp;</b><value id="acls"/></li>
+        <li><b>Authorization:&nbsp;</b><value id="authz"/></li>
       </ul>
     </div>
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/26974

So, several problems: 

- there were missing elemets like expiration date and kind,
- it's not a `Text()` node for rw/ro, it's a `<authorization>rw</authorization>` one


Adding test, now looks like: 

- simple case (rw)

![image](https://github.com/user-attachments/assets/63c9ef29-ab29-46f3-8289-107cc1cd0b5f)


- case for ACLs

![image](https://github.com/user-attachments/assets/8f44fb7d-89c3-4115-969b-bda5ced83c59)

- diff for ACLs is working, too (somehow)

![image](https://github.com/user-attachments/assets/a36f983a-3a95-4b21-911a-3b8a430f95ec)
