### PR TITLE
Fixes #27154: Create CampaignEventsStateHistory table

### DIFF
--- a/webapp/sources/.scalafmt.conf
+++ b/webapp/sources/.scalafmt.conf
@@ -6,6 +6,7 @@ runner.dialectOverride.allowExportClause = true
 runner.dialectOverride.allowOpaqueTypes = true
 runner.dialectOverride.allowGivenUsing = true
 runner.dialectOverride.allowTraitParameters = true
+runner.dialectOverride.allowDerives = true
 
 
 rewrite.scala3.convertToNewSyntax = true

--- a/webapp/sources/rudder/rudder-core/src/main/resources/reportsSchema.sql
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/reportsSchema.sql
@@ -314,19 +314,27 @@ ALTER TABLE statusupdate set (autovacuum_vacuum_threshold = 0);
  *************************************************************************************
  */
 
+CREATE TYPE campaignEventState AS enum ('scheduled', 'prehooks', 'running', 'posthooks', 'finished', 'skipped', 'deleted', 'failure');
+
 CREATE TABLE CampaignEvents (
   campaignId   text
-, eventid      text PRIMARY KEY
+, eventId      text PRIMARY KEY
 , name         text
-, state        jsonb
+, state        campaignEventState NOT NULL
 , startDate    timestamp with time zone NOT NULL
 , endDate      timestamp with time zone NOT NULL
 , campaignType text
 );
 
 
