### PR TITLE
Fixes #28759: Migrate Properties/Property hierarchy to zio-json

### DIFF
--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonQueryObjects.scala
@@ -663,12 +663,11 @@ trait RudderJsonDecoders {
   implicit val queryDecoder:                    JsonDecoder[StringQuery]         = DeriveJsonDecoder.gen[JQStringQuery].map(_.toQueryString)
 
   // Rest group
-  implicit val nodeGroupCategoryIdDecoder: JsonDecoder[NodeGroupCategoryId] = JsonDecoder[String].map(NodeGroupCategoryId.apply)
-  implicit val groupPropertyDecoder:       JsonDecoder[JQGroupProperty]     = DeriveJsonDecoder.gen
-  implicit val groupPropertyDecoder2:      JsonDecoder[GroupProperty]       = JsonDecoder[JQGroupProperty].map(_.toGroupProperty)
-  implicit val groupCategoryDecoder:       JsonDecoder[JQGroupCategory]     =
+  implicit val groupPropertyDecoder:  JsonDecoder[JQGroupProperty] = DeriveJsonDecoder.gen
+  implicit val groupPropertyDecoder2: JsonDecoder[GroupProperty]   = JsonDecoder[JQGroupProperty].map(_.toGroupProperty)
+  implicit val groupCategoryDecoder:  JsonDecoder[JQGroupCategory] =
     DeriveJsonDecoder.gen[JQGroupCategory].mapOrFail(JQGroupCategory.validate)
-  implicit val groupDecoder:               JsonDecoder[JQGroup]             = DeriveJsonDecoder.gen
+  implicit val groupDecoder:          JsonDecoder[JQGroup]         = DeriveJsonDecoder.gen
 
   // Settings
   implicit val allowedNetworkChunkDecoder: JsonDecoder[Chunk[AllowedNetwork]] =

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -45,6 +45,7 @@ import com.normation.cfclerk.domain.TechniqueVersion
 import com.normation.errors.*
 import com.normation.inventory.domain
 import com.normation.inventory.domain.*
+import com.normation.inventory.domain.JsonSerializers.implicits.*
 import com.normation.rudder.apidata.JsonResponseObjects.JRPropertyHierarchy.*
 import com.normation.rudder.domain.nodes
 import com.normation.rudder.domain.nodes.NodeGroup
@@ -58,6 +59,7 @@ import com.normation.rudder.domain.properties.*
 import com.normation.rudder.domain.properties.Visibility.Displayed
 import com.normation.rudder.domain.queries.*
 import com.normation.rudder.domain.reports.ComplianceLevel
+import com.normation.rudder.domain.reports.ComplianceLevelSerialisation
 import com.normation.rudder.domain.reports.ResultRepairedReport
 import com.normation.rudder.domain.reports.RunAnalysisKind
 import com.normation.rudder.domain.servers.Srv
@@ -66,6 +68,8 @@ import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.facts.nodes.IpAddress
 import com.normation.rudder.facts.nodes.NodeFact
 import com.normation.rudder.facts.nodes.NodeFact.ToCompat
+import com.normation.rudder.facts.nodes.NodeFactSerialisation.*
+import com.normation.rudder.facts.nodes.NodeFactSerialisation.SimpleCodec.*
 import com.normation.rudder.hooks.Hooks
 import com.normation.rudder.ncf.ResourceFile
 import com.normation.rudder.ncf.TechniqueParameter
@@ -77,6 +81,7 @@ import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.rule.category.RuleCategory
 import com.normation.rudder.rule.category.RuleCategoryId
 import com.normation.rudder.score.GlobalScore
+import com.normation.rudder.score.ScoreSerializer.*
 import com.normation.rudder.score.ScoreValue
 import com.normation.rudder.services.queries.*
 import com.normation.rudder.services.reports.ChangesByRule
@@ -91,7 +96,7 @@ import com.typesafe.config.ConfigRenderOptions
 import com.typesafe.config.ConfigValue
 import enumeratum.Enum
 import enumeratum.EnumEntry
-import io.scalaland.chimney.Transformer
+import io.scalaland.chimney.*
 import io.scalaland.chimney.dsl.*
 import java.time.Instant
 import java.time.LocalTime
@@ -126,9 +131,13 @@ object JsonResponseObjects {
     case object PendingInventory  extends JRInventoryStatus("pending")
     case object RemovedInventory  extends JRInventoryStatus("deleted")
 
+    given JsonEncoder[JRInventoryStatus] = JsonEncoder[String].contramap(_.name)
+
     implicit val transformer: Transformer[InventoryStatus, JRInventoryStatus] =
       Transformer.derive[InventoryStatus, JRInventoryStatus]
   }
+
+  private given JsonEncoder[Version] = JsonEncoder.string.contramap(_.value)
 
   final case class JRNodeInfo(
       id:          NodeId,
@@ -137,8 +146,9 @@ object JsonResponseObjects {
       osName:      String,
       osVersion:   Version,
       machineType: JRNodeDetailLevel.MachineType
-  )
-  object JRNodeInfo        {
+  ) derives JsonEncoder
+
+  object JRNodeInfo {
     implicit def transformer(implicit status: InventoryStatus): Transformer[NodeInfo, JRNodeInfo] = Transformer
       .define[NodeInfo, JRNodeInfo]
       .enableBeanGetters
@@ -162,7 +172,8 @@ object JsonResponseObjects {
       osName:      String,
       osVersion:   Option[Version],
       machineType: Option[JRNodeDetailLevel.MachineType]
-  )
+  ) derives JsonEncoder
+
   object JRNodeChangeStatus {
     implicit val srvTransformer: Transformer[Srv, JRNodeChangeStatus] =
       Transformer.define[Srv, JRNodeChangeStatus].enableOptionDefaultsToNone.buildTransformer
@@ -211,13 +222,16 @@ object JsonResponseObjects {
   final case class JRNodeIdStatus(
       id:     NodeId,
       status: JRInventoryStatus
-  )
+  ) derives JsonEncoder
 
   final case class JRNodeIdHostnameResult(
       id:       NodeId,
       hostname: String,
       result:   String
-  )
+  ) derives JsonEncoder
+
+  private given JsonEncoder[PolicyMode] = JsonEncoder[String].contramap(_.name)
+  private given JsonEncoder[NodeState]  = JsonEncoder[String].contramap(_.name)
 
   final case class JRUpdateNode(
       id:            NodeId,
@@ -225,8 +239,9 @@ object JsonResponseObjects {
       policyMode:    Option[PolicyMode],
       state:         NodeState,
       documentation: Option[String]
-  )
-  object JRUpdateNode       {
+  ) derives JsonEncoder
+
+  object JRUpdateNode {
     implicit val transformer: Transformer[CoreNodeFact, JRUpdateNode] = {
       Transformer
         .define[CoreNodeFact, JRUpdateNode]
@@ -284,9 +299,20 @@ object JsonResponseObjects {
       ports:                       Option[Chunk[domain.Port]],
       videos:                      Option[Chunk[domain.Video]],
       virtualMachines:             Option[Chunk[domain.VirtualMachine]]
-  )
+  ) derives JsonEncoder
 
   object JRNodeDetailLevel {
+
+    private given JsonEncoder[NodeKind]              = JsonEncoder[String].contramap(_.name)
+    private given JsonEncoder[Management]            = DeriveJsonEncoder.gen
+    private given JsonEncoder[ScheduleOverride]      = DeriveJsonEncoder.gen
+    private given JsonEncoder[ManagementDetails]     = DeriveJsonEncoder.gen
+    private given JsonEncoder[domain.License]        = DeriveJsonEncoder.gen
+    private given JsonEncoder[domain.SoftwareUuid]   = JsonEncoder[String].contramap(_.value)
+    private given JsonEncoder[domain.SoftwareEditor] = JsonEncoder.string.contramap(_.name)
+    private given JsonEncoder[domain.Software]       = DeriveJsonEncoder.gen
+    private given JsonEncoder[InstanceId]            = JsonEncoder.string.contramap(_.value)
+
     implicit def transformer(implicit
         nodeFact:   NodeFact,
         status:     InventoryStatus,
@@ -473,6 +499,8 @@ object JsonResponseObjects {
           }
           .buildTransformer
       }
+
+      given JsonEncoder[MachineType] = JsonEncoder[String].contramap(_.name)
     }
 
     /**
@@ -542,7 +570,8 @@ object JsonResponseObjects {
   final case class JRGlobalScore(
       score:   ScoreValue,
       details: Map[String, ScoreValue]
-  )
+  ) derives JsonEncoder
+
   object JRGlobalScore {
     implicit val transformer: Transformer[GlobalScore, JRGlobalScore] = {
       Transformer
@@ -553,7 +582,12 @@ object JsonResponseObjects {
     }
   }
 
-  final case class JRNodeCompliance(compliance: ComplianceLevel)       extends AnyVal
+  final case class JRNodeCompliance(compliance: ComplianceLevel) extends AnyVal
+  object JRNodeCompliance {
+    given JsonEncoder[JRNodeCompliance] =
+      JsonEncoder[ComplianceLevelSerialisation].contramap(_.compliance.transformInto[ComplianceLevelSerialisation])
+  }
+
   final case class JRNodeSystemCompliance(compliance: ComplianceLevel) extends AnyVal
   final case class JRNodeDetailTable(
       id:                      NodeId,
@@ -578,8 +612,10 @@ object JsonResponseObjects {
       properties:              Map[String, JRProperty],
       inheritedProperties:     Map[String, JRProperty],
       score:                   JRGlobalScore
-  )
+  ) derives JsonEncoder
+
   object JRNodeDetailTable {
+
     implicit def transformer(implicit
         globalPolicyMode:       GlobalPolicyMode,
         agentRunWithNodeConfig: Option[AgentRunWithNodeConfig],
@@ -660,7 +696,7 @@ object JsonResponseObjects {
   final case class JRActiveTechnique(
       name:     String,
       versions: List[String]
-  )
+  ) derives JsonEncoder
 
   object JRActiveTechnique {
     def fromTechnique(activeTechnique: FullActiveTechnique): JRActiveTechnique = {
@@ -697,7 +733,8 @@ object JsonResponseObjects {
   final case class JRDirectiveSectionVar(
       name:  String,
       value: String
-  )
+  ) derives JsonEncoder
+
   final case class JRDirectiveSection(
       name:     String, // we have one more "var" indirection level between a var and its details:
       // { vars":[ { "var":{ "name": .... } }, { "var": { ... }} ]
@@ -708,7 +745,7 @@ object JsonResponseObjects {
       // { sections":[ { "section":{ "name": .... } }, { "section": { ... }} ]
 
       sections: Option[List[Map[String, JRDirectiveSection]]]
-  ) {
+  ) derives JsonEncoder {
 
     // toMapVariable is just accumulating var by name in seq, see SectionVal.toMapVariables
     def toMapVariables: Map[String, Seq[String]] = {
@@ -734,7 +771,7 @@ object JsonResponseObjects {
   // we have one more level between a directive section and a section
   final case class JRDirectiveSectionHolder(
       section: JRDirectiveSection
-  )
+  ) derives JsonEncoder
 
   object JRDirectiveSection {
     def fromSectionVal(name: String, sectionVal: SectionVal): JRDirectiveSection = {
@@ -756,8 +793,9 @@ object JsonResponseObjects {
       date:     String,
       author:   String,
       message:  String
-  )
-  object JRRevisionInfo     {
+  ) derives JsonEncoder
+
+  object JRRevisionInfo {
     def fromRevisionInfo(r: RevisionInfo): JRRevisionInfo = {
       JRRevisionInfo(r.rev.value, DateFormaterService.serializeOffsetDateTime(r.date), r.author, r.message)
     }
@@ -846,7 +884,7 @@ object JsonResponseObjects {
       value:              String,
       message:            String,
       executionTimestamp: Instant
-  )
+  ) derives JsonEncoder
 
   object JRResultRepairedReport {
     import DateFormaterService.json.*
@@ -881,7 +919,7 @@ object JsonResponseObjects {
       policyMode:       String,
       tags:             List[Map[String, String]],
       security:         Option[SecurityTag]
-  ) {
+  ) derives JsonEncoder {
     def toDirective(): IOResult[(TechniqueName, Directive)] = {
       for {
         i <- DirectiveId.parse(id).toIO
@@ -938,15 +976,15 @@ object JsonResponseObjects {
     }
   }
 
-  final case class JRDirectives(directives: List[JRDirective])
+  final case class JRDirectives(directives: List[JRDirective]) derives JsonEncoder
 
   final case class JRDirectiveTreeCategory(
       name:          String,
       description:   String,
       subCategories: List[JRDirectiveTreeCategory],
       techniques:    List[JRDirectiveTreeTechnique]
-  )
-  object JRDirectiveTreeCategory  {
+  ) derives JsonEncoder
+  object JRDirectiveTreeCategory {
     def fromActiveTechniqueCategory(technique: FullActiveTechniqueCategory): JRDirectiveTreeCategory = {
       JRDirectiveTreeCategory(
         technique.name,
@@ -961,7 +999,8 @@ object JsonResponseObjects {
       id:         String,
       name:       String,
       directives: List[JRDirective]
-  )
+  ) derives JsonEncoder
+
   object JRDirectiveTreeTechnique {
     def fromActiveTechnique(technique: FullActiveTechnique): JRDirectiveTreeTechnique = {
       JRDirectiveTreeTechnique(
@@ -976,7 +1015,7 @@ object JsonResponseObjects {
   final case class JRApplicationStatus(
       value:   String,
       details: Option[String]
-  )
+  ) derives JsonEncoder
 
   /**
    * Rules as used in rules API.
@@ -1001,7 +1040,7 @@ object JsonResponseObjects {
       policyMode: Option[String],
       status:     Option[JRApplicationStatus],
       security:   Option[SecurityTag]
-  ) {
+  ) derives JsonEncoder {
     def toRule(): IOResult[Rule] = {
       for {
         i <- RuleId.parse(id).toIO
@@ -1073,12 +1112,13 @@ object JsonResponseObjects {
     }
   }
 
-  final case class JRRules(rules: List[JRRule])
+  final case class JRRules(rules: List[JRRule]) derives JsonEncoder
 
   sealed trait JRRuleTarget {
     def toRuleTarget: RuleTarget
   }
-  object JRRuleTarget       {
+
+  object JRRuleTarget {
     def apply(t: RuleTarget): JRRuleTarget = {
       def compose(x: TargetComposition): JRRuleTargetComposition = x match {
         case TargetUnion(targets)        => JRRuleTargetComposition.or(x.targets.toList.map(JRRuleTarget(_)))
@@ -1114,6 +1154,22 @@ object JsonResponseObjects {
     }
 
     implicit val transformer: Transformer[RuleTarget, JRRuleTarget] = apply
+
+    given JsonEncoder[JRRuleTarget] = new JsonEncoder[JRRuleTarget] {
+      implicit lazy val stringTargetEnc: JsonEncoder[JRRuleTargetString]          = JsonEncoder[String].contramap(_.r.target)
+      implicit lazy val andTargetEnc:    JsonEncoder[JRRuleTargetComposition.or]  = JsonEncoder[List[JRRuleTarget]].contramap(_.list)
+      implicit lazy val orTargetEnc:     JsonEncoder[JRRuleTargetComposition.and] = JsonEncoder[List[JRRuleTarget]].contramap(_.list)
+      implicit lazy val comp1TargetEnc:  JsonEncoder[JRRuleTargetComposed]        = DeriveJsonEncoder.gen
+      implicit lazy val comp2TargetEnc:  JsonEncoder[JRRuleTargetComposition]     = DeriveJsonEncoder.gen
+
+      override def unsafeEncode(a: JRRuleTarget, indent: Option[Int], out: Write): Unit = {
+        a match {
+          case x: JRRuleTargetString      => stringTargetEnc.unsafeEncode(x, indent, out)
+          case x: JRRuleTargetComposed    => comp1TargetEnc.unsafeEncode(x, indent, out)
+          case x: JRRuleTargetComposition => comp2TargetEnc.unsafeEncode(x, indent, out)
+        }
+      }
+    }
   }
 
   final case class JRRuleTargetInfo(
@@ -1122,7 +1178,7 @@ object JsonResponseObjects {
       description:                     String,
       @jsonField("enabled") isEnabled: Boolean,
       target:                          JRRuleTarget
-  )
+  ) derives JsonEncoder
 
   object JRRuleTargetInfo {
     implicit val transformer: Transformer[RuleTargetInfo, JRRuleTargetInfo] =
@@ -1138,7 +1194,8 @@ object JsonResponseObjects {
       parent:      Option[String],
       categories:  List[JRFullRuleCategory],
       rules:       List[JRRule]
-  )
+  ) derives JsonEncoder
+
   object JRFullRuleCategory {
     /*
      * Prepare for json.
@@ -1165,9 +1222,9 @@ object JsonResponseObjects {
   }
 
   // when returning a root category, we have a "data":{"ruleCategories":{.... }}. Seems like a bug, though
-  final case class JRCategoriesRootEntryFull(ruleCategories: JRFullRuleCategory)
-  final case class JRCategoriesRootEntrySimple(ruleCategories: JRSimpleRuleCategory)
-  final case class JRCategoriesRootEntryInfo(ruleCategories: JRRuleCategoryInfo)
+  final case class JRCategoriesRootEntryFull(ruleCategories: JRFullRuleCategory) derives JsonEncoder
+  final case class JRCategoriesRootEntrySimple(ruleCategories: JRSimpleRuleCategory) derives JsonEncoder
+  final case class JRCategoriesRootEntryInfo(ruleCategories: JRRuleCategoryInfo) derives JsonEncoder
 
   final case class JRSimpleRuleCategory(
       id:          String,
@@ -1176,7 +1233,8 @@ object JsonResponseObjects {
       parent:      String,
       categories:  List[String],
       rules:       List[String]
-  )
+  ) derives JsonEncoder
+
   object JRSimpleRuleCategory {
     def fromCategory(cat: RuleCategory, parent: String, rules: List[String]): JRSimpleRuleCategory = {
       cat
@@ -1196,8 +1254,9 @@ object JsonResponseObjects {
       parent:      Option[String],
       categories:  List[JRRuleCategoryInfo],
       rules:       List[JRRuleInfo]
-  )
-  object JRRuleCategoryInfo   {
+  ) derives JsonEncoder
+
+  object JRRuleCategoryInfo {
     def fromCategory(
         cat:      RuleCategory,
         allRules: Map[RuleCategoryId, Seq[Rule]],
@@ -1226,8 +1285,9 @@ object JsonResponseObjects {
       longDescription:  String,
       enabled:          Boolean,
       tags:             List[Map[String, String]]
-  )
-  object JRRuleInfo           {
+  ) derives JsonEncoder
+
+  object JRRuleInfo {
     def fromRule(rule: Rule): JRRuleInfo = {
       rule
         .into[JRRuleInfo]
@@ -1240,6 +1300,21 @@ object JsonResponseObjects {
     }
   }
 
+  private given JsonEncoder[InheritMode] = JsonEncoder[String].contramap(_.value)
+
+  // used in plugins - use "implicit" for import with "*"
+  implicit val configValueEncoder: JsonEncoder[ConfigValue] = new JsonEncoder[ConfigValue] {
+    override def unsafeEncode(a: ConfigValue, indent: Option[Int], out: Write): Unit = {
+      val options = ConfigRenderOptions.concise().setJson(true).setFormatted(indent.isDefined)
+      out.write(a.render(options))
+    }
+  }
+
+  private given JsonEncoder[Option[PropertyProvider]] = JsonEncoder[Option[String]].contramap {
+    case None | Some(PropertyProvider.defaultPropertyProvider) => None
+    case Some(x)                                               => Some(x.value)
+  }
+
   final case class JRGlobalParameter(
       changeRequestId: Option[String] = None,
       id:              String,
@@ -1249,12 +1324,29 @@ object JsonResponseObjects {
       provider:        Option[PropertyProvider]
   )
 
-  object JRGlobalParameter         {
+  object JRGlobalParameter {
     import GenericProperty.*
     def empty(name: String): JRGlobalParameter = JRGlobalParameter(None, name, "".toConfigValue, "", None, None)
     def fromGlobalParameter(p: GlobalParameter, crId: Option[ChangeRequestId]): JRGlobalParameter = {
       JRGlobalParameter(crId.map(_.value.toString), p.name, p.value, p.description, p.inheritMode, p.provider)
     }
+
+    given JsonEncoder[JRGlobalParameter] = DeriveJsonEncoder
+      .gen[JRGlobalParameter]
+      .contramap { g =>
+        // when inheritMode or property provider are set to their default value, don't write them
+        g.modify(_.inheritMode)
+          .using {
+            case Some(InheritMode.Default) => None
+            case x                         => x
+          }
+          .modify(_.provider)
+          .using {
+            case Some(PropertyProvider.defaultPropertyProvider) => None
+            case x                                              => x
+          }
+      }
+
   }
 
   final case class JRPropertyHierarchyStatus(
@@ -1262,7 +1354,11 @@ object JsonResponseObjects {
       fullHierarchy:         JRParentPropertyDetails,
       errorMessage:          Option[String]
   )
+
   object JRPropertyHierarchyStatus {
+
+    given JsonEncoder[JRPropertyHierarchyStatus] = DeriveJsonEncoder.gen
+
     def fromInherited(
         inheritedPropertyStatus: InheritedPropertyStatus
     ): JRPropertyHierarchyStatus = {
@@ -1294,6 +1390,9 @@ object JsonResponseObjects {
   }
 
   object JRParentPropertyDetails {
+
+    given JsonEncoder[JRParentPropertyDetails] = DeriveJsonEncoder.gen
+
     @jsonHint("global")
     final case class JRParentGlobalDetails(
         valueType: String
@@ -1337,7 +1436,11 @@ object JsonResponseObjects {
       hierarchyStatus: Option[JRPropertyHierarchyStatus],
       origval:         Option[ConfigValue]
   )
+
   object JRProperty {
+
+    given JsonEncoder[JRProperty] = DeriveJsonEncoder.gen
+
     def fromGroupProp(p: GroupProperty): JRProperty = {
       val desc = if (p.description.trim.isEmpty) None else Some(p.description)
       JRProperty(p.name, p.value, desc, p.inheritMode, p.provider, None, None, None)
@@ -1347,6 +1450,7 @@ object JsonResponseObjects {
       val desc = if (p.description.trim.isEmpty) None else Some(p.description)
       JRProperty(p.name, p.value, desc, p.inheritMode, p.provider, None, None, None)
     }
+
     def fromInheritedPropertyStatus(
         inheritedPropertyStatus: InheritedPropertyStatus,
         renderInHtml:            RenderInheritedProperties,
@@ -1452,18 +1556,19 @@ object JsonResponseObjects {
             n.parentProperty
               .map(renderHtml)
               .getOrElse(Nil) :::
-            (s"<p>from <b>Node ${n.name} (${n.id})</b>:<pre>${(if (escapeHtml) xml.Utility.escape(_: String)
-                                                               else identity[String])
+            (s"<p>from <b>node '${n.name}' (${n.id})</b>:<pre>${(if (escapeHtml) xml.Utility.escape(_: String)
+                                                                 else identity[String])
                 .apply(n.value.value.render(ConfigRenderOptions.defaults().setOriginComments(false)))}</pre></p>" :: Nil)
           case g: ParentProperty.Group =>
             g.parentProperty
               .map(renderHtml)
               .getOrElse(Nil) :::
-            (s"<p>from <b>Group ${g.name} (${g.id})</b>:<pre>${(if (escapeHtml) xml.Utility.escape(_: String)
-                                                                else identity[String])
+            (s"<p>from <b>group '${g.name}' (${g.id})</b>:<pre>${(if (escapeHtml) xml.Utility.escape(_: String)
+                                                                  else identity[String])
                 .apply(g.value.value.render(ConfigRenderOptions.defaults().setOriginComments(false)))}</pre></p>" :: Nil)
           case ParentProperty.Global(v) =>
-            s"<p>from <b>Global parameter </b>:<pre>${(if (escapeHtml) xml.Utility.escape(_: String) else identity[String])
+            s"<p>from <b>global property '${v.name}'</b>:<pre>${(if (escapeHtml) xml.Utility.escape(_: String)
+                                                                 else identity[String])
                 .apply(v.value.render(ConfigRenderOptions.defaults().setOriginComments(false)))}</pre></p>" :: Nil
         }
       }
@@ -1486,6 +1591,9 @@ object JsonResponseObjects {
 
   @jsonDiscriminator("kind") sealed trait JRParentProperty { def value: ConfigValue }
   object JRParentProperty                                  {
+
+    given JsonEncoder[JRParentProperty] = DeriveJsonEncoder.gen
+
     @jsonHint("global")
     final case class JRParentGlobal(
         value: ConfigValue
@@ -1521,16 +1629,28 @@ object JsonResponseObjects {
   }
 
   sealed trait JRPropertyHierarchy extends Product
+
   object JRPropertyHierarchy {
     final case class JRPropertyHierarchyHtml(html: String)              extends JRPropertyHierarchy
     final case class JRPropertyHierarchyJson(parents: JRParentProperty) extends JRPropertyHierarchy
+
+    given JsonEncoder[JRPropertyHierarchy] = new JsonEncoder[JRPropertyHierarchy] {
+      override def unsafeEncode(a: JRPropertyHierarchy, indent: Option[Int], out: Write): Unit = {
+        a match {
+          case JRPropertyHierarchy.JRPropertyHierarchyJson(parents) =>
+            JsonEncoder[JRParentProperty].unsafeEncode(parents, indent, out)
+          case JRPropertyHierarchy.JRPropertyHierarchyHtml(html)    =>
+            JsonEncoder[String].unsafeEncode(html, indent, out)
+        }
+      }
+    }
   }
 
   final case class JRGroupInheritedProperties(
       groupId:      String,
       properties:   Chunk[JRProperty],
       errorMessage: Option[String]
-  )
+  ) derives JsonEncoder
 
   final case class JRPropertyId(value: String) extends AnyVal
   object JRPropertyId {
@@ -1760,6 +1880,7 @@ object JsonResponseObjects {
       }
     }
   }
+
   object JRGroupInheritedProperties {
     def fromGroup(
         groupId:          NodeGroupId,
@@ -1782,8 +1903,9 @@ object JsonResponseObjects {
       nodeId:       NodeId,
       properties:   Chunk[JRProperty],
       errorMessage: Option[String]
-  )
-  object JRNodeInheritedProperties  {
+  ) derives JsonEncoder
+
+  object JRNodeInheritedProperties {
     def fromNode(
         nodeId:           NodeId,
         propertyStatuses: Iterable[PropertyStatus],
@@ -1806,11 +1928,12 @@ object JsonResponseObjects {
       attribute:  String,
       comparator: String,
       value:      String
-  ) {
+  ) derives JsonEncoder {
     def toStringCriterionLine: StringCriterionLine = StringCriterionLine(objectType, attribute, comparator, Some(value))
   }
 
   object JRCriterium {
+
     def fromCriterium(c: CriterionLine): JRCriterium = {
       c.into[JRCriterium]
         .withFieldComputed(_.objectType, _.objectType.objectType)
@@ -1825,9 +1948,10 @@ object JsonResponseObjects {
       composition: String,
       transform:   Option[String],
       where:       List[JRCriterium]
-  )
+  ) derives JsonEncoder
 
   object JRQuery {
+
     def fromQuery(query: Query): JRQuery = {
       JRQuery(
         query.returnType.value,
@@ -1855,7 +1979,7 @@ object JsonResponseObjects {
       properties:      List[JRProperty],
       target:          String,
       system:          Boolean
-  )
+  ) derives JsonEncoder
 
   /**
    * Group as used in groups API.
@@ -1878,7 +2002,7 @@ object JsonResponseObjects {
       target:                              String,
       system:                              Boolean,
       security:                            Option[SecurityTag]
-  ) {
+  ) derives JsonEncoder {
     def toGroup(queryParser: CmdbQueryParser): IOResult[(NodeGroupCategoryId, NodeGroup)] = {
       for {
         i <- NodeGroupId.parse(id).toIO
@@ -1954,8 +2078,8 @@ object JsonResponseObjects {
   /**
    * Data container for the whole group category tree, provides the "groupCategories" dataContainer
    */
-  final case class JRGroupCategoriesFull(groupCategories: JRFullGroupCategory)
-  final case class JRGroupCategoriesFullV21(groupCategories: JRFullGroupCategoryV21)
+  final case class JRGroupCategoriesFull(groupCategories: JRFullGroupCategory) derives JsonEncoder
+  final case class JRGroupCategoriesFullV21(groupCategories: JRFullGroupCategoryV21) derives JsonEncoder
   object JRGroupCategoriesFullV21 {
     given Transformer[JRGroupCategoriesFull, JRGroupCategoriesFullV21] =
       Transformer.derive[JRGroupCategoriesFull, JRGroupCategoriesFullV21]
@@ -1964,7 +2088,7 @@ object JsonResponseObjects {
   /**
    * Data container for the group category tree with minimal info, provides the "groupCategories" dataContainer
    */
-  final case class JRGroupCategoriesMinimal(groupCategories: JRMinimalGroupCategory)
+  final case class JRGroupCategoriesMinimal(groupCategories: JRMinimalGroupCategory) derives JsonEncoder
 
   /**
    * Representation of a group category with full group information
@@ -1977,7 +2101,7 @@ object JsonResponseObjects {
       @jsonField("categories") subCategories: List[JRFullGroupCategory],
       groups:                                 List[JRGroup],
       @jsonField("targets") targetInfos:      List[JRRuleTargetInfo]
-  )
+  ) derives JsonEncoder
 
   /**
    * Representation with the API format < version 21 of groups
@@ -1990,7 +2114,7 @@ object JsonResponseObjects {
       @jsonField("categories") subCategories: List[JRFullGroupCategoryV21],
       groups:                                 List[JRGroupV21],
       @jsonField("targets") targetInfos:      List[JRRuleTargetInfo]
-  )
+  ) derives JsonEncoder
 
   object JRFullGroupCategory {
     /*
@@ -2042,7 +2166,7 @@ object JsonResponseObjects {
       @jsonField("categories") subCategories: List[NodeGroupCategoryId],
       groups:                                 List[NodeGroupId],
       @jsonField("targets") targetInfos:      List[JRRuleTargetInfo]
-  )
+  ) derives JsonEncoder
 
   object JRMinimalGroupCategory {
     def fromCategory(
@@ -2086,7 +2210,7 @@ object JsonResponseObjects {
       @jsonField("categories") subCategories: List[JRGroupCategoryInfo],
       groups:                                 List[JRGroupCategoryInfo.JRGroupInfo],
       @jsonField("targets") targetInfos:      List[JRRuleTargetInfo]
-  )
+  ) derives JsonEncoder
 
   object JRGroupCategoryInfo {
     final case class JRGroupInfo(
@@ -2097,7 +2221,8 @@ object JsonResponseObjects {
         @jsonField("dynamic") isDynamic: Boolean,
         @jsonField("enabled") isEnabled: Boolean,
         target:                          String
-    )
+    ) derives JsonEncoder
+
     object JRGroupInfo {
       implicit def transformer(implicit categoryId: Option[NodeGroupCategoryId]): Transformer[NodeGroup, JRGroupInfo] = {
         Transformer
@@ -2141,7 +2266,7 @@ object JsonResponseObjects {
 
       numberOfNodes:      Int,
       numberOfDirectives: Int
-  )
+  ) derives JsonEncoder
 
   object JRRuleNodesDirectives {
     // create an empty json rule with just ID set
@@ -2156,7 +2281,7 @@ object JsonResponseObjects {
   final case class JRHooks(
       basePath:  String,
       hooksFile: List[String]
-  )
+  ) derives JsonEncoder
 
   object JRHooks {
     def fromHook(hook: Hooks): JRHooks = {
@@ -2168,12 +2293,15 @@ object JsonResponseObjects {
     }
   }
 
-  final case class JRAllowedNetworksNode(allowed_networks: Chunk[JRAllowedNetwork])
-  final case class JRAllowedNetwork(id: String, allowed_networks: Chunk[AllowedNetwork])
+  private given JsonEncoder[AllowedNetwork]        = JsonEncoder[String].contramap(_.inet)
+  private given JsonEncoder[Chunk[AllowedNetwork]] = JsonEncoder.chunk[AllowedNetwork].contramap(_.sortBy(_.inet))
 
-  final case class JRAllowedNetworks(allowed_networks: Chunk[AllowedNetwork])
+  final case class JRAllowedNetworksNode(allowed_networks: Chunk[JRAllowedNetwork]) derives JsonEncoder
+  final case class JRAllowedNetwork(id: String, allowed_networks: Chunk[AllowedNetwork]) derives JsonEncoder
 
-  final case class JRSettings(settings: Json.Obj)
+  final case class JRAllowedNetworks(allowed_networks: Chunk[AllowedNetwork]) derives JsonEncoder
+
+  final case class JRSettings(settings: Json.Obj) derives JsonEncoder
   object JRSettings {
     def apply(keyValue: (String, Json)):        JRSettings = JRSettings(Json.Obj(keyValue))
     def apply(chunk:    Chunk[(String, Json)]): JRSettings = JRSettings(Json.Obj(chunk))
@@ -2183,184 +2311,4 @@ object JsonResponseObjects {
     (a: Seq[A]) => Chunk.fromIterable(a.map(transformer.transform))
   }
 
-}
-//////////////////////////// zio-json encoders ////////////////////////////
-
-object JRRuleEncoder {
-
-  import JsonResponseObjects.*
-  import JsonResponseObjects.JRRuleTarget.*
-
-  // FIXME: hide / split some encoders to reduce method size
-  implicit val targetEncoder: JsonEncoder[JRRuleTarget] = new JsonEncoder[JRRuleTarget] {
-    implicit lazy val stringTargetEnc: JsonEncoder[JRRuleTargetString]          = JsonEncoder[String].contramap(_.r.target)
-    implicit lazy val andTargetEnc:    JsonEncoder[JRRuleTargetComposition.or]  = JsonEncoder[List[JRRuleTarget]].contramap(_.list)
-    implicit lazy val orTargetEnc:     JsonEncoder[JRRuleTargetComposition.and] = JsonEncoder[List[JRRuleTarget]].contramap(_.list)
-    implicit lazy val comp1TargetEnc:  JsonEncoder[JRRuleTargetComposed]        = DeriveJsonEncoder.gen
-    implicit lazy val comp2TargetEnc:  JsonEncoder[JRRuleTargetComposition]     = DeriveJsonEncoder.gen
-
-    override def unsafeEncode(a: JRRuleTarget, indent: Option[Int], out: Write): Unit = {
-      a match {
-        case x: JRRuleTargetString      => stringTargetEnc.unsafeEncode(x, indent, out)
-        case x: JRRuleTargetComposed    => comp1TargetEnc.unsafeEncode(x, indent, out)
-        case x: JRRuleTargetComposition => comp2TargetEnc.unsafeEncode(x, indent, out)
-      }
-    }
-  }
-
-  implicit lazy val applicationStatusEncoder:  JsonEncoder[JRApplicationStatus]   = DeriveJsonEncoder.gen
-  implicit lazy val ruleTargetInfoEncoder:     JsonEncoder[JRRuleTargetInfo]      = DeriveJsonEncoder.gen
-  implicit lazy val ruleEncoder:               JsonEncoder[JRRule]                = DeriveJsonEncoder.gen
-  implicit lazy val ruleNodesDirectiveEncoder: JsonEncoder[JRRuleNodesDirectives] = DeriveJsonEncoder.gen
-  implicit lazy val ruleInfoEncoder:           JsonEncoder[JRRuleInfo]            = DeriveJsonEncoder.gen
-}
-
-object CategoryEncoder {
-  import JRRuleEncoder.*
-  import JsonResponseObjects.*
-
-  implicit lazy val simpleCategoryEncoder: JsonEncoder[JRSimpleRuleCategory]        = DeriveJsonEncoder.gen
-  implicit lazy val fullCategoryEncoder:   JsonEncoder[JRFullRuleCategory]          = DeriveJsonEncoder.gen
-  implicit lazy val infoCategoryEncoder:   JsonEncoder[JRRuleCategoryInfo]          = DeriveJsonEncoder.gen
-  implicit lazy val rootCategoryEncoder1:  JsonEncoder[JRCategoriesRootEntryFull]   = DeriveJsonEncoder.gen
-  implicit lazy val rootCategoryEncoder2:  JsonEncoder[JRCategoriesRootEntrySimple] = DeriveJsonEncoder.gen
-  implicit lazy val rootCategoryEncoder3:  JsonEncoder[JRCategoriesRootEntryInfo]   = DeriveJsonEncoder.gen
-
-}
-
-object DirectiveEncoder {
-  import JsonResponseObjects.*
-
-  implicit lazy val directiveSectionVarEncoder:    JsonEncoder[JRDirectiveSectionVar]    = DeriveJsonEncoder.gen
-  implicit lazy val directiveSectionHolderEncoder: JsonEncoder[JRDirectiveSectionHolder] = DeriveJsonEncoder.gen
-  implicit lazy val directiveSectionEncoder:       JsonEncoder[JRDirectiveSection]       = DeriveJsonEncoder.gen
-  implicit lazy val directiveEncoder:              JsonEncoder[JRDirective]              = DeriveJsonEncoder.gen
-  implicit lazy val directivesEncoder:             JsonEncoder[JRDirectives]             = DeriveJsonEncoder.gen
-  implicit lazy val directiveTreeTechniqueEncoder: JsonEncoder[JRDirectiveTreeTechnique] = DeriveJsonEncoder.gen
-  implicit lazy val directiveTreeEncoder:          JsonEncoder[JRDirectiveTreeCategory]  = DeriveJsonEncoder.gen
-}
-
-trait RudderJsonEncoders {
-  export CategoryEncoder.*
-  export DirectiveEncoder.*
-  export JRRuleEncoder.*
-  import JsonResponseObjects.*
-  import JsonResponseObjects.JRNodeDetailLevel.*
-  import com.normation.inventory.domain.JsonSerializers.implicits.*
-  import com.normation.rudder.domain.reports.ComplianceLevelSerialisation.array.*
-  import com.normation.rudder.facts.nodes.NodeFactSerialisation.*
-  import com.normation.rudder.facts.nodes.NodeFactSerialisation.SimpleCodec.*
-  import com.normation.rudder.score.ScoreSerializer.*
-
-  implicit lazy val groupCategoryIdEncoder: JsonEncoder[NodeGroupCategoryId] = JsonEncoder[String].contramap(_.value)
-  implicit lazy val hookEncoder:            JsonEncoder[JRHooks]             = DeriveJsonEncoder.gen
-  implicit lazy val rulesEncoder:           JsonEncoder[JRRules]             = DeriveJsonEncoder.gen
-  implicit lazy val activeTechniqueEncoder: JsonEncoder[JRActiveTechnique]   = DeriveJsonEncoder.gen
-
-  implicit lazy val configValueEncoder:      JsonEncoder[ConfigValue]              = new JsonEncoder[ConfigValue] {
-    override def unsafeEncode(a: ConfigValue, indent: Option[Int], out: Write): Unit = {
-      val options = ConfigRenderOptions.concise().setJson(true).setFormatted(indent.isDefined)
-      out.write(a.render(options))
-    }
-  }
-  implicit lazy val propertyProviderEncoder: JsonEncoder[Option[PropertyProvider]] = JsonEncoder[Option[String]].contramap {
-    case None | Some(PropertyProvider.defaultPropertyProvider) => None
-    case Some(x)                                               => Some(x.value)
-  }
-  implicit lazy val inheritModeEncoder:      JsonEncoder[InheritMode]              = JsonEncoder[String].contramap(_.value)
-  implicit lazy val globalParameterEncoder:  JsonEncoder[JRGlobalParameter]        = DeriveJsonEncoder
-    .gen[JRGlobalParameter]
-    .contramap(g => {
-      // when inheritMode or property provider are set to their default value, don't write them
-      g.modify(_.inheritMode)
-        .using {
-          case Some(InheritMode.Default) => None
-          case x                         => x
-        }
-        .modify(_.provider)
-        .using {
-          case Some(PropertyProvider.defaultPropertyProvider) => None
-          case x                                              => x
-        }
-    })
-
-  implicit lazy val propertyJRParentProperty: JsonEncoder[JRParentProperty] = DeriveJsonEncoder.gen
-
-  implicit lazy val propertyHierarchyEncoder:        JsonEncoder[JRPropertyHierarchy]        = new JsonEncoder[JRPropertyHierarchy] {
-    override def unsafeEncode(a: JRPropertyHierarchy, indent: Option[Int], out: Write): Unit = {
-      a match {
-        case JRPropertyHierarchy.JRPropertyHierarchyJson(parents) =>
-          JsonEncoder[JRParentProperty].unsafeEncode(parents, indent, out)
-        case JRPropertyHierarchy.JRPropertyHierarchyHtml(html)    =>
-          JsonEncoder[String].unsafeEncode(html, indent, out)
-      }
-    }
-  }
-  implicit lazy val propertyDetailsEncoder:          JsonEncoder[JRParentPropertyDetails]    = DeriveJsonEncoder.gen
-  implicit lazy val propertyHierarchyStatusEncoder:  JsonEncoder[JRPropertyHierarchyStatus]  = DeriveJsonEncoder.gen
-  implicit lazy val propertyEncoder:                 JsonEncoder[JRProperty]                 = DeriveJsonEncoder.gen
-  implicit lazy val criteriumEncoder:                JsonEncoder[JRCriterium]                = DeriveJsonEncoder.gen
-  implicit lazy val queryEncoder:                    JsonEncoder[JRQuery]                    = DeriveJsonEncoder.gen
-  implicit lazy val groupV21Encoder:                 JsonEncoder[JRGroupV21]                 = DeriveJsonEncoder.gen
-  implicit lazy val groupEncoder:                    JsonEncoder[JRGroup]                    = DeriveJsonEncoder.gen
-  implicit lazy val objectInheritedObjectProperties: JsonEncoder[JRGroupInheritedProperties] = DeriveJsonEncoder.gen
-
-  implicit lazy val fullGroupCategoryEncoder:      JsonEncoder[JRFullGroupCategory]             = DeriveJsonEncoder.gen
-  implicit lazy val fullGroupCategoryV21Encoder:   JsonEncoder[JRFullGroupCategoryV21]          = DeriveJsonEncoder.gen
-  implicit lazy val minimalGroupCategoryEncoder:   JsonEncoder[JRMinimalGroupCategory]          = DeriveJsonEncoder.gen
-  implicit lazy val groupCategoriesFullEncoder:    JsonEncoder[JRGroupCategoriesFull]           = DeriveJsonEncoder.gen
-  implicit lazy val groupCategoriesFullV21Encoder: JsonEncoder[JRGroupCategoriesFullV21]        = DeriveJsonEncoder.gen
-  implicit lazy val groupCategoriesMinimalEncoder: JsonEncoder[JRGroupCategoriesMinimal]        = DeriveJsonEncoder.gen
-  implicit lazy val groupInfoEncoder:              JsonEncoder[JRGroupCategoryInfo.JRGroupInfo] = DeriveJsonEncoder.gen
-  implicit lazy val groupCategoryInfoEncoder:      JsonEncoder[JRGroupCategoryInfo]             = DeriveJsonEncoder.gen
-
-  implicit lazy val nodeIdEncoder:                  JsonEncoder[NodeId]                    = JsonEncoder[String].contramap(_.value)
-  implicit lazy val nodeInheritedPropertiesEncdoer: JsonEncoder[JRNodeInheritedProperties] = DeriveJsonEncoder.gen
-
-  implicit lazy val revisionInfoEncoder: JsonEncoder[JRRevisionInfo] = DeriveJsonEncoder.gen
-
-  implicit lazy val statusEncoder: JsonEncoder[JRInventoryStatus] = JsonEncoder[String].contramap(_.name)
-  implicit lazy val stateEncoder:  JsonEncoder[NodeState]         = JsonEncoder[String].contramap(_.name)
-
-  implicit lazy val machineTypeEncoder: JsonEncoder[MachineType] = JsonEncoder[String].contramap(_.name)
-
-  implicit lazy val nodeInfoEncoder: JsonEncoder[JRNodeInfo] = DeriveJsonEncoder.gen
-
-  implicit lazy val nodeChangeStatusEncoder: JsonEncoder[JRNodeChangeStatus] = DeriveJsonEncoder.gen
-
-  implicit lazy val nodeIdStatusEncoder:         JsonEncoder[JRNodeIdStatus]         = DeriveJsonEncoder.gen
-  implicit lazy val nodeIdHostnameResultEncoder: JsonEncoder[JRNodeIdHostnameResult] = DeriveJsonEncoder.gen
-
-  implicit lazy val updateNodeEncoder: JsonEncoder[JRUpdateNode] = DeriveJsonEncoder.gen
-
-  // Node details
-
-  implicit lazy val vmTypeEncoder: JsonEncoder[VmType] = JsonEncoder[String].contramap(_.name)
-
-  implicit lazy val nodeKindEncoder:          JsonEncoder[NodeKind]            = JsonEncoder[String].contramap(_.name)
-  implicit lazy val managementEncoder:        JsonEncoder[Management]          = DeriveJsonEncoder.gen
-  implicit lazy val scheduleOverrideEncoder:  JsonEncoder[ScheduleOverride]    = DeriveJsonEncoder.gen
-  implicit lazy val managementDetailsEncoder: JsonEncoder[ManagementDetails]   = DeriveJsonEncoder.gen
-  implicit lazy val licenseEncoder:           JsonEncoder[domain.License]      = DeriveJsonEncoder.gen
-  implicit lazy val softwareUuidEncoder:      JsonEncoder[domain.SoftwareUuid] = JsonEncoder[String].contramap(_.value)
-  implicit lazy val softwareEncoder:          JsonEncoder[domain.Software]     = DeriveJsonEncoder.gen
-
-  implicit lazy val encoderInstanceId:      JsonEncoder[InstanceId]        = JsonEncoder.string.contramap(_.value)
-  implicit lazy val nodeDetailLevelEncoder: JsonEncoder[JRNodeDetailLevel] = DeriveJsonEncoder.gen
-
-  implicit lazy val runAnalysisKindEncoder:  JsonEncoder[RunAnalysisKind]   = JsonEncoder[String].contramap(_.entryName)
-  implicit lazy val jrNodeComplianceEncoder: JsonEncoder[JRNodeCompliance]  = JsonEncoder[ComplianceLevel].contramap(_.compliance)
-  implicit lazy val policyModeSerializer:    JsonEncoder[PolicyMode]        = JsonEncoder[String].contramap(_.name)
-  implicit lazy val jrGlobalScoreEncoder:    JsonEncoder[JRGlobalScore]     = DeriveJsonEncoder.gen
-  implicit lazy val nodeDetailTableEncoder:  JsonEncoder[JRNodeDetailTable] = DeriveJsonEncoder.gen
-
-  implicit lazy val allowedNetworkEncoder:        JsonEncoder[AllowedNetwork]        = JsonEncoder[String].contramap(_.inet)
-  implicit lazy val allowedNetworkChunkEncoder:   JsonEncoder[Chunk[AllowedNetwork]] =
-    JsonEncoder.chunk[AllowedNetwork].contramap(_.sortBy(_.inet))
-  implicit lazy val jrAllowedNetworkEncoder:      JsonEncoder[JRAllowedNetwork]      = DeriveJsonEncoder.gen
-  implicit lazy val jrAllowedNetworksNodeEncoder: JsonEncoder[JRAllowedNetworksNode] = DeriveJsonEncoder.gen
-  implicit lazy val jrAllowedNetworksEncoder:     JsonEncoder[JRAllowedNetworks]     = DeriveJsonEncoder.gen
-  implicit lazy val jrSettingsEncoder:            JsonEncoder[JRSettings]            = DeriveJsonEncoder.gen
-
-  implicit lazy val jrResultRepairedReport: JsonEncoder[JRResultRepairedReport] = DeriveJsonEncoder.gen
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/implicits.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/implicits.scala
@@ -37,4 +37,4 @@
 
 package com.normation.rudder.apidata
 
-object implicits extends RudderJsonDecoders with RudderJsonEncoders
+object implicits extends RudderJsonDecoders

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeGroupCategory.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/nodes/NodeGroupCategory.scala
@@ -41,11 +41,16 @@ import com.normation.rudder.domain.categories.ItemCategory
 import com.normation.rudder.domain.policies.RuleTargetInfo
 import com.normation.rudder.tenants.HasSecurityTag
 import com.normation.rudder.tenants.SecurityTag
+import zio.json.JsonCodec
 
 /**
  * The Id for the server group category
  */
 final case class NodeGroupCategoryId(value: String) extends AnyVal
+
+object NodeGroupCategoryId {
+  given JsonCodec[NodeGroupCategoryId] = JsonCodec.string.transform(NodeGroupCategoryId.apply, _.value)
+}
 
 /**
  * A server group category is quite similar to a Technique category :

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/Properties.scala
@@ -48,8 +48,6 @@ import com.normation.rudder.tenants.HasSecurityTag
 import com.normation.rudder.tenants.SecurityTag
 import com.typesafe.config.*
 import enumeratum.*
-import net.liftweb.json.*
-import scala.annotation.nowarn
 import zio.json
 import zio.json.*
 import zio.json.ast.*
@@ -369,14 +367,6 @@ object GenericProperty {
       value.render(option)
     }
   }
-  def serializeJson(value: JValue):                               String = {
-    // special case for string: we need to remove "" for compat with agents
-    value match {
-      case JNothing   => ""
-      case JString(s) => s
-      case x          => compactRender(x)
-    }
-  }
 
   /*
    * Merge two json values, overriding or merging recursively
@@ -571,27 +561,6 @@ object GenericProperty {
     def serializeGlobalParameter: String = value.render(ConfigRenderOptions.concise().setComments(true))
   }
 
-  /**
-   * Parse a JSON JValue to ConfigValue. It always succeeds.
-   * @deprecated for removal, please use the {@link #fromZioJson()} method instead.
-   */
-  @Deprecated(since = "7.0", forRemoval = true)
-  def fromJsonValue(value: JValue):          ConfigValue = {
-    import scala.jdk.CollectionConverters.*
-    value match {
-      case JNothing | JNull => ConfigValueFactory.fromAnyRef("")
-      case JString(s)       => ConfigValueFactory.fromAnyRef(s)
-      case JDouble(d)       => ConfigValueFactory.fromAnyRef(d)
-      case JInt(num)        => ConfigValueFactory.fromAnyRef(num)
-      case JBool(b)         => ConfigValueFactory.fromAnyRef(b)
-      case JObject(arr)     => {
-        val m = new java.util.HashMap[String, ConfigValue]()
-        arr.foreach(f => m.put(f.name, fromJsonValue(f.value): @nowarn("msg=deprecated")))
-        ConfigValueFactory.fromMap(m)
-      }
-      case JArray(arr)      => ConfigValueFactory.fromIterable(arr.map(x => fromJsonValue(x): @nowarn("msg=deprecated")).asJava)
-    }
-  }
   def fromZioJson(value: zio.json.ast.Json): ConfigValue = {
     import zio.json.ast.Json.*
 
@@ -618,27 +587,6 @@ object GenericProperty {
         ConfigValueFactory.fromMap(m)
       }
       case Arr(arr) => ConfigValueFactory.fromIterable(arr.map(x => fromZioJson(x)).asJava)
-    }
-  }
-
-  def toJsonValue(value: ConfigValue): JValue = {
-    value.valueType() match {
-      case ConfigValueType.NULL    => JNothing
-      case ConfigValueType.BOOLEAN => JBool(value.unwrapped().asInstanceOf[Boolean])
-      case ConfigValueType.NUMBER  =>
-        value.unwrapped() match {
-          case f: java.lang.Float   => JDouble(f.doubleValue())
-          case d: java.lang.Double  => JDouble(d)
-          case i: java.lang.Integer => JInt(BigInt(i))
-          case l: java.lang.Long    => JInt(BigInt(l))
-          case error =>
-            throw new IllegalArgumentException(
-              s"Error with config value '${value}': it says it is a NUMBER but it is: ${value.unwrapped()}. Please report the bug."
-            )
-        }
-      case ConfigValueType.STRING  => JString(value.unwrapped().asInstanceOf[String])
-      // the only safe and compatible way for array/object seems to be to render and then parse
-      case _                       => parse(value.render(ConfigRenderOptions.concise()))
     }
   }
 
@@ -738,7 +686,6 @@ object GenericProperty {
     // get the Hocon string, with comments if any
     def valueAsDebugString: String = GenericProperty.serializeToHocon(p.value)
     // get value as a JValue
-    def jsonValue:          JValue = toJsonValue(p.value)
     def jsonZio:            Json   = toJsonZio(p.value)
   }
 
@@ -770,29 +717,14 @@ object GenericProperty {
    * Implicit class to render properties to JSON
    */
   implicit class PropertyToJson(val x: GenericProperty[?]) extends AnyVal {
-
-    def toJsonObj: JObject = {
-      import net.liftweb.json.JsonDSL.*
-      (
-        ("name"          -> x.name)
-        ~ ("value"       -> parse(x.value.render(ConfigRenderOptions.concise())))
-        ~ ("provider"    -> x.provider.map(_.value))
-        ~ ("inheritMode" -> x.inheritMode.map(_.value))
-      )
-    }
-
     def toData: String = x.config.root().render(ConfigRenderOptions.concise().setComments(true))
   }
 
   implicit class JsonProperties(val props: Seq[GenericProperty[?]]) extends AnyVal {
-    def toApiJson: JArray = {
-      JArray(props.map(_.toJsonObj).toList)
-    }
 
-    def toDataJson: JObject = {
-      import net.liftweb.json.JsonDSL.*
-
-      props.map(x => JField(x.name, x.jsonValue)).toList.sortBy(_.name)
+    // used in policy generation
+    def toDataJson: Json = {
+      Json.Obj(props.map(x => (x.name, x.jsonZio)).toList.sortBy(_._1)*)
     }
   }
 }
@@ -971,23 +903,10 @@ object CompareProperties {
  */
 object JsonPropertySerialisation {
 
-  import net.liftweb.json.*
-  import net.liftweb.json.JsonDSL.*
-
-  implicit class JsonParameter(val x: ParameterEntry) extends AnyVal {
-    def toJson: JObject = (
-      ("name"      -> x.parameterName)
-        ~ ("value" -> x.escapedValue)
-    )
-  }
-
+  // used in policy generation
   implicit class JsonParameters(val parameters: Set[ParameterEntry]) extends AnyVal {
-    def dataJson(x: ParameterEntry): JField = {
-      JField(x.parameterName, x.escapedValue)
-    }
-
-    def toDataJson: JObject = {
-      parameters.map(dataJson(_)).toList.sortBy(_.name)
+    def toDataJson: Json = {
+      Json.Obj(parameters.map(p => (p.parameterName, Json.Str(p.escapedValue))).toList.sortBy(_._1)*)
     }
   }
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/PropertyHierarchy.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/properties/PropertyHierarchy.scala
@@ -8,10 +8,8 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.domain.properties.ParentProperty.VertexParentProperty
 import com.normation.rudder.properties.GroupProp
-import com.typesafe.config.ConfigRenderOptions
 import enumeratum.Enum
 import enumeratum.EnumEntry
-import org.apache.commons.text.StringEscapeUtils
 import zio.*
 import zio.json.enumeratum.*
 
@@ -324,7 +322,7 @@ case class FailedNodePropertyHierarchy private (
 object FailedNodePropertyHierarchy {
 
   /**
-   * Constuctor needs to validate that properties in success does not intersect specific node property errors
+   * Constructor needs to validate that properties in success does not intersect specific node property errors
    */
   def apply(
       it:             Iterable[PropertyHierarchy],
@@ -375,82 +373,4 @@ object ResolvedNodePropertyHierarchy {
     }
   }
 
-}
-
-/**
- * The part dealing with JsonSerialisation of node related
- * attributes (especially properties) and parameters
- */
-object JsonPropertyHierarchySerialisation {
-
-  import net.liftweb.json.*
-  import net.liftweb.json.JsonDSL.*
-
-  implicit class ParentPropertyToJSon(val p: ParentProperty[?]) extends AnyVal {
-    def toJson: JValue = {
-      p match {
-        case ParentProperty.Global(value) =>
-          (
-            ("kind"            -> p.kind.entryName)
-            ~ ("name"          -> p.name)
-            ~ ("value"         -> GenericProperty.toJsonValue(p.value.value))
-            ~ ("resolvedValue" -> GenericProperty.toJsonValue(p.resolvedValue.value))
-          )
-
-        case _ =>
-          (
-            ("kind"            -> p.kind.entryName)
-            ~ ("name"          -> p.name)
-            ~ ("id"            -> p.id)
-            ~ ("value"         -> GenericProperty.toJsonValue(p.value.value))
-            ~ ("resolvedValue" -> GenericProperty.toJsonValue(p.resolvedValue.value))
-          )
-      }
-    }
-  }
-
-  implicit class JsonNodePropertyHierarchy(val prop: PropertyHierarchy) extends AnyVal {
-    private def buildHierarchy(displayParents: ParentProperty[?] => JValue): JObject = {
-
-      prop.prop.toJsonObj ~ ("hierarchy" -> displayParents(prop.hierarchy)) ~ ("origval" -> GenericProperty.toJsonValue(
-        prop.hierarchy.value.value
-      ))
-
-    }
-
-    def toApiJson: JObject = {
-      buildHierarchy(list => list.toJson)
-    }
-
-    def toApiJsonRenderParents: JObject = {
-      def displayElem(p: ParentProperty[?]): String = {
-        (p match {
-          case _: ParentProperty.Global => None
-          case n: ParentProperty.Node   => n.parentProperty.map(displayElem)
-          case g: ParentProperty.Group  => g.parentProperty.map(displayElem)
-        }).getOrElse("") +
-        s"<p>from ${p.kind match {
-            case ParentPropertyKind.Global => p.kind.entryName + " property"
-            case _                         => p.kind.entryName
-          }} <b>${p.name}${if (p.id.isEmpty) {
-            ""
-          } else s" (${p.id})"}</b>:<pre>${StringEscapeUtils
-            .escapeHtml4(p.value.value.render(ConfigRenderOptions.defaults().setOriginComments(false)))}</pre></p>"
-      }
-
-      buildHierarchy(displayElem.andThen(JString))
-    }
-
-  }
-
-  implicit class JsonNodePropertiesHierarchy(val props: List[PropertyHierarchy]) extends AnyVal {
-    def toApiJson: JArray = {
-      JArray(props.sortBy(_.prop.name).map(p => p.toApiJson))
-    }
-
-    def toApiJsonRenderParents: JArray = {
-      JArray(props.sortBy(_.prop.name).map(p => p.toApiJsonRenderParents))
-    }
-
-  }
 }

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/domain/reports/StatusReports.scala
@@ -49,6 +49,7 @@ import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import scala.collection.MapView
 import zio.*
+import zio.json.*
 import zio.json.ast.Json.*
 
 /**
@@ -243,6 +244,9 @@ object RunAnalysisKind       extends Enum[RunAnalysisKind] {
   case object ComputeCompliance         extends RunAnalysisKind
 
   override def values: IndexedSeq[RunAnalysisKind] = findValues
+
+  given JsonEncoder[RunAnalysisKind] = JsonEncoder[String].contramap(_.entryName)
+
 }
 
 final case class RunAnalysis(

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/write/PolicyWriterService.scala
@@ -84,8 +84,6 @@ import java.nio.file.StandardOpenOption
 import java.nio.file.attribute.PosixFilePermission
 import java.util.concurrent.TimeUnit
 import net.liftweb.common.*
-import net.liftweb.json.JsonAST
-import net.liftweb.json.JsonAST.JValue
 import org.apache.commons.io.FileUtils
 import org.joda.time.DateTime
 import zio.*
@@ -297,15 +295,14 @@ class PolicyWriterServiceImpl(
 
   private def writeNodePropertiesFile(agentNodeConfig: AgentNodeConfiguration) = {
 
-    def generateNodePropertiesJson(properties: Seq[NodeProperty]): JValue = {
-      import net.liftweb.json.JsonDSL.*
-      ("properties" -> properties.toDataJson)
+    def generateNodePropertiesJson(properties: Seq[NodeProperty]): Json = {
+      Json.Obj("properties" -> properties.toDataJson)
     }
 
     val path            = Constants.GENERATED_PROPERTY_DIR
     val file            = File(agentNodeConfig.paths.newFolder, path, Constants.GENERATED_PROPERTY_FILE)
     val jsonProperties  = generateNodePropertiesJson(agentNodeConfig.config.nodeInfo.properties)
-    val propertyContent = JsonAST.prettyRender(jsonProperties)
+    val propertyContent = jsonProperties.toJsonPretty
 
     for {
       _ <-
@@ -317,17 +314,16 @@ class PolicyWriterServiceImpl(
   }
 
   private def writeRudderParameterFile(agentNodeConfig: AgentNodeConfiguration): IOResult[Unit] = {
-    def generateParametersJson(parameters: Set[ParameterEntry]): JValue = {
+    def generateParametersJson(parameters: Set[ParameterEntry]): Json = {
       import com.normation.rudder.domain.properties.JsonPropertySerialisation.*
-      import net.liftweb.json.JsonDSL.*
-      ("parameters" -> parameters.toDataJson)
+      Json.Obj("parameters" -> parameters.toDataJson)
     }
 
     val file             = File(agentNodeConfig.paths.newFolder, Constants.GENERATED_PARAMETER_FILE)
     val jsonParameters   = generateParametersJson(
       agentNodeConfig.config.parameters.map(x => ParameterEntry(x.name, x.value, agentNodeConfig.agentType))
     )
-    val parameterContent = JsonAST.prettyRender(jsonParameters)
+    val parameterContent = jsonParameters.toJsonPretty
 
     for {
       _ <- PolicyGenerationLoggerPure.trace(s"Create parameter file '${agentNodeConfig.paths.newFolder}/${file.name}'")
@@ -341,7 +337,7 @@ class PolicyWriterServiceImpl(
    * For all the writing part, we want to limit the number of concurrent workers on two aspects:
    * - we want an I/O thread-pool, which knows what to do when a thread is blocked for a long time,
    *   and risks thread exhaustion
-   *   (it can happens, since we have a number of files to write, some maybe big)
+   *   (it can happen, since we have a number of files to write, some maybe big)
    * - we want to limit the total number of concurrent execution to avoid blowing up the number
    *   of open files, concurrent hooks, etc. This is not directly linked to the number of CPU,
    *   but clearly there is no point having a pool of 4 threads for 1000 nodes which will

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-cfe-with-500-directives/rules/cfengine-community/properties.d/properties.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-cfe-with-500-directives/rules/cfengine-community/properties.d/properties.json
@@ -1,3 +1,3 @@
 {
-  "properties":{}
+  "properties" : {}
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-cfe-with-500-directives/rules/cfengine-community/rudder-parameters.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-cfe-with-500-directives/rules/cfengine-community/rudder-parameters.json
@@ -1,5 +1,5 @@
 {
-  "parameters":{
-    "rudder_file_edit_header":"### Managed by Rudder, edit with care ###"
+  "parameters" : {
+    "rudder_file_edit_header" : "### Managed by Rudder, edit with care ###"
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-cfe-with-two-directives/rules/cfengine-community/properties.d/properties.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-cfe-with-two-directives/rules/cfengine-community/properties.d/properties.json
@@ -1,3 +1,3 @@
 {
-  "properties":{}
+  "properties" : {}
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-cfe-with-two-directives/rules/cfengine-community/rudder-parameters.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-cfe-with-two-directives/rules/cfengine-community/rudder-parameters.json
@@ -1,5 +1,5 @@
 {
-  "parameters":{
-    "rudder_file_edit_header":"### Managed by Rudder, edit with care ###"
+  "parameters" : {
+    "rudder_file_edit_header" : "### Managed by Rudder, edit with care ###"
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-gen-var-def-override/rules/cfengine-community/properties.d/properties.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-gen-var-def-override/rules/cfengine-community/properties.d/properties.json
@@ -1,3 +1,3 @@
 {
-  "properties":{}
+  "properties" : {}
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-gen-var-def-override/rules/cfengine-community/rudder-parameters.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/node-gen-var-def-override/rules/cfengine-community/rudder-parameters.json
@@ -1,5 +1,5 @@
 {
-  "parameters":{
-    "rudder_file_edit_header":"### Managed by Rudder, edit with care ###"
+  "parameters" : {
+    "rudder_file_edit_header" : "### Managed by Rudder, edit with care ###"
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-default-install/properties.d/properties.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-default-install/properties.d/properties.json
@@ -1,5 +1,5 @@
 {
-  "properties":{
-    "hidden":"hiddenValue"
+  "properties" : {
+    "hidden" : "hiddenValue"
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-default-install/rudder-parameters.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-default-install/rudder-parameters.json
@@ -1,6 +1,6 @@
 {
-  "parameters":{
-    "ntpserver":"pool.\"ntp\".org",
-    "rudder_file_edit_header":"### Managed by Rudder, edit with care ###"
+  "parameters" : {
+    "ntpserver" : "pool.\"ntp\".org",
+    "rudder_file_edit_header" : "### Managed by Rudder, edit with care ###"
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-sys-var-false/properties.d/properties.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-sys-var-false/properties.d/properties.json
@@ -1,3 +1,3 @@
 {
-  "properties":{}
+  "properties" : {}
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-sys-var-false/rudder-parameters.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-sys-var-false/rudder-parameters.json
@@ -1,5 +1,5 @@
 {
-  "parameters":{
-    "rudder_file_edit_header":"### Managed by Rudder, edit with care ###"
+  "parameters" : {
+    "rudder_file_edit_header" : "### Managed by Rudder, edit with care ###"
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-one-multipolicy/properties.d/properties.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-one-multipolicy/properties.d/properties.json
@@ -1,5 +1,5 @@
 {
-  "properties":{
-    "hidden":"hiddenValue"
+  "properties" : {
+    "hidden" : "hiddenValue"
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-one-multipolicy/rudder-parameters.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-one-multipolicy/rudder-parameters.json
@@ -1,6 +1,6 @@
 {
-  "parameters":{
-    "ntpserver":"pool.\"ntp\".org",
-    "rudder_file_edit_header":"### Managed by Rudder, edit with care ###"
+  "parameters" : {
+    "ntpserver" : "pool.\"ntp\".org",
+    "rudder_file_edit_header" : "### Managed by Rudder, edit with care ###"
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-two-directives/properties.d/properties.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-two-directives/properties.d/properties.json
@@ -1,5 +1,5 @@
 {
-  "properties":{
-    "hidden":"hiddenValue"
+  "properties" : {
+    "hidden" : "hiddenValue"
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-two-directives/rudder-parameters.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/root-with-two-directives/rudder-parameters.json
@@ -1,6 +1,6 @@
 {
-  "parameters":{
-    "ntpserver":"pool.\"ntp\".org",
-    "rudder_file_edit_header":"### Managed by Rudder, edit with care ###"
+  "parameters" : {
+    "ntpserver" : "pool.\"ntp\".org",
+    "rudder_file_edit_header" : "### Managed by Rudder, edit with care ###"
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/technique-and-revisions/properties.d/properties.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/technique-and-revisions/properties.d/properties.json
@@ -1,3 +1,3 @@
 {
-  "properties":{}
+  "properties" : {}
 }

--- a/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/technique-and-revisions/rudder-parameters.json
+++ b/webapp/sources/rudder/rudder-core/src/test/resources/configuration-repository/expected-share/technique-and-revisions/rudder-parameters.json
@@ -1,6 +1,6 @@
 {
-  "parameters":{
-    "ntpserver":"pool.\"ntp\".org",
-    "rudder_file_edit_header":"### Managed by Rudder, edit with care ###"
+  "parameters" : {
+    "ntpserver" : "pool.\"ntp\".org",
+    "rudder_file_edit_header" : "### Managed by Rudder, edit with care ###"
   }
 }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/properties/NodePropertiesTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/properties/NodePropertiesTest.scala
@@ -41,6 +41,8 @@ import net.liftweb.common.*
 import org.junit.runner.RunWith
 import org.specs2.mutable.*
 import org.specs2.runner.*
+import zio.json.*
+import zio.json.ast.*
 
 /*
  * Our internal representation of node properties must correctly serialize/unserialise to JSON
@@ -67,21 +69,21 @@ class NodePropertiesTest extends Specification with Loggable {
 
     val expected = {
       """{
-        |  "jsonArray":[
+        |  "jsonArray" : [
         |    "one",
         |    2,
         |    true
         |  ],
-        |  "jsonProp":{
-        |    "jsonObject":"ok"
+        |  "jsonProp" : {
+        |    "jsonObject" : "ok"
         |  },
-        |  "stringArray":[
+        |  "stringArray" : [
         |    "array"
         |  ],
-        |  "stringSimple":"simple string"
+        |  "stringSimple" : "simple string"
         |}""".stripMargin
     }
-    val json     = net.liftweb.json.prettyRender(props.toDataJson)
+    val json     = props.toDataJson.toJsonPretty
 
     json === expected
   }

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/queries/JsonSelectTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/domain/queries/JsonSelectTest.scala
@@ -39,10 +39,11 @@ package com.normation.rudder.domain.queries
 
 import com.normation.BoxSpecMatcher
 import net.liftweb.common.*
-import net.liftweb.json.*
 import org.junit.runner.RunWith
 import org.specs2.mutable.*
 import org.specs2.runner.JUnitRunner
+import zio.json.*
+import zio.json.ast.*
 
 @RunWith(classOf[JUnitRunner])
 class JsonSelectTest extends Specification with BoxSpecMatcher with Loggable {
@@ -66,14 +67,7 @@ class JsonSelectTest extends Specification with BoxSpecMatcher with Loggable {
     "retrieve first" in {
       val res = JsonSelect.fromPath("$.store.book", json).map(_.head)
 
-      res mustFullEq (compactRender(parse("""
-            {
-                "category": "reference",
-                "author": "Nigel Rees",
-                "title": "Sayings of the Century",
-                "price": 8.95
-            }
-        """)))
+      res mustFullEq ("""{"category":"reference","author":"Nigel Rees","title":"Sayings of the Century","price":8.95}""")
     }
   }
 
@@ -106,7 +100,7 @@ class JsonSelectTest extends Specification with BoxSpecMatcher with Loggable {
                 "isbn": "0-395-19395-8",
                 "price": 22.99
             }"""
-      ).map(s => compactRender(parse(s))))
+      ).map(_.fromJson[Json].getOrElse(throw RuntimeException("parsing error")).toJson))
     }
     "retrieve NUMBER childrens forming an array" in {
       JsonSelect.fromPath("$.store.book[*].price", json) mustFullEq (List("8.95", "12.99", "8.99", "22.99"))

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
@@ -42,6 +42,9 @@ import com.normation.GitVersion
 import com.normation.errors.PureResult
 import com.normation.inventory.domain.AcceptedInventory
 import com.normation.inventory.domain.NodeId
+import com.normation.rudder.apidata.JsonResponseObjects.InheritedPropertyStatus
+import com.normation.rudder.apidata.JsonResponseObjects.JRProperty
+import com.normation.rudder.apidata.RenderInheritedProperties
 import com.normation.rudder.domain.nodes.*
 import com.normation.rudder.domain.policies.FullGroupTarget
 import com.normation.rudder.domain.policies.GroupTarget
@@ -71,15 +74,14 @@ import com.normation.rudder.services.policies.NodeConfigData
 import com.softwaremill.quicklens.*
 import com.typesafe.config.ConfigValue
 import com.typesafe.config.ConfigValueFactory
-import net.liftweb.json.*
-import net.liftweb.json.JsonDSL.*
 import org.junit.runner.*
 import org.specs2.matcher.Matcher
 import org.specs2.mutable.*
 import org.specs2.runner.*
 import scala.reflect.ClassTag
-import zio.Chunk
-import zio.NonEmptyChunk
+import zio.*
+import zio.json.*
+import zio.json.ast.Json.*
 
 @RunWith(classOf[JUnitRunner])
 class TestMergeGroupProperties extends Specification {
@@ -763,46 +765,52 @@ class TestMergeGroupProperties extends Specification {
         )
 
       successMerged must haveClass[SuccessNodePropertyHierarchy]
-      val props    = successMerged.resolved
-      val actual   = props.toList.toApiJsonRenderParents
-      val expected = JArray(
-        List(
-          ("name"          -> "foo")
-          ~ ("value"       -> (
-            ("child"       -> "child value")
-            ~ ("global"    -> "global value")
-            ~ ("node"      -> "node value")
-            ~ ("override"  -> "node")
-            ~ ("parent"    -> "parent value")
-          ))
-          ~ ("provider"    -> "overridden")
-          ~ ("inheritMode" -> JNothing) // I don't understand why I need to add it
-          ~ ("hierarchy"   ->
-          """<p>from global property <b>foo (foo)</b>:<pre>{
-            |    &quot;global&quot; : &quot;global value&quot;,
-            |    &quot;override&quot; : &quot;global&quot;
-            |}
-            |</pre></p><p>from group <b>parent1 (parent1)</b>:<pre>{
-            |    &quot;override&quot; : &quot;parent&quot;,
-            |    &quot;parent&quot; : &quot;parent value&quot;
-            |}
-            |</pre></p><p>from group <b>child (child)</b>:<pre>{
-            |    &quot;child&quot; : &quot;child value&quot;,
-            |    &quot;override&quot; : &quot;child&quot;
-            |}
-            |</pre></p><p>from node <b>node1.localhost (node1)</b>:<pre>{
-            |    &quot;node&quot; : &quot;node value&quot;,
-            |    &quot;override&quot; : &quot;node&quot;
-            |}
-            |</pre></p>""".stripMargin)
-          ~ ("origval"     -> (
-            ("node"        -> "node value")
-            ~ ("override"  -> "node")
-          ))
+      val props    = successMerged.resolved.map(InheritedPropertyStatus.from)
+      val actual   = props
+        .map(
+          JRProperty
+            .fromInheritedPropertyStatus(_, RenderInheritedProperties.HTML, escapeHtml = true)
+            // we set hierarchy to none since we don't have a real hierarchy here
+            .modify(_.hierarchyStatus)
+            .setTo(None)
+        )
+        .toJson
+      val expected = Arr(
+        Chunk(
+          Obj(
+            "name"      -> Str("foo"),
+            "value"     -> Obj(
+              "child"    -> Str("child value"),
+              "global"   -> Str("global value"),
+              "node"     -> Str("node value"),
+              "override" -> Str("node"),
+              "parent"   -> Str("parent value")
+            ),
+            "provider"  -> Str("overridden"),
+            "hierarchy" ->
+            Str("""<p>from <b>global property 'foo'</b>:<pre>{
+                  |    &quot;global&quot; : &quot;global value&quot;,
+                  |    &quot;override&quot; : &quot;global&quot;
+                  |}
+                  |</pre></p><p>from <b>group 'parent1' (parent1)</b>:<pre>{
+                  |    &quot;override&quot; : &quot;parent&quot;,
+                  |    &quot;parent&quot; : &quot;parent value&quot;
+                  |}
+                  |</pre></p><p>from <b>group 'child' (child)</b>:<pre>{
+                  |    &quot;child&quot; : &quot;child value&quot;,
+                  |    &quot;override&quot; : &quot;child&quot;
+                  |}
+                  |</pre></p><p>from <b>node 'node1.localhost' (node1)</b>:<pre>{
+                  |    &quot;node&quot; : &quot;node value&quot;,
+                  |    &quot;override&quot; : &quot;node&quot;
+                  |}
+                  |</pre></p>""".stripMargin),
+            "origval"   -> Obj("node" -> Str("node value"), "override" -> Str("node"))
+          )
         )
       )
 
-      actual must beEqualTo(expected)
+      actual must beEqualTo(expected.toJson)
     }
   }
   // only match error sub type to expected one

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/nodes/TestMergeGroupProperties.scala
@@ -54,7 +54,6 @@ import com.normation.rudder.domain.properties.GlobalParameter
 import com.normation.rudder.domain.properties.GroupProperty
 import com.normation.rudder.domain.properties.GroupPropertyHierarchy
 import com.normation.rudder.domain.properties.InheritMode
-import com.normation.rudder.domain.properties.JsonPropertyHierarchySerialisation.*
 import com.normation.rudder.domain.properties.NodeProperty
 import com.normation.rudder.domain.properties.NodePropertyHierarchy
 import com.normation.rudder.domain.properties.ParentProperty
@@ -849,7 +848,7 @@ class TestMergeGroupProperties extends Specification {
             ok("")
           } else {
             ko(
-              s"Properties were not the ones expected, got Both with left : ${l} and right ${r.props}\nbut expected left ${leftError} and right ${rightSuccess}"
+              s"Properties were not the ones expected, got Both with left : ${l} and right ${r}\nbut expected left ${leftError} and right ${rightSuccess}"
             )
           }
         case o: Ior[?, ?] =>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -331,7 +331,7 @@ object GroupApi       extends Enum[GroupApi] with ApiModuleProvider[GroupApi] {
       extends GroupApi with InternalApi with OneParam with StartsAtVersion13 with SortIndex {
     val z: Int = implicitly[Line].value
     val description    =
-      "Get all proporeties for that group, included inherited ones, for displaying in group property tab (internal)"
+      "Get all properties for that group, included inherited ones, for displaying in group property tab (internal)"
     val (action, path) = GET / "groups" / "{id}" / "displayInheritedProperties"
     val authz: List[AuthorizationType] = AuthorizationType.Group.Read :: Nil
   }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/CreateNodeData.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/CreateNodeData.scala
@@ -189,8 +189,6 @@ final case class ResultHolder(
 )
 
 object ResultHolder {
-  import com.normation.rudder.apidata.implicits.*
-
   implicit val failureEncoder: JsonEncoder[(String, CreationError)] =
     JsonEncoder[Map[String, CreationError]].contramap(Map(_))
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/GroupsInternalAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/GroupsInternalAPI.scala
@@ -39,7 +39,6 @@ package com.normation.rudder.rest.internal
 import com.normation.errors.IOResult
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.apidata.JsonResponseObjects.*
-import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.repository.RoNodeGroupRepository
 import com.normation.rudder.rest.ApiModuleProvider
 import com.normation.rudder.rest.ApiPath

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/internal/RulesInternalAPI.scala
@@ -40,7 +40,6 @@ import com.normation.errors.EitherToIoResult
 import com.normation.errors.IOResult
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.apidata.JsonResponseObjects.*
-import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.domain.logger.TimingDebugLoggerPure
 import com.normation.rudder.domain.policies.Rule
 import com.normation.rudder.domain.policies.RuleId

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/DirectiveApi.scala
@@ -50,7 +50,6 @@ import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.apidata.JsonQueryObjects.*
 import com.normation.rudder.apidata.JsonResponseObjects.*
 import com.normation.rudder.apidata.ZioJsonExtractor
-import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.configuration.ConfigurationRepository

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/GroupsApi.scala
@@ -43,7 +43,6 @@ import com.normation.rudder.apidata.JsonQueryObjects.*
 import com.normation.rudder.apidata.JsonResponseObjects.*
 import com.normation.rudder.apidata.RenderInheritedProperties
 import com.normation.rudder.apidata.ZioJsonExtractor
-import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.config.ReasonBehavior

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/HookApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/HookApi.scala
@@ -4,7 +4,6 @@ import better.files.File
 import com.normation.errors.IOResult
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.apidata.JsonResponseObjects.JRHooks
-import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.hooks.RunHooks
 import com.normation.rudder.rest.ApiModuleProvider
 import com.normation.rudder.rest.ApiPath

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/NodeApi.scala
@@ -49,7 +49,6 @@ import com.normation.rudder.apidata.JsonResponseObjects.*
 import com.normation.rudder.apidata.NodeDetailLevel
 import com.normation.rudder.apidata.RenderInheritedProperties
 import com.normation.rudder.apidata.ZioJsonExtractor
-import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.config.ReasonBehavior
 import com.normation.rudder.config.UserPropertyService
 import com.normation.rudder.domain.logger.NodeLogger
@@ -245,10 +244,6 @@ class NodeApi(
     ): LiftResponse = {
       implicit val qc: QueryContext = authzToken.qc
 
-      implicit val nodeDetailLevelEncoder: JsonEncoder[JRNodeDetailLevel] = {
-        com.normation.rudder.apidata.implicits.nodeDetailLevelEncoder
-      }
-
       (for {
         level <- restExtractor.extractNodeDetailLevelFromParams(req.params).chainError("error with node level detail").toIO
         res   <-
@@ -410,10 +405,7 @@ class NodeApi(
     val schema: API.ListAcceptedNodes.type = API.ListAcceptedNodes
     val restExtractor = zioJsonExtractor
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      implicit val qc:                     QueryContext                   = authzToken.qc
-      implicit val nodeDetailLevelEncoder: JsonEncoder[JRNodeDetailLevel] = {
-        com.normation.rudder.apidata.implicits.nodeDetailLevelEncoder
-      }
+      implicit val qc: QueryContext = authzToken.qc
       val state = AcceptedInventory
       (for {
         optLevel <-
@@ -436,10 +428,7 @@ class NodeApi(
     val restExtractor = zioJsonExtractor
 
     def process0(version: ApiVersion, path: ApiPath, req: Req, params: DefaultParams, authzToken: AuthzToken): LiftResponse = {
-      implicit val qc:                     QueryContext                   = authzToken.qc
-      implicit val nodeDetailLevelEncoder: JsonEncoder[JRNodeDetailLevel] = {
-        com.normation.rudder.apidata.implicits.nodeDetailLevelEncoder
-      }
+      implicit val qc: QueryContext = authzToken.qc
       val state = PendingInventory
       (for {
         optLevel <-

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ParametersApi.scala
@@ -44,7 +44,6 @@ import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.apidata.JsonQueryObjects.JQGlobalParameter
 import com.normation.rudder.apidata.JsonResponseObjects.JRGlobalParameter
 import com.normation.rudder.apidata.ZioJsonExtractor
-import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.domain.properties.*
 import com.normation.rudder.repository.RoParameterRepository
 import com.normation.rudder.rest.ApiModuleProvider

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RecentChangesAPI.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RecentChangesAPI.scala
@@ -41,7 +41,6 @@ import com.normation.errors.*
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.apidata.JsonResponseObjects.JRRecentChanges
 import com.normation.rudder.apidata.JsonResponseObjects.JRResultRepairedReport
-import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.policies.RuleUid
 import com.normation.rudder.rest.ApiPath

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -46,7 +46,6 @@ import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.apidata.JsonQueryObjects.*
 import com.normation.rudder.apidata.JsonResponseObjects.*
 import com.normation.rudder.apidata.ZioJsonExtractor
-import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.configuration.ConfigurationRepository

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/SettingsApi.scala
@@ -48,7 +48,6 @@ import com.normation.inventory.domain.NodeId
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.apidata.JsonResponseObjects.*
 import com.normation.rudder.apidata.ZioJsonExtractor
-import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.batch.PolicyGenerationTrigger

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/TechniqueApi.scala
@@ -43,7 +43,6 @@ import com.normation.cfclerk.services.TechniqueRepository
 import com.normation.errors.*
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.apidata.JsonResponseObjects.*
-import com.normation.rudder.apidata.implicits.*
 import com.normation.rudder.config.ReasonBehavior
 import com.normation.rudder.config.UserPropertyService
 import com.normation.rudder.domain.logger.ApiLoggerPure

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_groups.yml
@@ -280,7 +280,7 @@ response:
                 },
                 "description":"a simple string param",
                 "provider":"overridden",
-                "hierarchy":"<p>from <b>Global parameter </b>:<pre>{\n    \"array\" : [\n        1,\n        3,\n        2\n    ],\n    \"json\" : {\n        \"var1\" : \"val1\",\n        \"var2\" : \"val2\"\n    },\n    \"string\" : \"a string\"\n}\n</pre></p><p>from <b>Group Real nodes (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>{\n    \"array\" : [\n        5,\n        6\n    ],\n    \"group\" : \"string\",\n    \"json\" : {\n        \"g1\" : \"g1\"\n    }\n}\n</pre></p>",
+                "hierarchy":"<p>from <b>global property 'jsonParam'</b>:<pre>{\n    \"array\" : [\n        1,\n        3,\n        2\n    ],\n    \"json\" : {\n        \"var1\" : \"val1\",\n        \"var2\" : \"val2\"\n    },\n    \"string\" : \"a string\"\n}\n</pre></p><p>from <b>group 'Real nodes' (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>{\n    \"array\" : [\n        5,\n        6\n    ],\n    \"group\" : \"string\",\n    \"json\" : {\n        \"g1\" : \"g1\"\n    }\n}\n</pre></p>",
                 "hierarchyStatus":{
                   "hasChildTypeConflicts":false,
                   "fullHierarchy":{
@@ -299,7 +299,7 @@ response:
                 "description":"a simple string param",
                 "inheritMode":"opa",
                 "provider":"inherited",
-                "hierarchy":"<p>from <b>Global parameter </b>:<pre>\"some string\"</pre></p>",
+                "hierarchy":"<p>from <b>global property 'modeParam'</b>:<pre>\"some string\"</pre></p>",
                 "hierarchyStatus":{
                   "hasChildTypeConflicts":false,
                   "fullHierarchy":{"kind":"global","valueType":"String"}
@@ -311,7 +311,7 @@ response:
                 "value":{ "compliance_expiration_policy":{"mode":"expire_immediately"} },
                 "description":"rudder system config",
                 "provider":"inherited",
-                "hierarchy":"<p>from <b>Global parameter </b>:<pre>{\n    \"compliance_expiration_policy\" : {\n        \"mode\" : \"expire_immediately\"\n    }\n}\n</pre></p>",
+                "hierarchy":"<p>from <b>global property 'rudder'</b>:<pre>{\n    \"compliance_expiration_policy\" : {\n        \"mode\" : \"expire_immediately\"\n    }\n}\n</pre></p>",
                 "hierarchyStatus":{
                   "hasChildTypeConflicts":false,
                   "fullHierarchy":{"kind":"global","valueType":"Object"}
@@ -324,7 +324,7 @@ response:
                 "description":"a simple string param",
                 "inheritMode":"map",
                 "provider":"overridden",
-                "hierarchy":"<p>from <b>Global parameter </b>:<pre>\"some string\"</pre></p><p>from <b>Group Real nodes (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>\"string\"</pre></p>",
+                "hierarchy":"<p>from <b>global property 'stringParam'</b>:<pre>\"some string\"</pre></p><p>from <b>group 'Real nodes' (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>\"string\"</pre></p>",
                 "hierarchyStatus":{
                   "hasChildTypeConflicts":false,
                   "fullHierarchy":{
@@ -342,7 +342,7 @@ response:
                 "value":"some string",
                 "description":"a simple string param",
                 "provider":"inherited",
-                "hierarchy":"<p>from <b>Global parameter </b>:<pre>\"some string\"</pre></p>",
+                "hierarchy":"<p>from <b>global property 'systemParam'</b>:<pre>\"some string\"</pre></p>",
                 "hierarchyStatus":{
                   "hasChildTypeConflicts":false,
                   "fullHierarchy":{"kind":"global","valueType":"String"}

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_nodes.yml
@@ -1194,7 +1194,7 @@ response:
             "description" : "a simple string param",
             "inheritMode" : "map",
             "provider" : "inherited",
-            "hierarchy" : "<p>from <b>Global parameter </b>:<pre>&quot;some string&quot;</pre></p><p>from <b>Group Real nodes (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>&quot;string&quot;</pre></p>",
+            "hierarchy" : "<p>from <b>global property 'stringParam'</b>:<pre>&quot;some string&quot;</pre></p><p>from <b>group 'Real nodes' (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>&quot;string&quot;</pre></p>",
             "hierarchyStatus" : {
               "hasChildTypeConflicts" : false,
               "fullHierarchy" : {
@@ -1440,7 +1440,7 @@ response:
         "value" : "some string",
         "description" : "a simple string param",
         "provider" : "inherited",
-        "hierarchy" : "<p>from <b>Global parameter </b>:<pre>&quot;some string&quot;</pre></p>",
+        "hierarchy" : "<p>from <b>global property 'stringParam'</b>:<pre>&quot;some string&quot;</pre></p>",
         "hierarchyStatus" : {
           "hasChildTypeConflicts" : false,
           "fullHierarchy" : {
@@ -1455,7 +1455,7 @@ response:
         "value" : "some string",
         "description" : "a simple string param",
         "provider" : "inherited",
-        "hierarchy" : "<p>from <b>Global parameter </b>:<pre>&quot;some string&quot;</pre></p>",
+        "hierarchy" : "<p>from <b>global property 'stringParam'</b>:<pre>&quot;some string&quot;</pre></p>",
         "hierarchyStatus" : {
           "hasChildTypeConflicts" : false,
           "fullHierarchy" : {
@@ -1471,7 +1471,7 @@ response:
         "description" : "a simple string param",
         "inheritMode" : "map",
         "provider" : "inherited",
-        "hierarchy" : "<p>from <b>Global parameter </b>:<pre>&quot;some string&quot;</pre></p><p>from <b>Group Real nodes (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>&quot;string&quot;</pre></p>",
+        "hierarchy" : "<p>from <b>global property 'stringParam'</b>:<pre>&quot;some string&quot;</pre></p><p>from <b>group 'Real nodes' (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>&quot;string&quot;</pre></p>",
         "hierarchyStatus" : {
           "hasChildTypeConflicts" : false,
           "fullHierarchy" : {
@@ -1493,7 +1493,7 @@ response:
         "description" : "a simple string param",
         "inheritMode" : "map",
         "provider" : "inherited",
-        "hierarchy" : "<p>from <b>Global parameter </b>:<pre>&quot;some string&quot;</pre></p><p>from <b>Group Real nodes (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>&quot;string&quot;</pre></p>",
+        "hierarchy" : "<p>from <b>global property 'stringParam'</b>:<pre>&quot;some string&quot;</pre></p><p>from <b>group 'Real nodes' (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>&quot;string&quot;</pre></p>",
         "hierarchyStatus" : {
           "hasChildTypeConflicts" : false,
           "fullHierarchy" : {
@@ -1515,7 +1515,7 @@ response:
         "description" : "a simple string param",
         "inheritMode" : "map",
         "provider" : "inherited",
-        "hierarchy" : "<p>from <b>Global parameter </b>:<pre>&quot;some string&quot;</pre></p><p>from <b>Group Real nodes (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>&quot;string&quot;</pre></p>",
+        "hierarchy" : "<p>from <b>global property 'stringParam'</b>:<pre>&quot;some string&quot;</pre></p><p>from <b>group 'Real nodes' (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>&quot;string&quot;</pre></p>",
         "hierarchyStatus" : {
           "hasChildTypeConflicts" : false,
           "fullHierarchy" : {
@@ -1536,7 +1536,7 @@ response:
         "value" : "some string",
         "description" : "a simple string param",
         "provider" : "inherited",
-        "hierarchy" : "<p>from <b>Global parameter </b>:<pre>&quot;some string&quot;</pre></p>",
+        "hierarchy" : "<p>from <b>global property 'stringParam'</b>:<pre>&quot;some string&quot;</pre></p>",
         "hierarchyStatus" : {
           "hasChildTypeConflicts" : false,
           "fullHierarchy" : {
@@ -1551,7 +1551,7 @@ response:
         "value" : "some string",
         "description" : "a simple string param",
         "provider" : "inherited",
-        "hierarchy" : "<p>from <b>Global parameter </b>:<pre>&quot;some string&quot;</pre></p>",
+        "hierarchy" : "<p>from <b>global property 'stringParam'</b>:<pre>&quot;some string&quot;</pre></p>",
         "hierarchyStatus" : {
           "hasChildTypeConflicts" : false,
           "fullHierarchy" : {

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api_inherited_prop/global_group_param.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api_inherited_prop/global_group_param.yml
@@ -301,7 +301,7 @@ response:
                   "now":"a json"
                 },
                "description":"a string at first",
-               "hierarchy":"<p>from <b>Global parameter </b>:<pre>\"a string\"</pre></p><p>from <b>Group Real nodes (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>{\n    \"now\" : \"a json\"\n}\n</pre></p>",
+               "hierarchy":"<p>from <b>global property 'badOverrideType'</b>:<pre>\"a string\"</pre></p><p>from <b>group 'Real nodes' (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>{\n    \"now\" : \"a json\"\n}\n</pre></p>",
                 "hierarchyStatus" : {
                   "hasChildTypeConflicts" : true,
                  "fullHierarchy" : {
@@ -337,7 +337,7 @@ response:
                 },
                "description":"a simple string param",
                "provider" : "overridden",
-               "hierarchy":"<p>from <b>Global parameter </b>:<pre>{\n    \"array\" : [\n        1,\n        3,\n        2\n    ],\n    \"json\" : {\n        \"var1\" : \"val1\",\n        \"var2\" : \"val2\"\n    },\n    \"string\" : \"a string\"\n}\n</pre></p><p>from <b>Group Real nodes (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>{\n    \"array\" : [\n        5,\n        6\n    ],\n    \"group\" : \"string\",\n    \"json\" : {\n        \"g1\" : \"g1\"\n    }\n}\n</pre></p>",
+               "hierarchy":"<p>from <b>global property 'jsonParam'</b>:<pre>{\n    \"array\" : [\n        1,\n        3,\n        2\n    ],\n    \"json\" : {\n        \"var1\" : \"val1\",\n        \"var2\" : \"val2\"\n    },\n    \"string\" : \"a string\"\n}\n</pre></p><p>from <b>group 'Real nodes' (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>{\n    \"array\" : [\n        5,\n        6\n    ],\n    \"group\" : \"string\",\n    \"json\" : {\n        \"g1\" : \"g1\"\n    }\n}\n</pre></p>",
                 "hierarchyStatus" : {
                   "hasChildTypeConflicts" : false,
                  "fullHierarchy" : {
@@ -368,7 +368,7 @@ response:
                "description":"a simple string param",
                 "inheritMode":"opa",
                 "provider":"inherited",
-               "hierarchy":"<p>from <b>Global parameter </b>:<pre>\"some string\"</pre></p>",
+               "hierarchy":"<p>from <b>global property 'modeParam'</b>:<pre>\"some string\"</pre></p>",
                 "hierarchyStatus" : {
                   "hasChildTypeConflicts" : false,
                  "fullHierarchy" : {
@@ -387,7 +387,7 @@ response:
                 },
                "description":"rudder system config",
                 "provider":"inherited",
-               "hierarchy":"<p>from <b>Global parameter </b>:<pre>{\n    \"compliance_expiration_policy\" : {\n        \"mode\" : \"expire_immediately\"\n    }\n}\n</pre></p>",
+               "hierarchy":"<p>from <b>global property 'rudder'</b>:<pre>{\n    \"compliance_expiration_policy\" : {\n        \"mode\" : \"expire_immediately\"\n    }\n}\n</pre></p>",
                 "hierarchyStatus" : {
                   "hasChildTypeConflicts" : false,
                  "fullHierarchy" : {
@@ -407,7 +407,7 @@ response:
                "description":"a simple string param",
                "inheritMode":"map",
                "provider" : "overridden",
-               "hierarchy":"<p>from <b>Global parameter </b>:<pre>\"some string\"</pre></p><p>from <b>Group Real nodes (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>\"string\"</pre></p>",
+               "hierarchy":"<p>from <b>global property 'stringParam'</b>:<pre>\"some string\"</pre></p><p>from <b>group 'Real nodes' (0000f5d3-8c61-4d20-88a7-bb947705ba8a)</b>:<pre>\"string\"</pre></p>",
                 "hierarchyStatus" : {
                   "hasChildTypeConflicts" : false,
                  "fullHierarchy" : {
@@ -428,7 +428,7 @@ response:
                 "value":"some string",
                "description":"a simple string param",
                 "provider":"inherited",
-               "hierarchy":"<p>from <b>Global parameter </b>:<pre>\"some string\"</pre></p>",
+               "hierarchy":"<p>from <b>global property 'systemParam'</b>:<pre>\"some string\"</pre></p>",
                 "hierarchyStatus" : {
                   "hasChildTypeConflicts" : false,
                  "fullHierarchy" : {

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/ArchiveApiTest.scala
@@ -1032,8 +1032,6 @@ class ArchiveApiTest extends Specification with AfterAll with Loggable {
 
   // see https://issues.rudder.io/issues/28007, the groups format have changed in 9.0 API, but archives API needs to support old ones
   "import group with JSON format previous to API v21" >> {
-    import com.normation.rudder.apidata.implicits.*
-
     /*
      * Copy the content of a existing archive into an import directory, zip-it
      */


### PR DESCRIPTION
https://issues.rudder.io/issues/28759

Last bit of `net.liftweb.json` in rudder. Needed by https://github.com/Normation/rudder-plugins/pull/949 and https://github.com/Normation/rudder-plugins-private/pull/1363

The first commit is a massive refactoring of `JsonResponseObject` to change the `implicit val JsonEncoder` defined in dedicated objects into `derives JsonEncoder` directly on `case class`es and `given`. 

There is only one interesting fact in that bit (appart the massive simplification): I needed to keep one `implicit val` to avoid imposing an `import ...given` in plugins. 

Remaingin part is just cleaning and transforming lift AST to `zio.json.ast` and adding spaces in tests. 

I normalized the HTML view of property hierarchy to always have the same naming shape (kind of level, quote around oject name, use property and not parameter, etc). No migration needed, it's purely human oriented info. 