### PR TITLE
Fixes #27387: Cannot delete a technique from technique tree with grayed screen

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/ComponentTechniqueEditForm.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/components/ComponentTechniqueEditForm.html
@@ -36,11 +36,9 @@ All text that will be modified will be put in []
 </component-comment>
 
 <component-body>
-	<div>
-		<div id="editForm" ></div>
-		<div id="removeActionDialog" ></div>
-		<div id="disactivateActionDialog" ></div>
-	</div>
+    <div id="editForm" ></div>
+    <div id="removeActionDialog" ></div>
+    <div id="disactivateActionDialog" ></div>
 </component-body>
 
 <component-form>
@@ -89,54 +87,49 @@ All text that will be modified will be put in []
 </component-form>
 
 <component-popupremoveform>
-    <div>
-        <div id="deleteActionDialog" class="modal fade" tabindex="-1">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title">Delete a Technique</h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+    <div id="deleteActionDialog" class="modal fade" tabindex="-1" data-bs-backdrop="false">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Delete a Technique</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="row space-bottom">
+                        <div class="col-xl-12">
+                            <h4 class="text-center">
+                                Are you sure that you want to completely delete this item ?
+                            </h4>
+                        </div>
                     </div>
-                    <div class="modal-body">
-                        <div class="row space-bottom">
-                            <div class="col-xl-12">
-                                <h4 class="text-center">
-                                    Are you sure that you want to completely delete this item ?
-                                </h4>
-                            </div>
-                        </div>
-                        <div id="deleteItemDependencies" class="well col-xl-12 col-sm-12 col-md-12" >
-                            [Here comes the tree of Directives / Rules that will be removed]
-                        </div>
-                        <div class="alert alert-warning col-xl-12 col-md-12 col-sm-12 text-center space-bottom" role="alert">
-                            <span class="fa fa-exclamation-triangle" aria-hidden="true"></span>
-                            <span class="d-none">Warning:</span>
-                            Deleting this Technique will also delete its history and compliance reports,
-                            and the Directives and Rules above.
-                        </div>
-                        <h4 class="col-xl-12 col-md-12 col-sm-12 audit-title">Change Audit Log</h4>
-                        <div class="reasonsFieldset">
-                            <div id="reasonsField">
-                                Here comes the reasons field
-                            </div>
-                        </div>
-                        <hr class="spacer" />
-
+                    <div id="deleteItemDependencies" class="well col-xl-12 col-sm-12 col-md-12" >
+                        [Here comes the tree of Directives / Rules that will be removed]
                     </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-bs-dismiss="modal">Cancel</button>
-                        <button id="dialogDeleteButton" class="btn btn-danger">[Delete]</button>
-                    </div>  
+                    <div class="alert alert-warning col-xl-12 col-md-12 col-sm-12 text-center space-bottom" role="alert">
+                        <span class="fa fa-exclamation-triangle" aria-hidden="true"></span>
+                        <span class="d-none">Warning:</span>
+                        Deleting this Technique will also delete its history and compliance reports,
+                        and the Directives and Rules above.
+                    </div>
+                    <h4 class="col-xl-12 col-md-12 col-sm-12 audit-title">Change Audit Log</h4>
+                    <div class="reasonsFieldset">
+                        <div id="reasonsField">
+                            Here comes the reasons field
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-bs-dismiss="modal">Cancel</button>
+                    <button id="dialogDeleteButton" class="btn btn-danger">[Delete]</button>
                 </div>
             </div>
         </div>
     </div>
 </component-popupremoveform>
 
-<component-popupdisableform>    
-<div>
-    <div id="disableActionDialog" class="modal fade" tabindex="-1">
-        <div class="modal-dialog">
+<component-popupdisableform>
+    <div id="disableActionDialog" class="modal fade" tabindex="-1" data-bs-backdrop="false">
+        <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">
@@ -177,7 +170,6 @@ All text that will be modified will be put in []
             </div>
         </div>
     </div>
-</div>
 </component-popupdisableform>
 
 </xml:group>


### PR DESCRIPTION
https://issues.rudder.io/issues/27387

I removed the extra modal backdrop that was displayed in front of the modal, here is the result :
<img width="1622" height="932" alt="modal-technique" src="https://github.com/user-attachments/assets/5892eb35-6b62-4bfc-94d9-f6d2fdfc3f7d" />

It's not perfect because the modal is displayed in the tab and doesn't cover the entire interface, but that's another issue: it stems from the page structure which needs to be completely redesigned, but that's another issue.