### PR TITLE
Fixes #26980: API account form should not display tenants when full access is selected 

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewModals.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewModals.elm
@@ -127,10 +127,10 @@ displayModal model =
                           else
                               text ""
 
-                      -- if the plugin is disable, only show a read-only view of tenants. Else, it's an option among all, none, a list
+                      -- if the plugin is disabled, only show a read-only view of tenants. Else, it's an option among all, none, a list. Tenants should not be set for full RW access, so we disable it in that case
                       displayTenantAccess =
                           if model.tenantsPluginEnabled then
-                              select [ id "newAccount-tenants", class "form-select", onInput (\s -> UpdateAccountForm { account | tenantMode = Tuple.first (parseTenants s) }) ]
+                              select [ id "newAccount-tenants", class "form-select", onInput (\s -> UpdateAccountForm { account | tenantMode = Tuple.first (parseTenants s) }), disabled (account.authorisationType == "rw") ]
                                   [ option [ value "*", selected (account.tenantMode == AllAccess) ] [ text "Access to all tenants" ]
                                   , option [ value "-", selected (account.tenantMode == NoAccess) ] [ text "Access to no tenant" ]
                                   , option [ value "list", selected (account.tenantMode == ByTenants) ]


### PR DESCRIPTION
https://issues.rudder.io/issues/26980
When `Full access` ("rw") is selected, the tenants should not be edited so we just disable it :
![Screenshot from 2025-05-28 09-10-35](https://github.com/user-attachments/assets/caa1baba-40a2-42a3-9e9c-7b7429384e55).

Several doubts, the app deserves some improvements :
* the UX ends up being weird : tenants are selected BEFORE selecting the access level. This is not the case for custom ACLs selection, which is turn is after the access level. Please let me know if there is something to do for now.  
* "rw" should not be a string but a known type in Elm.
