### PR TITLE
Fixes #27364: Add a generic json codec for enumeratum

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/DataTypes.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/DataTypes.scala
@@ -47,6 +47,7 @@ import java.time.ZoneId
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import zio.json.*
+import zio.json.enumeratum.*
 
 case class CampaignParsingInfo(
     campaignType: CampaignType,
@@ -274,7 +275,7 @@ object CampaignEventId {
  */
 sealed abstract class CampaignEventStateType(override val entryName: String) extends EnumEntry
 
-object CampaignEventStateType extends Enum[CampaignEventStateType] {
+object CampaignEventStateType extends Enum[CampaignEventStateType] with EnumCodec[CampaignEventStateType] {
   case object Scheduled extends CampaignEventStateType("scheduled")
   case object Running   extends CampaignEventStateType("running")
   case object Finished  extends CampaignEventStateType("finished")
@@ -283,10 +284,6 @@ object CampaignEventStateType extends Enum[CampaignEventStateType] {
   case object Failure   extends CampaignEventStateType("failure")
 
   override def values: IndexedSeq[CampaignEventStateType] = findValues
-
-  implicit val encoder: JsonEncoder[CampaignEventStateType] = JsonEncoder[String].contramap(_.entryName)
-  implicit val decoder: JsonDecoder[CampaignEventStateType] =
-    JsonDecoder[String].mapOrFail(withNameInsensitiveEither(_).left.map(_.getMessage))
 }
 
 case class CampaignEvent(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/PropertyHierarchy.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/PropertyHierarchy.scala
@@ -14,20 +14,19 @@ import enumeratum.EnumEntry
 import org.apache.commons.text.StringEscapeUtils
 import zio.*
 import zio.json.*
+import zio.json.enumeratum.*
 
 /*
  * Kind of properties in the hierarchy
  */
 sealed trait ParentPropertyKind(override val entryName: String) extends EnumEntry
-object ParentPropertyKind                                       extends Enum[ParentPropertyKind] {
+
+object ParentPropertyKind extends Enum[ParentPropertyKind] with EnumCodec[ParentPropertyKind] {
   case object Node   extends ParentPropertyKind("node")
   case object Group  extends ParentPropertyKind("group")
   case object Global extends ParentPropertyKind("global")
 
   override def values: IndexedSeq[ParentPropertyKind] = findValues
-
-  implicit val codecParentPropertyKind: JsonCodec[ParentPropertyKind] =
-    JsonCodec.string.transformOrFail(ParentPropertyKind.withNameInsensitiveEither(_).left.map(_.getMessage), _.entryName)
 }
 
 /*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/NodeComplianceExpiration.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/NodeComplianceExpiration.scala
@@ -4,6 +4,7 @@ import enumeratum.Enum
 import enumeratum.EnumEntry
 import scala.concurrent.duration.Duration
 import zio.json.*
+import zio.json.enumeratum.*
 
 /*
  * This file defines data structures to inform what we should display when a node compliance
@@ -12,7 +13,7 @@ import zio.json.*
 
 sealed abstract class NodeComplianceExpirationMode(override val entryName: String) extends EnumEntry
 
-object NodeComplianceExpirationMode extends Enum[NodeComplianceExpirationMode] {
+object NodeComplianceExpirationMode extends Enum[NodeComplianceExpirationMode] with EnumCodec[NodeComplianceExpirationMode] {
 
   /*
    * Historical expiration based on a 2 agent run duration + a grace period.
@@ -31,15 +32,6 @@ object NodeComplianceExpirationMode extends Enum[NodeComplianceExpirationMode] {
   case object KeepLast extends NodeComplianceExpirationMode("keep_last")
 
   override def values: IndexedSeq[NodeComplianceExpirationMode] = findValues
-
-  implicit val decoderNodeComplianceExpirationMode: JsonDecoder[NodeComplianceExpirationMode] = {
-    JsonDecoder.string.mapOrFail(s => {
-      NodeComplianceExpirationMode
-        .withNameInsensitiveEither(s)
-        .left
-        .map(_ => s"Can not parse '${s}' as node compliance expiration mode")
-    })
-  }
 }
 
 case class NodeComplianceExpiration(mode: NodeComplianceExpirationMode, duration: Option[Duration])

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/ApiAccount.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/ApiAccount.scala
@@ -65,6 +65,7 @@ import java.time.ZonedDateTime
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import zio.json.*
+import zio.json.enumeratum.*
 import zio.json.internal.Write
 import zio.syntax.*
 
@@ -79,49 +80,31 @@ import zio.syntax.*
  * Account status: enabled or not
  */
 sealed trait ApiAccountStatus extends EnumEntry with EnumEntry.Lowercase
-object ApiAccountStatus       extends Enum[ApiAccountStatus] {
+object ApiAccountStatus       extends Enum[ApiAccountStatus] with EnumCodec[ApiAccountStatus] {
   case object Enabled  extends ApiAccountStatus
   case object Disabled extends ApiAccountStatus
 
   override def values: IndexedSeq[ApiAccountStatus] = findValues
-
-  implicit val codecApiAccountStatus: JsonCodec[ApiAccountStatus] = new JsonCodec[ApiAccountStatus](
-    JsonEncoder.string.contramap(_.entryName),
-    JsonDecoder.string.mapOrFail(withNameInsensitiveEither(_).left.map(_.getMessage()))
-  )
 }
 
 /**
  * Token state: undef, generated
  */
 sealed trait ApiTokenState extends EnumEntry with EnumEntry.Lowercase
-object ApiTokenState       extends Enum[ApiTokenState] {
+object ApiTokenState       extends Enum[ApiTokenState] with EnumCodec[ApiTokenState] {
   case object Undef       extends ApiTokenState
   case object GeneratedV1 extends ApiTokenState
   case object GeneratedV2 extends ApiTokenState
 
   override def values: IndexedSeq[ApiTokenState] = findValues
-
-  implicit val codecApiTokenState: JsonCodec[ApiTokenState] = new JsonCodec[ApiTokenState](
-    JsonEncoder.string.contramap(_.entryName),
-    JsonDecoder.string.mapOrFail(withNameInsensitiveEither(_).left.map(_.getMessage()))
-  )
 }
 
-sealed trait ApiAccountExpirationPolicy extends EnumEntry with EnumEntry.Lowercase
-object ApiAccountExpirationPolicy       extends Enum[ApiAccountExpirationPolicy] {
-
-  case object Never      extends ApiAccountExpirationPolicy
-  case object AtDateTime extends ApiAccountExpirationPolicy {
-    override def entryName: String = "datetime"
-  }
+sealed trait ApiAccountExpirationPolicy(override val entryName: String) extends EnumEntry
+object ApiAccountExpirationPolicy                                       extends Enum[ApiAccountExpirationPolicy] with EnumCodec[ApiAccountExpirationPolicy] {
+  case object Never      extends ApiAccountExpirationPolicy("never")
+  case object AtDateTime extends ApiAccountExpirationPolicy("datetime")
 
   override def values: IndexedSeq[ApiAccountExpirationPolicy] = findValues
-
-  implicit val codecApiTokenExpirationPolicy: JsonCodec[ApiAccountExpirationPolicy] = new JsonCodec[ApiAccountExpirationPolicy](
-    JsonEncoder.string.contramap(_.entryName),
-    JsonDecoder.string.mapOrFail(withNameInsensitiveEither(_).left.map(_.getMessage()))
-  )
 }
 
 // encapsulate Option[JsonAcl] into a type so that it's easier to map to business object

--- a/webapp/sources/utils/src/main/scala/zio/json/other/package.scala
+++ b/webapp/sources/utils/src/main/scala/zio/json/other/package.scala
@@ -1,0 +1,42 @@
+package zio.json
+
+import _root_.enumeratum.*
+
+package object enumeratum {
+
+  def buildDecoder[A <: EnumEntry](cn: Enum[A], parse: String => Either[NoSuchMember[A], A]): JsonDecoder[A] = {
+    JsonDecoder.string.mapOrFail { s =>
+      parse(s).left.map { e =>
+        s"Error decoding enum '${cn.getClass.getSimpleName
+            .replaceAll("\\$", "")}': ${e.getMessage} ; values: ${cn.values.mkString("'", "','", "'")}"
+      }
+    }
+  }
+
+  /*
+   * Exact codec for EnumEntry
+   * It is isomorphic to enum `entryName`, case sensitive
+   */
+  trait EnumCodecCaseSensitive[A <: EnumEntry] {
+    this: Enum[A] =>
+
+    implicit val decoderEnumEntry: JsonDecoder[A] = buildDecoder(this, this.withNameEither)
+    implicit val encoderEnumEntry: JsonEncoder[A] = JsonEncoder.string.contramap(_.entryName)
+  }
+
+  /*
+   * Codec for EnumEntry that:
+   *   - encode using exactly `entryName`
+   *   - decode case insensitive
+   */
+  trait EnumCodecCaseInsensitive[A <: EnumEntry] {
+    this: Enum[A] =>
+
+    implicit val decoderEnumEntry: JsonDecoder[A] = buildDecoder(this, this.withNameInsensitiveEither)
+    implicit val encoderEnumEntry: JsonEncoder[A] = JsonEncoder.string.contramap(_.entryName)
+  }
+
+  // by default, encode lc, decode ci
+  type EnumCodec[A <: EnumEntry] = EnumCodecCaseInsensitive[A]
+
+}

--- a/webapp/sources/utils/src/test/scala/zio/json/other/EnumCodecTest.scala
+++ b/webapp/sources/utils/src/test/scala/zio/json/other/EnumCodecTest.scala
@@ -1,0 +1,139 @@
+/*
+ *************************************************************************************
+ * Copyright 2025 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+package zio.json.other
+
+import enumeratum.*
+import org.junit.*
+import org.junit.runner.RunWith
+import zio.*
+import zio.json.*
+import zio.json.enumeratum.*
+import zio.test.*
+import zio.test.Assertion.*
+import zio.test.junit.ZTestJUnitRunner
+
+/*
+ * It's absolutely mandatory to define that out of ZIOSpecDefault
+ * because macro used in it breaks in cryptic way enumeratum "findValues" macro
+ */
+object Data {
+  /*
+   * exact derivation from the exact scala name.
+   * Warning, unstable to refactoring
+   */
+  sealed trait A extends EnumEntry
+
+  object A extends Enum[A] with EnumCodecCaseSensitive[A] {
+    case object CaseOne extends A
+    case object casetwo extends A
+
+    override def values: IndexedSeq[A] = findValues
+  }
+
+  case class ContentA(a: A) derives JsonCodec
+
+  /*
+   * default derivation encode lower case, decode case insensitive.
+   * (Use override entryName to be stable to refactoring)
+   */
+  sealed trait B(override val entryName: String) extends EnumEntry
+
+  object B extends Enum[B] with EnumCodec[B] {
+    case object CaseOne        extends B("CaseOne")
+    case object CaseRefactored extends B("casetwo")
+
+    override def values: IndexedSeq[B] = findValues
+  }
+
+  case class ContentB(a: B) derives JsonCodec
+}
+
+@RunWith(classOf[ZTestJUnitRunner])
+class EnumCodecTest extends ZIOSpecDefault {
+
+  import zio.json.other.Data.*
+
+  val s1   = """{"a":"CaseOne"}"""
+  val s1lc = """{"a":"caseone"}"""
+  val s2   = """{"a":"casetwo"}"""
+  val s2cc = """{"a":"CaseTwo"}"""
+
+  def spec = suiteAll("encoding enum") {
+
+    suite("Using scala case object name")(
+      test("encode CaseOne") {
+        assert(ContentA(A.CaseOne).toJson)(equalTo(s1))
+      },
+      test("decode CaseOne ok") {
+        assert(s1.fromJson[ContentA])(isRight(equalTo(ContentA(A.CaseOne))))
+      },
+      test("fail decode caseone (lower case)") {
+        assert(s1lc.fromJson[ContentA])(isLeft)
+      },
+      test("encode casetwo") {
+        assert(ContentA(A.casetwo).toJson)(equalTo(s2))
+      },
+      test("decode casetwo ok") {
+        assert(s2.fromJson[ContentA])(isRight(equalTo(ContentA(A.casetwo))))
+      },
+      test("fail decode CaseTwo (camel case)") {
+        assert(s2cc.fromJson[ContentA])(isLeft)
+      }
+    )
+
+    suite("Using scala case object name")(
+      test("encode CaseOne as is") {
+        assert(ContentB(B.CaseOne).toJson)(equalTo(s1))
+      },
+      test("decode CaseOne ok") {
+        assert(s1.fromJson[ContentB])(isRight(equalTo(ContentB(B.CaseOne))))
+      },
+      test("decode caseone (lower case) ok") {
+        assert(s1lc.fromJson[ContentB])(isRight(equalTo(ContentB(B.CaseOne))))
+      },
+      test("encode casetwo as is using entryName") {
+        assert(ContentB(B.CaseRefactored).toJson)(equalTo(s2))
+      },
+      test("decode casetwo ok") {
+        assert(s2.fromJson[ContentB])(isRight(equalTo(ContentB(B.CaseRefactored))))
+      },
+      test("decode CaseTwo (camel case) ok") {
+        assert(s2cc.fromJson[ContentB])(isRight(equalTo(ContentB(B.CaseRefactored))))
+      }
+    )
+  }
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/27364

An enumeratum json codec that can be used with:

```
import enumeratum.*
import zio.json.other.*

  sealed trait A extends EnumEntry

  object A extends Enum[A] with EnumCodec[A] {
    case object CaseOne extends A
    case object casetwo extends A

    override def values: IndexedSeq[A] = findValues
  }
```

It comes with two variants that differ only in the parsing: 
-  `EnumCodecCaseSensitive[A]` : expects exactly `enumEntry` value
- `EnumCodecCaseInsensitive[A]`: pase case insensively

The default is case insensitive parsing, given by the alias `EnumCodec[A]`
