### PR TITLE
Fixes #27273: Export in CSV concatenate IPs without spaces or delimiters

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -69,6 +69,7 @@ const csvButtonConfig = (filename, additionalCls) => ({
   filename: 'rudder_' + csvRenameFilename(filename) + '_' + getDateString(),
   text: 'Export',
   exportOptions: {
+    orthogonal: 'exportCsv',
     customizeData: function (data) {
       // export compliance percent
       const complianceColumnIdx = data.header.findIndex(s => s.toLowerCase() === "compliance")

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/NodeGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/NodeGrid.scala
@@ -149,7 +149,7 @@ final class NodeGrid(
             "aoColumns": [
               { "sWidth": "30%" },
               { "sWidth": "27%" },
-              { "sWidth": "20%" } ${aoColumns}
+              { "sWidth": "20%", "render": (data, type) => ( type !== "exportCsv" ? data : $$(data).find(".ip").map(function() {return this.innerHTML;}).get().join() )  } ${aoColumns}
             ],
             "lengthMenu": [ [10, 25, 50, 100, 500, 1000, -1], [10, 25, 50, 100, 500, 1000, "All"] ],
             "pageLength": 25 ,
@@ -223,7 +223,7 @@ final class NodeGrid(
         (if (isEmpty(server.hostname)) "(Missing host name) " + server.id.value else escapeHTML(server.hostname))
       } &
       ".fullos *" #> escapeHTML(server.osFullName) &
-      ".ips *" #> ((server.ips.flatMap(ip => <div class="ip">{escapeHTML(ip)}</div>)):         NodeSeq) & // TODO : enhance this
+      ".ips *" #> ((server.ips.flatMap(ip => <li class="ip">{escapeHTML(ip)}</li>)):           NodeSeq) &
       ".other" #> ((columns flatMap { c => <td style="overflow:hidden">{c._2(server)}</td> }): NodeSeq) &
       ".nodetr [jsuuid]" #> { server.id.value.replaceAll("-", "") } &
       ".nodetr [nodeid]" #> { server.id.value } &
@@ -240,7 +240,7 @@ final class NodeGrid(
     <tr class="nodetr curspoint" jsuuid="id" nodeid="nodeid" nodestatus="status">
       <td class="curspoint"><span class="hostname listopen"></span></td>
       <td class="fullos curspoint"></td>
-      <td class="ips curspoint"></td>
+      <td class="curspoint"><ul class="ips"></ul></td>
       <td class="other"></td>
     </tr>
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/27273

Very tricky solution to find in DataTable documentation, because the datatable for pending nodes is not a "regular" datatable, its data is populated from scala XML (directly as HTML), and the rendering even for CSV export is the "HTML as seen" i.e. the text, without spaces.

* **Problem :** the [CSV export](https://datatables.net/reference/button/csv#exportOptions) relies on the [orthogonal](https://datatables.net/reference/api/buttons.exportData()#buttons.exportData(-[-options-]-)) which relies on the [render](https://datatables.net/reference/option/columns.render#render(-data,-type,-row,-meta-)) function which is called when exporting CSV data function (by default renders the "HTML as seen" too)
* **Solution :** set the `orthogonal` option when exporting CSV to a custom one and customize the rendering in that case for the specific columns which need special CSV rendering. Here, for IP addresses, we can use list items for display and use the structure to export them as a comma-separated list (just as for IP addresses in the export of nodes list) 