### PR TITLE
Fixes #28651: Ignored node compliance are seens as no report

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactChangeEventCallback.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactChangeEventCallback.scala
@@ -66,7 +66,7 @@ import com.normation.rudder.services.reports.InvalidateCache
 import com.normation.utils.DateFormaterService
 import com.normation.utils.StringUuidGenerator
 import java.time.Instant
-import zio.ZIO
+import zio.*
 
 /*
  * This file store callbacks for node events.
@@ -171,7 +171,10 @@ class ScoreUpdateOnNodeFactChange(scoreServiceManager: ScoreServiceManager, scor
 }
 
 /*
- * Callback related to cache invalidation when a node changes
+ * Callback related to cache invalidation when a node changes.
+ * It is:
+ *  - when a node is accepted or deleted,
+ *  - when its NodeState changes
  */
 class CacheInvalidateNodeFactEventCallback(
     cacheExpectedReports:   InvalidateCache[CacheExpectedReportAction],
@@ -182,6 +185,25 @@ class CacheInvalidateNodeFactEventCallback(
   import com.normation.rudder.services.reports.CacheExpectedReportAction.*
 
   override def name: String = "node-fact-cec: invalidate caches"
+
+  private def clearCaches(nodeId: NodeId): IOResult[Unit] = {
+    val a = CacheExpectedReportAction.RemoveNodeInCache(nodeId)
+    for {
+      _ <-
+        cacheNodeStatusReports
+          .invalidateWithAction(Seq((nodeId, CacheComplianceQueueAction.ExpectedReportAction(a))))
+          .catchAll(err => {
+            NodeLoggerPure.Delete
+              .error(s"Error when removing node ${nodeId.value} from node configuration cache: ${err.fullMsg}")
+          })
+      _ <- cacheExpectedReports
+             .invalidateWithAction(Seq((nodeId, a)))
+             .catchAll(err => {
+               NodeLoggerPure.Delete
+                 .error(s"Error when removing node ${nodeId.value} from compliance cache: ${err.fullMsg}")
+             })
+    } yield ()
+  }
 
   override def run(change: NodeFactChangeEventCC): IOResult[Unit] = {
     change.event match {
@@ -202,24 +224,16 @@ class CacheInvalidateNodeFactEventCallback(
           ()
         }
       case NodeFactChangeEvent.Refused(node, attrs)                    => ZIO.unit
-      case NodeFactChangeEvent.Updated(oldNode, newNode, attrs)        => ZIO.unit
-      case NodeFactChangeEvent.Deleted(node, attrs)                    =>
-        val a = CacheExpectedReportAction.RemoveNodeInCache(node.id)
-        for {
-          _ <- NodeLoggerPure.Delete.debug(s"  - remove node ${node.id.value} from compliance and expected report cache")
-          _ <-
-            cacheNodeStatusReports
-              .invalidateWithAction(Seq((node.id, CacheComplianceQueueAction.ExpectedReportAction(a))))
-              .catchAll(err => {
-                NodeLoggerPure.Delete
-                  .error(s"Error when removing node ${node.id.value} from node configuration cache: ${err.fullMsg}")
-              })
-          _ <- cacheExpectedReports
-                 .invalidateWithAction(Seq((node.id, a)))
-                 .catchAll(err =>
-                   NodeLoggerPure.Delete.error(s"Error when removing node ${node.id.value} from compliance cache: ${err.fullMsg}")
-                 )
-        } yield ()
+      case NodeFactChangeEvent.Updated(oldNode, newNode, attrs)        =>
+        if (oldNode.rudderSettings.state.isEnabled != newNode.rudderSettings.state.isEnabled) {
+          NodeLoggerPure.info(
+            s"Node '${newNode.fqdn}' [${oldNode.id.value}] state changed from '${oldNode.rudderSettings.state.name}' to '${newNode.rudderSettings.state.name}': remove that node from compliance and expected report cache to recompute them"
+          ) *> clearCaches(newNode.id)
+        } else ZIO.unit
+
+      case NodeFactChangeEvent.Deleted(node, attrs) =>
+        NodeLoggerPure.Delete.debug(s"  - remove node ${node.id.value} from compliance and expected report cache") *>
+        clearCaches(node.id)
 
       case NodeFactChangeEvent.Noop(nodeId, attrs) => NodeLoggerPure.debug(s"No change for node '${nodeId.value}'")
     }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/facts/nodes/NodeFactRepository.scala
@@ -427,16 +427,16 @@ class CoreNodeFactRepository(
 ) extends NodeFactRepository {
   import NodeFactChangeEvent.*
 
-  // number of accepted, enambled node
-  private def coundEnabled(nodes: Map[NodeId, CoreNodeFact]) = nodes.count(_._2.rudderSettings.state.isEnabled)
+  // number of accepted, enabled nodes
+  private def countEnabled(nodes: Map[NodeId, CoreNodeFact]) = nodes.count(_._2.rudderSettings.state.isEnabled)
   private val enabledNodes:         Ref[Int]  = (for {
     n <- acceptedNodes.get
-    r <- Ref.make(coundEnabled(n))
+    r <- Ref.make(countEnabled(n))
   } yield r).runNow
   private def updateEnabledCount(): UIO[Unit] = {
     for {
       n <- acceptedNodes.get
-      r <- enabledNodes.set(coundEnabled(n))
+      r <- enabledNodes.set(countEnabled(n))
     } yield r
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ComputeNodeStatusReportService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ComputeNodeStatusReportService.scala
@@ -42,6 +42,7 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.logger.ComplianceLoggerPure
 import com.normation.rudder.domain.logger.ReportLoggerPure
 import com.normation.rudder.domain.logger.TimingDebugLoggerPure
+import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.domain.reports.*
 import com.normation.rudder.facts.nodes.ChangeContext
 import com.normation.rudder.facts.nodes.NodeFactRepository
@@ -488,6 +489,7 @@ class FindNewNodeStatusReportsImpl(
     nodeConfigService:       NodeConfigurationService,
     reportsRepository:       ReportsRepository,
     agentRunRepository:      RoReportsExecutionRepository,
+    nodeFactRepository:      NodeFactRepository,
     getGlobalComplianceMode: () => IOResult[GlobalComplianceMode],
     jdbcMaxBatchSize:        Int
 ) extends FindNewNodeStatusReports {
@@ -612,6 +614,8 @@ class FindNewNodeStatusReportsImpl(
       complianceModeName: ComplianceModeName
   ): IOResult[Map[NodeId, NodeStatusReport]] = {
 
+    given qc: QueryContext = QueryContext.systemQC
+
     val batchedRunsInfos = runInfos.grouped(jdbcMaxBatchSize).toSeq
     val result           = ZIO.foreach(batchedRunsInfos) { runBatch =>
       /*
@@ -648,17 +652,20 @@ class FindNewNodeStatusReportsImpl(
                               s"Compliance: get Execution Reports in batch for ${runInfos.size} runInfos: ${(t1 - t0) / 1000}µs"
                             )
         t2               <- currentTimeNanos
+        nodeStates       <- nodeFactRepository
+                              .getAll()
+                              .map(_.collect { case (id, n) if runBatch.keySet.contains(id) => (id, n.rudderSettings.state) }.toMap)
         // we want to have nodeStatus for all asked node, not only the ones with reports
-        nodeStatusReports = runBatch.map {
-                              case (nodeId, runInfo) =>
-                                val status = {
-                                  ExecutionBatch.getNodeStatusReports(
-                                    nodeId,
-                                    runInfo,
-                                    reports.getOrElse(nodeId, Seq())
-                                  )
-                                }
-                                (status.nodeId, status)
+        nodeStatusReports = runBatch.map { (nodeId, runInfo) =>
+                              val status = {
+                                ExecutionBatch.getNodeStatusReports(
+                                  nodeId,
+                                  nodeStates.getOrElse(nodeId, NodeState.Ignored),
+                                  runInfo,
+                                  reports.getOrElse(nodeId, Seq())
+                                )
+                              }
+                              (status.nodeId, status)
                             }
         t3               <- currentTimeNanos
         _                <- u2.update(_ + (t3 - t2))

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ExecutionBatch.scala
@@ -41,6 +41,7 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.logger.ComplianceDebugLogger
 import com.normation.rudder.domain.logger.ComplianceDebugLogger.*
 import com.normation.rudder.domain.logger.TimingDebugLogger
+import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.PolicyMode
 import com.normation.rudder.domain.policies.PolicyTypeName
@@ -717,14 +718,6 @@ object ExecutionBatch extends Loggable {
           // Then analyse the consistency of the result.
           //
           case Some(runInfos) =>
-//          ComplianceDebugLogger.node(nodeId).debug(s"Node run configuration: ${(nodeId, complianceMode, runInfos).toLog }")
-//
-//          val computed =    computeNodeRunInfo(
-//                    nodeId, optInfo, missingReportType
-//                  , intervalInfo, updateValidityTime(intervalInfo), runValidityTime(intervalInfo)
-//                  , now, run
-//              )
-
             (runInfos, currentNodeConfigs.get(nodeId).flatten) match {
 
               //
@@ -935,240 +928,251 @@ object ExecutionBatch extends Loggable {
    *  It returns a properly merged NodeStatusReports
    */
   def getNodeStatusReports(
-      nodeId:  NodeId,           // run info: if we have a run, we have a datetime for it
+      nodeId:    NodeId,           // run info: if we have a run, we have a datetime for it
       // and perhaps a configId
-
-      runInfo: RunAndConfigInfo, // reports we get on the last know run
+      nodeState: NodeState,
+      runInfo:   RunAndConfigInfo, // reports we get on the last know run
 
       agentExecutionReports: Seq[Reports]
   ): NodeStatusReport = {
+    // early return, no need to continue
+    if (!nodeState.isEnabled) {
+      val status = runInfo match {
+        case r: (ExpiringStatus & ExpectedConfigAvailable) => NoReportInInterval(r.expectedConfig, r.expirationDateTime)
+        case _ => NoRunNoExpectedReport
+      }
 
-    // only interesting reports: for that node, with a status
-    val nodeStatusReports = agentExecutionReports.collect { case r: ResultReports if (r.nodeId == nodeId) => r }
+      NodeStatusReportInternal.buildWith(nodeId, status, RunComplianceInfo.OK, List(), Set()).toNodeStatusReport()
 
-    ComplianceDebugLogger.node(nodeId).debug(s"Computing compliance for node ${nodeId.value} with: [${runInfo.toLog}]")
+    } else {
 
-    val t1        = System.currentTimeMillis
-    val overrides = runInfo match {
-      case x: ExpectedConfigAvailable => x.expectedConfig.overrides
-      case _ => Nil
-    }
+      // only interesting reports: for that node, with a status
+      val nodeStatusReports = agentExecutionReports.collect { case r: ResultReports if (r.nodeId == nodeId) => r }
 
-    val ruleNodeStatusReports = runInfo match {
+      ComplianceDebugLogger.node(nodeId).debug(s"Computing compliance for node ${nodeId.value} with: [${runInfo.toLog}]")
 
-      case ReportsDisabledInInterval(expectedConfig, _) =>
-        ComplianceDebugLogger
-          .node(nodeId)
-          .debug(s"Compliance mode is ${ReportsDisabled.name}, so we don't have to try to merge/compare with expected reports")
-        buildRuleNodeStatusReport(
-          // these reports don't really expires - without change, it will
-          // always be the same.
-          MergeInfo(nodeId, None, Some(expectedConfig.nodeConfigId), END_OF_TIME),
-          expectedConfig,
-          ReportType.Disabled,
-          overrides
-        )
+      val t1        = System.currentTimeMillis
+      val overrides = runInfo match {
+        case x: ExpectedConfigAvailable => x.expectedConfig.overrides
+        case _ => Nil
+      }
 
-      case ComputeCompliance(lastRunDateTime, expectedConfig, expirationTime) =>
-        ComplianceDebugLogger
-          .node(nodeId)
-          .debug(
-            s"Using merge/compare strategy between last reports from run at ${lastRunDateTime} and expect reports ${expectedConfig.toLog}"
+      val ruleNodeStatusReports = runInfo match {
+
+        case ReportsDisabledInInterval(expectedConfig, _) =>
+          ComplianceDebugLogger
+            .node(nodeId)
+            .debug(s"Compliance mode is ${ReportsDisabled.name}, so we don't have to try to merge/compare with expected reports")
+          buildRuleNodeStatusReport(
+            // these reports don't really expires - without change, it will
+            // always be the same.
+            MergeInfo(nodeId, None, Some(expectedConfig.nodeConfigId), END_OF_TIME),
+            expectedConfig,
+            ReportType.Disabled,
+            overrides
           )
-        mergeCompareByRule(
-          MergeInfo(nodeId, Some(lastRunDateTime), Some(expectedConfig.nodeConfigId), expirationTime),
-          nodeStatusReports,
-          expectedConfig,
-          expectedConfig,
-          overrides
-        )
 
-      case Pending(expectedConfig, optLastRun, expirationTime) =>
-        optLastRun match {
-          case None =>
-            ComplianceDebugLogger
-              .node(nodeId)
-              .debug(s"Node is Pending with no reports from a previous run, everything is pending")
-            // we don't have previous run, so we can simply say that all component in node are Pending
-            buildRuleNodeStatusReport(
-              MergeInfo(nodeId, None, Some(expectedConfig.nodeConfigId), expirationTime),
-              expectedConfig,
-              ReportType.Pending,
-              overrides
+        case ComputeCompliance(lastRunDateTime, expectedConfig, expirationTime) =>
+          ComplianceDebugLogger
+            .node(nodeId)
+            .debug(
+              s"Using merge/compare strategy between last reports from run at ${lastRunDateTime} and expect reports ${expectedConfig.toLog}"
             )
+          mergeCompareByRule(
+            MergeInfo(nodeId, Some(lastRunDateTime), Some(expectedConfig.nodeConfigId), expirationTime),
+            nodeStatusReports,
+            expectedConfig,
+            expectedConfig,
+            overrides
+          )
 
-          case Some((runTime, runConfig)) =>
-            /*
-             * In that case, we need to compute the status of all component in the previous run,
-             * then keep these result for component in the new expected config and for
-             * component in new expected config BUT NOT is the one for which we have the run,
-             * set pending.
-             */
-            ComplianceDebugLogger
-              .node(nodeId)
-              .debug(
-                "Node is Pending with reports from previous run, using merge/compare strategy between last "
-                + s"reports from run ${runConfig.toLog} and expect reports ${expectedConfig.toLog}"
+        case Pending(expectedConfig, optLastRun, expirationTime) =>
+          optLastRun match {
+            case None =>
+              ComplianceDebugLogger
+                .node(nodeId)
+                .debug(s"Node is Pending with no reports from a previous run, everything is pending")
+              // we don't have previous run, so we can simply say that all component in node are Pending
+              buildRuleNodeStatusReport(
+                MergeInfo(nodeId, None, Some(expectedConfig.nodeConfigId), expirationTime),
+                expectedConfig,
+                ReportType.Pending,
+                overrides
               )
-            mergeCompareByRule(
-              MergeInfo(nodeId, Some(runTime), Some(expectedConfig.nodeConfigId), expirationTime),
-              nodeStatusReports,
-              runConfig,
-              expectedConfig,
-              overrides
+
+            case Some((runTime, runConfig)) =>
+              /*
+               * In that case, we need to compute the status of all component in the previous run,
+               * then keep these result for component in the new expected config and for
+               * component in new expected config BUT NOT is the one for which we have the run,
+               * set pending.
+               */
+              ComplianceDebugLogger
+                .node(nodeId)
+                .debug(
+                  "Node is Pending with reports from previous run, using merge/compare strategy between last "
+                  + s"reports from run ${runConfig.toLog} and expect reports ${expectedConfig.toLog}"
+                )
+              mergeCompareByRule(
+                MergeInfo(nodeId, Some(runTime), Some(expectedConfig.nodeConfigId), expirationTime),
+                nodeStatusReports,
+                runConfig,
+                expectedConfig,
+                overrides
+              )
+          }
+
+        case NoReportInInterval(expectedConfig, expirationTime) =>
+          ComplianceDebugLogger
+            .node(nodeId)
+            .debug(s"Node didn't received reports recently, status depend of the compliance mode and previous report status")
+          buildRuleNodeStatusReport(
+            // these reports need to expire, so that we can recompute them automatically
+            // at expiration, and store that the nodes were not answering
+            MergeInfo(nodeId, None, Some(expectedConfig.nodeConfigId), expirationTime),
+            expectedConfig,
+            ReportType.NoAnswer,
+            overrides
+          )
+
+        case KeepLastCompliance(expectedConfig, expirationTime, keepUntil, optLastRun) =>
+          ComplianceDebugLogger
+            .node(nodeId)
+            .debug(
+              s"Node didn't received reports recently, status depend of the compliance mode and previous report status and will be kept until ${keepUntil}"
             )
-        }
-
-      case NoReportInInterval(expectedConfig, expirationTime) =>
-        ComplianceDebugLogger
-          .node(nodeId)
-          .debug(s"Node didn't received reports recently, status depend of the compliance mode and previous report status")
-        buildRuleNodeStatusReport(
-          // these reports need to expire, so that we can recompute them automatically
-          // at expiration, and store that the nodes were not answering
-          MergeInfo(nodeId, None, Some(expectedConfig.nodeConfigId), expirationTime),
-          expectedConfig,
-          ReportType.NoAnswer,
-          overrides
-        )
-
-      case KeepLastCompliance(expectedConfig, expirationTime, keepUntil, optLastRun) =>
-        ComplianceDebugLogger
-          .node(nodeId)
-          .debug(
-            s"Node didn't received reports recently, status depend of the compliance mode and previous report status and will be kept until ${keepUntil}"
+          buildRuleNodeStatusReport(
+            // these reports need to expire, so that we can recompute them automatically
+            // at expiration, and store that the nodes were not answering
+            MergeInfo(nodeId, None, Some(expectedConfig.nodeConfigId), expirationTime),
+            expectedConfig,
+            ReportType.NoAnswer,
+            overrides
           )
-        buildRuleNodeStatusReport(
-          // these reports need to expire, so that we can recompute them automatically
-          // at expiration, and store that the nodes were not answering
-          MergeInfo(nodeId, None, Some(expectedConfig.nodeConfigId), expirationTime),
-          expectedConfig,
-          ReportType.NoAnswer,
-          overrides
-        )
 
-      case UnexpectedVersion(runTime, Some(runConfig), runExpiration, expectedConfig, expectedExpiration, _) =>
-        ComplianceDebugLogger
-          .node(nodeId)
-          .warn(
-            s"Received a run at ${runTime} for node '${nodeId.value}' with configId '${runConfig.nodeConfigId.value}' but that node should be sending reports for configId ${expectedConfig.nodeConfigId.value}"
-          )
-        buildUnexpectedVersion(
-          nodeId,
-          runTime,
-          Some(runConfig.configInfo),
-          runExpiration,
-          expectedConfig,
-          expectedExpiration,
-          nodeStatusReports,
-          overrides
-        )
-
-      case UnexpectedNoVersion(
+        case UnexpectedVersion(runTime, Some(runConfig), runExpiration, expectedConfig, expectedExpiration, _) =>
+          ComplianceDebugLogger
+            .node(nodeId)
+            .warn(
+              s"Received a run at ${runTime} for node '${nodeId.value}' with configId '${runConfig.nodeConfigId.value}' but that node should be sending reports for configId ${expectedConfig.nodeConfigId.value}"
+            )
+          buildUnexpectedVersion(
+            nodeId,
             runTime,
-            runId,
+            Some(runConfig.configInfo),
             runExpiration,
             expectedConfig,
             expectedExpiration,
-            _
-          ) => // same as unexpected, different log
-        ComplianceDebugLogger
-          .node(nodeId)
-          .warn(
-            s"Received a run at ${runTime} for node '${nodeId.value}' without any configId but that node should be sending reports for configId ${expectedConfig.nodeConfigId.value}"
+            nodeStatusReports,
+            overrides
           )
-        buildUnexpectedVersion(
-          nodeId,
-          runTime,
-          None,
-          runExpiration,
-          expectedConfig,
-          expectedExpiration,
-          nodeStatusReports,
-          overrides
-        )
 
-      case UnexpectedUnknownVersion(
+        case UnexpectedNoVersion(
+              runTime,
+              runId,
+              runExpiration,
+              expectedConfig,
+              expectedExpiration,
+              _
+            ) => // same as unexpected, different log
+          ComplianceDebugLogger
+            .node(nodeId)
+            .warn(
+              s"Received a run at ${runTime} for node '${nodeId.value}' without any configId but that node should be sending reports for configId ${expectedConfig.nodeConfigId.value}"
+            )
+          buildUnexpectedVersion(
+            nodeId,
             runTime,
-            runId,
+            None,
+            runExpiration,
             expectedConfig,
             expectedExpiration,
-            expirationTime
-          ) => // same as unextected, different log
-        ComplianceDebugLogger
-          .node(nodeId)
-          .warn(
-            s"Received a run at ${runTime} for node '${nodeId.value}' configId '${runId.value}' which is not known by Rudder, and that node should be sending reports for configId ${expectedConfig.nodeConfigId.value}."
+            nodeStatusReports,
+            overrides
           )
-        buildUnexpectedVersion(nodeId, runTime, None, runTime, expectedConfig, expectedExpiration, nodeStatusReports, overrides)
 
-      case NoUserRulesDefined(runTime, expectedConfig, runId, _, _) => // same as unextected, different log
-        val expectedExpiration = expectedConfig.beginDate.plus(expectedConfig.agentRun.interval.plus(GRACE_TIME_PENDING))
-        ComplianceDebugLogger
-          .node(nodeId)
-          .warn(
-            s"Received a run at ${runTime} for node '${nodeId.value}' configId '${runId.value}' which is not known by Rudder, and that node should be sending reports for configId ${expectedConfig.nodeConfigId.value}"
-          )
-        buildUnexpectedVersion(nodeId, runTime, None, runTime, expectedConfig, expectedExpiration, nodeStatusReports, overrides)
+        case UnexpectedUnknownVersion(
+              runTime,
+              runId,
+              expectedConfig,
+              expectedExpiration,
+              expirationTime
+            ) => // same as unextected, different log
+          ComplianceDebugLogger
+            .node(nodeId)
+            .warn(
+              s"Received a run at ${runTime} for node '${nodeId.value}' configId '${runId.value}' which is not known by Rudder, and that node should be sending reports for configId ${expectedConfig.nodeConfigId.value}."
+            )
+          buildUnexpectedVersion(nodeId, runTime, None, runTime, expectedConfig, expectedExpiration, nodeStatusReports, overrides)
 
-      case NoExpectedReport(runTime, optConfigId) =>
-        // these reports where not expected
-        ComplianceDebugLogger
-          .node(nodeId)
-          .warn(
-            s"Node '${nodeId.value}' sent reports for run at '${runInfo}' (with ${optConfigId.map(x => s" configuration ID: '${x.value}'").getOrElse(" no configuration ID")}). No expected configuration matches these reports."
-          )
-        buildUnexpectedReports(MergeInfo(nodeId, Some(runTime), optConfigId, END_OF_TIME), nodeStatusReports, overrides)
+        case NoUserRulesDefined(runTime, expectedConfig, runId, _, _) => // same as unextected, different log
+          val expectedExpiration = expectedConfig.beginDate.plus(expectedConfig.agentRun.interval.plus(GRACE_TIME_PENDING))
+          ComplianceDebugLogger
+            .node(nodeId)
+            .warn(
+              s"Received a run at ${runTime} for node '${nodeId.value}' configId '${runId.value}' which is not known by Rudder, and that node should be sending reports for configId ${expectedConfig.nodeConfigId.value}"
+            )
+          buildUnexpectedVersion(nodeId, runTime, None, runTime, expectedConfig, expectedExpiration, nodeStatusReports, overrides)
 
-      case NoRunNoExpectedReport =>
-        /*
-         * Really, this node exists ? Shouldn't we just declare Ragnarök at that point ?
-         */
-        ComplianceDebugLogger
-          .node(nodeId)
-          .warn(
-            s"Can not get compliance for node with ID '${nodeId.value}' because it has no configuration id initialised nor sent reports (node just added ?)"
-          )
-        Set[RuleNodeStatusReport]()
+        case NoExpectedReport(runTime, optConfigId) =>
+          // these reports where not expected
+          ComplianceDebugLogger
+            .node(nodeId)
+            .warn(
+              s"Node '${nodeId.value}' sent reports for run at '${runInfo}' (with ${optConfigId.map(x => s" configuration ID: '${x.value}'").getOrElse(" no configuration ID")}). No expected configuration matches these reports."
+            )
+          buildUnexpectedReports(MergeInfo(nodeId, Some(runTime), optConfigId, END_OF_TIME), nodeStatusReports, overrides)
 
-    }
+        case NoRunNoExpectedReport =>
+          /*
+           * Really, this node exists ? Shouldn't we just declare Ragnarök at that point ?
+           */
+          ComplianceDebugLogger
+            .node(nodeId)
+            .warn(
+              s"Can not get compliance for node with ID '${nodeId.value}' because it has no configuration id initialised nor sent reports (node just added ?)"
+            )
+          Set[RuleNodeStatusReport]()
 
-    /*
-     * We must adapt the node run compliance info if we have
-     * an abort message or at least one mixed mode result
-     */
-
-    val t2 = System.currentTimeMillis
-    TimingDebugLogger.trace(s"Compliance: getNodeStatusReports - computing compliance for node ${nodeId}: ${t2 - t1}ms")
-
-    val status = {
-      val abort = agentExecutionReports.collect {
-        case r: LogReports if (r.nodeId == nodeId && r.component.toLowerCase == "abort run") =>
-          RunComplianceInfo.PolicyModeError.AgentAbortMessage(r.keyValue, r.message)
-      }.toSet
-      val mixed = ruleNodeStatusReports.collect {
-        case r =>
-          r.directives.collect {
-            case (_, d) if (d.compliance.badPolicyMode > 0) =>
-              RunComplianceInfo.PolicyModeError.TechniqueMixedMode(
-                s"Error for node '${nodeId.value}' in directive '${d.directiveId.debugString}': either that directive is" +
-                " not sending the correct Policy Mode reports (for example Enforce reports in place of Audit one - does the directive's Technique is up-to-date?)" +
-                " or at least one other directive on that node based on the same Technique sends reports for a different Policy Mode"
-              )
-          }.toSet
-      }.flatten
-
-      (abort ++ mixed).toList match {
-        case Nil  => RunComplianceInfo.OK
-        case list => RunComplianceInfo.PolicyModeInconsistency(list)
       }
+
+      /*
+       * We must adapt the node run compliance info if we have
+       * an abort message or at least one mixed mode result
+       */
+
+      val t2 = System.currentTimeMillis
+      TimingDebugLogger.trace(s"Compliance: getNodeStatusReports - computing compliance for node ${nodeId}: ${t2 - t1}ms")
+
+      val status = {
+        val abort = agentExecutionReports.collect {
+          case r: LogReports if (r.nodeId == nodeId && r.component.toLowerCase == "abort run") =>
+            RunComplianceInfo.PolicyModeError.AgentAbortMessage(r.keyValue, r.message)
+        }.toSet
+        val mixed = ruleNodeStatusReports.collect {
+          case r =>
+            r.directives.collect {
+              case (_, d) if (d.compliance.badPolicyMode > 0) =>
+                RunComplianceInfo.PolicyModeError.TechniqueMixedMode(
+                  s"Error for node '${nodeId.value}' in directive '${d.directiveId.debugString}': either that directive is" +
+                  " not sending the correct Policy Mode reports (for example Enforce reports in place of Audit one - does the directive's Technique is up-to-date?)" +
+                  " or at least one other directive on that node based on the same Technique sends reports for a different Policy Mode"
+                )
+            }.toSet
+        }.flatten
+
+        (abort ++ mixed).toList match {
+          case Nil  => RunComplianceInfo.OK
+          case list => RunComplianceInfo.PolicyModeInconsistency(list)
+        }
+      }
+      val t3     = System.currentTimeMillis
+      TimingDebugLogger.trace(s"Compliance: computing policy status for ${nodeId}: ${t3 - t2}ms")
+
+      NodeStatusReportInternal.buildWith(nodeId, runInfo, status, overrides, ruleNodeStatusReports.toSet).toNodeStatusReport()
     }
-    val t3     = System.currentTimeMillis
-    TimingDebugLogger.trace(s"Compliance: computing policy status for ${nodeId}: ${t3 - t2}ms")
 
-    NodeStatusReportInternal.buildWith(nodeId, runInfo, status, overrides, ruleNodeStatusReports.toSet).toNodeStatusReport()
   }
-
   // utility method to find how missing report should be reported given the compliance
   // mode of the node.
   private[reports] def missingReportType(complianceMode: ComplianceMode, policyMode: PolicyMode) = complianceMode.mode match {

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -62,7 +62,7 @@ object ReportingServiceUtils {
  * A simple implementation of reporting service that just uses an underlying NodeStatusReport
  * repository to get reports, and then do basic filtering/computation on them.
  */
-class ReportingServiceImpl2(nsrRepo: NodeStatusReportRepository) extends ReportingService {
+class ReportingServiceImpl(nsrRepo: NodeStatusReportRepository) extends ReportingService {
 
   override def findRuleNodeStatusReports(nodeIds: Set[NodeId], filterByRules: Set[RuleId])(implicit
       qc: QueryContext

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ComplianceTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ComplianceTest.scala
@@ -38,6 +38,7 @@
 package com.normation.rudder.services.reports
 
 import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.RuleId
@@ -249,7 +250,7 @@ class ComplianceTest extends Specification {
       // here, we assume "compute compliance", i.e we are only testing the compliance engine, not
       // the meta-analysis on run consistency (correct run, at the correct time, etc)
       val runinfo = ComputeCompliance(runTime, config, runTime)
-      val status  = ExecutionBatch.getNodeStatusReports(config.nodeId, runinfo, reports)
+      val status  = ExecutionBatch.getNodeStatusReports(config.nodeId, NodeState.Enabled, runinfo, reports)
 
       // we really have 26 (ie 18+8) values
       status.compliance must beEqualTo(ComplianceLevel(success = 18, notApplicable = 8))
@@ -271,7 +272,7 @@ class ComplianceTest extends Specification {
       // here, we assume "compute compliance", i.e we are only testing the compliance engine, not
       // the meta-analysis on run consistancy (correct run, at the correct time, etc)
       val runinfo = ComputeCompliance(runTime, config, runTime)
-      val status  = ExecutionBatch.getNodeStatusReports(config.nodeId, runinfo, reports)
+      val status  = ExecutionBatch.getNodeStatusReports(config.nodeId, NodeState.Enabled, runinfo, reports)
 
       // we really have 39 values in total
       status.compliance must beEqualTo(ComplianceLevel(success = 34, notApplicable = 5))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/reports/ExecutionBatchTest.scala
@@ -41,6 +41,7 @@ import ch.qos.logback.classic.Logger
 import com.normation.cfclerk.domain.ReportingLogic
 import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.inventory.domain.NodeId
+import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.DirectiveUid
 import com.normation.rudder.domain.policies.GlobalPolicyMode
@@ -184,8 +185,9 @@ class ExecutionBatchTest extends Specification {
       nodeIds:    Seq[String],
       ruleId:     String,
       serial:     Int,
-      directives: List[DirectiveExpectedReports]
-  ): Map[NodeId, NodeExpectedReports] = {
+      directives: List[DirectiveExpectedReports],
+      states:     Map[String, NodeState] = Map()
+  ): Map[NodeId, (NodeExpectedReports, NodeState)] = {
     val globalPolicyMode = GlobalPolicyMode(PolicyMode.Audit, PolicyModeOverrides.Always)
     val now              = DateTime.now
     val mode             = NodeModeConfig(
@@ -197,7 +199,7 @@ class ExecutionBatchTest extends Specification {
       Some(PolicyMode.Enforce)
     )
     nodeIds.map { id =>
-      (NodeId(id) -> NodeExpectedReports(
+      (NodeId(id) -> (NodeExpectedReports(
         NodeId(id),
         NodeConfigId("version_" + id),
         now,
@@ -205,31 +207,30 @@ class ExecutionBatchTest extends Specification {
         mode,
         List(RuleExpectedReports(RuleId(ruleId), directives)),
         Nil
-      ))
+      ), states.getOrElse(id, NodeState.Enabled)))
     }.toMap
   }
 
   def getNodeStatusReportsByRule(
-      nodeExpectedReports: Map[NodeId, NodeExpectedReports],
+      nodeExpectedReports: Map[NodeId, (NodeExpectedReports, NodeState)],
       reportsParam:        Seq[Reports] // this is the agent execution interval, in minutes
   ): Map[NodeId, NodeStatusReport] = {
 
     val res = (for {
-      (nodeId, expected) <- nodeExpectedReports.toSeq
+      (nodeId, (expected, state)) <- nodeExpectedReports.toSeq
     } yield {
       val runTime = reportsParam.headOption.map(_.executionTimestamp).getOrElse(DateTime.now)
-      val info    = nodeExpectedReports(nodeId)
-      val runInfo = ComputeCompliance(runTime, info, runTime.plusMinutes(5))
+      val runInfo = ComputeCompliance(runTime, expected, runTime.plusMinutes(5))
 
-      (nodeId, ExecutionBatch.getNodeStatusReports(nodeId, runInfo, reportsParam))
+      (nodeId, ExecutionBatch.getNodeStatusReports(nodeId, state, runInfo, reportsParam))
     })
 
     res.toMap
   }
 
-  val getNodeStatusByRule: ((Map[NodeId, NodeExpectedReports], Seq[Reports])) => Map[NodeId, NodeStatusReport] =
+  val getNodeStatusByRule: ((Map[NodeId, (NodeExpectedReports, NodeState)], Seq[Reports])) => Map[NodeId, NodeStatusReport] =
     (getNodeStatusReportsByRule).tupled
-  val one:                 NodeId                                                                              = NodeId("one")
+  val one:                 NodeId                                                                                           = NodeId("one")
 
   sequential
 
@@ -357,7 +358,7 @@ class ExecutionBatchTest extends Specification {
     val oldRunTime = ISODateTimeFormat.dateTimeParser().parseDateTime("2023-01-01T15:15:00+00:00")
 
     // we had a config ID for the old run (just it does not exist anymore in base)
-    val oldRunExpectedReport = expectedReports.copy(
+    val oldRunExpectedReport = expectedReports._1.copy(
       nodeConfigId = NodeConfigId("configId-old-run"),
       beginDate = oldRunTime,
       endDate = Some(oldRunTime.plusHours(10)) // next generation was 10h after and closed that expected report span
@@ -365,7 +366,7 @@ class ExecutionBatchTest extends Specification {
 
     // expected reports were generated 12 days, 5 hours after old run
     val generationTime           = oldRunTime.minusDays(11).plusHours(3)
-    val generatedExpectedReports = expectedReports.copy(beginDate = generationTime)
+    val generatedExpectedReports = expectedReports._1.copy(beginDate = generationTime)
     val currentNodeConfigs       = Map(nodeId -> Some(generatedExpectedReports))
 
     "if we don't have the old config for expected report" in {
@@ -3609,7 +3610,7 @@ class ExecutionBatchTest extends Specification {
             PolicyTypes.rudderBase,
             components = List(
               new ValueExpectedReport("component", ExpectedValueMatch("value", "value") :: Nil)
-            ) // here, we automatically must have "value" infered as unexpanded var
+            ) // here, we automatically must have "value" inferred as unexpanded var
           )
         )
       ),
@@ -3645,6 +3646,47 @@ class ExecutionBatchTest extends Specification {
 
     "have no detailed rule non-success directive when we create it with one success report" in {
       nodeStatus(one).reports.head._2.compliance === ComplianceLevel(success = 1)
+    }
+  }
+
+  "A detailed execution Batch for an IGNORED node, with one component, cardinality one, one node" should {
+
+    val param = (
+      buildExpected(
+        List("one"),
+        "rule",
+        12,
+        List(
+          DirectiveExpectedReports(
+            directiveId = "policy",
+            policyMode = None,
+            PolicyTypes.rudderBase,
+            components = List(
+              new ValueExpectedReport("component", ExpectedValueMatch("value", "value") :: Nil)
+            ) // here, we automatically must have "value" inferred as unexpanded var
+          )
+        ),
+        Map("one" -> NodeState.Ignored)
+      ),
+      Seq[Reports](
+        new ResultSuccessReport(
+          DateTime.now(DateTimeZone.UTC),
+          "rule",
+          "policy",
+          "one",
+          "report_id12",
+          "component",
+          "value",
+          DateTime.now(DateTimeZone.UTC),
+          "message"
+        )
+      )
+    )
+
+    val nodeStatus = (getNodeStatusReportsByRule).tupled(param)
+
+    "have ZERO detailed reports when we create it with one report" in {
+      nodeStatus(one).reports.size === 0
     }
   }
 
@@ -4610,18 +4652,21 @@ class ExecutionBatchTest extends Specification {
           )
         )
       ).map { // we want to say we have an overriding rule, `overridingRule`
-        case (k, v) =>
+        case (k, (v, s)) =>
           (
             k,
-            v.modify(_.overrides)
-              .setTo(
-                List(
-                  OverriddenPolicy(
-                    policy = PolicyId(RuleId(RuleUid("rule")), DirectiveId(DirectiveUid("policy1")), TechniqueVersion.V1_0),
-                    overriddenBy = overridingPolicyId
+            (
+              v.modify(_.overrides)
+                .setTo(
+                  List(
+                    OverriddenPolicy(
+                      policy = PolicyId(RuleId(RuleUid("rule")), DirectiveId(DirectiveUid("policy1")), TechniqueVersion.V1_0),
+                      overriddenBy = overridingPolicyId
+                    )
                   )
-                )
-              )
+                ),
+              s
+            )
           )
       },
       Seq[Reports](
@@ -4706,18 +4751,21 @@ class ExecutionBatchTest extends Specification {
           )
         )
       ).map { // we want to say we have an overriding rule, `overridingRule`
-        case (k, v) =>
+        case (k, (v, s)) =>
           (
             k,
-            v.modify(_.overrides)
-              .setTo(
-                List(
-                  OverriddenPolicy(
-                    policy = PolicyId(RuleId(RuleUid("rule")), DirectiveId(DirectiveUid("policy1")), TechniqueVersion.V1_0),
-                    overriddenBy = overridingPolicyId
+            (
+              v.modify(_.overrides)
+                .setTo(
+                  List(
+                    OverriddenPolicy(
+                      policy = PolicyId(RuleId(RuleUid("rule")), DirectiveId(DirectiveUid("policy1")), TechniqueVersion.V1_0),
+                      overriddenBy = overridingPolicyId
+                    )
                   )
-                )
-              )
+                ),
+              s
+            )
           )
       },
       Seq[Reports]()

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RunComplianceComputation.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RunComplianceComputation.scala
@@ -68,7 +68,7 @@ import com.normation.rudder.services.reports.InMemoryNodeStatusReportStorage
 import com.normation.rudder.services.reports.NodeStatusReportInternal
 import com.normation.rudder.services.reports.NodeStatusReportRepositoryImpl
 import com.normation.rudder.services.reports.ReportingService
-import com.normation.rudder.services.reports.ReportingServiceImpl2
+import com.normation.rudder.services.reports.ReportingServiceImpl
 import com.normation.zio.*
 import org.joda.time.DateTime
 import scala.collection.MapView
@@ -267,7 +267,7 @@ class SetUpCompliance(numNodes: Int, numRules: Int) {
 
   def reportingService(statusReports: Map[NodeId, NodeStatusReport]): ReportingService = {
     val ref = Ref.make(statusReports).runNow
-    new ReportingServiceImpl2(new NodeStatusReportRepositoryImpl(new InMemoryNodeStatusReportStorage(ref), ref))
+    new ReportingServiceImpl(new NodeStatusReportRepositoryImpl(new InMemoryNodeStatusReportStorage(ref), ref))
   }
 
   val complianceAPIService: ComplianceAPIService = {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -3255,6 +3255,7 @@ object RudderConfigInit {
       cachedNodeConfigurationService,
       reportsRepository,
       roAgentRunsRepository,
+      nodeFactRepository,
       () => globalComplianceModeService.getGlobalComplianceMode,
       RUDDER_JDBC_BATCH_MAX_SIZE
     )
@@ -3293,7 +3294,7 @@ object RudderConfigInit {
     // and can construct the nodeConfigurationService without the compliance cache
     cachedNodeConfigurationService.addHook(computeNodeStatusReportService)
 
-    lazy val reportingService: ReportingService = new ReportingServiceImpl2(nodeStatusReportRepository)
+    lazy val reportingService: ReportingService = new ReportingServiceImpl(nodeStatusReportRepository)
 
     lazy val pgIn                  = new PostgresqlInClause(70)
     lazy val findExpectedRepo      = new FindExpectedReportsJdbcRepository(doobie, pgIn, RUDDER_JDBC_BATCH_MAX_SIZE)


### PR DESCRIPTION
https://issues.rudder.io/issues/28651

So, the correction is easy, but finding the best place to put it was not obvious. 
The idea is that a node in `Ignored` state should not have any `NodeStatusReport`. It's absolutly necessary to have that computation done in only one place so that everything is consistent. 

The idea is: somewhere appropriated, for all disabled nodes, replace whatever `NodeStatusReport` the node could have to a `NodeStatusReport` with type `ReportsDisabledInInterval` and zero compliance reports in it. 


I first thought to put the change in `FindNewNodeStatusReports` (either in `findUncomputedNodeStatusReports()` since it would make sense to just avoid getting reports from DB and computing things into it, or in `buildNodeStatusReports` which is the computation part, and used in all path where we do compute compliance). 
But it was hard to test, and it's just a pur computation (a simple if/then/else, even), and it didn't seem to fit that part of the code which does a lot of I/O. 

So I looked where it would better fit without hurting the general design and separation of concerns, and `ExecutionBatch.scala` is the perfect fit: it's pure `NodeStatusReport` computation. 

Then, we need to force cleaning-up compliance cache when the node becomes ignored, because since it removes it from policy generation (it's the goal), we won't have new expected reports, and so we won't have update until the next node run or until we overflow the run frequency. 

For that, I used a `CoreNodeFactHook`, which is really such a good design/power tool. Actuall, there was already a hook for that purpose, so I just extended it. 

There is a new info log for that, it looks like it's interesting enought from ops debug pow: 

```
2026-04-02 16:38:39+0000 INFO  nodes - Node 'node1.rudder.local' [e25a8aec-1e1c-4c5d-871e-617867b86060] state changed from 'enabled' to 'ignored': remove that node from compliance and expected report cache to recompute them
```

Remaning things are just cleaning up (typo, bad naming, old commented code...). 

And ignored node appears with compliance "N/A" which seems ok. 

<img width="1495" height="406" alt="image" src="https://github.com/user-attachments/assets/9ef3f946-9863-4450-bd71-c77ea26dbcb6" />

<img width="1457" height="290" alt="image" src="https://github.com/user-attachments/assets/5334a0fa-a981-49a7-b334-addc8f1d9476" />

<img width="1487" height="612" alt="image" src="https://github.com/user-attachments/assets/6311110b-d280-4934-85f8-fd84b7117d39" />
