### PR TITLE
Fixes #26991: Sometimes too long properties values move out actions buttons from window

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.scss
@@ -128,7 +128,11 @@ pre.json-beautify, .content-wrapper pre.json-beautify{
   white-space: pre-wrap;
   word-break: break-all;
   word-wrap: break-word;
-  overflow-wrap: anywhere;
+
+  &,
+  & > code{
+    overflow-wrap: anywhere;
+  }
 }
 pre.json-beautify.toggle, .content-wrapper pre.json-beautify.toggle{
   height:auto;
@@ -158,6 +162,7 @@ pre.json-beautify.toggle:after, .content-wrapper pre.json-beautify.toggle:after{
 /* override syntax highlighting background */
 pre.json-beautify code.elmsh {
   background: transparent !important;
+
 }
 
 /* - LABEL BOOTSTRAP */


### PR DESCRIPTION
https://issues.rudder.io/issues/26991

The css rule `overflow-wrap: anywhere;` must also be applied to the <**code**> tag containing the value of the json