### PR TITLE
Fixes #27012: Scala3 - reorganize imports, clean unused values

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -611,8 +611,8 @@ limitations under the License.
           <exclusion>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-	  </exclusion>
-	  <exclusion>
+          </exclusion>
+          <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
           </exclusion>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/Technique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/Technique.scala
@@ -54,8 +54,6 @@ import org.apache.commons.text.StringEscapeUtils
 final case class TechniqueName(value: String) extends AnyVal with Ordered[TechniqueName] {
   override def compare(that: TechniqueName): Int = this.value.compare(that.value)
 
-  // to avoid compat error
-  @deprecated(s"Please call `.value` in place of toString()", "7.0")
   override def toString: String = value
 }
 
@@ -66,7 +64,7 @@ final case class TechniqueName(value: String) extends AnyVal with Ordered[Techni
  */
 final case class TechniqueId(name: TechniqueName, version: TechniqueVersion) extends Ordered[TechniqueId] {
   // intended for debug/log, not serialization
-  def debugString = serialize
+  def debugString:    String      = serialize
   // a technique
   def serialize:      String      = name.value + "/" + version.serialize
   def withDefaultRev: TechniqueId = TechniqueId(name, version.withDefaultRev)
@@ -77,8 +75,6 @@ final case class TechniqueId(name: TechniqueName, version: TechniqueVersion) ext
     else c
   }
 
-  // to avoid compat error
-  @deprecated(s"Please use `debugString` or `serialize` in place of toString()", "7.0")
   override def toString: String = serialize
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/TechniqueVersion.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/TechniqueVersion.scala
@@ -68,8 +68,6 @@ final case class TechniqueVersion protected (version: Version, rev: Revision) ex
     case r                      => version.toVersionString + "+" + r.value
   }
 
-  // to avoid compatibility error
-  @deprecated(s"Please use `debugString` or `serialize` in place of toString()", "7.0")
   override def toString: String = serialize
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
@@ -42,6 +42,7 @@ import cats.data.*
 import com.normation.NamedZioLogger
 import com.normation.box.*
 import com.normation.errors.*
+import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.db.json.implicits.*
@@ -318,6 +319,10 @@ object Doobie {
       (_, _, _) => sys.error("update not supported, sorry")
     )
   }
