### PR TITLE
Fixes #28769: Migrate to Lift 4.0.0-RC1 in scala 3

### DIFF
--- a/webapp/sources/ldap-inventory/inventory-repository/pom.xml
+++ b/webapp/sources/ldap-inventory/inventory-repository/pom.xml
@@ -57,7 +57,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     </dependency>
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-util_2.13</artifactId>
+      <artifactId>lift-util_3</artifactId>
     </dependency>
   </dependencies>
 

--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -368,8 +368,8 @@ limitations under the License.
     <scala-version>3.7.3</scala-version>
     <scala2-version>2.13.18</scala2-version>
     <scala-binary-version>3</scala-binary-version>
-    <scala-xml-version>1.3.1</scala-xml-version>
-    <lift-version>4.0.0-M2</lift-version>
+    <scala-xml-version>2.4.0</scala-xml-version>
+    <lift-version>4.0.0-RC1</lift-version>
     <slf4j-version>2.0.17</slf4j-version>
     <logback-version>1.5.27</logback-version>
     <janino-version>3.1.12</janino-version>
@@ -397,7 +397,7 @@ limitations under the License.
     <postgresql-version>42.7.9</postgresql-version>
     <json-path-version>2.10.0</json-path-version>
     <json-smart-version>2.6.0</json-smart-version>
-    <scalaj-version>2.4.2</scalaj-version>
+    <scalaj-version>2.5.0</scalaj-version>
     <unboundid-version>7.0.4</unboundid-version>
     <fastparse-version>3.1.1</fastparse-version>
     <config-version>1.4.5</config-version>
@@ -499,7 +499,7 @@ limitations under the License.
       </dependency>
       <dependency>
         <groupId>org.scala-lang.modules</groupId>
-        <artifactId>scala-xml_2.13</artifactId>
+        <artifactId>scala-xml_3</artifactId>
         <version>${scala-xml-version}</version>
       </dependency>
       <dependency>
@@ -542,7 +542,8 @@ limitations under the License.
         <groupId>com.softwaremill.quicklens</groupId>
         <artifactId>quicklens_${scala-binary-version}</artifactId>
         <version>${quicklens-version}</version>
-      </dependency><!--
+      </dependency>
+      <!--
         lift-web
       -->
       <dependency>
@@ -552,7 +553,7 @@ limitations under the License.
       </dependency>
       <dependency>
         <groupId>net.liftweb</groupId>
-        <artifactId>lift-common_2.13</artifactId>
+        <artifactId>lift-common_3</artifactId>
         <version>${lift-version}</version>
         <exclusions>
           <exclusion>
@@ -567,9 +568,13 @@ limitations under the License.
       </dependency>
       <dependency>
         <groupId>net.liftweb</groupId>
-        <artifactId>lift-util_2.13</artifactId>
+        <artifactId>lift-util_3</artifactId>
         <version>${lift-version}</version>
         <exclusions>
+          <exclusion>
+            <artifactId>scala3-compiler_3</artifactId>
+            <groupId>org.scala-lang</groupId>
+          </exclusion>
           <exclusion>
             <artifactId>mail</artifactId>
             <groupId>javax.mail</groupId>
@@ -580,11 +585,11 @@ limitations under the License.
       <dependency>
         <groupId>org.mozilla</groupId>
         <artifactId>rhino</artifactId>
-        <version>1.7.15.1</version>
+        <version>1.9.1</version>
       </dependency>
       <dependency>
         <groupId>net.liftweb</groupId>
-        <artifactId>lift-webkit_2.13</artifactId>
+        <artifactId>lift-webkit_3</artifactId>
         <version>${lift-version}</version>
         <exclusions>
           <exclusion>

--- a/webapp/sources/rudder/rudder-core/pom.xml
+++ b/webapp/sources/rudder/rudder-core/pom.xml
@@ -244,7 +244,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-webkit_2.13</artifactId>
+      <artifactId>lift-webkit_3</artifactId>
       <version>${lift-version}</version>
     </dependency>
     <dependency>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/SectionSpecParser.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/cfclerk/xmlparsers/SectionSpecParser.scala
