### PR TITLE
Fixes #27081: Update to last version of Scala 3

### DIFF
--- a/webapp/sources/.scalafmt.conf
+++ b/webapp/sources/.scalafmt.conf
@@ -4,12 +4,12 @@ runner.debug = true
 runner.dialect = scala213Source3
 // see https://github.com/scalameta/scalameta/blob/main/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
 // for all supported dialectOverride
-runner.dialectOverride.allowExportClause = true
-runner.dialectOverride.allowOpaqueTypes = true
-runner.dialectOverride.allowGivenUsing = true
-runner.dialectOverride.allowTraitParameters = true
 runner.dialectOverride.allowDerives = true
+runner.dialectOverride.allowExportClause = true
 runner.dialectOverride.allowExtensionMethods = true
+runner.dialectOverride.allowGivenUsing = true
+runner.dialectOverride.allowOpaqueTypes = true
+runner.dialectOverride.allowTraitParameters = true
 
 rewrite.scala3.convertToNewSyntax = true
 

--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/JsonSerializers.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/JsonSerializers.scala
@@ -40,7 +40,6 @@ package com.normation.inventory.domain
 import com.normation.utils.DateFormaterService
 import java.net.InetAddress
 import java.time.Instant
-import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormatter
 import org.joda.time.format.ISODateTimeFormat
 import zio.json.*
