### PR TITLE
Fixes #27638: Scala compilation should happen in maven compile phase

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -150,7 +150,7 @@ limitations under the License.
         <executions>
           <execution>
             <id>scala-compile-first</id>
-            <phase>process-resources</phase>
+            <phase>compile</phase>
             <goals>
               <goal>add-source</goal>
               <goal>compile</goal>
@@ -158,7 +158,7 @@ limitations under the License.
           </execution>
           <execution>
             <id>scala-test-compile</id>
-            <phase>process-test-resources</phase>
+            <phase>test-compile</phase>
             <goals>
               <goal>testCompile</goal>
             </goals>


### PR DESCRIPTION
https://issues.rudder.io/issues/27638

I don't think it breaks anything in CI/etc, but I will happily use a second sight on that. 
Moving to `compile` allows to have a quick(er at least) css compilation, which is needed to have correct resources with the rudder version correctly replaced, which is not the case after a `mvn clean` and a pur intellij compilation.