### PR TITLE
Fixes #27319: NodeInfo instead of CoreNodeFact causing compilation error

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/NodeGroupForm.scala
@@ -828,7 +828,7 @@ class NodeGroupForm(
             case DGModAction.Disable if !savedGroup.isSystem => false
             case _                                           => savedGroup._isEnabled
           },
-          serverList = srvList.getOrElse(Set.empty[NodeInfo]).map(_.id).toSet
+          serverList = srvList.getOrElse(Set.empty[CoreNodeFact]).map(_.id).toSet
         )
 
         displayConfirmationPopup(action, newGroup, optContainer, None)


### PR DESCRIPTION
https://issues.rudder.io/issues/27319
Probably a small mistake during an upmerge from 8.2 introduce by https://github.com/Normation/rudder/pull/6479