### PR TITLE
Fixes #27147: Enable fatal warning and disable variable initialization check

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -166,9 +166,10 @@ limitations under the License.
             <arg>-language:higherKinds</arg>         <!-- Allow higher-kinded types -->
             <arg>-language:implicitConversions</arg> <!-- Allow definition of implicit functions called views -->
             <arg>-Xmax-inlines</arg><arg>100</arg>
-            <arg>-Ysafe-init</arg>                   <!--  Wrap field accessors to throw an exception on uninitialized access. -->
-            <!-- Removed during scala3 migration -->
-            <!-- <arg>-Xfatal-warnings</arg> -->     <!-- Fail the compilation if there are any warnings. -->
+            <!-- Ignore warning for BoxTrait existential type, no way to change that -->
+            <arg>-Wconf:msg=An existential type that came from a Scala-2 classfile for trait BoxTrait:s</arg>
+            <!--<arg>-Wsafe-init</arg> -->      <!--  Wrap field accessors to throw an exception on uninitialized access. Disabled because of technique repo and API -->
+            <arg>-Xfatal-warnings</arg>         <!-- Fail the compilation if there are any warnings. -->
             <arg>-Wunused:imports</arg>         <!-- Warn if an import selector is not referenced. -->
             <arg>-Wunused:locals</arg>          <!-- Warn if a local definition is unused. -->
             <arg>-Wunused:implicits</arg>       <!-- Warn if an implicit parameter is unused. -->
@@ -255,7 +256,7 @@ limitations under the License.
             <goals>
               <goal>check</goal>
             </goals>
