### PR TITLE
Fixes #27365: Allow per-hook-kind logger

### DIFF
--- a/webapp/sources/.scalafmt.conf
+++ b/webapp/sources/.scalafmt.conf
@@ -2,12 +2,14 @@ version = "3.7.17"
 maxColumn = 130
 runner.debug = true
 runner.dialect = scala213Source3
+// see https://github.com/scalameta/scalameta/blob/main/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+// for all supported dialectOverride
 runner.dialectOverride.allowExportClause = true
 runner.dialectOverride.allowOpaqueTypes = true
 runner.dialectOverride.allowGivenUsing = true
 runner.dialectOverride.allowTraitParameters = true
 runner.dialectOverride.allowDerives = true
-
+runner.dialectOverride.allowExtensionMethods = true
 
 rewrite.scala3.convertToNewSyntax = true
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/PostCommits.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/inventory/PostCommits.scala
@@ -78,21 +78,23 @@ class PostCommitInventoryHooks[A](
     val node  = inventory.node.main
     val hooks = (for {
       systemEnv <- IOResult.attempt(java.lang.System.getenv.asScala.toSeq).map(seq => HookEnvPairs.build(seq*))
-      hooks     <- nodeFactRepo.getStatus(node.id).flatMap { s =>
-                     s match {
-                       case PendingInventory  =>
-                         RunHooks.getHooksPure(HOOKS_D + "/node-inventory-received-pending", HOOKS_IGNORE_SUFFIXES)
-                       case AcceptedInventory =>
-                         RunHooks.getHooksPure(HOOKS_D + "/node-inventory-received-accepted", HOOKS_IGNORE_SUFFIXES)
-                       case s                 =>
-                         Inconsistency(
-                           s"node-inventory-received-* hooks are not supported for node '${node.hostname}' [${node.id.value}] with status '${s.name}'"
-                         ).fail
-                     }
+      nHooks    <- nodeFactRepo.getStatus(node.id).flatMap {
+                     case PendingInventory  =>
+                       val n = "node-inventory-received-pending"
+                       RunHooks.getHooksPure(HOOKS_D + "/" + n, HOOKS_IGNORE_SUFFIXES).map(h => (n, h))
+                     case AcceptedInventory =>
+                       val n = "node-inventory-received-accepted"
+                       RunHooks.getHooksPure(HOOKS_D + "/" + n, HOOKS_IGNORE_SUFFIXES).map(h => (n, h))
+                     case s                 =>
+                       Inconsistency(
+                         s"node-inventory-received-* hooks are not supported for node '${node.hostname}' [${node.id.value}] with status '${s.name}'"
+                       ).fail
                    }
+      (n, hooks) = nHooks
       _         <- for {
                      timeHooks0 <- currentTimeMillis
                      res        <- RunHooks.asyncRun(
+                                     n,
                                      hooks,
                                      HookEnvPairs.build(
                                        ("RUDDER_NODE_ID", node.id.value),
@@ -109,7 +111,7 @@ class PostCommitInventoryHooks[A](
                                      1.minutes // warn if a hook took more than a minute
                                    )
                      timeHooks1 <- currentTimeMillis
-                     _          <- PureHooksLogger.trace(s"Inventory received hooks ran in ${timeHooks1 - timeHooks0} ms")
+                     _          <- PureHooksLogger.For(n).trace(s"Inventory received hooks ran in ${timeHooks1 - timeHooks0} ms")
                    } yield ()
     } yield ()).catchAll(err => PureHooksLogger.error(err.fullMsg))
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NewNodeManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NewNodeManager.scala
@@ -146,6 +146,8 @@ class PostNodeAcceptanceHookScripts(
     import scala.jdk.CollectionConverters.*
 
     HooksLogger.debug(s"Executing node-post-acceptance hooks for node with id '${nodeId.value}'")
+    val name = "node-post-acceptance"
+
     (for {
       systemEnv      <- IOResult.attempt(java.lang.System.getenv.asScala.toSeq).map(seq => HookEnvPairs.build(seq*))
       nodeFact       <- nodeFactRepository
@@ -160,13 +162,13 @@ class PostNodeAcceptanceHookScripts(
                           ("RUDDER_NODE_POLICY_SERVER_ID", nodeFact.rudderSettings.policyServerId.value),
                           ("RUDDER_AGENT_TYPE", nodeFact.rudderAgent.agentType.id)
                         )
-      postHooks      <- RunHooks.getHooksPure(HOOKS_D + "/node-post-acceptance", HOOKS_IGNORE_SUFFIXES)
+      postHooks      <- RunHooks.getHooksPure(HOOKS_D + "/" + name, HOOKS_IGNORE_SUFFIXES)
       postHooksTime0 <- currentTimeMillis
-      runPostHook    <- RunHooks.asyncRun(postHooks, hookEnv, systemEnv, 1.minutes)
+      runPostHook    <- RunHooks.asyncRun(name, postHooks, hookEnv, systemEnv, 1.minutes)
       postHooksTime1 <- currentTimeMillis
       timePostHooks   = (postHooksTime1 - postHooksTime0)
-      _              <- PureHooksLogger.trace(s"node-post-acceptance scripts hooks ran in $timePostHooks ms")
-    } yield ()).catchAll(err => PureHooksLogger.error(err.fullMsg))
+      _              <- PureHooksLogger.For(name).trace(s"node-post-acceptance scripts hooks ran in $timePostHooks ms")
+    } yield ()).catchAll(err => PureHooksLogger.For(name).error(err.fullMsg))
   }
 }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/RemoveNodeService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/RemoveNodeService.scala
@@ -379,7 +379,7 @@ class RemoveNodeServiceImpl(
     for {
       start <- currentTimeMillis
       hooks <- RunHooks.getHooksPure(HOOKS_D + "/" + name, HOOKS_IGNORE_SUFFIXES)
-      res   <- RunHooks.asyncRun(hooks, env._1, env._2)
+      res   <- RunHooks.asyncRun(name, hooks, env._1, env._2)
       end   <- currentTimeMillis
       _     <- NodeLoggerPure.Delete.debug(s"    ${name} scripts hooks ran in ${end - start} ms")
     } yield {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/HooksTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/HooksTest.scala
@@ -72,6 +72,7 @@ class HooksTest() extends Specification with AfterAll {
 
   def runHooks(hooks: List[String], params: List[HookEnvPair]): HookReturnCode = {
     RunHooks.syncRun(
+      "test.hooks",
       Hooks(tmp.pathAsString, hooks.map(f => (f, HookTimeout(None, None)))),
       HookEnvPairs(params),
       HookEnvPairs(Nil),
@@ -127,6 +128,7 @@ class HooksTest() extends Specification with AfterAll {
     val name    = "timeout_ok.sh"
     val timeout = RunHooks.effectfulGetHookTimeout(File(tmp.pathAsString, name).toJava)
     val res     = RunHooks.syncRun(
+      "test.hooks",
       Hooks(tmp.pathAsString, List((name, timeout))),
       HookEnvPairs(HookEnvPair("CODE", "0") :: Nil),
       HookEnvPairs(Nil),

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/Argon2.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/users/Argon2.scala
@@ -70,7 +70,7 @@ opaque type Argon2Variant = Int
 object Argon2Variant {
   def apply(v: Int): Argon2Variant = v
 
-  extension(v: Argon2Variant) {
+  extension (v: Argon2Variant) {
     def toInt: Int = v
   }
 }
@@ -80,7 +80,7 @@ opaque type Argon2Version = Int
 object Argon2Version {
   def apply(v: Int): Argon2Version = v
 
-  extension(v: Argon2Version) {
+  extension (v: Argon2Version) {
     def toInt: Int = v
   }
 }
@@ -90,7 +90,7 @@ opaque type Argon2Memory = Int
 object Argon2Memory {
   def apply(v: Int): Argon2Memory = v
 
-  extension(v: Argon2Memory) {
+  extension (v: Argon2Memory) {
     def toInt: Int = v
   }
 }
@@ -100,7 +100,7 @@ opaque type Argon2Parallelism = Int
 object Argon2Parallelism {
   def apply(v: Int): Argon2Parallelism = v
 
-  extension(v: Argon2Parallelism) {
+  extension (v: Argon2Parallelism) {
     def toInt: Int = v
   }
 }
@@ -110,7 +110,7 @@ opaque type Argon2Iterations = Int
 object Argon2Iterations {
   def apply(v: Int): Argon2Iterations = v
 
-  extension(v: Argon2Iterations) {
+  extension (v: Argon2Iterations) {
     def toInt: Int = v
   }
 }
@@ -120,7 +120,7 @@ opaque type Argon2HashSize = Int
 object Argon2HashSize {
   def apply(v: Int): Argon2HashSize = v
 
-  extension(v: Argon2HashSize) {
+  extension (v: Argon2HashSize) {
     def toInt: Int = v
   }
 }
@@ -130,7 +130,7 @@ opaque type Argon2SaltSize = Int
 object Argon2SaltSize {
   def apply(v: Int): Argon2SaltSize = v
 
-  extension(v: Argon2SaltSize) {
+  extension (v: Argon2SaltSize) {
     def toInt: Int = v
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/resources/logback.xml
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/logback.xml
@@ -84,8 +84,8 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
     You should not have to modify that.
   -->
-  
-  
+
+
   <if condition='property("run.mode").equalsIgnoreCase("production")'>
     <then>
       <appender name="STDOUT" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -302,7 +302,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
   <logger name="org.eclipse.jetty" level="info" />
   <logger name="policy.generation.timing.buildNodeConfig" level="info" />
-  
+
   <!--
     Startup
     =======
@@ -391,7 +391,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
   </logger>
 
   <!--
-    Log information about user authentication and user-related access to Rudder 
+    Log information about user authentication and user-related access to Rudder
     (rights, session, user management in general).
   -->
   <!-- Uncomment to have precise log about user management and authentication -->
@@ -481,6 +481,12 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
   <logger name="hooks" level="info" additivity="false">
     <appender-ref ref="STDOUT" />
   </logger>
+
+  <!--
+    You can debug one kind of hooks independently of other by using the name of the hooks directory in
+    /opt/rudder/etc/hooks.d/. For example, to debug only hooks from "policy-generation-node-finished" phase, use:
+  -->
+  <!--  <logger name="hooks.policy-generation-node-finished" level="debug"/>-->
 
 
   <!--


### PR DESCRIPTION
https://issues.rudder.io/issues/27365

The main problem to adress is the cost of multiplying loggers classes in the case of per-campaign (or other ephemeral objects) loggers. 
We could add a cache for the "hook" loggers, which is quite simple, but it duplicates the work of logback that already does exactly that. 

So the chosen solution is to build a 0-cost abstraction in top of `SLF4J` logger to add our own methods. This is possible thanks to scala 3 `opaque` type + `extension methods`. 

I also removed `ZioLogger` to replace it with the new opaque `RudderLogger` because now, ZIO framework has its own logging framework, which blur things. It wasn't use anywhere, so that is a cheap enhancement (`NamedZioLogger` is used everywhere).

Once we have that in place, we can: 

- have one dedicated logger for each hook types, ie for each directory under `/opt/rudder/etc/hooks.d`. That gives us the immediate quick-win of being able to debug one hook sets without being poluted by all other unrelated hooks
- document in default logback.xml how to use them. 
