### PR TITLE
Fixes #28681: Buttons in tree headers do not auto-wrap when the screen becomes too small

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueList.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewTechniqueList.elm
@@ -89,7 +89,7 @@ techniqueList model techniques =
   in
     div [ class "template-sidebar sidebar-left col-techniques", onClick OpenTechniques ] [
       div [ class "sidebar-header"] [
-        div [ class "header-title flex-wrap" ] [
+        div [ class "header-title" ] [
           h1 [class "d-flex align-items-center"] [
             text "Techniques"
           , span [ id "nb-techniques", class "badge badge-secondary badge-resources" ] [
@@ -97,11 +97,11 @@ techniqueList model techniques =
             ]
           ]
         , div [ class "header-buttons", hidden (not model.hasWriteRights)] [ -- Need to add technique-write rights
-            label [class "btn btn-sm btn-primary", onClick StartImport] [
+            label [class "btn btn-primary", onClick StartImport] [
               text "Import "
             , i [ class "fa fa-upload" ] []
             ]
-          , button [ class "btn btn-sm btn-success", onClick  (GenerateId (\s -> NewTechnique (TechniqueId s))) ] [
+          , button [ class "btn btn-success", onClick  (GenerateId (\s -> NewTechnique (TechniqueId s))) ] [
               text "Create "
             , i [ class "fa fa-plus-circle"] []
             ]

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-template.scss
@@ -151,6 +151,8 @@ ul {
 .rudder-template .header-title{
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: .5rem;
 }
 .rudder-template .header-title .title-icon{
   font-size: 0.8em;
@@ -202,12 +204,12 @@ ul {
 
 // HEADER BUTTONS
 .rudder-template .header-buttons {
-  white-space: nowrap;
+  display: flex;
   align-self: flex-start;
+  flex-wrap: wrap;
+  gap: .5rem;
 
   .btn {
-    margin-left: 10px;
-
     &.btn-default:hover{
       background-color: #eef1f9;
     }
@@ -368,11 +370,7 @@ ul {
   margin-left: 6px !important;
 }
 #nb-techniques {
-  background-color: #d3d5d9;
-  color: #5d6778;
-  margin-left: 10px;
   margin-top: 4px;
-  font-size:14px;
 }
 .badge-parameters,
 .badge-resources{


### PR DESCRIPTION
https://issues.rudder.io/issues/28681

This PR globally fixes the line-break issue in the sidebar headers:

<img width="464" height="215" alt="Capture d’écran du 2026-04-02 15-46-09" src="https://github.com/user-attachments/assets/36b7cba8-bf39-4605-bd54-62448924f751" />

----

<img width="464" height="215" alt="Capture d’écran du 2026-04-02 15-45-04" src="https://github.com/user-attachments/assets/6917742d-9adc-4fad-9305-569054c53dee" />

----

<img width="464" height="213" alt="Capture d’écran du 2026-04-02 15-44-42" src="https://github.com/user-attachments/assets/00385ecc-2400-4150-a21f-6cea857a9107" />
