### PR TITLE
Fixes #27315: Upmerge of API tests on user permissions in 9.0

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_usermanagement.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_usermanagement.yml
@@ -613,7 +613,7 @@ response:
           }
         ],
         "tenantsEnabled" : false,
-        "digest" : "BCRYPT"
+        "digest" : "ARGON2ID"
         }
       }
     }
@@ -778,7 +778,7 @@ response:
           }
         ],
         "tenantsEnabled" : false,
-        "digest" : "BCRYPT"
+        "digest" : "ARGON2ID"
         }
       }
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/27315

In 9.0 the default digest is now ARGON2ID