### PR TITLE
Fixes #27234: Upmerge of user API definition breaks with Scala 3

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/policies/RuleTargetTest.scala
@@ -16,8 +16,6 @@ import com.normation.rudder.reports.ReportingConfiguration
 import com.normation.rudder.repository.FullNodeGroupCategory
 import java.time.Instant
 import net.liftweb.common.*
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
 import org.junit.runner.RunWith
 import org.specs2.mutable.*
 import org.specs2.runner.*

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestNodeFactSerialisation.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/facts/nodes/TestNodeFactSerialisation.scala
@@ -22,7 +22,6 @@ import com.normation.rudder.domain.nodes.NodeKind
 import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.reports.ReportingConfiguration
 import com.normation.utils.DateFormaterService
-import org.joda.time.DateTime
 import org.junit.runner.RunWith
 import org.specs2.matcher.Matcher
 import org.specs2.mutable.Specification

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LDAPEntityMapperTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/repository/ldap/LDAPEntityMapperTest.scala
@@ -44,7 +44,6 @@ import com.normation.rudder.facts.nodes.MockLdapFactStorage
 import com.normation.rudder.reports.AgentRunInterval
 import com.normation.rudder.reports.HeartbeatConfiguration
 import com.normation.utils.DateFormaterService
-import java.time.Instant
 import org.joda.time.DateTime
 import org.junit.runner.*
 import org.specs2.mutable.*

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/UserManagementApi.scala
@@ -740,7 +740,7 @@ sealed trait UserManagementInternalApi extends EnumEntry with EndpointSchema wit
 
 object UserManagementInternalApi extends Enum[UserManagementInternalApi] with ApiModuleProvider[UserManagementInternalApi] {
 
-  final case object SafeHashes extends UserManagementInternalApi with ZeroParam with StartsAtVersion20 {
+  case object SafeHashes extends UserManagementInternalApi with ZeroParam with StartsAtVersion20 {
     val z              = implicitly[Line].value
     val description    = "Get the status of password encoder being used"
     val (action, path) = GET / "usermanagementinternal" / "safeHashes"


### PR DESCRIPTION
https://issues.rudder.io/issues/27234

This is true :
```scala
[ERROR] 743 |  final case object SafeHashes extends UserManagementInternalApi with ZeroParam with StartsAtVersion20 {
[ERROR]     |  ^^^^^
[INFO]     |  Modifier final is redundant for this definition
```