### PR TITLE
Fixes #27281: Fix compilation with doobie import in 26900

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/ScoreRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/score/ScoreRepository.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.score
 import com.normation.errors.*
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.db.Doobie
+import com.normation.rudder.db.Doobie.*
 import com.normation.zio.*
 import doobie.Fragments
 import doobie.Meta


### PR DESCRIPTION
https://issues.rudder.io/issues/27281

Since https://github.com/typelevel/doobie/releases/tag/v1.0.0-RC7, derivation of doobie typeclass is not derived automatically, here we can just import our existing instance of `Put[NodeId]`