### PR TITLE
Fixes #27204: Add the x86_64-pc-windows-gnu cross compilation target to the rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.88.0"
+targets = [ "x86_64-pc-windows-gnu" ]


### PR DESCRIPTION
https://issues.rudder.io/issues/27204