### PR TITLE
Fixes #27622: Password setting from standard user technique fails after upgrade to Rudder 9.0 Beta 2

### DIFF
--- a/policies/lib/tree/30_generic_methods/user_password_hash.cf
+++ b/policies/lib/tree/30_generic_methods/user_password_hash.cf
@@ -43,33 +43,34 @@ bundle agent user_password_hash(login, password)
       "epoch_days"        int => int("${epoch_days_str}");
 
   classes:
+      "pass3"       expression => "pass2";
+      "pass2"       expression => "pass1";
+      "pass1"       expression => "any";
       "user_exists" expression => userexists("${login}");
 
       # with variables that are not unique, the emptiness detection is quite tricky
       # either the variable is not defined, or the variable value is ""
-      "password_not_empty" not => strcmp("", "${password}");
-
+      "password_not_empty"                       not => strcmp("", "${password}");
       "user_exist_and_password_not_empty" expression => "password_not_empty.user_exists";
 
   files:
+    user_exist_and_password_not_empty::
       # Define password when user has already been created
       "/etc/shadow"
                create => "false",
             edit_line => set_user_field("${login}", 2, "${password}"),
         edit_defaults => ncf_empty_select("false"),
-              classes => classes_generic_two("${report_data.method_id}", "${class_prefix}"),
-                   if => "user_exist_and_password_not_empty";
+              classes => classes_generic_two("${report_data.method_id}", "${class_prefix}");
 
       # set the last update date if password has been updated
       "/etc/shadow"
                create => "false",
             edit_line => set_user_field("${login}", 3, "${epoch_days}"),
-        edit_defaults => ncf_empty_select("false"),
-                   if => "${report_data.method_id}_repaired";
+        edit_defaults => ncf_empty_select("false");
 
   methods:
     pass3.!user_exist_and_password_not_empty::
-      "${report_data.method_id}" usebundle => _classes_failure("${result_classes_prefix}");
+      "${report_data.method_id}" usebundle => _classes_failure("${class_prefix}");
 
       "${report_data.method_id}" usebundle => log_rudder_v4("${login}", "User ${login} does not exist. Can't set user ${login} password", ""),
                                         if => "!user_exists.password_not_empty";


### PR DESCRIPTION
https://issues.rudder.io/issues/27622