### PR TITLE
Fixes #28734: Migrate system api to zio-json

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -1126,14 +1126,16 @@ sealed trait SystemApi extends EnumEntry with EndpointSchema with GeneralApi wit
 object SystemApi       extends Enum[SystemApi] with ApiModuleProvider[SystemApi]            {
 
   case object Info extends SystemApi with ZeroParam with StartsAtVersion10 with SortIndex {
-    val z: Int = implicitly[Line].value
+    val z:             Int    = implicitly[Line].value
+    override def name: String = "getSystemInfo"
     val description    = "Get information about system installation (version, etc)"
     val (action, path) = GET / "system" / "info"
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Read :: Nil
   }
 
   case object Status extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
-    val z: Int = implicitly[Line].value
+    val z:             Int    = implicitly[Line].value
+    override val name: String = "getStatus"
     val description    = "Get Api status"
     val (action, path) = GET / "system" / "status"
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Read :: Nil
@@ -1157,28 +1159,32 @@ object SystemApi       extends Enum[SystemApi] with ApiModuleProvider[SystemApi]
   }
 
   case object TechniquesReload extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
-    val z: Int = implicitly[Line].value
+    val z:             Int    = implicitly[Line].value
+    override val name: String = "reloadTechniques"
     val description    = "reload all techniques" // automatically done every 5 minutes
     val (action, path) = POST / "system" / "reload" / "techniques"
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   case object DyngroupsReload extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
-    val z: Int = implicitly[Line].value
+    val z:             Int    = implicitly[Line].value
+    override val name: String = "reloadGroups"
     val description    = "reload all dynamic groups"
     val (action, path) = POST / "system" / "reload" / "groups"
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   case object PoliciesUpdate extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
-    val z: Int = implicitly[Line].value
+    val z:             Int    = implicitly[Line].value
+    override val name: String = "updatePolicies"
     val description    = "update policies"
     val (action, path) = POST / "system" / "update" / "policies"
     val authz: List[AuthorizationType] = AuthorizationType.Technique.Write :: Nil
   }
 
   case object PoliciesRegenerate extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
-    val z: Int = implicitly[Line].value
+    val z:             Int    = implicitly[Line].value
+    override val name: String = "regeneratePolicies"
     val description    = "regenerate all policies"
     val (action, path) = POST / "system" / "regenerate" / "policies"
     val authz: List[AuthorizationType] = AuthorizationType.Technique.Write :: Nil
@@ -1187,35 +1193,40 @@ object SystemApi       extends Enum[SystemApi] with ApiModuleProvider[SystemApi]
   // Archive list endpoints
 
   case object ArchivesGroupsList extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
-    val z: Int = implicitly[Line].value
+    val z:             Int    = implicitly[Line].value
+    override val name: String = "listGroupsArchive"
     val description    = "list groups archives"
     val (action, path) = GET / "system" / "archives" / "groups"
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil
   }
 
   case object ArchivesDirectivesList extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
-    val z: Int = implicitly[Line].value
+    val z:             Int    = implicitly[Line].value
+    override val name: String = "listDirectivesArchive"
     val description    = "list directives archives"
     val (action, path) = GET / "system" / "archives" / "directives"
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Read :: Nil
   }
 
   case object ArchivesRulesList extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
-    val z: Int = implicitly[Line].value
+    val z:             Int    = implicitly[Line].value
+    override val name: String = "listRulesArchive"
     val description    = "list rules archives"
     val (action, path) = GET / "system" / "archives" / "rules"
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Read :: Nil
   }
 
   case object ArchivesParametersList extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
-    val z: Int = implicitly[Line].value
+    val z:             Int    = implicitly[Line].value
+    override val name: String = "listParametersArchive"
     val description    = "list parameters archives"
     val (action, path) = GET / "system" / "archives" / "parameters"
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Read :: Nil
   }
 
   case object ArchivesFullList extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
-    val z: Int = implicitly[Line].value
+    val z:             Int    = implicitly[Line].value
+    override val name: String = "listFullArchive"
     val description    = "list all archives"
     val (action, path) = GET / "system" / "archives" / "full"
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Read :: Nil
@@ -1364,7 +1375,8 @@ object SystemApi       extends Enum[SystemApi] with ApiModuleProvider[SystemApi]
   }
 
   case object ArchiveFull extends SystemApi with ZeroParam with StartsAtVersion11 with SortIndex {
-    val z: Int = implicitly[Line].value
+    val z:             Int    = implicitly[Line].value
+    override val name: String = "archiveAll"
     val description    = "archive full"
     val (action, path) = POST / "system" / "archives" / "full"
     val authz: List[AuthorizationType] = AuthorizationType.Administration.Write :: Nil

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SystemApi.scala
@@ -37,7 +37,6 @@
 
 package com.normation.rudder.rest.lift
 
-import com.normation.box.*
 import com.normation.cfclerk.services.UpdateTechniqueLibrary
 import com.normation.errors.*
 import com.normation.eventlog.EventActor
@@ -60,9 +59,8 @@ import com.normation.rudder.rest.ApiPath
 import com.normation.rudder.rest.AuthzToken
 import com.normation.rudder.rest.EndpointSchema
 import com.normation.rudder.rest.OneParam
-import com.normation.rudder.rest.RestUtils
-import com.normation.rudder.rest.RestUtils.toJsonError
-import com.normation.rudder.rest.RestUtils.toJsonResponse
+import com.normation.rudder.rest.RudderJsonResponse
+import com.normation.rudder.rest.RudderJsonResponse.ResponseSchema
 import com.normation.rudder.rest.SystemApi as API
 import com.normation.rudder.rest.data.*
 import com.normation.rudder.rest.data.SystemInfoJson.*
@@ -95,14 +93,12 @@ import net.liftweb.common.*
 import net.liftweb.http.InMemoryResponse
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
-import net.liftweb.json.JsonAST.JArray
-import net.liftweb.json.JsonAST.JField
-import net.liftweb.json.JsonAST.JObject
-import net.liftweb.json.JsonDSL.*
-import net.liftweb.json.JValue
 import org.eclipse.jgit.lib.PersonIdent
 import org.eclipse.jgit.revwalk.RevWalk
 import zio.*
+import zio.json.*
+import zio.json.ast.*
+import zio.json.ast.Json.*
 
 class SystemApi(
     apiv11service:     SystemApiService11,
@@ -159,9 +155,15 @@ class SystemApi(
   }
 
   object Info extends LiftApiModule0 {
-    val schema: API.Info.type = API.Info
+    override val schema: API.Info.type = API.Info
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
 
       systemInfoService
         .getAll()
@@ -171,32 +173,49 @@ class SystemApi(
   }
 
   object Status extends LiftApiModule0 {
-    val schema: API.Status.type = API.Status
+    override val schema: API.Status.type = API.Status
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      implicit val prettify = false
-      implicit val action   = "getStatus"
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      given prettify: Boolean = false
 
-      toJsonResponse(None, ("global" -> "OK"))
+      RudderJsonResponse.successOne(ResponseSchema("getStatus", None), Map("global" -> "OK"), None)
     }
   }
 
   object DebugInfo extends LiftApiModule0 {
-    val schema: API.DebugInfo.type = API.DebugInfo
+    override val schema: API.DebugInfo.type = API.DebugInfo
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      apiv11service.debugInfo(params)
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      apiv11service.debugInfo(schema, params)
     }
   }
 
   // Reload [techniques / dynamics groups] endpoint implementation
 
   object TechniquesReload extends LiftApiModule0 {
-    val schema: API.TechniquesReload.type = API.TechniquesReload
+    override val schema: API.TechniquesReload.type = API.TechniquesReload
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.reloadTechniques(req, params)
+      apiv11service.reloadTechniques(req, schema, params)
     }
   }
 
