### PR TITLE
Fixes #27486: Add includeSystem parameter to filter system groups in API

### DIFF
--- a/webapp/sources/api-doc/code_samples/curl/groups/tree.sh
+++ b/webapp/sources/api-doc/code_samples/curl/groups/tree.sh
@@ -1,1 +1,1 @@
-curl --header "X-API-Token: yourToken" --request GET https://rudder.example.com/rudder/api/latest/groups/tree
+curl --header "X-API-Token: yourToken" --request GET https://rudder.example.com/rudder/api/latest/groups/tree?includeSystem=true

--- a/webapp/sources/api-doc/components/schemas/directive-tree.yml
+++ b/webapp/sources/api-doc/components/schemas/directive-tree.yml
@@ -8,35 +8,35 @@ properties:
     type: string
     example: This category contains Techniques designed to install, configure and manage applications
     description: Category description
-  subcategories:
+  subCategories:
     description: Sub categories of the category
     type: array
     items:
       type: object
-        properties:
-          name:
-            type: string
-            description: Category name
-          description:
-            type: string
-            description: Category description
-          subcategories:
-            type: array
-            description: Sub categories of the sub category
-          techniques:
-            type: array
-            description: Techniques of the sub category
+      properties:
+        name:
+          type: string
+          description: Category name
+        description:
+          type: string
+          description: Category description
+        subCategories:
+          type: array
+          description: Sub categories of the sub category
+        techniques:
+          type: array
+          description: Techniques of the sub category
   techniques:
     type: array
     items:
       type: object
-        properties:
-          name:
-            type: string
-            example: checkGenericFileContent
-            description: technique name
-          directives:
-            type: array
-            description: Directives of the techniques
-            items:
-              $ref: directive.yml
+      properties:
+        name:
+          type: string
+          example: checkGenericFileContent
+          description: technique name
+        directives:
+          type: array
+          description: Directives of the techniques
+          items:
+            $ref: directive.yml

--- a/webapp/sources/api-doc/openapi.src.yml
+++ b/webapp/sources/api-doc/openapi.src.yml
@@ -313,6 +313,8 @@ paths:
     $ref: paths/directives/id.yml
   "/directives/{directiveId}/check":
     $ref: paths/directives/id-check.yml
+  "/directives/tree":
+    $ref: paths/directives/tree.yml
   "/rules":
     $ref: paths/rules/all.yml
   "/rules/{ruleId}":

--- a/webapp/sources/api-doc/paths/directives/tree.yml
+++ b/webapp/sources/api-doc/paths/directives/tree.yml
@@ -1,7 +1,18 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2025 Normation SAS
 get:
   summary: Get directive tree
   description: Get all information about all directives in a tree like structure (with categories and techniques)
   operationId: directivesTree
+  parameters:
+    - name: "includeSystem"
+      in: query
+      required: false
+      schema:
+        type: boolean
+        default: false
+      example: true
+      description: Should we include system techniques and categories in the tree or not.
   requestBody:
     required: false
     content:
@@ -12,7 +23,7 @@ get:
             includeSystem:
               type: boolean
               example: false
-              description: Should we include or not system techniques and categories in the tree.
+              description: Should we include system techniques and categories in the tree or not.
   responses:
     '200':
       description: Directives tree
@@ -20,10 +31,10 @@ get:
         application/json:
           schema:
             type: object
-              required:
-                - result
-                - action
-                - data
+            required:
+              - result
+              - action
+              - data
             properties:
               result:
                 type: string
@@ -36,15 +47,15 @@ get:
                 description: The id of the action
                 enum:
                   - directivesTree
-            data:
-              type: object
-              required:
-                - directiveTree
-              properties:
-                directives:
-                    type: object
+              data:
+                type: object
+                required:
+                  - directives
+                properties:
+                  directives:
+                    type: array
                     items:
-                      $ref: ../../components/schemas/directiveTree.yml
+                      $ref: ../../components/schemas/directive-tree.yml
   tags:
     - Directives
   x-codeSamples:

--- a/webapp/sources/api-doc/paths/groups/tree.yml
+++ b/webapp/sources/api-doc/paths/groups/tree.yml
@@ -4,6 +4,15 @@ get:
   summary: Get groups tree
   description: Get all available groups and their categories in a tree
   operationId: GetGroupTree
+  parameters:
+    - name: "includeSystem"
+      in: query
+      required: false
+      schema:
+        type: boolean
+        default: true
+      example: false
+      description: Whether to include system categories and groups in results.
   responses:
     "200":
       description: Groups information
@@ -67,6 +76,9 @@ get:
                             - root
                           dynamic: true
                           enabled: true