+
+  implicit val eventActorCompositeRead:  Read[EventActor]  = Read[String].map(s => EventActor(s))
+  implicit val eventActorCompositeWrite: Write[EventActor] = Write[String].contramap(_.name)
+
 }
 
 // Same as doobie-circe , but for zio-json, did not find someone who already have done it, should be in a dependency

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
@@ -44,8 +44,7 @@ import com.normation.errors.PureResult
 import com.normation.errors.RudderError
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
-import com.normation.inventory.domain.*
-import com.normation.inventory.domain.Version as SVersion
+import com.normation.inventory.domain.{Version as SVersion, *}
 import com.normation.rudder.apidata.NodeDetailLevel
 import com.normation.rudder.domain.eventlog
 import com.normation.rudder.domain.logger.PolicyGenerationLogger

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/EventLogJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/EventLogJdbcRepository.scala
@@ -153,6 +153,7 @@ class EventLogJdbcRepository(
     }
 
     transactIOResult(s"Error when retrieving event logs for change request '${changeRequest.value}'")(xa => {
+      import com.normation.rudder.db.Doobie.*
       (for {
 
         // def stream[A: Read](sql: String, prep: PreparedStatementIO[Unit], chunkSize: Int): Stream[ConnectionIO, A] =

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPRuleRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPRuleRepository.scala
@@ -222,7 +222,7 @@ class WoLDAPRuleRepository(
                            logPure.info(s"Rule with ID '${rule.id.serialize}' is already loaded: updating it.")
                          }
         crEntry        = mapper.rule2Entry(rule)
-        result        <- con.save(crEntry).chainError(s"Error when saving rule entry in repository: ${crEntry}")
+        _             <- con.save(crEntry).chainError(s"Error when saving rule entry in repository: ${crEntry}")
         // we don't persist a diff in git here because it wouldn't make any sens, but perhaps we
         // at least need to store an new event log for that. Since it's a WIP API, not doing it right now.
         // That's also why there is a modId/actor/reason not used.
@@ -233,13 +233,13 @@ class WoLDAPRuleRepository(
   override def unload(ruleId: RuleId, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[Unit] = {
     ruleMutex.writeLock(
       for {
-        _       <- ZIO.when(ruleId.rev == GitVersion.DEFAULT_REV) {
-                     Inconsistency(
-                       s"Error: you can't unload a rule with default revision like here for rule with id '${ruleId.uid.serialize}'. Use delete for that."
-                     ).fail
-                   }
-        con     <- ldap
-        deleted <-
+        _   <- ZIO.when(ruleId.rev == GitVersion.DEFAULT_REV) {
+                 Inconsistency(
+                   s"Error: you can't unload a rule with default revision like here for rule with id '${ruleId.uid.serialize}'. Use delete for that."
+                 ).fail
+               }
+        con <- ldap
+        _   <-
           con
             .delete(rudderDit.RULES.configRuleDN(ruleId))
             .chainError(s"Error when unloading rule with ID '${ruleId.uid.serialize}' for revision '${ruleId.rev.value}'")
@@ -252,32 +252,32 @@ class WoLDAPRuleRepository(
 
   def create(rule: Rule, modId: ModificationId, actor: EventActor, reason: Option[String]): IOResult[AddRuleDiff] = {
     ruleMutex.writeLock(for {
-      _               <- ZIO.when(rule.id.rev != GitVersion.DEFAULT_REV) {
-                           Inconsistency(
-                             s"Error: you can't create a rule with a specific revision like here for rule with id '${rule.id.uid.serialize}' which has revision '${rule.id.rev.value}'"
-                           ).fail
-                         }
-      con             <- ldap
-      ruleExits       <- con.exists(rudderDit.RULES.configRuleDN(rule.id))
-      idDoesntExist   <- ZIO.when(ruleExits) {
-                           s"Cannot create a rule with ID '${rule.id.serialize}' : there is already a rule with the same id".fail
-                         }
-      nameExists      <- nodeRuleNameExists(con, rule.name, rule.id)
-      nameIsAvailable <- ZIO.when(nameExists) {
-                           "Cannot create a rule with name %s : there is already a rule with the same name".format(rule.name).fail
-                         }
-      crEntry          = mapper.rule2Entry(rule)
-      result          <- con.save(crEntry).chainError(s"Error when saving rule entry in repository: ${crEntry}")
-      diff            <- diffMapper.addChangeRecords2RuleDiff(crEntry.dn, result).toIO
-      loggedAction    <- actionLogger.saveAddRule(modId, principal = actor, addDiff = diff, reason = reason)
-      autoArchive     <- ZIO.when(autoExportOnModify && !rule.isSystem) {
-                           for {
-                             commiter <- personIdentService.getPersonIdentOrDefault(actor.name)
-                             archive  <- gitCrArchiver.archiveRule(rule, Some((modId, commiter, reason)))
-                           } yield {
-                             archive
-                           }
-                         }
+      _          <- ZIO.when(rule.id.rev != GitVersion.DEFAULT_REV) {
+                      Inconsistency(
+                        s"Error: you can't create a rule with a specific revision like here for rule with id '${rule.id.uid.serialize}' which has revision '${rule.id.rev.value}'"
+                      ).fail
+                    }
+      con        <- ldap
+      ruleExits  <- con.exists(rudderDit.RULES.configRuleDN(rule.id))
+      _          <- ZIO.when(ruleExits) {
+                      s"Cannot create a rule with ID '${rule.id.serialize}' : there is already a rule with the same id".fail
+                    }
+      nameExists <- nodeRuleNameExists(con, rule.name, rule.id)
+      _          <- ZIO.when(nameExists) {
+                      "Cannot create a rule with name %s : there is already a rule with the same name".format(rule.name).fail
+                    }
+      crEntry     = mapper.rule2Entry(rule)
+      result     <- con.save(crEntry).chainError(s"Error when saving rule entry in repository: ${crEntry}")
+      diff       <- diffMapper.addChangeRecords2RuleDiff(crEntry.dn, result).toIO
+      _          <- actionLogger.saveAddRule(modId, principal = actor, addDiff = diff, reason = reason)
+      _          <- ZIO.when(autoExportOnModify && !rule.isSystem) {
+                      for {
+                        commiter <- personIdentService.getPersonIdentOrDefault(actor.name)
+                        archive  <- gitCrArchiver.archiveRule(rule, Some((modId, commiter, reason)))
+                      } yield {
+                        archive
+                      }
+                    }
     } yield {
       diff
     })

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapPolicyLibrary.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapPolicyLibrary.scala
@@ -111,30 +111,30 @@ class ImportTechniqueLibraryImpl(
           }
 
           for {
-            category      <-
+            _ <-
               con.save(categoryEntry).chainError("Error when persisting category with DN '%s' in LDAP".format(categoryEntry.dn))
-            techniques    <- ZIO.foreach(content.templates) {
-                               case ActiveTechniqueContent(activeTechnique, directives) =>
-                                 val uptEntry = mapper.activeTechnique2Entry(activeTechnique, categoryEntry.dn)
-                                 for {
-                                   uptSaved <- con
-                                                 .save(uptEntry)
-                                                 .chainError(
-                                                   "Error when persisting User Policy entry with DN '%s' in LDAP".format(uptEntry.dn)
-                                                 )
-                                   pisSaved <- ZIO.foreach(directives) { directive =>
-                                                 val piEntry = mapper.userDirective2Entry(directive, uptEntry.dn)
-                                                 con
-                                                   .save(piEntry, removeMissingAttributes = true)
-                                                   .chainError(
-                                                     "Error when persisting directive entry with DN '%s' in LDAP".format(piEntry.dn)
-                                                   )
-                                               }
-                                 } yield {
-                                   "OK"
-                                 }
-                             }
-            subCategories <- ZIO.foreach(content.categories)(cat => recSaveUserLib(categoryEntry.dn, cat, isRoot = false))
+            _ <- ZIO.foreach(content.templates) {
+                   case ActiveTechniqueContent(activeTechnique, directives) =>
+                     val uptEntry = mapper.activeTechnique2Entry(activeTechnique, categoryEntry.dn)
+                     for {
+                       _ <- con
+                              .save(uptEntry)
+                              .chainError(
+                                "Error when persisting User Policy entry with DN '%s' in LDAP".format(uptEntry.dn)
+                              )
+                       _ <- ZIO.foreach(directives) { directive =>
+                              val piEntry = mapper.userDirective2Entry(directive, uptEntry.dn)
+                              con
+                                .save(piEntry, removeMissingAttributes = true)
+                                .chainError(
+                                  "Error when persisting directive entry with DN '%s' in LDAP".format(piEntry.dn)
+                                )
+                            }
+                     } yield {
+                       "OK"
+                     }
+                 }
+            _ <- ZIO.foreach(content.categories)(cat => recSaveUserLib(categoryEntry.dn, cat, isRoot = false))
           } yield {
             () // unit is expected
           }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/GitArchivers.scala
@@ -473,10 +473,10 @@ class TechniqueArchiverImpl(
       tech      <- techniqueParser.parseXml(metadata, techniqueId).toIO
       files      = getFilesToCommit(tech, techniqueGitPath, fileStates)
       ident     <- personIdentservice.getPersonIdentOrDefault(committer.name)
-      added     <- ZIO.foreach(files.add)(f => IOResult.attempt(gitRepo.git.add.addFilepattern(f).call()))
-      removed   <- ZIO.foreach(files.delete)(f => IOResult.attempt(gitRepo.git.rm.addFilepattern(f).call()))
-      staged    <- ZIO.foreach(files.stage)(f => IOResult.attempt(gitRepo.git.add.setUpdate(true).addFilepattern(f).call()))
-      commit    <- IOResult.attempt(gitRepo.git.commit.setCommitter(ident).setMessage(msg).call())
+      _         <- ZIO.foreach(files.add)(f => IOResult.attempt(gitRepo.git.add.addFilepattern(f).call()))
+      _         <- ZIO.foreach(files.delete)(f => IOResult.attempt(gitRepo.git.rm.addFilepattern(f).call()))
+      _         <- ZIO.foreach(files.stage)(f => IOResult.attempt(gitRepo.git.add.setUpdate(true).addFilepattern(f).call()))
+      _         <- IOResult.attempt(gitRepo.git.commit.setCommitter(ident).setMessage(msg).call())
     } yield ()).chainError(s"error when committing Technique '${techniqueId.serialize}'").unit
   }
 
@@ -767,19 +767,19 @@ class UpdatePiOnActiveTechniqueEvent(
                                      None.succeed
                                    } else {
                                      for {
-                                       technique  <-
+                                       technique <-
                                          techniqeRepository
                                            .get(TechniqueId(activeTechnique.techniqueName, directive.techniqueVersion))
                                            .notOptional(
                                              s"Can not find Technique '${activeTechnique.techniqueName.value}:${directive.techniqueVersion.debugString}'"
                                            )
-                                       archivedPi <- gitDirectiveArchiver.archiveDirective(
-                                                       directive,
-                                                       technique.id.name,
-                                                       parents,
-                                                       technique.rootSection,
-                                                       gitCommit
-                                                     )
+                                       _         <- gitDirectiveArchiver.archiveDirective(
+                                                      directive,
+                                                      technique.id.name,
+                                                      parents,
+                                                      technique.rootSection,
+                                                      gitCommit
+                                                    )
                                      } yield {
                                        None
                                      }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/modification/ModificationService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/modification/ModificationService.scala
@@ -43,7 +43,6 @@ import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.git.GitCommitId
 import com.normation.rudder.repository.*
-import com.normation.rudder.repository.EventLogRepository
 import com.normation.utils.StringUuidGenerator
 import net.liftweb.common.*
 import org.eclipse.jgit.lib.PersonIdent

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NewNodeManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NewNodeManager.scala
@@ -379,24 +379,24 @@ class RefuseGroups(
   override def refuseOne(cnf: CoreNodeFact)(implicit cc: ChangeContext): IOResult[Unit] = {
     // remove server id in all groups
     for {
-      groupIds       <- roGroupRepo.findGroupWithAnyMember(Seq(cnf.id))
-      modifiedGroups <- ZIO.foreach(groupIds) { groupId =>
-                          for {
-                            groupPair <- roGroupRepo.getNodeGroup(groupId)(cc.toQuery)
-                            modGroup   = groupPair._1.copy(serverList = groupPair._1.serverList - cnf.id)
-                            msg        = Some("Automatic update of groups due to refusal of node " + cnf.id.value)
-                            saved     <- {
-                              val res = if (modGroup.isSystem) {
-                                woGroupRepo.updateSystemGroup(modGroup, cc.modId, cc.actor, cc.message)
-                              } else {
-                                woGroupRepo.update(modGroup, cc.modId, cc.actor, cc.message)
-                              }
-                              res
-                            }
-                          } yield {
-                            saved
-                          }
+      groupIds <- roGroupRepo.findGroupWithAnyMember(Seq(cnf.id))
+      _        <- ZIO.foreach(groupIds) { groupId =>
+                    for {
+                      groupPair <- roGroupRepo.getNodeGroup(groupId)(cc.toQuery)
+                      modGroup   = groupPair._1.copy(serverList = groupPair._1.serverList - cnf.id)
+                      msg        = Some("Automatic update of groups due to refusal of node " + cnf.id.value)
+                      saved     <- {
+                        val res = if (modGroup.isSystem) {
+                          woGroupRepo.updateSystemGroup(modGroup, cc.modId, cc.actor, cc.message)
+                        } else {
+                          woGroupRepo.update(modGroup, cc.modId, cc.actor, cc.message)
                         }
+                        res
+                      }
+                    } yield {
+                      saved
+                    }
+                  }
     } yield ()
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/RemoveNodeService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/RemoveNodeService.scala
@@ -549,7 +549,7 @@ class ResetKeyStatus(ldap: LDAPConnectionProvider[RwLDAPConnection], deletedDit:
       NodeLoggerPure.Delete.debug(s"  - reset node key certification status for '${nodeId.value}'") *>
       (for {
         con <- ldap
-        res <- con.modify(
+        _   <- con.modify(
                  deletedDit.NODES.NODE.dn(nodeId.value),
                  new Modification(ModificationType.REPLACE, A_KEY_STATUS, UndefinedKey.value)
                )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/InventoryHistoryJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/InventoryHistoryJdbcRepository.scala
@@ -36,7 +36,6 @@ import doobie.Meta
 import doobie.Read
 import doobie.Write
 import doobie.implicits.*
-import doobie.implicits.toSqlInterpolator
 import org.joda.time.DateTime
 import zio.interop.catz.*
 import zio.json.*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/JavascriptEngine.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/JavascriptEngine.scala
@@ -48,10 +48,6 @@ import com.normation.rudder.services.policies.JsEngine.*
 import enumeratum.*
 import java.security.NoSuchAlgorithmException
 import java.util.concurrent.*
-import java.util.concurrent.Callable
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeoutException
-import java.util.concurrent.TimeUnit
 import javax.script.Bindings
 import javax.script.ScriptException
 import org.apache.commons.codec.digest.Md5Crypt

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/ParameterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/ParameterService.scala
@@ -43,7 +43,6 @@ import com.normation.eventlog.ModificationId
 import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.domain.properties.*
-import com.normation.rudder.domain.properties.PropertyProvider
 import com.normation.rudder.repository.RoParameterRepository
 import com.normation.rudder.repository.WoParameterRepository
 import net.liftweb.common.*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/SystemVariableService.scala
@@ -432,8 +432,6 @@ class SystemVariableServiceImpl(
                   Some(x)
               }
               Some((node, cert, parsedCert))
-            case _ =>
-              None
           }
       }
       val varManagedNodesCertificate =

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
@@ -87,7 +87,6 @@ import net.liftweb.json.JsonAST.JValue
 import org.apache.commons.io.FileUtils
 import org.joda.time.DateTime
 import zio.*
-import zio.Duration
 import zio.syntax.*
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PrepareTemplateVariables.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PrepareTemplateVariables.scala
@@ -175,12 +175,6 @@ class PrepareTemplateVariablesImpl(
             n.nodeInfo.rudderAgent.securityToken match {
               case cert: Certificate =>
                 cert.key.succeed
-              case _ =>
-                "".succeed.tap { _ =>
-                  PolicyGenerationLoggerPure.error(
-                    s"Policy server '${nodeId.value}' does not have a stored certificate: can not use it in policy generation"
-                  )
-                }
             }
         }
       }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
@@ -39,7 +39,6 @@ package com.normation.rudder.services.queries
 import cats.implicits.*
 import com.normation.NamedZioLogger
 import com.normation.errors.*
-import com.normation.errors.RudderError
 import com.normation.inventory.domain.*
 import com.normation.inventory.ldap.core.*
 import com.normation.inventory.ldap.core.LDAPConstants.*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchService.scala
@@ -116,14 +116,12 @@ object QuickSearchService {
   implicit class QSBackendImpl(b: QSBackend)(implicit
       directiveRepo:   RoDirectiveRepository,
       ldap:            LDAPConnectionProvider[RoLDAPConnection],
-      inventoryDit:    InventoryDit,
-      nodeDit:         NodeDit,
       rudderDit:       RudderDit,
       nodeFactRepo:    NodeFactRepository,
       techniqueReader: EditorTechniqueReader
   ) {
 
-    import QSBackend.*
+    import com.normation.rudder.services.quicksearch.QSBackend.*
 
     def search(query: Query)(implicit qc: QueryContext): IOResult[Seq[QuickSearchResult]] = b match {
       case LdapBackend      => QSLdapBackend.search(query)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ComputeNodeStatusReportService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ComputeNodeStatusReportService.scala
@@ -43,7 +43,6 @@ import com.normation.rudder.domain.logger.ComplianceLoggerPure
 import com.normation.rudder.domain.logger.ReportLoggerPure
 import com.normation.rudder.domain.logger.TimingDebugLoggerPure
 import com.normation.rudder.domain.reports.*
-import com.normation.rudder.domain.reports.NodeStatusReport
 import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.NodeFactRepository
 import com.normation.rudder.facts.nodes.QueryContext

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
@@ -1764,7 +1764,7 @@ object ExecutionBatch extends Loggable {
           // we look in the free values for one matching the report. If found, we return (remaining freevalues, Some[paired value]
           // else (all free values, None).
           // never increment the cardinality for free value.
-          val (newFreeValues, tryPair) = findMatchingValue(report, freeValues, (value, report) => false)
+          val (newFreeValues, tryPair) = findMatchingValue(report, freeValues, (_, _) => false)
 
           logger.trace(s"found unpaired value for '${report.keyValue}'? " + tryPair)
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeChangesService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeChangesService.scala
@@ -46,8 +46,6 @@ import com.normation.rudder.repository.CachedRepository
 import com.normation.rudder.repository.ReportsRepository
 import com.normation.zio.*
 import net.liftweb.common.*
-import net.liftweb.common.Box
-import net.liftweb.common.Loggable
 import net.liftweb.http.js
 import net.liftweb.http.js.JE.*
 import org.joda.time.DateTime

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -43,7 +43,6 @@ import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.PolicyTypeName
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.*
-import com.normation.rudder.domain.reports.NodeStatusReport
 import com.normation.rudder.domain.reports.NodeStatusReport.*
 import com.normation.rudder.facts.nodes.QueryContext
 import zio.{System as _, *}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/system/DatabaseManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/system/DatabaseManager.scala
@@ -41,7 +41,6 @@ import com.normation.rudder.repository.ReportsRepository
 import com.normation.rudder.repository.UpdateExpectedReportsRepository
 import com.normation.utils.Control
 import net.liftweb.common.*
-import net.liftweb.common.Loggable
 import org.joda.time.DateTime
 import scala.concurrent.duration.Duration
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/ChangeRequestService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/ChangeRequestService.scala
@@ -52,7 +52,6 @@ import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.properties.ChangeRequestGlobalParameterDiff
 import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.workflows.*
-import com.normation.rudder.domain.workflows.ChangeRequestInfo
 import org.joda.time.DateTime
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/TechniqueRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/TechniqueRepositoryTest.scala
@@ -63,7 +63,6 @@ import com.normation.utils.StringUuidGeneratorImpl
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import net.liftweb.common.*
-import net.liftweb.common.Loggable
 import org.apache.commons.io.FileUtils
 import org.joda.time.DateTime
 import org.junit.runner.RunWith

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/campaign/CampaignSchedulerTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/campaign/CampaignSchedulerTest.scala
@@ -39,7 +39,6 @@ package com.normation.rudder.campaign
 
 import com.normation.errors.*
 import com.normation.rudder.campaigns.*
-import com.normation.rudder.campaigns.WeeklySchedule
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import org.joda.time.format.ISODateTimeFormat

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestCoreNodeFactInventory.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestCoreNodeFactInventory.scala
@@ -41,8 +41,7 @@ import better.files.*
 import com.normation.errors.*
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
-import com.normation.inventory.domain.*
-import com.normation.inventory.domain.Version as SVersion
+import com.normation.inventory.domain.{Version as SVersion, *}
 import com.normation.inventory.ldap.core.InventoryDit
 import com.normation.inventory.ldap.core.LDAPConstants
 import com.normation.inventory.ldap.core.ReadOnlySoftwareDAOImpl
@@ -56,7 +55,6 @@ import com.normation.rudder.tenants.DefaultTenantService
 import com.normation.rudder.tenants.TenantId
 import com.normation.utils.DateFormaterService
 import com.normation.zio.*
-import com.normation.zio.ZioRuntime
 import com.softwaremill.quicklens.*
 import com.unboundid.ldap.sdk.SearchScope
 import java.security.Security
@@ -333,7 +331,7 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
         node.bios.head === Bios(
           "bios1",
           None,
-          Some(new Version("6.00")),
+          Some(new SVersion("6.00")),
           Some(SoftwareEditor("Phoenix Technologies LTD"))
         )
       ) and
@@ -351,7 +349,7 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
       ) and
       (node.software.size === 2) and
       (node.software must containTheSameElementsAs(
-        List(SoftwareFact("Software 0", Some(new Version("1.0.0"))), SoftwareFact("Software 4", None))
+        List(SoftwareFact("Software 0", Some(new SVersion("1.0.0"))), SoftwareFact("Software 4", None))
       )) and
       (node7UndefinedElements(node) must contain((x: Chunk[?]) => x must beEmpty).foreach)
 
@@ -379,7 +377,7 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
       (node.fileSystems.size === 0) and
       (node.software.size === 2) and
       (node.software must containTheSameElementsAs(
-        List(SoftwareFact("Software 0", Some(new Version("1.0.0"))), SoftwareFact("Software 4", None))
+        List(SoftwareFact("Software 0", Some(new SVersion("1.0.0"))), SoftwareFact("Software 4", None))
       )) and
       (node7UndefinedElements(node) must contain((x: Chunk[?]) => x must beEmpty).foreach)
     }
@@ -397,7 +395,7 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
         node.bios.head === Bios(
           "bios1",
           None,
-          Some(new Version("6.00")),
+          Some(new SVersion("6.00")),
           Some(SoftwareEditor("Phoenix Technologies LTD"))
         )
       ) and
@@ -569,7 +567,7 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
 
       val updated = node
         .modify(_.software)
-        .using(_.appended(SoftwareFact("s2", Some(new Version("1.2")))))
+        .using(_.appended(SoftwareFact("s2", Some(new SVersion("1.2")))))
         .modify(_.environmentVariables)
         .using(_.appended(("envVAR", "envVALUE")))
         .modify(_.networks)
@@ -612,7 +610,7 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
 
       val updated = node
         .modify(_.software)
-        .using(_.appended(SoftwareFact("s3", Some(new Version("1.3")))))
+        .using(_.appended(SoftwareFact("s3", Some(new SVersion("1.3")))))
         .modify(_.environmentVariables)
         .using(_.appended(("bad", "bad")))
         .modify(_.networks)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSaveInventory.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSaveInventory.scala
@@ -67,7 +67,6 @@ import com.normation.rudder.tenants.DefaultTenantService
 import com.normation.utils.DateFormaterService
 import com.normation.utils.StringUuidGeneratorImpl
 import com.normation.zio.*
-import com.normation.zio.ZioRuntime
 import com.softwaremill.quicklens.*
 import com.typesafe.config.ConfigValueFactory
 import cron4s.Cron

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
@@ -75,8 +75,6 @@ import com.normation.rudder.domain.policies.PolicyTypes
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.domain.workflows.ChangeRequest
 import com.normation.rudder.hooks.CmdResult
-import com.normation.rudder.ncf.ParameterType.PlugableParameterTypeService
-import com.normation.rudder.ncf.TechniqueWriterImpl
 import com.normation.rudder.repository.CategoryWithActiveTechniques
 import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.rudder.repository.RoDirectiveRepository
@@ -360,9 +358,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
 
   val propertyEngineService = new PropertyEngineServiceImpl(List.empty)
   val valueCompiler         = new InterpolatedValueCompilerImpl(propertyEngineService)
-  val parameterTypeService: PlugableParameterTypeService = new PlugableParameterTypeService
 
-  import ParameterType.*
+  import com.normation.rudder.ncf.ParameterType.*
   val defaultConstraint: List[Constraint.Constraint]    =
     Constraint.AllowEmpty(allow = false) :: Constraint.AllowWhiteSpace(allow = false) :: Constraint.MaxLength(16384) :: Nil
   val methods:           Map[BundleName, GenericMethod] = (GenericMethod(

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/history/impl/TestFileHistoryLogRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/history/impl/TestFileHistoryLogRepository.scala
@@ -21,7 +21,6 @@
 package com.normation.rudder.services.nodes.history.impl
 
 import com.normation.errors.*
-import com.normation.errors.RudderError
 import com.normation.zio.ZioRuntime
 import java.io.File
 import org.apache.commons.io.FileUtils

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
@@ -47,6 +47,7 @@ import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.queries.*
 import com.normation.rudder.domain.queries.CriterionComposition.*
 import com.normation.rudder.facts.nodes.*
+import com.normation.rudder.services.queries.TestNodeFactAlgebra.*
 import com.normation.rudder.services.servers.InstanceId
 import com.normation.rudder.services.servers.InstanceIdService
 import com.normation.rudder.tenants.DefaultTenantService
@@ -59,7 +60,8 @@ import org.junit.runner.RunWith
 import org.junit.runners.BlockJUnit4ClassRunner
 import zio.*
 import zio.syntax.*
-import zio.test.ZIOSpecDefault
+import zio.test.*
+import zio.test.Assertion.*
 import zio.test.junit.ZTestJUnitRunner
 
 /*
@@ -1508,9 +1510,6 @@ class TestNodeFactQueryProcessor {
 
 @RunWith(classOf[ZTestJUnitRunner])
 class TestNodeFactAlgebra extends ZIOSpecDefault {
-  import TestNodeFactAlgebra.*
-  import zio.test.*
-  import zio.test.Assertion.*
 
   override def spec: Spec[TestEnvironment & Scope, Any] = {
     // testing the values of the boolean algebra

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -64,7 +64,6 @@ import org.junit.runner.RunWith
 import org.specs2.mutable.*
 import org.specs2.runner.JUnitRunner
 import zio.*
-import zio.Chunk
 import zio.syntax.*
 
 /*

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -51,8 +51,6 @@ import com.normation.rudder.domain.policies.PolicyTypes
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.domain.reports.*
-import com.normation.rudder.domain.reports.BlockExpectedReport
-import com.normation.rudder.domain.reports.DirectiveExpectedReports
 import com.normation.rudder.reports.AgentRunInterval
 import com.normation.rudder.reports.FullCompliance
 import com.normation.rudder.reports.GlobalComplianceMode

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/appconfig/ConfigService.scala
@@ -57,9 +57,6 @@ import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.domain.policies.PolicyMode.*
 import com.normation.rudder.domain.policies.PolicyModeOverrides
 import com.normation.rudder.reports.*
-import com.normation.rudder.reports.ChangesOnly
-import com.normation.rudder.reports.ComplianceMode
-import com.normation.rudder.reports.FullCompliance
 import com.normation.rudder.services.policies.SendMetrics
 import com.normation.rudder.services.servers.RelaySynchronizationMethod
 import com.normation.rudder.services.servers.RelaySynchronizationMethod.*

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestUtils.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestUtils.scala
@@ -46,7 +46,6 @@ import net.liftweb.common.EmptyBox
 import net.liftweb.common.Failure
 import net.liftweb.common.Full
 import net.liftweb.http.*
-import net.liftweb.http.Req
 import net.liftweb.http.provider.HTTPCookie
 import net.liftweb.json.*
 import net.liftweb.json.JsonAST.RenderSettings

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonResponse.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonResponse.scala
@@ -45,7 +45,6 @@ import net.liftweb.http.InMemoryResponse
 import net.liftweb.http.LiftResponse
 import scala.collection.immutable
 import zio.json.*
-import zio.json.DeriveJsonEncoder
 
 /*
  * This class deals with everything serialisation related for API.

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/ApiAccount.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/ApiAccount.scala
@@ -38,7 +38,6 @@
 package com.normation.rudder.rest.data
 
 import com.normation.errors.*
-import com.normation.errors.IOResult
 import com.normation.rudder.api.ApiAccount
 import com.normation.rudder.api.ApiAccountId
 import com.normation.rudder.api.ApiAccountKind

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Plugin.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Plugin.scala
@@ -150,8 +150,7 @@ final case class JsonPluginsLicense(
 )
 object JsonPluginsLicense {
 
-  import DateFormaterService.JodaTimeToJava
-  import GlobalPluginsLicense.*
+  import com.normation.plugins.GlobalPluginsLicense.*
 
   implicit val dateFieldEncoder: JsonFieldEncoder[ZonedDateTime] =
     JsonFieldEncoder[String].contramap(DateFormaterService.serializeZDT)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/SharedFilesAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/SharedFilesAPI.scala
@@ -41,7 +41,6 @@ import better.files.*
 import cats.syntax.apply.*
 import com.normation.box.*
 import com.normation.errors.*
-import com.normation.errors.IOResult
 import com.normation.rudder.rest.OldInternalApiAuthz
 import com.normation.rudder.users.UserService
 import com.normation.utils.FileUtils.*

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ApiAccountApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ApiAccountApi.scala
@@ -42,8 +42,7 @@ import com.normation.eventlog.ModificationId
 import com.normation.rudder.api.*
 import com.normation.rudder.apidata.ZioJsonExtractor
 import com.normation.rudder.domain.logger.ApiLoggerPure
-import com.normation.rudder.rest.*
-import com.normation.rudder.rest.ApiAccounts as API
+import com.normation.rudder.rest.{ApiAccounts as API, *}
 import com.normation.rudder.rest.data.*
 import com.normation.rudder.rest.implicits.*
 import com.normation.rudder.users.UserService

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/CampaignApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/CampaignApi.scala
@@ -4,16 +4,7 @@ import com.normation.errors.Unexpected
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.apidata.ZioJsonExtractor
 import com.normation.rudder.campaigns.*
-import com.normation.rudder.campaigns.CampaignEventId
-import com.normation.rudder.campaigns.CampaignEventRepository
-import com.normation.rudder.campaigns.CampaignId
-import com.normation.rudder.campaigns.CampaignLogger
-import com.normation.rudder.campaigns.CampaignRepository
-import com.normation.rudder.campaigns.CampaignSerializer
 import com.normation.rudder.campaigns.CampaignSerializer.*
-import com.normation.rudder.campaigns.CampaignStatusValue
-import com.normation.rudder.campaigns.MainCampaignService
-import com.normation.rudder.campaigns.ScheduleTimeZone
 import com.normation.rudder.rest.ApiModuleProvider
 import com.normation.rudder.rest.ApiPath
 import com.normation.rudder.rest.AuthzToken

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -74,10 +74,11 @@ import com.normation.rudder.repository.FullActiveTechnique
 import com.normation.rudder.repository.RoDirectiveRepository
 import com.normation.rudder.repository.RoNodeGroupRepository
 import com.normation.rudder.repository.RoRuleRepository
-import com.normation.rudder.rest.*
-import com.normation.rudder.rest.ComplianceApi as API
+import com.normation.rudder.rest.{ComplianceApi as API, *}
 import com.normation.rudder.rest.RestUtils.*
 import com.normation.rudder.rest.data.*
+import com.normation.rudder.rest.data.CsvCompliance.*
+import com.normation.rudder.rest.data.JsonCompliance.*
 import com.normation.rudder.services.reports.ReportingService
 import com.normation.rudder.web.services.ComputePolicyMode
 import com.normation.rudder.web.services.ComputePolicyMode.ComputedPolicyMode
@@ -98,9 +99,6 @@ class ComplianceApi(
     complianceService: ComplianceAPIService,
     readDirective:     RoDirectiveRepository
 ) extends LiftApiModuleProvider[API] {
-
-  import CsvCompliance.*
-  import JsonCompliance.*
 
   def extractComplianceLevel(params: Map[String, List[String]]): Box[Option[Int]] = {
     params.get("level") match {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
@@ -68,10 +68,7 @@ import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.repository.FullActiveTechniqueCategory
 import com.normation.rudder.repository.RoDirectiveRepository
 import com.normation.rudder.repository.WoDirectiveRepository
-import com.normation.rudder.rest.*
-import com.normation.rudder.rest.ApiPath
-import com.normation.rudder.rest.AuthzToken
-import com.normation.rudder.rest.DirectiveApi as API
+import com.normation.rudder.rest.{DirectiveApi as API, *}
 import com.normation.rudder.rest.data.*
 import com.normation.rudder.rest.implicits.*
 import com.normation.rudder.services.workflows.ChangeRequestService
@@ -373,9 +370,9 @@ class DirectiveApiService14(
     source match {
       case Some(cloneId) =>
         for {
-          name          <- restDirective.displayName.checkMandatory(
+          _             <- restDirective.displayName.checkMandatory(
                              _.size > 3,
-                             v => "'displayName' is mandatory and must be at least 3 char long"
+                             _ => "'displayName' is mandatory and must be at least 3 char long"
                            )
           ad            <- configRepository.getDirective(cloneId).notOptional(s"Can not find directive to clone: ${cloneId.debugString}")
           // technique version: by default, directive one. It techniqueVersion is given, use that. If techniqueRevision is specified, use it.
@@ -393,7 +390,7 @@ class DirectiveApiService14(
         for {
           name            <- restDirective.displayName.checkMandatory(
                                _.size > 3,
-                               v => "'displayName' is mandatory and must be at least 3 char long"
+                               _ => "'displayName' is mandatory and must be at least 3 char long"
                              )
           technique       <- getTechniqueWithVersion(restDirective.techniqueName, restDirective.techniqueVersion).chainError(
                                s"Technique is not correctly defined in request data."

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -62,8 +62,7 @@ import com.normation.rudder.properties.PropertiesRepository
 import com.normation.rudder.repository.CategoryAndNodeGroup
 import com.normation.rudder.repository.RoNodeGroupRepository
 import com.normation.rudder.repository.WoNodeGroupRepository
-import com.normation.rudder.rest.*
-import com.normation.rudder.rest.GroupApi as API
+import com.normation.rudder.rest.{GroupApi as API, *}
 import com.normation.rudder.rest.RudderJsonRequest.*
 import com.normation.rudder.rest.implicits.*
 import com.normation.rudder.services.queries.CmdbQueryParser
@@ -510,7 +509,7 @@ class GroupApiService14(
     }
 
     (for {
-      name    <- restGroup.displayName.checkMandatory(_.size > 3, v => "'displayName' is mandatory and must be at least 3 char long")
+      name    <- restGroup.displayName.checkMandatory(_.size > 3, _ => "'displayName' is mandatory and must be at least 3 char long")
       change  <- createOrClone(restGroup, nodeGroupId, name, clone, params, actor)
       created <- actualGroupCreation(change, nodeGroupId)
     } yield {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InfoApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/InfoApi.scala
@@ -39,8 +39,7 @@ package com.normation.rudder.rest.lift
 
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.api.HttpAction
-import com.normation.rudder.rest.*
-import com.normation.rudder.rest.InfoApi as API
+import com.normation.rudder.rest.{InfoApi as API, *}
 import com.normation.rudder.rest.implicits.*
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -43,7 +43,6 @@ import cats.data.ValidatedNel
 import com.normation.errors.*
 import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.*
-import com.normation.inventory.domain.NodeId
 import com.normation.inventory.ldap.core.InventoryDit
 import com.normation.inventory.ldap.core.UUID_ENTRY
 import com.normation.ldap.sdk.LDAPConnectionProvider
@@ -96,13 +95,9 @@ import com.normation.rudder.rest.OneParam
 import com.normation.rudder.rest.RudderJsonResponse
 import com.normation.rudder.rest.data.*
 import com.normation.rudder.rest.data.Creation.CreationError
-import com.normation.rudder.rest.data.NodeSetup
-import com.normation.rudder.rest.data.NodeTemplate
 import com.normation.rudder.rest.data.NodeTemplate.AcceptedNodeTemplate
 import com.normation.rudder.rest.data.NodeTemplate.PendingNodeTemplate
-import com.normation.rudder.rest.data.Rest
 import com.normation.rudder.rest.data.Rest.NodeDetails
-import com.normation.rudder.rest.data.Validation
 import com.normation.rudder.rest.data.Validation.NodeValidationError
 import com.normation.rudder.rest.implicits.*
 import com.normation.rudder.score.GlobalScore

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
@@ -39,7 +39,6 @@ package com.normation.rudder.rest.lift
 
 import com.normation.GitVersion
 import com.normation.errors.*
-import com.normation.errors.IOResult
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.ModificationId
 import com.normation.rudder.api.ApiVersion
@@ -48,8 +47,6 @@ import com.normation.rudder.apidata.JsonResponseObjects.JRGlobalParameter
 import com.normation.rudder.apidata.ZioJsonExtractor
 import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.domain.properties.*
-import com.normation.rudder.domain.properties.ChangeRequestGlobalParameterDiff
-import com.normation.rudder.domain.properties.GenericProperty
 import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.repository.RoParameterRepository

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -52,17 +52,11 @@ import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.configuration.ConfigurationRepository
 import com.normation.rudder.domain.logger.ConfigurationLoggerPure
 import com.normation.rudder.domain.policies.*
-import com.normation.rudder.domain.policies.ApplicationStatus
-import com.normation.rudder.domain.policies.ChangeRequestRuleDiff
 import com.normation.rudder.facts.nodes.*
 import com.normation.rudder.repository.*
-import com.normation.rudder.rest.*
-import com.normation.rudder.rest.ApiPath
-import com.normation.rudder.rest.AuthzToken
-import com.normation.rudder.rest.RuleApi as API
+import com.normation.rudder.rest.{RuleApi as API, *}
 import com.normation.rudder.rest.implicits.*
 import com.normation.rudder.rule.category.*
-import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.services.policies.RuleApplicationStatusService
 import com.normation.rudder.services.workflows.*
 import com.normation.rudder.web.services.ComputePolicyMode
@@ -726,7 +720,7 @@ class RuleApiService14(
       actor:     EventActor
   ): IOResult[JRCategoriesRootEntrySimple] = {
     for {
-      name     <- restData.name.checkMandatory(_.size > 3, v => "'displayName' is mandatory and must be at least 3 char long")
+      name     <- restData.name.checkMandatory(_.size > 3, _ => "'displayName' is mandatory and must be at least 3 char long")
       update    = RuleCategory(RuleCategoryId(restData.id.getOrElse(defaultId())), name, restData.description.getOrElse(""), Nil)
       parent    = restData.parent.getOrElse("rootRuleCategory")
       modId     = ModificationId(uuidGen.newUuid)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
@@ -38,7 +38,7 @@
 package com.normation.rudder.rest.lift
 
 import better.files.File
-import com.normation.cfclerk.domain.*
+import com.normation.cfclerk.domain.{BundleName as _, *}
 import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.errors.*
 import com.normation.eventlog.ModificationId
@@ -50,7 +50,6 @@ import com.normation.rudder.config.UserPropertyService
 import com.normation.rudder.domain.logger.ApiLoggerPure
 import com.normation.rudder.domain.policies.Directive
 import com.normation.rudder.ncf.*
-import com.normation.rudder.ncf.BundleName
 import com.normation.rudder.ncf.yaml.YamlTechniqueSerializer
 import com.normation.rudder.repository.RoDirectiveRepository
 import com.normation.rudder.repository.xml.TechniqueRevisionRepository

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
@@ -102,7 +102,7 @@ sealed trait UserManagementApi extends EnumEntry with EndpointSchema with Genera
 
 object UserManagementApi extends Enum[UserManagementApi] with ApiModuleProvider[UserManagementApi] {
 
-  final case object GetUserInfo extends UserManagementApi with ZeroParam with StartsAtVersion10 {
+  case object GetUserInfo extends UserManagementApi with ZeroParam with StartsAtVersion10 {
     val z              = implicitly[Line].value
     val description    = "Get information about registered users in Rudder"
     val (action, path) = GET / "usermanagement" / "users"
@@ -111,7 +111,7 @@ object UserManagementApi extends Enum[UserManagementApi] with ApiModuleProvider[
     override def dataContainer: Option[String]          = None
   }
 
-  final case object GetRoles extends UserManagementApi with ZeroParam with StartsAtVersion10 {
+  case object GetRoles extends UserManagementApi with ZeroParam with StartsAtVersion10 {
     val z              = implicitly[Line].value
     val description    = "Get roles and their authorizations"
     val (action, path) = GET / "usermanagement" / "roles"
@@ -124,7 +124,7 @@ object UserManagementApi extends Enum[UserManagementApi] with ApiModuleProvider[
    * This one does not return the list of users so that it can allow script integration
    * but without revealing the actual list of users.
    */
-  final case object ReloadUsersConf extends UserManagementApi with ZeroParam with StartsAtVersion10 {
+  case object ReloadUsersConf extends UserManagementApi with ZeroParam with StartsAtVersion10 {
     val z              = implicitly[Line].value
     val description    = "Reload (read again rudder-users.xml and process result) information about registered users in Rudder"
     val (action, path) = POST / "usermanagement" / "users" / "reload"
@@ -132,7 +132,7 @@ object UserManagementApi extends Enum[UserManagementApi] with ApiModuleProvider[
     val authz:                  List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object DeleteUser extends UserManagementApi with OneParam with StartsAtVersion10 {
+  case object DeleteUser extends UserManagementApi with OneParam with StartsAtVersion10 {
     val z              = implicitly[Line].value
     val description    = "Delete a user from the system"
     val (action, path) = DELETE / "usermanagement" / "{username}"
@@ -142,7 +142,7 @@ object UserManagementApi extends Enum[UserManagementApi] with ApiModuleProvider[
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object AddUser extends UserManagementApi with ZeroParam with StartsAtVersion10 {
+  case object AddUser extends UserManagementApi with ZeroParam with StartsAtVersion10 {
     val z              = implicitly[Line].value
     val description    = "Add a user with his information and privileges"
     val (action, path) = POST / "usermanagement"
@@ -152,7 +152,7 @@ object UserManagementApi extends Enum[UserManagementApi] with ApiModuleProvider[
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object UpdateUser extends UserManagementApi with OneParam with StartsAtVersion10 {
+  case object UpdateUser extends UserManagementApi with OneParam with StartsAtVersion10 {
     val z              = implicitly[Line].value
     val description    = "Update user's administration fields"
     val (action, path) = POST / "usermanagement" / "update" / "{username}"
@@ -162,7 +162,7 @@ object UserManagementApi extends Enum[UserManagementApi] with ApiModuleProvider[
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object UpdateUserInfo extends UserManagementApi with OneParam with StartsAtVersion10 {
+  case object UpdateUserInfo extends UserManagementApi with OneParam with StartsAtVersion10 {
     val z              = implicitly[Line].value
     val description    = "Update user's information"
     val (action, path) = POST / "usermanagement" / "update" / "info" / "{username}"
@@ -172,7 +172,7 @@ object UserManagementApi extends Enum[UserManagementApi] with ApiModuleProvider[
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object ActivateUser extends UserManagementApi with OneParam with StartsAtVersion10 {
+  case object ActivateUser extends UserManagementApi with OneParam with StartsAtVersion10 {
     val z              = implicitly[Line].value
     val description    = "Activate a user"
     val (action, path) = PUT / "usermanagement" / "status" / "activate" / "{username}"
@@ -182,7 +182,7 @@ object UserManagementApi extends Enum[UserManagementApi] with ApiModuleProvider[
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object DisableUser extends UserManagementApi with OneParam with StartsAtVersion10 {
+  case object DisableUser extends UserManagementApi with OneParam with StartsAtVersion10 {
     val z              = implicitly[Line].value
     val description    = "Disable a user"
     val (action, path) = PUT / "usermanagement" / "status" / "disable" / "{username}"
@@ -192,7 +192,7 @@ object UserManagementApi extends Enum[UserManagementApi] with ApiModuleProvider[
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
-  final case object RoleCoverage extends UserManagementApi with OneParam with StartsAtVersion10 {
+  case object RoleCoverage extends UserManagementApi with OneParam with StartsAtVersion10 {
     val z              = implicitly[Line].value
     val description    = "Get the coverage of roles over rights"
     val (action, path) = POST / "usermanagement" / "coverage" / "{username}"

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
@@ -82,11 +82,11 @@ sealed abstract class PasswordEncoderType(override val entryName: String) extend
 }
 
 object PasswordEncoderType extends Enum[PasswordEncoderType] {
-  final case object MD5    extends PasswordEncoderType("MD5")
-  final case object SHA1   extends PasswordEncoderType("SHA-1")
-  final case object SHA256 extends PasswordEncoderType("SHA-256")
-  final case object SHA512 extends PasswordEncoderType("SHA-512")
-  final case object BCRYPT extends PasswordEncoderType("BCRYPT")
+  case object MD5    extends PasswordEncoderType("MD5")
+  case object SHA1   extends PasswordEncoderType("SHA-1")
+  case object SHA256 extends PasswordEncoderType("SHA-256")
+  case object SHA512 extends PasswordEncoderType("SHA-512")
+  case object BCRYPT extends PasswordEncoderType("BCRYPT")
 
   // Default value, same as in RudderPasswordEncoder
   val DEFAULT: PasswordEncoderType = BCRYPT

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
@@ -41,8 +41,6 @@ import com.normation.rudder.Rights
 import com.normation.rudder.Role
 import com.normation.rudder.Role.Custom
 import com.normation.rudder.rest.ProviderRoleExtension
-import com.normation.rudder.users.RudderUserDetail
-import com.normation.rudder.users.UserStatus
 import com.normation.utils.DateFormaterService
 import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.dsl.*

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/DirectiveEditor.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/DirectiveEditor.scala
@@ -41,7 +41,6 @@ import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.domain.VariableSpec
 import com.normation.rudder.domain.policies.DirectiveUid
 import net.liftweb.common.*
-import net.liftweb.common.Box
 import net.liftweb.http.*
 import net.liftweb.http.js.*
 import net.liftweb.http.js.JE.*

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -43,7 +43,6 @@ import com.normation.rudder.api.*
 import com.normation.rudder.batch.ErrorStatus
 import com.normation.rudder.batch.SuccessStatus
 import com.normation.rudder.domain.eventlog.*
-import com.normation.rudder.domain.eventlog.WorkflowStepChanged
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.domain.properties.GlobalParameter

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/Translator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/Translator.scala
@@ -161,7 +161,6 @@ object Translator {
 import com.normation.rudder.web.model.FilePerms
 import java.io.File
 import org.joda.time.DateTime
-import org.joda.time.format.DateTimeFormatter
 
 object StringTranslator
     extends Translator[String](

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -52,7 +52,6 @@ import com.normation.inventory.domain.NodeId
 import com.normation.inventory.domain.Software
 import com.normation.rudder.api.*
 import com.normation.rudder.api.ApiAccountKind.PublicApi
-import com.normation.rudder.api.HttpAction
 import com.normation.rudder.batch.AsyncWorkflowInfo
 import com.normation.rudder.domain.Constants
 import com.normation.rudder.domain.appconfig.RudderWebProperty
@@ -66,7 +65,6 @@ import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.domain.reports.*
 import com.normation.rudder.domain.reports.NodeStatusReport.*
-import com.normation.rudder.domain.reports.ValueStatusReport
 import com.normation.rudder.facts.nodes.*
 import com.normation.rudder.reports.AgentRunInterval
 import com.normation.rudder.reports.FullCompliance
@@ -122,7 +120,6 @@ import scala.collection.immutable.SortedMap
 import zio.*
 import zio.System as _
 import zio.Tag as _
-import zio.ZIO
 import zio.json.ast.Json
 import zio.syntax.*
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RunComplianceComputation.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RunComplianceComputation.scala
@@ -55,8 +55,6 @@ import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.domain.reports.*
 import com.normation.rudder.facts.nodes.*
-import com.normation.rudder.facts.nodes.ChangeContext
-import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.reports.AgentRunInterval
 import com.normation.rudder.reports.FullCompliance
 import com.normation.rudder.reports.GlobalComplianceMode

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
@@ -40,8 +40,6 @@ package com.normation.rudder.rest
 import better.files.*
 import com.normation.box.IOManaged
 import com.normation.errors.*
-import com.normation.errors.IOResult
-import com.normation.errors.effectUioUnit
 import com.normation.rudder.AuthorizationType
 import com.normation.rudder.api.ApiAuthorization
 import com.normation.rudder.api.ApiVersion

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -47,7 +47,6 @@ import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.facts.nodes.NodeSecurityContext
 import com.normation.rudder.rest.ProviderRoleExtension
 import com.normation.rudder.users.*
-import com.normation.rudder.users.RudderUserDetail
 import com.normation.rudder.web.services.UserSessionLogEvent
 import com.normation.zio.*
 import com.softwaremill.quicklens.*

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -54,6 +54,7 @@ import com.normation.plugins.RudderPluginLicenseStatus
 import com.normation.plugins.RudderPluginModule
 import com.normation.plugins.RudderPluginVersion
 import com.normation.rudder.AuthorizationType
+import com.normation.rudder.AuthorizationType as Authz
 import com.normation.rudder.domain.eventlog.ApplicationStarted
 import com.normation.rudder.domain.eventlog.LogoutEventLog
 import com.normation.rudder.domain.logger.ApplicationLogger
@@ -84,11 +85,10 @@ import java.util.Locale
 import net.liftweb.common.*
 import net.liftweb.http.*
 import net.liftweb.http.js.JE.JsRaw
+import net.liftweb.http.provider.HTTPRequest
 import net.liftweb.http.rest.RestHelper
 import net.liftweb.sitemap.*
 import net.liftweb.sitemap.Loc.*
-import net.liftweb.sitemap.Loc.TestAccess
-import net.liftweb.sitemap.Menu
 import net.liftweb.util.TimeHelpers.*
 import net.liftweb.util.Vendor
 import org.apache.commons.text.StringEscapeUtils
@@ -270,7 +270,6 @@ object PluginsInfo {
             case Some(x) =>
               x.schemas match {
                 case p: ApiModuleProvider[?] => recApi(p.endpoints ::: apis, tail)
-                case _ => recApi(apis, tail)
               }
           }
       }
@@ -746,9 +745,6 @@ class Boot extends Loggable {
      * to allow explicit locale switch with just the addition
      * of &locale=en at the end of urls
      */
-    import net.liftweb.http.provider.HTTPRequest
-    import java.util.Locale
-    import com.normation.rudder.AuthorizationType as Authz
     val DefaultLocale = new Locale("")
     LiftRules.localeCalculator = { (request: Box[HTTPRequest]) =>
       {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -100,13 +100,11 @@ import com.normation.rudder.repository.*
 import com.normation.rudder.repository.jdbc.*
 import com.normation.rudder.repository.ldap.*
 import com.normation.rudder.repository.xml.*
-import com.normation.rudder.repository.xml.GitParseTechniqueLibrary
 import com.normation.rudder.rest.*
 import com.normation.rudder.rest.data.ApiAccountMapping
 import com.normation.rudder.rest.internal.*
 import com.normation.rudder.rest.lift.*
 import com.normation.rudder.rule.category.*
-import com.normation.rudder.rule.category.GitRuleCategoryArchiverImpl
 import com.normation.rudder.score.*
 import com.normation.rudder.services.*
 import com.normation.rudder.services.eventlog.*
@@ -2920,7 +2918,6 @@ object RudderConfigInit {
       roLDAPParameterRepository,
       woLDAPParameterRepository,
       gitConfigRepo,
-      gitRevisionProviderImpl,
       gitRuleArchiver,
       gitRuleCategoryArchiver,
       gitActiveTechniqueCategoryArchiver,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/migration/MigrateJsonTechniquesToYaml.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/migration/MigrateJsonTechniquesToYaml.scala
@@ -43,7 +43,6 @@ import bootstrap.liftweb.BootstrapLogger
 import com.normation.NamedZioLogger
 import com.normation.cfclerk.services.UpdateTechniqueLibrary
 import com.normation.errors.*
-import com.normation.errors.IOResult
 import com.normation.eventlog.ModificationId
 import com.normation.rudder.domain.eventlog.RudderEventActor
 import com.normation.rudder.ncf.*

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPlugin.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPlugin.scala
@@ -43,7 +43,6 @@ import bootstrap.liftweb.FileSystemResource
 import bootstrap.liftweb.RudderProperties
 import com.normation.errors.IOResult
 import com.normation.plugins.*
-import com.normation.plugins.PluginService
 import com.normation.plugins.cli.RudderPackagePlugin
 import com.normation.plugins.cli.RudderPackagePlugin.LicenseInfo.*
 import com.normation.plugins.cli.RudderPackageService

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/ComplianceModeEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/ComplianceModeEditForm.scala
@@ -173,9 +173,6 @@ class ComplianceModeEditForm[T <: ComplianceMode](
             startNewPolicyGeneration()
             JsRaw("""createSuccessNotification("Compliance mode saved")""")
         }
-      // necessary to avoid the non-exhaustive warning due to "type pattern T is unchecked since eliminated by erasure" pb above
-      case x =>
-        JsRaw(s"""createErrorNotification("Compliance mode is not of the awaited type (dev error): please report that error")""")
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -62,7 +62,6 @@ import com.normation.rudder.web.model.*
 import com.normation.zio.UnsafeRun
 import net.liftweb.common.*
 import net.liftweb.http.*
-import net.liftweb.http.LocalSnippet
 import net.liftweb.http.js.*
 import net.liftweb.http.js.JE.*
 import net.liftweb.http.js.JsCmds.*

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/SearchNodeComponent.scala
@@ -46,10 +46,8 @@ import com.normation.inventory.ldap.core.LDAPConstants.*
 import com.normation.rudder.domain.RudderLDAPConstants.A_NODE_PROPERTY
 import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.domain.queries.*
-import com.normation.rudder.domain.queries.CriterionComposition
 import com.normation.rudder.domain.queries.CriterionComposition.And
 import com.normation.rudder.domain.queries.CriterionComposition.Or
-import com.normation.rudder.domain.queries.CriterionLine
 import com.normation.rudder.domain.queries.QueryReturnType.*
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.facts.nodes.QueryContext

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
@@ -64,7 +64,6 @@ import com.typesafe.config.ConfigValue
 import com.typesafe.config.ConfigValueType
 import net.liftweb.common.*
 import net.liftweb.http.*
-import net.liftweb.http.DispatchSnippet
 import net.liftweb.http.js.*
 import net.liftweb.http.js.JE.*
 import net.liftweb.http.js.JsCmds.*

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleModificationValidationPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleModificationValidationPopup.scala
@@ -122,7 +122,6 @@ class RuleModificationValidationPopup(
       case (false, Enable)  => ("Enable", "btn-primary")
       case (false, Disable) => ("Disable", "btn-primary")
       case (false, Create)  => ("Create", "btn-success")
-      case (false, _)       => ("Save", "btn-success")
       case (true, _)        => ("Open request", "wideButton btn-primary")
     }
 
@@ -247,7 +246,6 @@ class RuleModificationValidationPopup(
         changeRequest.action match {
           case Delete                             => DeleteRuleDiff(changeRequest.newRule).succeed
           case Update | Disable | Enable | Create => ModifyToRuleDiff(changeRequest.newRule).succeed
-          case _                                  => Inconsistency(s"Action ${changeRequest.action.name} is not possible on a existing Rule").fail
         }
     }
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/AsyncComplianceService.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/AsyncComplianceService.scala
@@ -49,7 +49,6 @@ import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.services.reports.ReportingService
 import com.normation.rudder.users.CurrentUser
 import net.liftweb.common.*
-import net.liftweb.common.Box
 import net.liftweb.http.SHtml
 import net.liftweb.http.js.JE.*
 import net.liftweb.http.js.JsCmd

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayDirectiveTree.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayDirectiveTree.scala
@@ -51,7 +51,6 @@ import com.normation.rudder.web.model.JsTreeNode
 import net.liftweb.common.Loggable
 import net.liftweb.http.SHtml
 import net.liftweb.http.js.JE.*
-import net.liftweb.http.js.JE.JsRaw
 import net.liftweb.http.js.JsCmd
 import net.liftweb.http.js.JsCmds.*
 import net.liftweb.util.Helpers
@@ -386,7 +385,7 @@ object DisplayDirectiveTree extends Loggable {
           NodeSeq.Empty
         }
 
-        val (isDeprecated, deprecationInfo, deprecatedIcon) = {
+        val (_, deprecationInfo, deprecatedIcon) = {
           if (activeTechnique.techniques.values.forall(t => t.deprecrationInfo.isDefined)) {
             val message = <p><b>↳ Deprecated: </b>{
               technique.flatMap(_.deprecrationInfo).map(_.message).getOrElse("this technique is deprecated.")

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/JsTreeUtilService.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/JsTreeUtilService.scala
@@ -44,7 +44,6 @@ import com.normation.cfclerk.domain.TechniqueCategoryId
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.rudder.domain.policies.*
-import com.normation.rudder.domain.policies.ActiveTechniqueCategory
 import com.normation.rudder.repository.*
 import net.liftweb.common.*
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -45,8 +45,7 @@ import com.normation.rudder.AuthorizationType
 import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.domain.policies.PolicyTypeName
-import com.normation.rudder.domain.reports.*
-import com.normation.rudder.domain.reports.RunAnalysisKind as R
+import com.normation.rudder.domain.reports.{RunAnalysisKind as R, *}
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.facts.nodes.NodeFactRepository
 import com.normation.rudder.facts.nodes.QueryContext

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HealthcheckInfo.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HealthcheckInfo.scala
@@ -117,7 +117,6 @@ class HealthcheckInfo(
               case Warning(_, _, _)  => Some(("warning", "Something may cause an anomaly", transformed))
               case _                 => None
             }
-          case _      => None
         }
         notifInfo match {
           case Some((notifiClass, msg, liHtml)) => notifHtml(notifiClass, msg, liHtml)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DatabaseManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DatabaseManagement.scala
@@ -43,7 +43,6 @@ import com.normation.rudder.domain.reports.*
 import com.normation.utils.DateFormaterService
 import net.liftweb.common.*
 import net.liftweb.http.*
-import net.liftweb.http.DispatchSnippet
 import net.liftweb.http.js.*
 import net.liftweb.http.js.JE.JsRaw
 import net.liftweb.http.js.JsCmds.*

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
@@ -75,10 +75,8 @@ import net.liftweb.common.Box.*
 import net.liftweb.http.*
 import net.liftweb.http.js.*
 import net.liftweb.http.js.JE.*
-import net.liftweb.http.js.JE.JsArray
 import net.liftweb.http.js.JsCmds.*
 import net.liftweb.util.Helpers.*
-import net.liftweb.util.Helpers.TimeSpan
 import org.apache.commons.text.StringEscapeUtils
 import org.joda.time.DateTime
 import scala.xml.*
@@ -950,11 +948,11 @@ sealed trait NextStatus extends EnumEntry        {
   def booleanValue: Boolean
 }
 object NextStatus       extends Enum[NextStatus] {
-  final case object Enabled  extends NextStatus {
+  case object Enabled  extends NextStatus {
     val action       = "Enable"
     val booleanValue = true
   }
-  final case object Disabled extends NextStatus {
+  case object Disabled extends NextStatus {
     val action       = "Disable"
     val booleanValue = false
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/ParameterManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/ParameterManagement.scala
@@ -50,7 +50,6 @@ import com.normation.rudder.web.components.popup.CreateOrUpdateGlobalParameterPo
 import com.normation.zio.UnsafeRun
 import net.liftweb.common.*
 import net.liftweb.http.*
-import net.liftweb.http.DispatchSnippet
 import net.liftweb.http.SHtml.*
 import net.liftweb.http.js.*
 import net.liftweb.http.js.JE.JsRaw

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
@@ -43,9 +43,6 @@ import com.normation.eventlog.ModificationId
 import com.normation.plugins.DefaultExtendableSnippet
 import com.normation.rudder.AuthorizationType
 import com.normation.rudder.domain.nodes.*
-import com.normation.rudder.domain.nodes.NodeGroup
-import com.normation.rudder.domain.nodes.NodeGroupCategory
-import com.normation.rudder.domain.nodes.NodeGroupCategoryId
 import com.normation.rudder.domain.policies.*
 import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.rudder.facts.nodes.ChangeContext
@@ -58,7 +55,6 @@ import com.normation.rudder.web.components.popup.CreateCategoryOrGroupPopup
 import com.normation.rudder.web.services.DisplayNodeGroupTree
 import net.liftweb.common.*
 import net.liftweb.http.*
-import net.liftweb.http.LocalSnippet
 import net.liftweb.http.js.*
 import net.liftweb.http.js.JE.*
 import net.liftweb.http.js.JsCmds.*

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/PendingHistoryGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/PendingHistoryGrid.scala
@@ -42,7 +42,6 @@ import com.normation.box.*
 import com.normation.eventlog.*
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.eventlog.*
-import com.normation.rudder.domain.eventlog.DeleteNodeEventLog
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.services.DisplayNode

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
@@ -184,9 +184,9 @@ class RudderUserDetailsTest extends Specification {
 
     sealed trait PluginAuth extends AuthorizationType { def authzKind = "pluginAuth" }
     object PluginAuth {
-      final case object Read  extends PluginAuth with ActionType.Read with AuthorizationType
-      final case object Edit  extends PluginAuth with ActionType.Edit with AuthorizationType
-      final case object Write extends PluginAuth with ActionType.Write with AuthorizationType
+      case object Read  extends PluginAuth with ActionType.Read with AuthorizationType
+      case object Edit  extends PluginAuth with ActionType.Edit with AuthorizationType
+      case object Write extends PluginAuth with ActionType.Write with AuthorizationType
       def values: Set[AuthorizationType] = Set(Read, Edit, Write)
     }
     val pluginRole = Builtin(BuiltinName.PluginRoleName("plugin"), Rights(PluginAuth.values))

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/components/RuleLineTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/components/RuleLineTest.scala
@@ -46,7 +46,6 @@ import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.web.components.RuleGrid.*
 import net.liftweb.http.SHtml
 import net.liftweb.http.js.JE.*
-import net.liftweb.http.js.JE.AnonFunc
 import net.liftweb.http.js.JsCmds.*
 import org.junit.runner.RunWith
 import org.specs2.mutable.*


### PR DESCRIPTION
https://issues.rudder.io/issues/27012

- remove unused import, especially the ones where `*` is already present, and sometimes because the var is not used,
- remove unused vars, esp. in for loop in the lhs, 
- remove unreachable case in pattern matching (we only have `Certificate` now)
- add the serialization for doobie for EventActor,
- remove `final` in case objects