### PR TITLE
Fixes #25584: the hover on compliance shows HTML

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Directivecompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Directivecompliance.elm
@@ -89,7 +89,7 @@ update msg model =
           NodesView -> { ui | nodeFilters = newFilters}
         newModel = { model | ui = newUi }
       in
-        (newModel, Cmd.none)
+        (newModel, initTooltips "")
 
     ToggleRowSort rowId sortId order ->
       let
@@ -103,13 +103,13 @@ update msg model =
           NodesView -> { ui | nodeFilters = newFilters}
         newModel = { model | ui = newUi }
       in
-        (newModel, Cmd.none)
+        (newModel, initTooltips "")
 
     GetPolicyModeResult res ->
       case res of
         Ok p ->
             ( { model | policyMode = p }
-              , Cmd.none
+              , initTooltips ""
             )
         Err err ->
           processApiError "Getting Policy Mode" err model
@@ -122,7 +122,7 @@ update msg model =
         case res of
           Ok compliance ->
             ( { newModel | directiveCompliance = Just compliance }
-              , Cmd.none
+              , initTooltips ""
             )
           Err err ->
             processApiError "Getting directive compliance" err newModel

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Nodecompliance.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Nodecompliance.elm
@@ -81,7 +81,7 @@ update msg model =
         newUi = { ui | tableFilters = newFilters}
         newModel = { model | ui = newUi }
       in
-        (newModel, Cmd.none)
+        (newModel, initTooltips "")
 
     ToggleRowSort rowId sortId order ->
       let
@@ -91,7 +91,7 @@ update msg model =
         newUi = { ui | tableFilters = newFilters}
         newModel = { model | ui = newUi }
       in
-        (newModel, Cmd.none)
+        (newModel, initTooltips "")
 
     GetPolicyModeResult res ->
       case res of

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
@@ -619,9 +619,9 @@ update msg model =
             newMode = RuleForm {r | ui = newDetails }
             newModel = { model | mode = newMode }
           in
-            (newModel, Cmd.none)
+            (newModel, initTooltips "")
         _ ->
-            (model, Cmd.none)
+            (model, initTooltips "")
     GetRepairedReport ruleId idChange ->
       case Dict.get ruleId.value model.changes of
         Nothing -> (model, Cmd.none)
@@ -638,9 +638,9 @@ update msg model =
             newMode = RuleForm {r | ui = newDetails }
             newModel = { model | mode = newMode }
           in
-            (newModel, Cmd.none)
+            (newModel, initTooltips "")
         _ ->
-            (model, Cmd.none)
+            (model, initTooltips "")
 
     GoTo link -> (model, Nav.load link)
 


### PR DESCRIPTION
https://issues.rudder.io/issues/25584

When toggling compliance rows, the compliance bars HTML is rendered but some JS tooltip initialization is needed in all compliances : node, rules and directive compliance (which also needs an initialization in the Elm _init_)   