### PR TITLE
Fixes #26883: Add campaign hooks in the campaign workflow engine

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/resources/reportsSchema.sql
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/reportsSchema.sql
@@ -314,7 +314,7 @@ ALTER TABLE statusupdate set (autovacuum_vacuum_threshold = 0);
  *************************************************************************************
  */
 
-CREATE TYPE campaignEventState AS enum ('scheduled', 'prehooks', 'running', 'posthooks', 'finished', 'skipped', 'deleted', 'failure');
+CREATE TYPE campaignEventState AS enum ('scheduled', 'pre-hooks', 'running', 'post-hooks', 'finished', 'skipped', 'deleted', 'failure');
 
 CREATE TABLE CampaignEvents (
   campaignId   text

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/CampaignHooksService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/CampaignHooksService.scala
@@ -1,0 +1,197 @@
+/*
+ *************************************************************************************
+ * Copyright 2025 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package com.normation.rudder.campaigns
+
+import better.files.File
+import com.normation.errors.*
+import com.normation.rudder.hooks.*
+import com.normation.zio.*
+import scala.jdk.CollectionConverters.*
+import zio.*
+import zio.syntax.*
+
+/*
+ * This service is in charge of managing campaign hooks.
+ */
+trait CampaignHooksService {
+
+  /*
+   * Run hooks that are configured to run before the campaign time slot is reached.
+   * Hooks results are collected to for trace.
+   */
+  def runPreHooks(c: Campaign, e: CampaignEvent): IOResult[HookResults]
+
+  /*
+   * Run hooks that are configured to run before the campaign time slot is reached.
+   * Hooks results are collected to for trace.
+   */
+  def runPostHooks(c: Campaign, e: CampaignEvent): IOResult[HookResults]
+}
+
+object NoopCampaignHooksService extends CampaignHooksService {
+  override def runPreHooks(c: Campaign, e: CampaignEvent): IOResult[HookResults] = {
+    HookResults(List(HookResult("pre-hook", 0, "", "", ""))).succeed
+  }
+
+  override def runPostHooks(c: Campaign, e: CampaignEvent): IOResult[HookResults] = {
+    HookResults(List(HookResult("post-hook", 0, "", "", ""))).succeed
+  }
+}
+
+/*
+ * Hooks are by-campaign, so we need some help to create the overall structure when
+ * a new campaign is created, and delete the whole thing when the campaign is deleted.
+ */
+trait CampaignHooksRepository {
+  /*
+   * Create the pre-/post-hook sub-directories specific to that campaign
+   */
+  def initHooks(cid: CampaignId): IOResult[Unit]
+
+  /*
+   * Delete hook directory related to that campaign.
+   */
+  def deleteHooks(cid: CampaignId): IOResult[Unit]
+}
+
+object NoopCampaignHooksRepository extends CampaignHooksRepository {
+  override def initHooks(cid:   CampaignId): IOResult[Unit] = ZIO.unit
+  override def deleteHooks(cid: CampaignId): IOResult[Unit] = ZIO.unit
+}
+
+/*
+ *  The standard layout for hooks is:
+ *  - HOOKS_D/campaigns
+ *     |- <campaign-uuid>
+ *     |     |- pre-hooks
+ *     |     |    ` scripts
+ *     |     `- post-hooks
+ *     |          ` scripts
+ *     ...
+ */
+class FsCampaignHooksRepository(HOOKS_D: String) extends CampaignHooksRepository {
+  val campaignRootHooksDir: File = File(HOOKS_D) / FsCampaignHooksRepository.CampaignDirName
+
+  private def getDir(cid: CampaignId): File = {
+    // perhaps we will want per-revision hook directory some day?
+    campaignRootHooksDir / cid.serialize
+  }
+
+  override def initHooks(cid: CampaignId): IOResult[Unit] = {
+    IOResult.attempt(s"Error when initializing hook directories for campaign '${cid.serialize}'") {
+      val campaignHooksDir = getDir(cid)
+      CampaignHookTypes.values.foreach(t => (campaignHooksDir / t.entryName).createDirectoryIfNotExists(createParents = true))
+    }
+  }
+
+  override def deleteHooks(cid: CampaignId): IOResult[Unit] = {
+    val campaignHooksDir = getDir(cid)
+    IOResult.attempt(s"Error when deleting hook directory for campaign '${cid.serialize}'") {
+      campaignHooksDir.delete()
+    }
+  }
+}
+
+object FsCampaignHooksRepository {
+
+  val CampaignDirName: String = "campaigns"
+
+}
+
+class FsCampaignHooksService(
+    HOOKS_D:               String,
+    HOOKS_IGNORE_SUFFIXES: List[String]
+) extends CampaignHooksService {
+
+  def runPreHooks(c: Campaign, e: CampaignEvent): IOResult[HookResults] = {
+    runHooks("pre-hooks", HOOKS_D, HOOKS_IGNORE_SUFFIXES, c, e, CampaignHookTypes.CampaignPreHooks)
+  }
+
+  def runPostHooks(c: Campaign, e: CampaignEvent): IOResult[HookResults] = {
+    runHooks("post-hooks", HOOKS_D, HOOKS_IGNORE_SUFFIXES, c, e, CampaignHookTypes.CampaignPostHooks)
+  }
+
+  /*
+   * Run hooks for the campaign. By defaults, hooks are located with other Rudder hooks in
+   * /opt/rudder/etc/hooks.d.
+   * Each campaign can have different hooks, so they
+   * We only need campaign ID to find hooks, but campaign and event are for giving context.
+   */
+  private def runHooks(
+      rootDir:        String,
+      name:           String,
+      ignoreSuffixes: List[String],
+      c:              Campaign,
+      e:              CampaignEvent,
+      hookType:       CampaignHookTypes // pre or post
+  ): IOResult[HookResults] = {
+
+    val loggerName = name + "." + hookType.entryName
+    val dir        = rootDir + "/" + name + "/" + hookType.entryName
+
+    (
+      for {
+        systemEnv <- IOResult.attempt(java.lang.System.getenv.asScala.toSeq).map(seq => HookEnvPairs.build(seq*))
+        hooks     <- RunHooks.getHooksPure(dir, HOOKS_IGNORE_SUFFIXES)
+        res       <- for {
+                       timeHooks0 <- currentTimeMillis
+                       res        <- RunHooks.asyncRunHistory(
+                                       loggerName,
+                                       hooks,
+                                       HookEnvPairs.build(
+                                         ("CAMPAIGN_ID", c.info.id.serialize),
+                                         ("CAMPAIGN_NAME", c.info.name),
+                                         ("CAMPAIGN_TYPE", c.campaignType.value),
+                                         ("CAMPAIGN_EVENT_ID", e.id.value),
+                                         ("CAMPAIGN_EVENT_NAME", e.name)
+                                       ),
+                                       systemEnv,
+                                       HookExecutionHistory.Keep,
+                                       1.minutes // warn if a hook took more than a minute
+                                     )
+                       timeHooks1 <- currentTimeMillis
+                       _          <-
+                         PureHooksLogger.For(loggerName).trace(s"Inventory received hooks ran in ${timeHooks1 - timeHooks0} ms")
+                     } yield res
+      } yield HookResults((res._1 :: res._2).map(HookResult.fromCode))
+    ).catchAll { err =>
+      PureHooksLogger.For(loggerName).error(err.fullMsg) *>
+      HookResults(List(HookResult(loggerName, 1, "", err.fullMsg, "System error when executing hook"))).succeed
+    }
+  }
+}

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/CampaignRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/CampaignRepository.scala
@@ -41,21 +41,23 @@ import better.files.File
 import com.normation.errors.Inconsistency
 import com.normation.errors.IOResult
 import com.normation.errors.Unexpected
+import com.normation.rudder.facts.nodes.ChangeContext
 import zio.*
 import zio.syntax.*
 
 trait CampaignRepository {
   def getAll(typeFilter: List[CampaignType], statusFilter: List[CampaignStatusValue]): IOResult[List[Campaign]]
   def get(id:            CampaignId): IOResult[Option[Campaign]]
-  def delete(id:         CampaignId): IOResult[CampaignId]
+  def delete(id:         CampaignId): IOResult[Unit]
   def save(c:            Campaign): IOResult[Campaign]
 }
 
 object CampaignRepositoryImpl {
   def make(
-      campaignSerializer:      CampaignSerializer,
-      path:                    File,
-      campaignEventRepository: CampaignEventRepository
+      path:               File,
+      campaignArchiver:   CampaignArchiver,
+      campaignSerializer: CampaignSerializer,
+      hooksRepository:    CampaignHooksRepository
   ): IOResult[CampaignRepositoryImpl] = {
     IOResult.attemptZIO {
       if (path.exists) {
@@ -66,7 +68,10 @@ object CampaignRepositoryImpl {
         path.createDirectoryIfNotExists(createParents = true).succeed
       }
     } *>
-    new CampaignRepositoryImpl(campaignSerializer, path, campaignEventRepository).succeed
+    // init archiver
+    campaignArchiver.init(ChangeContext.newForRudder()) *>
+    // return campaign repo
+    new CampaignRepositoryImpl(path, campaignArchiver, campaignSerializer, hooksRepository).succeed
   }
 }
 
@@ -74,10 +79,14 @@ object CampaignRepositoryImpl {
  * A default implementation for the campaign repository. Campaigns are stored in a json file
  * (by default for Rudder in /var/rudder/configuration-repository/campaigns)
  */
-class CampaignRepositoryImpl(campaignSerializer: CampaignSerializer, path: File, campaignEventRepository: CampaignEventRepository)
-    extends CampaignRepository {
+class CampaignRepositoryImpl(
+    path:               File,
+    campaignArchiver:   CampaignArchiver,
+    campaignSerializer: CampaignSerializer,
+    hooksRepository:    CampaignHooksRepository
+) extends CampaignRepository {
 
-  def getAll(typeFilter: List[CampaignType], statusFilter: List[CampaignStatusValue]): IOResult[List[Campaign]] = {
+  override def getAll(typeFilter: List[CampaignType], statusFilter: List[CampaignStatusValue]): IOResult[List[Campaign]] = {
     if (path.exists) {
       for {
         jsonFiles          <- IOResult.attempt(path.collectChildren(_.extension.exists(_ == ".json")))
@@ -101,7 +110,7 @@ class CampaignRepositoryImpl(campaignSerializer: CampaignSerializer, path: File,
     }
   }
 
-  def get(id: CampaignId): IOResult[Option[Campaign]] = {
+  override def get(id: CampaignId): IOResult[Option[Campaign]] = {
     val file = path / (s"${id.value}.json")
     for {
       campaign <- ZIO.when(file.exists) {
@@ -112,10 +121,18 @@ class CampaignRepositoryImpl(campaignSerializer: CampaignSerializer, path: File,
     }
   }
 
-  def save(c: Campaign): IOResult[Campaign] = {
+  /*
+   * When we save a campaign, we also init hook directories for that campaign.
+   */
+  override def save(c: Campaign): IOResult[Campaign] = {
     for {
       _       <- ZIO.when(c.info.id.value.isBlank)(Inconsistency("A campaign id must be defined and non empty").fail)
       _       <- ZIO.when(c.info.name.isBlank)(Inconsistency("A campaign name must be defined and non empty").fail)
+      _       <- hooksRepository
+                   .initHooks(c.info.id)
+                   .chainError(
+                     s"Error with hook directory initialization for campaign '${c.info.id}'"
+                   )
       file    <- IOResult.attempt(s"error when creating campaign file for campaign with id '${c.info.id.value}'") {
                    val file = path / (s"${c.info.id.value}.json")
                    file.createFileIfNotExists(true)
@@ -123,21 +140,20 @@ class CampaignRepositoryImpl(campaignSerializer: CampaignSerializer, path: File,
                  }
       content <- campaignSerializer.serialize(c)
       _       <- IOResult.attempt(file.write(content))
+      _       <- campaignArchiver.saveCampaign(c.info.id)(ChangeContext.newForRudder())
     } yield {
       c
     }
   }
 
-  def delete(id: CampaignId): IOResult[CampaignId] = {
+  override def delete(id: CampaignId): IOResult[Unit] = {
     for {
       campaign_deleted <- IOResult.attempt(s"error when delete campaign file for campaign with id '${id.value}'") {
                             val file = path / (s"${id.value}.json")
                             file.delete()
                           }
-      events_deleted   <- campaignEventRepository.deleteEvent(campaignId = Some(id))
-    } yield {
-      id
-    }
+      _                <- campaignArchiver.deleteCampaign(id)(ChangeContext.newForRudder())
+    } yield ()
   }
 
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
@@ -375,9 +375,9 @@ class PolicyWriterServiceImpl(
       }
       val msg                 = errorCode match {
         // we need to limit sdtout/sdterr length
-        case HookReturnCode.ScriptError(code, stdout, stderr, msg) =>
+        case HookReturnCode.ScriptError(_, code, stdout, stderr, msg) =>
           s"${msg} [stdout:${limitOut(stdout)}][stderr:${limitOut(stderr)}]"
-        case x                                                     => x.msg
+        case x                                                        => x.msg
       }
     }
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/MockServices.scala
@@ -3257,17 +3257,17 @@ class MockCampaign() {
       }
     }
 
-    override def get(id: CampaignId): IOResult[Option[Campaign]] =
-      items.get.map(_.get(id))
-    override def save(c: Campaign):   IOResult[Campaign]         = {
+    override def get(id: CampaignId): IOResult[Option[Campaign]] = items.get.map(_.get(id))
+
+    override def save(c: Campaign): IOResult[Campaign] = {
       c match {
         case x: DumbCampaignTrait => items.update(_ + (x.info.id -> x)) *> c.succeed
         case _ => Inconsistency("Unknown campaign type").fail
       }
     }
 
-    def delete(id: CampaignId): IOResult[CampaignId] = {
-      items.update(_ - id) *> id.succeed
+    override def delete(id: CampaignId): IOResult[Unit] = {
+      items.update(_ - id)
     }
   }
 
@@ -3310,7 +3310,7 @@ class MockCampaign() {
     }
 
     def isActive(e: CampaignEvent): Boolean = {
-      e.state == CampaignEventStateType.Scheduled || e.state == CampaignEventStateType.Running
+      e.state == CampaignEventStateType.TScheduled || e.state == CampaignEventStateType.TRunning
     }
 
     override def get(id: CampaignEventId): IOResult[Option[CampaignEvent]] = {
@@ -3453,7 +3453,15 @@ class MockCampaign() {
     }
   }
 
-  val mainCampaignService =
-    new MainCampaignService(dumbCampaignEventRepository, repo, campaignArchive, new StringUuidGeneratorImpl(), 0, 0)
+  val mainCampaignService = {
+    new MainCampaignService(
+      dumbCampaignEventRepository,
+      repo,
+      NoopCampaignHooksService,
+      new StringUuidGeneratorImpl(),
+      0,
+      0
+    )
+  }
 
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/HooksTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/HooksTest.scala
@@ -42,6 +42,7 @@ import com.normation.rudder.hooks.HookReturnCode.Ok
 import com.normation.rudder.hooks.HookReturnCode.ScriptError
 import com.normation.rudder.hooks.HookReturnCode.SystemError
 import com.normation.rudder.hooks.HookReturnCode.Warning
+import com.normation.zio.ZioRuntime
 import java.nio.file.attribute.PosixFilePermissions
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
@@ -64,13 +65,15 @@ class HooksTest() extends Specification with AfterAll {
   val tmp: File = File(s"/tmp/rudder-test-hook/${DateTime.now(DateTimeZone.UTC).toString(ISODateTimeFormat.dateTime())}")
   tmp.createDirectoryIfNotExists(true)
 
+  def cmd(s: String): String = (tmp / s).pathAsString
+
   List("error10.sh", "success.sh", "warning50.sh", "echoCODE.sh", "timeout.sh", "timeout_ok.sh").foreach { i =>
     val f = File(tmp, i)
     f.write(Resource.getAsString(s"hooks.d/test/$i"))
     f.setPermissions(PosixFilePermissions.fromString("rwxr--r--").asScala.toSet)
   }
 
-  def runHooks(hooks: List[String], params: List[HookEnvPair]): HookReturnCode = {
+  def runHooks(hooks: List[String], params: List[HookEnvPair]):       HookReturnCode       = {
     RunHooks.syncRun(
       "test.hooks",
       Hooks(tmp.pathAsString, hooks.map(f => (f, HookTimeout(None, None)))),
@@ -79,6 +82,22 @@ class HooksTest() extends Specification with AfterAll {
       1.second,
       500.millis,
       5.seconds
+    )
+  }
+  def runHookHistory(hooks: List[String], params: List[HookEnvPair]): List[HookReturnCode] = {
+    ZioRuntime.runNow(
+      RunHooks
+        .asyncRunHistory(
+          "test.hooks",
+          Hooks(tmp.pathAsString, hooks.map(f => (f, HookTimeout(None, None)))),
+          HookEnvPairs(params),
+          HookEnvPairs(Nil),
+          HookExecutionHistory.Keep,
+          1.second,
+          500.millis,
+          5.seconds
+        )
+        .map(c => c._1 :: c._2)
     )
   }
 
@@ -96,27 +115,37 @@ class HooksTest() extends Specification with AfterAll {
 
   "A successful hook should be a success" >> {
     val res = runHooks(List("success.sh"), Nil)
-    res must beEqualTo(Ok("", ""))
+    res must beEqualTo(Ok(cmd("success.sh"), "", ""))
   }
 
   "A success, then a warning should keep the warning" >> {
     val res = runHooks(List("success.sh", "warning50.sh"), Nil)
-    res must beEqualTo(Warning(50, "", "", s"Exit code=50 for hook: '${tmp.pathAsString}/warning50.sh'."))
+    res must beEqualTo(Warning(cmd("warning50.sh"), 50, "", "", s"Exit code=50 for hook: '${tmp.pathAsString}/warning50.sh'."))
   }
 
   "A warning shouldn't stop execution" >> {
     val res = runHooks(List("warning50.sh", "success.sh"), Nil)
-    res must beEqualTo(Ok("", ""))
+    res must beEqualTo(Ok(cmd("success.sh"), "", ""))
+  }
+
+  "We can store several result history" >> {
+    val res = runHookHistory(List("warning50.sh", "success.sh"), Nil)
+    res must beEqualTo(
+      List(
+        Ok(cmd("success.sh"), "", ""),
+        Warning(cmd("warning50.sh"), 50, "", "", s"Exit code=50 for hook: '${tmp.pathAsString}/warning50.sh'.")
+      )
+    )
   }
 
   "An error should stop the execution" >> {
     val res = runHooks(List("error10.sh", "warning50.sh"), Nil)
-    res must beEqualTo(ScriptError(10, "", "", s"Exit code=10 for hook: '${tmp.pathAsString}/error10.sh'."))
+    res must beEqualTo(ScriptError(cmd("error10.sh"), 10, "", "", s"Exit code=10 for hook: '${tmp.pathAsString}/error10.sh'."))
   }
 
   "A hook should be able to read env variables as parameter" >> {
     val res = runHooks(List("echoCODE.sh"), HookEnvPair("CODE", "0") :: Nil)
-    res must beEqualTo(Ok("", ""))
+    res must beEqualTo(Ok(cmd("echoCODE.sh"), "", ""))
   }
 
   "A hook should be killed after time-out duration is reached and message contains what script failed" >> {
@@ -137,7 +166,7 @@ class HooksTest() extends Specification with AfterAll {
       500.millis
     )
     timeout must beEqualTo(HookTimeout(Some(6.seconds), Some(10.seconds)))
-    res must beEqualTo(Ok("", ""))
+    res must beEqualTo(Ok(cmd("timeout_ok.sh"), "", ""))
   }
 
 // This one is more for testing performance. I don't want to make it a test, because in

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/CampaignApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/CampaignApi.scala
@@ -207,7 +207,7 @@ class CampaignApi(
         c           = if (campaign.info.schedule.tz.isDefined) campaign else campaign.setScheduleTimeZone(ScheduleTimeZone.now())
         withId      = if (campaign.info.id.value.isEmpty) c.copyWithId(CampaignId(stringUuidGenerator.newUuid)) else c
         saved      <- mainCampaignService.saveCampaign(withId)
-        serialized <- campaignSerializer.getJson(saved)
+        serialized <- campaignSerializer.getJson(withId)
       } yield {
         serialized
       }).tapError(err => CampaignLogger.error(s"Error when saving campaign: " + err.fullMsg))

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/CampaignApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/CampaignApiTest.scala
@@ -160,7 +160,7 @@ class CampaignApiTest extends Specification with AfterAll with Loggable with Jso
               .getOrElse(throw new IllegalArgumentException(s"Missing test value"))
             // it's in the future
             (next.start.getMillis must be_>(System.currentTimeMillis())) and
-            (next.state.value must beEqualTo(Scheduled)) and
+            (next.state.value must beEqualTo(TScheduled)) and
             (next.campaignId must beEqualTo(ce0.campaignId))
           }
 

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/earlyconfig/db/TestMigrateTableCampaignEvents.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/earlyconfig/db/TestMigrateTableCampaignEvents.scala
@@ -283,7 +283,7 @@ class TestMigrateTableCampaignEvents extends DBCommon {
       val sql1 = sql"""SELECT state FROM CampaignEvents WHERE eventid = '7cca021a'"""
       doobie.transactRunEither(sql1.query[String].option.transact(_)) must beRight(
         beSome(
-          CampaignEventStateType.Failure.entryName
+          CampaignEventStateType.TFailure.entryName
         )
       )
 
@@ -291,7 +291,7 @@ class TestMigrateTableCampaignEvents extends DBCommon {
       doobie.transactRunEither(sql2.query[(String, Json)].option.transact(_)) must beRight(
         beSome(
           (
-            CampaignEventStateType.Failure.entryName,
+            CampaignEventStateType.TFailure.entryName,
             Json.Obj(
               "cause"   -> Json.Str("An error occurred when processing event"),
               "message" -> Json.Str("An error occurred when processing event: inconsistency in migration")
@@ -323,7 +323,7 @@ class TestMigrateTableCampaignEvents extends DBCommon {
     "be able to do by criteria search" in {
       repo
         .getWithCriteria(
-          CampaignEventStateType.Finished :: CampaignEventStateType.Failure :: Nil,
+          CampaignEventStateType.TFinished :: CampaignEventStateType.TFailure :: Nil,
           CampaignType("system-update") :: Nil,
           None,
           Some(5),


### PR DESCRIPTION
https://issues.rudder.io/issues/26883

Create the `CampaignHooksService` and the corresponding step in campaign workflow and persistence in base. 
There is no unit tests, they will be added after https://github.com/Normation/rudder/pull/6555 make them easier to code. 

So, the main thing is the addition of: 

## `CampaignHooksService` and its implementation

That adds a service that run campaign related hooks, which are located on FS along with other Rudder hooks. The difference is that for these ones, each campaign can have different hooks and so, under the `.../hook.d/campaign/` directoty, there is one directoty for each campaign with its subdirectories for `pre-hooks` and `post-hooks`. 

- `CampaignHooksRepository` allows to create and delete the relevant directories when a campaign is created/deleted. 
- `CampaignHooksService`: the hook execution by itself is not interesting: it's the same than for all other hooks, with the following environment variables (all obvious I think): 
```
"CAMPAIGN_ID"
"CAMPAIGN_NAME"
"CAMPAIGN_TYPE"
"CAMPAIGN_EVENT_ID"
"CAMPAIGN_EVENT_NAME"
```
- `RunHooks` was updated to be able to add a variant of `asyncExec` that keep the whole logs of all run hooks, not only the last (failledà one. That will allow to store them in the corresponding campaign event and for forensic. 

## Campaign logic

The main things is to add the too new state and their type. I normalized their name to `pre-hooks` and `post-hooks` (with a '-') to be  consistent on FS and base and JSON. 

The logic is to call the hook service when we are in the corresponding event state. 


## Refactoring

Some light refactoring was done:
- pattern matching on the even state types, 
- addind a `T` to differentiate between event state and event state type. 
- adding the hook name as a recorded data in the `HookReturnCode` so that we have the command name with the logs,
- hide `CampaignArchiver` in `CampaignRepositoryImpl`, it's an implementation details that should not be top-level