### PR TITLE
Fixes #27107: Still missing cats-effect-std_3

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -521,6 +521,12 @@ limitations under the License.
         <artifactId>doobie-core_${scala-binary-version}</artifactId>
         <version>${doobie-version}</version>
       </dependency>
+      <!-- this is needed for doobie/cats/zio compat in scala 3 -->
+      <dependency>
+        <groupId>org.typelevel</groupId>
+        <artifactId>cats-effect-std_${scala-binary-version}</artifactId>
+        <version>${cats-effect-version}</version>
+      </dependency>
       <dependency>
         <groupId>com.lihaoyi</groupId>
         <artifactId>sourcecode_${scala-binary-version}</artifactId>
@@ -894,12 +900,6 @@ limitations under the License.
       <artifactId>cats-effect_${scala-binary-version}</artifactId>
       <version>${cats-effect-version}</version>
     </dependency>
-    <!-- this is needed for doobie/cats/zio compat in scala 3 -->
-    <dependency>
-      <groupId>org.typelevel</groupId>
-      <artifactId>cats-effect-std_${scala-binary-version}</artifactId>
-      <version>${cats-effect-version}</version>
-    </dependency>
     <!-- graph library for group properties -->
     <dependency>
       <groupId>org.jgrapht</groupId>
@@ -937,8 +937,7 @@ limitations under the License.
       <artifactId>doobie-specs2_${scala-binary-version}</artifactId>
       <version>${doobie-version}</version>
       <scope>test</scope>
-    </dependency>
-    <!-- zio tests -->
+    </dependency>    <!-- zio tests -->
     <dependency>
       <groupId>dev.zio</groupId>
       <artifactId>zio-test_${scala-binary-version}</artifactId>

--- a/webapp/sources/rudder/rudder-core/pom.xml
+++ b/webapp/sources/rudder/rudder-core/pom.xml
@@ -198,17 +198,11 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <artifactId>doobie-postgres_${scala-binary-version}</artifactId>
       <version>${doobie-version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.tpolecat</groupId>
-      <artifactId>doobie-specs2_${scala-binary-version}</artifactId>
-      <version>${doobie-version}</version>
-      <scope>test</scope>
-    </dependency>
+    <!-- this is needed for doobie/cats/zio compat in scala 3 -->
     <dependency>
       <groupId>org.typelevel</groupId>
       <artifactId>cats-effect-std_${scala-binary-version}</artifactId>
       <version>${cats-effect-version}</version>
-      <scope>test</scope>
     </dependency>
 
     <!-- cache used in compliance logger -->

--- a/webapp/sources/rudder/rudder-web/pom.xml
+++ b/webapp/sources/rudder/rudder-web/pom.xml
@@ -298,6 +298,13 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <version>${spring-security-version}</version>
     </dependency>
 
+    <!-- this is needed for doobie/cats/zio compat in scala 3 - it must be at compile level else rudder breaks -->
+    <dependency>
+      <groupId>org.typelevel</groupId>
+      <artifactId>cats-effect-std_${scala-binary-version}</artifactId>
+      <version>${cats-effect-version}</version>
+    </dependency>
+
     <!-- TESTS -->
     <dependency>
       <groupId>com.normation.rudder</groupId>
@@ -311,12 +318,6 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
       <artifactId>rudder-rest</artifactId>
       <version>${rudder-version}</version>
       <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.typelevel</groupId>
-      <artifactId>cats-effect-std_${scala-binary-version}</artifactId>
-      <version>${cats-effect-version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
https://issues.rudder.io/issues/27107

Dependency was overridden at `test` level in rudder-web, so not included in the final war