### PR TITLE
Fixes #27026: Workspace directory is missing when saving a technique

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
@@ -427,12 +427,11 @@ class TechniqueApi(
         _            <- ZIO
                           .whenZIO(IOResult.attempt(workspaceDir.exists)) {
                             IOResult.attempt("Error when moving resource file from workspace to final destination") {
-                              finalDir.createDirectoryIfNotExists(true)
+                              finalDir.createDirectoryIfNotExists(createParents = true)
                               workspaceDir.moveTo(finalDir)(File.CopyOptions.apply(true))
                               workspaceDir.parent.parent.delete()
                             }
                           }
-                          .notOptional(s"Error: the workspace directory for techniques '${workspaceDir}' is missing")
       } yield ()
     }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/27026

An optionnal action has become mandatory for no reasons. 