### PR TITLE
Fixes #28611: When no rules are applied, the message in the compliance tab of a node is missleading

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeCompliance/View.elm
@@ -70,7 +70,7 @@ view model =
               , tbody []
                 ( if List.length childs <= 0 then
                   [ tr[]
-                    [ td[class "empty", colspan 2][i [class"fa fa-exclamation-triangle"][], text "There is no compliance for this directive."] ]
+                    [ td[class "alert alert-info px-4 py-3 rounded-0", colspan 2][i [class"fa fa-info-circle"][], text "There is no active policy applied to this node."] ]
                   ]
                 else if List.length children == 0 then
                   [ tr[]


### PR DESCRIPTION
https://issues.rudder.io/issues/28611

<img width="2422" height="378" alt="image" src="https://github.com/user-attachments/assets/88f908d4-82df-4cfb-9b0b-d42da39adbbb" />

I needed to add [`rounded-0`](https://getbootstrap.com/docs/5.3/utilities/borders/#sizes) because somehow there is a default radius to the blue background : 
<img width="972" height="150" alt="image" src="https://github.com/user-attachments/assets/c3831dcd-2d69-416d-ae61-0a3e17a73e45" />
