### PR TITLE
Fixes #27005: License setup should update the list of plugins

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/settings/PluginSettings.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/settings/PluginSettings.scala
@@ -39,7 +39,8 @@ package com.normation.plugins.settings
 
 /**
   * Rudder plugins are managed by an external service,
-  * which can be setup using the following settings
+  * which can be setup using the following settings.
+  * (Strings are in non-empty strings)
   */
 case class PluginSettings(
     url:           Option[String],
@@ -49,17 +50,17 @@ case class PluginSettings(
     proxyUser:     Option[String],
     proxyPassword: Option[String]
 ) {
+  import PluginSettings.*
+
   def isDefined: Boolean = {
-    // Also, the special case : username="username" is empty
+    // Also, the special case : username="username" means that settings are not defined
     val hasDefaultUser = username.contains("username")
     !isEmpty && !hasDefaultUser
   }
 
-  // Strings are in fact non-empty strings
-  private def isEmpty = url.isEmpty &&
-    username.isEmpty &&
-    password.isEmpty &&
-    proxyUrl.isEmpty &&
-    proxyUser.isEmpty &&
-    proxyPassword.isEmpty
+  private def isEmpty = this == empty
+}
+
+object PluginSettings {
+  def empty = PluginSettings(None, None, None, None, None, None)
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Plugin.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Plugin.scala
@@ -37,6 +37,7 @@
 package com.normation.rudder.rest.data
 
 import com.normation.plugins.*
+import com.normation.plugins.settings.PluginSettings
 import com.normation.utils.DateFormaterService
 import com.normation.utils.Version
 import enumeratum.Enum
@@ -231,4 +232,27 @@ object JsonPluginError {
       .withFieldComputed(_.message, _.displayMsg)
       .buildTransformer
   }
+}
+
+/**
+ * (De)Serialized version of the PluginSettings structure,
+ * without leaking passwords.
+ */
+final case class JsonPluginSettings(
+    url:                        Option[String],
+    username:                   Option[String],
+    @jsonExclude password:      Option[String],
+    proxyUrl:                   Option[String],
+    proxyUser:                  Option[String],
+    @jsonExclude proxyPassword: Option[String]
+)
+
+object JsonPluginSettings {
+  implicit val encoder: JsonEncoder[JsonPluginSettings] = DeriveJsonEncoder.gen[JsonPluginSettings]
+  implicit val decoder: JsonDecoder[JsonPluginSettings] = DeriveJsonDecoder.gen[JsonPluginSettings]
+
+  implicit val transformer:     Transformer[PluginSettings, JsonPluginSettings] =
+    Transformer.derive[PluginSettings, JsonPluginSettings]
+  implicit val backTransformer: Transformer[JsonPluginSettings, PluginSettings] =
+    Transformer.derive[JsonPluginSettings, PluginSettings]
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/PluginInternalApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/PluginInternalApi.scala
@@ -44,7 +44,6 @@ import com.normation.plugins.PluginInstallStatus
 import com.normation.plugins.PluginService
 import com.normation.plugins.PluginsMetadata
 import com.normation.plugins.cli.RudderPackageService.PluginSettingsError
-import com.normation.plugins.settings.PluginSettings
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.rest.ApiModuleProvider
@@ -59,10 +58,6 @@ import io.scalaland.chimney.syntax.*
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
 import zio.Chunk
-import zio.json.DeriveJsonDecoder
-import zio.json.DeriveJsonEncoder
-import zio.json.JsonDecoder
-import zio.json.JsonEncoder
 import zio.syntax.*
 
 class PluginInternalApi(
@@ -80,9 +75,6 @@ class PluginInternalApi(
       case API.ChangePluginsStatus => ChangePluginsStatus
     }
   }
-
-  implicit val encoder: JsonEncoder[PluginSettings] = DeriveJsonEncoder.gen[PluginSettings]
-  implicit val decoder: JsonDecoder[PluginSettings] = DeriveJsonDecoder.gen[PluginSettings]
 
   object UpdatePluginsIndex extends LiftApiModule0 {
     val schema:                                                                                                API.UpdatePluginsIndex.type = API.UpdatePluginsIndex

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2277,7 +2277,7 @@ object RudderConfigInit {
             )
           ),
           new InventoryApi(restExtractorService, inventoryWatcher, better.files.File(INVENTORY_DIR_INCOMING)),
-          new PluginApi(restExtractorService, pluginSettingsService, PluginsInfo.pluginJsonInfos.succeed),
+          new PluginApi(pluginSettingsService, pluginSystemService, PluginsInfo.pluginJsonInfos.succeed),
           new PluginInternalApi(pluginSystemService),
           new RecentChangesAPI(recentChangesService, restExtractorService),
           new RulesInternalApi(ruleInternalApiService, ruleApiService13),


### PR DESCRIPTION
https://issues.rudder.io/issues/27005

When updating settings in [the public API](https://docs.rudder.io/api/v/21/#tag/Plugins/operation/updateSettings) (the endpoint needs `Administration.Write` rights), the rudder package index needs an attempt to be updated. In case of an error the, like a 401 if credentials are wrong, the response will directly contain the error (the setting file is still updated) 

EDIT: did the cleaning of the APIs, there were some unsuitable JSON encoders, I added a new one that prevents from leaking the password by never encoding it, and added tests