### PR TITLE
Fixes #27596: Multiple JS error on properties page

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
@@ -626,7 +626,7 @@ function callRemoteRun(nodeId, refreshCompliance) {
   $("#visibilityOutput").hide();
   $("#report").removeClass("border-success");
   $("#report").removeClass("border-fail");
-  $("pre").remove();
+  $panelContent.remove();
   $(".alert-danger").remove();
   $("#countDown").find("span").empty();
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/ReportDisplayer.scala
@@ -413,7 +413,7 @@ class ReportDisplayer(
                        */
                       def triggerAgent(node: CoreNodeFact): NodeSeq = if (tableId == "reportsGrid") {
                         if (node.rudderAgent.agentType == AgentType.CfeCommunity) {
-                          <div id="triggerAgent">
+                          <div id="triggerAgent" class="mb-3">
             <button id="triggerBtn" class="btn btn-primary btn-trigger"  onclick={
                             s"callRemoteRun('${node.id.value}', ${refreshReportDetail(node, tableId, getReports, defaultRunInterval).toJsCmd});"
                           }>
@@ -429,11 +429,11 @@ class ReportDisplayer(
               <span style="color:#b1bbcb;"></span>
             </div>
             <div id="report" style="margin-top:10px;" class="collapse">
-              <pre></pre>
+              <pre class="p-2"></pre>
             </div>
           </div>
                         } else {
-                          <div id="triggerAgent">
+                          <div id="triggerAgent" class="mb-3">
             <button id="triggerBtn" class="btn btn-primary btn-trigger" disabled="disabled" title="This action is not supported for Windows node">
               <span>Trigger Agent</span>
               &nbsp;

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-node.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-node.scss
@@ -85,7 +85,6 @@ form select.selectField {
 
 #node-compliance-intro {
   padding: 10px 15px;
-  margin: 10px 0;
 }
 
 #nodeHeaderInfo {


### PR DESCRIPTION
https://issues.rudder.io/issues/27596


The multiple JS errors were caused by the line `$(“pre”).remove();` which was attemptng to remove all <pre> tags from the page, including those from the Elm app.