### PR TITLE
Fixes #27175: Plugins get silently disabled when number of licensed nodes exceeded.

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/PluginData.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/PluginData.scala
@@ -65,11 +65,12 @@ object PluginId {
   }
 }
 
-final case class Licensee(value: String)      extends AnyVal
-final case class SoftwareId(value: String)    extends AnyVal
-final case class MinVersion(value: String)    extends AnyVal
-final case class MaxVersion(value: String)    extends AnyVal
-final case class MaxNodes(value: Option[Int]) extends AnyVal
+final case class Licensee(value: String)                     extends AnyVal
+final case class SoftwareId(value: String)                   extends AnyVal
+final case class MinVersion(value: String)                   extends AnyVal
+final case class MaxVersion(value: String)                   extends AnyVal
+final case class MaxNodes(value: Option[Int])                extends AnyVal
+final case class StatusDisabledReason(value: Option[String]) extends AnyVal
 object MaxNodes {
   val unlimited:            MaxNodes                           = MaxNodes(None)
   implicit val transformer: Transformer[MaxNodes, Option[Int]] = _.value
@@ -137,12 +138,21 @@ object PluginInstallStatus {
   case object Disabled    extends PluginInstallStatus
   case object Uninstalled extends PluginInstallStatus
 
-  def from(pluginType: PluginType, installed: Boolean, enabled: Boolean): PluginInstallStatus = {
+  def from(
+      pluginType:           PluginType,
+      installed:            Boolean,
+      enabled:              Boolean,
+      statusDisabledReason: StatusDisabledReason
+  ): PluginInstallStatus = {
     import PluginType.*
-    (pluginType, installed, enabled) match {
-      case (_, false, _)                                => Uninstalled
-      case (_, true, true) | (Integration, true, false) => Enabled
-      case (Webapp, true, false)                        => Disabled
+    if (statusDisabledReason.value.isDefined) {
+      Disabled
+    } else {
+      (pluginType, installed, enabled) match {
+        case (_, false, _)                                => Uninstalled
+        case (_, true, true) | (Integration, true, false) => Enabled
+        case (Webapp, true, false)                        => Disabled
+      }
     }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/cli/RudderPackagePlugin.scala.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/plugins/cli/RudderPackagePlugin.scala.scala
@@ -102,10 +102,11 @@ object RudderPackagePlugin {
     * we can return needed plugin details
     */
   implicit def transformer(implicit
-      rudderFullVersion: String,
-      abiVersion:        AbiVersion,
-      pluginVersion:     PluginVersion,
-      transformLicense:  Transformer[LicenseInfo, PluginLicense]
+      rudderFullVersion:    String,
+      abiVersion:           AbiVersion,
+      pluginVersion:        PluginVersion,
+      statusDisabledReason: StatusDisabledReason,
+      transformLicense:     Transformer[LicenseInfo, PluginLicense]
   ): Transformer[RudderPackagePlugin, Plugin] = {
     val _ = transformLicense // variable is used below
     Transformer
@@ -117,7 +118,8 @@ object RudderPackagePlugin {
           PluginInstallStatus.from(
             if (p.webappPlugin) PluginType.Webapp else PluginType.Integration,
             installed = p.installed,
-            enabled = p.enabled
+            enabled = p.enabled,
+            statusDisabledReason = statusDisabledReason
           )
         }
       )
@@ -125,7 +127,7 @@ object RudderPackagePlugin {
       .withFieldConst(_.abiVersion, abiVersion.value)                       // field is computed upstream
       .withFieldConst(_.pluginVersion, pluginVersion.value)                 // field is computed upstream
       .withFieldComputed(_.pluginType, p => if (p.webappPlugin) PluginType.Webapp else PluginType.Integration)
-      .withFieldConst(_.statusMessage, None)
+      .withFieldConst(_.statusMessage, statusDisabledReason.value)
       .withFieldComputed(
         _.errors,
         PluginError.fromRudderPackagePlugin(_)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/plugins/PluginDataTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/plugins/PluginDataTest.scala
@@ -12,11 +12,29 @@ class PluginDataTest extends Specification {
   import PluginInstallStatus.*
 
   "PluginSystemStatus" should {
+    "be disabled when there is a reason" in {
+      PluginInstallStatus.from(
+        PluginType.Webapp,
+        installed = true,
+        enabled = true,
+        statusDisabledReason = StatusDisabledReason(Some("invalid license checked at runtime"))
+      ) === Disabled
+    }
     "map from a disabled webapp plugin" in {
-      PluginInstallStatus.from(PluginType.Webapp, installed = true, enabled = false) === Disabled
+      PluginInstallStatus.from(
+        PluginType.Webapp,
+        installed = true,
+        enabled = false,
+        statusDisabledReason = StatusDisabledReason(None)
+      ) === Disabled
     }
     "not map from an integration plugin to 'disabled'" in {
-      PluginInstallStatus.from(PluginType.Integration, installed = true, enabled = false) === Enabled
+      PluginInstallStatus.from(
+        PluginType.Integration,
+        installed = true,
+        enabled = false,
+        statusDisabledReason = StatusDisabledReason(None)
+      ) === Enabled
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Action.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Action.elm
@@ -47,10 +47,8 @@ type ActionDisallowedResult
     | UninstalledPluginCannotBeEnabled
     | UninstalledPluginCannotBeDisabled -- --       (InstallStatus ⊗ (ActivationStatus \ InstallStatus))
     | IntegrationPluginCannotBeDisabled -- --       (PluginType ⊗ ActivationStatus)
-    | ExpiredLicensePreventPluginInstallation -- -- (LicenseStatus ⊗ InstallStatus)
-    | MissingLicensePreventPluginInstallation
-    | ExpiredLicensePreventPluginActivation -- --   (LicenseStatus ⊗ ActivationStatus)
-    | MissingLicensePreventPluginActivation
+    | InvalidLicensePreventPluginInstallation -- -- (LicenseStatus ⊗ InstallStatus)
+    | InvalidLicensePreventPluginActivation -- --   (LicenseStatus ⊗ ActivationStatus)
 
 
 
@@ -271,10 +269,8 @@ allSortedActionDisallowedResult =
     , UninstalledPluginCannotBeEnabled
     , UninstalledPluginCannotBeDisabled
     , IntegrationPluginCannotBeDisabled
-    , ExpiredLicensePreventPluginInstallation
-    , MissingLicensePreventPluginInstallation
-    , ExpiredLicensePreventPluginActivation
-    , MissingLicensePreventPluginActivation
+    , InvalidLicensePreventPluginInstallation
+    , InvalidLicensePreventPluginActivation
     ]
 
 
@@ -399,17 +395,11 @@ findPluginsAction action plugins =
 getActionResult : Action -> Plugin -> ActionModel
 getActionResult action { installStatus, pluginType, licenseStatus } =
     case ( action, ( installStatus, pluginType, licenseStatus ) ) of
-        ( ActionInstall, ( _, _, ExpiredLicense _ ) ) ->
-            DisallowedAction ExpiredLicensePreventPluginInstallation
+        ( ActionInstall, ( _, _, InvalidLicense _ ) ) ->
+            DisallowedAction InvalidLicensePreventPluginInstallation
 
-        ( ActionInstall, ( _, _, MissingLicense _ ) ) ->
-            DisallowedAction MissingLicensePreventPluginInstallation
-
-        ( ActionEnable, ( _, _, ExpiredLicense _ ) ) ->
-            DisallowedAction ExpiredLicensePreventPluginActivation
-
-        ( ActionEnable, ( _, _, MissingLicense _ ) ) ->
-            DisallowedAction MissingLicensePreventPluginActivation
+        ( ActionEnable, ( _, _, InvalidLicense _ ) ) ->
+            DisallowedAction InvalidLicensePreventPluginActivation
 
         ( ActionDisable, ( Installed Enabled, Integration, _ ) ) ->
             DisallowedAction IntegrationPluginCannotBeDisabled
@@ -480,14 +470,8 @@ explainDisallowedResult arg =
             IntegrationPluginCannotBeDisabled ->
                 "IntegrationPluginCannotBeDisabled"
 
-            ExpiredLicensePreventPluginInstallation ->
-                "ExpiredLicensePreventPluginInstallation"
+            InvalidLicensePreventPluginActivation ->
+                "InvalidLicensePreventPluginActivation"
 
-            MissingLicensePreventPluginInstallation ->
-                "MissingLicensePreventPluginInstallation"
-
-            ExpiredLicensePreventPluginActivation ->
-                "ExpiredLicensePreventPluginActivation"
-
-            MissingLicensePreventPluginActivation ->
-                "MissingLicensePreventPluginActivation"
+            InvalidLicensePreventPluginInstallation ->
+                "InvalidLicensePreventPluginInstallation"

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/JsonDecoder.elm
@@ -55,6 +55,7 @@ decodePluginInfo =
         |> required "pluginType" decodePluginType
         |> required "errors" (list decodePluginError)
         |> required "status" decodePluginStatus
+        |> optional "statusMessage" (maybe string) Nothing
         |> optional "license" (maybe decodeLicenseInfo) Nothing
 
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Select.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/Select.elm
@@ -160,10 +160,7 @@ findNotSelectablePlugins plugins =
     let
         notSelectable { installStatus, licenseStatus } =
             case ( installStatus, licenseStatus ) of
-                ( Uninstalled, ExpiredLicense _ ) ->
-                    Just NotSelectable
-
-                ( Uninstalled, MissingLicense _ ) ->
+                ( Uninstalled, InvalidLicense _ ) ->
                     Just NotSelectable
 
                 _ ->

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Plugins/View.elm
@@ -90,7 +90,7 @@ displayMainHeader v license now loading contextPath =
         [ h1 []
             [ span [] [ text "Plugins management" ]
             ]
-        , div [class "text-danger"] [settingError]
+        , div [ class "text-danger" ] [ settingError ]
         ]
         :: (if loading then
                 []
@@ -486,11 +486,11 @@ displayMainLicense license now contextPath =
 
 pluginBadge : Plugin -> List (Html msg)
 pluginBadge p =
-    case ( p.installStatus, p.licenseStatus ) of
+    case ( p.installStatus, p.noLicense ) of
         ( Installed Disabled, _ ) ->
             [ div [ class "position-absolute top-0 start-0" ] [ span [ class "badge float-start" ] [ text "Disabled" ] ] ]
 
-        ( _, MissingLicense _ ) ->
+        ( _, True ) ->
             [ div [ class "position-absolute top-0 start-0" ] [ span [ class "badge float-start text-dark" ] [ i [ class "fa fa-info-circle me-1" ] [], text "No license" ] ] ]
 
         ( Installed Enabled, _ ) ->
@@ -502,8 +502,8 @@ pluginBadge p =
 
 pluginCardBgClass : Plugin -> Maybe String
 pluginCardBgClass p =
-    case ( p.installStatus, p.licenseStatus ) of
-        ( _, MissingLicense _ ) ->
+    case ( p.installStatus, p.noLicense ) of
+        ( _, True ) ->
             Just "plugin-card-missing-license"
 
         ( Installed Disabled, _ ) ->
@@ -514,22 +514,17 @@ pluginCardBgClass p =
 
 
 pluginErrorCallouts : Plugin -> List (Html Msg)
-pluginErrorCallouts { licenseStatus, abiVersionError } =
-    case ( licenseStatus, abiVersionError ) of
-        ( ExpiredLicense message, _ ) ->
-            [ div [ class "callout-fade callout-danger" ] [ i [ class "me-1 fa fa-warning" ] [], text message ] ]
+pluginErrorCallouts { errors } =
+    errors
+        |> List.map
+            (\e ->
+                case e of
+                    CalloutError message ->
+                        div [ class "callout-fade callout-danger" ] [ i [ class "me-1 fa fa-warning" ] [], text message ]
 
-        ( MissingLicense message, _ ) ->
-            [ div [ class "callout-fade callout-danger" ] [ i [ class "me-1 fa fa-warning" ] [], text message ] ]
-
-        ( NearExpirationLicense message, _ ) ->
-            [ div [ class "callout-fade callout-warning" ] [ i [ class "me-1 fa fa-warning" ] [], text message ] ]
-
-        ( _, Just message ) ->
-            [ div [ class "callout-fade callout-warning" ] [ i [ class "me-1 fa fa-warning" ] [], text message ] ]
-
-        _ ->
-            []
+                    CalloutWarning message ->
+                        div [ class "callout-fade callout-warning" ] [ i [ class "me-1 fa fa-warning" ] [], text message ]
+            )
 
 
 pluginInputCheck : { a | id : PluginId } -> Selected -> List (Html Msg)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPlugin.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/plugins/RudderPlugin.scala
@@ -387,8 +387,12 @@ class PluginsServiceImpl(
       .get(PluginName("rudder-plugin-" + p.name)) // rudder package name does not have the prefix used in names
       .flatMap(pluginDef => {
         val details = pluginDef.transformInto[JsonPluginDetails]
-        implicit val abiVersion:    AbiVersion    = AbiVersion(pluginDef.version.rudderAbi)
-        implicit val pluginVersion: PluginVersion =
+        implicit val statusDisabledReason: StatusDisabledReason = StatusDisabledReason(pluginDef.status.current match {
+          case RudderPluginLicenseStatus.Disabled(reason, _) => Some(reason)
+          case _                                             => None
+        })
+        implicit val abiVersion:           AbiVersion           = AbiVersion(pluginDef.version.rudderAbi)
+        implicit val pluginVersion:        PluginVersion        =
           PluginVersion(pluginDef.version.pluginVersion)
 
         // plugin listed from rudder package but with no license information :
@@ -408,10 +412,11 @@ class PluginsServiceImpl(
         // we need to attempt to parse versions from latest available version
         val bothVersions   = p.latestVersion.flatMap(RudderPluginVersion.from)
         def defaultVersion = Version(0, PartType.Numeric(0), List.empty)
-        implicit val abiVersion:    AbiVersion    =
+        implicit val abiVersion:           AbiVersion           =
           AbiVersion(bothVersions.map(_.rudderAbi).getOrElse(defaultVersion))
-        implicit val pluginVersion: PluginVersion =
+        implicit val pluginVersion:        PluginVersion        =
           PluginVersion(bothVersions.map(_.pluginVersion).getOrElse(defaultVersion))
+        implicit val statusDisabledReason: StatusDisabledReason = StatusDisabledReason(None)
 
         p.transformInto[Plugin]
       }


### PR DESCRIPTION
https://issues.rudder.io/issues/27175

* the plugin status displayed in the Plugins page was only taking into account the status from rudder-package, not from the webapp which does license runtime check :
  * use the webapp plugin definition to return the correct `status` and details with the `statusMessage` field
  * display the `statusMessage` message as an error in Elm, it behaves just like when license is expired/missing
* refactor : 
  * some duplicate code in the snippet with the plugins icon warning
  * the Elm callouts and handling of license status to avoid code repetition/duplication