### PR TITLE
Fixes #26976: Rudder webapp migration create table ScoreDetails with message constraint

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/resources/reportsSchema.sql
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/reportsSchema.sql
@@ -438,7 +438,7 @@ Create table GlobalScore (
 , details jsonb  NOT NULL
 );
 
-Create table scoreDetails (
+Create table ScoreDetails (
   nodeId  text NOT NULL
 , scoreId text NOT NULL
 , score   score NOT NULL

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/ScoreRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/ScoreRepository.scala
@@ -138,7 +138,7 @@ class ScoreRepositoryImpl(doobie: Doobie) extends ScoreRepository {
 
   import doobie.*
   override def getAll(): IOResult[Map[NodeId, List[Score]]] = {
-    val q = sql"select nodeId, scoreId, score, message, details from scoreDetails "
+    val q = sql"select nodeId, scoreId, score, message, details from scoredetails "
     transactIOResult(s"error when getting scores for node")(xa => q.query[(NodeId, Score)].to[List].transact(xa))
       .map(_.groupMap(_._1)(_._2))
   }
@@ -147,7 +147,7 @@ class ScoreRepositoryImpl(doobie: Doobie) extends ScoreRepository {
 
     val whereName = fr"scoreId = ${scoreId}"
     val where     = Fragments.whereAnd(whereName)
-    val q         = sql"select nodeid, scoreId, score, message, details from scoreDetails " ++ where
+    val q         = sql"select nodeid, scoreId, score, message, details from scoredetails " ++ where
     transactIOResult(s"error when getting one score for all nodes")(xa => q.query[(NodeId, Score)].toMap.transact(xa))
   }
 
@@ -156,7 +156,7 @@ class ScoreRepositoryImpl(doobie: Doobie) extends ScoreRepository {
     val whereNode = Some(fr"nodeId = ${nodeId.value}")
     val whereName = scoreId.map(n => fr"scoreId = ${n}")
     val where     = Fragments.whereAndOpt(whereNode, whereName)
-    val q         = sql"select scoreId, score, message, details from scoreDetails " ++ where
+    val q         = sql"select scoreId, score, message, details from scoredetails " ++ where
     transactIOResult(s"error when getting scores for node ${nodeId} ")(xa => q.query[Score].to[List].transact(xa))
   }
 
@@ -164,14 +164,14 @@ class ScoreRepositoryImpl(doobie: Doobie) extends ScoreRepository {
     val whereNode = fr"nodeId = ${nodeId.value}"
     val whereName = fr"scoreId = ${scoreId}"
     val where     = Fragments.whereAnd(whereNode, whereName)
-    val q         = sql"select scoreId, score, message, details from scoreDetails " ++ where
+    val q         = sql"select scoreId, score, message, details from scoredetails " ++ where
     transactIOResult(s"error when getting scores for node")(xa => q.query[Score].unique.transact(xa))
   }
 
   override def saveScore(nodeId: NodeId, score: Score): IOResult[Unit] = {
 
     val query = {
-      sql"""insert into scoreDetails (nodeId, scoreId, score, message, details) values (${(nodeId, score)})
+      sql"""insert into scoredetails (nodeId, scoreId, score, message, details) values (${(nodeId, score)})
            |  ON CONFLICT (nodeId, scoreId) DO UPDATE
            |  SET score = ${score.value}, message = ${score.message}, details = ${score.details} ; """.stripMargin
     }
@@ -184,7 +184,7 @@ class ScoreRepositoryImpl(doobie: Doobie) extends ScoreRepository {
     val whereNode = Some(fr"nodeId = ${nodeId.value}")
     val whereName = scoreId.map(n => fr"scoreId = ${n}")
     val where     = Fragments.whereAndOpt(whereNode, whereName)
-    val q         = sql"delete from scoreDetails " ++ where
+    val q         = sql"delete from scoredetails " ++ where
     transactIOResult(s"error when deleting score for node ${nodeId.value}")(xa => q.update.run.transact(xa).unit)
   }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/26976

Add two migration, each for removing the non empty contstraint on message: one for `GlobalScore`, the other for `ScoreDetails`