### PR TITLE
Fixes #27450: Fix the rudder_info! macro to make it usable in audit mode

### DIFF
--- a/policies/rudder-module-type/src/cfengine/log.rs
+++ b/policies/rudder-module-type/src/cfengine/log.rs
@@ -36,7 +36,8 @@ impl fmt::Display for Level {
                 Level::Critical => "critical",
                 Level::Error => "error",
                 Level::Warning => "warning",
-                Level::Info => "info",
+                // 'notice' is used in place of 'info' for allowing Level::Info to be used in audit mode.
+                Level::Info => "notice",
                 Level::Debug => "verbose",
                 Level::Trace => "debug",
             }


### PR DESCRIPTION
https://issues.rudder.io/issues/27450

CFEngine offers multiple [log levels](https://docs.cfengine.com/docs/3.26/reference-promise-types.html#log_priority). The `info` level previously used in our macro is intended to be used only in [enforce mode](https://github.com/cfengine/core/blob/37e62318b14c9b581fea20b0f02b069b758223ac/libpromises/mod_custom.c#L1039). The `rudder_info!` macro will now use the `notice` priority level to retain the same semantics while avoiding CFEngine errors when running in audit mode.