### PR TITLE
Fixes #28687: Migrate recent changes API to zio-json 

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -58,6 +58,7 @@ import com.normation.rudder.domain.properties.*
 import com.normation.rudder.domain.properties.Visibility.Displayed
 import com.normation.rudder.domain.queries.*
 import com.normation.rudder.domain.reports.ComplianceLevel
+import com.normation.rudder.domain.reports.ResultRepairedReport
 import com.normation.rudder.domain.reports.RunAnalysisKind
 import com.normation.rudder.domain.servers.Srv
 import com.normation.rudder.domain.workflows.ChangeRequestId
@@ -78,6 +79,7 @@ import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.score.GlobalScore
 import com.normation.rudder.score.ScoreValue
 import com.normation.rudder.services.queries.*
+import com.normation.rudder.services.reports.ChangesByRule
 import com.normation.rudder.services.servers.AllowedNetwork
 import com.normation.rudder.services.servers.InstanceId
 import com.normation.rudder.tenants.SecurityTag
@@ -812,6 +814,50 @@ object JsonResponseObjects {
       name:  String,
       value: Option[String]
   )
+
+  final case class JRRecentChanges(
+      start:   Instant,
+      end:     Instant,
+      changes: Int
+  ) derives JsonEncoder
+  object JRRecentChanges      {
+    given Transformer[ChangesByRule, Map[RuleId, List[JRRecentChanges]]] = { (changesByRule: ChangesByRule) =>
+      {
+        changesByRule.mapChanges(
+          _.toList
+            .sortBy((i, _) => i.getStart)
+            .map((interval, number) => JRRecentChanges(interval.getStart.toJavaInstant, interval.getEnd.toJavaInstant, number))
+        )
+      }
+    }
+  }
+
+  /**
+   * JSON of ResultRepairedReport for recent changes, for a given rule.
+   * (It should be within a whole ADT mapping of all report results, if we need all results in the API)
+   */
+  final case class JRResultRepairedReport(
+      executionDate:      Instant,
+      /*ruleId:             RuleId,*/
+      nodeId:             String,
+      directiveId:        String,
+      /*reportId:           String,*/
+      component:          String,
+      value:              String,
+      message:            String,
+      executionTimestamp: Instant
+  )
+
+  object JRResultRepairedReport {
+    import DateFormaterService.json.*
+    given Transformer[ResultRepairedReport, JRResultRepairedReport] = {
+      Transformer
+        .define[ResultRepairedReport, JRResultRepairedReport]
+        .withFieldRenamed(_.keyValue, _.value)
+        .withFieldComputed(_.directiveId, _.directiveId.serialize)
+        .buildTransformer
+    }
+  }
 
   /**
    * Directive as used in techniques/directives API.
@@ -2317,4 +2363,6 @@ trait RudderJsonEncoders {
   implicit lazy val jrAllowedNetworksNodeEncoder: JsonEncoder[JRAllowedNetworksNode] = DeriveJsonEncoder.gen
   implicit lazy val jrAllowedNetworksEncoder:     JsonEncoder[JRAllowedNetworks]     = DeriveJsonEncoder.gen
   implicit lazy val jrSettingsEncoder:            JsonEncoder[JRSettings]            = DeriveJsonEncoder.gen
+
+  implicit lazy val jrResultRepairedReport: JsonEncoder[JRResultRepairedReport] = DeriveJsonEncoder.gen
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeChangesService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeChangesService.scala
@@ -40,19 +40,48 @@ package com.normation.rudder.services.reports
 import com.normation.box.*
 import com.normation.errors.*
 import com.normation.rudder.domain.logger.ReportLoggerPure
+import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.ResultRepairedReport
 import com.normation.rudder.repository.CachedRepository
 import com.normation.rudder.repository.ReportsRepository
 import com.normation.zio.*
 import net.liftweb.common.*
-import net.liftweb.http.js
-import net.liftweb.http.js.JE.*
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import org.joda.time.Interval
 import zio.{System as _, *}
+import zio.json.JsonEncoder
 import zio.syntax.*
+
+opaque type ChangesByRule = Map[RuleId, Map[Interval, Int]]
+
+object ChangesByRule {
+  private[reports] def apply(map: Map[RuleId, Map[Interval, Int]]): ChangesByRule = map
+  def empty: ChangesByRule = Map.empty
+  def of(head: (RuleId, Map[Interval, Int])): ChangesByRule = Map(head)
+
+  extension (self: ChangesByRule) {
+    private[reports] def getWithFallback(k: RuleId, defaultMap: => Map[Interval, Int])(i: Interval, default: Int): Int         =
+      self.getOrElse(k, defaultMap).getOrElse(i, default)
+    private[reports] def keySet:                                                                                   Set[RuleId] = (self: Map[RuleId, Map[Interval, Int]]).keySet
+    private[reports] def debugString:                                                                              String      = {
+      self.map {
+        case (ruleId, x) =>
+          val byInt = x.map {
+            case (int, size) =>
+              s" ${int}:${size}"
+          }.mkString(" ", "\n ", "")
+
+          s"${ruleId.serialize}\n${byInt}"
+      }.mkString("\n")
+    }
+
+    def defaultRulesWith(rules: Iterable[Rule])(default: Map[Interval, Int]): ChangesByRule =
+      (rules.map(r => (r.id, default)) ++ self).toMap
+    def mapChanges[A](f: Map[Interval, Int] => A): Map[RuleId, A] = self.map((k, v) => (k, f(v)))
+  }
+}
 
 /**
  * This service is responsible to make available node changes for nodes.
@@ -63,7 +92,6 @@ import zio.syntax.*
  */
 
 trait NodeChangesService {
-  type ChangesByRule = Map[RuleId, Map[Interval, Int]]
 
   /*
    * Max number of days to look back for changes.
@@ -153,11 +181,11 @@ class NodeChangesServiceImpl(
     val intervals = getCurrentValidIntervals(None)
     // Regroup changes by interval
     for {
-      changes <- reportsRepository.countChangeReportsByBatch(intervals)
+      (count, changes) <- reportsRepository.countChangeReportsByBatch(intervals)
     } yield {
       val endTime = System.currentTimeMillis()
       logger.debug(s"Fetched all changes for all rules in ${(endTime - beginTime)} ms")
-      changes
+      (count, ChangesByRule(changes))
     }
   }
 
@@ -179,7 +207,7 @@ object ChangesUpdate {
 final case class ChangesCache(
     highestId: Long, // the highest id in the cache
 
-    changes: Map[RuleId, Map[Interval, Int]] // the map of aggregated changes by rules and by interval
+    changes: ChangesByRule
 )
 
 /**
@@ -267,30 +295,20 @@ class CachedNodeChangesServiceImpl(
     )
   }
 
-  private def cacheToLog(changes: ChangesByRule): String = {
-    changes.map {
-      case (ruleId, x) =>
-        val byInt = x.map {
-          case (int, size) =>
-            s" ${int}:${size}"
-        }.mkString(" ", "\n ", "")
-
-        s"${ruleId.serialize}\n${byInt}"
-    }.mkString("\n")
-  }
-
   /**
    * For intervals "on", merge change1 and change2 (respective to rules). Intervals not in "on"
    * are removed from the result.
    * For a given rule, on a given interval, changes from change1 and change2 are added.
+   *
+   * This could be in an extension method
    */
   private def merge(on: Seq[Interval], changes1: ChangesByRule, changes2: ChangesByRule): ChangesByRule = {
     // shortcut that get map(k1)(k2) and return an empty seq if key not found
     def get(changes: ChangesByRule, ruleId: RuleId, i: Interval): Int = {
-      changes.getOrElse(ruleId, Map()).getOrElse(i, 0)
+      changes.getWithFallback(ruleId, Map())(i, 0)
     }
 
-    (changes1.keySet ++ changes2.keySet).map { ruleId =>
+    ChangesByRule((changes1.keySet ++ changes2.keySet).map { ruleId =>
       (
         ruleId,
         on.map { i =>
@@ -298,7 +316,7 @@ class CachedNodeChangesServiceImpl(
           (i, updated)
         }.toMap
       )
-    }.toMap
+    }.toMap)
   }
 
   /**
@@ -400,7 +418,7 @@ class CachedNodeChangesServiceImpl(
                      Failure(msg)
                  }).toIO
       _       <- ReportLoggerPure.Changes.debug("NodeChanges cache initialized")
-      _       <- ReportLoggerPure.Changes.trace("NodeChanges cache content: " + cacheToLog(changes._2))
+      _       <- ReportLoggerPure.Changes.trace("NodeChanges cache content: " + changes._2.debugString)
     } yield {
       ChangesCache(changes._1, changes._2)
     }
@@ -423,8 +441,8 @@ class CachedNodeChangesServiceImpl(
                    }
       time1     <- currentTimeMillis
       _         <- ReportLoggerPure.Changes.debug(s"Rule Changes cache updated in ${time1 - time0} ms")
-      updates    = merge(intervals, previous.changes, newChanges)
-      _         <- ReportLoggerPure.Changes.trace("NodeChanges cache content: " + cacheToLog(updates))
+      updates    = merge(intervals, previous.changes, ChangesByRule(newChanges))
+      _         <- ReportLoggerPure.Changes.trace("NodeChanges cache content: " + updates.debugString)
     } yield {
       ChangesCache(highestId, updates)
     }
@@ -456,7 +474,7 @@ class CachedNodeChangesServiceImpl(
     } yield {
       opt match {
         case Some(c) => (c.highestId, c.changes)
-        case None    => (-1L, Map[RuleId, Map[Interval, Int]]())
+        case None    => (-1L, ChangesByRule.empty)
       }
     }
 
@@ -472,34 +490,43 @@ class CachedNodeChangesServiceImpl(
 
 }
 
-object NodeChanges {
+opaque type PeriodJson = Interval
+object PeriodJson {
   // a format for interval like "2016-01-27 06:00 - 12:00"
-  val day         = "yyyy-MM-dd"
-  val startFormat = "HH:mm"
-  val endFormat   = "- HH:mm"
+  private val day         = "yyyy-MM-dd"
+  private val startFormat = "HH:mm"
+  private val endFormat   = "- HH:mm"
 
-  private def displayPeriod(interval: Interval) = {
-    JsArray(
-      Str(interval.getStart().toString(day)) :: Str(interval.getStart().toString(startFormat)) :: Str(
+  def apply(interval: Interval): PeriodJson = interval
+  given JsonEncoder[PeriodJson] = JsonEncoder
+    .chunk[String]
+    .contramap(interval => {
+      Chunk(
+        interval.getStart().toString(day),
+        interval.getStart().toString(startFormat),
         interval.getEnd().toString(endFormat)
-      ) :: Nil
-    )
-  }
+      )
+    })
+}
+
+object NodeChanges {
+  // Used in RulesGrid
+  final case class ChangesGridJson(
+      labels: List[PeriodJson],
+      values: List[Int],
+      t:      List[Long] // interval start, in millis
+  ) derives JsonEncoder
 
   /**
    * Display the list of intervals, sorted by start time, and for each put
    * the number of changes from changes.
    * Intervals must be equals in changes and intervals.
    */
-  def json(changes: Map[Interval, Int], intervals: List[Interval]): js.JsObj = {
+  def json(changes: Map[Interval, Int], intervals: List[Interval]): ChangesGridJson = {
 
     // sort intervals, get number of changes for each (or 0)
-    val data = intervals.sortBy(_.getStartMillis).map(i => (displayPeriod(i), changes.getOrElse(i, 0), i.getStartMillis))
-
-    JsObj(
-      ("labels" -> JsArray(data.map(a => a._1))),
-      ("values" -> JsArray(data.map(a => Num(a._2)))),
-      ("t"      -> JsArray(data.map(a => Num(a._3))))
-    )
+    val data                = intervals.sortBy(_.getStartMillis).map(i => (PeriodJson(i), changes.getOrElse(i, 0), i.getStartMillis))
+    val (labels, values, t) = data.unzip3
+    ChangesGridJson(labels, values, t)
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -585,14 +585,16 @@ sealed trait ChangesApi extends EnumEntry with EndpointSchema with InternalApi w
 object ChangesApi       extends Enum[ChangesApi] with ApiModuleProvider[ChangesApi]           {
 
   case object GetRecentChanges extends ChangesApi with ZeroParam with StartsAtVersion14 with SortIndex {
-    val z: Int = implicitly[Line].value
+    override val name: String = "getRulesChanges"
+    val z:             Int    = implicitly[Line].value
     val description    = "Get changes for all Rules over the last 3 days (internal)"
     val (action, path) = GET / "changes"
     val authz: List[AuthorizationType] = AuthorizationType.Rule.Read :: Nil
   }
 
   case object GetRuleRepairedReports extends ChangesApi with OneParam with StartsAtVersion14 with SortIndex {
-    val z: Int = implicitly[Line].value
+    override val name: String = "getRuleChange"
+    val z:             Int    = implicitly[Line].value
     val description    = "Get all repaired report for a Rule in a interval of time specified as parameter(internal)"
     val (action, path) = GET / "changes" / "{ruleId}"
     val authz: List[AuthorizationType] = AuthorizationType.Rule.Read :: Nil

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RecentChangesAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RecentChangesAPI.scala
@@ -37,26 +37,23 @@
 
 package com.normation.rudder.rest.lift
 
-import com.normation.box.IOToBox
-import com.normation.errors.BoxToIO
-import com.normation.errors.Inconsistency
-import com.normation.errors.IOResult
+import com.normation.errors.*
 import com.normation.rudder.api.ApiVersion
+import com.normation.rudder.apidata.JsonResponseObjects.JRRecentChanges
+import com.normation.rudder.apidata.JsonResponseObjects.JRResultRepairedReport
+import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
-import com.normation.rudder.domain.reports.ResultRepairedReport
 import com.normation.rudder.rest.ApiPath
 import com.normation.rudder.rest.AuthzToken
 import com.normation.rudder.rest.ChangesApi
 import com.normation.rudder.rest.ChangesApi as API
-import com.normation.rudder.rest.RestUtils.*
+import com.normation.rudder.rest.RudderJsonResponse.syntax.*
 import com.normation.rudder.services.reports.NodeChangesService
-import com.normation.utils.DateFormaterService
+import io.scalaland.chimney.syntax.*
 import net.liftweb.common.*
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
-import net.liftweb.json.JsonAST.JValue
-import net.liftweb.json.JsonDSL.*
 import org.joda.time.DateTime
 import org.joda.time.Interval
 import zio.syntax.ToZio
@@ -64,30 +61,6 @@ import zio.syntax.ToZio
 class RecentChangesAPI(
     nodeChangesService: NodeChangesService
 ) extends LiftApiModuleProvider[API] {
-
-  def serialize(changesByRules: Map[RuleId, Map[Interval, Int]]): JValue = {
-    changesByRules.map {
-      case (ruleId, changes) =>
-        val serializedChanges = {
-          changes.toList.sortBy(_._1.getStart).map {
-            case (interval, number) =>
-              (("start"    -> DateFormaterService.serialize(interval.getStart))
-              ~ ("end"     -> DateFormaterService.serialize(interval.getEnd))
-              ~ ("changes" -> number))
-          }
-        }
-        (ruleId.serialize, serializedChanges)
-    }
-  }
-  def serialize(report: ResultRepairedReport):                    JValue = {
-    (("executionDate"       -> DateFormaterService.serialize(report.executionDate))
-    ~ ("nodeId"             -> report.nodeId.value)
-    ~ ("directiveId"        -> report.directiveId.serialize)
-    ~ ("component"          -> report.component)
-    ~ ("value"              -> report.keyValue)
-    ~ ("message"            -> report.message)
-    ~ ("executionTimestamp" -> DateFormaterService.serialize(report.executionTimestamp)))
-  }
 
   def schemas: API.type = API
 
@@ -102,16 +75,12 @@ class RecentChangesAPI(
     val schema: ChangesApi.GetRecentChanges.type = API.GetRecentChanges
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      implicit val prettify: Boolean = params.prettify
-      implicit val action:   String  = "getRulesChanges"
-      nodeChangesService.countChangesByRuleByInterval() match {
-        case Full((_, changes)) =>
-          val json = serialize(changes)
-          toJsonResponse(None, json)
-        case eb: EmptyBox =>
-          val msg = (eb ?~! s"Could not get recent changes for all Rules").messageChain
-          toJsonError(None, msg)
-      }
+      nodeChangesService
+        .countChangesByRuleByInterval()
+        .toIO
+        .map((_, c) => c.transformInto[Map[RuleId, List[JRRecentChanges]]].map((k, v) => (k.serialize, v)))
+        .chainError(s"Could not get recent changes for all rules")
+        .toLiftResponseOne(params, schema, None)
     }
   }
 
@@ -126,9 +95,6 @@ class RecentChangesAPI(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      implicit val action:   String  = "getRuleChange"
-      implicit val prettify: Boolean = false
-
       (for {
         startDate <- req.params.get("start") match {
                        case Some(start :: Nil) =>
@@ -145,16 +111,10 @@ class RecentChangesAPI(
         reports   <-
           nodeChangesService.getChangesForInterval(RuleId(RuleUid(ruleId)), new Interval(startDate, endDate), Some(10000)).toIO
       } yield {
-        reports
-      }).toBox match {
-        case Full(reports) =>
-          val json = reports.map(serialize)
-          toJsonResponse(None, json)
-        case eb: EmptyBox =>
-          val msg = (eb ?~! s"Could not get repaired report for Rule '$ruleId'").messageChain
-          toJsonError(None, msg)
-      }
-
+        reports.map(_.transformInto[JRResultRepairedReport])
+      })
+        .chainError(s"Could not get repaired report for Rule '${ruleId}'")
+        .toLiftResponseList(params, schema)
     }
   }
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_changes.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_changes.yml
@@ -1,0 +1,67 @@
+description: Get changes for all rules
+method: GET
+url: /secure/api/changes
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getRulesChanges",
+      "result" : "success",
+      "data" : {
+        "rule1" : [
+          {
+            "start" : "1970-01-01T00:00:00Z",
+            "end" : "1970-01-01T00:00:01Z",
+            "changes" : 1
+          }
+        ]
+      }
+    }
+---
+description: Get all repaired report for a rule in a interval of time specified as parameter
+method: GET
+url: /secure/api/changes/rule1?start=1970-01-01T00:00:00Z&end=1970-01-01T00:00:01Z
+response:
+  code: 200
+  content: >-
+    {
+      "action" : "getRuleChange",
+      "result" : "success",
+      "data" : [
+        {
+          "executionDate" : "1970-01-01T00:00:00Z",
+          "nodeId" : "node1",
+          "directiveId" : "directive1",
+          "component" : "Time synchronization (NTP)",
+          "value" : "",
+          "message" : "ntp daemon installed, configured and running",
+          "executionTimestamp" : "1970-01-01T00:00:00Z"
+        }
+      ]
+    }
+---
+description: Get all repaired report for a rule in a interval of time with no params
+method: GET
+comment: missing params
+url: /secure/api/changes/rule1
+response:
+  code: 500
+  content: >-
+    {
+      "action" : "getRuleChange",
+      "result" : "error",
+      "errorDetails" : "Could not get repaired report for Rule 'rule1'; cause was: Inconsistency: No start date defined"
+    }
+---
+description: Get all repaired report for a rule in a interval of time with bad interval
+method: GET
+comment: start but no end
+url: /secure/api/changes/rule1?start=1970-01-01T00:00:00Z
+response:
+  code: 500
+  content: >-
+    {
+      "action" : "getRuleChange",
+      "result" : "error",
+      "errorDetails" : "Could not get repaired report for Rule 'rule1'; cause was: Inconsistency: No end date defined"
+    }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -76,8 +76,10 @@ import com.normation.rudder.domain.policies.PolicyMode.Enforce
 import com.normation.rudder.domain.policies.PolicyModeOverrides
 import com.normation.rudder.domain.policies.PolicyModeOverrides.Always
 import com.normation.rudder.domain.policies.Rule
+import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleTarget
 import com.normation.rudder.domain.reports.NodeStatusReport
+import com.normation.rudder.domain.reports.ResultRepairedReport
 import com.normation.rudder.domain.secret.Secret
 import com.normation.rudder.domain.workflows.ChangeRequestId
 import com.normation.rudder.facts.nodes.CoreNodeFact
@@ -140,6 +142,8 @@ import com.normation.rudder.services.policies.RuleApplicationStatusServiceImpl
 import com.normation.rudder.services.queries.DynGroupService
 import com.normation.rudder.services.queries.DynGroupUpdaterServiceImpl
 import com.normation.rudder.services.quicksearch.FullQuickSearchService
+import com.normation.rudder.services.reports.ChangesByRule
+import com.normation.rudder.services.reports.NodeChangesService
 import com.normation.rudder.services.servers.DeleteMode
 import com.normation.rudder.services.servers.InstanceId
 import com.normation.rudder.services.servers.InstanceIdService
@@ -171,6 +175,7 @@ import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.time.ZonedDateTime
 import net.liftweb.common.Box
+import net.liftweb.common.Empty
 import net.liftweb.common.EmptyBox
 import net.liftweb.common.Full
 import net.liftweb.http.LiftResponse
@@ -984,6 +989,37 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
   val mockApiAccounts = new MockApiAccountService(userService)
   val apiAccountApi: ApiAccountApi = new ApiAccountApi(mockApiAccounts.service)
 
+  val fakeNodeChangesService: NodeChangesService = new NodeChangesService {
+    import org.joda.time.Interval
+    override def changesMaxAge:                  Int                        = 0
+    override def countChangesByRuleByInterval(): Box[(Long, ChangesByRule)] = Full(
+      (1, ChangesByRule.of(mockRules.rules.clockRule.id -> Map(new Interval(0L, 1_000L) -> 1)))
+    )
+    override def getChangesForInterval(
+        ruleId:   RuleId,
+        interval: Interval,
+        limit:    Option[Int]
+    ): Box[Seq[ResultRepairedReport]] = {
+      if (ruleId == mockRules.rules.clockRule.id) {
+        Full(
+          List(
+            ResultRepairedReport(
+              new DateTime(0),
+              ruleId,
+              mockDirectives.directives.clockDirective.id,
+              MockNodes.node1Node.id,
+              "0",
+              "Time synchronization (NTP)",
+              "",
+              new DateTime(0),
+              "ntp daemon installed, configured and running"
+            )
+          )
+        )
+      } else Empty
+    }
+  }
+
   val apiModules: List[LiftApiModuleProvider[? <: EndpointSchema & SortIndex]] = List(
     systemApi,
     parameterApi,
@@ -1049,7 +1085,8 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
     eventLogApi,
     new PluginInternalApi(pluginsSystemService),
     new InventoryApi(mockInventoryFileWatcher, mockInventoryDir),
-    new QuicksearchApi(quickSearchService, linkUtil)
+    new QuicksearchApi(quickSearchService, linkUtil),
+    new RecentChangesAPI(fakeNodeChangesService)
   )
 
   val (rudderApi, liftRules) = TraitTestApiFromYamlFiles.buildLiftRules(apiModules, apiVersions, Some(userService))

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
@@ -48,6 +48,7 @@ import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.repository.*
 import com.normation.rudder.rule.category.RuleCategory
 import com.normation.rudder.rule.category.RuleCategoryId
+import com.normation.rudder.services.reports.ChangesByRule
 import com.normation.rudder.services.reports.NodeChanges
 import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.web.ChooseTemplate
@@ -65,11 +66,11 @@ import net.liftweb.http.js.JsCmds.*
 import net.liftweb.json.*
 import net.liftweb.util.Helpers.*
 import org.apache.commons.text.StringEscapeUtils
-import org.joda.time.Interval
 import scala.collection.MapView
 import scala.concurrent.*
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.xml.*
+import zio.json.*
 
 /**
  * An ADT to denote if a column should be display or not,
@@ -346,42 +347,41 @@ class RuleGrid(
     }
   }
 
-  private def changesFuture(rules: Seq[Rule]): Future[Box[Map[RuleId, Map[Interval, Int]]]] = {
+  private def changesFuture(rules: Seq[Rule]): Future[Box[ChangesByRule]] = {
     Future {
       if (rules.isEmpty) {
-        Full(Map())
+        Full(ChangesByRule.empty)
       } else {
         val default = recentChanges.getCurrentValidIntervals(None).map((_, 0)).toMap
         val start   = System.currentTimeMillis
         for {
           changes <- recentChanges.countChangesByRuleByInterval()
         } yield {
-          val nodeChanges = rules.map(rule => (rule.id, changes._2.getOrElse(rule.id, default)))
+          val nodeChanges = changes._2.defaultRulesWith(rules)(default)
           val after       = System.currentTimeMillis
           TimingDebugLogger.debug(s"computing recent changes in Future took ${after - start}ms")
-          nodeChanges.toMap
+          nodeChanges
         }
       }
     }
   }
 
   // Ajax call back to get recent changes
-  private def ajaxChanges(future: Future[Box[Map[RuleId, Map[Interval, Int]]]]): JsCmd = {
+  private def ajaxChanges(future: Future[Box[ChangesByRule]]): JsCmd = {
     SHtml.ajaxInvoke(() => {
       // Is my future completed ?
       if (future.isCompleted) {
         // Yes wait/get for result
         Await.result(future, scala.concurrent.duration.Duration.Inf) match {
           case Full(changes) =>
-            val computeGraphs = for {
-              (ruleId, change) <- changes
-            } yield {
-              val changeCount = change.values.sum
-              val data        = NodeChanges.json(change, recentChanges.getCurrentValidIntervals(None))
-              s"""computeChangeGraph(${data.toJsCmd},"${StringEscapeUtils.escapeEcmaScript(
-                  ruleId.serialize
-                )}",currentPageIds, ${changeCount}, ${showChangesGraph})"""
-            }
+            val computeGraphs = changes
+              .mapChanges(c => c.values.sum -> NodeChanges.json(c, recentChanges.getCurrentValidIntervals(None)))
+              .map {
+                case (ruleId, (changeCount, data)) =>
+                  s"""computeChangeGraph(${data.toJson},"${StringEscapeUtils.escapeEcmaScript(
+                      ruleId.serialize
+                    )}",currentPageIds, ${changeCount}, ${showChangesGraph})"""
+              }
 
             JsRaw(s"""
             const ruleTable = new DataTable('#'+"${htmlId_rulesGridId}");


### PR DESCRIPTION
https://issues.rudder.io/issues/28687

Migration of the RecentChangesAPI : there are 2 endpoints, `GET /api/changes` and `GET api/change/<ruleid>?start=...,end=...`.
Also, there is some JSON serialization in RuleGrid

* added unit tests (also for parameters validation)
* enforced restricted manipulation of the "changes by rules" _rudder-core_ business object, which is a map : it's encapsulated in an opaque type, and the usage in _rudder-rest_ is restricted to API & display concerns, such as mapping it to serialized values

---

Further migrations would be :
* avoiding usage of joda-time `Interval` and `DateTime`
* migrating `Box` to `IOResult` in all called dependencies, it would impact a quite huge codebase in `NodeChangesService` and `ReportsJdbcRepository`
* refactor the business object further, to simplify the API and exposed methods