### PR TITLE
Fixes #28741: Port SharedFileApi to zio-json

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/SharedFilesAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/SharedFilesAPI.scala
@@ -42,6 +42,10 @@ import cats.syntax.apply.*
 import com.normation.box.*
 import com.normation.errors.*
 import com.normation.rudder.rest.OldInternalApiAuthz
+import com.normation.rudder.rest.RudderJsonRequest.*
+import com.normation.rudder.rest.RudderJsonResponse
+import com.normation.rudder.rest.internal.SharedFileApiProcessing.*
+import com.normation.rudder.rest.internal.SharedFilePostQueries.*
 import com.normation.rudder.users.UserService
 import com.normation.utils.DateFormaterService.toJodaDateTime
 import com.normation.utils.FileUtils.*
@@ -55,21 +59,17 @@ import net.liftweb.common.EmptyBox
 import net.liftweb.common.Failure
 import net.liftweb.common.Full
 import net.liftweb.common.Loggable
-import net.liftweb.http.JsonResponse
 import net.liftweb.http.LiftResponse
 import net.liftweb.http.Req
 import net.liftweb.http.StreamingResponse
 import net.liftweb.http.rest.RestHelper
-import net.liftweb.json.JsonAST.JArray
-import net.liftweb.json.JsonAST.JField
-import net.liftweb.json.JsonAST.JNull
-import net.liftweb.json.JsonAST.JObject
-import net.liftweb.json.JsonAST.JString
-import net.liftweb.json.JsonAST.JValue
 import org.apache.commons.fileupload2.core.FileUploadSizeException
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
 import zio.ZIO