@@ -204,219 +223,357 @@ class SystemApi(
     val schema: API.DyngroupsReload.type = API.DyngroupsReload
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      apiv11service.reloadDyngroups(params)
+      apiv11service.reloadDyngroups(schema, params)
     }
   }
 
   object ReloadAll extends LiftApiModule0 {
-    val schema: API.ReloadAll.type = API.ReloadAll
+    override val schema: API.ReloadAll.type = API.ReloadAll
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.reloadAll(req, params)
+      apiv11service.reloadAll(req, schema, params)
     }
   }
 
   // Policies update and regenerate endpoint implementation
 
   object PoliciesUpdate extends LiftApiModule0 {
-    val schema: API.PoliciesUpdate.type = API.PoliciesUpdate
+    override val schema: API.PoliciesUpdate.type = API.PoliciesUpdate
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.updatePolicies(req, params)
+      apiv11service.updatePolicies(req, schema, params)
     }
   }
 
   object PoliciesRegenerate extends LiftApiModule0 {
-    val schema: API.PoliciesRegenerate.type = API.PoliciesRegenerate
+    override val schema: API.PoliciesRegenerate.type = API.PoliciesRegenerate
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.regeneratePolicies(req, params)
+      apiv11service.regeneratePolicies(req, schema, params)
     }
   }
 
   // Archives endpoint implementation
 
   object ArchivesGroupsList extends LiftApiModule0 {
-    val schema: API.ArchivesGroupsList.type = API.ArchivesGroupsList
+    override val schema: API.ArchivesGroupsList.type = API.ArchivesGroupsList
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      apiv11service.listGroupsArchive(params)
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      apiv11service.listGroupsArchive(schema, params)
     }
   }
 
   object ArchivesDirectivesList extends LiftApiModule0 {
-    val schema: API.ArchivesDirectivesList.type = API.ArchivesDirectivesList
+    override val schema: API.ArchivesDirectivesList.type = API.ArchivesDirectivesList
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      apiv11service.listDirectivesArchive(params)
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      apiv11service.listDirectivesArchive(schema, params)
     }
   }
 
   object ArchivesRulesList extends LiftApiModule0 {
-    val schema: API.ArchivesRulesList.type = API.ArchivesRulesList
+    override val schema: API.ArchivesRulesList.type = API.ArchivesRulesList
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      apiv11service.listRulesArchive(params)
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      apiv11service.listRulesArchive(schema, params)
     }
   }
 
   object ArchivesParametersList extends LiftApiModule0 {
-    val schema: API.ArchivesParametersList.type = API.ArchivesParametersList
+    override val schema: API.ArchivesParametersList.type = API.ArchivesParametersList
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      apiv11service.listParametersArchive(params)
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      apiv11service.listParametersArchive(schema, params)
     }
   }
 
   object ArchivesFullList extends LiftApiModule0 {
-    val schema: API.ArchivesFullList.type = API.ArchivesFullList
+    override val schema: API.ArchivesFullList.type = API.ArchivesFullList
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      apiv11service.listFullArchive(params)
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      apiv11service.listFullArchive(schema, params)
     }
   }
 
   object RestoreGroupsLatestArchive extends LiftApiModule0 {
-    val schema: API.RestoreGroupsLatestArchive.type = API.RestoreGroupsLatestArchive
+    override val schema: API.RestoreGroupsLatestArchive.type = API.RestoreGroupsLatestArchive
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.restoreGroupsLatestArchive(req, params)
+      apiv11service.restoreGroupsLatestArchive(req, schema, params)
     }
   }
 
   object RestoreDirectivesLatestArchive extends LiftApiModule0 {
-    val schema: API.RestoreDirectivesLatestArchive.type = API.RestoreDirectivesLatestArchive
+    override val schema: API.RestoreDirectivesLatestArchive.type = API.RestoreDirectivesLatestArchive
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.restoreDirectivesLatestArchive(req, params)
+      apiv11service.restoreDirectivesLatestArchive(req, schema, params)
     }
   }
 
   object RestoreRulesLatestArchive extends LiftApiModule0 {
-    val schema: API.RestoreRulesLatestArchive.type = API.RestoreRulesLatestArchive
+    override val schema: API.RestoreRulesLatestArchive.type = API.RestoreRulesLatestArchive
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.restoreRulesLatestArchive(req, params)
+      apiv11service.restoreRulesLatestArchive(req, schema, params)
     }
   }
 
   object RestoreParametersLatestArchive extends LiftApiModule0 {
-    val schema: API.RestoreParametersLatestArchive.type = API.RestoreParametersLatestArchive
+    override val schema: API.RestoreParametersLatestArchive.type = API.RestoreParametersLatestArchive
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.restoreParametersLatestArchive(req, params)
+      apiv11service.restoreParametersLatestArchive(req, schema, params)
     }
   }
 
   object RestoreFullLatestArchive extends LiftApiModule0 {
-    val schema: API.RestoreFullLatestArchive.type = API.RestoreFullLatestArchive
+    override val schema: API.RestoreFullLatestArchive.type = API.RestoreFullLatestArchive
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.restoreFullLatestArchive(req, params)
+      apiv11service.restoreFullLatestArchive(req, schema, params)
     }
   }
 
   object RestoreGroupsLatestCommit extends LiftApiModule0 {
-    val schema: API.RestoreGroupsLatestCommit.type = API.RestoreGroupsLatestCommit
+    override val schema: API.RestoreGroupsLatestCommit.type = API.RestoreGroupsLatestCommit
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.restoreGroupsLatestCommit(req, params)
+      apiv11service.restoreGroupsLatestCommit(req, schema, params)
     }
   }
 
   object RestoreDirectivesLatestCommit extends LiftApiModule0 {
-    val schema: API.RestoreDirectivesLatestCommit.type = API.RestoreDirectivesLatestCommit
+    override val schema: API.RestoreDirectivesLatestCommit.type = API.RestoreDirectivesLatestCommit
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.restoreDirectivesLatestCommit(req, params)
+      apiv11service.restoreDirectivesLatestCommit(req, schema, params)
     }
   }
 
   object RestoreRulesLatestCommit extends LiftApiModule0 {
-    val schema: API.RestoreRulesLatestCommit.type = API.RestoreRulesLatestCommit
+    override val schema: API.RestoreRulesLatestCommit.type = API.RestoreRulesLatestCommit
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.restoreRulesLatestCommit(req, params)
+      apiv11service.restoreRulesLatestCommit(req, schema, params)
     }
   }
 
   object RestoreParametersLatestCommit extends LiftApiModule0 {
-    val schema: API.RestoreParametersLatestCommit.type = API.RestoreParametersLatestCommit
+    override val schema: API.RestoreParametersLatestCommit.type = API.RestoreParametersLatestCommit
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.restoreParametersLatestCommit(req, params)
+      apiv11service.restoreParametersLatestCommit(req, schema, params)
     }
   }
 
   object RestoreFullLatestCommit extends LiftApiModule0 {
-    val schema: API.RestoreFullLatestCommit.type = API.RestoreFullLatestCommit
+    override val schema: API.RestoreFullLatestCommit.type = API.RestoreFullLatestCommit
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.restoreFullLatestCommit(req, params)
+      apiv11service.restoreFullLatestCommit(req, schema, params)
     }
   }
 
   object ArchiveGroups     extends LiftApiModule0 {
-    val schema: API.ArchiveGroups.type = API.ArchiveGroups
+    override val schema: API.ArchiveGroups.type = API.ArchiveGroups
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.archiveGroups(req, params)
+      apiv11service.archiveGroups(req, schema, params)
     }
   }
   object ArchiveDirectives extends LiftApiModule0 {
-    val schema: API.ArchiveDirectives.type = API.ArchiveDirectives
+    override val schema: API.ArchiveDirectives.type = API.ArchiveDirectives
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.archiveDirectives(req, params)
+      apiv11service.archiveDirectives(req, schema, params)
     }
   }
 
   object ArchiveRules extends LiftApiModule0 {
-    val schema: API.ArchiveRules.type = API.ArchiveRules
+    override val schema: API.ArchiveRules.type = API.ArchiveRules
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.archiveRules(req, params)
+      apiv11service.archiveRules(req, schema, params)
     }
   }
 
   object ArchiveParameters extends LiftApiModule0 {
-    val schema: API.ArchiveParameters.type = API.ArchiveParameters
+    override val schema: API.ArchiveParameters.type = API.ArchiveParameters
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.archiveParameters(req, params)
+      apiv11service.archiveParameters(req, schema, params)
     }
   }
 
   object ArchiveAll extends LiftApiModule0 {
-    val schema: API.ArchiveFull.type = API.ArchiveFull
+    override val schema: API.ArchiveFull.type = API.ArchiveFull
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.archiveAll(req, params)
+      apiv11service.archiveAll(req, schema, params)
     }
   }
 
   object ArchiveGroupDateRestore extends LiftApiModule {
-    val schema: OneParam = API.ArchiveGroupDateRestore
+    override val schema: OneParam = API.ArchiveGroupDateRestore
 
-    def process(
+    override def process(
         version:    ApiVersion,
         path:       ApiPath,
         dateTime:   String,
@@ -425,14 +582,14 @@ class SystemApi(
         authzToken: AuthzToken
     ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.archiveGroupDateRestore(req, params, dateTime)
+      apiv11service.archiveGroupDateRestore(req, schema, params, dateTime)
     }
   }
 
   object ArchiveDirectiveDateRestore extends LiftApiModule {
-    val schema: OneParam = API.ArchiveDirectiveDateRestore
+    override val schema: OneParam = API.ArchiveDirectiveDateRestore
 
-    def process(
+    override def process(
         version:    ApiVersion,
         path:       ApiPath,
         dateTime:   String,
@@ -441,14 +598,14 @@ class SystemApi(
         authzToken: AuthzToken
     ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.archiveDirectiveDateRestore(req, params, dateTime)
+      apiv11service.archiveDirectiveDateRestore(req, schema, params, dateTime)
     }
   }
 
   object ArchiveRuleDateRestore extends LiftApiModule {
-    val schema: OneParam = API.ArchiveRuleDateRestore
+    override val schema: OneParam = API.ArchiveRuleDateRestore
 
-    def process(
+    override def process(
         version:    ApiVersion,
         path:       ApiPath,
         dateTime:   String,
@@ -457,7 +614,7 @@ class SystemApi(
         authzToken: AuthzToken
     ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.archiveRuleDateRestore(req, params, dateTime)
+      apiv11service.archiveRuleDateRestore(req, schema, params, dateTime)
     }
   }
 
@@ -473,7 +630,7 @@ class SystemApi(
         authzToken: AuthzToken
     ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.archiveParameterDateRestore(req, params, dateTime)
+      apiv11service.archiveParameterDateRestore(req, schema, params, dateTime)
     }
   }
 
@@ -489,14 +646,14 @@ class SystemApi(
         authzToken: AuthzToken
     ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
-      apiv11service.archiveFullDateRestore(req, params, dateTime)
+      apiv11service.archiveFullDateRestore(req, schema, params, dateTime)
     }
   }
 
   object GetGroupsZipArchive extends LiftApiModule {
-    val schema: OneParam = API.GetGroupsZipArchive
+    override val schema: OneParam = API.GetGroupsZipArchive
 
-    def process(
+    override def process(
         version:    ApiVersion,
         path:       ApiPath,
         commitId:   String,
@@ -504,7 +661,7 @@ class SystemApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      apiv11service.getGroupsZipArchive(params, commitId)
+      apiv11service.getZipResponse(schema, params, commitId, ArchiveType.Groups)
     }
   }
 
@@ -519,14 +676,14 @@ class SystemApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      apiv11service.getDirectivesZipArchive(params, commitId)
+      apiv11service.getZipResponse(schema, params, commitId, ArchiveType.Directives)
     }
   }
 
   object GetRulesZipArchive extends LiftApiModule {
-    val schema: OneParam = API.GetRulesZipArchive
+    override val schema: OneParam = API.GetRulesZipArchive
 
-    def process(
+    override def process(
         version:    ApiVersion,
         path:       ApiPath,
         commitId:   String,
@@ -534,14 +691,14 @@ class SystemApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      apiv11service.getRulesZipArchive(params, commitId)
+      apiv11service.getZipResponse(schema, params, commitId, ArchiveType.Rules)
     }
   }
 
   object GetParametersZipArchive extends LiftApiModule {
-    val schema: OneParam = API.GetParametersZipArchive
+    override val schema: OneParam = API.GetParametersZipArchive
 
-    def process(
+    override def process(
         version:    ApiVersion,
         path:       ApiPath,
         commitId:   String,
@@ -549,14 +706,14 @@ class SystemApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      apiv11service.getParametersZipArchive(params, commitId)
+      apiv11service.getZipResponse(schema, params, commitId, ArchiveType.Parameters)
     }
   }
 
   object GetAllZipArchive extends LiftApiModule {
-    val schema: OneParam = API.GetAllZipArchive
+    override val schema: OneParam = API.GetAllZipArchive
 
-    def process(
+    override def process(
         version:    ApiVersion,
         path:       ApiPath,
         commitId:   String,
@@ -564,22 +721,34 @@ class SystemApi(
         params:     DefaultParams,
         authzToken: AuthzToken
     ): LiftResponse = {
-      apiv11service.getAllZipArchive(params, commitId)
+      apiv11service.getZipResponse(schema, params, commitId, ArchiveType.All)
     }
   }
 
   object GetHealthcheckResult extends LiftApiModule0 {
-    val schema: API.GetHealthcheckResult.type = API.GetHealthcheckResult
+    override val schema: API.GetHealthcheckResult.type = API.GetHealthcheckResult
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       apiv13service.getHealthcheck(schema, params)
     }
   }
 
   object PurgeSoftware extends LiftApiModule0 {
-    val schema: API.PurgeSoftware.type = API.PurgeSoftware
+    override val schema: API.PurgeSoftware.type = API.PurgeSoftware
 
-    def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
+    override def process0(
+        version:    ApiVersion,
+        path:       ApiPath,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
       apiv13service.purgeSoftware(schema, params)
     }
   }
@@ -591,49 +760,61 @@ class SystemApiService13(
     softwareService:    SoftwareService
 ) extends Loggable {
 
+  /*
+   * This one is hard to test because it depends of the machine status.
+   * The awaited format is:
+   *
+   *  "data" : [
+   *    {
+   *      "name" : "CPU cores",
+   *      "msg" : "16 cores",
+   *      "status" : "Ok"
+   *    },
+   *    {
+   *      "name" : "Free disk space",
+   *      "msg" : "Enough available free space:\n/var/tmp has 45% free space etc",
+   *      "status" : "Ok"
+   *    },
+   *    {
+   *      "name" : "File descriptor limit",
+   *      "msg" : "Maximum number of file descriptors is 524288",
+   *      "status" : "Ok"
+   *    }
+   *  ]
+   */
+  private case class JHealthcheck(name: String, msg: String, status: String) derives JsonEncoder
   def getHealthcheck(schema: EndpointSchema, params: DefaultParams): LiftResponse = {
-    implicit val action   = schema.name
-    implicit val prettify = params.prettify
-
-    def serializeHealthcheckResult(check: HealthcheckResult): JValue = {
+    def serializeHealthcheckResult(check: HealthcheckResult): JHealthcheck = {
       val status = check match {
         case _: Critical => "Critical"
         case _: Ok       => "Ok"
         case _: Warning  => "Warning"
       }
-      (("name" -> check.name.value)
-      ~ ("msg"    -> check.msg)
-      ~ ("status" -> status))
+      JHealthcheck(check.name.value, check.msg, status)
     }
 
-    val result = for {
+    (for {
       checks <- healthcheckService.runAll
       _      <- hcNotifService.updateCacheFromExt(checks)
     } yield {
       checks.map(serializeHealthcheckResult)
-    }
-    result.toBox match {
-      case Full(json) =>
-        RestUtils.toJsonResponse(None, JArray(json))
-      case eb: EmptyBox =>
-        val message = (eb ?~ s"Error when trying to run healthcheck").messageChain
-        RestUtils.toJsonError(None, message)(using action, prettify = true)
-    }
+    }).toLiftResponseList(params, schema)
   }
 
   def purgeSoftware(schema: EndpointSchema, params: DefaultParams): LiftResponse = {
-    implicit val action   = schema.name
-    implicit val prettify = params.prettify
-
     // create it an async daemon to execute and handle error
     softwareService.deleteUnreferencedSoftware().forkDaemon.runNow
 
-    RestUtils.toJsonResponse(
-      None,
-      JArray(List("Purge of unreference software started. More information in /var/log/rudder/webapp/ logs"))
-    )
+    given prettify: Boolean = params.prettify
+    val msg = "Purge of unreferenced software started. More information in /var/log/rudder/webapp/webapp.log"
+    RudderJsonResponse.successOne(ResponseSchema.fromSchema(schema), msg, None)
   }
 }
+
+// used in SystemApiService11 and tests, so need to be accessible
+final case class JArchiveInfo(id: String, date: String, committer: String, gitCommit: String) derives JsonEncoder
+final case class JArchiveLog(committer: String, gitCommit: String, id: String) derives JsonEncoder
+final case class JReloadStatus(groups: Option[String], techniques: Option[String]) derives JsonEncoder
 
 class SystemApiService11(
     updatePTLibService:   UpdateTechniqueLibrary,
@@ -646,15 +827,15 @@ class SystemApiService11(
     personIdentService:   PersonIdentService,
     repo:                 GitRepositoryProvider
 ) extends Loggable {
-  import SystemApi.*
+  import com.normation.rudder.rest.lift.SystemApi.*
 
   // The private methods are the internal behavior of the API.
   // They are helper functions called by the public method (implemented lower) to avoid code repetition.
 
-  private def reloadTechniquesWrapper(req: Req)(implicit qc: QueryContext): Either[String, JField] = {
+  private def reloadTechniquesWrapper(req: Req)(implicit qc: QueryContext): Either[String, String] = {
     ApiLogger.info(s"Trigger technique reload")
     updatePTLibService.update()(using qc.newCC(Some("Technique library reloaded from REST API"))) match {
-      case Full(_) => Right(JField("techniques", "Started"))
+      case Full(_) => Right("Started")
       case eb: EmptyBox =>
         val e = eb ?~! "An error occurred when updating the Technique library from file system"
         logger.error(e.messageChain)
@@ -665,10 +846,10 @@ class SystemApiService11(
 
   // For now we are not able to give information about the group reload process.
   // We still send OK instead to inform the endpoint has correctly triggered.
-  private def reloadDyngroupsWrapper(): Either[String, JField] = {
+  private def reloadDyngroupsWrapper(): Either[String, String] = {
     ApiLogger.info(s"Trigger dynamic group reload")
     updateDynamicGroups.forceStartUpdate
-    Right(JField("groups", "Started"))
+    Right("Started")
   }
 
   /**
@@ -676,7 +857,7 @@ class SystemApiService11(
     * (the most recent is the first in the array)
     * { "archiveType" : [ { "id" : "datetimeID", "date": "human readable date" , "commiter": "name", "gitPath": "path" }, ... ]
     */
-  private def formatList(archiveType: String, availableArchives: Map[Instant, GitArchiveId]): JField = {
+  private def formatList(archiveType: String, availableArchives: Map[Instant, GitArchiveId]): (String, List[JArchiveInfo]) = {
     val ordered = availableArchives.toList.sortWith { case ((d1, _), (d2, _)) => d1.isAfter(d2) }.map {
       case (date, tag) =>
         // archiveId is contained in gitPath, archive is archives/<kind>/archiveId
@@ -685,12 +866,15 @@ class SystemApiService11(
 
         val datetime = dateAsArchiveFormat(date)
         // json
-        ("id" -> id) ~ ("date" -> datetime) ~ ("committer" -> tag.commiter.getName) ~ ("gitCommit" -> tag.commit.value)
+        JArchiveInfo(id, datetime, tag.commiter.getName, tag.commit.value)
     }
-    JField(archiveType, ordered)
+    (archiveType, ordered)
   }
 
-  private def listTags(list: () => IOResult[Map[Instant, GitArchiveId]], archiveType: String): Either[String, JField] = {
+  private def listTags(
+      list:        () => IOResult[Map[Instant, GitArchiveId]],
+      archiveType: String
+  ): Either[String, (String, List[JArchiveInfo])] = {
     list().either.runNow.fold(
       err => Left(s"Error when trying to list available archives for ${archiveType}. Error was: ${err.fullMsg}"),
       map => Right(formatList(archiveType, map))
@@ -704,7 +888,7 @@ class SystemApiService11(
       list:        () => IOResult[Map[Instant, GitArchiveId]],
       restore:     (GitCommitId, PersonIdent) => IOResult[GitCommitId],
       archiveType: String
-  )(implicit qc: QueryContext): Either[String, JField] = {
+  )(implicit qc: QueryContext): Either[String, (String, String)] = {
     (for {
       archives   <- list()
       commiter   <- personIdentService.getPersonIdentOrDefault(qc.actor.name)
@@ -719,7 +903,7 @@ class SystemApiService11(
       restored
     }).either.runNow.fold(
       err => Left(s"Error when trying to restore the latest archive for ${archiveType}. Error was: ${err.fullMsg}"),
-      x => Right(JField(archiveType, "Started"))
+      x => Right((archiveType, "Started"))
     )
   }
 
@@ -727,7 +911,7 @@ class SystemApiService11(
       req:         Req,
       restore:     PersonIdent => IOResult[GitCommitId],
       archiveType: String
-  )(implicit qc: QueryContext): Either[String, JField] = {
+  )(implicit qc: QueryContext): Either[String, (String, String)] = {
     (for {
       commiter <- personIdentService.getPersonIdentOrDefault(qc.actor.name)
       restored <- restore(
@@ -737,7 +921,7 @@ class SystemApiService11(
       restored
     }).either.runNow.fold(
       err => Left(s"Error when trying to restore the latest archive for ${archiveType}. Error was: ${err.fullMsg}"),
-      x => Right(JField(archiveType, "Started"))
+      x => Right((archiveType, "Started"))
     )
   }
 
@@ -747,7 +931,7 @@ class SystemApiService11(
       restore:     (GitCommitId, PersonIdent) => IOResult[GitCommitId],
       datetime:    String,
       archiveType: String
-  )(implicit qc: QueryContext): Either[String, JField] = {
+  )(implicit qc: QueryContext): Either[String, (String, String)] = {
     (for {
       valideDate <- IOResult.attempt(s"The given archive id is not a valid archive tag: ${datetime}")(
                       DateFormaterService.parseAsGitTag(datetime)
@@ -768,7 +952,7 @@ class SystemApiService11(
       restored
     }).either.runNow.fold(
       err => Left(s"Error when trying to restore archive '${datetime}' for ${archiveType}. Error was: ${err.fullMsg}"),
-      x => Right(JField(archiveType, "Started"))
+      x => Right((archiveType, "Started"))
     )
   }
 
@@ -776,7 +960,7 @@ class SystemApiService11(
       req:         Req,
       archive:     (PersonIdent, ModificationId, EventActor, Option[String]) => IOResult[GitArchiveId],
       archiveType: String
-  )(implicit qc: QueryContext): Either[String, JField] = {
+  )(implicit qc: QueryContext): Either[String, (String, JArchiveLog)] = {
     (for {
       committer <- personIdentService.getPersonIdentOrDefault(qc.actor.name)
       archiveId <-
@@ -789,8 +973,8 @@ class SystemApiService11(
         // archiveId is contained in gitPath, archive is archives/<kind>/archiveId
         // splitting on last an getting back last part, falling back to full Id
         val archiveId = x.path.value.split("/").lastOption.getOrElse(x.path.value)
-        val res       = ("committer" -> x.commiter.getName) ~ ("gitCommit" -> x.commit.value) ~ ("id" -> archiveId)
-        Right(JField(archiveType, res))
+        val res       = JArchiveLog(x.commiter.getName, x.commit.value, archiveId)
+        Right((archiveType, res))
       }
     )
   }
@@ -824,10 +1008,12 @@ class SystemApiService11(
       .runNow
   }
 
-  private def getZipResponse(
+  def getZipResponse(
+      schema:      EndpointSchema,
+      params:      DefaultParams,
       commitId:    String,
       archiveType: ArchiveType
-  )(implicit prettify: Boolean, action: String): LiftResponse = {
+  ): LiftResponse = {
     getZip(commitId, archiveType) match {
       case Right((bytes, filename)) =>
         val headers = {
@@ -836,13 +1022,14 @@ class SystemApiService11(
           Nil
         }
         InMemoryResponse(bytes, headers, Nil, 200)
-      case Left(err)                => toJsonError(None, err)
+      case Left(err)                =>
+        given prettify: Boolean = params.prettify
+        RudderJsonResponse.internalError(None, ResponseSchema.fromSchema(schema), err)
     }
   }
 
-  def debugInfo(params: DefaultParams): LiftResponse = {
-    implicit val action   = "getDebugInfo"
-    implicit val prettify = params.prettify
+  def debugInfo(schema: EndpointSchema, params: DefaultParams): LiftResponse = {
+    given prettify: Boolean = params.prettify
 
     debugScriptService.launch().either.runNow match {
       case Right(DebugInfoScriptResult(fileName, bytes)) =>
@@ -855,50 +1042,26 @@ class SystemApiService11(
         )
       case Left(error)                                   =>
         val fail = Chained("Error has occurred while getting debug script result", error)
-        toJsonError(None, "debug script" -> s"An Error occurred: ${fail.fullMsg}")
+        RudderJsonResponse.internalError(None, ResponseSchema.fromSchema(schema), fail.fullMsg)
     }
-  }
-
-  def getGroupsZipArchive(params: DefaultParams, commitId: String): LiftResponse = {
-    implicit val action   = "getGroupsZipArchive"
-    implicit val prettify = params.prettify
-
-    getZipResponse(commitId, ArchiveType.Groups)
-  }
-
-  def getDirectivesZipArchive(params: DefaultParams, commitId: String): LiftResponse = {
-    implicit val action   = "getDirectivesZipArchive"
-    implicit val prettify = params.prettify
-
-    getZipResponse(commitId, ArchiveType.Directives)
-  }
-
-  def getRulesZipArchive(params: DefaultParams, commitId: String): LiftResponse = {
-    implicit val action   = "getRulesZipArchive"
-    implicit val prettify = params.prettify
-
-    getZipResponse(commitId, ArchiveType.Rules)
-  }
-
-  def getParametersZipArchive(params: DefaultParams, commitId: String): LiftResponse = {
-    implicit val action   = "getParametersZipArchive"
-    implicit val prettify = params.prettify
-
-    getZipResponse(commitId, ArchiveType.Parameters)
-  }
-
-  def getAllZipArchive(params: DefaultParams, commitId: String): LiftResponse = {
-    implicit val action   = "getFullZipArchive"
-    implicit val prettify = params.prettify
-
-    getZipResponse(commitId, ArchiveType.All)
   }
 
   // Archive RESTORE based on a date given as the last part of the URL
 
-  def archiveGroupDateRestore(req: Req, params: DefaultParams, dateTime: String)(implicit qc: QueryContext): LiftResponse = {
-    implicit val action   = "archiveGroupDateRestore"
-    implicit val prettify = params.prettify
+  extension [A: JsonEncoder](res: Either[String, (String, A)]) {
+    private def toLiftResponse(schema: EndpointSchema)(using prettify: Boolean): LiftResponse = {
+      val s = ResponseSchema.fromSchema(schema)
+      res match {
+        case Left(error)   => RudderJsonResponse.internalError(None, s, error)
+        case Right((k, v)) => RudderJsonResponse.successOne(s, Map((k, v)), None)
+      }
+    }
+  }
+
+  def archiveGroupDateRestore(req: Req, schema: EndpointSchema, params: DefaultParams, dateTime: String)(implicit
+      qc: QueryContext
+  ): LiftResponse = {
+    given prettify:  Boolean       = params.prettify
     implicit val cc: ChangeContext = qc.newCC(Some(s"Restore archive for date time ${dateTime} requested from REST API"))
 
     restoreByDatetime(
@@ -907,15 +1070,13 @@ class SystemApiService11(
       itemArchiveManager.importGroupLibrary,
       dateTime,
       "group"
-    ) match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    ).toLiftResponse(schema)
   }
 
-  def archiveDirectiveDateRestore(req: Req, params: DefaultParams, dateTime: String)(implicit qc: QueryContext): LiftResponse = {
-    implicit val action   = "archiveDirectiveDateRestore"
-    implicit val prettify = params.prettify
+  def archiveDirectiveDateRestore(req: Req, schema: EndpointSchema, params: DefaultParams, dateTime: String)(implicit
+      qc: QueryContext
+  ): LiftResponse = {
+    given prettify:  Boolean       = params.prettify
     implicit val cc: ChangeContext = qc.newCC(Some(s"Restore archive for date time ${dateTime} requested from REST API"))
 
     restoreByDatetime(
@@ -924,26 +1085,23 @@ class SystemApiService11(
       itemArchiveManager.importTechniqueLibrary,
       dateTime,
       "directive"
-    ) match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    ).toLiftResponse(schema)
   }
 
-  def archiveRuleDateRestore(req: Req, params: DefaultParams, dateTime: String)(implicit qc: QueryContext): LiftResponse = {
-    implicit val action   = "archiveRuleDateRestore"
-    implicit val prettify = params.prettify
+  def archiveRuleDateRestore(req: Req, schema: EndpointSchema, params: DefaultParams, dateTime: String)(implicit
+      qc: QueryContext
+  ): LiftResponse = {
+    given prettify:  Boolean       = params.prettify
     implicit val cc: ChangeContext = qc.newCC(Some(s"Restore archive for date time ${dateTime} requested from REST API"))
 
-    restoreByDatetime(req, () => itemArchiveManager.getRulesTags, itemArchiveManager.importRules, dateTime, "rule") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    restoreByDatetime(req, () => itemArchiveManager.getRulesTags, itemArchiveManager.importRules, dateTime, "rule")
+      .toLiftResponse(schema)
   }
 
-  def archiveParameterDateRestore(req: Req, params: DefaultParams, dateTime: String)(implicit qc: QueryContext): LiftResponse = {
-    implicit val action   = "archiveParameterDateRestore"
-    implicit val prettify = params.prettify
+  def archiveParameterDateRestore(req: Req, schema: EndpointSchema, params: DefaultParams, dateTime: String)(implicit
+      qc: QueryContext
+  ): LiftResponse = {
+    given prettify:  Boolean       = params.prettify
     implicit val cc: ChangeContext = qc.newCC(Some(s"Restore archive for date time ${dateTime} requested from REST API"))
 
     restoreByDatetime(
@@ -952,95 +1110,69 @@ class SystemApiService11(
       itemArchiveManager.importParameters,
       dateTime,
       "parameter"
-    ) match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    ).toLiftResponse(schema)
   }
 
-  def archiveFullDateRestore(req: Req, params: DefaultParams, dateTime: String)(implicit qc: QueryContext): LiftResponse = {
-    implicit val action   = "archiveFullDateRestore"
-    implicit val prettify = params.prettify
+  def archiveFullDateRestore(req: Req, schema: EndpointSchema, params: DefaultParams, dateTime: String)(implicit
+      qc: QueryContext
+  ): LiftResponse = {
+    given prettify:  Boolean       = params.prettify
     implicit val cc: ChangeContext = qc.newCC(Some(s"Restore archive for date time ${dateTime} requested from REST API"))
 
-    restoreByDatetime(req, () => itemArchiveManager.getFullArchiveTags, itemArchiveManager.importAll, dateTime, "full") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    restoreByDatetime(req, () => itemArchiveManager.getFullArchiveTags, itemArchiveManager.importAll, dateTime, "full")
+      .toLiftResponse(schema)
   }
 
   // Archiving endpoints
 
-  def archiveGroups(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-    implicit val action   = "archiveGroups"
-    implicit val prettify = params.prettify
+  def archiveGroups(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
+    given prettify: Boolean = params.prettify
 
-    archive(req, itemArchiveManager.exportGroupLibrary, "groups") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    archive(req, itemArchiveManager.exportGroupLibrary, "groups").toLiftResponse(schema)
   }
 
-  def archiveDirectives(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-    implicit val action   = "archiveDirectives"
-    implicit val prettify = params.prettify
+  def archiveDirectives(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
+    given prettify: Boolean = params.prettify
 
-    archive(req, ((a, b, c, d) => itemArchiveManager.exportTechniqueLibrary(a, b, c, d).map(_._1)), "directives") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    archive(req, ((a, b, c, d) => itemArchiveManager.exportTechniqueLibrary(a, b, c, d).map(_._1)), "directives")
+      .toLiftResponse(schema)
   }
-  def archiveRules(req: Req, params: DefaultParams)(implicit qc: QueryContext):      LiftResponse = {
-    implicit val action   = "archiveRules"
-    implicit val prettify = params.prettify
+  def archiveRules(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit qc: QueryContext):      LiftResponse = {
+    given prettify: Boolean = params.prettify
 
-    archive(req, itemArchiveManager.exportRules, "rules") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    archive(req, itemArchiveManager.exportRules, "rules").toLiftResponse(schema)
   }
-  def archiveParameters(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-    implicit val action   = "archiveParameters"
-    implicit val prettify = params.prettify
+  def archiveParameters(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
+    given prettify: Boolean = params.prettify
 
-    archive(req, itemArchiveManager.exportParameters, "parameters") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    archive(req, itemArchiveManager.exportParameters, "parameters").toLiftResponse(schema)
   }
 
-  def archiveAll(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-    implicit val action   = "archiveAll"
-    implicit val prettify = params.prettify
+  def archiveAll(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
+    given prettify: Boolean = params.prettify
 
-    archive(req, ((a, b, c, d) => itemArchiveManager.exportAll(a, b, c, d).map(_._1)), "full") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    archive(req, ((a, b, c, d) => itemArchiveManager.exportAll(a, b, c, d).map(_._1)), "full").toLiftResponse(schema)
   }
 
   // All archives RESTORE functions implemented by the API (latest archive or latest commit)
 
-  def restoreGroupsLatestArchive(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-
-    implicit val action   = "restoreGroupsLatestArchive"
-    implicit val prettify = params.prettify
+  def restoreGroupsLatestArchive(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit
+      qc: QueryContext
+  ): LiftResponse = {
+    given prettify:  Boolean       = params.prettify
     implicit val cc: ChangeContext = qc.newCC(Some("Restore latest archive required from REST API"))
     restoreLatestArchive(
       req,
       () => itemArchiveManager.getGroupLibraryTags,
       itemArchiveManager.importGroupLibrary,
       "groups"
-    ) match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    ).toLiftResponse(schema)
   }
 
-  def restoreDirectivesLatestArchive(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-
-    implicit val action   = "restoreDirectivesLatestArchive"
-    implicit val prettify = params.prettify
+  def restoreDirectivesLatestArchive(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit
+      qc: QueryContext
+  ): LiftResponse = {
+    given prettify:  Boolean       = params.prettify
     implicit val cc: ChangeContext = qc.newCC(Some("Restore latest archive required from REST API"))
 
     restoreLatestArchive(
@@ -1048,26 +1180,23 @@ class SystemApiService11(
       () => itemArchiveManager.getTechniqueLibraryTags,
       itemArchiveManager.importTechniqueLibrary,
       "directives"
-    ) match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    ).toLiftResponse(schema)
   }
 
-  def restoreRulesLatestArchive(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-    implicit val action   = "restoreRulesLatestArchive"
-    implicit val prettify = params.prettify
+  def restoreRulesLatestArchive(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit
+      qc: QueryContext
+  ): LiftResponse = {
+    given prettify:  Boolean       = params.prettify
     implicit val cc: ChangeContext = qc.newCC(Some("Restore latest archive required from REST API"))
 
-    restoreLatestArchive(req, () => itemArchiveManager.getRulesTags, itemArchiveManager.importRules, "rules") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    restoreLatestArchive(req, () => itemArchiveManager.getRulesTags, itemArchiveManager.importRules, "rules")
+      .toLiftResponse(schema)
   }
 
-  def restoreParametersLatestArchive(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-    implicit val action   = "restoreParametersLatestArchive"
-    implicit val prettify = params.prettify
+  def restoreParametersLatestArchive(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit
+      qc: QueryContext
+  ): LiftResponse = {
+    given prettify:  Boolean       = params.prettify
     implicit val cc: ChangeContext = qc.newCC(Some("Restore latest archive required from REST API"))
 
     restoreLatestArchive(
@@ -1075,200 +1204,132 @@ class SystemApiService11(
       () => itemArchiveManager.getParametersTags,
       itemArchiveManager.importParameters,
       "parameters"
-    ) match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    ).toLiftResponse(schema)
   }
 
-  def restoreFullLatestArchive(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-
-    implicit val action   = "restoreFullLatestArchive"
-    implicit val prettify = params.prettify
+  def restoreFullLatestArchive(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit
+      qc: QueryContext
+  ): LiftResponse = {
+    given prettify:  Boolean       = params.prettify
     implicit val cc: ChangeContext = qc.newCC(Some("Restore latest archive required from REST API"))
 
-    restoreLatestArchive(req, () => itemArchiveManager.getFullArchiveTags, itemArchiveManager.importAll, "full") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    restoreLatestArchive(req, () => itemArchiveManager.getFullArchiveTags, itemArchiveManager.importAll, "full")
+      .toLiftResponse(schema)
   }
 
-  def restoreGroupsLatestCommit(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-
-    implicit val action   = "restoreGroupsLatestCommit"
-    implicit val prettify = params.prettify
+  def restoreGroupsLatestCommit(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit
+      qc: QueryContext
+  ): LiftResponse = {
+    given prettify:  Boolean       = params.prettify
     implicit val cc: ChangeContext = qc.newCC(Some("Restore archive from latest commit on HEAD required from REST API"))
 
-    restoreLatestCommit(req, itemArchiveManager.importHeadGroupLibrary, "groups") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    restoreLatestCommit(req, itemArchiveManager.importHeadGroupLibrary, "groups").toLiftResponse(schema)
   }
 
-  def restoreDirectivesLatestCommit(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-
-    implicit val action   = "restoreDirectivesLatestCommit"
-    implicit val prettify = params.prettify
+  def restoreDirectivesLatestCommit(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit
+      qc: QueryContext
+  ): LiftResponse = {
+    given prettify:  Boolean       = params.prettify
     implicit val cc: ChangeContext = qc.newCC(Some("Restore archive from latest commit on HEAD required from REST API"))
 
-    restoreLatestCommit(req, itemArchiveManager.importHeadTechniqueLibrary, "directives") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    restoreLatestCommit(req, itemArchiveManager.importHeadTechniqueLibrary, "directives").toLiftResponse(schema)
   }
 
-  def restoreRulesLatestCommit(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-
-    implicit val action   = "restoreRulesLatestCommit"
-    implicit val prettify = params.prettify
+  def restoreRulesLatestCommit(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit
+      qc: QueryContext
+  ): LiftResponse = {
+    given prettify:  Boolean       = params.prettify
     implicit val cc: ChangeContext = qc.newCC(Some("Restore latest archive required from REST API"))
 
-    restoreLatestCommit(req, itemArchiveManager.importHeadRules, "rules") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    restoreLatestCommit(req, itemArchiveManager.importHeadRules, "rules").toLiftResponse(schema)
   }
 
-  def restoreParametersLatestCommit(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-
-    implicit val action   = "restoreParametersLatestCommit"
-    implicit val prettify = params.prettify
+  def restoreParametersLatestCommit(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit
+      qc: QueryContext
+  ): LiftResponse = {
+    given prettify:  Boolean       = params.prettify
     implicit val cc: ChangeContext = qc.newCC(Some("Restore latest archive required from REST API"))
 
-    restoreLatestCommit(req, itemArchiveManager.importHeadParameters, "parameters") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    restoreLatestCommit(req, itemArchiveManager.importHeadParameters, "parameters").toLiftResponse(schema)
   }
-  def restoreFullLatestCommit(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-
-    implicit val action   = "restoreFullLatestCommit"
-    implicit val prettify = params.prettify
+  def restoreFullLatestCommit(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit
+      qc: QueryContext
+  ): LiftResponse = {
+    given prettify:  Boolean       = params.prettify
     implicit val cc: ChangeContext = qc.newCC(Some("Restore latest archive required from REST API"))
 
-    restoreLatestCommit(req, itemArchiveManager.importHeadAll, "full") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    restoreLatestCommit(req, itemArchiveManager.importHeadAll, "full").toLiftResponse(schema)
   }
 
   // All list action implemented by the API
 
-  def listGroupsArchive(params: DefaultParams): LiftResponse = {
+  def listGroupsArchive(schema: EndpointSchema, params: DefaultParams): LiftResponse = {
+    given prettify: Boolean = params.prettify
 
-    implicit val action   = "listGroupsArchive"
-    implicit val prettify = params.prettify
-
-    listTags(() => itemArchiveManager.getGroupLibraryTags, "groups") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    listTags(() => itemArchiveManager.getGroupLibraryTags, "groups").toLiftResponse(schema)
   }
 
-  def listDirectivesArchive(params: DefaultParams): LiftResponse = {
+  def listDirectivesArchive(schema: EndpointSchema, params: DefaultParams): LiftResponse = {
+    given prettify: Boolean = params.prettify
 
-    implicit val action   = "listDirectivesArchive"
-    implicit val prettify = params.prettify
-
-    listTags(() => itemArchiveManager.getTechniqueLibraryTags, "directives") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    listTags(() => itemArchiveManager.getTechniqueLibraryTags, "directives").toLiftResponse(schema)
   }
 
-  def listRulesArchive(params: DefaultParams): LiftResponse = {
+  def listRulesArchive(schema: EndpointSchema, params: DefaultParams): LiftResponse = {
+    given prettify: Boolean = params.prettify
 
-    implicit val action   = "listRulesArchive"
-    implicit val prettify = params.prettify
-
-    listTags(() => itemArchiveManager.getRulesTags, "rules") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    listTags(() => itemArchiveManager.getRulesTags, "rules").toLiftResponse(schema)
   }
 
-  def listParametersArchive(params: DefaultParams): LiftResponse = {
+  def listParametersArchive(schema: EndpointSchema, params: DefaultParams): LiftResponse = {
+    given prettify: Boolean = params.prettify
 
-    implicit val action   = "listParametersArchive"
-    implicit val prettify = params.prettify
-
-    listTags(() => itemArchiveManager.getParametersTags, "parameters") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    listTags(() => itemArchiveManager.getParametersTags, "parameters").toLiftResponse(schema)
   }
 
-  def listFullArchive(params: DefaultParams): LiftResponse = {
+  def listFullArchive(schema: EndpointSchema, params: DefaultParams): LiftResponse = {
+    given prettify: Boolean = params.prettify
 
-    implicit val action   = "listFullArchive"
-    implicit val prettify = params.prettify
-
-    listTags(() => itemArchiveManager.getFullArchiveTags, "full") match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+    listTags(() => itemArchiveManager.getFullArchiveTags, "full").toLiftResponse(schema)
   }
 
   // Reload Function
 
-  def reloadDyngroups(params: DefaultParams): LiftResponse = {
-
-    implicit val action   = "reloadGroups"
-    implicit val prettify = params.prettify
-
-    reloadDyngroupsWrapper() match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+  def reloadDyngroups(schema: EndpointSchema, params: DefaultParams): LiftResponse = {
+    reloadDyngroupsWrapper().map(s => JReloadStatus(Some(s), None)).toIO.toLiftResponseOne(params, schema, None)
   }
 
-  def reloadTechniques(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-    implicit val action   = "reloadTechniques"
-    implicit val prettify = params.prettify
-
-    reloadTechniquesWrapper(req) match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+  def reloadTechniques(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
+    reloadTechniquesWrapper(req).map(s => JReloadStatus(None, Some(s))).toIO.toLiftResponseOne(params, schema, None)
   }
 
-  def reloadAll(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-
-    implicit val action   = "reloadAll"
-    implicit val prettify = params.prettify
-
+  def reloadAll(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
     (for {
       groups     <- reloadDyngroupsWrapper()
       techniques <- reloadTechniquesWrapper(req)
     } yield {
-      List(groups, techniques)
-    }) match {
-      case Left(error)  => toJsonError(None, error)
-      case Right(field) => toJsonResponse(None, JObject(field))
-    }
+      JReloadStatus(Some(groups), Some(techniques))
+    }).toIO.toLiftResponseOne(params, schema, None)
   }
 
   // Update and Regenerate(update + clear Cache) policies
 
-  def updatePolicies(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
-
-    implicit val action   = "updatePolicies"
-    implicit val prettify = params.prettify
-    val dest              = ManualStartDeployment(newModId, qc.actor, "Policy update asked by REST request")
-
+  def updatePolicies(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
+    val dest = ManualStartDeployment(newModId, qc.actor, "Policy update asked by REST request")
     asyncDeploymentAgent.launchDeployment(dest)
-    toJsonResponse(None, "policies" -> "Started")
+
+    given prettify: Boolean = params.prettify
+    RudderJsonResponse.successOne(ResponseSchema.fromSchema(schema), Obj(("policies" -> Str("Started"))), None)
   }
 
-  def regeneratePolicies(req: Req, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
+  def regeneratePolicies(req: Req, schema: EndpointSchema, params: DefaultParams)(implicit qc: QueryContext): LiftResponse = {
 
-    implicit val action   = "regeneratePolicies"
-    implicit val prettify = params.prettify
-    val dest              = ManualStartDeployment(newModId, qc.actor, "Policy regenerate asked by REST request")
-
+    val dest = ManualStartDeployment(newModId, qc.actor, "Policy regenerate asked by REST request")
     clearCacheService.action(qc.actor).runNow
     asyncDeploymentAgent.launchDeployment(dest)
-    toJsonResponse(None, "policies" -> "Started")
+
+    given prettify: Boolean = params.prettify
+    RudderJsonResponse.successOne(ResponseSchema.fromSchema(schema), Obj("policies" -> Str("Started")), None)
   }
 }
 

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_system.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_system.yml
@@ -6,7 +6,7 @@ response:
   code: 200
   content: >-
     {
-      "action":"info",
+      "action":"getSystemInfo",
       "result":"success",
       "data":{
         "rudder" : {
@@ -48,5 +48,53 @@ response:
             }
           ]
         }
+      }
+    }
+---
+description: Get system status
+method: GET
+url: /api/latest/system/status
+response:
+  code: 200
+  content: >-
+    {
+      "action":"getStatus",
+      "result":"success",
+      "data":{ "global":"OK"  }
+    }
+---
+description: Get archive list
+method: GET
+url: /api/latest/system/archives/full
+response:
+  code: 200
+  content: >-
+    {
+      "action":"listFullArchive",
+      "result":"success",
+      "data":{ 
+        "full" : [
+          {
+            "id" : "path",
+            "date" : "1970-01-01T010000Z",
+            "committer" : "test-user",
+            "gitCommit" : "6d6b2ceb46adeecd845ad0c0812fee07e2727104"
+          }
+        ]
+      }
+    }
+---
+description: Reload all
+method: POST
+url: /api/latest/system/reload
+response:
+  code: 200
+  content: >-
+    {
+      "action":"reloadAll",
+      "result":"success",
+      "data":{ 
+        "groups" : "Started",
+        "techniques" : "Started"
       }
     }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SystemApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SystemApiTest.scala
@@ -38,8 +38,8 @@
 package com.normation.rudder.rest
 
 import com.normation.rudder.domain.archives.ArchiveType
-import com.normation.rudder.rest.RestUtils.toJsonResponse
-import com.normation.rudder.rest.lift.SystemApi
+import com.normation.rudder.rest.RudderJsonResponse.ResponseSchema
+import com.normation.rudder.rest.lift.*
 import com.normation.rudder.rest.v1.RestStatus
 import java.io.File
 import java.nio.file.Files
@@ -49,18 +49,18 @@ import net.liftweb.common.*
 import net.liftweb.http.InMemoryResponse
 import net.liftweb.http.PlainTextResponse
 import net.liftweb.http.Req
-import net.liftweb.json.JsonAST.*
-import net.liftweb.json.JsonDSL.*
 import org.apache.commons.io.FileUtils
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import org.specs2.specification.AfterAll
 import scala.annotation.nowarn
+import zio.json.ast.Json.*
 
 @nowarn("msg=a type was inferred to be `\\w+`; this may indicate a programming error.")
 @RunWith(classOf[JUnitRunner])
 class SystemApiTest extends Specification with AfterAll with Loggable {
+  given prettify: Boolean = false
 
   private val restTestSetUp = RestTestSetUp.newEnv
   private val restTest      = new RestTest(restTestSetUp.liftRules)
@@ -77,10 +77,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing system API status" should {
     "match the response defined below" in {
 
-      implicit val action   = "getStatus"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "global" -> "OK")
+      val schema   = ResponseSchema("getStatus", None)
+      val response = RudderJsonResponse.successOne(schema, Map("global" -> "OK"), None)
 
       restTest.testGET("/api/latest/system/status") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -91,10 +89,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing technique reload of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "reloadTechniques"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "techniques" -> "Started")
+      val schema   = ResponseSchema("reloadTechniques", None)
+      val response = RudderJsonResponse.successOne(schema, JReloadStatus(None, Some("Started")), None)
 
       restTest.testEmptyPost("/api/latest/system/reload/techniques") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -105,10 +101,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing dynamic groups reload on System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "reloadGroups"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "groups" -> "Started")
+      val schema   = ResponseSchema("reloadGroups", None)
+      val response = RudderJsonResponse.successOne(schema, JReloadStatus(Some("Started"), None), None)
 
       restTest.testEmptyPost("/api/latest/system/reload/groups") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -119,10 +113,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing dynamic groups and techniques reload of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "reloadAll"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, List(JField("groups", "Started"), JField("techniques", "Started")))
+      val schema   = ResponseSchema("reloadAll", None)
+      val response = RudderJsonResponse.successOne(schema, JReloadStatus(Some("Started"), Some("Started")), None)
 
       restTest.testEmptyPost("/api/latest/system/reload") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -133,10 +125,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing policies update of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "updatePolicies"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "policies" -> "Started")
+      val schema   = ResponseSchema("updatePolicies", None)
+      val response = RudderJsonResponse.successOne(schema, Obj("policies", Str("Started")), None)
 
       restTest.testEmptyPost("/api/latest/system/update/policies") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -147,10 +137,9 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing policies regenerate of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "regeneratePolicies"
-      implicit val prettify = false
+      val schema   = ResponseSchema("regeneratePolicies", None)
+      val response = RudderJsonResponse.successOne(schema, Obj("policies", Str("Started")), None)
 
-      val response = toJsonResponse(None, "policies" -> "Started")
       restTest.testEmptyPost("/api/latest/system/regenerate/policies") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
       }
@@ -162,24 +151,16 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
 
   private val dateTimeId = "1970-01-01_01-00-00.042"
 
-  private val archive1: JObject = JObject(
-    List(
-      JField("id", "path"),
-      JField("date", "1970-01-01T010000Z"),
-      JField("committer", "test-user"),
-      JField("gitCommit", "6d6b2ceb46adeecd845ad0c0812fee07e2727104")
-    )
-  )
+  private val archive1: JArchiveInfo =
+    JArchiveInfo("path", "1970-01-01T010000Z", "test-user", "6d6b2ceb46adeecd845ad0c0812fee07e2727104")
 
-  private val archives: List[JObject] = List(archive1)
+  private val archives: List[JArchiveInfo] = List(archive1)
 
   "Testing archive groups listing of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "listGroupsArchive"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "groups" -> JArray(archives))
+      val schema   = ResponseSchema("listGroupsArchive", None)
+      val response = RudderJsonResponse.successOne(schema, Map("groups" -> archives), None)
 
       restTest.testGET("/api/latest/system/archives/groups") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -190,10 +171,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing archive directives of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "listDirectivesArchive"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "directives" -> JArray(archives))
+      val schema   = ResponseSchema("listDirectivesArchive", None)
+      val response = RudderJsonResponse.successOne(schema, Map("directives" -> archives), None)
 
       restTest.testGET("/api/latest/system/archives/directives") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -204,10 +183,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing archive rules listing of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "listRulesArchive"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "rules" -> JArray(archives))
+      val schema   = ResponseSchema("listRulesArchive", None)
+      val response = RudderJsonResponse.successOne(schema, Map("rules" -> archives), None)
 
       restTest.testGET("/api/latest/system/archives/rules") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -218,10 +195,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing full archive listing of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "listFullArchive"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "full" -> JArray(archives))
+      val schema   = ResponseSchema("listFullArchive", None)
+      val response = RudderJsonResponse.successOne(schema, Map("full" -> archives), None)
 
       restTest.testGET("/api/latest/system/archives/full") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -232,10 +207,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing restore groups latest archive of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "restoreGroupsLatestArchive"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "groups" -> "Started")
+      val schema   = ResponseSchema("restoreGroupsLatestArchive", None)
+      val response = RudderJsonResponse.successOne(schema, Map("groups" -> "Started"), None)
 
       restTest.testEmptyPost("/api/latest/system/archives/groups/restore/latestArchive") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -246,10 +219,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing restore directives latest archive of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "restoreDirectivesLatestArchive"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "directives" -> "Started")
+      val schema   = ResponseSchema("restoreDirectivesLatestArchive", None)
+      val response = RudderJsonResponse.successOne(schema, Map("directives" -> "Started"), None)
 
       restTest.testEmptyPost("/api/latest/system/archives/directives/restore/latestArchive") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -260,10 +231,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing restore rules latest archive of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "restoreRulesLatestArchive"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "rules" -> "Started")
+      val schema   = ResponseSchema("restoreRulesLatestArchive", None)
+      val response = RudderJsonResponse.successOne(schema, Map("rules" -> "Started"), None)
 
       restTest.testEmptyPost("/api/latest/system/archives/rules/restore/latestArchive") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -274,10 +243,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing restore full latest archive of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "restoreFullLatestArchive"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "full" -> "Started")
+      val schema   = ResponseSchema("restoreFullLatestArchive", None)
+      val response = RudderJsonResponse.successOne(schema, Map("full" -> "Started"), None)
 
       restTest.testEmptyPost("/api/latest/system/archives/full/restore/latestArchive") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -288,10 +255,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing restore groups latest commit archive of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "restoreGroupsLatestCommit"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "groups" -> "Started")
+      val schema   = ResponseSchema("restoreGroupsLatestCommit", None)
+      val response = RudderJsonResponse.successOne(schema, Map("groups" -> "Started"), None)
 
       restTest.testEmptyPost("/api/latest/system/archives/groups/restore/latestCommit") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -302,10 +267,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing restore directives latest commit archive of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "restoreDirectivesLatestCommit"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "directives" -> "Started")
+      val schema   = ResponseSchema("restoreDirectivesLatestCommit", None)
+      val response = RudderJsonResponse.successOne(schema, Map("directives" -> "Started"), None)
 
       restTest.testEmptyPost("/api/latest/system/archives/directives/restore/latestCommit") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -316,10 +279,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing restore rules latest commit archive of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "restoreRulesLatestCommit"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "rules" -> "Started")
+      val schema   = ResponseSchema("restoreRulesLatestCommit", None)
+      val response = RudderJsonResponse.successOne(schema, Map("rules" -> "Started"), None)
 
       restTest.testEmptyPost("/api/latest/system/archives/rules/restore/latestCommit") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -330,10 +291,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing restore full latest commit archive of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "restoreFullLatestCommit"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "full" -> "Started")
+      val schema   = ResponseSchema("restoreFullLatestCommit", None)
+      val response = RudderJsonResponse.successOne(schema, Map("full" -> "Started"), None)
 
       restTest.testEmptyPost("/api/latest/system/archives/full/restore/latestCommit") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -341,21 +300,13 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
     }
   }
 
-  private val archive2: JObject = JObject(
-    List(
-      JField("committer", "test-user"),
-      JField("gitCommit", "6d6b2ceb46adeecd845ad0c0812fee07e2727104"),
-      JField("id", "path")
-    )
-  )
+  private val archive2: JArchiveLog = JArchiveLog("test-user", "6d6b2ceb46adeecd845ad0c0812fee07e2727104", "path")
 
   "Testing archive groups of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "archiveGroups"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "groups" -> archive2)
+      val schema   = ResponseSchema("archiveGroups", None)
+      val response = RudderJsonResponse.successOne(schema, Map("groups" -> archive2), None)
 
       restTest.testEmptyPost("/api/latest/system/archives/groups") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -366,10 +317,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing archive directives of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "archiveDirectives"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "directives" -> archive2)
+      val schema   = ResponseSchema("archiveDirectives", None)
+      val response = RudderJsonResponse.successOne(schema, Map("directives" -> archive2), None)
 
       restTest.testEmptyPost("/api/latest/system/archives/directives") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -380,10 +329,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing archive rules of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "archiveRules"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "rules" -> archive2)
+      val schema   = ResponseSchema("archiveRules", None)
+      val response = RudderJsonResponse.successOne(schema, Map("rules" -> archive2), None)
 
       restTest.testEmptyPost("/api/latest/system/archives/rules") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -394,10 +341,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing all archive of System Api" should {
     "match the response defined below" in {
 
-      implicit val action   = "archiveAll"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "full" -> archive2)
+      val schema   = ResponseSchema("archiveAll", None)
+      val response = RudderJsonResponse.successOne(schema, Map("full" -> archive2), None)
 
       restTest.testEmptyPost("/api/latest/system/archives/full") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -408,10 +353,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing group archive restore based on a date time" should {
     "match the response defined below" in {
 
-      implicit val action   = "archiveGroupDateRestore"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "group" -> "Started")
+      val schema   = ResponseSchema("archiveGroupDateRestore", None)
+      val response = RudderJsonResponse.successOne(schema, Map("group" -> "Started"), None)
 
       restTest.testEmptyPost(s"/api/latest/system/archives/groups/restore/$dateTimeId") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -422,10 +365,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing directive archive restore based on its date time" should {
     "match the response defined below" in {
 
-      implicit val action   = "archiveDirectiveDateRestore"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "directive" -> "Started")
+      val schema   = ResponseSchema("archiveDirectiveDateRestore", None)
+      val response = RudderJsonResponse.successOne(schema, Map("directive" -> "Started"), None)
 
       restTest.testEmptyPost(s"/api/latest/system/archives/directives/restore/$dateTimeId") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -436,10 +377,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing rule archive restore based on its date time" should {
     "match the response defined below" in {
 
-      implicit val action   = "archiveRuleDateRestore"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "rule" -> "Started")
+      val schema   = ResponseSchema("archiveRuleDateRestore", None)
+      val response = RudderJsonResponse.successOne(schema, Map("rule" -> "Started"), None)
 
       restTest.testEmptyPost(s"/api/latest/system/archives/rules/restore/$dateTimeId") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))
@@ -450,10 +389,8 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
   "Testing full archive restore based on its datetime" should {
     "match the response defined below" in {
 
-      implicit val action   = "archiveFullDateRestore"
-      implicit val prettify = false
-
-      val response = toJsonResponse(None, "full" -> "Started")
+      val schema   = ResponseSchema("archiveFullDateRestore", None)
+      val response = RudderJsonResponse.successOne(schema, Map("full" -> "Started"), None)
 
       restTest.testEmptyPost(s"/api/latest/system/archives/full/restore/$dateTimeId") { req =>
         restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() must beEqualTo(Full(response))


### PR DESCRIPTION
https://issues.rudder.io/issues/28734

This migration is ad-hoc with some normalization: 
- I added tests, but for a lot of them it's not possible since they are returning binary results or are machine dependant (like healthchecks). Also, all the archive are similar, I only added one test for all. 
- I use schema everywhere. I tried to keep doc consistant, but I may have missed some - It might lead to some change in action naming, but that's really not important. 
- A lot of methods where using a kind of `Either[String, (String, Json)]` pattern then used to builed a json object or error. I kept that, adding the minimum of DTO : I kep String and List for very simple cases. 