### PR TITLE
Fixes #28805: Only share the cargo sources caches between jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -302,7 +302,7 @@ pipeline {
                             script {
                                 docker.image('postgres:11-bullseye').withRun('-u 0:0 -e POSTGRES_USER=${POSTGRES_USER} -e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} -e POSTGRES_DB=${POSTGRES_DB}', '-c listen_addresses="*"') { c ->
                                     docker.build('relayd', "-f relay/sources/relayd/Dockerfile --build-arg USER_ID=${env.JENKINS_UID} --pull .")
-                                          .inside("-u 0:0 -v /srv/cache/cargo:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache --link=${c.id}:postgres") {
+                                          .inside("-u 0:0 -v /srv/cache/cargo/cache:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache --link=${c.id}:postgres") {
                                         dir('relay/sources/relayd') {
                                             sh script: "PGPASSWORD=${POSTGRES_PASSWORD} psql -U ${POSTGRES_USER} -h postgres -d ${POSTGRES_DB} -a -f tools/create-database.sql", label: 'provision database'
                                             sh script: 'make check', label: 'relayd tests'
@@ -339,7 +339,7 @@ pipeline {
                             label 'generic-docker'
                             filename 'relay/sources/rudder-package/Dockerfile'
                             // mount cache
-                            args '-u 0:0 -v /srv/cache/cargo:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache'
+                            args '-u 0:0 -v /srv/cache/cargo/cache:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache'
                         }
                     }
                     steps {
@@ -381,7 +381,7 @@ pipeline {
                             label 'generic-docker'
                             filename 'policies/Dockerfile'
                             additionalBuildArgs  "--build-arg RUDDER_VER=${env.RUDDER_VERSION}-nightly --build-arg PSANALYZER_VER=1.20.0"
-                            args '-u 0:0 -v /srv/cache/cargo:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache'
+                            args '-u 0:0 -v /srv/cache/cargo/cache:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache'
                         }
                     }
                     steps {
@@ -651,7 +651,7 @@ pipeline {
                             filename 'policies/Dockerfile'
                             additionalBuildArgs  "--build-arg RUDDER_VER=${env.RUDDER_VERSION}-nightly"
                             // mount cache
-                            args '-u 0:0 -v /srv/cache/cargo:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache'
+                            args '-u 0:0 -v /srv/cache/cargo/cache:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache'
                         }
                     }
                     steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -302,7 +302,7 @@ pipeline {
                             script {
                                 docker.image('postgres:11-bullseye').withRun('-u 0:0 -e POSTGRES_USER=${POSTGRES_USER} -e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} -e POSTGRES_DB=${POSTGRES_DB}', '-c listen_addresses="*"') { c ->
                                     docker.build('relayd', "-f relay/sources/relayd/Dockerfile --build-arg USER_ID=${env.JENKINS_UID} --pull .")
-                                          .inside("-u 0:0 -v /srv/cache/cargo:/usr/local/cargo/registry -v /srv/cache/sccache:/root/.cache/sccache -v /srv/cache/cargo-vet:/root/.cache/cargo-vet --link=${c.id}:postgres") {
+                                          .inside("-u 0:0 -v /srv/cache/cargo:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache --link=${c.id}:postgres") {
                                         dir('relay/sources/relayd') {
                                             sh script: "PGPASSWORD=${POSTGRES_PASSWORD} psql -U ${POSTGRES_USER} -h postgres -d ${POSTGRES_DB} -a -f tools/create-database.sql", label: 'provision database'
                                             sh script: 'make check', label: 'relayd tests'
@@ -339,7 +339,7 @@ pipeline {
                             label 'generic-docker'
                             filename 'relay/sources/rudder-package/Dockerfile'
                             // mount cache
-                            args '-u 0:0 -v /srv/cache/cargo:/usr/local/cargo/registry -v /srv/cache/sccache:/root/.cache/sccache -v /srv/cache/cargo-vet:/root/.cache/cargo-vet'
+                            args '-u 0:0 -v /srv/cache/cargo:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache'
                         }
                     }
                     steps {
@@ -381,7 +381,7 @@ pipeline {
                             label 'generic-docker'
                             filename 'policies/Dockerfile'
                             additionalBuildArgs  "--build-arg RUDDER_VER=${env.RUDDER_VERSION}-nightly --build-arg PSANALYZER_VER=1.20.0"
-                            args '-u 0:0 -v /srv/cache/cargo:/usr/local/cargo/registry -v /srv/cache/sccache:/root/.cache/sccache -v /srv/cache/cargo-vet:/root/.cache/cargo-vet'
+                            args '-u 0:0 -v /srv/cache/cargo:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache'
                         }
                     }
                     steps {
@@ -651,7 +651,7 @@ pipeline {
                             filename 'policies/Dockerfile'
                             additionalBuildArgs  "--build-arg RUDDER_VER=${env.RUDDER_VERSION}-nightly"
                             // mount cache
-                            args '-u 0:0 -v /srv/cache/cargo:/usr/local/cargo/registry -v /srv/cache/sccache:/root/.cache/sccache'
+                            args '-u 0:0 -v /srv/cache/cargo:/usr/local/cargo/registry/cache -v /srv/cache/sccache:/root/.cache/sccache'
                         }
                     }
                     steps {

--- a/Jenkinsfile-security
+++ b/Jenkinsfile-security
@@ -92,7 +92,7 @@ pipeline {
                     label 'generic-docker'
                     filename 'relay/sources/relayd/Dockerfile'
                     // mount cache
-                    args '-u 0:0 -v /srv/cache/cargo:/usr/local/cargo/registry'
+                    args '-u 0:0 -v /srv/cache/cargo:/usr/local/cargo/registry/cache'
                 }
             }
             steps {

--- a/Jenkinsfile-security
+++ b/Jenkinsfile-security
@@ -92,7 +92,7 @@ pipeline {
                     label 'generic-docker'
                     filename 'relay/sources/relayd/Dockerfile'
                     // mount cache
-                    args '-u 0:0 -v /srv/cache/cargo:/usr/local/cargo/registry/cache'
+                    args '-u 0:0 -v /srv/cache/cargo/cache:/usr/local/cargo/registry/cache'
                 }
             }
             steps {


### PR DESCRIPTION
https://issues.rudder.io/issues/28805

* only share registry/cache which should be safe
* remove cargo-vet cache which has been unused for some time