### PR TITLE
Fixes #28804: provide a dev environment for Nix users

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,62 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782535326,
+        "narHash": "sha256-ZeRxu4yn6shd3SNF5ZUQb4r7BaVo1zBKMjRhfoNSBmw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "714a5f8c4ead6b31148d829288440ed033ccc041",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rudder-tools": "rudder-tools"
+      }
+    },
+    "rudder-tools": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1781795952,
+        "narHash": "sha256-kE9002kJsRx6e5dqAl1pjAd+PU3hcN2dDoLg20eAZgU=",
+        "owner": "Normation",
+        "repo": "rudder-tools",
+        "rev": "a0a79d3e87437574bc3ea9948c9b0c56c00800e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Normation",
+        "repo": "rudder-tools",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,65 @@
+{
+  description = "Rudder";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+  inputs.rudder-tools.url = "github:Normation/rudder-tools";
+
+  outputs =
+    { self, ... }@inputs:
+
+    let
+      javaVersion = 17; # Change this value to update the whole stack
+
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forEachSupportedSystem =
+        f:
+        inputs.nixpkgs.lib.genAttrs supportedSystems (
+          system:
+          f {
+            pkgs = import inputs.nixpkgs {
+              inherit system;
+              overlays = [ inputs.self.overlays.default ];
+            };
+            rudder-tools = inputs.rudder-tools.packages.${system};
+          }
+        );
+    in
+    {
+      overlays.default =
+        final: prev:
+        let
+          jdk = prev."jdk${toString javaVersion}_headless";
+        in
+        {
+          maven = prev.maven.override { jdk_headless = jdk; };
+        };
+
+      devShells = forEachSupportedSystem (
+        { pkgs, rudder-tools }:
+        let
+          fhs = pkgs.buildFHSEnv {
+            name = "rudder fhs";
+            targetPkgs = pkgs: with pkgs; [
+              rudder-tools.rudder-dev
+              cacert
+              maven
+              coreutils
+              nodejs_22
+              bash
+              elmPackages.elm
+              elmPackages.elm-format
+              elmPackages.elm-test
+            ];
+          };
+        in
+        {
+          default = fhs.env;
+        }
+      );
+    };
+}


### PR DESCRIPTION
https://issues.rudder.io/issues/28804

The rudder-tools url can be changed once https://github.com/Normation/rudder-tools/pull/867 is merged

You can test the environment using any Nix env by running `nix develop`