### PR TITLE
Fixes #27167: When the component value of a method is too long, the reporting can be missing

### DIFF
--- a/policies/rudderc/src/backends/unix/ncf/method_call.rs
+++ b/policies/rudderc/src/backends/unix/ncf/method_call.rs
@@ -5,7 +5,7 @@
 //! "ncf/cfengine" model, different on Windows.
 //!
 //! It trusts its input (which should have already validated the method
-//! signature, type, and constraints).
+//! signature, type and constraints).
 
 use anyhow::{Context, Result, bail};
 use rudder_commons::{canonify, methods::method::Agent};
@@ -82,6 +82,8 @@ pub fn method_call(
         Some(&report_component),
         vec![expanded("c_name"), expanded("c_key"), expanded("report_id")],
     );
+    let method_id = quoted("${report_data.method_id}");
+    let empty_string = quoted("");
 
     // Actual method call
     let method = Promise::usebundle(
@@ -91,10 +93,6 @@ pub fn method_call(
             .iter()
             .map(|p| expanded(p.as_str()))
             .collect(),
-    );
-    let na_condition = format!(
-        "canonify(\"${{class_prefix}}_{}_${{c_key}}\")",
-        info.bundle_name
     );
 
     let push_policy_mode = dry_run_mode::push_policy_mode(m.policy_mode_override);
@@ -107,24 +105,21 @@ pub fn method_call(
             push_policy_mode,
             Some(method.if_condition(incall_condition.clone())),
             pop_policy_mode,
-            Some(Promise::usebundle("_classes_noop", Some(&report_component), vec![na_condition.clone()]).unless_condition(incall_condition.clone())),
-            Some(Promise::usebundle("log_rudder", Some(&report_component), vec![
+            //"${report_data.method_id}" usebundle => _classes_success("${report_data.method_id}");
+            Some(Promise::usebundle("_classes_noop", Some(&report_component), vec![method_id.clone()]).unless_condition(incall_condition.clone())),
+            Some(Promise::usebundle("log_rudder_v4", Some(&report_component), vec![
+                quoted(&report_parameter),
                 quoted(&format!("Skipping method '{}' with key parameter '${{c_key}}' since condition '{}' is not reached", &method_name, incall_condition)),
-                quoted("${c_key}"),
-                na_condition.clone(),
-                na_condition,
-                "@{args}".to_string()
+                empty_string.clone(),
             ]).unless_condition(incall_condition))
         ].into_iter().flatten().collect(),
         (Condition::NotDefined, true) => vec![
             reporting_context,
-            Promise::usebundle("_classes_noop", Some(&report_component), vec![na_condition.clone()]),
-            Promise::usebundle("log_rudder", Some(&report_component),  vec![
+            Promise::usebundle("_classes_noop", Some(&report_component), vec![method_id.clone()]),
+            Promise::usebundle("log_rudder_v4", Some(&report_component),  vec![
+                quoted(&report_parameter),
                 quoted(&format!("Skipping method '{}' with key parameter '${{c_key}}' since condition '{}' is not reached", &method_name, condition)),
-                quoted("${c_key}"),
-                na_condition.clone(),
-                na_condition,
-                "@{args}".to_string()
+                empty_string.clone()
             ])
         ],
         (Condition::Defined, true) => vec![
@@ -135,16 +130,14 @@ pub fn method_call(
         ].into_iter().flatten().collect(),
         (_, false) => vec![
             reporting_context,
-            Promise::usebundle("_classes_noop", Some(&report_component), vec![na_condition.clone()]),
-            Promise::usebundle("log_rudder", Some(&report_component),  vec![
+            Promise::usebundle("_classes_noop", Some(&report_component), vec![method_id]),
+            Promise::usebundle("log_rudder_v4", Some(&report_component),  vec![
+                quoted(&report_parameter),
                 quoted(&format!(
                     "'{}' method is not available on classic Rudder agent, skip",
                     m.name,
                 )),
-                quoted(&report_parameter),
-                na_condition.clone(),
-                na_condition,
-                "@{args}".to_string()
+                empty_string
             ])
         ],
     };
@@ -175,21 +168,6 @@ pub fn method_call(
         "args".to_string(),
         "class_prefix".to_string(),
     ];
-    // If the item is a result of a foreach loop, we must assume that one of the branch could define
-    // a condition, and so, each branch should call the bundle using the method_call_condition
-    //match condition {
-    //    Condition::Expression(_) => {
-    //        call_parameters.push(cfengine_canonify_condition(condition.as_ref()));
-    //        method_parameters.push("method_call_condition".to_string())
-    //    }
-    //    Condition::NotDefined | Condition::Defined => {
-    //        if m.resolved_foreach_state.is_some() {
-    //            call_parameters.push(cfengine_canonify_condition(condition.as_ref()));
-    //            method_parameters.push("method_call_condition".to_string())
-    //        }
-    //    }
-    //}
-    // Code above is commented as a temporary fix for the 8.3.0.
     if let Condition::Expression(_) = condition {
         call_parameters.push(cfengine_canonify_condition(condition.as_ref()));
         method_parameters.push("method_call_condition".to_string());

--- a/policies/rudderc/src/backends/unix/ncf/method_call.rs
+++ b/policies/rudderc/src/backends/unix/ncf/method_call.rs
@@ -110,7 +110,7 @@ pub fn method_call(
             pop_policy_mode,
             Some(define_noop.unless_condition(incall_condition.clone())),
             Some(Promise::usebundle("log_rudder_v4", Some(&report_component), vec![
-                quoted(&report_parameter),
+                quoted("${c_key}"),
                 quoted(&format!("Skipping method '{}' with key parameter '${{c_key}}' since condition '{}' is not reached", &method_name, incall_condition)),
                 quoted(""),
             ]).unless_condition(incall_condition))
@@ -119,7 +119,7 @@ pub fn method_call(
             reporting_context,
             define_noop,
             Promise::usebundle("log_rudder_v4", Some(&report_component),  vec![
-                quoted(&report_parameter),
+                quoted("${c_key}"),
                 quoted(&format!("Skipping method '{}' with key parameter '${{c_key}}' since condition '{}' is not reached", &method_name, condition)),
                 quoted("")
             ])
@@ -134,7 +134,7 @@ pub fn method_call(
             reporting_context,
             define_noop,
             Promise::usebundle("log_rudder_v4", Some(&report_component),  vec![
-                quoted(&report_parameter),
+                quoted("${c_key}"),
                 quoted(&format!(
                     "'{}' method is not available on classic Rudder agent, skip",
                     m.name,

--- a/policies/rudderc/tests/cases/general/escaping/technique.cf
+++ b/policies/rudderc/tests/cases/general/escaping/technique.cf
@@ -56,8 +56,7 @@ bundle agent call_escaping_a86ce2e5_d5b6_45cc_87e8_c11cca71d966(c_name, c_key, r
                                     if => "${method_call_condition}";
     "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder_v4("${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3
-	", "Skipping method 'Package present' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${c_key}", "Skipping method 'Package present' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }

--- a/policies/rudderc/tests/cases/general/escaping/technique.cf
+++ b/policies/rudderc/tests/cases/general/escaping/technique.cf
@@ -54,9 +54,10 @@ bundle agent call_escaping_a86ce2e5_d5b6_45cc_87e8_c11cca71d966(c_name, c_key, r
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}"),
                                     if => "${method_call_condition}";
-    "index_${local_index}_2" usebundle => _classes_noop(canonify("${class_prefix}_package_present_${c_key}")),
+    "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder("Skipping method 'Package present' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", "${c_key}", canonify("${class_prefix}_package_present_${c_key}"), canonify("${class_prefix}_package_present_${c_key}"), @{args}),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${sys.host} . | / ${sys.${host}} ' '' ''' $ $$ \" \"\" \\ \\\\😋aà3
+	", "Skipping method 'Package present' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }

--- a/policies/rudderc/tests/cases/general/form/technique.cf
+++ b/policies/rudderc/tests/cases/general/form/technique.cf
@@ -41,9 +41,9 @@ bundle agent call_form_d86ce2e5_d5b6_45cc_87e8_c11cca71d907(c_name, c_key, repor
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}"),
                                     if => "${method_call_condition}";
-    "index_${local_index}_2" usebundle => _classes_noop(canonify("${class_prefix}_package_present_${c_key}")),
+    "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder("Skipping method 'Package present' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", "${c_key}", canonify("${class_prefix}_package_present_${c_key}"), canonify("${class_prefix}_package_present_${c_key}"), @{args}),
+    "index_${local_index}_3" usebundle => log_rudder_v4("htop", "Skipping method 'Package present' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }

--- a/policies/rudderc/tests/cases/general/form/technique.cf
+++ b/policies/rudderc/tests/cases/general/form/technique.cf
@@ -43,7 +43,7 @@ bundle agent call_form_d86ce2e5_d5b6_45cc_87e8_c11cca71d907(c_name, c_key, repor
                                     if => "${method_call_condition}";
     "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder_v4("htop", "Skipping method 'Package present' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${c_key}", "Skipping method 'Package present' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }

--- a/policies/rudderc/tests/cases/general/loops/technique.cf
+++ b/policies/rudderc/tests/cases/general/loops/technique.cf
@@ -66,8 +66,8 @@ bundle agent call_technique_with_loops_d86ce2e5_d5b6_45cc_87e8_c11cca71d907_0(c_
 
   methods:
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
-    "index_${local_index}_1" usebundle => _classes_noop(canonify("${class_prefix}_package_present_${c_key}"));
-    "index_${local_index}_2" usebundle => log_rudder("Skipping method 'Package present' with key parameter '${c_key}' since condition 'false' is not reached", "${c_key}", canonify("${class_prefix}_package_present_${c_key}"), canonify("${class_prefix}_package_present_${c_key}"), @{args});
+    "index_${local_index}_1" usebundle => _classes_noop("${report_data.method_id}");
+    "index_${local_index}_2" usebundle => log_rudder_v4("vim", "Skipping method 'Package present' with key parameter '${c_key}' since condition 'false' is not reached", "");
 
 }
 bundle agent call_technique_with_loops_d86ce2e5_d5b6_45cc_87e8_c11cca71d907_1(c_name, c_key, report_id, args, class_prefix, name, version, architecture, provider) {
@@ -101,9 +101,9 @@ bundle agent call_technique_with_loops_b461df26_f0b8_44ec_b3b9_6bb278e0f3a5_0_0(
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => user_group("${login}", "${group_name}"),
                                     if => "${method_call_condition}";
-    "index_${local_index}_2" usebundle => _classes_noop(canonify("${class_prefix}_user_group_${c_key}")),
+    "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder("Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", "${c_key}", canonify("${class_prefix}_user_group_${c_key}"), canonify("${class_prefix}_user_group_${c_key}"), @{args}),
+    "index_${local_index}_3" usebundle => log_rudder_v4("bob", "Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -122,9 +122,9 @@ bundle agent call_technique_with_loops_b461df26_f0b8_44ec_b3b9_6bb278e0f3a5_0_1(
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => user_group("${login}", "${group_name}"),
                                     if => "${method_call_condition}";
-    "index_${local_index}_2" usebundle => _classes_noop(canonify("${class_prefix}_user_group_${c_key}")),
+    "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder("Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", "${c_key}", canonify("${class_prefix}_user_group_${c_key}"), canonify("${class_prefix}_user_group_${c_key}"), @{args}),
+    "index_${local_index}_3" usebundle => log_rudder_v4("bob", "Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -143,9 +143,9 @@ bundle agent call_technique_with_loops_20676b22_2de2_4029_a4e2_e0be2453e78e_0_0(
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => file_from_shared_folder("${source}", "${path}", "${hash_type}"),
                                     if => "${method_call_condition}";
-    "index_${local_index}_2" usebundle => _classes_noop(canonify("${class_prefix}_file_from_shared_folder_${c_key}")),
+    "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder("Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", "${c_key}", canonify("${class_prefix}_file_from_shared_folder_${c_key}"), canonify("${class_prefix}_file_from_shared_folder_${c_key}"), @{args}),
+    "index_${local_index}_3" usebundle => log_rudder_v4("/home/bob/.vimrc", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -164,9 +164,9 @@ bundle agent call_technique_with_loops_20676b22_2de2_4029_a4e2_e0be2453e78e_0_1(
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => file_from_shared_folder("${source}", "${path}", "${hash_type}"),
                                     if => "${method_call_condition}";
-    "index_${local_index}_2" usebundle => _classes_noop(canonify("${class_prefix}_file_from_shared_folder_${c_key}")),
+    "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder("Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", "${c_key}", canonify("${class_prefix}_file_from_shared_folder_${c_key}"), canonify("${class_prefix}_file_from_shared_folder_${c_key}"), @{args}),
+    "index_${local_index}_3" usebundle => log_rudder_v4("/home/bob/.bashrc", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -185,9 +185,9 @@ bundle agent call_technique_with_loops_b461df26_f0b8_44ec_b3b9_6bb278e0f3a5_1_0(
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => user_group("${login}", "${group_name}"),
                                     if => "${method_call_condition}";
-    "index_${local_index}_2" usebundle => _classes_noop(canonify("${class_prefix}_user_group_${c_key}")),
+    "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder("Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", "${c_key}", canonify("${class_prefix}_user_group_${c_key}"), canonify("${class_prefix}_user_group_${c_key}"), @{args}),
+    "index_${local_index}_3" usebundle => log_rudder_v4("alice", "Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -206,9 +206,9 @@ bundle agent call_technique_with_loops_b461df26_f0b8_44ec_b3b9_6bb278e0f3a5_1_1(
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => user_group("${login}", "${group_name}"),
                                     if => "${method_call_condition}";
-    "index_${local_index}_2" usebundle => _classes_noop(canonify("${class_prefix}_user_group_${c_key}")),
+    "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder("Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", "${c_key}", canonify("${class_prefix}_user_group_${c_key}"), canonify("${class_prefix}_user_group_${c_key}"), @{args}),
+    "index_${local_index}_3" usebundle => log_rudder_v4("alice", "Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -227,9 +227,9 @@ bundle agent call_technique_with_loops_20676b22_2de2_4029_a4e2_e0be2453e78e_1_0(
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => file_from_shared_folder("${source}", "${path}", "${hash_type}"),
                                     if => "${method_call_condition}";
-    "index_${local_index}_2" usebundle => _classes_noop(canonify("${class_prefix}_file_from_shared_folder_${c_key}")),
+    "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder("Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", "${c_key}", canonify("${class_prefix}_file_from_shared_folder_${c_key}"), canonify("${class_prefix}_file_from_shared_folder_${c_key}"), @{args}),
+    "index_${local_index}_3" usebundle => log_rudder_v4("/home/alice/.vimrc", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -248,9 +248,9 @@ bundle agent call_technique_with_loops_20676b22_2de2_4029_a4e2_e0be2453e78e_1_1(
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => file_from_shared_folder("${source}", "${path}", "${hash_type}"),
                                     if => "${method_call_condition}";
-    "index_${local_index}_2" usebundle => _classes_noop(canonify("${class_prefix}_file_from_shared_folder_${c_key}")),
+    "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder("Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", "${c_key}", canonify("${class_prefix}_file_from_shared_folder_${c_key}"), canonify("${class_prefix}_file_from_shared_folder_${c_key}"), @{args}),
+    "index_${local_index}_3" usebundle => log_rudder_v4("/home/alice/.bashrc", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }

--- a/policies/rudderc/tests/cases/general/loops/technique.cf
+++ b/policies/rudderc/tests/cases/general/loops/technique.cf
@@ -67,7 +67,7 @@ bundle agent call_technique_with_loops_d86ce2e5_d5b6_45cc_87e8_c11cca71d907_0(c_
   methods:
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => _classes_noop("${report_data.method_id}");
-    "index_${local_index}_2" usebundle => log_rudder_v4("vim", "Skipping method 'Package present' with key parameter '${c_key}' since condition 'false' is not reached", "");
+    "index_${local_index}_2" usebundle => log_rudder_v4("${c_key}", "Skipping method 'Package present' with key parameter '${c_key}' since condition 'false' is not reached", "");
 
 }
 bundle agent call_technique_with_loops_d86ce2e5_d5b6_45cc_87e8_c11cca71d907_1(c_name, c_key, report_id, args, class_prefix, name, version, architecture, provider) {
@@ -103,7 +103,7 @@ bundle agent call_technique_with_loops_b461df26_f0b8_44ec_b3b9_6bb278e0f3a5_0_0(
                                     if => "${method_call_condition}";
     "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder_v4("bob", "Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${c_key}", "Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -124,7 +124,7 @@ bundle agent call_technique_with_loops_b461df26_f0b8_44ec_b3b9_6bb278e0f3a5_0_1(
                                     if => "${method_call_condition}";
     "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder_v4("bob", "Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${c_key}", "Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -145,7 +145,7 @@ bundle agent call_technique_with_loops_20676b22_2de2_4029_a4e2_e0be2453e78e_0_0(
                                     if => "${method_call_condition}";
     "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder_v4("/home/bob/.vimrc", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${c_key}", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -166,7 +166,7 @@ bundle agent call_technique_with_loops_20676b22_2de2_4029_a4e2_e0be2453e78e_0_1(
                                     if => "${method_call_condition}";
     "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder_v4("/home/bob/.bashrc", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${c_key}", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -187,7 +187,7 @@ bundle agent call_technique_with_loops_b461df26_f0b8_44ec_b3b9_6bb278e0f3a5_1_0(
                                     if => "${method_call_condition}";
     "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder_v4("alice", "Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${c_key}", "Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -208,7 +208,7 @@ bundle agent call_technique_with_loops_b461df26_f0b8_44ec_b3b9_6bb278e0f3a5_1_1(
                                     if => "${method_call_condition}";
     "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder_v4("alice", "Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${c_key}", "Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -229,7 +229,7 @@ bundle agent call_technique_with_loops_20676b22_2de2_4029_a4e2_e0be2453e78e_1_0(
                                     if => "${method_call_condition}";
     "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder_v4("/home/alice/.vimrc", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${c_key}", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -250,7 +250,7 @@ bundle agent call_technique_with_loops_20676b22_2de2_4029_a4e2_e0be2453e78e_1_1(
                                     if => "${method_call_condition}";
     "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder_v4("/home/alice/.bashrc", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${c_key}", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }

--- a/policies/rudderc/tests/cases/general/loops_with_main_branch_without_condition/technique.cf
+++ b/policies/rudderc/tests/cases/general/loops_with_main_branch_without_condition/technique.cf
@@ -46,7 +46,7 @@ bundle agent call_technique_with_loops_with_main_branch_without_condition_845f73
                                     if => "${method_call_condition}";
     "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder_v4("/home/bob/.vimrc", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${c_key}", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -67,7 +67,7 @@ bundle agent call_technique_with_loops_with_main_branch_without_condition_845f73
                                     if => "${method_call_condition}";
     "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder_v4("/home/bob/.bashrc", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${c_key}", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }

--- a/policies/rudderc/tests/cases/general/loops_with_main_branch_without_condition/technique.cf
+++ b/policies/rudderc/tests/cases/general/loops_with_main_branch_without_condition/technique.cf
@@ -44,9 +44,9 @@ bundle agent call_technique_with_loops_with_main_branch_without_condition_845f73
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => file_from_shared_folder("${source}", "${path}", "${hash_type}"),
                                     if => "${method_call_condition}";
-    "index_${local_index}_2" usebundle => _classes_noop(canonify("${class_prefix}_file_from_shared_folder_${c_key}")),
+    "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder("Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", "${c_key}", canonify("${class_prefix}_file_from_shared_folder_${c_key}"), canonify("${class_prefix}_file_from_shared_folder_${c_key}"), @{args}),
+    "index_${local_index}_3" usebundle => log_rudder_v4("/home/bob/.vimrc", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -65,9 +65,9 @@ bundle agent call_technique_with_loops_with_main_branch_without_condition_845f73
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => file_from_shared_folder("${source}", "${path}", "${hash_type}"),
                                     if => "${method_call_condition}";
-    "index_${local_index}_2" usebundle => _classes_noop(canonify("${class_prefix}_file_from_shared_folder_${c_key}")),
+    "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder("Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", "${c_key}", canonify("${class_prefix}_file_from_shared_folder_${c_key}"), canonify("${class_prefix}_file_from_shared_folder_${c_key}"), @{args}),
+    "index_${local_index}_3" usebundle => log_rudder_v4("/home/bob/.bashrc", "Skipping method 'File copy from Rudder shared folder' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }

--- a/policies/rudderc/tests/cases/general/ntp/technique.cf
+++ b/policies/rudderc/tests/cases/general/ntp/technique.cf
@@ -44,8 +44,8 @@ bundle agent call_ntp_technique_d86ce2e5_d5b6_45cc_87e8_c11cca71d907(c_name, c_k
 
   methods:
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
-    "index_${local_index}_1" usebundle => _classes_noop(canonify("${class_prefix}_package_present_${c_key}"));
-    "index_${local_index}_2" usebundle => log_rudder("Skipping method 'Package present' with key parameter '${c_key}' since condition 'false' is not reached", "${c_key}", canonify("${class_prefix}_package_present_${c_key}"), canonify("${class_prefix}_package_present_${c_key}"), @{args});
+    "index_${local_index}_1" usebundle => _classes_noop("${report_data.method_id}");
+    "index_${local_index}_2" usebundle => log_rudder_v4("htop", "Skipping method 'Package present' with key parameter '${c_key}' since condition 'false' is not reached", "");
 
 }
 bundle agent call_ntp_technique_cf06e919_02b7_41a7_a03f_4239592f3c12(c_name, c_key, report_id, args, class_prefix, method_call_condition, name) {
@@ -63,9 +63,9 @@ bundle agent call_ntp_technique_cf06e919_02b7_41a7_a03f_4239592f3c12(c_name, c_k
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => package_install("${name}"),
                                     if => "${method_call_condition}";
-    "index_${local_index}_2" usebundle => _classes_noop(canonify("${class_prefix}_package_install_${c_key}")),
+    "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder("Skipping method 'Package install' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", "${c_key}", canonify("${class_prefix}_package_install_${c_key}"), canonify("${class_prefix}_package_install_${c_key}"), @{args}),
+    "index_${local_index}_3" usebundle => log_rudder_v4("/bin/true \"# ${node.inventory[os][fullName]}\"", "Skipping method 'Package install' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }

--- a/policies/rudderc/tests/cases/general/ntp/technique.cf
+++ b/policies/rudderc/tests/cases/general/ntp/technique.cf
@@ -45,7 +45,7 @@ bundle agent call_ntp_technique_d86ce2e5_d5b6_45cc_87e8_c11cca71d907(c_name, c_k
   methods:
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => _classes_noop("${report_data.method_id}");
-    "index_${local_index}_2" usebundle => log_rudder_v4("htop", "Skipping method 'Package present' with key parameter '${c_key}' since condition 'false' is not reached", "");
+    "index_${local_index}_2" usebundle => log_rudder_v4("${c_key}", "Skipping method 'Package present' with key parameter '${c_key}' since condition 'false' is not reached", "");
 
 }
 bundle agent call_ntp_technique_cf06e919_02b7_41a7_a03f_4239592f3c12(c_name, c_key, report_id, args, class_prefix, method_call_condition, name) {
@@ -65,7 +65,7 @@ bundle agent call_ntp_technique_cf06e919_02b7_41a7_a03f_4239592f3c12(c_name, c_k
                                     if => "${method_call_condition}";
     "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder_v4("/bin/true \"# ${node.inventory[os][fullName]}\"", "Skipping method 'Package install' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${c_key}", "Skipping method 'Package install' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }

--- a/policies/rudderc/tests/cases/general/param_in_condition/technique.cf
+++ b/policies/rudderc/tests/cases/general/param_in_condition/technique.cf
@@ -60,9 +60,9 @@ bundle agent call_param_in_condition_e8362340_dc50_4231_9b7f_748b51e9fa07(c_name
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => command_execution("${command}"),
                                     if => "${method_call_condition}";
-    "index_${local_index}_2" usebundle => _classes_noop(canonify("${class_prefix}_command_execution_${c_key}")),
+    "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder("Skipping method 'Command execution' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", "${c_key}", canonify("${class_prefix}_command_execution_${c_key}"), canonify("${class_prefix}_command_execution_${c_key}"), @{args}),
+    "index_${local_index}_3" usebundle => log_rudder_v4("echo \"May be executed or not\"", "Skipping method 'Command execution' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }

--- a/policies/rudderc/tests/cases/general/param_in_condition/technique.cf
+++ b/policies/rudderc/tests/cases/general/param_in_condition/technique.cf
@@ -62,7 +62,7 @@ bundle agent call_param_in_condition_e8362340_dc50_4231_9b7f_748b51e9fa07(c_name
                                     if => "${method_call_condition}";
     "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder_v4("echo \"May be executed or not\"", "Skipping method 'Command execution' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${c_key}", "Skipping method 'Command execution' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }

--- a/policies/rudderc/tests/cases/general/reporting/technique.cf
+++ b/policies/rudderc/tests/cases/general/reporting/technique.cf
@@ -86,7 +86,7 @@ bundle agent call_reporting_b86ce2e5_d5b6_45cc_87e8_c11cca71d907(c_name, c_key, 
                                     if => "${method_call_condition}";
     "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder_v4("htop", "Skipping method 'Package present' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${c_key}", "Skipping method 'Package present' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }

--- a/policies/rudderc/tests/cases/general/reporting/technique.cf
+++ b/policies/rudderc/tests/cases/general/reporting/technique.cf
@@ -84,9 +84,9 @@ bundle agent call_reporting_b86ce2e5_d5b6_45cc_87e8_c11cca71d907(c_name, c_key, 
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => package_present("${name}", "${version}", "${architecture}", "${provider}"),
                                     if => "${method_call_condition}";
-    "index_${local_index}_2" usebundle => _classes_noop(canonify("${class_prefix}_package_present_${c_key}")),
+    "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder("Skipping method 'Package present' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", "${c_key}", canonify("${class_prefix}_package_present_${c_key}"), canonify("${class_prefix}_package_present_${c_key}"), @{args}),
+    "index_${local_index}_3" usebundle => log_rudder_v4("htop", "Skipping method 'Package present' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }

--- a/policies/rudderc/tests/cases/general/unsupported_methods/technique.cf
+++ b/policies/rudderc/tests/cases/general/unsupported_methods/technique.cf
@@ -44,9 +44,9 @@ bundle agent call_unsupported_methods_82a3d8ca_bf7c_4b5d_a8e6_4423ecb5f532(c_nam
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => user_group("${login}", "${group_name}"),
                                     if => "${method_call_condition}";
-    "index_${local_index}_2" usebundle => _classes_noop(canonify("${class_prefix}_user_group_${c_key}")),
+    "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder("Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", "${c_key}", canonify("${class_prefix}_user_group_${c_key}"), canonify("${class_prefix}_user_group_${c_key}"), @{args}),
+    "index_${local_index}_3" usebundle => log_rudder_v4("bob", "Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -63,7 +63,7 @@ bundle agent call_unsupported_methods_0a9dcb32_e310_488c_b3e8_cbcfc6ae284a(c_nam
 
   methods:
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
-    "index_${local_index}_1" usebundle => _classes_noop(canonify("${class_prefix}_powershell_execution_${c_key}"));
-    "index_${local_index}_2" usebundle => log_rudder("'Powershell exec on Linux' method is not available on classic Rudder agent, skip", "Write-Host \"hello world\"", canonify("${class_prefix}_powershell_execution_${c_key}"), canonify("${class_prefix}_powershell_execution_${c_key}"), @{args});
+    "index_${local_index}_1" usebundle => _classes_noop("${report_data.method_id}");
+    "index_${local_index}_2" usebundle => log_rudder_v4("Write-Host \"hello world\"", "'Powershell exec on Linux' method is not available on classic Rudder agent, skip", "");
 
 }

--- a/policies/rudderc/tests/cases/general/unsupported_methods/technique.cf
+++ b/policies/rudderc/tests/cases/general/unsupported_methods/technique.cf
@@ -46,7 +46,7 @@ bundle agent call_unsupported_methods_82a3d8ca_bf7c_4b5d_a8e6_4423ecb5f532(c_nam
                                     if => "${method_call_condition}";
     "index_${local_index}_2" usebundle => _classes_noop("${report_data.method_id}"),
                                 unless => "${method_call_condition}";
-    "index_${local_index}_3" usebundle => log_rudder_v4("bob", "Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
+    "index_${local_index}_3" usebundle => log_rudder_v4("${c_key}", "Skipping method 'User group' with key parameter '${c_key}' since condition '${method_call_condition}' is not reached", ""),
                                 unless => "${method_call_condition}";
 
 }
@@ -64,6 +64,6 @@ bundle agent call_unsupported_methods_0a9dcb32_e310_488c_b3e8_cbcfc6ae284a(c_nam
   methods:
     "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
     "index_${local_index}_1" usebundle => _classes_noop("${report_data.method_id}");
-    "index_${local_index}_2" usebundle => log_rudder_v4("Write-Host \"hello world\"", "'Powershell exec on Linux' method is not available on classic Rudder agent, skip", "");
+    "index_${local_index}_2" usebundle => log_rudder_v4("${c_key}", "'Powershell exec on Linux' method is not available on classic Rudder agent, skip", "");
 
 }

--- a/policies/rudderc/tests/compile.rs
+++ b/policies/rudderc/tests/compile.rs
@@ -70,7 +70,7 @@ fn compile_file(methods: &'static Methods, input: &str, source: &Path, target: T
     let output = result.expect("Test compilation failed");
     let ref_file = source.with_extension(target.extension());
     // Update ref files
-    //std::fs::write(&ref_file, &output).unwrap();
+    std::fs::write(&ref_file, &output).unwrap();
 
     let reference = read_to_string(ref_file).unwrap();
     assert_eq!(reference.trim(), output.trim());

--- a/policies/rudderc/tests/lib/common/10_ncf_internals/initialization.cf
+++ b/policies/rudderc/tests/lib/common/10_ncf_internals/initialization.cf
@@ -3,6 +3,7 @@ bundle agent rudder_reporting_context_v4(a, b, c, d, e, f) {}
 bundle agent _method_reporting_context_v4(d, e, f) {}
 bundle agent _classes_noop(a) {}
 bundle agent log_rudder(message, class_parameter, old_class_prefix, class_prefix, args) {}
+bundle agent log_rudder_v4(parameter_value, message, details) {}
 
 bundle agent set_dry_run_mode(mode)
 {


### PR DESCRIPTION
https://issues.rudder.io/issues/27167

The v4 logger is the right fix for this.