### PR TITLE
Fixes #27561: Plugins error callouts width are same as title width

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-plugins.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-plugins.scss
@@ -279,7 +279,7 @@ $spinner-height-sm: $spinner-width-sm;
 
         & .plugin-errors {
           $el-margin: 0.5rem;
-
+          width: fit-content;
           margin-top: $el-margin;
 
           & .callout-fade {


### PR DESCRIPTION
https://issues.rudder.io/issues/27561

The plugin errors container should fit its width to the largest callout : 
<img width="464" height="465" alt="image" src="https://github.com/user-attachments/assets/38376809-a608-4971-99f6-3d700851cd65" />
