### PR TITLE
Fixes #27308: The Rudderc static binary still includes the outdated ncf library rather than the 8.3+ one

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -388,8 +388,8 @@ pipeline {
                         catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                             dir('policies/rudderc') {
                                 dir('target/repos') {
-                                    dir('ncf') {
-                                        git url: 'https://github.com/normation/ncf.git'
+                                    dir('rudder') {
+                                        git url: 'https://github.com/normation/rudder.git'
                                     }
                                     dir('dsc') {
                                         git url: 'https://github.com/normation/rudder-agent-windows.git',

--- a/policies/rudderc/Makefile
+++ b/policies/rudderc/Makefile
@@ -16,7 +16,7 @@ test-docs: $(DOC_EXAMPLES_CF)
 test: libs
 	cargo test --locked --package rudderc
 	# Parse lib
-	cargo run --quiet --bin rudderc -- --quiet lib -f json --stdout -l target/repos/ncf/tree/30_generic_methods/ -l target/repos/dsc/plugin/src/ncf/30_generic_methods/ >/dev/null
+	cargo run --quiet --bin rudderc -- --quiet lib -f json --stdout -l target/repos/rudder/policies/lib/tree/30_generic_methods -l target/repos/dsc/plugin/src/ncf/30_generic_methods/ >/dev/null
 
 test-powershell:
 	pwsh -command 'Get-ChildItem -Recurse -Path tests/cases/general -Include "*.ps1" | ? { $$_.FullName -inotmatch "target" } | %{ echo $$_.Directory.FullName; Invoke-ScriptAnalyzer -Settings ./PSScriptAnalyzerSettings.psd1 -Path $$_.Directory.FullName -EnableExit -ReportSummary }'
@@ -25,24 +25,22 @@ static: libs version
 	cargo auditable build --release --locked --features embedded-lib
 
 %.cf: %.yml libs
-	cd $(shell dirname $@) && cargo run --quiet --bin rudderc -- --quiet build -l ../../../../target/repos/ncf/tree/30_generic_methods/
+	cd $(shell dirname $@) && cargo run --quiet --bin rudderc -- --quiet build -l ../../../../target/repos/rudder/policies/lib/tree/30_generic_methods/
 
 docs: libs
-	cargo run --quiet --bin rudderc -- lib -l target/repos/ncf/tree/30_generic_methods/ -l target/repos/dsc/plugin/src/ncf/30_generic_methods/
+	cargo run --quiet --bin rudderc -- lib -l target/repos/rudder/policies/lib/tree/30_generic_methods/ -l target/repos/dsc/plugin/src/ncf/30_generic_methods/
 
 libs:
 	mkdir -p target/repos
-	[ -d target/repos/ncf ] || git clone git@github.com:Normation/ncf.git target/repos/ncf
-	cd target/repos/ncf && git checkout master && git pull origin master
-	[ -d target/repos/dsc ] || git clone git@github.com:Normation/rudder-agent-windows.git target/repos/dsc || mkdir -p target/repos/dsc/plugin/ncf/30_generic_methods/
-	cd target/repos/dsc && git checkout master && git pull origin master || true
+	[ -d target/repos/rudder ] || git clone --branch master --single-branch --depth 1 git@github.com:Normation/rudder.git target/repos/rudder
+	[ -d target/repos/dsc ] || git clone --branch master --single-branch --depth 1 git@github.com:Normation/rudder-agent-windows.git target/repos/dsc || mkdir -p target/repos/dsc/plugin/ncf/30_generic_methods/
 
 agent-windows: libs
 	curl -sS --output target/rudder-agent.msi https://publisher.normation.com/misc/windows/8.1/latest
 	msiextract target/rudder-agent.msi -C target/agent-windows/
 	# Sadly, we need to add .cf files to the agent to have everything in one place for now
 	mkdir -p target/agent-windows/Rudder/share/initial-policy/ncf/cf/
-	cp target/repos/ncf/tree/30_generic_methods/*.cf target/agent-windows/Rudder/share/initial-policy/ncf/cf/
+	cp target/repos/rudder/policies/lib/tree/30_generic_methods/*.cf target/agent-windows/Rudder/share/initial-policy/ncf/cf/
 	cp target/repos/dsc/plugin/src/ncf/30_generic_methods/*.cf target/agent-windows/Rudder/share/initial-policy/ncf/cf/
 	# Simulate a real agent to get correct reporting
 	echo "1d58a791-7278-4a2c-a10d-048c7b4be2a6" > target/agent-windows/Rudder/etc/uuid.hive

--- a/policies/rudderc/build.rs
+++ b/policies/rudderc/build.rs
@@ -14,7 +14,7 @@ fn main() {
         // Done in `Jenkinsfile`
         let libs = [
             // Unix
-            PathBuf::from("target/repos/ncf/tree"),
+            PathBuf::from("target/repos/rudder/policies/lib/tree"),
             // Windows
             PathBuf::from("target/repos/dsc/plugin/src/ncf"),
         ];


### PR DESCRIPTION
https://issues.rudder.io/issues/27308