### PR TITLE
Fixes #26767: 

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/Authorizations.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/Authorizations.scala
@@ -312,6 +312,10 @@ object Rights {
 
   val AnyRights: Rights = Rights.forAuthzs(AuthorizationType.AnyRights)
 
+  def apply(authorizationTypes: AuthorizationType*): Rights = {
+    apply(authorizationTypes)
+  }
+
   def apply(authorizationTypes: Iterable[AuthorizationType]): Rights = {
     if (authorizationTypes.isEmpty) {
       NoRights
@@ -322,7 +326,7 @@ object Rights {
 
   def forAuthzs(authorizationTypes: AuthorizationType*): Rights = apply(authorizationTypes.toSeq)
 
-  def combineAll(rights: Iterable[Rights]): Rights = Rights(rights.map(_.authorizationTypes).toList.combineAll)
+  def combineAll(rights: Iterable[Rights]): Rights = apply(rights.map(_.authorizationTypes).toList.combineAll)
 }
 
 /*

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala
@@ -50,7 +50,6 @@ import com.normation.rudder.domain.logger.ApiLogger
 import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.users.AuthenticatedUser
 import com.normation.rudder.users.CurrentUser
-import com.normation.rudder.users.RudderAccount
 import com.normation.rudder.users.UserService
 import net.liftweb.common.*
 import net.liftweb.http.LiftResponse
@@ -135,7 +134,7 @@ class AclApiAuthorization(logger: Log, userService: UserService, aclEnabled: () 
                * - an user API account is disabled.
                */
                 // without plugin, api account linked to user are disabled
-                case (false, _, RudderAccount.Api(ApiAccount(_, ApiAccountKind.User, _, _, _, _, _, _, _))) =>
+                case (false, _, Some(ApiAccount(_, ApiAccountKind.User, _, _, _, _, _, _, _))) =>
                   logger.warn(
                     s"API account linked to a user account '${user.actor.name}' is disabled because the API Authorization plugin is disabled."
                   )
@@ -146,7 +145,7 @@ class AclApiAuthorization(logger: Log, userService: UserService, aclEnabled: () 
                 case (
                       false,
                       ApiAuthz.ACL(acl),
-                      RudderAccount.Api(ApiAccount(_, _: ApiAccountKind.PublicApi, _, _, _, _, _, _, _))
+                      Some(ApiAccount(_, _: ApiAccountKind.PublicApi, _, _, _, _, _, _, _))
                     ) =>
                   logger.info(
                     s"API account '${user.actor.name}' has ACL authorization but no plugin allows to interpret them. Removing all rights for that token."
@@ -154,7 +153,7 @@ class AclApiAuthorization(logger: Log, userService: UserService, aclEnabled: () 
                   None
 
                 // in other cases, we interpret rights are they are reported (system user has ACL or RW independently of plugin status)
-                case (_, ApiAuthz.None, _)                                                                  =>
+                case (_, ApiAuthz.None, _)                                                     =>
                   logger.debug(s"Account '${user.actor.name}' does not have any authorizations.")
                   None
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/RudderUserDetailsFile.scala
@@ -126,23 +126,6 @@ object RudderPasswordEncoder {
 
   private val secureRandom = new SecureRandom()
 
-  // see https://stackoverflow.com/a/44227131
-  // produce a random hexa string of 32 chars
-  def randomHexa32: String = {
-    // here, we can be unlucky with the chosen token which convert to an int starting with one or more 0.
-    // In that case, just complete the string
-    def randInternal: String = {
-      val token = new Array[Byte](16)
-      secureRandom.nextBytes(token)
-      new java.math.BigInteger(1, token).toString(16)
-    }
-    var s = randInternal
-    while (s.size < 32) { // we can be very unlucky and keep drawing 000s
-      s = s + randInternal.substring(0, 32 - s.size)
-    }
-    s
-  }
-
   // Proper password hash functions
   class bcryptEncoder(cost: Int)                          extends PasswordEncoder {
     override def encode(rawPassword: CharSequence):                           String  = {
@@ -454,7 +437,12 @@ object UserFileProcessing {
 
   // utility classes for a parsed custom role/user/everything before sanity check is done on them
   final case class ParsedRole(name: String, permissions: List[String])
-  final case class ParsedUser(name: String, password: String, permissions: List[String], tenants: Option[List[String]])
+  final case class ParsedUser(
+      name:        String,
+      password:    UserPassword,
+      permissions: List[String],
+      tenants:     Option[List[String]]
+  )
   final case class ParsedUserFile(
       encoder:         PasswordEncoderType,
       isCaseSensitive: Boolean,
@@ -637,14 +625,9 @@ object UserFileProcessing {
             getCommaSeparatedList("tenants", node)
           ) match {
             case (Some(name :: Nil), pwd, permissions, tenants) if (name.size > 0) =>
-              // password can be optional when an other authentication backend is used.
-              // When the tag is omitted, we generate a 32 bytes random value in place of the pass internally
-              // to avoid any cases where the empty string will be used if all other backend are in failure.
-              // Also forbid empty or all blank passwords.
-              // If the attribute is defined several times, use the first occurrence.
               val p = pwd match {
-                case Some(p :: _) if (p.strip().size > 0) => p
-                case _                                    => RudderPasswordEncoder.randomHexa32
+                case Some(UserPassword.checkHashedPassword(p) :: _) => p
+                case _                                              => UserPassword.randomHexa32
               }
               Some(ParsedUser(name, p, permissions, tenants)).succeed
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -244,7 +244,8 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
   implicit val userService: TestUserService = new TestUserService
   class TestUserService extends UserService {
     val user:           AuthenticatedUser = new AuthenticatedUser {
-      val account: RudderAccount = RudderAccount.User("test-user", "pass")
+      val user:    Option[RudderAccount.User] = Some(RudderAccount.User("test-user", UserPassword.unsafeHashed("pass")))
+      val account: Option[ApiAccount]         = None
       def checkRights(auth: AuthorizationType) = true
       def getApiAuthz: ApiAuthz            = ApiAuthz.allAuthz
       def nodePerms:   NodeSecurityContext = NodeSecurityContext.All

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/TraitTestApiFromYamlFiles.scala
@@ -41,6 +41,7 @@ import better.files.*
 import com.normation.box.IOManaged
 import com.normation.errors.*
 import com.normation.rudder.AuthorizationType
+import com.normation.rudder.api.ApiAccount
 import com.normation.rudder.api.ApiAuthorization
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.domain.logger.ApplicationLogger
@@ -107,7 +108,8 @@ object TraitTestApiFromYamlFiles {
       case None    =>
         new UserService {
           val user = new AuthenticatedUser {
-            val account: RudderAccount = RudderAccount.User("test-user", "pass")
+            val user:    Option[RudderAccount.User] = Some(RudderAccount.User("test-user", UserPassword.unsafeHashed("pass")))
+            val account: Option[ApiAccount]         = None
             def checkRights(auth: AuthorizationType) = true
             def getApiAuthz: ApiAuthorization    = ApiAuthorization.allAuthz
             def nodePerms:   NodeSecurityContext = NodeSecurityContext.All

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -369,7 +369,7 @@ class AppConfigAuth extends ApplicationContextAware {
           login -> RudderUserDetail(
             RudderAccount.User(
               login,
-              password
+              UserPassword.unsafeHashed(password)
             ),
             UserStatus.Active,
             Set(Role.Administrator),
@@ -532,7 +532,7 @@ class RudderInMemoryUserDetailsService(val authConfigProvider: UserDetailListPro
               // when the user is not found, we return a default "no roles" user.
               // It will be the responsibility of other backend to provided the correct set of rights.
               RudderUserDetail(
-                RudderAccount.User(user.id, ""),
+                RudderAccount.User(user.id, UserPassword.unknown),
                 user.status,
                 Set(),
                 ApiAuthorization.None,


### PR DESCRIPTION
https://issues.rudder.io/issues/26767

For the Api account, the token is already redacted, we need the same for the user password : add a dedicated structure.

There are some sub-types, and we can avoid invalid representations (empty password, and secret unhashed password was used in the same `String` field)