### PR TITLE
Fixes #28739: Migrate RuleGrid and JsDataTable

### DIFF
--- a/webapp/sources/.scalafmt.conf
+++ b/webapp/sources/.scalafmt.conf
@@ -2,7 +2,7 @@ version = "3.7.17"
 maxColumn = 130
 runner.debug = true
 runner.dialect = scala213Source3
-// see https://github.com/scalameta/scalameta/blob/main/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+// see https://github.com/scalameta/scalameta/blob/main/scalameta/dialects2/shared/src/main/scala/scala/meta/Dialect.scala
 // for all supported dialectOverride
 runner.dialectOverride.allowDerives = true
 runner.dialectOverride.allowEnums = true
@@ -11,6 +11,7 @@ runner.dialectOverride.allowExtensionMethods = true
 runner.dialectOverride.allowGivenUsing = true
 runner.dialectOverride.allowOpaqueTypes = true
 runner.dialectOverride.allowTraitParameters = true
+runner.dialectOverride.allowTypeLambdas = true
 
 rewrite.scala3.convertToNewSyntax = true
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/JsTableData.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/web/services/JsTableData.scala
@@ -39,24 +39,16 @@ package com.normation.rudder.web.services
 
 import com.normation.rudder.domain.reports.ComplianceLevel
 import net.liftweb.common.Loggable
-import net.liftweb.http.js.JE.JsArray
-import net.liftweb.http.js.JsExp
-import net.liftweb.http.js.JsObj
-import net.liftweb.util.Helpers.*
-import org.apache.commons.text.StringEscapeUtils
+import zio.json.*
+import zio.json.ast.*
 
 /*
  * That class represent a Line in a DataTable.
  */
 trait JsTableLine extends Loggable {
 
-  def json(freshName: () => String): JsObj
-
-  // this is needed because DataTable doesn't escape HTML element when using table.rows.add
-  def escapeHTML(s: String): JsExp = JsExp.strToJsExp(StringEscapeUtils.escapeHtml4(s))
-
   import com.normation.rudder.domain.reports.ComplianceLevelSerialisation.*
-  def jsCompliance(compliance: ComplianceLevel) = compliance.toJsArray
+  def jsCompliance(compliance: ComplianceLevel): Json.Arr = compliance.toJsArray
 
 }
 
