### PR TITLE
Fixes #28738: Migrate several rudder-web js param to zio-json

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -64,6 +64,7 @@ import com.normation.rudder.rest.ApiModuleProvider
 import com.normation.rudder.rest.AuthorizationMappingListEndpoint
 import com.normation.rudder.rest.EndpointSchema
 import com.normation.rudder.rest.InfoApi as InfoApiDef
+import com.normation.rudder.rest.RudderJsonResponse.LiftJsonResponse
 import com.normation.rudder.rest.data.JsonGlobalPluginLimits
 import com.normation.rudder.rest.data.JsonPluginDetails
 import com.normation.rudder.rest.data.JsonPluginsDetails
@@ -487,13 +488,11 @@ class Boot extends Loggable {
           && req.json.isEmpty) =>
         () => {
           Full(
-            JsonResponse(
-              net.liftweb.json.parse(
-                """{"result": "error"
-                  |, "errorDetails": "The request has a JSON content type but the body is not valid JSON"}""".stripMargin
-              ),
+            LiftJsonResponse[Map[String, String]](
+              Map("result" -> "error", "errorDetails" -> "The request has a JSON content type but the body is not valid JSON"),
+              false,
               412
-            )
+            ).toResponse
           )
         }
     }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/AgentScheduleEditForm.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/AgentScheduleEditForm.scala
@@ -97,40 +97,27 @@ class AgentScheduleEditForm(
    * Parse a json input into a cf-agent Scedule
    */
   def parseJsonSchedule(s: String): Box[AgentRunInterval] = {
-    import net.liftweb.json.*
-    val json = parse(s)
-
     (for {
-      case JObject(child) <- json
-      case JField("overrides", ov) <- child
-      case JField("interval", JInt(i)) <- child
-      case JField("startHour", JInt(h)) <- child
-      case JField("startMinute", JInt(m)) <- child
-      case JField("splayHour", JInt(sh)) <- child
-      case JField("splayMinute", JInt(sm)) <- child
+      parsed <- s.fromJson[JsonSchedule]
     } yield {
-      val splayTime     = (sh.toInt * 60) + sm.toInt
-      val overrideValue = ov match {
-        case JBool(ov) => Some(ov)
-        case _         => None
-      }
+      val splayTime = (parsed.splayHour * 60) + parsed.splayMinute
 
       AgentRunInterval(
-        overrideValue,
-        i.toInt,
-        m.toInt,
-        h.toInt,
+        parsed.overrides,
+        parsed.interval,
+        parsed.startMinute,
+        parsed.startHour,
         splayTime
       )
     }) match {
-      case head :: _ =>
+      case Right(head) =>
         if (head.interval <= head.splaytime) {
           Failure("Cannot save an agent schedule with a splaytime higher than or equal to agent run interval")
         } else {
           Full(head)
         }
-      case Nil       =>
-        Failure(s"Could not parse ${s} as a valid cf-agent schedule")
+      case Left(err)   =>
+        Failure(s"Could not parse ${s} as a valid cf-agent schedule: ${err}")
     }
   }
 
@@ -177,6 +164,15 @@ class AgentScheduleEditForm(
     transform(agentScheduleTemplate);
   }
 }
+
+final private case class JsonSchedule(
+    overrides:   Option[Boolean],
+    interval:    Int,
+    startHour:   Int,
+    startMinute: Int,
+    splayHour:   Int,
+    splayMinute: Int
+) derives JsonDecoder
 
 // this one is only needed for the elm init in cfagentScheduleConfiguration above
 @jsonExplicitNull

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleCategoryTree.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleCategoryTree.scala
@@ -50,10 +50,10 @@ import net.liftweb.http.SHtml
 import net.liftweb.http.js.*
 import net.liftweb.http.js.JE.*
 import net.liftweb.http.js.JsCmds.*
-import net.liftweb.json.*
 import net.liftweb.util.Helpers.*
 import org.apache.commons.text.StringEscapeUtils
 import scala.xml.*
