### PR TITLE
Fixes #28669: A "compliance" hover appears on top of the node lists in group page

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -1182,7 +1182,6 @@ function createNodeTable(gridId, nodeIds, refresh, scores) {
     , "filter" : true
     , "paging" : true
     , "lengthChange": true
-    , "fixedHeader": true
     , "deferRender" : true
     , "destroy" : true
     , "pagingType": "full_numbers"

--- a/webapp/sources/rudder/rudder-web/src/main/package-lock.json
+++ b/webapp/sources/rudder/rudder-web/src/main/package-lock.json
@@ -9,7 +9,6 @@
         "chart.js": "^4.5.1",
         "datatables.net": "^2.3.4",
         "datatables.net-buttons": "^3.2.5",
-        "datatables.net-fixedheader": "^4.0.4",
         "datatables.net-plugins": "^2.3.2",
         "datatables.net-rowgroup": "^1.6.0",
         "diff": "^8.0.2",
@@ -1783,16 +1782,6 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/datatables.net-buttons/-/datatables.net-buttons-3.2.5.tgz",
       "integrity": "sha512-OSTl7evbfe0SMee11lyzu5iv/z8Yp05eh3s1QBte/FNqHcoXN8hlAVSSGpYgk5pj8zwHPYIu6fHeMEue4ARUNg==",
-      "license": "MIT",
-      "dependencies": {
-        "datatables.net": "^2",
-        "jquery": ">=1.7"
-      }
-    },
-    "node_modules/datatables.net-fixedheader": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/datatables.net-fixedheader/-/datatables.net-fixedheader-4.0.4.tgz",
-      "integrity": "sha512-O3/A+4afoVd/j5VaLpKClivxaLQUi3KVb5vihPz1h63fCJHTz4/BDxkaeDmxIZkjh5AlCaOTWFdTHc5v30jq5w==",
       "license": "MIT",
       "dependencies": {
         "datatables.net": "^2",
@@ -7301,6 +7290,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/webapp/sources/rudder/rudder-web/src/main/package.json
+++ b/webapp/sources/rudder/rudder-web/src/main/package.json
@@ -7,7 +7,6 @@
     "chart.js": "^4.5.1",
     "datatables.net": "^2.3.4",
     "datatables.net-buttons": "^3.2.5",
-    "datatables.net-fixedheader": "^4.0.4",
     "datatables.net-plugins": "^2.3.2",
     "datatables.net-rowgroup": "^1.6.0",
     "diff": "^8.0.2",

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/common-layout.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/common-layout.html
@@ -21,7 +21,6 @@
     <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-quicksearch.css" media="screen" />
 
     <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/datatables/rowGroup-bootstrap-1.2.0.min.css" media="screen" />
-    <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/datatables/fixedHeader-bootstrap-3.2.3.min.css" media="screen" />
     <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-main.css"/>
 
     <link type="text/css" rel="stylesheet" data-lift="with-cached-resource" href="/style/rudder/rudder-menu.css"/>
@@ -39,7 +38,6 @@
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/libs/jstree.min.js"></script>
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/libs/dataTables.min.js"></script>
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/libs/dataTables.rowGroup.min.js"></script>
-    <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/libs/dataTables.fixedHeader.min.js"></script>
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/libs/dataTables.buttons.min.js"></script>
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/libs/buttons.html5.min.js"></script>
     <script type="text/javascript" data-lift="with-cached-resource" src="/javascript/libs/natural.js"></script>


### PR DESCRIPTION
https://issues.rudder.io/issues/28669

The [fixedHeader](https://datatables.net/extensions/fixedheader/) plugin is actually unused, and is the cause of the problem of "shadow headers" in nodes table. It can simply be removed as it was only declared in the nodes table.