### PR TITLE
Fixes #27153: Add types to campaign event data structures

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -3224,8 +3224,17 @@ class MockCampaign() {
     ),
     DumbCampaignDetails("campaign #0")
   )
-  val e0: CampaignEvent =
-    CampaignEvent(CampaignEventId("e0"), c0.info.id, "campaign #0", Finished, new DateTime(0), new DateTime(1), DumbCampaignType)
+  val e0: CampaignEvent = {
+    CampaignEvent(
+      CampaignEventId("e0"),
+      c0.info.id,
+      "campaign #0",
+      CampaignEventState.Finished,
+      new DateTime(0),
+      new DateTime(1),
+      DumbCampaignType
+    )
+  }
 
   object repo extends CampaignRepository {
     val items: Ref[Map[CampaignId, DumbCampaignTrait]] = Ref.make(Map[CampaignId, DumbCampaignTrait]((c0.info.id -> c0))).runNow
@@ -3283,7 +3292,7 @@ class MockCampaign() {
     val items: Ref[Map[CampaignEventId, CampaignEvent]] = Ref.make(Map[CampaignEventId, CampaignEvent]((e0.id -> e0))).runNow
 
     def isActive(e: CampaignEvent): Boolean = {
-      e.state == Scheduled || e.state == Running
+      e.state == CampaignEventState.Scheduled || e.state == CampaignEventState.Running
     }
 
     def get(id: CampaignEventId):            IOResult[Option[CampaignEvent]] = {
@@ -3296,15 +3305,15 @@ class MockCampaign() {
     }
 
     def getWithCriteria(
-        states:       List[String],
+        states:       List[CampaignEventState],
         campaignType: List[CampaignType],
         campaignId:   Option[CampaignId],
         limit:        Option[Int],
         offset:       Option[Int],
         afterDate:    Option[DateTime],
         beforeDate:   Option[DateTime],
-        order:        Option[String],
-        asc:          Option[String]
+        order:        Option[CampaignSortOrder],
+        asc:          Option[CampaignSortDirection]
     ): IOResult[List[CampaignEvent]] = {
 
       val allEvents            = items.get.map(_.values.toList)
@@ -3318,7 +3327,7 @@ class MockCampaign() {
       }
       val stateFiltered        = states match {
         case Nil => campaignTypeFiltered
-        case s   => campaignTypeFiltered.map(_.filter(ev => states.contains(s)))
+        case s   => campaignTypeFiltered.map(_.filter(ev => s.contains(ev.state)))
       }
 
       val afterDateFiltered  = afterDate match {
@@ -3331,21 +3340,21 @@ class MockCampaign() {
       }
 
       val ordered = order match {
-        case Some("endDate" | "end")                =>
+        case Some(CampaignSortOrder.EndDate)              =>
           beforeDateFiltered.map(
             _.sortWith((a, b) => {
               asc match {
-                case Some("asc") => a.end.isBefore(b.end)
-                case _           => a.end.isAfter(b.end)
+                case Some(CampaignSortDirection.Asc) => a.end.isBefore(b.end)
+                case _                               => a.end.isAfter(b.end)
               }
             })
           )
-        case Some("startDate" | "start") | None | _ =>
+        case Some(CampaignSortOrder.StartDate) | None | _ =>
           beforeDateFiltered.map(
             _.sortWith((a, b) => {
               asc match {
-                case Some("asc") => a.start.isBefore(b.start)
-                case _           => a.start.isAfter(b.start)
+                case Some(CampaignSortDirection.Asc) => a.start.isBefore(b.start)
+                case _                               => a.start.isAfter(b.start)
               }
             })
           )
@@ -3366,7 +3375,7 @@ class MockCampaign() {
 
     def deleteEvent(
         id:           Option[CampaignEventId],
-        states:       List[String],
+        states:       List[CampaignEventState],
         campaignType: Option[CampaignType],
         campaignId:   Option[CampaignId],
         afterDate:    Option[DateTime],
@@ -3390,7 +3399,7 @@ class MockCampaign() {
 
       val stateFiltered: CampaignEvent => Boolean = states match {
         case Nil => campaignTypeFiltered
-        case s   => ev => campaignTypeFiltered(ev) && !states.contains(s)
+        case s   => ev => campaignTypeFiltered(ev) && !s.contains(ev.state)
       }
 
       val afterDateFiltered:  CampaignEvent => Boolean = afterDate match {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/CampaignApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/CampaignApi.scala
@@ -220,15 +220,15 @@ class CampaignApi(
     val schema: API.GetCampaignEvents.type = API.GetCampaignEvents
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      val states       = req.params.get("state").getOrElse(Nil)
-      val campaignType = req.params.get("campaignType").getOrElse(Nil).map(campaignSerializer.campaignType)
+      val states       = req.params.getOrElse("state", Nil).flatMap(s => CampaignEventState.parse(s).toOption)
+      val campaignType = req.params.getOrElse("campaignType", Nil).map(campaignSerializer.campaignType)
       val campaignId   = req.params.get("campaignId").flatMap(_.headOption).map(i => CampaignId(i))
       val limit        = req.params.get("limit").flatMap(_.headOption).flatMap(i => i.toIntOption)
       val offset       = req.params.get("offset").flatMap(_.headOption).flatMap(i => i.toIntOption)
       val beforeDate   = req.params.get("before").flatMap(_.headOption).flatMap(i => DateFormaterService.parseDate(i).toOption)
       val afterDate    = req.params.get("after").flatMap(_.headOption).flatMap(i => DateFormaterService.parseDate(i).toOption)
-      val order        = req.params.get("order").flatMap(_.headOption)
-      val asc          = req.params.get("asc").flatMap(_.headOption)
+      val order        = req.params.get("order").flatMap(l => l.headOption.flatMap(CampaignSortOrder.withNameInsensitiveOption))
+      val asc          = req.params.get("asc").flatMap(l => l.headOption.flatMap(CampaignSortDirection.withNameInsensitiveOption))
       campaignEventRepository
         .getWithCriteria(states, campaignType, campaignId, limit, offset, afterDate, beforeDate, order, asc)
         .toLiftResponseList(params, schema)
@@ -262,18 +262,17 @@ class CampaignApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      val states       = req.params.get("state").getOrElse(Nil)
-      val campaignType = req.params.get("campaignType").getOrElse(Nil).map(campaignSerializer.campaignType)
+      val states       = req.params.getOrElse("state", Nil).flatMap(s => CampaignEventState.parse(s).toOption)
+      val campaignType = req.params.getOrElse("campaignType", Nil).map(campaignSerializer.campaignType)
       val limit        = req.params.get("limit").flatMap(_.headOption).flatMap(i => i.toIntOption)
       val offset       = req.params.get("offset").flatMap(_.headOption).flatMap(i => i.toIntOption)
       val beforeDate   = req.params.get("before").flatMap(_.headOption).flatMap(i => DateFormaterService.parseDate(i).toOption)
       val afterDate    = req.params.get("after").flatMap(_.headOption).flatMap(i => DateFormaterService.parseDate(i).toOption)
-      val order        = req.params.get("order").flatMap(_.headOption)
-      val asc          = req.params.get("asc").flatMap(_.headOption)
+      val order        = req.params.get("order").flatMap(l => l.headOption.flatMap(CampaignSortOrder.withNameInsensitiveOption))
+      val asc          = req.params.get("asc").flatMap(l => l.headOption.flatMap(CampaignSortDirection.withNameInsensitiveOption))
       campaignEventRepository
         .getWithCriteria(states, campaignType, Some(CampaignId(resources)), limit, offset, afterDate, beforeDate, order, asc)
         .toLiftResponseList(params, schema)
-
     }
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/CampaignApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/CampaignApiTest.scala
@@ -40,8 +40,8 @@ package com.normation.rudder.rest
 import better.files.File
 import com.normation.JsonSpecMatcher
 import com.normation.rudder.campaigns.CampaignEvent
+import com.normation.rudder.campaigns.CampaignEventState.*
 import com.normation.rudder.campaigns.MainCampaignService
-import com.normation.rudder.campaigns.Scheduled
 import com.normation.rudder.rest.RudderJsonResponse.JsonRudderApiResponse
 import com.normation.rudder.rest.RudderJsonResponse.LiftJsonResponse
 import com.normation.utils.DateFormaterService


### PR DESCRIPTION
https://issues.rudder.io/issues/27153

Some cleaning-up in campaign code:

-  use standard layout for CampaignEventState (case object/class in object CampaignEventState)
-  create enums for query parameters in place of string: CampaignSortOrder, CampaignSortDirection
-  factor out default value for CampaignSortOrder in pattern matching
-  use the actual CampaignEventState in place of its string value in query
-  remove MainCampaignService from CampaignHandler which is not used and create a dependency loop

Replaces https://github.com/Normation/rudder/pull/6424
Needed for https://github.com/Normation/rudder-plugins-private/pull/1038