### PR TITLE
Fixes #28509: Port quicksearch to zio-json

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -1668,6 +1668,26 @@ object ArchiveApi       extends Enum[ArchiveApi] with ApiModuleProvider[ArchiveA
   def values = findValues
 }
 
+sealed trait QuickSearchApi extends EnumEntry with EndpointSchema with InternalApi with SortIndex {
+  override def dataContainer: Option[String] = None
+}
+object QuickSearchApi       extends Enum[QuickSearchApi] with ApiModuleProvider[QuickSearchApi]   {
+
+  case object CompleteTagsValue extends QuickSearchApi with ZeroParam with StartsAtVersion23 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Do a quicksearch"
+    val (action, path) = GET / "quicksearch"
+    val authz: List[AuthorizationType] = {
+      import com.normation.rudder.AuthorizationType.*
+      Group.Read :: Rule.Read :: Directive.Read :: Technique.Read :: Parameter.Read :: Configuration.Read :: Node.Read :: Nil
+    }
+  }
+
+  def endpoints: List[QuickSearchApi] = values.toList.sortBy(_.z)
+
+  def values = findValues
+}
+
 /*
  * All API.
  */
@@ -1687,6 +1707,7 @@ object AllApi {
     InfoApi.endpoints :::
     HookApi.endpoints :::
     ApiAccounts.endpoints :::
+    QuickSearchApi.endpoints :::
     // UserApi is not declared here, it will be contributed by plugin
     Nil
   }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/QuicksearchApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/QuicksearchApi.scala
@@ -37,24 +37,25 @@
 
 package com.normation.rudder.rest.internal
 
-import com.normation.box.*
 import com.normation.rudder.AuthorizationType
+import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.domain.nodes.NodeGroupUid
 import com.normation.rudder.domain.policies.RuleUid
-import com.normation.rudder.rest.OldInternalApiAuthz
-import com.normation.rudder.rest.RestUtils.*
+import com.normation.rudder.rest.{QuickSearchApi as API, *}
+import com.normation.rudder.rest.RudderJsonResponse.syntax.*
+import com.normation.rudder.rest.lift.DefaultParams
+import com.normation.rudder.rest.lift.LiftApiModule
+import com.normation.rudder.rest.lift.LiftApiModule0
+import com.normation.rudder.rest.lift.LiftApiModuleProvider
 import com.normation.rudder.services.quicksearch.FullQuickSearchService
 import com.normation.rudder.services.quicksearch.QSObject
 import com.normation.rudder.services.quicksearch.QuickSearchResult
-import com.normation.rudder.tenants.QueryContext
-import com.normation.rudder.users.UserService
+import com.normation.rudder.users.AuthenticatedUser
 import com.normation.rudder.web.model.LinkUtil
-import net.liftweb.common.*
 import net.liftweb.http.LiftResponse
-import net.liftweb.http.rest.RestHelper
-import net.liftweb.json.JArray
-import net.liftweb.json.JsonAST.*
-import net.liftweb.json.JsonDSL.*
+import net.liftweb.http.Req
+import zio.Chunk
+import zio.json.JsonEncoder
 
 /**
  * A class for the Quicksearch rest endpoint.
@@ -76,67 +77,71 @@ import net.liftweb.json.JsonDSL.*
  *     - ex: attribute:hostname,nodeId,ipAddresses
  *
  */