+                          properties: []
+                          target: "group:hasPolicyServer-root"
+                          system: true
                     - id: 38dd2107-a73b-45fb-916d-e110312abb87
                       name: production groups
                       description: ""
@@ -87,6 +99,8 @@ get:
                           nodeIds: []
                           dynamic: false
                           enabled: true
+                          target: "group:79d83ff9-24d8-4be6-b1f7-cbb1c173f7a5"
+                          system: false
                   groups:
                     - id: af208515-c2f2-4577-bbf4-9fffebbe6629
                       displayName: Test Clients
@@ -106,6 +120,8 @@ get:
                       nodeIds: []
                       dynamic: true
                       enabled: true
+                      target: "group:af208515-c2f2-4577-bbf4-9fffebbe6629"
+                      system: false
                     - id: d7634b2d-7189-422b-9971-24c29b75da46
                       displayName: Test Clients
                       description: ""
@@ -124,6 +140,8 @@ get:
                       nodeIds: []
                       dynamic: true
                       enabled: true
+                      target: "group:d7634b2d-7189-422b-9971-24c29b75da46"
+                      system: false
 
   tags:
     - Groups

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -61,6 +61,7 @@ import com.normation.rudder.facts.nodes.QueryContext
 import com.normation.rudder.properties.NodePropertiesService
 import com.normation.rudder.properties.PropertiesRepository
 import com.normation.rudder.repository.CategoryAndNodeGroup
+import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.repository.RoNodeGroupRepository
 import com.normation.rudder.repository.WoNodeGroupRepository
 import com.normation.rudder.rest.*
@@ -260,15 +261,16 @@ class GroupsApi(
   object GetTree        extends LiftApiModule0      {
     val schema:                                                                                                API.GetGroupTree.type = API.GetGroupTree
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse          = {
-      service
-        .getCategoryTree(version)
-        .map(JRGroupCategoriesFull(_))
-        .chainError("Could not fetch Group tree")
-        .toLiftResponseOne(
-          params,
-          schema,
-          _ => None
-        )
+      (for {
+        includeSystem <- zioJsonExtractor.extractIncludeSystem(req).toIO
+        res           <-
+          service
+            .getCategoryTree(includeSystem.getOrElse(true))
+            .map(JRGroupCategoriesFull(_))
+            .chainError("Could not fetch Group tree")
+      } yield {
+        res
+      }).toLiftResponseOne(params, schema, _ => None)
     }
   }
   object GetCategory    extends LiftApiModuleString {
@@ -590,8 +592,21 @@ class GroupApiService14(
     }
   }
 
-  def getCategoryTree(apiVersion: ApiVersion): IOResult[JRFullGroupCategory] = {
-    readGroup.getFullGroupLibrary().map(JRFullGroupCategory.fromCategory(_, None))
+  def getCategoryTree(includeSystem: Boolean): IOResult[JRFullGroupCategory] = {
+    def filterSystem(cat: FullNodeGroupCategory): FullNodeGroupCategory = {
+      if (includeSystem) {
+        cat
+      } else {
+        // system categories are only at root level
+        cat.copy(
+          subCategories = cat.subCategories.filterNot(_.isSystem),
+          targetInfos = cat.targetInfos.filterNot(_.isSystem)
+        )
+      }
+    }
+    readGroup
+      .getFullGroupLibrary()
+      .map(c => JRFullGroupCategory.fromCategory(filterSystem(c), None))
   }
 
   def getCategoryDetails(id: NodeGroupCategoryId): IOResult[JRMinimalGroupCategory] = {

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
@@ -551,7 +551,7 @@ response:
           {
             "id" : "all-nodes",
             "displayName" : "All nodes",
-            "description" : "All nodes known by Rudder(including Rudder policy servers)",
+            "description" : "All nodes known by Rudder (including Rudder policy servers)",
             "category" : "GroupRoot",
             "nodeIds" : [
               "0",
@@ -579,6 +579,7 @@ response:
         ]
       }
     }
+---
 description: Create a node group (JSON)
 method: PUT
 url: /api/latest/groups
@@ -2213,6 +2214,359 @@ response:
         }
       }
     }