@@ -68,10 +67,10 @@ object JsonSerializers {
 
   // We need another JSON data tree for older versions where some JSON are serialized in humanized form
   object implicits {
-    export InventoryJsonDecoders.*
-    export InventoryJsonEncoders.*
-    export SoftwareUpdateJsonDecoders.*
-    export SoftwareUpdateJsonEncoders.*
+    export com.normation.inventory.domain.InventoryJsonDecoders.*
+    export com.normation.inventory.domain.InventoryJsonEncoders.*
+    export com.normation.inventory.domain.SoftwareUpdateJsonDecoders.*
+    export com.normation.inventory.domain.SoftwareUpdateJsonEncoders.*
   }
 
   // the update date is normalized in RFC3339, UTC, no millis
@@ -87,23 +86,13 @@ object JsonSerializers {
 }
 
 private object SoftwareUpdateJsonEncoders {
-  private object PrivateEncoders {
-    implicit val encoderDateTime: JsonEncoder[DateTime] =
-      JsonEncoder[String].contramap[DateTime](d => d.toString(JsonSerializers.softwareUpdateDateTimeFormat))
+  implicit val encoderSoftwareUpdateKind:     JsonEncoder[SoftwareUpdateKind]     = JsonEncoder[String].contramap {
+    case SoftwareUpdateKind.Other(v) => v
+    case kind                        => kind.name
   }
-  import PrivateEncoders.*
-
-  implicit val encoderSoftwareUpdateKind:     JsonEncoder[SoftwareUpdateKind]     = JsonEncoder[String].contramap { k =>
-    k match {
-      case SoftwareUpdateKind.Other(v) => v
-      case kind                        => kind.name
-    }
-  }
-  implicit val encoderSoftwareUpdateSeverity: JsonEncoder[SoftwareUpdateSeverity] = JsonEncoder[String].contramap { k =>
-    k match {
-      case SoftwareUpdateSeverity.Other(v) => v
-      case kind                            => kind.name
-    }
+  implicit val encoderSoftwareUpdateSeverity: JsonEncoder[SoftwareUpdateSeverity] = JsonEncoder[String].contramap {
+    case SoftwareUpdateSeverity.Other(v) => v
+    case kind                            => kind.name
   }
 
   implicit val encoderSoftwareUpdate: JsonEncoder[SoftwareUpdate] = DeriveJsonEncoder.gen
@@ -161,8 +150,6 @@ private object InventoryCommonJsonDecoders {
 // encoder from object to json string
 private object InventoryJsonEncoders {
   export InventoryCommonJsonEncoders.*
-  import com.normation.utils.DateFormaterService.json.*
-
   implicit val encoderMemorySize: JsonEncoder[MemorySize] = JsonEncoder[Long].contramap(_.size)
   implicit val encoderFileSystem: JsonEncoder[FileSystem] = DeriveJsonEncoder.gen
   implicit val encoderMemorySlot: JsonEncoder[MemorySlot] = DeriveJsonEncoder.gen
@@ -174,7 +161,6 @@ private object InventoryJsonEncoders {
 
 private object InventoryJsonDecoders {
   export InventoryCommonJsonDecoders.*
-  import com.normation.utils.DateFormaterService.json.*
   implicit val decoderController:     JsonDecoder[Controller]     = DeriveJsonDecoder.gen
   implicit val decoderFileSystem:     JsonDecoder[FileSystem]     = DeriveJsonDecoder.gen
   implicit val decoderMemorySlot:     JsonDecoder[MemorySlot]     = DeriveJsonDecoder.gen

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/PreInventoryParserCheckConsistency.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/main/scala/com/normation/inventory/provisioning/fusion/PreInventoryParserCheckConsistency.scala
@@ -71,13 +71,13 @@ class PreInventoryParserCheckConsistency extends PreInventoryParser {
 
     // hostname is now only check in FusionInventoryParser
     val checks = {
-      checkId(rudderTagContent) _ ::
-      checkRoot(agentTagContent) _ ::
-      checkPolicyServer(agentTagContent) _ ::
-      checkOS _ ::
-      checkKernelVersion _ ::
-      checkAgentType(agentTagContent) _ ::
-      checkSecurityToken(agentTagContent) _ ::
+      checkId(rudderTagContent) ::
+      checkRoot(agentTagContent) ::
+      checkPolicyServer(agentTagContent) ::
+      checkOS ::
+      checkKernelVersion ::
+      checkAgentType(agentTagContent) ::
+      checkSecurityToken(agentTagContent) ::
       Nil
     }
 
@@ -240,7 +240,7 @@ class PreInventoryParserCheckConsistency extends PreInventoryParser {
   private class AddChildrenTo(label: String, newChild: scala.xml.Node) extends scala.xml.transform.RewriteRule {
     override def transform(n: scala.xml.Node): scala.collection.Seq[Node] = n match {
       case Elem(prefix, "OPERATINGSYSTEM", attribs, scope, child*) =>
-        Elem(prefix, label, attribs, scope, minimizeEmpty = false, child ++ newChild: _*)
+        Elem(prefix, label, attribs, scope, minimizeEmpty = false, child ++ newChild*)
       case other                                                   => other
     }
   }

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryMapper.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/InventoryMapper.scala
@@ -623,7 +623,7 @@ class InventoryMapper(
     // mutable, yep
     def setSeqAddress(e: LDAPEntry, attr: String, list: Seq[InetAddress]): Unit = {
       if (list.isEmpty) {
-        e deleteAttribute attr
+        e.deleteAttribute(attr)
       } else {
         e.resetValuesTo(attr, list.map(_.getHostAddress)*)
       }

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/ReadOnlySoftwareInventoryDAOImpl.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/ReadOnlySoftwareInventoryDAOImpl.scala
@@ -75,7 +75,7 @@ class ReadOnlySoftwareDAOImpl(
                     n1      <- currentTimeMillis
                     entries <- con.searchOne(
                                  inventoryDitService.getSoftwareBaseDN,
-                                 OR(softIds map { (x: SoftwareUuid) => EQ(A_SOFTWARE_UUID, x.value) }: _*)
+                                 OR(softIds map { (x: SoftwareUuid) => EQ(A_SOFTWARE_UUID, x.value) }*)
                                )
                     n2      <- currentTimeMillis
 

--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -368,7 +368,7 @@ limitations under the License.
     <rudder-version>9.0.0~alpha2-SNAPSHOT</rudder-version>
 
     <servlet-version>5.0.0</servlet-version>
-    <scala-version>3.3.6</scala-version>
+    <scala-version>3.7.2</scala-version>
     <scala2-version>2.13.16</scala2-version>
     <scala-binary-version>3</scala-binary-version>
     <!-- lift force us to remain with 1.3.0 because of

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/TechniqueVersion.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/TechniqueVersion.scala
@@ -42,7 +42,7 @@ import com.normation.GitVersion.Revision
 import com.normation.utils.*
 
 final case class TechniqueVersion protected (version: Version, rev: Revision) extends Ordered[TechniqueVersion] {
-  def compare(v: TechniqueVersion): Int = (version compare v.version) match {
+  def compare(v: TechniqueVersion): Int = (version.compare(v.version)) match {
     case 0 =>
       // we can't compare two rev, so just use alpha-num order
       // A rev is always before none (which means "HEAD")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/services/impl/GitTechniqueReader.scala
@@ -805,7 +805,7 @@ class GitTechniqueReader(
   )
 
   private def processTechnique(
-      is:              ZIO[Any with Scope, RudderError, InputStream],
+      is:              ZIO[Any & Scope, RudderError, InputStream],
       filePath:        String,
       techniquesInfo:  Ref[InternalTechniquesInfo],
       parseDescriptor: Boolean, // that option is a success optimization for the case diff between old/new commit
@@ -906,7 +906,7 @@ class GitTechniqueReader(
 
     ZIO.attempt {
       if (descriptor.exists()) {
-        val yaml = descriptor.contentAsString(StandardCharsets.UTF_8)
+        val yaml = descriptor.contentAsString(using StandardCharsets.UTF_8)
         yaml.fromYaml[YamlTechnique] match {
           // in the case where the descriptor is invalid but we have an xml metadata file, things are strange.
           // We raise an error so that the technique is ignored. The user can delete the bad yaml file if he
@@ -985,7 +985,7 @@ class GitTechniqueReader(
    * Load a descriptor document.
    */
   private def loadDescriptorFile(
-      managedStream: ZIO[Any with Scope, RudderError, InputStream],
+      managedStream: ZIO[Any & Scope, RudderError, InputStream],
       filePath:      String
   ): IOResult[Elem] = {
     ZIO.scoped(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/PluginData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/PluginData.scala
@@ -266,7 +266,7 @@ object GlobalPluginsLicense {
     implicit val minZonedDateTime: Semigroup[ZonedDateTime] = Semigroup.instance((x, y) => if (x.isBefore(y)) x else y)
   }
 
-  def fromLicense[T: ToEndDate: Semigroup](info: PluginLicense): GlobalPluginsLicense[T] = {
+  def fromLicense[T: ToEndDate](info: PluginLicense): GlobalPluginsLicense[T] = {
     new GlobalPluginsLicense[T](
       Some(NonEmptyChunk(info.licensee.value)),
       Some(info.startDate),

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -669,7 +669,7 @@ object ZioJsonExtractor {
  * This last class provides utility methods to get JsonQuery objects from the request.
  * We want to get ride of RestExtractorService but for now, we keep it for the parameter parts.
  */
-class ZioJsonExtractor(queryParser: CmdbQueryParser with JsonQueryLexer) {
+class ZioJsonExtractor(queryParser: CmdbQueryParser & JsonQueryLexer) {
   import JsonQueryObjects.*
   import JsonResponseObjects.*
   import ZioJsonExtractor.parseJson

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -1019,7 +1019,7 @@ object JsonResponseObjects {
       }
     }
 
-    implicit val transformer: Transformer[RuleTarget, JRRuleTarget] = apply _
+    implicit val transformer: Transformer[RuleTarget, JRRuleTarget] = apply
   }
 
   final case class JRRuleTargetInfo(
@@ -1821,7 +1821,7 @@ object JsonResponseObjects {
         .withFieldConst(_.category, catId.value)
         .withFieldComputed(_.query, _.query.map(JRQuery.fromQuery(_)))
         .withFieldComputed(_.nodeIds, _.serverList.toList.map(_.value).sorted)
-        .withFieldComputed(_.groupClass, x => List(x.id.serialize, x.name).map(RuleTarget.toCFEngineClassName _).sorted)
+        .withFieldComputed(_.groupClass, x => List(x.id.serialize, x.name).map(RuleTarget.toCFEngineClassName).sorted)
         .withFieldComputed(_.properties, _.properties.filter(_.visibility == Displayed).map(JRProperty.fromGroupProp(_)))
         .withFieldComputed(_.target, x => GroupTarget(x.id).target)
         .withFieldComputed(_.system, _.isSystem)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportLogger.scala
@@ -115,7 +115,7 @@ class AutomaticReportLogger(
             logger.warn("Automatic report logger has never run, logging latest 100 non compliant reports")
             val isSuccess = (for {
               hundredReports <- reportsRepository.getLastHundredErrorReports(reportsKind).toIO
-              nodes          <- nodeFactRepository.getAll()(QueryContext.systemQC)
+              nodes          <- nodeFactRepository.getAll()(using QueryContext.systemQC)
               rules          <- ruleRepository.getAll(true)
               directives     <- directiveRepository.getFullDirectiveLibrary()
             } yield {
@@ -229,7 +229,7 @@ class AutomaticReportLogger(
       val startAt = lastProcessedId + 1
       logger.debug(s"Writing non-compliant-report logs between ids ${startAt} and ${maxId} (both included)")
       (for {
-        nodes      <- nodeFactRepository.getAll()(QueryContext.systemQC)
+        nodes      <- nodeFactRepository.getAll()(using QueryContext.systemQC)
         rules      <- ruleRepository.getAll(true)
         directives <- directiveRepository.getFullDirectiveLibrary()
       } yield {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportsCleaner.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportsCleaner.scala
@@ -53,7 +53,6 @@ import net.liftweb.actor.LAPinger
 import net.liftweb.actor.SpecializedLiftActor
 import net.liftweb.common.*
 import org.joda.time.*
-import scala.annotation.nowarn
 import zio.*
 import zio.syntax.*
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/UpdateDynamicGroups.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/UpdateDynamicGroups.scala
@@ -321,7 +321,7 @@ class UpdateDynamicGroups(
               initialTime                  <- currentTimeMillis
               results                      <- dynGroupIds.accumulateParN(maxParallelism) { dynGroupId =>
                                                 dynGroupUpdaterService
-                                                  .update(dynGroupId)(
+                                                  .update(dynGroupId)(using
                                                     ChangeContext(
                                                       modId,
                                                       RudderEventActor,
@@ -343,7 +343,7 @@ class UpdateDynamicGroups(
               preComputeDependantGroups    <- currentTimeMillis
               results2                     <- dynGroupsWithDependencyIds.accumulateParN(1) { dynGroupId =>
                                                 dynGroupUpdaterService
-                                                  .update(dynGroupId)(
+                                                  .update(dynGroupId)(using
                                                     ChangeContext(
                                                       modId,
                                                       RudderEventActor,
@@ -363,7 +363,7 @@ class UpdateDynamicGroups(
                 )
               // sync properties status
               _                            <- propertiesSyncService
-                                                .syncProperties()(QueryContext.systemQC)
+                                                .syncProperties()(using QueryContext.systemQC)
                                                 .chainError("Properties cannot be updated when computing new dynamic groups")
             } yield {
               results ++ results2

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/CampaignEventRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/CampaignEventRepository.scala
@@ -102,7 +102,6 @@ trait CampaignEventRepository {
 
 class CampaignEventRepositoryImpl(doobie: Doobie, campaignSerializer: CampaignSerializer) extends CampaignEventRepository {
 
-  import com.normation.rudder.campaigns.CampaignSerializer.*
   import com.normation.rudder.db.Doobie.DateTimeMeta
   import doobie.*
 
@@ -184,8 +183,6 @@ class CampaignEventRepositoryImpl(doobie: Doobie, campaignSerializer: CampaignSe
 
   private object CampaignEventInsert {
     implicit val transformCampaignEvent: Transformer[CampaignEvent, CampaignEventInsert] = {
-      import com.normation.rudder.campaigns.CampaignEventState.*
-
       Transformer
         .define[CampaignEvent, CampaignEventInsert]
         .withFieldComputed(_.state, _.state.value)
@@ -368,12 +365,12 @@ class CampaignEventRepositoryImpl(doobie: Doobie, campaignSerializer: CampaignSe
   }
 
   private def internalDelete(
-      id:           Option[CampaignEventId] = None,
-      states:       List[CampaignEventStateType] = Nil,
-      campaignType: Option[CampaignType] = None,
-      campaignId:   Option[CampaignId] = None,
-      afterDate:    Option[DateTime] = None,
-      beforeDate:   Option[DateTime] = None
+      id:           Option[CampaignEventId],
+      states:       List[CampaignEventStateType],
+      campaignType: Option[CampaignType],
+      campaignId:   Option[CampaignId],
+      afterDate:    Option[DateTime],
+      beforeDate:   Option[DateTime]
   ): ConnectionIO[RuntimeFlags] = {
 
     import _root_.cats.syntax.list.*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/CampaignRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/CampaignRepository.scala
@@ -69,7 +69,7 @@ object CampaignRepositoryImpl {
       }
     } *>
     // init archiver
-    campaignArchiver.init(ChangeContext.newForRudder()) *>
+    campaignArchiver.init(using ChangeContext.newForRudder()) *>
     // return campaign repo
     new CampaignRepositoryImpl(path, campaignArchiver, campaignSerializer, hooksRepository).succeed
   }
@@ -140,7 +140,7 @@ class CampaignRepositoryImpl(
                  }
       content <- campaignSerializer.serialize(c)
       _       <- IOResult.attempt(file.write(content))
-      _       <- campaignArchiver.saveCampaign(c.info.id)(ChangeContext.newForRudder())
+      _       <- campaignArchiver.saveCampaign(c.info.id)(using ChangeContext.newForRudder())
     } yield {
       c
     }
@@ -152,7 +152,7 @@ class CampaignRepositoryImpl(
                             val file = path / (s"${id.value}.json")
                             file.delete()
                           }
-      _                <- campaignArchiver.deleteCampaign(id)(ChangeContext.newForRudder())
+      _                <- campaignArchiver.deleteCampaign(id)(using ChangeContext.newForRudder())
     } yield ()
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
@@ -268,12 +268,10 @@ object Doobie {
    * It's Put/Get since it will be hold on a single column
    */
   implicit val jNodeStatusReportGet: Get[JNodeStatusReport] = {
-    import com.normation.rudder.domain.reports.JsonPostgresqlSerialization.*
     Get.Advanced.other[PGobject](NonEmptyList.of("json")).temap[JNodeStatusReport](o => o.getValue.fromJson[JNodeStatusReport])
   }
 
   implicit val jNodeStatusReportPut: Put[JNodeStatusReport] = {
-    import com.normation.rudder.domain.reports.JsonPostgresqlSerialization.*
     Put.Advanced.other[PGobject](NonEmptyList.of("json")).tcontramap[JNodeStatusReport] { j =>
       val o = new PGobject
       o.setType("json")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderLDAPConstants.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/RudderLDAPConstants.scala
@@ -292,7 +292,7 @@ object RudderLDAPConstants extends Loggable {
     }
 
     variables
-      .collect(toPartial(parsePolicyVariable _))
+      .collect(toPartial(parsePolicyVariable))
       .groupBy { case (x, i, y) => x }
       .map {
         case (k, seq) =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/RuleTarget.scala
@@ -199,7 +199,7 @@ final case class TargetExclusion(
    * Add a target to the included target
    */
   def updateInclude(target: RuleTarget): TargetExclusion = {
-    val newIncluded = includedTarget addTarget target
+    val newIncluded = includedTarget.addTarget(target)
     copy(newIncluded)
   }
 
@@ -207,7 +207,7 @@ final case class TargetExclusion(
    * Add a target to the excluded target
    */
   def updateExclude(target: RuleTarget): TargetExclusion = {
-    val newExcluded = excludedTarget addTarget target
+    val newExcluded = excludedTarget.addTarget(target)
     copy(includedTarget, newExcluded)
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -37,7 +37,6 @@
 
 package com.normation.rudder.domain.properties
 
-import cats.syntax.semigroup.*
 import com.normation.GitVersion
 import com.normation.GitVersion.Revision
 import com.normation.errors.*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/PropertyHierarchy.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/PropertyHierarchy.scala
@@ -13,7 +13,6 @@ import enumeratum.Enum
 import enumeratum.EnumEntry
 import org.apache.commons.text.StringEscapeUtils
 import zio.*
-import zio.json.*
 import zio.json.enumeratum.*
 
 /*
@@ -58,7 +57,8 @@ object ParentProperty {
     override def id:            String                        = nodeId.value
     override val resolvedValue: GenericProperty[NodeProperty] = parentProperty match {
       case None    => value
-      case Some(v) => NodeProperty(GenericProperty.mergeConfig(v.resolvedValue.config, value.config)(v.resolvedValue.inheritMode))
+      case Some(v) =>
+        NodeProperty(GenericProperty.mergeConfig(v.resolvedValue.config, value.config)(using v.resolvedValue.inheritMode))
     }
 
   }
@@ -79,7 +79,7 @@ object ParentProperty {
     override val resolvedValue: GenericProperty[GroupProperty] = parentProperty match {
       case None    => value
       case Some(v) =>
-        GroupProperty(GenericProperty.mergeConfig(v.resolvedValue.config, value.config)(v.resolvedValue.inheritMode))
+        GroupProperty(GenericProperty.mergeConfig(v.resolvedValue.config, value.config)(using v.resolvedValue.inheritMode))
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
@@ -409,7 +409,7 @@ final case class NodePropertyComparator(ldapAttr: String) extends NodeCriterionT
         new NodeInfoMatcher {
           val kv                   = NodePropertyMatcherUtils.splitInput(value, ":")
           val path                 = JsonSelect.compilePath(kv.value).toPureResult
-          val matcher              = NodePropertyMatcherUtils.matchJsonPath(kv.key, path) _
+          val matcher              = NodePropertyMatcherUtils.matchJsonPath(kv.key, path)
           override val debugString = s"Prop json select '${value}'"
           override def matches(node: NodeInfo): Boolean = node.properties.exists(matcher)
         }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/NodeQueryCriteriaData.scala
@@ -485,7 +485,7 @@ trait NodeCriterionOrderedValueMatcher[A] extends NodeCriterionMatcher {
   }
 
   def matches(n: CoreNodeFact, comparator: CriterionComparator, value: String): IOResult[Boolean] = {
-    implicit val ser = serialise _
+    implicit val ser = serialise(_)
 
     comparator match {
       case Equals    =>
@@ -596,7 +596,7 @@ case object MatchineTypeCriterionMatcherCaseIgnoreString extends NodeCriterionMa
           case _          => false
         }
       })
-    )(_.kind)
+    )(using _.kind)
   }
 
   override def matches(n: CoreNodeFact, comparator: CriterionComparator, value: String): IOResult[Boolean] = {
@@ -613,7 +613,7 @@ case object VmTypeCriterionMatcherCaseIgnoreString extends NodeCriterionMatcher 
       DebugInfo(Equals.id, Some(value)),
       Chunk(n.machine.machineType),
       _.exists(t => t.kind.equalsIgnoreCase(value))
-    )(_.kind)
+    )(using _.kind)
   }
 
   override def matches(n: CoreNodeFact, comparator: CriterionComparator, value: String): IOResult[Boolean] = {
@@ -735,7 +735,7 @@ trait NodeCriterionKeyValueMatcher[A] extends NodeCriterionMatcher {
   def order: Ordering[String] = Ordering.String
 
   def matches(n: CoreNodeFact, comparator: CriterionComparator, value: String): IOResult[Boolean] = {
-    implicit val ser = serialise _
+    implicit val ser = serialise(_)
 
     // for Key/Value comparator, we have an expected format for the value for some operator:
     // Equals and NotEquals: value is: ${key}=${value}, ie "=" is mandatory

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/workflows/ChangeRequest.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/workflows/ChangeRequest.scala
@@ -144,7 +144,7 @@ final case class ConfigurationChangeRequest(
       (directives.values ++ rules.values ++ nodeGroups.values ++ globalParams.values).toSeq
     val change:  Seq[Change[?, ?, ? <: ChangeItem[?]]]  = changes.map(_.changes)
     val firsts:  Seq[ChangeItem[?]]                     = change.map(_.firstChange)
-    firsts.sortWith((a, b) => a.creationDate isAfter b.creationDate).headOption.map(_.actor.name).getOrElse("No One")
+    firsts.sortWith((a, b) => a.creationDate.isAfter(b.creationDate)).headOption.map(_.actor.name).getOrElse("No One")
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
@@ -1385,7 +1385,7 @@ object SelectFacts {
   // given a core node fact, add attributes from an other fact based on what attrs says
   def mergeCore(cnf: CoreNodeFact, fact: NodeFact)(implicit attrs: SelectFacts): NodeFact = {
     // from a implementation point of view, it's the opposite of merge WRT SelectFacts
-    merge(NodeFact.fromMinimal(cnf), Some(fact))(attrs.invert)
+    merge(NodeFact.fromMinimal(cnf), Some(fact))(using attrs.invert)
   }
 
   // mask the given NodeFact to only expose attrs that are in "Retrieve"

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactChangeEventCallback.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactChangeEventCallback.scala
@@ -161,7 +161,7 @@ class ScoreUpdateOnNodeFactChange(scoreServiceManager: ScoreServiceManager, scor
         scoreServiceManager.handleEvent(SystemUpdateScoreEvent(node.id, node.softwareUpdate.toList))
       case NodeFactChangeEvent.Updated(_, newNode, _) =>
         scoreServiceManager.handleEvent(SystemUpdateScoreEvent(newNode.id, newNode.softwareUpdate.toList))
-      case NodeFactChangeEvent.Deleted(node, _)       => scoreService.deleteNodeScore(node.id)(change.cc.toQuery)
+      case NodeFactChangeEvent.Deleted(node, _)       => scoreService.deleteNodeScore(node.id)(using change.cc.toQuery)
       case _                                          => ZIO.unit
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunHooks.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/hooks/RunHooks.scala
@@ -477,7 +477,7 @@ object RunHooks {
     val filename = hook.getAbsolutePath
     val lines    = {
       try {
-        new String(better.files.File(filename).chars(StandardCharsets.UTF_8).take(1000).toArray).split("\n").toList
+        new String(better.files.File(filename).chars(using StandardCharsets.UTF_8).take(1000).toArray).split("\n").toList
       } catch {
         case NonFatal(ex) => Nil // ignore.
       }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryFileWatcher.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryFileWatcher.scala
@@ -207,8 +207,8 @@ final class Watchers(incoming: FileMonitor, updates: FileMonitor) {
   def start(): IOResult[Unit] = {
     IOResult.attempt {
       // Execution context is not used here - binding to scala default global to satisfy scalac
-      incoming.start()(scala.concurrent.ExecutionContext.global)
-      updates.start()(scala.concurrent.ExecutionContext.global)
+      incoming.start()(using scala.concurrent.ExecutionContext.global)
+      updates.start()(using scala.concurrent.ExecutionContext.global)
       Right(())
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
@@ -459,16 +459,16 @@ class InventoryMover(
         // move to received dir
         safeMove(
           signature,
-          signature.moveTo(received / InventoryMover.normalizeReceivedName(signature))(File.CopyOptions(overwrite = true))
+          signature.moveTo(received / InventoryMover.normalizeReceivedName(signature))(using File.CopyOptions(overwrite = true))
         ) *>
         safeMove(
           inventory,
-          inventory.moveTo(received / InventoryMover.normalizeReceivedName(inventory))(File.CopyOptions(overwrite = true))
+          inventory.moveTo(received / InventoryMover.normalizeReceivedName(inventory))(using File.CopyOptions(overwrite = true))
         )
       case _: InventoryProcessStatus.SignatureInvalid | _: InventoryProcessStatus.SaveError =>
         val failedName = failed / inventory.name
-        safeMove(signature, signature.moveTo(failed / signature.name)(File.CopyOptions(overwrite = true))) *>
-        safeMove(inventory, inventory.moveTo(failedName)(File.CopyOptions(overwrite = true))) *>
+        safeMove(signature, signature.moveTo(failed / signature.name)(using File.CopyOptions(overwrite = true))) *>
+        safeMove(inventory, inventory.moveTo(failedName)(using File.CopyOptions(overwrite = true))) *>
         writeErrorLogFile(failedName, result) *>
         failedHook.runHooks(failed / inventory.name)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/PostCommits.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/PostCommits.scala
@@ -133,7 +133,8 @@ class FactRepositoryPostCommit[A](
   override def apply(inventory: Inventory, records: A): IOResult[A] = {
     (for {
       optInfo <- if (inventory.node.main.status == RemovedInventory) None.succeed
-                 else nodeFactRepository.getCompat(inventory.node.main.id, inventory.node.main.status)(QueryContext.systemQC)
+                 else
+                   nodeFactRepository.getCompat(inventory.node.main.id, inventory.node.main.status)(using QueryContext.systemQC)
       _       <- optInfo match {
                    case None =>
                      InventoryProcessingLogger.info(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/DeleteEditorTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/DeleteEditorTechnique.scala
@@ -140,7 +140,7 @@ class DeleteEditorTechniqueImpl(
                                       .map(createCr(_, technique.rootSection))
                                       .reduceOption(mergeCrs)
                                       .notOptional(s"Could not create a change request to delete '${techniqueId.serialize}' directives")
-                              _  <- wf.startWorkflow(cr)(
+                              _  <- wf.startWorkflow(cr)(using
                                       ChangeContext(
                                         modId,
                                         committer.actor,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/ResourceFileService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/ResourceFileService.scala
@@ -117,7 +117,7 @@ class GitResourceFileService(gitReposProvider: GitRepositoryProvider) extends Re
                     }
     } yield {
 
-      val toResourceFixed = toResource(resourcesPath) _
+      val toResourceFixed = toResource(resourcesPath)
 
       // New files not added
       val added    = status.getUntracked.asScala.toList.flatMap(toResourceFixed(_, New))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueCompiler.scala
@@ -81,7 +81,7 @@ trait TechniqueCompiler {
     val yamlFile = techniqueBaseDirectory / TechniqueFiles.yaml
     for {
       yaml <- IOResult.attempt(s"Error when reading technique metadata '${yamlFile}'") {
-                yamlFile.contentAsString(StandardCharsets.UTF_8)
+                yamlFile.contentAsString(using StandardCharsets.UTF_8)
               }
       t    <- yaml.fromYaml[EditorTechnique].toIO
       _    <- EditorTechnique.checkTechniqueIdConsistency(techniqueBaseDirectory, t)
@@ -141,7 +141,7 @@ trait TechniqueCompiler {
     (for {
       f       <- IOResult.attempt(Option.when(file.exists)(file))
       content <-
-        ZIO.foreach(f)(c => IOResult.attempt(c.contentAsString(StandardCharsets.UTF_8)))
+        ZIO.foreach(f)(c => IOResult.attempt(c.contentAsString(using StandardCharsets.UTF_8)))
       out     <- ZIO.foreach(content)(_.fromYaml[TechniqueCompilationOutput].toIO)
     } yield {
       out
@@ -321,7 +321,7 @@ class RuddercServiceImpl(
                           } else {
                             ResourceFile(dest.name, ResourceFileState.New)
                           }
-                          f.moveTo(techniqueDir / f.name)(Seq[CopyOption](StandardCopyOption.REPLACE_EXISTING))
+                          f.moveTo(techniqueDir / f.name)(using Seq[CopyOption](StandardCopyOption.REPLACE_EXISTING))
                           s
                         }
                       } <*
@@ -460,7 +460,7 @@ class RuddercTechniqueCompiler(
       content <- IOResult.attempt(s"Error when writing compilation file for technique '${getTechniqueRelativePath(technique)}'") {
                    val config = getCompilationConfigFile(technique)
                    if (config.exists) { // this is optional
-                     val s = config.contentAsString(StandardCharsets.UTF_8)
+                     val s = config.contentAsString(using StandardCharsets.UTF_8)
                      if (s.strip().isEmpty) None else Some(s)
                    } else {
                      None

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/TechniqueSerializer.scala
@@ -104,7 +104,7 @@ class TechniqueSerializer(parameterTypeService: ParameterTypeService) {
       case None    => Nil
     }
 
-    editorTechnique.toJsonAST.map(_.merge(Json(("source", Json.Str("editor")) :: output: _*)))
+    editorTechnique.toJsonAST.map(_.merge(Json(("source", Json.Str("editor")) :: output*)))
   }
 
   def serializeMethodMetadata(method: GenericMethod): Json = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/migration/MigrateJsonTechniquesService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/migration/MigrateJsonTechniquesService.scala
@@ -207,7 +207,7 @@ object MigrateJsonTechniquesService {
       .whenZIO(IOResult.attempt(jsonFile.exists)) {
         for {
           json <- IOResult.attempt(s"Error when reading file '${jsonFile.pathAsString}'") {
-                    jsonFile.contentAsString(StandardCharsets.UTF_8)
+                    jsonFile.contentAsString(using StandardCharsets.UTF_8)
                   }
           yaml <- toYaml(json).toIO
           _    <- IOResult.attempt(yamlFile.write(yaml))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/MergeNodeProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/MergeNodeProperties.scala
@@ -39,7 +39,6 @@ package com.normation.rudder.properties
 
 import cats.data.Chain
 import cats.data.Ior
-import cats.syntax.functor.*
 import cats.syntax.list.*
 import cats.syntax.traverse.*
 import com.normation.errors.*
@@ -495,7 +494,7 @@ object MergeNodeProperties {
                      List.empty[List[GroupProp]]
                    }
       // add global values as the most default NodePropertyHierarchy
-      overridden = sorted.map(groups => overrideValues(groups.map(_.toNodePropHierarchy(globalParams))))
+      overridden = sorted.map(groups => overrideValues(groups.map(_.toNodePropHierarchy(using globalParams))))
       // now flatten properties from all groups so that we can check for duplicates
       flatten    = overridden.map(_.values).flatten
       merged    <- mergeAll(flatten)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/NodePropertiesService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/properties/NodePropertiesService.scala
@@ -71,7 +71,7 @@ class NodePropertiesServiceImpl(
     for {
       params      <- globalPropsRepo.getAllGlobalParameters().map(_.map(x => (x.name, x)).toMap)
       groups      <- roNodeGroupRepository.getFullGroupLibrary()
-      nodes       <- nodeFactRepository.getAll()(QueryContext.systemQC).map(_.values)
+      nodes       <- nodeFactRepository.getAll()(using QueryContext.systemQC).map(_.values)
       mergedGroups = {
         groups.allGroups.map {
           case (gid, group) =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/RudderDatasourceProvider.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/RudderDatasourceProvider.scala
@@ -75,7 +75,7 @@ class RudderDatasourceProvider(
   // since we use JDBC4 driver, we MUST NOT set `setConnectionTestQuery("SELECT 1")`
   // more over, it causes problems, see: https://issues.rudder.io/issues/14789
 
-  lazy val datasource: DataSource with Closeable = {
+  lazy val datasource: DataSource & Closeable = {
     try {
 
       val pool = new HikariDataSource(config)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/json/JsonExctractorUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/json/JsonExctractorUtils.scala
@@ -50,7 +50,7 @@ trait JsonExtractorUtils[A[_]] {
   def getOrElse[T](value: A[T], default: T): T
   def boxedIdentity[T]: T => Box[T] = Full(_)
   def emptyValue[T](id: String): Box[A[T]]
-  protected[this] def extractJson[T, U](
+  protected def extractJson[T, U](
       json:      JValue,
       key:       String,
       convertTo: U => Box[T],
@@ -63,7 +63,7 @@ trait JsonExtractorUtils[A[_]] {
       case invalidJson                           => Failure(s"Not a good value for parameter ${key}: ${compactRender(invalidJson)}")
     }
   }
-  protected[this] def extractJson[T, U](
+  protected def extractJson[T, U](
       json:      JValue,
       keys:      List[String],
       convertTo: U => Box[T],

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeGroupRepository.scala
@@ -1197,13 +1197,13 @@ class WoLDAPNodeGroupRepository(
                          case Some(diff) =>
                            actionlogEffect.saveModifyNodeGroup(modId, principal = actor, modifyDiff = diff, reason = message)
                        }
-      res           <- getNodeGroup(nodeGroupId)(cc.toQuery)
+      res           <- getNodeGroup(nodeGroupId)(using cc.toQuery)
       (nodeGroup, _) = res
       autoArchive   <-
         ZIO
           .when(autoExportOnModify && optDiff.isDefined && !nodeGroup.isSystem) { // only persists if that was a real move (not a move in the same category)
             for {
-              get      <- getNodeGroup(nodeGroupId)(cc.toQuery)
+              get      <- getNodeGroup(nodeGroupId)(using cc.toQuery)
               (ng, cId) = get
               parents  <- getParents_NodeGroupCategory(cId)
               commiter <- personIdentService.getPersonIdentOrDefault(actor.name)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
@@ -141,7 +141,7 @@ class WoLDAPNodeRepository(
                          }
         con           <- ldap
         existingEntry <- con
-                           .get(acceptedDit.NODES.NODE.dn(nodeId.value), A_KEY_STATUS :: A_AGENT_NAME :: Nil: _*)
+                           .get(acceptedDit.NODES.NODE.dn(nodeId.value), A_KEY_STATUS :: A_AGENT_NAME :: Nil*)
                            .notOptional(
                              s"Cannot update node with id ${nodeId.value}: there is no node with that id"
                            )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/RudderPrettyPrinter.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/RudderPrettyPrinter.scala
@@ -58,19 +58,16 @@ class RudderPrettyPrinter(width: Int, step: Int) {
     val tmp = width - cur
     if (s.length <= tmp)
       return List(Box(ind, s))
-    var i   = s indexOf ' '
+    var i   = s.indexOf(' ')
     if (i > tmp || i == -1) throw new BrokenException() // cannot break
 
-    var last: List[Int]  = Nil
+    var last: List[Int] = Nil
     while (i != -1 && i < tmp) {
       last = i :: last
       i = s.indexOf(' ', i + 1)
     }
-    var res:  List[Item] = Nil
     while (Nil != last) try {
-      val b = Box(ind, s.substring(0, last.head))
       cur = ind
-      res = b :: Break :: cut(s.substring(last.head, s.length), ind)
       // backtrack
       last = last.tail
     } catch {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/XmlArchiverUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/xml/XmlArchiverUtils.scala
@@ -83,7 +83,7 @@ trait XmlArchiverUtils {
       val file = fileName.toScala
       file.parent.createDirectoryIfNotExists(true).setPermissions(directoryPerms).setGroup(groupOwner)
       file
-        .writeText(xmlPrettyPrinter.format(elem))(Seq(WRITE, TRUNCATE_EXISTING, CREATE), Charset.forName(encoding))
+        .writeText(xmlPrettyPrinter.format(elem))(using Seq(WRITE, TRUNCATE_EXISTING, CREATE), Charset.forName(encoding))
         .setPermissions(filePerms)
         .setGroup(groupOwner)
       GitArchiveLogger.debug(logMessage)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/RuleCategory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/RuleCategory.scala
@@ -39,7 +39,6 @@ package com.normation.rudder.rule.category
 
 import com.normation.rudder.domain.policies.Rule
 import net.liftweb.common.*
-import scala.annotation.nowarn
 
 /**
  * The Id for the server group category
@@ -79,7 +78,8 @@ final case class RuleCategory(
     childPath(categoryId) match {
       // special case for long hierarchy
       case Right(list) if list.size > 2     =>
-        val parent :: category :: Nil = list.takeRight(2): @nowarn("msg=match may not be exhaustive") // because we checked size
+        val parent :: category :: Nil =
+          list.takeRight(2): @unchecked // because we checked size
         Full((category, parent.id))
       case Right(parent :: category :: Nil) => Full((category, parent.id))
       case Right(category :: Nil)           => Full((category, category.id))
@@ -162,6 +162,6 @@ final case class RuleCategory(
     val baseMap: ChildMap = Map((List.empty[RuleCategoryId]) -> (this :: Nil))
 
     // fold all maps together
-    augmentedChildMap.foldLeft(baseMap)(mergeChildMaps _)
+    augmentedChildMap.foldLeft(baseMap)(mergeChildMaps)
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/RuleCategoryService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/rule/category/RuleCategoryService.scala
@@ -75,7 +75,7 @@ class RuleCategoryService {
 
   // Get the short fqdn from the id of a Rule category
   def shortFqdn(rootCategory: RuleCategory, id: RuleCategoryId): Box[String] = {
-    rootCategory.childPath(id).map(toShortFqdn _) match {
+    rootCategory.childPath(id).map(toShortFqdn) match {
       case Left(value)  => Failure(value)
       case Right(value) => Full(value)
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/GlobalScoreRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/GlobalScoreRepository.scala
@@ -58,8 +58,8 @@ trait GlobalScoreRepository {
  * a repository that doesn't do anything, for tests
  */
 class InMemoryGlobalScoreRepository extends GlobalScoreRepository {
-  private[this] val cache: Ref[Map[NodeId, GlobalScore]]      = Ref.make(Map[NodeId, GlobalScore]()).runNow
-  override def getAll():   IOResult[Map[NodeId, GlobalScore]] = cache.get
+  private val cache:     Ref[Map[NodeId, GlobalScore]]      = Ref.make(Map[NodeId, GlobalScore]()).runNow
+  override def getAll(): IOResult[Map[NodeId, GlobalScore]] = cache.get
   override def get(id:    NodeId): IOResult[Option[GlobalScore]] = cache.get.map(_.get(id))
   override def delete(id: NodeId): IOResult[Unit]                = cache.update(_.removed(id))
   override def save(nodeId: NodeId, globalScore: GlobalScore): IOResult[(NodeId, GlobalScore)] =
@@ -68,8 +68,8 @@ class InMemoryGlobalScoreRepository extends GlobalScoreRepository {
 
 object GlobalScoreRepositoryImpl {
 
-  import ScoreSerializer.*
   import com.normation.rudder.db.json.implicits.*
+  import com.normation.rudder.score.ScoreSerializer.*
   import doobie.*
 
   implicit val scoreMeta: Meta[ScoreValue] = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/ScoreRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/ScoreRepository.scala
@@ -69,7 +69,7 @@ trait ScoreRepository {
  * A score repository that does nothing, for tests
  */
 class InMemoryScoreRepository extends ScoreRepository {
-  private[this] val cache:                                                Ref[Map[NodeId, List[Score]]]      = Ref.make(Map[NodeId, List[Score]]()).runNow
+  private val cache:                                                      Ref[Map[NodeId, List[Score]]]      = Ref.make(Map[NodeId, List[Score]]()).runNow
   override def getAll():                                                  IOResult[Map[NodeId, List[Score]]] = cache.get
   override def getAllOneScore(scoreId: String):                           IOResult[Map[NodeId, Score]]       = {
     for {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/SystemUpdateScore.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/SystemUpdateScore.scala
@@ -133,7 +133,7 @@ class SystemUpdateScoreHandler(nodeFactRepository: NodeFactRepository) extends S
 
   override def initEvents: UIO[Chunk[ScoreEvent]] = {
     nodeFactRepository
-      .slowGetAll()(
+      .slowGetAll()(using
         QueryContext.systemQC,
         SelectNodeStatus.Accepted,
         SelectFacts.none

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
@@ -917,7 +917,7 @@ class EventLogDetailsServiceImpl(
                                ((s \ "acl").toList.traverse { x =>
                                  for {
                                    path    <- AclPath.parse((x \ "@path").head.text)
-                                   actions <- (x \ "@actions").head.text.split(",").toList.traverse(HttpAction.parse _)
+                                   actions <- (x \ "@actions").head.text.split(",").toList.traverse(HttpAction.parse)
                                  } yield {
                                    ApiAclElement(path, actions.toSet)
                                  }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/healthcheck/HealthcheckService.scala
@@ -153,7 +153,7 @@ final class CheckFileDescriptorLimit(val nodeFactRepository: NodeFactRepository)
                       ).fail
                     }
       limit      <- IOResult.attempt(res.stdout.trim.toLong)
-      nodeCount  <- nodeFactRepository.getAll()(QueryContext.systemQC).map(_.size)
+      nodeCount  <- nodeFactRepository.getAll()(using QueryContext.systemQC).map(_.size)
     } yield {
       val reasonableMaxLimit   = 64_000
       val approximatedMinLimit = 100 * nodeCount

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/marshalling/XmlUnserialisationImpl.scala
@@ -493,7 +493,7 @@ class ChangeRequestChangesUnserialisationImpl(
     def unserialiseNodeGroupChange(changeRequest: XNode): PureResult[Map[NodeGroupId, NodeGroupChanges]] = {
 
       for {
-        groupsNode <- getChild(changeRequest, "groups")(changeRequestEntryType)
+        groupsNode <- getChild(changeRequest, "groups")(using changeRequestEntryType)
       } yield {
 
         implicit val entryType: XmlEntryType = XmlEntryType("changeRequest group changes")
@@ -548,7 +548,7 @@ class ChangeRequestChangesUnserialisationImpl(
     def unserialiseDirectiveChange(changeRequest: XNode): PureResult[Map[DirectiveId, DirectiveChanges]] = {
 
       for {
-        directivesNode <- getChild(changeRequest, "directives")(changeRequestEntryType)
+        directivesNode <- getChild(changeRequest, "directives")(using changeRequestEntryType)
       } yield {
 
         implicit val entryType: XmlEntryType = XmlEntryType("changeRequest directive changes")
@@ -624,7 +624,7 @@ class ChangeRequestChangesUnserialisationImpl(
     def unserialiseRuleChange(changeRequest: XNode): PureResult[Map[RuleId, RuleChanges]] = {
 
       for {
-        rulesNode <- getChild(changeRequest, "rules")(changeRequestEntryType)
+        rulesNode <- getChild(changeRequest, "rules")(using changeRequestEntryType)
       } yield {
 
         implicit val entryType: XmlEntryType = XmlEntryType("changeRequest rule changes")
@@ -680,7 +680,7 @@ class ChangeRequestChangesUnserialisationImpl(
     def unserialiseGlobalParameterChange(changeRequest: XNode): PureResult[Map[String, GlobalParameterChanges]] = {
 
       for {
-        paramsNode <- getChild(changeRequest, "globalParameters")(changeRequestEntryType)
+        paramsNode <- getChild(changeRequest, "globalParameters")(using changeRequestEntryType)
       } yield {
 
         implicit val entryType: XmlEntryType = XmlEntryType("globalParameters Global Parameter changes")
@@ -734,7 +734,7 @@ class ChangeRequestChangesUnserialisationImpl(
     }
 
     (for {
-      changeRequest <- checkEntry(xml)(changeRequestEntryType)
+      changeRequest <- checkEntry(xml)(using changeRequestEntryType)
       _             <- TestFileFormat.check(changeRequest)
       groups        <- unserialiseNodeGroupChange(changeRequest)
       directives    <- {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/modification/DiffService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/modification/DiffService.scala
@@ -86,7 +86,7 @@ class DiffServiceImpl extends DiffService {
   ): ModifyDirectiveDiff = {
     import com.normation.rudder.domain.policies.SectionVal.*
 
-    def toDirectiveDiff[T]: (Directive => T) => Option[SimpleDiff[T]] = toDiff[Directive, T](reference, newItem) _
+    def toDirectiveDiff[T]: (Directive => T) => Option[SimpleDiff[T]] = toDiff[Directive, T](reference, newItem)
     val refSectionVal        = refRootSection.map(directiveValToSectionVal(_, reference.parameters))
     val newSectionVal        = newRootSection.map(directiveValToSectionVal(_, newItem.parameters))
     val diffParameters       = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/modification/ModificationService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/modification/ModificationService.scala
@@ -81,7 +81,7 @@ class ModificationService(
                           target,
                           "after",
                           includeSystem = false
-                        )(
+                        )(using
                           ChangeContext(
                             ModificationId(uuidGen.newUuid),
                             eventLog.principal,
@@ -120,7 +120,7 @@ class ModificationService(
                           target,
                           "before",
                           includeSystem = false
-                        )(
+                        )(using
                           ChangeContext(
                             ModificationId(uuidGen.newUuid),
                             eventLog.principal,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/DeploymentService.scala
@@ -933,10 +933,10 @@ trait PromiseGeneration_performeIO extends PromiseGenerationService {
   def getGlobalPolicyMode:          () => Box[GlobalPolicyMode]
 
   override def findDependantRules(): Box[Seq[Rule]]                     = roRuleRepo.getAll(true).toBox
-  override def getNodeFacts():       Box[MapView[NodeId, CoreNodeFact]] = nodeFactRepository.getAll()(QueryContext.systemQC).toBox
+  override def getNodeFacts():       Box[MapView[NodeId, CoreNodeFact]] = nodeFactRepository.getAll()(using QueryContext.systemQC).toBox
 
   override def getNodeProperties: IOResult[Map[NodeId, ResolvedNodePropertyHierarchy]] = {
-    propertiesRepository.getAllNodeProps()(QueryContext.systemQC)
+    propertiesRepository.getAllNodeProps()(using QueryContext.systemQC)
   }
 
   override def getDirectiveLibrary(ids: Set[DirectiveId]): Box[FullActiveTechniqueCategory] = {
@@ -2115,7 +2115,7 @@ trait PromiseGeneration_Hooks extends PromiseGenerationService with PromiseGener
       _ <- IOResult.attempt(s"Can not move previous updated node IDs file to '${savedOld.pathAsString}'") {
              file.parent.createDirectoryIfNotExists(true)
              if (file.exists) {
-               file.moveTo(savedOld)(File.CopyOptions(overwrite = true))
+               file.moveTo(savedOld)(using File.CopyOptions(overwrite = true))
              }
            }
       _ <- IOResult.attempt(s"Can not write updated node IDs file '${file.pathAsString}'") {
@@ -2198,7 +2198,7 @@ trait PromiseGeneration_Hooks extends PromiseGenerationService with PromiseGener
       _ <- IOResult.attempt(s"Can not move previous updated node IDs file to '${savedOld.pathAsString}'") {
              file.parent.createDirectoryIfNotExists(true)
              if (file.exists) {
-               file.moveTo(savedOld)(File.CopyOptions(overwrite = true))
+               file.moveTo(savedOld)(using File.CopyOptions(overwrite = true))
              }
            }
       _ <- IOResult.attempt(s"Can not write error message file '${file.pathAsString}'") {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/InterpolatedValueCompiler.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/InterpolatedValueCompiler.scala
@@ -241,7 +241,7 @@ trait AnalyseInterpolation[T, I <: GenericInterpolationContext[T]] {
       }
     }
 
-    build _
+    build
   }
 
   /*
@@ -497,7 +497,7 @@ object PropertyParser {
   import fastparse.NoWhitespace.*
 
   def parse(value: String): PureResult[List[Token]] = {
-    (fastparse.parse(value, all(_)): @unchecked) match {
+    fastparse.parse(value, { case given P[?] => all }) match {
       case Parsed.Success(value, index)    => Right(value)
       case Parsed.Failure(label, i, extra) =>
         Left(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/JavascriptEngine.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/JavascriptEngine.scala
@@ -413,7 +413,7 @@ object JsEngine {
   }
 
   final case class GraalEngine(engine: Engine) {
-    def buildContext: ZIO[Any with Any with Scope, SystemError, Context] = ZIO.acquireRelease(
+    def buildContext: ZIO[Any & Any & Scope, SystemError, Context] = ZIO.acquireRelease(
       IOResult.attempt(
         Context
           .newBuilder("js")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/MergePolicyService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/MergePolicyService.scala
@@ -191,7 +191,7 @@ object MergePolicyService {
             // Be careful, there is TWO merge to consider:
             // 1. the order on which the vars are merged. It must follow existing semantic, i.e:
             //    first by priority, then by rule order, then by directive order.
-            sortedVars         = NonEmptyList(d, tail).sorted(priorityThenBundleOrder).map { d =>
+            sortedVars         = NonEmptyList(d, tail).sorted(using priorityThenBundleOrder).map { d =>
                                    PolicyVars(
                                      d.id,
                                      d.policyMode,
@@ -203,7 +203,7 @@ object MergePolicyService {
             // 2. what is the rule / directive (and corresponding bundle order) to use. Here,
             //    we need to keep the most prioritary based on BundleOrder to ensure that variables
             //    are correctly initialized before there use in the bundle sequence.
-            mainDraft         <- NonEmptyList(d, tail).sorted(onlyBundleOrder).head.toPolicy(agentType)
+            mainDraft         <- NonEmptyList(d, tail).sorted(using onlyBundleOrder).head.toPolicy(agentType)
           } yield {
             // and then we merge all draft values into main draft.
             mainDraft.copy(policyVars = sortedVars, policyMode = samePolicyMode)
@@ -372,7 +372,7 @@ object MergePolicyService {
     // (ie: some directive id => only keep the first by (rule name, directive name)
     val deduplicatedMultiDirective = groupedDrafts.multiDirectives.groupBy(_.id.directiveId).map {
       case (directiveId, set) =>
-        val sorted = set.toList.sorted(onlyBundleOrder.toOrdering)
+        val sorted = set.toList.sorted(using onlyBundleOrder.toOrdering)
         setOverrides(sorted.head, sorted.tail) // head can't be null because of groupBy
     }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/RuleValGeneratedHookService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/RuleValGeneratedHookService.scala
@@ -15,7 +15,7 @@ trait RuleValGeneratedHook {
 
 class RuleValGeneratedHookService {
 
-  private[this] val hooksRef: Ref[Chunk[RuleValGeneratedHook]] = Ref.make(Chunk.empty[RuleValGeneratedHook]).runNow
+  private val hooksRef: Ref[Chunk[RuleValGeneratedHook]] = Ref.make(Chunk.empty[RuleValGeneratedHook]).runNow
 
   def addHook(hook: RuleValGeneratedHook): UIO[Unit] = {
     hooksRef.update(_ :+ hook)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/WriteNodeCertificatesPem.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/WriteNodeCertificatesPem.scala
@@ -86,7 +86,7 @@ class WriteNodeCertificatesPemImpl(reloadScriptPath: Option[String]) extends Wri
       _    <- checkParentDirOK(file)
       certs = allNodeInfos.map { case (_, node) => node.rudderAgent.securityToken.key }
       _    <- writeCertificatesToNew(allCertsNew, certs)
-      _    <- IOResult.attempt(allCertsNew.moveTo(file)(File.CopyOptions(overwrite = true)))
+      _    <- IOResult.attempt(allCertsNew.moveTo(file)(using File.CopyOptions(overwrite = true)))
       _    <- execHook(reloadScriptPath)
     } yield ()
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepository.scala
@@ -483,7 +483,7 @@ class FileBasedNodeConfigurationHashRepository(path: String) extends NodeConfigu
   // read the file, of return the empty string if file does not exist
   def readHashesAsJsonString(): IOResult[String] = {
     IOResult.attempt(hashesFile.exists).flatMap {
-      case true  => IOResult.attempt(hashesFile.contentAsString(StandardCharsets.UTF_8))
+      case true  => IOResult.attempt(hashesFile.contentAsString(using StandardCharsets.UTF_8))
       case false => "".succeed
     }
   }
@@ -516,7 +516,10 @@ class FileBasedNodeConfigurationHashRepository(path: String) extends NodeConfigu
   private def nonAtomicWrite(hashes: NodeConfigurationHashes): IOResult[Unit] = {
     import java.nio.file.StandardOpenOption.*
     IOResult.attempt(
-      hashesFile.writeText(NodeConfigurationHashes.toJson(hashes))(Seq(WRITE, CREATE, TRUNCATE_EXISTING), StandardCharsets.UTF_8)
+      hashesFile.writeText(NodeConfigurationHashes.toJson(hashes))(using
+        Seq(WRITE, CREATE, TRUNCATE_EXISTING),
+        StandardCharsets.UTF_8
+      )
     )
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/BuildBundleSequence.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/BuildBundleSequence.scala
@@ -205,7 +205,7 @@ object BuildBundleSequence {
               ("", "component", None),
               ("", "value", None),
               (id.directiveId.serialize ++ id.ruleId.serialize, "report_id", None)
-            ).map((BundleParam.DoubleQuote.apply _).tupled)
+            ).map((BundleParam.DoubleQuote.apply).tupled)
           ) :: Nil
       }
       .flatten

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupService.scala
@@ -347,7 +347,7 @@ class CheckPendingNodeInDynGroups(
         case (h :: tail, b, res) => // standard step: takes the group and deals with it
           NodeLogger.PendingNode.Policies.trace("==> process " + h.id.serialize)
           (queryChecker
-            .check(h.query, Some(h.testNodes.toSeq))(QueryContext.systemQC) // dyn groups need access to all nodes
+            .check(h.query, Some(h.testNodes.toSeq))(using QueryContext.systemQC) // dyn groups need access to all nodes
             .flatMap { nIds =>
               // node matching that group - also include the one from "include" coming from "or" dep
               val setNodeIds                       = nIds.toSet ++ h.includeNodes

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/DynGroupUpdaterService.scala
@@ -124,7 +124,7 @@ class DynGroupUpdaterServiceImpl(
       dynGroups  = allGroups.filter(_.isDynamic)
       result    <- com.normation.utils.Control.traverse(dynGroups) { group =>
                      for {
-                       newGroup   <- computeDynGroup(group)(cc.toQuery)
+                       newGroup   <- computeDynGroup(group)(using cc.toQuery)
                        savedGroup <-
                          woNodeGroupRepository
                            .updateDynGroupNodes(newGroup, cc.modId, cc.actor, cc.message)
@@ -143,8 +143,8 @@ class DynGroupUpdaterServiceImpl(
   )(implicit cc: ChangeContext): Box[DynGroupDiff] = {
     val timePreUpdate = System.currentTimeMillis
     for {
-      (group, _)     <- roNodeGroupRepository.getNodeGroup(dynGroupId)(cc.toQuery).toBox
-      newGroup       <- computeDynGroup(group)(cc.toQuery)
+      (group, _)     <- roNodeGroupRepository.getNodeGroup(dynGroupId)(using cc.toQuery).toBox
+      newGroup       <- computeDynGroup(group)(using cc.toQuery)
       savedGroup     <- woNodeGroupRepository
                           .updateDynGroupNodes(newGroup, cc.modId, cc.actor, cc.message)
                           .toBox ?~! s"Error when saving update for dynamic group '${group.name}' (${group.id.serialize})"

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/NodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/NodeFactQueryProcessor.scala
@@ -238,7 +238,7 @@ class NodeFactQueryProcessor(
         t1  <- currentTimeMillis
         _   <- FactQueryProcessorLoggerPure.Metrics.debug(s"Analyse query in ${t1 - t0} ms")
         res <- nodeFactRepo
-                 .getAll()(qc, s)
+                 .getAll()(using qc, s)
                  .flatMap { all =>
                    ZIO
                      .filterPar(all.values)(node => FactQueryProcessorLoggerPure.debug(m.debugString) *> processOne(m, node))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchBackendImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchBackendImpl.scala
@@ -336,7 +336,7 @@ object QSTechniqueBackend extends Loggable {
     private def toMatch(tech: EditorTechnique): Option[Set[(String, String)]] = {
       def getParam(methods: MethodElem): List[(String, List[String])] = {
         methods match {
-          case b: MethodBlock => b.calls.flatten(getParam)
+          case b: MethodBlock => b.calls.flatten(using getParam)
           case c: MethodCall  => List((c.method.value, c.parameters.values.toList))
         }
       }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchQueryParser.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/quicksearch/QuickSearchQueryParser.scala
@@ -76,7 +76,7 @@ object QSRegexQueryParser {
     if (value.trim.isEmpty()) {
       Left(Unexpected("You can't search with an empty or whitespace only query"))
     } else {
-      (fastparse.parse(value, all(_)): @unchecked) match {
+      fastparse.parse(value, { case given P[?] => all }) match {
         case Parsed.Success(parsed, index)   => interprete(parsed)
         case Parsed.Failure(label, i, extra) =>
           Left(Unexpected(s"""Error when parsing query "${value}", error message is: ${label}"""))
@@ -98,8 +98,8 @@ object QSRegexQueryParser {
         val in = filters.collect { case FilterAttr(set) => set }.flatten
 
         (for {
-          o <- getObjects(is.toSet) chainError ("The 'is' filter(s) contain unknown value(s)")
-          a <- getAttributes(in.toSet) chainError ("The 'in' filter(s) contain unknown value(s)")
+          o <- getObjects(is.toSet).chainError("The 'is' filter(s) contain unknown value(s)")
+          a <- getAttributes(in.toSet).chainError("The 'in' filter(s) contain unknown value(s)")
         } yield {
           val (objs, oKeys)  = o
           val (attrs, aKeys) = a
@@ -227,7 +227,7 @@ object QSRegexQueryParser {
     if (keys == names) {
       Right((values, keys))
     } else {
-      Left(Unexpected(s"These filters are not known: [${(names -- keys).mkString("', '")}]")) chainError {
+      Left(Unexpected(s"These filters are not known: [${(names -- keys).mkString("', '")}]")).chainError {
         s"Please choose among: '${map.keys.mkString("', '")}'"
       }
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ComplianceExpirationService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ComplianceExpirationService.scala
@@ -86,7 +86,7 @@ class NodePropertyBasedComplianceExpirationService(
   override def getExpirationPolicy(nodeIds: Iterable[NodeId]): IOResult[Map[NodeId, NodeComplianceExpiration]] = {
     val ids = nodeIds.toSet
     for {
-      propMap <- propRepository.getNodesProp(ids, propertyKey)(QueryContext.systemQC)
+      propMap <- propRepository.getNodesProp(ids, propertyKey)(using QueryContext.systemQC)
       res      = nodeIds.map { id =>
                    (
                      id,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeChangesService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeChangesService.scala
@@ -418,7 +418,7 @@ class CachedNodeChangesServiceImpl(
       intervals <- IOResult.attempt(changeService.getCurrentValidIntervals(None))
       newChanges = changes.groupBy(_.ruleId).map {
                      case (id, ch) =>
-                       val c = intervals.map(interval => (interval, ch.filter(interval contains _.executionTimestamp).size))
+                       val c = intervals.map(interval => (interval, ch.filter(x => interval.contains(x.executionTimestamp)).size))
                        (id, c.toMap)
                    }
       time1     <- currentTimeMillis

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeConfigurationService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeConfigurationService.scala
@@ -156,7 +156,7 @@ class CachedNodeConfigurationService(
     for {
       _       <- logger.debug("Init cache in NodeConfigurationService")
       // first, get all nodes
-      nodeIds <- nodeFactRepository.getAll()(QueryContext.systemQC).map(_.keySet)
+      nodeIds <- nodeFactRepository.getAll()(using QueryContext.systemQC).map(_.keySet)
       // void the cache
       _       <- semaphore.withPermit(cache.set(nodeIds.map(_ -> None).toMap))
     } yield ()

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/CommitAndDeployChangeRequestService.scala
@@ -353,7 +353,7 @@ class CommitAndDeployChangeRequestServiceImpl(
                       Failure("You should not be able to create a group with a change request")
                     case ModifyToNodeGroupDiff(n) =>
                       // we first need to refresh the node list if it's a dynamic group
-                      val group = if (n.isDynamic) updateDynamicGroups.computeDynGroup(n)(qc) else Full(n)
+                      val group = if (n.isDynamic) updateDynamicGroups.computeDynGroup(n)(using qc) else Full(n)
 
                       // If we could get a nodeList, then we apply the change, else we bubble up the error
                       group.flatMap { resultingGroup =>
@@ -495,7 +495,7 @@ class CommitAndDeployChangeRequestServiceImpl(
     }
 
     val params     = bestEffort(sortedParam)(param => doParamChange(param))
-    val groups     = bestEffort(sortedGroups)(nodeGroupChange => doNodeGroupChange(nodeGroupChange)(cc.toQuery))
+    val groups     = bestEffort(sortedGroups)(nodeGroupChange => doNodeGroupChange(nodeGroupChange)(using cc.toQuery))
     val directives = bestEffort(sortedDirectives)(directiveChange => doDirectiveChange(directiveChange))
     val rules      = bestEffort(sortedRules)(rule => doRuleChange(rule))
     // TODO: we will want to keep tracks of all the modification done, and in

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/BoxSpecMatcher.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/BoxSpecMatcher.scala
@@ -47,6 +47,7 @@ import org.specs2.matcher.Matcher
 import org.specs2.matcher.MatchResult
 import org.specs2.matcher.NoShouldExpectations
 import org.specs2.mutable.Specification
+import scala.annotation.nowarn
 
 /**
  * Here we manage all the initialisation of services and database
@@ -84,11 +85,11 @@ trait BoxSpecMatcher extends Specification with Loggable with NoShouldExpectatio
       case Full(x) => f(x)
     }
 
-    def mustFullEq(res: T): MatchResult[Any] = matchRes((x: T) => x === res)
+    infix def mustFullEq(res: T): MatchResult[Any] = matchRes((x: T) => x === res)
 
-    def mustMatch(m: Matcher[T], name: String): MatchResult[Any] = matchRes((x: T) => (x aka name) must m)
+    infix def mustMatch(m: Matcher[T], name: String): MatchResult[Any] = matchRes((x: T) => (x aka name) must m)
 
-    def mustFull: MatchResult[Any] = matchRes((x: T) => ok(s"Got a ${x}"))
+    infix def mustFull: MatchResult[Any] = matchRes((x: T) => ok(s"Got a ${x}"))
 
   }
 
@@ -97,7 +98,8 @@ trait BoxSpecMatcher extends Specification with Loggable with NoShouldExpectatio
 import org.specs2.matcher.describe.Diffable
 
 trait BoxMatchers {
-  def beFull[T: Diffable]: BoxMatcher[T] = BoxMatcher()
+  @nowarn
+  infix def beFull[T: Diffable]: BoxMatcher[T] = BoxMatcher()
 }
 
 case class BoxMatcher[T]() extends Matcher[Box[T]] {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/JsonSpecMatcher.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/JsonSpecMatcher.scala
@@ -12,9 +12,9 @@ import org.specs2.matcher.MustMatchers
 import org.specs2.matcher.StandardMatchResults
 import org.specs2.mutable.Specification
 
-trait JsonSpecMatcher { self: MustMatchers with Specification =>
+trait JsonSpecMatcher { self: MustMatchers & Specification =>
 
-  import JsonSpecMatcher.*
+  import com.normation.JsonSpecMatcher.*
 
   /**
       * Tests for a non-strict equality of json, by comparing the string.

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/VariableTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/VariableTest.scala
@@ -277,8 +277,8 @@ class VariableTest extends Specification {
     saveHaveValue()
 
     val constrainedVariable = variables(itemName)
-    saveHaveValue()(constrainedVariable)
-    beASelect(constrainedVariable)
+    saveHaveValue()(using constrainedVariable)
+    beASelect(using constrainedVariable)
   }
 
   "Variable with default" should {
@@ -294,7 +294,7 @@ class VariableTest extends Specification {
     beAnInput
     haveType("datetime")
 
-    haveValue(ISODateTimeFormat.dateTime.withZoneUTC().print(ISODateTimeFormat.dateTimeParser.parseDateTime(dateValue)))(
+    haveValue(ISODateTimeFormat.dateTime.withZoneUTC().print(ISODateTimeFormat.dateTimeParser.parseDateTime(dateValue)))(using
       dateVariable.copyWithSavedValue(dateValue).orThrow
     )
   }
@@ -581,7 +581,7 @@ class VariableTest extends Specification {
   }
 
   private def saveHaveValue(value: String = refValue)(implicit variable: Variable) = {
-    haveValue(value)(variable.copyWithSavedValue(value).orThrow)
+    haveValue(value)(using variable.copyWithSavedValue(value).orThrow)
   }
 
   private def haveNbValues(nbValues: Int)(implicit variable: Variable) = {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitRepositoryTest.scala
@@ -133,7 +133,7 @@ class JGitRepositoryTest extends Specification with Loggable with AfterAll {
   // for test, we use as a group owner whatever git root directory has
   val currentUserName: String = repo.rootDirectory.groupName
 
-  val archive: GitConfigItemRepository with XmlArchiverUtils = new GitConfigItemRepository with XmlArchiverUtils {
+  val archive: GitConfigItemRepository & XmlArchiverUtils = new GitConfigItemRepository with XmlArchiverUtils {
     override val gitRepo:      GitRepositoryProvider = repo
     override def relativePath: String                = ""
     override def xmlPrettyPrinter = prettyPrinter

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/plugins/PluginErrorTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/plugins/PluginErrorTest.scala
@@ -112,7 +112,7 @@ class PluginErrorTest extends Specification {
           license = None
         )
 
-        val errors = PluginError.fromRudderPackagePlugin(plugin)(
+        val errors = PluginError.fromRudderPackagePlugin(plugin)(using
           rudderVersion,
           AbiVersion(ParseVersion.parse("9.9.9").getOrElse(throw new Exception("bad version in test")))
         )
@@ -130,7 +130,7 @@ class PluginErrorTest extends Specification {
         )
 
         val v      = s"${rudderVersion}-SNAPSHOT"
-        val errors = PluginError.fromRudderPackagePlugin(plugin)(
+        val errors = PluginError.fromRudderPackagePlugin(plugin)(using
           v,
           AbiVersion(ParseVersion.parse(v).getOrElse(throw new Exception("bad version in test")))
         )
@@ -157,7 +157,7 @@ class PluginErrorTest extends Specification {
           license = None
         )
 
-        val errors = PluginError.fromRudderPackagePlugin(plugin)(
+        val errors = PluginError.fromRudderPackagePlugin(plugin)(using
           rudderVersion,
           AbiVersion(ParseVersion.parse("9.9.9").getOrElse(throw new Exception("bad version in test")))
         )

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/plugins/settings/PluginSettingsServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/plugins/settings/PluginSettingsServiceTest.scala
@@ -46,6 +46,7 @@ import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import org.specs2.specification.core.AsExecution
+import scala.annotation.nowarn
 import zio.Ref
 import zio.syntax.*
 
@@ -102,6 +103,7 @@ class PluginSettingsServiceTest extends Specification {
     })
   }
 
+  @nowarn
   private def withPluginSettingsService[A: AsExecution](
       resourceName: String,
       read:         IOResult[Boolean],

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -1552,7 +1552,6 @@ class MockConfigRepo(
 }
 
 class MockGlobalParam() {
-  import com.normation.rudder.domain.properties.GenericProperty.*
 
   val mode: InheritMode = {
     import com.normation.rudder.domain.properties.InheritMode.*

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/api/TestApiData.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/api/TestApiData.scala
@@ -70,7 +70,7 @@ class TestApiData extends Specification {
         Nil
       }
 
-      apis.map(AclPath.parse(_).get).sorted(AclPath.orderingaAclPath) must beEqualTo(expected.map(AclPath.parse(_).get))
+      apis.map(AclPath.parse(_).get).sorted(using AclPath.orderingaAclPath) must beEqualTo(expected.map(AclPath.parse(_).get))
     }
     "correctly sort path of same size" in {
 
@@ -90,7 +90,7 @@ class TestApiData extends Specification {
         Nil
       }
 
-      apis.map(AclPath.parse(_).get).sorted(AclPath.orderingaAclPath) must beEqualTo(expected.map(AclPath.parse(_).get))
+      apis.map(AclPath.parse(_).get).sorted(using AclPath.orderingaAclPath) must beEqualTo(expected.map(AclPath.parse(_).get))
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/DBCommon.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/DBCommon.scala
@@ -149,7 +149,7 @@ trait DBCommon extends Specification with Loggable with BeforeAfterAll {
   }
 
   // init DB and repositories
-  lazy val dataSource: DataSource with Closeable = {
+  lazy val dataSource: DataSource & Closeable = {
     val config = new RudderDatasourceProvider(
       properties.getProperty("jdbc.driverClassName"),
       properties.getProperty("jdbc.url"),

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/ExpectedReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/ExpectedReportTest.scala
@@ -71,7 +71,7 @@ class ExpectedReportTest extends Specification {
   implicit private def r2n(s: String): RuleId      = RuleId(RuleUid(s))
   implicit private def d2n(s: String): DirectiveId = DirectiveId(DirectiveUid(s), GitVersion.DEFAULT_REV)
 
-  val parse: String => Box[JsonNodeExpectedReports] = ExpectedReportsSerialisation.parseJsonNodeExpectedReports _
+  val parse: String => Box[JsonNodeExpectedReports] = ExpectedReportsSerialisation.parseJsonNodeExpectedReports
   def serialize(e: ExpectedReportsSerialisation.JsonNodeExpectedReports) = {
     e.toJson
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSaveInventory.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSaveInventory.scala
@@ -176,7 +176,7 @@ class TestSaveInventoryLdap extends TestSaveInventory {
                      exist
                    )
                  )
-        inv <- factRepo.get(linuxCert)(QueryContext.testQC)
+        inv <- factRepo.get(linuxCert)(using QueryContext.testQC)
       } yield (res, inv)
     ).runNow
 
@@ -201,7 +201,7 @@ class TestSaveInventoryLdap extends TestSaveInventory {
                      exist
                    )
                  )
-        inv <- factRepo.get(linuxCert)(QueryContext.testQC)
+        inv <- factRepo.get(linuxCert)(using QueryContext.testQC)
       } yield (res, inv)
     ).runNow
 
@@ -216,7 +216,7 @@ class TestSaveInventoryLdap extends TestSaveInventory {
   "hostname does not matter and can change with fallback logic" in {
     val (start, res, inv) = (
       for {
-        start <- factRepo.get(linuxCert)(QueryContext.testQC)
+        start <- factRepo.get(linuxCert)(using QueryContext.testQC)
 
         res <- inventoryProcessorInternal
                  .saveInventoryInternal(
@@ -227,7 +227,7 @@ class TestSaveInventoryLdap extends TestSaveInventory {
                      exist
                    )
                  )
-        inv <- factRepo.get(linuxCert)(QueryContext.testQC)
+        inv <- factRepo.get(linuxCert)(using QueryContext.testQC)
       } yield (start, res, inv)
     ).runNow
 
@@ -242,7 +242,7 @@ class TestSaveInventoryLdap extends TestSaveInventory {
   "hostname does not matter and can change with override logic" in {
     val (start, res, inv) = (
       for {
-        start <- factRepo.get(linuxCert)(QueryContext.testQC)
+        start <- factRepo.get(linuxCert)(using QueryContext.testQC)
 
         res <- inventoryProcessorInternal
                  .saveInventoryInternal(
@@ -253,7 +253,7 @@ class TestSaveInventoryLdap extends TestSaveInventory {
                      exist
                    )
                  )
-        inv <- factRepo.get(linuxCert)(QueryContext.testQC)
+        inv <- factRepo.get(linuxCert)(using QueryContext.testQC)
       } yield (start, res, inv)
     ).runNow
 
@@ -277,7 +277,7 @@ class TestSaveInventoryLdap extends TestSaveInventory {
                      exist
                    )
                  )
-        inv <- factRepo.get(linuxCert)(QueryContext.testQC)
+        inv <- factRepo.get(linuxCert)(using QueryContext.testQC)
       } yield (res, inv)
     ).runNow
 
@@ -299,7 +299,7 @@ class TestSaveInventoryLdap extends TestSaveInventory {
                      exist
                    )
                  )
-        inv <- factRepo.get(windows)(QueryContext.testQC)
+        inv <- factRepo.get(windows)(using QueryContext.testQC)
       } yield (res, inv)
     ).runNow
 
@@ -313,7 +313,7 @@ class TestSaveInventoryLdap extends TestSaveInventory {
   "when a node is in repository with a registered key, it is ok to add it again with a signature" in {
     val (start, res, inv) = (
       for {
-        start <- factRepo.get(windows)(QueryContext.testQC)
+        start <- factRepo.get(windows)(using QueryContext.testQC)
 
         res <- inventoryProcessorInternal
                  .saveInventoryInternal(
@@ -324,7 +324,7 @@ class TestSaveInventoryLdap extends TestSaveInventory {
                      exist
                    )
                  )
-        inv <- factRepo.get(windows)(QueryContext.testQC)
+        inv <- factRepo.get(windows)(using QueryContext.testQC)
       } yield (start, res, inv)
     ).runNow
 
@@ -340,7 +340,7 @@ class TestSaveInventoryLdap extends TestSaveInventory {
   "when a node is in repository with a registered key; signature must match existing certificate, not the one in inventory" in {
     val (start, res, inv) = (
       for {
-        start <- factRepo.get(windows)(QueryContext.testQC)
+        start <- factRepo.get(windows)(using QueryContext.testQC)
 
         res <- inventoryProcessorInternal
                  .saveInventoryInternal(
@@ -351,7 +351,7 @@ class TestSaveInventoryLdap extends TestSaveInventory {
                      exist
                    )
                  )
-        inv <- factRepo.get(windows)(QueryContext.testQC)
+        inv <- factRepo.get(windows)(using QueryContext.testQC)
       } yield (start, res, inv)
     ).runNow
 
@@ -536,7 +536,7 @@ trait TestSaveInventory extends Specification with BeforeAfterAll {
       4,
       new InventoryDigestServiceV1(id => {
         // this is always Rudder system that is doing these queries, even in tests
-        factRepo.get(id)(QueryContext.systemQC)
+        factRepo.get(id)(using QueryContext.systemQC)
       }),
       () => ZIO.unit
     )

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSelectFacts.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSelectFacts.scala
@@ -76,7 +76,7 @@ class TestSelectFacts extends Specification {
   val nodeFact1: NodeFact = NodeFact.fromCompat(node1, Right(FullInventory(nodeInventory1, Some(machine1))), softwares, None)
 
   "masking 1" >> {
-    (SelectFacts.mask(nodeFact1)(SelectFacts.all) === nodeFact1) and
+    (SelectFacts.mask(nodeFact1)(using SelectFacts.all) === nodeFact1) and
     (nodeFact1.software must not(beEmpty)) and
     (nodeFact1.environmentVariables must not(beEmpty)) and
     (nodeFact1.bios must not(beEmpty)) and
@@ -84,11 +84,11 @@ class TestSelectFacts extends Specification {
   }
 
   "masking 2" >> {
-    SelectFacts.mask(nodeFact1)(SelectFacts.noSoftware) === nodeFact1.modify(_.software).setTo(Chunk())
+    SelectFacts.mask(nodeFact1)(using SelectFacts.noSoftware) === nodeFact1.modify(_.software).setTo(Chunk())
   }
 
   "masking 3" >> {
-    SelectFacts.mask(nodeFact1)(SelectFacts.none) === nodeFact1
+    SelectFacts.mask(nodeFact1)(using SelectFacts.none) === nodeFact1
       .modify(_.swap)
       .setTo(None)
       .modify(_.accounts)
@@ -136,7 +136,7 @@ class TestSelectFacts extends Specification {
   }
 
   "masking 4" >> {
-    SelectFacts.mask(nodeFact1)(
+    SelectFacts.mask(nodeFact1)(using
       SelectFacts.none
         .modify(_.bios.mode)
         .setTo(SelectMode.Retrieve)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/metrics/NodeCountHistorizationTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/metrics/NodeCountHistorizationTest.scala
@@ -114,7 +114,7 @@ class NodeCountHistorizationTest extends Specification with BeforeAfter {
       }
     }
     ZioRuntime.unsafeRun(prog.provideLayer(Scope.default >>> testEnvironment))
-    val lines = File(rootDir, "nodes-2020-03").lines(StandardCharsets.UTF_8).toVector
+    val lines = File(rootDir, "nodes-2020-03").lines(using StandardCharsets.UTF_8).toVector
 
     lines.size must beEqualTo(3)
     lines(1) must beEqualTo(""""2020-03-20T03:49:36Z";"1";"2";"3";"4";"5";"6"""")

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsTest.scala
@@ -172,7 +172,7 @@ class ReportsTest extends DBCommon {
       val runs = Set(("n0", run1), ("n1", run1), ("n2", run1))
       val result: Map[NodeId, Seq[Reports]] = repostsRepo.getExecutionReports(runs).open
       val actual: Seq[Reports]              = result.values.toSeq.flatten
-      actual must contain(exactly(reports("n0") ++ reports("n1").reverse.tail ++ reports("n2"): _*))
+      actual must contain(exactly(reports("n0") ++ reports("n1").reverse.tail ++ reports("n2")*))
     }
 
     "not find report for none existing agent run id" in {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LoadDemoDataTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LoadDemoDataTest.scala
@@ -67,7 +67,7 @@ class LoadDemoDataTest extends Specification {
       i + x
   }
 
-  val ldap: InMemoryDsConnectionProvider[RwLDAPConnection with RoLDAPConnection] =
+  val ldap: InMemoryDsConnectionProvider[RwLDAPConnection & RoLDAPConnection] =
     InitTestLDAPServer.newLdapConnectionProvider(InitTestLDAPServer.schemaLDIFs, bootstrapLDIFs)
 
   "The in memory LDAP directory" should {
@@ -98,8 +98,8 @@ object InitTestLDAPServer {
   def newLdapConnectionProvider(
       schema:        List[String],
       fullLdifPaths: List[String]
-  ): InMemoryDsConnectionProvider[RwLDAPConnection with RoLDAPConnection] = {
-    InMemoryDsConnectionProvider[RwLDAPConnection with RoLDAPConnection](
+  ): InMemoryDsConnectionProvider[RwLDAPConnection & RoLDAPConnection] = {
+    InMemoryDsConnectionProvider[RwLDAPConnection & RoLDAPConnection](
       baseDNs = baseDN :: Nil,
       schemaLDIFPaths = schema,
       bootstrapLDIFPaths = fullLdifPaths,

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/xml/TestGitFindUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/xml/TestGitFindUtils.scala
@@ -156,7 +156,7 @@ class TestGitFindUtils extends Specification with Loggable with AfterAll with Co
     }
 
     "return both files under 'a' and 'b'" in {
-      list(List("a", "b"), Nil) must contain(exactly(allDirA ++ allDirB: _*))
+      list(List("a", "b"), Nil) must contain(exactly(allDirA ++ allDirB*))
     }
 
     "return all .txt" in {
@@ -164,7 +164,7 @@ class TestGitFindUtils extends Specification with Loggable with AfterAll with Co
     }
 
     "return all .txt and .pdf" in {
-      list(Nil, List(".txt", "pdf")) must contain(exactly(allTxt ++ allPdf: _*))
+      list(Nil, List(".txt", "pdf")) must contain(exactly(allTxt ++ allPdf*))
     }
 
     "return x/f.txt/f.txt" in {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/score/ScoreServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/score/ScoreServiceTest.scala
@@ -53,12 +53,12 @@ class ScoreServiceTest extends Specification {
   "Score service" should {
 
     "Should contain score for initialised nodes" in {
-      val scores = scoreService.getAll()(QueryContext.testQC).runNow
+      val scores = scoreService.getAll()(using QueryContext.testQC).runNow
       scores.map(c => (c._1, c._2.value)) must havePairs(rootId -> A, id2 -> D)
     }
     "Should not contain score of non existing nodes (maybe pending nodes ?)" in {
       scoreManager.handleEvent(TestScoreEvent(NodeId("non-existing-node"))).runNow
-      val scores = scoreService.getAll()(QueryContext.testQC).runNow
+      val scores = scoreService.getAll()(using QueryContext.testQC).runNow
       scores.map(c => (c._1, c._2.value)) must havePairs(rootId -> A, id2 -> D)
     }
     "Should not contain score of non existing nodes (maybe pending nodes ?)" in {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestWriteNodeCertificatesPem.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/TestWriteNodeCertificatesPem.scala
@@ -145,7 +145,7 @@ class TestWriteNodeCertificatesPem extends Specification {
       val res    = ZioRuntime.runNow(writer.writeCertificates(dest, nodes).either)
 
       (res must beRight) and
-      (dest.contentAsString(StandardCharsets.UTF_8) must beEqualTo(expectedFileContent))
+      (dest.contentAsString(using StandardCharsets.UTF_8) must beEqualTo(expectedFileContent))
     }
   }
 
@@ -189,6 +189,6 @@ class TestWriteNodeCertificatesPem extends Specification {
       """(?s).*Unexpected: Error when executing reload command.*code: -2147483648.*""".r
     )
       .eventually(10, 100.millis.asScala)) and
-    (dest.contentAsString(StandardCharsets.UTF_8) must beEqualTo(expectedFileContent).eventually(10, 100.millis.asScala))
+    (dest.contentAsString(using StandardCharsets.UTF_8) must beEqualTo(expectedFileContent).eventually(10, 100.millis.asScala))
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
@@ -250,7 +250,7 @@ trait TechniquesTest extends Specification with Loggable with BoxSpecMatcher wit
    * put regex for line you don't want to be compared for difference
    */
   def ignoreSomeLinesMatcher(regex: List[String]): LinesPairComparisonMatcher[File, File] = {
-    LinesPairComparisonMatcher[File, File]()(RegexFileContent(regex), RegexFileContent(regex))
+    LinesPairComparisonMatcher[File, File]()(using RegexFileContent(regex), RegexFileContent(regex))
   }
 
   //////////// set-up auto test cleaning ////////////
@@ -280,7 +280,7 @@ trait TechniquesTest extends Specification with Loggable with BoxSpecMatcher wit
      * of the (temp) directory where we wrote them
      */
     path must haveSameFilesAs(EXPECTED_SHARE / expectedPath)
-      .withFilter(filterGeneratedFile _)
+      .withFilter(filterGeneratedFile)
       .withMatcher(
         ignoreSomeLinesMatcher(
           """.*rudder_node_config_id" string => .*"""
@@ -707,7 +707,7 @@ class WriteSystemTechniqueWithRevisionTest extends TechniquesTest {
     def updateTemplate(rootPath: File): Unit = {
       val clockTemplate =
         new File(rootPath, "configuration-repository/techniques/systemSettings/misc/clockConfiguration/3.0/clockConfiguration.st")
-      better.files.File(clockTemplate.getAbsolutePath).append(APPENED_TEXT)(StandardCharsets.UTF_8)
+      better.files.File(clockTemplate.getAbsolutePath).append(APPENED_TEXT)(using StandardCharsets.UTF_8)
       // commit
       repo.git.commit().setAll(true).setMessage("Update template file").call()
     }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
@@ -106,7 +106,7 @@ class TestNodeFactQueryProcessor {
 //  val nodes = File(Resource.getUrl("node-facts").getPath).children.toList.flatMap { f =>
 //    if (f.extension != Some(".json")) None
 //    else {
-//      f.contentAsString(StandardCharsets.UTF_8).fromJson[NodeFact] match {
+//      f.contentAsString(using StandardCharsets.UTF_8).fromJson[NodeFact] match {
 //        case Left(err) => throw new IllegalArgumentException(s"Unable to read node from file '${f.pathAsString}': ${err}")
 //        case Right(n)  => Some(n)
 //      }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ComplianceExpirationServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ComplianceExpirationServiceTest.scala
@@ -181,9 +181,9 @@ class ComplianceExpirationServiceTest extends Specification {
 
     val nodeId1: NodeId = NodeId("node1")
     val res = (for {
-      n1 <- mockNodes.nodeFactRepo.get(nodeId1)(QueryContext.testQC)
+      n1 <- mockNodes.nodeFactRepo.get(nodeId1)(using QueryContext.testQC)
       up  = n1.force.modify(_.properties).using(ps => ps.appended(expirationPolicyProp))
-      _  <- mockNodes.nodeFactRepo.save(up)(ChangeContext.newForRudder())
+      _  <- mockNodes.nodeFactRepo.save(up)(using ChangeContext.newForRudder())
       _  <- mockGroup.propService.updateAll()
       v  <- expirationService.getExpirationPolicy(List(nodeId1))
     } yield v).runNow

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -228,7 +228,7 @@ class ExecutionBatchTest extends Specification {
   }
 
   val getNodeStatusByRule: ((Map[NodeId, NodeExpectedReports], Seq[Reports])) => Map[NodeId, NodeStatusReport] =
-    (getNodeStatusReportsByRule _).tupled
+    (getNodeStatusReportsByRule).tupled
   val one:                 NodeId                                                                              = NodeId("one")
 
   sequential
@@ -3628,7 +3628,7 @@ class ExecutionBatchTest extends Specification {
       )
     )
 
-    val nodeStatus = (getNodeStatusReportsByRule _).tupled(param)
+    val nodeStatus = (getNodeStatusReportsByRule).tupled(param)
 
     "have one detailed reports when we create it with one report" in {
       nodeStatus(one).reports.size === 1
@@ -4460,19 +4460,19 @@ class ExecutionBatchTest extends Specification {
     val runData = nodeList.map(buildDataForMergeCompareByRule(_, 15, 12, 5))
 
     "init correctly" in {
-      val result = (ExecutionBatch.mergeCompareByRule _).tupled(initData)
+      val result = (ExecutionBatch.mergeCompareByRule).tupled(initData)
       result.size === nbRuleInit and
       result.toSeq.map(x => x.compliance).map(x => x.success).sum === 576
     }
 
     "run fast enough" in {
-      runData.map(x => (ExecutionBatch.mergeCompareByRule _).tupled(x))
+      runData.map(x => (ExecutionBatch.mergeCompareByRule).tupled(x))
 
       val t0 = System.currentTimeMillis
 
       for (i <- 1 to 10) {
         val t0_0 = System.currentTimeMillis
-        runData.map(x => (ExecutionBatch.mergeCompareByRule _).tupled(x))
+        runData.map(x => (ExecutionBatch.mergeCompareByRule).tupled(x))
         val t1_1 = System.currentTimeMillis
         logger.trace(s"${i}th call to mergeCompareByRule for ${nodeList.size} nodes took ${t1_1 - t0_0}ms")
       }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/Authorizations.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/Authorizations.scala
@@ -463,7 +463,7 @@ object RudderRoles {
   // our database of roles. Everything is case insensitive, so role name are mapped "to lower string"
 
   // role names are case insensitive
-  implicit val roleOrdering: Ordering[String] = Ordering.comparatorToOrdering(String.CASE_INSENSITIVE_ORDER)
+  implicit val roleOrdering: Ordering[String] = Ordering.comparatorToOrdering(using String.CASE_INSENSITIVE_ORDER)
 
   private val logger = ApplicationLoggerPure.Auth
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonResponse.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonResponse.scala
@@ -178,7 +178,7 @@ object RudderJsonResponse {
       prettify: Boolean,
       encoder:  JsonEncoder[A]
   ): LiftJsonResponse[
-    ? <: JsonRudderApiResponse[? <: immutable.Iterable[Any] with PartialFunction[Int with String, Any] with Equals]
+    ? <: JsonRudderApiResponse[? <: immutable.Iterable[Any] & PartialFunction[Int & String, Any] & Equals]
   ] = {
     schema.dataContainer match {
       case None      =>
@@ -359,12 +359,12 @@ object RudderJsonResponse {
       def toLiftResponseOneEither[B: JsonEncoder](params: DefaultParams, schema: EndpointSchema, id: Option[String])(implicit
           ev: A <:< Either[ResponseError, B]
       ): LiftResponse = {
-        toLiftResponseOneEither(params, ResponseSchema.fromSchema(schema), ConstIdTrace(id))(JsonEncoder[B], ev)
+        toLiftResponseOneEither(params, ResponseSchema.fromSchema(schema), ConstIdTrace(id))(using JsonEncoder[B], ev)
       }
       def toLiftResponseOneEither[B: JsonEncoder](params: DefaultParams, schema: EndpointSchema, id: A => Option[String])(implicit
           ev: A <:< Either[ResponseError, B]
       ): LiftResponse = {
-        toLiftResponseOneEither(params, ResponseSchema.fromSchema(schema), SuccessIdTrace(id))(JsonEncoder[B], ev)
+        toLiftResponseOneEither(params, ResponseSchema.fromSchema(schema), SuccessIdTrace(id))(using JsonEncoder[B], ev)
       }
 
       def toLiftResponseZeroEither(
@@ -391,12 +391,12 @@ object RudderJsonResponse {
       def toLiftResponseZeroEither(params: DefaultParams, schema: EndpointSchema, id: Option[String])(implicit
           ev: A <:< Either[ResponseError, Any]
       ): LiftResponse = {
-        toLiftResponseZeroEither(params, ResponseSchema.fromSchema(schema), ConstIdTrace(id))(ev)
+        toLiftResponseZeroEither(params, ResponseSchema.fromSchema(schema), ConstIdTrace(id))(using ev)
       }
       def toLiftResponseZeroEither(params: DefaultParams, schema: EndpointSchema, id: A => Option[String])(implicit
           ev: A <:< Either[ResponseError, Any]
       ): LiftResponse = {
-        toLiftResponseZeroEither(params, ResponseSchema.fromSchema(schema), SuccessIdTrace(id))(ev)
+        toLiftResponseZeroEither(params, ResponseSchema.fromSchema(schema), SuccessIdTrace(id))(using ev)
       }
 
     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/ApiAccount.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/ApiAccount.scala
@@ -229,7 +229,7 @@ object ApiAccountDetails extends ApiAccountCodecs {
     case _                                                          => ApiAccountExpirationPolicy.Never
   }
 
-  implicit val transformApiAclElement: Transformer[List[ApiAclElement], JsonApiAcl] = JsonApiAcl.from _
+  implicit val transformApiAclElement: Transformer[List[ApiAclElement], JsonApiAcl] = JsonApiAcl.from
 
   // authorization name is only defined for public API
   implicit val transformApiAccountKindAuthz: Transformer[ApiAccountKind, Option[ApiAuthorizationKind]] = {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
@@ -184,7 +184,7 @@ final case class ByRuleBlockCompliance(
     reportingLogic: ReportingLogic,
     subComponents:  Seq[ByRuleComponentCompliance]
 ) extends ByRuleComponentCompliance with BlockComplianceByNode[ByRuleComponentCompliance] {
-  override def subs: List[ByRuleComponentCompliance with ComponentCompliance] = subComponents.toList
+  override def subs: List[ByRuleComponentCompliance & ComponentCompliance] = subComponents.toList
 
   override def componentName: String = name
 }
@@ -246,7 +246,7 @@ final case class ByRuleByNodeByDirectiveByBlockCompliance(
     reportingLogic: ReportingLogic,
     subComponents:  Seq[ByRuleByNodeByDirectiveByComponentCompliance]
 ) extends ByRuleByNodeByDirectiveByComponentCompliance with BlockCompliance[ByRuleByNodeByDirectiveByComponentCompliance] {
-  override def subs: List[ByRuleByNodeByDirectiveByComponentCompliance with ComponentCompliance] = subComponents.toList
+  override def subs: List[ByRuleByNodeByDirectiveByComponentCompliance & ComponentCompliance] = subComponents.toList
 
   override def componentName: String = name
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestCompletion.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RestCompletion.scala
@@ -109,10 +109,10 @@ class RestCompletion(
       fetchTags match {
         case eb: EmptyBox =>
           val e = eb ?~! s"Error when looking for object containing ${token}"
-          toJsonError(None, e.messageChain)("quicksearch", prettify = false)
+          toJsonError(None, e.messageChain)(using "quicksearch", prettify = false)
 
         case Full(results) =>
-          toJsonResponse(None, results.map(("value", _)))("completeTags", prettify = false)
+          toJsonResponse(None, results.map(("value", _)))(using "completeTags", prettify = false)
       }
 
     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
@@ -114,7 +114,7 @@ class RulesInternalApi(
           _.flatMap(seq => seq.split(',').map(_.strip()))
             .flatMap(RuleId.parse(_).toOption)
         )
-      val getMissingCategory = ruleApiService.getMissingCategories _
+      val getMissingCategory = ruleApiService.getMissingCategories
       (for {
         r <- ruleInternalApiService
                .getGroupRelatedRules(ruleIdsFilter, getMissingCategory, ruleApiService.MISSING_RULE_CAT_ID)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/SharedFilesAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/SharedFilesAPI.scala
@@ -101,7 +101,7 @@ class SharedFilesAPI(
       catch { case _: NoSuchFileException => 0L }))
       ~ ("type"   -> (if (file.isDirectory) "dir" else "file"))
       ~ ("date"   -> date.toString("yyyy-MM-dd HH:mm:ss"))
-      ~ ("rights" -> file.permissionsAsString(File.LinkOptions.noFollow)))
+      ~ ("rights" -> file.permissionsAsString(using File.LinkOptions.noFollow)))
     }
   }
   def errorResponse(message: String, code: Int = 500): LiftResponse           = {
@@ -163,7 +163,7 @@ class SharedFilesAPI(
       if (file.exists) {
         if (file.isRegularFile) {
           import net.liftweb.json.JsonDSL.*
-          val result = JObject(List(JField("result", file.contentAsString(StandardCharsets.UTF_8))))
+          val result = JObject(List(JField("result", file.contentAsString(using StandardCharsets.UTF_8))))
           JsonResponse(result, List(), List(), 200).succeed
         } else {
           Unexpected(s"File '${file.name}' is not a regular file").fail

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -325,7 +325,7 @@ class ArchiveApi(
             merge   <- parseMergePolicy(req)
             archive <- parseArchive(zip, originalFilename)
             _       <- checkArchiveService.check(archive)
-            _       <- saveArchiveService.save(archive, merge)(authzToken.qc)
+            _       <- saveArchiveService.save(archive, merge)(using authzToken.qc)
             _       <- ApplicationLoggerPure.Archive.info(s"Uploaded archive '${originalFilename}' processed successfully")
           } yield JRArchiveImported(success = true)
       }).tapError(err => ApplicationLoggerPure.Archive.error(s"Error when processing uploaded archive: ${err.fullMsg}"))
@@ -1568,7 +1568,7 @@ class SaveArchiveServicebyRepo(
              )
            }
       // now we can check if we create a new group or update one
-      x <- roGroupRepos.getNodeGroupOpt(g.group.id)(cc.toQuery)
+      x <- roGroupRepos.getNodeGroupOpt(g.group.id)(using cc.toQuery)
       _ <- x match {
              case Some((_, parentId)) =>
                woGroupRepos.update(g.group, modId, actor, message) *>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/CampaignApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/CampaignApi.scala
@@ -82,7 +82,7 @@ class CampaignApi(
       val res = {
         for {
           campaign   <- campaignRepository.get(CampaignId(resources))
-          serialized <- ZIO.foreach(campaign)(campaignSerializer.getJson _)
+          serialized <- ZIO.foreach(campaign)(campaignSerializer.getJson)
         } yield {
           serialized
         }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -564,7 +564,7 @@ class ComplianceApi(
     }
   }
 
-  private[this] def parseSimpleTargetOrNodeGroupId(str: String): PureResult[SimpleTarget] = {
+  private def parseSimpleTargetOrNodeGroupId(str: String): PureResult[SimpleTarget] = {
     // attempt to parse a "target" first because format is more specific
     RuleTarget.unserOne(str) match {
       case None        => NodeGroupId.parse(str).map(GroupTarget(_)).left.map(Inconsistency(_))
@@ -1682,7 +1682,7 @@ class ComplianceAPIService(
     this.reportingService.getGlobalUserCompliance()
   }
 
-  private[this] def targetServerList(target: NonGroupRuleTarget)(nodeSettings: Map[NodeId, RudderSettings]) = {
+  private def targetServerList(target: NonGroupRuleTarget)(nodeSettings: Map[NodeId, RudderSettings]) = {
 
     target match {
       case AllTarget                    => nodeSettings.keySet

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/LiftApiDispatcher.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/LiftApiDispatcher.scala
@@ -245,7 +245,7 @@ class LiftHandler(
      * This should not provided on all url. It seems very strange to
      */
     def getVersionFromHeader() = {
-      forceVersion orElse RestUtils.apiVersionFromRequest(req)(supportedVersions).toOption
+      forceVersion orElse RestUtils.apiVersionFromRequest(req)(using supportedVersions).toOption
     }
 
     for {
@@ -263,7 +263,7 @@ class LiftHandler(
       case ApiError.BadParam(x, _)   => "Bad parameters for request: " + x
       case ApiError.Authz(x, _)      => "Authorization error: " + x
     }
-    Full(RestUtils.toJsonError(None, JString(msg), error.restCode)(error.apiName, prettify = true))
+    Full(RestUtils.toJsonError(None, JString(msg), error.restCode)(using error.apiName, prettify = true))
   }
 
   // Get the lift object that can be added in lift rooting logic

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -332,7 +332,7 @@ class RuleApiService14(
                         params.reason
                       )
       id           <- workflow
-                        .startWorkflow(cr)(
+                        .startWorkflow(cr)(using
                           ChangeContext(
                             ModificationId(uuidGen.newUuid),
                             actor,

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -85,7 +85,7 @@ import zio.*
 import zio.syntax.*
 
 class SettingsApi(
-    val configService:                 ReadConfigService with UpdateConfigService,
+    val configService:                 ReadConfigService & UpdateConfigService,
     val asyncDeploymentAgent:          AsyncDeploymentActor,
     val uuidGen:                       StringUuidGenerator,
     val policyServerManagementService: PolicyServerManagementService,
@@ -165,7 +165,7 @@ class SettingsApi(
         JField(setting.key, result)
       }
       val data     = {
-        val networks = GetAllAllowedNetworks.getAllowedNetworks()(authzToken.qc).either.runNow match {
+        val networks = GetAllAllowedNetworks.getAllowedNetworks()(using authzToken.qc).either.runNow match {
           case Right(nets) =>
             nets
           case Left(err)   =>
@@ -176,7 +176,7 @@ class SettingsApi(
       }
 
       // sort settings alphanum
-      RestUtils.response("settings", None)(Full(data.sortBy(_.name)), req, s"Could not settings")(
+      RestUtils.response("settings", None)(Full(data.sortBy(_.name)), req, s"Could not settings")(using
         "getAllSettings",
         params.prettify
       )
@@ -195,7 +195,7 @@ class SettingsApi(
         JField(setting.key, value)
       }
       startNewPolicyGeneration(authzToken.qc.actor)
-      RestUtils.response("settings", None)(Full(data), req, s"Could not modfiy settings")(
+      RestUtils.response("settings", None)(Full(data), req, s"Could not modfiy settings")(using
         "modifySettings",
         params.prettify
       )
@@ -218,7 +218,7 @@ class SettingsApi(
       } yield {
         (key -> value)
       }
-      RestUtils.response("settings", Some(key))(data, req, s"Could not get parameter '${key}'")(
+      RestUtils.response("settings", Some(key))(data, req, s"Could not get parameter '${key}'")(using
         "getSetting",
         params.prettify
       )
@@ -241,7 +241,7 @@ class SettingsApi(
       } yield {
         (key -> value)
       }
-      RestUtils.response("settings", Some(key))(data, req, s"Could not modify parameter '${key}'")(
+      RestUtils.response("settings", Some(key))(data, req, s"Could not modify parameter '${key}'")(using
         "modifySetting",
         params.prettify
       )
@@ -340,7 +340,7 @@ class SettingsApi(
     val key                   = "global_policy_mode"
     val startPolicyGeneration = true
     def get: IOResult[PolicyMode]                                       = configService.rudder_policy_mode_name()
-    def set: (PolicyMode, EventActor, Option[String]) => IOResult[Unit] = configService.set_rudder_policy_mode_name _
+    def set: (PolicyMode, EventActor, Option[String]) => IOResult[Unit] = configService.set_rudder_policy_mode_name
     def toJson(value: PolicyMode): JValue = value.name
     def parseJson(json: JValue):   Box[PolicyMode] = {
       json match {
@@ -404,32 +404,32 @@ class SettingsApi(
     val key                   = "global_policy_mode_overridable"
     val startPolicyGeneration = true
     def get: IOResult[Boolean]                                       = configService.rudder_policy_overridable()
-    def set: (Boolean, EventActor, Option[String]) => IOResult[Unit] = configService.set_rudder_policy_overridable _
+    def set: (Boolean, EventActor, Option[String]) => IOResult[Unit] = configService.set_rudder_policy_overridable
   }
 
   case object RestRunFrequency                extends RestIntSetting                          {
     val key                   = "run_frequency"
     val startPolicyGeneration = true
     def get: IOResult[Int]                                       = configService.agent_run_interval()
-    def set: (Int, EventActor, Option[String]) => IOResult[Unit] = configService.set_agent_run_interval _
+    def set: (Int, EventActor, Option[String]) => IOResult[Unit] = configService.set_agent_run_interval
   }
   case object RestRunHour                     extends RestIntSetting                          {
     val key                   = "first_run_hour"
     val startPolicyGeneration = true
     def get: IOResult[Int]                                       = configService.agent_run_start_hour()
-    def set: (Int, EventActor, Option[String]) => IOResult[Unit] = configService.set_agent_run_start_hour _
+    def set: (Int, EventActor, Option[String]) => IOResult[Unit] = configService.set_agent_run_start_hour
   }
   case object RestRunMinute                   extends RestIntSetting                          {
     val key                   = "first_run_minute"
     val startPolicyGeneration = true
     def get: IOResult[Int]                                       = configService.agent_run_start_minute()
-    def set: (Int, EventActor, Option[String]) => IOResult[Unit] = configService.set_agent_run_start_minute _
+    def set: (Int, EventActor, Option[String]) => IOResult[Unit] = configService.set_agent_run_start_minute
   }
   case object RestSplayTime                   extends RestIntSetting                          {
     val key                   = "splay_time"
     val startPolicyGeneration = true
     def get: IOResult[Int]                                       = configService.agent_run_splaytime()
-    def set: (Int, EventActor, Option[String]) => IOResult[Unit] = configService.set_agent_run_splaytime _
+    def set: (Int, EventActor, Option[String]) => IOResult[Unit] = configService.set_agent_run_splaytime
   }
   case object RestModifiedFileTTL             extends RestIntSetting                          {
     val key                   = "modified_file_ttl"
@@ -473,7 +473,7 @@ class SettingsApi(
     val startPolicyGeneration = true
     val key                   = "heartbeat_frequency"
     def get: IOResult[Int]                                       = configService.rudder_compliance_heartbeatPeriod()
-    def set: (Int, EventActor, Option[String]) => IOResult[Unit] = configService.set_rudder_compliance_heartbeatPeriod _
+    def set: (Int, EventActor, Option[String]) => IOResult[Unit] = configService.set_rudder_compliance_heartbeatPeriod
   }
   case object RestChangeMessageEnabled        extends RestBooleanSetting                      {
     val startPolicyGeneration = false
@@ -626,7 +626,7 @@ class SettingsApi(
     }
     val key = "send_metrics"
     def get:                                IOResult[Option[SendMetrics]]                                       = configService.send_server_metrics()
-    def set:                                (Option[SendMetrics], EventActor, Option[String]) => IOResult[Unit] = configService.set_send_server_metrics _
+    def set:                                (Option[SendMetrics], EventActor, Option[String]) => IOResult[Unit] = configService.set_send_server_metrics
   }
 
   case object RestJSEngine extends RestSetting[FeatureSwitch] {
@@ -807,7 +807,7 @@ class SettingsApi(
     def getAllowedNetworks()(implicit qc: QueryContext): ZIO[Any, RudderError, JArray] = {
       for {
         servers         <- nodeFactRepo
-                             .getAll()(qc, SelectNodeStatus.Accepted)
+                             .getAll()(using qc, SelectNodeStatus.Accepted)
                              .map(_.collect { case (_, n) if (n.rudderSettings.kind != NodeKind.Node) => n.id }.toSeq)
         allowedNetworks <- policyServerManagementService.getAllAllowedNetworks()
       } yield {
@@ -829,7 +829,7 @@ class SettingsApi(
       implicit val action = "getAllAllowedNetworks"
       implicit val prettify: Boolean = params.prettify
       RestUtils.response(getRootNameForVersion(version), None)(
-        getAllowedNetworks()(authzToken.qc).toBox,
+        getAllowedNetworks()(using authzToken.qc).toBox,
         req,
         s"Could not get allowed networks"
       )
@@ -850,7 +850,7 @@ class SettingsApi(
       implicit val action = "getAllowedNetworks"
       implicit val prettify: Boolean = params.prettify
       val result = for {
-        nodeInfo <- nodeFactRepo.get(NodeId(id))(authzToken.qc)
+        nodeInfo <- nodeFactRepo.get(NodeId(id))(using authzToken.qc)
         isServer <- nodeInfo match {
                       case Some(info) if info.rudderSettings.isPolicyServer =>
                         ZIO.unit
@@ -904,7 +904,7 @@ class SettingsApi(
       val modificationId = new ModificationId(uuidGen.newUuid)
       val nodeId         = NodeId(id)
       val result         = for {
-        nodeInfo <- nodeFactRepo.get(nodeId)(authzToken.qc).toBox
+        nodeInfo <- nodeFactRepo.get(nodeId)(using authzToken.qc).toBox
         isServer <- nodeInfo match {
                       case Some(info) if info.rudderSettings.isPolicyServer =>
                         Full(())
@@ -990,7 +990,7 @@ class SettingsApi(
       implicit val formats = DefaultFormats
 
       val result = for {
-        nodeInfo <- nodeFactRepo.get(nodeId)(authzToken.qc).toBox
+        nodeInfo <- nodeFactRepo.get(nodeId)(using authzToken.qc).toBox
         isServer <- nodeInfo match {
                       case Some(info) if info.rudderSettings.isPolicyServer =>
                         Full(())

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
@@ -609,7 +609,7 @@ class SystemApiService13(
         RestUtils.toJsonResponse(None, JArray(json))
       case eb: EmptyBox =>
         val message = (eb ?~ s"Error when trying to run healthcheck").messageChain
-        RestUtils.toJsonError(None, message)(action, prettify = true)
+        RestUtils.toJsonError(None, message)(using action, prettify = true)
     }
   }
 
@@ -1010,7 +1010,7 @@ class SystemApiService11(
     implicit val action   = "archiveGroups"
     implicit val prettify = params.prettify
 
-    archive(req, itemArchiveManager.exportGroupLibrary _, "groups") match {
+    archive(req, itemArchiveManager.exportGroupLibrary, "groups") match {
       case Left(error)  => toJsonError(None, error)
       case Right(field) => toJsonResponse(None, JObject(field))
     }
@@ -1029,7 +1029,7 @@ class SystemApiService11(
     implicit val action   = "archiveRules"
     implicit val prettify = params.prettify
 
-    archive(req, itemArchiveManager.exportRules _, "rules") match {
+    archive(req, itemArchiveManager.exportRules, "rules") match {
       case Left(error)  => toJsonError(None, error)
       case Right(field) => toJsonResponse(None, JObject(field))
     }
@@ -1038,7 +1038,7 @@ class SystemApiService11(
     implicit val action   = "archiveParameters"
     implicit val prettify = params.prettify
 
-    archive(req, itemArchiveManager.exportParameters _, "parameters") match {
+    archive(req, itemArchiveManager.exportParameters, "parameters") match {
       case Left(error)  => toJsonError(None, error)
       case Right(field) => toJsonResponse(None, JObject(field))
     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
@@ -96,7 +96,6 @@ class TechniqueApi(
     configRepoPath:      String
 ) extends LiftApiModuleProvider[API] {
 
-  import com.normation.rudder.rest.lift.TechniqueApi.*
   import zio.json.*
   import zio.json.yaml.*
 
@@ -389,7 +388,7 @@ class TechniqueApi(
                           .whenZIO(IOResult.attempt(workspaceDir.exists)) {
                             IOResult.attempt("Error when moving resource file from workspace to final destination") {
                               finalDir.createDirectoryIfNotExists(createParents = true)
-                              workspaceDir.moveTo(finalDir)(File.CopyOptions.apply(true))
+                              workspaceDir.moveTo(finalDir)(using File.CopyOptions.apply(true))
                               workspaceDir.parent.parent.delete()
                             }
                           }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
@@ -74,7 +74,6 @@ import com.normation.rudder.users.JsonUser
 import com.normation.rudder.users.JsonUserFormData
 import com.normation.rudder.users.Serialisation.*
 import com.normation.rudder.users.UpdateUserInfo
-import com.normation.rudder.users.User
 import com.normation.rudder.users.UserInfo
 import com.normation.rudder.users.UserManagementService
 import com.normation.rudder.users.UserRepository

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
@@ -291,7 +291,7 @@ object ValidatedUserList {
           .groupBy(_.path.parts.head)
           .flatMap {
             case (_, seq) =>
-              seq.sortBy(_.path)(AclPath.orderingaAclPath).sortBy(_.path.parts.head.value)
+              seq.sortBy(_.path)(using AclPath.orderingaAclPath).sortBy(_.path.parts.head.value)
           }
           .toList
         // init status to deleted, it will be set correctly latter on

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/UserManagement.scala
@@ -595,7 +595,7 @@ final case class JsonCoverage(
 )
 object JsonCoverage     {
   implicit val transformer: Transformer[(Set[Role], Set[Custom]), JsonCoverage] = (x: (Set[Role], Set[Custom])) =>
-    x.transformInto[JsonRoleCoverage].transformInto[JsonCoverage](coverage => JsonCoverage(coverage))
+    x.transformInto[JsonRoleCoverage].transformInto[JsonCoverage](using coverage => JsonCoverage(coverage))
 }
 
 final case class JsonRoleCoverage(

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/FilePermissions.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/model/FilePermissions.scala
@@ -89,6 +89,7 @@ package com.normation.rudder.web.model
 
 import Perm.*
 import com.normation.utils.Utils.isEmpty
+import scala.annotation.nowarn
 import scala.collection.BitSet
 
 trait Perm {
@@ -244,20 +245,18 @@ final case class PermSet(file: FilePerms, perms: (Perm => Unit, () => Perm)*) {
 }
 
 @unchecked // it should be checked
+@nowarn
 object PermSet {
-  val u:   FilePerms => PermSet = (file: FilePerms) => new PermSet(file, (file._u_= _, () => file._u))
-  val g:   FilePerms => PermSet = (file: FilePerms) => new PermSet(file, (file._g_= _, () => file._g))
-  val o:   FilePerms => PermSet = (file: FilePerms) => new PermSet(file, (file._o_= _, () => file._o))
-  val ug:  FilePerms => PermSet = (file: FilePerms) =>
-    new PermSet(file, (file._u_= _, () => file._u), (file._g_= _, () => file._g))
-  val uo:  FilePerms => PermSet = (file: FilePerms) =>
-    new PermSet(file, (file._u_= _, () => file._u), (file._o_= _, () => file._o))
-  val go:  FilePerms => PermSet = (file: FilePerms) =>
-    new PermSet(file, (file._g_= _, () => file._g), (file._o_= _, () => file._o))
+  val u:   FilePerms => PermSet = (file: FilePerms) => new PermSet(file, (file._u_=, () => file._u))
+  val g:   FilePerms => PermSet = (file: FilePerms) => new PermSet(file, (file._g_=, () => file._g))
+  val o:   FilePerms => PermSet = (file: FilePerms) => new PermSet(file, (file._o_=, () => file._o))
+  val ug:  FilePerms => PermSet = (file: FilePerms) => new PermSet(file, (file._u_=, () => file._u), (file._g_=, () => file._g))
+  val uo:  FilePerms => PermSet = (file: FilePerms) => new PermSet(file, (file._u_=, () => file._u), (file._o_=, () => file._o))
+  val go:  FilePerms => PermSet = (file: FilePerms) => new PermSet(file, (file._g_=, () => file._g), (file._o_=, () => file._o))
   val ugo: FilePerms => PermSet = (file: FilePerms) =>
-    new PermSet(file, (file._u_= _, () => file._u), (file._g_= _, () => file._g), (file._o_= _, () => file._o))
+    new PermSet(file, (file._u_=, () => file._u), (file._g_=, () => file._g), (file._o_=, () => file._o))
   val a:   FilePerms => PermSet = (file: FilePerms) =>
-    new PermSet(file, (file._u_= _, () => file._u), (file._g_= _, () => file._g), (file._o_= _, () => file._o))
+    new PermSet(file, (file._u_=, () => file._u), (file._g_=, () => file._g), (file._o_=, () => file._o))
 }
 
 @unchecked

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/DiffDisplayer.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/DiffDisplayer.scala
@@ -183,7 +183,7 @@ class DiffDisplayer(linkUtil: LinkUtil) extends Loggable {
               Seq(Unchanged(newIncluded))
             case _                                                                                 =>
               (Seq(Deleted(oldIncluded), Added(newIncluded)))
-          }).flatMap(_.display(displayKind))
+          }).flatMap(_.display(using displayKind))
         }
         val excludedKind    = {
           ((newExcluded, oldExcluded) match {
@@ -191,7 +191,7 @@ class DiffDisplayer(linkUtil: LinkUtil) extends Loggable {
               Seq(Unchanged(newExcluded))
             case _                                                                                 =>
               (Seq(Deleted(oldExcluded), Added(newExcluded)))
-          }).flatMap(_.display(displayKind))
+          }).flatMap(_.display(using displayKind))
         }
         val includedTargets = displayRuleTargets(newIncluded.targets.toSeq, oldIncluded.targets.toSeq, groupLib)
         val excludedTargets = displayRuleTargets(newExcluded.targets.toSeq, oldExcluded.targets.toSeq, groupLib)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -1727,13 +1727,13 @@ class EventLogDetailsGenerator(
   case object RollbackTo extends RollBackAction {
     val name = "after"
     val op   = ">"
-    def action: (EventLog, PersonIdent, Seq[EventLog], EventLog) => Box[GitCommitId] = modificationService.restoreToEventLog _
+    def action: (EventLog, PersonIdent, Seq[EventLog], EventLog) => Box[GitCommitId] = modificationService.restoreToEventLog
   }
 
   case object RollbackBefore extends RollBackAction {
     val name = "before"
     val op   = ">="
-    def action: (EventLog, PersonIdent, Seq[EventLog], EventLog) => Box[GitCommitId] = modificationService.restoreBeforeEventLog _
+    def action: (EventLog, PersonIdent, Seq[EventLog], EventLog) => Box[GitCommitId] = modificationService.restoreBeforeEventLog
   }
 
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/Section2FieldService.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/Section2FieldService.scala
@@ -185,7 +185,7 @@ class Section2FieldService(val fieldFactory: DirectiveFieldFactory, val translat
     val fieldKey = varSpec.name
     val field    = fieldFactory.forType(varSpec, fieldKey)
 
-    val varMappings = translators.get(field.manifest) match {
+    val varMappings = translators.get(using field.manifest) match {
       case None    => throw new IllegalArgumentException("No translator from type: " + field.manifest.toString)
       case Some(t) =>
         t.to.get("self") match {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/Translator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/Translator.scala
@@ -120,7 +120,7 @@ class Translators {
    * @param m
    */
   def add[T](t: Translator[T])(implicit m: ClassTag[T]): Unit = {
-    get(m) match {
+    get(using m) match {
       case None           => reg += (m -> t)
       case Some(existing) => {
         t.to.iterator foreach { existing.to.add(_) }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestDataExtractorTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestDataExtractorTest.scala
@@ -63,7 +63,7 @@ class RestDataExtractorTest extends ZIOSpecDefault {
   val mockDirectives = new MockDirectives(mockTechniques)
   val mockRules      = new MockRules()
 
-  override def spec: Spec[TestEnvironment with Scope, Any] = {
+  override def spec: Spec[TestEnvironment & Scope, Any] = {
     suite("All tests")(
       suite("extract RuleTarget")(
         List(

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RunComplianceComputation.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RunComplianceComputation.scala
@@ -109,7 +109,7 @@ object RunTestCompliance {
 
     // This is the actual thing we want to measure
     /////////////// -- ///////////////
-    val (t, x) = cs.getRulesCompliancePure(Some(1))(QueryContext.systemQC).timed.runNow
+    val (t, x) = cs.getRulesCompliancePure(Some(1))(using QueryContext.systemQC).timed.runNow
     /////////////// -- ///////////////
 
     // it looks like if we want to be sure to have the file written, we must dump it before stop...

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SystemApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SystemApiTest.scala
@@ -523,7 +523,7 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
           beEqualTo(SystemApi.getArchiveName(archiveType, commitDate))
         )) and (testDir must org.specs2.matcher.ContentMatchers
           .haveSameFilesAs(restTestSetUp.mockGitRepo.configurationRepositoryRoot.toJava)
-          .withFilter(filterGeneratedFile _))
+          .withFilter(filterGeneratedFile))
       case Full(JsonResponsePrettify(json, _, _, code, _)) =>
         import net.liftweb.http.js.JsExp.*
         (code must beEqualTo(500)) and

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestInheritedProperties.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestInheritedProperties.scala
@@ -99,7 +99,7 @@ class TestInheritedProperties extends ZIOSpecDefault {
 
   val g0Id: NodeGroupId = restTestSetUp.mockNodeGroups.g0.id
   (for {
-    g <- restTestSetUp.mockNodeGroups.groupsRepo.getNodeGroupOpt(g0Id)(QueryContext.testQC).notOptional("test")
+    g <- restTestSetUp.mockNodeGroups.groupsRepo.getNodeGroupOpt(g0Id)(using QueryContext.testQC).notOptional("test")
     up = g._1.modify(_.properties).using(_.appended(gProp))
     _ <- restTestSetUp.mockNodeGroups.groupsRepo.update(up, ModificationId("test"), eventlog.RudderEventActor, None)
     _ <- restTestSetUp.mockNodeGroups.propService.updateAll() // the properties also need to be recomputed after group is updated
@@ -111,7 +111,7 @@ class TestInheritedProperties extends ZIOSpecDefault {
     .asInstanceOf[ch.qos.logback.classic.Logger]
     .setLevel(ch.qos.logback.classic.Level.OFF)
 
-  override def spec: Spec[TestEnvironment with Scope, Any] = {
+  override def spec: Spec[TestEnvironment & Scope, Any] = {
     (suite("All REST tests defined in files") {
 
       for {

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestFromFileDef.scala
@@ -79,12 +79,12 @@ class TestRestFromFileDef extends ZIOSpecDefault {
   val yamlDestTmpDirectory: File   = tmpApiTemplate
 
   val transformations: Map[String, String => String] = Map(
-    ("api_revisions.yml" -> copyTransformApiRevision(restTestSetUp) _)
+    ("api_revisions.yml" -> copyTransformApiRevision(restTestSetUp))
   )
 
   tmpApiTemplate.createDirectories()
 
-  override def spec: Spec[TestEnvironment with Scope, Any] = {
+  override def spec: Spec[TestEnvironment & Scope, Any] = {
     suite("All REST tests defined in files") {
 
       for {

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestPluginInfo.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestPluginInfo.scala
@@ -179,7 +179,7 @@ class TestRestPluginInfo extends Specification with JsonSpecMatcher {
   }
 
   val pluginApi = new PluginApi(pluginSettingsService, pluginService, pluginInfo.succeed)
-  val apiModules: List[LiftApiModuleProvider[? <: EndpointSchema with SortIndex]] = List(pluginApi)
+  val apiModules: List[LiftApiModuleProvider[? <: EndpointSchema & SortIndex]] = List(pluginApi)
 
   val (handlers, rules) = TraitTestApiFromYamlFiles.buildLiftRules(apiModules, List(ApiVersion(42, deprecated = false)), None)
   val test              = new RestTest(rules)
@@ -192,7 +192,7 @@ class TestRestPluginInfo extends Specification with JsonSpecMatcher {
     val mockReq = new MockHttpServletRequest("http://localhost:8080")
     mockReq.method = "GET"
     mockReq.path = "/api/latest/plugins/info"
-    mockReq.body = ""
+    mockReq.body = "".getBytes
     mockReq.headers = Map()
     mockReq.contentType = "application/json"
 
@@ -274,7 +274,7 @@ class TestRestPluginInfo extends Specification with JsonSpecMatcher {
       "proxyUrl": "http://localhost:8888",
       "proxyUser": "testuser",
       "proxyPassword": "testpassword"
-    }"""
+    }""".getBytes
     mockReq.headers = Map()
     mockReq.contentType = "application/json"
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestPlusInPath.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TestRestPlusInPath.scala
@@ -77,10 +77,15 @@ class TestRestPlusInPath extends Specification with BeforeAfterAll {
   override def beforeAll(): Unit = {
 
     val nodeCom = NodeFact.fromMinimal(
-      env.mockNodes.nodeFactRepo.get(NodeId("node1"))(QueryContext.testQC).runNow.get.modify(_.id.value).setTo("node@domain.com")
+      env.mockNodes.nodeFactRepo
+        .get(NodeId("node1"))(using QueryContext.testQC)
+        .runNow
+        .get
+        .modify(_.id.value)
+        .setTo("node@domain.com")
     )
     ZioRuntime.unsafeRun {
-      env.mockNodes.nodeFactRepo.save(nodeCom)(ChangeContext.newForRudder()) *>
+      env.mockNodes.nodeFactRepo.save(nodeCom)(using ChangeContext.newForRudder()) *>
       env.mockRules.ruleRepo.rulesMap.update(_ + (rule.id -> rule))
     }
   }
@@ -95,7 +100,7 @@ class TestRestPlusInPath extends Specification with BeforeAfterAll {
     val mockReq = new MockHttpServletRequest("http://localhost:8080")
     mockReq.method = "GET"
     mockReq.path = "/api/latest/rules/ff44fb97-b65e-43c4-b8c2-0df8d5e8549f+gitrevision" // should be kept
-    mockReq.body = ""
+    mockReq.body = "".getBytes
     mockReq.headers = Map()
     mockReq.contentType = "text/plain"
 
@@ -131,7 +136,7 @@ class TestRestPlusInPath extends Specification with BeforeAfterAll {
     mockReq.method = "GET"
     mockReq.path = "/api/latest/nodes/node@domain.com" // should be kept
     mockReq.queryString = "include=minimal"
-    mockReq.body = ""
+    mockReq.body = "".getBytes
     mockReq.headers = Map()
     mockReq.contentType = "text/plain"
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
@@ -161,7 +161,7 @@ object TraitTestApiFromYamlFiles {
 
     // transform templates based on the map of transformation, or ident if not registered
     def transform(transformations: Map[String, String => String], name: String, s: String): String = {
-      transformations.getOrElse(name, identity[String] _)(s)
+      transformations.getOrElse(name, identity[String])(s)
     }
 
     // file are copier directly into destDir

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserManagementServiceTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/users/UserManagementServiceTest.scala
@@ -15,7 +15,7 @@ class UserManagementServiceTest extends Specification {
       val allRoles = Role.allBuiltInRoles.values.toSet
       val parsed   = UserManagementService.parsePermissions(
         Set("node_write", "node_read", "read_only", "some_unknown_permission")
-      )(allRoles)
+      )(using allRoles)
 
       parsed must be equalTo (
         (

--- a/webapp/sources/rudder/rudder-templates-cli/src/main/scala/com/normation/templates/cli/TemplateCli.scala
+++ b/webapp/sources/rudder/rudder-templates-cli/src/main/scala/com/normation/templates/cli/TemplateCli.scala
@@ -171,9 +171,9 @@ object TemplateCli {
       _         <- if (config.templates.nonEmpty) {
                      val filler = { // if we are writing to stdout, use a different filler and ignore outputExtension
                        if (config.outputToStdout) {
-                         fillToStdout(variables.toSeq, config.inputExtension, timer) _
+                         fillToStdout(variables.toSeq, config.inputExtension, timer)
                        } else {
-                         fill(variables.toSeq, config.outdir, config.inputExtension, config.outputExtension, timer) _
+                         fill(variables.toSeq, config.outdir, config.inputExtension, config.outputExtension, timer)
                        }
                      }
                      config.templates.accumulate(filler)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -703,7 +703,7 @@ class AuthBackendProvidersManager() extends DynamicRudderProviderManager {
   private var springProviders = Map[String, AuthenticationProvider]()
 
   // a map of properties registered for each backend
-  private[this] var backendProperties = Map[String, AuthBackendProviderProperties]()
+  private var backendProperties = Map[String, AuthBackendProviderProperties]()
 
   // add default providers into mutable variables
   initializeDefaultProviders()

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1530,7 +1530,7 @@ case class RudderServiceApi(
     systemApiService:                    SystemApiService11,
     stringUuidGenerator:                 StringUuidGenerator,
     inventoryWatcher:                    InventoryFileWatcher,
-    configService:                       ReadConfigService with UpdateConfigService,
+    configService:                       ReadConfigService & UpdateConfigService,
     historizeNodeCountBatch:             IOResult[Unit],
     policyGenerationBootGuard:           zio.Promise[Nothing, Unit],
     healthcheckNotificationService:      HealthcheckNotificationService,
@@ -1740,7 +1740,7 @@ object RudderConfigInit {
         woLDAPParameterRepository,
         asyncDeploymentAgent,
         dependencyAndDeletionService,
-        configService.rudder_workflow_enabled _,
+        configService.rudder_workflow_enabled,
         xmlSerializer,
         xmlUnserializer,
         sectionSpecParser,
@@ -1798,7 +1798,7 @@ object RudderConfigInit {
 
     // REST API - old
     lazy val restQuicksearch = new RestQuicksearch(
-      new FullQuickSearchService()(
+      new FullQuickSearchService()(using
         roLDAPConnectionProvider,
         nodeDit,
         acceptedNodesDit,
@@ -2034,7 +2034,7 @@ object RudderConfigInit {
         maxParallel,
         // it's always rudder doing these checking queries
         new InventoryDigestServiceV1((id: NodeId) =>
-          nodeFactRepository.get(id)(QueryContext.systemQC, SelectNodeStatus.Accepted)
+          nodeFactRepository.get(id)(using QueryContext.systemQC, SelectNodeStatus.Accepted)
         ),
         checkLdapAlive
       )
@@ -2135,7 +2135,7 @@ object RudderConfigInit {
           roDirectiveRepository,
           roNodeGroupRepository,
           nodeFactRepository,
-          configService.rudder_global_policy_mode _,
+          configService.rudder_global_policy_mode,
           ruleApplicationStatus
         )
       }
@@ -2359,7 +2359,7 @@ object RudderConfigInit {
       )
     }
     lazy val asyncWorkflowInfo = new AsyncWorkflowInfo
-    lazy val configService: ReadConfigService with UpdateConfigService = {
+    lazy val configService: ReadConfigService & UpdateConfigService = {
       new GenericConfigService(
         RudderProperties.config,
         new LdapConfigRepository(rudderDit, rwLdap, ldapEntityMapper, eventLogRepository, stringUuidGenerator),
@@ -2574,9 +2574,9 @@ object RudderConfigInit {
     }
 
     lazy val userPropertyServiceImpl = new StatelessUserPropertyService(
-      configService.rudder_ui_changeMessage_enabled _,
-      configService.rudder_ui_changeMessage_mandatory _,
-      configService.rudder_ui_changeMessage_explanation _
+      configService.rudder_ui_changeMessage_enabled,
+      configService.rudder_ui_changeMessage_mandatory,
+      configService.rudder_ui_changeMessage_explanation
     )
     lazy val userPropertyService: UserPropertyService = userPropertyServiceImpl
 
@@ -3290,12 +3290,12 @@ object RudderConfigInit {
       doobie
     }
 
-    lazy val parseRules:                  ParseRules with RuleRevisionRepository         = new GitParseRules(
+    lazy val parseRules:                  ParseRules & RuleRevisionRepository         = new GitParseRules(
       ruleUnserialisation,
       gitConfigRepo,
       rulesDirectoryName
     )
-    lazy val parseActiveTechniqueLibrary: GitParseActiveTechniqueLibrary                 = new GitParseActiveTechniqueLibrary(
+    lazy val parseActiveTechniqueLibrary: GitParseActiveTechniqueLibrary              = new GitParseActiveTechniqueLibrary(
       activeTechniqueCategoryUnserialisation,
       activeTechniqueUnserialisation,
       directiveUnserialisation,
@@ -3303,35 +3303,35 @@ object RudderConfigInit {
       gitRevisionProvider,
       userLibraryDirectoryName
     )
-    lazy val importTechniqueLibrary:      ImportTechniqueLibrary                         = new ImportTechniqueLibraryImpl(
+    lazy val importTechniqueLibrary:      ImportTechniqueLibrary                      = new ImportTechniqueLibraryImpl(
       rudderDitImpl,
       rwLdap,
       ldapEntityMapper,
       uptLibReadWriteMutex
     )
-    lazy val parseGroupLibrary:           ParseGroupLibrary with GroupRevisionRepository = new GitParseGroupLibrary(
+    lazy val parseGroupLibrary:           ParseGroupLibrary & GroupRevisionRepository = new GitParseGroupLibrary(
       nodeGroupCategoryUnserialisation,
       nodeGroupUnserialisation,
       gitConfigRepo,
       groupLibraryDirectoryName
     )
-    lazy val parseGlobalParameter:        ParseGlobalParameters                          = new GitParseGlobalParameters(
+    lazy val parseGlobalParameter:        ParseGlobalParameters                       = new GitParseGlobalParameters(
       globalParameterUnserialisation,
       gitConfigRepo,
       parametersDirectoryName
     )
-    lazy val parseRuleCategories:         ParseRuleCategories                            = new GitParseRuleCategories(
+    lazy val parseRuleCategories:         ParseRuleCategories                         = new GitParseRuleCategories(
       ruleCategoryUnserialisation,
       gitConfigRepo,
       ruleCategoriesDirectoryName
     )
-    lazy val importGroupLibrary:          ImportGroupLibrary                             = new ImportGroupLibraryImpl(
+    lazy val importGroupLibrary:          ImportGroupLibrary                          = new ImportGroupLibraryImpl(
       rudderDitImpl,
       rwLdap,
       ldapEntityMapper,
       groupLibReadWriteMutex
     )
-    lazy val importRuleCategoryLibrary:   ImportRuleCategoryLibrary                      = new ImportRuleCategoryLibraryImpl(
+    lazy val importRuleCategoryLibrary:   ImportRuleCategoryLibrary                   = new ImportRuleCategoryLibraryImpl(
       rudderDitImpl,
       rwLdap,
       ldapEntityMapper,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/UserSessionInvalidationFilter.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/UserSessionInvalidationFilter.scala
@@ -229,7 +229,7 @@ private[liftweb] object UserSessionInvalidationFilter {
 
   // special case of user that is not logged-in : hashed with known values
   // admin check needs to be the first one because it is more important than status check
-  private[this] def hashRudderUserDetail(user: RudderUserDetail, status: UserStatus): Int = {
+  private def hashRudderUserDetail(user: RudderUserDetail, status: UserStatus): Int = {
     if (user.isAdmin) {
       HASH_USER_ADMIN
     } else if (status.isInvalid) {
@@ -240,7 +240,7 @@ private[liftweb] object UserSessionInvalidationFilter {
   }
 
   // used on a user that has no known password and roles, not a RudderUserDetail
-  private[this] def hashUser(username: String, status: UserStatus): Int = {
+  private def hashUser(username: String, status: UserStatus): Int = {
     if (status.isInvalid) {
       HASH_USER_INVALID_STATUS
     } else {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/MigrateChangeValidationEnforceSchema.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/MigrateChangeValidationEnforceSchema.scala
@@ -100,8 +100,8 @@ class MigrateChangeValidationEnforceSchema(
   }
 
   val migrateAsync: URIO[Any, Fiber.Runtime[RudderError, Unit]] = {
-    transactIOResult(s"Error with 'EventLog' table migration")(
-      migrationEffect(_)
+    transactIOResult(s"Error with 'EventLog' table migration") { t =>
+      migrationEffect(using t)
         .foldZIO(
           err =>
             BootstrapLogger.Early.DB.error(
@@ -111,7 +111,7 @@ class MigrateChangeValidationEnforceSchema(
             ),
           _ => BootstrapLogger.Early.DB.info(s"Migrated ${msg}")
         )
-    ).forkDaemon
+    }.forkDaemon
   }
 
   override def checks(): Unit = {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/action/LoadNodeComplianceCache.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/action/LoadNodeComplianceCache.scala
@@ -101,7 +101,7 @@ class LoadNodeComplianceCache(
   // compute from last available runs, for example for migration
   def computeNewCompliance(): IOResult[Unit] = {
     for {
-      nodeIds <- nodeFactRepository.getAll()(QueryContext.systemQC).map(_.keys)
+      nodeIds <- nodeFactRepository.getAll()(using QueryContext.systemQC).map(_.keys)
       _       <- ReportLoggerPure.Repository.debug(s"Initialize node status reports for ${nodeIds.size} nodes")
       _       <- computeNodeStatusReportService.invalidateWithAction(
                    nodeIds.toSeq.map(x => (x, ExpectedReportAction(InsertNodeInCache(x))))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/action/RemoveDefaultRootDescription.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/action/RemoveDefaultRootDescription.scala
@@ -52,9 +52,9 @@ class RemoveDefaultRootDescription(nodeFactRepository: NodeFactRepository) exten
 
   override def checks(): Unit = {
     (for {
-      root <- nodeFactRepository.get(NodeId("root"))(QueryContext.systemQC).notOptional("no root node in inventory")
+      root <- nodeFactRepository.get(NodeId("root"))(using QueryContext.systemQC).notOptional("no root node in inventory")
       _    <- if (root.documentation == Some("the policy server")) {
-                nodeFactRepository.save(root.copy(documentation = None))(
+                nodeFactRepository.save(root.copy(documentation = None))(using
                   ChangeContext.newForRudder(Some("Removing default not documentation"))
                 )
               } else {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/migration/MigrateNodeAcceptationInventories.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/migration/MigrateNodeAcceptationInventories.scala
@@ -77,7 +77,7 @@ import zio.*
 class MigrateNodeAcceptationInventories(
     nodeFactRepo:      NodeFactRepository,
     fileLogRepository: InventoryHistoryLogRepository,
-    jdbcLogRepository: HistoryLogRepository[NodeId, DateTime, FactLogData, FactLog] with InventoryHistoryDelete,
+    jdbcLogRepository: HistoryLogRepository[NodeId, DateTime, FactLogData, FactLog] & InventoryHistoryDelete,
     MAX_KEEP_REFUSED:  Duration
 ) extends BootstrapChecks {
 
@@ -132,7 +132,7 @@ class MigrateNodeAcceptationInventories(
             case None    => ZIO.unit
             case Some(l) =>
               for {
-                opt <- nodeFactRepo.get(nodeId)(QueryContext.systemQC)
+                opt <- nodeFactRepo.get(nodeId)(using QueryContext.systemQC)
                 _   <- ZIO.when(opt.isDefined || l.datetime.plus(MAX_KEEP_REFUSED.toMillis).isAfter(now)) {
                          saveInDB(nodeId, l.datetime, l.data, !opt.isDefined)
                        }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/onetimeinit/CheckInitXmlExport.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/onetimeinit/CheckInitXmlExport.scala
@@ -82,7 +82,7 @@ class CheckInitXmlExport(
                     RudderEventActor,
                     Some("Initialising configuration-repository sub-system"),
                     includeSystem = false
-                  )(QueryContext.systemQC)
+                  )(using QueryContext.systemQC)
                 } else {
                   BootstrapLogger.trace("At least a full archive of configuration items done, no need for further initialisation") *>
                   ZIO.unit

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/metrics/SystemInfoServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/metrics/SystemInfoServiceImpl.scala
@@ -89,7 +89,9 @@ class SystemInfoServiceImpl(
       fv  <- rudderFullVersion.toIO
       bt  <- builtTimestamp.toIO
       r   <-
-        nodeFactRepository.get(Constants.ROOT_POLICY_SERVER_ID)(QueryContext.systemQC).notOptional(s"The root server is missing!")
+        nodeFactRepository
+          .get(Constants.ROOT_POLICY_SERVER_ID)(using QueryContext.systemQC)
+          .notOptional(s"The root server is missing!")
       jvmN = System.getProperty("java.vm.name")
       jvmV = System.getProperty("java.vm.version")
       cmd <- IOResult
@@ -108,7 +110,7 @@ class SystemInfoServiceImpl(
   override def getPrivateInfo(): IOResult[PrivateSystemInfo] = {
     for {
       servers <- policyServerService.getPolicyServers()
-      nodes   <- nodeFactRepository.getAll()(QueryContext.systemQC)
+      nodes   <- nodeFactRepository.getAll()(using QueryContext.systemQC)
     } yield {
       val pi = PluginsInfo.pluginInfos
       PrivateSystemInfo(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/ExtendableSnippet.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/ExtendableSnippet.scala
@@ -82,7 +82,7 @@ trait PluginExtensionPoint[T] extends SnippetExtensionPoint[T] {
 
   // protect all compose method with the guard. The check is done each time to allow runtime
   // switch on plugin status
-  final def compose(snippet: T): Map[String, NodeSeq => NodeSeq] = pluginCompose(snippet).view.mapValues(guard _).toMap
+  final def compose(snippet: T): Map[String, NodeSeq => NodeSeq] = pluginCompose(snippet).view.mapValues(guard).toMap
 
   def pluginCompose(snippet: T): Map[String, NodeSeq => NodeSeq]
 }
@@ -158,7 +158,7 @@ trait ExtendableSnippet[T] extends DispatchSnippet {
 object ExtendableSnippet {
   type DispatchIt = PartialFunction[String, NodeSeq => NodeSeq]
 
-  private val cache = scala.collection.mutable.Map.empty[SnippetExtensionKey, _ => DispatchIt]
+  private val cache = scala.collection.mutable.Map.empty[SnippetExtensionKey, ? => DispatchIt]
 
   def chached[T](forSnippet: SnippetExtensionKey, withDefault: => T => DispatchIt): T => DispatchIt = {
     if (true) withDefault

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/PublicPlugin.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/PublicPlugin.scala
@@ -149,15 +149,15 @@ trait DefaultPluginDef extends RudderPluginDef {
         val parent = optParent.getOrElse(MenuUtils.administrationMenu)
 
         menu.map {
-          case m @ Menu(l, _*) if (l.name == parent) =>
+          case m: Menu if (m.loc.name == parent) =>
             // We need to avoid collision on name/loc
             if (m.kids.exists(_.loc.name == newMenu.loc.name)) {
               PluginLogger.error(s"There is already a menu with id (${newMenu.loc.name}, please contact Plugin team")
               m
             } else {
-              Menu(l, (m.kids :+ newMenu).sortBy(_.loc.name)*)
+              Menu(m.loc, (m.kids :+ newMenu).sortBy(_.loc.name)*)
             }
-          case m                                     => m
+          case m => m
         }
     }
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPluginJson.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPluginJson.scala
@@ -114,7 +114,7 @@ class ReadPluginPackageInfo(val index: File) {
 
   def readIndex(): IOResult[String] = {
     IOResult.attempt {
-      index.contentAsString(StandardCharsets.UTF_8)
+      index.contentAsString(using StandardCharsets.UTF_8)
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/comet/AsyncDeployment.scala
@@ -441,7 +441,7 @@ class AsyncDeployment extends CometActor with CometListener with Loggable {
       val btnId = nodeBtnId(node)
       scriptLinkButton(btnId, link)
     }
-    val allNodes = nodeFactRepo.getAll()(QueryContext.systemQC).runNow
+    val allNodes = nodeFactRepo.getAll()(using QueryContext.systemQC).runNow
     val nodesErrors:                   Map[MinimalNodeFactInterface, String] = nodeProperties.flatMap {
       case (_, _: SuccessNodePropertyHierarchy)     => None
       case (nodeId, f: FailedNodePropertyHierarchy) => allNodes.get(nodeId).map(_ -> f.getMessage)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
@@ -139,7 +139,9 @@ class DirectiveEditForm(
       throw new RuntimeException("Error when retrieving the rule root category - it is most likelly a bug. Pleae report.")
     )
   val directiveApp = new DirectiveApplicationManagement(directive, rules, rootCategory)
-  def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "showForm" => { _ => showForm()(CurrentUser.queryContext) } }
+  def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = {
+    case "showForm" => { _ => showForm()(using CurrentUser.queryContext) }
+  }
 
   def isNcfTechnique(id: TechniqueId): Boolean = {
     val test = for {
@@ -343,7 +345,7 @@ class DirectiveEditForm(
                           parameterEditor.toFormNodeSeq
                         }) &
       "#directiveRulesTab *" #> ruleDisplayer &
-      "#save" #> { SHtml.ajaxSubmit("Save", onSubmitSave _) % ("id" -> htmlId_save) % ("class" -> "btn btn-success") } &
+      "#save" #> { SHtml.ajaxSubmit("Save", onSubmitSave) % ("id" -> htmlId_save) % ("class" -> "btn btn-success") } &
       "#notifications" #> displayNotifications() &
       "#showTechnical *" #> <button type="button" class="btn btn-technical-details btn-default" onclick="$('#technicalDetails').toggle(400);$(this).toggleClass('opened');">Technical details</button> &
       "#isSingle *" #> showIsSingle() &
@@ -417,7 +419,7 @@ class DirectiveEditForm(
     showErrorNotifications()
   }
 
-  private[this] def showVariablesErrorNotifications(): JsCmd = {
+  private def showVariablesErrorNotifications(): JsCmd = {
     // only replace notification container to avoid resetting the tab state
     onFailureCallback() & Replace("notification", displayNotifications())
   }
@@ -476,13 +478,13 @@ class DirectiveEditForm(
   ///////////// fields for Directive settings ///////////////////
 
   private val directiveName = new WBTextField("Name", directive.name) {
-    override def setFilter             = notNull _ :: trim _ :: Nil
+    override def setFilter             = notNull :: trim :: Nil
     override def className             = "form-control"
     override def labelClassName        = "col-sm-12"
     override def subContainerClassName = "col-sm-12"
     override def errorClassName        = ""
     override def validations           =
-      valMinLen(1, "Name must not be empty") _ :: Nil
+      valMinLen(1, "Name must not be empty") :: Nil
   }
 
   private val directiveShortDescription = {
@@ -490,7 +492,7 @@ class DirectiveEditForm(
       override def className             = "form-control"
       override def labelClassName        = "col-sm-12"
       override def subContainerClassName = "col-sm-12"
-      override def setFilter             = notNull _ :: trim _ :: Nil
+      override def setFilter             = notNull :: trim :: Nil
       override val maxLen                = 255
       override def validations: List[String => List[FieldError]] = Nil
     }
@@ -498,7 +500,7 @@ class DirectiveEditForm(
 
   private val directiveLongDescription = {
     new WBTextAreaField("Description", directive.longDescription) {
-      override def setFilter             = notNull _ :: trim _ :: Nil
+      override def setFilter             = notNull :: trim :: Nil
       override def className             = "form-control"
       override def labelClassName        = ""
       override def subContainerClassName = ""
@@ -644,7 +646,7 @@ class DirectiveEditForm(
         case _         => NodeSeq.Empty
       }
     ) {
-      override def setFilter             = notNull _ :: trim _ :: Nil
+      override def setFilter             = notNull :: trim :: Nil
       override def className             = "checkbox-group policymode-group"
       override def labelClassName        = "d-none"
       override def subContainerClassName = "col-sm-12"

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupCategoryForm.scala
@@ -156,7 +156,7 @@ class NodeGroupCategoryForm(
            (
              "directive-save" #> (
                if (CurrentUser.checkRights(AuthorizationType.Group.Edit))
-                 SHtml.ajaxSubmit("Update", onSubmit _, ("class", "btn btn-success"))
+                 SHtml.ajaxSubmit("Update", onSubmit, ("class", "btn btn-success"))
                else NodeSeq.Empty
              )
              & "directive-delete" #> (
@@ -207,7 +207,7 @@ class NodeGroupCategoryForm(
                </div>
                <div class="modal-footer" style="text-align:center">
                  <button type="button" class="btn btn-default" data-bs-dismiss="modal">Close</button>
-                 {SHtml.ajaxButton("Delete", onDelete _, ("class", "btn btn-danger"))}
+                 {SHtml.ajaxButton("Delete", () => onDelete(), ("class", "btn btn-danger"))}
                </div>
              </div>
            </div>
@@ -247,16 +247,16 @@ class NodeGroupCategoryForm(
 
   ///////////// fields for category settings ///////////////////
   private val name = new WBTextField("Category name", _nodeGroupCategory.name) {
-    override def setFilter             = notNull _ :: trim _ :: Nil
+    override def setFilter             = notNull :: trim :: Nil
     override def className             = "form-control"
     override def labelClassName        = ""
     override def subContainerClassName = ""
     override def validations           =
-      valMinLen(1, "Name must not be empty") _ :: Nil
+      valMinLen(1, "Name must not be empty") :: Nil
   }
 
   private val description = new WBTextAreaField("Category description", _nodeGroupCategory.description.toString) {
-    override def setFilter             = notNull _ :: trim _ :: Nil
+    override def setFilter             = notNull :: trim :: Nil
     override def className             = "form-control"
     override def labelClassName        = ""
     override def subContainerClassName = ""
@@ -279,7 +279,7 @@ class NodeGroupCategoryForm(
         override def labelClassName        = ""
         override def subContainerClassName = ""
         override def validations           =
-          valMinLen(1, "Please select a category") _ :: Nil
+          valMinLen(1, "Please select a category") :: Nil
       }
     case Full(category) =>
       new WBSelectField(
@@ -293,13 +293,11 @@ class NodeGroupCategoryForm(
         override def labelClassName        = ""
         override def subContainerClassName = ""
         override def validations           =
-          valMinLen(1, "Please select a category") _ :: Nil
+          valMinLen(1, "Please select a category") :: Nil
       }
   }
 
   private val formTracker = new FormTracker(name, description, container)
-
-  private var notifications = List.empty[NodeSeq]
 
   private def updateFormClientSide: JsCmd = {
     SetHtml(htmlIdCategory, showForm())
@@ -308,8 +306,6 @@ class NodeGroupCategoryForm(
   private def error(msg: String) = <span class="col-sm-12 errors-container">{msg}</span>
 
   private def onSuccess: JsCmd = {
-
-    notifications ::= <span class="text-success">Category was correctly updated</span>
     updateFormClientSide
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -123,7 +123,7 @@ class NodeGroupForm(
   private val searchNodeComponent   = new LocalSnippet[SearchNodeComponent]
 
   private var query:   Option[Query]          = nodeGroup.toOption.flatMap(_.query)
-  private var srvList: Box[Seq[CoreNodeFact]] = getNodeList(nodeGroup)(CurrentUser.queryContext)
+  private var srvList: Box[Seq[CoreNodeFact]] = getNodeList(nodeGroup)(using CurrentUser.queryContext)
 
   private def setSearchNodeComponent: Unit = {
     searchNodeComponent.set(
@@ -242,7 +242,7 @@ class NodeGroupForm(
     )
   }
 
-  private[this] def showGroupCompliance(targetOrGroupIdStr: String): NodeSeq = {
+  private def showGroupCompliance(targetOrGroupIdStr: String): NodeSeq = {
     Script(
       OnLoad(
         JsRaw(s"""
@@ -368,7 +368,7 @@ class NodeGroupForm(
         if (CurrentUser.checkRights(AuthorizationType.Group.Edit)) {
           <span class="save-tooltip-container">
                       {
-            SHtml.ajaxOnSubmit(onSubmit _)(
+            SHtml.ajaxOnSubmit(onSubmit)(
               <button class="btn btn-success btn-icon ui-button ui-corner-all ui-widget" id={saveButtonId}>
                             <span>Save <i class="fa fa-download"></i></span>
                           </button>
@@ -545,13 +545,13 @@ class NodeGroupForm(
 
   private val groupName = {
     new WBTextField("Group name", groupNameString) {
-      override def setFilter             = notNull _ :: trim _ :: Nil
+      override def setFilter             = notNull :: trim :: Nil
       override def className             = "form-control"
       override def labelClassName        = ""
       override def subContainerClassName = ""
       override def inputField            = super.inputField % ("onkeydown" -> "return processKey(event , '%s')".format(saveButtonId))
       override def validations           =
-        valMinLen(1, "Name must not be empty") _ :: Nil
+        valMinLen(1, "Name must not be empty") :: Nil
     }
   }
 
@@ -561,7 +561,7 @@ class NodeGroupForm(
       _.description
     )
     new WBTextAreaField("Description", desc) {
-      override def setFilter             = notNull _ :: trim _ :: Nil
+      override def setFilter             = notNull :: trim :: Nil
       override def className             = "form-control"
       override def labelClassName        = ""
       override def subContainerClassName = ""
@@ -597,7 +597,7 @@ class NodeGroupForm(
         case _         => NodeSeq.Empty // guarding against NoMatchE
       }
     ) {
-      override def setFilter             = notNull _ :: trim _ :: Nil
+      override def setFilter             = notNull :: trim :: Nil
       override def className             = "switch"
       override def labelClassName        = ""
       override def subContainerClassName = ""

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeStateForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeStateForm.scala
@@ -92,7 +92,7 @@ class NodeStateForm(
     // bind button to logic
     val bind = (
       "#nodeStateSelect" #> SHtml.selectObj[NodeState](states, Full(state), state = _)
-        & "#nodeStateSelect *+" #> SHtml.hidden(process _)
+        & "#nodeStateSelect *+" #> SHtml.hidden(process)
         & "#currentNodeState *" #> state.name
     )
     bind(nodeStateTemplate)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleCategoryTree.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleCategoryTree.scala
@@ -214,7 +214,7 @@ class RuleCategoryTree(
             if( destCatId ) {
               if( sourceCatId ) {
                 var arg = JSON.stringify({ 'sourceCatId' : sourceCatId, 'destCatId' : destCatId });
-                ${SHtml.ajaxCall(JsVar("arg"), moveCategory _)._2.toJsCmd};
+                ${SHtml.ajaxCall(JsVar("arg"), moveCategory)._2.toJsCmd};
               } else {
                 alert("Can not move that kind of object");
                 $$.jstree.rollback(data.rlbk);
@@ -270,7 +270,7 @@ class RuleCategoryTree(
             // Create the checkbox with their values, then set the "indeterminate" content
             SHtml.ajaxCheckbox(
               directiveApplication.isCompletecategory(category.id),
-              check _,
+              check,
               ("id", toCheckboxId(category.id)),
               ("style", "margin : 2px 5px 0px 2px;")
             ) ++

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
@@ -93,10 +93,10 @@ class RuleGrid(
 
   import RuleGrid.*
 
-  private val getFullNodeGroupLib      = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
-  private val getFullDirectiveLib      = RudderConfig.roDirectiveRepository.getFullDirectiveLibrary _
-  private val getRuleApplicationStatus = RudderConfig.ruleApplicationStatus.isApplied _
-  private val getRootRuleCategory      = RudderConfig.roRuleCategoryRepository.getRootCategory _
+  private val getFullNodeGroupLib      = () => RudderConfig.roNodeGroupRepository.getFullGroupLibrary()
+  private val getFullDirectiveLib      = () => RudderConfig.roDirectiveRepository.getFullDirectiveLibrary()
+  private val getRuleApplicationStatus = RudderConfig.ruleApplicationStatus.isApplied
+  private val getRootRuleCategory      = () => RudderConfig.roRuleCategoryRepository.getRootCategory()
 
   private val recentChanges          = RudderConfig.recentChangesService
   private val techniqueRepository    = RudderConfig.techniqueRepository
@@ -345,7 +345,7 @@ class RuleGrid(
             var data = $$("#${htmlId_rulesGridId}").dataTable()._('tr', {"filter":"applied", "page":"current"});
             var rules = $$.map(data, function(e,i) { return e.id })
             var rulesIds = JSON.stringify({ "rules" : rules });
-            ${SHtml.ajaxCall(JsVar("rulesIds"), moveCategory _)};
+            ${SHtml.ajaxCall(JsVar("rulesIds"), moveCategory)};
         """) // JsRaw ok, no user inputs
       case None               => Noop
     }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/ShowNodeDetailsFromNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/ShowNodeDetailsFromNode.scala
@@ -128,7 +128,7 @@ class ShowNodeDetailsFromNode(
                    .toBox // we can't change the state of a missing node
       newNode  = oldNode.modify(_.rudderSettings.state).setTo(nodeState)
       result  <- nodeFactRepo
-                   .save(newNode)(ChangeContext(modId, qc.actor, Instant.now(), None, None, qc.nodePerms))
+                   .save(newNode)(using ChangeContext(modId, qc.actor, Instant.now(), None, None, qc.nodePerms))
                    .toBox
     } yield {
       asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.actor)
@@ -165,7 +165,7 @@ class ShowNodeDetailsFromNode(
     val cc          = ChangeContext(modId, CurrentUser.actor, Instant.now(), None, None, CurrentUser.nodePerms)
 
     (for {
-      _ <- nodeFactRepo.save(newNodeFact)(cc)
+      _ <- nodeFactRepo.save(newNodeFact)(using cc)
     } yield {
       asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.actor)
     }).toBox
@@ -220,7 +220,7 @@ class ShowNodeDetailsFromNode(
           <p>Error message was: {e.messageChain}</p>
         </div>
       case Full(Some(node)) => // currentSelectedNode = Some(server)
-        nodeFactRepo.slowGet(node.id)(CurrentUser.queryContext, attrs = SelectFacts.noSoftware).toBox match {
+        nodeFactRepo.slowGet(node.id)(using CurrentUser.queryContext, attrs = SelectFacts.noSoftware).toBox match {
           case Full(Some(nf)) =>
             val tab  = displayDetailsMode.tab
             val jsId = JsNodeId(nodeId, "")

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueCategoryEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueCategoryEditForm.scala
@@ -99,7 +99,7 @@ class TechniqueCategoryEditForm(
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-bs-dismiss="modal">Cancel</button>
-                {SHtml.ajaxButton(<span>Delete</span>, deleteCategory _) % ("class" -> "btn btn-danger")}
+                {SHtml.ajaxButton(<span>Delete</span>, () => deleteCategory()) % ("class" -> "btn btn-danger")}
             </div>
         </div>
     </div>
@@ -139,13 +139,13 @@ class TechniqueCategoryEditForm(
   /////////////////////  Category Details Form  /////////////////////
 
   val categoryName: WBTextField = new WBTextField("Category name", currentCategory.name) {
-    override def setFilter   = notNull _ :: trim _ :: Nil
+    override def setFilter   = notNull :: trim :: Nil
     override def validations =
-      valMinLen(1, "Name must not be empty") _ :: Nil
+      valMinLen(1, "Name must not be empty") :: Nil
   }
 
   val categoryDescription: WBTextAreaField = new WBTextAreaField("Category description", currentCategory.description.toString) {
-    override def setFilter  = notNull _ :: trim _ :: Nil
+    override def setFilter  = notNull :: trim :: Nil
     override def inputField = super.inputField % ("style" -> "height:10em")
 
     override def validations: List[String => List[FieldError]] = Nil

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueEditForm.scala
@@ -290,12 +290,12 @@ class TechniqueEditForm(
 
   def buildReasonField(mandatory: Boolean, containerClass: String = "twoCol"): WBTextAreaField = {
     new WBTextAreaField("Change audit message", "") {
-      override def setFilter             = notNull _ :: trim _ :: Nil
+      override def setFilter             = notNull :: trim :: Nil
       override def inputField            = super.inputField % ("placeholder" -> { userPropertyService.reasonsFieldExplanation })
       override def subContainerClassName = containerClass
       override def validations           = {
         if (mandatory) {
-          valMinLen(5, "The reason must have at least 5 characters.") _ :: Nil
+          valMinLen(5, "The reason must have at least 5 characters.") :: Nil
         } else {
           Nil
         }
@@ -395,7 +395,7 @@ class TechniqueEditForm(
       }
     }
 
-    SHtml.ajaxSubmit("Delete", deleteActiveTechnique _)
+    SHtml.ajaxSubmit("Delete", deleteActiveTechnique)
   }
 
   private def dialogDeleteTree(htmlId: String, activeTechnique: ActiveTechnique): NodeSeq = {
@@ -416,9 +416,9 @@ class TechniqueEditForm(
     }
 
     if (activeTechnique.isEnabled) {
-      SHtml.ajaxSubmit("Disable", switchActivation(false) _)
+      SHtml.ajaxSubmit("Disable", switchActivation(false))
     } else {
-      SHtml.ajaxSubmit("Enable", switchActivation(true) _)
+      SHtml.ajaxSubmit("Enable", switchActivation(true))
     }
   }
 
@@ -486,7 +486,7 @@ class TechniqueEditForm(
 
               SHtml.ajaxButton(
                 Text("Add this Technique to user library category ") ++ <b>{category.name}</b>,
-                onClickAddTechniqueToCategory _
+                () => onClickAddTechniqueToCategory()
               )
             }
           }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueTree.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/TechniqueTree.scala
@@ -71,7 +71,7 @@ class TechniqueTree(
   val activeTechniqueRepository = RudderConfig.roDirectiveRepository
   val dependencyService         = RudderConfig.dependencyAndDeletionService
   val ruleRepository            = RudderConfig.roRuleRepository
-  val getGrouLib: () => errors.IOResult[FullNodeGroupCategory] = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
+  val getGrouLib: () => errors.IOResult[FullNodeGroupCategory] = RudderConfig.roNodeGroupRepository.getFullGroupLibrary
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "tree" => { _ => tree() } }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateActiveTechniqueCategoryPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateActiveTechniqueCategoryPopup.scala
@@ -75,7 +75,7 @@ class CreateActiveTechniqueCategoryPopup(
 
   private val categories = activeTechniqueCategoryRepository.getAllActiveTechniqueCategories().toBox
 
-  def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "popupContent" => popupContent _ }
+  def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "popupContent" => popupContent }
 
   def popupContent(html: NodeSeq): NodeSeq = {
     SHtml.ajaxForm(
@@ -86,7 +86,7 @@ class CreateActiveTechniqueCategoryPopup(
         & "item-cancel" #> (SHtml.ajaxButton("Cancel", () => closePopup()) % ("tabindex" -> "4")                   % ("class"    -> "btn btn-default"))
         & "item-save" #> (SHtml.ajaxSubmit(
           "Save",
-          onSubmit _
+          onSubmit
         )                                                                  % ("id"       -> "createATCSaveButton") % ("tabindex" -> "3") % ("class" -> "btn btn-success"))
         andThen
         "item-notifications" #> updateAndDisplayNotifications()
@@ -96,16 +96,16 @@ class CreateActiveTechniqueCategoryPopup(
 
 ///////////// fields for category settings ///////////////////
   private val categoryName = new WBTextField("Name", "") {
-    override def setFilter      = notNull _ :: trim _ :: Nil
+    override def setFilter      = notNull :: trim :: Nil
     override def errorClassName = "col-xl-12 errors-container"
     override def inputField     =
       super.inputField % ("onkeydown" -> "return processKey(event , 'createATCSaveButton')") % ("tabindex" -> "1")
     override def validations =
-      valMinLen(1, "Name must not be empty") _ :: Nil
+      valMinLen(1, "Name must not be empty") :: Nil
   }
 
   private val categoryDescription = new WBTextAreaField("Description", "") {
-    override def setFilter      = notNull _ :: trim _ :: Nil
+    override def setFilter      = notNull :: trim :: Nil
     override def inputField     = super.inputField % ("class" -> "form-control col-xl-12 col-md-12 col-sm-12") % ("tabindex" -> "2")
     override def errorClassName = "col-xl-12 errors-container"
     override def validations: List[String => List[FieldError]] = Nil
@@ -116,7 +116,7 @@ class CreateActiveTechniqueCategoryPopup(
     new WBSelectField("Parent category: ", (categories.getOrElse(Seq()).map(x => (x.id.value -> x.name))), "") {
       override def className   = "form-select col-xl-12 col-md-12 col-sm-12"
       override def validations =
-        valMinLen(1, "Please select a category") _ :: Nil
+        valMinLen(1, "Please select a category") :: Nil
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCategoryOrGroupPopup.scala
@@ -140,7 +140,7 @@ class CreateCategoryOrGroupPopup(
       & "item-cancel" #> (SHtml.ajaxButton("Cancel", () => closePopup()) % ("tabindex" -> "6")                   % ("class"    -> "btn btn-default"))
       & "item-save" #> (SHtml.ajaxSubmit(
         "Create",
-        onSubmit _
+        onSubmit
       )                                                                  % ("id"       -> "createCOGSaveButton") % ("tabindex" -> "5") % ("class" -> "btn btn-success"))
       andThen
       // Updating notification should be done at the end because it empties the form tracker
@@ -152,16 +152,16 @@ class CreateCategoryOrGroupPopup(
 
   ///////////// fields for category settings ///////////////////
   private val piName = new WBTextField("Name", "") {
-    override def setFilter      = notNull _ :: trim _ :: Nil
+    override def setFilter      = notNull :: trim :: Nil
     override def errorClassName = "col-xl-12 errors-container"
     override def inputField     =
       super.inputField % ("onkeydown" -> "return processKey(event , 'createCOGSaveButton')") % ("tabindex" -> "2") % ("autofocus" -> "true")
     override def validations =
-      valMinLen(1, "Name must not be empty.") _ :: Nil
+      valMinLen(1, "Name must not be empty.") :: Nil
   }
 
   private val piDescription = new WBTextAreaField("Description", "") {
-    override def setFilter      = notNull _ :: trim _ :: Nil
+    override def setFilter      = notNull :: trim :: Nil
     override def inputField     = super.inputField % ("style" -> "height:5em") % ("tabindex" -> "4")
     override def errorClassName = "col-xl-12 errors-container"
     override def validations: List[String => List[FieldError]] = Nil
@@ -183,12 +183,12 @@ class CreateCategoryOrGroupPopup(
     },
     Some(5)
   ) {
-    override def setFilter      = notNull _ :: trim _ :: Nil
+    override def setFilter      = notNull :: trim :: Nil
     override def className      = "align-radio-generate-input"
     override def errorClassName = "col-xl-12 errors-container"
     override def inputField     = super.inputField % ("onkeydown" -> "return processKey(event , 'createCOGSaveButton')")
     override def validations    =
-      valMinLen(1, "Please choose a group type.") _ :: Nil
+      valMinLen(1, "Please choose a group type.") :: Nil
   }
 
   private val piItemType = {
@@ -204,12 +204,12 @@ class CreateCategoryOrGroupPopup(
       },
       Some(1)
     ) {
-      override def setFilter      = notNull _ :: trim _ :: Nil
+      override def setFilter      = notNull :: trim :: Nil
       override def className      = "align-radio-generate-input"
       override def errorClassName = "col-xl-12 errors-container"
       override def inputField     = super.inputField % ("onkeydown" -> "return processKey(event , 'createCOGSaveButton')")
       override def validations    =
-        valMinLen(1, "Please choose between group or category.") _ :: Nil
+        valMinLen(1, "Please choose between group or category.") :: Nil
     }
   }
 
@@ -223,7 +223,7 @@ class CreateCategoryOrGroupPopup(
     override def inputField     =
       super.inputField % ("onkeydown" -> "return processKey(event , 'createCOGSaveButton')") % ("tabindex" -> "3")
     override def validations =
-      valMinLen(1, "Please select a category") _ :: Nil
+      valMinLen(1, "Please select a category") :: Nil
   }
 
   private val formTracker = new FormTracker(piName, piDescription, piContainer, piStatic)
@@ -323,13 +323,13 @@ class CreateCategoryOrGroupPopup(
 
   def buildReasonField(mandatory: Boolean, containerClass: String = "twoCol"): WBTextAreaField = {
     new WBTextAreaField("Change audit message", "") {
-      override def setFilter  = notNull _ :: trim _ :: Nil
+      override def setFilter  = notNull :: trim :: Nil
       override def inputField = super.inputField %
         ("style" -> "height:5em;") % ("placeholder" -> { userPropertyService.reasonsFieldExplanation })
       override def errorClassName = "col-xl-12 errors-container"
       override def validations    = {
         if (mandatory) {
-          valMinLen(5, "The reason must have at least 5 characters.") _ :: Nil
+          valMinLen(5, "The reason must have at least 5 characters.") :: Nil
         } else {
           Nil
         }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneDirectivePopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneDirectivePopup.scala
@@ -115,7 +115,7 @@ class CreateCloneDirectivePopup(
     & "#cancel" #> (SHtml.ajaxButton("Cancel", () => closePopup()) % ("tabindex" -> "4")                         % ("class"    -> "btn btn-default"))
     & "#save" #> (SHtml.ajaxSubmit(
       "Clone",
-      onSubmit _
+      onSubmit
     )                                                              % ("id"       -> "createDirectiveSaveButton") % ("tabindex" -> "3") % ("class" -> "btn"))
     andThen
     "#notifications" #> updateAndDisplayNotifications())(html)
@@ -135,14 +135,14 @@ class CreateCloneDirectivePopup(
 
   def buildReasonField(mandatory: Boolean, containerClass: String = "twoCol"): WBTextAreaField = {
     new WBTextAreaField("Change audit message", "") {
-      override def setFilter      = notNull _ :: trim _ :: Nil
+      override def setFilter      = notNull :: trim :: Nil
       override def inputField     = super.inputField % ("style" -> "height:5em;") % ("tabindex" -> "3") % ("placeholder" -> {
         userPropertyService.reasonsFieldExplanation
       })
       override def errorClassName = "col-xl-12 errors-container"
       override def validations    = {
         if (mandatory) {
-          valMinLen(5, "The reason must have at least 5 characters.") _ :: Nil
+          valMinLen(5, "The reason must have at least 5 characters.") :: Nil
         } else {
           Nil
         }
@@ -151,17 +151,17 @@ class CreateCloneDirectivePopup(
   }
 
   private val directiveName = new WBTextField("Name", "Copy of <%s>".format(directive.name)) {
-    override def setFilter      = notNull _ :: trim _ :: Nil
+    override def setFilter      = notNull :: trim :: Nil
     override def errorClassName = "col-xl-12 errors-container"
     override def inputField     =
       super.inputField % ("onkeydown" -> "return processKey(event , 'createDirectiveSaveButton')") % ("tabindex" -> "1")
     override def validations =
-      valMinLen(1, "Name must not be empty") _ :: Nil
+      valMinLen(1, "Name must not be empty") :: Nil
   }
 
   private val directiveShortDescription = {
     new WBTextAreaField("Short description", directive.shortDescription) {
-      override def setFilter      = notNull _ :: trim _ :: Nil
+      override def setFilter      = notNull :: trim :: Nil
       override def inputField     = super.inputField % ("style" -> "height:7em") % ("tabindex" -> "2")
       override def errorClassName = "col-xl-12 errors-container"
       override def validations: List[String => List[FieldError]] = Nil

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateCloneGroupPopup.scala
@@ -74,7 +74,7 @@ class CreateCloneGroupPopup(
         & "item-cancel" #> (SHtml.ajaxButton("Cancel", () => closePopup()) % ("tabindex" -> "6")                   % ("class"    -> "btn btn-default"))
         & "item-save" #> (SHtml.ajaxSubmit(
           "Clone",
-          onSubmit _
+          onSubmit
         )                                                                  % ("id"       -> "createCOGSaveButton") % ("tabindex" -> "5") % ("class" -> "btn btn-success"))
         andThen
         "item-notifications" #> updateAndDisplayNotifications(formTracker)
@@ -222,13 +222,13 @@ class CreateCloneGroupPopup(
 
   def buildReasonField(mandatory: Boolean, containerClass: String = "twoCol"): WBTextAreaField = {
     new WBTextAreaField("Change audit message", "") {
-      override def setFilter  = notNull _ :: trim _ :: Nil
+      override def setFilter  = notNull :: trim :: Nil
       override def inputField = super.inputField %
         ("style" -> "height:5em;") % ("placeholder" -> { userPropertyService.reasonsFieldExplanation })
       override def errorClassName = "col-xl-12 errors-container"
       override def validations    = {
         if (mandatory) {
-          valMinLen(5, "The reason must have at least 5 characters.") _ :: Nil
+          valMinLen(5, "The reason must have at least 5 characters.") :: Nil
         } else {
           Nil
         }
@@ -238,17 +238,17 @@ class CreateCloneGroupPopup(
 
   private val groupName = {
     new WBTextField("Name", nodeGroup.map(x => "Copy of <%s>".format(x.name)).getOrElse("")) {
-      override def setFilter      = notNull _ :: trim _ :: Nil
+      override def setFilter      = notNull :: trim :: Nil
       override def errorClassName = "col-xl-12 errors-container"
       override def inputField     =
         super.inputField % ("onkeydown" -> "return processKey(event , 'createCOGSaveButton')") % ("tabindex" -> "1")
       override def validations =
-        valMinLen(1, "Name must not be empty") _ :: Nil
+        valMinLen(1, "Name must not be empty") :: Nil
     }
   }
 
   private val groupDescription = new WBTextAreaField("Description", nodeGroup.map(x => x.description).getOrElse("")) {
-    override def setFilter      = notNull _ :: trim _ :: Nil
+    override def setFilter      = notNull :: trim :: Nil
     override def inputField     = super.inputField % ("style" -> "height:5em") % ("tabindex" -> "3")
     override def errorClassName = "col-xl-12 errors-container"
     override def validations: List[String => List[FieldError]] = Nil
@@ -269,7 +269,7 @@ class CreateCloneGroupPopup(
     ) {
       override def className      = "col-xl-12 col-md-12 col-sm-12"
       override def errorClassName = "col-xl-12 errors-container"
-      override def setFilter      = notNull _ :: trim _ :: Nil
+      override def setFilter      = notNull :: trim :: Nil
       override def inputField     = super.inputField % ("onkeydown" -> "return processKey(event , 'createCOGSaveButton')")
     }
   }
@@ -280,7 +280,7 @@ class CreateCloneGroupPopup(
         super.inputField % ("onkeydown" -> "return processKey(event , 'createCOGSaveButton')") % ("tabindex" -> "2")
       override def className   = "col-xl-12 col-md-12 col-sm-12  form-select"
       override def validations =
-        valMinLen(1, "Please select a category") _ :: Nil
+        valMinLen(1, "Please select a category") :: Nil
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateRulePopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateRulePopup.scala
@@ -122,7 +122,7 @@ class CreateOrCloneRulePopup(
         & "item-cancel" #> (SHtml.ajaxButton("Cancel", () => closePopup()) % ("tabindex" -> "5")                  % ("class"    -> "btn btn-default"))
         & "item-save" #> (SHtml.ajaxSubmit(
           if (clonedRule.isDefined) "Clone" else "Create",
-          onSubmit _
+          onSubmit
         )                                                                  % ("id"       -> "createCRSaveButton") % ("tabindex" -> "4") % ("class" -> "btn btn-success"))
         andThen
         "item-notifications" #> updateAndDisplayNotifications()
@@ -143,14 +143,14 @@ class CreateOrCloneRulePopup(
 
   def buildReasonField(mandatory: Boolean, containerClass: String = "twoCol"): WBTextAreaField = {
     new WBTextAreaField("Change audit message", "") {
-      override def setFilter      = notNull _ :: trim _ :: Nil
+      override def setFilter      = notNull :: trim :: Nil
       override def inputField     = super.inputField % ("style" -> "height:5em;") % ("tabindex" -> "3") % ("placeholder" -> {
         userPropertyService.reasonsFieldExplanation
       })
       override def errorClassName = "col-xl-12 errors-container"
       override def validations    = {
         if (mandatory) {
-          valMinLen(5, "The reason must have at least 5 characters.") _ :: Nil
+          valMinLen(5, "The reason must have at least 5 characters.") :: Nil
         } else {
           Nil
         }
@@ -159,16 +159,16 @@ class CreateOrCloneRulePopup(
   }
 
   private val ruleName = new WBTextField("Name", clonedRule.map(r => "Copy of <%s>".format(r.name)).getOrElse("")) {
-    override def setFilter      = notNull _ :: trim _ :: Nil
+    override def setFilter      = notNull :: trim :: Nil
     override def errorClassName = "col-xl-12 errors-container"
     override def inputField     =
       super.inputField % ("onkeydown" -> "return processKey(event , 'createCRSaveButton')") % ("tabindex" -> "1")
     override def validations =
-      valMinLen(1, "Name must not be empty") _ :: Nil
+      valMinLen(1, "Name must not be empty") :: Nil
   }
 
   private val ruleShortDescription = new WBTextAreaField("Description", clonedRule.map(_.shortDescription).getOrElse("")) {
-    override def setFilter      = notNull _ :: trim _ :: Nil
+    override def setFilter      = notNull :: trim :: Nil
     override def inputField     = super.inputField % ("style" -> "height:7em") % ("tabindex" -> "2")
     override def errorClassName = "col-xl-12 errors-container"
     override def validations: List[String => List[FieldError]] = Nil
@@ -183,7 +183,7 @@ class CreateOrCloneRulePopup(
     ) {
       override def className   = "form-select col-xl-12 col-md-12 col-sm-12"
       override def validations =
-        valMinLen(1, "Please select a category") _ :: Nil
+        valMinLen(1, "Please select a category") :: Nil
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/GiveReasonPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/GiveReasonPopup.scala
@@ -78,7 +78,7 @@ class GiveReasonPopup(
   private val userPropertyService         = RudderConfig.userPropertyService
   private val techniqueRepository         = RudderConfig.techniqueRepository
 
-  def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "popupContent" => popupContent _ }
+  def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "popupContent" => popupContent }
 
   def popupContent(html: NodeSeq): NodeSeq = {
     SHtml.ajaxForm(
@@ -93,7 +93,7 @@ class GiveReasonPopup(
           .ajaxButton("Cancel", () => closePopup() & refreshActiveTreeLibrary(), ("tabindex", "4"), ("class", "btn btn-default"))
         & "item-save" #> SHtml.ajaxSubmit(
           "Save",
-          onSubmit _,
+          onSubmit,
           ("id", "createATCSaveButton"),
           ("tabindex", "3"),
           ("class", "btn btn-success")
@@ -113,13 +113,13 @@ class GiveReasonPopup(
 
   def buildReasonField(mandatory: Boolean, containerClass: String = "twoCol"): WBTextAreaField = {
     new WBTextAreaField("Change audit message", "") {
-      override def setFilter  = notNull _ :: trim _ :: Nil
+      override def setFilter  = notNull :: trim :: Nil
       override def inputField = super.inputField %
         ("style" -> "height:8em;") % ("placeholder" -> { userPropertyService.reasonsFieldExplanation })
       override def subContainerClassName = containerClass
       override def validations           = {
         if (mandatory) {
-          valMinLen(5, "The reason must have at least 5 characters.") _ :: Nil
+          valMinLen(5, "The reason must have at least 5 characters.") :: Nil
         } else {
           Nil
         }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ModificationValidationPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ModificationValidationPopup.scala
@@ -221,7 +221,7 @@ class ModificationValidationPopup(
   private val woDirectiveRepository = RudderConfig.woDirectiveRepository
 
   // function to read state of things
-  private val getGroupLib = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
+  private val getGroupLib = () => RudderConfig.roNodeGroupRepository.getFullGroupLibrary()
 
   def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = {
     case "popupContent" =>
@@ -398,13 +398,13 @@ class ModificationValidationPopup(
 
   def buildReasonField(mandatory: Boolean, containerClass: String = "twoCol"): WBTextAreaField = {
     new WBTextAreaField("Change audit message", "") {
-      override def setFilter   = notNull _ :: trim _ :: Nil
+      override def setFilter   = notNull :: trim :: Nil
       override def inputField  = super.inputField % ("style" -> "height:8em;") % ("tabindex" -> "2") % ("placeholder" -> {
         userPropertyService.reasonsFieldExplanation
       })
       override def validations = {
         if (mandatory) {
-          valMinLen(5, "The reason must have at least 5 characters.") _ :: Nil
+          valMinLen(5, "The reason must have at least 5 characters.") :: Nil
         } else {
           Nil
         }
@@ -413,16 +413,16 @@ class ModificationValidationPopup(
   }
 
   private val changeRequestName = new WBTextField("Change request title", defaultRequestName) {
-    override def setFilter      = notNull _ :: trim _ :: Nil
+    override def setFilter      = notNull :: trim :: Nil
     override def errorClassName = "col-xl-12 errors-container"
     override def inputField     =
       super.inputField % ("onkeydown" -> "return processKey(event , 'createDirectiveSaveButton')") % ("tabindex" -> "1")
     override def validations =
-      valMinLen(1, "Name must not be empty") _ :: Nil
+      valMinLen(1, "Name must not be empty") :: Nil
   }
 
   private val changeRequestDescription = new WBTextAreaField("Description", "") {
-    override def setFilter      = notNull _ :: trim _ :: Nil
+    override def setFilter      = notNull :: trim :: Nil
     override def inputField     = super.inputField % ("style" -> "height:7em") % ("tabindex" -> "2") % ("class" -> "d-none")
     override def errorClassName = "col-xl-12 errors-container"
     override def validations: List[String => List[FieldError]] = Nil
@@ -576,7 +576,7 @@ class ModificationValidationPopup(
             .move(
               nodeGroup.id,
               parentCategoryId
-            )(
+            )(using
               ChangeContext(
                 ModificationId(uuidGen.newUuid),
                 CurrentUser.actor,
@@ -615,7 +615,7 @@ class ModificationValidationPopup(
     (for {
       cr <- purecr.toIO
       id <- workflowService
-              .startWorkflow(cr)(
+              .startWorkflow(cr)(using
                 ChangeContext(
                   ModificationId(uuidGen.newUuid),
                   CurrentUser.actor,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleCategoryPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleCategoryPopup.scala
@@ -151,18 +151,18 @@ class RuleCategoryPopup(
   ///////////// fields for category settings ///////////////////
 
   private val categoryName = new WBTextField("Name", targetCategory.map(_.name).getOrElse("")) {
-    override def setFilter             = notNull _ :: trim _ :: Nil
+    override def setFilter             = notNull :: trim :: Nil
     override def subContainerClassName = "col-xl-9 col-md-12 col-sm-12"
     override def errorClassName        = "col-xl-12 errors-container"
     override def inputField            =
       super.inputField % ("onkeydown" -> "return processKey(event , 'createRuleCategorySaveButton')") % ("tabindex" -> "2")
     override def validations =
-      valMinLen(1, "The name must not be empty.") _ :: Nil
+      valMinLen(1, "The name must not be empty.") :: Nil
   }
 
   private val categoryDescription = new WBTextAreaField("Description", targetCategory.map(_.description).getOrElse("")) {
     override def subContainerClassName = "col-xl-9 col-md-12 col-sm-12"
-    override def setFilter             = notNull _ :: trim _ :: Nil
+    override def setFilter             = notNull :: trim :: Nil
     override def inputField            = super.inputField % ("tabindex" -> "4")
     override def errorClassName        = "col-xl-12 errors-container"
     override def validations: List[String => List[FieldError]] = Nil
@@ -181,7 +181,7 @@ class RuleCategoryPopup(
       override def inputField            = super.inputField % ("tabindex" -> "3")
       override def className             = "col-xl-12 col-md-12 col-sm-12 form-select"
       override def validations           =
-        valMinLen(1, "Please select a category") _ :: Nil
+        valMinLen(1, "Please select a category") :: Nil
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleModificationValidationPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleModificationValidationPopup.scala
@@ -108,7 +108,7 @@ class RuleModificationValidationPopup(
   import RuleModificationValidationPopup.*
 
   private val userPropertyService = RudderConfig.userPropertyService
-  private[this] val uuidGen       = RudderConfig.stringUuidGenerator
+  private val uuidGen             = RudderConfig.stringUuidGenerator
 
   val validationNeeded: Boolean = workflowService.needExternalValidation()
 
@@ -181,14 +181,14 @@ class RuleModificationValidationPopup(
 
   def buildReasonField(mandatory: Boolean, containerClass: String = "twoCol"): WBTextAreaField = {
     new WBTextAreaField("Change audit message", "") {
-      override def setFilter   = notNull _ :: trim _ :: Nil
+      override def setFilter   = notNull :: trim :: Nil
       override def inputField  = super.inputField % ("style" -> "height:8em;") % ("tabindex" -> "2") % ("placeholder" -> {
         userPropertyService.reasonsFieldExplanation
       })
       // override def subContainerClassName = containerClass
       override def validations = {
         if (mandatory) {
-          valMinLen(5, "The reason must have at least 5 characters.") _ :: Nil
+          valMinLen(5, "The reason must have at least 5 characters.") :: Nil
         } else {
           Nil
         }
@@ -199,12 +199,12 @@ class RuleModificationValidationPopup(
   private val defaultRequestName = s"${changeRequest.action.name.capitalize} Rule ${changeRequest.newRule.name}"
 
   private val changeRequestName = new WBTextField("Change request title", defaultRequestName) {
-    override def setFilter      = notNull _ :: trim _ :: Nil
+    override def setFilter      = notNull :: trim :: Nil
     override def errorClassName = "col-xl-12 errors-container"
     override def inputField     =
       super.inputField % ("onkeydown" -> "return processKey(event , 'createDirectiveSaveButton')") % ("tabindex" -> "1")
     override def validations =
-      valMinLen(1, "Name must not be empty") _ :: Nil
+      valMinLen(1, "Name must not be empty") :: Nil
   }
 
   // The formtracker needs to check everything only if there is workflow
@@ -268,7 +268,7 @@ class RuleModificationValidationPopup(
                     crReasons.map(_.get)
                   )
           id   <- workflowService
-                    .startWorkflow(cr)(
+                    .startWorkflow(cr)(using
                       ChangeContext(
                         ModificationId(uuidGen.newUuid),
                         CurrentUser.actor,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/model/RudderBaseField.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/model/RudderBaseField.scala
@@ -228,7 +228,7 @@ class WBTextField(override val name: String, override val defaultValue: String =
     extends RudderBaseField with StringValidators {
   type ValueType = String
 
-  def inputField: Elem = SHtml.text(value, set _)
+  def inputField: Elem = SHtml.text(value, set)
 
   protected def valueTypeToBoxString(in: ValueType):   Box[String] = Full(in)
   protected def boxStrToValType(in:      Box[String]): ValueType   = in openOr ("")
@@ -240,7 +240,7 @@ class WBTextAreaField(override val name: String, override val defaultValue: Stri
     extends RudderBaseField with StringValidators {
   type ValueType = String
 
-  def inputField: Elem = SHtml.textarea(value, set _)
+  def inputField: Elem = SHtml.textarea(value, set)
 
   protected def valueTypeToBoxString(in: ValueType):   Box[String] = Full(in)
   protected def boxStrToValType(in:      Box[String]): ValueType   = in openOr ("")
@@ -255,7 +255,7 @@ class WBCheckboxField(
 ) extends RudderBaseField {
   type ValueType = Boolean
 
-  def inputField: Elem = <span>{SHtml.checkbox(value, set _, (attrs: Seq[ElemAttr])*)}</span>
+  def inputField: Elem = <span>{SHtml.checkbox(value, set, (attrs: Seq[ElemAttr])*)}</span>
 }
 
 class WBSelectField(
@@ -274,7 +274,7 @@ class WBSelectField(
     }
   }
 
-  def inputField: Elem = SHtml.select(opts, defaultVal, set _, attrs*)
+  def inputField: Elem = SHtml.select(opts, defaultVal, set, attrs*)
 
   protected def valueTypeToBoxString(in: ValueType):   Box[String] = Full(in)
   protected def boxStrToValType(in:      Box[String]): ValueType   = in openOr ("")
@@ -297,7 +297,7 @@ class WBSelectObjField[T](
       Empty
   }
 
-  def inputField: Elem = SHtml.selectObj[T](opts, defaultVal, set _, attrs*)
+  def inputField: Elem = SHtml.selectObj[T](opts, defaultVal, set, attrs*)
 }
 
 class WBRadioField(
@@ -322,7 +322,7 @@ class WBRadioField(
     }
   }
 
-  def choiceHolder: ChoiceHolder[String] = SHtml.radio(opts, Full(value), set _, parameters*)
+  def choiceHolder: ChoiceHolder[String] = SHtml.radio(opts, Full(value), set, parameters*)
 
   def inputField: Elem = {
     <div>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -793,7 +793,7 @@ object DisplayNode extends Loggable {
 
     (for {
       node   <- RudderConfig.nodeFactRepository
-                  .get(nodeFact.id)(cc.toQuery)
+                  .get(nodeFact.id)(using cc.toQuery)
                   .notOptional(s"Cannot update node with id ${nodeFact.id.value}: there is no node with that id")
       newNode = node.modify(_.rudderSettings.keyStatus).setTo(UndefinedKey)
       _      <- RudderConfig.nodeFactRepository.save(newNode)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/NodeGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/NodeGrid.scala
@@ -185,7 +185,7 @@ final class NodeGrid(
                 var node = $$(this).attr("nodeid");
                 var ajaxParam = JSON.stringify({"jsid":jsid , "id":$$(this).attr("nodeid") , "status":$$(this).attr("nodeStatus")});
                 ${jsVarNameForId(tableId)}.fnOpen( this, fnFormatDetails(jsid), 'details' );
-                ${SHtml.ajaxCall(JsVar("ajaxParam"), details _)._2.toJsCmd}
+                ${SHtml.ajaxCall(JsVar("ajaxParam"), details)._2.toJsCmd}
               }
             }
           } );
@@ -230,7 +230,7 @@ final class NodeGrid(
       ".nodetr [nodestatus]" #> { server.status.name })(datatableXml)
     }
 
-    val lines: NodeSeq = servers.flatMap(serverLine _)
+    val lines: NodeSeq = servers.flatMap(serverLine)
 
     ("table [id]" #> tableId &
     "#header *+" #> headers &

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -542,7 +542,7 @@ class ReportDisplayer(
   }
 
   // Handle show/hide logic of buttons, and rewrite button/container ids to avoid conflicts between tabs
-  private[this] def displayRunLogs(nodeId: NodeId, runDate: Option[DateTime], tabId: String, tableId: String): NodeSeq = {
+  private def displayRunLogs(nodeId: NodeId, runDate: Option[DateTime], tabId: String, tableId: String): NodeSeq = {
     val btnId               = s"allLogButton-${tabId}"
     val logRunId            = s"logRun-${tabId}"
     val complianceLogGridId = s"complianceLogsGrid-${tabId}"

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/HomePage.scala
@@ -140,7 +140,7 @@ object HomePage {
     }
   }
 
-  object nodeFacts extends RequestVar[MapView[NodeId, CoreNodeFact]](initNodeInfos()(CurrentUser.queryContext))
+  object nodeFacts extends RequestVar[MapView[NodeId, CoreNodeFact]](initNodeInfos()(using CurrentUser.queryContext))
 }
 
 class HomePage extends StatefulSnippet {
@@ -396,7 +396,7 @@ class HomePage extends StatefulSnippet {
     val agents = getRudderAgentVersion(HomePage.nodeFacts.get)
     TimingDebugLogger.debug(s"Get software: ${System.currentTimeMillis - n4}ms")
 
-    val agentsValue = agents.toList.sortBy(_._2)(Ordering[Int]).foldLeft((Nil: List[JsExp], Nil: List[JsExp])) {
+    val agentsValue = agents.toList.sortBy(_._2)(using Ordering[Int]).foldLeft((Nil: List[JsExp], Nil: List[JsExp])) {
       case ((labels, values), (label, value)) => (label :: labels, value :: values)
     }
     val agentsData  = JsObj("labels" -> JsArray(agentsValue._1), "values" -> JsArray(agentsValue._2))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/Archives.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/Archives.scala
@@ -122,8 +122,9 @@ class Archives extends DispatchSnippet with Loggable {
       archiveListFunction = () => itemArchiver.getFullArchiveTags,
       restoreButtonId = "importAllButton",
       restoreButtonName = "Restore everything",
-      restoreFunction =
-        restoreWithImport((ps: ImportFuncParams) => (cc: ChangeContext) => (itemArchiver.importAll(ps._1, ps._2, ps._3)(cc))),
+      restoreFunction = restoreWithImport((ps: ImportFuncParams) =>
+        (cc: ChangeContext) => (itemArchiver.importAll(ps._1, ps._2, ps._3)(using cc))
+      ),
       restoreErrorMessage = "Error when importing groups, parameters, directive library and rules.",
       restoreSuccessDebugMessage = "Restoring groups, parameters, directive library and rules on user request",
       downloadButtonId = "downloadAllButton",
@@ -144,8 +145,9 @@ class Archives extends DispatchSnippet with Loggable {
       archiveListFunction = () => itemArchiver.getRulesTags,
       restoreButtonId = "importRulesButton",
       restoreButtonName = "Restore rules",
-      restoreFunction =
-        restoreWithImport((ps: ImportFuncParams) => (cc: ChangeContext) => (itemArchiver.importRules(ps._1, ps._2, ps._3)(cc))),
+      restoreFunction = restoreWithImport((ps: ImportFuncParams) =>
+        (cc: ChangeContext) => (itemArchiver.importRules(ps._1, ps._2, ps._3)(using cc))
+      ),
       restoreErrorMessage = "Error when importing rules.",
       restoreSuccessDebugMessage = "Restoring rules on user request",
       downloadButtonId = "downloadRulesButton",
@@ -167,7 +169,7 @@ class Archives extends DispatchSnippet with Loggable {
       restoreButtonId = "importDirectiveLibraryButton",
       restoreButtonName = "Restore directive library",
       restoreFunction = restoreWithImport((ps: ImportFuncParams) =>
-        (cc: ChangeContext) => (itemArchiver.importTechniqueLibrary(ps._1, ps._2, ps._3)(cc))
+        (cc: ChangeContext) => (itemArchiver.importTechniqueLibrary(ps._1, ps._2, ps._3)(using cc))
       ),
       restoreErrorMessage = "Error when importing directive library.",
       restoreSuccessDebugMessage = "Restoring directive library on user request",
@@ -190,7 +192,7 @@ class Archives extends DispatchSnippet with Loggable {
       restoreButtonId = "importGroupLibraryButton",
       restoreButtonName = "Restore groups",
       restoreFunction = restoreWithImport((ps: ImportFuncParams) =>
-        (cc: ChangeContext) => (itemArchiver.importGroupLibrary(ps._1, ps._2, ps._3)(cc))
+        (cc: ChangeContext) => (itemArchiver.importGroupLibrary(ps._1, ps._2, ps._3)(using cc))
       ),
       restoreErrorMessage = "Error when importing groups.",
       restoreSuccessDebugMessage = "Restoring groups on user request",
@@ -213,7 +215,7 @@ class Archives extends DispatchSnippet with Loggable {
       restoreButtonId = "importParametersButton",
       restoreButtonName = "Restore Parameters",
       restoreFunction = restoreWithImport((ps: ImportFuncParams) =>
-        (cc: ChangeContext) => (itemArchiver.importParameters(ps._1, ps._2, ps._3)(cc))
+        (cc: ChangeContext) => (itemArchiver.importParameters(ps._1, ps._2, ps._3)(using cc))
       ),
       restoreErrorMessage = "Error when importing global properties.",
       restoreSuccessDebugMessage = "Restoring global properties on user request",
@@ -385,7 +387,7 @@ class Archives extends DispatchSnippet with Loggable {
     ////////// Template filling //////////
 
     ("#" + archiveButtonId) #> {
-      SHtml.ajaxSubmit(archiveButtonName, archive _, ("id" -> archiveButtonId), ("class", "btn btn-primary btn-archive"))
+      SHtml.ajaxSubmit(archiveButtonName, archive, ("id" -> archiveButtonId), ("class", "btn btn-primary btn-archive"))
     } &
     ("#" + archiveDateSelectId) #> {
       // we have at least "Choose a backup to restore..." and "get archive from current Git HEAD"
@@ -405,7 +407,7 @@ class Archives extends DispatchSnippet with Loggable {
             restoreButtonName,
             SHtml.ajaxButton(
               "Confirm",
-              restore _,
+              () => restore(),
               ("form"            -> formName),
               ("class"           -> "btn btn-success"),
               ("type"            -> "submit"),
@@ -428,7 +430,7 @@ class Archives extends DispatchSnippet with Loggable {
       ): NodeSeq
     } &
     ("#" + downloadButtonId) #> {
-      (SHtml.ajaxSubmit(downloadButtonName, download _, ("id" -> downloadButtonId), ("class", "btn btn-default")) ++
+      (SHtml.ajaxSubmit(downloadButtonName, download, ("id" -> downloadButtonId), ("class", "btn btn-default")) ++
       WithNonce.scriptWithNonce(
         Script(
           OnLoad(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ClearCache.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/ClearCache.scala
@@ -72,7 +72,7 @@ class ClearCache extends DispatchSnippet with Loggable {
 
     // process the list of networks
     "#clearCacheButton" #> {
-      SHtml.ajaxSubmit("Clear caches", process _, ("class", "btn btn-primary"))
+      SHtml.ajaxSubmit("Clear caches", process, ("class", "btn btn-primary"))
     }
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DatabaseManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DatabaseManagement.scala
@@ -86,7 +86,7 @@ class DatabaseManagement extends DispatchSnippet with Loggable {
             </li>)
     }
         </ul> &
-    "#deleteReports" #> SHtml.ajaxSubmit("Clean reports", process _, ("class", "btn btn-default")) &
+    "#deleteReports" #> SHtml.ajaxSubmit("Clean reports", process, ("class", "btn btn-default")) &
     "#reportFromDate" #> SHtml.text(from, x => from = x))(xml) ++ WithNonce.scriptWithNonce(
       Script(
         OnLoad(JsRaw("""initReportDatepickler("#reportFromDate");""") & updateValue) // JsRaw ok, const

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DyngroupReloading.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/DyngroupReloading.scala
@@ -68,7 +68,7 @@ class DyngroupReloading extends DispatchSnippet with Loggable {
     val initJs = SetHtml("dynGroupUpdateInterval", <span>{updateDynamicGroupsInterval}</span>)
     // process the list of networks
     "#dyngroupReloadingButton" #> {
-      (SHtml.ajaxSubmit("Reload dynamic groups", process _, ("class", "btn btn-primary dyngroupReloadingButton")) ++ WithNonce
+      (SHtml.ajaxSubmit("Reload dynamic groups", process, ("class", "btn btn-primary dyngroupReloadingButton")) ++ WithNonce
         .scriptWithNonce(
           Script(
             OnLoad(initJs)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/EditPolicyServerAllowedNetwork.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/EditPolicyServerAllowedNetwork.scala
@@ -244,7 +244,7 @@ class EditPolicyServerAllowedNetwork extends DispatchSnippet with Loggable {
         } &
         "#addNetworkButton" #> SHtml.ajaxButton(
           <span class="fa fa-plus"></span>,
-          add _,
+          () => add(),
           ("id", s"addNetworkButton${policyServerId.value}")
         ) &
         "#addaNetworkfield" #> SHtml.ajaxText(
@@ -255,7 +255,7 @@ class EditPolicyServerAllowedNetwork extends DispatchSnippet with Loggable {
         "#submitAllowedNetwork" #> {
           (SHtml.ajaxSubmit(
             "Save changes",
-            process _,
+            process,
             ("id", s"submitAllowedNetwork${policyServerId.value}"),
             ("class", "btn btn-success")
           ): NodeSeq) ++ WithNonce.scriptWithNonce(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/PropertiesManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/PropertiesManagement.scala
@@ -75,7 +75,7 @@ import scala.xml.Text
  */
 class PropertiesManagement extends DispatchSnippet with Loggable {
 
-  private val configService: ReadConfigService with UpdateConfigService = RudderConfig.configService
+  private val configService: ReadConfigService & UpdateConfigService = RudderConfig.configService
   private val asyncDeploymentAgent = RudderConfig.asyncDeploymentAgent
   private val uuidGen              = RudderConfig.stringUuidGenerator
 
@@ -183,7 +183,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
         case Full(value) =>
           SHtml.ajaxCheckbox(
             value,
-            initJs _,
+            initJs,
             ("id", "enabled"),
             ("class", "twoCol")
           )
@@ -267,7 +267,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
     } &
 
     "#changeMessageSubmit " #> {
-      SHtml.ajaxSubmit("Save changes", submit _, ("class", "btn btn-success"))
+      SHtml.ajaxSubmit("Save changes", submit, ("class", "btn btn-success"))
     }) apply (xml ++ WithNonce.scriptWithNonce(Script(initJs(enabled))))
   }
 
@@ -324,7 +324,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
     } &
 
     "#cfserverNetworkSubmit " #> {
-      SHtml.ajaxSubmit("Save changes", submit _, ("class", "btn btn-success space-top"))
+      SHtml.ajaxSubmit("Save changes", submit, ("class", "btn btn-success space-top"))
     }) apply (xml ++ WithNonce.scriptWithNonce(Script(check())))
   }
 
@@ -471,7 +471,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
         }
       } &
       "#relaySynchronizationSubmit " #> {
-        SHtml.ajaxSubmit("Save changes", submit _, ("class", "btn btn-success"))
+        SHtml.ajaxSubmit("Save changes", submit, ("class", "btn btn-success"))
       }
     ) apply (xml ++ WithNonce.scriptWithNonce(Script(check())))
   }
@@ -581,7 +581,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
       }
     } &
     "#cfengineGlobalPropsSubmit " #> {
-      SHtml.ajaxSubmit("Save changes", submit _, ("class", "btn btn-success"))
+      SHtml.ajaxSubmit("Save changes", submit, ("class", "btn btn-success"))
     }) apply (xml ++ WithNonce.scriptWithNonce(Script(check())))
   }
 
@@ -635,7 +635,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
       }
     } &
     "#loggingConfigurationSubmit " #> {
-      SHtml.ajaxSubmit("Save changes", submit _, ("class", "btn btn-success"))
+      SHtml.ajaxSubmit("Save changes", submit, ("class", "btn btn-success"))
     }) apply (xml ++ WithNonce.scriptWithNonce(Script(check())))
   }
 
@@ -707,7 +707,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
         )
       } &
       "#generationHookCfpromiseSubmit " #> {
-        SHtml.ajaxSubmit("Save changes", submit _, ("class", "btn btn-success"))
+        SHtml.ajaxSubmit("Save changes", submit, ("class", "btn btn-success"))
       } &
       "#generationHookCfpromiseSubmit *+" #> {
         WithNonce.scriptWithNonce(Script(check()))
@@ -741,7 +741,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
     }
 
     def readProp(): TriggerProp = {
-      (try { Right(File(propPath).lineIterator(StandardCharsets.UTF_8).toVector) }
+      (try { Right(File(propPath).lineIterator(using StandardCharsets.UTF_8).toVector) }
       catch {
         case ex: Exception =>
           Left(s"Error when trying to read properties for hook in '${propPath}': ${ex.getClass.getSimpleName}: ${ex.getMessage}")
@@ -754,7 +754,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
 
     def writeProp(maxNodes: Int, percent: Int): Result[Unit] = {
       try {
-        val lines    = File(propPath).lineIterator(StandardCharsets.UTF_8).toVector
+        val lines    = File(propPath).lineIterator(using StandardCharsets.UTF_8).toVector
         val replaced = lines.map {
           case l =>
             l match {
@@ -767,7 +767,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
               case _                           => l
             }
         }
-        File(propPath).writeText(replaced.mkString("\n"))(better.files.File.OpenOptions.default, StandardCharsets.UTF_8)
+        File(propPath).writeText(replaced.mkString("\n"))(using better.files.File.OpenOptions.default, StandardCharsets.UTF_8)
         Right(())
       } catch {
         case ex: Exception =>
@@ -891,7 +891,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
             )
           } &
           "#generationHookTriggerNodeUpdateSubmit " #> {
-            SHtml.ajaxSubmit("Save changes", submit _, ("class", "btn btn-success"))
+            SHtml.ajaxSubmit("Save changes", submit, ("class", "btn btn-success"))
           } &
           "#generationHookTriggerNodeUpdateSubmit *+" #> {
             WithNonce.scriptWithNonce(Script(check()))
@@ -934,7 +934,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
 
         } &
         "#sendMetricsSubmit " #> {
-          SHtml.ajaxSubmit("Save changes", submit _, ("class", "btn btn-success"))
+          SHtml.ajaxSubmit("Save changes", submit, ("class", "btn btn-success"))
         } &
         "#sendMetricsSubmit *+" #> {
           WithNonce.scriptWithNonce(Script(check()))
@@ -986,7 +986,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
           )
         } &
         "#displayGraphsSubmit " #> {
-          SHtml.ajaxSubmit("Save changes", submit _, ("class", "btn btn-success"))
+          SHtml.ajaxSubmit("Save changes", submit, ("class", "btn btn-success"))
         } &
         "#displayColumnsCheckbox" #> {
           SHtml.ajaxCheckbox(
@@ -1060,7 +1060,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
           )
         } &
         "#directiveScriptEngineSubmit " #> {
-          SHtml.ajaxSubmit("Save changes", submit _, ("class", "btn btn-success"))
+          SHtml.ajaxSubmit("Save changes", submit, ("class", "btn btn-success"))
         } &
         "#directiveScriptEngineSubmit *+" #> {
           WithNonce.scriptWithNonce(Script(check()))
@@ -1140,7 +1140,7 @@ class PropertiesManagement extends DispatchSnippet with Loggable {
         ("id", "nodeOnAcceptPolicyMode")
       ) &
       "#nodeOnAcceptDefaultsSubmit" #> {
-        SHtml.ajaxSubmit("Save changes", submit _, ("class", "btn btn-success"))
+        SHtml.ajaxSubmit("Save changes", submit, ("class", "btn btn-success"))
       } &
       "#nodeOnAcceptDefaultsSubmit *+" #> {
         WithNonce.scriptWithNonce(Script(check()))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/SupportScript.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/SupportScript.scala
@@ -76,7 +76,7 @@ class DebugScript extends DispatchSnippet with Loggable {
     "#launchDebugScriptButton" #> {
       SHtml.ajaxButton(
         (<span class="fa fa-download"></span>: NodeSeq) ++ Text(" Download debug information"),
-        process _,
+        () => process(),
         ("class", "btn btn-primary")
       )
     }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/TechniqueLibraryManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/TechniqueLibraryManagement.scala
@@ -166,7 +166,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
         new GiveReasonPopup(
           onSuccessCallback = { onSuccessReasonPopup },
           onFailureCallback = { onFailureReasonPopup },
-          refreshActiveTreeLibrary = { refreshActiveTreeLibrary _ },
+          refreshActiveTreeLibrary = { () => refreshActiveTreeLibrary() },
           sourceActiveTechniqueId = s,
           destCatId = d
         )
@@ -333,11 +333,11 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
                   // %1$s
                   htmlId_activeTechniquesTree,
                   // %2$s
-                  SHtml.ajaxCall(JsVar("arg"), bindTechnique _)._2.toJsCmd,
+                  SHtml.ajaxCall(JsVar("arg"), bindTechnique)._2.toJsCmd,
                   // %3$s
-                  SHtml.ajaxCall(JsVar("arg"), moveTechnique _)._2.toJsCmd,
+                  SHtml.ajaxCall(JsVar("arg"), moveTechnique)._2.toJsCmd,
                   // %4$s
-                  SHtml.ajaxCall(JsVar("arg"), moveCategory _)._2.toJsCmd,
+                  SHtml.ajaxCall(JsVar("arg"), moveCategory)._2.toJsCmd,
                   htmlId_techniqueLibraryTree
                 )
               ) // JsRaw ok, escaped
@@ -820,7 +820,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
       override def body: NodeSeq = {
         val tooltipContent = s"<h3>${category.name}</h3>\n<div>${category.description}</div>"
         SHtml.a(
-          onClickUserCategory _,
+          () => onClickUserCategory(),
           <span class="treeActiveTechniqueCategoryName" data-bs-toggle="tooltip" title={tooltipContent}>{
             category.name
           }</span>
@@ -891,7 +891,7 @@ class TechniqueLibraryManagement extends DispatchSnippet with Loggable {
     }
 
     (WithNonce.scriptWithNonce(Script(OnLoad(initJs))): NodeSeq) ++
-    SHtml.ajaxButton("Reload techniques", process _, ("class", "btn btn-primary"))
+    SHtml.ajaxButton("Reload techniques", () => process(), ("class", "btn btn-primary"))
   }
 
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
@@ -184,7 +184,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
               var hashJsonObj = JSON.parse(hashJson);
               if ("directiveId" in hashJsonObj) {
                 // displayDetails needs stringified object
-                ${SHtml.ajaxCall(JsVar("hashJson"), displayDetails _)._2.toJsCmd};
+                ${SHtml.ajaxCall(JsVar("hashJson"), displayDetails)._2.toJsCmd};
               }
             } catch {}
           }
@@ -197,7 +197,7 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
           directiveId = null;
         }
         if( directiveId != null && directiveId.length > 0) {
-          ${SHtml.ajaxCall(JsVar("directiveId"), displayDetails _)._2.toJsCmd};
+          ${SHtml.ajaxCall(JsVar("directiveId"), displayDetails)._2.toJsCmd};
         }
         removeBsTooltips();
     """) // JsRaw ok, escaped

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/ParameterManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/ParameterManagement.scala
@@ -70,7 +70,9 @@ class ParameterManagement extends DispatchSnippet with Loggable {
   // the current GlobalParameterForm component
   private val parameterPopup = new LocalSnippet[CreateOrUpdateGlobalParameterPopup]
 
-  def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = { case "display" => { _ => display()(CurrentUser.queryContext) } }
+  def dispatch: PartialFunction[String, NodeSeq => NodeSeq] = {
+    case "display" => { _ => display()(using CurrentUser.queryContext) }
+  }
 
   def display()(implicit qc: QueryContext): NodeSeq = {
     (for {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
@@ -168,7 +168,7 @@ class AcceptNode extends DispatchSnippet with Loggable {
     val modId = ModificationId(uuidGen.newUuid)
     listNode.foreach { id =>
       newNodeManager
-        .refuse(id)(
+        .refuse(id)(using
           ChangeContext(
             modId,
             CurrentUser.actor,
@@ -245,7 +245,7 @@ class AcceptNode extends DispatchSnippet with Loggable {
     }
 
     nodeFactRepository
-      .getAll()(CurrentUser.queryContext, SelectNodeStatus.Pending)
+      .getAll()(using CurrentUser.queryContext, SelectNodeStatus.Pending)
       .map(_.collect { case (id, n) if listNode.contains(id) => n })
       .toBox match {
       case Full(servers) =>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
@@ -81,7 +81,7 @@ object Groups {
 class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with Loggable {
   import Groups.*
 
-  private val getFullGroupLibrary   = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
+  private val getFullGroupLibrary   = () => RudderConfig.roNodeGroupRepository.getFullGroupLibrary()
   private val woNodeGroupRepository = RudderConfig.woNodeGroupRepository
   private val uuidGen               = RudderConfig.stringUuidGenerator
   private val linkUtil              = RudderConfig.linkUtil
@@ -92,7 +92,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
     implicit val qc: QueryContext = CurrentUser.queryContext // bug https://issues.rudder.io/issues/26605
 
     Map(
-      "head"           -> head _,
+      "head"           -> head,
       "detailsPopup"   -> { (_: NodeSeq) => NodeGroupForm.staticBody },
       "initRightPanel" -> { (_: NodeSeq) => initRightPanel() },
       "groupHierarchy" -> groupHierarchy(boxGroupLib)
@@ -292,10 +292,10 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
           targetName = null;
         }
         if( groupId != null && groupId.length > 0) {
-          ${SHtml.ajaxCall(JsVar("groupId"), displayDetailsGroup _)._2.toJsCmd};
+          ${SHtml.ajaxCall(JsVar("groupId"), displayDetailsGroup)._2.toJsCmd};
           hasGroupToDisplay = true;
         } else if( targetName != null && targetName.length > 0) {
-          ${SHtml.ajaxCall(JsVar("targetName"), displayDetailsTarget _)._2.toJsCmd};
+          ${SHtml.ajaxCall(JsVar("targetName"), displayDetailsTarget)._2.toJsCmd};
           hasGroupToDisplay = true;
         }
     """) // JsRaw ok, escaped
@@ -425,10 +425,10 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
           if( destCatId ) {
             if(sourceGroupId) {
               var arg = JSON.stringify({ 'sourceGroupId' : sourceGroupId, 'destCatId' : destCatId });
-              ${SHtml.ajaxCall(JsVar("arg"), moveGroup(lib) _)._2.toJsCmd};
+              ${SHtml.ajaxCall(JsVar("arg"), moveGroup(lib))._2.toJsCmd};
             } else if(  sourceCatId ) {
               var arg = JSON.stringify({ 'sourceCatId' : sourceCatId, 'destCatId' : destCatId });
-              ${SHtml.ajaxCall(JsVar("arg"), moveCategory(lib) _)._2.toJsCmd};
+              ${SHtml.ajaxCall(JsVar("arg"), moveCategory(lib))._2.toJsCmd};
             } else {
               alert("Can not move that kind of object");
               $$.jstree.rollback(data.rlbk);
@@ -473,7 +473,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
                 .move(
                   NodeGroupId(NodeGroupUid(sourceGroupId)),
                   NodeGroupCategoryId(destCatId)
-                )(
+                )(using
                   ChangeContext(
                     ModificationId(uuidGen.newUuid),
                     qc.actor,
@@ -610,7 +610,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
     showGroupProperties(g, parentCategoryId)
   }
 
-  private[this] def showGroupProperties(g: Either[NonGroupRuleTarget, NodeGroup], parentCategoryId: NodeGroupCategoryId) = {
+  private def showGroupProperties(g: Either[NonGroupRuleTarget, NodeGroup], parentCategoryId: NodeGroupCategoryId) = {
     val value = StringEscapeUtils.escapeEcmaScript(g.fold(_.target, _.id.serialize))
     val js    = g match {
       case Left(_)  => s"'target':'${value}'"

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Node.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Node.scala
@@ -51,7 +51,7 @@ import net.liftweb.http.StatefulSnippet
  */
 class Node extends StatefulSnippet {
 
-  private val getFullGroupLibrary = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
+  private val getFullGroupLibrary = () => RudderConfig.roNodeGroupRepository.getFullGroupLibrary()
 
   private val groupLibrary = getFullGroupLibrary().toBox match {
     case Full(x) => x

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/NodeHistoryViewer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/NodeHistoryViewer.scala
@@ -67,7 +67,7 @@ class NodeHistoryViewer extends StatefulSnippet {
   // id of html element to update
   var hid = ""
 
-  var dispatch: DispatchIt = { case "render" => render _ }
+  var dispatch: DispatchIt = { case "render" => render }
 
   def render(xml: NodeSeq): NodeSeq = {
 
@@ -78,7 +78,7 @@ class NodeHistoryViewer extends StatefulSnippet {
         initState(s)
 
         <div>
-          <p>{SHtml.ajaxSelectObj[DateTime](dates, Full(selectedDate), onSelect _)}</p>
+          <p>{SHtml.ajaxSelectObj[DateTime](dates, Full(selectedDate), onSelect)}</p>
           {
           (for {
             globalMode <- configService

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Nodes.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Nodes.scala
@@ -44,7 +44,7 @@ import scala.xml.NodeSeq
 class Nodes extends StatefulSnippet with Loggable {
   val srvGrid = RudderConfig.srvGrid
 
-  val dispatch: DispatchIt = { case "table" => table _ }
+  val dispatch: DispatchIt = { case "table" => table }
 
   def table(html: NodeSeq): NodeSeq = {
     srvGrid.displayAndInit(None, "nodes")

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/PendingHistoryGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/PendingHistoryGrid.scala
@@ -209,7 +209,7 @@ object PendingHistoryGrid extends Loggable {
                   } );
                 })
           """
-        .format(SHtml.ajaxCall(JsVar("ajaxParam"), displayPastInventory(deletedNodes) _)._2.toJsCmd)
+        .format(SHtml.ajaxCall(JsVar("ajaxParam"), displayPastInventory(deletedNodes))._2.toJsCmd)
         .replaceAll("#table_var#", jsVarNameForId()) // JsRaw ok, escaped
     )
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/SearchNodes.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/SearchNodes.scala
@@ -83,7 +83,7 @@ import zio.json.*
 class SearchNodes extends StatefulSnippet with Loggable {
 
   private val queryParser         = RudderConfig.cmdbQueryParser
-  private val getFullGroupLibrary = RudderConfig.roNodeGroupRepository.getFullGroupLibrary _
+  private val getFullGroupLibrary = () => RudderConfig.roNodeGroupRepository.getFullGroupLibrary()
   private val linkUtil            = RudderConfig.linkUtil
 
   // the popup component to create the group
@@ -104,11 +104,11 @@ class SearchNodes extends StatefulSnippet with Loggable {
   var dispatch: DispatchIt = {
     case "showQuery"   =>
       searchNodeComponent.get match {
-        case Full(component) => { _ => queryForm(component)(CurrentUser.queryContext) }
+        case Full(component) => { _ => queryForm(component)(using CurrentUser.queryContext) }
         case _               => { _ => <div>loading...</div><div></div> }
       }
-    case "head"        => head(_)(CurrentUser.queryContext)
-    case "createGroup" => createGroup _
+    case "head"        => head(_)(using CurrentUser.queryContext)
+    case "createGroup" => createGroup
   }
 
   var activateSubmitButton = true
@@ -222,7 +222,7 @@ class SearchNodes extends StatefulSnippet with Loggable {
       ) & JsRaw("$('#SubmitSearch').click();") // JsRaw ok, const
     }
 
-    JsRaw(s"""parseSearchHash(function(x) { ${SHtml.ajaxCall(JsVar("x"), executeQuery _)._2.toJsCmd} })""") // JsRaw ok, escaped
+    JsRaw(s"""parseSearchHash(function(x) { ${SHtml.ajaxCall(JsVar("x"), executeQuery)._2.toJsCmd} })""") // JsRaw ok, escaped
   }
 
   /**

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/Argon2Test.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/Argon2Test.scala
@@ -38,7 +38,6 @@
 package bootstrap.liftweb
 
 import com.normation.rudder.users.*
-import org.junit.*
 import org.junit.runner.RunWith
 import zio.*
 import zio.test.*

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/PasswordEncoderTypeTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/PasswordEncoderTypeTest.scala
@@ -38,7 +38,6 @@
 package bootstrap.liftweb
 
 import com.normation.rudder.users.*
-import org.junit.*
 import org.junit.runner.RunWith
 import zio.*
 import zio.test.*

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderPasswordEncoderTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderPasswordEncoderTest.scala
@@ -38,7 +38,6 @@
 package bootstrap.liftweb
 
 import com.normation.rudder.users.*
-import org.junit.*
 import org.junit.runner.RunWith
 import zio.*
 import zio.test.*

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/RudderUserDetailsTest.scala
@@ -157,7 +157,7 @@ class RudderUserDetailsTest extends ZIOSpecDefault {
 
   val pluginRole: Builtin = Builtin(BuiltinName.PluginRoleName("plugin"), Rights(PluginAuth.values))
 
-  override def spec: Spec[TestEnvironment with Scope, Any] = {
+  override def spec: Spec[TestEnvironment & Scope, Any] = {
 
     suiteAll("All REST tests defined in files") {
 

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/earlyconfig/db/TestCheckUsersFile.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/earlyconfig/db/TestCheckUsersFile.scala
@@ -43,6 +43,7 @@ import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import org.specs2.specification.core.AsExecution
+import scala.annotation.nowarn
 import scala.xml.Elem
 
 @RunWith(classOf[JUnitRunner])
@@ -95,6 +96,7 @@ class TestCheckUsersFile extends Specification {
     }
   }
 
+  @nowarn("any")
   private def withMigrationCtx[A: AsExecution](
       resourceFile: String
   )(block: (() => Elem, CheckUsersFile) => A): A = {

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/earlyconfig/db/TestMigrateChangeValidationEnforceSchema.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/earlyconfig/db/TestMigrateChangeValidationEnforceSchema.scala
@@ -159,7 +159,7 @@ object TestMigrateChangeValidationEnforceSchema {
     override def changeRequestTableName:                         String     = tempCRTableName
     override def workflowTableName:                              String     = tempWorkflowTableName
     override def migrationEffect(implicit xa: Transactor[Task]): Task[Unit] = {
-      val default = super.migrationEffect(xa)
+      val default = super.migrationEffect
       overrideEffect.getOrElse(default)
     }
   }

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/migration/TestMigrateNodeAcceptationInventories.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/migration/TestMigrateNodeAcceptationInventories.scala
@@ -242,7 +242,7 @@ trait TestMigrateNodeAcceptationInventories extends Specification with AfterAll 
     Vector(NodeId("1bd58a1f-3faa-4783-a7a2-52d84021663a"), NodeId("59512a56-53e9-41e1-b36f-ca22d3cdfcbc"))
 
   // lazy val needed to be able to not init datasource when tests are skipped
-  lazy val testFactLog: HistoryLogRepository[NodeId, DateTime, FactLogData, FactLog] with InventoryHistoryDelete =
+  lazy val testFactLog: HistoryLogRepository[NodeId, DateTime, FactLogData, FactLog] & InventoryHistoryDelete =
     if (doJdbcTest && doobie != null) new InventoryHistoryJdbcRepository(doobie) else fileFactLog
 
   // 0afa1d13-d125-4c91-9d71-24c47dc867e9 => deleted, far too old, not supported format

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/ReportLineTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/ReportLineTest.scala
@@ -129,8 +129,8 @@ object ReportLineTest {
       message
     )
 
-    def toRS: ResultSuccessReport  = (ResultSuccessReport.apply _).tupled.apply(toT)
-    def toRE: ResultErrorReport    = (ResultErrorReport.apply _).tupled.apply(toT)
-    def toAC: AuditCompliantReport = (AuditCompliantReport.apply _).tupled.apply(toT)
+    def toRS: ResultSuccessReport  = (ResultSuccessReport.apply).tupled.apply(toT)
+    def toRE: ResultErrorReport    = (ResultErrorReport.apply).tupled.apply(toT)
+    def toAC: AuditCompliantReport = (AuditCompliantReport.apply).tupled.apply(toT)
   }
 }

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPEntry.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPEntry.scala
@@ -305,7 +305,7 @@ object LDAPEntry {
   def apply(rdn: Option[RDN], parentDn: Option[DN], attributes: Attribute*): LDAPEntry = {
     (rdn, parentDn) match {
       case (Some(r), Some(p)) => apply(new DN(r, p), attributes)
-      case (Some(r), _)       => apply(new DN(r :: Nil: _*), attributes)
+      case (Some(r), _)       => apply(new DN(r :: Nil*), attributes)
       case _                  => apply(NULL_DN, attributes)
     }
   }

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPTree.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/LDAPTree.scala
@@ -99,14 +99,14 @@ trait LDAPTree extends Tree[LDAPEntry] with ToLDIFRecords with ToLDIFString {
 }
 
 object LDAPTree {
-  // loggin
+  // log
   val logger: Logger = org.slf4j.LoggerFactory.getLogger(classOf[LDAPTree])
 
   def apply(r: LDAPEntry, c: Iterable[(RDN, LDAPTree)]): LDAPTree = new LDAPTree {
     require(null != r, "root of a tree can't be null")
     require(null != c, "children map of a tree can't be null")
 
-    val root = r
+    override val root: LDAPEntry = r
     c foreach { x => _children += x }
   }
 

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/Tree.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/Tree.scala
@@ -61,10 +61,12 @@ object Tree {
     require(null != r, "root of a tree can't be null")
     require(null != c, "children map of a tree can't be null")
 
-    val root     = r
-    var children = Map[RDN, Tree[X]]() ++ c
+    private var _children = Map[RDN, Tree[X]]() ++ c
 
-    override def addChild(rdn: RDN, child: Tree[X]): Unit = children += ((rdn, child))
+    override val root:     X                 = r
+    override def children: Map[RDN, Tree[X]] = _children
+
+    override def addChild(rdn: RDN, child: Tree[X]): Unit = _children += ((rdn, child))
   }
 
   def apply[X](r: X): Tree[X] = apply(r, Seq[(RDN, Tree[X])]())

--- a/webapp/sources/scala-ldap/src/test/scala/com/normation/ldap/sdk/LoadDemoDataTest.scala
+++ b/webapp/sources/scala-ldap/src/test/scala/com/normation/ldap/sdk/LoadDemoDataTest.scala
@@ -77,8 +77,8 @@ class LoadDemoDataTest extends Specification {
       i + x
   }
 
-  val ldap: InMemoryDsConnectionProvider[RwLDAPConnection with RoLDAPConnection] = {
-    InMemoryDsConnectionProvider[RwLDAPConnection with RoLDAPConnection](
+  val ldap: InMemoryDsConnectionProvider[RwLDAPConnection & RoLDAPConnection] = {
+    InMemoryDsConnectionProvider[RwLDAPConnection & RoLDAPConnection](
       baseDNs = baseDN :: Nil,
       schemaLDIFPaths = schemaLDIFs,
       bootstrapLDIFPaths = bootstrapLDIFs

--- a/webapp/sources/utils/src/main/scala/com/normation/utils/Version.scala
+++ b/webapp/sources/utils/src/main/scala/com/normation/utils/Version.scala
@@ -267,7 +267,7 @@ object ParseVersion {
   }
 
   def parse(s: String): Either[String, Version] = {
-    fastparse.parse(s, version(_)) match {
+    fastparse.parse(s, { case given P[?] => version }) match {
       case Parsed.Success(value, index) => Right(value)
       case _: Parsed.Failure =>
         Left(

--- a/webapp/sources/utils/src/test/scala/zio/json/other/EnumCodecTest.scala
+++ b/webapp/sources/utils/src/test/scala/zio/json/other/EnumCodecTest.scala
@@ -37,7 +37,6 @@
 package zio.json.other
 
 import enumeratum.*
-import org.junit.*
 import org.junit.runner.RunWith
 import zio.*
 import zio.json.*


### PR DESCRIPTION
https://issues.rudder.io/issues/27081

For plugins, we need: 
- public: https://github.com/Normation/rudder-plugins/pull/878
- private : https://github.com/Normation/rudder-plugins-private/pull/1123

Below: description of the main change

### Mandatory `using` for explicit implicits

If you pass an implicit parameter explicitly, it is now mandatory to use the keyword `using`. 
Actually it's just a warning in 3.7 but at some point, we will need to pay that tax, it could be when we officially switch to scala 3. 

### No more trailing _ for function application in paramters

Just use the name, without postponing a `_` behind. 

### `_ => XXX` in signature becomes `? => XXX`

The underscore is replaced by `?` when use in a type signature

### Fastparse change impact

See: 
https://stackoverflow.com/questions/77966105/how-to-test-fastparse-parsers-in-a-separate-class

We must change the way we call fastparse. 

### `A with B` is replaced by `A & B` in signature

All in the tible. 