### PR TITLE
Fixes #28608: API account tooltips are broken when table is sorted or refreshed

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts.elm
@@ -100,15 +100,21 @@ update msg model =
                 tenants =
                     editAccount |> Maybe.andThen .selectedTenants |> Maybe.withDefault []
             in
-            ( { model | ui = { ui | modalState = modalState }, editAccount = editAccount }, Cmd.batch [ shareAcl (encodeTokenAcl tokenId acl), focusAccountTenants (encodeAccountTenants tokenId tenants) ] )
+            ( { model | ui = { ui | modalState = modalState }, editAccount = editAccount }, Cmd.batch [ shareAcl (encodeTokenAcl tokenId acl), focusAccountTenants (encodeAccountTenants tokenId tenants), clearTooltips () ] )
 
 
         UpdateFilters filters ->
             let
                 ui =
                     model.ui
+                cmd =
+                    if filters /= ui.filters then
+                        resetTooltips ()
+
+                    else
+                        Cmd.none
             in
-            ( { model | ui = { ui | filters = filters } }, Cmd.none )
+            ( { model | ui = { ui | filters = filters } }, cmd )
 
         GetAccountsResult res ->
             case res of
@@ -123,7 +129,7 @@ update msg model =
 
                     in
                     ( { model | accounts = accounts, ui = { modelUi | loadingAccounts = False, pluginAclInit = True, pluginTenantsInit = True } }
-                    , Cmd.batch [ initTooltips "" ]
+                    , resetTooltips ()
                     )
 
                 Err err ->

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/Init.elm
@@ -23,8 +23,10 @@ port successNotification : String -> Cmd msg
 port errorNotification : String -> Cmd msg
 
 
-port initTooltips : String -> Cmd msg
+port clearTooltips : () -> Cmd msg
 
+
+port resetTooltips : () -> Cmd msg
 
 
 -- for desktop copy to clipboard

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Accounts/ViewUtils.elm
@@ -82,7 +82,7 @@ displayAccountsTable model =
                     [ class "relative-date"
                     , attribute "data-bs-toggle" "tooltip"
                     , attribute "data-bs-placement" "top"
-                    , attribute "title" (buildTooltipContent "Token last used on" (posixToString model.ui.datePickerInfo.zone d))
+                    , attribute "data-bs-original-title" (buildTooltipContent "Token last used on" (posixToString model.ui.datePickerInfo.zone d))
                     , onClick (Copy (Iso8601.fromTime d))
                     ]
                     , DateFormat.Relative.relativeTimeWithOptions relativeTimeOptions now d