+---
+description: List all group categories and group without system ones in a tree format
+method: GET
+url: /api/latest/groups/tree?includeSystem=false
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getGroupTree",
+      "result" : "success",
+      "data" : {
+        "groupCategories" : {
+          "id" : "GroupRoot",
+          "name" : "GroupRoot",
+          "description" : "root of group categories",
+          "parent" : "GroupRoot",
+          "categories" : [
+            {
+              "id" : "219b9c98-3d1e-44c9-0001-95b4fc7c4ada",
+              "name" : "category 2",
+              "description" : "",
+              "parent" : "GroupRoot",
+              "categories" : [],
+              "groups" : [],
+              "targets" : []
+            },
+            {
+              "id" : "219b9c98-3d1e-44c9-aff5-95b4fc7c4ada",
+              "name" : "category 2",
+              "description" : "",
+              "parent" : "GroupRoot",
+              "categories" : [],
+              "groups" : [],
+              "targets" : []
+            },
+            {
+              "id" : "category1",
+              "name" : "category 1",
+              "description" : "the first category",
+              "parent" : "GroupRoot",
+              "categories" : [
+                {
+                  "id" : "219b9c98-3d1e-44c9-0001-95b4fc7c4ada",
+                  "name" : "category 2 update",
+                  "description" : "category 2",
+                  "parent" : "category1",
+                  "categories" : [],
+                  "groups" : [],
+                  "targets" : []
+                },
+                {
+                  "id" : "219b9c98-3d1e-44c9-aff5-95b4fc7c4ada",
+                  "name" : "category 2 update",
+                  "description" : "category 2",
+                  "parent" : "category1",
+                  "categories" : [],
+                  "groups" : [],
+                  "targets" : []
+                }
+              ],
+              "groups" : [
+                {
+                  "id" : "0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "displayName" : "Real nodes",
+                  "description" : "",
+                  "category" : "category1",
+                  "query" : {
+                    "select" : "nodeAndPolicyServer",
+                    "composition" : "or",
+                    "where" : [
+                      {
+                        "objectType" : "node",
+                        "attribute" : "nodeId",
+                        "comparator" : "eq",
+                        "value" : "node1"
+                      },
+                      {
+                        "objectType" : "node",
+                        "attribute" : "nodeId",
+                        "comparator" : "eq",
+                        "value" : "node2"
+                      },
+                      {
+                        "objectType" : "node",
+                        "attribute" : "nodeId",
+                        "comparator" : "eq",
+                        "value" : "root"
+                      }
+                    ]
+                  },
+                  "nodeIds" : [
+                    "node1",
+                    "node2",
+                    "root"
+                  ],
+                  "dynamic" : false,
+                  "enabled" : true,
+                  "groupClass" : [
+                    "group_0000f5d3_8c61_4d20_88a7_bb947705ba8a",
+                    "group_real_nodes"
+                  ],
+                  "properties" : [
+                    {
+                      "name" : "stringParam",
+                      "value" : "string",
+                      "inheritMode" : "map",
+                      "provider" : "datasources"
+                    },
+                    {
+                      "name" : "jsonParam",
+                      "value" : {
+                        "array" : [
+                          5,
+                          6
+                        ],
+                        "group" : "string",
+                        "json" : {
+                          "g1" : "g1"
+                        }
+                      }
+                    }
+                  ],
+                  "target" : "group:0000f5d3-8c61-4d20-88a7-bb947705ba8a",
+                  "system" : false
+                }
+              ],
+              "targets" : []
+            }
+          ],
+          "groups" : [
+            {
+              "id" : "00000000-cb9d-4f7b-0001-ca38c5d643ea",
+              "displayName" : "clone from api of debian group",
+              "description" : "Some long description",
+              "category" : "GroupRoot",
+              "query" : {
+                "select" : "node",
+                "composition" : "and",
+                "where" : [
+                  {
+                    "objectType" : "node",
+                    "attribute" : "osName",
+                    "comparator" : "eq",
+                    "value" : "Debian"
+                  },
+                  {
+                    "objectType" : "node",
+                    "attribute" : "osVersion",
+                    "comparator" : "regex",
+                    "value" : "10\\..*"
+                  }
+                ]
+              },
+              "nodeIds" : [],
+              "dynamic" : true,
+              "enabled" : true,
+              "groupClass" : [
+                "group_00000000_cb9d_4f7b_0001_ca38c5d643ea",
+                "group_clone_from_api_of_debian_group"
+              ],
+              "properties" : [
+                {
+                  "name" : "os",
+                  "value" : {
+                    "name" : "debian",
+                    "nickname" : "Buster"
+                  }
+                }
+              ],
+              "target" : "group:00000000-cb9d-4f7b-0001-ca38c5d643ea",
+              "system" : false
+            },
+            {
+              "id" : "00000000-cb9d-4f7b-abda-ca38c5d643ea",
+              "displayName" : "clone from api of debian group",
+              "description" : "Some long description",
+              "category" : "GroupRoot",
+              "query": {
+                "select": "nodeAndPolicyServer",
+                "composition": "and",
+                "transform": "invert",
+                "where":[
+                  {
+                    "objectType": "node",
+                    "attribute": "nodeId",
+                    "comparator": "eq",
+                    "value": ""
+                  }
+                ]
+              },
+              "nodeIds" : [],
+              "dynamic" : true,
+              "enabled" : true,
+              "groupClass" : [
+                "group_00000000_cb9d_4f7b_abda_ca38c5d643ea",
+                "group_clone_from_api_of_debian_group"
+              ],
+              "properties" : [
+                {
+                  "name" : "os",
+                  "value" : {
+                    "name" : "debian",
+                    "nickname" : "Buster"
+                  }
+                }
+              ],
+              "target" : "group:00000000-cb9d-4f7b-abda-ca38c5d643ea",
+              "system" : false
+            },
+            {
+              "id" : "1111f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "displayName" : "Empty group",
+              "description" : "",
+              "category" : "GroupRoot",
+              "nodeIds" : [],
+              "dynamic" : false,
+              "enabled" : true,
+              "groupClass" : [
+                "group_1111f5d3_8c61_4d20_88a7_bb947705ba8a",
+                "group_empty_group"
+              ],
+              "properties" : [],
+              "target" : "group:1111f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "system" : false
+            },
+            {
+              "id" : "2222f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "displayName" : "only root",
+              "description" : "",
+              "category" : "GroupRoot",
+              "nodeIds" : [
+                "root"
+              ],
+              "dynamic" : false,
+              "enabled" : true,
+              "groupClass" : [
+                "group_2222f5d3_8c61_4d20_88a7_bb947705ba8a",
+                "group_only_root"
+              ],
+              "properties" : [],
+              "target" : "group:2222f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "system" : false
+            },
+            {
+              "id" : "3333f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "displayName" : "Even nodes",
+              "description" : "",
+              "category" : "GroupRoot",
+              "nodeIds" : [
+                "0",
+                "10",
+                "2",
+                "4",
+                "6",
+                "8"
+              ],
+              "dynamic" : false,
+              "enabled" : true,
+              "groupClass" : [
+                "group_3333f5d3_8c61_4d20_88a7_bb947705ba8a",
+                "group_even_nodes"
+              ],
+              "properties" : [],
+              "target" : "group:3333f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "system" : false
+            },
+            {
+              "id" : "4444f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "displayName" : "Odd nodes",
+              "description" : "",
+              "category" : "GroupRoot",
+              "nodeIds" : [
+                "1",
+                "3",
+                "5",
+                "7",
+                "9"
+              ],
+              "dynamic" : false,
+              "enabled" : true,
+              "groupClass" : [
+                "group_4444f5d3_8c61_4d20_88a7_bb947705ba8a",
+                "group_odd_nodes"
+              ],
+              "properties" : [],
+              "target" : "group:4444f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "system" : false
+            },
+            {
+              "id" : "5555f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "displayName" : "Nodes id divided by 3",
+              "description" : "",
+              "category" : "GroupRoot",
+              "nodeIds" : [
+                "0",
+                "3",
+                "6",
+                "9"
+              ],
+              "dynamic" : false,
+              "enabled" : true,
+              "groupClass" : [
+                "group_5555f5d3_8c61_4d20_88a7_bb947705ba8a",
+                "group_nodes_id_divided_by_3"
+              ],
+              "properties" : [],
+              "target" : "group:5555f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "system" : false
+            },
+            {
+              "id" : "6666f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "displayName" : "Nodes id divided by 5",
+              "description" : "",
+              "category" : "GroupRoot",
+              "nodeIds" : [
+                "0",
+                "10",
+                "5"
+              ],
+              "dynamic" : false,
+              "enabled" : true,
+              "groupClass" : [
+                "group_6666f5d3_8c61_4d20_88a7_bb947705ba8a",
+                "group_nodes_id_divided_by_5"
+              ],
+              "properties" : [],
+              "target" : "group:6666f5d3-8c61-4d20-88a7-bb947705ba8a",
+              "system" : false
+            },
+            {
+              "id" : "a-group-for-root-only",
+              "displayName" : "Serveurs [€ðŋ] cassés",
+              "description" : "Liste de l'ensemble de serveurs cassés à réparer",
+              "category" : "GroupRoot",
+              "nodeIds" : [
+                "root"
+              ],
+              "dynamic" : true,
+              "enabled" : true,
+              "groupClass" : [
+                "group_a_group_for_root_only",
+                "group_serveurs_______casses"
+              ],
+              "properties" : [],
+              "target" : "group:a-group-for-root-only",
+              "system" : false
+            }
+          ],
+          "targets" : []
+        }
+      }
+    }
+
 
 
 #


### PR DESCRIPTION
https://issues.rudder.io/issues/27486

Reusing the existing parameter extractor (used in the directives tree).
The filtering is also very similar, see https://github.com/Normation/rudder/blob/cd64fe5017654f3a988080d0c3fb2d6cc5bbc915/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala#L280-L288