### PR TITLE
Fixes #27001: OpenAPI doc for plugin infos endpoint has a warning on details field

### DIFF
--- a/webapp/sources/api-doc/components/schemas/plugins-info.yml
+++ b/webapp/sources/api-doc/components/schemas/plugins-info.yml
@@ -31,69 +31,71 @@ properties:
   details:
     type: array
     description: the list of details for each plugins
-    properties:
-      id:
-        type: string
-        description: internal id of the plugin
-        example: com.normation.plugins.authbackends.AuthBackendsPluginDef
-      name:
-        type: string
-        description: fully qualified name of the plugin
-        example: rudder-plugin-auth-backends
-      shortName:
-        type: string
-        description: short name of the plugin
-        example: auth-backends
-      description:
-        type: string
-        description: description of the plugin
-        example: <p>This plugin provides additional authentication backends for Rudder, like LDAP, OIDC, etc</p>
-      version:
-        type: string
-        description: version of the plugin
-        example: 7.3.12-2.1.0
-      status:
-        type: string
-        description: status of the plugin, enabled or disabled
-        example: enabled
-        enum:
-          - enabled
-          - disabled
-      statusMessage:
-        type: string
-        description: a message explaining the status when disabled
-        example: this plugin is disabled because its end of validity date is in the past
-      license:
-        type: object
-        description: information about the plugin
-        properties:
-          licensee:
-            type: string
-            description: name of the licensee for that plugin
-            example: Customer Inc
-          softwareId:
-            type: string
-            description: the fully qualified name of the plugin for which that license was issued
-            example: rudder-plugin-auth-backends
-          minVersion:
-            type: string
-            description: lowest version of the software for which that license is valid
-            example: 0.0-0.0
-          maxVersion:
-            type: string
-            description: highest version of the software for which that license is valid
-            example: 2023-08-14T02:00:00+02:00
-          startDate:
-            type: string
-            description: start of validity date
-            example: 2023-08-14T02:00:00+02:00
-          endDate:
-            type: string
-            description: end of validity date
-            example: 2023-08-14T02:00:00+02:00
-          maxNodes:
-            type: integer
-            description: maximum number of node in Rudder for that license
-          additionalInfo:
-            type: object
-            description: additional information provided by the license
+    items:
+      type: object
+      properties:
+        id:
+          type: string
+          description: internal id of the plugin
+          example: com.normation.plugins.authbackends.AuthBackendsPluginDef
+        name:
+          type: string
+          description: fully qualified name of the plugin
+          example: rudder-plugin-auth-backends
+        shortName:
+          type: string
+          description: short name of the plugin
+          example: auth-backends
+        description:
+          type: string
+          description: description of the plugin
+          example: <p>This plugin provides additional authentication backends for Rudder, like LDAP, OIDC, etc</p>
+        version:
+          type: string
+          description: version of the plugin
+          example: 7.3.12-2.1.0
+        status:
+          type: string
+          description: status of the plugin, enabled or disabled
+          example: enabled
+          enum:
+            - enabled
+            - disabled
+        statusMessage:
+          type: string
+          description: a message explaining the status when disabled
+          example: this plugin is disabled because its end of validity date is in the past
+        license:
+          type: object
+          description: information about the plugin
+          properties:
+            licensee:
+              type: string
+              description: name of the licensee for that plugin
+              example: Customer Inc
+            softwareId:
+              type: string
+              description: the fully qualified name of the plugin for which that license was issued
+              example: rudder-plugin-auth-backends
+            minVersion:
+              type: string
+              description: lowest version of the software for which that license is valid
+              example: 0.0-0.0
+            maxVersion:
+              type: string
+              description: highest version of the software for which that license is valid
+              example: 2023-08-14T02:00:00+02:00
+            startDate:
+              type: string
+              description: start of validity date
+              example: 2023-08-14T02:00:00+02:00
+            endDate:
+              type: string
+              description: end of validity date
+              example: 2023-08-14T02:00:00+02:00
+            maxNodes:
+              type: integer
+              description: maximum number of node in Rudder for that license
+            additionalInfo:
+              type: object
+              description: additional information provided by the license


### PR DESCRIPTION
https://issues.rudder.io/issues/27001
![Screenshot from 2025-06-05 14-42-49](https://github.com/user-attachments/assets/08e11293-f960-4326-85e1-28b828282e16)

the details field with `type: array` must have `items` which describes each object of the array (so most of the diff is because of one more level of indentation) 