+import zio.json.*
+import zio.json.ast.*
+import zio.json.ast.Json.*
 import zio.syntax.*
 
 object SharedFilesAPI {
@@ -79,178 +79,53 @@ object SharedFilesAPI {
   val MAX_FILE_SIZE: Int = 8388608
 }
 
+@jsonExplicitNull
+final case class JStatusResponse(success: Boolean, error: Option[String]) derives JsonEncoder
+
+final private case class JResponseResult[A](result: A) derives JsonEncoder
+
+final private case class JFileInfo(
+    name:   String,
+    size:   Long,
+    `type`: String,
+    date:   String,
+    rights: String
+) derives JsonEncoder
+
+private object JFileInfo {
+
+  // this one is not a Transformer because impure
+
+  def from(file: File): IOResult[JFileInfo] = {
+    IOResult.attempt(s"Error when reading information about '${file.name}'") {
+      val date = Files.getLastModifiedTime(file.path, File.LinkOptions.noFollow*).toInstant.toJodaDateTime
+      JFileInfo(
+        file.name,
+        try { file.size }
+        catch { case _: NoSuchFileException => 0L },
+        if (file.isDirectory) "dir" else "file",
+        date.toString("yyyy-MM-dd HH:mm:ss"),
+        file.permissionsAsString(using File.LinkOptions.noFollow)
+      )
+    }
+  }
+}
+
 class SharedFilesAPI(
     userService:      UserService,
     sharedFolderPath: String,
     configRepoPath:   String
 ) extends RestHelper with Loggable {
 
-  private def checkPathAndContinue(path: String, baseFolder: File)(
-      fun: File => IOResult[LiftResponse]
-  ): IOResult[LiftResponse] = {
-    sanitizePath(baseFolder, path).flatMap(fun)
-  }
-
-  def serialize(file: File):                           IOResult[JValue]       = {
-    import net.liftweb.json.JsonDSL.*
-    IOResult.attempt(s"Error when serializing file ${file.name}") {
-      val date = Files.getLastModifiedTime(file.path, File.LinkOptions.noFollow*).toInstant.toJodaDateTime
-      (("name"    -> file.name)
-      ~ ("size"   -> (try { file.size }
-      catch { case _: NoSuchFileException => 0L }))
-      ~ ("type"   -> (if (file.isDirectory) "dir" else "file"))
-      ~ ("date"   -> date.toString("yyyy-MM-dd HH:mm:ss"))
-      ~ ("rights" -> file.permissionsAsString(using File.LinkOptions.noFollow)))
-    }
-  }
-  def errorResponse(message: String, code: Int = 500): LiftResponse           = {
-    import net.liftweb.json.JsonDSL.*
-    val content = {
-      (("success" -> false)
-      ~ ("error"  -> message))
-    }
-    JsonResponse(content, Nil, Nil, code)
-  }
-  val basicSuccessResponse:                            LiftResponse           = {
-    import net.liftweb.json.JsonDSL.*
-    val content = {
-      (("success" -> true)
-      ~ ("error"  -> JNull))
-    }
-    JsonResponse(content, Nil, Nil, 200)
-  }
-  def downloadFile(file: File):                        IOResult[LiftResponse] = {
-    IOResult.attemptZIO {
-      if (file.exists) {
-        if (file.isRegularFile) {
-          val fileSize = file.size
-          val headers  = {
-            ("Content-type"        -> "application/octet-stream") ::
-            ("Content-length"      -> fileSize.toString) ::
-            ("Content-disposition" -> s"attachment; filename=${file.name}") ::
-            Nil
-          }
-          StreamingResponse(file.newInputStream, () => {}, fileSize, headers, Nil, 200).succeed
-        } else {
-          Unexpected(s"File '${file.name}' is not a regular file").fail
-        }
-      } else {
-        Unexpected(s"File '${file.name}' does not exist").fail
-      }
-    }
-  }
-  def directoryContent(directory: File):               IOResult[LiftResponse] = {
-
-    IOResult.attemptZIO {
-      if (directory.exists) {
-        if (directory.isDirectory()) {
-          val jsonFiles: IOResult[List[JValue]] = directory.children.toSeq.accumulate(serialize)
-          jsonFiles.map { files =>
-            val result = JObject(List(JField("result", JArray(files))))
-            JsonResponse(result, List(), List(), 200)
-          }
-        } else {
-          Unexpected(s"File '${directory.name}' is not a directory").fail
-        }
-      } else {
-        Unexpected(s"File '${directory.name}' does not exist").fail
-      }
-    }
-  }
-  def fileContent(file: File): IOResult[LiftResponse] = {
-    IOResult.attemptZIO {
-      if (file.exists) {
-        if (file.isRegularFile) {
-          import net.liftweb.json.JsonDSL.*
-          val result = JObject(List(JField("result", file.contentAsString(using StandardCharsets.UTF_8))))
-          JsonResponse(result, List(), List(), 200).succeed
-        } else {
-          Unexpected(s"File '${file.name}' is not a regular file").fail
-        }
-      } else {
-        Unexpected(s"File '${file.name}' does not exist").fail
-      }
-    }
-  }
-
-  def editFile(content: String)(file: File):     IOResult[LiftResponse] = {
-    IOResult.attemptZIO {
-      if (file.exists) {
-        if (file.isRegularFile) {
-          file.write(content)
-          basicSuccessResponse.succeed
-        } else {
-          Unexpected(s"File '${file.name}' is not a regular file").fail
-        }
-      } else {
-        Unexpected(s"File '${file.name}' does not exist").fail
-      }
-    }
-  }
-  def setPerms(rawPerms: String)(file: File):    IOResult[LiftResponse] = {
-    IOResult.attempt {
-      val perms = PosixFilePermissions.fromString(rawPerms).asScala.toSet
-      file.setPermissions(perms)
-      basicSuccessResponse
-    }
-  }
-  def removeFile(file: File):                    IOResult[LiftResponse] = {
-    IOResult.attempt {
-      file.delete(true)
-      basicSuccessResponse
-    }
-  }
-  def moveToDirectory(oldFile: File)(dir: File): IOResult[LiftResponse] = {
-    IOResult.attemptZIO {
-      if (oldFile.exists) {
-        oldFile.moveToDirectory(dir)
-        basicSuccessResponse.succeed
-      } else {
-        Unexpected(s"File '${oldFile.name}' does not exist").fail
-      }
-    }
-  }
-  def copyToDirectory(oldFile: File)(dir: File): IOResult[LiftResponse] = {
-    IOResult.attemptZIO {
-      if (oldFile.exists) {
-        oldFile.copyToDirectory(dir)
-        basicSuccessResponse.succeed
-      } else {
-        Unexpected(s"File '${oldFile.name}' does not exist").fail
-      }
-    }
-  }
-  def renameFile(oldFile: File)(newFile: File):  IOResult[LiftResponse] = {
-
-    IOResult.attemptZIO {
-      if (oldFile.exists) {
-        oldFile.moveTo(newFile)
-        basicSuccessResponse.succeed
-      } else {
-        Unexpected(s"File '${oldFile.name}' does not exist").fail
-      }
-    }
-  }
-
-  def createFile(newFile: File): IOResult[LiftResponse] = {
-    IOResult.attempt {
-      newFile.createFileIfNotExists(false)
-      basicSuccessResponse
-    }
-  }
-
-  def createFolder(newdirectory: File): IOResult[LiftResponse] = {
-    IOResult.attempt {
-      newdirectory.createDirectoryIfNotExists(false)
-      basicSuccessResponse
-    }
+  private def errorResponse(message: String, code: Int = 500): LiftResponse = {
+    RudderJsonResponse.LiftJsonResponse(JStatusResponse(false, Some(message)), false, code)
   }
 
   def requestDispatch(basePath: File): PartialFunction[Req, () => Box[LiftResponse]] = {
 
     case Get(Nil, req) => {
-      implicit val prettify = false
-      implicit val action: String = "readFileResource"
+      given prettify: Boolean = false
+      given action:   String  = "readFileResource"
 
       OldInternalApiAuthz.withReadConfig(userService.getCurrentUser) {
         (req.params.get("action") match {
@@ -258,7 +133,7 @@ class SharedFilesAPI(
           case Some("download" :: Nil) =>
             req.params.get("path") match {
               case Some(path :: Nil) =>
-                checkPathAndContinue(path, basePath)(downloadFile).toBox
+                checkPathAndContinue(path, basePath)(SharedFileApiProcessing.downloadFile).toBox
               case None              =>
                 Failure("Path of file to download is not defined")
               case Some(values)      =>
@@ -280,8 +155,8 @@ class SharedFilesAPI(
     }
 
     case Post(Nil, req) => {
-      implicit val prettify = false
-      implicit val action: String = "writeFileResource"
+      given prettify: Boolean = false
+      given action:   String  = "readFileResource"
 
       OldInternalApiAuthz.withWriteConfig(userService.getCurrentUser) {
         // Accessing any of params, body and uploadedFiles on request may cause an Exception : Lift initializes
@@ -321,122 +196,73 @@ class SharedFilesAPI(
                     )
                 }
 
-              case _ => {
-                (req.json match {
+              case _ =>
+                val action = JsonCursor.field("action").isString
+
+                (req.fromJson[Json].toBox match {
                   case Full(json) => {
-                    def simpleAction(actionName: String, itemName: String, action: File => IOResult[LiftResponse]) = {
-                      json \ itemName match {
-                        case JString(path) =>
-                          checkPathAndContinue(path, basePath)(f => {
-                            (IOResult.attemptZIO(s"An error occurred while running action '${actionName}' ") {
-                              action(f)
-                            })
-                          }).toBox
-                        case _             => Failure(s"'${itemName}' is not correctly defined for '${actionName}' action")
-                      }
-                    }
+                    (json.get(action) match {
 
-                    def actionWithParam(
-                        actionName: String,
-                        itemName:   String,
-                        paramName:  String,
-                        action:     String => File => IOResult[LiftResponse]
-                    ) = {
-                      json \ itemName match {
-                        case JString(item) =>
-                          json \ paramName match {
-                            case JString(param) =>
-                              checkPathAndContinue(item, basePath)(action(param)).toBox
-                            case _              => Failure(s"'${paramName}' is not correctly defined for '${actionName}' action")
-                          }
-                        case _             => Failure(s"'${itemName}' is not correctly defined for '${actionName}' action")
-                      }
-                    }
+                      case Right(Str("list")) =>
+                        simpleAction(json, basePath, "list", "path", directoryContent)
 
-                    def actionList(
-                        actionName: String,
-                        itemName:   String,
-                        paramName:  String,
-                        action:     String => File => IOResult[LiftResponse]
-                    ) = {
-                      json \ itemName match {
-                        case JArray(items) =>
-                          ZIO
-                            .foreach(items) {
-                              case JString(item) =>
-                                json \ paramName match {
-                                  case JString(param) =>
-                                    checkPathAndContinue(item, basePath)(action(param))
-                                  case _              => Unexpected(s"'${paramName}' is not correctly defined for '${actionName}' action").fail
-                                }
-                              case item          =>
-                                Unexpected(
-                                  s"a value from array '${itemName}', for action '${actionName}' is not valid, should be a string but is: ${net.liftweb.json
-                                      .compactRender(item)}"
-                                ).fail
-                            }
-                            .map(_ => basicSuccessResponse)
-                            .toBox
-                        case _             => Failure(s"'${itemName}' is not correctly defined for '${actionName}' action")
-                      }
-                    }
+                      case Right(Str("getContent")) =>
+                        simpleAction(json, basePath, "getContent", "item", fileContent)
 
-                    (json \ "action" match {
+                      case Right(Str("createFolder")) =>
+                        simpleAction(json, basePath, "createFolder", "newPath", createFolder)
 
-                      case JString("list") =>
-                        simpleAction("list", "path", directoryContent)
+                      case Right(Str("createFile")) =>
+                        simpleAction(json, basePath, "createFolder", "newPath", createFile)
 
-                      case JString("getContent") =>
-                        simpleAction("getContent", "item", fileContent)
+                      case Right(Str("edit")) =>
+                        actionWithParam(json, basePath, "edit", "item", "content", editFile)
 
-                      case JString("createFolder") =>
-                        simpleAction("createFolder", "newPath", createFolder)
-
-                      case JString("createFile") =>
-                        simpleAction("createFolder", "newPath", createFile)
-
-                      case JString("edit") =>
-                        actionWithParam("edit", "item", "content", editFile)
-
-                      case JString("rename") =>
+                      case Right(Str("rename")) =>
                         actionWithParam(
+                          json,
+                          basePath,
                           "rename",
                           "item",
                           "newItemPath",
                           (newItem => oldFile => checkPathAndContinue(newItem, basePath)(renameFile(oldFile)))
                         )
 
-                      case JString("remove") =>
-                        json \ "items" match {
-                          case JArray(items) =>
+                      case Right(Str("remove")) =>
+                        val items = JsonCursor.field("items").isArray
+                        json.get(items) match {
+                          case Right(Arr(list)) =>
                             ZIO
-                              .foreach(items) {
-                                case JString(item) =>
+                              .foreach(list) {
+                                case Str(item) =>
                                   checkPathAndContinue(item, basePath)(removeFile)
-                                case item          =>
+                                case item      =>
                                   Unexpected(
-                                    s"a value from array 'items', for action 'remove' is not valid, should be a string but is: ${net.liftweb.json
-                                        .compactRender(item)}"
+                                    s"a value from array 'items', for action 'remove' is not valid, should be a string but is: ${item.toJson}"
                                   ).fail
                               }
                               .map(_ => basicSuccessResponse)
                               .toBox
-                          case _             => Failure("'item' is not correctly defined for 'getContent' action")
+                          case _                => Failure("'item' is not correctly defined for 'getContent' action")
                         }
 
-                      case JString("changePermissions") =>
-                        actionList("changePermissions", "items", "perms", setPerms)
+                      case Right(Str("changePermissions")) =>
+                        actionList(json, basePath, "changePermissions", "items", "perms", setPerms)
 
-                      case JString("move") =>
+                      case Right(Str("move")) =>
                         actionList(
+                          json,
+                          basePath,
                           "move",
                           "items",
                           "newPath",
                           (newItem => oldFile => checkPathAndContinue(newItem, basePath)(moveToDirectory(oldFile)))
                         )
 
-                      case JString("copy") =>
+                      case Right(Str("copy")) =>
                         actionList(
+                          json,
+                          basePath,
                           "copy",
                           "items",
                           "newPath",
@@ -456,7 +282,6 @@ class SharedFilesAPI(
                     logger.error(fail.messageChain)
                     errorResponse(fail.messageChain)
                 }
-              }
             }
           }
         }.recover {
@@ -476,9 +301,9 @@ class SharedFilesAPI(
     }
   }
 
-  def ncfRequestDispatch: PartialFunction[Req, () => Box[LiftResponse]] = {
+  private def ncfRequestDispatch: PartialFunction[Req, () => Box[LiftResponse]] = {
     new PartialFunction[Req, () => Box[LiftResponse]] {
-      def isDefinedAt(req: Req): Boolean                 = {
+      override def isDefinedAt(req: Req): Boolean = {
         req.path.partPath match {
           case "draft" :: techniqueId :: techniqueVersion :: _ =>
             val path = File(s"${configRepoPath}/workspace/${techniqueId}/${techniqueVersion}/resources")
@@ -494,7 +319,8 @@ class SharedFilesAPI(
             false
         }
       }
-      def apply(req: Req):       () => Box[LiftResponse] = {
+
+      override def apply(req: Req): () => Box[LiftResponse] = {
         req.path.partPath match {
           case "draft" :: techniqueId :: techniqueVersion :: _ =>
             val path = {
@@ -517,9 +343,245 @@ class SharedFilesAPI(
         }
       }
     }
-
   }
+
   serve("secure" :: "api" :: "sharedfile" :: Nil prefix requestDispatch(File(sharedFolderPath)))
 
   serve("secure" :: "api" :: "resourceExplorer" :: Nil prefix ncfRequestDispatch)
+}
+
+/*
+ * A separated object for the post cases
+ */
+object SharedFilePostQueries {
+
+  def checkPathAndContinue(path: String, baseFolder: File)(
+      fun: File => IOResult[LiftResponse]
+  ): IOResult[LiftResponse] = {
+    sanitizePath(baseFolder, path).flatMap(fun)
+  }
+
+  def simpleAction(
+      json:       Json,
+      basePath:   File,
+      actionName: String,
+      itemName:   String,
+      action:     File => IOResult[LiftResponse]
+  ): Box[LiftResponse] = {
+    val itemCursor = JsonCursor.field(itemName).isString
+
+    json.get(itemCursor) match {
+      case Right(Str(path)) =>
+        checkPathAndContinue(path, basePath)(f => {
+          (
+            IOResult.attemptZIO(s"An error occurred while running action '${actionName}' ") {
+              action(f)
+            }
+          )
+        }).toBox
+
+      case _ => Failure(s"'${itemName}' is not correctly defined for '${actionName}' action")
+    }
+  }
+
+  def actionWithParam(
+      json:       Json,
+      basePath:   File,
+      actionName: String,
+      itemName:   String,
+      paramName:  String,
+      action:     String => File => IOResult[LiftResponse]
+  ): Box[LiftResponse] = {
+    val itemCursor  = JsonCursor.field(itemName).isString
+    val paramCursor = JsonCursor.field(paramName).isString
+
+    json.get(itemCursor) match {
+      case Right(Str(item)) =>
+        json.get(paramCursor) match {
+          case Right(Str(param)) =>
+            checkPathAndContinue(item, basePath)(action(param)).toBox
+          case _                 =>
+            Failure(s"'${paramName}' is not correctly defined for '${actionName}' action")
+        }
+      case _                =>
+        Failure(s"'${itemName}' is not correctly defined for '${actionName}' action")
+    }
+  }
+
+  def actionList(
+      json:       Json,
+      basePath:   File,
+      actionName: String,
+      itemName:   String,
+      paramName:  String,
+      action:     String => File => IOResult[LiftResponse]
+  ): Box[LiftResponse] = {
+    val itemCursor  = JsonCursor.field(itemName).isArray
+    val paramCursor = JsonCursor.field(paramName).isString
+
+    json.get(itemCursor) match {
+      case Right(Arr(items)) =>
+        ZIO
+          .foreach(items) {
+            case Str(item) =>
+              json.get(paramCursor) match {
+                case Right(Str(param)) =>
+                  checkPathAndContinue(item, basePath)(action(param))
+                case _                 =>
+                  Unexpected(s"'${paramName}' is not correctly defined for '${actionName}' action").fail
+              }
+            case item      =>
+              Unexpected(
+                s"a value from array '${itemName}', for action '${actionName}' is not valid, should be a string but is: ${item.toJson}"
+              ).fail
+          }
+          .map(_ => basicSuccessResponse)
+          .toBox
+
+      case _ =>
+        Failure(s"'${itemName}' is not correctly defined for '${actionName}' action")
+    }
+  }
+
+}
+
+object SharedFileApiProcessing {
+
+  val basicSuccessResponse: LiftResponse = {
+    RudderJsonResponse.LiftJsonResponse(JStatusResponse(true, None), false, 200)
+  }
+
+  def downloadFile(file: File): IOResult[LiftResponse] = {
+    IOResult.attemptZIO {
+      if (file.exists) {
+        if (file.isRegularFile) {
+          val fileSize = file.size
+          val headers  = {
+            ("Content-type"        -> "application/octet-stream") ::
+            ("Content-length"      -> fileSize.toString) ::
+            ("Content-disposition" -> s"attachment; filename=${file.name}") ::
+            Nil
+          }
+          StreamingResponse(file.newInputStream, () => {}, fileSize, headers, Nil, 200).succeed
+        } else {
+          Unexpected(s"File '${file.name}' is not a regular file").fail
+        }
+      } else {
+        Unexpected(s"File '${file.name}' does not exist").fail
+      }
+    }
+  }
+
+  def directoryContent(directory: File): IOResult[LiftResponse] = {
+    IOResult.attemptZIO {
+      if (directory.exists) {
+        if (directory.isDirectory()) {
+          for {
+            children  <- IOResult.attempt(directory.children.toSeq)
+            jsonFiles <- ZIO.foreach(children)(JFileInfo.from)
+          } yield {
+            RudderJsonResponse.LiftJsonResponse(JResponseResult(jsonFiles), false, 200)
+          }
+        } else {
+          Unexpected(s"File '${directory.name}' is not a directory").fail
+        }
+      } else {
+        Unexpected(s"File '${directory.name}' does not exist").fail
+      }
+    }
+  }
+
+  def fileContent(file: File): IOResult[LiftResponse] = {
+    IOResult.attemptZIO {
+      if (file.exists) {
+        if (file.isRegularFile) {
+          val result = JResponseResult(file.contentAsString(using StandardCharsets.UTF_8))
+          RudderJsonResponse.LiftJsonResponse(result, false, 200).succeed
+        } else {
+          Unexpected(s"File '${file.name}' is not a regular file").fail
+        }
+      } else {
+        Unexpected(s"File '${file.name}' does not exist").fail
+      }
+    }
+  }
+
+  def editFile(content: String)(file: File): IOResult[LiftResponse] = {
+    IOResult.attemptZIO {
+      if (file.exists) {
+        if (file.isRegularFile) {
+          file.write(content)
+          basicSuccessResponse.succeed
+        } else {
+          Unexpected(s"File '${file.name}' is not a regular file").fail
+        }
+      } else {
+        Unexpected(s"File '${file.name}' does not exist").fail
+      }
+    }
+  }
+
+  def setPerms(rawPerms: String)(file: File): IOResult[LiftResponse] = {
+    IOResult.attempt {
+      val perms = PosixFilePermissions.fromString(rawPerms).asScala.toSet
+      file.setPermissions(perms)
+      basicSuccessResponse
+    }
+  }
+
+  def removeFile(file: File): IOResult[LiftResponse] = {
+    IOResult.attempt {
+      file.delete(true)
+      basicSuccessResponse
+    }
+  }
+
+  def moveToDirectory(oldFile: File)(dir: File): IOResult[LiftResponse] = {
+    IOResult.attemptZIO {
+      if (oldFile.exists) {
+        oldFile.moveToDirectory(dir)
+        basicSuccessResponse.succeed
+      } else {
+        Unexpected(s"File '${oldFile.name}' does not exist").fail
+      }
+    }
+  }
+
+  def copyToDirectory(oldFile: File)(dir: File): IOResult[LiftResponse] = {
+    IOResult.attemptZIO {
+      if (oldFile.exists) {
+        oldFile.copyToDirectory(dir)
+        basicSuccessResponse.succeed
+      } else {
+        Unexpected(s"File '${oldFile.name}' does not exist").fail
+      }
+    }
+  }
+
+  def renameFile(oldFile: File)(newFile: File): IOResult[LiftResponse] = {
+
+    IOResult.attemptZIO {
+      if (oldFile.exists) {
+        oldFile.moveTo(newFile)
+        basicSuccessResponse.succeed
+      } else {
+        Unexpected(s"File '${oldFile.name}' does not exist").fail
+      }
+    }
+  }
+
+  def createFile(newFile: File): IOResult[LiftResponse] = {
+    IOResult.attempt {
+      newFile.createFileIfNotExists(false)
+      basicSuccessResponse
+    }
+  }
+
+  def createFolder(newdirectory: File): IOResult[LiftResponse] = {
+    IOResult.attempt {
+      newdirectory.createDirectoryIfNotExists(false)
+      basicSuccessResponse
+    }
+  }
+
 }

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SharedFilesApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SharedFilesApiTest.scala
@@ -38,14 +38,18 @@
 package com.normation.rudder.rest
 
 import com.normation.JsonSpecMatcher
+import com.normation.rudder.rest.RudderJsonResponse.LiftJsonResponse
+import com.normation.rudder.rest.internal.JStatusResponse
 import com.normation.rudder.rest.internal.SharedFilesAPI
 import net.liftweb.common.Full
-import net.liftweb.http.JsonResponse
 import org.junit.runner.*
 import org.specs2.mutable.*
 import org.specs2.runner.*
+import scala.annotation.nowarn
+import zio.json.*
 
 @RunWith(classOf[JUnitRunner])
+@nowarn
 class SharedFilesApiTest extends Specification with JsonSpecMatcher {
 
   val restTestSetUp = RestTestSetUp.newEnv
@@ -61,14 +65,14 @@ class SharedFilesApiTest extends Specification with JsonSpecMatcher {
         Map("destination" -> "/")
       ) {
         // This is still the old Lift Json response, migrate to JsonRudderApiResponse after migrating SharedFilesAPI to zio-json
-        case Full(jsonResponse: JsonResponse) =>
+        case Full(jsonResponse: LiftJsonResponse[JStatusResponse]) =>
           jsonResponse.code must beEqualTo(200)
-          jsonResponse.json.toJsCmd must equalsJsonSemantic("""
-                                                              |{
-                                                              |  "success":true,
-                                                              |  "error":null
-                                                              |}
-                                                              |""".stripMargin)
+          jsonResponse.json.toJson must equalsJsonSemantic("""
+                                                             |{
+                                                             |  "success":true,
+                                                             |  "error":null
+                                                             |}
+                                                             |""".stripMargin)
 
         case err => ko(s"I got an error in test: ${err}")
       }
@@ -87,15 +91,15 @@ class SharedFilesApiTest extends Specification with JsonSpecMatcher {
         Map("destination" -> "/")
       ) {
         // This is still the old Lift Json response, migrate to JsonRudderApiResponse after migrating SharedFilesAPI to zio-json
-        case Full(jsonResponse: JsonResponse) =>
+        case Full(jsonResponse: LiftJsonResponse[JStatusResponse]) =>
           jsonResponse.code must beEqualTo(413)
           val maxSize = restTestSetUp.liftRules.maxMimeSize / 1024 / 1024
-          jsonResponse.json.toJsCmd must equalsJsonSemantic(s"""
-                                                               |{
-                                                               |  "success":false,
-                                                               |  "error":"File exceeds the maximum upload size of ${maxSize}MB"
-                                                               |}
-                                                               |""".stripMargin)
+          jsonResponse.json.toJson must equalsJsonSemantic(s"""
+                                                              |{
+                                                              |  "success":false,
+                                                              |  "error":"File exceeds the maximum upload size of ${maxSize}MB"
+                                                              |}
+                                                              |""".stripMargin)
 
         case err => ko(s"I got an error in test: ${err}")
       }


### PR DESCRIPTION
https://issues.rudder.io/issues/28741

This one was a bit more complicated because it is not idiomatic at all: 
- it's a direc liftjson API, 
- the API processing, the parameter parsing, the logic, everything was mixed-up, 
- it uses direct `json` AST exploration. 

# Refactoring a bit the code structure

I splitted the file in three parts: 
- the first one (`SharedFilesAPI`) is the same API declaration, it only deals with the wiring into lift API 
- the second (`SharedFilePostQueries`) is the query processing step that analyses parameters and call the actual action on file, 
- the last (`SharedFileApiProcessing`) actually do the requested processing (like delete file, move it, etc). 

The 2 and 3 are objects, they don't need external services. 

# Json processing

Since that file uses direct AST exploration for parameters in the flow in a dynamic way and I didn't want to change too much the logic to add parameters case classes, I kept the parsing of an AST (in zio-json) and using `jsonCursor` to mimic previous AST exploration. 
The resulting code is almost identical. 