### PR TITLE
Fixes #28667: Layout of table header in group detail is ugly in 9.1

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.scss
@@ -39,7 +39,6 @@
 
 .content-wrapper td, .content-wrapper th {
   padding: 4px 3px;
-  line-height: 1.42857143;
 }
 
 /* <WRAPPER TOP> */
@@ -749,6 +748,14 @@ div.dt-scroll-body {
 			}
 		}
 	}
+}
+div.dt-column-header {
+  display: flex;
+  align-items: center;
+
+  .dt-column-title{
+    white-space: nowrap;
+  }
 }
 
 /* GROUPS NODE TABLE */


### PR DESCRIPTION
https://issues.rudder.io/issues/28667



### Before:
<img width="900" height="384" alt="Capture d’écran du 2026-04-09 15-37-51" src="https://github.com/user-attachments/assets/48bac7e8-b3c7-48aa-acd0-540700704572" />

### After:
<img width="900" height="384" alt="Capture d’écran du 2026-04-09 15-37-44" src="https://github.com/user-attachments/assets/8de86e56-14cc-40d4-ad78-51377da0d815" />