+import zio.json.*
 
 /**
  * A component to display a tree based on a
@@ -149,17 +149,16 @@ class RuleCategoryTree(
   }
   private val isDirectiveApplication = directive.isDefined
 
+  final case class JsonMoveCategory(sourceCatId: String, destCatId: String) derives JsonDecoder
   private def moveCategory(arg: String)(using qc: QueryContext): JsCmd = {
     // parse arg, which have to  be json object with sourceGroupId, destCatId
     try {
       (for {
-        case JObject(child) <- JsonParser.parse(arg)
-        case JField("sourceCatId", JString(sourceCatId)) <- child
-        case JField("destCatId", JString(destCatId)) <- child
+        parsed <- arg.fromJson[JsonMoveCategory]
       } yield {
-        (RuleCategoryId(sourceCatId), RuleCategoryId(destCatId))
+        (RuleCategoryId(parsed.sourceCatId), RuleCategoryId(parsed.destCatId))
       }) match {
-        case (sourceCatId, destCatId) :: Nil =>
+        case Right(sourceCatId, destCatId) =>
           (for {
             category <- roRuleCategoryRepository.get(sourceCatId)
             result   <-
@@ -189,7 +188,7 @@ class RuleCategoryTree(
                 )
               )
           }
-        case _                               => Alert("Error while trying to move group: bad client parameters")
+        case _                             => Alert("Error while trying to move group: bad client parameters")
       }
     } catch {
       case e: Exception => Alert("Error while trying to move group")

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/model/DirectiveFieldEditors.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/model/DirectiveFieldEditors.scala
@@ -37,6 +37,7 @@
 
 package com.normation.rudder.web.model
 
+import com.normation.box.*
 import com.normation.cfclerk.domain.*
 import com.normation.cfclerk.domain.HashAlgoConstraint.PLAIN
 import com.normation.cfclerk.domain.HashAlgoConstraint.PreHashed
@@ -66,6 +67,7 @@ import org.joda.time.format.DateTimeFormatter
 import scala.reflect.ClassTag
 import scala.reflect.classTag
 import scala.xml.*
+import zio.json.*
 
 /**
  * This field is a simple input text, without any
@@ -710,32 +712,24 @@ class PasswordField(
    * }
    *
    */