-CREATE INDEX event_state_index ON CampaignEvents ((state->>'value'));
-
+CREATE TABLE CampaignEventsStateHistory (
+  eventId   text references CampaignEvents(eventId) ON DELETE CASCADE
+, state     campaignEventState
+, startDate timestamp with time zone NOT NULL
+, endDate   timestamp with time zone
+, data      jsonb
+, PRIMARY KEY (eventId, state)
+);
 
 /*
  *************************************************************************************

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JsonCampaignSerializer.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/JsonCampaignSerializer.scala
@@ -166,15 +166,6 @@ object CampaignSerializer {
   implicit val campaignTypeDecoder: JsonDecoder[CampaignType]     = JsonDecoder[String].map(CampaignType.apply)
   implicit val campaignInfoDecoder: JsonDecoder[CampaignInfo]     = DeriveJsonDecoder.gen
 
-  implicit val campaignEventIdDecoder:    JsonDecoder[CampaignEventId]    = JsonDecoder[String].map(CampaignEventId.apply)
-  implicit val campaignEventStateDecoder: JsonDecoder[CampaignEventState] = DeriveJsonDecoder.gen
-  implicit val campaignEventDecoder:      JsonDecoder[CampaignEvent]      = DeriveJsonDecoder.gen
-
-  implicit val campaignTypeEncoder:       JsonEncoder[CampaignType]       = JsonEncoder[String].contramap(_.value)
-  implicit val campaignEventIdEncoder:    JsonEncoder[CampaignEventId]    = JsonEncoder[String].contramap(_.value)
-  implicit val campaignEventStateEncoder: JsonEncoder[CampaignEventState] = DeriveJsonEncoder.gen
-  implicit val campaignEventEncoder:      JsonEncoder[CampaignEvent]      = DeriveJsonEncoder.gen
-
   implicit val parsingInfoDecoder: JsonDecoder[CampaignParsingInfo] = DeriveJsonDecoder.gen
   implicit val parsingInfoEncoder: JsonEncoder[CampaignParsingInfo] = DeriveJsonEncoder.gen
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/CampaignApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/CampaignApi.scala
@@ -4,7 +4,6 @@ import com.normation.errors.Unexpected
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.apidata.ZioJsonExtractor
 import com.normation.rudder.campaigns.*
-import com.normation.rudder.campaigns.CampaignSerializer.*
 import com.normation.rudder.rest.ApiModuleProvider
 import com.normation.rudder.rest.ApiPath
 import com.normation.rudder.rest.AuthzToken
@@ -221,7 +220,7 @@ class CampaignApi(
     val schema: API.GetCampaignEvents.type = API.GetCampaignEvents
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      val states       = req.params.getOrElse("state", Nil).flatMap(s => CampaignEventState.parse(s).toOption)
+      val states       = req.params.getOrElse("state", Nil).flatMap(s => CampaignEventStateType.withNameInsensitiveOption(s))
       val campaignType = req.params.getOrElse("campaignType", Nil).map(campaignSerializer.campaignType)
       val campaignId   = req.params.get("campaignId").flatMap(_.headOption).map(i => CampaignId(i))
       val limit        = req.params.get("limit").flatMap(_.headOption).flatMap(i => i.toIntOption)
@@ -263,7 +262,7 @@ class CampaignApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      val states       = req.params.getOrElse("state", Nil).flatMap(s => CampaignEventState.parse(s).toOption)
+      val states       = req.params.getOrElse("state", Nil).flatMap(s => CampaignEventStateType.withNameInsensitiveOption(s))
       val campaignType = req.params.getOrElse("campaignType", Nil).map(campaignSerializer.campaignType)
       val limit        = req.params.get("limit").flatMap(_.headOption).flatMap(i => i.toIntOption)
       val offset       = req.params.get("offset").flatMap(_.headOption).flatMap(i => i.toIntOption)

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_campaigns.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_campaigns.yml
@@ -1,0 +1,107 @@
+description: Get all campaigns
+method: GET
+url: /api/latest/campaigns
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getCampaigns",
+      "result" : "success",
+      "data" : {
+        "campaigns" : [
+          {
+            "campaignType" : "dumb-campaign",
+            "info" : {
+              "id" : "c0",
+              "name" : "first campaign",
+              "description" : "a test campaign present when rudder boot",
+              "status" : {
+                "value" : "enabled"
+              },
+              "schedule" : {
+                "type" : "weekly",
+                "start" : {
+                  "day" : 1,
+                  "hour" : 3,
+                  "minute" : 42
+                },
+                "end" : {
+                  "day" : 1,
+                  "hour" : 4,
+                  "minute" : 42
+                }
+              }
+            },
+            "details" : {
+              "name" : "campaign #0"
+            },
+            "version" : 1
+          }
+        ]
+      }
+    }
+
+---
+description: Get all events
+method: GET
+url: /api/latest/campaigns/events
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getCampaignEvents",
+      "result" : "success",
+      "data" : {
+        "campaignEvents" : [
+          {
+            "id" : "e0",
+            "campaignId" : "c0",
+            "name" : "campaign #0",
+            "state" : {
+              "value": "finished"
+            },
+            "start" : "1970-01-01T00:00:00Z",
+            "end" : "1970-01-01T00:00:00Z",
+            "campaignType" : "dumb-campaign"
+          }
+        ]
+      }
+    }
+
+---
+description: Save an event
+method: POST
+headers:
+  - "Content-Type: application/json"
+url: /api/latest/campaigns/events/739e1295
+body: >-
+  { 
+    "id": "739e1295",
+    "campaignId": "c0",
+    "name": "c0 #2",
+    "state" : { "value" : "skipped", "reason":"user did it"},
+    "start" : "2025-03-09T09:00:00Z",
+    "end" : "2025-03-10T10:00:00Z",
+    "campaignType" : "dumb-campaign"
+  }
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "saveCampaignEvent",
+      "result" : "success",
+      "data" : {
+        "campaignEvents": [
+          { 
+            "id": "739e1295",
+            "campaignId": "c0",
+            "name": "c0 #2",
+            "state" : { "value" : "skipped", "reason":"user did it"},
+            "start" : "2025-03-09T09:00:00Z",
+            "end" : "2025-03-10T10:00:00Z",
+            "campaignType" : "dumb-campaign"
+          }
+        ]
+      }
+    }
+

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/CampaignApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/CampaignApiTest.scala
@@ -40,7 +40,7 @@ package com.normation.rudder.rest
 import better.files.File
 import com.normation.JsonSpecMatcher
 import com.normation.rudder.campaigns.CampaignEvent
-import com.normation.rudder.campaigns.CampaignEventState.*
+import com.normation.rudder.campaigns.CampaignEventStateType.*
 import com.normation.rudder.campaigns.MainCampaignService
 import com.normation.rudder.rest.RudderJsonResponse.JsonRudderApiResponse
 import com.normation.rudder.rest.RudderJsonResponse.LiftJsonResponse
@@ -160,7 +160,7 @@ class CampaignApiTest extends Specification with AfterAll with Loggable with Jso
               .getOrElse(throw new IllegalArgumentException(s"Missing test value"))
             // it's in the future
             (next.start.getMillis must be_>(System.currentTimeMillis())) and
-            (next.state must beEqualTo(Scheduled)) and
+            (next.state.value must beEqualTo(Scheduled)) and
             (next.campaignId must beEqualTo(ce0.campaignId))
           }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -3281,7 +3281,8 @@ object RudderConfigInit {
         new MigrateEventLogEnforceSchema(doobie),
         new MigrateChangeValidationEnforceSchema(doobie),
         new CheckTableReportsExecutionTz(doobie),
-        new DeleteArchiveTables(doobie)
+        new DeleteArchiveTables(doobie),
+        new MigrateTableCampaignEvents(doobie)
       )
 
       earlyDbChecks.checks()

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/MigrateTableCampaignEvents.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/earlyconfig/db/MigrateTableCampaignEvents.scala
@@ -1,0 +1,206 @@
+/*
+ *************************************************************************************
+ * Copyright 2025 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+package bootstrap.liftweb.checks.earlyconfig.db
+
+import bootstrap.liftweb.*
+import com.normation.errors.IOResult
+import com.normation.rudder.db.Doobie
+import com.normation.zio.*
+import doobie.implicits.*
+import zio.interop.catz.*
+
+/*
+ * In rudder 9.0, we split CampaignEvents table in two:
+ *   - CampaignEvents is only about the runtime persistence of the workflow and does not keep data
+ *     => `state` change into an enum
+ *   - CampaignEventsStateHistory is about keeping a log of past state and corresponding results
+ *     => it get messages and etc.
+ *
+ * So we are migrating things like:
+ * table CampaignEvents
+ * campaignId| eventId   |  name             |  state                                              | startDate              | endDate                | campaignType
+ * 77d4c...  | ca021a... | 'testing time #2' | {"value": "skipped", "reason": "An error occurred"} | 2024-03-05 10:59:00+00 | 2024-03-05 11:59:00+00 | 'system-update '
+ *
+ * Into two tables:
+ * CampaignEvents
+ * campaignId| eventId   |  name             |  state    | startDate              | endDate                | campaignType
+ * 77d4c...  | ca021a... | 'testing time #2' | 'skipped' | 2024-03-05 10:59:00+00 | 2024-03-05 11:59:00+00 | 'system-update '
+ *
+ * CampaignEventsStateHistory
+ * eventId   |  state     | startDate              | endDate                | data
+ * ca021a... |  'skipped' | 2024-03-05 10:59:00+00 | 2024-03-05 11:59:00+00 | {"reason": "An error occurred"}
+ */
+class MigrateTableCampaignEvents(doobie: Doobie) extends BootstrapChecks {
+  import bootstrap.liftweb.checks.earlyconfig.db.MigrateTableCampaignEvents.*
+  import doobie.*
+
+  override def description: String = "Check if campaign events state history exist"
+
+  def createScoreTables: IOResult[Unit] = {
+
+    // General migration logic:
+    // - step1:
+    //   - create an enum for state
+    // - step2 (only if state is not of type enum)
+    //   - move column CampaignEvents->state to stateJson
+    //   - create column CampaignEvents->state of type enum and copy state value from stateJson
+    // - step3 (only if table CampaignEventsStateHistory doesn't exist)
+    //   - create table CampaignEventsStateHistory
+    //   - copy reason messages for skipped state from CampaignEvents
+    //   - delete CampaignEvents->stateJson
+    // - step4 : correct skipped that are actually failures
+    //   - select all eventId in history that are skipped and reason like "An error occurred when processing event%"
+    //   - update both CampaignEvents and CampaignEventStateHistory table with state = failure, new message
+
+    // they must be done in sequence, an error interrupting following statements
+    transactIOResult(s"Error when creating 'campaignEventState' enumeration")(xa => sql1.update.run.transact(xa)).unit *>
+    transactIOResult(s"Error when changing column 'state' of 'CampaignEvents' to 'campaignEventState'")(xa =>
+      sql2.update.run.transact(xa)
+    ).unit *>
+    transactIOResult(s"Error when creating table 'CampaignEventsStateHistory'")(xa => sql3.update.run.transact(xa)).unit *>
+    transactIOResult(s"Error when updating skipped to failure event in 'CampaignEventsStateHistory'")(xa =>
+      sql4.update.run.transact(xa)
+    ).unit
+  }
+
+  override def checks(): Unit = {
+    val prog = {
+      for {
+        _ <- createScoreTables
+      } yield ()
+    }
+
+    // Actually run the migration async to avoid blocking for that.
+    // There is no need to have it sync.
+    prog
+      .catchAll(err =>
+        BootstrapLogger.Early.DB.error(s"Error when trying to migrate/create CampaignEventsStateHistory table: ${err.fullMsg}")
+      )
+      .forkDaemon
+      .runNow
+  }
+}
+
+object MigrateTableCampaignEvents {
+
+  // create new enum for campaign event state
+  val sql1 = {
+    sql"""DO $$$$ BEGIN
+                    CREATE TYPE campaignEventState AS enum (
+                      'scheduled', 'prehooks', 'running', 'posthooks', 'finished', 'skipped', 'deleted', 'failure'
+                    );
+                  EXCEPTION
+                    WHEN duplicate_object THEN null;
+                  END $$$$;"""
+  }
+
+  // migrate state to the new enum for table CampaignEvents
+  // (data_type changes from 'jsonb' to 'USER-DEFINED'
+  val sql2 = {
+    sql"""
+    DO $$$$ BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'campaignevents' AND column_name = 'state' AND data_type = 'jsonb'
+      ) THEN
+        ALTER TABLE campaignevents RENAME state TO stateJson;
+        ALTER TABLE campaignevents ADD COLUMN state campaigneventstate;
+        UPDATE campaignevents SET state = (stateJson ->> 'value')::campaigneventstate;
+        ALTER TABLE campaignevents ALTER COLUMN state SET NOT NULL;
+        DROP INDEX IF EXISTS event_state_index;
+      END IF;
+    END $$$$;"""
+  }
+
+  // create the new table and fill it with data from CampaignEvents, then delete old column
+  // WARNING : in pg_tables, names are lower-case and case sensitive
+  val sql3 = {
+    sql"""
+    DO $$$$ BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_tables WHERE tablename  = 'campaigneventsstatehistory'
+      ) THEN
+        CREATE TABLE CampaignEventsStateHistory (
+          eventId   text references CampaignEvents(eventId) ON DELETE CASCADE
+        , state     campaignEventState
+        , startDate timestamp with time zone NOT NULL
+        , endDate   timestamp with time zone
+        , data      jsonb
+        , PRIMARY KEY (eventId, state)
+        );
+
+        INSERT INTO campaigneventsstatehistory (eventid, state, startdate, enddate, data)
+        SELECT
+          c.eventid,
+          c.state,
+          c.startdate,
+          c.enddate,
+          (SELECT jsonb_build_object('reason', COALESCE(c.statejson ->> 'reason', ''))::json WHERE c.state = 'skipped')
+        FROM campaignevents c;
+
+        ALTER TABLE campaignevents DROP COLUMN IF EXISTS statejson;
+      END IF;
+    END $$$$;"""
+  }
+
+  // Update `skipped` cases that are actually `failure` : when the message looks like that:
+  //       "- into campaign of type system-update version 1"
+  // Then we need to update `CampaignEvents` state to failure and `CampaignEventStateHistory` to failure with new message.
+
+  val sql4 = {
+    sql"""
+    DO $$$$ BEGIN
+      IF EXISTS (
+        SELECT 1 FROM pg_tables WHERE tablename  = 'campaigneventsstatehistory'
+      ) THEN
+          WITH updatedEvents AS (
+            UPDATE campaigneventsstatehistory
+            SET
+              state = 'failure',
+              data = jsonb_build_object('cause', 'An error occurred when processing event', 'message', data ->> 'reason')::json
+            WHERE data ->> 'reason' like 'An error occurred when processing event%'
+            RETURNING eventid
+          )
+          UPDATE campaignevents
+          SET
+            state = 'failure'
+          WHERE eventid in (SELECT eventid FROM updatedEvents);
+      END IF;
+    END $$$$;"""
+  }
+
+}

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/earlyconfig/db/TestMigrateTableCampaignEvents.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/earlyconfig/db/TestMigrateTableCampaignEvents.scala
@@ -1,0 +1,423 @@
+/*
+ *************************************************************************************
+ * Copyright 2023 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package bootstrap.liftweb.checks.earlyconfig.db
+
+import cats.*
+import cats.implicits.*
+import com.normation.rudder.campaigns.*
+import com.normation.rudder.db.DBCommon
+import com.normation.rudder.db.json.implicits.*
+import com.normation.utils.DateFormaterService
+import com.normation.zio.*
+import doobie.*
+import doobie.implicits.*
+import doobie.postgres.implicits.*
+import io.scalaland.chimney.*
+import io.scalaland.chimney.syntax.*
+import java.time.*
+import java.time.format.DateTimeFormatter
+import org.joda.time.DateTime
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+import zio.*
+import zio.interop.catz.*
+import zio.json.*
+import zio.json.ast.*
+
+@RunWith(classOf[JUnitRunner])
+class TestMigrateTableCampaignEvents extends DBCommon {
+  import doobie.*
+
+//  private lazy val migrate = new MigrateTableCampaignEvents(doobie)
+
+  // The previous schema, with the renamed table for this test
+  // We need to know for sure the initial state and the final state of the migrated table,
+  // so we define and use the previous schema without conflicting with the current one (with all values renamed)
+  private val previousSchemaDDL = sql"""
+    DROP TABLE CampaignEventsStateHistory;
+    DROP TABLE CampaignEvents;
+    DROP TYPE campaignEventState;
+
+    CREATE TABLE CampaignEvents (
+      campaignId   text
+    , eventid      text PRIMARY KEY
+    , name         text
+    , state        jsonb
+    , startDate    timestamp with time zone NOT NULL
+    , endDate      timestamp with time zone NOT NULL
+    , campaignType text
+    );
+
+    CREATE INDEX event_state_index ON CampaignEvents ((state->>'value'));
+  """
+
+  // some data to check that the migration actually works
+
+  case class OldCampaignEvent(
+      campaignId:   String,
+      eventId:      String,
+      name:         String,
+      state:        Json,
+      start:        Instant,
+      end:          Instant,
+      campaignType: String
+  ) {
+    def getStateName: String = {
+      def err = new RuntimeException(s"can't find state name in: ${state.toJson}")
+      state match {
+        case Json.Obj(pairs) => pairs.collectFirst { case (k, Json.Str(v)) if k == "value" => v }.getOrElse(throw err)
+        case _               => throw err
+      }
+    }
+
+    def getData: Option[Json] = {
+      // when we don't have a correct pair, we say that reason is the empty message
+      val REASON = "reason"
+      def toJson(k: String, v: String) = Some(Json.Obj(Chunk((REASON, Json.Str(v)))))
+
+      state match {
+        case Json.Obj(pairs) =>
+          pairs.collectFirst {
+            case (k, v) if k == REASON =>
+              v match {
+                case Json.Str(s) => toJson(REASON, s)
+                case _           => toJson(REASON, "")
+              }
+          }.flatten
+
+        case _ =>
+          None
+      }
+    }
+
+  }
+
+  object OldCampaignEvent {
+    implicit val transformOldCampaignEvent: Transformer[OldCampaignEvent, NewCampaignEvent] = {
+      Transformer
+        .define[OldCampaignEvent, NewCampaignEvent]
+        .withFieldComputed(_.state, _.getStateName)
+        .buildTransformer
+    }
+
+    implicit val transformToHistory: Transformer[OldCampaignEvent, EventHistory] = {
+      Transformer
+        .define[OldCampaignEvent, EventHistory]
+        .withFieldComputed(_.state, _.getStateName)
+        .withFieldComputed(_.data, _.getData)
+        .buildTransformer
+    }
+  }
+
+  // a simple test version for new events
+  case class NewCampaignEvent(
+      campaignId:   String,
+      eventId:      String,
+      name:         String,
+      state:        String,
+      start:        Instant,
+      end:          Instant,
+      campaignType: String
+  )
+
+  case class EventHistory(
+      eventId: String,
+      state:   String,
+      start:   Instant,
+      end:     Instant,
+      data:    Option[Json]
+  )
+
+  implicit private class ToDate(s: String) {
+    private val format = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssX")
+
+    def date: Instant = {
+      // parse postgresql format: 2024-04-02 09:59:00+00
+      OffsetDateTime.parse(s, format).toInstant
+    }
+
+    def dateJT: DateTime = {
+      DateFormaterService.toDateTime(date)
+    }
+  }
+
+  implicit private class ToJson(s: String) {
+    def json: Json = {
+      s.fromJson[Json] match {
+        case Left(err) => throw new RuntimeException(s"error in json test data, parsing: \n${s}\nerror: ${err}")
+        case Right(x)  => x
+      }
+    }
+  }
+
+  // format: off
+  private val oldData = Vector(
+    // this one is special and need to become a failure
+    OldCampaignEvent("77d4cb38","7cca021a", "testing time #2" , """{"value": "skipped", "reason": "An error occurred when processing event: inconsistency in migration"}""".json, "2024-03-05 10:59:00+00".date, "2024-03-05 11:59:00+00".date, "system-update"),
+    OldCampaignEvent("77d4cb38","a97ccca1", "testing time #7" , """{"value": "skipped", "reason": "User skipped campaign event"}""".json, "2024-03-26 10:59:00+00".date, "2024-03-26 11:59:00+00".date, "system-update"),
+    OldCampaignEvent("1c2fceec","7aab5d52", "test1 #2"        , """{"value": "finished"}                                        """.json, "2024-04-01 10:00:00+00".date, "2024-04-01 16:00:00+00".date, "software-update"),
+    OldCampaignEvent("840494c4","eab80401", "rearezarezr #3"  , """{"value": "running"}                                         """.json, "2024-04-01 10:00:00+00".date, "2024-04-01 16:00:00+00".date, "system-update"),
+    OldCampaignEvent("77d4cb38","c34cf085", "testing time #8" , """{"value": "finished"}                                        """.json, "2024-04-02 09:59:00+00".date, "2024-04-02 10:59:00+00".date, "system-update"),
+    OldCampaignEvent("77d4cb38","af039286", "testing time #9" , """{"value": "skipped", "reason": null}                         """.json, "2024-04-09 09:59:00+00".date, "2024-04-09 10:59:00+00".date, "system-update"),
+    OldCampaignEvent("f2f68d18","4e615889", "test badge #2"   , """{"value": "scheduled"}                                       """.json, "2024-07-10 13:20:00+00".date, "2024-07-10 19:20:00+00".date, "software-update"),
+ )
+  // format: on
+
+  // expected after migration
+  private val newData = oldData.map(_.transformInto[NewCampaignEvent])
+  private val history = oldData.map(_.transformInto[EventHistory])
+
+  private val initDataOldSql = Update[OldCampaignEvent]("""
+    INSERT INTO CampaignEvents (campaignId, eventid, name, state, startDate, endDate, campaignType)
+    VALUES (?, ?, ?, ?, ?, ?, ?)""").updateMany(oldData)
+
+  override def initDb(): Unit = {
+    super.initDb()
+    doobie
+      .transactRunEither(xa => {
+        (for {
+          _ <- previousSchemaDDL.update.run
+          _ <- initDataOldSql
+        } yield ()).transact(xa)
+      })
+      .left
+      .map(throw _)
+  }
+
+  private lazy val repo = new CampaignEventRepositoryImpl(doobie, new CampaignSerializer())
+
+  sequential
+
+  "MigrateTableCampaignEvents" should {
+
+    "data are correctly initialized" in {
+
+      val sql = sql"""SELECT count(*) FROM CampaignEvents"""
+
+      doobie.transactRunEither(sql.query[Int].unique.transact(_)) must beRight(beEqualTo(oldData.size))
+
+    }
+
+    "correctly execute step1 and step2 - update state column to new enum type" in {
+
+      val step12 = (
+        transactIOResult(s"step1")(xa => MigrateTableCampaignEvents.sql1.update.run.transact(xa)) *>
+          transactIOResult(s"step2")(xa => MigrateTableCampaignEvents.sql2.update.run.transact(xa))
+      ).either.runNow
+
+      // get back events as new one
+      val sql = sql"""SELECT campaignId, eventid, name, state, startDate, endDate, campaignType from CampaignEvents"""
+
+      step12 must beRight
+
+      doobie.transactRunEither(sql.query[NewCampaignEvent].to[Seq].transact(_)) must beRight(
+        containTheSameElementsAs(newData)
+      )
+    }
+
+    "correctly execute step3 - create history table and migrate data" in {
+      val step3 = (
+        transactIOResult(s"step3")(xa => MigrateTableCampaignEvents.sql3.update.run.transact(xa))
+      ).either.runNow
+
+      // we should have details for all skipped
+      step3 must beRight
+
+      val sql1 = sql"""SELECT eventid, state, startDate, endDate, data from CampaignEventsStateHistory"""
+
+      doobie.transactRunEither(sql1.query[EventHistory].to[Seq].transact(_)) must beRight(
+        containTheSameElementsAs(history)
+      )
+
+      // jsonstate column was deleted
+      val sql2 = sql"""SELECT jsontate from CampaignEvents"""
+      val res  = doobie.transactRunEither(sql2.query[EventHistory].to[Seq].transact(_))
+
+      // for some reason, the "matching" matcher does not work here
+      res must beLeft
+    }
+
+    "correctly execute step4 - skipped to failure" in {
+      val step4 = (
+        transactIOResult(s"step4")(xa => MigrateTableCampaignEvents.sql4.update.run.transact(xa))
+      ).either.runNow
+
+      step4 must beRight
+
+      // event with id 7cca021a must be a failure with the correct messages
+      val sql1 = sql"""SELECT state FROM CampaignEvents WHERE eventid = '7cca021a'"""
+      doobie.transactRunEither(sql1.query[String].option.transact(_)) must beRight(
+        beSome(
+          CampaignEventStateType.Failure.entryName
+        )
+      )
+
+      val sql2 = sql"""SELECT state, data FROM CampaignEventsStateHistory  WHERE eventid = '7cca021a'"""
+      doobie.transactRunEither(sql2.query[(String, Json)].option.transact(_)) must beRight(
+        beSome(
+          (
+            CampaignEventStateType.Failure.entryName,
+            Json.Obj(
+              "cause"   -> Json.Str("An error occurred when processing event"),
+              "message" -> Json.Str("An error occurred when processing event: inconsistency in migration")
+            )
+          )
+        )
+      )
+    }
+  }
+
+  "Repository on new table" should {
+
+    "be able to do simple get" in {
+      repo.get(CampaignEventId("7aab5d52")).either.runNow must beRight(
+        beSome(
+          CampaignEvent(
+            CampaignEventId("7aab5d52"),
+            CampaignId("1c2fceec"),
+            "test1 #2",
+            CampaignEventState.Finished,
+            "2024-04-01 10:00:00+00".dateJT,
+            "2024-04-01 16:00:00+00".dateJT,
+            CampaignType("software-update")
+          )
+        )
+      )
+    }
+
+    "be able to do by criteria search" in {
+      repo
+        .getWithCriteria(
+          CampaignEventStateType.Finished :: CampaignEventStateType.Failure :: Nil,
+          CampaignType("system-update") :: Nil,
+          None,
+          Some(5),
+          None,
+          afterDate = Some("2024-03-01 10:00:00+00".dateJT),
+          beforeDate = Some("2024-05-01 10:00:00+00".dateJT),
+          Some(CampaignSortOrder.StartDate),
+          Some(CampaignSortDirection.Desc)
+        )
+        .either
+        .runNow
+        .map(_.map(_.id)) must beRight(
+        beEqualTo(
+          List(
+            CampaignEventId("c34cf085"),
+            CampaignEventId("7cca021a")
+          )
+        )
+      )
+    }
+
+    "save and retrieve several time a new event with different states" in {
+      val e = CampaignEvent(
+        CampaignEventId("ba43ca8b"),
+        CampaignId("1c2fceec"),
+        "test new #1",
+        CampaignEventState.Scheduled,
+        "2024-04-01 10:00:00+00".dateJT,
+        "2024-04-01 16:00:00+00".dateJT,
+        CampaignType("software-update")
+      )
+
+      val s = e.copy(
+        state = CampaignEventState.Skipped("user asked to skip event"),
+        start = "2024-04-02 10:00:00+00".dateJT,
+        end = "2024-04-02 10:00:00+00".dateJT
+      )
+
+      val res = (for {
+        _  <- repo.saveCampaignEvent(e)
+        e1 <- repo.get(e.id)
+        _  <- repo.saveCampaignEvent(s)
+        e2 <- repo.get(e.id)
+      } yield (e1, e2)).either.runNow
+
+      res must beRight(beEqualTo((Some(e), Some(s))))
+    }
+
+    // I'm not at all sure that's the semantic we want.
+    // Here, we say that a state is only reachable one time, ie that the progression
+    // in the state graph is linear without loop. So we "can't" have an update
+    // to an existing state, only the end data can change.
+    // Another semantic would be that a state identity is (eventId, state type, start date) so
+    // that we can reach several times each state. If it's needed, the SQL schema
+    // will need to be changed for a new key definition.
+    "update an existing event with different states" in {
+
+      val e = CampaignEvent(
+        CampaignEventId("a97ccca1"),
+        CampaignId("77d4cb38"),
+        "testing time #7",
+        CampaignEventState.Skipped("User skipped campaign event"),
+        "2024-03-26 10:59:00+00".dateJT,
+        "2024-03-26 11:59:00+00".dateJT,
+        CampaignType("system-update")
+      )
+
+      val s = e.copy(
+        state = CampaignEventState.Skipped("user asked to skip event"),
+        start = "2024-04-02 10:00:00+00".dateJT,
+        end = "2024-04-02 10:00:00+00".dateJT
+      )
+
+      val expectedUpdate = s.copy(state = e.state) // keep state
+
+      val res = (for {
+        _  <- repo.saveCampaignEvent(e)
+        e1 <- repo.get(e.id)
+        _  <- repo.saveCampaignEvent(s)
+        e2 <- repo.get(e.id)
+      } yield (e1, e2)).either.runNow
+
+      res must beRight(beEqualTo((Some(e), Some(expectedUpdate))))
+    }
+
+    "deleting an event works" in {
+      val id = CampaignEventId("a97ccca1")
+
+      val res = (for {
+        _ <- repo.deleteEvent(Some(id))
+        e <- repo.get(id)
+      } yield e).either.runNow
+
+      res must beRight(beNone)
+    }
+  }
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/27154

Needed by https://github.com/Normation/rudder-plugins-private/pull/1071

This PR allows to split the campaign event table into two parts: 
- the old one, `CampaignEvents`, represents the current state of the campaign, 
- the new one, `CampaignEventsStateHistory`, represents the log of states that the campaign went through. 

The migration adds new states to prepare for the future : `deleted` (not sure if needed), `failure` (to differentiate a user-skipped event from a failed one), and the pre/post hooks.
The migration also change the event that were `skipped` but with an error message to `failure` state. 

The other big change is that now, `state` is only an (enum) type, and not the full JSON with added information. This added information is now stored in `CampaignEventsStateHistory.data` column (jsonb). 
This was needed to be able to prepare the fact that for future `pre/post-hooks` events, we will want to be able to see what happened even if the campaign current state is not the one with details. 

So, that make for a bit of a complicated migration process for existing table in 4 steps.
 Of course for them, only the current state can be added in history. 
The misgration process is (well, I hope) unit tested in `TestMigrateTableCampaignEvents`.

Then, other changes are mainly impact of that. I tried to make as little changes as possible in external APIs, so the added tests for the campaign API. Nothing changed here, even if backend storage is totaly different. 

The business representation changed a bit, but not that much once I finally found a satisfying encoding: 
- there is a new enum(eratum) for the state kind: `CampaignEventStateType`
- it's used in another sealed hierachy, which is NOT an enum, `CampaignEventState`. This data structure is the one derived for API and matches encoding in 8.3
- in the DB part, I used intermediate data structure to match table column for insert, and a broader one for select that is join between the two
- then there is dedicated data structure for each kind of details and their json encoder/decoder (which are just `derives` thanks to scala 3)

I chose to not have the state kind in the `data` column, only the actual optionnal details, so that `finished`/etc has not details, and for `skipped` there is no duplication of the state part, only a `reason`. 
This is nice when working in sql and avoid having to think about inconsistencies between columns. 
On the other hand, it means that I need to test each decoder one after the other to find the correct one. 

And that's in that PR. 
The next one will be about actually adding pre/post-hooks state in the workflow engine and corresponding execution. 
