### PR TITLE
Fixes #27031: Export node inventories tables into CSV

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -56,11 +56,16 @@ const equalsCheck = (a, b) =>
     a.length === b.length &&
     a.every((v, i) => v === b[i]);
 
+// Renaming table ids to specific CSV file name, also later enforce snake_case if necessary
+const csvRenameFilename = (filename) => (({
+  "serverGrid": "nodes_search_result"
+})[filename] ?? filename)
+
 // Shared config for DataTables Button CSV
-const csvButtonConfig = (filename) => ({
+const csvButtonConfig = (filename, additionalCls) => ({
   extend: 'csv',
-  className: 'btn btn-primary btn-export',
-  filename: filename,
+  className: 'btn btn-primary btn-export ' + (additionalCls ?? ''),
+  filename: 'rudder_' + csvRenameFilename(filename) + '_' + getDateString(),
   text: 'Export',
   exportOptions: {
     customizeData: function (data) {

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
@@ -741,6 +741,16 @@ function changeTimezone(date, ianatz) {
   return new Date(date.getTime() - diff);
 }
 
+/**
+ * Get the date as a string in "yyyy-mm-dd" format, taking timezone into account
+ * see https://stackoverflow.com/a/29774197
+ */
+function getDateString(date = new Date()) {
+  const offset = date.getTimezoneOffset()
+  return new Date(date.getTime() - (offset*60*1000)).toISOString().split('T')[0]
+}
+
+
 function updateNodeIdAndReload(nodeId) {
   try {
     var json = JSON.parse(location.hash);

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -146,7 +146,8 @@ object DisplayNode extends Loggable {
                     },
             "bAutoWidth": false,
             "aoColumns": [ {"sWidth": "200px"},{"sWidth": "150px"},{"sWidth": "350px"}],
-            "sDom": '<"dataTables_wrapper_top"f>rt<"dataTables_wrapper_bottom"lip>',
+            "sDom": '<"dataTables_wrapper_top d-flex" f <"d-flex ms-auto my-auto" B>>rt<"dataTables_wrapper_bottom"lip>',
+            "buttons" : [ csvButtonConfig("node_${nodeId}_software", "btn-sm") ],
             "lengthMenu": [ [10, 25, 50, 100, 500, 1000, -1], [10, 25, 50, 100, 500, 1000, "All"] ],
             "pageLength": 25
         });
@@ -205,7 +206,8 @@ object DisplayNode extends Loggable {
                 "bPaginate": true,
                 "bAutoWidth": false,
                 "bInfo":true,
-                "sDom": '<"dataTables_wrapper_top"f>rt<"dataTables_wrapper_bottom"lip>',
+                "sDom": '<"dataTables_wrapper_top d-flex" f <"d-flex ms-auto my-auto" B>>rt<"dataTables_wrapper_bottom"lip>',
+                "buttons" : [ csvButtonConfig("node_${nodeId.value}_${i}", "btn-sm") ],
                 "lengthMenu": [ [10, 25, 50, 100, 500, 1000, -1], [10, 25, 50, 100, 500, 1000, "All"] ],
                 "pageLength": 25
               });
@@ -239,7 +241,8 @@ object DisplayNode extends Loggable {
                     },
                 "bAutoWidth": false,
                 "bInfo":true,
-                "sDom": '<"dataTables_wrapper_top"f>rt<"dataTables_wrapper_bottom"lip>',
+                "sDom": '<"dataTables_wrapper_top d-flex" f <"d-flex ms-auto my-auto" B>>rt<"dataTables_wrapper_bottom"lip>',
+                "buttons" : [ csvButtonConfig("node_${nodeId.value}_${id}", "btn-sm") ],
                 "lengthMenu": [ [10, 25, 50, 100, 500, 1000, -1], [10, 25, 50, 100, 500, 1000, "All"] ],
                 "pageLength": 25
               });


### PR DESCRIPTION
https://issues.rudder.io/issues/27031

* add the button to all inventories table, wrapping the `B` just like for the nodes table in https://github.com/Normation/rudder/pull/6245 
* making export more flexible with additional button classes
* renaming previous nodes and node search exports to the same naming convention : `rudder_XXXX_<date>.csv`