@@ -64,9 +56,9 @@ trait JsTableLine extends Loggable {
  * That class a set of Data to use in datatable
  * It should be used as data parameter when creating datatable in javascript
  */
-final case class JsTableData[T <: JsTableLine](lines: List[T]) {
+final case class JsTableData[T <: JsTableLine](lines: List[T])
 
-  def json(freshName: () => String): JsArray = JsArray(lines.map(_.json(freshName)))
+object JsTableData {
 
-  def toJson: JsArray = json(() => nextFuncName)
+  given jsTableDataEncoder[T <: JsTableLine: JsonEncoder]: JsonEncoder[JsTableData[T]] = JsonEncoder.list.contramap(_.lines)
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/RuleGrid.scala
@@ -58,12 +58,13 @@ import com.normation.rudder.web.services.JsTableLine
 import com.normation.utils.Control.traverse
 import com.normation.utils.SimpleStatus
 import com.normation.zio.*
+import io.scalaland.chimney.*
+import io.scalaland.chimney.syntax.*
 import net.liftweb.common.*
 import net.liftweb.http.*
 import net.liftweb.http.js.*
 import net.liftweb.http.js.JE.*
 import net.liftweb.http.js.JsCmds.*
-import net.liftweb.json.*
 import net.liftweb.util.Helpers.*
 import org.apache.commons.text.StringEscapeUtils
 import scala.collection.MapView
@@ -71,6 +72,7 @@ import scala.concurrent.*
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.xml.*
 import zio.json.*
+import zio.json.internal.Write
 
 /**
  * An ADT to denote if a column should be display or not,
@@ -214,7 +216,7 @@ class RuleGrid(
               ruleCompliances = {};
               recentChanges = {};
               recentGraphs = {};
-              refreshTable("${htmlId_rulesGridId}", ${newData.toJson.toJsCmd});
+              refreshTable("${htmlId_rulesGridId}", ${newData.toJson});
               ${futureCompliance.toJsCmd}
               ${futureChanges.toJsCmd}
           """) // JsRaw ok, escaped
@@ -273,7 +275,7 @@ class RuleGrid(
         val onLoad              = {
           s"""createRuleTable (
                   "${htmlId_rulesGridId}"
-                , ${tableData.toJson.toJsCmd}
+                , ${tableData.toJson}
                 , ${showCheckboxColumn}
                 , ${showActionsColumn}
                 , ${showComplianceAndChangesColumn}
@@ -301,6 +303,8 @@ class RuleGrid(
 
   //////////////////////////////// utility methods ////////////////////////////////
 
+  final case class JsonRuleIds(rules: List[RuleId]) derives JsonDecoder
+
   private def selectAllVisibleRules(status: Boolean): JsCmd = {
     directiveApplication match {
       case Some(directiveApp) =>
@@ -308,12 +312,11 @@ class RuleGrid(
           // parse arg, which have to  be json object with sourceGroupId, destCatId
           try {
             (for {
-              case JObject(JField("rules", JArray(childs)) :: Nil) <- JsonParser.parse(arg)
-              case JString(ruleId) <- childs
+              ruleIds <- arg.fromJson[JsonRuleIds]
             } yield {
-              RuleId(RuleUid(ruleId))
+              ruleIds.rules
             }) match {
-              case ruleIds =>
+              case Right(ruleIds) =>
                 directiveApp.checkRules(ruleIds, status) match {
                   case DirectiveApplicationResult(rules, completeCategories, indeterminate) =>
                     def toId(s: String): String = StringEscapeUtils.escapeEcmaScript(s) + "Checkbox"
@@ -327,6 +330,7 @@ class RuleGrid(
                   """) // JsRaw ok, escaped
                     )
                 }
+              case Left(err)      => throw RuntimeException(err)
             }
           } catch {
             case e: Exception =>
@@ -789,42 +793,53 @@ final case class RuleLine(
     explanation:      String,
     tags:             String,
     tagsDisplayed:    Tags
-) extends JsTableLine {
+) extends JsTableLine
 
-  private def serializeTags(tags: Tags): JValue = {
-    // sort all the tags by name
-    import net.liftweb.json.JsonDSL.*
-    val m: JValue = JArray(
-      tags.tags.toList.sortBy(_.name.value).map(t => ("key", t.name.value) ~ ("value", t.value.value))
-    )
-    m
+object RuleLine {
+  // this is needed because DataTable doesn't escape HTML element when using table.rows.add
+  def escapeHTML(s: String): String = StringEscapeUtils.escapeHtml4(s)
+
+  final private case class JsonTag(key: String, value: String) derives JsonEncoder
+
+  private given Transformer[Tag, JsonTag] = (src: Tag) => JsonTag(src.name.value, src.value.value)
+
+  // the callbacks are pure JS, which should not be authorized in pur JSON. It's historical.
+  final private case class JsRaw(value: String)
+  private object JsRaw {
+
+    given JsonEncoder[JsRaw] = new JsonEncoder[JsRaw] {
+      override def unsafeEncode(a: JsRaw, indent: Option[Int], out: Write): Unit = {
+        out.write(a.value)
+      }
+    }
+
   }
 
-  /* Would love to have a reflexive way to generate that map ...  */
-  override def json(freshName: () => String): JsObj = {
+  final private case class JsonRuleLine(
+      name:             String,
+      id:               RuleId,
+      description:      String,
+      applying:         Boolean,
+      category:         String,
+      status:           String,
+      trClass:          String,
+      policyMode:       String,
+      explanation:      String,
+      tags:             String,
+      tagsDisplayed:    List[JsonTag],
+      callback:         Option[JsRaw],
+      checkboxCallback: Option[JsRaw],
+      reasons:          Option[String]
+  ) derives JsonEncoder
 
-    val reasonField = reasons.map(r => ("reasons" -> escapeHTML(r)))
+  private given Transformer[RuleLine, JsonRuleLine] = Transformer
+    .define[RuleLine, JsonRuleLine]
+    .withFieldComputed(_.reasons, _.reasons.map(r => escapeHTML(r)))
+    .withFieldComputed(_.callback, _.callback.map(x => JsRaw(x.toJsCmd)))
+    .withFieldComputed(_.checkboxCallback, _.checkboxCallback.map(x => JsRaw(x.toJsCmd)))
+    .withFieldComputed(_.tagsDisplayed, _.tagsDisplayed.tags.toList.map(_.transformInto[JsonTag]))
+    .buildTransformer
 
-    val cbCallbackField = checkboxCallback.map(cb => ("checkboxCallback" -> cb))
+  given JsonEncoder[RuleLine] = JsonEncoder[JsonRuleLine].contramap(_.transformInto[JsonRuleLine])
 
-    val callbackField = callback.map(cb => ("callback" -> cb))
-
-    val optFields: Seq[(String, JsExp)] = reasonField.toSeq ++ cbCallbackField ++ callbackField
-
-    val base = JsObj(
-      ("name", name),
-      ("id", id.serialize),
-      ("description", description),
-      ("applying", applying),
-      ("category", category),
-      ("status", status),
-      ("trClass", trClass),
-      ("policyMode", policyMode),
-      ("explanation", explanation),
-      ("tags", tags),
-      ("tagsDisplayed", serializeTags(tagsDisplayed))
-    )
-
-    base +* JsObj(optFields*)
-  }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/LogDisplayer.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/LogDisplayer.scala
@@ -49,6 +49,8 @@ import com.normation.rudder.repository.RoRuleRepository
 import com.normation.rudder.web.ChooseTemplate
 import com.normation.rudder.web.model.*
 import com.normation.utils.DateFormaterService
+import io.scalaland.chimney.*
+import io.scalaland.chimney.syntax.*
 import net.liftweb.common.*
 import net.liftweb.http.*
 import net.liftweb.http.js.*
@@ -59,7 +61,7 @@ import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
 import scala.collection.*
-import zio.json.DecoderOps
+import zio.json.*
 
 /**
  * Show the reports from cfengine (raw data)
@@ -184,7 +186,7 @@ class LogDisplayer(
 
     val data = LogDisplayer.getReportsLineForNode(reports, getDirectiveName, getRuleName)
 
-    OnLoad(JsRaw(s"""refreshTable("${StringEscapeUtils.escapeEcmaScript(tableId)}",${data.toJson.toJsCmd});"""))
+    OnLoad(JsRaw(s"""refreshTable("${StringEscapeUtils.escapeEcmaScript(tableId)}",${data.toJson});"""))
   }
 }
 
@@ -273,27 +275,44 @@ final case class ReportLine(
     component:     String,
     value:         String,
     message:       String
-) extends JsTableLine {
+) extends JsTableLine
 
-  val (kind, status): (String, String) = {
-    severity.split("_").toList match {
-      case _ :: Nil     => (severity, severity)
-      case head :: rest => (head, rest.mkString("_"))
-      case Nil          => (severity, severity)
+object ReportLine {
+  // this is needed because DataTable doesn't escape HTML element when using table.rows.add
+  def escapeHTML(s: String): String = StringEscapeUtils.escapeHtml4(s)
+
+  final private case class JsonReportLine(
+      executionDate: String,
+      runDate:       String,
+      kind:          String,
+      status:        String,
+      ruleName:      String,
+      directiveName: String,
+      component:     String,
+      value:         String,
+      message:       String
+  ) derives JsonEncoder
+
+  private given Transformer[ReportLine, JsonReportLine] = (src: ReportLine) => {
+    val (kind, status): (String, String) = {
+      src.severity.split("_").toList match {
+        case _ :: Nil     => (src.severity, src.severity)
+        case head :: rest => (head, rest.mkString("_"))
+        case Nil          => (src.severity, src.severity)
+      }
     }
-  }
-
-  def json(freshName: () => String): js.JsObj = {
-    JsObj(
-      ("executionDate", DateFormaterService.getDisplayDate(executionDate)),
-      ("runDate", DateFormaterService.getDisplayDate(runDate)),
-      ("kind", kind),
-      ("status", status),
-      ("ruleName", escapeHTML(ruleName)),
-      ("directiveName", escapeHTML(directiveName)),
-      ("component", escapeHTML(component)),
-      ("value", escapeHTML(value)),
-      ("message", escapeHTML(message))
+    JsonReportLine(
+      DateFormaterService.getDisplayDate(src.executionDate),
+      DateFormaterService.getDisplayDate(src.runDate),
+      kind,
+      status,
+      escapeHTML(src.ruleName),
+      escapeHTML(src.directiveName),
+      escapeHTML(src.component),
+      escapeHTML(src.value),
+      escapeHTML(src.message)
     )
   }
+
+  given JsonEncoder[ReportLine] = JsonEncoder[JsonReportLine].contramap(_.transformInto[JsonReportLine])
 }

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/components/RuleLineTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/components/RuleLineTest.scala
@@ -50,6 +50,7 @@ import net.liftweb.http.js.JsCmds.*
 import org.junit.runner.RunWith
 import org.specs2.mutable.*
 import org.specs2.runner.JUnitRunner
+import zio.json.*
 
 @RunWith(classOf[JUnitRunner])
 class RuleLineTest extends Specification {
@@ -82,22 +83,22 @@ class RuleLineTest extends Specification {
       )
     )
 
-    RuleGrid.getRulesData(lines, None, callback, catName).toJson.toJsCmd.replaceAll("\n", "") ===
-    """[{"name": "50. Deploy PLOP STACK", "id": "rule2", "description": "global config for all nodes",
-      | "applying": false, "category": "root rule category", "status": "In application", "trClass": "",
-      | "policyMode": "enabled", "explanation": "the mode is enabled", "tags": "{}", "tagsDisplayed": [],
-      | "callback": function(action) {lift.ajax('cb=' + encodeURIComponent(window.location = "rule2";), null, null, null);}
+    RuleGrid.getRulesData(lines, None, callback, catName).toJson.replaceAll("\n", "") ===
+    """[{"name":"50. Deploy PLOP STACK","id":"rule2","description":"global config for all nodes",
+      |"applying":false,"category":"root rule category","status":"In application","trClass":"",
+      |"policyMode":"enabled","explanation":"the mode is enabled","tags":"{}","tagsDisplayed":[],
+      |"callback":function(action) {lift.ajax('cb=' + encodeURIComponent(window.location = "rule2";), null, null, null);}
       |}]""".stripMargin.replaceAll("\n", "")
   }
 
   "Error Line serialisation" >> {
     val lines = List(ErrorLine(mockRules.rules.rpmRule, "enabled", "the mode is enabled", nodeIsEmpty = false))
 
-    RuleGrid.getRulesData(lines, None, callback, catName).toJson.toJsCmd.replaceAll("\n", "") ===
-    """[{"name": "50. Deploy PLOP STACK", "id": "rule2", "description": "global config for all nodes",
-      | "applying": false, "category": "root rule category", "status": "N/A", "trClass": " error",
-      | "policyMode": "enabled", "explanation": "the mode is enabled", "tags": "{}", "tagsDisplayed": [],
-      | "callback": function(action) {lift.ajax('cb=' + encodeURIComponent(window.location = "rule2";), null, null, null);}
+    RuleGrid.getRulesData(lines, None, callback, catName).toJson.replaceAll("\n", "") ===
+    """[{"name":"50. Deploy PLOP STACK","id":"rule2","description":"global config for all nodes",
+      |"applying":false,"category":"root rule category","status":"N/A","trClass":" error",
+      |"policyMode":"enabled","explanation":"the mode is enabled","tags":"{}","tagsDisplayed":[],
+      |"callback":function(action) {lift.ajax('cb=' + encodeURIComponent(window.location = "rule2";), null, null, null);}
       |}]""".stripMargin.replaceAll("\n", "")
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/ReportLineTest.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/com/normation/rudder/web/services/ReportLineTest.scala
@@ -47,6 +47,7 @@ import org.joda.time.DateTime
 import org.junit.runner.RunWith
 import org.specs2.mutable.*
 import org.specs2.runner.JUnitRunner
+import zio.json.*
 
 @RunWith(classOf[JUnitRunner])
 class ReportLineTest extends Specification {
@@ -96,10 +97,10 @@ class ReportLineTest extends Specification {
       case "cr" => Full("Rule name")
     }
 
-    LogDisplayer.getReportsLineForNode(reports, dirName, ruleName).toJson.toJsCmd.strip() must beEqualTo(
-      """[{"executionDate": "2024-12-14 14:47:53Z", "runDate": "2024-12-14 14:47:53Z", "kind": "result", "status": "error", "ruleName": "Rule name", "directiveName": "Directive name", "component": "component", "value": "foo", "message": "message"},
-        | {"executionDate": "2024-12-14 14:47:53Z", "runDate": "2024-12-14 14:47:53Z", "kind": "audit", "status": "compliant", "ruleName": "Rule name", "directiveName": "Directive name", "component": "component", "value": "foo", "message": "message"},
-        | {"executionDate": "2024-12-14 14:47:53Z", "runDate": "2024-12-14 14:47:53Z", "kind": "result", "status": "success", "ruleName": "Rule name", "directiveName": "Directive name", "component": "component", "value": "bar", "message": "message"}
+    LogDisplayer.getReportsLineForNode(reports, dirName, ruleName).toJson.strip() must beEqualTo(
+      """[{"executionDate":"2024-12-14 14:47:53Z","runDate":"2024-12-14 14:47:53Z","kind":"result","status":"error","ruleName":"Rule name","directiveName":"Directive name","component":"component","value":"foo","message":"message"},
+        |{"executionDate":"2024-12-14 14:47:53Z","runDate":"2024-12-14 14:47:53Z","kind":"audit","status":"compliant","ruleName":"Rule name","directiveName":"Directive name","component":"component","value":"foo","message":"message"},
+        |{"executionDate":"2024-12-14 14:47:53Z","runDate":"2024-12-14 14:47:53Z","kind":"result","status":"success","ruleName":"Rule name","directiveName":"Directive name","component":"component","value":"bar","message":"message"}
         |]""".stripMargin.replaceAll("\n", "").strip()
     )
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/28739

Needed for https://github.com/Normation/rudder-plugins/pull/948

This one was a bit more complicated because I needed to remove all the homegrown kind of JsonEncore framework we add to transform it into real `JsonEncoder`. 

The main idea is that `JsTableData` encoder is just here to require `JsTableLine` encoders. 

Then, for each kind of `JsTableLine`, the same strategy is used: 
- create a private `JsonXXX` class that mimics the old json object that was provided by `override def json(freshName: () => String): JsObj` 
- (we can notice that `freshName` isn't used anywhere anymore, so I removed it, else it would have been one more implicit parameter to deal with)
- then, create a transformer from the `XXX` to the `JsonXXX` that basically do what was on the `json()` method, 
- delete everything from the `XXX` case class. 

One noticable thing: `RuleLine` json has some JS callback in it. Since it's not real valid json, I needed to add a `JsRaw` class with a `JsonEncoder` that just output the callback string. 