### PR TITLE
Fixes #26718: When the JSON property is invalid in global properties, the error is nasty

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -40,6 +40,7 @@ package com.normation.rudder.domain.properties
 import cats.data.Ior
 import cats.kernel.Monoid
 import cats.kernel.Semigroup
+import cats.syntax.either.*
 import cats.syntax.semigroup.*
 import com.normation.GitVersion
 import com.normation.GitVersion.Revision
@@ -471,7 +472,7 @@ object GenericProperty {
   /**
    * Parse a value that was correctly serialized to hocon (ie string are quoted, etc)
    */
-  def parseSerialisedValue(value: String): PureResult[ConfigValue] = {
+  def parseSerialisedValue(value: String): Either[SystemError, ConfigValue] = {
     PureResult.attempt(s"Error: value is not parsable as a property: ${value}") {
       ConfigFactory
         .parseString(
@@ -501,7 +502,10 @@ object GenericProperty {
           Right(ConfigValueFactory.fromAnyRef(value))
         // root can be an object or an array
         case Some(c) if (c == '{' || c == '[') =>
-          parseSerialisedValue(value)
+          // parsing error does not need stack trace here, simply the root cause message
+          parseSerialisedValue(value).leftMap(e =>
+            Inconsistency(s"The JSON object or array is not valid : ${e.msg}, ${e.cause.getMessage}")
+          )
         case _                                 => // it's a string that should be understood as a string
           Right(ConfigValueFactory.fromAnyRef(value))
       }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/nodes/GenericPropertiesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/nodes/GenericPropertiesTest.scala
@@ -39,6 +39,7 @@ package com.normation.rudder.domain.nodes
 
 import com.normation.BoxSpecMatcher
 import com.normation.errors.PureResult
+import com.normation.errors.RudderError
 import com.normation.rudder.domain.properties.GenericProperty
 import com.normation.rudder.domain.properties.GenericProperty.*
 import com.normation.rudder.domain.properties.NodeProperty
@@ -127,10 +128,14 @@ class GenericPropertiesTest extends Specification with Loggable with BoxSpecMatc
       (GenericProperty.parseValue(s) must beRight(ConfigValueFactory.fromMap(jmap(("a", "b")))))
     }
     "fails in a badly eneded json-like structure" in {
-      GenericProperty.parseValue("""{"a":"b" """) must beLeft
+      GenericProperty.parseValue("""{"a":"b" """) must beLeft[RudderError].like(
+        _.msg must beMatching("The JSON object or array is not valid.*")
+      )
     }
     "fails in a non key/value property structure" in {
-      GenericProperty.parseValue("""{"a"} """) must beLeft
+      GenericProperty.parseValue("""{"a"} """) must beLeft[RudderError].like(
+        _.msg must beMatching("The JSON object or array is not valid.*")
+      )
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/popup/CreateOrUpdateGlobalParameterPopup.scala
@@ -129,7 +129,11 @@ class CreateOrUpdateGlobalParameterPopup(
       // in case of string, we need to force parse as string
       v <- if (jsonRequired) GenericProperty.parseValue(value) else Right(value.toConfigValue)
       _ <- if (jsonRequired && v.valueType() == ConfigValueType.STRING) {
-             Left(Inconsistency("JSON check is enabled, but the value format is invalid."))
+             Left(
+               Inconsistency(
+                 "JSON check is enabled, but the value appears to be a String. Please select the String format instead."
+               )
+             )
            } else Right(())
     } yield {
       v
@@ -188,7 +192,7 @@ class CreateOrUpdateGlobalParameterPopup(
         case Full(res) =>
           res
         case eb: EmptyBox =>
-          val msg = (eb ?~! "An error occurred while updating the parameter").messageChain
+          val msg = (eb ?~! s"An error occurred while attempting to ${change.action.name} the parameter").messageChain
           logger.error(msg)
           formTracker.addFormError(error(msg))
           onFailure


### PR DESCRIPTION
https://issues.rudder.io/issues/26718

The error : 
* no longer has a stack trace
* has a the generic action message fixed ("create"/"update" parameter)
* still has the parsing error message

Result :
<img width="590" height="531" alt="image" src="https://github.com/user-attachments/assets/5ef25272-b644-4546-ab92-7a04a5e8d0ba" />
