### PR TITLE
Fixes #28503: Migrate Node hash repo to zio-jon

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/Identifiers.scala
+++ b/webapp/sources/ldap-inventory/inventory-api/src/main/scala/com/normation/inventory/domain/Identifiers.scala
@@ -41,6 +41,7 @@ import com.normation.errors.Inconsistency
 import com.normation.errors.IOResult
 import java.security.MessageDigest
 import scala.util.matching.Regex
+import zio.json.JsonCodec
 import zio.syntax.ToZio
 
 trait Uuid extends Any {
@@ -49,6 +50,10 @@ trait Uuid extends Any {
 
 // TODO: migration-scala3 - bug: https://github.com/lampepfl/dotty/issues/16467
 final case class NodeId(val value: String) extends AnyVal with Uuid
+
+object NodeId {
+  given JsonCodec[NodeId] = JsonCodec.string.transform[NodeId](NodeId(_), _.value)
+}
 
 final case class MachineUuid(val value: String) extends AnyVal with Uuid
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/TechniqueVersion.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/domain/TechniqueVersion.scala
@@ -40,6 +40,9 @@ package com.normation.cfclerk.domain
 import com.normation.GitVersion
 import com.normation.GitVersion.Revision
 import com.normation.utils.*
+import zio.json.JsonCodec
+import zio.json.JsonDecoder
+import zio.json.JsonEncoder
 
 final case class TechniqueVersion protected (version: Version, rev: Revision) extends Ordered[TechniqueVersion] {
   def compare(v: TechniqueVersion): Int = (version.compare(v.version)) match {
@@ -72,6 +75,10 @@ final case class TechniqueVersion protected (version: Version, rev: Revision) ex
 }
 
 object TechniqueVersion {
+  given JsonCodec[TechniqueVersion] = new JsonCodec(
+    JsonEncoder.string.contramap(_.serialize),
+    JsonDecoder.string.mapOrFail(TechniqueVersion.parse)
+  )
 
   // predefined object 1.0 because we use it in a lot of places
   val V1_0: TechniqueVersion = new TechniqueVersion(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -565,7 +565,6 @@ trait RudderJsonDecoders {
   implicit val jqDeleteModeDecoder: JsonDecoder[JQDeleteMode] = DeriveJsonDecoder.gen[JQDeleteMode]
   implicit val classesDecoder:      JsonDecoder[JQClasses]    = DeriveJsonDecoder.gen[JQClasses].orElse((_, _) => JQClasses(None))
 
-  implicit val nodeIdDecoder:             JsonDecoder[NodeId]                      = JsonDecoder[String].map(NodeId.apply)
   implicit val nodeIdChunkDecoder:        JsonDecoder[JQNodeIdChunk]               = DeriveJsonDecoder.gen[JQNodeIdChunk]
   implicit val nodeStatusActionDecoder:   JsonDecoder[JQNodeStatusAction]          =
     JsonDecoder[String].mapOrFail(JQNodeStatusAction.withNameInsensitiveEither(_).left.map(_.getMessage()))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Directive.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Directive.scala
@@ -45,6 +45,9 @@ import com.normation.rudder.campaigns.CampaignId
 import com.normation.rudder.tenants.HasSecurityTag
 import com.normation.rudder.tenants.SecurityTag
 import scala.xml.*
+import zio.json.JsonCodec
+import zio.json.JsonDecoder
+import zio.json.JsonEncoder
 
 /*
  * Two way of modeling the couple (directiveId, rev) :
@@ -119,6 +122,11 @@ object DirectiveId {
         DirectiveId(DirectiveUid(id), rev)
     }
   }
+
+  given JsonCodec[DirectiveId] = new JsonCodec(
+    JsonEncoder[String].contramap[DirectiveId](_.serialize),
+    JsonDecoder[String].mapOrFail(DirectiveId.parse)
+  )
 }
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Rule.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/policies/Rule.scala
@@ -41,6 +41,9 @@ import com.normation.GitVersion.Revision
 import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.tenants.HasSecurityTag
 import com.normation.rudder.tenants.SecurityTag
+import zio.json.JsonCodec
+import zio.json.JsonDecoder
+import zio.json.JsonEncoder
 
 final case class RuleUid(value: String) extends AnyVal {
   def debugString: String = value
@@ -58,13 +61,18 @@ final case class RuleId(uid: RuleUid, rev: Revision = GitVersion.DEFAULT_REV) {
 
 object RuleId {
 
-  // parse a directiveId which was serialize by "id.serialize"
+  // parse a directiveId which was serialized by "id.serialize"
   def parse(s: String): Either[String, RuleId] = {
     GitVersion.parseUidRev(s).map {
       case (id, rev) =>
         RuleId(RuleUid(id), rev)
     }
   }
+
+  given JsonCodec[RuleId] = new JsonCodec(
+    JsonEncoder[String].contramap[RuleId](_.serialize),
+    JsonDecoder[String].mapOrFail(RuleId.parse)
+  )
 }
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/ExpectedReports.scala
@@ -229,16 +229,6 @@ object ExpectedReportsSerialisation {
     JsonCodec[PolicyModeOverrides](enc, dec)
   }
   implicit val codecGlobalPolicyMode:    JsonCodec[GlobalPolicyMode]    = DeriveJsonCodec.gen
-  implicit val codecRuleId:              JsonCodec[RuleId]              = {
-    implicit val encoderRuleId: JsonEncoder[RuleId] = JsonEncoder[String].contramap[RuleId](_.serialize)
-    implicit val decoderRuleId: JsonDecoder[RuleId] = JsonDecoder[String].mapOrFail(RuleId.parse(_))
-    JsonCodec(encoderRuleId, decoderRuleId)
-  }
-  implicit val codecDirectiveId:         JsonCodec[DirectiveId]         = {
-    implicit val encoderDirectiveId: JsonEncoder[DirectiveId] = JsonEncoder[String].contramap[DirectiveId](_.serialize)
-    implicit val decoderDirectiveId: JsonDecoder[DirectiveId] = JsonDecoder[String].mapOrFail(DirectiveId.parse(_))
-    JsonCodec(encoderDirectiveId, decoderDirectiveId)
-  }
   implicit val codecReportingLogic:      JsonCodec[ReportingLogic]      = {
     implicit val encoderReportingLogic: JsonEncoder[ReportingLogic] = JsonEncoder[String].contramap[ReportingLogic](_.value)
     implicit val decoderReportingLogic: JsonDecoder[ReportingLogic] =

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -918,7 +918,6 @@ object JsonPostgresqlSerialization {
 
   import com.normation.cfclerk.domain.TechniqueVersion
   import com.normation.rudder.apidata.implicits.given
-  import com.normation.rudder.domain.reports.ExpectedReportsSerialisation.*
   import com.normation.rudder.domain.reports.RunComplianceInfo.PolicyModeError
   import com.normation.rudder.services.policies.PolicyId
   import com.normation.utils.DateFormaterService.json.*
@@ -964,10 +963,6 @@ object JsonPostgresqlSerialization {
     }
   )
   implicit lazy val codecOverriddenPolicy:  JsonCodec[OverriddenPolicy]  = DeriveJsonCodec.gen
-  implicit lazy val codecTechniqueVersion:  JsonCodec[TechniqueVersion]  = new JsonCodec(
-    JsonEncoder.string.contramap(_.serialize),
-    JsonDecoder.string.mapOrFail(TechniqueVersion.parse)
-  )
 
   final case class JRunAnalysis(
       @jsonField("k")

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFact.scala
@@ -1653,7 +1653,6 @@ object NodeFactSerialisation {
 
   object SimpleCodec {
 
-    implicit val codecNodeId:        JsonCodec[NodeId]        = JsonCodec.string.transform[NodeId](NodeId(_), _.value)
     implicit val codecJsonOsDetails: JsonCodec[JsonOsDetails] = DeriveJsonCodec.gen
 
     implicit val decoderOsDetails: JsonDecoder[OsDetails] = JsonDecoder[JsonOsDetails].map { jod =>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepository.scala
@@ -43,12 +43,6 @@ import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.cfclerk.domain.Variable
 import com.normation.errors.*
 import com.normation.inventory.domain.NodeId
-import com.normation.ldap.sdk.LDAPConnectionProvider
-import com.normation.ldap.sdk.LDAPEntry
-import com.normation.ldap.sdk.RwLDAPConnection
-import com.normation.rudder.domain.RudderDit
-import com.normation.rudder.domain.RudderLDAPConstants.A_NODE_CONFIG
-import com.normation.rudder.domain.RudderLDAPConstants.OC_NODES_CONFIG
 import com.normation.rudder.domain.logger.ApplicationLoggerPure
 import com.normation.rudder.domain.logger.PolicyGenerationLoggerPure
 import com.normation.rudder.domain.policies.DirectiveId
@@ -56,15 +50,15 @@ import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.services.policies.NodeConfiguration
 import com.normation.rudder.services.policies.Policy
 import com.normation.rudder.services.policies.PolicyId
+import com.normation.utils.DateFormaterService
 import com.normation.zio.*
+import io.scalaland.chimney.*
+import io.scalaland.chimney.syntax.*
 import java.nio.charset.StandardCharsets
-import net.liftweb.common.Loggable
-import net.liftweb.json.*
-import net.liftweb.json.JsonDSL.*
+import java.time.Instant
 import org.joda.time.DateTime
-import org.joda.time.format.ISODateTimeFormat
-import scala.util.control.NonFatal
 import zio.*
+import zio.json.*
 import zio.syntax.*
 
 final case class PolicyHash(
@@ -76,38 +70,27 @@ final case class NodeConfigurationHashes(hashes: List[NodeConfigurationHash])
 
 object NodeConfigurationHashes {
 
+  import com.normation.rudder.services.policies.nodeconfig.NodeConfigurationHash.NodeConfigurationHashJson
+
+  private[nodeconfig] case class NodeConfigurationHashesJson(hashes: List[NodeConfigurationHashJson]) derives JsonCodec
+  private[nodeconfig] object NodeConfigurationHashesJson {
+    given Transformer[NodeConfigurationHashesJson, NodeConfigurationHashes] = Transformer
+      .define[NodeConfigurationHashesJson, NodeConfigurationHashes]
+      .buildTransformer
+  }
+
+  private[nodeconfig] given Transformer[NodeConfigurationHashes, NodeConfigurationHashesJson] = Transformer
+    .define[NodeConfigurationHashes, NodeConfigurationHashesJson]
+    .withFieldComputed(_.hashes, _.hashes.sortBy(_.id.value).map(_.transformInto[NodeConfigurationHashJson]))
+    .buildTransformer
+
   // we really want to have one line by node
   def toJson(hashes: NodeConfigurationHashes): String = {
-    s"""{"hashes": [${hashes.hashes.map(x => NodeConfigurationHash.toJson(x)).mkString("\n  ", ",\n  ", "\n")}] }"""
+    hashes.transformInto[NodeConfigurationHashesJson].toJsonPretty
   }
 
   def fromJson(json: String): IOResult[NodeConfigurationHashes] = {
-    for {
-      jval <- IOResult.attempt(parse(json))
-      arr  <- (jval \ "hashes") match {
-                case JNothing | JNull => Nil.succeed
-                case JArray(arr)      => arr.succeed
-                case x                =>
-                  Inconsistency(
-                    s"Can not parse json as a cache of node configuration hashes. Found: ${compactRender(x).take(100)}..."
-                  ).fail
-              }
-      // ignore only invalide node config hashses
-      hs   <- ZIO.foldLeft(arr)(List.empty[NodeConfigurationHash]) {
-                case (all, current) =>
-                  NodeConfigurationHash.extractNodeConfigCache(current) match {
-                    case Left((m, j)) =>
-                      PolicyGenerationLoggerPure.error(
-                        s"Can not parse following json as node configuration hash: ${m}; corresponding entry will be ignored: ${compactRender(j)}. "
-                      ) *>
-                      all.succeed
-                    case Right(h)     =>
-                      (h :: all).succeed
-                  }
-              }
-    } yield {
-      NodeConfigurationHashes(hs)
-    }
+    json.fromJson[NodeConfigurationHashesJson].toIO.map(_.transformInto[NodeConfigurationHashes])
   }
 
 }
@@ -147,94 +130,61 @@ final case class NodeConfigurationHash(
 }
 
 object NodeConfigurationHash {
+  import com.normation.utils.DateFormaterService.json.*
 
   /*
    * Serialization / unserialization to json.
    * We want something as compact as possible, so NodeConfigurationHash are serialized like that:
-   * { i: [ "nodeid"(string), "writtendate"(string), nodeInfoCache(int), parameterHash(int), nodecContextHash(int)]
+   * { i: [ "nodeid"(string), "writtendate"(string), nodeInfoHash(int), parameterHash(int), nodecContextHash(int)]
    * , p: [ [ "ruleId"(string), "directiveid"(string), "techniqueversion"(string), hash(int)]
    *      , [ ....
    *      ]
    * } (minified)
    *
    */
-  def toJvalue(hash: NodeConfigurationHash): JValue = {
-    (
-      ("i"   -> JArray(
-        List(
-          hash.id.value,
-          hash.writtenDate.toString(ISODateTimeFormat.dateTime().withZoneUTC()),
-          hash.nodeInfoHash,
-          hash.parameterHash,
-          hash.nodeContextHash
-        )
-      ))
-      ~ ("p" -> JArray(
-        hash.policyHash.toList.map(p => {
-          JArray(
-            List(p.draftId.ruleId.serialize, p.draftId.directiveId.serialize, p.draftId.techniqueVersion.serialize, p.cacheValue)
+  final private[nodeconfig] case class NodeConfigurationHashJson(
+      i: (NodeId, Instant, Int, Int, Int),
+      p: Chunk[(RuleId, DirectiveId, TechniqueVersion, Int)]
+  )
+
+  private[nodeconfig] object NodeConfigurationHashJson {
+    given Transformer[NodeConfigurationHashJson, NodeConfigurationHash] = Transformer
+      .define[NodeConfigurationHashJson, NodeConfigurationHash]
+      .withFieldComputed(_.id, _.i._1)
+      .withFieldComputed(_.writtenDate, _.i._2.transformInto[DateTime])
+      .withFieldComputed(_.nodeInfoHash, _.i._3)
+      .withFieldComputed(_.parameterHash, _.i._4)
+      .withFieldComputed(_.nodeContextHash, _.i._5)
+      .withFieldComputed(_.policyHash, _.p.map((r, d, t, h) => PolicyHash(PolicyId(r, d, t), h)).toSet)
+      .buildTransformer
+
+    import com.normation.utils.DateFormaterService.json.*
+
+    given JsonEncoder[NodeConfigurationHashJson] = DeriveJsonEncoder.gen
+    given JsonDecoder[NodeConfigurationHashJson] = DeriveJsonDecoder.gen
+  }
+
+  private[nodeconfig] given Transformer[NodeConfigurationHash, NodeConfigurationHashJson] = {
+    Transformer
+      .define[NodeConfigurationHash, NodeConfigurationHashJson]
+      .withFieldComputed(
+        _.i,
+        x => {
+          (
+            x.id,
+            x.writtenDate.transformInto[Instant],
+            x.nodeInfoHash,
+            x.parameterHash,
+            x.nodeContextHash
           )
-        })
-      ))
-    )
-  }
-  def toJson(hash: NodeConfigurationHash):   String = {
-    compactRender(toJvalue(hash))
-  }
-
-  def extractNodeConfigCache(j: JValue): Either[(String, JValue), NodeConfigurationHash] = {
-    def readDate(date: String): Either[(String, JValue), DateTime] = try {
-      Right(ISODateTimeFormat.dateTimeParser().withZoneUTC().parseDateTime(date))
-    } catch {
-      case NonFatal(ex) => Left((s"Error, written date can not be parsed as a date: ${date}", JString(date)))
-    }
-
-    def readPolicy(p: JValue) = {
-      p match {
-        case JArray(List(JString(ruleId), JString(directiveId), JString(techniqueVerion), JInt(policyHash))) =>
-          for {
-            version <- TechniqueVersion.parse(techniqueVerion).leftMap(err => (err, p))
-            did     <- DirectiveId.parse(directiveId).leftMap(err => (err, p))
-            rid     <- RuleId.parse(ruleId).leftMap(err => (err, p))
-          } yield PolicyHash(PolicyId(rid, did, version), policyHash.toInt)
-        case x                                                                                               => Left((s"Error when parsing policy: a json array", x))
-      }
-    }
-
-    j match {
-      case JObject(
-            List(
-              JField(
-                "i",
-                JArray(List(JString(nodeId), JString(date), JInt(nodeInfoCache), JInt(paramCache), JInt(nodeContextCache)))
-              ),
-              JField("p", JArray(policies))
-            )
-          ) =>
-        for {
-          d <- readDate(date)
-          p <- policies.traverse(readPolicy(_))
-        } yield {
-          NodeConfigurationHash(NodeId(nodeId), d, nodeInfoCache.toInt, paramCache.toInt, nodeContextCache.toInt, p.toSet)
         }
-      case _ => Left((s"Cannot parse node configuration hash (use 'DEBUG' log level for details).", j))
-    }
-  }
-
-  def fromJson(json: String): Either[(String, JValue), NodeConfigurationHash] = {
-    def jval = try {
-      Right(parse(json))
-    } catch {
-      case NonFatal(ex) =>
-        Left((s"Error when parsing node configuration cache entry. Expection was: ${ex.getMessage}", JString(json)))
-    }
-
-    for {
-      v <- jval
-      x <- extractNodeConfigCache(v)
-    } yield {
-      x
-    }
+      )
+      .withFieldComputed(
+        _.p,
+        x =>
+          Chunk.fromIterable(x.policyHash).sortBy(_.draftId.value).map { case PolicyHash(PolicyId(r, d, t), h) => (r, d, t, h) }
+      )
+      .buildTransformer
   }
 
   /**
@@ -571,131 +521,5 @@ class FileBasedNodeConfigurationHashRepository(path: String) extends NodeConfigu
         }
       }
     )
-  }
-}
-
-/**
- * An implementation into LDAP
- */
-class LdapNodeConfigurationHashRepository(
-    rudderDit: RudderDit,
-    ldapCon:   LDAPConnectionProvider[RwLDAPConnection]
-) extends NodeConfigurationHashRepository with Loggable {
-
-  /**
-   * Logic: there is only one object that contains all node config cache.
-   * Each node config cache is stored in one value of the "nodeConfig" attribute.
-   * The serialisation is simple json.
-   * We won't be able to simply delete one value with that method, but it is not
-   * the principal use case.
-   */
-
-  /**
-   * That mapping ignore malformed node configuration and work in a
-   * "best effort" way. Bad config are logged as error.
-   * We fail if the entry is not of the expected type
-   */
-  private def fromLdap(entry: Option[LDAPEntry]): IOResult[Set[NodeConfigurationHash]] = {
-    entry match {
-      case None    => Set.empty[NodeConfigurationHash].succeed
-      case Some(e) =>
-        for {
-          typeOk <- ZIO.when(!e.isA(OC_NODES_CONFIG)) {
-                      Inconsistency(
-                        s"Entry ${e.dn} is not a '${OC_NODES_CONFIG}', can not find node configuration caches. Entry details: ${e}"
-                      ).fail
-                    }
-        } yield {
-          e.valuesFor(A_NODE_CONFIG).flatMap { json =>
-            NodeConfigurationHash.fromJson(json) match {
-              case Right(value)        => Some(value)
-              case Left((error, json)) =>
-                logger.info(s"Ignoring node configuration cache info because of deserialization issue: ${error}")
-                logger.debug(s"Json causing node configuration deserialization issue: ${net.liftweb.json.compactRender(json)}")
-                None
-            }
-          }
-        }
-    }
-  }
-
-  private def toLdap(nodeConfigs: Set[NodeConfigurationHash]): LDAPEntry = {
-    val caches = nodeConfigs.map(x => NodeConfigurationHash.toJson(x))
-    val entry  = rudderDit.NODE_CONFIGS.model
-    entry.resetValuesTo(A_NODE_CONFIG, caches.toSeq*)
-    entry
-  }
-
-  /*
-   * Delete node config matching predicate.
-   * Return the list of remaining ids.
-   */
-  private def deleteCacheMatching(shouldDeleteConfig: NodeConfigurationHash => Boolean): IOResult[Set[NodeId]] = {
-    for {
-      ldap         <- ldapCon
-      currentEntry <- ldap.get(rudderDit.NODE_CONFIGS.dn)
-      remaining    <- fromLdap(currentEntry).map(_.filterNot(shouldDeleteConfig))
-      newEntry      = toLdap(remaining)
-      saved        <- ldap.save(newEntry)
-    } yield {
-      remaining.map(_.id)
-    }
-  }
-
-  /**
-   * Delete node config by its id
-   */
-  override def deleteNodeConfigurations(nodeIds: Set[NodeId]): IOResult[Unit] = {
-    deleteCacheMatching(nodeConfig => nodeIds.contains(nodeConfig.id)).unit
-  }
-
-  /**
-   * Inverse of delete: delete all node configuration not
-   * given in the argument.
-   */
-  override def onlyKeepNodeConfiguration(nodeIds: Set[NodeId]): IOResult[Set[NodeId]] = {
-    for {
-      _ <- deleteCacheMatching(nodeConfig => !nodeIds.contains(nodeConfig.id))
-    } yield {
-      nodeIds
-    }
-  }
-
-  /**
-   * delete all node configuration
-   */
-  override def deleteAllNodeConfigurations(): IOResult[Unit] = {
-    for {
-      ldap    <- ldapCon
-      deleted <- ldap.delete(rudderDit.NODE_CONFIGS.dn)
-      cleaned <- ldap.save(rudderDit.NODE_CONFIGS.model)
-    } yield {
-      ()
-    }
-  }
-
-  override def getAll(): IOResult[Map[NodeId, NodeConfigurationHash]] = {
-    for {
-      ldap        <- ldapCon
-      entry       <- ldap.get(rudderDit.NODE_CONFIGS.dn)
-      nodeConfigs <- fromLdap(entry)
-    } yield {
-      nodeConfigs.map(x => (x.id, x)).toMap
-    }
-  }
-
-  override def save(caches: Set[NodeConfigurationHash]): IOResult[Set[NodeId]] = {
-    val updatedIds = caches.map(_.id)
-    for {
-      ldap          <- ldapCon
-      existingEntry <- ldap.get(rudderDit.NODE_CONFIGS.dn)
-      existingCache <- fromLdap(existingEntry)
-      // only update and add, keep existing config cache not updated
-      keptConfigs    = existingCache.map(x => (x.id, x)).toMap.view.filterKeys(k => !updatedIds.contains(k)).toMap
-      entry          = toLdap(caches ++ keptConfigs.values)
-      saved         <- ldap.save(entry)
-    } yield {
-      updatedIds
-    }
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/policies/nodeconfig/NodeConfigurationCacheRepositoryTest.scala
@@ -178,11 +178,27 @@ class NodeConfigurationCacheRepositoryTest extends Specification with AfterAll w
 
     "be written sorted" in {
       val json = {
-        """{"hashes": [
-          |  {"i":["node0","1970-01-01T00:00:00.100Z",0,0,0],"p":[]},
-          |  {"i":["node1","1970-01-01T00:00:00.100Z",0,0,0],"p":[["r0","d0","1.0",0],["r1","d1","1.0",0]]},
-          |  {"i":["node2","1970-01-01T00:00:00.100Z",0,0,0],"p":[["r0","d0","1.0",0]]}
-          |] }""".stripMargin
+        """{
+          |  "hashes" : [
+          |    {
+          |      "i" : ["node0", "1970-01-01T00:00:00.100Z", 0, 0, 0],
+          |      "p" : []
+          |    },
+          |    {
+          |      "i" : ["node1", "1970-01-01T00:00:00.100Z", 0, 0, 0],
+          |      "p" : [
+          |        ["r0", "d0", "1.0", 0],
+          |        ["r1", "d1", "1.0", 0]
+          |      ]
+          |    },
+          |    {
+          |      "i" : ["node2", "1970-01-01T00:00:00.100Z", 0, 0, 0],
+          |      "p" : [
+          |        ["r0", "d0", "1.0", 0]
+          |      ]
+          |    }
+          |  ]
+          |}""".stripMargin
       }
 
       configHashesRepo.hashesFile.contentAsString must beEqualTo(json)
@@ -200,12 +216,33 @@ class NodeConfigurationCacheRepositoryTest extends Specification with AfterAll w
 
     "still be written sorted" in {
       val json = {
-        """{"hashes": [
-          |  {"i":["node0","1970-01-01T00:00:00.100Z",0,0,0],"p":[]},
-          |  {"i":["node1","1970-01-01T00:00:00.500Z",0,0,0],"p":[["r0","d0","1.0",0],["r2","d2","1.0",0]]},
-          |  {"i":["node2","1970-01-01T00:00:00.100Z",0,0,0],"p":[["r0","d0","1.0",0]]},
-          |  {"i":["node3","1970-01-01T00:00:00.500Z",0,0,0],"p":[["r3","d3","1.0",0]]}
-          |] }""".stripMargin
+        """{
+          |  "hashes" : [
+          |    {
+          |      "i" : ["node0", "1970-01-01T00:00:00.100Z", 0, 0, 0],
+          |      "p" : []
+          |    },
+          |    {
+          |      "i" : ["node1", "1970-01-01T00:00:00.500Z", 0, 0, 0],
+          |      "p" : [
+          |        ["r0", "d0", "1.0", 0],
+          |        ["r2", "d2", "1.0", 0]
+          |      ]
+          |    },
+          |    {
+          |      "i" : ["node2", "1970-01-01T00:00:00.100Z", 0, 0, 0],
+          |      "p" : [
+          |        ["r0", "d0", "1.0", 0]
+          |      ]
+          |    },
+          |    {
+          |      "i" : ["node3", "1970-01-01T00:00:00.500Z", 0, 0, 0],
+          |      "p" : [
+          |        ["r3", "d3", "1.0", 0]
+          |      ]
+          |    }
+          |  ]
+          |}""".stripMargin
       }
 
       configHashesRepo.hashesFile.contentAsString must beEqualTo(json)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/AcceptNode.scala
@@ -66,8 +66,6 @@ import zio.json.*
  *
  */
 class AcceptNode extends SecureDispatchSnippet with Loggable {
-  import AcceptNodeJson.*
-
   val newNodeManager     = RudderConfig.newNodeManager
   val rudderDit          = RudderConfig.rudderDit
   val serverGrid         = RudderConfig.nodeGrid
@@ -324,8 +322,4 @@ class AcceptNode extends SecureDispatchSnippet with Loggable {
    */
   val selectAll: Node =
     <input type="checkbox" id="selectAll" onclick="jqCheckAll('selectAll', 'serverids')"/>
-}
-
-object AcceptNodeJson {
-  implicit val decodeNodeId: JsonDecoder[NodeId] = JsonDecoder[String].map(NodeId.apply)
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/28503

This might be better targeted to 9.2 - keeping in draft for now. 

The core of that PR is to remove `lift-json` from `NodeConfigurationCacheRepository.scala`. 

That core manages the hashes of node's policy information to know if they are up to date of nore a new policy generation. 
The saved hashes used to be in LDAP, but are in a file (`/var/rudder/policy-generation-info/node-configuration-hashes.json`) since Rudder 6.1. So first, we can clean-up the LDAP related code. 

Next, we switch from an ad-hoc json serialization to a standard one, adding `case classes` that will be automatically derived into json codec. 

The chosen design is to place these case classes in the companion objects of the related business classes, with a restricted visibility : they are not used anywhere else, and placing them here is more idiomatic than placing them in the repository implementation, and it avoid fighting against scala for `given` resolution (no `import` needed). 

So, for each class, we have: 
- the business class (for ex `NodeConfigurationHash`), 
- in the companion object : 
  - a `protected[nodeconfig]` DTO with a `Json` suffix (for ex: `NodeConfigurationHashJson`)
  - chimney transformers between the two, in the corresponding companion object so that the `given` is correctly looked-up, 
  - the JSON codec for the DTO. 

In addition, I moved `NodeId`, `RuleId` and `DirectiveId` JSON codecs to their companion objects to continue to make that design more systematic.

*Format impact on `node-configuration-hashes.json`*

The main functionnal change is that there is now many more spaces and lines in `node-configuration-hashes.json`. This is because the previous encoding chose to have one line per node exactly. 
The idea was that is was simpler for an human looking in the file that way, but the reality is not very convincing. 
The lines are VERY long, since each policy is >80 chars, and a node generally have tens of them. 
So the new encoding, which is `.toJsonPretty`, put each policy on one line. 
If anybody wants to look into that file, it will be easier for a given node to see the list of policies and their hashes.