@@ -263,7 +263,7 @@ class SectionSpecParser(variableParser: VariableSpecParser, validateReporting: B
     }
 
     (node.child
-      .filter(child => !child.isEmpty && child.label != "#PCDATA")
+      .filter(child => !child.isEmpty && child.label != "#PCDATA" && child.label != "#REM")
       .toList
       .traverse { child =>
         child.label match {

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/VariableTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/domain/VariableTest.scala
@@ -109,8 +109,7 @@ class VariableTest extends Specification {
     val variables = scala.collection.mutable.Map[String, Variable]()
     for {
       elt      <- (doc \\ "VARIABLES")
-      specNode <- elt.nonEmptyChildren
-      if (!specNode.isInstanceOf[Text])
+      specNode <- elt.nonEmptyChildren.collect { case x: Elem => x }
     } {
       val (spec, other) = variableSpecParser
         .parseSectionVariableSpec("default section", specNode)

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/ncf/TestEditorTechniqueWriter.scala
@@ -626,7 +626,8 @@ class TestEditorTechniqueWriter extends Specification with ContentMatchers with 
   s"Preparing files for technique ${technique.id.value}" should {
 
     "Should write yaml file without problem" in {
-      TechniqueWriterImpl.writeYaml(technique_any)(basePath).runNow must beEqualToIgnoringSep(techniquePath_yaml)
+      val res = TechniqueWriterImpl.writeYaml(technique_any)(basePath).runNow
+      res must beEqualToIgnoringSep(techniquePath_yaml)
     }
 
     "Should generate expected yaml content for our technique" in {

--- a/webapp/sources/rudder/rudder-rest/pom.xml
+++ b/webapp/sources/rudder/rudder-rest/pom.xml
@@ -121,8 +121,8 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
 
     <!-- Doing HTTP requests for remote run -->
     <dependency>
-      <groupId>org.scalaj</groupId>
-      <artifactId>scalaj-http_2.13</artifactId>
+      <groupId>com.codacy</groupId>
+      <artifactId>scalaj-http_3</artifactId>
       <version>${scalaj-version}</version>
     </dependency>
 
@@ -135,7 +135,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Testing Liftweb -->
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-testkit_2.13</artifactId>
+      <artifactId>lift-testkit_3</artifactId>
       <version>${lift-version}</version>
       <scope>test</scope>
     </dependency>

--- a/webapp/sources/rudder/rudder-templates-cli/pom.xml
+++ b/webapp/sources/rudder/rudder-templates-cli/pom.xml
@@ -85,7 +85,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
   <dependencies>
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-common_2.13</artifactId>
+      <artifactId>lift-common_3</artifactId>
       <version>${lift-version}</version>
     </dependency>
 

--- a/webapp/sources/rudder/rudder-templates-cli/src/test/scala/com/normation/templates/cli/TemplateCliTest.scala
+++ b/webapp/sources/rudder/rudder-templates-cli/src/test/scala/com/normation/templates/cli/TemplateCliTest.scala
@@ -49,8 +49,10 @@ import org.specs2.matcher.ContentMatchers
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import org.specs2.specification.AfterAll
+import scala.annotation.nowarn
 
 @RunWith(classOf[JUnitRunner])
+@nowarn("cat=deprecation")
 class TemplateCliTest extends Specification with ContentMatchers with AfterAll {
 
   sequential

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -148,7 +148,7 @@ object Boot {
               replaceCSPRestrictionDirectives("object-src", "'none'")(_)
             )
             .pipe(
-              _ :+ ("base-uri" -> "'none'") :+ ("report-uri" -> s"${S.contextPath}/${LiftRules.liftContextRelativePath}/content-security-policy-report")
+              _ :+ ("base-uri" -> "'none'") :+ ("report-uri" -> s"${S.contextPath}/${LiftRules.liftContextRelativePath().mkString("/")}/content-security-policy-report")
             )
         )
         val newCspHeaders = csp
@@ -185,7 +185,7 @@ object Boot {
       }
     }
 
-    // Assembles directives, separated by ";" and ommits empty directives
+    // Assembles directives, separated by ";" and omits empty directives
     private def compileCSPHeader(directives: List[(String, String)]): String = {
       directives.collect { // copied also from lift header generation
         case (category, restrictions) if restrictions.nonEmpty =>

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/migration/FixedPathLoggerMigration.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/checks/endconfig/migration/FixedPathLoggerMigration.scala
@@ -116,7 +116,7 @@ class FixedPathLoggerMigration extends BootstrapChecks {
     }
   }
 
-  def migrateLogback(xml: NodeSeq) = {
+  def migrateLogback(xml: NodeSeq): NodeSeq = {
     addProperties(addApiAppender(addAppender(removeProperties(removeStdoutAppender(xml)))))
   }
 
@@ -158,7 +158,9 @@ class FixedPathLoggerMigration extends BootstrapChecks {
 
       val prettyPrinter = new PrettyPrinter(120, 4)
 
-      logbackFile.write(prettyPrinter.formatNodes(newLogback))
+      val content           = prettyPrinter.formatNodes(newLogback)
+      val withLastLineBreak = if (content.lastOption.contains('\n')) content else content + '\n'
+      logbackFile.write(withLastLineBreak)
     }
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/CustomPageJs.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/snippet/CustomPageJs.scala
@@ -53,7 +53,7 @@ object CustomPageJs extends DispatchSnippet {
 
   val liftJsScriptSrc = s"${S.contextPath}/${LiftRules.resourceServerPath}/lift.js"
 
-  def pageJsScriptSrc = s"${S.contextPath}/${LiftRules.liftContextRelativePath}/page/${S.renderVersion}.js"
+  def pageJsScriptSrc = s"${S.contextPath}/${LiftRules.liftContextRelativePath().mkString("/")}/page/${S.renderVersion}.js"
 
   def dispatch: DispatchIt = { case "pageScript" => _ => pageScript }
 
@@ -68,6 +68,6 @@ object CustomPageJs extends DispatchSnippet {
   }
 
   private def scriptUrl(scriptFile: String) = {
-    S.encodeURL(s"/${LiftRules.liftContextRelativePath}/$scriptFile")
+    S.encodeURL(s"/${LiftRules.liftContextRelativePath().mkString("/")}/$scriptFile")
   }
 }

--- a/webapp/sources/rudder/rudder-web/src/test/resources/logback-samples/logback-8.2-migrated.xml
+++ b/webapp/sources/rudder/rudder-web/src/test/resources/logback-samples/logback-8.2-migrated.xml
@@ -1,4 +1,4 @@
-<configuration scanPeriod="5 seconds" scan="true">
+<configuration scan="true" scanPeriod="5 seconds">
     <property name="WEBAPP_DIR" value="/var/log/rudder/webapp"/>
     <property name="APILOG_DIR" value="${WEBAPP_DIR}/api"/>
     <appender name="APILOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -71,7 +71,7 @@
       It can be overwritten when the application is launched with the
       Java system property syntax: java -DOPSLOG_DIR="/some/other/directory/"
     -->
-    <property value="/var/log/rudder/compliance" name="REPORT_DIR"/>
+    <property name="REPORT_DIR" value="/var/log/rudder/compliance"/>
     <!--
       A file log appender for exploitation logs about Rest API Calls
      -->
@@ -85,7 +85,7 @@
     <!--
       A file log appender for exploitation logs about failure reports.
     -->
-    <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="REPORTLOG">
+    <appender name="REPORTLOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${REPORT_DIR}/non-compliant-reports.log</file>
         <append>true</append>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -127,21 +127,21 @@
       to be written.
       You should activate that log only for debugging purpose.
     -->
-    <logger level="off" name="trace.ldif.in.file"/>
+    <logger name="trace.ldif.in.file" level="off"/>
     <!--
       Debug inventory processing
       ==========================
       This logger allows to log information about inventories processing: detection in
       /var/rudder/inventories/incoming, parsing, signature validity, etc
     -->
-    <logger level="info" name="inventory-processing"/>
+    <logger name="inventory-processing" level="info"/>
     <!--
       Debug LDAP queries related to inventory search
       ==============================================
       Uncomment and set to "debug" or "trace" to have precise logs about
       LDAP queries done by the node search engine
     -->
-    <logger level="info" name="com.normation.rudder.services.queries"/>
+    <logger name="com.normation.rudder.services.queries" level="info"/>
     <!--
       Debug Node acceptation/group
       ============================
@@ -151,9 +151,9 @@
       - nodes.pending.policies: info about policies applied to a pending node once accepted
       - nodes.delete: information about cleaning steps when deleting a node.
     -->
-    <logger level="info" name="nodes"/>
+    <logger name="nodes" level="info"/>
     <!-- Specific logger for Dynamic group update -->
-    <logger level="info" name="dynamic-group"/>
+    <logger name="dynamic-group" level="info"/>
     <!-- timing info for dynamic groups -->
     <!--  <logger name="dynamic-group.timing" level="info" />-->
     <!--
@@ -165,14 +165,14 @@
       To enable that debug, set level to "debug".
       To disable that debug, set level to "off".
      -->
-    <logger level="off" name="rudder.debug.nodeconfiguration"/>
+    <logger name="rudder.debug.nodeconfiguration" level="off"/>
     <!--
       New node registration
       =====================
       Set level to debug or trace to have more precise information
       about the different acceptation steps of nodes.
      -->
-    <logger level="info" name="nodes.pending"/>
+    <logger name="nodes.pending" level="info"/>
     <!--
       if you want detailled information about how policies that will be applied
       to a node are calculated, uncomment that:
@@ -186,7 +186,7 @@
       Set level to debug or trace to have more information about plugin
       registration and information.
      -->
-    <logger level="info" name="com.normation.rudder.plugins"/>
+    <logger name="com.normation.rudder.plugins" level="info"/>
     <!--
        Promise generation and writing
        ==============================
@@ -198,32 +198,32 @@
       Set to info to only have macro information, debug to have timing information about
       sub-steps (good for debugging performances issues), trace to have more information.
     -->
-    <logger level="info" name="com.normation.rudder.services.policies.PolicyGenerationServiceImpl"/>
+    <logger name="com.normation.rudder.services.policies.PolicyGenerationServiceImpl" level="info"/>
     <!--
       The following logger take care of promises writing. Set to debug or trace to
       have these information.
     -->
-    <logger level="info" name="com.normation.rudder.services.policies.write"/>
+    <logger name="com.normation.rudder.services.policies.write" level="info"/>
     <!--
       The following logger take care of information about reading techniques in repository
     -->
-    <logger level="info" name="techniques.reader"/>
+    <logger name="techniques.reader" level="info"/>
     <!--
       This logger may help debug cases in JS Directive engine, like ticket #13014.
       Set to debug to get stack traces and more details errors.
     -->
-    <logger level="info" name="jsDirectiveParam"/>
+    <logger name="jsDirectiveParam" level="info"/>
     <!--
         This logger allows to log information about policy generation
     -->
-    <logger additivity="false" level="info" name="policy.generation">
+    <logger name="policy.generation" level="info" additivity="false">
         <appender-ref ref="OPSLOG"/>
         <appender-ref ref="STDOUT"/>
     </logger>
     <!--
         This logger allows to log information about expected reports in policy generation
     -->
-    <logger additivity="false" level="info" name="policy.generation.expected_reports">
+    <logger name="policy.generation.expected_reports" level="info" additivity="false">
         <appender-ref ref="OPSLOG"/>
         <appender-ref ref="STDOUT"/>
     </logger>
@@ -231,9 +231,9 @@
         These two loggers allows to log information about policy generation performance.
         Use debug or trace level. Trace is very verbose.
     -->
-    <logger level="info" name="policy.generation.timing"/>
-    <logger level="info" name="org.eclipse.jetty"/>
-    <logger level="info" name="policy.generation.timing.buildNodeConfig"/>
+    <logger name="policy.generation.timing" level="info"/>
+    <logger name="org.eclipse.jetty" level="info"/>
+    <logger name="policy.generation.timing.buildNodeConfig" level="info"/>
     <!--
       For the following logger where "OPSLOG" is defined, will get the logs in both the
       webapp logs and file config in OPSLOG (by default, /var/log/rudder/core/rudder-webapp.log
@@ -249,7 +249,7 @@
       what is sooooo long - and should not.
       Set to debug or trace to have information.
     -->
-    <logger additivity="false" level="info" name="bootstrap">
+    <logger name="bootstrap" level="info" additivity="false">
         <appender-ref ref="OPSLOG"/>
         <!-- comment the following appender if you don't want to have logs about report in both stdout and opslog -->
         <appender-ref ref="STDOUT"/>
@@ -262,7 +262,7 @@
       of Rudder internals.
       Set to debug or trace to have information.
     -->
-    <logger additivity="false" level="info" name="debug_timing">
+    <logger name="debug_timing" level="info" additivity="false">
         <appender-ref ref="OPSLOG"/>
         <appender-ref ref="STDOUT"/>
     </logger>
@@ -272,7 +272,7 @@
       Information on cache, interesting for Rudder 3.0 and up
       Set to debug or trace to have information.
     -->
-    <logger level="info" name="compliance"/>
+    <logger name="compliance" level="info"/>
     <!--
       =================
       Compliance calcul
@@ -284,7 +284,7 @@
       date/time ok regarding run interval and compliance mode, etc.)
       Trace level is quite verbose.
     -->
-    <logger additivity="false" level="info" name="explain_compliance">
+    <logger name="explain_compliance" level="info" additivity="false">
         <appender-ref ref="OPSLOG"/>
         <appender-ref ref="STDOUT"/>
     </logger>
@@ -307,7 +307,7 @@
       takes more than 100ms to complete.
       At trace, you get them all.
     -->
-    <logger additivity="false" level="off" name="sql">
+    <logger name="sql" level="off" additivity="false">
         <appender-ref ref="OPSLOG"/>
         <!-- comment the following appender if you don't want to have logs about report in both stdout and opslog -->
         <appender-ref ref="STDOUT"/>
@@ -323,7 +323,7 @@
       in clear text by some loggers, just add the setting and
       the appropriate comment for them in the current file.
     -->
-    <logger additivity="false" level="info" name="application">
+    <logger name="application" level="info" additivity="false">
         <appender-ref ref="OPSLOG"/>
         <appender-ref ref="STDOUT"/>
     </logger>
@@ -338,7 +338,7 @@
       ================
       This logger is in charge of all scheduled jobs and batches
     -->
-    <logger additivity="false" level="info" name="scheduled.job">
+    <logger name="scheduled.job" level="info" additivity="false">
         <appender-ref ref="OPSLOG"/>
         <appender-ref ref="STDOUT"/>
     </logger>
@@ -347,7 +347,7 @@
       ========================
       Log information about migration processus, for example in case of internal data format updates
     -->
-    <logger additivity="false" level="info" name="migration">
+    <logger name="migration" level="info" additivity="false">
         <appender-ref ref="OPSLOG"/>
         <appender-ref ref="STDOUT"/>
     </logger>
@@ -355,30 +355,30 @@
       Log historization activity (name historization for configuration elements).
       You most likelly don't want more information on that.
     -->
-    <logger additivity="false" level="info" name="historization">
+    <logger name="historization" level="info" additivity="false">
         <appender-ref ref="OPSLOG"/>
         <appender-ref ref="STDOUT"/>
     </logger>
     <!--
       Log about configuration information for the status of some specific parts of Rudder
     -->
-    <logger level="info" name="status">
+    <logger name="status" level="info">
         <appender-ref ref="STDOUT"/>
     </logger>
     <!--
         This logger allows to log information about reports, especially DB cleaning operation
     -->
-    <logger additivity="false" level="info" name="report">
+    <logger name="report" level="info" additivity="false">
         <appender-ref ref="OPSLOG"/>
         <appender-ref ref="STDOUT"/>
     </logger>
-    <logger additivity="false" level="info" name="campaign">
+    <logger name="campaign" level="info" additivity="false">
         <appender-ref ref="STDOUT"/>
     </logger>
     <!--
       Logs about change requests and validation workflows
     -->
-    <logger additivity="false" level="info" name="changeRequest">
+    <logger name="changeRequest" level="info" additivity="false">
         <appender-ref ref="OPSLOG"/>
         <appender-ref ref="STDOUT"/>
     </logger>
@@ -389,7 +389,7 @@
       Log all non compliant reports in the REPORTLOG defined above
       (by default, /var/log/rudder/compliance/non-compliant-reports.log
     -->
-    <logger additivity="false" level="info" name="non-compliant-reports">
+    <logger name="non-compliant-reports" level="info" additivity="false">
         <appender-ref ref="REPORTLOG"/>
     </logger>
     <!--
@@ -399,7 +399,7 @@
       Uncomment and set to "debug" or "trace" to get debugging information about the
       quicksearch: what is the parsed query, how many results come from each backend, etc.
      -->
-    <logger level="info" name="com.normation.rudder.services.quicksearch"/>
+    <logger name="com.normation.rudder.services.quicksearch" level="info"/>
     <!--
       Hooks
       ==========
@@ -409,7 +409,7 @@
       Debug level will display hooks with their parameter (may be quite noisy when there
       is a lot of nodes implied). Trace add system information (like environment variables).
     -->
-    <logger additivity="false" level="info" name="hooks">
+    <logger name="hooks" level="info" additivity="false">
         <appender-ref ref="OPSLOG"/>
         <!-- comment the following appender if you don't want to have logs about report in both stdout and opslog -->
         <appender-ref ref="STDOUT"/>
@@ -425,7 +425,7 @@
         Trace level is quite verbose and print for each request result for ALL path tested (100 of lines)
 
     -->
-    <logger additivity="false" level="info" name="api-processing">
+    <logger name="api-processing" level="info" additivity="false">
         <appender-ref ref="APILOG"/>
         <appender-ref ref="STDOUT"/>
     </logger>
@@ -443,7 +443,7 @@
       sensitive information (e.g. session ID, cookie) to be output
       in clear text. Change it at your own risk!
     -->
-    <logger level="info" name="comet_trace"/>
+    <logger name="comet_trace" level="info"/>
     <!--
       Spring Framework log level
       ==========================
@@ -454,7 +454,7 @@
       sensitive information (e.g. session ID, cookie) to be output
       in clear text. Change it at your own risk!
     -->
-    <logger level="warn" name="org.springframework"/>
+    <logger name="org.springframework" level="warn"/>
     <!--
       We don't need to have timing information for each
       HTTP request.
@@ -462,13 +462,13 @@
       level for that logger to (at least) "info"
       Nor information about CometActor or session lifecycle
      -->
-    <logger level="warn" name="net.liftweb.util.TimeHelpers"/>
-    <logger level="warn" name="net.liftweb.http.CometActor"/>
-    <logger level="warn" name="net.liftweb.http.SessionMaster"/>
+    <logger name="net.liftweb.util.TimeHelpers" level="warn"/>
+    <logger name="net.liftweb.http.CometActor" level="warn"/>
+    <logger name="net.liftweb.http.SessionMaster" level="warn"/>
     <!--
       We don't need logs about each autoCommit for postgresql connection
      -->
-    <logger level="warn" name="com.zaxxer.hikari"/>
+    <logger name="com.zaxxer.hikari" level="warn"/>
     <!-- Uncomment to have precise log about LDAP queries done by the node search engine -->
     <!--   <logger name="com.normation.rudder.services.queries.InternalLDAPQueryProcessor" level="debug" /> -->
     <!-- Uncomment to have precise log about auth-backends plugin if installed -->

--- a/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/migration/TestMigrateLogbackXml.scala
+++ b/webapp/sources/rudder/rudder-web/src/test/scala/bootstrap/liftweb/checks/endconfig/migration/TestMigrateLogbackXml.scala
@@ -54,8 +54,7 @@ import scala.xml.PrettyPrinter
 @RunWith(classOf[JUnitRunner])
 class TestMigrateLogbackXml extends Specification with ContentMatchers with AfterAll {
 
-  val xml    = {
-    <configuration scan="true" scanPeriod="5 seconds">
+  val xml = <configuration scan="true" scanPeriod="5 seconds">
       <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
           <Pattern>%d{{[yyyy-MM-dd HH:mm:ssZ]}} %-5level %logger - %msg%n%ex{{full}}</Pattern>
@@ -117,9 +116,8 @@ class TestMigrateLogbackXml extends Specification with ContentMatchers with Afte
         <appender-ref ref="STDOUT"/>
       </logger>
     </configuration>
-  }
-  val result = {
-    <configuration scan="true" scanPeriod="5 seconds">
+
+  val result = <configuration scan="true" scanPeriod="5 seconds">
     <property name="WEBAPP_DIR" value="/var/log/rudder/webapp"/>
     <property name="APILOG_DIR" value="${WEBAPP_DIR}/api"/>
     <appender name="APILOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -180,7 +178,6 @@ class TestMigrateLogbackXml extends Specification with ContentMatchers with Afte
         <appender-ref ref="STDOUT"/>
       </logger>
     </configuration>
-  }
 
   val migration     = new FixedPathLoggerMigration()
   val prettyPrinter = new PrettyPrinter(120, 4)
@@ -213,6 +210,7 @@ class TestMigrateLogbackXml extends Specification with ContentMatchers with Afte
 
     content must beEqualTo(previous_content)
   }
+
   "may be ran twice without breaking the logback.xml file" >> {
 
     val logback8_2_migrated = tmpDir / "logback-8.2-migrated.xml"

--- a/webapp/sources/utils/pom.xml
+++ b/webapp/sources/utils/pom.xml
@@ -51,7 +51,7 @@ limitations under the License.
     </dependency>
     <dependency>
       <groupId>net.liftweb</groupId>
-      <artifactId>lift-common_2.13</artifactId>
+      <artifactId>lift-common_3</artifactId>
     </dependency>
     <dependency>
         <groupId>com.lihaoyi</groupId>


### PR DESCRIPTION
https://issues.rudder.io/issues/28769

Switch to Lift 4.0.0-RC1 and other remaning lib in scala 2.13. 
With that, we are now full scala3 without any dependencies in Scala 2.13. 

The main impacts are: 
- switch to `scala-xml` 2.4.0. Specs 4 was compiled with 1.3.1 but it looks like it works, and specs 5 is out of reach. In any case, it's test-side only, and they pass everywhere, included in plugins. 

- it looks like some `LiftRules` function behavior as changed, like `liftContextRelativePath` which is not interpreted anymore. It might be due to change in imports. Other similar case may happen.

# Impact of `scala-xml 2.4.0`

- comments are kepts in the doc, so in several places we have to filter out `#REM` labeled node. It might be needed elsewhere, 
- the order of attributes when written changed again, and it's still not the orginal one. 
Long term solution is to avoid XML, or use good old Java XML libs. 

# Removing scala-compiler 

`lift-json` used to need it, but not json4s (https://github.com/json4s/json4s/issues/108) so we don't need it anymore until it's cleaned-up in lift side. 
