### PR TITLE
Fixes #27119: CSP headers for pages without scripts are always set with static nonce

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/snippet/WithNonce.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/snippet/WithNonce.scala
@@ -27,8 +27,8 @@ object WithNonce extends StatefulSnippet {
   }
 
   def scriptWithNonce(base: Node): Node = {
-    nonce.setIfUnset(generateNonce)
-    val attributes = MetaData.update(base.attributes, base.scope, new UnprefixedAttribute("nonce", getCurrentNonce, Null))
+    val currentNonce = nonce.setIfUnset(generateNonce)
+    val attributes   = MetaData.update(base.attributes, base.scope, new UnprefixedAttribute("nonce", currentNonce, Null))
 
     base match {
       case e: Elem => e.copy(attributes = attributes)
@@ -44,11 +44,13 @@ object WithNonce extends StatefulSnippet {
 
   /**
     * Get the nonce value defined within the lifetime of the current request, and used in all html tags.
-    *
-    * @return
+    * @return None if the nonce has not been generated in the current request (it means that no script has been set with a nonce in the page)
     */
-  def getCurrentNonce: String = {
-    nonce.get
+  def getRequestNonce: Option[String] = {
+    nonce.get match {
+      case `defaultValue` => None
+      case value          => Some(value)
+    }
   }
 
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -133,15 +133,17 @@ object Boot {
       * Returns default headers with all other initial CSP directive, using current request nonce unless CSP are disabled
       */
     private def addCspHeaders(allHeaders: List[(String, String)]): List[(String, String)] = {
-      if (WithDisabledCSP.isDisabled) {
-        allHeaders // no headers to override
+      if (WithDisabledCSP.isDisabled) { // no headers to override
+        allHeaders
       } else {
-        val nonce = WithNonce.getCurrentNonce
+        val nonce = WithNonce.getRequestNonce
 
         val cspHeader     = compileCSPHeader(
           cspDirectives
             .pipe(
-              replaceCSPRestrictionDirectives("script-src", s"'nonce-${nonce}' 'strict-dynamic'")(_)
+              replaceCSPRestrictionDirectives("script-src", nonce.map(n => s"'nonce-${n}' 'strict-dynamic'").getOrElse("'none'"))(
+                _
+              )
             )
             .pipe(
               replaceCSPRestrictionDirectives("object-src", "'none'")(_)


### PR DESCRIPTION
https://issues.rudder.io/issues/27119

Keep the `script-src: 'nonce-<randomnonce>' 'script-dynamic'` in pages where the nonce has been generated to be put in script tags (`<script nonce="<therandomnonce>/>`),

But in other pages (e.g. served files, like `css`, `svg`, ...) we don't have script tags and the nonce has not been generated so we need `script-src: 'none'` (it's [the safest policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src#none))