### PR TITLE
Fixes #27649: APT agents are built without apt support in system-updates

### DIFF
--- a/policies/module-types/system-updates/Makefile
+++ b/policies/module-types/system-updates/Makefile
@@ -2,3 +2,4 @@ include ../../../rust.makefile
 
 check: lint
 	cargo test --features=apt
+	cargo test --features=apt-compat

--- a/policies/module-types/system-updates/src/package_manager.rs
+++ b/policies/module-types/system-updates/src/package_manager.rs
@@ -7,7 +7,7 @@ use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[cfg(feature = "apt")]
+#[cfg(any(feature = "apt", feature = "apt-compat"))]
 use crate::package_manager::apt::AptPackageManager;
 use crate::{
     campaign::FullCampaignType,
@@ -17,7 +17,7 @@ use crate::{
 use rudder_module_type::os_release::OsRelease;
 use std::str::FromStr;
 
-#[cfg(feature = "apt")]
+#[cfg(any(feature = "apt", feature = "apt-compat"))]
 mod apt;
 mod rpm;
 mod yum;
@@ -175,12 +175,12 @@ impl PackageManager {
     pub fn get(self) -> Result<Box<dyn LinuxPackageManager>> {
         Ok(match self {
             PackageManager::Yum => Box::new(YumPackageManager::new()?),
-            #[cfg(feature = "apt")]
+            #[cfg(any(feature = "apt", feature = "apt-compat"))]
             PackageManager::Apt => {
                 let os_release = OsRelease::new()?;
                 Box::new(AptPackageManager::new(&os_release)?)
             }
-            #[cfg(not(feature = "apt"))]
+            #[cfg(not(any(feature = "apt", feature = "apt-compat")))]
             PackageManager::Apt => bail!("This module was not build with APT support"),
             PackageManager::Zypper => Box::new(ZypperPackageManager::new()?),
             _ => bail!("This package manager does not provide patch management features"),

--- a/policies/module-types/system-updates/src/package_manager/apt.rs
+++ b/policies/module-types/system-updates/src/package_manager/apt.rs
@@ -24,6 +24,10 @@ use regex::Regex;
 #[cfg(not(debug_assertions))]
 use rudder_module_type::ensure_root_user;
 use rudder_module_type::os_release::OsRelease;
+
+#[cfg(feature = "apt-compat")]
+use rust_apt_compat as rust_apt;
+
 use rust_apt::{
     Cache, PackageSort,
     cache::Upgrade,

--- a/policies/module-types/system-updates/src/package_manager/apt/filter.rs
+++ b/policies/module-types/system-updates/src/package_manager/apt/filter.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2024 Normation SAS
 
+#[cfg(feature = "apt-compat")]
+use rust_apt_compat as rust_apt;
+
 use anyhow::{Result, bail};
 use rudder_module_type::os_release::OsRelease;
 use rust_apt::{PackageFile, Version};

--- a/policies/module-types/system-updates/src/package_manager/apt/progress.rs
+++ b/policies/module-types/system-updates/src/package_manager/apt/progress.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2024 Normation SAS
 
+#[cfg(feature = "apt-compat")]
+use rust_apt_compat as rust_apt;
+
 use memfile::MemFile;
 use rust_apt::{
     error::pending_error,


### PR DESCRIPTION
https://issues.rudder.io/issues/27649

The APT support was not built when only `apt-compat` was passed.