-class RestQuicksearch(
+class QuicksearchApi(
     quicksearch: FullQuickSearchService,
-    userService: UserService,
     linkUtil:    LinkUtil
-) extends RestHelper with Loggable {
+) extends LiftApiModuleProvider[API] {
 
-  final private val MAX_RES_BY_KIND = 10
+  def schemas: ApiModuleProvider[API] = API
 
-  given prettify:            Boolean      = false
-  private def errorResponse: LiftResponse = toJsonError(None, s"Quicksearch can't be accessed in current security context")
-
-  serve {
-    case Get("secure" :: "api" :: "quicksearch" :: Nil, req) =>
-      userService.getCurrentUser.map(_.qc).withQCOr(errorResponse) {
-        given action: String = "completeTagsValue"
-        OldInternalApiAuthz.withReadUser(userService.getCurrentUser) {
-          val token = req.params.get("value") match {
-            case Some(value :: Nil) => value
-            case None               => ""
-            // Should not happen, but for now make one token from it, maybe we should only take head ?
-            case Some(values)       => values.mkString("")
-          }
-          val limit = req.params.get("limit").flatMap(_.headOption).flatMap(_.toIntOption)
-          quicksearch.search(token, limit).toBox match {
-            case eb: EmptyBox =>
-              val e = eb ?~! s"Error when looking for object containing '${token}'"
-              toJsonError(None, e.messageChain)
-
-            case Full(results) =>
-              toJsonResponse(None, prepare(results, limit.getOrElse(MAX_RES_BY_KIND)))
-          }
-        }
-      }
+  def getLiftEndpoints(): List[LiftApiModule] = {
+    API.endpoints.map { case API.CompleteTagsValue => CompleteTagsValue }
   }
 
-  private def filter(results: Set[QuickSearchResult]) = {
+  // serve: PartialFunction[Req, () => Box[LiftResponse]]
+  // So we just have to return a
+  /*
+   * Since that API doesn't follow the standard Public API schema, we will need to build
+   * by hand some part, on a model similar to `RudderJsonResponse#toLiftResponseList)
+   */
+
+  object CompleteTagsValue extends LiftApiModule0 {
+    final private val MAX_RES_BY_KIND = 10
+    val schema: API.CompleteTagsValue.type = API.CompleteTagsValue
+
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+
+      val token = req.params.get("value") match {
+        case Some(value :: Nil) => value
+        case None               => ""
+        // Should not happen, but for now make one token from it, maybe we should only take head ?
+        case Some(values)       => values.mkString("")
+      }
+      val limit = req.params.get("limit").flatMap(_.headOption).flatMap(_.toIntOption)
+
+      (for {
+        results <- quicksearch.search(token, limit)(using authzToken.qc)
+        filtered = prepare(results, limit.getOrElse(MAX_RES_BY_KIND), authzToken.user)
+      } yield filtered).toLiftResponseList(params, schema)
+    }
+  }
+
+  private def filter(results: Set[QuickSearchResult], u: AuthenticatedUser) = {
     import com.normation.rudder.services.quicksearch.QuickSearchResultId.*
 
-    val user = userService.getCurrentUser
-    user match {
-      case None    =>
-        Set.empty
-      case Some(u) =>
-        val nodeOK       = u.checkRights(AuthorizationType.Node.Read)
-        val groupOK      = u.checkRights(AuthorizationType.Group.Read)
-        val ruleOK       = u.checkRights(AuthorizationType.Configuration.Read) || u.checkRights(AuthorizationType.Rule.Read)
-        val directiveOK  = u.checkRights(AuthorizationType.Configuration.Read) || u.checkRights(AuthorizationType.Directive.Read)
-        val techniqueOK  = u.checkRights(AuthorizationType.Technique.Read)
-        val parametersOK =
-          u.checkRights(AuthorizationType.Configuration.Read) || u.checkRights(AuthorizationType.Parameter.Read)
+    val nodeOK       = u.checkRights(AuthorizationType.Node.Read)
+    val groupOK      = u.checkRights(AuthorizationType.Group.Read)
+    val ruleOK       = u.checkRights(AuthorizationType.Configuration.Read) || u.checkRights(AuthorizationType.Rule.Read)
+    val directiveOK  = u.checkRights(AuthorizationType.Configuration.Read) || u.checkRights(AuthorizationType.Directive.Read)
+    val techniqueOK  = u.checkRights(AuthorizationType.Technique.Read)
+    val parametersOK =
+      u.checkRights(AuthorizationType.Configuration.Read) || u.checkRights(AuthorizationType.Parameter.Read)
 
-        results.filter {
-          _.id match {
-            case _: QRNodeId      => nodeOK
-            case _: QRGroupId     => groupOK
-            case _: QRRuleId      => ruleOK
-            case _: QRParameterId => parametersOK
-            case _: QRDirectiveId => directiveOK
-            case _: QRTechniqueId => techniqueOK
-          }
-        }
+    results.filter {
+      _.id match {
+        case _: QRNodeId      => nodeOK
+        case _: QRGroupId     => groupOK
+        case _: QRRuleId      => ruleOK
+        case _: QRParameterId => parametersOK
+        case _: QRDirectiveId => directiveOK
+        case _: QRTechniqueId => techniqueOK
+      }
 
     }
   }
@@ -150,8 +155,8 @@ class RestQuicksearch(
    *   crunching the browser with thousands of answers
    */
 
-  private def prepare(results: Set[QuickSearchResult], maxByKind: Int): JValue = {
-    val filteredResult = filter(results)
+  private def prepare(results: Set[QuickSearchResult], maxByKind: Int, user: AuthenticatedUser): List[JsonResultType] = {
+    val filteredResult = filter(results, user)
     // group by kind, and build the summary for each
     val map            = filteredResult.groupBy(_.id.tpe).map {
       case (tpe, set) =>
@@ -160,7 +165,7 @@ class RestQuicksearch(
         // take the nth first
         val returned = unique.take(maxByKind)
 
-        val summary = ResultTypeSummary(tpe.name, unique.size, returned.size)
+        val summary = JsonResultTypeSummary.from(tpe.name, unique.size, returned.size)
 
         (tpe, (summary, returned))
     }
@@ -173,52 +178,66 @@ class RestQuicksearch(
     // - parameters
     // - rules
     import com.normation.rudder.services.quicksearch.QSObject.sortQSObject
-    val jsonList = QSObject.all.toList.sortWith(sortQSObject).flatMap { tpe =>
-      val (summary, res) = map.getOrElse(tpe, (ResultTypeSummary(tpe.name, 0, 0), Seq()))
+    QSObject.all.toList.sortWith(sortQSObject).flatMap { tpe =>
+      val (summary, res) = map.getOrElse(tpe, (JsonResultTypeSummary.from(tpe.name, 0, 0), Seq()))
       if (res.isEmpty) {
         None
       } else {
         Some(
-          ("header"  -> summary.toJson)
-          ~ ("items" -> JArray(res.toList.map(_.toJson)))
+          JsonResultType(summary, Chunk.fromIterable(res.map(JsonSearchResultItem.from)))
         )
       }
     }
-    JArray(jsonList)
   }
 
+  private case class JsonResultType(
+      header: JsonResultTypeSummary,
+      items:  Chunk[JsonSearchResultItem]
+  ) derives JsonEncoder
+
   // private case class cannot be final because of scalac bug
-  private case class ResultTypeSummary(
-      tpe:            String,
-      originalNumber: Int,
-      returnedNumber: Int
-  )
+  private case class JsonResultTypeSummary(
+      `type`:  String,
+      summary: String,
+      numbers: Int
+  ) derives JsonEncoder
 
-  implicit private class JsonResultTypeSummary(t: ResultTypeSummary) {
+  private object JsonResultTypeSummary {
 
-    val desc: String = if (t.originalNumber <= t.returnedNumber) {
-      s"${t.originalNumber} found"
-    } else { // we elided some results
-      s"${t.originalNumber} found, only displaying the first ${t.returnedNumber}. Please refine your query."
-    }
+    def from(tpe: String, originalNumber: Int, returnedNumber: Int): JsonResultTypeSummary = {
 
-    def toJson: JObject = {
-      (
-        ("type"      -> t.tpe.capitalize)
-        ~ ("summary" -> desc)
-        ~ ("numbers" -> t.originalNumber)
+      val desc: String = if (originalNumber <= returnedNumber) {
+        s"${originalNumber} found"
+      } else { // we elided some results
+        s"${originalNumber} found, only displaying the first ${returnedNumber}. Please refine your query."
+      }
+
+      JsonResultTypeSummary(
+        tpe.capitalize,
+        desc,
+        originalNumber
       )
     }
   }
 
-  implicit private class JsonSearchResult(r: QuickSearchResult) {
-    import com.normation.inventory.domain.NodeId
-    import com.normation.rudder.domain.nodes.NodeGroupId
-    import com.normation.rudder.domain.policies.DirectiveUid
-    import com.normation.rudder.domain.policies.RuleId
-    import com.normation.rudder.services.quicksearch.QuickSearchResultId.*
+  private case class JsonSearchResultItem(
+      name:   String,
+      `type`: String,
+      id:     String,
+      value:  String,
+      desc:   String,
+      url:    String
+  ) derives JsonEncoder
 
-    def toJson: JObject = {
+  private object JsonSearchResultItem {
+
+    def from(r: QuickSearchResult): JsonSearchResultItem = {
+      import com.normation.inventory.domain.NodeId
+      import com.normation.rudder.domain.nodes.NodeGroupId
+      import com.normation.rudder.domain.policies.DirectiveUid
+      import com.normation.rudder.domain.policies.RuleId
+      import com.normation.rudder.services.quicksearch.QuickSearchResultId.*
+
       import linkUtil.*
       val url = r.id match {
         case QRNodeId(value)      => nodeLink(NodeId(value))
@@ -238,14 +257,14 @@ class RestQuicksearch(
 
       val desc = s"${r.attribute.map(_.display + ": ").getOrElse("")}${v}"
 
-      (
-        ("name"    -> r.name)
-        ~ ("type"  -> r.id.tpe.name)
-        ~ ("id"    -> r.id.value)
+      JsonSearchResultItem(
+        r.name,
+        r.id.tpe.name,
+        r.id.value,
         // matched value
-        ~ ("value" -> r.value)
-        ~ ("desc"  -> desc)
-        ~ ("url"   -> url)
+        r.value,
+        desc,
+        url
       )
     }
   }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -117,14 +117,7 @@ import com.normation.rudder.rest.EndpointSchema.syntax.*
 import com.normation.rudder.rest.data.Creation
 import com.normation.rudder.rest.data.Creation.CreationError
 import com.normation.rudder.rest.data.NodeSetup
-import com.normation.rudder.rest.internal.EventLogAPI
-import com.normation.rudder.rest.internal.EventLogService
-import com.normation.rudder.rest.internal.GroupInternalApiService
-import com.normation.rudder.rest.internal.GroupsInternalApi
-import com.normation.rudder.rest.internal.RestQuicksearch
-import com.normation.rudder.rest.internal.RuleInternalApiService
-import com.normation.rudder.rest.internal.RulesInternalApi
-import com.normation.rudder.rest.internal.SharedFilesAPI
+import com.normation.rudder.rest.internal.*
 import com.normation.rudder.rest.lift.*
 import com.normation.rudder.rest.v1.RestStatus
 import com.normation.rudder.rule.category.RuleCategoryService
@@ -1055,7 +1048,8 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
     infoApi,
     eventLogApi,
     new PluginInternalApi(pluginsSystemService),
-    new InventoryApi(mockInventoryFileWatcher, mockInventoryDir)
+    new InventoryApi(mockInventoryFileWatcher, mockInventoryDir),
+    new QuicksearchApi(quickSearchService, linkUtil)
   )
 
   val (rudderApi, liftRules) = TraitTestApiFromYamlFiles.buildLiftRules(apiModules, apiVersions, Some(userService))
@@ -1063,13 +1057,6 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
   // RestHelpers
   liftRules.statelessDispatch.append(RestStatus)
   liftRules.statelessDispatch.append(sharedFilesApi)
-  liftRules.statelessDispatch.append(
-    new RestQuicksearch(
-      quickSearchService,
-      userService,
-      linkUtil
-    )
-  )
 
   val baseTempDirectory = mockGitRepo.abstractRoot
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -507,7 +507,6 @@ class Boot extends Loggable {
     LiftRules.statelessDispatch.append(RestStatus)
 
     // REST API Internal
-    LiftRules.statelessDispatch.append(RudderConfig.restQuicksearch)
     LiftRules.statelessDispatch.append(RudderConfig.restCompletion)
     LiftRules.statelessDispatch.append(RudderConfig.sharedFileApi)
     // REST API (all public/internal API)

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -1418,7 +1418,6 @@ object RudderConfig extends Loggable {
   val reportingService:                    ReportingService                         = rci.reportingService
   val reportsRepository:                   ReportsRepository                        = rci.reportsRepository
   val restCompletion:                      RestCompletion                           = rci.restCompletion
-  val restQuicksearch:                     RestQuicksearch                          = rci.restQuicksearch
   val roleApiMapping:                      RoleApiMapping                           = rci.roleApiMapping
   val roAgentRunsRepository:               RoReportsExecutionRepository             = rci.roAgentRunsRepository
   val roApiAccountRepository:              RoApiAccountRepository                   = rci.roApiAccountRepository
@@ -1567,7 +1566,6 @@ case class RudderServiceApi(
     allBootstrapChecks:                  BootstrapChecks,
     authenticationProviders:             AuthBackendProvidersManager,
     rudderUserListProvider:              FileUserDetailListProvider,
-    restQuicksearch:                     RestQuicksearch,
     restCompletion:                      RestCompletion,
     sharedFileApi:                       SharedFilesAPI,
     eventLogCoreService:                 EventLogCoreService,
@@ -1848,20 +1846,7 @@ object RudderConfigInit {
     lazy val linkUtil = new LinkUtil(roRuleRepository, roNodeGroupRepository, roDirectiveRepository, nodeFactRepository)
 
     // REST API - old
-    lazy val restQuicksearch = new RestQuicksearch(
-      new FullQuickSearchService()(using
-        roLDAPConnectionProvider,
-        nodeDit,
-        acceptedNodesDit,
-        rudderDit,
-        roDirectiveRepository,
-        nodeFactRepository,
-        ncfTechniqueReader
-      ),
-      userService,
-      linkUtil
-    )
-    lazy val restCompletion  = new RestCompletion(new RestCompletionService(roDirectiveRepository, roRuleRepository), userService)
+    lazy val restCompletion = new RestCompletion(new RestCompletionService(roDirectiveRepository, roRuleRepository), userService)
 
     lazy val clearCacheService = new ClearCacheServiceImpl(
       nodeConfigurationHashRepo,
@@ -2181,9 +2166,36 @@ object RudderConfigInit {
     lazy val systemTokenSecret = ApiTokenSecret.generate(tokenGenerator, suffix = "system")
 
     // we need to init API internal services into the {} block to avoid bug https://issues.rudder.io/issues/26416
-    lazy val rudderApi = {
+    // need to be out of RudderApi else "Platform restriction: a parameter list's length cannot exceed 254."
+    lazy val rudderApi = ApiInit.api
+
+    object ApiInit {
       import com.normation.rudder.rest.lift.*
       // need to be out of RudderApi else "Platform restriction: a parameter list's length cannot exceed 254."
+
+      // Internal APIs
+      lazy val sharedFileApi       =
+        new SharedFilesAPI(userService, RUDDER_DIR_SHARED_FILES_FOLDER, RUDDER_GIT_ROOT_CONFIG_REPO)
+      lazy val eventLogCoreService = new EventLogServiceImpl(logRepository)
+      lazy val eventLogApi         = {
+        new EventLogAPI(
+          new RestEventLogService(eventLogRepository, eventLogDetailsGenerator, personIdentService),
+          eventLogCoreService,
+          eventLogDetailsGenerator
+        )
+      }
+      lazy val quicksearchApi      = new QuicksearchApi(
+        new FullQuickSearchService()(using
+          roLDAPConnectionProvider,
+          nodeDit,
+          acceptedNodesDit,
+          rudderDit,
+          roDirectiveRepository,
+          nodeFactRepository,
+          ncfTechniqueReader
+        ),
+        linkUtil
+      )
 
       lazy val ruleApiService13 = {
         new RuleApiService14(
@@ -2263,6 +2275,7 @@ object RudderConfigInit {
 
       lazy val apiModules = {
         import com.normation.rudder.rest.lift.*
+
         List(
           new ComplianceApi(complianceAPIService, roDirectiveRepository),
           new GroupsApi(
@@ -2395,7 +2408,8 @@ object RudderConfigInit {
           new HookApi(hookApiService),
           archiveApi,
           new ScoreApiImpl(scoreService),
-          eventLogApi
+          eventLogApi,
+          quicksearchApi
           // info api must be resolved latter, because else it misses plugin apis !
         )
       }
@@ -2407,21 +2421,10 @@ object RudderConfigInit {
         None
       )
       apiModules.foreach(module => api.addModules(module.getLiftEndpoints()))
-      api
+
     }
 
-    // Internal APIs
-    lazy val sharedFileApi       =
-      new SharedFilesAPI(userService, RUDDER_DIR_SHARED_FILES_FOLDER, RUDDER_GIT_ROOT_CONFIG_REPO)
-    lazy val eventLogCoreService = new EventLogServiceImpl(logRepository)
-    lazy val eventLogApi         = {
-      new EventLogAPI(
-        new RestEventLogService(eventLogRepository, eventLogDetailsGenerator, personIdentService),
-        eventLogCoreService,
-        eventLogDetailsGenerator
-      )
-    }
-    lazy val asyncWorkflowInfo   = new AsyncWorkflowInfo
+    lazy val asyncWorkflowInfo = new AsyncWorkflowInfo
     lazy val configService: ReadConfigService & UpdateConfigService = {
       new GenericConfigService(
         RudderProperties.config,
@@ -3946,11 +3949,10 @@ object RudderConfigInit {
       allBootstrapChecks,
       authenticationProviders,
       rudderUserListProvider,
-      restQuicksearch,
       restCompletion,
-      sharedFileApi,
-      eventLogCoreService,
-      eventLogApi,
+      ApiInit.sharedFileApi,
+      ApiInit.eventLogCoreService,
+      ApiInit.eventLogApi,
       systemApiService11,
       staticResourceRewrite,
       stringUuidGenerator,


### PR DESCRIPTION
https://issues.rudder.io/issues/28509

# Commit 1: First part of the work: port to "new" API framework. 
This is a bit tedious because we once again it the "platform is limited to 254 params", so I tried a new approach where I user an intermediate object to avoid building a list because of the `lazy val`. 

Everything else is rather automatic, and we remove the direct use of `userService`, which is good!

# Commit 2: port to zio-json

Nothing special, the usual workflow: 
- create case classes/objects to describe the data structure, 
- use our standard utilities for response generation. 

The only difference compared to other API is that I needed to define some special constructors (the `CompanionObject.from` methods) to minimze the changes, because some computation is done on the inputs compared to what is returned in JSON. 