### PR TITLE
Fixes #28682: We should have consistant behaviour when creating group with empty criteria

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/NodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/NodeFactQueryProcessor.scala
@@ -300,9 +300,16 @@ class NodeFactQueryProcessor(
       subgroupLines = subGroupMatcher(sortedLines.subGroup, groupRepo)
       ldapLines     = ldapMatcher(sortedLines.ldap, query)
       nodeLines     = nodeFactMatcher(sortedLines.coreNodeFact)
-      lineResult   <- ZIO.foldLeft(globalLines ++ subgroupLines ++ ldapLines ++ nodeLines)(group.neutral: NodeFactMatcher) {
-                        case (matcher, line) =>
-                          line.map(group.compose(matcher, _))
+      allMatcher    = globalLines ++ subgroupLines ++ ldapLines ++ nodeLines
+      lineResult   <- if (allMatcher.isEmpty) {
+                        // take care of the empty set case, which breaks our inner set law, by adding a never matching
+                        // matcher. With that, other latter transformation like `inversion` will work.
+                        AbsorbingMatcher("no criteria provided", false).succeed
+                      } else {
+                        ZIO.foldLeft(allMatcher)(group.neutral: NodeFactMatcher) {
+                          case (matcher, line) =>
+                            line.map(group.compose(matcher, _))
+                        }
                       }
     } yield {
       // inverse now if needed, because we don't want to return root if not asked *even* when inverse is present

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
@@ -200,7 +200,7 @@ class TestNodeFactQueryProcessor {
     val q2 = TestQuery(
       "q2",
       parser("""
-      {  "select":"node", "composition":"and", "where":[
+      { "select":"node", "composition":"and", "where":[
         { "objectType":"node"   , "attribute":"nodeId"  , "comparator":"eq", "value":"node1" },
         { "objectType":"node"   , "attribute":"nodeId"  , "comparator":"eq", "value":"node5" }
       ] }
@@ -208,7 +208,45 @@ class TestNodeFactQueryProcessor {
       Nil
     )
 
-    testQueries(q0 :: q1 :: q2 :: Nil, doInternalQueryTest = false)
+    /* find nothing when where is empty */
+    val q3and = TestQuery(
+      "q3and",
+      parser("""
+      { "select":"node", "composition":"and", "where":[
+      ] }
+      """).openOrThrowException("For tests"),
+      Nil
+    )
+
+    val q3or = TestQuery(
+      "q3or",
+      parser("""
+      { "select":"node", "composition":"or", "where":[
+      ] }
+      """).openOrThrowException("For tests"),
+      Nil
+    )
+
+    /* find everything when where is empty and result inverted */
+    val q4and = TestQuery(
+      "q4and",
+      parser("""
+      { "select":"node", "composition":"and", "transform":"invert", "where":[
+      ] }
+      """).openOrThrowException("For tests"),
+      s
+    )
+
+    val q4or = TestQuery(
+      "q4or",
+      parser("""
+      { "select":"node", "composition":"and", "transform":"invert", "where":[
+      ] }
+      """).openOrThrowException("For tests"),
+      s
+    )
+
+    testQueries(q0 :: q1 :: q2 :: q3and :: q3or :: q4and :: q4or :: Nil, doInternalQueryTest = false)
   }
 
   @Test def basicQueriesOnOneNodeParameter(): Unit = {


### PR DESCRIPTION
https://issues.rudder.io/issues/28682

We weren't taking appart the case where there is 0 criteria, and since we are *filtering* things, we weren't filtering anything at all. 
Since the "save" without criteria actually create a query with 0 criteria, we were falling in that case. 