### PR TITLE
Fixes #27245: Inventory user sees technical logs table

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/server/server_details.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/server/server_details.html
@@ -119,9 +119,13 @@
         <li class="nav-item">
           <button class="nav-link" data-bs-toggle="tab" data-bs-target="#system_status" type="button" role="tab" aria-controls="system_status" aria-selected="false">System status</button>
         </li>
-        <li class="nav-item">
-          <button class="nav-link" data-bs-toggle="tab" data-bs-target="#node_logs" type="button" role="tab" aria-controls="node_logs" aria-selected="false">Technical logs</button>
-        </li>
+        <lift:authz role="node_read">
+          <lift:authz role="compliance_read">
+            <li class="nav-item">
+              <button class="nav-link" data-bs-toggle="tab" data-bs-target="#node_logs" type="button" role="tab" aria-controls="node_logs" aria-selected="false">Technical logs</button>
+            </li>
+          </lift:authz>
+        </lift:authz>
         <li class="nav-item">
           <button class="nav-link" data-bs-toggle="tab" data-bs-target="#node_parameters" type="button" role="tab" aria-controls="node_parameters" aria-selected="false">Settings</button>
         </li>
@@ -150,9 +154,13 @@
                 <div id="reportsDetails"></div>
               </div>
 
-              <div id="node_logs" class="tab-pane">
-                <div id="logsDetails"></div>
-              </div>
+              <lift:authz role="node_read">
+                <lift:authz role="compliance_read">
+                  <div id="node_logs" class="tab-pane">
+                    <div id="logsDetails"></div>
+                  </div>
+                </lift:authz>
+              </lift:authz>
 
               <div id="node_properties" class="tab-pane">
                 <div id="nodeProperties"></div>


### PR DESCRIPTION
https://issues.rudder.io/issues/27245

Completely hide the tab when it's not relevant. From the data that the table contains, it requires `node_read` and `compliance_read` permissions (so it's the same as in https://github.com/Normation/rudder/pull/6432)