### PR TITLE
Fixes #28748: Migrate CampaignApiTest and last bit in rudder-rest to zio-jons

### DIFF
--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiAuthorization.scala
@@ -54,7 +54,6 @@ import com.normation.rudder.users.RudderAccount
 import com.normation.rudder.users.UserService
 import net.liftweb.common.*
 import net.liftweb.http.LiftResponse
-import net.liftweb.json.JsonDSL.*
 
 /*
  * This trait allows to check for authorisation on a given boundedendpoint
@@ -316,7 +315,7 @@ object OldInternalApiAuthz {
           resp
         } else {
           ApiLogger.warn(fail(u.name).messageChain)
-          RestUtils.toJsonError(None, fail(u.name).messageChain, ForbiddenError)
+          RudderJsonResponse.generic.forbiddenError(false, fail(u.name).messageChain)
         }
       case None    =>
         val failure = {
@@ -325,7 +324,7 @@ object OldInternalApiAuthz {
           )
         }
         ApiLogger.warn(failure.messageChain)
-        RestUtils.toJsonError(None, failure.messageChain, ForbiddenError)
+        RudderJsonResponse.generic.unauthorizedError(false, failure.messageChain)
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestUtils.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RestUtils.scala
@@ -38,39 +38,12 @@
 package com.normation.rudder.rest
 
 import com.normation.rudder.api.ApiVersion
-import com.normation.rudder.domain.logger.ApiLogger
 import net.liftweb.common.Box
 import net.liftweb.common.EmptyBox
 import net.liftweb.common.Failure
 import net.liftweb.common.Full
 import net.liftweb.http.*
-import net.liftweb.http.provider.HTTPCookie
-import net.liftweb.json.*
-import net.liftweb.json.JsonAST.RenderSettings
-import net.liftweb.json.JsonDSL.*
 import net.liftweb.util.Helpers.tryo
-
-/*
- * A JsonResponse able to keep pretty format is asked to.
- * It's basically a copy/post of lift JsonResponse
- */
-case class JsonResponsePrettify(
-    json:     JValue,
-    headers:  List[(String, String)],
-    cookies:  List[HTTPCookie],
-    code:     Int,
-    prettify: Boolean
-) extends LiftResponse {
-  def toResponse: InMemoryResponse = {
-    val bytes = (if (prettify) RestUtils.render(json) else compactRender(json)).getBytes("UTF-8")
-    InMemoryResponse(
-      bytes,
-      ("Content-Length", bytes.length.toString) :: ("Content-Type", "application/json; charset=utf-8") :: headers,
-      cookies,
-      code
-    )
-  }
-}
 
 /**
  */
@@ -107,72 +80,6 @@ object RestUtils {
       case eb: EmptyBox => eb ?~ ("Error when getting header X-API-VERSION")
     }
   }