@@ -133,7 +133,7 @@ displayAccountsTable model =
           , span
             [ attribute "data-bs-toggle" "tooltip"
             , attribute "data-bs-placement" "top"
-            , attribute "title"
+            , attribute "data-bs-original-title"
               ( buildTooltipContent "Token"
                 ( a.tokenGenerationDate
                     |> Maybe.Extra.unpack
@@ -199,7 +199,7 @@ displayAccountDescription a =
       [ class "fa fa-question-circle icon-info"
       , attribute "data-bs-toggle" "tooltip"
       , attribute "data-bs-placement" "top"
-      , attribute "title" (buildTooltipContent "Description" a.description)
+      , attribute "data-bs-original-title" (buildTooltipContent "Description" a.description)
       ][]
 
 exposeToken : Maybe Token -> String

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
@@ -906,23 +906,34 @@ function logout(cb){
 }
 
 // BOOTSTRAP 5
-function initBsTooltips(){
-  var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+const bsTooltipsRemovalListener = () => removeBsTooltips()
+
+function initBsTooltips(selector = null){
+  const sel = selector ?? '[data-bs-toggle="tooltip"]'
+  var tooltipTriggerList = [].slice.call(document.querySelectorAll(sel));
   return tooltipTriggerList.map(function (tooltipTriggerEl) {
     let dataTrigger = $(tooltipTriggerEl).attr('data-bs-trigger');
     let trigger = dataTrigger === undefined ? 'hover' : dataTrigger;
-    tooltipTriggerEl.addEventListener('hide.bs.tooltip', () => {
-      removeBsTooltips();
-    });
-    tooltipTriggerEl.addEventListener('show.bs.tooltip', () => {
-      removeBsTooltips()
-    });
+    tooltipTriggerEl.addEventListener('hide.bs.tooltip', bsTooltipsRemovalListener);
+    tooltipTriggerEl.addEventListener('show.bs.tooltip', bsTooltipsRemovalListener);
     return new bootstrap.Tooltip(tooltipTriggerEl,{container : "body", html : true, trigger : trigger});
   });
 }
 
 function removeBsTooltips(){
   document.querySelectorAll(".tooltip").forEach(e => e.remove());
+}
+
+// remove attributes, handlers left by tooltips: sometimes (with Elm replacing the DOM elements) they are still present
+function disposeBsTooltips(selector) {
+  removeBsTooltips()
+  document
+    .querySelectorAll(selector)
+    .forEach(tooltip => {
+      bootstrap.Tooltip.getInstance(tooltip)?.dispose()
+      tooltip.removeEventListener('hide.bs.tooltip', bsTooltipsRemovalListener)
+      tooltip.removeEventListener('show.bs.tooltip', bsTooltipsRemovalListener)
+    })
 }
 $('body').on('click', function (e) {
     $('[data-bs-toggle=tooltip]').each(function () {
@@ -966,6 +977,14 @@ function initBsTabs(isJsonHash = false, adjustNodeTables = false){
       return false;
     });
   });
+}
+
+// Fast promise resolver in the async loop, to make it work as expected when called from Elm ports
+function waitForElementAsync(selector) {
+  const element = document.querySelector(selector)
+  return element
+    ? new Promise((resolve) => setTimeout(() => resolve(element), 0))
+    : waitForElement(selector)
 }
 
 function waitForElement(selector) {

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/secure/access/apiManagement.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/secure/access/apiManagement.html
@@ -17,7 +17,9 @@
   </head>
 
   <div data-lift="administration.ApiAccounts.body">
-    <div id="accounts-app"></div>
+    <div id="accounts-app-container">
+      <div id="accounts-app"></div>
+    </div>
     <script data-lift="with-nonce">
       var app;
       $(document).ready(function () {
@@ -43,12 +45,14 @@
         app.ports.copy.subscribe(function (str) {
           copy(str);
         });
-        // Initialize tooltips
-        app.ports.initTooltips.subscribe(function (msg) {
-          setTimeout(function () {
-            initBsTooltips();
-          }, 600);
-        });
+        // Tooltips
+        app.ports.clearTooltips.subscribe(removeBsTooltips)
+        app.ports.resetTooltips.subscribe(async function () {
+          const tooltipsSelector = '#accounts-app-container [data-bs-toggle="tooltip"]'
+          disposeBsTooltips(tooltipsSelector)
+          await waitForElementAsync(tooltipsSelector)
+          initBsTooltips(tooltipsSelector)
+        })
       });
     </script>
     <div id="acl-app"></div>


### PR DESCRIPTION
https://issues.rudder.io/issues/28608

### EDIT : New understanding of tooltips
* the only attribute that seems to be universally working is `data-bs-original-title`, instead of `title`/`data-bs-title`
* `removeBsTooltips` is only a hack for removing "stale" tooltips in some specific UX concerns (_"the tooltip is frozen"_)
  * it leads to memory leaks : when using tooltips in Elm apps and e.g. filtering items, the DOM changes, but event handlers of tooltips are still there
  * it is used in this PR because a "button click" when opening a modal leads to a frozen one
  
* we need a new function to properly [dispose](https://getbootstrap.com/docs/5.0/components/tooltips/#dispose) of tooltips, it's called `disposeBsTooltips` :
  * it needs to be always followed by an initialization of tooltips, because when "sorting elements", the DOM elements would swap
  * `resetTooltips` is a single Port that guarantees that we have "dispose", then "init", and it is used in this PR upon the update of "table filters"

* to maximize performance, we could restrict tooltips actions to a selector of "tooltips within the Elm app" : just add a `<div id="app-container">` and pass to the "dispose" and "init" functions
 
---

Adding a new function to dispose of tooltips completely : `removeBsTooltips` is  to not work in this context because of how Elm swaps the DOM elements, by leaving tooltips at their previous location (which made the bug appear when : sorting the table, filtering, and adding and API account).

I could not get rid of them :
* the previous one always remains with a `data-bs-original-title` :
<img width="1143" height="445" alt="image" src="https://github.com/user-attachments/assets/89efaa53-392a-40c7-b660-04c41719a952" />

* sometimes it's the `title` that would remain, even on a `-` :  
<img width="1147" height="733" alt="image" src="https://github.com/user-attachments/assets/b21da69f-83a6-462a-a072-315e1a034847" />


I tried removing every attributes (including the `title`) upon calling `dispose()` on the tooltip, and this solves the issue, but would make all tooltips not work globally when applying some filters on the table :upside_down_face:, so I didn't risk doing that