### PR TITLE
Fixes #28592: When we create a Node with a PUT, the properties are not taken into account

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/CreateNodeData.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/CreateNodeData.scala
@@ -296,7 +296,8 @@ object Validation {
                 summary,
                 agents = Seq(agent),
                 machineId = Some((machine.id, PendingInventory)),
-                timezone = nodeDetails.timezone
+                timezone = nodeDetails.timezone,
+                serverIps = nodeDetails.ipAddresses
               ),
               Some(machine)
             )

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -44,27 +44,20 @@ import com.normation.errors.*
 import com.normation.eventlog.ModificationId
 import com.normation.inventory.domain.*
 import com.normation.inventory.domain.NodeId
-import com.normation.inventory.ldap.core.InventoryDit
-import com.normation.inventory.ldap.core.UUID_ENTRY
-import com.normation.ldap.sdk.LDAPConnectionProvider
-import com.normation.ldap.sdk.RwLDAPConnection
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.apidata.DefaultDetailLevel
 import com.normation.rudder.apidata.JsonQueryObjects.*
 import com.normation.rudder.apidata.JsonResponseObjects.*
 import com.normation.rudder.apidata.NodeDetailLevel
 import com.normation.rudder.apidata.RenderInheritedProperties
-import com.normation.rudder.apidata.RestDataSerializer
 import com.normation.rudder.apidata.ZioJsonExtractor
 import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.config.ReasonBehavior
 import com.normation.rudder.config.UserPropertyService
-import com.normation.rudder.domain.NodeDit
 import com.normation.rudder.domain.logger.NodeLogger
 import com.normation.rudder.domain.logger.NodeLoggerPure
 import com.normation.rudder.domain.logger.TimingDebugLoggerPure
 import com.normation.rudder.domain.nodes.Node
-import com.normation.rudder.domain.nodes.NodeState
 import com.normation.rudder.domain.policies.GlobalPolicyMode
 import com.normation.rudder.domain.properties.CompareProperties
 import com.normation.rudder.domain.properties.FailedNodePropertyHierarchy
@@ -85,10 +78,8 @@ import com.normation.rudder.facts.nodes.SelectFacts
 import com.normation.rudder.facts.nodes.SelectNodeStatus
 import com.normation.rudder.properties.NodePropertiesService
 import com.normation.rudder.properties.PropertiesRepository
-import com.normation.rudder.reports.ReportingConfiguration
 import com.normation.rudder.reports.execution.AgentRunWithNodeConfig
 import com.normation.rudder.reports.execution.RoReportsExecutionRepository
-import com.normation.rudder.repository.ldap.LDAPEntityMapper
 import com.normation.rudder.rest.ApiModuleProvider
 import com.normation.rudder.rest.ApiPath
 import com.normation.rudder.rest.AuthzToken
@@ -112,7 +103,6 @@ import com.normation.rudder.score.Score
 import com.normation.rudder.score.ScoreSerializer
 import com.normation.rudder.score.ScoreService
 import com.normation.rudder.score.ScoreValue
-import com.normation.rudder.services.nodes.NodeInfoService
 import com.normation.rudder.services.queries.*
 import com.normation.rudder.services.reports.ReportingService
 import com.normation.rudder.services.servers.DeleteMode
