### PR TITLE
Fixes #28798: Avoid displaying underscores in parameter names

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewMethod.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewMethod.elm
@@ -63,6 +63,7 @@ parameterName param =
 showParam: Model -> MethodCall -> ValidationState MethodCallParamError -> MethodParameter -> List CallParameter -> Element Msg
 showParam model call state methodParam params =
   let
+    paramLabel = String.Extra.toSentenceCase (String.replace "_" " " methodParam.name.value)
     displayedValue = List.Extra.find (.id >> (==) methodParam.name ) params |> Maybe.map (.value >> displayValue) |> Maybe.withDefault ""
     isMandatory =
       if methodParam.constraints.allowEmpty |> Maybe.withDefault False then
@@ -86,7 +87,7 @@ showParam model call state methodParam params =
           |> addAttribute (for "param-index")
           |> appendChildList
             [ element "span"
-              |> appendChild (element "span" |> appendText (String.Extra.toTitleCase methodParam.name.value))
+              |> appendChild (element "span" |> appendText paramLabel)
               |> appendChild isMandatory
               |> appendChild (element "span" |> appendText " -")
               |> appendChild (element "span" |> addClass "badge badge-secondary d-inline-flex align-items-center" |> appendText methodParam.type_)


### PR DESCRIPTION
https://issues.rudder.io/issues/28798

### Before:
<img width="1055" height="718" alt="parameters-name" src="https://github.com/user-attachments/assets/07d4f17d-1e46-4368-8c46-b1e764b7b88b" />


### After:
<img width="1046" height="724" alt="parameters-name-humanized" src="https://github.com/user-attachments/assets/bf7bf097-6ecb-4be7-a698-d197c4232ab1" />
