### PR TITLE
Fixes #28764: Policy generation could fail with runtime reflection error

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/MergePolicyService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/MergePolicyService.scala
@@ -257,18 +257,6 @@ object MergePolicyService {
             s"'${nodeInfo.id.value}' WITH DIFFERENT PARAMETERS VALUE. It's a bug, please report it. Taking one set of parameter " +
             s"at random for the policy generation."
           )
-          import net.liftweb.json.*
-          implicit val formats: Formats = DefaultFormats
-          def r(j: JValue) = if (j == JNothing) "{}" else prettyRender(j)
-
-          val jmain = Extraction.decompose(main)
-          PolicyGenerationLogger.error("First directivedraft: " + prettyRender(jmain))
-          seq.tail.foreach { x =>
-            val diff = jmain.diff(Extraction.decompose(x))
-            PolicyGenerationLogger.error(
-              s" Diff with other draft: \nadded:${r(diff.added)} \nchanged:${r(diff.changed)} \ndeleted:${r(diff.deleted)}"
-            )
-          }
         }
         main
     }


### PR DESCRIPTION
https://issues.rudder.io/issues/28764

The usage of lift-json makes it always produce an exception that breaks policy generation.
That blocking piece of code should be removed as we don't have diffing alternative, and it was an old (< Rudder 5) issue that has not surfaced until we test it now