### PR TITLE
Fixes #28168: Change request save button in rule page doesn't work properly

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/View.elm
@@ -259,6 +259,7 @@ view model =
       SaveAuditMsg creation rule originRule crSettings ->
         let
           action = if creation then "Create" else "Update"
+          saveBtnClass = if crSettings.enableChangeRequest then "btn-primary" else "btn-success"
         in
           div [ tabindex -1, class "modal fade show", style "display" "block" ]
           [ div [class "modal-backdrop fade show", onClick (ClosePopup Ignore)][]
@@ -274,16 +275,22 @@ view model =
                   , text (String.toLower action)
                   , text " this rule ?"
                   ]
+                , if crSettings.enableChangeRequest then
+                    div [class "text-center alert alert-info"]
+                    [ i [ class "fa fa-info-circle" ] []
+                    , text "Workflows are enabled, your change has to be validated in a change request"
+                    ]
+                  else
+                    text ""
                 , changeAuditForm crSettings
                 ]
               , div [ class "modal-footer" ]
                 [ button [ class "btn btn-default", onClick (ClosePopup Ignore) ]
                   [ text "Cancel "
                   ]
-                , button [ class "btn btn-success", onClick (ClosePopup (CallApi True (saveRuleDetails rule (isNothing originRule)))), disabled (crSettings.mandatoryChangeMessage && String.isEmpty crSettings.message) ]
+                , button [ class ("btn " ++ saveBtnClass), onClick (ClosePopup (CallApi True (saveRuleDetails rule (isNothing originRule)))), disabled (crSettings.mandatoryChangeMessage && String.isEmpty crSettings.message) ]
                   ( if crSettings.enableChangeRequest then
-                    [ text "Create change request "
-                    , i [ class "fa fa-plus" ] []
+                    [ text "Open request"
                     ]
                   else
                     [ text action

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewCategoryDetails.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewCategoryDetails.elm
@@ -112,7 +112,7 @@ editionTemplateCat model details =
                 [ button [ class "btn btn-danger" , onClick (OpenDeletionPopupCat category)]
                   [ text "Delete", i [ class "fa fa-times-circle"][]]
                 ]
-              , btnSave model.ui.saving False (CallApi True (saveCategoryDetails category details.parentId (Maybe.Extra.isNothing details.originCategory))) False
+              , btnSave model.ui.saving False (CallApi True (saveCategoryDetails category details.parentId (Maybe.Extra.isNothing details.originCategory)))
               ]
             else
               []

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRuleDetails.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRuleDetails.elm
@@ -151,7 +151,7 @@ editionTemplate model details =
       Just oR -> Maybe.withDefault 0 details.numberOfDirectives
       Nothing -> 0
 
-    (saveAction, enabledCR) =
+    saveAction =
       let
         defaultAction = checkAction (CallApi True (saveRuleDetails rule (Maybe.Extra.isNothing details.originRule)))
         checkAction action =
@@ -163,17 +163,11 @@ editionTemplate model details =
         case model.ui.crSettings of
           Just cr ->
             if cr.enableChangeMessage || cr.enableChangeRequest then
-              ( checkAction (OpenSaveAuditMsgPopup rule cr)
-              , cr.enableChangeRequest
-              )
+              checkAction (OpenSaveAuditMsgPopup rule cr)
             else
-              ( defaultAction
-              , cr.enableChangeRequest
-              )
+              defaultAction
           Nothing ->
-            ( defaultAction
-            , False
-            )
+            defaultAction
 
   in
     div [class "main-container"]
@@ -189,7 +183,7 @@ editionTemplate model details =
           :: (
             if model.ui.hasWriteRights then
               [ div [ class "btn-group" ]  topButtons
-              , btnSave model.ui.saving (String.isEmpty (String.trim rule.name)) saveAction enabledCR
+              , btnSave model.ui.saving (String.isEmpty (String.trim rule.name)) saveAction
               ]
             else
               []

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewUtils.elm
@@ -980,22 +980,19 @@ getGroupsNbResourcesBadge nbTargets nbInclude msg =
         ]
 
 
-btnSave : Bool -> Bool -> Msg -> Bool -> Html Msg
-btnSave saving disable action crEnabled =
+btnSave : Bool -> Bool -> Msg -> Html Msg
+btnSave saving disable action =
     let
         icon =
             if saving then
                 i [ class "fa fa-spinner fa-pulse" ] []
 
-            else if crEnabled then
-                i [ class "fa fa-plus" ] []
-
             else
                 i [ class "fa fa-download" ] []
 
         btnClass =
-            if crEnabled then
-                "btn-cr"
+            if saving then
+                "btn-save saving"
 
             else
                 "btn-save"
@@ -1004,12 +1001,6 @@ btnSave saving disable action crEnabled =
         [ class
             ("btn btn-success "
                 ++ btnClass
-                ++ (if saving then
-                        " saving"
-
-                    else
-                        ""
-                   )
             )
         , type_ "button"
         , disabled (saving || disable)


### PR DESCRIPTION
https://issues.rudder.io/issues/28168

<img width="2577" height="1158" alt="image" src="https://github.com/user-attachments/assets/0566216b-0671-486c-adb5-d4741b30f6c6" />


* The "save" button should be the same "success" button as in other pages (groups & directives), since "Create change request" does not always make sense
* The button within the modal is blue and has "Open request" (as in groups & directives)
* There is also a blue callout (as in groups/directives and node settings)
* When there is no change to save, the button is still not disabled (which is a major issue across all our pages, I have opened a dedicated issue : https://issues.rudder.io/issues/28686) 