-
-  def getPrettify(req: Req): Box[Boolean] = {
-    req.json match {
-      case Full(json) =>
-        json \ "prettify" match {
-          case JBool(prettify) => Full(prettify)
-          case JNothing        => Full(false)
-          case x               => Failure(s"Not a valid value for 'prettify' parameter, current value is : ${x}")
-        }
-      case _          =>
-        req.params.get("prettify") match {
-          case None                 => Full(false)
-          case Some("true" :: Nil)  => Full(true)
-          case Some("false" :: Nil) => Full(false)
-          case _                    => Failure("Prettify should only have one value, and should be set to true or false")
-        }
-    }
-  }
-
-  /**
-   * Our own JSON render function to extends net.liftweb.json.JsonAst.render function
-   * All code is taken from JsonAst object from lift-json_2.10-2.5.1.jar (dépendency used in rudder 2.10 at least)
-   * and available at: https://github.com/lift/framework/blob/2.5.1/core/json/src/main/scala/net/liftweb/json/JsonAST.scala#L392
-   * What we added:
-   *   - add a new line after each element in array
-   *   - Add a new line at the end and beginning of an array and indent one more level array data
-   *   - space after colon
-   *
-   *   TODO: see if/how it is possible to get the same behaviour
-   */
-  def render(value: JValue): String = {
-    JsonAST.render(value, RenderSettings.pretty.copy(spaceAfterFieldName = true))
-  }
-
-  def effectiveResponse(
-      id:       Option[String],
-      message:  JValue,
-      status:   HttpStatus,
-      action:   String,
-      prettify: Boolean
-  ): LiftResponse = {
-    status match {
-      case _: RestError =>
-        // Log any error
-        ApiLogger.ResponseError.info(compactRender(message))
-      case _ => // Do nothing
-    }
-    val json = ("action" -> action) ~
-      ("id"             -> id) ~
-      ("result"         -> status.status) ~
-      (status.container -> message)
-
-    JsonResponsePrettify(json, List(), List(), status.code, prettify)
-  }
-
-  def toJsonResponse(id: Option[String], message: JValue)(implicit action: String, prettify: Boolean): LiftResponse = {
-    effectiveResponse(id, message, RestOk, action, prettify)
-  }
-
-  def toJsonError(id: Option[String], message: JValue, error: RestError = InternalError)(implicit
-      action:   String = "rest",
-      prettify: Boolean
-  ): LiftResponse = {
-    effectiveResponse(id, message, error, action, prettify)
-  }
-
 }
 
 trait HttpStatus {

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonResponse.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/RudderJsonResponse.scala
@@ -112,7 +112,8 @@ object RudderJsonResponse {
 
   //////////////////////////// Lift JSON response ////////////////////////////
 
-  final case class LiftJsonResponse[A](json: A, prettify: Boolean, code: Int)(using encoder: JsonEncoder[A])
+  // val in using is necessary to access the encoder in tests
+  final case class LiftJsonResponse[A](json: A, prettify: Boolean, code: Int)(using val encoder: JsonEncoder[A])
       extends LiftResponse {
     def toResponse: InMemoryResponse = {
       // Indent is not the number of space per indentation, but the level of indentation for this elem starts...

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/LiftApiDispatcher.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/LiftApiDispatcher.scala
@@ -45,7 +45,6 @@ import com.normation.rudder.rest.*
 import net.liftweb.common.*
 import net.liftweb.http.*
 import net.liftweb.http.rest.RestHelper
-import net.liftweb.json.JsonAST.JString
 import scala.util.control.NonFatal
 
 final case class DefaultParams(
@@ -274,7 +273,17 @@ class LiftHandler(
       case ApiError.BadParam(x, _)   => "Bad parameters for request: " + x
       case ApiError.Authz(x, _)      => "Authorization error: " + x
     }
-    Full(RestUtils.toJsonError(None, JString(msg), error.restCode)(using error.apiName, prettify = true))
+    Full(
+      RudderJsonResponse.LiftJsonResponse(
+        RudderJsonResponse.JsonRudderApiResponse.error(
+          None,
+          RudderJsonResponse.ResponseSchema(error.apiName, Some(error.restCode.container)),
+          msg
+        ),
+        prettify = true,
+        error.restCode.code
+      )
+    )
   }
 
   // Get the lift object that can be added in lift rooting logic

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/CampaignApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/CampaignApiTest.scala
@@ -183,11 +183,16 @@ class CampaignApiTest extends Specification with AfterAll with Loggable with Jso
          |}""".stripMargin.replaceAll("""\n""", "")
     }
 
+    def parseJson(s: String): Json = s.fromJson[Json] match {
+      case Right(v)  => v
+      case Left(err) => throw new RuntimeException(s"Error when parsing test data: ${err}")
+    }
+
     "save one campaign" in {
 
       val resp = s"""[$c1json]"""
 
-      restTest.testPOSTResponse("/secure/api/campaigns", net.liftweb.json.parse(c1json)) {
+      restTest.testPOSTResponse("/secure/api/campaigns", parseJson(c1json)) {
         case Full(LiftJsonResponse(JsonRudderApiResponse(_, _, _, Some(map), _), _, _)) =>
           map.asInstanceOf[Map[String, List[Json]]]("campaigns").toJson must equalsJsonSemantic(resp)
         case err                                                                        =>
@@ -231,7 +236,7 @@ class CampaignApiTest extends Specification with AfterAll with Loggable with Jso
     "save campaign without schedule timezone" in {
       val resp = s"[${c2jsonTz(tz)}]"
 
-      restTest.testPOSTResponse("/secure/api/campaigns", net.liftweb.json.parse(c2json)) {
+      restTest.testPOSTResponse("/secure/api/campaigns", parseJson(c2json)) {
         case Full(LiftJsonResponse(JsonRudderApiResponse(_, _, _, Some(map), _), _, _)) =>
           map.asInstanceOf[Map[String, List[Json]]]("campaigns").toJson must equalsJsonSemantic(resp)
         case err                                                                        =>
@@ -243,7 +248,7 @@ class CampaignApiTest extends Specification with AfterAll with Loggable with Jso
       val jsonWithTz = c2jsonTz("Antarctica/South_Pole")
       val resp       = s"[${jsonWithTz}]"
 
-      restTest.testPOSTResponse("/secure/api/campaigns", net.liftweb.json.parse(jsonWithTz)) {
+      restTest.testPOSTResponse("/secure/api/campaigns", parseJson(jsonWithTz)) {
         case Full(LiftJsonResponse(JsonRudderApiResponse(_, _, _, Some(map), _), _, _)) =>
           map.asInstanceOf[Map[String, List[Json]]]("campaigns").toJson must equalsJsonSemantic(resp)
         case err                                                                        =>
@@ -254,7 +259,7 @@ class CampaignApiTest extends Specification with AfterAll with Loggable with Jso
     "refuse to save a campaign with offset timezone" in {
       val jsonWithTz = c2jsonTz("+01:00")
 
-      restTest.testPOSTResponse("/secure/api/campaigns", net.liftweb.json.parse(jsonWithTz)) {
+      restTest.testPOSTResponse("/secure/api/campaigns", parseJson(jsonWithTz)) {
         case Full(LiftJsonResponse(JsonRudderApiResponseError(_, _, _, Some(err)), _, _)) =>
           err must contain("Error parsing schedule time zone, unknown IANA ID : '+01:00'")
         case s                                                                            =>

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -184,7 +184,6 @@ import net.liftweb.http.LiftRulesMocker
 import net.liftweb.http.Req
 import net.liftweb.http.S
 import net.liftweb.http.SHtml
-import net.liftweb.json.JsonAST.JValue
 import net.liftweb.mocks.MockHttpServletRequest
 import net.liftweb.mockweb.MockWeb
 import net.liftweb.util.FieldError
@@ -206,6 +205,8 @@ import scala.xml.Elem
 import scala.xml.NodeSeq
 import sourcecode.Line
 import zio.*
+import zio.json.*
+import zio.json.ast.*
 import zio.syntax.*
 import zio.test.*
 
@@ -1242,11 +1243,10 @@ class RestTest(liftRules: LiftRules) {
   def POST(path:   String): MockHttpServletRequest = mockRequest(path, "POST")
   def DELETE(path: String): MockHttpServletRequest = mockRequest(path, "DELETE")
 
-  private def mockJsonRequest(path: String, method: String, data: JValue) = {
+  private def mockJsonRequest(path: String, method: String, data: Json) = {
     val mockReq = mockRequest(path, method)
-    import net.liftweb.json.JsonAST
 
-    mockReq.body = JsonAST.prettyRender(data).getBytes()
+    mockReq.body = data.toJson.getBytes()
     mockReq.contentType = "application/json"
     mockReq
   }
@@ -1258,7 +1258,7 @@ class RestTest(liftRules: LiftRules) {
     mockReq
   }
 
-  def jsonPUT(path: String, json: JValue): MockHttpServletRequest = {
+  def jsonPUT(path: String, json: Json): MockHttpServletRequest = {
     mockJsonRequest(path, "PUT", json)
   }
 
@@ -1266,7 +1266,7 @@ class RestTest(liftRules: LiftRules) {
     mockJsonRequest(path, "PUT", json)
   }
 
-  def jsonPOST(path: String, json: JValue): MockHttpServletRequest = {
+  def jsonPOST(path: String, json: Json): MockHttpServletRequest = {
     mockJsonRequest(path, "POST", json)
   }
 
@@ -1307,10 +1307,10 @@ class RestTest(liftRules: LiftRules) {
     execRequestResponse(DELETE(path))(tests)
   }
 
-  def testPUTResponse[T](path: String, json: JValue)(tests: Box[LiftResponse] => MatchResult[T]):  MatchResult[T] = {
+  def testPUTResponse[T](path: String, json: Json)(tests: Box[LiftResponse] => MatchResult[T]):    MatchResult[T] = {
     execRequestResponse(jsonPUT(path, json))(tests)
   }
-  def testPOSTResponse[T](path: String, json: JValue)(tests: Box[LiftResponse] => MatchResult[T]): MatchResult[T] = {
+  def testPOSTResponse[T](path: String, json: Json)(tests: Box[LiftResponse] => MatchResult[T]):   MatchResult[T] = {
     execRequestResponse(jsonPOST(path, json))(tests)
   }
   def testPUTResponse[T](path: String, json: String)(tests: Box[LiftResponse] => MatchResult[T]):  MatchResult[T] = {
@@ -1344,10 +1344,10 @@ class RestTest(liftRules: LiftRules) {
     doReq(DELETE(path))(tests)
   }
 
-  def testPUT[T](path: String, json: JValue)(tests: Req => MatchResult[T]):  MatchResult[T] = {
+  def testPUT[T](path: String, json: Json)(tests: Req => MatchResult[T]):  MatchResult[T] = {
     doReq(jsonPUT(path, json))(tests)
   }
-  def testPOST[T](path: String, json: JValue)(tests: Req => MatchResult[T]): MatchResult[T] = {
+  def testPOST[T](path: String, json: Json)(tests: Req => MatchResult[T]): MatchResult[T] = {
     doReq(jsonPOST(path, json))(tests)
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SystemApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/SystemApiTest.scala
@@ -55,6 +55,7 @@ import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import org.specs2.specification.AfterAll
 import scala.annotation.nowarn
+import zio.json.*
 import zio.json.ast.Json.*
 
 @nowarn("msg=a type was inferred to be `\\w+`; this may indicate a programming error.")
@@ -434,7 +435,7 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
 
     restTestSetUp.rudderApi.getLiftRestApi().apply(req).apply() match {
 
-      case Full(resp: InMemoryResponse)                    =>
+      case Full(resp: InMemoryResponse)                                 =>
         val filenameRegex = """attachment;\s*filename="(.*)"""".r
         val filename      = resp.headers.collectFirst {
           case (h, filenameRegex(filename)) if h.equalsIgnoreCase("Content-Disposition") => filename
@@ -458,13 +459,12 @@ class SystemApiTest extends Specification with AfterAll with Loggable {
         )) and (testDir must org.specs2.matcher.ContentMatchers
           .haveSameFilesAs(restTestSetUp.mockGitRepo.configurationRepositoryRoot.toJava)
           .withFilter(filterGeneratedFile))
-      case Full(JsonResponsePrettify(json, _, _, code, _)) =>
-        import net.liftweb.http.js.JsExp.*
+      case Full(r @ RudderJsonResponse.LiftJsonResponse(json, _, code)) =>
         (code must beEqualTo(500)) and
-        (json.toJsCmd must beMatching(
+        (r.encoder.encodeJson(json, None).toString must beMatching(
           ".*Error when trying to get archive as a Zip: SystemError: Error when retrieving commit revision.*"
         ))
-      case x                                               =>
+      case x                                                            =>
         ko
     }
   }


### PR DESCRIPTION
https://issues.rudder.io/issues/28748

Need https://github.com/Normation/rudder/pull/7084 and https://github.com/Normation/rudder/pull/7085 to be merged before. 

Last bit of migration in `rudder-rest` with some cleaning. 

The only novel part is that I needed to switch `encoder` implicit parameter of `LiftJsonResponse` to public so that it can be used in the response in tests. 
