### PR TITLE
Fixes #28654: Notification error on user without admin_read rights on node page

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Agentpolicymode/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Agentpolicymode/ApiCalls.elm
@@ -3,6 +3,7 @@ module Agentpolicymode.ApiCalls exposing (..)
 import Http exposing (..)
 import Http.Detailed as Detailed
 import Json.Decode exposing (Decoder)
+import Task exposing (Task)
 import Url.Builder exposing (QueryParameter)
 
 import Agentpolicymode.DataTypes exposing (..)
@@ -87,19 +88,61 @@ saveChanges reason model =
 
 getChangeMessageSettings : Model -> Cmd Msg
 getChangeMessageSettings model =
+  Task.attempt GetChangeMessageSettings (getChangeMessageSettingsTask model)
+
+
+getChangeMessageSettingsTask : Model -> Task (Detailed.Error String) ChangeMessageSettings
+getChangeMessageSettingsTask model =
   let
-    req =
-      request
-        { method  = "GET"
-        , headers = [header "X-Requested-With" "XMLHttpRequest"]
-        , url     = getUrl model [ "settings" ] []
-        , body    = emptyBody
-        , expect  = expectJson GetChangeMessageSettings decodeGetChangeMessageSettings
-        , timeout = Nothing
-        , tracker = Nothing
-        }
+    default =
+      ChangeMessageSettings False False ""
+    allSettings : Task (Detailed.Error String) ChangeMessageSettings
+    allSettings =
+      Task.map3 ChangeMessageSettings
+        (getEnableChangeMessageSetting model)
+        (getMandatoryChangeMessageSetting model)
+        (getChangeMessagePromptSetting model)
   in
-    req
+  allSettings
+    |> handle403With default
+
+
+
+getEnableChangeMessageSetting : Model -> Task (Detailed.Error String) (Bool)
+getEnableChangeMessageSetting model =
+  Http.task
+    { method   = "GET"
+    , headers  = [header "X-Requested-With" "XMLHttpRequest"]
+    , url      = getUrl model [ "settings", "enable_change_message" ] []
+    , body     = emptyBody
+    , resolver = Http.stringResolver <| handleJsonResponse <| decodeGetEnableChangeMsg
+    , timeout  = Nothing
+    }
+
+
+getMandatoryChangeMessageSetting : Model -> Task (Detailed.Error String) (Bool)
+getMandatoryChangeMessageSetting model =
+  Http.task
+    { method   = "GET"
+    , headers  = [header "X-Requested-With" "XMLHttpRequest"]
+    , url      = getUrl model [ "settings", "mandatory_change_message" ] []
+    , body     = emptyBody
+    , resolver = Http.stringResolver <| handleJsonResponse <| decodeGetMandatoryMsg
+    , timeout  = Nothing
+    }
+
+
+getChangeMessagePromptSetting : Model -> Task (Detailed.Error String) (String)
+getChangeMessagePromptSetting model =
+  Http.task
+    { method   = "GET"
+    , headers  = [header "X-Requested-With" "XMLHttpRequest"]
+    , url      = getUrl model [ "settings", "change_message_prompt" ] []
+    , body     = emptyBody
+    , resolver = Http.stringResolver <| handleJsonResponse <| decodeGetMsgPrompt
+    , timeout  = Nothing
+    }
+
 
 changeMessageReasonParams : String -> List Url.Builder.QueryParameter
 changeMessageReasonParams reason =
@@ -109,3 +152,39 @@ changeMessageReasonParams reason =
 expectJson : (Result (Detailed.Error String) b -> c) -> Decoder b -> Expect c
 expectJson msg =
   Detailed.expectJson (Result.map Tuple.second >> msg)
+
+
+handleJsonResponse : Decoder a -> Http.Response String -> Result (Detailed.Error String) a
+handleJsonResponse decoder response =
+    case response of
+        Http.BadUrl_ url ->
+            Err (Detailed.BadUrl url)
+
+        Http.Timeout_ ->
+            Err Detailed.Timeout
+
+        Http.BadStatus_ metadata body ->
+            Err (Detailed.BadStatus metadata body)
+
+        Http.NetworkError_ ->
+            Err Detailed.NetworkError
+
+        Http.GoodStatus_ metadata body ->
+          Json.Decode.decodeString decoder body
+            |> Result.mapError (Json.Decode.errorToString >> Detailed.BadBody metadata body)
+
+handle403With : a -> Task (Detailed.Error body) a -> Task (Detailed.Error body) a
+handle403With default =
+    Task.onError
+      ( \e -> case e of
+          Detailed.BadStatus { statusCode } _ ->
+              case statusCode of
+                403 ->
+                  Task.succeed default
+
+                _ ->
+                  Task.fail e
+
+          _ ->
+            Task.fail e
+      )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Agentpolicymode/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Agentpolicymode/JsonDecoder.elm
@@ -35,16 +35,19 @@ decodeSaveNodeDetails =
   at [ "data" ] decodeNodePolicyMode
 
 
-decodeGetChangeMessageSettings : Decoder ChangeMessageSettings
-decodeGetChangeMessageSettings =
-  at ["data", "settings" ] decodeChangeMessageSettings
+-- Same as in Rules
+decodeGetEnableChangeMsg : Decoder Bool
+decodeGetEnableChangeMsg =
+  at ["data", "settings", "enable_change_message" ] bool
 
-decodeChangeMessageSettings : Decoder ChangeMessageSettings
-decodeChangeMessageSettings =
-  succeed ChangeMessageSettings
-    |> required "enable_change_message"    Json.Decode.bool
-    |> required "mandatory_change_message" Json.Decode.bool
-    |> required "change_message_prompt"    Json.Decode.string
+decodeGetMandatoryMsg : Decoder Bool
+decodeGetMandatoryMsg =
+  at ["data", "settings", "mandatory_change_message" ] bool
+
+decodeGetMsgPrompt : Decoder String
+decodeGetMsgPrompt =
+  at ["data", "settings", "change_message_prompt" ] string
+
 
 
 decodeGetGlobalSettings : Decoder Settings


### PR DESCRIPTION
https://issues.rudder.io/issues/28654

The previous implementation was getting 3 settings values from `/api/settings` (i.e. by getting all settings values), but that endpoint would return a `500 Server error` error without admin rights.

The solution is to fetch each individual settings `/api/settings/enable_change_request`, etc., which will return `403 Forbidden`.
We need to fetch 3 of them into a single `type alias ChangeMessageSettings`, so I followed the idea of [this blog post](https://korban.net/posts/elm/2019-02-15-combining-http-requests-with-task-in-elm/) to do that : 
* use the Elm `Task` module and compose the Http results using the [`map3`](https://package.elm-lang.org/packages/elm/core/latest/Task#map3) method (without that, there would have been 3 messages and so much additional noise)
* handle 403 error once again with the `onError` method


### Benefits of using Task
* We are short-circuiting on the first error (because of how `onError` is used), which would have been a pain to handle in the update function otherwise
* All the logic are local and composable, otherwise there would have been many indirection levels between the "updates", "api calls" and "messages" 