### PR TITLE
Fixes #28736: The eventlogs API no longer returns the format expected by the dashboard's Elm app

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Dashboard/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Dashboard/DataTypes.elm
@@ -12,7 +12,6 @@ type alias Activity =
     { id : Int
     , actor : String
     , description : String
-    , actType : String
     , date : Posix
     }
 

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Dashboard/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Dashboard/JsonDecoder.elm
@@ -20,7 +20,6 @@ decodeActivity =
         |> required "id" int
         |> required "actor" string
         |> required "description" string
-        |> required "type" string
         |> required "date" Json.Decode.Extra.datetime
 
 decodeErrorDetails : String -> ( String, String )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Dashboard/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Dashboard/View.elm
@@ -40,6 +40,8 @@ view model =
             let
                 (activityDate, relativeActivityDate) =
                     (a.date, DateFormat.Relative.relativeTimeWithOptions relativeTimeOptions model.currentTime a.date)
+
+                tooltipTitle = "<div class='d-flex align-items-baseline'><i class='fa fa-user me-2'></i>" ++ a.actor ++ "</div>"
             in
                 li[class "activity-item d-flex flex-column w-100"]
                     [ div[]
@@ -47,7 +49,7 @@ view model =
                             [ class "relative-date"
                             , attribute "data-bs-toggle" "tooltip"
                             , attribute "data-bs-placement" "top"
-                            , attribute "title" (buildTooltipContent (a.actType) (posixToString model.zone activityDate))
+                            , attribute "title" (buildTooltipContent tooltipTitle (posixToString model.zone activityDate))
                             , onClick (Copy (Iso8601.fromTime activityDate))
                             ]
                             [ text relativeActivityDate ]

--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/changeLogs.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/changeLogs.js
@@ -71,10 +71,6 @@ function createEventLogTable(gridId, data, contextPath, refresh) {
   , "data" : "actor"
   , "title": "Actor"
   } , {
-    "width": "30%"
-  , "data" : "type"
-  , "title": "Type"
-  } , {
     "width"    : "30%"
   , "data"     : "description"
   , "title"    : "Description"


### PR DESCRIPTION
https://issues.rudder.io/issues/28736

Events 'type' were used in tooltips title, it has been replaced by the event actor.
I also removed to column 'type' from the change logs table.

<img width="432" height="183" alt="Capture d’écran du 2026-04-17 11-41-31" src="https://github.com/user-attachments/assets/eaeea24f-5738-4f66-8d11-77dd96eca8e6" />

<img width="1620" height="759" alt="Capture d’écran du 2026-04-17 11-45-02" src="https://github.com/user-attachments/assets/eb856f71-5831-47f6-925b-a20a9d357e02" />

