### PR TITLE
Fixes #27131: Iterator items that have exactly the same values are considered to be a single object

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTabForeach.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTabForeach.elm
@@ -310,7 +310,7 @@ displayTabForeach uiInfo =
               foreachItems = case foreach of
                 Just items ->
                   items
-                    |> List.map (\f ->
+                    |> List.indexedMap (\index f ->
                       let
                         values = keys
                           |> List.map (\k ->
@@ -319,9 +319,9 @@ displayTabForeach uiInfo =
                                 Just v -> v
                                 Nothing -> ""
 
-                              updateForeachVal : String -> List (Dict String String) -> Dict String String -> Maybe (List (Dict String String))
-                              updateForeachVal newVal list currentForeach =
-                                Just (List.Extra.updateIf (\i -> i == currentForeach) (\i -> Dict.update k (always (Just newVal)) i) list)
+                              updateForeachVal : String -> List (Dict String String) -> Int -> Maybe (List (Dict String String))
+                              updateForeachVal newVal list ind =
+                                Just (List.Extra.updateAt ind (\i -> Dict.update k (always (Just newVal)) i) list)
                             in
                               element "td"
                               |> appendChild ( element "input"
@@ -330,7 +330,7 @@ displayTabForeach uiInfo =
                                   , value val
                                   , class "form-control input-sm"
                                   ]
-                                |> addInputHandler  (\s -> MethodCallModified (updateForeach (updateForeachVal s items f)) Nothing)
+                                |> addInputHandler  (\s -> MethodCallModified (updateForeach (updateForeachVal s items index)) Nothing)
                               )
                           )
                         actionBtns =


### PR DESCRIPTION
https://issues.rudder.io/issues/27131

We need to compare the index of the modified item, not its value.