### PR TITLE
Fixes #27016: Scala3: port RestDataExtractorTest to ZIO

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestDataExtractorTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestDataExtractorTest.scala
@@ -50,51 +50,53 @@ import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.*
 import org.junit.runner.RunWith
-import org.specs2.mutable.*
-import org.specs2.runner.JUnitRunner
-import org.specs2.specification.core.Fragments
+import zio.{Tag as _, *}
+import zio.test.*
+import zio.test.Assertion.*
+import zio.test.junit.ZTestJUnitRunner
 
-@RunWith(classOf[JUnitRunner])
-class RestDataExtractorTest extends Specification {
+@RunWith(classOf[ZTestJUnitRunner])
+class RestDataExtractorTest extends ZIOSpecDefault {
 
   val mockGitRepo = new MockGitConfigRepo("")
   val mockTechniques: MockTechniques = MockTechniques(mockGitRepo)
   val mockDirectives = new MockDirectives(mockTechniques)
   val mockRules      = new MockRules()
 
-  "extract RuleTarget" >> {
-    val tests = List(
-      (
-        """group:3d5d1d6c-4ba5-4ffc-b5a4-12ce02336f52""",
-        JRRuleTarget(GroupTarget(NodeGroupId(NodeGroupUid("3d5d1d6c-4ba5-4ffc-b5a4-12ce02336f52"))))
+  override def spec: Spec[TestEnvironment with Scope, Any] = {
+    suite("All tests")(
+      suite("extract RuleTarget")(
+        List(
+          (
+            """group:3d5d1d6c-4ba5-4ffc-b5a4-12ce02336f52""",
+            JRRuleTarget(GroupTarget(NodeGroupId(NodeGroupUid("3d5d1d6c-4ba5-4ffc-b5a4-12ce02336f52"))))
+          ),
+          ("""group:hasPolicyServer-root""", JRRuleTarget(GroupTarget(NodeGroupId(NodeGroupUid("hasPolicyServer-root"))))),
+          ("""policyServer:root""", JRRuleTarget(PolicyServerTarget(NodeId("root")))),
+          ("""special:all""", JRRuleTarget(AllTarget)),
+          (
+            """{"include":{"or":["special:all"]},"exclude":{"or":["group:all-nodes-with-dsc-agent"]}}""",
+            JRRuleTarget(
+              TargetExclusion(
+                TargetUnion(Set(AllTarget)),
+                TargetUnion(Set(GroupTarget(NodeGroupId(NodeGroupUid("all-nodes-with-dsc-agent")))))
+              )
+            )
+          ),
+          (
+            """{"include":{"or":[]},"exclude":{"or":[]}}""",
+            JRRuleTarget(TargetExclusion(TargetUnion(Set()), TargetUnion(Set())))
+          ),
+          ("""{"or":["special:all"]}""", JRRuleTarget(TargetUnion(Set(AllTarget))))
+        ).map {
+          case (json, expected) =>
+            test(json)(assert(extractRuleTargetJson(json))(isRight(equalTo(expected))))
+        }
       ),
-      ("""group:hasPolicyServer-root""", JRRuleTarget(GroupTarget(NodeGroupId(NodeGroupUid("hasPolicyServer-root"))))),
-      ("""policyServer:root""", JRRuleTarget(PolicyServerTarget(NodeId("root")))),
-      ("""special:all""", JRRuleTarget(AllTarget)),
-      (
-        """{"include":{"or":["special:all"]},"exclude":{"or":["group:all-nodes-with-dsc-agent"]}}""",
-        JRRuleTarget(
-          TargetExclusion(
-            TargetUnion(Set(AllTarget)),
-            TargetUnion(Set(GroupTarget(NodeGroupId(NodeGroupUid("all-nodes-with-dsc-agent")))))
-          )
-        )
-      ),
-      ("""{"include":{"or":[]},"exclude":{"or":[]}}""", JRRuleTarget(TargetExclusion(TargetUnion(Set()), TargetUnion(Set())))),
-      ("""{"or":["special:all"]}""", JRRuleTarget(TargetUnion(Set(AllTarget))))
-    )
-
-    Fragments.foreach(tests) {
-      case (json, expected) =>
-        (extractRuleTargetJson(json) must beEqualTo(Right(expected)))
-    }
-  }
-
-  "extract JsonRule" >> {
-
-    val tests = List(
-      (
-        """{
+      suite("extract JsonRule")(
+        List(
+          (
+            """{
             "source": "b9f6d98a-28bc-4d80-90f7-d2f14269e215",
             "id": "0c1713ae-cb9d-4f7b-abda-ca38c5d643ea",
             "displayName": "Security policy",
@@ -114,55 +116,52 @@ class RestDataExtractorTest extends Specification {
               }
             ]
          }""",
-        JQRule(
-          RuleId.parse("0c1713ae-cb9d-4f7b-abda-ca38c5d643ea").toOption,
-          Some("Security policy"),
-          Some("38e0c6ea-917f-47b8-82e0-e6a1d3dd62ca"),
-          Some("Baseline applying CIS guidelines"),
-          Some("This rules should be applied to all Linux nodes required basic hardening"),
-          Some(Set(DirectiveId(DirectiveUid("16617aa8-1f02-4e4a-87b6-d0bcdfb4019f")))),
-          Some(Set(JRRuleTargetString(AllTarget))),
-          Some(true),
-          Some(Tags(Set(Tag(TagName("customer"), TagValue("MyCompany"))))),
-          RuleId.parse("b9f6d98a-28bc-4d80-90f7-d2f14269e215").toOption
-        )
-      ),
-      (
-        """{
+            JQRule(
+              RuleId.parse("0c1713ae-cb9d-4f7b-abda-ca38c5d643ea").toOption,
+              Some("Security policy"),
+              Some("38e0c6ea-917f-47b8-82e0-e6a1d3dd62ca"),
+              Some("Baseline applying CIS guidelines"),
+              Some("This rules should be applied to all Linux nodes required basic hardening"),
+              Some(Set(DirectiveId(DirectiveUid("16617aa8-1f02-4e4a-87b6-d0bcdfb4019f")))),
+              Some(Set(JRRuleTargetString(AllTarget))),
+              Some(true),
+              Some(Tags(Set(Tag(TagName("customer"), TagValue("MyCompany"))))),
+              RuleId.parse("b9f6d98a-28bc-4d80-90f7-d2f14269e215").toOption
+            )
+          ),
+          (
+            """{
             "source": "b9f6d98a-28bc-4d80-90f7-d2f14269e215"
          }""",
-        JQRule(source = RuleId.parse("b9f6d98a-28bc-4d80-90f7-d2f14269e215").toOption)
-      ),
-      (
-        """{
+            JQRule(source = RuleId.parse("b9f6d98a-28bc-4d80-90f7-d2f14269e215").toOption)
+          ),
+          (
+            """{
             "category": "38e0c6ea-917f-47b8-82e0-e6a1d3dd62ca"
          }""",
-        JQRule(category = Some("38e0c6ea-917f-47b8-82e0-e6a1d3dd62ca"))
-      ),
-      (
-        """{
+            JQRule(category = Some("38e0c6ea-917f-47b8-82e0-e6a1d3dd62ca"))
+          ),
+          (
+            """{
             "tags": []
          }""",
-        JQRule(tags = Some(Tags(Set())))
+            JQRule(tags = Some(Tags(Set())))
+          )
+        ).map {
+          case (json, expected) =>
+            test(json)(assert(ruleDecoder.decodeJson(json))(isRight(equalTo(expected))))
+        }
+      ),
+      suite("extract node Classes")(
+        List(
+          ("", JQClasses(None)),
+          ("""{"classes":[]}""", JQClasses(Some(List.empty))),
+          ("""{"classes":["class1"]}""", JQClasses(Some(List("class1"))))
+        ).map {
+          case (json, expected) =>
+            test(json)(assert(classesDecoder.decodeJson(json))(isRight(equalTo(expected))))
+        }
       )
     )
-
-    Fragments.foreach(tests) {
-      case (json, expected) =>
-        (ruleDecoder.decodeJson(json)) must beEqualTo(Right(expected))
-    }
-  }
-
-  "extract node Classes" >> {
-    val tests = List(
-      ("", JQClasses(None)),
-      ("""{"classes":[]}""", JQClasses(Some(List.empty))),
-      ("""{"classes":["class1"]}""", JQClasses(Some(List("class1"))))
-    )
-
-    Fragments.foreach(tests) {
-      case (json, expected) =>
-        (classesDecoder.decodeJson(json)) must beRight(expected)
-    }
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
@@ -59,21 +59,19 @@ import com.normation.rudder.users.UserFileProcessing
 import com.normation.rudder.users.ValidatedUserList
 import com.normation.zio.*
 import org.junit.runner.RunWith
-import org.specs2.mutable.*
-import org.specs2.runner.JUnitRunner
-import org.specs2.specification.core.Fragments
-import scala.annotation.nowarn
 import scala.xml.Elem
+import zio.*
 import zio.Chunk
+import zio.test.*
+import zio.test.Assertion.*
+import zio.test.junit.ZTestJUnitRunner
 
 /*
  * Test hash algo for user password.
  */
 
-@nowarn("msg=a type was inferred to be `AnyVal`")
-@RunWith(classOf[JUnitRunner])
-class RudderUserDetailsTest extends Specification {
-  sequential
+@RunWith(classOf[ZTestJUnitRunner])
+class RudderUserDetailsTest extends ZIOSpecDefault {
 
   implicit class ForceEither[A](iores: IOResult[A]) {
     def force: A = iores.either.runNow match {
@@ -109,47 +107,6 @@ class RudderUserDetailsTest extends Specification {
     <user name="admin" roles="administrator"/>
   </authentication>
 
-  "simple file with case sensitivity should discern users with similar username" >> {
-    val userDetailList = getUserDetailList(userXML_1, "userXML_1")
-
-    (userDetailList.isCaseSensitive must beTrue) and
-    (userDetailList.users.size must beEqualTo(2))
-  }
-
-  "simple file *without* case sensitivity should filter out ALL similar username" >> {
-    val userDetailList = getUserDetailList(userXML_2, "userXML_2")
-
-    (userDetailList.isCaseSensitive must beFalse) and
-    (userDetailList.users.size must beEqualTo(0))
-  }
-
-  "retrieving user by name with case sensitivity" >> {
-    val userDetailListProvider = new UserDetailListProvider {
-      override def authConfig: ValidatedUserList = getUserDetailList(userXML_1, "userXML_1")
-
-    }
-
-    (userDetailListProvider.getUserByName("admin") must beRight) and (
-      userDetailListProvider.getUserByName("Admin") must beLeft
-    )
-  }
-
-  "retrieving user by name *without* case sensitivity" >> {
-    val userDetailListProvider = new UserDetailListProvider {
-      override def authConfig: ValidatedUserList = getUserDetailList(userXML_empty, "userXML_empty")
-    }
-
-    (userDetailListProvider.getUserByName("admin") must beRight) and (
-      userDetailListProvider.getUserByName("Admin") must beRight
-    )
-  }
-
-  "an account without password field get a random 32 chars pass" >> {
-    val userDetailList = getUserDetailList(userXML_empty, "userXML_empty")
-
-    (userDetailList.users.size must beEqualTo(1)) and (userDetailList.users("admin").getPassword.size must beEqualTo(32))
-  }
-
   val userXML_3: Elem = <authentication>
     <custom-roles>
       <role name="role-a1" permissions="ROLE-a0,roLE-A0"/>                    <!-- node_read,node_write,config_*,parameter_*,technique_*,directive_*,rule_* -->
@@ -177,135 +134,209 @@ class RudderUserDetailsTest extends Specification {
     <user name="user_a1" password="..." permissions="role-A1"/>   <!-- node_read,node_write,config_*,parameter_*,technique_*,directive_*,rule_* -->
   </authentication>
 
-  "general rules around custom roles definition and error should be parsed correctly" >> {
-    import AuthorizationType.*
+  override def spec: Spec[TestEnvironment with Scope, Any] = {
 
-    // add a plugin built-in role and check it is available too
+    suiteAll("All REST tests defined in files") {
 
-    sealed trait PluginAuth extends AuthorizationType { def authzKind = "pluginAuth" }
-    object PluginAuth {
-      case object Read  extends PluginAuth with ActionType.Read with AuthorizationType
-      case object Edit  extends PluginAuth with ActionType.Edit with AuthorizationType
-      case object Write extends PluginAuth with ActionType.Write with AuthorizationType
-      def values: Set[AuthorizationType] = Set(Read, Edit, Write)
-    }
-    val pluginRole = Builtin(BuiltinName.PluginRoleName("plugin"), Rights(PluginAuth.values))
-    RudderRoles.registerBuiltin(pluginRole).force
+      test("simple file with case sensitivity should discern users with similar username") {
 
-    val userDetailList = getUserDetailList(userXML_3, "userXML_3")
+        val userDetailList = getUserDetailList(userXML_1, "userXML_1")
 
-    val roleA0 = NamedCustom(
-      "role-a0",
-      List(Role.forRight(Node.Read), Role.forRight(Node.Write), Role.allBuiltInRoles(Role.BuiltinName.Configuration.value))
-    )
-    val roleA1 = NamedCustom("role-a1", List(roleA0))
-    val roleA2 = NamedCustom("role-a2", List(pluginRole))
-    val roleB0 = NamedCustom("ROLE-B0", List(Role.allBuiltInRoles(Role.BuiltinName.Inventory.value)))
-    val roleC0 = NamedCustom("role-c0", List(Role.allBuiltInRoles(Role.BuiltinName.RuleOnly.value)))
-    val roleC1 = NamedCustom("role-c1", List(Role.allBuiltInRoles(Role.BuiltinName.RuleOnly.value)))
-    val roleC2 = NamedCustom("role-c2", List())
+        assert(userDetailList.isCaseSensitive)(isTrue) &&
+        assert(userDetailList.users.size)(equalTo(2))
+      }
 
-    val parsedRoles = {
-      roleA0 ::
-      roleA1 ::
-      roleA2 ::
-      roleB0 ::
-      roleC0 ::
-      roleC1 ::
-      roleC2 ::
-      NamedCustom("role-d0", List(roleA1, roleB0, roleC0)) ::
-      NamedCustom("role-e6", Nil) ::
-      Nil
-    }
+      test("simple file *without* case sensitivity should filter out ALL similar username") {
+        val userDetailList = getUserDetailList(userXML_2, "userXML_2")
 
-    (userDetailList.isCaseSensitive must beTrue) and
-    (userDetailList.users.size must beEqualTo(3)) and
-    (userDetailList.customRoles must containTheSameElementsAs(parsedRoles)) and
-    (userDetailList.users("user_a1").roles must containTheSameElementsAs(List(roleA1))) and
-    (roleC2.rights must beEqualTo(Role.NoRights.rights))
-  }
+        assert(userDetailList.isCaseSensitive)(isFalse) &&
+        assert(userDetailList.users)(isEmpty)
+      }
 
-  /// role specific  unit tests
+      test("retrieving user by name with case sensitivity") {
+        val userDetailListProvider = new UserDetailListProvider {
+          override def authConfig: ValidatedUserList = getUserDetailList(userXML_1, "userXML_1")
+        }
 
-  "Unknown roles in user list are ignored but don't lead to no_right" >> {
-    RudderRoles.parseRoles(List("configuration", "non-existing-role", "inventory")).runNow must beEqualTo(
-      List(Role.allBuiltInRoles(Role.BuiltinName.Configuration.value), Role.allBuiltInRoles(Role.BuiltinName.Inventory.value))
-    )
-  }
+        assert(userDetailListProvider.getUserByName("admin"))(isRight) &&
+        assert(userDetailListProvider.getUserByName("Admin"))(isLeft)
+      }
 
-  "if one role leads to NoRights, parseRoles is only one NoRights" >> {
-    RudderRoles.parseRoles(List("configuration", "no_rights", "inventory")).runNow must beEqualTo(List(Role.NoRights))
-  }
+      test("retrieving user by name *without* case sensitivity") {
+        val userDetailListProvider = new UserDetailListProvider {
+          override def authConfig: ValidatedUserList = getUserDetailList(userXML_empty, "userXML_empty")
+        }
 
-  "Administrator does not gibe additional roles but it give the special right 'any-rights'" >> {
-    (RudderRoles.parseRoles(List("administrator")).runNow must beEqualTo(List(Role.Administrator))) and
-    (Role.Administrator.rights.authorizationTypes.collect { case a if (a == AuthorizationType.AnyRights) => a } must beEqualTo(
-      Set(AuthorizationType.AnyRights)
-    ))
-  }
+        assert(userDetailListProvider.getUserByName("admin"))(isRight) &&
+        assert(userDetailListProvider.getUserByName("Admin"))(isRight)
+      }
 
-  "We have reserved word for named custom role: authorization-like named are forbidden" >> {
-    val crs        = List("any", "foo_all", "foo_read", "foo_write", "foo_edit").map(n => UncheckedCustomRole(n, Nil))
-    val knownRoles = RudderRoles.getAllRoles.runNow
-    Fragments.foreach(crs) { cr =>
-      s"'${cr.name}' can not be part of a named custom role" >> {
-        RudderRoles.resolveCustomRoles(List(cr), knownRoles).runNow must beEqualTo(
-          CustomRoleResolverResult(
-            Nil,
-            List((cr, "'any' and patterns 'kind_[read,edit,write,all] are reserved that can't be used for a custom role"))
+      test("an account without password field get a random 32 chars pass") {
+        val userDetailList = getUserDetailList(userXML_empty, "userXML_empty")
+
+        assert(userDetailList.users.size)(equalTo(1)) &&
+        assert(userDetailList.users("admin").getPassword.length)(equalTo(32))
+      }
+
+      test("general rules around custom roles definition and error should be parsed correctly") {
+        import com.normation.rudder.AuthorizationType.*
+
+        // add a plugin built-in role and check it is available too
+
+        sealed trait PluginAuth extends AuthorizationType { def authzKind = "pluginAuth" }
+        object PluginAuth {
+          case object Read  extends PluginAuth with ActionType.Read with AuthorizationType
+          case object Edit  extends PluginAuth with ActionType.Edit with AuthorizationType
+          case object Write extends PluginAuth with ActionType.Write with AuthorizationType
+          def values: Set[AuthorizationType] = Set(Read, Edit, Write)
+        }
+        val pluginRole = Builtin(BuiltinName.PluginRoleName("plugin"), Rights(PluginAuth.values))
+        RudderRoles.registerBuiltin(pluginRole).force
+
+        val userDetailList = getUserDetailList(userXML_3, "userXML_3")
+
+        val roleA0 = NamedCustom(
+          "role-a0",
+          List(Role.forRight(Node.Read), Role.forRight(Node.Write), Role.allBuiltInRoles(Role.BuiltinName.Configuration.value))
+        )
+        val roleA1 = NamedCustom("role-a1", List(roleA0))
+        val roleA2 = NamedCustom("role-a2", List(pluginRole))
+        val roleB0 = NamedCustom("ROLE-B0", List(Role.allBuiltInRoles(Role.BuiltinName.Inventory.value)))
+        val roleC0 = NamedCustom("role-c0", List(Role.allBuiltInRoles(Role.BuiltinName.RuleOnly.value)))
+        val roleC1 = NamedCustom("role-c1", List(Role.allBuiltInRoles(Role.BuiltinName.RuleOnly.value)))
+        val roleC2 = NamedCustom("role-c2", List())
+
+        val parsedRoles = {
+          roleA0 ::
+          roleA1 ::
+          roleA2 ::
+          roleB0 ::
+          roleC0 ::
+          roleC1 ::
+          roleC2 ::
+          NamedCustom("role-d0", List(roleA1, roleB0, roleC0)) ::
+          NamedCustom("role-e6", Nil) ::
+          Nil
+        }
+
+        assert(userDetailList.isCaseSensitive)(isTrue) &&
+        assert(userDetailList.users.size)(equalTo(3)) &&
+        assert(userDetailList.customRoles)(equalTo(parsedRoles)) &&
+        assert(userDetailList.users("user_a1").roles)(equalTo(Set[Role](roleA1))) &&
+        assert(roleC2.rights)(equalTo(Role.NoRights.rights))
+      }
+
+      /// role specific  unit tests
+      test("Unknown roles in user list are ignored but don't lead to no_right") {
+        for {
+          res <- RudderRoles.parseRoles(List("configuration", "non-existing-role", "inventory"))
+        } yield assert(res)(
+          equalTo(
+            List(
+              Role.allBuiltInRoles(Role.BuiltinName.Configuration.value),
+              Role.allBuiltInRoles(Role.BuiltinName.Inventory.value)
+            )
           )
         )
       }
+
+      test("if one role leads to NoRights, parseRoles is only one NoRights") {
+        for {
+          res <- RudderRoles.parseRoles(List("configuration", "no_rights", "inventory"))
+        } yield assert(res)(equalTo(List(Role.NoRights)))
+      }
+
+      test("Administrator does not gibe additional roles but it give the special right 'any-rights'") {
+        for {
+          res <- RudderRoles.parseRoles(List("administrator"))
+        } yield {
+
+          val roles = Role.Administrator.rights.authorizationTypes.collect {
+            case a if (a == AuthorizationType.AnyRights) => a
+          }
+
+          assert(res)(equalTo(List(Role.Administrator))) &&
+          assert(roles)(equalTo(Set[AuthorizationType](AuthorizationType.AnyRights)))
+        }
+      }
+
+      suite("We have reserved word for named custom role: authorization-like named are forbidden") {
+        val crs = List("any", "foo_all", "foo_read", "foo_write", "foo_edit").map(n => UncheckedCustomRole(n, Nil))
+        for {
+          knownRoles <- RudderRoles.getAllRoles
+          tests      <- ZIO.foreach(crs) { cr =>
+                          RudderRoles
+                            .resolveCustomRoles(List(cr), knownRoles)
+                            .map { res =>
+                              val expected = List(
+                                (
+                                  cr,
+                                  "'any' and patterns 'kind_[read,edit,write,all] are reserved that can't be used for a custom role"
+                                )
+                              )
+                              test(s"'${cr.name}' can not be part of a named custom role")(
+                                assert(res)(equalTo(CustomRoleResolverResult(Nil, expected)))
+                              )
+                            }
+                        }
+        } yield tests
+      }
+
+      suiteAll("In definition of tenants, we") {
+
+        val tenantXML_1 = <authentication hash="sha512" case-sensitivity="true">
+        <!-- single tenants -->
+        <user name="user_single" role="administrator" tenants="zoneA"/>
+        <!-- multiple tenants -->
+        <user name="user_multi" role="administrator" tenants="zoneA, zoneB"/>
+        <!-- compat: access to all -->
+        <user name="user_all_compat" role="administrator" />
+        <!-- explicit access to all + check merge -->
+        <user name="user_all_explicit" role="administrator" tenants="*,zoneA" />
+        <!-- no tenant: none -->
+        <user name="user_empty_list" role="administrator" tenants="" />
+        <!-- explicit none, win over everything -->
+        <user name="user_none_explicit" role="administrator" tenants="-, *, zoneA"/>
+        <!-- non alnum are ignored -->
+        <user name="user_ascii" role="administrator" tenants="zoneA, @reza\,,"/>
+      </authentication>
+
+        val userDetailList = getUserDetailList(tenantXML_1, "tenantXML_1")
+
+        test("be able to define one tenants") {
+          assert(userDetailList.users("user_single").nodePerms)(equalTo(NodeSecurityContext.ByTenants(Chunk(TenantId("zoneA")))))
+        }
+
+        test("be able to define a list of tenants") {
+          assert(userDetailList.users("user_multi").nodePerms)(
+            equalTo(
+              NodeSecurityContext.ByTenants(
+                Chunk(TenantId("zoneA"), TenantId("zoneB"))
+              )
+            )
+          )
+        }
+
+        test("have no tenants attribute means ALL for compat reason") {
+          assert(userDetailList.users("user_all_compat").nodePerms)(equalTo(NodeSecurityContext.All))
+        }
+
+        test("have explicit '*' means ALL") {
+          assert(userDetailList.users("user_all_explicit").nodePerms)(equalTo(NodeSecurityContext.All))
+        }
+
+        test("have an empty list means NONE") {
+          assert(userDetailList.users("user_empty_list").nodePerms)(equalTo(NodeSecurityContext.None))
+        }
+
+        test("have explicit '-' means NONE") {
+          assert(userDetailList.users("user_none_explicit").nodePerms)(equalTo(NodeSecurityContext.None))
+        }
+
+        test("only have access to sane ascii identifier") {
+          assert(userDetailList.users("user_ascii").nodePerms)(equalTo(NodeSecurityContext.ByTenants(Chunk(TenantId("zoneA")))))
+        }
+      }
     }
   }
-
-  "In definition of tenants, we" should {
-    val tenantXML_1 = <authentication hash="sha512" case-sensitivity="true">
-      <!-- single tenants -->
-      <user name="user_single" role="administrator" tenants="zoneA"/>
-      <!-- multiple tenants -->
-      <user name="user_multi" role="administrator" tenants="zoneA, zoneB"/>
-      <!-- compat: access to all -->
-      <user name="user_all_compat" role="administrator" />
-      <!-- explicit access to all + check merge -->
-      <user name="user_all_explicit" role="administrator" tenants="*,zoneA" />
-      <!-- no tenant: none -->
-      <user name="user_empty_list" role="administrator" tenants="" />
-      <!-- explicit none, win over everything -->
-      <user name="user_none_explicit" role="administrator" tenants="-, *, zoneA"/>
-      <!-- non alnum are ignored -->
-      <user name="user_ascii" role="administrator" tenants="zoneA, @reza\,,"/>
-    </authentication>
-
-    val userDetailList = getUserDetailList(tenantXML_1, "tenantXML_1")
-
-    "be able to define one tenants" in {
-      userDetailList.users("user_single").nodePerms === NodeSecurityContext.ByTenants(Chunk(TenantId("zoneA")))
-    }
-
-    "be able to define a list of tenants" in {
-      userDetailList.users("user_multi").nodePerms === NodeSecurityContext.ByTenants(Chunk(TenantId("zoneA"), TenantId("zoneB")))
-    }
-
-    "have no tenants attribute means ALL for compat reason" in {
-      userDetailList.users("user_all_compat").nodePerms === NodeSecurityContext.All
-    }
-
-    "have explicit '*' means ALL" in {
-      userDetailList.users("user_all_explicit").nodePerms === NodeSecurityContext.All
-    }
-
-    "have an empty list means NONE" in {
-      userDetailList.users("user_empty_list").nodePerms === NodeSecurityContext.None
-    }
-
-    "have explicit '-' means NONE" in {
-      userDetailList.users("user_none_explicit").nodePerms === NodeSecurityContext.None
-    }
-
-    "only have access to sane ascii identifier" in {
-      userDetailList.users("user_ascii").nodePerms === NodeSecurityContext.ByTenants(Chunk(TenantId("zoneA")))
-    }
-  }
-
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/27016

The two last test classes with some `Fragments.foreach`. 

Porting was done "as directly as possible" to avoid risking changing test semantic.  It's easier to understand with `?w=1` in url