-            <phase>verify</phase> <!-- verify: default value -->
+            <phase>validate</phase>
           </execution>
         </executions>
       </plugin>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -344,8 +344,19 @@ object JsonQueryObjects {
       transform:   Option[String],
       where:       Option[List[StringCriterionLine]]
   ) {
-    def toQueryString: StringQuery =
-      StringQuery(select.getOrElse(NodeReturnType), composition, transform, where.getOrElse(Nil))
+    def toQueryString: StringQuery = {
+      val c = composition.flatMap {
+        case x if (x.strip().isEmpty) => None
+        case x                        => Some(x)
+      }
+
+      def d = transform.flatMap {
+        case x if (x.strip().isEmpty) => None
+        case x                        => Some(x)
+      }
+
+      StringQuery(select.getOrElse(NodeReturnType), c, d, where.getOrElse(Nil))
+    }
   }
 
   final case class GroupPatch(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/queries/CmdbQuery.scala
@@ -932,6 +932,7 @@ final case class JsonCriterionLine(
 
 object JsonCriterionLine {
   implicit val encoderJsonCriterionLine: JsonEncoder[JsonCriterionLine] = DeriveJsonEncoder.gen
+  implicit val decoderJsonCriterionLine: JsonDecoder[JsonCriterionLine] = DeriveJsonDecoder.gen
 }
 
 sealed abstract class CriterionComposition { def value: String }
@@ -941,15 +942,17 @@ object CriterionComposition {
   case object And extends CriterionComposition { val value = "and" }
   case object Or  extends CriterionComposition { val value = "or"  }
 
-  def parse(s: String): Option[CriterionComposition] = {
+  def parse(s: String): PureResult[CriterionComposition] = {
     s.toLowerCase match {
-      case "and" => Some(And)
-      case "or"  => Some(Or)
-      case _     => None
+      case "and" => Right(And)
+      case "or"  => Right(Or)
+      case x     => Left(Inconsistency(s"The requested composition '${x}' is unknown"))
     }
   }
 
   implicit val encoderCriterionComposition: JsonEncoder[CriterionComposition] = JsonEncoder.string.contramap(_.value)
+  implicit val decoderCriterionComposition: JsonDecoder[CriterionComposition] =
+    JsonDecoder.string.mapOrFail(parse(_).left.map(_.fullMsg))
 }
 
 sealed trait QueryReturnType {
@@ -973,6 +976,7 @@ object QueryReturnType {
   }
 
   implicit val encoderQueryReturnType: JsonEncoder[QueryReturnType] = JsonEncoder.string.contramap(_.value)
+  implicit val decoderQueryReturnType: JsonDecoder[QueryReturnType] = JsonDecoder.string.mapOrFail(apply(_).left.map(_.fullMsg))
 }
 
 sealed trait ResultTransformation extends EnumEntry {
@@ -1001,8 +1005,23 @@ object ResultTransformation extends Enum[ResultTransformation] {
   }
 
   implicit val encoderResultTransformation: JsonEncoder[ResultTransformation] = JsonEncoder.string.contramap(_.value)
+  implicit val decoderResultTransformation: JsonDecoder[ResultTransformation] =
+    JsonDecoder.string.mapOrFail(parse(_).left.map(_.fullMsg))
 }
 
+/*
+ * Structure of the Query:
+ * var query = {
+ *   'select' : 'server' ,  //what we are looking for at the end (servers, software...)
+ *   'composition' : 'and' ,  // or 'or'
+ *   'where': [
+ *     { 'objectType' : '....' , 'attribute': '....' , 'comparator': '.....' , 'value': '....' } ,  //value is optionnal, other are mandatory
+ *     { 'objectType' : '....' , 'attribute': '....' , 'comparator': '.....' , 'value': '....' } ,
+ *     ...
+ *     { 'objectType' : '....' , 'attribute': '....' , 'comparator': '.....' , 'value': '....' }
+ *   ]
+ * }
+ */
 final case class JsonQuery(
     select:      QueryReturnType,
     composition: CriterionComposition,
@@ -1012,6 +1031,7 @@ final case class JsonQuery(
 
 object JsonQuery {
   implicit val encoderJsonQuery: JsonEncoder[JsonQuery] = DeriveJsonEncoder.gen
+  implicit val decoderJsonQuery: JsonDecoder[JsonQuery] = DeriveJsonDecoder.gen
 }
 
 object Query {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
@@ -945,7 +945,6 @@ object ExecutionBatch extends Loggable {
     val t1        = System.currentTimeMillis
     val overrides = runInfo match {
       case x: ExpectedConfigAvailable => x.expectedConfig.overrides
-      case x: LastRunAvailable        => x.lastRunConfigInfo.map(_.overrides).getOrElse(Nil).toList
       case _ => Nil
     }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestJsonQueryLexing.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestJsonQueryLexing.scala
@@ -111,7 +111,7 @@ class TestJsonQueryLexing {
 {  "select":"node", "transform":"invert", "where":[] }
 """
 
-  val errorMissing1 =
+  val noSelectDefaultToNode =
     """
 {  "composition":"or", "where":[
   { "objectType":"processor", "attribute":"speed", "comparator":"gteq"   , "value":"2000" },
@@ -140,28 +140,28 @@ class TestJsonQueryLexing {
 ]}
 """
 
-  val errorEmpty1   =
+  val errorEmpty1       =
     """
 {  "select":"", "composition":"or", "where":[
   { "objectType":"processor", "attribute":"speed", "comparator":"gteq"   , "value":"2000" },
   { "objectType":"node"   , "attribute":"ram"  , "comparator":"exists" }
 ]}
 """
-  val errorEmpty2_0 =
+  val okEmptyObjectName =
     """
 {  "select":"node", "composition":"or", "where":[
   { "objectType":"processor", "attribute":"speed", "comparator":"gteq"   , "value":"2000" },
   { "objectType":""   , "attribute":"ram"  , "comparator":"exists" }
 ]}
 """
-  val errorEmpty2_1 =
+  val errorEmpty2_1     =
     """
 {  "select":"node", "composition":"or", "where":[
   { "objectType":"processor", "":"speed", "comparator":"gteq"   , "value":"2000" },
   { "objectType":"node"   , "attribute":"ram"  , "comparator":"exists" }
 ]}
 """
-  val errorEmpty2_2 =
+  val okComparatorEmpty =
     """
 {  "select":"node", "composition":"or", "where":[
   { "objectType":"processor", "attribute":"speed", "comparator":"gteq"   , "value":"2000" },
@@ -192,14 +192,17 @@ class TestJsonQueryLexing {
 
     assertEquals(Full(StringQuery(NodeReturnType, None, Some("invert"), Nil)), lexer.lex(valid5_0))
 
-    assertFalse(lexer.lex(errorMissing1).isDefined)
+    assertEquals(lexer.lex(noSelectDefaultToNode).map(_.returnType), Full(NodeReturnType))
+
     assertFalse(lexer.lex(errorMissing2_0).isDefined)
     assertFalse(lexer.lex(errorMissing2_1).isDefined)
     assertFalse(lexer.lex(errorMissing2_2).isDefined)
 
     assertFalse(lexer.lex(errorEmpty1).isDefined)
-    assertFalse(lexer.lex(errorEmpty2_0).isDefined)
+
+    assertTrue(lexer.lex(okEmptyObjectName).isDefined) // ok, we parse after that with known objects
+
     assertFalse(lexer.lex(errorEmpty2_1).isDefined)
-    assertFalse(lexer.lex(errorEmpty2_2).isDefined)
+    assertTrue(lexer.lex(okComparatorEmpty).isDefined) // ok, it's checked for each object latter on
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
@@ -201,7 +201,7 @@ class TestNodeFactQueryProcessor {
       "q2",
       parser("""
       {  "select":"node", "composition":"and", "where":[
-        { "objectType":"node"   , "attribute":"nodeId"  , "comparator":"eq", "value":"node1" }
+        { "objectType":"node"   , "attribute":"nodeId"  , "comparator":"eq", "value":"node1" },
         { "objectType":"node"   , "attribute":"nodeId"  , "comparator":"eq", "value":"node5" }
       ] }
       """).openOrThrowException("For tests"),
@@ -642,7 +642,7 @@ class TestNodeFactQueryProcessor {
       "q0",
       parser("""
       {  "select":"node", "composition":"or" , "where":[
-        , { "objectType":"fileSystemLogicalElement", "attribute":"description", "comparator":"regex", "value":"matchOnM[e]" }
+          { "objectType":"fileSystemLogicalElement", "attribute":"description", "comparator":"regex", "value":"matchOnM[e]" }
       ] }
       """).openOrThrowException("For tests"),
       s(3) :: Nil
@@ -734,7 +734,7 @@ class TestNodeFactQueryProcessor {
       "q5",
       parser("""
       {  "select":"nodeAndPolicyServer","composition":"or",  "where":[
-        , { "objectType":"fileSystemLogicalElement" , "attribute":"mountPoint" , "comparator":"regex", "value":"[/]" }
+         { "objectType":"fileSystemLogicalElement" , "attribute":"mountPoint" , "comparator":"regex", "value":"[/]" }
       ] }
       """).openOrThrowException("For tests"),
       s(3) :: s(7) :: root :: Nil
@@ -829,7 +829,7 @@ class TestNodeFactQueryProcessor {
       "q0",
       parser("""
       {  "select":"node", "composition":"or" , "where":[
-        , { "objectType":"fileSystemLogicalElement", "attribute":"description", "comparator":"regex", "value":"matchOnM[e]" }
+          { "objectType":"fileSystemLogicalElement", "attribute":"description", "comparator":"regex", "value":"matchOnM[e]" }
       ] }
       """).openOrThrowException("For tests"),
       s(3) :: Nil
@@ -863,7 +863,7 @@ class TestNodeFactQueryProcessor {
       "q5",
       parser("""
       {  "select":"nodeAndPolicyServer","composition":"or",  "where":[
-        , { "objectType":"fileSystemLogicalElement" , "attribute":"mountPoint" , "comparator":"regex", "value":"[/]" }
+          { "objectType":"fileSystemLogicalElement" , "attribute":"mountPoint" , "comparator":"regex", "value":"[/]" }
       ] }
       """).openOrThrowException("For tests"),
       s(3) :: s(7) :: root :: Nil


### PR DESCRIPTION
https://issues.rudder.io/issues/27147

Enable back `-Werror`. 

I needed to disable some checks: 

- disable safe initiationlization check. There is too much work to do, and that work is hard, long, and not correlated with the switch to scala 3
- remove an existantial warning on `BoxTrait`, because we can't do anything about it, 

And correct two other: 

- `ExecutionBatch`: actually, all `LastRunAvailable` are also `ExpectedConfigAvailable`. That makes little sense for a run with a deleted exepected config, so I'm not sure what happens here, but the encoding say so and scalac3 saw it - there is an `Unexpected` case
- `Query` lexer/parser : there was `lift-json` objects used as intermediary, that we really don't need anymore. Just use direct `zio-json` decoding, simplify everything. Some tests were irrelevant (checking for non empty string while the soundess is done later on)
- some sub-component encoding was relying on uncheck runtime erasure, so I changed it a bit. 

Now, everything compiles without warning :tada: 

Also, I changed `spotless` from `verify` (of very late phase, just before installing) to `validate` (a very early phase, before compilation). 