+  final case class JsonAction(action: String, hash: String, password: Option[String]) derives JsonDecoder
   def parseClient(s: String): Unit   = {
-    import net.liftweb.json.*
     errors = Nil
-    val json = parse(s)
     (for {
-      action       <- json \ "action" match {
-                        case JString(action) => Full(action)
-                        case _               => Failure("Could not parse 'action' field in password input")
-                      }
-      (keep, blank) = action match {
+      parsed       <- s.fromJson[JsonAction].toBox
+      (keep, blank) = parsed.action match {
                         case "delete" => (false, true)
                         case "keep"   => (true, false)
                         case _        => (false, false)
                       }
-      password     <- json \ "password" match {
-                        case JString(password)        => Full(password)
-                        case JNothing if canBeDeleted => Full("")
-                        case _                        => Failure("Could not parse 'password' field in password input")
+      password     <- parsed.password match {
+                        case Some(password)       => Full(password)
+                        case None if canBeDeleted => Full("")
+                        case _                    => Failure("Could not parse 'password' field in password input")
                       }
-      hash         <- json \ "hash" match {
-                        case JString(hash) => Full(hash)
-                        case _             => Failure("Could not parse 'hash' field in password input")
-                      }
-      algo          = HashAlgoConstraint.parse(hash).getOrElse(currentAlgo.getOrElse(PLAIN))
+      algo          = HashAlgoConstraint.parse(parsed.hash).getOrElse(currentAlgo.getOrElse(PLAIN))
     } yield {
-      currentAction = action
+      currentAction = parsed.action
       if (!keep) {
         previousAlgo = currentAlgo
         previousHash = currentHash
@@ -744,7 +738,7 @@ class PasswordField(
     }) match {
       case Full(newValue) => set(newValue)
       case eb: EmptyBox =>
-        val fail = eb ?~! s"Error while parsing password input, value received is: ${compactRender(json)}"
+        val fail = eb ?~! s"Error while parsing password input, value received is: ${s}"
         logger.error(fail.messageChain)
         errors = errors ::: List(FieldError(this, fail.messageChain))
     }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/EventListDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/EventListDisplayer.scala
@@ -52,12 +52,15 @@ import net.liftweb.http.SHtml
 import net.liftweb.http.js.*
 import net.liftweb.http.js.JE.*
 import net.liftweb.http.js.JsCmds.*
-import net.liftweb.json.*
 import net.liftweb.util.Helpers.*
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
 import scala.xml.*
+import zio.json.*
+
+// also used in LogDisplayer
+final case class JsonLogInterval(start: String, end: String) derives JsonDecoder
 
 /**
  * Used to display the event list, in the pending modification (AsyncDeployment),
@@ -92,30 +95,25 @@ class EventListDisplayer(service: EventLogService, staticResourceRewrite: Static
       val format = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss")
 
       displayEvents(for {
-        parsed   <- tryo(
-                      parse(jsonInterval) // TODO use zio-json
-                    ) ?~! s"Error when trying to parse '${jsonInterval}' as a JSON data structure with fields 'start' and 'end'"
-        startStr <- parsed \ "start" match {
-                      case JString(startStr) if startStr.nonEmpty =>
-                        val date =
-                          tryo(DateTime.parse(startStr, format)) ?~! s"Error when trying to parse start date '${startStr}"
-                        date match {
-                          case Full(d) => Full(Some(new Timestamp(d.getMillis)))
-                          case eb: EmptyBox =>
-                            eb ?~! s"Invalid start date"
-                        }
-                      case _                                      => Full(None)
-                    }
-        endStr   <- parsed \ "end" match {
-                      case JString(endStr) if endStr.nonEmpty =>
-                        val date = tryo(DateTime.parse(endStr, format)) ?~! s"Error when trying to parse end date '${endStr}"
-                        date match {
-                          case Full(d) => Full(Some(new Timestamp(d.getMillis)))
-                          case eb: EmptyBox =>
-                            eb ?~! s"Invalid end date"
-                        }
-                      case _                                  => Full(None)
-                    }
+        parsed   <-
+          jsonInterval
+            .fromJson[JsonLogInterval]
+            .toBox ?~! s"Error when trying to parse '${jsonInterval}' as a JSON data structure with fields 'start' and 'end'"
+        startStr <- {
+          val date =
+            tryo(DateTime.parse(parsed.start, format)) ?~! s"Error when trying to parse start date '${parsed.start}"
+          date match {
+            case Full(d) => Full(Some(new Timestamp(d.getMillis)))
+            case eb: EmptyBox => eb ?~! s"Invalid start date"
+          }
+        }
+        endStr   <- {
+          val date = tryo(DateTime.parse(parsed.end, format)) ?~! s"Error when trying to parse end date '${parsed.end}"
+          date match {
+            case Full(d) => Full(Some(new Timestamp(d.getMillis)))
+            case eb: EmptyBox => eb ?~! s"Invalid end date"
+          }
+        }
         filter    = EventLogRequest(
                       0,
                       0,

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/LogDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/LogDisplayer.scala
@@ -54,12 +54,12 @@ import net.liftweb.http.*
 import net.liftweb.http.js.*
 import net.liftweb.http.js.JE.*
 import net.liftweb.http.js.JsCmds.*
-import net.liftweb.json.JsonAST.JString
 import org.apache.commons.text.StringEscapeUtils
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
 import scala.collection.*
+import zio.json.DecoderOps
 
 /**
  * Show the reports from cfengine (raw data)
@@ -94,25 +94,23 @@ class LogDisplayer(
     val refresh = ajaxRefresh(nodeId, runDate, tableId)
     def getEventsInterval(jsonInterval: String): JsCmd = {
       import net.liftweb.util.Helpers.tryo
-      import net.liftweb.json.parse
 
       val format = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss")
 
       (for {
-        parsed   <- tryo(
-                      parse(jsonInterval)
-                    ) ?~! s"Error when trying to parse '${jsonInterval}' as a JSON datastructure with fields 'start' and 'end'"
-        startStr <- parsed \ "start" match {
-                      case JString("")       => Full(None)
-                      case JString(startStr) =>
+        parsed   <-
+          jsonInterval
+            .fromJson[JsonLogInterval]
+            .toBox ?~! s"Error when trying to parse '${jsonInterval}' as a JSON datastructure with fields 'start' and 'end'"
+        startStr <- parsed.start match {
+                      case ""       => Full(None)
+                      case startStr =>
                         tryo(Some(DateTime.parse(startStr, format))) ?~! s"Error when trying to parse start date '${startStr}"
-                      case _                 => Failure("Invalid value for start date")
                     }
-        endStr   <- parsed \ "end" match {
-                      case JString("")     => Full(None)
-                      case JString(endStr) =>
+        endStr   <- parsed.end match {
+                      case ""     => Full(None)
+                      case endStr =>
                         tryo(Some(DateTime.parse(endStr, format))) ?~! s"Error when trying to parse end date '${endStr}"
-                      case _               => Failure("Invalid value for end date")
                     }
       } yield {
         (startStr, endStr) match {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/TechniqueLibraryManagement.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/administration/TechniqueLibraryManagement.scala
@@ -62,10 +62,10 @@ import net.liftweb.http.SHtml.ElemAttr.pairToBasic
 import net.liftweb.http.js.*
 import net.liftweb.http.js.JE.*
 import net.liftweb.http.js.JsCmds.*
-import net.liftweb.json.*
 import net.liftweb.util.Helpers.*
 import org.apache.commons.text.StringEscapeUtils
 import scala.xml.*
+import zio.json.*
 
 /**
  * Snippet for managing the System and User Technique libraries.
@@ -394,18 +394,16 @@ class TechniqueLibraryManagement extends SecureDispatchSnippet with Loggable {
   }
 
   ///////////////////// Callback function for Drag'n'drop in the tree /////////////////////
-
+  final case class JsonMoveTechnique(sourceactiveTechniqueId: String, destCatId: String) derives JsonDecoder
   private def moveTechnique(arg: String)(using qc: QueryContext): JsCmd = {
     // parse arg, which have to  be json object with sourceactiveTechniqueId, destCatId
     try {
       (for {
-        case JObject(child) <- JsonParser.parse(arg)
-        case JField("sourceactiveTechniqueId", JString(sourceactiveTechniqueId)) <- child
-        case JField("destCatId", JString(destCatId)) <- child
+        parsed <- arg.fromJson[JsonMoveTechnique]
       } yield {
-        (sourceactiveTechniqueId, destCatId)
+        (parsed.sourceactiveTechniqueId, parsed.destCatId)
       }) match {
-        case (sourceactiveTechniqueId, destCatId) :: Nil =>
+        case Right(sourceactiveTechniqueId, destCatId) =>
           (for {
             activeTechnique <- roActiveTechniqueRepository
                                  .getActiveTechnique(TechniqueName(sourceactiveTechniqueId))
@@ -435,24 +433,23 @@ class TechniqueLibraryManagement extends SecureDispatchSnippet with Loggable {
                   .format(sourceactiveTechniqueId, destCatId)
               )
           }
-        case _                                           => Alert("Error while trying to move active technique: bad client parameters")
+        case _                                         => Alert("Error while trying to move active technique: bad client parameters")
       }
     } catch {
       case e: Exception => Alert("Error while trying to move active technique")
     }
   }
 
+  final case class JsonMoveCategory(sourceCatId: String, destCatId: String) derives JsonDecoder
   private def moveCategory(arg: String)(using qc: QueryContext): JsCmd = {
     // parse arg, which have to  be json object with sourceactiveTechniqueId, destCatId
     try {
       (for {
-        case JObject(child) <- JsonParser.parse(arg)
-        case JField("sourceCatId", JString(sourceCatId)) <- child
-        case JField("destCatId", JString(destCatId)) <- child
+        parsed <- arg.fromJson[JsonMoveCategory]
       } yield {
-        (sourceCatId, destCatId)
+        (parsed.sourceCatId, parsed.destCatId)
       }) match {
-        case (sourceCatId, destCatId) :: Nil =>
+        case Right(sourceCatId, destCatId) =>
           (for {
             result <- rwActiveTechniqueRepository
                         .move(ActiveTechniqueCategoryId(sourceCatId), ActiveTechniqueCategoryId(destCatId), None)(using
@@ -482,7 +479,7 @@ class TechniqueLibraryManagement extends SecureDispatchSnippet with Loggable {
                 )
               )
           }
-        case _                               => Alert("Error while trying to move category: bad client parameters")
+        case _                             => Alert("Error while trying to move category: bad client parameters")
       }
     } catch {
       case e: Exception => Alert("Error while trying to move category")
@@ -493,13 +490,11 @@ class TechniqueLibraryManagement extends SecureDispatchSnippet with Loggable {
     // parse arg, which have to be json object with sourceactiveTechniqueId, destCatId
     try {
       (for {
-        case JObject(child) <- JsonParser.parse(arg)
-        case JField("sourceactiveTechniqueId", JString(sourceactiveTechniqueId)) <- child
-        case JField("destCatId", JString(destCatId)) <- child
+        parsed <- arg.fromJson[JsonMoveTechnique]
       } yield {
-        (sourceactiveTechniqueId, destCatId)
+        (parsed.sourceactiveTechniqueId, parsed.destCatId)
       }) match {
-        case (sourceactiveTechniqueId, destCatId) :: Nil =>
+        case Right(sourceactiveTechniqueId, destCatId) =>
           if (userPropertyService.reasonsFieldBehavior != Disabled) {
             showGiveReasonPopup(ActiveTechniqueId(sourceactiveTechniqueId), ActiveTechniqueCategoryId(destCatId))
           } else {
@@ -534,7 +529,7 @@ class TechniqueLibraryManagement extends SecureDispatchSnippet with Loggable {
                 Alert(errorMess.format(sourceactiveTechniqueId, destCatId))
             }
           }
-        case _                                           =>
+        case _                                         =>
           Alert("Error while trying to move active technique: bad client parameters")
       }
     } catch {

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/node/Groups.scala
@@ -58,10 +58,10 @@ import net.liftweb.http.*
 import net.liftweb.http.js.*
 import net.liftweb.http.js.JE.*
 import net.liftweb.http.js.JsCmds.*
-import net.liftweb.json.*
 import net.liftweb.util.*
 import org.apache.commons.text.StringEscapeUtils
 import scala.xml.*
+import zio.json.*
 
 object Groups {
   val htmlId_groupTree           = "groupTree"
@@ -456,17 +456,16 @@ class Groups extends StatefulSnippet with SecureExtendableSnippet[Groups] {
   }
 
   ///////////////////// Callback function for Drag'n'drop in the tree /////////////////////
+  final private case class JsonArg(sourceGroupId: String, destCatId: String) derives JsonDecoder
   private def moveGroup(lib: FullNodeGroupCategory)(arg: String)(implicit qc: QueryContext): JsCmd = {
     // parse arg, which have to  be json object with sourceGroupId, destCatId
     try {
       (for {
-        case JObject(child) <- JsonParser.parse(arg)
-        case JField("sourceGroupId", JString(sourceGroupId)) <- child
-        case JField("destCatId", JString(destCatId)) <- child
+        parsed <- arg.fromJson[JsonArg]
       } yield {
-        (sourceGroupId, destCatId)
+        (parsed.sourceGroupId, parsed.destCatId)
       }) match {
-        case (sourceGroupId, destCatId) :: Nil =>
+        case Right(sourceGroupId, destCatId) =>
           (for {
             result <-
               woNodeGroupRepository
@@ -498,7 +497,7 @@ class Groups extends StatefulSnippet with SecureExtendableSnippet[Groups] {
                 )
               )
           }
-        case _                                 => Alert("Error while trying to move group: bad client parameters")
+        case _                               => Alert("Error while trying to move group: bad client parameters")
       }
     } catch {
       case e: Exception => Alert("Error while trying to move group")
@@ -509,13 +508,11 @@ class Groups extends StatefulSnippet with SecureExtendableSnippet[Groups] {
     // parse arg, which have to  be json object with sourceGroupId, destCatId
     try {
       (for {
-        case JObject(child) <- JsonParser.parse(arg)
-        case JField("sourceCatId", JString(sourceCatId)) <- child
-        case JField("destCatId", JString(destCatId)) <- child
+        parsed <- arg.fromJson[JsonArg]
       } yield {
-        (sourceCatId, destCatId)
+        (parsed.sourceGroupId, parsed.destCatId)
       }) match {
-        case (sourceCatId, destCatId) :: Nil =>
+        case Right(sourceCatId, destCatId) =>
           (for {
             category <- Box(
                           lib.allCategories.get(NodeGroupCategoryId(sourceCatId))
@@ -550,7 +547,7 @@ class Groups extends StatefulSnippet with SecureExtendableSnippet[Groups] {
                 )
               )
           }
-        case _                               => Alert("Error while trying to move group: bad client parameters")
+        case _                             => Alert("Error while trying to move group: bad client parameters")
       }
     } catch {
       case e: Exception => Alert("Error while trying to move group")


### PR DESCRIPTION
https://issues.rudder.io/issues/28738

Always a bit the same logic: 
- create a trivial `case class` with the shape of the parameter that `derives JsonDecoder`
- use that in place of lift json decoding, simplify 

I tried to change as little things as possible in these migration (so, not even old school formater). 