### PR TITLE
Fixes #27035: ReportType json serialization in base is incorrect

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -484,9 +484,9 @@ limitations under the License.
     <doobie-version>1.0.0-RC5</doobie-version>
     <fs2-version>3.10.2</fs2-version>
     <cats-effect-version>3.5.5</cats-effect-version>
-    <dev-zio-version>2.1.16</dev-zio-version>
+    <dev-zio-version>2.1.19</dev-zio-version>
     <zio-cats-version>23.1.0.3</zio-cats-version> <!-- gives fs2 3.10.2, but doobie 1.0.0-RC5 is in 3.9.3 -->
-    <zio-json-version>0.7.36</zio-json-version>
+    <zio-json-version>0.7.43</zio-json-version>
     <enumeratum-version>1.7.5</enumeratum-version>
 
     <!--

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ReportType.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ReportType.scala
@@ -37,12 +37,14 @@
 
 package com.normation.rudder.domain.reports
 import com.normation.rudder.domain.policies.PolicyMode
+import enumeratum.Enum
+import enumeratum.EnumEntry
 
 /**
  * Kind of reports that we can get as result of
  * a merge/compare with expected reports.
  */
-sealed trait ReportType {
+sealed trait ReportType extends EnumEntry {
 
   def severity: String
 
@@ -52,7 +54,7 @@ sealed trait ReportType {
   def level: Int
 }
 
-object ReportType {
+object ReportType extends Enum[ReportType] {
   // report type are declared sorted in level to ease maintenance
 
   case object EnforceNotApplicable extends ReportType { val level = 0; val severity = "NotApplicable"      }
@@ -91,6 +93,8 @@ object ReportType {
       case (_, _)                            => Unexpected
     }
   }
+
+  override def values: IndexedSeq[ReportType] = findValues
 }
 
 /**

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/domain/reports/JsonPostresqlSerializationTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/domain/reports/JsonPostresqlSerializationTest.scala
@@ -262,6 +262,10 @@ class JsonPostresqlSerializationTest extends Specification {
     fromJson(ExpectedJson.test1) === JNodeStatusReport.from(nsr1)
   }
 
+  "Old Rudder 8.2 serialization of ReportType must be readable" >> {
+    fromJson(ExpectedJson.rudder82ReportType) === JNodeStatusReport.from(nsr1)
+  }
+
 }
 
 object ExpectedJson {
@@ -317,9 +321,7 @@ object ExpectedJson {
       |                                    "rtid" : "reportId-check2.1",
       |                                    "msrs" : [
       |                                      {
-      |                                        "rt" : {
-      |                                          "EnforceRepaired" : {}
-      |                                        },
+      |                                        "rt" : "EnforceRepaired",
       |                                        "m" : "check 2.1 is repaired"
       |                                      }
       |                                    ]
@@ -338,9 +340,242 @@ object ExpectedJson {
       |                                    "rtid" : "reportId-check2.2",
       |                                    "msrs" : [
       |                                      {
-      |                                        "rt" : {
-      |                                          "EnforceRepaired" : {}
-      |                                        },
+      |                                        "rt" : "EnforceRepaired",
+      |                                        "m" : "check 2.2 is repaired"
+      |                                      }
+      |                                    ]
+      |                                  }
+      |                                ]
+      |                              }
+      |                            }
+      |                          ]
+      |                        }
+      |                      },
+      |                      {
+      |                        "bsr" : {
+      |                          "cn" : "block1",
+      |                          "rl" : "worst-case-weighted-one",
+      |                          "csrs" : [
+      |                            {
+      |                              "vsr" : {
+      |                                "cn" : "component2",
+      |                                "ecn" : "exp-component2",
+      |                                "cvsrs" : [
+      |                                  {
+      |                                    "cn" : "check3",
+      |                                    "ecn" : "expected-check3",
+      |                                    "rtid" : "reportId-check3",
+      |                                    "msrs" : [
+      |                                      {
+      |                                        "rt" : "AuditCompliant",
+      |                                        "m" : "check 3 is compliant"
+      |                                      }
+      |                                    ]
+      |                                  }
+      |                                ]
+      |                              }
+      |                            },
+      |                            {
+      |                              "vsr" : {
+      |                                "cn" : "component1",
+      |                                "ecn" : "exp-component1",
+      |                                "cvsrs" : [
+      |                                  {
+      |                                    "cn" : "check2",
+      |                                    "ecn" : "expected-check2",
+      |                                    "rtid" : "reportId-check2",
+      |                                    "msrs" : [
+      |                                      {
+      |                                        "rt" : "EnforceError",
+      |                                        "m" : "check 2 failed"
+      |                                      }
+      |                                    ]
+      |                                  },
+      |                                  {
+      |                                    "cn" : "check1",
+      |                                    "ecn" : "expected-check1",
+      |                                    "rtid" : "reportId-check1",
+      |                                    "msrs" : [
+      |                                      {
+      |                                        "rt" : "EnforceSuccess",
+      |                                        "m" : "check 1#1 is valid"
+      |                                      },
+      |                                      {
+      |                                        "rt" : "EnforceSuccess",
+      |                                        "m" : "check 1#2 is valid"
+      |                                      }
+      |                                    ]
+      |                                  }
+      |                                ]
+      |                              }
+      |                            }
+      |                          ]
+      |                        }
+      |                      }
+      |                    ]
+      |                  }
+      |                }
+      |              ]
+      |            },
+      |            {
+      |              "did" : "directive1",
+      |              "pts" : [
+      |                "system"
+      |              ],
+      |              "csrs" : [
+      |                {
+      |                  "bsr" : {
+      |                    "cn" : "block3",
+      |                    "rl" : "focus:check4",
+      |                    "csrs" : [
+      |                      {
+      |                        "vsr" : {
+      |                          "cn" : "component5",
+      |                          "ecn" : "exp-component5",
+      |                          "cvsrs" : [
+      |                            {
+      |                              "cn" : "check6",
+      |                              "ecn" : "expected-check6",
+      |                              "rtid" : "reportId-check6",
+      |                              "msrs" : [
+      |                                {
+      |                                  "rt" : "EnforceError",
+      |                                  "m" : "check 6 is in error"
+      |                                }
+      |                              ]
+      |                            },
+      |                            {
+      |                              "cn" : "check5",
+      |                              "ecn" : "expected-check5",
+      |                              "rtid" : "reportId-check5",
+      |                              "msrs" : [
+      |                                {
+      |                                  "rt" : "EnforceNotApplicable",
+      |                                  "m" : "check 5 is N/A"
+      |                                }
+      |                              ]
+      |                            },
+      |                            {
+      |                              "cn" : "check4",
+      |                              "ecn" : "expected-check4",
+      |                              "rtid" : "reportId-check4",
+      |                              "msrs" : [
+      |                                {
+      |                                  "rt" : "EnforceRepaired",
+      |                                  "m" : "check 4 is repaired"
+      |                                }
+      |                              ]
+      |                            }
+      |                          ]
+      |                        }
+      |                      }
+      |                    ]
+      |                  }
+      |                }
+      |              ]
+      |            }
+      |          ]
+      |        }
+      |      ]
+      |    }],
+      |    ["user", {
+      |       "rnsrs" : [
+      |         {
+      |           "nid" : "n0",
+      |           "rid" : "rule1",
+      |           "ct" : "user",
+      |           "art" : "2024-01-05T05:05:00Z",
+      |           "cid" : "config0_0",
+      |           "exp" : "2024-01-12T03:03:03Z",
+      |           "dsrs" : [
+      |             {
+      |               "did" : "directive2",
+      |               "pts" : [
+      |                 "user"
+      |               ],
+      |               "o" : "rule2",
+      |               "csrs" : []
+      |             }
+      |           ]
+      |         }
+      |       ]
+      |    }]
+      |  ]
+      |}
+      |""".stripMargin
+  }
+
+  val rudder82ReportType = {
+    """{
+      |  "nid" : "n0",
+      |  "ri" : {
+      |    "k" : "ComputeCompliance",
+      |    "ecid" : "config0_0",
+      |    "ecs" : "2024-01-01T01:00:00Z",
+      |    "rt" : "2024-01-05T05:05:00Z",
+      |    "rid" : "config0_0"
+      |  },
+      |  "si" : {
+      |    "OK" : {}
+      |  },
+      |  "rs" : [
+      |    ["system", {
+      |      "rnsrs" : [
+      |        {
+      |          "nid" : "n0",
+      |          "rid" : "rule0",
+      |          "ct" : "system",
+      |          "art" : "2024-01-05T05:05:00Z",
+      |          "cid" : "config0_0",
+      |          "exp" : "2024-01-12T03:03:03Z",
+      |          "dsrs" : [
+      |            {
+      |              "did" : "directive0",
+      |              "pts" : [
+      |                "system"
+      |              ],
+      |              "csrs" : [
+      |                {
+      |                  "bsr" : {
+      |                    "cn" : "block0",
+      |                    "rl" : "weighted",
+      |                    "csrs" : [
+      |                      {
+      |                        "bsr" : {
+      |                          "cn" : "block2",
+      |                          "rl" : "weighted",
+      |                          "csrs" : [
+      |                            {
+      |                              "vsr" : {
+      |                                "cn" : "component3",
+      |                                "ecn" : "exp-component3",
+      |                                "cvsrs" : [
+      |                                  {
+      |                                    "cn" : "check2.1",
+      |                                    "ecn" : "expected-check2.1",
+      |                                    "rtid" : "reportId-check2.1",
+      |                                    "msrs" : [
+      |                                      {
+      |                                        "rt" : "EnforceRepaired",
+      |                                        "m" : "check 2.1 is repaired"
+      |                                      }
+      |                                    ]
+      |                                  }
+      |                                ]
+      |                              }
+      |                            },
+      |                            {
+      |                              "vsr" : {
+      |                                "cn" : "component4",
+      |                                "ecn" : "exp-component4",
+      |                                "cvsrs" : [
+      |                                  {
+      |                                    "cn" : "check2.2",
+      |                                    "ecn" : "expected-check2.2",
+      |                                    "rtid" : "reportId-check2.2",
+      |                                    "msrs" : [
+      |                                      {
+      |                                        "rt" : "EnforceRepaired",
       |                                        "m" : "check 2.2 is repaired"
       |                                      }
       |                                    ]


### PR DESCRIPTION
https://issues.rudder.io/issues/27035

To make the change transparent for both Scala 2 and 3, I switched `ReportType` to `Enumeratum` and parse by hand. It has also a fallback to the a decoder able to deserialize the old syntaxt for transparent migration. 

It also updates ZIO lib and ZIO json to last version, because there was a ton of serialization bugs corrected in between. 