### PR TITLE
Fixes #27578: Nodes server list can no longer be exported to CSV

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -75,7 +75,7 @@ const csvButtonConfig = (filename, additionalCls) => ({
       const complianceColumnIdx = data.header.findIndex(s => s.toLowerCase() === "compliance")
       if (complianceColumnIdx >= 0) {
         data.body.forEach((row, idx) => {
-          data.body[idx][complianceColumnIdx] = computeCompliancePercentFromString(row[complianceColumnIdx]).toString() + "%"
+          data.body[idx][complianceColumnIdx] = computeCompliancePercent(row[complianceColumnIdx]).toString() + "%"
         })
       }
       return data


### PR DESCRIPTION
https://issues.rudder.io/issues/27578

The data does no longer contain a compliance string, but the compliance array since adding a specific "exportCsv" type in https://github.com/Normation/rudder/pull/6522