### PR TITLE
Fixes #27213: Allow to distribute Linux policies in tar.gz

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/resources/hooks.d/policy-generation-node-finished/91-compress-linux-policies
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/hooks.d/policy-generation-node-finished/91-compress-linux-policies
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Hooks parameter are passed by environment variable:
+#
+# - RUDDER_GENERATION_DATETIME: generation datetime: ISO-8601 YYYY-MM-ddTHH:mm:ss.sssZ date/time that identify that policy generation start
+# - RUDDER_NODEID             : the nodeId
+# - RUDDER_POLICIES_DIRECTORY : policies directory (for ex for nodes under root: /var/rudder/share/$RUDDER_NODEID/rules/$AGENT_NAME)
+# - RUDDER_AGENT_TYPE         : agent type ("cfengine-nova" or "cfengine-community")
+
+ARCHIVE_NAME=rudder.tar.bz2
+# archive is directly under "rules" directory
+ARCHIVE_PATH="${RUDDER_POLICIES_DIRECTORY}/.."
+
+if [ -z "${RUDDER_POLICIES_DIRECTORY}" ]; then
+  #bad rules.new directory
+  echo "The directory for node ${RUDDER_NODEID} new policies is empty"
+  exit 1;
+else
+  case "${RUDDER_AGENT_TYPE}" in
+    "cfengine-community")
+      # Go to the folder to prevent storing the full path
+      cd  ${ARCHIVE_PATH}
+
+      # Create the archive first in a part file, then move it to avoid partial archives to be downloaded.
+      # The archive is created in /var/rudder/${RUDDER_NODEID}/rules/${ARCHIVE_NAME} directly. It must
+      # be in `/rules/`, because it's what ensure Rudder that the archive content is synchronized with the files under
+      # `../rules/cfengine-community/`
+      /usr/bin/tar -cjf ${ARCHIVE_PATH}/${ARCHIVE_NAME}.part --transform "s|^cfengine-community|policies_next|" cfengine-community
+      mv ${ARCHIVE_PATH}/${ARCHIVE_NAME}.part ${ARCHIVE_PATH}/${ARCHIVE_NAME}
+
+      # enforce permissions
+      chown root:rudder-policy-reader ${ARCHIVE_PATH}/${ARCHIVE_NAME} || true
+      ;;
+
+    *)
+      #do nothing for other agent type
+      exit 0
+    ;;
+  esac
+fi


### PR DESCRIPTION
https://issues.rudder.io/issues/27213

So, the idea is to have a PoC with a `policy-generation-node-finished` hook that will do the archive/compression. 

The script: 
- create an archive in `/var/rudder/shate/${nodeid}/rules/policies.tar.bz2`
- the archive is the content of `/var/rudder/shate/${nodeid}/rules/cfengine-community` with the base directory renamed to `policies_next` 
-  `/var/rudder/shate/${nodeid}/rules/cfengine-community/` is not deleted (so that old nodes can still use that)

The benefits are : 

- it's extermelly quick to reach an E2E working solution and not block the whole feature any longer. 
- it's will become symetric to what is done for Windows agent, so can go forward on the next steps (performance, node generation rework) for both at the same time
- it's easier to tweak for non scala developers for the PoC duration (even for 9.0)

The cons are: 

- well, performance wise, it's Not Good : we can't implement an all-in-memory solution to policy generation with that
- it adds a dependency to `bzip2` (or other compression algorithm). 
- it's harder to precisely define what nodes get the new scheme. Here, it's all-or-none solution. We can disable it globally by making the hook non executable, but we can't defined by-group, or (not easily) by-node preferences. 

![image](https://github.com/user-attachments/assets/532bca81-9816-47bd-babd-8917a11c94f3)
