### PR TITLE
Fixes #27180: Node compliance persistence fails when all reports from sysevents are cleaned

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -257,6 +257,24 @@ final case class RunAnalysis(
     lastRunConfigId:     Option[NodeConfigId],
     lastRunExpiration:   Option[DateTime]
 ) {
+  // used to manage the KeepLastCompliance update
+  def copyLastRunInfo(other: RunAnalysis): RunAnalysis = {
+    this.copy(
+      lastRunDateTime = other.lastRunDateTime,
+      lastRunConfigId = other.lastRunConfigId,
+      lastRunExpiration = other.lastRunExpiration
+    )
+  }
+
+  // Used to compare KeepLastCompliance without taking care of lastRun difference
+  def equalsWithoutLastRun(other: RunAnalysis): Boolean = {
+    this.kind == other.kind &&
+    this.expectedConfigId == other.expectedConfigId &&
+    this.expectedConfigStart == other.expectedConfigStart &&
+    this.expirationDateTime == other.expirationDateTime &&
+    this.expiredSince == other.expiredSince
+  }
+
   def debugString: String = {
     def d(o: Option[DateTime]): String = {
       o.map(_.toString).getOrElse("N/A")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
@@ -697,9 +697,15 @@ object ExecutionBatch extends Loggable {
                   val expireTime = currentConfig.beginDate.plus(updateValidityDuration(currentConfig.agentRun))
 
                   if (expireTime.isBefore(now)) {
-                    runType("no run (ever or too old)", NoReportInInterval(currentConfig, complianceComputationExpirationTime))
+                    runType(
+                      "no run (ever or too old/cleaned-up)",
+                      NoReportInInterval(currentConfig, complianceComputationExpirationTime)
+                    )
                   } else {
-                    runType(s"no run (ever or too old), Pending until ${expireTime}", Pending(currentConfig, None, expireTime))
+                    runType(
+                      s"no run (ever or too old/cleaned-up), Pending until ${expireTime}",
+                      Pending(currentConfig, None, expireTime)
+                    )
                   }
                 }
             }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeStatusReportRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeStatusReportRepository.scala
@@ -160,20 +160,34 @@ class NodeStatusReportRepositoryImpl(
                          // if we are asked to keep compliance, start by checking we do have one
                          case RunAnalysisKind.KeepLastCompliance =>
                            m.get(id) match {
-                             case Some(e) =>
-                               e.runInfo.kind match { // here we need to check for all expiring status from `def outDatedCompliance`
+                             case Some(cached) =>
+                               cached.runInfo.kind match { // here we need to check for all expiring status from `def outDatedCompliance`
                                  case RunAnalysisKind.ComputeCompliance | RunAnalysisKind.Pending =>
                                    // For ComputeCompliance: it's the standard case of keeping existing compliance.
                                    // If the saved node is pending, it means that we are in a case where the node never saved
                                    // anything else than pending since it was first processed, so the node never had a computed
                                    // compliance (it was a new report, directly in pending). Let it blue.
                                    // In both case: keep existing compliance, change run info to avoid loop.
-                                   Some((id, e.modify(_.runInfo).setTo(report.runInfo)))
+
+                                   // we need to copy new report information BUT NOT the one regarding "last run",
+                                   // which were lost if we reach that point
+                                   val runInfo = report.runInfo.copyLastRunInfo(cached.runInfo)
+                                   Some((id, cached.modify(_.runInfo).setTo(runInfo)))
+
+                                 // comparison for KeepLastCompliance: we need to check if configId/things not linked to
+                                 // last run changed, perhaps during a reboot, and update them if it's the case
+                                 case RunAnalysisKind.KeepLastCompliance                          =>
+                                   if (cached.runInfo.equalsWithoutLastRun(report.runInfo)) None
+                                   else {
+                                     // keep last run from cache, but update other runInfo data
+                                     val newRunInfo = report.runInfo.copyLastRunInfo(cached.runInfo)
+                                     Some((id, cached.modify(_.runInfo).setTo(newRunInfo)))
+                                   }
 
                                  case _ => // in any other case, change nothing but check if there's an actual change
-                                   if (e == report) None else Some((id, e))
+                                   if (cached == report) None else Some((id, cached))
                                }
-                             case None    => // ok, just a new report
+                             case None         => // ok, just a new report
                                Some((id, report))
                            }
                          // in other case, just update what is in cache if it's actually different

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/NodeStatusReportRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/NodeStatusReportRepositoryTest.scala
@@ -190,4 +190,39 @@ class NodeStatusReportRepositoryTest extends Specification {
     counter.get("p").reports must not(beEmpty)
   }
 
+  // see issue: https://issues.rudder.io/issues/27180 - when a missing node is cleaned up, we need to keep compliance
+  "When the node runs are cleaned-up, if still in keep-compliance windows, then the old run info are kept" >> {
+    val (counter, repo) = initServices()
+    implicit val cc     = ChangeContext.newForRudder()
+
+    val okReport = counter.get("cc")
+
+    // so, currently, the node last run date is set to something
+    counter.get("cc").runInfo.lastRunDateTime must beSome(beEqualTo(expiration))
+
+    // so we have the "compute compliance one", and it becomes missing
+    // We MUST NOT update anything, especially not the last run info saved
+    val x       = expected("cc", None)
+    val missing = nsr("cc", NoReportInInterval(x, expiration)).modify(_.runInfo.kind).setTo(RunAnalysisKind.KeepLastCompliance)
+
+    repo.saveNodeStatusReports((missing :: Nil).map(x => (x.nodeId, x))).runNow
+
+    // we have one modification because we changed kind from pending to "keep"
+    counter.getCount("cc") === 1
+    // but we kept the existing report with some report (vs missing which has no rule status reports)
+    counter.get("cc").reports must equalTo(okReport.reports)
+
+    // and we kept the run compliance - that part was in error because of #27180
+    counter.get("cc").runInfo.lastRunDateTime must beSome(beEqualTo(expiration))
+
+    // moreover, on next missing report, we don't change anything in backend
+    repo.saveNodeStatusReports((missing :: Nil).map(x => (x.nodeId, x))).runNow
+    counter.getCount("cc") === 1
+
+    // and getting a good report stop the keepLastCompliance
+    repo.saveNodeStatusReports((okReport :: Nil).map(x => (x.nodeId, x))).runNow
+    counter.getCount("cc") === 2
+    counter.get("cc") == okReport
+  }
+
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/27180