### PR TITLE
Fixes #27428: Missing migration for existing directives with the bad select input identifier

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/test-migrate-select/1.0/metadata.xml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/test-migrate-select/1.0/metadata.xml
@@ -1,0 +1,51 @@
+<TECHNIQUE name="test-migrate-select">
+  <DESCRIPTION>test</DESCRIPTION>
+  <USEMETHODREPORTING>true</USEMETHODREPORTING>
+  <MULTIINSTANCE>true</MULTIINSTANCE>
+  <POLICYGENERATION>separated-with-parameters</POLICYGENERATION>
+  <AGENT type="cfengine-community">
+    <BUNDLES>
+      <NAME>test</NAME>
+    </BUNDLES>
+    <FILES>
+      <FILE name="technique.cf">
+        <INCLUDED>true</INCLUDED>
+      </FILE>
+    </FILES>
+  </AGENT>
+  <AGENT type="dsc">
+    <BUNDLES>
+      <NAME>Technique-Test</NAME>
+    </BUNDLES>
+    <FILES>
+      <FILE name="technique.ps1">
+        <INCLUDED>true</INCLUDED>
+      </FILE>
+    </FILES>
+  </AGENT>
+  <SECTIONS>
+    <SECTION name="Technique parameters">
+      <SELECT1>
+        <NAME>8BECA52F-7D5A-4C55-B5AE-FB56B7E50DDF</NAME>
+        <VARIABLENAME>test</VARIABLENAME>
+        <DESCRIPTION>Mode</DESCRIPTION>
+        <ITEM>
+          <LABEL>Enfore</LABEL>
+          <VALUE>enforce</VALUE>
+        </ITEM>
+        <ITEM>
+          <LABEL>Audit</LABEL>
+          <VALUE>audit</VALUE>
+        </ITEM>
+        <CONSTRAINT>
+          <TYPE>textarea</TYPE>
+        </CONSTRAINT>
+      </SELECT1>
+    </SECTION>
+    <SECTION name="Command execution" id="c7b5c43e-3bd2-492f-b926-de6ceb200a94" component="true" multivalued="true">
+      <REPORTKEYS>
+        <VALUE id="c7b5c43e-3bd2-492f-b926-de6ceb200a94">/bin/echo &quot;toto&quot;</VALUE>
+      </REPORTKEYS>
+    </SECTION>
+  </SECTIONS>
+</TECHNIQUE>

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/test-migrate-select/1.0/technique.cf
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/test-migrate-select/1.0/technique.cf
@@ -1,0 +1,44 @@
+# @name test
+# @version 1.0
+
+bundle agent test(test) {
+
+  vars:
+    "report_data.index" int => int(eval("${report_data.index}+1", "math", "infix")),
+                           unless => "rudder_increment_guard";
+    "local_index"       int => ${report_data.index},
+                           unless => "rudder_increment_guard";
+
+    "args"              slist => {"${test}"};
+    "report_param"      string => join("_", args);
+    "full_class_prefix" string => canonify("test_${report_param}");
+    "class_prefix"      string => string_head("${full_class_prefix}", "1000");
+
+  classes:
+    "rudder_increment_guard" expression => "any";
+
+    "pass3" expression => "pass2";
+    "pass2" expression => "pass1";
+    "pass1" expression => "any";
+
+  methods:
+    "index_${local_index}_0" usebundle => call_test_c7b5c43e_3bd2_492f_b926_de6ceb200a94("Command execution", "/bin/echo \"toto\"", "c7b5c43e-3bd2-492f-b926-de6ceb200a94", @{args}, "${class_prefix}", "/bin/echo \"toto\""),
+                                    if => "pass3";
+
+}
+bundle agent call_test_c7b5c43e_3bd2_492f_b926_de6ceb200a94(c_name, c_key, report_id, args, class_prefix, command) {
+
+  vars:
+    "report_data.index" int => int(eval("${report_data.index}+1", "math", "infix")),
+                           unless => "rudder_increment_guard";
+    "local_index"       int => ${report_data.index},
+                           unless => "rudder_increment_guard";
+
+  classes:
+    "rudder_increment_guard" expression => "any";
+
+  methods:
+    "index_${local_index}_0" usebundle => _method_reporting_context_v4("${c_name}", "${c_key}", "${report_id}");
+    "index_${local_index}_1" usebundle => command_execution("${command}");
+
+}

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/test-migrate-select/1.0/technique.ps1
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/test-migrate-select/1.0/technique.ps1
@@ -1,0 +1,75 @@
+﻿function Technique-Test {
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $true)]
+        [string]$reportId,
+        [parameter(Mandatory = $true)]
+        [string]$techniqueName,
+
+        [parameter(Mandatory = $true)]
+        [string]$test,
+        [Rudder.PolicyMode]$policyMode
+    )
+    $techniqueParams = @{
+
+        "test" = $test
+    }
+    BeginTechniqueCall -Name $techniqueName -Parameters $techniqueParams
+    $reportIdBase = $reportId.Substring(0, $reportId.Length - 1)
+
+    $fallBackReportParams = @{
+        ClassPrefix = 'skipped_method'
+        ComponentKey = 'None'
+        ComponentName = 'None'
+        TechniqueName = $techniqueName
+    }
+
+
+    $reportId=$reportIdBase + "c7b5c43e-3bd2-492f-b926-de6ceb200a94"
+    try {
+        $componentKey = @'
+/bin/echo "toto"
+'@
+        $reportParams = @{
+            ClassPrefix = ([Rudder.Condition]::canonify(("command_execution_" + $componentKey)))
+            ComponentKey = $componentKey
+            ComponentName = @'
+Command execution
+'@
+            PolicyMode = $policyMode
+            ReportId = $reportId
+            DisableReporting = $false
+            TechniqueName = $techniqueName
+        }
+        
+        $methodParams = @{
+            Command = @'
+/bin/echo "toto"
+'@
+            
+        }
+        $call = Command-Execution @methodParams -PolicyMode $policyMode
+        Compute-Method-Call @reportParams -MethodCall $call
+        
+    } catch [Nustache.Core.NustacheDataContextMissException], [Nustache.Core.NustacheException] {
+        $failedCall = [Rudder.MethodResult]::Error(
+            ([String]::Format(
+                'The method call was skipped because it references an undefined variable "{0}"',
+                $_.ToString()
+            )),
+            $techniqueName
+        )
+        Compute-Method-Call @fallBackReportParams -PolicyMode $policyMode -ReportId $reportId -DisableReporting:$false -MethodCall $failedCall
+    } catch {
+        $failedCall = [Rudder.MethodResult]::Error(
+            ([String]::Format(
+                'The method call was skipped as an unexpected error was thrown "{0}"',
+                (Format-Exception $_)[1]
+            )),
+            $techniqueName
+        )
+        Compute-Method-Call @fallBackReportParams -PolicyMode $policyMode -ReportId $reportId -DisableReporting:$false -MethodCall $failedCall
+    }
+
+    EndTechniqueCall -Name $techniqueName
+}

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/test-migrate-select/1.0/technique.yml
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/techniques/ncf_techniques/test-migrate-select/1.0/technique.yml
@@ -1,0 +1,21 @@
+id: test-migrate-select
+name: test
+version: '1.0'
+category: ncf_techniques
+params:
+  - id: 8beca52f-7d5a-4c55-b5ae-fb56b7e50ddf
+    name: test
+    description: Mode
+    constraints:
+      allow_empty: false
+      select:
+        - value: enforce
+          name: Enfore
+        - value: audit
+          name: Audit
+items:
+  - id: c7b5c43e-3bd2-492f-b926-de6ceb200a94
+    name: ''
+    method: command_execution
+    params:
+      command: /bin/echo "toto"

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_directives.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_directives.yml
@@ -2094,6 +2094,11 @@ response:
                     ]
                   },
                   {
+                    "id" : "test-migrate-select",
+                    "name" : "test-migrate-select",
+                    "directives" : []
+                  },
+                  {
                     "id": "test_import_export_archive",
                     "name": "test import/export archive",
                     "directives": [
@@ -2108,8 +2113,7 @@ response:
                           "section":{
                             "name":"sections",
                             "sections":[]
-                          }
-                        },
+                          }                        },
                         "priority":5,
                         "enabled": true,
                         "system": false,

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_techniques.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_techniques.yml
@@ -23,6 +23,12 @@ response:
             ]
           },
           {
+            "name" : "test-migrate-select",
+            "versions" : [
+              "1.0"
+            ]
+          },
+          {
             "name":"technique_by_Rudder",
             "versions":[
               "1.0"

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
@@ -690,7 +690,10 @@ class ArchiveApiTest extends Specification with AfterAll with Loggable {
             "test_18205",
             "1.0",
             "metadata.xml",
-            "test_18205.st"
+            "test_18205.st",
+            "test-migrate-select",
+            "technique.yml",
+            "1.0"
           )
         )
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -3469,6 +3469,12 @@ object RudderConfigInit {
 
       new CheckRudderGlobalParameter(roLDAPParameterRepository, woLDAPParameterRepository, stringUuidGenerator),
       new CheckInitXmlExport(itemArchiveManagerImpl, personIdentServiceImpl, stringUuidGenerator),
+      new MigrateDirectiveWithSelectInputBroken(
+        ncfTechniqueReader,
+        roDirectiveRepository,
+        woDirectiveRepository,
+        stringUuidGenerator
+      ),
       new CheckNcfTechniqueUpdate(
         ncfTechniqueWriter,
         roLDAPApiAccountRepository.systemAPIAccount,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/migration/MigrateDirectiveWithSelectInputBroken.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/migration/MigrateDirectiveWithSelectInputBroken.scala
@@ -1,0 +1,138 @@
+/*
+ *************************************************************************************
+ * Copyright 2025 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package bootstrap.liftweb.checks.endconfig.migration
+
+import bootstrap.liftweb.BootstrapChecks
+import bootstrap.liftweb.BootstrapLogger
+import com.normation.cfclerk.domain.TechniqueName
+import com.normation.errors.*
+import com.normation.eventlog.ModificationId
+import com.normation.rudder.domain.eventlog.RudderEventActor
+import com.normation.rudder.domain.policies.ActiveTechniqueId
+import com.normation.rudder.ncf.*
+import com.normation.rudder.repository.RoDirectiveRepository
+import com.normation.rudder.repository.WoDirectiveRepository
+import com.normation.utils.StringUuidGenerator
+import com.normation.zio.*
+import zio.*
+import zio.syntax.ToZio
+
+/**
+ * Check at webapp startup if ncf Technique needs to be rewritten by Rudder
+ * Controlled by presence of flag file /opt/rudder/etc/force_ncf_technique_update
+ */
+class MigrateDirectiveWithSelectInputBroken(
+    techniqueReader:       EditorTechniqueReader,
+    roDirectiveRepository: RoDirectiveRepository,
+    writeDirectives:       WoDirectiveRepository,
+    uuidGenerator:         StringUuidGenerator
+) extends BootstrapChecks {
+
+  override val description = "Migrate directives with invalid parameters"
+
+  def updateDirectivesWithSelectInputBroken: ZIO[Any, RudderError, Unit] = {
+    val modificationId = ModificationId(uuidGenerator.newUuid)
+    for {
+      res        <- techniqueReader.readTechniquesMetadataFile
+      techniques  = res._1.filter(_.parameters.exists(_.constraints.exists(_.select.isDefined)))
+      directives <- ZIO.foreach(techniques) { t =>
+                      val selectParameters = t.parameters.filter(_.constraints.exists(_.select.isDefined))
+                      for {
+                        res                 <- roDirectiveRepository
+                                                 .getActiveTechnique(TechniqueName(t.id.value))
+                                                 .map(_.map(at => (at.id, at.directives)).getOrElse((ActiveTechniqueId("notFound"), Nil)))
+                        (atId, directiveIds) = res
+                        directives          <- ZIO.foreach(directiveIds)(roDirectiveRepository.getDirective).map(_.flatten)
+                        directiveToUpdate    = directives.filter(_.parameters.exists(p => selectParameters.exists(_.name == p._1)))
+                        _                   <-
+                          BootstrapLogger.info(
+                            s"Some directives (${directiveToUpdate.size}) needs to be updated, directive ids: ${directiveToUpdate.map(_.id.serialize).mkString(", ")}"
+                          )
+                        updatedDirectives    = {
+                          directiveToUpdate.map(d => {
+                            selectParameters.foldLeft(d) {
+                              case (directive, param) =>
+                                directive.parameters.get(param.name) match {
+                                  case None        => directive
+                                  case Some(value) =>
+                                    directive.copy(parameters =
+                                      directive.parameters.removed(param.name).updated(param.id.value.toUpperCase, value)
+                                    )
+                                }
+                            }
+                          })
+                        }
+                        saved               <- ZIO.foreach(updatedDirectives)(d => {
+                                                 writeDirectives
+                                                   .saveDirective(
+                                                     atId,
+                                                     d,
+                                                     modificationId,
+                                                     RudderEventActor,
+                                                     Some(s"Updating invalid parameters in directive ${d.id.serialize}")
+                                                   )
+                                                   .map(_ => Right(d.id))
+                                                   .catchAll(err => Left((d.id, err)).succeed)
+                                               })
+                        (err, ok)            = saved.partitionMap(identity(_))
+                        _                   <- if (err.isEmpty) BootstrapLogger.info("All directives were migrated")
+                                               else {
+                                                 BootstrapLogger.info(
+                                                   s"Some directives (${ok.size}) were migrated, ids : ${ok.map(_.serialize).mkString(", ")}"
+                                                 ) *>
+                                                 BootstrapLogger.error(
+                                                   s"Some directives (${err.size}) were not migrated, errors below, ids : ${err.map(_._1.serialize) mkString (", ")}"
+                                                 ) *>
+                                                 ZIO.foreach(err) {
+                                                   case (id, e) => BootstrapLogger.error(s"For directive ${id.serialize}, error is: ${e.msg}")
+                                                 }
+                                               }
+                      } yield {}
+                    }
+    } yield ()
+  }
+
+  override def checks(): Unit = {
+
+    ZioRuntime.runNowLogError(err => {
+      BootstrapLogger.logEffect.error(
+        s"An error occurred while migrating directives with wrong select parameters: ${err.fullMsg}"
+      )
+    })(updateDirectivesWithSelectInputBroken)
+  }
+}

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/migration/TestMigrateDirectiveWithSelectInputBroken.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/migration/TestMigrateDirectiveWithSelectInputBroken.scala
@@ -1,0 +1,144 @@
+/*
+ *************************************************************************************
+ * Copyright 2025 Normation SAS
+ *************************************************************************************
+ *
+ * This file is part of Rudder.
+ *
+ * Rudder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In accordance with the terms of section 7 (7. Additional Terms.) of
+ * the GNU General Public License version 3, the copyright holders add
+ * the following Additional permissions:
+ * Notwithstanding to the terms of section 5 (5. Conveying Modified Source
+ * Versions) and 6 (6. Conveying Non-Source Forms.) of the GNU General
+ * Public License version 3, when you create a Related Module, this
+ * Related Module is not considered as a part of the work and may be
+ * distributed under the license agreement of your choice.
+ * A "Related Module" means a set of sources files including their
+ * documentation that, without modification of the Source Code, enables
+ * supplementary functions or services in addition to those offered by
+ * the Software.
+ *
+ * Rudder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
+
+ *
+ *************************************************************************************
+ */
+
+package bootstrap.liftweb.checks.endconfig.migration
+
+import com.normation.cfclerk.domain.TechniqueName
+import com.normation.cfclerk.domain.TechniqueVersion
+import com.normation.errors
+import com.normation.errors.IOResult
+import com.normation.errors.RudderError
+import com.normation.eventlog.ModificationId
+import com.normation.inventory.domain.Version
+import com.normation.rudder.MockDirectives
+import com.normation.rudder.MockGitConfigRepo
+import com.normation.rudder.MockTechniques
+import com.normation.rudder.domain.eventlog
+import com.normation.rudder.domain.policies.Directive
+import com.normation.rudder.domain.policies.DirectiveId
+import com.normation.rudder.domain.policies.DirectiveUid
+import com.normation.rudder.hooks.CmdResult
+import com.normation.rudder.ncf.*
+import com.normation.utils.StringUuidGeneratorImpl
+import com.normation.zio.*
+import org.junit.runner.*
+import org.specs2.matcher.ContentMatchers
+import org.specs2.mutable.*
+import org.specs2.runner.*
+import zio.syntax.*
+
+@RunWith(classOf[JUnitRunner])
+class TestMigrateDirectiveWithSelectInputBroken extends Specification with ContentMatchers {
+  sequential
+
+  // uses configuration repository from rudder-core tests resources
+  val mockDirectives = new MockDirectives(MockTechniques(new MockGitConfigRepo("")))
+
+  val editorTech      = EditorTechnique(
+    BundleName("test-migrate-select"),
+    new Version("1.0"),
+    "test",
+    "",
+    Seq(),
+    "",
+    "",
+    Seq(
+      TechniqueParameter(
+        ParameterId("8beca52f-7d5a-4c55-b5ae-fb56b7e50ddf"),
+        "test",
+        None,
+        None,
+        false,
+        Some(
+          Constraints(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(SelectOption("audit", Some("Audit")) :: SelectOption("enforce", Some("Enforce")) :: Nil)
+          )
+        )
+      )
+    ),
+    Seq(),
+    Map.empty,
+    None
+  )
+  val techniqueReader = new EditorTechniqueReader {
+    override def readTechniquesMetadataFile
+        : IOResult[(List[EditorTechnique], Map[BundleName, GenericMethod], List[errors.RudderError])] =
+      (editorTech :: Nil, Map.empty[BundleName, GenericMethod], List[RudderError]()).succeed
+
+    override def getMethodsMetadata: IOResult[Map[BundleName, GenericMethod]] = Map.empty[BundleName, GenericMethod].succeed
+
+    override def updateMethodsMetadataFile: IOResult[CmdResult] = ???
+  }
+
+  val directive = Directive(
+    DirectiveId(DirectiveUid("test")),
+    TechniqueVersion.V1_0,
+    Map.empty.updated("test", Seq("enforce")),
+    "test-directive",
+    "",
+    None
+  )
+
+  val atId = mockDirectives.directiveRepo
+    .getActiveTechnique(TechniqueName("test-migrate-select"))
+    .notOptional("should not empty")
+    .runNow
+    .id
+  mockDirectives.directiveRepo.saveDirective(atId, directive, ModificationId("..."), eventlog.RudderEventActor, None).runNow
+
+  val migration = new MigrateDirectiveWithSelectInputBroken(
+    techniqueReader,
+    mockDirectives.directiveRepo,
+    mockDirectives.directiveRepo,
+    new StringUuidGeneratorImpl()
+  )
+
+  "After migration, a directive with a faulty select parameter is migrated" >> {
+    migration.checks()
+    mockDirectives.directiveRepo.getDirective(DirectiveUid("test")).runNow === Some(
+      directive.copy(parameters =
+        directive.parameters.removed("test").updated("8BECA52F-7D5A-4C55-B5AE-FB56B7E50DDF", Seq("enforce"))
+      )
+    )
+  }
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/27428

The migration check technique with a select parameter, then get all technique based on this directive, then check if the directives has a parameter using the name of a technique parameter (instead of an id) and if the name is used, remove it and add a parameter with the id of the technique parameter with previous value