@@ -157,7 +147,6 @@ import zio.syntax.*
 class NodeApi(
     zioJsonExtractor:      ZioJsonExtractor,
     nodePropertiesService: NodePropertiesService,
-    serializer:            RestDataSerializer,
     nodeApiService:        NodeApiService,
     userPropertyService:   UserPropertyService,
     inheritedProperties:   NodeApiInheritedProperties,
@@ -807,15 +796,10 @@ class NodeApiInheritedProperties(
 }
 
 class NodeApiService(
-    ldapConnection:             LDAPConnectionProvider[RwLDAPConnection],
     val nodeFactRepository:     NodeFactRepository,
     propertiesRepo:             PropertiesRepository,
     reportsExecutionRepository: RoReportsExecutionRepository,
-    ldapEntityMapper:           LDAPEntityMapper,
     uuidGen:                    StringUuidGenerator,
-    nodeDit:                    NodeDit,
-    pendingDit:                 InventoryDit,
-    acceptedDit:                InventoryDit,
     newNodeManager:             NewNodeManager,
     removeNodeService:          RemoveNodeService,
     restExtractor:              ZioJsonExtractor,
@@ -845,6 +829,7 @@ class NodeApiService(
       }
     }
 
+    implicit val q:  QueryContext  = qc
     implicit val cc: ChangeContext = ChangeContext(
       ModificationId(uuidGen.newUuid),
       qc.actor,
@@ -865,36 +850,21 @@ class NodeApiService(
       _         <- NodeLoggerPure.debug(s"Create node API: update node properties and setting if needed")
       nodeId    <- saveRudderNode(validated.inventory.node.main.id, nodeSetup)
     } yield {
-      nodeId
+      created
     }
   }
 
   /*
    * You can't use an existing UUID (neither pending nor accepted)
    */
-  def checkUuid(nodeId: NodeId): IO[CreationError, Unit] = {
-    // we don't want a node in pending/accepted
-    def inventoryExists(con: RwLDAPConnection, id: NodeId) = {
-      ZIO
-        .foldLeft(Seq((acceptedDit, AcceptedInventory), (pendingDit, PendingInventory)))(Option.empty[InventoryStatus]) {
-          case (current, (dit, s)) =>
-            current match {
-              case None    => con.exists((dit.NODES.NODE: UUID_ENTRY[NodeId]).dn(id)).map(exists => if (exists) Some(s) else None)
-              case Some(v) => Some(v).succeed
-            }
-        }
-        .flatMap {
-          case None    => // ok, it doesn't exists
-            ZIO.unit
-          case Some(s) => // oups, already present
-            Inconsistency(s"A node with id '${nodeId.value}' already exists with status '${s.name}'").fail
-        }
-    }
-
-    (for {
-      con <- ldapConnection
-      _   <- inventoryExists(con, nodeId)
-    } yield ()).mapError(err => CreationError.OnSaveInventory(s"Error during node ID check: ${err.fullMsg}"))
+  def checkUuid(nodeId: NodeId)(implicit qc: QueryContext): IO[CreationError, Unit] = {
+    nodeFactRepository
+      .get(nodeId)
+      .mapError(err => CreationError.OnSaveInventory(s"Error during node ID check: ${err.fullMsg}"))
+      .flatMap {
+        case None    => ZIO.unit
+        case Some(x) => CreationError.OnSaveInventory(s"Error during node ID check: that ID already exists").fail
+      }
   }
 
   /*
@@ -904,8 +874,10 @@ class NodeApiService(
   def saveInventory(inventory: FullInventory)(implicit cc: ChangeContext): IO[CreationError, NodeId] = {
     nodeFactRepository
       .updateInventory(inventory, software = None)
-      .map(_ => inventory.node.main.id)
-      .mapError(err => CreationError.OnSaveInventory(s"Error during node creation: ${err.fullMsg}"))
+      .mapBoth(
+        err => CreationError.OnSaveInventory(s"Error when saving node: ${err.fullMsg}"),
+        _ => inventory.node.main.id
+      )
   }
 
   def accept(template: NodeTemplate)(implicit cc: ChangeContext): IO[CreationError, NodeSetup] = {
@@ -948,38 +920,16 @@ class NodeApiService(
    * we provide a default node context but we can't ensure that
    * policyMode / node state will be set (validation must forbid that)
    */
-  def saveRudderNode(id: NodeId, setup: NodeSetup): IO[CreationError, NodeId] = {
-    // a default Node
-    def default() = {
-      Node(
-        id,
-        id.value,
-        "",
-        NodeState.Enabled,
-        isSystem = false,
-        isPolicyServer = false,
-        creationDate = DateTime.now,
-        nodeReportingConfiguration = ReportingConfiguration(None, None, None),
-        properties = Nil,
-        policyMode = None,
-        securityTag = None
-      )
-    }
+  def saveRudderNode(id: NodeId, setup: NodeSetup)(implicit cc: ChangeContext): IO[CreationError, NodeId] = {
+    implicit val qc: QueryContext = cc.toQuery
 
     (for {
-      ldap    <- ldapConnection
-      // try t get node
-      entry   <- ldap.get(nodeDit.NODES.NODE.dn(id.value), NodeInfoService.nodeInfoAttributes*)
-      current <- entry match {
-                   case Some(x) => ldapEntityMapper.entryToNode(x).toIO
-                   case None    => default().succeed
-                 }
-      merged   = mergeNodeSetup(current, setup)
-      // we ony want to touch things that were asked by the user
-      nSaved  <- ldap.save(ldapEntityMapper.nodeToEntry(merged))
+      n <- nodeFactRepository.get(id).notOptional(s"Can not merge node: missing")
+      n2 = CoreNodeFact.updateNode(n, mergeNodeSetup(n.toNode, setup))
+      _ <- nodeFactRepository.save(n2)
     } yield {
-      merged.id
-    }).mapError(err => CreationError.OnSaveNode(s"Error during node creation: ${err.fullMsg}"))
+      n.id
+    }).mapError(err => CreationError.OnSaveInventory(err.fullMsg))
   }
 
   /*

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
@@ -459,7 +459,92 @@ response:
       }
     }
 ---
+description: Check node correctly created
+method: GET
+url: /api/latest/nodes/378740d3-c4a9-4474-8485-478e7e52db53?include=default,properties,manufacturer,managementTechnologyDetails
+response:
+  code: 200
+  content: >-
+    {
+      "action":"nodeDetails",
+      "id":"378740d3-c4a9-4474-8485-478e7e52db53",
+      "result":"success",
+      "data":{
+        "nodes":[
+          {
+            "id":"378740d3-c4a9-4474-8485-478e7e52db53",
+            "hostname":"node2.hostname.local",
+            "status" : "accepted",
+            "state" : "enabled",
+            "os" : {
+              "type" : "Linux",
+              "name" : "Debian",
+              "version" : "9.5",
+              "fullName" : "Debian GNU/Linux 9 (stretch)",
+              "kernelVersion" : "N/A",
+              "servicePack" : "string"
+            },
+            "machine" : {
+              "id" : "45f70964-7ec9-ed75-61a5-ed7acbde17f4",
+              "type" : "Virtual",
+              "provider" : "vmware",
+              "manufacturer" : "corp inc.",
+              "serialNumber" : "ece12459-2b90-49c9-ab1e-72e38f797421"
+            },
+            "ipAddresses" : [
+              "192.168.180.90"
+            ],
+            "description" : "",
+            "acceptanceDate" : "2021-01-30T00:20:00Z",
+            "lastInventoryDate" : "2021-01-30T00:20:00Z",
+            "policyServerId" : "root",
+            "managementTechnology" : [
+              {
+                "name" : "Rudder",
+                "version" : "Missing version",
+                "capabilities" : [],
+                "nodeKind" : "node"
+              }
+            ],
+            "properties" : [
+              {
+                "name" : "another-property",
+                "value" : [
+                  "arrvalue1",
+                  "arrvalue2"
+                ]
+              },
+              {
+                "name": "datacenter",
+                "value": "AMS2"
+              },
+              {
+                "name": "some-json-property",
+                "value": {
+                  "key": "value"
+                }
+              }
+            ],
+            "policyMode" : "enforce",
+            "timezone" : {
+              "name" : "CEST",
+              "offset" : "+0200"
+            },
+            "managementTechnologyDetails" : {
+              "cfengineKeys" : [
+                "-----BEGIN CERTIFICATE-----\nMIIFTjCCAzagAwIBAgIUfa0+S+CyJahRzuwNNOFLNQQjIH8wDQYJKoZIhvcNAQEL\nBQAwFzEVMBMGCgmSJomT8ixkAQEMBW5vZGU3MB4XDTI0MDMwMTExMDIxM1oXDTM0\nMDIyNzExMDIxM1owFzEVMBMGCgmSJomT8ixkAQEMBW5vZGU3MIICIjANBgkqhkiG\n9w0BAQEFAAOCAg8AMIICCgKCAgEAsmBUYI1A5vqkOTCW24m/mQhBaRu4WaAUXDAr\nArdIAAMN0KyHhEXP1/X32Flw90E0VjtUH4P+DYLBozXYWhJrUxdWLyn3TRSbv3Kr\npXoCWhMhMp8OK2s/mG+rfiMpTXIwaMhPnBaJFNV3c+bkijGAMHtFjl3+leXJvNZ7\nw3bIg4cA3e77kz7EWMyqxOUvvLMyY6wpd03ahe/By+iLgtOkgUwl9hMqMU8tJeaz\nNIeUporsHk5rrk8bSf6Mxxdknm43Sk6oflnueNCIUFdd4rS2JLieMugsTh8n/oH+\nk29ZyirE3ikhftmZ3vY8GQ3IcIzaXwiAOGnCKcze79zVx5jmOTGSZitGZaU/cZc6\nLjzEp+ZDmE8caVIksiA+hIlaZeBXNHB+YRv/gV1Rbt7kS1am+XUZJSfVFf+99YqE\nlZ5p0hqJsczkBb2RuMxWxxsWO3pesPUNCuL/yaeggTIp7eK06tQWi1EfXr40ctrf\noimbzMAKNBpRKWruL7652SlF75Usaq+PaPi1TtqYQjLRZmbpr+IR4uMeKnEMIZPw\n3dLDKBV6d71XkTAalCmcJU+fgYrRmgz1dEnaZDIXY+f+fYR15hsFpDrZ0avHgkzJ\nca/nT/rKeX7136BttxVSbZaTU9hnmjAvl+v0BF+JUWPQ3VPTcrmyUNAICt8xdVae\nuo1tsvkCAwEAAaOBkTCBjjAMBgNVHRMEBTADAQH/MB0GA1UdDgQWBBSRG0uHQRIA\ngl91YqzSjaeaw+F7PDBSBgNVHSMESzBJgBSRG0uHQRIAgl91YqzSjaeaw+F7PKEb\npBkwFzEVMBMGCgmSJomT8ixkAQEMBW5vZGU3ghR9rT5L4LIlqFHO7A004Us1BCMg\nfzALBgNVHQ8EBAMCArwwDQYJKoZIhvcNAQELBQADggIBABR2vTH/6WlqjaTZ/hQc\nB+crqRlFimqCiVTRdX6qfkt0tLX2dK6scHNTBT04ORLjLTAn0KbcOUz3k6i0mIqB\nnG5UjqCFEQR+i2V4Hz7aK6+7LBQuwXWRhDhvO5xMn7MxjvP0LGgNf5iiA4r/N22L\nEMc1prDESIOGmWdKg9XlfLxd877R2d8/3hXyT82Y2uJHO25b53skj4pbUOWLsGSw\nd4FBNnWqM+7Hbg2v9xFvmtfs2G2Inqk4Xjtjnj8qkVk3ft6KzClUIMXGXQ8QqaRp\nYPkTJm5g2UBYDiguD/tlz3VmbsNYU6fkap7DKqhttbaseIx1zDwdAv4jtVOWDyjx\nWq4b7pljYiczfRa84X/9v1x05pT3raELy5udY+Pxmnz+hOXOM+jY5bzSKS24b8rS\n5Sklmutm0IdflMKd5vNrXd9yPFLu3QzN50ArzHHXczwBLgjaMlZsPAp1wITlqM7+\nWCjy3qM5/KgAjH3L24MPTq23o9PokBVh1NH7lesZqgJPgsj+OG7FMQDvKzg7ytrs\nQlIDF1c8Ko+9/RrnRVAS8C4GZOqbmMmfJjMp09GBz2d0ixlTusF6m6iwfIVMf/nI\nP/V0D7STRiV62cfnZ3e0w8kIeZwWAgXI7RMHJU3skLyurUu8yxkp635IQyzQsW2A\nYo7t7O7fxjqD9yVI2QfkERZ7\n-----END CERTIFICATE-----\n"
+              ],
+              "cfengineUser" : "root"            
+            }
+          }
+        ]
+      }
+    }
+---
 description: Create node with some validation errors
+# - case 1: invalid uuid,
+# - case 2: already exists,
+# - case 3: OK (so we check that we actually report errors on all case but accept valid ones)
 method: PUT
 url: /api/latest/nodes
 headers:
@@ -470,6 +555,20 @@ body: >-
       "id": "an-invalid-uuid-hihihi",
       "hostname": "node3.hostname.local",
       "status": "removed",
+      "os": {
+        "type": "linux",
+        "name": "debian",
+        "version": "9.5",
+        "fullName": "Debian GNU/Linux 9 (stretch)",
+        "servicePack": "string"
+      },
+      "properties": [],
+      "ipAddresses": []
+    },
+    {
+      "id": "378740d3-c4a9-4474-8485-478e7e52db53", 
+      "hostname": "node4.hostname.local",
+      "status": "accepted",
       "os": {
         "type": "linux",
         "name": "debian",
@@ -511,6 +610,9 @@ response:
               "[validation] Only ID matching the shape of an UUID (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) are authorized but 'an-invalid-uuid-hihihi' provided",
               "[validation] Node 'status' must be one of 'accepted, pending' but 'removed' provided"
             ]
+          },
+          {
+            "378740d3-c4a9-4474-8485-478e7e52db53" : "[save inventory] Error during node ID check: that ID already exists"
           }
         ]
       }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -49,7 +49,6 @@ import com.normation.eventlog.EventLog
 import com.normation.eventlog.EventLogDetails
 import com.normation.eventlog.EventLogFilter
 import com.normation.eventlog.ModificationId
-import com.normation.inventory.domain.FullInventory
 import com.normation.inventory.domain.Linux
 import com.normation.inventory.domain.NodeId
 import com.normation.inventory.domain.RockyLinux
@@ -855,15 +854,10 @@ class RestTestSetUp {
 
   val nodeApiService: nodeApiService = new nodeApiService
   class nodeApiService extends NodeApiService(
-        null,
         mockNodes.nodeFactRepo,
         mockNodes.propRepo,
         roReportsExecutionRepository,
-        null,
         uuidGen,
-        null,
-        null,
-        null,
         mockNodes.newNodeManager,
         mockNodes.removeNodeService,
         zioJsonExtractor,
@@ -875,43 +869,15 @@ class RestTestSetUp {
         mockNodes.scoreService,
         new InstanceIdService(InstanceId("rudder-test-instance"))
       ) {
-    implicit val testCC: ChangeContext = {
-      ChangeContext(
-        ModificationId(uuidGen.newUuid),
-        EventActor("test"),
-        DateTime.now(),
-        None,
-        None,
-        QueryContext.testQC.nodePerms
-      )
-    }
-    import QueryContext.testQC
-
-    override def checkUuid(nodeId: NodeId): IO[Creation.CreationError, Unit] = {
-      mockNodes.nodeFactRepo
-        .get(nodeId)
-        .map(_.nonEmpty)
-        .mapError(err => CreationError.OnSaveInventory(s"Error during node ID check: ${err.fullMsg}"))
-        .unit
-    }
-
-    override def saveInventory(inventory: FullInventory)(implicit cc: ChangeContext): IO[Creation.CreationError, NodeId] = {
-      mockNodes.nodeFactRepo
-        .updateInventory(inventory, None)(cc)
-        .mapBoth(
-          err => CreationError.OnSaveInventory(s"Error when saving node: ${err.fullMsg}"),
-          _ => inventory.node.main.id
-        )
-    }
-
-    override def saveRudderNode(id: NodeId, setup: NodeSetup): IO[Creation.CreationError, NodeId] = {
-      (for {
-        n <- mockNodes.nodeFactRepo.get(id).notOptional(s"Can not merge node: missing")
-        n2 = CoreNodeFact.updateNode(n, mergeNodeSetup(n.toNode, setup))
-        _ <- mockNodes.nodeFactRepo.save(n2)(testCC)
-      } yield {
-        n.id
-      }).mapError(err => CreationError.OnSaveInventory(err.fullMsg))
+    override def saveRudderNode(id: NodeId, setup: NodeSetup)(implicit cc: ChangeContext): IO[Creation.CreationError, NodeId] = {
+      import com.softwaremill.quicklens.*
+      // we need to have a stable date for tests
+      val refDate = DateTime.parse("2021-01-30T00:20:00Z")
+      implicit val qc: QueryContext = cc.toQuery
+      super.saveRudderNode(id, setup) *> (for {
+        n <- mockNodes.nodeFactRepo.get(id).notOptional("Rest created node wasn't found back")
+        _ <- mockNodes.nodeFactRepo.save(n.modify(_.creationDate).setTo(refDate).modify(_.lastInventoryDate).setTo(Some(refDate)))
+      } yield id).mapError(err => CreationError.OnSaveInventory(s"Error during test for node creation: ${err.fullMsg}"))
     }
   }
 
@@ -1115,7 +1081,6 @@ class RestTestSetUp {
     new NodeApi(
       zioJsonExtractor,
       mockNodeGroups.propService,
-      restDataSerializer,
       nodeApiService,
       userPropertyService,
       new NodeApiInheritedProperties(mockNodes.propRepo),

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2195,17 +2195,11 @@ object RudderConfigInit {
           new NodeApi(
             zioJsonExtractor,
             propertiesService,
-            restDataSerializer,
             new NodeApiService(
-              rwLdap,
               nodeFactRepository,
               propertiesRepository,
               roAgentRunsRepository,
-              ldapEntityMapper,
               stringUuidGenerator,
-              nodeDit,
-              pendingNodesDit,
-              acceptedNodesDit,
               newNodeManagerImpl,
               removeNodeServiceImpl,
               zioJsonExtractor,


### PR DESCRIPTION
https://issues.rudder.io/issues/28592

*SO*. We had a bit forgotten to migrate the node creation with API to `NodeFactRepository`. The tests were good them. So use that code in place of the direct LDAP queries, that can't work anymore. 

With all these implicit and cc.toQuery, the upmerge will be funny.