### PR TITLE
Fixes #28685: The Campaigns API documentation has erroneous response/request schemas

### DIFF
--- a/webapp/sources/api-doc/components/schemas/campaign-software-update.yml
+++ b/webapp/sources/api-doc/components/schemas/campaign-software-update.yml
@@ -29,7 +29,7 @@ properties:
           type : string
           description: Target version of the package to update to
           example: "49.3"
-        arch:
+        architecture:
           type : string
           description: Architecture of the package to update
           example: "x64"


### PR DESCRIPTION
https://issues.rudder.io/issues/28685

The REST API sends/expects a JSON with an "architecture" field for package details of software campaigns, but the field was erroneously  named "arch" in the REST API documentation. The API documentation was modified in order to conform to the JSON format that is actually sent/expected by the REST API