### PR TITLE
Fixes #27239: When a technique is enabled, the directive page button to disabled it is way too exposed

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/View.elm
@@ -196,7 +196,7 @@ view model =
           ]
       DeactivationValidation rule crSettings ->
         let
-          txtDisable = if rule.enabled then "Disable" else "Enable"
+          (txtDisabled, iconDisabled) = if rule.enabled then ("Disable", "fa fa-ban") else ("Enable", "fa fa-check-circle")
           (auditForm, btnDisabled) = case crSettings of
             Just s  ->
               ( changeAuditForm s
@@ -213,11 +213,11 @@ view model =
           , div [ class "modal-dialog" ] [
               div [ class "modal-content" ]  [
                 div [ class "modal-header" ] [
-                  h5[ class "modal-title" ] [ text (txtDisable ++" Rule")]
+                  h5[ class "modal-title" ] [ text (txtDisabled ++" Rule")]
                 , button [type_ "button", class "btn-close", onClick (ClosePopup Ignore), attribute "aria-label" "Close"][]
                 ]
               , div [ class "modal-body" ]
-                [ h4 [class "text-center"][text ("Are you sure you want to "++ String.toLower txtDisable ++" rule '"++ rule.name ++"'?")]
+                [ h4 [class "text-center"][text ("Are you sure you want to "++ String.toLower txtDisabled ++" rule '"++ rule.name ++"'?")]
                 , auditForm
                 ]
               , div [ class "modal-footer" ] [
@@ -225,8 +225,8 @@ view model =
                   [ text "Cancel "
                   ]
                 , button [ class "btn btn-primary", onClick (ClosePopup DisableRule), disabled btnDisabled ]
-                  [ text (txtDisable ++ " ")
-                  , i [ class "fa fa-ban" ] []
+                  [ text (txtDisabled ++ " ")
+                  , i [ class iconDisabled ] []
                   ]
                 ]
               ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRuleDetails.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRuleDetails.elm
@@ -42,7 +42,7 @@ editionTemplate model details =
       case originRule of
         Just or ->
           let
-            txtDisabled = if rule.enabled then "Disable" else "Enable"
+            (txtDisabled, iconDisabled) = if rule.enabled then ("Disable", "fa fa-ban") else ("Enable", "fa fa-check-circle")
           in
             (
             [ button [ class "btn btn-default dropdown-toggle" , attribute "data-bs-toggle" "dropdown" ]
@@ -58,7 +58,7 @@ editionTemplate model details =
                 ]
               , li []
                 [ a [ class "dropdown-item", onClick (OpenDeactivationPopup rule)]
-                  [ i [ class "fa fa-ban"] []
+                  [ i [ class iconDisabled] []
                   , text txtDisabled
                   ]
                 ]

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/configuration/DirectiveManagement.scala
@@ -336,6 +336,12 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
                  * with registered acceptation date time.
                  * Also sort by version, reverse
                  */
+                def showPopup(nextStatus: NextStatus)(implicit qc: QueryContext): JsCmd = {
+                  SetHtml(
+                    "showTechniqueValidationPopup",
+                    showTechniquePopup("showTechniqueValidationPopup", fullActiveTechnique, nextStatus)
+                  )
+                }
 
                 val validTechniqueVersions = fullActiveTechnique.techniques.map {
                   case (v, t) =>
@@ -364,11 +370,29 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
                   currentDirectiveSettingForm.get.map(piForm => (".directive *" #> piForm.directive.name))
                 } &
                 "#techniqueName" #> <span>
-                    {technique.name}{
-                  if (fullActiveTechnique.isEnabled) NodeSeq.Empty
-                  else <span class="badge-disabled"></span>
-                }
+                    {technique.name}
                   </span> &
+                ".header-buttons *" #> {
+                  if (!fullActiveTechnique.isEnabled) {
+                    SHtml.ajaxButton(
+                      <span>
+                      Enable
+                      <i class="fa fa-check-circle"></i>
+                    </span>,
+                      () => showPopup(NextStatus.Enabled),
+                      ("class", "btn btn-default")
+                    )
+                  } else {
+                    SHtml.ajaxButton(
+                      <span>
+                      Disable
+                      <i class="fa fa-ban"></i>
+                    </span>,
+                      () => showPopup(NextStatus.Disabled),
+                      ("class", "btn btn-default")
+                    )
+                  }
+                } &
                 "#techniqueID *" #> technique.id.name.value &
                 "#techniqueDocumentation [class]" #> (if (technique.longDescription.isEmpty) "d-none" else "") &
                 "#techniqueLongDescription *" #> Script(
@@ -379,29 +403,23 @@ class DirectiveManagement extends DispatchSnippet with Loggable {
                 "#techniqueDescription" #> technique.description &
                 "#isSingle *" #> showIsSingle(technique) &
                 "#isDisabled" #> {
-                  def showPopup(nextStatus: NextStatus)(implicit qc: QueryContext): JsCmd = {
-                    SetHtml(
-                      "showTechniqueValidationPopup",
-                      showTechniquePopup("showTechniqueValidationPopup", fullActiveTechnique, nextStatus)
-                    )
-                  }
-
                   if (!fullActiveTechnique.isEnabled) {
                     <div class="main-alert alert alert-warning">
                         <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                         This Technique is disabled.
                         {
-                      SHtml.ajaxButton("Enable", () => showPopup(NextStatus.Enabled), ("class", "btn btn-sm btn-default mx-2"))
+                      SHtml.ajaxButton(
+                        <span>
+                        Enable
+                        <i class="fa fa-check-circle ms-2"></i>
+                      </span>,
+                        () => showPopup(NextStatus.Enabled),
+                        ("class", "btn btn-sm btn-default ms-2")
+                      )
                     }
                     </div>
                   } else {
-                    <div class="main-alert alert alert-success">
-                        <i class="fa fa-check" aria-hidden="true"></i>
-                        This Technique is enabled.
-                        {
-                      SHtml.ajaxButton("Disable", () => showPopup(NextStatus.Disabled), ("class", "btn btn-sm btn-default mx-2"))
-                    }
-                    </div>
+                    NodeSeq.Empty
                   }
                 } &
                 "#techniqueversion-app *+" #> showVersions(fullActiveTechnique, validTechniqueVersions)

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-directives.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-directives.scss
@@ -59,6 +59,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  background-color: #fff;
 }
 #versionTable > thead > tr > th:last-child,
 #versionTable > tbody > tr > td:last-child{

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/directiveManagement.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/configurationManager/directiveManagement.html
@@ -48,16 +48,19 @@
                 <i class="title-icon fa fa-cog"></i>
                 <span id="info-title">Technique <b id="techniqueName"></b></span>
               </h1>
+              <div class="header-buttons">
+                <button id="disableAction"></button>
+              </div>
             </div>
           </div>
           <div class="main-navbar">
-            <ul class="ui-tabs-nav"></ul>
+            <ul class="nav nav-underline"></ul>
           </div>
+          <div id="isDisabled"></div>
           <div class="main-details" id="details">
             <div id="directiveIntro">
               The Directive <b class="directive">[Directive]</b> is based on following Technique:
             </div>
-            <div id="isDisabled">[Disabled Technique]</div>
             <div class="my-2">
               <h4>Description</h4>
                 <span id="techniqueDescription">[technique.description]</span>


### PR DESCRIPTION
https://issues.rudder.io/issues/27239

**Before:**
<img width="800" height="517" alt="technique-enabled-before" src="https://github.com/user-attachments/assets/af9e0ca3-620a-4a40-af73-b0514ae24e61" />

**After:**
(Enabled :arrow_down:)
<img width="1133" height="191" alt="technique-enabled" src="https://github.com/user-attachments/assets/fb6e809f-1505-421d-8650-1ef64129f548" />
(Disabled :arrow_down:)
<img width="1135" height="251" alt="technique-disable" src="https://github.com/user-attachments/assets/558e8af2-b355-4921-8eda-e8b975b304a4" />

There is no more message when a technique is enabled, and the disable/enable button has been moved to the header.

I also took the opportunity to fix the enabled/disabled icons in the Rules interface to remain consistent with that change.