### PR TITLE
Fixes #27084: Enforce UTC timezone for datetime

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/JsonSerializers.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/JsonSerializers.scala
@@ -39,6 +39,7 @@ package com.normation.inventory.domain
 
 import com.normation.utils.DateFormaterService
 import java.net.InetAddress
+import java.time.Instant
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormatter
 import org.joda.time.format.ISODateTimeFormat
@@ -74,9 +75,9 @@ object JsonSerializers {
   }
 
   // the update date is normalized in RFC3339, UTC, no millis
-  def parseSoftwareUpdateDateTime(d: String): Either[String, DateTime] = {
+  def parseSoftwareUpdateInstant(d: String): Either[String, Instant] = {
     try {
-      Right(JsonSerializers.softwareUpdateDateTimeFormat.parseDateTime(d))
+      Right(DateFormaterService.toInstant(JsonSerializers.softwareUpdateDateTimeFormat.parseDateTime(d)))
     } catch {
       case e: IllegalArgumentException =>
         Left(s"Error when parsing date '${d}', we expect an RFC3339, UTC no millis format. Error: ${e.getMessage}")
@@ -111,8 +112,8 @@ private object SoftwareUpdateJsonEncoders {
 private object SoftwareUpdateJsonDecoders {
   // This is a trick to avoid the warning of unused encoder and avoid exposing encoders that should be in private scope
   private object PrivateDecoders {
-    implicit val decoderDateTime: JsonDecoder[DateTime] =
-      JsonDecoder[String].mapOrFail(d => JsonSerializers.parseSoftwareUpdateDateTime(d))
+    implicit val decoderDateTime: JsonDecoder[Instant] =
+      JsonDecoder[String].mapOrFail(d => JsonSerializers.parseSoftwareUpdateInstant(d))
   }
   import PrivateDecoders.*
 

--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/MachineInventory.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/MachineInventory.scala
@@ -38,7 +38,7 @@
 package com.normation.inventory.domain
 
 import enumeratum.*
-import org.joda.time.DateTime
+import java.time.Instant
 import zio.json.*
 
 sealed trait PhysicalElement {
@@ -51,7 +51,7 @@ final case class Bios(
     description:  Option[String] = None,
     version:      Option[Version] = None,
     editor:       Option[SoftwareEditor] = None,
-    releaseDate:  Option[DateTime] = None,
+    releaseDate:  Option[Instant] = None,
     manufacturer: Option[Manufacturer] = None,
     serialNumber: Option[String] = None,
     quantity:     Int = 1
@@ -197,8 +197,8 @@ final case class MachineInventory(
     machineType:        MachineType,
     name:               Option[String] = None,
     mbUuid:             Option[MotherBoardUuid] = None,
-    inventoryDate:      Option[DateTime] = None,
-    receiveDate:        Option[DateTime] = None,
+    inventoryDate:      Option[Instant] = None,
+    receiveDate:        Option[Instant] = None,
     manufacturer:       Option[Manufacturer] = None,
     systemSerialNumber: Option[String] = None,
     bios:               Seq[Bios] = Nil,

--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/NodeInventory.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/NodeInventory.scala
@@ -39,7 +39,7 @@ package com.normation.inventory.domain
 
 import enumeratum.*
 import java.net.InetAddress
-import org.joda.time.DateTime
+import java.time.Instant
 import zio.json.*
 import zio.json.ast.*
 
@@ -552,7 +552,7 @@ final case class SoftwareUpdate(
     source:      Option[String],
     description: Option[String],
     severity:    Option[SoftwareUpdateSeverity],
-    date:        Option[DateTime],
+    date:        Option[Instant],
     ids:         Option[List[String]]
 )
 
@@ -578,11 +578,11 @@ final case class NodeInventory(
     description:          Option[String] = None,
     ram:                  Option[MemorySize] = None,
     swap:                 Option[MemorySize] = None,
-    inventoryDate:        Option[DateTime] = None,
-    receiveDate:          Option[DateTime] = None,
+    inventoryDate:        Option[Instant] = None,
+    receiveDate:          Option[Instant] = None,
     archDescription:      Option[String] = None,
     lastLoggedUser:       Option[String] = None,
-    lastLoggedUserTime:   Option[DateTime] = None,
+    lastLoggedUserTime:   Option[Instant] = None,
     agents:               Seq[AgentInfo] = Seq(),
     serverIps:            Seq[String] = Seq(),
     machineId:            Option[(MachineUuid, InventoryStatus)] =

--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/Software.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/Software.scala
@@ -37,6 +37,7 @@
 
 package com.normation.inventory.domain
 
+import java.time.Instant
 import org.joda.time.DateTime
 
 final case class License(
@@ -45,7 +46,7 @@ final case class License(
     productId:      Option[String] = None,
     productKey:     Option[String] = None,
     oem:            Option[String] = None,
-    expirationDate: Option[DateTime] = None
+    expirationDate: Option[Instant] = None
 )
 
 final case class Software(

--- a/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestReportParsing.scala
+++ b/webapp/sources/ldap-inventory/inventory-fusion/src/test/scala/com/normation/inventory/provisioning/fusion/TestReportParsing.scala
@@ -351,7 +351,7 @@ class TestInventoryParsing extends Specification with Loggable {
             source = Some("security-backport"),
             Some("Local privilege escalation in pkexec due to incorrect handling of argument vector (CVE-2021-4034)"),
             Some(SoftwareUpdateSeverity.Low),
-            JsonSerializers.parseSoftwareUpdateDateTime("2022-01-26T00:00:00Z").toOption,
+            JsonSerializers.parseSoftwareUpdateInstant("2022-01-26T00:00:00Z").toOption,
             Some(List("RHSA-2020-4566", "CVE-2021-4034"))
           )
         )

--- a/webapp/sources/ldap-inventory/inventory-provisioning-core/src/main/scala/com/normation/inventory/ldap/provisioning/PreCommits.scala
+++ b/webapp/sources/ldap-inventory/inventory-provisioning-core/src/main/scala/com/normation/inventory/ldap/provisioning/PreCommits.scala
@@ -40,6 +40,7 @@ package com.normation.inventory.ldap.provisioning
 import com.normation.errors.*
 import com.normation.inventory.domain.*
 import com.normation.inventory.services.provisioning.*
+import java.time.Instant
 import zio.syntax.*
 
 /**
@@ -71,12 +72,11 @@ object CheckOsType extends PreCommit {
  * Update last inventory date for Server and machine
  */
 class LastInventoryDate() extends PreCommit {
-  import org.joda.time.DateTime
 
   override val name = "pre_commit_inventory:set_last_inventory_date"
 
   override def apply(inventory: Inventory): IOResult[Inventory] = {
-    val now = DateTime.now()
+    val now = Instant.now
 
     inventory
       .copy(

--- a/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/SoftwareService.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/main/scala/com/normation/inventory/ldap/core/SoftwareService.scala
@@ -7,6 +7,7 @@ import com.normation.inventory.services.core.WriteOnlySoftwareDAO
 import com.normation.utils.DateFormaterService
 import com.normation.zio.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import zio.*
 import zio.syntax.*
 
@@ -60,7 +61,10 @@ class SoftwareServiceImpl(
                                     f <- IOResult.attempt {
                                            val dir = File("/var/rudder/tmp/purgeSoftware")
                                            dir.createDirectories()
-                                           File(dir, s"${DateFormaterService.serialize(DateTime.now())}-unreferenced-software-dns.txt")
+                                           File(
+                                             dir,
+                                             s"${DateFormaterService.serialize(DateTime.now(DateTimeZone.UTC))}-unreferenced-software-dns.txt"
+                                           )
                                          }
                                     _ <- IOResult.attempt {
                                            extraSoftware.foreach(x => (f << softwareDIT.SOFTWARE.SOFT.dn(x).toString))

--- a/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestInventory.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestInventory.scala
@@ -508,7 +508,7 @@ class TestInventory extends Specification {
       val inv = repo.get(NodeId("node0")).testRunGet
       val su1 = inv.node.softwareUpdates
       val d0  = "2022-01-01T00:00:00Z"
-      val dt0 = JsonSerializers.parseSoftwareUpdateDateTime(d0).toOption
+      val dt0 = JsonSerializers.parseSoftwareUpdateInstant(d0).toOption
       val id0 = "RHSA-2020-4566"
       val id1 = "CVE-2021-4034"
 

--- a/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestNodeUnserialisation.scala
+++ b/webapp/sources/ldap-inventory/inventory-repository/src/test/scala/com/normation/inventory/ldap/core/TestNodeUnserialisation.scala
@@ -259,7 +259,7 @@ class TestNodeUnserialisation extends Specification {
     }
 
     "correctly unserialize software updates node from 7_0" in {
-      val date = JsonSerializers.parseSoftwareUpdateDateTime("2022-01-26T00:00:00Z")
+      val date = JsonSerializers.parseSoftwareUpdateInstant("2022-01-26T00:00:00Z")
       (date must beRight) and (node(linux70Ldif).softwareUpdates(0) must beEqualTo(
         SoftwareUpdate(
           "rudder-agent",

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/eventlog/EventLog.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/eventlog/EventLog.scala
@@ -23,7 +23,7 @@ package com.normation.eventlog
 import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.utils.StringUuidGeneratorImpl
 import io.scalaland.chimney.Transformer
-import org.joda.time.DateTime
+import java.time.Instant
 import scala.xml.*
 
 final case class EventActor(name: String) extends AnyVal
@@ -97,7 +97,7 @@ final case class EventLogDetails(
     val id:             Option[Int] = None,
     val modificationId: Option[ModificationId],
     val principal:      EventActor,
-    val creationDate:   DateTime = DateTime.now(),
+    val creationDate:   Instant = Instant.now(),
     val cause:          Option[Int] = None,
     val severity:       Int = 100,
     val reason:         Option[String],
@@ -136,7 +136,7 @@ trait EventLog {
 
   def principal: EventActor = eventDetails.principal
 
-  def creationDate: DateTime = eventDetails.creationDate
+  def creationDate: Instant = eventDetails.creationDate
 
   /**
    * When we create the EventLog, it usually shouldn't have an id, so the cause cannot be set

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/api/ApiAccountRepository.scala
@@ -56,6 +56,7 @@ import com.normation.rudder.repository.ldap.LDAPEntityMapper
 import com.normation.rudder.services.user.PersonIdentService
 import com.normation.zio.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import zio.*
 import zio.syntax.*
 
@@ -110,8 +111,8 @@ final class RoLDAPApiAccountRepository(
       Some(systemToken),
       "For internal use",
       isEnabled = true,
-      creationDate = DateTime.now,
-      tokenGenerationDate = DateTime.now,
+      creationDate = DateTime.now(DateTimeZone.UTC),
+      tokenGenerationDate = DateTime.now(DateTimeZone.UTC),
       tenants = NodeSecurityContext.All
     )
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -89,8 +89,8 @@ import enumeratum.Enum
 import enumeratum.EnumEntry
 import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.dsl.*
+import java.time.Instant
 import java.time.LocalTime
-import org.joda.time.DateTime
 import zio.*
 import zio.Tag as _
 import zio.json.*
@@ -250,9 +250,9 @@ object JsonResponseObjects {
       machine:                     Option[nodes.MachineInfo],
       ipAddresses:                 Option[Chunk[String]],
       description:                 Option[String],
-      acceptanceDate:              Option[DateTime],
-      lastInventoryDate:           Option[DateTime],
-      lastRunDate:                 Option[DateTime],
+      acceptanceDate:              Option[Instant],
+      lastInventoryDate:           Option[Instant],
+      lastRunDate:                 Option[Instant],
       policyServerId:              Option[NodeId],
       managementTechnology:        Option[Chunk[JRNodeDetailLevel.Management]],
       properties:                  Option[Chunk[JRProperty]],
@@ -309,7 +309,7 @@ object JsonResponseObjects {
         .withFieldComputed(_.lastInventoryDate, levelField("lastInventoryDate")(nodeInfo.inventoryDate))
         .withFieldComputed(
           _.lastRunDate,
-          levelField(_)("lastRunDate")(agentRun.map(_.agentRunId.date))
+          levelField(_)("lastRunDate")(agentRun.map(x => DateFormaterService.toInstant(x.agentRunId.date)))
         )
         .withFieldComputed(_.policyServerId, levelField("policyServerId")(nodeInfo.policyServerId))
         .withFieldComputed(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportsCleaner.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/AutomaticReportsCleaner.scala
@@ -217,7 +217,7 @@ final case class Hourly(min: Int) extends CleanFrequency {
   def checker(date: DateTime): DateTime = date.withMinuteOfHour(min)
 
   def next: DateTime = {
-    val now = DateTime.now()
+    val now = DateTime.now(DateTimeZone.UTC)
     if (now.isBefore(checker(now)))
       checker(now)
     else
@@ -237,7 +237,7 @@ final case class Daily(hour: Int, min: Int) extends CleanFrequency {
   def checker(date: DateTime): DateTime = date.withMinuteOfHour(min).withHourOfDay(hour)
 
   def next: DateTime = {
-    val now = DateTime.now()
+    val now = DateTime.now(DateTimeZone.UTC)
     if (now.isBefore(checker(now)))
       checker(now)
     else
@@ -257,7 +257,7 @@ final case class Weekly(day: Int, hour: Int, min: Int) extends CleanFrequency {
   def checker(date: DateTime): DateTime = date.withMinuteOfHour(min).withHourOfDay(hour).withDayOfWeek(day)
 
   def next: DateTime = {
-    val now = DateTime.now()
+    val now = DateTime.now(DateTimeZone.UTC)
     if (now.isBefore(checker(now)))
       checker(now)
     else
@@ -484,7 +484,7 @@ class AutomaticReportsCleaning(
           currentState match {
             case IdleCleaner =>
               logger.trace("***** Check launch *****")
-              if (freq.check(DateTime.now)) {
+              if (freq.check(DateTime.now(DateTimeZone.UTC))) {
                 logger.trace("***** Automatic %s entering in active State *****".format(cleanaction.name.toLowerCase()))
                 currentState = ActiveCleaner
                 (this) ! CleanDatabase
@@ -512,7 +512,7 @@ class AutomaticReportsCleaning(
         currentState match {
 
           case ActiveCleaner =>
-            val now               = DateTime.now
+            val now               = DateTime.now(DateTimeZone.UTC)
             val reportsCommand    = DeleteCommand.Reports(now.minusDays(reportsttl))
             val complianceCommand = if (compliancettl > 0) {
               Some(DeleteCommand.ComplianceLevel(now.minusDays(compliancettl)))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/CheckPolicyTemplateLibrary.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/CheckPolicyTemplateLibrary.scala
@@ -51,6 +51,7 @@ import net.liftweb.actor.SpecializedLiftActor
 import net.liftweb.common.EmptyBox
 import net.liftweb.common.Full
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.ISODateTimeFormat
 
 final case class StartLibUpdate(actor: EventActor)
@@ -116,7 +117,7 @@ class CheckTechniqueLibrary(
         policyPackageUpdater.update(
           ModificationId(uuidGen.newUuid),
           actor,
-          Some(s"Automatic batch update at ${DateTime.now.toString(ISODateTimeFormat.basicDateTime())}")
+          Some(s"Automatic batch update at ${DateTime.now(DateTimeZone.UTC).toString(ISODateTimeFormat.basicDateTime())}")
         ) match {
           case Full(t) =>
             logger.trace(s"***** udpate successful for ${t.size} techniques")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/CleanupUsers.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/CleanupUsers.scala
@@ -46,6 +46,7 @@ import com.normation.utils.DateFormaterService
 import com.normation.zio.*
 import cron4s.CronExpr
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import zio.*
 
 /**
@@ -85,7 +86,7 @@ class CleanupUsers(
    */
   val cleanup: UIO[Unit] = for {
     t0   <- currentTimeMillis
-    d     = new DateTime(t0)
+    d     = new DateTime(t0, DateTimeZone.UTC)
     trace = EventTrace(RudderEventActor, d, _)
     _    <-
       // disable current users known not to be admin

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeDeletedInventories.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeDeletedInventories.scala
@@ -43,6 +43,7 @@ import com.normation.rudder.domain.logger.ScheduledJobLoggerPure
 import com.normation.rudder.services.servers.PurgeDeletedNodes
 import com.normation.zio.ZioRuntime
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.concurrent.duration.FiniteDuration
 import zio.*
 
@@ -69,7 +70,7 @@ class PurgeDeletedInventories(
         s"***** starting batch that purge deleted inventories older than ${TTL} days, every ${updateInterval.toString()} *****"
       )
       val prog: UIO[Unit] = purgeDeletedNodes
-        .purgeDeletedNodesPreviousDate(DateTime.now().withTimeAtStartOfDay().minusDays(TTL))
+        .purgeDeletedNodesPreviousDate(DateTime.now(DateTimeZone.UTC).withTimeAtStartOfDay().minusDays(TTL))
         .either
         .flatMap(_ match {
           case Right(nodes) =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeOldInventoryData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/PurgeOldInventoryData.scala
@@ -46,6 +46,7 @@ import com.normation.zio.*
 import cron4s.CronExpr
 import java.time.Instant
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import zio.*
 
 /**
@@ -106,7 +107,7 @@ class PurgeOldInventoryData(
 
   // the part for inventory data in jdbc
   val cleanHistoricalInventories: ZIO[Any, Nothing, Unit] = {
-    val now            = DateTime.now()
+    val now            = DateTime.now(DateTimeZone.UTC)
     val deleteAccepted = (for {
       ids <- inventoryHistory.deleteFactCreatedBefore(now.minus(deleteLogAccepted.toMillis))
       _   <- InventoryProcessingLogger.info(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/UpdateDynamicGroups.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/UpdateDynamicGroups.scala
@@ -50,9 +50,11 @@ import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.services.queries.*
 import com.normation.rudder.utils.ParseMaxParallelism
+import com.normation.utils.DateFormaterService
 import com.normation.utils.StringUuidGenerator
 import com.normation.utils.Utils.DateToIsoString
 import com.normation.zio.*
+import java.time.Instant
 import net.liftweb.actor.*
 import net.liftweb.common.*
 import org.joda.time.*
@@ -68,8 +70,8 @@ object GroupUpdateMessage {
   final case class DynamicUpdateResult(
       id:      Long,
       modId:   ModificationId,
-      start:   DateTime,
-      end:     DateTime,
+      start:   Instant,
+      end:     Instant,
       results: Box[List[(NodeGroupId, Either[RudderError, DynGroupDiff])]]
   ) extends GroupUpdateMessage
 }
@@ -81,7 +83,7 @@ sealed trait DynamicGroupUpdaterStates //states into wich the updater process ca
 //the process is idle
 case object IdleGroupUpdater extends DynamicGroupUpdaterStates
 //an update is currently running for the given nodes
-final case class StartDynamicUpdate(id: Long, modId: ModificationId, started: DateTime, groupIds: GroupsToUpdate)
+final case class StartDynamicUpdate(id: Long, modId: ModificationId, started: Instant, groupIds: GroupsToUpdate)
     extends DynamicGroupUpdaterStates
 
 /**
@@ -138,7 +140,7 @@ class UpdateDynamicGroups(
     updateManager =>
 
     private var updateId       = 0L
-    private var lastUpdateTime = new DateTime(0)
+    private var lastUpdateTime = new DateTime(0, DateTimeZone.UTC)
     private var avoidedUpdate  = 0L
     private var currentState: DynamicGroupUpdaterStates = IdleGroupUpdater
     private var onePending         = false
@@ -180,7 +182,7 @@ class UpdateDynamicGroups(
                 LAUpdateDyngroup ! StartDynamicUpdate(
                   updateId,
                   ModificationId(uuidGen.newUuid),
-                  DateTime.now,
+                  Instant.now(),
                   GroupsToUpdate(groupIds._1, groupIds._2)
                 )
               case e: EmptyBox =>
@@ -227,7 +229,7 @@ class UpdateDynamicGroups(
         processUpdate(true)
 
       case GroupUpdateMessage.ForceStartUpdate                                    =>
-        lastUpdateTime = new DateTime(0)
+        lastUpdateTime = new DateTime(0, DateTimeZone.UTC)
         processUpdate(true)
 
       // This case is launched when an update was pending, it only launch the process
@@ -241,7 +243,7 @@ class UpdateDynamicGroups(
       //
       case GroupUpdateMessage.DynamicUpdateResult(id, modId, start, end, results) => // TODO: other log ?
         DynamicGroupLoggerPure.logEffect.trace(s"Get result for process: ${id}")
-        lastUpdateTime = start
+        lastUpdateTime = DateFormaterService.toDateTime(start)
         currentState = IdleGroupUpdater
 
         // If one update is pending, immediately start a new group update
@@ -257,7 +259,8 @@ class UpdateDynamicGroups(
 
         // log some information
         DynamicGroupLoggerPure.logEffect.debug(
-          s"Dynamic group update in ${new Duration(end.getMillis - start.getMillis).toPeriod().toString} (started at ${start.toIsoStringNoMillis}, ended at ${end.toIsoStringNoMillis})"
+          s"Dynamic group update in ${new Duration(end.toEpochMilli - start.toEpochMilli).toPeriod().toString} (started at ${DateFormaterService
+              .serializeInstant(start)}, ended at ${DateFormaterService.serializeInstant(end)})"
         )
 
         for {
@@ -322,7 +325,7 @@ class UpdateDynamicGroups(
                                                     ChangeContext(
                                                       modId,
                                                       RudderEventActor,
-                                                      new DateTime(),
+                                                      Instant.now(),
                                                       Some("Update group due to batch update of dynamic groups"),
                                                       None,
                                                       QueryContext.systemQC.nodePerms
@@ -344,7 +347,7 @@ class UpdateDynamicGroups(
                                                     ChangeContext(
                                                       modId,
                                                       RudderEventActor,
-                                                      new DateTime(),
+                                                      Instant.now(),
                                                       Some("Update group due to batch update of dynamic groups"),
                                                       None,
                                                       QueryContext.systemQC.nodePerms
@@ -374,14 +377,20 @@ class UpdateDynamicGroups(
                 )
             }).toBox
 
-            updateManager ! GroupUpdateMessage.DynamicUpdateResult(processId, modId, startTime, DateTime.now, result)
+            updateManager ! GroupUpdateMessage.DynamicUpdateResult(
+              processId,
+              modId,
+              startTime,
+              Instant.now(),
+              result
+            )
           } catch {
             case e: Exception =>
               updateManager ! GroupUpdateMessage.DynamicUpdateResult(
                 processId,
                 modId,
                 startTime,
-                DateTime.now,
+                Instant.now(),
                 Failure("Exception caught during update process.", Full(e), Empty)
               )
           }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/db/Doobie.scala
@@ -63,6 +63,7 @@ import java.sql.SQLXML
 import javax.sql.DataSource
 import net.liftweb.common.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.postgresql.util.PGobject
 import scala.xml.Elem
 import scala.xml.XML
@@ -179,7 +180,7 @@ object Doobie {
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   implicit val DateTimeMeta: Meta[DateTime] =
-    Meta[java.sql.Timestamp].imap(ts => new DateTime(ts.getTime()))(dt => new java.sql.Timestamp(dt.getMillis))
+    Meta[java.sql.Timestamp].imap(ts => new DateTime(ts.getTime(), DateTimeZone.UTC))(dt => new java.sql.Timestamp(dt.getMillis))
 
   implicit val ReadRuleId: Get[RuleId] = {
     Get[String].map(r => {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/eventlog/ArchiveEventLog.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/eventlog/ArchiveEventLog.scala
@@ -41,6 +41,7 @@ import com.normation.eventlog.*
 import com.normation.rudder.domain.Constants
 import com.normation.rudder.git.GitArchiveId
 import com.normation.rudder.git.GitCommitId
+import com.normation.utils.DateFormaterService
 import scala.xml.*
 sealed trait ImportExportEventLog extends EventLog {
   final override val eventLogCategory: EventLogCategory = ImportExportItemsLogCategory
@@ -389,7 +390,7 @@ object Rollback extends EventLogFilter {
                 <id>{ev.id.get}</id>
                 <type>{ev.eventType.serialize}</type>
                 <author>{ev.principal.name}</author>
-                <date>{ev.creationDate.toString("yyyy-MM-dd HH:mm")}</date>
+                <date>{DateFormaterService.serializeInstant(ev.creationDate)}</date>
               </rollbackedEvent>
             }
           }
@@ -399,7 +400,7 @@ object Rollback extends EventLogFilter {
                 <id>{targetEvent.id.get}</id>
                 <type>{targetEvent.eventType.serialize}</type>
                 <author>{targetEvent.principal.name}</author>
-                <date>{targetEvent.creationDate.toString("yyyy-MM-dd HH:mm")}</date>
+                <date>{DateFormaterService.serializeInstant(targetEvent.creationDate)}</date>
             </main>
           }
           events ++ main

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/eventlog/AssetsEventLog.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/eventlog/AssetsEventLog.scala
@@ -41,7 +41,8 @@ import com.normation.eventlog.*
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.Constants
 import com.normation.rudder.domain.nodes.NodeInfo
-import org.joda.time.DateTime
+import com.normation.utils.DateFormaterService
+import java.time.Instant
 import scala.xml.Node
 
 /**
@@ -50,7 +51,7 @@ import scala.xml.Node
 
 final case class InventoryLogDetails(
     nodeId:           NodeId,
-    inventoryVersion: DateTime,
+    inventoryVersion: Instant,
     hostname:         String,
     fullOsName:       String,
     actorIp:          String
@@ -73,7 +74,7 @@ object InventoryEventLog {
     scala.xml.Utility.trim(
       <node action={action} fileFormat={Constants.XML_CURRENT_FILE_FORMAT.toString}>
         <id>{logDetails.nodeId.value}</id>
-        <inventoryVersion>{logDetails.inventoryVersion}</inventoryVersion>
+        <inventoryVersion>{DateFormaterService.serializeInstant(logDetails.inventoryVersion)}</inventoryVersion>
         <hostname>{logDetails.hostname}</hostname>
         <fullOsName>{logDetails.fullOsName}</fullOsName>
         <actorIp>{logDetails.actorIp}</actorIp>
@@ -98,7 +99,7 @@ object AcceptNodeEventLog extends EventLogFilter {
       id:               Option[Int] = None,
       principal:        EventActor,
       inventoryDetails: InventoryLogDetails,
-      creationDate:     DateTime = DateTime.now(),
+      creationDate:     Instant = Instant.now(),
       severity:         Int = 100,
       description:      Option[String] = None
   ): AcceptNodeEventLog = {
@@ -129,7 +130,7 @@ object RefuseNodeEventLog extends EventLogFilter {
       id:               Option[Int] = None,
       principal:        EventActor,
       inventoryDetails: InventoryLogDetails,
-      creationDate:     DateTime = DateTime.now(),
+      creationDate:     Instant = Instant.now(),
       severity:         Int = 100,
       description:      Option[String] = None
   ): RefuseNodeEventLog = {
@@ -166,7 +167,7 @@ object DeleteNodeEventLog extends EventLogFilter {
       id:               Option[Int] = None,
       principal:        EventActor,
       inventoryDetails: InventoryLogDetails,
-      creationDate:     DateTime = DateTime.now(),
+      creationDate:     Instant = Instant.now(),
       severity:         Int = 100,
       description:      Option[String] = None
   ): DeleteNodeEventLog = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/DebugNodeConfigurationLogger.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/logger/DebugNodeConfigurationLogger.scala
@@ -45,6 +45,7 @@ import java.io.PrintWriter
 import net.liftweb.common.*
 import net.liftweb.json.Serialization.writePretty
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.slf4j
 import org.slf4j.LoggerFactory
 
@@ -97,7 +98,9 @@ class NodeConfigurationLoggerImpl(
 
     if (logger.isDebugEnabled) {
       for {
-        logTime <- writeIn(new File(path, "lastWritenTime"))(printWriter => Full(printWriter.write(DateTime.now.toString())))
+        logTime <- writeIn(new File(path, "lastWritenTime"))(printWriter =>
+                     Full(printWriter.write(DateTime.now(DateTimeZone.UTC).toString()))
+                   )
         configs <- (traverse(nodeConfiguration) { config =>
                      val logFile = new File(path, config.nodeInfo.fqdn + "_" + config.nodeInfo.id.value)
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/Node.scala
@@ -52,7 +52,7 @@ import com.normation.rudder.reports.AgentRunInterval
 import com.normation.rudder.reports.HeartbeatConfiguration
 import com.normation.rudder.reports.ReportingConfiguration
 import enumeratum.*
-import org.joda.time.DateTime
+import java.time.Instant
 
 /**
  * The entry point for a REGISTERED node in Rudder.
@@ -67,7 +67,7 @@ final case class Node(
     state:                      NodeState,
     isSystem:                   Boolean,
     isPolicyServer:             Boolean,
-    creationDate:               DateTime,
+    creationDate:               Instant,
     nodeReportingConfiguration: ReportingConfiguration,
     properties:                 List[NodeProperty],
     policyMode:                 Option[PolicyMode],
@@ -83,7 +83,7 @@ case object Node {
       NodeState.Enabled,
       isSystem = false,
       isPolicyServer = false,
-      creationDate = inventory.node.inventoryDate.getOrElse(new DateTime(0)),
+      creationDate = inventory.node.inventoryDate.getOrElse(Instant.ofEpochMilli(0)),
       nodeReportingConfiguration = ReportingConfiguration(None, None, None),
       properties = Nil,
       policyMode = None,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeInfo.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeInfo.scala
@@ -48,12 +48,12 @@ import java.security.KeyFactory
 import java.security.MessageDigest
 import java.security.interfaces.RSAPublicKey
 import java.security.spec.X509EncodedKeySpec
+import java.time.Instant
 import net.liftweb.common.*
 import org.apache.commons.codec.binary.Base64
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import org.bouncycastle.util.encoders.Hex
-import org.joda.time.DateTime
 import zio.*
 import zio.syntax.*
 
@@ -94,7 +94,7 @@ final case class NodeInfo(
     machine:                       Option[MachineInfo],
     osDetails:                     OsDetails,
     ips:                           List[String],
-    inventoryDate:                 DateTime,
+    inventoryDate:                 Instant,
     keyStatus:                     KeyStatus,
     agentsName:                    Seq[AgentInfo],
     policyServerId:                NodeId,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/ActiveTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/ActiveTechnique.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.domain.policies
 import com.normation.cfclerk.domain.TechniqueName
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.ldap.sdk.GeneralizedTime
+import com.normation.utils.DateFormaterService
 import org.joda.time.DateTime
 import zio.json.*
 
@@ -85,9 +86,12 @@ object AcceptationDateTime {
 
   implicit val codecDateTime: JsonCodec[DateTime] = new JsonCodec(
     JsonEncoder.string.contramap(s => GeneralizedTime(s).toString()),
-    JsonDecoder.string.mapOrFail(x =>
-      GeneralizedTime.parse(x).map(_.dateTime).toRight(s"Error when parsing '${x}' as a generalized time'")
-    )
+    JsonDecoder.string.mapOrFail(x => {
+      GeneralizedTime
+        .parse(x)
+        .map(x => DateFormaterService.toDateTime(x.instant))
+        .toRight(s"Error when parsing '${x}' as a generalized time'")
+    })
   )
 
   // we're forced to spell it

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
@@ -57,6 +57,7 @@ import io.scalaland.chimney.*
 import io.scalaland.chimney.syntax.*
 import java.util.regex.PatternSyntaxException
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.format.DateTimeFormatter
 import zio.json.*
@@ -530,7 +531,7 @@ case object DateComparator extends LDAPCriterionType {
 
   private def parseDate(value: String): PureResult[DateTime] = {
     allFmts
-      .map(f => Either.catchOnly[Exception](f.parseDateTime(value)))
+      .map(f => Either.catchOnly[Exception](f.parseDateTime(value).withZone(DateTimeZone.UTC)))
       .reduceLeft(_ orElse _)
       .leftMap(error(value, _))
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -48,6 +48,7 @@ import io.scalaland.chimney.*
 import io.scalaland.chimney.syntax.*
 import net.liftweb.common.Loggable
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.collection.MapView
 import zio.*
 import zio.json.*
@@ -452,7 +453,7 @@ object RuleNodeStatusReport {
         val newDirectives = DirectiveStatusReport.merge(reports.toList.flatMap(_.directives.values))
 
         // the merge of two reports expire when the first one expire
-        val expire = new DateTime(reports.map(_.expirationDate.getMillis).min)
+        val expire = new DateTime(reports.map(_.expirationDate.getMillis).min, DateTimeZone.UTC)
         (id, RuleNodeStatusReport(id._1, id._2, id._3, id._4, id._5, newDirectives, expire))
     }
   }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactStorage.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactStorage.scala
@@ -70,8 +70,8 @@ import com.normation.zio.*
 import com.softwaremill.quicklens.*
 import com.unboundid.ldap.sdk.DN
 import java.nio.charset.StandardCharsets
+import java.time.Instant
 import org.eclipse.jgit.lib.PersonIdent
-import org.joda.time.DateTime
 import scala.annotation.unused
 import zio.*
 import zio.json.*
@@ -858,7 +858,7 @@ class LdapNodeFactStorage(
               inv.machine.map(m => MachineInfo(m.id, m.machineType, m.systemSerialNumber, m.manufacturer)),
               inv.node.main.osDetails,
               inv.node.serverIps.toList,
-              inv.node.inventoryDate.getOrElse(DateTime.now),
+              inv.node.inventoryDate.getOrElse(Instant.now),
               inv.node.main.keyStatus,
               inv.node.agents,
               inv.node.main.policyServerId,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitFindUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/git/GitFindUtils.scala
@@ -58,6 +58,7 @@ import org.eclipse.jgit.treewalk.TreeWalk
 import org.eclipse.jgit.treewalk.filter.PathFilter
 import org.eclipse.jgit.treewalk.filter.TreeFilter
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import zio.*
 import zio.syntax.*
 
@@ -150,7 +151,7 @@ object GitFindUtils extends NamedZioLogger {
       ZIO.foreach(git.log().addPath(path).call().asScala) { commit =>
         RevisionInfo(
           Revision(commit.getId.getName),
-          new DateTime(commit.getCommitTime.toLong * 1000),
+          new DateTime(commit.getCommitTime.toLong * 1000, DateTimeZone.UTC),
           commit.getAuthorIdent.getName,
           commit.getFullMessage
         ).succeed

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryFileWatcher.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryFileWatcher.scala
@@ -51,6 +51,7 @@ import java.util.concurrent.TimeUnit
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.filefilter.TrueFileFilter
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.annotation.unused
 import scala.concurrent.ExecutionContext
 import zio.*
@@ -358,7 +359,7 @@ class CheckExistingInventoryFilesImpl(
 ) extends CheckExistingInventoryFiles {
 
   def processOldFiles(files: List[File]): UIO[Unit] = {
-    val now           = DateTime.now()
+    val now           = DateTime.now(DateTimeZone.UTC)
     val purgeTime     = now.minusMillis(purgeAfter.toMillis.toInt)
     val orphanTime    = now.minusMillis(waitingSignatureTime.toMillis.toInt)
     val filteredFiles = filterFiles(purgeTime, orphanTime, files)
@@ -459,7 +460,7 @@ class CheckExistingInventoryFilesImpl(
     import scala.jdk.CollectionConverters.*
     (for {
       // if that fails, just exit
-      ageLimit <- IOResult.attempt(DateTime.now().minusMillis(d.toMillis.toInt))
+      ageLimit <- IOResult.attempt(DateTime.now(DateTimeZone.UTC).minusMillis(d.toMillis.toInt))
       filter    = (f: File) => {
                     if (
                       f.exists && InventoryProcessingUtils

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/InventoryProcessor.scala
@@ -64,6 +64,7 @@ import java.io.InputStream
 import java.nio.file.NoSuchFileException
 import java.security.PublicKey as JavaSecPubKey
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.Duration
 import org.joda.time.format.PeriodFormat
 import scala.annotation.nowarn
@@ -438,7 +439,7 @@ class InventoryMover(
    */
   def writeErrorLogFile(failedInventoryPath: File, result: InventoryProcessStatus): UIO[Unit] = {
     import com.normation.rudder.inventory.StatusLog.*
-    val date       = DateFormaterService.serialize(DateTime.now())
+    val date       = DateFormaterService.serialize(DateTime.now(DateTimeZone.UTC))
     val rejectPath = failedInventoryPath.pathAsString + s".reject-${date}.log"
 
     // this must never lead to a bubbling failure

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/DeleteEditorTechnique.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/ncf/DeleteEditorTechnique.scala
@@ -59,7 +59,7 @@ import com.normation.rudder.repository.WoDirectiveRepository
 import com.normation.rudder.repository.xml.TechniqueArchiver
 import com.normation.rudder.services.workflows.ChangeRequestService
 import com.normation.rudder.services.workflows.WorkflowLevelService
-import org.joda.time.DateTime
+import java.time.Instant
 import zio.*
 import zio.syntax.*
 
@@ -144,7 +144,7 @@ class DeleteEditorTechniqueImpl(
                                       ChangeContext(
                                         modId,
                                         committer.actor,
-                                        new DateTime(),
+                                        Instant.now(),
                                         Some(s"Deleting technique '${techniqueId.serialize}'"),
                                         None,
                                         committer.nodePerms

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/DirectiveRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/DirectiveRepository.scala
@@ -55,6 +55,7 @@ import com.softwaremill.quicklens.*
 import net.liftweb.common.Box
 import net.liftweb.common.Full
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.collection.SortedMap
 
 /**
@@ -124,7 +125,7 @@ final case class FullActiveTechnique(
     // must not change from generation to the next, so => Epoch.
     this.copy(
       techniques = techniques ++ here.map(t => (t.id.version, t)),
-      acceptationDatetimes = acceptationDatetimes ++ here.map(t => (t.id.version, new DateTime(0)))
+      acceptationDatetimes = acceptationDatetimes ++ here.map(t => (t.id.version, new DateTime(0, DateTimeZone.UTC)))
     )
   }
 
@@ -278,7 +279,7 @@ final case class FullActiveTechniqueCategory(
     if (this.id == categoryId) {
       // only keep technique with the good name
       val techs    = techniques.filter(_.id.name == techniqueName)
-      val now      = DateTime.now()
+      val now      = DateTime.now(DateTimeZone.UTC)
       val newTimes = techs.map(t => (t.id.version, now))
       val newTechs = techs.map(t => (t.id.version, t))
       val updated  = activeTechniques.find(_.id.value == techniqueName.value) match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/EventLogRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/EventLogRepository.scala
@@ -71,7 +71,7 @@ import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.rudder.domain.workflows.WorkflowStepChange
 import com.normation.rudder.services.eventlog.EventLogFactory
 import doobie.*
-import org.joda.time.DateTime
+import java.time.Instant
 
 trait EventLogRepository {
   def eventLogFactory: EventLogFactory
@@ -438,7 +438,7 @@ trait EventLogRepository {
       principal:  EventActor,
       modifyDiff: ModifyNodeDiff,
       reason:     Option[String],
-      eventDate:  DateTime
+      eventDate:  Instant
   ): IOResult[EventLog] = {
     for {
       e <- saveEventLog(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ExpectedReportsJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/jdbc/ExpectedReportsJdbcRepository.scala
@@ -57,6 +57,7 @@ import doobie.implicits.*
 import net.liftweb.common.*
 import net.liftweb.json.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.annotation.nowarn
 import zio.{System as _, *}
 import zio.interop.catz.*
@@ -534,7 +535,7 @@ final case class ReportAndNodeMapping(
     val cardinality:          Int,
     val componentsValues:     Seq[String],
     val unexpandedCptsValues: Seq[String],
-    val beginDate:            DateTime = DateTime.now(),
+    val beginDate:            DateTime = DateTime.now(DateTimeZone.UTC),
     val endDate:              Option[DateTime] = None,
     val nodeId:               NodeId,
     val nodeConfigVersions:   List[NodeConfigId]
@@ -550,7 +551,7 @@ final case class ReportMapping(
     val cardinality:          Int,
     val componentsValues:     Seq[String],
     val unexpandedCptsValues: Seq[String],
-    val beginDate:            DateTime = DateTime.now(),
+    val beginDate:            DateTime = DateTime.now(DateTimeZone.UTC),
     val endDate:              Option[DateTime] = None
 )
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDiffMapper.scala
@@ -61,6 +61,7 @@ import com.normation.rudder.domain.properties.PropertyProvider
 import com.normation.rudder.domain.properties.Visibility
 import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.services.queries.*
+import com.normation.utils.DateFormaterService
 import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.Modification
 import com.unboundid.ldap.sdk.ModificationType.ADD
@@ -608,15 +609,18 @@ class LDAPDiffMapper(
                                 }
                               case A_API_TOKEN_CREATION_DATETIME =>
                                 nonNull(diff, mod.getOptValueDefault("")) { (d, value) =>
-                                  val diffDate = GeneralizedTime.parse(value).map(_.dateTime)
-                                  d.copy(modTokenGenerationDate =
-                                    diffDate.map(date => (SimpleDiff(oldAccount.tokenGenerationDate, date)))
-                                  )
+                                  val diffDate = GeneralizedTime.parse(value).map(_.instant)
+                                  d.copy(modTokenGenerationDate = {
+                                    diffDate
+                                      .map(date => (SimpleDiff(oldAccount.tokenGenerationDate, DateFormaterService.toDateTime(date))))
+                                  })
                                 }
                               case A_CREATION_DATETIME           =>
                                 nonNull(diff, mod.getOptValueDefault("")) { (d, value) =>
-                                  val diffDate = GeneralizedTime.parse(value).map(_.dateTime)
-                                  d.copy(modCreationDate = diffDate.map(date => (SimpleDiff(oldAccount.creationDate, date))))
+                                  val diffDate = GeneralizedTime.parse(value).map(_.instant)
+                                  d.copy(modCreationDate =
+                                    diffDate.map(date => (SimpleDiff(oldAccount.creationDate, DateFormaterService.toDateTime(date))))
+                                  )
                                 }
                               case A_API_EXPIRATION_DATETIME     =>
                                 val expirationDate = oldAccount.kind match {
@@ -627,7 +631,7 @@ class LDAPDiffMapper(
                                   try {
                                     mod.getOptValueDefault("") match {
                                       case "None" => None
-                                      case v      => GeneralizedTime.parse(v).map(_.dateTime)
+                                      case v      => GeneralizedTime.parse(v).map(x => DateFormaterService.toDateTime(x.instant))
                                     }
                                   } catch {
                                     case ex: Exception => None

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDirectiveRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPDirectiveRepository.scala
@@ -75,6 +75,7 @@ import com.normation.utils.StringUuidGenerator
 import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.Filter
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.collection.immutable.SortedMap
 import zio.*
 import zio.json.*
@@ -1184,7 +1185,7 @@ class WoLDAPDirectiveRepository(
       newActiveTechnique = ActiveTechnique(
                              ActiveTechniqueId(techniqueName.value),
                              techniqueName,
-                             AcceptationDateTime(versions.map(x => x -> DateTime.now()).toMap),
+                             AcceptationDateTime(versions.map(x => x -> DateTime.now(DateTimeZone.UTC)).toMap),
                              policyTypes = policyTypes
                            )
       uptEntry           = mapper.activeTechnique2Entry(newActiveTechnique, categoryEntry.dn)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPNodeRepository.scala
@@ -57,7 +57,7 @@ import com.normation.rudder.repository.WoNodeRepository
 import com.normation.rudder.services.reports.CacheComplianceQueueAction
 import com.normation.rudder.services.reports.CacheExpectedReportAction
 import com.normation.rudder.services.reports.InvalidateCache
-import org.joda.time.DateTime
+import java.time.Instant
 import zio.*
 import zio.json.*
 import zio.syntax.*
@@ -101,7 +101,7 @@ class WoLDAPNodeRepository(
                            case LDIFNoopChangeRecord(_) => ZIO.unit
                            case _                       =>
                              val diff = ModifyNodeDiff.compat(oldNode, node, None, None)
-                             actionLogger.saveModifyNode(modId, actor, diff, reason, DateTime.now())
+                             actionLogger.saveModifyNode(modId, actor, diff, reason, Instant.now())
                          }
       } yield {
         node
@@ -167,7 +167,7 @@ class WoLDAPNodeRepository(
                            case _                       =>
                              val diff =
                                ModifyNodeDiff.keyInfo(nodeId, agentsInfo._1.map(_.securityToken), agentsInfo._2, agentKey, agentKeyStatus)
-                             actionLogger.saveModifyNode(modId, actor, diff, reason, DateTime.now())
+                             actionLogger.saveModifyNode(modId, actor, diff, reason, Instant.now())
                          }
       } yield ())
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPParameterRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPParameterRepository.scala
@@ -56,6 +56,7 @@ import com.normation.rudder.repository.*
 import com.normation.rudder.services.user.PersonIdentService
 import com.unboundid.ldif.LDIFChangeRecord
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.ISODateTimeFormat
 import zio.*
 import zio.syntax.*
@@ -293,7 +294,7 @@ class WoLDAPParameterRepository(
 
     ///// actual code for swapRules /////
 
-    val id = ParameterArchiveId((DateTime.now()).toString(ISODateTimeFormat.dateTime))
+    val id = ParameterArchiveId((DateTime.now(DateTimeZone.UTC)).toString(ISODateTimeFormat.dateTime))
     val ou = rudderDit.ARCHIVES.parameterModel(id)
 
     paramMutex.writeLock(for {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPRuleRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPRuleRepository.scala
@@ -55,6 +55,7 @@ import com.normation.rudder.domain.policies.*
 import com.normation.rudder.services.user.PersonIdentService
 import com.unboundid.ldif.LDIFChangeRecord
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.ISODateTimeFormat
 import zio.*
 import zio.syntax.*
@@ -386,7 +387,7 @@ class WoLDAPRuleRepository(
 
     ///// actual code for swapRules /////
 
-    val id = RuleArchiveId((DateTime.now()).toString(ISODateTimeFormat.dateTime))
+    val id = RuleArchiveId((DateTime.now(DateTimeZone.UTC)).toString(ISODateTimeFormat.dateTime))
     val ou = rudderDit.ARCHIVES.ruleModel(id)
     // filter systemCr if they are not included, so that merge does not have to deal with that.
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapGroupLibrary.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapGroupLibrary.scala
@@ -52,6 +52,7 @@ import com.normation.rudder.repository.NodeGroupLibraryArchiveId
 import com.unboundid.ldap.sdk.DN
 import com.unboundid.ldap.sdk.RDN
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.ISODateTimeFormat
 import scala.annotation.tailrec
 import zio.*
@@ -210,7 +211,7 @@ class ImportGroupLibraryImpl(
         recSaveUserLib(rudderDit.GROUP.dn.getParent, userLib)
       }
 
-      val archiveId       = NodeGroupLibraryArchiveId(DateTime.now().toString(ISODateTimeFormat.dateTime))
+      val archiveId       = NodeGroupLibraryArchiveId(DateTime.now(DateTimeZone.UTC).toString(ISODateTimeFormat.dateTime))
       val targetArchiveDN = rudderDit.ARCHIVES.groupLibDN(archiveId)
 
       // the sequence of operation to actually perform the swap with rollback

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapPolicyLibrary.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/repository/ldap/LDAPSwapPolicyLibrary.scala
@@ -55,6 +55,7 @@ import com.normation.rudder.repository.ActiveTechniqueLibraryArchiveId
 import com.normation.rudder.repository.ImportTechniqueLibrary
 import com.unboundid.ldap.sdk.DN
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.ISODateTimeFormat
 import zio.*
 import zio.syntax.*
@@ -106,7 +107,7 @@ class ImportTechniqueLibraryImpl(
           val categoryEntry = mapper.activeTechniqueCategory2ldap(content.category, parentDN)
           if (isRoot) {
             categoryEntry.addValues(A_OC, OC_ACTIVE_TECHNIQUE_LIB_VERSION)
-            categoryEntry.resetValuesTo(A_INIT_DATETIME, GeneralizedTime(DateTime.now()).toString)
+            categoryEntry.resetValuesTo(A_INIT_DATETIME, GeneralizedTime(DateTime.now(DateTimeZone.UTC)).toString)
             gitId.foreach(x => categoryEntry.resetValuesTo(A_TECHNIQUE_LIB_VERSION, x))
           }
 
@@ -143,7 +144,7 @@ class ImportTechniqueLibraryImpl(
         recSaveUserLib(rudderDit.ACTIVE_TECHNIQUES_LIB.dn.getParent, userLib, isRoot = true)
       }
 
-      val archiveId       = ActiveTechniqueLibraryArchiveId(DateTime.now().toString(ISODateTimeFormat.dateTime))
+      val archiveId       = ActiveTechniqueLibraryArchiveId(DateTime.now(DateTimeZone.UTC).toString(ISODateTimeFormat.dateTime))
       val targetArchiveDN = rudderDit.ARCHIVES.userLibDN(archiveId)
 
       // the sequence of operation to actually perform the swap with rollback

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogDetailsService.scala
@@ -74,6 +74,7 @@ import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.services.marshalling.*
 import com.normation.rudder.services.queries.CmdbQueryParser
 import com.normation.utils.Control.traverse
+import com.normation.utils.DateFormaterService
 import com.typesafe.config.ConfigValue
 import net.liftweb.common.*
 import net.liftweb.common.Box.*
@@ -559,7 +560,7 @@ class EventLogDetailsServiceImpl(
     } yield {
       InventoryLogDetails(
         nodeId = NodeId(nodeId),
-        inventoryVersion = ISODateTimeFormat.dateTimeParser.parseDateTime(version),
+        inventoryVersion = DateFormaterService.toInstant(ISODateTimeFormat.dateTimeParser.parseDateTime(version)),
         hostname = hostname,
         fullOsName = os,
         actorIp = actorIp

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/eventlog/EventLogFactory.scala
@@ -57,6 +57,7 @@ import com.normation.rudder.domain.queries.Query
 import com.normation.rudder.domain.secret.Secret
 import com.normation.rudder.domain.workflows.WorkflowStepChange
 import com.normation.rudder.services.marshalling.*
+import java.time.Instant
 import net.liftweb.util.Helpers.*
 import org.apache.commons.text.StringEscapeUtils
 import org.joda.time.DateTime
@@ -71,7 +72,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       addDiff:        AddRuleDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): AddRule
@@ -81,7 +82,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       deleteDiff:     DeleteRuleDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): DeleteRule
@@ -91,7 +92,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       modifyDiff:     ModifyRuleDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ModifyRule
@@ -102,7 +103,7 @@ trait EventLogFactory {
       principal:           EventActor,
       addDiff:             AddDirectiveDiff,
       varsRootSectionSpec: SectionSpec,
-      creationDate:        DateTime = DateTime.now(),
+      creationDate:        Instant = Instant.now(),
       severity:            Int = 100,
       reason:              Option[String]
   ): AddDirective
@@ -113,7 +114,7 @@ trait EventLogFactory {
       principal:           EventActor,
       deleteDiff:          DeleteDirectiveDiff,
       varsRootSectionSpec: SectionSpec,
-      creationDate:        DateTime = DateTime.now(),
+      creationDate:        Instant = Instant.now(),
       severity:            Int = 100,
       reason:              Option[String]
   ): DeleteDirective
@@ -123,7 +124,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       modifyDiff:     ModifyDirectiveDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ModifyDirective
@@ -133,7 +134,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       addDiff:        AddNodeGroupDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): AddNodeGroup
@@ -143,7 +144,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       deleteDiff:     DeleteNodeGroupDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): DeleteNodeGroup
@@ -153,7 +154,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       modifyDiff:     ModifyNodeGroupDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ModifyNodeGroup
@@ -163,7 +164,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       addDiff:        AddTechniqueDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): AddTechnique
@@ -173,7 +174,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       modifyDiff:     ModifyTechniqueDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ModifyTechnique
@@ -183,7 +184,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       deleteDiff:     DeleteTechniqueDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): DeleteTechnique
@@ -193,7 +194,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       addDiff:        AddGlobalParameterDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): AddGlobalParameter
@@ -203,7 +204,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       deleteDiff:     DeleteGlobalParameterDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): DeleteGlobalParameter
@@ -213,7 +214,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       modifyDiff:     ModifyGlobalParameterDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ModifyGlobalParameter
@@ -223,7 +224,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       diff:           ChangeRequestDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ChangeRequestEventLog
@@ -233,7 +234,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       step:           WorkflowStepChange,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): WorkflowStepChanged
@@ -243,7 +244,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       addDiff:        AddApiAccountDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): CreateAPIAccountEventLog
@@ -253,7 +254,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       modifyDiff:     ModifyApiAccountDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ModifyAPIAccountEventLog
@@ -263,7 +264,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       deleteDiff:     DeleteApiAccountDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): DeleteAPIAccountEventLog
@@ -272,7 +273,7 @@ trait EventLogFactory {
       id:             Option[Int] = None,
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String],
       oldProperty:    RudderWebProperty,
@@ -285,7 +286,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       modifyDiff:     ModifyNodeDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ModifyNode
@@ -295,7 +296,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       promotedNode:   NodeInfo,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): PromoteNode
@@ -305,7 +306,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       demotedRelay:   NodeInfo,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): DemoteRelay
@@ -315,7 +316,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       secret:         Secret,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): AddSecret
@@ -325,7 +326,7 @@ trait EventLogFactory {
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       secret:         Secret,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): DeleteSecret
@@ -336,7 +337,7 @@ trait EventLogFactory {
       principal:      EventActor,
       oldSecret:      Secret,
       newSecret:      Secret,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ModifySecret
@@ -363,7 +364,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       addDiff:        AddRuleDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): AddRule = {
@@ -386,7 +387,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       deleteDiff:     DeleteRuleDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): DeleteRule = {
@@ -409,7 +410,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       modifyDiff:     ModifyRuleDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ModifyRule = {
@@ -468,7 +469,7 @@ class EventLogFactoryImpl(
       principal:           EventActor,
       addDiff:             AddDirectiveDiff,
       varsRootSectionSpec: SectionSpec,
-      creationDate:        DateTime = DateTime.now(),
+      creationDate:        Instant = Instant.now(),
       severity:            Int = 100,
       reason:              Option[String]
   ): AddDirective = {
@@ -498,7 +499,7 @@ class EventLogFactoryImpl(
       principal:           EventActor,
       deleteDiff:          DeleteDirectiveDiff,
       varsRootSectionSpec: SectionSpec,
-      creationDate:        DateTime = DateTime.now(),
+      creationDate:        Instant = Instant.now(),
       severity:            Int = 100,
       reason:              Option[String]
   ): DeleteDirective = {
@@ -527,7 +528,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       modifyDiff:     ModifyDirectiveDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ModifyDirective = {
@@ -576,7 +577,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       addDiff:        AddNodeGroupDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): AddNodeGroup = {
@@ -599,7 +600,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       deleteDiff:     DeleteNodeGroupDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): DeleteNodeGroup = {
@@ -622,7 +623,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       modifyDiff:     ModifyNodeGroupDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ModifyNodeGroup = {
@@ -674,7 +675,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       addDiff:        AddTechniqueDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): AddTechnique = {
@@ -702,7 +703,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       modifyDiff:     ModifyTechniqueDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ModifyTechnique = {
@@ -732,7 +733,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       deleteDiff:     DeleteTechniqueDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): DeleteTechnique = {
@@ -762,7 +763,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       addDiff:        AddGlobalParameterDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): AddGlobalParameter = {
@@ -785,7 +786,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       deleteDiff:     DeleteGlobalParameterDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): DeleteGlobalParameter = {
@@ -808,7 +809,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       modifyDiff:     ModifyGlobalParameterDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ModifyGlobalParameter = {
@@ -838,7 +839,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       diff:           ChangeRequestDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ChangeRequestEventLog = {
@@ -881,7 +882,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       step:           WorkflowStepChange,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): WorkflowStepChanged = {
@@ -912,7 +913,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       addDiff:        AddApiAccountDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): CreateAPIAccountEventLog = {
@@ -935,7 +936,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       diff:           ModifyApiAccountDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ModifyAPIAccountEventLog = {
@@ -985,7 +986,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       deleteDiff:     DeleteApiAccountDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): DeleteAPIAccountEventLog = {
@@ -1007,7 +1008,7 @@ class EventLogFactoryImpl(
       id:             Option[Int] = None,
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String],
       oldProperty:    RudderWebProperty,
@@ -1034,7 +1035,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       promotedNode:   NodeInfo,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): PromoteNode = {
@@ -1065,7 +1066,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       promotedNode:   NodeInfo,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): DemoteRelay = {
@@ -1096,7 +1097,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       modifyDiff:     ModifyNodeDiff,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ModifyNode = {
@@ -1195,7 +1196,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       secret:         Secret,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): AddSecret = {
@@ -1218,7 +1219,7 @@ class EventLogFactoryImpl(
       modificationId: Option[ModificationId] = None,
       principal:      EventActor,
       secret:         Secret,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): DeleteSecret = {
@@ -1243,7 +1244,7 @@ class EventLogFactoryImpl(
       principal:      EventActor,
       oldSecret:      Secret,
       newSecret:      Secret,
-      creationDate:   DateTime = DateTime.now(),
+      creationDate:   Instant = Instant.now(),
       severity:       Int = 100,
       reason:         Option[String]
   ): ModifySecret = {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/modification/ModificationService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/modification/ModificationService.scala
@@ -44,12 +44,11 @@ import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.git.GitCommitId
 import com.normation.rudder.repository.*
 import com.normation.utils.StringUuidGenerator
+import java.time.Instant
 import net.liftweb.common.*
 import org.eclipse.jgit.lib.PersonIdent
-import org.joda.time.DateTime
 
 class ModificationService(
-    eventLogRepository:        EventLogRepository,
     gitModificationRepository: GitModificationRepository,
     itemArchiveManager:        ItemArchiveManager,
     uuidGen:                   StringUuidGenerator
@@ -86,7 +85,7 @@ class ModificationService(
                           ChangeContext(
                             ModificationId(uuidGen.newUuid),
                             eventLog.principal,
-                            new DateTime(),
+                            Instant.now(),
                             None,
                             None,
                             QueryContext.systemQC.nodePerms
@@ -125,7 +124,7 @@ class ModificationService(
                           ChangeContext(
                             ModificationId(uuidGen.newUuid),
                             eventLog.principal,
-                            new DateTime(),
+                            Instant.now(),
                             None,
                             None,
                             QueryContext.systemQC.nodePerms

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/FileHistoryLogRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/FileHistoryLogRepository.scala
@@ -25,6 +25,7 @@ import com.normation.inventory.domain.InventoryError
 import com.normation.rudder.services.nodes.history.HistoryLogRepository
 import java.io.File
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.reflect.ClassTag
 import zio.*
 import zio.syntax.*
@@ -77,7 +78,7 @@ trait VersionToFilenameConverter[V] {
  *
  * Any datas type may be used, as long as they can be read/write from
  * files.
- * 
+ *
  * Version is DateTime but can be abstracted over, if DefaultHLog is abstracted.
  */
 class FileHistoryLogRepository[ID: ClassTag, T](
@@ -133,7 +134,7 @@ class FileHistoryLogRepository[ID: ClassTag, T](
    * Save an inventory and return the ID of the saved inventory, and
    * its version
    */
-  def save(id: ID, data: T, datetime: DateTime = DateTime.now): IOResult[HLog] = {
+  def save(id: ID, data: T, datetime: DateTime = DateTime.now(DateTimeZone.UTC)): IOResult[HLog] = {
     converter.idToFilename(id) match {
       case null | ""                                                         =>
         InventoryError.Inconsistency("History log name can not be null nor empty").fail

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/InventoryHistoryJdbcRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/history/impl/InventoryHistoryJdbcRepository.scala
@@ -93,9 +93,9 @@ class InventoryHistoryJdbcRepository(
   import com.normation.rudder.facts.nodes.NodeFactSerialisation.*
   import doobie.*
 
-  implicit val nodeAcceptRefuseEventaMeta: Meta[NodeAcceptRefuseEvent] = new Meta(pgDecoderGet, pgEncoderPut)
-  implicit val nodeDeleteEventaMeta:       Meta[NodeDeleteEvent]       = new Meta(pgDecoderGet, pgEncoderPut)
-  implicit val nodeFactMeta:               Meta[NodeFact]              = new Meta(pgDecoderGet, pgEncoderPut)
+  implicit val nodeAcceptRefuseEventMeta: Meta[NodeAcceptRefuseEvent] = new Meta(pgDecoderGet, pgEncoderPut)
+  implicit val nodeDeleteEventMeta:       Meta[NodeDeleteEvent]       = new Meta(pgDecoderGet, pgEncoderPut)
+  implicit val nodeFactMeta:              Meta[NodeFact]              = new Meta(pgDecoderGet, pgEncoderPut)
 
   implicit val lotWrite: Write[FactLog] = {
     Write[(String, NodeAcceptRefuseEvent, NodeFact)].contramap {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/RuleValService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/RuleValService.scala
@@ -48,6 +48,7 @@ import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.utils.Control.bestEffort
 import net.liftweb.common.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.collection.MapView
 import zio.syntax.*
 
@@ -191,7 +192,7 @@ class RuleValServiceImpl(
               technique, // if the technique don't have an acceptation date time, this is bad. Use "now",
               // which mean that it will be considered as new every time.
 
-              fullActiveTechnique.acceptationDatetimes.get(technique.id.version).getOrElse(DateTime.now),
+              fullActiveTechnique.acceptationDatetimes.get(technique.id.version).getOrElse(DateTime.now(DateTimeZone.UTC)),
               directive.priority,
               directive.isSystem,
               directive.policyMode,

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueAcceptationDatetimeUpdater.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/TechniqueAcceptationDatetimeUpdater.scala
@@ -58,6 +58,7 @@ import com.normation.utils.StringUuidGenerator
 import com.normation.zio.*
 import net.liftweb.common.Box
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import zio.*
 import zio.syntax.*
 
@@ -277,7 +278,7 @@ class TechniqueAcceptationUpdater(
       }
     }
 
-    val acceptationDatetime = DateTime.now()
+    val acceptationDatetime = DateTime.now(DateTimeZone.UTC)
 
     (for {
       _               <- handleCategoriesUpdate(updatedCategories)

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepository.scala
@@ -166,7 +166,7 @@ object NodeConfigurationHash {
       ("i"   -> JArray(
         List(
           hash.id.value,
-          hash.writtenDate.toString(ISODateTimeFormat.dateTime()),
+          hash.writtenDate.toString(ISODateTimeFormat.dateTime().withZoneUTC()),
           hash.nodeInfoHash,
           hash.parameterHash,
           hash.nodeContextHash
@@ -187,7 +187,7 @@ object NodeConfigurationHash {
 
   def extractNodeConfigCache(j: JValue): Either[(String, JValue), NodeConfigurationHash] = {
     def readDate(date: String): Either[(String, JValue), DateTime] = try {
-      Right(ISODateTimeFormat.dateTimeParser().parseDateTime(date))
+      Right(ISODateTimeFormat.dateTimeParser().withZoneUTC().parseDateTime(date))
     } catch {
       case NonFatal(ex) => Left((s"Error, written date can not be parsed as a date: ${date}", JString(date)))
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ComputeNodeStatusReportService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ComputeNodeStatusReportService.scala
@@ -287,7 +287,7 @@ class ComputeNodeStatusReportServiceImpl(
       _       <- ReportLoggerPure.Cache.trace(
                    s"Reports to save: ${newReports.map { case (id, r) => s"${id.value}: ${r.runInfo}" }.mkString("\n  ")}"
                  )
-      kept    <- updateKeepCompliance(new DateTime(now), newReports)
+      kept    <- updateKeepCompliance(new DateTime(now, DateTimeZone.UTC), newReports)
       updated <- nsrRepo.saveNodeStatusReports(kept)(ChangeContext.newForRudder())
       // exec hooks
       hooks   <- hooksRef.get
@@ -594,7 +594,7 @@ class FindNewNodeStatusReportsImpl(
       t3                <- currentTimeMillis
       _                 <- TimingDebugLoggerPure.trace(s"Compliance: get Node Config Id Infos: ${t3 - t2}ms")
     } yield {
-      ExecutionBatch.computeNodesRunInfo(runs, currentConfigs, nodeConfigIdInfos, DateTime.now())
+      ExecutionBatch.computeNodesRunInfo(runs, currentConfigs, nodeConfigIdInfos, DateTime.now(DateTimeZone.UTC))
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
@@ -486,7 +486,7 @@ object NodeStatusReportInternal {
             Nil
           )
         ),
-        ra.expirationDateTime.orElse(ra.lastRunExpiration).getOrElse(DateTime.now())
+        ra.expirationDateTime.orElse(ra.lastRunExpiration).getOrElse(DateTime.now(DateTimeZone.UTC))
       )
     }
 
@@ -540,7 +540,7 @@ object ExecutionBatch extends Loggable {
   /**
    * Then end of times, used to denote report which are not expiring
    */
-  final val END_OF_TIME = new DateTime(Long.MaxValue)
+  final val END_OF_TIME = new DateTime(Long.MaxValue, DateTimeZone.UTC)
 
   /**
    * Takes a string, that should contains a CFEngine var ( $(xxx) or ${xxx} )

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeChangesService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeChangesService.scala
@@ -49,6 +49,7 @@ import net.liftweb.common.*
 import net.liftweb.http.js
 import net.liftweb.http.js.JE.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.Interval
 import zio.{System as _, *}
 import zio.syntax.*
@@ -94,8 +95,8 @@ trait NodeChangesService {
    *
    */
   final def getCurrentValidIntervals(since: Option[DateTime]): List[Interval] = {
-    val startTime = since.getOrElse(DateTime.now.minusDays(changesMaxAge))
-    val endTime   = DateTime.now
+    val startTime = since.getOrElse(DateTime.now(DateTimeZone.UTC).minusDays(changesMaxAge))
+    val endTime   = DateTime.now(DateTimeZone.UTC)
     getInterval(startTime, endTime)
   }
 
@@ -121,7 +122,7 @@ trait NodeChangesService {
       // utility that create an interval from the given date to date+6hours
       def sixHours(t: DateTime): Interval = {
         // 6 hours in milliseconds
-        new Interval(t, new DateTime(t.getMillis + 6L * 3600 * 1000))
+        new Interval(t, new DateTime(t.getMillis + 6L * 3600 * 1000, DateTimeZone.UTC))
       }
 
       // find the starting time, set minute/seconds/millis to 0

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeStatusReportRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeStatusReportRepository.scala
@@ -53,6 +53,7 @@ import com.softwaremill.quicklens.*
 import doobie.*
 import doobie.implicits.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import zio.{System as _, *}
 import zio.interop.catz.*
 
@@ -239,7 +240,7 @@ class JdbcNodeStatusReportStorage(doobie: Doobie, jdbcBatchSize: Int) extends No
   }
 
   override def save(reports: Iterable[(NodeId, NodeStatusReport)]): IOResult[Unit] = {
-    val t = DateTime.now()
+    val t = DateTime.now(DateTimeZone.UTC)
 
     def toRows(rs: Iterable[(NodeId, NodeStatusReport)]): Vector[(NodeId, DateTime, JNodeStatusReport)] = {
       rs.map { case (a, b) => (a, t, JNodeStatusReport.from(b)) }.toVector

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/system/DatabaseManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/system/DatabaseManager.scala
@@ -42,6 +42,7 @@ import com.normation.rudder.repository.UpdateExpectedReportsRepository
 import com.normation.utils.Control
 import net.liftweb.common.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.concurrent.duration.Duration
 
 sealed trait DeleteCommand {
@@ -99,7 +100,7 @@ class DatabaseManagerImpl(
   }
 
   override def deleteLogReports(since: Duration): Box[Int] = {
-    val date = DateTime.now().minus(since.toMillis)
+    val date = DateTime.now(DateTimeZone.UTC).minus(since.toMillis)
     reportsRepository.deleteLogReports(date) ?~! "An error occurred while deleting log reports"
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/ChangeRequestService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/workflows/ChangeRequestService.scala
@@ -53,6 +53,7 @@ import com.normation.rudder.domain.properties.ChangeRequestGlobalParameterDiff
 import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.workflows.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 
 /**
  * A service that handle all the logic about how
@@ -80,7 +81,7 @@ object ChangeRequestService {
     }
     val change        = DirectiveChange(
       initialState = initialState,
-      firstChange = DirectiveChangeItem(actor, DateTime.now, reason, diff),
+      firstChange = DirectiveChangeItem(actor, DateTime.now(DateTimeZone.UTC), reason, diff),
       Seq()
     )
     val changeRequest = ConfigurationChangeRequest(
@@ -107,7 +108,7 @@ object ChangeRequestService {
     val change = RuleChanges(
       RuleChange(
         Some(baseRule),
-        RuleChangeItem(actor, DateTime.now, reason, ModifyToRuleDiff(finalRule)),
+        RuleChangeItem(actor, DateTime.now(DateTimeZone.UTC), reason, ModifyToRuleDiff(finalRule)),
         Seq()
       ),
       Seq()
@@ -136,7 +137,7 @@ object ChangeRequestService {
 
     val change        = DirectiveChange(
       initialState = initialState,
-      firstChange = DirectiveChangeItem(actor, DateTime.now, reason, diff),
+      firstChange = DirectiveChangeItem(actor, DateTime.now(DateTimeZone.UTC), reason, diff),
       Seq()
     )
     val rulesChanges  = (rulesToUpdate zip updatedRules).map(r => rulechange(r._1, r._2, actor, reason)).toMap
@@ -192,7 +193,7 @@ object ChangeRequestService {
   ): ChangeRequest = {
     val change        = RuleChange(
       initialState = originalRule,
-      firstChange = RuleChangeItem(actor, DateTime.now, reason, diff),
+      firstChange = RuleChangeItem(actor, DateTime.now(DateTimeZone.UTC), reason, diff),
       Seq()
     )
     val changeRequest = ConfigurationChangeRequest(
@@ -223,7 +224,7 @@ object ChangeRequestService {
 
     val change        = NodeGroupChange(
       initialState = originalNodeGroup,
-      firstChange = NodeGroupChangeItem(actor, DateTime.now, reason, diff),
+      firstChange = NodeGroupChangeItem(actor, DateTime.now(DateTimeZone.UTC), reason, diff),
       Seq()
     )
     val changeRequest = ConfigurationChangeRequest(
@@ -253,7 +254,7 @@ object ChangeRequestService {
   ): ChangeRequest = {
     val change        = GlobalParameterChange(
       initialState = originalGlobalParam,
-      firstChange = GlobalParameterChangeItem(actor, DateTime.now, reason, diff),
+      firstChange = GlobalParameterChangeItem(actor, DateTime.now(DateTimeZone.UTC), reason, diff),
       Seq()
     )
     val changeRequest = ConfigurationChangeRequest(

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/VariableTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/VariableTest.scala
@@ -68,7 +68,7 @@ class VariableTest extends Specification {
   val refDescription  = "description"
   val refValue        = "value"
   val refVariableName = Some("variable_name")
-  val dateValue       = "2010-01-16T12:00:00.000+01:00"
+  val dateValue       = "2010-01-16T11:00:00.000Z"
   val listValue       = "value1;value2"
   val defaultValue    = "default_value"
 
@@ -290,11 +290,11 @@ class VariableTest extends Specification {
   }
 
   "Date variable" should {
-    implicit val dateVariable = variables(varDate)
+    implicit val dateVariable: Variable = variables(varDate)
     beAnInput
     haveType("datetime")
 
-    haveValue(ISODateTimeFormat.dateTimeParser.parseDateTime(dateValue).toString)(
+    haveValue(ISODateTimeFormat.dateTime.withZoneUTC().print(ISODateTimeFormat.dateTimeParser.parseDateTime(dateValue)))(
       dateVariable.copyWithSavedValue(dateValue).orThrow
     )
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitPackageReaderTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitPackageReaderTest.scala
@@ -54,6 +54,7 @@ import org.apache.commons.io.FileUtils
 import org.apache.commons.io.IOUtils
 import org.eclipse.jgit.api.Git
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.matcher.MatchResult
 import org.specs2.mutable.Specification
@@ -383,7 +384,7 @@ trait JGitPackageReaderSpec extends Specification with Loggable with AfterAll {
  */
 @RunWith(classOf[JUnitRunner])
 class JGitPackageReader_SameRootTest extends JGitPackageReaderSpec {
-  lazy val gitRoot = new File("/tmp/test-jgit-" + DateTime.now().toString())
+  lazy val gitRoot = new File("/tmp/test-jgit-" + DateTime.now(DateTimeZone.UTC).toString())
   lazy val ptLib   = gitRoot
   lazy val relativePathArg: Option[String] = None
   def postInitHook():       Unit           = {}
@@ -397,7 +398,7 @@ class JGitPackageReader_SameRootTest extends JGitPackageReaderSpec {
  */
 @RunWith(classOf[JUnitRunner])
 class JGitPackageReader_ChildRootTest extends JGitPackageReaderSpec {
-  lazy val gitRoot      = new File("/tmp/test-jgit-" + DateTime.now().toString())
+  lazy val gitRoot      = new File("/tmp/test-jgit-" + DateTime.now(DateTimeZone.UTC).toString())
   lazy val ptLibDirName = "techniques"
   lazy val ptLib        = new File(gitRoot, ptLibDirName)
   lazy val relativePathArg: Some[String] = Some("  /" + ptLibDirName + "/  ")

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitRepositoryTest.scala
@@ -70,6 +70,7 @@ import org.eclipse.jgit.lib.PersonIdent
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.revwalk.RevWalk
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -89,7 +90,7 @@ import zio.syntax.*
 @RunWith(classOf[JUnitRunner])
 class JGitRepositoryTest extends Specification with Loggable with AfterAll {
 
-  val gitRoot: File = File("/tmp/test-jgit-" + DateTime.now().toString())
+  val gitRoot: File = File("/tmp/test-jgit-" + DateTime.now(DateTimeZone.UTC).toString())
 
   // Set sequential execution
   sequential

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/campaign/CampaignSchedulerTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/campaign/CampaignSchedulerTest.scala
@@ -50,7 +50,7 @@ import org.specs2.runner.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class CampaignSchedulerTest extends Specification {
 
-  val now:       DateTime     = DateTime.now().withZone(DateTimeZone.UTC)
+  val now:       DateTime     = DateTime.now(DateTimeZone.UTC)
   val defaultTz: DateTimeZone = DateTimeZone.getDefault()
 
   "A monthly campaign schedule set during december" should {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/DBCommon.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/db/DBCommon.scala
@@ -45,6 +45,7 @@ import java.util.Properties
 import javax.sql.DataSource
 import net.liftweb.common.Loggable
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.specs2.mutable.Specification
 import org.specs2.specification.BeforeAfterAll
 import scala.io.Source
@@ -57,7 +58,7 @@ import zio.interop.catz.*
  */
 trait DBCommon extends Specification with Loggable with BeforeAfterAll {
 
-  lazy val now = DateTime.now
+  lazy val now = DateTime.now(DateTimeZone.UTC)
 
   lazy val doDatabaseConnection: Boolean = java.lang.System.getProperty("test.postgres", "").toLowerCase match {
     case "true" | "1" => true

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
@@ -14,8 +14,10 @@ import com.normation.rudder.domain.nodes.NodeInfo
 import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.reports.ReportingConfiguration
 import com.normation.rudder.repository.FullNodeGroupCategory
+import java.time.Instant
 import net.liftweb.common.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.mutable.*
 import org.specs2.runner.*
@@ -38,7 +40,7 @@ class RuleTargetTest extends Specification with Loggable {
       NodeState.Enabled,
       isSystem = false,
       isPolicyServer = false,
-      creationDate = DateTime.now,
+      creationDate = Instant.now(),
       nodeReportingConfiguration = ReportingConfiguration(None, None, None),
       properties = List(),
       policyMode = None,
@@ -56,7 +58,7 @@ class RuleTargetTest extends Specification with Loggable {
         None,
         Linux(Debian, "Jessie", new Version("7.0"), None, new Version("3.2")),
         Nil,
-        DateTime.now,
+        Instant.now(),
         UndefinedKey,
         Seq(),
         NodeId("root"),

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/reports/StatusReportTest.scala
@@ -50,6 +50,7 @@ import com.normation.rudder.services.policies.NodeConfigData
 import com.normation.rudder.services.reports.NodeStatusReportInternal
 import com.normation.rudder.services.reports.Pending
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -223,7 +224,7 @@ class StatusReportTest extends Specification {
           NodeExpectedReports(
             NodeId("n1"),
             NodeConfigId("plop"),
-            DateTime.now(),
+            DateTime.now(DateTimeZone.UTC),
             None,
             modesConfig,
             Nil,

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestCoreNodeFactInventory.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestCoreNodeFactInventory.scala
@@ -58,9 +58,11 @@ import com.normation.zio.*
 import com.softwaremill.quicklens.*
 import com.unboundid.ldap.sdk.SearchScope
 import java.security.Security
+import java.time.Instant
 import org.apache.commons.io.FileUtils
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.*
 import org.specs2.matcher.MatchResult
 import org.specs2.mutable.*
@@ -182,7 +184,7 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
 
   implicit def stringToNodeId(id: String): NodeId = NodeId(id)
 
-  val basePath: String = s"/tmp/test-rudder-nodefact/${DateFormaterService.gitTagFormat.print(DateTime.now())}"
+  val basePath: String = s"/tmp/test-rudder-nodefact/${DateFormaterService.gitTagFormat.print(DateTime.now(DateTimeZone.UTC))}"
 
   override def beforeAll(): Unit = {}
 
@@ -258,8 +260,16 @@ class TestCoreNodeFactInventory extends Specification with BeforeAfterAll {
     n.vms
   )
 
-  implicit val testChangeContext: ChangeContext =
-    ChangeContext(ModificationId("test-mod-id"), EventActor("test"), DateTime.now(), None, None, QueryContext.testQC.nodePerms)
+  implicit val testChangeContext: ChangeContext = {
+    ChangeContext(
+      ModificationId("test-mod-id"),
+      EventActor("test"),
+      Instant.now(),
+      None,
+      None,
+      QueryContext.testQC.nodePerms
+    )
+  }
   implicit val qc:                QueryContext  = QueryContext.todoQC
 
   "basic change in node fact" should {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestNodeFactSerialisation.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestNodeFactSerialisation.scala
@@ -21,6 +21,7 @@ import com.normation.rudder.domain.nodes.MachineInfo
 import com.normation.rudder.domain.nodes.NodeKind
 import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.reports.ReportingConfiguration
+import com.normation.utils.DateFormaterService
 import org.joda.time.DateTime
 import org.junit.runner.RunWith
 import org.specs2.matcher.Matcher
@@ -103,8 +104,8 @@ class TestNodeFactSerialisation extends Specification with JsonSpecMatcher {
           Chunk.empty
         ),
         Chunk.empty,
-        DateTime.parse("2024-05-16T15:20:12Z"),
-        DateTime.parse("2024-05-16T15:20:12Z")
+        DateFormaterService.parseInstant("2024-05-16T15:20:12Z").getOrElse(throw new IllegalArgumentException("error")),
+        DateFormaterService.parseInstant("2024-05-16T15:20:12Z").getOrElse(throw new IllegalArgumentException("error"))
       )
 
       // we have to match machineType specifically because nodefact does not seem to be exactly equal

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSaveInventory.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestSaveInventory.scala
@@ -75,6 +75,7 @@ import java.security.Security
 import org.apache.commons.io.FileUtils
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.*
 import org.specs2.matcher.MatchResult
 import org.specs2.mutable.*
@@ -429,7 +430,7 @@ trait TestSaveInventory extends Specification with BeforeAfterAll {
 
   implicit def stringToNodeId(id: String): NodeId = NodeId(id)
 
-  val basePath: String = s"/tmp/test-rudder-inventory/${DateFormaterService.gitTagFormat.print(DateTime.now())}"
+  val basePath: String = s"/tmp/test-rudder-inventory/${DateFormaterService.gitTagFormat.print(DateTime.now(DateTimeZone.UTC))}"
 
   val INVENTORY_ROOT_DIR:     String = basePath + "/inventories"
   val INVENTORY_DIR_INCOMING: String = INVENTORY_ROOT_DIR + "/incoming"

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/git/ZipUtilsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/git/ZipUtilsTest.scala
@@ -44,6 +44,7 @@ import com.normation.utils.DateFormaterService
 import com.normation.zio.ZioRuntime
 import org.apache.commons.io.FileUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -53,7 +54,7 @@ import zio.ZIO
 @RunWith(classOf[JUnitRunner])
 class ZipUtilsTest extends Specification with BeforeAfterAll {
 
-  val basePath: File = File(s"/tmp/test-rudder-zip/${DateFormaterService.gitTagFormat.print(DateTime.now())}")
+  val basePath: File = File(s"/tmp/test-rudder-zip/${DateFormaterService.gitTagFormat.print(DateTime.now(DateTimeZone.UTC))}")
 
   override def beforeAll(): Unit = {}
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/HooksTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/HooksTest.scala
@@ -44,6 +44,7 @@ import com.normation.rudder.hooks.HookReturnCode.SystemError
 import com.normation.rudder.hooks.HookReturnCode.Warning
 import java.nio.file.attribute.PosixFilePermissions
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.ISODateTimeFormat
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
@@ -60,7 +61,7 @@ import zio.{System as _, *}
 @RunWith(classOf[JUnitRunner])
 class HooksTest() extends Specification with AfterAll {
 
-  val tmp: File = File(s"/tmp/rudder-test-hook/${DateTime.now.toString(ISODateTimeFormat.dateTime())}")
+  val tmp: File = File(s"/tmp/rudder-test-hook/${DateTime.now(DateTimeZone.UTC).toString(ISODateTimeFormat.dateTime())}")
   tmp.createDirectoryIfNotExists(true)
 
   List("error10.sh", "success.sh", "warning50.sh", "echoCODE.sh", "timeout.sh", "timeout_ok.sh").foreach { i =>

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/RunNuCommandTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/RunNuCommandTest.scala
@@ -41,6 +41,7 @@ import com.normation.errors.*
 import com.normation.zio.*
 import java.io.File
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.ISODateTimeFormat
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
@@ -96,7 +97,7 @@ class RunNuCommandTest() extends Specification {
     }
 
     "can actually modify the file system" in {
-      val date = DateTime.now().toString(ISODateTimeFormat.dateTime())
+      val date = DateTime.now(DateTimeZone.UTC).toString(ISODateTimeFormat.dateTime())
       val file = new File(s"/tmp/rudder-test/test-nucmd-$date")
       file.getParentFile.deleteOnExit()
       file.deleteOnExit()

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/metrics/NodeCountHistorizationTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/metrics/NodeCountHistorizationTest.scala
@@ -61,7 +61,7 @@ class NodeCountHistorizationTest extends Specification with BeforeAfter {
     }
   }
 
-  lazy val startDate: DateTime = DateTime.now()
+  lazy val startDate: DateTime = DateTime.now(DateTimeZone.UTC)
   lazy val rootDir:   String   = s"/tmp/rudder-test-nodecount/${startDate.toString(ISODateTimeFormat.dateTime())}"
 
   val rudder: CommitInformation = CommitInformation(

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
@@ -96,6 +96,7 @@ import net.liftweb.common.Full
 import net.liftweb.common.Loggable
 import org.apache.commons.io.FileUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.matcher.ContentMatchers
 import org.specs2.mutable.Specification
@@ -109,7 +110,7 @@ import zio.syntax.*
 @RunWith(classOf[JUnitRunner])
 class TestEditorTechniqueWriter extends Specification with ContentMatchers with Loggable with BeforeAfterAll {
   sequential
-  lazy val basePath: String = "/tmp/test-technique-writer-" + DateTime.now.toString()
+  lazy val basePath: String = "/tmp/test-technique-writer-" + DateTime.now(DateTimeZone.UTC).toString()
 
   override def beforeAll(): Unit = {
     new JFile(basePath).mkdirs()

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ExpectedReportTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ExpectedReportTest.scala
@@ -185,7 +185,7 @@ class ExpectedReportsTest extends DBCommon {
 
 //    val expected = DB.ExpectedReports[Long](100, 100, r1, serial, d1.directiveId
 //      , c1.componentName, c1.cardinality, ComponentsValuesSerialiser.serializeComponents(c1.componentsValues)
-//      , "[]", DateTime.now, None
+//      , "[]", DateTime.now(DateTimeZone.UTC), None
 //    )
 
 //    "the first time, just insert" in {
@@ -298,7 +298,7 @@ class ExpectedReportsTest extends DBCommon {
 //      val c1 = d1_exp.components(0)
 //      DB.ExpectedReports[Long](100, 100, r1, serial, d1.directiveId
 //      , c1.componentName, c1.cardinality, ComponentsValuesSerialiser.serializeComponents(c1.componentsValues)
-//      , """["d1_value"]""", DateTime.now, None
+//      , """["d1_value"]""", DateTime.now(DateTimeZone.UTC), None
 //      )
 //    }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/jdbc/ReportsTest.scala
@@ -54,6 +54,7 @@ import doobie.*
 import doobie.implicits.*
 import net.liftweb.common.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import zio.interop.catz.*
@@ -231,7 +232,7 @@ class ReportsTest extends DBCommon {
      * - test case where there is no StartRun/EndRun
      */
     "get reports" in {
-      val res      = repostsRepo.getReportsFromId(0, DateTime.now().plusDays(1)).open
+      val res      = repostsRepo.getReportsFromId(0, DateTime.now(DateTimeZone.UTC).plusDays(1)).open
       val expected = Seq(
         AgentRun(AgentRunId(NodeId("n0"), run1), None, 109),
         AgentRun(AgentRunId(NodeId("n1"), run1), Some(NodeConfigId("n1_run1")), 115),

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LDAPEntityMapperTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LDAPEntityMapperTest.scala
@@ -43,6 +43,9 @@ import com.normation.rudder.domain.policies.AcceptationDateTime
 import com.normation.rudder.facts.nodes.MockLdapFactStorage
 import com.normation.rudder.reports.AgentRunInterval
 import com.normation.rudder.reports.HeartbeatConfiguration
+import com.normation.utils.DateFormaterService
+import java.time.Instant
+import org.joda.time.DateTime
 import org.junit.runner.*
 import org.specs2.mutable.*
 import org.specs2.runner.*
@@ -85,16 +88,16 @@ class LDAPEntityMapperTest extends Specification {
 
   "active technique acceptationTimestamp map" >> {
     implicit class GetGT(s: String) {
-      def getGT = {
+      def getGT: DateTime = {
         GeneralizedTime.parse(s) match {
-          case Some(gt) => gt.dateTime
+          case Some(gt) => DateFormaterService.toDateTime(gt.instant)
           case None     => throw new IllegalArgumentException(s"Can not parse GeneralizedTime from: ${s}")
         }
       }
     }
 
     implicit class GetTV(s: String) {
-      def getTV = {
+      def getTV: TechniqueVersion = {
         TechniqueVersion.parse(s) match {
           case Left(err) => throw new IllegalArgumentException(s"Can not parse technique version from '${s}': ${err}")
           case Right(tv) => tv

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/xml/TestGitFindUtils.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/xml/TestGitFindUtils.scala
@@ -52,6 +52,7 @@ import org.eclipse.jgit.internal.storage.file.FileRepository
 import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.matcher.ContentMatchers
 import org.specs2.mutable.Specification
@@ -63,7 +64,7 @@ class TestGitFindUtils extends Specification with Loggable with AfterAll with Co
 
   ////////// set up / clean-up and utilities //////////
 
-  lazy val root    = new File("/tmp/test-jgit-" + DateTime.now().toString())
+  lazy val root    = new File("/tmp/test-jgit-" + DateTime.now(DateTimeZone.UTC).toString())
   lazy val gitRoot = new File(root, "repo")
 
   override def afterAll(): Unit = {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/NodeConfigData.scala
@@ -86,9 +86,11 @@ import com.softwaremill.quicklens.*
 import java.io.File
 import java.nio.file.*
 import java.nio.file.attribute.BasicFileAttributes
+import java.time.Instant
 import net.liftweb.common.Full
 import org.apache.commons.io.FileUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.collection.MapView
 import scala.collection.SortedMap
 import zio.Chunk
@@ -263,8 +265,8 @@ object NodeConfigData {
     ),
     RudderAgent(CfeCommunity, rootAdmin, AgentVersion("7.0.0"), Certificate(CERT), Chunk.empty),
     Chunk.empty,
-    DateTime.now,
-    DateTime.now,
+    Instant.now(),
+    Instant.now(),
     None,
     Chunk(IpAddress("127.0.0.1"), IpAddress("192.168.0.100")),
     Some(NodeTimezone("UTC", "+00")),
@@ -293,8 +295,8 @@ object NodeConfigData {
     ),
     RudderAgent(CfeCommunity, admin1, AgentVersion("6.0.0"), Certificate(CERT), Chunk.empty),
     Chunk.empty,
-    DateTime.now,
-    DateTime.now,
+    Instant.now(),
+    Instant.now(),
     None,
     Chunk(IpAddress("192.168.0.10")),
     None,
@@ -359,8 +361,8 @@ object NodeConfigData {
     ),
     RudderAgent(Dsc, admin1, AgentVersion("7.0.0"), Certificate(CERT), Chunk.empty),
     Chunk.empty,
-    DateTime.now,
-    DateTime.now,
+    Instant.now(),
+    Instant.now(),
     None,
     Chunk(IpAddress("192.168.0.5")),
     None,
@@ -470,8 +472,8 @@ object NodeConfigData {
       ),
       RudderAgent(CfeCommunity, admin1, AgentVersion("6.0.0"), Certificate("node certificate"), Chunk.empty),
       Chunk.empty,
-      DateTime.now,
-      DateTime.now,
+      Instant.now(),
+      Instant.now(),
       None,
       Chunk(),
       None,
@@ -897,7 +899,7 @@ class TestNodeConfiguration(
       ruleName,
       directiveName,
       technique,
-      DateTime.now,
+      DateTime.now(DateTimeZone.UTC),
       variableMap,
       variableMap,
       technique.trackerVariableSpec.toVariable(Seq(id.getReportId)),

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/RuleValServiceTest.scala
@@ -57,6 +57,7 @@ import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.services.nodes.PropertyEngineServiceImpl
 import com.normation.zio.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.*
 import org.specs2.mutable.*
 import org.specs2.runner.*
@@ -171,7 +172,7 @@ class RuleValServiceTest extends Specification {
     FullActiveTechnique(
       ActiveTechniqueId("activeTechId"),
       techniqueId.name,
-      acceptationDatetimes = SortedMap((techniqueId.version, new DateTime())),
+      acceptationDatetimes = SortedMap((techniqueId.version, new DateTime(DateTimeZone.UTC))),
       techniques = SortedMap((techniqueId.version, technique)),
       directives = List(directive),
       isEnabled = true,

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepositoryTest.scala
@@ -50,6 +50,7 @@ import net.liftweb.common.Full
 import net.liftweb.common.Loggable
 import org.apache.commons.io.FileUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.ISODateTimeFormat
 import org.junit.runner.*
 import org.specs2.mutable.*
@@ -75,7 +76,9 @@ class NodeConfigurationCacheRepositoryTest extends Specification with AfterAll w
     }
   }
 
-  val root: File = File(s"/tmp/rudder-test-config-hashes/${new DateTime().toString(ISODateTimeFormat.dateTimeNoMillis())}")
+  val root: File = File(
+    s"/tmp/rudder-test-config-hashes/${new DateTime(DateTimeZone.UTC).toString(ISODateTimeFormat.dateTimeNoMillis())}"
+  )
 
   root.createDirectories()
 
@@ -89,8 +92,8 @@ class NodeConfigurationCacheRepositoryTest extends Specification with AfterAll w
 
   val configHashesRepo = new FileBasedNodeConfigurationHashRepository((root / "node-config-hashes.json").pathAsString)
 
-  val d0 = new DateTime(100)
-  val d1 = new DateTime(500)
+  val d0 = new DateTime("1970-01-01T00:00:00.100Z", DateTimeZone.UTC)
+  val d1 = new DateTime("1970-01-01T00:00:00.500Z", DateTimeZone.UTC)
 
   val h0_0: NodeConfigurationHash = NodeConfigurationHash(NodeId("node0"), d0, 0, 0, 0, Set())
 
@@ -175,9 +178,9 @@ class NodeConfigurationCacheRepositoryTest extends Specification with AfterAll w
     "be written sorted" in {
       val json = {
         """{"hashes": [
-          |  {"i":["node0","1970-01-01T01:00:00.100+01:00",0,0,0],"p":[]},
-          |  {"i":["node1","1970-01-01T01:00:00.100+01:00",0,0,0],"p":[["r0","d0","1.0",0],["r1","d1","1.0",0]]},
-          |  {"i":["node2","1970-01-01T01:00:00.100+01:00",0,0,0],"p":[["r0","d0","1.0",0]]}
+          |  {"i":["node0","1970-01-01T00:00:00.100Z",0,0,0],"p":[]},
+          |  {"i":["node1","1970-01-01T00:00:00.100Z",0,0,0],"p":[["r0","d0","1.0",0],["r1","d1","1.0",0]]},
+          |  {"i":["node2","1970-01-01T00:00:00.100Z",0,0,0],"p":[["r0","d0","1.0",0]]}
           |] }""".stripMargin
       }
 
@@ -197,10 +200,10 @@ class NodeConfigurationCacheRepositoryTest extends Specification with AfterAll w
     "still be written sorted" in {
       val json = {
         """{"hashes": [
-          |  {"i":["node0","1970-01-01T01:00:00.100+01:00",0,0,0],"p":[]},
-          |  {"i":["node1","1970-01-01T01:00:00.500+01:00",0,0,0],"p":[["r0","d0","1.0",0],["r2","d2","1.0",0]]},
-          |  {"i":["node2","1970-01-01T01:00:00.100+01:00",0,0,0],"p":[["r0","d0","1.0",0]]},
-          |  {"i":["node3","1970-01-01T01:00:00.500+01:00",0,0,0],"p":[["r3","d3","1.0",0]]}
+          |  {"i":["node0","1970-01-01T00:00:00.100Z",0,0,0],"p":[]},
+          |  {"i":["node1","1970-01-01T00:00:00.500Z",0,0,0],"p":[["r0","d0","1.0",0],["r2","d2","1.0",0]]},
+          |  {"i":["node2","1970-01-01T00:00:00.100Z",0,0,0],"p":[["r0","d0","1.0",0]]},
+          |  {"i":["node3","1970-01-01T00:00:00.500Z",0,0,0],"p":[["r3","d3","1.0",0]]}
           |] }""".stripMargin
       }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PolicyAgregationTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/PolicyAgregationTest.scala
@@ -54,6 +54,7 @@ import com.normation.rudder.services.policies.NodeConfigData
 import com.normation.rudder.services.policies.PolicyId
 import com.softwaremill.quicklens.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.matcher.MatchResult
 import org.specs2.mutable.Specification
@@ -144,7 +145,7 @@ class PolicyAgregationTest extends Specification {
       ruleName = "rule name",
       directiveName = "directive name",
       technique.modify(_.rootSection.children).setTo(List(v.spec)),
-      acceptationDate = DateTime.now,
+      acceptationDate = DateTime.now(DateTimeZone.UTC),
       expandedVars = Map(ComponentId(v.spec.name, List("root"), None) -> v),
       originalVars = Map(ComponentId(v.spec.name, List("root"), None) -> v),
       trackerVariable,

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/write/WriteTechniquesTest.scala
@@ -80,6 +80,7 @@ import net.liftweb.common.Loggable
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.IOUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.io.FileLinesContent
 import org.specs2.matcher.ContentMatchers
@@ -337,7 +338,7 @@ class WriteSystemTechniquesTest extends TechniquesTest {
         Map(root.id -> rnc.nodeInfo),
         Map(root.id -> NodeConfigId("root-cfg-id")),
         globalPolicyMode,
-        DateTime.now,
+        DateTime.now(DateTimeZone.UTC),
         parallelism
       )
     }
@@ -451,7 +452,7 @@ class WriteSystemTechniquesTest extends TechniquesTest {
           Map(root.id -> getRootNodeConfig(emptyGroupLib).nodeInfo),
           Map(root.id -> NodeConfigId("root-cfg-id")),
           globalPolicyMode,
-          DateTime.now,
+          DateTime.now(DateTimeZone.UTC),
           parallelism
         )
         .openOrThrowException("Can not write template!")
@@ -477,7 +478,7 @@ class WriteSystemTechniquesTest extends TechniquesTest {
           Map(root.id -> rnc.nodeInfo),
           Map(root.id -> NodeConfigId("root-cfg-id")),
           globalPolicyMode,
-          DateTime.now,
+          DateTime.now(DateTimeZone.UTC),
           parallelism
         )
         .openOrThrowException("Can not write template!")
@@ -512,7 +513,7 @@ class WriteSystemTechniquesTest extends TechniquesTest {
         Map(root.id -> rnc.nodeInfo, cfeNode.id                -> cfeNC.nodeInfo),
         Map(root.id -> NodeConfigId("root-cfg-id"), cfeNode.id -> NodeConfigId("cfe-node-cfg-id")),
         globalPolicyMode,
-        DateTime.now,
+        DateTime.now(DateTimeZone.UTC),
         parallelism
       )
 
@@ -551,7 +552,7 @@ class WriteSystemTechniquesTest extends TechniquesTest {
         Map(root.id -> rnc.nodeInfo, cfeNode.id                -> cfeNC.nodeInfo),
         Map(root.id -> NodeConfigId("root-cfg-id"), cfeNode.id -> NodeConfigId("cfe-node-cfg-id")),
         globalPolicyMode,
-        DateTime.now,
+        DateTime.now(DateTimeZone.UTC),
         parallelism
       )
 
@@ -604,7 +605,7 @@ class WriteSystemTechniques500Test extends TechniquesTest {
         Map(root.id -> rnc.nodeInfo),
         Map(root.id -> NodeConfigId("root-cfg-id"), cfeNode.id -> NodeConfigId("cfe-node-sys-bool-false-cfg-id")),
         globalPolicyMode,
-        DateTime.now,
+        DateTime.now(DateTimeZone.UTC),
         parallelism
       )
 
@@ -645,7 +646,7 @@ class WriteSystemTechniques500Test extends TechniquesTest {
         Map(root.id -> rnc.nodeInfo, cfeNode.id                -> cfeNC.nodeInfo),
         Map(root.id -> NodeConfigId("root-cfg-id"), cfeNode.id -> NodeConfigId("cfe-node-cfg-id-500")),
         globalPolicyMode,
-        DateTime.now,
+        DateTime.now(DateTimeZone.UTC),
         parallelism
       )
 
@@ -725,7 +726,7 @@ class WriteSystemTechniqueWithRevisionTest extends TechniquesTest {
         Map(root.id -> rnc.nodeInfo),
         Map(root.id -> NodeConfigId("root-cfg-id")),
         globalPolicyMode,
-        DateTime.now,
+        DateTime.now(DateTimeZone.UTC),
         parallelism
       )
     }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
@@ -58,7 +58,7 @@ import net.liftweb.common.Failure
 import org.junit.*
 import org.junit.runner.RunWith
 import org.junit.runners.BlockJUnit4ClassRunner
-import zio.*
+import zio.{test as _, *}
 import zio.syntax.*
 import zio.test.*
 import zio.test.Assertion.*

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/CachedFindRuleNodeStatusReportsTest.scala
@@ -60,6 +60,7 @@ import com.normation.rudder.services.reports.CacheExpectedReportAction.InsertNod
 import com.normation.zio.*
 import com.softwaremill.quicklens.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.mutable.*
 import org.specs2.runner.JUnitRunner
@@ -87,7 +88,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
   // (node, expired report, still ok report)
   def expected(id: String): NodeExpectedReports = NodeExpectedReports(NodeId(id), NodeConfigId(id), null, null, null, Nil, Nil)
 
-  val date0         = new DateTime(0)
+  val date0         = new DateTime(0, DateTimeZone.UTC)
   val dummyExpected = NodeExpectedReports(NodeId("dummy"), NodeConfigId("dummy"), date0, null, null, Nil, Nil)
 
   val nodes: List[((NodeId, CoreNodeFact), NodeStatusReport, NodeStatusReport)] = List(
@@ -231,7 +232,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
     // now node was ask, it will return all nodes, even expired, see: https://issues.rudder.io/issues/16612
     val n2 = repo.getNodeStatusReports(finder.reports.keySet).runNow
     // check for outdated compliance
-    computer.outDatedCompliance(DateTime.now(), Set.empty).runNow
+    computer.outDatedCompliance(DateTime.now(DateTimeZone.UTC), Set.empty).runNow
 
     // let a chance for zio to exec again to find back expired
     Thread.sleep(1000)
@@ -303,7 +304,7 @@ class CachedFindRuleNodeStatusReportsTest extends Specification {
     // now node was ask, it will return only non expired reports (ie only NoReport and such here)
     val n2 = repo.getNodeStatusReports(finder.reports.keySet).runNow
     // check for outdated compliance
-    computer.outDatedCompliance(DateTime.now(), Set.empty).runNow
+    computer.outDatedCompliance(DateTime.now(DateTimeZone.UTC), Set.empty).runNow
 
     // let a chance for zio to exec again to find back expired
     Thread.sleep(1000)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -61,6 +61,7 @@ import com.normation.rudder.services.reports.ExecutionBatch.ComputeComplianceTim
 import com.normation.rudder.services.reports.ExecutionBatch.MergeInfo
 import com.softwaremill.quicklens.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.ISODateTimeFormat
 import org.junit.runner.*
 import org.specs2.mutable.*
@@ -87,7 +88,7 @@ class ExecutionBatchTest extends Specification {
 
   import ReportType.*
 
-  val executionTimestamp = new DateTime()
+  val executionTimestamp = new DateTime(DateTimeZone.UTC)
 
   val globalPolicyMode: GlobalPolicyMode = GlobalPolicyMode(PolicyMode.Enforce, PolicyModeOverrides.Always)
   val mode:             NodeModeConfig   = NodeModeConfig(
@@ -383,7 +384,7 @@ class ExecutionBatchTest extends Specification {
         )
       }
 
-      val res = ExecutionBatch.computeNodesRunInfo(runs, currentNodeConfigs, runInfo, DateTime.now())(nodeId)
+      val res = ExecutionBatch.computeNodesRunInfo(runs, currentNodeConfigs, runInfo, DateTime.now(DateTimeZone.UTC))(nodeId)
 
       // here, the end date depend on run time, so we need to check by case
       res match {
@@ -416,7 +417,7 @@ class ExecutionBatchTest extends Specification {
         )
       }
 
-      val res = ExecutionBatch.computeNodesRunInfo(runs, currentNodeConfigs, runInfo, DateTime.now())(nodeId)
+      val res = ExecutionBatch.computeNodesRunInfo(runs, currentNodeConfigs, runInfo, DateTime.now(DateTimeZone.UTC))(nodeId)
 
       res match {
         case NoReportInInterval(exp, t) => exp must beEqualTo(generatedExpectedReports)
@@ -1329,7 +1330,7 @@ class ExecutionBatchTest extends Specification {
       )
     }
     val ruleExpectedReports      = RuleExpectedReports(RuleId("cr"), directiveExpectedReports :: Nil)
-    val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now())
+    val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now(DateTimeZone.UTC))
 
     val withGood = ExecutionBatch
       .getComplianceForRule(
@@ -1509,7 +1510,7 @@ class ExecutionBatchTest extends Specification {
       )
     }
     val ruleExpectedReports      = RuleExpectedReports(RuleId("cr"), directiveExpectedReports :: Nil)
-    val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now())
+    val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now(DateTimeZone.UTC))
 
     val withLoop = ExecutionBatch
       .getComplianceForRule(
@@ -1655,7 +1656,7 @@ class ExecutionBatchTest extends Specification {
       )
     }
     val ruleExpectedReports      = RuleExpectedReports(RuleId("cr"), directiveExpectedReports :: Nil)
-    val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now())
+    val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now(DateTimeZone.UTC))
 
     val withLoop = ExecutionBatch
       .getComplianceForRule(
@@ -1873,7 +1874,7 @@ class ExecutionBatchTest extends Specification {
       )
     }
     val ruleExpectedReports      = RuleExpectedReports(RuleId("cr"), directiveExpectedReports :: Nil)
-    val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now())
+    val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now(DateTimeZone.UTC))
 
     val withGood = ExecutionBatch
       .getComplianceForRule(
@@ -2090,7 +2091,7 @@ class ExecutionBatchTest extends Specification {
       )
     }
     val ruleExpectedReports      = RuleExpectedReports(RuleId("cr"), directiveExpectedReports :: Nil)
-    val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now())
+    val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now(DateTimeZone.UTC))
 
     val withGood = ExecutionBatch
       .getComplianceForRule(
@@ -2267,7 +2268,7 @@ class ExecutionBatchTest extends Specification {
       )
     }
     val ruleExpectedReports      = RuleExpectedReports(RuleId("cr"), directiveExpectedReports :: Nil)
-    val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now())
+    val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now(DateTimeZone.UTC))
 
     val statusReports = ExecutionBatch
       .getComplianceForRule(
@@ -2429,7 +2430,7 @@ class ExecutionBatchTest extends Specification {
       )
     }
     val ruleExpectedReports      = RuleExpectedReports(RuleId("cr"), directiveExpectedReports :: Nil)
-    val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now())
+    val mergeInfo                = MergeInfo(NodeId("nodeId"), None, None, DateTime.now(DateTimeZone.UTC))
 
     val statusReports = ExecutionBatch
       .getComplianceForRule(
@@ -3056,7 +3057,7 @@ class ExecutionBatchTest extends Specification {
     )
 
     val ruleExpectedReports = RuleExpectedReports(RuleId("cr"), d1 :: d2 :: Nil)
-    val mergeInfo           = MergeInfo(NodeId("nodeId"), None, None, DateTime.now())
+    val mergeInfo           = MergeInfo(NodeId("nodeId"), None, None, DateTime.now(DateTimeZone.UTC))
 
     val result = ExecutionBatch.getComplianceForRule(
       mergeInfo,
@@ -3614,14 +3615,14 @@ class ExecutionBatchTest extends Specification {
       ),
       Seq[Reports](
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "one",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         )
       )
@@ -3664,14 +3665,14 @@ class ExecutionBatchTest extends Specification {
       ),
       Seq[Reports](
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "two",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         )
       )
@@ -3709,25 +3710,25 @@ class ExecutionBatchTest extends Specification {
       ),
       Seq[Reports](
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "one",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "one",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         )
       )
@@ -3764,14 +3765,14 @@ class ExecutionBatchTest extends Specification {
       ),
       Seq[Reports](
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "one",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         )
       )
@@ -3807,25 +3808,25 @@ class ExecutionBatchTest extends Specification {
       ),
       Seq[Reports](
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "one",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "two",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         )
       )
@@ -3872,80 +3873,80 @@ class ExecutionBatchTest extends Specification {
       ),
       Seq[Reports](
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "one",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "one",
           "report_id12",
           "component2",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy2",
           "one",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy2",
           "one",
           "report_id12",
           "component2",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "two",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "two",
           "report_id12",
           "component2",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy2",
           "two",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         )
       )
@@ -3993,91 +3994,91 @@ class ExecutionBatchTest extends Specification {
       ),
       Seq[Reports](
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "one",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "one",
           "report_id12",
           "component2",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy2",
           "one",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy2",
           "one",
           "report_id12",
           "component2",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "two",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "two",
           "report_id12",
           "component2",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy2",
           "two",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "three",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         )
       )
@@ -4143,69 +4144,69 @@ class ExecutionBatchTest extends Specification {
       ),
       Seq[Reports](
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "one",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "one",
           "report_id12",
           "component",
           "value2",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "one",
           "report_id12",
           "component",
           "value3",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "two",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "two",
           "report_id12",
           "component",
           "value2",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy",
           "three",
           "report_id12",
           "component",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         )
       )
@@ -4274,14 +4275,14 @@ class ExecutionBatchTest extends Specification {
       ),
       Seq[Reports](
         new ResultSuccessReport(
-          new DateTime(),
+          new DateTime(DateTimeZone.UTC),
           "rule",
           "policy",
           "one",
           "report_id12",
           "component",
           """some\"text""",
-          new DateTime(),
+          new DateTime(DateTimeZone.UTC),
           "message"
         )
       )
@@ -4322,14 +4323,14 @@ class ExecutionBatchTest extends Specification {
       ),
       Seq[Reports](
         new ResultSuccessReport(
-          new DateTime(),
+          new DateTime(DateTimeZone.UTC),
           "rule",
           "policy",
           "nodeId",
           "report_id12",
           "component",
           """/var/cfengine/inputs/\"test""",
-          new DateTime(),
+          new DateTime(DateTimeZone.UTC),
           "message"
         )
       )
@@ -4369,14 +4370,14 @@ class ExecutionBatchTest extends Specification {
       ),
       Seq[Reports](
         new ResultSuccessReport(
-          new DateTime(),
+          new DateTime(DateTimeZone.UTC),
           "rule",
           "policy",
           "nodeId",
           "report_id12",
           "component",
           """/var/cfengine/inputs/"test""",
-          new DateTime(),
+          new DateTime(DateTimeZone.UTC),
           "message"
         )
       )
@@ -4512,47 +4513,47 @@ class ExecutionBatchTest extends Specification {
       ),
       Seq[Reports](
         new ResultErrorReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy1",
           "one",
           "report_id12",
           "component1",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy1",
           "one",
           "report_id12",
           "component2",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy2",
           "one",
           "report_id12",
           "component1",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy2",
           "one",
           "report_id12",
           "component2",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         )
       )
@@ -4625,47 +4626,47 @@ class ExecutionBatchTest extends Specification {
       },
       Seq[Reports](
         new ResultErrorReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy1",
           "one",
           "report_id12",
           "component1",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy1",
           "one",
           "report_id12",
           "component2",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy2",
           "one",
           "report_id12",
           "component1",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         ),
         new ResultSuccessReport(
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "rule",
           "policy2",
           "one",
           "report_id12",
           "component2",
           "value",
-          DateTime.now(),
+          DateTime.now(DateTimeZone.UTC),
           "message"
         )
       )

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/NodeStatusReportRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/NodeStatusReportRepositoryTest.scala
@@ -54,6 +54,7 @@ import com.normation.rudder.services.policies.NodeConfigData
 import com.normation.zio.*
 import com.softwaremill.quicklens.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.mutable.*
 import org.specs2.runner.JUnitRunner
@@ -67,7 +68,7 @@ import zio.*
 @RunWith(classOf[JUnitRunner])
 class NodeStatusReportRepositoryTest extends Specification {
 
-  val expiration: DateTime = DateTime.now()
+  val expiration: DateTime = DateTime.now(DateTimeZone.UTC)
   val beginDate:  DateTime = expiration.minusMinutes(10) // report generation time
   val expired:    DateTime = expiration.minusMinutes(5)
   val stillOk:    DateTime = expiration.plusMinutes(5)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ReportingServiceUtilsTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ReportingServiceUtilsTest.scala
@@ -54,6 +54,7 @@ import com.normation.rudder.domain.reports.RunComplianceInfo
 import com.normation.rudder.services.policies.PolicyId
 import com.softwaremill.quicklens.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.*
 import org.specs2.matcher.MatchResult
 import org.specs2.mutable.*
@@ -75,7 +76,7 @@ class ReportingServiceUtilsTest extends Specification {
   val dir2:  DirectiveId = DirectiveId(DirectiveUid("dir2"))
   val dir3:  DirectiveId = DirectiveId(DirectiveUid("dir3"))
 
-  val expiration = new DateTime(0) // not used
+  val expiration = new DateTime(0, DateTimeZone.UTC) // not used
 
   val noOverrides = Nil
   def dirReport(id: DirectiveId): (DirectiveId, DirectiveStatusReport) =
@@ -133,8 +134,9 @@ class ReportingServiceUtilsTest extends Specification {
     }
 
     def isSameReportAs(report2: AggregatedStatusReport): MatchResult[Set[RuleNodeStatusReport]] = {
-      report1.reports.modify(_.each.expirationDate).setTo(new DateTime(0)) ===
-      report2.reports.modify(_.each.expirationDate).setTo(new DateTime(0))
+      report1.reports.modify(_.each.expirationDate).setTo(new DateTime(0, DateTimeZone.UTC)) === report2.reports
+        .modify(_.each.expirationDate)
+        .setTo(new DateTime(0, DateTimeZone.UTC))
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/servers/TestRemoveNodeService.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/servers/TestRemoveNodeService.scala
@@ -43,7 +43,9 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.zio.*
+import java.time.Instant
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.ISODateTimeFormat
 import org.junit.runner.RunWith
 import org.specs2.mutable.*
@@ -54,7 +56,9 @@ import org.specs2.specification.AfterAll
 class TestRemoveNodeService extends Specification with AfterAll {
 
   // let's say that's /var/rudder/share
-  val varRudderShare: File = File(s"/tmp/rudder-test-delete-node-${DateTime.now().toString(ISODateTimeFormat.dateTime())}")
+  val varRudderShare: File = File(
+    s"/tmp/rudder-test-delete-node-${DateTime.now(DateTimeZone.UTC).toString(ISODateTimeFormat.dateTime())}"
+  )
 
   // nodeXX appears at seleral places
 
@@ -94,8 +98,16 @@ class TestRemoveNodeService extends Specification with AfterAll {
   )
 
   val cleanUp = new CleanUpNodePolicyFiles(varRudderShare.pathAsString)
-  implicit val testChangeContext: ChangeContext =
-    ChangeContext(ModificationId("test-mod-id"), EventActor("test"), DateTime.now(), None, None, QueryContext.testQC.nodePerms)
+  implicit val testChangeContext: ChangeContext = {
+    ChangeContext(
+      ModificationId("test-mod-id"),
+      EventActor("test"),
+      Instant.now(),
+      None,
+      None,
+      QueryContext.testQC.nodePerms
+    )
+  }
 
   /*
    *

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/users/UserRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/users/UserRepositoryTest.scala
@@ -705,7 +705,7 @@ trait UserRepositoryTest extends Specification with Loggable {
         .runNow must containTheSameElementsAs(List("alice", "charlie", "mallory", "bob")) // william is already deleted
 
       repo
-        .purge(Nil, Some(dateInit.plusYears(1)), Nil, EventTrace(actor, DateTime.now()))
+        .purge(Nil, Some(dateInit.plusYears(1)), Nil, EventTrace(actor, DateTime.now(DateTimeZone.UTC)))
         .tap(users => errors.effectUioUnit(logger.debug(s"Users were purged: ${users}")))
         .runNow must containTheSameElementsAs(List("alice", "charlie", "mallory", "bob", "william", "xavier"))
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/ApiAccount.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/ApiAccount.scala
@@ -63,6 +63,7 @@ import io.scalaland.chimney.partial.Result
 import io.scalaland.chimney.syntax.*
 import java.time.ZonedDateTime
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import zio.json.*
 import zio.json.internal.Write
 import zio.syntax.*
@@ -414,7 +415,7 @@ class ApiAccountMapping(
                   case (None, None, None)                                        => None
                   case (_, Some(ApiAccountExpirationPolicy.Never), _)            => None
                   case (_, _, Some(d))                                           => Some(d.transformInto[DateTime])
-                  case (None, Some(ApiAccountExpirationPolicy.AtDateTime), None) => Some(DateTime.now())
+                  case (None, Some(ApiAccountExpirationPolicy.AtDateTime), None) => Some(DateTime.now(DateTimeZone.UTC))
                   case (Some(e), _, None)                                        => Some(e)
                 }
               }
@@ -485,7 +486,7 @@ object ApiAccountMapping extends DateTimeCodecs {
       uuidGen:        StringUuidGenerator,
       tokenGenerator: TokenGenerator
   ) = {
-    val getNow         = DateTime.now().succeed
+    val getNow         = DateTime.now(DateTimeZone.UTC).succeed
     val generateId     = ApiAccountId(uuidGen.newUuid).succeed
     val generateSecret = ApiTokenSecret.generate(tokenGenerator).transformInto[ClearTextSecret].succeed
     def generateToken(secret: ClearTextSecret): IOResult[ApiTokenHash] =

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/EventLog.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/EventLog.scala
@@ -85,28 +85,17 @@ object RestEventLog {
     Transformer
       .define[EventLog, RestEventLog]
       .enableMethodAccessors // because source is a trait
-      .withFieldComputed(
-        _.actor,
-        _.principal
-      )
-      .withFieldComputed(
-        _.eventType,
-        e => translateEventType(e.eventType)
-      )
-      .withFieldComputed(
-        _.description,
-        eventLogDetail.displayDescription(_)
-      )
-      .withFieldComputed(
-        _.hasDetails,
-        _.details != <entry></entry>
-      )
+      .withFieldComputed(_.actor, _.principal)
+      .withFieldComputed(_.eventType, e => translateEventType(e.eventType))
+      .withFieldComputed(_.description, eventLogDetail.displayDescription)
+      .withFieldComputed(_.hasDetails, _.details != <entry></entry>)
+      .withFieldComputed(_.creationDate, e => DateFormaterService.toDateTime(e.creationDate))
       .buildTransformer
   }
 }
 
 /**
-  * Response data from the event log API : 
+  * Response data from the event log API :
   * - success has non-empty "data"
   * - error has "error" message
   */

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ArchiveApi.scala
@@ -116,12 +116,14 @@ import java.io.OutputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.NoSuchFileException
 import java.text.Normalizer
+import java.time.Instant
 import java.util.zip.ZipEntry
 import net.liftweb.http.FileParamHolder
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.OutputStreamResponse
 import net.liftweb.http.Req
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.util.matching.Regex
 import zio.*
 import zio.json.*
@@ -1614,7 +1616,7 @@ class SaveArchiveServicebyRepo(
     implicit val cc: ChangeContext = ChangeContext(
       ModificationId(uuidGen.newUuid),
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       Some(s"Importing archive '${archive.metadata.filename}'"),
       None,
       qc.nodePerms

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/CampaignApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/CampaignApi.scala
@@ -18,6 +18,7 @@ import net.liftweb.common.Full
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import zio.ZIO
 import zio.syntax.*
 
@@ -131,7 +132,7 @@ class CampaignApi(
       val res = {
         for {
           campaign <- campaignRepository.get(CampaignId(resources)).notOptional(s"Campaign with id ${resources} not found")
-          newEvent <- mainCampaignService.scheduleCampaignEvent(campaign, DateTime.now())
+          newEvent <- mainCampaignService.scheduleCampaignEvent(campaign, DateTime.now(DateTimeZone.UTC))
         } yield {
           newEvent
         }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
@@ -79,10 +79,12 @@ import com.normation.rudder.web.services.DirectiveEditorService
 import com.normation.utils.Control.*
 import com.normation.utils.StringUuidGenerator
 import com.softwaremill.quicklens.*
+import java.time.Instant
 import net.liftweb.common.*
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import zio.*
 import zio.syntax.*
 
@@ -449,7 +451,7 @@ class DirectiveApiService14(
     implicit val cc: ChangeContext = ChangeContext(
       ModificationId(uuidGen.newUuid),
       actor,
-      new DateTime(),
+      Instant.now(),
       params.reason,
       None,
       qc.nodePerms
@@ -482,7 +484,7 @@ class DirectiveApiService14(
     implicit val cc: ChangeContext = ChangeContext(
       ModificationId(uuidGen.newUuid),
       actor,
-      new DateTime(),
+      Instant.now(),
       params.reason,
       None,
       qc.nodePerms

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -69,9 +69,9 @@ import com.normation.rudder.services.queries.CmdbQueryParser
 import com.normation.rudder.services.queries.QueryProcessor
 import com.normation.rudder.services.workflows.*
 import com.normation.utils.StringUuidGenerator
+import java.time.Instant
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
-import org.joda.time.DateTime
 import zio.Chunk
 import zio.ZIO
 import zio.syntax.*
@@ -368,7 +368,7 @@ class GroupsApi(
       val cc = ChangeContext(
         ModificationId(uuidGen.newUuid),
         authzToken.qc.actor,
-        new DateTime(),
+        Instant.now(),
         reason,
         None,
         authzToken.qc.nodePerms
@@ -538,7 +538,7 @@ class GroupApiService14(
                 val reloadGroupDiff = ModifyToNodeGroupDiff(updatedGroup)
                 val change          = NodeGroupChangeRequest(DGModAction.Update, updatedGroup, Some(cat), Some(group))
                 implicit val cc: ChangeContext =
-                  ChangeContext(ModificationId(uuidGen.newUuid), actor, new DateTime(), None, None, qc.nodePerms)
+                  ChangeContext(ModificationId(uuidGen.newUuid), actor, Instant.now(), None, None, qc.nodePerms)
                 createChangeRequest(reloadGroupDiff, change, params, actor)
               }
               .chainError(s"Could not reload Group ${sid} details")
@@ -562,7 +562,7 @@ class GroupApiService14(
           val deleteGroupDiff = DeleteNodeGroupDiff(group)
           val change          = NodeGroupChangeRequest(DGModAction.Delete, group, Some(cat), Some(group))
           implicit val cc: ChangeContext =
-            ChangeContext(ModificationId(uuidGen.newUuid), actor, new DateTime(), None, None, qc.nodePerms)
+            ChangeContext(ModificationId(uuidGen.newUuid), actor, Instant.now(), None, None, qc.nodePerms)
           createChangeRequest(deleteGroupDiff, change, params, actor)
 
         case None =>
@@ -572,7 +572,7 @@ class GroupApiService14(
 
   def updateGroup(restGroup: JQGroup, params: DefaultParams, actor: EventActor)(implicit qc: QueryContext): IOResult[JRGroup] = {
     implicit val cc: ChangeContext =
-      ChangeContext(ModificationId(uuidGen.newUuid), actor, new DateTime(), None, None, qc.nodePerms)
+      ChangeContext(ModificationId(uuidGen.newUuid), actor, Instant.now(), None, None, qc.nodePerms)
     for {
       id      <- restGroup.id.notOptional(s"You must specify the ID of the group that you want to update")
       pair    <- readGroup.getNodeGroup(id)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -123,6 +123,7 @@ import java.io.PipedInputStream
 import java.io.PipedOutputStream
 import java.net.ConnectException
 import java.nio.charset.StandardCharsets
+import java.time.Instant
 import java.util.Arrays
 import net.liftweb.common.Box
 import net.liftweb.common.Failure
@@ -130,6 +131,7 @@ import net.liftweb.http.LiftResponse
 import net.liftweb.http.OutputStreamResponse
 import net.liftweb.http.Req
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.collection.MapView
 import scalaj.http.Http
 import scalaj.http.HttpOptions
@@ -368,7 +370,7 @@ class NodeApi(
                       ChangeContext(
                         ModificationId(uuidGen.newUuid),
                         authzToken.qc.actor,
-                        new DateTime(),
+                        Instant.now(),
                         _,
                         Some(req.remoteAddr),
                         authzToken.qc.nodePerms
@@ -378,7 +380,7 @@ class NodeApi(
                       ChangeContext(
                         ModificationId(uuidGen.newUuid),
                         authzToken.qc.actor,
-                        new DateTime(),
+                        Instant.now(),
                         restNode.reason,
                         Some(req.remoteAddr),
                         authzToken.qc.nodePerms
@@ -807,7 +809,7 @@ class NodeApiService(
     implicit val cc: ChangeContext = ChangeContext(
       ModificationId(uuidGen.newUuid),
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       None,
       Some(actorIp),
       qc.nodePerms
@@ -917,7 +919,7 @@ class NodeApiService(
         NodeState.Enabled,
         isSystem = false,
         isPolicyServer = false,
-        creationDate = DateTime.now,
+        creationDate = Instant.now(),
         nodeReportingConfiguration = ReportingConfiguration(None, None, None),
         properties = Nil,
         policyMode = None,
@@ -1158,7 +1160,7 @@ class NodeApiService(
       _ <- NodeLogger.PendingNodePure.debug(s" Nodes to change Status : ${nodeIds.mkString("[ ", ", ", " ]")}")
 
       res <- modifyStatusFromAction(nodeIds, nodeStatusAction)(
-               ChangeContext(modId, qc.actor, DateTime.now(), None, actorIp, qc.nodePerms)
+               ChangeContext(modId, qc.actor, Instant.now(), None, actorIp, qc.nodePerms)
              )
     } yield {
       res
@@ -1468,8 +1470,9 @@ class NodeApiService(
     val modId = ModificationId(uuidGen.newUuid)
 
     for {
-      info <- removeNodeService
-                .removeNodePure(id, mode)(ChangeContext(modId, qc.actor, DateTime.now(), None, actorIp, qc.nodePerms))
+      info <-
+        removeNodeService
+          .removeNodePure(id, mode)(ChangeContext(modId, qc.actor, Instant.now(), None, actorIp, qc.nodePerms))
     } yield {
       Chunk.fromIterable(info.map(_.toNodeInfo.transformInto[JRNodeInfo]))
     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
@@ -60,9 +60,9 @@ import com.normation.rudder.services.workflows.GlobalParamChangeRequest
 import com.normation.rudder.services.workflows.GlobalParamModAction
 import com.normation.rudder.services.workflows.WorkflowLevelService
 import com.normation.utils.StringUuidGenerator
+import java.time.Instant
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
-import org.joda.time.DateTime
 import zio.syntax.*
 
 class ParameterApi(
@@ -168,7 +168,7 @@ class ParameterApiService14(
       actor:     EventActor
   )(implicit qc: QueryContext): IOResult[JRGlobalParameter] = {
     implicit val cc: ChangeContext =
-      ChangeContext(ModificationId(uuidGen.newUuid), actor, new DateTime(), params.reason, None, qc.nodePerms)
+      ChangeContext(ModificationId(uuidGen.newUuid), actor, Instant.now(), params.reason, None, qc.nodePerms)
     for {
       workflow <- workflowLevelService.getForGlobalParam(actor, change)
       cr        = ChangeRequestService.createChangeRequestFromGlobalParameter(

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -62,9 +62,9 @@ import com.normation.rudder.services.workflows.*
 import com.normation.rudder.web.services.ComputePolicyMode
 import com.normation.rudder.web.services.ComputePolicyMode.ComputedPolicyMode
 import com.normation.utils.StringUuidGenerator
+import java.time.Instant
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
-import org.joda.time.DateTime
 import scala.collection.MapView
 import zio.*
 import zio.syntax.*
@@ -333,7 +333,14 @@ class RuleApiService14(
                       )
       id           <- workflow
                         .startWorkflow(cr)(
-                          ChangeContext(ModificationId(uuidGen.newUuid), actor, new DateTime(), params.reason, None, qc.nodePerms)
+                          ChangeContext(
+                            ModificationId(uuidGen.newUuid),
+                            actor,
+                            Instant.now(),
+                            params.reason,
+                            None,
+                            qc.nodePerms
+                          )
                         )
       directiveLib <- readDirectives.getFullDirectiveLibrary()
       groupLib     <- readGroup.getFullGroupLibrary()

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
@@ -84,6 +84,7 @@ import com.normation.rudder.users.UserService
 import com.normation.utils.DateFormaterService
 import com.normation.utils.StringUuidGenerator
 import com.normation.zio.*
+import java.time.Instant
 import net.liftweb.common.*
 import net.liftweb.http.InMemoryResponse
 import net.liftweb.http.LiftResponse
@@ -99,6 +100,7 @@ import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.format.DateTimeFormatterBuilder
+import org.joda.time.format.ISODateTimeFormat.basicTimeNoMillis
 import zio.*
 
 class SystemApi(
@@ -809,7 +811,7 @@ class SystemApiService11(
                        }
           treeId    <- IOResult.attempt(revCommit.getTree.getId)
           bytes     <- GitFindUtils.getZip(repo.db, treeId, archiveType.directories)
-          date       = new DateTime(revCommit.getCommitTime.toLong * 1000)
+          date       = new DateTime(revCommit.getCommitTime.toLong * 1000, DateTimeZone.UTC)
         } yield {
           (bytes, date)
         }
@@ -900,7 +902,7 @@ class SystemApiService11(
     implicit val cc: ChangeContext = ChangeContext(
       newModId,
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       Some(s"Restore archive for date time ${dateTime} requested from REST API"),
       None,
       qc.nodePerms
@@ -924,7 +926,7 @@ class SystemApiService11(
     implicit val cc: ChangeContext = ChangeContext(
       newModId,
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       Some(s"Restore archive for date time ${dateTime} requested from REST API"),
       None,
       qc.nodePerms
@@ -948,7 +950,7 @@ class SystemApiService11(
     implicit val cc: ChangeContext = ChangeContext(
       newModId,
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       Some(s"Restore archive for date time ${dateTime} requested from REST API"),
       None,
       qc.nodePerms
@@ -966,7 +968,7 @@ class SystemApiService11(
     implicit val cc: ChangeContext = ChangeContext(
       newModId,
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       Some(s"Restore archive for date time ${dateTime} requested from REST API"),
       None,
       qc.nodePerms
@@ -990,7 +992,7 @@ class SystemApiService11(
     implicit val cc: ChangeContext = ChangeContext(
       newModId,
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       Some(s"Restore archive for date time ${dateTime} requested from REST API"),
       None,
       qc.nodePerms
@@ -1061,7 +1063,7 @@ class SystemApiService11(
     implicit val cc: ChangeContext = ChangeContext(
       newModId,
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       Some("Restore latest archive required from REST API"),
       None,
       qc.nodePerms
@@ -1084,7 +1086,7 @@ class SystemApiService11(
     implicit val cc: ChangeContext = ChangeContext(
       newModId,
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       Some("Restore latest archive required from REST API"),
       None,
       qc.nodePerms
@@ -1107,7 +1109,7 @@ class SystemApiService11(
     implicit val cc: ChangeContext = ChangeContext(
       newModId,
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       Some("Restore latest archive required from REST API"),
       None,
       qc.nodePerms
@@ -1125,7 +1127,7 @@ class SystemApiService11(
     implicit val cc: ChangeContext = ChangeContext(
       newModId,
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       Some("Restore latest archive required from REST API"),
       None,
       qc.nodePerms
@@ -1149,7 +1151,7 @@ class SystemApiService11(
     implicit val cc: ChangeContext = ChangeContext(
       newModId,
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       Some("Restore latest archive required from REST API"),
       None,
       qc.nodePerms
@@ -1168,7 +1170,7 @@ class SystemApiService11(
     implicit val cc: ChangeContext = ChangeContext(
       newModId,
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       Some("Restore archive from latest commit on HEAD required from REST API"),
       None,
       qc.nodePerms
@@ -1187,7 +1189,7 @@ class SystemApiService11(
     implicit val cc: ChangeContext = ChangeContext(
       newModId,
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       Some("Restore archive from latest commit on HEAD required from REST API"),
       None,
       qc.nodePerms
@@ -1206,7 +1208,7 @@ class SystemApiService11(
     implicit val cc: ChangeContext = ChangeContext(
       newModId,
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       Some("Restore latest archive required from REST API"),
       None,
       qc.nodePerms
@@ -1225,7 +1227,7 @@ class SystemApiService11(
     implicit val cc: ChangeContext = ChangeContext(
       newModId,
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       Some("Restore latest archive required from REST API"),
       None,
       qc.nodePerms
@@ -1243,7 +1245,7 @@ class SystemApiService11(
     implicit val cc: ChangeContext = ChangeContext(
       newModId,
       qc.actor,
-      new DateTime(),
+      Instant.now(),
       Some("Restore latest archive required from REST API"),
       None,
       qc.nodePerms
@@ -1380,11 +1382,14 @@ private[rest] object SystemApi {
   /**
     * Public format to display archive tagged at date
     */
-  val archiveDateFormat = new DateTimeFormatterBuilder()
-    .append(DateTimeFormat.forPattern("YYYY-MM-dd"))
-    .appendLiteral('T')
-    .append(DateTimeFormat.forPattern("HHmmss'Z'")) // we want only utc here to avoid getting + or other strange char in URI
-    .toFormatter
+  val archiveDateFormat = {
+    new DateTimeFormatterBuilder()
+      .append(DateTimeFormat.forPattern("YYYY-MM-dd"))
+      .appendLiteral('T')
+      .append(basicTimeNoMillis())
+      .toFormatter
+      .withZoneUTC()
+  }
 
   def getArchiveName(archiveType: ArchiveType, date: DateTime): String =
     s"rudder-conf-${archiveType.entryName}-${archiveDateFormat.print(date.toDateTime(DateTimeZone.UTC))}.zip"

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
@@ -89,6 +89,7 @@ import io.scalaland.chimney.dsl.*
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import sourcecode.Line
 import zio.ZIO
 import zio.syntax.*
@@ -499,7 +500,7 @@ class UserManagementApiImpl(
                         case UserStatus.Disabled => {
                           val eventTrace = EventTrace(
                             authzToken.qc.actor,
-                            DateTime.now,
+                            DateTime.now(DateTimeZone.UTC),
                             "User current disabled status set to 'active' by user management API"
                           )
                           (userRepo.setActive(List(user.id), eventTrace) *> userService.reloadPure())
@@ -532,7 +533,7 @@ class UserManagementApiImpl(
                         case UserStatus.Active   => {
                           val eventTrace = EventTrace(
                             authzToken.qc.actor,
-                            DateTime.now,
+                            DateTime.now(DateTimeZone.UTC),
                             "User current active status set to 'disabled' by user management API"
                           )
                           (userRepo.disable(List(user.id), None, List.empty, eventTrace) *> userService.reloadPure())

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/Translator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/Translator.scala
@@ -41,6 +41,7 @@ import com.normation.utils.Utils.isEmpty
 import java.util.Locale
 import net.liftweb.common.*
 import org.apache.commons.io.FilenameUtils
+import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.format.DateTimeFormatter
 import scala.collection.mutable.Map as MutMap
@@ -188,7 +189,7 @@ class DateTimeTranslator(
         try {
           datetimeFormatter match {
             case Some(dtf) => Full(dtf.parseDateTime(x))
-            case None      => Full(new DateTime(x))
+            case None      => Full(new DateTime(x, DateTimeZone.UTC))
           }
         } catch {
           case e: IllegalArgumentException =>

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_eventlogs.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_eventlogs.yml
@@ -83,7 +83,7 @@ response:
       "data" : [
         {
           "id" : 42,
-          "date" : "2024-12-04 15:30:10+0100",
+          "date" : "2024-12-04 15:30:10Z",
           "actor" : "test",
           "type" : "NodeGroupModified",
           "description" : "Group ",

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
@@ -948,9 +948,9 @@ response:
         "ipAddresses" : [
           "192.168.0.5"
         ],
-        "acceptanceDate" : "2021-01-30 01:20:00+0100",
+        "acceptanceDate" : "2021-01-30 00:20:00Z",
         "lastRun" : "Never",
-        "lastInventory" : "2021-01-30 01:20:00+0100",
+        "lastInventory" : "2021-01-30 00:20:00Z",
         "software" : {},
         "properties" : {},
         "inheritedProperties" : {},
@@ -975,9 +975,9 @@ response:
         "ipAddresses" : [
           "192.168.0.10"
         ],
-        "acceptanceDate" : "2021-01-30 01:20:00+0100",
+        "acceptanceDate" : "2021-01-30 00:20:00Z",
         "lastRun" : "Never",
-        "lastInventory" : "2021-01-30 01:20:00+0100",
+        "lastInventory" : "2021-01-30 00:20:00Z",
         "software" : {},
         "properties" : {},
         "inheritedProperties" : {},
@@ -1002,9 +1002,9 @@ response:
         "ipAddresses" : [
           "192.168.0.10"
         ],
-        "acceptanceDate" : "2021-01-30 01:20:00+0100",
+        "acceptanceDate" : "2021-01-30 00:20:00Z",
         "lastRun" : "Never",
-        "lastInventory" : "2021-01-30 01:20:00+0100",
+        "lastInventory" : "2021-01-30 00:20:00Z",
         "software" : {},
         "properties" : {},
         "inheritedProperties" : {},
@@ -1028,9 +1028,9 @@ response:
         "ipAddresses" : [
           "192.168.0.100"
         ],
-        "acceptanceDate" : "2021-01-30 01:20:00+0100",
+        "acceptanceDate" : "2021-01-30 00:20:00Z",
         "lastRun" : "Never",
-        "lastInventory" : "2021-01-30 01:20:00+0100",
+        "lastInventory" : "2021-01-30 00:20:00Z",
         "software" : {},
         "properties" : {},
         "inheritedProperties" : {},
@@ -1072,9 +1072,9 @@ response:
         "ipAddresses" : [
           "192.168.0.10"
         ],
-        "acceptanceDate" : "2021-01-30 01:20:00+0100",
+        "acceptanceDate" : "2021-01-30 00:20:00Z",
         "lastRun" : "Never",
-        "lastInventory" : "2021-01-30 01:20:00+0100",
+        "lastInventory" : "2021-01-30 00:20:00Z",
         "software" : {
           "s05" : "1.0"
         },

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/domain/reports/JsonPostresqlSerializationTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/domain/reports/JsonPostresqlSerializationTest.scala
@@ -46,6 +46,7 @@ import com.normation.rudder.domain.reports.ReportType.*
 import com.normation.rudder.domain.reports.RunAnalysisKind.*
 import com.normation.utils.DateFormaterService
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.mutable.*
 import org.specs2.runner.*
@@ -166,7 +167,7 @@ class JsonPostresqlSerializationTest extends Specification {
     )
   }
 
-  val date0 = new DateTime(0)
+  val date0 = new DateTime(0, DateTimeZone.UTC)
   val tConfig0Start: Option[DateTime]     = DateFormaterService.parseDate("2024-01-01T01:00:00Z").toOption
   val tConfig0End:   Option[DateTime]     = None
   val lastRun0:      Option[DateTime]     = DateFormaterService.parseDate("2024-01-05T05:05:00Z").toOption

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
@@ -80,6 +80,7 @@ import net.liftweb.http.OutputStreamResponse
 import org.apache.commons.io.FileUtils
 import org.eclipse.jgit.revwalk.RevWalk
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -100,7 +101,7 @@ class ArchiveApiTest extends Specification with AfterAll with Loggable {
   val mockTechniques: MockTechniques = MockTechniques(mockGitRepo)
   val mockDirectives = new MockDirectives(mockTechniques)
 
-  val testDir: File = File(s"/tmp/test-rudder-response-content-${DateFormaterService.serialize(DateTime.now())}")
+  val testDir: File = File(s"/tmp/test-rudder-response-content-${DateFormaterService.serialize(DateTime.now(DateTimeZone.UTC))}")
   testDir.createDirectoryIfNotExists(true)
 
   override def afterAll(): Unit = {

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/CampaignApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/CampaignApiTest.scala
@@ -70,7 +70,7 @@ class CampaignApiTest extends Specification with AfterAll with Loggable with Jso
   ZioRuntime.unsafeRun(MainCampaignService.start(restTestSetUp.mockCampaign.mainCampaignService))
   val restTest      = new RestTest(restTestSetUp.liftRules)
 
-  val testDir: File = File(s"/tmp/test-rudder-campaign-${DateFormaterService.serialize(DateTime.now())}")
+  val testDir: File = File(s"/tmp/test-rudder-campaign-${DateFormaterService.serialize(DateTime.now(DateTimeZone.UTC))}")
   testDir.createDirectoryIfNotExists(true)
 
   override def afterAll(): Unit = {

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -181,11 +181,13 @@ import com.normation.rudder.web.services.DirectiveFieldFactory
 import com.normation.rudder.web.services.EventLogDetailsGenerator
 import com.normation.rudder.web.services.Section2FieldService
 import com.normation.rudder.web.services.Translator
+import com.normation.utils.DateFormaterService
 import com.normation.utils.ParseVersion
 import com.normation.utils.StringUuidGeneratorImpl
 import com.normation.zio.*
 import doobie.*
 import java.nio.charset.StandardCharsets
+import java.time.Instant
 import java.time.ZonedDateTime
 import net.liftweb.common.Box
 import net.liftweb.common.EmptyBox
@@ -209,6 +211,7 @@ import org.apache.commons.io.FileUtils
 import org.apache.commons.io.output.ByteArrayOutputStream
 import org.eclipse.jgit.lib.PersonIdent
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.specs2.matcher.MatchResult
 import scala.collection.MapView
 import scala.concurrent.duration.Duration
@@ -317,7 +320,7 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
       id = Some(42),
       modificationId = None,
       principal = EventActor("test"),
-      creationDate = DateTime.parse("2024-12-04T15:30:10"),
+      creationDate = DateFormaterService.toInstant(DateTime.parse("2024-12-04T15:30:10Z")),
       details = <test/>,
       reason = None
     )
@@ -373,7 +376,7 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
 
   }
   val eventLogDetailsService = new EventLogDetailsServiceImpl(null, null, null, null, null, null, null, null, null)
-  val modificationService = new ModificationService(null, null, null, null) {
+  val modificationService = new ModificationService(null, null, null) {
     override def restoreToEventLog(
         eventLog:         EventLog,
         commiter:         PersonIdent,
@@ -651,7 +654,7 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
       * Here, we want to make these methods returning fake archives for testing the API logic.
       */
     val fakeArchives:                     Map[DateTime, GitArchiveId]           = Map[DateTime, GitArchiveId](
-      new DateTime(42) -> fakeGitArchiveId
+      new DateTime("1970-01-01T01:00:00.042Z", DateTimeZone.UTC) -> fakeGitArchiveId
     )
     override def getFullArchiveTags:      IOResult[Map[DateTime, GitArchiveId]] = ZIO.succeed(fakeArchives)
     override def getGroupLibraryTags:     IOResult[Map[DateTime, GitArchiveId]] = ZIO.succeed(fakeArchives)
@@ -863,7 +866,7 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
       ChangeContext(
         ModificationId(uuidGen.newUuid),
         EventActor("test"),
-        DateTime.now(),
+        Instant.now(),
         None,
         None,
         QueryContext.testQC.nodePerms

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SystemApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SystemApiTest.scala
@@ -52,6 +52,7 @@ import net.liftweb.json.JsonAST.*
 import net.liftweb.json.JsonDSL.*
 import org.apache.commons.io.FileUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -473,7 +474,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   private val commitId: String = commit.getName
 
   private val commitDate: DateTime = new DateTime(
-    restTestSetUp.mockGitRepo.gitRepo.db.parseCommit(commit.toObjectId()).getCommitterIdent().getWhenAsInstant.toEpochMilli
+    restTestSetUp.mockGitRepo.gitRepo.db.parseCommit(commit.toObjectId()).getCommitterIdent().getWhenAsInstant.toEpochMilli,
+    DateTimeZone.UTC
   )
 
   // Init directory needed to temporary store archive data that zip API returns.

--- a/webapp/sources/rudder/rudder-templates-cli/src/test/scala/com/normation/templates/cli/TemplateCliTest.scala
+++ b/webapp/sources/rudder/rudder-templates-cli/src/test/scala/com/normation/templates/cli/TemplateCliTest.scala
@@ -43,6 +43,7 @@ import java.io.FileInputStream
 import java.io.PrintStream
 import org.apache.commons.io.FileUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.matcher.ContentMatchers
 import org.specs2.mutable.Specification
@@ -54,7 +55,7 @@ class TemplateCliTest extends Specification with ContentMatchers with AfterAll {
 
   sequential
 
-  val testDir = new File("/tmp/test-template-cli-" + DateTime.now.toString())
+  val testDir = new File("/tmp/test-template-cli-" + DateTime.now(DateTimeZone.UTC).toString())
 
   override def afterAll(): Unit = {
     if (System.getProperty("tests.clean.tmp") != "false") {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -61,6 +61,7 @@ import jakarta.servlet.http.HttpServletResponse
 import java.util.Collection
 import net.liftweb.common.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
@@ -397,7 +398,7 @@ class AppConfigAuth extends ApplicationContextAware {
       _                   <- rootAccountUserRepo.setExistingUsers(
                                "root-account",
                                admins.keys.toList,
-                               EventTrace(com.normation.rudder.domain.eventlog.RudderEventActor, DateTime.now())
+                               EventTrace(com.normation.rudder.domain.eventlog.RudderEventActor, DateTime.now(DateTimeZone.UTC))
                              )
     } yield {
       val provider = new DaoAuthenticationProvider()
@@ -852,8 +853,8 @@ class RestAuthenticationFilter(
                   Some(ApiTokenHash.disabled()),
                   "API Account for un-authenticated API",
                   isEnabled = true,
-                  creationDate = new DateTime(0),
-                  tokenGenerationDate = DateTime.now(),
+                  creationDate = new DateTime(0, DateTimeZone.UTC),
+                  tokenGenerationDate = DateTime.now(DateTimeZone.UTC),
                   tenants = NodeSecurityContext.None
                 )
 
@@ -915,13 +916,13 @@ class RestAuthenticationFilter(
                           )
                         case ApiAccountKind.PublicApi(authz, expirationDate) =>
                           expirationDate match {
-                            case Some(date) if (DateTime.now().isAfter(date)) =>
+                            case Some(date) if (DateTime.now(DateTimeZone.UTC).isAfter(date)) =>
                               failsAuthentication(
                                 httpRequest,
                                 httpResponse,
                                 Inconsistency(s"Account with ID ${principal.id.value} is disabled")
                               )
-                            case _                                            => // no expiration date or expiration date not reached
+                            case _                                                            => // no expiration date or expiration date not reached
                               val user = RudderUserDetail(
                                 RudderAccount.Api(principal),
                                 UserStatus.Active,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -93,6 +93,7 @@ import net.liftweb.util.TimeHelpers.*
 import net.liftweb.util.Vendor
 import org.apache.commons.text.StringEscapeUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.reflections.Reflections
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
@@ -379,7 +380,7 @@ object UserLogout {
         auth.getPrincipal() match {
           case u: RudderUserDetail =>
             val redirects: IterableOnce[Option[URI]] = {
-              (RudderConfig.userRepository.logCloseSession(u.getUsername, DateTime.now(), endCause) *>
+              (RudderConfig.userRepository.logCloseSession(u.getUsername, DateTime.now(DateTimeZone.UTC), endCause) *>
               RudderConfig.eventLogRepository
                 .saveEventLog(
                   ModificationId(RudderConfig.stringUuidGenerator.newUuid),

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderAuthorizationFileReloadCallback.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderAuthorizationFileReloadCallback.scala
@@ -40,6 +40,7 @@ package bootstrap.liftweb
 import com.normation.rudder.domain.eventlog.RudderEventActor
 import com.normation.rudder.users.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 
 /*
  * A callback that is in charge of updating the list of UserInfo managed by the file authenticator.
@@ -53,7 +54,11 @@ object UserRepositoryUpdateOnFileReload {
           .setExistingUsers(
             DefaultAuthBackendProvider.FILE,
             userList.users.keys.toList,
-            EventTrace(RudderEventActor, DateTime.now(), "Updating users because `rudder-users.xml` was reloaded"),
+            EventTrace(
+              RudderEventActor,
+              DateTime.now(DateTimeZone.UTC),
+              "Updating users because `rudder-users.xml` was reloaded"
+            ),
             userList.isCaseSensitive
           )
           .unit

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2758,14 +2758,14 @@ object RudderConfigInit {
       new InventoryHistoryLogRepository(
         HISTORY_INVENTORIES_ROOTDIR,
         new FullInventoryFileParser(fullInventoryFromLdapEntries, inventoryMapper),
-        new JodaDateTimeConverter(ISODateTimeFormat.dateTime())
+        new JodaDateTimeConverter(ISODateTimeFormat.dateTime().withZoneUTC())
       )
     }
 
     lazy val nodeGridImpl = new NodeGrid(nodeFactRepository, configService)
 
     lazy val modificationService      =
-      new ModificationService(logRepository, gitModificationRepository, itemArchiveManagerImpl, stringUuidGenerator)
+      new ModificationService(gitModificationRepository, itemArchiveManagerImpl, stringUuidGenerator)
     lazy val eventListDisplayerImpl   = new EventListDisplayer(logRepository)
     lazy val eventLogDetailsGenerator = new EventLogDetailsGenerator(
       eventLogDetailsServiceImpl,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/UserSessionInvalidationFilter.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/UserSessionInvalidationFilter.scala
@@ -51,6 +51,7 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import java.io.IOException
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.filter.OncePerRequestFilter
 import zio.*
@@ -121,7 +122,7 @@ class UserSessionInvalidationFilter(userRepository: UserRepository, userDetailLi
                       _ => {
                         userRepository.logCloseSession(
                           user.getUsername,
-                          DateTime.now,
+                          DateTime.now(DateTimeZone.UTC),
                           endSessionReason
                         ) *>
                         ApplicationLoggerPure.info(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/consistency/CloseOpenUserSessions.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/consistency/CloseOpenUserSessions.scala
@@ -43,6 +43,7 @@ import com.normation.rudder.users.*
 import com.normation.zio.*
 import jakarta.servlet.UnavailableException
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 
 /**
  * This class check that all user sessions are closed
@@ -56,7 +57,7 @@ class CloseOpenUserSessions(
   @throws(classOf[UnavailableException])
   override def checks(): Unit = {
     userRepository
-      .closeAllOpenSession(DateTime.now(), "sessions still opened while Rudder is starting")
+      .closeAllOpenSession(DateTime.now(DateTimeZone.UTC), "sessions still opened while Rudder is starting")
       .catchAll(err => BootstrapLogger.error(s"Error when closing user sessions when Rudder restart: ${err.fullMsg}"))
       .runNow
   }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/migration/FixedPathLoggerMigration.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/migration/FixedPathLoggerMigration.scala
@@ -4,6 +4,7 @@ import bootstrap.liftweb.BootstrapChecks
 import bootstrap.liftweb.BootstrapLogger
 import com.normation.utils.DateFormaterService
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.springframework.core.io.ClassPathResource
 import scala.xml.Elem
 import scala.xml.Node as XmlNode
@@ -146,7 +147,7 @@ class FixedPathLoggerMigration extends BootstrapChecks {
 
     if (shouldMigrateLogback) {
       val newLogback = migrateLogback(xml)
-      val backPath   = logbackFile.parent / s"logback.xml-backup-${DateFormaterService.serialize(DateTime.now())}"
+      val backPath   = logbackFile.parent / s"logback.xml-backup-${DateFormaterService.serialize(DateTime.now(DateTimeZone.UTC))}"
 
       // In case file already exists
       logbackFile.copyTo(backPath, overwrite = true)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/migration/MigrateNodeAcceptationInventories.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/migration/MigrateNodeAcceptationInventories.scala
@@ -56,6 +56,7 @@ import com.normation.rudder.services.nodes.history.impl.InventoryHistoryLogRepos
 import com.normation.zio.*
 import org.apache.commons.io.FileUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import zio.*
 
 /*
@@ -96,7 +97,7 @@ class MigrateNodeAcceptationInventories(
       FactLogData(NodeFact.newFromFullInventory(data, None), migrationActor, data.node.main.status),
       date
     ) *> ZIO.when(deleted) {
-      jdbcLogRepository.saveDeleteEvent(id, DateTime.now(), migrationActor)
+      jdbcLogRepository.saveDeleteEvent(id, DateTime.now(DateTimeZone.UTC), migrationActor)
     }
   }
 
@@ -153,7 +154,7 @@ class MigrateNodeAcceptationInventories(
   override def checks(): Unit = {
     val prog = {
       for {
-        _ <- migrateAll(DateTime.now())
+        _ <- migrateAll(DateTime.now(DateTimeZone.UTC))
       } yield ()
     }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/onetimeinit/CheckInitUserTemplateLibrary.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/onetimeinit/CheckInitUserTemplateLibrary.scala
@@ -50,9 +50,11 @@ import com.normation.rudder.domain.RudderDit
 import com.normation.rudder.domain.RudderLDAPConstants.*
 import com.normation.rudder.domain.eventlog.RudderEventActor
 import com.normation.rudder.repository.*
+import com.normation.utils.DateFormaterService
 import com.normation.utils.StringUuidGenerator
 import net.liftweb.common.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 
 /**
  * That class add all the available reference template in
@@ -93,7 +95,7 @@ class CheckInitUserTemplateLibrary(
         root.getAsGTime(A_INIT_DATETIME) match {
           case Some(date) =>
             BootstrapLogger.logEffect.debug(
-              "The root user template library was initialized on %s".format(date.dateTime.toString("YYYY/MM/dd HH:mm"))
+              s"The root user template library was initialized on ${DateFormaterService.serializeInstant(date.instant)}"
             )
           case None       =>
             BootstrapLogger.logEffect.info(
@@ -112,7 +114,7 @@ class CheckInitUserTemplateLibrary(
                 asyncDeploymentAgent ! AutomaticStartDeployment(ModificationId(uuidGen.newUuid), RudderEventActor)
             }
             root.addValues(A_OC, OC_ACTIVE_TECHNIQUE_LIB_VERSION)
-            root.resetValuesTo(A_INIT_DATETIME, GeneralizedTime(DateTime.now()).toString)
+            root.resetValuesTo(A_INIT_DATETIME, GeneralizedTime(DateTime.now(DateTimeZone.UTC)).toString)
             ldap.flatMap(_.save(root)).toBox match {
               case eb: EmptyBox =>
                 val e = eb ?~! "Error when updating information about the LDAP root entry of technique library."

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/ShowNodeDetailsFromNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/ShowNodeDetailsFromNode.scala
@@ -64,6 +64,7 @@ import com.normation.rudder.web.services.DisplayNode.showDeleteButton
 import com.normation.rudder.web.services.DisplayNodeGroupTree
 import com.normation.rudder.web.snippet.WithNonce
 import com.softwaremill.quicklens.*
+import java.time.Instant
 import net.liftweb.common.*
 import net.liftweb.http.DispatchSnippet
 import net.liftweb.http.S
@@ -73,6 +74,7 @@ import net.liftweb.http.js.JsExp
 import net.liftweb.util.Helpers.*
 import org.apache.commons.text.StringEscapeUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.xml.NodeSeq
 
 object ShowNodeDetailsFromNode {
@@ -128,7 +130,7 @@ class ShowNodeDetailsFromNode(
                    .toBox // we can't change the state of a missing node
       newNode  = oldNode.modify(_.rudderSettings.state).setTo(nodeState)
       result  <- nodeFactRepo
-                   .save(newNode)(ChangeContext(modId, qc.actor, DateTime.now(), None, None, qc.nodePerms))
+                   .save(newNode)(ChangeContext(modId, qc.actor, Instant.now(), None, None, qc.nodePerms))
                    .toBox
     } yield {
       asyncDeploymentAgent ! AutomaticStartDeployment(modId, CurrentUser.actor)
@@ -162,7 +164,7 @@ class ShowNodeDetailsFromNode(
   def saveSchedule(nodeFact: CoreNodeFact)(schedule: AgentRunInterval): Box[Unit] = {
     val newNodeFact = nodeFact.modify(_.rudderSettings.reportingConfiguration.agentRunInterval).setTo(Some(schedule))
     val modId       = ModificationId(uuidGen.newUuid)
-    val cc          = ChangeContext(modId, CurrentUser.actor, DateTime.now(), None, None, CurrentUser.nodePerms)
+    val cc          = ChangeContext(modId, CurrentUser.actor, Instant.now(), None, None, CurrentUser.nodePerms)
 
     (for {
       _ <- nodeFactRepo.save(newNodeFact)(cc)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
@@ -62,6 +62,7 @@ import com.normation.rudder.web.model.*
 import com.normation.zio.UnsafeRun
 import com.typesafe.config.ConfigValue
 import com.typesafe.config.ConfigValueType
+import java.time.Instant
 import net.liftweb.common.*
 import net.liftweb.http.*
 import net.liftweb.http.js.*
@@ -70,6 +71,7 @@ import net.liftweb.http.js.JsCmds.*
 import net.liftweb.util.FieldError
 import net.liftweb.util.Helpers.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.xml.*
 import zio.syntax.*
 
@@ -171,7 +173,7 @@ class CreateOrUpdateGlobalParameterPopup(
                        ChangeContext(
                          ModificationId(uuidGen.newUuid),
                          qc.actor,
-                         new DateTime(),
+                         Instant.now(),
                          paramReasons.map(_.get),
                          None,
                          qc.nodePerms

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ModificationValidationPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/ModificationValidationPopup.scala
@@ -66,6 +66,7 @@ import com.normation.rudder.web.components.DisplayColumn
 import com.normation.rudder.web.components.RuleGrid
 import com.normation.rudder.web.model.*
 import com.normation.zio.UnsafeRun
+import java.time.Instant
 import net.liftweb.common.Full
 import net.liftweb.common.Loggable
 import net.liftweb.http.DispatchSnippet
@@ -76,6 +77,7 @@ import net.liftweb.http.js.JsCmds.*
 import net.liftweb.util.FieldError
 import net.liftweb.util.Helpers.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.xml.*
 import zio.syntax.*
 
@@ -580,7 +582,7 @@ class ModificationValidationPopup(
               ChangeContext(
                 ModificationId(uuidGen.newUuid),
                 CurrentUser.actor,
-                new DateTime(),
+                Instant.now(),
                 crReasons.map(_.get),
                 None,
                 CurrentUser.nodePerms
@@ -619,7 +621,7 @@ class ModificationValidationPopup(
                 ChangeContext(
                   ModificationId(uuidGen.newUuid),
                   CurrentUser.actor,
-                  new DateTime(),
+                  Instant.now(),
                   crReasons.map(_.get),
                   None,
                   CurrentUser.nodePerms

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleModificationValidationPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/RuleModificationValidationPopup.scala
@@ -51,6 +51,7 @@ import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.ChooseTemplate
 import com.normation.rudder.web.model.*
 import com.normation.zio.UnsafeRun
+import java.time.Instant
 import net.liftweb.common.*
 import net.liftweb.http.DispatchSnippet
 import net.liftweb.http.SHtml
@@ -59,6 +60,7 @@ import net.liftweb.http.js.JE.*
 import net.liftweb.http.js.JsCmds.*
 import net.liftweb.util.Helpers.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.xml.*
 import zio.syntax.ToZio
 
@@ -272,7 +274,7 @@ class RuleModificationValidationPopup(
                       ChangeContext(
                         ModificationId(uuidGen.newUuid),
                         CurrentUser.actor,
-                        new DateTime(),
+                        Instant.now(),
                         crReasons.map(_.get),
                         None,
                         CurrentUser.nodePerms

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/model/DirectiveFieldEditors.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/model/DirectiveFieldEditors.scala
@@ -58,6 +58,7 @@ import net.liftweb.util.Helpers
 import net.liftweb.util.Helpers.*
 import org.apache.commons.text.StringEscapeUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.LocalDate
 import org.joda.time.LocalTime
 import org.joda.time.Period
@@ -424,7 +425,7 @@ class DateField(format: DateTimeFormatter)(val id: String) extends DirectiveFiel
   }
 
   def getPossibleValues(filters: (ValueType => Boolean)*): Option[Set[ValueType]] = None // not supported in the general cases
-  def getDefaultValue: LocalDate = DateTime.now().toLocalDate // default datetime
+  def getDefaultValue: LocalDate = DateTime.now(DateTimeZone.UTC).toLocalDate // default datetime
 }
 
 class TimeField(format: DateTimeFormatter)(val id: String) extends DirectiveField {
@@ -474,7 +475,7 @@ class TimeField(format: DateTimeFormatter)(val id: String) extends DirectiveFiel
   }
 
   def getPossibleValues(filters: (ValueType => Boolean)*): Option[Set[ValueType]] = None // not supported in the general cases
-  def getDefaultValue: LocalTime = DateTime.now().toLocalTime // default datetime
+  def getDefaultValue: LocalTime = DateTime.now(DateTimeZone.UTC).toLocalTime // default datetime
 }
 
 class PeriodField(showSeconds: Boolean = true, showMinutes: Boolean = true, showHours: Boolean = true, showDays: Boolean = true)(

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -67,6 +67,7 @@ import com.normation.zio.*
 import com.softwaremill.quicklens.*
 import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.syntax.*
+import java.time.Instant
 import net.liftweb.common.*
 import net.liftweb.http.*
 import net.liftweb.http.js.*
@@ -79,6 +80,7 @@ import net.liftweb.util.*
 import net.liftweb.util.Helpers.*
 import org.apache.commons.text.StringEscapeUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.xml.*
 import zio.json.*
 import zio.syntax.*
@@ -533,7 +535,7 @@ object DisplayNode extends Loggable {
   def showNodeDetails(
       nodeFact:            NodeFact,
       globalMode:          GlobalPolicyMode,
-      creationDate:        Option[DateTime],
+      creationDate:        Option[Instant],
       salt:                String = "",
       isDisplayingInPopup: Boolean = false
   )(implicit qc: QueryContext): NodeSeq = {
@@ -749,7 +751,7 @@ object DisplayNode extends Loggable {
                 SHA1.hash(cert.getEncoded).grouped(2).mkString(":")
               }</samp></div>
                     <div><label>Expiration date: </label> {
-                DateFormaterService.getDisplayDate(new DateTime(cert.getNotAfter))
+                DateFormaterService.getDisplayDate(new DateTime(cert.getNotAfter, DateTimeZone.UTC))
               }</div>
             )
           }
@@ -783,7 +785,7 @@ object DisplayNode extends Loggable {
     implicit val cc: ChangeContext = ChangeContext(
       ModificationId(RudderConfig.stringUuidGenerator.newUuid),
       CurrentUser.actor,
-      DateTime.now(),
+      Instant.now(),
       Some("Trusted key status reset to accept new key (first use)"),
       None,
       CurrentUser.nodePerms
@@ -1319,7 +1321,7 @@ object DisplayNode extends Loggable {
     implicit val cc: ChangeContext = ChangeContext(
       ModificationId(uuidGen.newUuid),
       CurrentUser.actor,
-      DateTime.now(),
+      Instant.now(),
       None,
       S.request.map(_.remoteAddr).toOption,
       CurrentUser.nodePerms

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -65,6 +65,7 @@ import net.liftweb.http.js.JsCmd
 import net.liftweb.http.js.JsCmds.*
 import net.liftweb.util.Helpers.*
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.xml.NodeSeq
 import scala.xml.NodeSeq.seqToNodeSeq
 import zio.json.*
@@ -200,8 +201,9 @@ class ReportDisplayer(
                   // very unlikely that it will start to answer.
                   val runIntervalMinutes =
                     nodeSettings.reportingConfiguration.agentRunInterval.map(_.interval).getOrElse(defaultInterval)
-                  val minDate            = info.expectedConfigStart.getOrElse(DateTime.now()).minusMinutes(runIntervalMinutes * 2)
-                  val expiration         = info.expirationDateTime.getOrElse(DateTime.now()).plus(runIntervalMinutes * 2L)
+                  val minDate            =
+                    info.expectedConfigStart.getOrElse(DateTime.now(DateTimeZone.UTC)).minusMinutes(runIntervalMinutes * 2)
+                  val expiration         = info.expirationDateTime.getOrElse(DateTime.now(DateTimeZone.UTC)).plus(runIntervalMinutes * 2L)
 
                   if (date.isBefore(minDate)) { // most likely a disconnected node
                     s"The node was reporting on a previous configuration policy, and didn't send reports since a long time: please" +

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/Archives.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/Archives.scala
@@ -52,6 +52,7 @@ import com.normation.rudder.rest.lift.SystemApiService11
 import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.snippet.WithNonce
 import com.normation.utils.DateFormaterService
+import java.time.Instant
 import java.util.Base64
 import net.liftweb.common.*
 import net.liftweb.http.*
@@ -61,6 +62,7 @@ import net.liftweb.http.js.JsCmds.*
 import net.liftweb.util.Helpers.*
 import org.eclipse.jgit.lib.PersonIdent
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.xml.Elem
 import scala.xml.NodeSeq
 import scala.xml.Text
@@ -95,7 +97,7 @@ class Archives extends DispatchSnippet with Loggable {
         implicit val cc: ChangeContext = ChangeContext(
           ModificationId(uuidGen.newUuid),
           qc.actor,
-          new DateTime(),
+          Instant.now(),
           Some("User requested backup restoration to commit %s".format(commit.value)),
           None,
           qc.nodePerms

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
@@ -51,6 +51,7 @@ import com.normation.rudder.users.CurrentUser
 import com.normation.rudder.web.ChooseTemplate
 import com.normation.rudder.web.components.popup.ExpectedPolicyPopup
 import com.normation.utils.DateFormaterService
+import java.time.Instant
 import net.liftweb.common.*
 import net.liftweb.http.*
 import net.liftweb.http.js.*
@@ -59,6 +60,7 @@ import net.liftweb.http.js.JsCmds.*
 import net.liftweb.util.Helpers.*
 import org.apache.commons.text.StringEscapeUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.xml.*
 import zio.json.*
 
@@ -130,7 +132,7 @@ class AcceptNode extends DispatchSnippet with Loggable {
         ChangeContext(
           modId,
           CurrentUser.actor,
-          DateTime.now(),
+          Instant.now(),
           None,
           S.request.map(_.remoteAddr).toOption,
           CurrentUser.nodePerms
@@ -172,7 +174,7 @@ class AcceptNode extends DispatchSnippet with Loggable {
           ChangeContext(
             modId,
             CurrentUser.actor,
-            DateTime.now(),
+            Instant.now(),
             None,
             S.request.map(_.remoteAddr).toOption,
             CurrentUser.nodePerms

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
@@ -54,6 +54,7 @@ import com.normation.rudder.web.components.NodeGroupForm
 import com.normation.rudder.web.components.popup.CreateCategoryOrGroupPopup
 import com.normation.rudder.web.services.DisplayNodeGroupTree
 import com.normation.rudder.web.snippet.WithNonce
+import java.time.Instant
 import net.liftweb.common.*
 import net.liftweb.http.*
 import net.liftweb.http.js.*
@@ -63,6 +64,7 @@ import net.liftweb.json.*
 import net.liftweb.util.*
 import org.apache.commons.text.StringEscapeUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import scala.xml.*
 
 object Groups {
@@ -477,7 +479,7 @@ class Groups extends StatefulSnippet with DefaultExtendableSnippet[Groups] with 
                   ChangeContext(
                     ModificationId(uuidGen.newUuid),
                     qc.actor,
-                    new DateTime(),
+                    Instant.now(),
                     Some("Group moved by user"),
                     None,
                     qc.nodePerms

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/migration/TestMigrateNodeAcceptationInventories.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/migration/TestMigrateNodeAcceptationInventories.scala
@@ -68,6 +68,7 @@ import com.softwaremill.quicklens.*
 import com.unboundid.ldap.sdk.DN
 import org.apache.commons.io.FileUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.format.DateTimeFormatter
 import org.junit.runner.*
@@ -121,7 +122,7 @@ trait TestMigrateNodeAcceptationInventories extends Specification with AfterAll 
 
   val dateFormat: DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HHmmss.SSSZ")
 
-  val testDir: File = File(s"/tmp/test-rudder-migrate-historical-inventories-${dateFormat.print(DateTime.now())}")
+  val testDir: File = File(s"/tmp/test-rudder-migrate-historical-inventories-${dateFormat.print(DateTime.now(DateTimeZone.UTC))}")
 
   //////////// set-up auto test cleaning ////////////
   def cleanTmpFiles():     Unit = {
@@ -314,7 +315,7 @@ trait TestMigrateNodeAcceptationInventories extends Specification with AfterAll 
   "check that deletion of old deleted works as expected" >> {
     // during migration, we set the deletion time at "now" to avoid having to query the whole evenl log base.
     // So to test cleaning, we must say before "now" (which is after the migration now)
-    val res = testFactLog.deleteFactIfDeleteEventBefore(DateTime.now()).runNow
+    val res = testFactLog.deleteFactIfDeleteEventBefore(DateTime.now(DateTimeZone.UTC)).runNow
     res must containTheSameElementsAs(deleteBefore)
   }
 

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/plugins/RudderPluginJsonTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/plugins/RudderPluginJsonTest.scala
@@ -43,6 +43,7 @@ import com.normation.utils.Version
 import com.normation.zio.*
 import org.apache.commons.io.IOUtils
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.joda.time.format.ISODateTimeFormat
 import org.junit.runner.RunWith
 import org.specs2.mutable.*
@@ -74,7 +75,7 @@ class RudderPluginJsonTest extends Specification {
                              |      },
                              |      "version": "5.0-1.3",
                              |      "build-commit": "81edd3edf4f28c13821af8014da0520b72b9df94",
-                             |      "build-date": "2018-10-11T12:23:40+02:00",
+                             |      "build-date": "2018-10-11T10:23:40Z",
                              |      "type": "plugin"
                              |    },
                              |    "rudder-plugin-centreon": {
@@ -111,7 +112,7 @@ class RudderPluginJsonTest extends Specification {
                              |      },
                              |      "version": "5.0-1.1",
                              |      "build-commit": "5c4592d93912ef56de0c506295d22fb2a86146ac",
-                             |      "build-date": "2018-10-29T18:34:16+01:00",
+                             |      "build-date": "2018-10-29T17:34:16Z",
                              |      "type": "plugin"
                              |    }
                              |  }
@@ -128,7 +129,7 @@ class RudderPluginJsonTest extends Specification {
       ),
       List("/opt/rudder/share/plugins/branding/branding.jar"),
       "81edd3edf4f28c13821af8014da0520b72b9df94",
-      DateTime.parse("2018-10-11T12:23:40+02:00", ISODateTimeFormat.dateTimeNoMillis())
+      DateTime.parse("2018-10-11T10:23:40Z", ISODateTimeFormat.dateTimeNoMillis()).withZone(DateTimeZone.UTC)
     ),
     JsonPluginDef(
       "rudder-plugin-centreon",
@@ -162,7 +163,7 @@ class RudderPluginJsonTest extends Specification {
       ),
       List(),
       "5c4592d93912ef56de0c506295d22fb2a86146ac",
-      DateTime.parse("2018-10-29T18:34:16+01:00", ISODateTimeFormat.dateTimeNoMillis())
+      DateTime.parse("2018-10-29T18:34:16+01:00", ISODateTimeFormat.dateTimeNoMillis()).withZone(DateTimeZone.UTC)
     )
   )
 

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/ReportLineTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/ReportLineTest.scala
@@ -97,9 +97,9 @@ class ReportLineTest extends Specification {
     }
 
     LogDisplayer.getReportsLineForNode(reports, dirName, ruleName).toJson.toJsCmd.strip() must beEqualTo(
-      """[{"executionDate": "2024-12-14 15:47:53+0100", "runDate": "2024-12-14 15:47:53+0100", "kind": "result", "status": "error", "ruleName": "Rule name", "directiveName": "Directive name", "component": "component", "value": "foo", "message": "message"},
-        | {"executionDate": "2024-12-14 15:47:53+0100", "runDate": "2024-12-14 15:47:53+0100", "kind": "audit", "status": "compliant", "ruleName": "Rule name", "directiveName": "Directive name", "component": "component", "value": "foo", "message": "message"},
-        | {"executionDate": "2024-12-14 15:47:53+0100", "runDate": "2024-12-14 15:47:53+0100", "kind": "result", "status": "success", "ruleName": "Rule name", "directiveName": "Directive name", "component": "component", "value": "bar", "message": "message"}
+      """[{"executionDate": "2024-12-14 14:47:53Z", "runDate": "2024-12-14 14:47:53Z", "kind": "result", "status": "error", "ruleName": "Rule name", "directiveName": "Directive name", "component": "component", "value": "foo", "message": "message"},
+        | {"executionDate": "2024-12-14 14:47:53Z", "runDate": "2024-12-14 14:47:53Z", "kind": "audit", "status": "compliant", "ruleName": "Rule name", "directiveName": "Directive name", "component": "component", "value": "foo", "message": "message"},
+        | {"executionDate": "2024-12-14 14:47:53Z", "runDate": "2024-12-14 14:47:53Z", "kind": "result", "status": "success", "ruleName": "Rule name", "directiveName": "Directive name", "component": "component", "value": "bar", "message": "message"}
         |]""".stripMargin.replaceAll("\n", "").strip()
     )
   }

--- a/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/GeneralizedTime.scala
+++ b/webapp/sources/scala-ldap/src/main/scala/com/normation/ldap/sdk/GeneralizedTime.scala
@@ -20,8 +20,10 @@
 
 package com.normation.ldap.sdk
 
+import com.normation.utils.DateFormaterService
 import com.unboundid.util.StaticUtils
 import java.text.ParseException
+import java.time.Instant
 import org.joda.time.DateTime
 
 /**
@@ -33,15 +35,19 @@ import org.joda.time.DateTime
  * http://en.wikipedia.org/wiki/ISO_8601)
  *
  */
-final case class GeneralizedTime(val dateTime: DateTime) extends AnyVal {
+final case class GeneralizedTime(val instant: Instant) extends AnyVal {
 
   /**
    * Print the string into a well formed generalize time format.
    */
-  override def toString(): String = StaticUtils.encodeGeneralizedTime(dateTime.toDate)
+  override def toString(): String = StaticUtils.encodeGeneralizedTime(instant.toEpochMilli)
 }
 
 object GeneralizedTime {
+
+  def apply(dt: DateTime): GeneralizedTime = {
+    new GeneralizedTime(DateFormaterService.toInstant(dt))
+  }
 
   /**
    * Try to parse the given string into a GeneralizedTime.
@@ -50,7 +56,7 @@ object GeneralizedTime {
    */
   @throws(classOf[ParseException])
   def apply(s: String): GeneralizedTime = {
-    new GeneralizedTime(new DateTime(StaticUtils.decodeGeneralizedTime(s)))
+    new GeneralizedTime(StaticUtils.decodeGeneralizedTime(s).toInstant)
   }
 
   /**


### PR DESCRIPTION
https://issues.rudder.io/issues/27084

*Enforcing UTC for `DateTime` and first step toward using `java.time.Instant` internally.*

This PR is three folds:

- first, it port https://github.com/Normation/rudder/pull/6452 to Rudder with an issue number. Its goal was enforcing the internal timezone of parsed datetime as UTC.
- second, it adds a lot of the same everywhere, because once we start to break from JVM default somewhere, we must used the same everywhere, else all comparison (equals relative to date time) break. 

That last part was very unsatisfying, because once we have `DateTime.now(DefaultTimeZone.UTC)` everywhere, we are just mostly using `Instant`. In modern Java, an instant is represented in string as exactly that: an ISO/RFC3339 date time string with the UTC (`Z`) timezone. 

So :

- third, it brings a proof of concept of changing `DateTime` in business object to `Instant`, and it works quite well. Most of our code is semantically using `Instant` and not really `DateTime`, so for most part, it's easy. So remarks follow.


# Migrating to `Instant` as a default

We should use `Instant` for all our internal time representation, and just use `ZoneDateTime` at the periphery of businss code safe for very specific case like (date based) schedulers.

Bonus: *it's an easy path out of `joda.time`.* 

To ease that migration: 
- I created a parser for `Instant` that is more lenient than the java standard one and accept timezones (actually fallback to parsing as a `ZonedDateTime` and convert to `Instant`)
- there is a couple of helpers methods in `DateFormatService` that help translate between the different types. 
