### PR TITLE
Fixes #27034: Switch to Scala 3

### DIFF
--- a/webapp/sources/.scalafix.conf
+++ b/webapp/sources/.scalafix.conf
@@ -1,0 +1,3 @@
+rules = [
+  RemoveUnused
+]

--- a/webapp/sources/.scalafmt.conf
+++ b/webapp/sources/.scalafmt.conf
@@ -2,6 +2,7 @@ version = "3.7.17"
 maxColumn = 130
 runner.debug = true
 runner.dialect = scala213Source3
+runner.dialectOverride.allowExportClause = true
 
 rewrite.scala3.convertToNewSyntax = true
 

--- a/webapp/sources/ldap-inventory/inventory-repository/pom.xml
+++ b/webapp/sources/ldap-inventory/inventory-repository/pom.xml
@@ -58,11 +58,11 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-json_${scala-binary-version}</artifactId>
+      <artifactId>lift-json_2.13</artifactId>
     </dependency>
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-util_${scala-binary-version}</artifactId>
+      <artifactId>lift-util_2.13</artifactId>
     </dependency>
   </dependencies>
 

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/FullInventoryRepositoryImpl.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/FullInventoryRepositoryImpl.scala
@@ -329,7 +329,11 @@ class FullInventoryRepositoryImpl(
                      .getTreeFilter(
                        dit.NODES.dn,
                        // scala 3.3.3 resolve U as String in NODE unless we tell it it's NodeId
-                       buildSubTreeFilter[NodeId](dit.NODES.dn, nodeIds.toList, id => dit.NODES.NODE.dn(id).toString)
+                       buildSubTreeFilter[NodeId](
+                         dit.NODES.dn,
+                         nodeIds.toList,
+                         id => (dit.NODES.NODE: UUID_ENTRY[NodeId]).dn(id).toString
+                       )
                      )
                      .notOptional(s"Missing node root tree")
 

--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -108,6 +108,11 @@ limitations under the License.
     </extensions>
     <plugins>
       <plugin>
+        <groupId>io.github.evis</groupId>
+        <artifactId>scalafix-maven-plugin_2.13</artifactId>
+        <version>0.1.10_0.14.2</version>
+      </plugin>
+      <plugin>
         <!-- Specify maven resources plugin version because to avoid this bug from plugin 3.2+ https://issues.apache.org/jira/browse/MRESOURCES-269
 	especially with maven 3.9 that uses version 3.3.0 of this plugin by default, see https://issues.rudder.io/issues/22403
 	-->
@@ -149,47 +154,26 @@ limitations under the License.
         </executions>
         <configuration>
           <scalaCompatVersion>${scala-binary-version}</scalaCompatVersion>
+          <scalaVersion>${scala-version}</scalaVersion>
           <recompileMode>all</recompileMode>
           <args>
             <arg>-release:17</arg>
-            <arg>-dependencyfile</arg>
-            <arg>${basedir}/.scala_dependencies</arg>
-            <!-- standard warning, most of the one from https://tpolecat.github.io/2017/04/25/scalac-flags.html -->
-            <!-- corresponding scala line:
-              -language:existentials -language:higherKinds -language:implicitConversions
-              -Xlint:_,-nullary-unit,-missing-interpolator -Yno-adapted-args -Ywarn-dead-code -Ywarn-extra-implicit -Ywarn-inaccessible
-              -Ywarn-infer-any -Ywarn-nullary-override -Ywarn-numeric-widen -Ywarn-unused:imports -Ywarn-unused:locals -Ywarn-unused:privates
-            -->
-            <arg>-Xsource:3-cross</arg>
             <arg>-deprecation</arg>                  <!-- Emit warning and location for usages of deprecated APIs. -->
-            <arg>-explaintypes</arg>                 <!-- Explain type errors in more detail. -->
+            <arg>-explain-types</arg>                 <!-- Explain type errors in more detail. -->
             <arg>-feature</arg>                      <!-- Emit warning and location for usages of features that should be imported explicitly. -->
             <arg>-unchecked</arg>                    <!-- Enable additional warnings where generated code depends on assumptions. -->
             <arg>-language:existentials</arg>        <!-- Existential types (besides wildcard types) can be written and inferred -->
             <arg>-language:higherKinds</arg>         <!-- Allow higher-kinded types -->
             <arg>-language:implicitConversions</arg> <!-- Allow definition of implicit functions called views -->
-            <arg>-Xcheckinit</arg>                   <!--  Wrap field accessors to throw an exception on uninitialized access. -->
-            <!-- Xlint, minus non-local returns, nullary-units and missing interpolator (which brings false positive in Rudder).
-                 For -byname-implicit, it's because of Doobie, see: https://gitter.im/tpolecat/doobie?at=5f59e618765d633c54e74d52
-            -->
-            <arg>-Xfatal-warnings</arg>              <!-- Fail the compilation if there are any warnings. -->
-            <arg>-Xlint:_,-nonlocal-return,-nullary-unit,-missing-interpolator,-byname-implicit</arg>
-            <arg>-Ywarn-dead-code</arg>              <!-- Warn when dead code is identified. -->
-
-            <arg>-Ywarn-extra-implicit</arg>         <!-- Warn when more than one implicit parameter section is defined. -->
-            <arg>-Ywarn-numeric-widen</arg>          <!-- Warn when numerics are widened. -->
-            <arg>-Ywarn-unused:imports</arg>         <!-- Warn if an import selector is not referenced. -->
-            <arg>-Ywarn-unused:locals</arg>          <!-- Warn if a local definition is unused. -->
-            <arg>-Ywarn-unused:privates</arg>        <!-- Warn if a private member is unused. -->
-            <arg>-Ywarn-unused:implicits</arg>       <!-- Warn if an implicit parameter is unused. -->
-            <arg>-Ywarn-unused:privates</arg>        <!-- Warn if a private member is unused. -->
-            <arg>-Ybackend-parallelism</arg><arg>8</arg>         <!-- Enable parallelization — change to desired number! -->
-            <arg>-Ycache-plugin-class-loader:last-modified</arg> <!-- Enables caching of classloaders for compiler plugins -->
-            <arg>-Ycache-macro-class-loader:last-modified</arg>  <!-- and macro definitions. This can lead to performance improvements. -->
-
-            <!-- these warnings is no an actual issue, our smart constructor usage is fine with a scala 3 compiler-->
-            <arg>-Wconf:msg=constructor modifiers are assumed by synthetic:s</arg>
-            <arg>-Wconf:msg=access modifiers for .* method are copied from the case class constructor under Scala 3:s</arg>
+            <arg>-Xmax-inlines</arg><arg>100</arg>
+            <arg>-Ysafe-init</arg>                   <!--  Wrap field accessors to throw an exception on uninitialized access. -->
+            <!-- Removed during scala3 migration -->
+            <!-- <arg>-Xfatal-warnings</arg> -->     <!-- Fail the compilation if there are any warnings. -->
+            <arg>-Wunused:imports</arg>         <!-- Warn if an import selector is not referenced. -->
+            <arg>-Wunused:locals</arg>          <!-- Warn if a local definition is unused. -->
+            <arg>-Wunused:implicits</arg>       <!-- Warn if an implicit parameter is unused. -->
+            <arg>-Wunused:privates</arg>        <!-- Warn if a private member is unused. -->
+            <arg>-Ysemanticdb</arg>
           </args>
           <jvmArgs>
             <jvmArg>-Xmx${jvmArg-Xmx}</jvmArg>
@@ -209,23 +193,9 @@ limitations under the License.
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.zeroturnaround</groupId>
-        <artifactId>jrebel-maven-plugin</artifactId>
-        <version>1.1.10</version>
-        <executions>
-          <execution>
-            <id>generate-rebel-xml</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>generate</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
+        <version>3.13.0</version>
         <configuration>
           <release>17</release>
         </configuration>
@@ -241,7 +211,7 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -256,7 +226,7 @@ limitations under the License.
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.27.2</version>
+        <version>2.43.0</version>
         <configuration>
           <scala>
             <includes>
@@ -292,7 +262,7 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.12.4</version>
+        <version>3.5.1</version>
         <configuration>
           <argLine>-Dspecs2.commandline=console</argLine>
         </configuration>
@@ -304,7 +274,7 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.0</version> <!-- 3.4.x does not work -->
         <configuration>
           <archive>
             <addMavenDescriptor>false</addMavenDescriptor>
@@ -320,7 +290,7 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.3.2</version>
+        <version>3.4.0</version>
         <configuration>
           <archive>
             <addMavenDescriptor>false</addMavenDescriptor>
@@ -388,7 +358,7 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Maven plugin version -->
-    <scala-maven-plugin-version>4.7.2</scala-maven-plugin-version>
+    <scala-maven-plugin-version>4.8.1</scala-maven-plugin-version>
 
     <!-- Libraries version that MUST be used in all children project -->
 
@@ -397,8 +367,9 @@ limitations under the License.
     <rudder-version>9.0.0~alpha1-SNAPSHOT</rudder-version>
 
     <servlet-version>5.0.0</servlet-version>
-    <scala-version>2.13.16</scala-version>
-    <scala-binary-version>2.13</scala-binary-version>
+    <scala-version>3.3.6</scala-version>
+    <scala2-version>2.13.16</scala2-version>
+    <scala-binary-version>3</scala-binary-version>
     <!-- lift force us to remain with 1.3.0 because of
          java.lang.NoSuchMethodError: 'scala.collection.mutable.Stack scala.xml.parsing.NoBindingFactoryAdapter.scopeStack()'net.liftweb.util.Html5Parser.$anonfun$parse$1(HtmlParser.scala:373)
           And scala-xml 2.1.0 has non-trivial change on parsing semantic, can't
@@ -508,26 +479,31 @@ limitations under the License.
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-library</artifactId>
+        <version>${scala2-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala3-library_${scala-binary-version}</artifactId>
         <version>${scala-version}</version>
       </dependency>
       <dependency>
         <groupId>org.scala-lang</groupId>
-        <artifactId>scala-compiler</artifactId>
-        <version>${scala-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.scala-lang</groupId>
-        <artifactId>scala-reflect</artifactId>
-        <version>${scala-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.scala-lang</groupId>
-        <artifactId>scalap</artifactId>
+        <artifactId>scala-compiler_${scala-binary-version}</artifactId>
         <version>${scala-version}</version>
       </dependency>
       <dependency>
         <groupId>org.scala-lang.modules</groupId>
-        <artifactId>scala-xml_${scala-binary-version}</artifactId>
+        <artifactId>scala-parser-combinators_3</artifactId>
+        <version>2.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala-reflect_${scala-binary-version}</artifactId>
+        <version>${scala-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.scala-lang.modules</groupId>
+        <artifactId>scala-xml_2.13</artifactId>
         <version>${scala-xml-version}</version>
       </dependency>
       <dependency>
@@ -574,7 +550,7 @@ limitations under the License.
       </dependency>
       <dependency>
         <groupId>net.liftweb</groupId>
-        <artifactId>lift-common_${scala-binary-version}</artifactId>
+        <artifactId>lift-common_2.13</artifactId>
         <version>${lift-version}</version>
         <exclusions>
           <exclusion>
@@ -589,12 +565,12 @@ limitations under the License.
       </dependency>
       <dependency>
         <groupId>net.liftweb</groupId>
-        <artifactId>lift-json_${scala-binary-version}</artifactId>
+        <artifactId>lift-json_2.13</artifactId>
         <version>${lift-version}</version>
       </dependency>
       <dependency>
         <groupId>net.liftweb</groupId>
-        <artifactId>lift-util_${scala-binary-version}</artifactId>
+        <artifactId>lift-util_2.13</artifactId>
         <version>${lift-version}</version>
         <exclusions>
           <exclusion>
@@ -605,7 +581,7 @@ limitations under the License.
       </dependency>
       <dependency>
         <groupId>net.liftweb</groupId>
-        <artifactId>lift-webkit_${scala-binary-version}</artifactId>
+        <artifactId>lift-webkit_2.13</artifactId>
         <version>${lift-version}</version>
         <exclusions>
           <exclusion>

--- a/webapp/sources/rudder/rudder-core/pom.xml
+++ b/webapp/sources/rudder/rudder-core/pom.xml
@@ -204,6 +204,12 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <version>${doobie-version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.typelevel</groupId>
+      <artifactId>cats-effect-std_${scala-binary-version}</artifactId>
+      <version>${cats-effect-version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- cache used in compliance logger -->
     <dependency>
@@ -244,12 +250,12 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-webkit_${scala-binary-version}</artifactId>
+      <artifactId>lift-webkit_2.13</artifactId>
       <version>${lift-version}</version>
     </dependency>
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-json-ext_${scala-binary-version}</artifactId>
+      <artifactId>lift-json-ext_2.13</artifactId>
       <version>${lift-version}</version>
     </dependency>
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
@@ -56,7 +56,6 @@ import java.io.FileNotFoundException
 import java.io.InputStream
 import java.io.IOException
 import java.nio.charset.StandardCharsets
-import net.liftweb.common.*
 import org.eclipse.jgit.diff.DiffEntry.ChangeType
 import org.eclipse.jgit.diff.DiffFormatter
 import org.eclipse.jgit.errors.MissingObjectException
@@ -141,7 +140,7 @@ class GitTechniqueReader(
 
     val relativePathToGitRepos: Option[String],
     val directiveDefaultName:   String // full (with extension) name of the file containing default name for directive (default-directive-names.conf)
-) extends TechniqueReader with Loggable {
+) extends TechniqueReader {
 
   // semaphore to have consistent read
   val semaphore: Semaphore = Semaphore.make(1).runNow
@@ -399,21 +398,21 @@ class GitTechniqueReader(
                          }
                          ids match {
                            case Nil      =>
-                             logger.error(
+                             TechniqueReaderLoggerPure.logEffect.error(
                                s"Metadata file ${techniqueDescriptorName} was not found for technique with id ${techniqueId.debugString}."
                              )
                              Option.empty[ObjectStream]
                            case h :: Nil =>
                              Some(repo.db.open(h).openStream)
                            case _        =>
-                             logger.error(
+                             TechniqueReaderLoggerPure.logEffect.error(
                                s"There is more than one Technique with ID '${techniqueId.debugString}', what is forbidden. Please check if several categories have that Technique, and rename or delete the clones."
                              )
                              Option.empty[ObjectStream]
                          }
                        } catch {
                          case ex: FileNotFoundException =>
-                           logger.debug(() => "Template %s does not exist".format(path), ex)
+                           TechniqueReaderLoggerPure.logEffect.debug(s"Template '${path}' does not exist")
                            Option.empty[ObjectStream]
                        }
                      }
@@ -459,19 +458,23 @@ class GitTechniqueReader(
                          }
                          ids match {
                            case Nil      =>
-                             logger.error(s"Template with id ${techniqueResourceId.displayPath} was not found")
+                             TechniqueReaderLoggerPure.logEffect.error(
+                               s"Template with id ${techniqueResourceId.displayPath} was not found"
+                             )
                              Option.empty[ObjectStream]
                            case h :: Nil =>
                              Some(repo.db.open(h).openStream)
                            case _        =>
-                             logger.error(
+                             TechniqueReaderLoggerPure.logEffect.error(
                                s"There is more than one Technique with name '${techniqueResourceId.name}' which is forbidden. Please check if several categories have that Technique and rename or delete the clones"
                              )
                              Option.empty[ObjectStream]
                          }
                        } catch {
                          case ex: FileNotFoundException =>
-                           logger.debug(() => s"Technique Template ${techniqueResourceId.displayPath} does not exist", ex)
+                           TechniqueReaderLoggerPure.logEffect.debug(
+                             s"Technique Template ${techniqueResourceId.displayPath} does not exist"
+                           )
                            Option.empty[ObjectStream]
                        }
                      }
@@ -592,7 +595,7 @@ class GitTechniqueReader(
           prop.load(is)
         } catch {
           case ex: Exception =>
-            logger.error(
+            TechniqueReaderLoggerPure.logEffect.error(
               s"Error when trying to load directive default name from '${directiveDefaultName}' No specific default naming rules will be available. ",
               ex
             )
@@ -706,7 +709,7 @@ class GitTechniqueReader(
             case _                                                                                                          =>
               // unknown sub-technique category, may happen in case we end up in a corrupted technique library, just skip it
               // see https://issues.rudder.io/issues/26912
-              logger.warn(
+              TechniqueReaderLoggerPure.logEffect.warn(
                 s"Can not find the subcategory ${h} back in the parsed technique information, the technique library may have inconsistencies"
               )
               recBuildRoot(root, techniqueInfos, tail)
@@ -788,7 +791,7 @@ class GitTechniqueReader(
     }
   }
 
-  private val dummyTechnique = Technique(
+  private lazy val dummyTechnique = Technique(
     TechniqueId(
       TechniqueName("dummy"),
       TechniqueVersion.parse("1.0").getOrElse(throw new RuntimeException("Version of dummy technique is not parsable"))
@@ -831,7 +834,7 @@ class GitTechniqueReader(
               info.subCategories(sid) = cat.copy(techniqueIds = cat.techniqueIds.union(Set(techniqueId)))
               true
             case None      =>
-              logger.error(
+              TechniqueReaderLoggerPure.logEffect.error(
                 s"Can not find the parent (root) category '${descriptorFile.getParent}' for technique '${techniqueId.debugString}'"
               )
               false
@@ -869,9 +872,8 @@ class GitTechniqueReader(
                                      info.techniquesCategory(techniqueId) = parentCategoryId
                                    }
                                  case Some(v) => // error, policy package version already exists
-                                   logger.error(
-                                     "Ignoring package for policy with ID %s and root directory %s because an other policy is already defined with that id and root path %s"
-                                       .format(TechniqueId, descriptorFile.getParent, info.techniquesCategory(techniqueId).toString)
+                                   TechniqueReaderLoggerPure.logEffect.error(
+                                     s"Ignoring package for policy with ID '${techniqueId.debugString}' and root directory '${descriptorFile.getParent}' because an other policy is already defined with that id and root path '${info.techniquesCategory(techniqueId).toString}'"
                                    )
                                }
                            }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/TechniqueRepositoryImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/TechniqueRepositoryImpl.scala
@@ -47,6 +47,7 @@ import com.normation.utils.Control
 import com.normation.utils.StringUuidGenerator
 import java.io.InputStream
 import net.liftweb.common.*
+import scala.annotation.nowarn
 import scala.collection.SortedSet
 import zio.syntax.*
 
@@ -68,6 +69,7 @@ class TechniqueRepositoryImpl(
    * - techniques: Map[TechniqueName, SortedMap[TechniqueVersion, Technique]]
    * - categories: SortedMap[TechniqueCategoryId, TechniqueCategory]
    */
+  @nowarn("msg=Access non-initialized variable techniqueInfosCache.*") // we check for null when used
   private var techniqueInfosCache: TechniquesInfo = {
     /*
      * readTechniques result is updated only on

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -2111,23 +2111,19 @@ object JsonResponseObjects {
 }
 //////////////////////////// zio-json encoders ////////////////////////////
 
-trait RudderJsonEncoders {
-  import JsonResponseObjects.*
-  import JsonResponseObjects.JRNodeDetailLevel.*
-  import JsonResponseObjects.JRRuleTarget.*
-  import com.normation.inventory.domain.JsonSerializers.implicits.*
-  import com.normation.rudder.domain.reports.ComplianceLevelSerialisation.array.*
-  import com.normation.rudder.facts.nodes.NodeFactSerialisation.*
-  import com.normation.rudder.facts.nodes.NodeFactSerialisation.SimpleCodec.*
-  import com.normation.rudder.score.ScoreSerializer.*
-  import com.normation.utils.DateFormaterService.json.*
+object JRRuleEncoder {
 
-  implicit lazy val stringTargetEnc: JsonEncoder[JRRuleTargetString]          = JsonEncoder[String].contramap(_.r.target)
-  implicit lazy val andTargetEnc:    JsonEncoder[JRRuleTargetComposition.or]  = JsonEncoder[List[JRRuleTarget]].contramap(_.list)
-  implicit lazy val orTargetEnc:     JsonEncoder[JRRuleTargetComposition.and] = JsonEncoder[List[JRRuleTarget]].contramap(_.list)
-  implicit lazy val comp1TargetEnc:  JsonEncoder[JRRuleTargetComposed]        = DeriveJsonEncoder.gen
-  implicit lazy val comp2TargetEnc:  JsonEncoder[JRRuleTargetComposition]     = DeriveJsonEncoder.gen
-  implicit lazy val targetEncoder:   JsonEncoder[JRRuleTarget]                = new JsonEncoder[JRRuleTarget] {
+  import JsonResponseObjects.*
+  import JsonResponseObjects.JRRuleTarget.*
+
+  // FIXME: hide / split some encoders to reduce method size
+  implicit val targetEncoder: JsonEncoder[JRRuleTarget] = new JsonEncoder[JRRuleTarget] {
+    implicit lazy val stringTargetEnc: JsonEncoder[JRRuleTargetString]          = JsonEncoder[String].contramap(_.r.target)
+    implicit lazy val andTargetEnc:    JsonEncoder[JRRuleTargetComposition.or]  = JsonEncoder[List[JRRuleTarget]].contramap(_.list)
+    implicit lazy val orTargetEnc:     JsonEncoder[JRRuleTargetComposition.and] = JsonEncoder[List[JRRuleTarget]].contramap(_.list)
+    implicit lazy val comp1TargetEnc:  JsonEncoder[JRRuleTargetComposed]        = DeriveJsonEncoder.gen
+    implicit lazy val comp2TargetEnc:  JsonEncoder[JRRuleTargetComposition]     = DeriveJsonEncoder.gen
+
     override def unsafeEncode(a: JRRuleTarget, indent: Option[Int], out: Write): Unit = {
       a match {
         case x: JRRuleTargetString      => stringTargetEnc.unsafeEncode(x, indent, out)
@@ -2137,51 +2133,70 @@ trait RudderJsonEncoders {
     }
   }
 
-  implicit val ruleTargetInfoEncoder: JsonEncoder[JRRuleTargetInfo] = DeriveJsonEncoder.gen[JRRuleTargetInfo]
+  implicit lazy val applicationStatusEncoder:  JsonEncoder[JRApplicationStatus]   = DeriveJsonEncoder.gen
+  implicit lazy val ruleTargetInfoEncoder:     JsonEncoder[JRRuleTargetInfo]      = DeriveJsonEncoder.gen
+  implicit lazy val ruleEncoder:               JsonEncoder[JRRule]                = DeriveJsonEncoder.gen
+  implicit lazy val ruleNodesDirectiveEncoder: JsonEncoder[JRRuleNodesDirectives] = DeriveJsonEncoder.gen
+  implicit lazy val ruleInfoEncoder:           JsonEncoder[JRRuleInfo]            = DeriveJsonEncoder.gen
+}
 
-  implicit val ruleIdEncoder:          JsonEncoder[RuleId]              = JsonEncoder[String].contramap(_.serialize)
-  implicit val groupIdEncoder:         JsonEncoder[NodeGroupId]         = JsonEncoder[String].contramap(_.serialize)
-  implicit val groupCategoryIdEncoder: JsonEncoder[NodeGroupCategoryId] = JsonEncoder[String].contramap(_.value)
+object CategoryEncoder {
+  import JRRuleEncoder.*
+  import JsonResponseObjects.*
 
-  implicit val applicationStatusEncoder: JsonEncoder[JRApplicationStatus] = DeriveJsonEncoder.gen
+  implicit lazy val simpleCategoryEncoder: JsonEncoder[JRSimpleRuleCategory]        = DeriveJsonEncoder.gen
+  implicit lazy val fullCategoryEncoder:   JsonEncoder[JRFullRuleCategory]          = DeriveJsonEncoder.gen
+  implicit lazy val infoCategoryEncoder:   JsonEncoder[JRRuleCategoryInfo]          = DeriveJsonEncoder.gen
+  implicit lazy val rootCategoryEncoder1:  JsonEncoder[JRCategoriesRootEntryFull]   = DeriveJsonEncoder.gen
+  implicit lazy val rootCategoryEncoder2:  JsonEncoder[JRCategoriesRootEntrySimple] = DeriveJsonEncoder.gen
+  implicit lazy val rootCategoryEncoder3:  JsonEncoder[JRCategoriesRootEntryInfo]   = DeriveJsonEncoder.gen
 
-  implicit val ruleEncoder: JsonEncoder[JRRule]  = DeriveJsonEncoder.gen
-  implicit val hookEncoder: JsonEncoder[JRHooks] = DeriveJsonEncoder.gen
+}
 
-  implicit val ruleNodesDirectiveEncoder: JsonEncoder[JRRuleNodesDirectives] = DeriveJsonEncoder.gen
-  implicit val ruleInfoEncoder:           JsonEncoder[JRRuleInfo]            = DeriveJsonEncoder.gen
+object DirectiveEncoder {
+  import JsonResponseObjects.*
 
-  implicit val simpleCategoryEncoder:    JsonEncoder[JRSimpleRuleCategory]        = DeriveJsonEncoder.gen
-  implicit lazy val fullCategoryEncoder: JsonEncoder[JRFullRuleCategory]          = DeriveJsonEncoder.gen
-  implicit lazy val infoCategoryEncoder: JsonEncoder[JRRuleCategoryInfo]          = DeriveJsonEncoder.gen
-  implicit val rootCategoryEncoder1:     JsonEncoder[JRCategoriesRootEntryFull]   = DeriveJsonEncoder.gen
-  implicit val rootCategoryEncoder2:     JsonEncoder[JRCategoriesRootEntrySimple] = DeriveJsonEncoder.gen
-  implicit val rootCategoryEncoder3:     JsonEncoder[JRCategoriesRootEntryInfo]   = DeriveJsonEncoder.gen
-
-  implicit val rulesEncoder: JsonEncoder[JRRules] = DeriveJsonEncoder.gen
-
-  implicit val directiveSectionVarEncoder:         JsonEncoder[JRDirectiveSectionVar]    = DeriveJsonEncoder.gen
+  implicit lazy val directiveSectionVarEncoder:    JsonEncoder[JRDirectiveSectionVar]    = DeriveJsonEncoder.gen
   implicit lazy val directiveSectionHolderEncoder: JsonEncoder[JRDirectiveSectionHolder] = DeriveJsonEncoder.gen
   implicit lazy val directiveSectionEncoder:       JsonEncoder[JRDirectiveSection]       = DeriveJsonEncoder.gen
-  implicit val directiveEncoder:                   JsonEncoder[JRDirective]              = DeriveJsonEncoder.gen
-  implicit val directivesEncoder:                  JsonEncoder[JRDirectives]             = DeriveJsonEncoder.gen
-  implicit val directiveTreeTechniqueEncoder:      JsonEncoder[JRDirectiveTreeTechnique] = DeriveJsonEncoder.gen
-  implicit val directiveTreeEncoder:               JsonEncoder[JRDirectiveTreeCategory]  = DeriveJsonEncoder.gen
+  implicit lazy val directiveEncoder:              JsonEncoder[JRDirective]              = DeriveJsonEncoder.gen
+  implicit lazy val directivesEncoder:             JsonEncoder[JRDirectives]             = DeriveJsonEncoder.gen
+  implicit lazy val directiveTreeTechniqueEncoder: JsonEncoder[JRDirectiveTreeTechnique] = DeriveJsonEncoder.gen
+  implicit lazy val directiveTreeEncoder:          JsonEncoder[JRDirectiveTreeCategory]  = DeriveJsonEncoder.gen
+}
 
-  implicit val activeTechniqueEncoder: JsonEncoder[JRActiveTechnique] = DeriveJsonEncoder.gen
+trait RudderJsonEncoders {
+  export CategoryEncoder.*
+  export DirectiveEncoder.*
+  export JRRuleEncoder.*
+  import JsonResponseObjects.*
+  import JsonResponseObjects.JRNodeDetailLevel.*
+  import com.normation.inventory.domain.JsonSerializers.implicits.*
+  import com.normation.rudder.domain.reports.ComplianceLevelSerialisation.array.*
+  import com.normation.rudder.facts.nodes.NodeFactSerialisation.*
+  import com.normation.rudder.facts.nodes.NodeFactSerialisation.SimpleCodec.*
+  import com.normation.rudder.score.ScoreSerializer.*
+  import com.normation.utils.DateFormaterService.json.*
 
-  implicit val configValueEncoder:      JsonEncoder[ConfigValue]              = new JsonEncoder[ConfigValue] {
+  implicit lazy val ruleIdEncoder:          JsonEncoder[RuleId]              = JsonEncoder[String].contramap(_.serialize)
+  implicit lazy val groupIdEncoder:         JsonEncoder[NodeGroupId]         = JsonEncoder[String].contramap(_.serialize)
+  implicit lazy val groupCategoryIdEncoder: JsonEncoder[NodeGroupCategoryId] = JsonEncoder[String].contramap(_.value)
+  implicit lazy val hookEncoder:            JsonEncoder[JRHooks]             = DeriveJsonEncoder.gen
+  implicit lazy val rulesEncoder:           JsonEncoder[JRRules]             = DeriveJsonEncoder.gen
+  implicit lazy val activeTechniqueEncoder: JsonEncoder[JRActiveTechnique]   = DeriveJsonEncoder.gen
+
+  implicit lazy val configValueEncoder:      JsonEncoder[ConfigValue]              = new JsonEncoder[ConfigValue] {
     override def unsafeEncode(a: ConfigValue, indent: Option[Int], out: Write): Unit = {
       val options = ConfigRenderOptions.concise().setJson(true).setFormatted(indent.isDefined)
       out.write(a.render(options))
     }
   }
-  implicit val propertyProviderEncoder: JsonEncoder[Option[PropertyProvider]] = JsonEncoder[Option[String]].contramap {
+  implicit lazy val propertyProviderEncoder: JsonEncoder[Option[PropertyProvider]] = JsonEncoder[Option[String]].contramap {
     case None | Some(PropertyProvider.defaultPropertyProvider) => None
     case Some(x)                                               => Some(x.value)
   }
-  implicit val inheritModeEncoder:      JsonEncoder[InheritMode]              = JsonEncoder[String].contramap(_.value)
-  implicit val globalParameterEncoder:  JsonEncoder[JRGlobalParameter]        = DeriveJsonEncoder
+  implicit lazy val inheritModeEncoder:      JsonEncoder[InheritMode]              = JsonEncoder[String].contramap(_.value)
+  implicit lazy val globalParameterEncoder:  JsonEncoder[JRGlobalParameter]        = DeriveJsonEncoder
     .gen[JRGlobalParameter]
     .contramap(g => {
       // when inheritMode or property provider are set to their default value, don't write them
@@ -2197,9 +2212,9 @@ trait RudderJsonEncoders {
         }
     })
 
-  implicit val propertyJRParentProperty: JsonEncoder[JRParentProperty] = DeriveJsonEncoder.gen
+  implicit lazy val propertyJRParentProperty: JsonEncoder[JRParentProperty] = DeriveJsonEncoder.gen
 
-  implicit val propertyHierarchyEncoder:        JsonEncoder[JRPropertyHierarchy]        = new JsonEncoder[JRPropertyHierarchy] {
+  implicit lazy val propertyHierarchyEncoder:        JsonEncoder[JRPropertyHierarchy]        = new JsonEncoder[JRPropertyHierarchy] {
     override def unsafeEncode(a: JRPropertyHierarchy, indent: Option[Int], out: Write): Unit = {
       a match {
         case JRPropertyHierarchy.JRPropertyHierarchyJson(parents) =>
@@ -2209,64 +2224,59 @@ trait RudderJsonEncoders {
       }
     }
   }
-  implicit val propertyDetailsEncoder:          JsonEncoder[JRParentPropertyDetails]    = DeriveJsonEncoder.gen
-  implicit val propertyHierarchyStatusEncoder:  JsonEncoder[JRPropertyHierarchyStatus]  = DeriveJsonEncoder.gen
-  implicit val propertyEncoder:                 JsonEncoder[JRProperty]                 = DeriveJsonEncoder.gen
-  implicit val criteriumEncoder:                JsonEncoder[JRCriterium]                = DeriveJsonEncoder.gen
-  implicit val queryEncoder:                    JsonEncoder[JRQuery]                    = DeriveJsonEncoder.gen
-  implicit val groupEncoder:                    JsonEncoder[JRGroup]                    = DeriveJsonEncoder.gen
-  implicit val objectInheritedObjectProperties: JsonEncoder[JRGroupInheritedProperties] = DeriveJsonEncoder.gen
+  implicit lazy val propertyDetailsEncoder:          JsonEncoder[JRParentPropertyDetails]    = DeriveJsonEncoder.gen
+  implicit lazy val propertyHierarchyStatusEncoder:  JsonEncoder[JRPropertyHierarchyStatus]  = DeriveJsonEncoder.gen
+  implicit lazy val propertyEncoder:                 JsonEncoder[JRProperty]                 = DeriveJsonEncoder.gen
+  implicit lazy val criteriumEncoder:                JsonEncoder[JRCriterium]                = DeriveJsonEncoder.gen
+  implicit lazy val queryEncoder:                    JsonEncoder[JRQuery]                    = DeriveJsonEncoder.gen
+  implicit lazy val groupEncoder:                    JsonEncoder[JRGroup]                    = DeriveJsonEncoder.gen
+  implicit lazy val objectInheritedObjectProperties: JsonEncoder[JRGroupInheritedProperties] = DeriveJsonEncoder.gen
 
-  implicit val fullGroupCategoryEncoder:      JsonEncoder[JRFullGroupCategory]             =
-    DeriveJsonEncoder.gen[JRFullGroupCategory]
-  implicit val minimalGroupCategoryEncoder:   JsonEncoder[JRMinimalGroupCategory]          =
-    DeriveJsonEncoder.gen[JRMinimalGroupCategory]
-  implicit val groupCategoriesFullEncoder:    JsonEncoder[JRGroupCategoriesFull]           =
-    DeriveJsonEncoder.gen[JRGroupCategoriesFull]
-  implicit val groupCategoriesMinimalEncoder: JsonEncoder[JRGroupCategoriesMinimal]        =
-    DeriveJsonEncoder.gen[JRGroupCategoriesMinimal]
-  implicit val groupInfoEncoder:              JsonEncoder[JRGroupCategoryInfo.JRGroupInfo] =
-    DeriveJsonEncoder.gen[JRGroupCategoryInfo.JRGroupInfo]
-  implicit lazy val groupCategoryInfoEncoder: JsonEncoder[JRGroupCategoryInfo]             = DeriveJsonEncoder.gen[JRGroupCategoryInfo]
+  implicit lazy val fullGroupCategoryEncoder:      JsonEncoder[JRFullGroupCategory]             = DeriveJsonEncoder.gen
+  implicit lazy val minimalGroupCategoryEncoder:   JsonEncoder[JRMinimalGroupCategory]          = DeriveJsonEncoder.gen
+  implicit lazy val groupCategoriesFullEncoder:    JsonEncoder[JRGroupCategoriesFull]           = DeriveJsonEncoder.gen
+  implicit lazy val groupCategoriesMinimalEncoder: JsonEncoder[JRGroupCategoriesMinimal]        = DeriveJsonEncoder.gen
+  implicit lazy val groupInfoEncoder:              JsonEncoder[JRGroupCategoryInfo.JRGroupInfo] = DeriveJsonEncoder.gen
+  implicit lazy val groupCategoryInfoEncoder:      JsonEncoder[JRGroupCategoryInfo]             = DeriveJsonEncoder.gen
 
-  implicit val nodeIdEncoder:                  JsonEncoder[NodeId]                    = JsonEncoder[String].contramap(_.value)
-  implicit val nodeInheritedPropertiesEncdoer: JsonEncoder[JRNodeInheritedProperties] = DeriveJsonEncoder.gen
+  implicit lazy val nodeIdEncoder:                  JsonEncoder[NodeId]                    = JsonEncoder[String].contramap(_.value)
+  implicit lazy val nodeInheritedPropertiesEncdoer: JsonEncoder[JRNodeInheritedProperties] = DeriveJsonEncoder.gen
 
-  implicit val revisionInfoEncoder: JsonEncoder[JRRevisionInfo] = DeriveJsonEncoder.gen
+  implicit lazy val revisionInfoEncoder: JsonEncoder[JRRevisionInfo] = DeriveJsonEncoder.gen
 
-  implicit val statusEncoder: JsonEncoder[JRInventoryStatus] = JsonEncoder[String].contramap(_.name)
-  implicit val stateEncoder:  JsonEncoder[NodeState]         = JsonEncoder[String].contramap(_.name)
+  implicit lazy val statusEncoder: JsonEncoder[JRInventoryStatus] = JsonEncoder[String].contramap(_.name)
+  implicit lazy val stateEncoder:  JsonEncoder[NodeState]         = JsonEncoder[String].contramap(_.name)
 
-  implicit val machineTypeEncoder: JsonEncoder[MachineType] = JsonEncoder[String].contramap(_.name)
+  implicit lazy val machineTypeEncoder: JsonEncoder[MachineType] = JsonEncoder[String].contramap(_.name)
 
-  implicit val nodeInfoEncoder: JsonEncoder[JRNodeInfo] = DeriveJsonEncoder.gen[JRNodeInfo]
+  implicit lazy val nodeInfoEncoder: JsonEncoder[JRNodeInfo] = DeriveJsonEncoder.gen
 
-  implicit val nodeChangeStatusEncoder: JsonEncoder[JRNodeChangeStatus] = DeriveJsonEncoder.gen[JRNodeChangeStatus]
+  implicit lazy val nodeChangeStatusEncoder: JsonEncoder[JRNodeChangeStatus] = DeriveJsonEncoder.gen
 
-  implicit val nodeIdStatusEncoder:         JsonEncoder[JRNodeIdStatus]         = DeriveJsonEncoder.gen[JRNodeIdStatus]
-  implicit val nodeIdHostnameResultEncoder: JsonEncoder[JRNodeIdHostnameResult] = DeriveJsonEncoder.gen[JRNodeIdHostnameResult]
+  implicit lazy val nodeIdStatusEncoder:         JsonEncoder[JRNodeIdStatus]         = DeriveJsonEncoder.gen
+  implicit lazy val nodeIdHostnameResultEncoder: JsonEncoder[JRNodeIdHostnameResult] = DeriveJsonEncoder.gen
 
-  implicit val updateNodeEncoder: JsonEncoder[JRUpdateNode] = DeriveJsonEncoder.gen[JRUpdateNode]
+  implicit lazy val updateNodeEncoder: JsonEncoder[JRUpdateNode] = DeriveJsonEncoder.gen
 
   // Node details
 
-  implicit val vmTypeEncoder: JsonEncoder[VmType] = JsonEncoder[String].contramap(_.name)
+  implicit lazy val vmTypeEncoder: JsonEncoder[VmType] = JsonEncoder[String].contramap(_.name)
 
-  implicit val nodeKindEncoder:          JsonEncoder[NodeKind]            = JsonEncoder[String].contramap(_.name)
-  implicit val managementEncoder:        JsonEncoder[Management]          = DeriveJsonEncoder.gen[Management]
-  implicit val scheduleOverrideEncoder:  JsonEncoder[ScheduleOverride]    = DeriveJsonEncoder.gen[ScheduleOverride]
-  implicit val managementDetailsEncoder: JsonEncoder[ManagementDetails]   = DeriveJsonEncoder.gen[ManagementDetails]
-  implicit val licenseEncoder:           JsonEncoder[domain.License]      = DeriveJsonEncoder.gen[domain.License]
-  implicit val softwareUuidEncoder:      JsonEncoder[domain.SoftwareUuid] = JsonEncoder[String].contramap(_.value)
-  implicit val softwareEncoder:          JsonEncoder[domain.Software]     = DeriveJsonEncoder.gen[domain.Software]
+  implicit lazy val nodeKindEncoder:          JsonEncoder[NodeKind]            = JsonEncoder[String].contramap(_.name)
+  implicit lazy val managementEncoder:        JsonEncoder[Management]          = DeriveJsonEncoder.gen
+  implicit lazy val scheduleOverrideEncoder:  JsonEncoder[ScheduleOverride]    = DeriveJsonEncoder.gen
+  implicit lazy val managementDetailsEncoder: JsonEncoder[ManagementDetails]   = DeriveJsonEncoder.gen
+  implicit lazy val licenseEncoder:           JsonEncoder[domain.License]      = DeriveJsonEncoder.gen
+  implicit lazy val softwareUuidEncoder:      JsonEncoder[domain.SoftwareUuid] = JsonEncoder[String].contramap(_.value)
+  implicit lazy val softwareEncoder:          JsonEncoder[domain.Software]     = DeriveJsonEncoder.gen
 
-  implicit val nodeDetailLevelEncoder: JsonEncoder[JRNodeDetailLevel] = DeriveJsonEncoder.gen[JRNodeDetailLevel]
+  implicit lazy val nodeDetailLevelEncoder: JsonEncoder[JRNodeDetailLevel] = DeriveJsonEncoder.gen
 
-  implicit val runAnalysisKindEncoder:  JsonEncoder[RunAnalysisKind]   = JsonEncoder[String].contramap(_.entryName)
-  implicit val jrNodeComplianceEncoder: JsonEncoder[JRNodeCompliance]  = JsonEncoder[ComplianceLevel].contramap(_.compliance)
-  implicit val policyModeSerializer:    JsonEncoder[PolicyMode]        = JsonEncoder[String].contramap(_.name)
-  implicit val jrGlobalScoreEncoder:    JsonEncoder[JRGlobalScore]     = DeriveJsonEncoder.gen[JRGlobalScore]
-  implicit val nodeDetailTableEncoder:  JsonEncoder[JRNodeDetailTable] = DeriveJsonEncoder.gen[JRNodeDetailTable]
+  implicit lazy val runAnalysisKindEncoder:  JsonEncoder[RunAnalysisKind]   = JsonEncoder[String].contramap(_.entryName)
+  implicit lazy val jrNodeComplianceEncoder: JsonEncoder[JRNodeCompliance]  = JsonEncoder[ComplianceLevel].contramap(_.compliance)
+  implicit lazy val policyModeSerializer:    JsonEncoder[PolicyMode]        = JsonEncoder[String].contramap(_.name)
+  implicit lazy val jrGlobalScoreEncoder:    JsonEncoder[JRGlobalScore]     = DeriveJsonEncoder.gen
+  implicit lazy val nodeDetailTableEncoder:  JsonEncoder[JRNodeDetailTable] = DeriveJsonEncoder.gen
 }
 
 /*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
@@ -60,6 +60,7 @@ import net.liftweb.common.Failure
 import net.liftweb.common.Full
 import org.joda.time.DateTime
 import org.joda.time.Duration
+import scala.annotation.nowarn
 import zio.json.*
 import zio.json.internal.Write
 
@@ -686,6 +687,7 @@ object NodeConfigIdSerializer {
     else {
       implicit val formats = DefaultFormats
       val configs          = parse(ids)
+        // avoid Compiler synthesis of Manifest and OptManifest is deprecated
         .extractOrElse[List[Map[String, String]]](List())
         .flatMap {
           case map =>
@@ -696,7 +698,7 @@ object NodeConfigIdSerializer {
             }
         }
         .flatten
-        .sortBy(_._2.getMillis)
+        .sortBy(_._2.getMillis): @nowarn("cat=deprecation")
 
       // build interval
       configs match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -102,7 +102,7 @@ trait BlockCompliance[Sub] extends ComponentCompliance {
   }
 
   def compliance: ComplianceLevel = {
-    import ReportingLogic.*
+    import com.normation.cfclerk.domain.ReportingLogic.*
     reportingLogic match {
       // simple weighted compliance, as usual
       case WeightedReport => ComplianceLevel.sum(subs.map(_.compliance))
@@ -150,7 +150,7 @@ trait BlockComplianceByNode[Sub] extends ComponentComplianceByNode with BlockCom
   }
 
   override def compliance: ComplianceLevel = {
-    import ReportingLogic.*
+    import com.normation.cfclerk.domain.ReportingLogic.*
     reportingLogic match {
       // simple weighted compliance, as usual
       case WeightedReport => super.compliance
@@ -193,8 +193,8 @@ final class RuleStatusReport private (
     val forRule: RuleId,
     val report:  AggregatedStatusReport
 ) extends StatusReport {
-  lazy val compliance = report.compliance
-  lazy val byNodes: Map[NodeId, AggregatedStatusReport] =
+  lazy val compliance: ComplianceLevel                     = report.compliance
+  lazy val byNodes:    Map[NodeId, AggregatedStatusReport] =
     report.reports.groupBy(_.nodeId).view.mapValues(AggregatedStatusReport(_)).toMap
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ExpectedReportsJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ExpectedReportsJdbcRepository.scala
@@ -57,6 +57,7 @@ import doobie.implicits.*
 import net.liftweb.common.*
 import net.liftweb.json.*
 import org.joda.time.DateTime
+import scala.annotation.nowarn
 import zio.{System as _, *}
 import zio.interop.catz.*
 import zio.syntax.*
@@ -568,7 +569,8 @@ object ComponentsValuesSerialiser {
     if (null == ids || ids.trim == "") List()
     else {
       implicit val formats = DefaultFormats
-      parse(ids).extract[List[String]]
+      // avoid Compiler synthesis of Manifest and OptManifest is deprecated
+      parse(ids).extract[List[String]]: @nowarn("cat=deprecation")
     }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -77,7 +77,6 @@ import com.normation.rudder.services.queries.CmdbQueryParser
 import com.normation.utils.Control.traverse
 import net.liftweb.common.*
 import net.liftweb.common.Box.*
-import net.liftweb.util.Helpers.tryo
 import org.apache.commons.text.StringEscapeUtils
 import org.joda.time.format.ISODateTimeFormat
 import scala.util.Failure as Catch

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/GitModificationRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/GitModificationRepositoryTest.scala
@@ -37,7 +37,6 @@
 
 package com.normation.rudder.repository.jdbc
 
-import cats.implicits.*
 import com.normation.BoxSpecMatcher
 import com.normation.errors.*
 import com.normation.eventlog.ModificationId

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsTest.scala
@@ -163,7 +163,8 @@ class ReportsTest extends DBCommon {
 
     "find the last reports for node0" in {
       val result = repostsRepo.getExecutionReports(Set(AgentRunId(NodeId("n0"), run1))).open
-      result.values.flatten.toSeq must contain(exactly(reports("n0")(0)))
+      val actual: Seq[Reports] = result.values.toSeq.flatten
+      actual must contain(exactly(reports("n0")(0)))
     }
 
     "find reports for node 0,1,2" in {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestJsEngine.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestJsEngine.scala
@@ -152,7 +152,7 @@ class TestJsEngine extends Specification {
     }
   }
 
-  "When getting the sandboxed environement, one " should {
+  "When getting the sandboxed environment, one " should {
 
     "still be able to do dangerous things, because it's only the JsEngine which is sandboxed" in {
       runSandboxed() { box =>
@@ -252,6 +252,8 @@ class TestJsEngine extends Specification {
 
     val sha256Variable = variableSpec.toVariable(Seq(s"${JsEngine.EVALJS}rudder.password.sha256('secret')"))
     val sha512Variable = variableSpec.toVariable(Seq(s"${JsEngine.DEFAULT_EVAL}rudder.password.sha512('secret', '01234567')"))
+    val sha256Hash     = variableSpec.toVariable(Seq(s"${JsEngine.EVALJS}rudder.hash.sha256('secret')"))
+    val sha512HAsh     = variableSpec.toVariable(Seq(s"${JsEngine.DEFAULT_EVAL}rudder.hash.sha512('secret')"))
 
     "get the correct hashed value for Linux sha256" in {
       contextEnabled(engine => engine.eval(sha256Variable, JsRudderLibBinding.Crypt)) must beVariableValue(_.startsWith("$5$"))
@@ -259,6 +261,18 @@ class TestJsEngine extends Specification {
 
     "get the correct hashed value for Linux sha512" in {
       contextEnabled(engine => engine.eval(sha512Variable, JsRudderLibBinding.Crypt)) must beVariableValue(_.startsWith("$6$"))
+    }
+
+    "get the correct hashed value for sha256" in {
+      contextEnabled(engine => engine.eval(sha256Hash, JsRudderLibBinding.Crypt)) must beVariableValue(
+        _.startsWith("2bb80d537b1da3e38bd3")
+      )
+    }
+
+    "get the correct hashed value for sha512" in {
+      contextEnabled(engine => engine.eval(sha512HAsh, JsRudderLibBinding.Crypt)) must beVariableValue(
+        _.startsWith("bd2b1aaf7ef4f09be9f5")
+      )
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ReportingServiceUtilsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ReportingServiceUtilsTest.scala
@@ -126,10 +126,15 @@ class ReportingServiceUtilsTest extends Specification {
 
   // for aggregated status reports, we just compare directive list
   implicit class AggregatedReportMatcher(report1: AggregatedStatusReport) {
+    // Not sure it's a actual functor as the size of the Set can change after calling map, however, for this equality it
+    // doesn't matter to have a function as long as .each is happy
+    implicit val setFunctor: QuicklensFunctor[Set] = new QuicklensFunctor[Set] {
+      def map[A](fa: Set[A], f: A => A): Set[A] = fa.map(f)
+    }
+
     def isSameReportAs(report2: AggregatedStatusReport): MatchResult[Set[RuleNodeStatusReport]] = {
-      report1.reports.modify(_.each.expirationDate).setTo(new DateTime(0)) === report2.reports
-        .modify(_.each.expirationDate)
-        .setTo(new DateTime(0))
+      report1.reports.modify(_.each.expirationDate).setTo(new DateTime(0)) ===
+      report2.reports.modify(_.each.expirationDate).setTo(new DateTime(0))
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/pom.xml
+++ b/webapp/sources/rudder/rudder-rest/pom.xml
@@ -129,7 +129,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Doing HTTP requests for remote run -->
     <dependency>
       <groupId>org.scalaj</groupId>
-      <artifactId>scalaj-http_${scala-binary-version}</artifactId>
+      <artifactId>scalaj-http_2.13</artifactId>
       <version>${scalaj-version}</version>
     </dependency>
 
@@ -142,7 +142,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Testing Liftweb -->
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-testkit_${scala-binary-version}</artifactId>
+      <artifactId>lift-testkit_2.13</artifactId>
       <version>${lift-version}</version>
       <scope>test</scope>
     </dependency>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/Authorizations.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/Authorizations.scala
@@ -308,7 +308,7 @@ case class Rights private (authorizationTypes: Set[AuthorizationType]) {
 
 object Rights {
 
-  val NoRights: Rights = Rights.forAuthzs(AuthorizationType.NoRights)
+  val NoRights: Rights = new Rights(Set(AuthorizationType.NoRights))
 
   val AnyRights: Rights = Rights.forAuthzs(AuthorizationType.AnyRights)
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -50,19 +50,18 @@ import sourcecode.Line
  * in Rudder base.
  *
  * Any module wanting to contribute an API
- * More preciselly, it defines the data format of
+ * More precisely, it defines the data format of
  * an endpoint descriptor, an endpoint descriptor container,
- * and prefil all the known endpoints into the corner.
+ * and pre-fill all the known endpoints into the corner.
  *
- * It also defined interpretor for endpoint descriptor toward
+ * It also defined interpreter for endpoint descriptor toward
  * Lift RestAPI objects.
  *
  */
 
 // we need a marker trait to get endpoint in a sorted way. Bad, but nothing better
-// safe rewriting sealerate
 trait SortIndex {
-  protected[rest] def z: Int
+  def z: Int
 }
 
 sealed trait CampaignApi extends EnumEntry with EndpointSchema with GeneralApi with SortIndex

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
@@ -84,10 +84,10 @@ class EventLogAPI(
     eventLogDetail:     EventLogDetailsGenerator,
     translateEventType: EventLogType => String
 ) extends LiftApiModuleProvider[EventLogApi] {
-  import EventLogService.*
+  import com.normation.rudder.rest.internal.EventLogService.*
 
-  implicit val translateEventLogType: EventLogType => String   = translateEventType
-  implicit val eventLogDetailsGen:    EventLogDetailsGenerator = eventLogDetail
+  implicit lazy val translateEventLogType: EventLogType => String   = translateEventType
+  implicit lazy val eventLogDetailsGen:    EventLogDetailsGenerator = eventLogDetail
 
   override def schemas: ApiModuleProvider[EventLogApi] = EventLogApi
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
@@ -49,7 +49,6 @@ import com.normation.eventlog.ModificationId
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.apidata.JsonQueryObjects.*
 import com.normation.rudder.apidata.JsonResponseObjects.*
-import com.normation.rudder.apidata.JsonResponseObjects.JRDirective
 import com.normation.rudder.apidata.ZioJsonExtractor
 import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.batch.AsyncDeploymentActor

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -1019,7 +1019,8 @@ class SettingsApi(
           s""" "delete":["192.168.1.0/24", ...]"}}, got: ${if (json == JNothing) "nothing" else compactRender(json)}"""
         }
         _        <- if (json == JNothing) Failure(msg) else Full(())
-        diff     <- try { Full(json.extract[AllowedNetDiff]) }
+        // avoid Compiler synthesis of Manifest and OptManifest is deprecated
+        diff     <- try { Full(json.extract[AllowedNetDiff]): @annotation.nowarn("cat=deprecation") }
                     catch { case NonFatal(ex) => Failure(msg) }
         _        <- traverse(diff.add)(checkAllowedNetwork)
         // for now, we use inet as the name, too

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/FilePermissions.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/FilePermissions.scala
@@ -233,7 +233,7 @@ final case class PermSet(file: FilePerms, perms: (Perm => Unit, () => Perm)*) {
 
   def octal: String = perms.foldLeft("")((s, p) => s + p._2().octal.toString)
 
-  // simule erad/write/exec vars
+  // simulate read/write/exec vars
   def read: Boolean = perms.foldLeft(true)((b, p) => b & p._2().read)
   def read_=(b: Boolean): Unit = { if (b) this + (r) else this - (r) }
   def write: Boolean = perms.foldLeft(true)((b, p) => b & p._2().write)
@@ -243,6 +243,7 @@ final case class PermSet(file: FilePerms, perms: (Perm => Unit, () => Perm)*) {
 
 }
 
+@unchecked // it should be checked
 object PermSet {
   val u:   FilePerms => PermSet = (file: FilePerms) => new PermSet(file, (file._u_= _, () => file._u))
   val g:   FilePerms => PermSet = (file: FilePerms) => new PermSet(file, (file._g_= _, () => file._g))
@@ -259,6 +260,7 @@ object PermSet {
     new PermSet(file, (file._u_= _, () => file._u), (file._g_= _, () => file._g), (file._o_= _, () => file._o))
 }
 
+@unchecked
 class FilePerms( // special bits have to be explicitly set
     var _u: Perm = none,
     var _g: Perm = none,

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/domain/reports/JsonPostresqlSerializationTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/domain/reports/JsonPostresqlSerializationTest.scala
@@ -602,9 +602,7 @@ object ExpectedJson {
       |                                    "rtid" : "reportId-check3",
       |                                    "msrs" : [
       |                                      {
-      |                                        "rt" : {
-      |                                          "AuditCompliant" : {}
-      |                                        },
+      |                                        "rt" : "AuditCompliant",
       |                                        "m" : "check 3 is compliant"
       |                                      }
       |                                    ]
@@ -623,9 +621,7 @@ object ExpectedJson {
       |                                    "rtid" : "reportId-check2",
       |                                    "msrs" : [
       |                                      {
-      |                                        "rt" : {
-      |                                          "EnforceError" : {}
-      |                                        },
+      |                                        "rt" : "EnforceError",
       |                                        "m" : "check 2 failed"
       |                                      }
       |                                    ]
@@ -636,15 +632,11 @@ object ExpectedJson {
       |                                    "rtid" : "reportId-check1",
       |                                    "msrs" : [
       |                                      {
-      |                                        "rt" : {
-      |                                          "EnforceSuccess" : {}
-      |                                        },
+      |                                        "rt" : "EnforceSuccess",
       |                                        "m" : "check 1#1 is valid"
       |                                      },
       |                                      {
-      |                                        "rt" : {
-      |                                          "EnforceSuccess" : {}
-      |                                        },
+      |                                        "rt" : "EnforceSuccess",
       |                                        "m" : "check 1#2 is valid"
       |                                      }
       |                                    ]
@@ -682,9 +674,7 @@ object ExpectedJson {
       |                              "rtid" : "reportId-check6",
       |                              "msrs" : [
       |                                {
-      |                                  "rt" : {
-      |                                    "EnforceError" : {}
-      |                                  },
+      |                                  "rt" : "EnforceError",
       |                                  "m" : "check 6 is in error"
       |                                }
       |                              ]
@@ -695,9 +685,7 @@ object ExpectedJson {
       |                              "rtid" : "reportId-check5",
       |                              "msrs" : [
       |                                {
-      |                                  "rt" : {
-      |                                    "EnforceNotApplicable" : {}
-      |                                  },
+      |                                  "rt" : "EnforceNotApplicable",
       |                                  "m" : "check 5 is N/A"
       |                                }
       |                              ]
@@ -708,9 +696,7 @@ object ExpectedJson {
       |                              "rtid" : "reportId-check4",
       |                              "msrs" : [
       |                                {
-      |                                  "rt" : {
-      |                                    "EnforceRepaired" : {}
-      |                                  },
+      |                                  "rt" : "EnforceRepaired",
       |                                  "m" : "check 4 is repaired"
       |                                }
       |                              ]

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
@@ -38,7 +38,6 @@
 package com.normation.rudder.rest
 
 import better.files.*
-import better.files.File
 import com.normation.cfclerk.domain.TechniqueId
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersion

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -747,8 +747,8 @@ class RestTestSetUp {
     override def default(withId: String): DirectiveField = new DirectiveField {
       self => type ValueType = String
       def manifest: ClassTag[String] = classTag[String]
-      lazy val id = withId
-      def name    = id
+      val id   = withId
+      def name = id
       override val uniqueFieldId: Box[String]                      = Full(id)
       protected var _x:           String                           = getDefaultValue
       def validate:               List[FieldError]                 = Nil

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
@@ -68,6 +68,7 @@ import net.liftweb.mocks.MockHttpServletRequest
 import net.liftweb.util.Helpers.tryo
 import org.yaml.snakeyaml.Yaml
 import scala.jdk.CollectionConverters.*
+import scala.reflect.Selectable
 import scala.util.control.NonFatal
 import zio.*
 import zio.syntax.*
@@ -284,36 +285,33 @@ object TraitTestApiFromYamlFiles {
       case inMemory: InMemoryResponse => (inMemory.code, new String(inMemory.data, "UTF-8"))
 
       // copied from liftweb source code (sendResponse)
-      case StreamingResponse(stream, endFunc, _, _, _, code) =>
+      case streaming: StreamingResponse =>
         import scala.language.reflectiveCalls
+
+        // this is a workaround for a scala compiler bug, see https://github.com/scala/scala3/issues/11043
+        def read(array: Array[Byte]): Int =
+          Selectable.reflectiveSelectable(streaming.data).applyDynamic("read", classOf[Array[Byte]])(array).asInstanceOf[Int]
 
         val os = new ByteArrayOutputStream()
         try {
           var len = 0
-          val ba  = new Array[Byte](8192)
-          stream match {
-            case jio: java.io.InputStream => len = jio.read(ba)
-            case stream => len = stream.read(ba)
-          }
+          val ba: Array[Byte] = new Array[Byte](8192)
+          len = read(ba)
           while (len >= 0) {
-            if (len > 0) os.write(ba, 0, len)
-            stream match {
-              case jio: java.io.InputStream => len = jio.read(ba)
-              case stream => len = stream.read(ba)
-            }
+            len = read(ba)
           }
           os.flush()
         } finally {
-          endFunc()
+          streaming.onEnd()
         }
-        (code, os.toString(StandardCharsets.UTF_8))
+        (streaming.code, os.toString(StandardCharsets.UTF_8))
 
-      case OutputStreamResponse(out, _, _, _, code) =>
+      case outputStream: OutputStreamResponse =>
         val os = new ByteArrayOutputStream()
-        out(os)
+        outputStream.out(os)
         os.flush()
-        (code, os.toString(StandardCharsets.UTF_8))
-      case _                                        => (500, "Unknown response in test framework")
+        (outputStream.code, os.toString(StandardCharsets.UTF_8))
+      case _ => (500, "Unknown response in test framework")
     }
 
     (responseCode, responseContent)

--- a/webapp/sources/rudder/rudder-templates-cli/pom.xml
+++ b/webapp/sources/rudder/rudder-templates-cli/pom.xml
@@ -86,12 +86,12 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-json_${scala-binary-version}</artifactId>
+      <artifactId>lift-json_2.13</artifactId>
       <version>${lift-version}</version>
     </dependency>
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-common_${scala-binary-version}</artifactId>
+      <artifactId>lift-common_2.13</artifactId>
       <version>${lift-version}</version>
     </dependency>
 

--- a/webapp/sources/rudder/rudder-web/pom.xml
+++ b/webapp/sources/rudder/rudder-web/pom.xml
@@ -313,5 +313,11 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.typelevel</groupId>
+      <artifactId>cats-effect-std_${scala-binary-version}</artifactId>
+      <version>${cats-effect-version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -116,7 +116,8 @@ object Boot {
     */
   final class RequestHeadersFactoryVendor(csp: ContentSecurityPolicy) extends Vendor[List[(String, String)]] {
 
-    LiftRules.registerInjection(this)
+    // avoid Compiler synthesis of Manifest and OptManifest is deprecated
+    LiftRules.registerInjection(this): @annotation.nowarn("cat=deprecation")
 
     implicit override def make: Box[List[(String, String)]] = Empty // never used in LiftRules.supplementalHeaders, see `vend`
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1964,7 +1964,7 @@ object RudderConfigInit {
     }
 
     lazy val inventoryWatcher = {
-      val fileProcessor = new ProcessFile(inventoryProcessor, INVENTORY_DIR_INCOMING)
+      val fileProcessor = ProcessFile.start(inventoryProcessor, INVENTORY_DIR_INCOMING).runNow
 
       new InventoryFileWatcher(
         fileProcessor,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/consistency/CheckRudderGlobalParameter.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/consistency/CheckRudderGlobalParameter.scala
@@ -75,7 +75,9 @@ class CheckRudderGlobalParameter(
   def toParams(value: JValue): IOResult[List[GlobalParameter]] = {
     implicit val formats = DefaultFormats
     value match {
-      case JArray(list) => ZIO.foreach(list)(v => IOResult.attempt(v.extract[JsonParam].toGlobalParam))
+      // avoid Compiler synthesis of Manifest and OptManifest is deprecated
+      case JArray(list) =>
+        ZIO.foreach(list)(v => IOResult.attempt(v.extract[JsonParam].toGlobalParam: @annotation.nowarn("cat=deprecation")))
       case x            =>
         Inconsistency(s"Resources `${resource}` must contain an array of json object with keys name, description, value`").fail
     }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPluginJson.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPluginJson.scala
@@ -59,7 +59,7 @@ protected object JsonPluginFile {
 
 /**
   * The external json format of a plugin in the index file.
-  * 
+  *
   * Optional fields are there to obtain empty lists when mapping none
   */
 final protected case class JsonPluginRaw(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ModificationValidationPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ModificationValidationPopup.scala
@@ -521,7 +521,7 @@ class ModificationValidationPopup(
     }
   }
 
-  private def saveChangeRequest(): JsCmd = {
+  private def saveChangeRequest(): JsCmd = scala.util.boundary {
     // we only have quick change request now
     val purecr = item match {
       case Left(
@@ -594,7 +594,7 @@ class ModificationValidationPopup(
               // early return here
               logger.error(s"Exception when trying to update a change request:" + err.fullMsg)
               parentFormTracker.addFormError(error(err.fullMsg))
-              return onFailureCallback(Text(err.fullMsg))
+              scala.util.boundary.break(onFailureCallback(Text(err.fullMsg)))
           }
         }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/NodeGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/NodeGrid.scala
@@ -256,7 +256,8 @@ final class NodeGrid(
 
     (for {
       json       <- tryo(parse(jsonArg)).toIO.chainError("Error when trying to parse argument for node")
-      arg        <- tryo(json.extract[JsonArg]).toIO
+      // avoid Compiler synthesis of Manifest and OptManifest is deprecated
+      arg        <- tryo(json.extract[JsonArg]: @annotation.nowarn("cat=deprecation")).toIO
       status     <- InventoryStatus(arg.status).notOptional("Status parameter is mandatory")
       nodeId      = NodeId(arg.id)
       nodeFact   <- nodeFactRepo

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Node.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Node.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.web.snippet.node
 import bootstrap.liftweb.RudderConfig
 import com.normation.box.*
 import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.logger.ApplicationLogger
 import com.normation.rudder.web.components.ShowNodeDetailsFromNode
 import net.liftweb.common.*
 import net.liftweb.http.S
@@ -48,7 +49,7 @@ import net.liftweb.http.StatefulSnippet
 /**
  * Snippet that handle the "node details" (/node/uuid) page.
  */
-class Node extends StatefulSnippet with Loggable {
+class Node extends StatefulSnippet {
 
   private val getFullGroupLibrary = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
 
@@ -56,7 +57,7 @@ class Node extends StatefulSnippet with Loggable {
     case Full(x) => x
     case eb: EmptyBox =>
       val e = eb ?~! "Major error: can not get the node group library"
-      logger.error(e.messageChain)
+      ApplicationLogger.error(e.messageChain)
       throw new Exception(e.messageChain)
   }
 

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/earlyconfig/db/TestMigrateTableReportsExecution.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/earlyconfig/db/TestMigrateTableReportsExecution.scala
@@ -52,7 +52,7 @@ import zio.interop.catz.*
 
 @RunWith(classOf[JUnitRunner])
 class TestMigrateTableReportsExecution extends DBCommon with IOChecker {
-  import CheckTableReportsExecutionTz.*
+  import bootstrap.liftweb.checks.earlyconfig.db.CheckTableReportsExecutionTz.*
 
   val testTable = "reportsexecutiontest"
 

--- a/webapp/sources/utils/pom.xml
+++ b/webapp/sources/utils/pom.xml
@@ -43,11 +43,11 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-common_${scala-binary-version}</artifactId>
+      <artifactId>lift-common_2.13</artifactId>
     </dependency>
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-json_${scala-binary-version}</artifactId>
+      <artifactId>lift-json_2.13</artifactId>
     </dependency>
     <dependency>
         <groupId>com.lihaoyi</groupId>

--- a/webapp/sources/utils/src/test/scala/com/normation/utils/EnumLaws.scala
+++ b/webapp/sources/utils/src/test/scala/com/normation/utils/EnumLaws.scala
@@ -11,7 +11,7 @@ import zio.test.suite
 import zio.test.test
 
 object EnumLaws {
-  import scala.language.reflectiveCalls
+  import scala.reflect.Selectable.reflectiveSelectable
 
   def laws[A <: { def parse(s: String): Either[String, Any]; def values: Iterable[Any] }](
       `enum`:     A,


### PR DESCRIPTION
https://issues.rudder.io/issues/27034

Backport of https://github.com/Normation/rudder/pull/6365 rebased on last HEAD. 

Current state, OK:
- the whole project compile (both main sources and tests)
- the application starts and everything seems to work : policy generation, navigation to all pages, etc.
- all tests pass (see below for how the last failing ones were addressed)

Current state, Non OK:
- there is a lot of warning to address, especially regarding uninitialized values



# Addressed failing tests

## TestJsEngine

It fails with:

```
java.lang.Exception: Left(Chained(Invalid script 'evaljs:rudder.password.auto('sha256', 'secret')' for Variable test - 
please check method call and/or syntax,
SystemError(Error when evaluating value 'rudder.password.auto('sha256', 'secret')': TypeError: invokeMember (auto) on 
com.normation.rudder.services.policies.JsRudderLibImpl$$anon$1 failed due to: Unknown identifier: auto,org.graalvm.polyglot.PolyglotException: TypeError: invokeMember (auto) on 
com.normation.rudder.services.policies.JsRudderLibImpl$$anon$1 failed due to: Unknown identifier: auto))) is not a 
Full(InputVariable) that matches condition 
com.normation.rudder.services.policies.TestJsEngine$$Lambda/0x0000000800775358@2e0e8330 but a 
'Left(Chained(Invalid script 'evaljs:rudder.password.auto('sha256', 'secret')' for Variable test - please check method call and/or syntax,
SystemError(Error when evaluating value 'rudder.password.auto('sha256', 'secret')': TypeError: invokeMember (auto) on 
com.normation.rudder.services.policies.JsRudderLibImpl$$anon$1 failed due to: Unknown identifier: auto,org.graalvm.polyglot.PolyglotException: TypeError: invokeMember (auto) on com.normation.rudder.services.policies.JsRudderLibImpl$$anon$1 failed due to: Unknown identifier: auto)))'
```

=> traits have changed in Scala 3 wrt graalvm. Using an `abstract class` make it works again. 

## ReportingServiceUtilsTest

Most test in that class fails now. 

[info] Total for specification ReportingServiceUtilsTest
[info] Finished in 32 ms
5 examples, 4 failures, 0 error
[info]
Tests run: 5, Failures: 4, Errors: 0, Skipped: 0, Time elapsed: 0.039 sec <<< FAILURE!

This is likely due to the change regarding how `AggregatedStatusReports` are compared in specs2

=> Added a second false test

## EventLogJdbcRepositoryTest

Tests in error:
  initializationError(com.normation.rudder.repository.jdbc.EventLogJdbcRepositoryTest): cannot create an instance for class com.normation.rudder.repository.jdbc.EventLogJdbcRepositoryTest

=> it needs a new explicit dependency:
```
    <dependency>
      <groupId>org.typelevel</groupId>
      <artifactId>cats-effect-std_${scala-binary-version}</artifactId>
      <version>${cats-effect-version}</version>
      <scope>test</scope>
    </dependency>
```

## JsonPostresqlSerializationTest

Serialization error for `JsonCodec[ReportType]`

Might be a derivation bug for `zio-json` ? Now ? Very strange. It's sure we want the "now" case

Before:
```
"rt" : {
"EnforceRepaired" : {}
},
```

Now:
```
"rt" : "EnforceRepaired",
```
=> change the expected, and open https://issues.rudder.io/issues/27035