### PR TITLE
Fixes #28670: Wrong message for node deletion in activity 

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/EventLogDetailsGenerator.scala
@@ -125,7 +125,7 @@ class EventLogDetailsGenerator(
         case x  => x
       }
       Text("Node ") ++ {
-        if ((id.size < 1) || (actionName == Text(" deleted"))) Text(name)
+        if ((id.size < 1) || (actionName == Text(" deleted"))) Text(s"${name} deleted")
         else <a href={nodeLink(NodeId(id))}>{name}</a> ++ actionName
       }
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/28670

A logic flaw : we don't display the link for deleted node (since they no longer exist), but the "deleted" word was forgotten