### PR TITLE
Fixes #27577: Nodes table has CSP error with column containing JSON property

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -1179,8 +1179,10 @@ function propertyFunction(value, inherited) { return function (nTd, sData, oData
       provider = $('<span class="rudder-label label-provider label-sm" data-bs-toggle="tooltip" data-bs-placement="right">inherited</span>')
       provider.attr('title', "This property is inherited from these group(s) or global parameter: <div>"+ property.hierarchy + "</div>.")
     }
-    var pre = $("<pre onclick='$(this).toggleClass(\"toggle\")' class='json-beautify show-more'></pre>").text(text).prepend(provider);
-    $(nTd).prepend( pre );
+    const id = `property-${property.name}-${iRow}`;
+    const pre = $(`<pre class="collapse json-beautify show-more" id="${id}"></span>`).text(text).prepend(provider);
+    const el = $(`<a class="text-reset" data-bs-toggle="collapse" href="#${id}" role="button" aria-expanded="false" aria-controls="${id}"></a>`).prepend(pre);
+    $(nTd).prepend( el );
   }
 } }
 

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-main.scss
@@ -143,30 +143,45 @@ pre.json-beautify, .content-wrapper pre.json-beautify{
     overflow-wrap: anywhere;
   }
 }
-pre.json-beautify.toggle, .content-wrapper pre.json-beautify.toggle{
-  height:auto;
-  max-height:none;
-  -moz-box-shadow: none;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-}
-pre.json-beautify:after,.content-wrapper pre.json-beautify:after{
-  position:absolute;
-  right:10px;
-  top : 10px;
-  color:#041922;
-  content: "\f054";
-  display: inline-block;
-  font: normal normal normal 14px/1 inherit;
-  font-family: "Font Awesome 5 Free";
-  font-size: inherit;
-  text-rendering: auto;
-  -webkit-font-smoothing: antialiased;
-  transition-duration:.2s;
-  font-weight: 900;
-}
-pre.json-beautify.toggle:after, .content-wrapper pre.json-beautify.toggle:after{
-  transform:rotate(90deg);
+pre.json-beautify, .content-wrapper pre.json-beautify {
+
+  &.collapse {
+    &.show {
+      height:auto;
+      max-height:none;
+      -moz-box-shadow: none;
+      -webkit-box-shadow: none;
+      box-shadow: none;
+
+      &:after {
+        transform:rotate(90deg);
+      }
+    }
+    &:not(.show) {
+      display: block;
+    }
+  }
+
+  &.collapsing {
+    height: 100% !important;
+    transition: none;
+  }
+
+  &:after {
+    position:absolute;
+    right:10px;
+    top : 10px;
+    color:$rudder-txt-primary;
+    content: "\f054";
+    display: inline-block;
+    font: normal normal normal 14px/1 inherit;
+    font-family: "Font Awesome 5 Free";
+    font-size: inherit;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    transition-duration:.2s;
+    font-weight: 900;
+  }
 }
 /* override syntax highlighting background */
 pre.json-beautify code.elmsh {


### PR DESCRIPTION
https://issues.rudder.io/issues/27577

CSP does not supports the `onclick` which added the `toggle` class to collapse the JSON property :
:arrow_right: instead use the [collapse](https://getbootstrap.com/docs/5.3/components/collapse/) from Bootstrap 5, and override some of it's SCSS (to prevent completely hiding the collapsed element)