### PR TITLE
Fixes #27040: Inventory role allows to get system compliance and technical logs 

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/reports_server.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/reports_server.html
@@ -5,19 +5,27 @@
   <lastreportgrid-intro></lastreportgrid-intro>
 
 
-  <button id="AllLogButton" class="btn btn-primary">Show logs <i class="fa fa-table"></i></button>
+  <lift:authz role="node_read">
+    <lift:authz role="compliance_read">
+      <button id="AllLogButton" class="btn btn-primary">Show logs <i class="fa fa-table"></i></button>
+    </lift:authz>
+  </lift:authz>
 
   <lastreportgrid-grid></lastreportgrid-grid>
 
   <div class="clearfix"></div>
 
-  <div id="logRun"  class="space-top" style="display:none;">
-    <h3 class="page-title space-top">All logs for current run</h3>
-    <button id="AllLogHideButton" class="btn btn-primary">Hide logs</button>
-    <table id="complianceLogsGrid" cellspacing="0">
-    </table>
-  </div>
-  <lastreportgrid-missing></lastreportgrid-missing>
-  <lastreportgrid-unexpected></lastreportgrid-unexpected>
+  <lift:authz role="node_read">
+    <lift:authz role="compliance_read">
+      <div id="logRun"  class="space-top" style="display:none;">
+        <h3 class="page-title space-top">All logs for current run</h3>
+        <button id="AllLogHideButton" class="btn btn-primary">Hide logs</button>
+        <table id="complianceLogsGrid" cellspacing="0">
+        </table>
+      </div>
+      <lastreportgrid-missing></lastreportgrid-missing>
+      <lastreportgrid-unexpected></lastreportgrid-unexpected>
+    </lift:authz>
+  </lift:authz>
 
 </batches-list>


### PR DESCRIPTION
https://issues.rudder.io/issues/27040

User-based compliance are accessible under `compliance_read`, and can be found in system logs : a user with "inventory" role should not be able to see them. **EDIT: in fact users without `node_read`**
For now, until we know how to specifically handle system policy types in the system logs, that are visible in some parts of the UI, we should hide those parts for such user.