### PR TITLE
Fixes #27027: Change request count badge needs more contrast on hover

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-menu.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-menu.scss
@@ -954,7 +954,8 @@ header.main-header .logo-lg img{
   &:focus .rudder-badge,
   &:active .rudder-badge,
   &:visited .rudder-badge{
-    background-color:#fff;
+    background-color: #fff;
+    border-color: $rudder-border-color-default;
   }
 }
 
@@ -1009,7 +1010,7 @@ header.main-header .logo-lg img{
   border-color: #fff;
 }
 .notifications-menu a:hover .rudder-badge::before {
-  border-right-color: #fff;
+  border-right-color: $rudder-border-color-default;
 }
 .notifications-menu .rudder-badge::before {
   content: "";


### PR DESCRIPTION
https://issues.rudder.io/issues/27027

Use the default border color, it needs to be applied to both the badge on hover and the `:before` pseudo-element : 
![Peek 2025-06-03 14-17](https://github.com/user-attachments/assets/eb0aa05c-7300-4160-9e25-aa0793629aaa)