### PR TITLE
Fixes #27379: Users cleanup configuration is still too strict for disabling/deleting

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/configuration.properties.sample
@@ -605,8 +605,8 @@ rudder.users.cleanup.cron=0 17 1 * * ?
 # For users:
 # - when a user have not logged in for a certain period of time, its account can be marked as disabled.
 # - when the user account is already disabled and the user did not log in for some time, the account can marked as deleted.
-rudder.users.cleanup.account.disableAfterLastLogin=90 days
-rudder.users.cleanup.account.deleteAfterLastLogin=120 days
+rudder.users.cleanup.account.disableAfterLastLogin=180 days
+rudder.users.cleanup.account.deleteAfterLastLogin=never
 
 # - when an user is deleted (for example removed from `rudder-user.xml` file), then the user information,
 #   like status changes, are not purged immediately (typically to be able to do post-deletion accountability).

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1151,9 +1151,9 @@ object RudderParsedProperties {
     case Right(opt) => opt
   }
   val RUDDER_USERS_CLEAN_LAST_LOGIN_DISABLE: Duration         =
-    parseDuration("rudder.users.cleanup.account.disableAfterLastLogin", 90.days)
+    parseDuration("rudder.users.cleanup.account.disableAfterLastLogin", 180.days)
   val RUDDER_USERS_CLEAN_LAST_LOGIN_DELETE:  Duration         =
-    parseDuration("rudder.users.cleanup.account.deleteAfterLastLogin", 120.days)
+    parseDuration("rudder.users.cleanup.account.deleteAfterLastLogin", Duration.Infinity)
   val RUDDER_USERS_CLEAN_DELETED_PURGE:      Duration         = parseDuration("rudder.users.cleanup.purgeDeletedAfter", 30.days)
   val RUDDER_USERS_CLEAN_SESSIONS_PURGE:     Duration         = parseDuration("rudder.users.cleanup.sessions.purgeAfter", 30.days)
 
@@ -1166,6 +1166,7 @@ object RudderParsedProperties {
       }
     } catch {
       case ex: ConfigException       => // default
+        ApplicationLogger.info(s"Key '${propName}' is absent, defaulting to: ${default}")
         default
       case ex: NumberFormatException =>
         ApplicationLogger.error(


### PR DESCRIPTION
https://issues.rudder.io/issues/27379

Change default (and default in case of missing key) value to 6 months (180j) for disable, never for delete. 