### PR TITLE
Fixes #26972: When there is too many nodes in groups, we can't change criteria anymore

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -1389,7 +1389,7 @@ function createNodeTable(gridId, nodeIds, refresh, scores) {
   var allColumnsKeys =  Object.keys(allColumns)
 
   var isResizing = false,
-    hasHandle = $(tableWrapper + ' #drag').length > 0,
+    hasHandle = $('#drag').length > 0,
     offsetBottom = 250;
 
   $(function () {


### PR DESCRIPTION
https://issues.rudder.io/issues/26972

There is only one drag.
When the wrapper is an id `#groupNodesTable_wrapper` then the selectors seems to make the JS behave dreadfully...