### PR TITLE
Fixes #28695: Remove column type in change logs table

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/EventLog.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/EventLog.scala
@@ -38,7 +38,6 @@ package com.normation.rudder.rest.data
 
 import com.normation.eventlog.EventActor
 import com.normation.eventlog.EventLog
-import com.normation.eventlog.EventLogType
 import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.web.services.EventLogDetailsGenerator
 import com.normation.utils.DateFormaterService
@@ -63,7 +62,6 @@ final case class RestEventLog(
     id:                              Option[Int],
     @jsonField("date") creationDate: DateTime,
     actor:                           EventActor,
-    @jsonField("type") eventType:    String,
     description:                     NodeSeq,
     hasDetails:                      Boolean
 )
@@ -76,17 +74,13 @@ object RestEventLog {
   implicit val descriptionEncoder: JsonEncoder[NodeSeq]      = JsonEncoder[String].contramap(_.toString())
   implicit val encoder:            JsonEncoder[RestEventLog] = DeriveJsonEncoder.gen[RestEventLog]
 
-  // For localization we need to transform eventType using translation, passing liftweb.S is not so elegant
-  // so we need a conversion (poke at Scala 3's Conversion)
   implicit def transformer(implicit
-      translateEventType: EventLogType => String,
-      eventLogDetail:     EventLogDetailsGenerator
+      eventLogDetail: EventLogDetailsGenerator
   ): Transformer[EventLog, RestEventLog] = {
     Transformer
       .define[EventLog, RestEventLog]
       .enableMethodAccessors // because source is a trait
       .withFieldComputed(_.actor, _.principal)
-      .withFieldComputed(_.eventType, e => translateEventType(e.eventType))
       .withFieldComputed(_.description, eventLogDetail.displayDescription)
       .withFieldComputed(_.hasDetails, _.details != <entry></entry>)
       .withFieldComputed(_.creationDate, e => DateFormaterService.toDateTime(e.creationDate))

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/EventLogAPI.scala
@@ -41,7 +41,6 @@ import cats.data.NonEmptyList
 import com.normation.errors.*
 import com.normation.eventlog.*
 import com.normation.rudder.api.ApiVersion
-import com.normation.rudder.domain.eventlog.EventLogTypeTranslate
 import com.normation.rudder.domain.logger.EventLogsLoggerPure
 import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.facts.nodes.QueryContext
@@ -88,8 +87,7 @@ class EventLogAPI(
 ) extends LiftApiModuleProvider[EventLogApi] {
   import com.normation.rudder.rest.internal.EventLogService.*
 
-  implicit lazy val translateEventLogType: EventLogType => String   = e => EventLogTypeTranslate(e.serialize)
-  implicit lazy val eventLogDetailsGen:    EventLogDetailsGenerator = eventLogDetail
+  implicit lazy val eventLogDetailsGen: EventLogDetailsGenerator = eventLogDetail
 
   override def schemas: ApiModuleProvider[EventLogApi] = EventLogApi
 

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_eventlogs.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_eventlogs.yml
@@ -85,7 +85,6 @@ response:
           "id" : 42,
           "date" : "2024-12-04T15:30:10Z",
           "actor" : "test",
-          "type" : "Node Group modified",
           "description" : "Group ",
           "hasDetails" : true
         }

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder-datatable.js
@@ -1968,10 +1968,6 @@ function createEventLogTable(gridId, data, contextPath, refresh, serverTimezone)
   , "data" : "actor"
   , "title": "Actor"
   } , {
-    "width": "30%"
-  , "data" : "type"
-  , "title": "Type"
-  } , {
     "width"    : "30%"
   , "data"     : "description"
   , "title"    : "Description"


### PR DESCRIPTION
https://issues.rudder.io/issues/28695

Removing the field from API, and the column from DataTables initialization.

The translation added in https://github.com/Normation/rudder/pull/7002 is kept, as it's still used for the rollback details, but we should likely remove it too in another PR