### PR TITLE
Fixes #23507: API for history does not take before nor order into account

### DIFF
--- a/webapp/sources/api-doc/code_samples/curl/campaigns/allEvents.sh
+++ b/webapp/sources/api-doc/code_samples/curl/campaigns/allEvents.sh
@@ -1,1 +1,1 @@
-curl --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/campaigns/0076a379-f32d-4732-9e91-33ab219d8fde/events'
+curl --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/campaigns/events?campaignType=system-update&state=running&campaignId=0076a379-f32d-4732-9e91-33ab219d8fde&limit=1&order=start&asc=desc&before=2025-06-19T16:13:35%2B01:00'

--- a/webapp/sources/api-doc/code_samples/curl/campaigns/campaignEvents.sh
+++ b/webapp/sources/api-doc/code_samples/curl/campaigns/campaignEvents.sh
@@ -1,1 +1,1 @@
-curl --header "X-API-Token: yourToken" --request POST 'https://rudder.example.com/rudder/api/latest/campaigns/0076a379-f32d-4732-9e91-33ab219d8fde/events'
+curl --header "X-API-Token: yourToken" --request POST 'https://rudder.example.com/rudder/api/latest/campaigns/0076a379-f32d-4732-9e91-33ab219d8fde/events?campaignType=system-update&state=running&limit=1&order=start&asc=desc&before=2025-06-19T16:13:35%2B01:00'

--- a/webapp/sources/api-doc/code_samples/curl/systemUpdate/campaignHistory.sh
+++ b/webapp/sources/api-doc/code_samples/curl/systemUpdate/campaignHistory.sh
@@ -1,1 +1,1 @@
-curl --silent --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/systemUpdate/campaign/0076a379-f32d-4732-9e91-33ab219d8fde/history'
+curl --silent --header "X-API-Token: yourToken" --request GET 'https://rudder.example.com/rudder/api/latest/systemUpdate/campaign/0076a379-f32d-4732-9e91-33ab219d8fde/history?limit=1&order=start&asc=desc&before=2023-09-27T16:13:35%2B01:00'

--- a/webapp/sources/api-doc/components/parameters/campaign-id.yml
+++ b/webapp/sources/api-doc/components/parameters/campaign-id.yml
@@ -3,10 +3,7 @@
 name: campaignId
 in: query
 required: false
-description: id of the campaigns we want
+description: id of a specific campaign
 schema:
   type: string
-  enum:
-    - system-update
-    - software-update
-  example: system-update
+  example: 0076a379-f32d-4732-9e91-33ab219d8fde

--- a/webapp/sources/api-doc/components/parameters/order.yml
+++ b/webapp/sources/api-doc/components/parameters/order.yml
@@ -5,3 +5,12 @@ in: query
 required: false
 schema:
   type: string
+  enum:
+    - start
+    - startDate
+    - end
+    - endDate
+  description:
+    The start or end date column to sort (with 'asc' for the ascending or descending order)
+  example:
+    start


### PR DESCRIPTION
https://issues.rudder.io/issues/23507

* add exemple query parameters cURL urls (in dates, `+` needs to be encoded as `%2B`)
* fix some query parameters doc and add examples, as there could be a confusion between `order` and `asc` : https://github.com/Normation/rudder/blob/branches/rudder/8.2/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/CampaignEventRepository.scala#L143-L149