### PR TITLE
Fixes #27574: Post-hooks for campaigns should be executed even even if pre-hooks are in failure

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/resources/hooks.d/campaigns/hook-template
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/hooks.d/campaigns/hook-template
@@ -7,6 +7,7 @@
 # - CAMPAIGN_TYPE: campaign type, ie `system-update`, `software-update`, etc
 # - CAMPAIGN_EVENT_ID: id of current event triggering that hook
 # - CAMPAIGN_EVENT_NAME: human readable name of the event
+# - CAMPAIGN_NEXT_STATE: only defined for post-hooks. [failure,finished]. Did we come here because pre-hooks failed?
 
 # Errors code on hooks are interpreted as follow:
 # - 0     : success, no log (apart if debug one)          , continue to next hook

--- a/webapp/sources/rudder/rudder-core/src/main/resources/hooks.d/campaigns/readme.adoc
+++ b/webapp/sources/rudder/rudder-core/src/main/resources/hooks.d/campaigns/readme.adoc
@@ -23,3 +23,4 @@ Hooks parameters are passed by environment variable:
 - CAMPAIGN_TYPE: campaign type, ie `system-update`, `software-update`, etc
 - CAMPAIGN_EVENT_ID: id of current event triggering that hook
 - CAMPAIGN_EVENT_NAME: human readable name of the event
+- CAMPAIGN_NEXT_STATE: only defined for post-hooks. [failure,finished]. Did we come here because pre-hooks failed?

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/DataTypes.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/campaigns/DataTypes.scala
@@ -343,19 +343,25 @@ object CampaignEventState {
   @jsonHint(ScheduledType.entryName) case object Scheduled                            extends CampaignEventState(ScheduledType)
   @jsonHint(PreHooksType.entryName) case class PreHooks(hookResults: HookResults)     extends CampaignEventState(PreHooksType)
   @jsonHint(RunningType.entryName) case object Running                                extends CampaignEventState(RunningType)
-  @jsonHint(PostHooksType.entryName) case class PostHooks(hookResults: HookResults)   extends CampaignEventState(PostHooksType)
+  // post hook are given a potential "goto failure/skipped/etc" choice
+  @jsonHint(PostHooksType.entryName) case class PostHooks(nextState: CampaignEventStateType, hookResults: HookResults)
+      extends CampaignEventState(PostHooksType)
   @jsonHint(FinishedType.entryName) case object Finished                              extends CampaignEventState(FinishedType)
   @jsonHint(SkippedType.entryName) case class Skipped(reason: String)                 extends CampaignEventState(SkippedType)
   @jsonHint(DeletedType.entryName) case class Deleted(reason: String)                 extends CampaignEventState(DeletedType)
   @jsonHint(FailureType.entryName) case class Failure(cause: String, message: String) extends CampaignEventState(FailureType)
 
+  // initial value for pre and post hooks
+  val PreHooksInit:  PreHooks  = PreHooks(HookResults(Nil))
+  val PostHooksInit: PostHooks = PostHooks(FinishedType, HookResults(Nil))
+
   // when we don't have data for a state that could/should
   def getDefault(s: CampaignEventStateType): CampaignEventState = {
     s match {
       case ScheduledType => CampaignEventState.Scheduled
-      case PreHooksType  => CampaignEventState.PreHooks(HookResults(Nil))
+      case PreHooksType  => PreHooksInit
       case RunningType   => CampaignEventState.Running
-      case PostHooksType => CampaignEventState.PostHooks(HookResults(Nil))
+      case PostHooksType => PostHooksInit
       case FinishedType  => CampaignEventState.Finished
       case SkippedType   => CampaignEventState.Skipped("")
       case DeletedType   => CampaignEventState.Deleted("")

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/HooksTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/hooks/HooksTest.scala
@@ -73,7 +73,7 @@ class HooksTest() extends Specification with AfterAll {
     f.setPermissions(PosixFilePermissions.fromString("rwxr--r--").asScala.toSet)
   }
 
-  def runHooks(hooks: List[String], params: List[HookEnvPair]):       HookReturnCode       = {
+  def runHooks(hooks: List[String], params: List[HookEnvPair]): HookReturnCode = {
     RunHooks.syncRun(
       "test.hooks",
       Hooks(tmp.pathAsString, hooks.map(f => (f, HookTimeout(None, None)))),
@@ -84,6 +84,7 @@ class HooksTest() extends Specification with AfterAll {
       5.seconds
     )
   }
+
   def runHookHistory(hooks: List[String], params: List[HookEnvPair]): List[HookReturnCode] = {
     ZioRuntime.runNow(
       RunHooks
@@ -97,7 +98,7 @@ class HooksTest() extends Specification with AfterAll {
           500.millis,
           5.seconds
         )
-        .map(c => c._1 :: c._2)
+        .map(_._2.map(_._2))
     )
   }
 


### PR DESCRIPTION
https://issues.rudder.io/issues/27574

This commit handle one annoyance and a semantic change for campaign hooks:
- add clearer logs in case of warning or error with the corresponding log level and faulty script
- we always go to `post-hooks`, even if `pre-hooks` failed, so that we let user a chance to correct state changed in `pre-hooks`

# Clearer logs

Now, when a campaign hook fails or warn, it has a corresponding line in webapp logs: 

```
2025-10-03 22:40:58+0200 ERROR hooks.campaigns.1bb22fc5-f41c-46fb-a44b-54b68b8254f2.pre-hooks - Campaign 'test campaign' pre-hooks returned code '24' in 'test-hook.sh'
```

This needed some adaptation: 
- also keep hook names in the history from `RunHooks.asyncRunHistory`
- post process campaign hook history execution to log to correct level

# Workflow change: always go to `post-hook`

The idea here is that is we do something in `pre-hooks`, we may want to undo it in `post-hooks`. 
For that, we must always go to `post-hooks` - but we need to more info:
- one to let the user know that we came to that post-hooks because something failed and the campaign wasn't exec
- one to let the workflow know that after these post-hooks, the final campaign state must be "failure" even if all post hooks succeded. 

And actually, it's the same bit of information: we just need to set a `next-state` value in post-hook before we go to them: 
- if it's from a failure in `pre-hook`, the `next-state` is `failure` ,
- if it's from the running state, the `next-state` is `finished`. 
And we let the user know in the hook with a new environnment variable: `CAMPAIGN_NEXT_STATE`. 

From a code point of view, I had to: 
- change `CampaignEventState.PostHooks` to store `nextState: CampaignEventStateType` 
- change the workflow to direct to `post-hooks` in place of `failure` after pre hooks, seting `nextState`
- change serialisation to save the `nextState` in base for `post-hooks`
And add a unit test to demonstrate the behavior

