### PR TITLE
Fixes #27112: Hosts table contains local ipv6 address

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
@@ -96,7 +96,8 @@ import zio.json.internal.Write
  * - no resolved properties (for ex inherited ones)
  */
 final case class IpAddress(inet: String) {
-  def isLocalhostIPv4IPv6: Boolean = inet == "127.0.0.1" || inet == "0:0:0:0:0:0:0:1"
+  // fe80 is a local IPv6, see https://issues.rudder.io/issues/27112
+  def isLocalhostIPv4IPv6: Boolean = inet == "127.0.0.1" || inet == "0:0:0:0:0:0:0:1" || inet == "::1" || inet.startsWith("fe80:")
 }
 final case class ManagementTechnology(
     name:         String,


### PR DESCRIPTION
https://issues.rudder.io/issues/27112

It's just adding the filter at the correct place, so that the IP is not shown in node list but kept elsewhere:
<img width="1449" height="311" alt="image" src="https://github.com/user-attachments/assets/7eab1c25-d707-4e1b-9865-866e8f29c360" />
<img width="1275" height="451" alt="image" src="https://github.com/user-attachments/assets/0c308120-7926-4a86-9d4d-7d0489c5d6d6" />
