### PR TITLE
Fixes #24486: The migrate button in directive pages is always displayed and often useless and ugly

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/DirectiveEditForm.scala
@@ -660,9 +660,9 @@ class DirectiveEditForm(
 
       override def className = "form-select"
 
-      override def labelClassName = "col-sm-12 text-bold"
+      override def labelClassName = "col-sm-12"
 
-      override def subContainerClassName = "version-group"
+      override def subContainerClassName = "version-group w-auto"
     }
   }
 

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-directives.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-directives.scss
@@ -141,12 +141,11 @@
 #grid_rules_grid_zone tr.head th {
     padding: 4px 6px;
 }
-.version-group{
-  float:left;
-  padding:0 0 0 15px;
-}
-.version-group select.form-select{
-  margin-right:5px;
+#version{
+  flex-wrap : wrap;
+  input[type=submit]{
+    width: 100px;
+  }
 }
 .btn.new-icon.no-icon:after{
   content: "";


### PR DESCRIPTION
https://issues.rudder.io/issues/24486

Result :
<img width="201" height="76" alt="version-form" src="https://github.com/user-attachments/assets/f1affbae-c5fc-4a5b-9cd6-7fb3c46b08a3" />
