### PR TITLE
Fixes #28806: Update scala dependencies

### DIFF
--- a/webapp/sources/pom.xml
+++ b/webapp/sources/pom.xml
@@ -166,7 +166,7 @@ limitations under the License.
             <!-- Ignore warning for BoxTrait existential type, no way to change that -->
             <arg>-Wconf:msg=An existential type that came from a Scala-2 classfile for trait BoxTrait:s</arg>
             <!--<arg>-Wsafe-init</arg> -->      <!--  Wrap field accessors to throw an exception on uninitialized access. Disabled because of technique repo and API -->
-            <arg>-Xfatal-warnings</arg>         <!-- Fail the compilation if there are any warnings. -->
+            <arg>-Werror</arg>                  <!-- Fail the compilation if there are any warnings. -->
             <arg>-Wunused:imports</arg>         <!-- Warn if an import selector is not referenced. -->
             <arg>-Wunused:locals</arg>          <!-- Warn if a local definition is unused. -->
             <arg>-Wunused:implicits</arg>       <!-- Warn if an implicit parameter is unused. -->
@@ -356,7 +356,7 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Maven plugin version -->
-    <scala-maven-plugin-version>4.9.8</scala-maven-plugin-version>
+    <scala-maven-plugin-version>4.9.10</scala-maven-plugin-version>
 
     <!-- Libraries version that MUST be used in all children project -->
 
@@ -364,52 +364,51 @@ limitations under the License.
     <rudder-major-version>9.2</rudder-major-version>
     <rudder-version>9.2.0~alpha1-SNAPSHOT</rudder-version>
 
-    <servlet-version>5.0.0</servlet-version>
-    <scala-version>3.7.3</scala-version>
-    <scala2-version>2.13.18</scala2-version>
+    <servlet-version>6.1.0</servlet-version>
+    <scala-version>3.8.3</scala-version>
     <scala-binary-version>3</scala-binary-version>
     <scala-xml-version>2.4.0</scala-xml-version>
     <lift-version>4.0.0-RC1</lift-version>
     <slf4j-version>2.0.17</slf4j-version>
-    <logback-version>1.5.27</logback-version>
+    <logback-version>1.5.32</logback-version>
     <janino-version>3.1.12</janino-version>
-    <jodatime-version>2.14.0</jodatime-version>
+    <jodatime-version>2.14.1</jodatime-version>
     <jodaconvert-version>3.0.1</jodaconvert-version>
     <commons-io-version>2.21.0</commons-io-version>
     <commons-lang-version>3.20.0</commons-lang-version>
     <commons-text-version>1.15.0</commons-text-version>
     <commons-codec-version>1.21.0</commons-codec-version>
+    <!-- keep M4 because https://issues.rudder.io/issues/28527 -->
     <commons-fileupload>2.0.0-M4</commons-fileupload>
     <commons-csv-version>1.14.1</commons-csv-version>
-    <jgit-version>7.5.0.202512021534-r</jgit-version>
-    <spring-version>6.2.16</spring-version>
-    <spring-security-version>6.5.9</spring-security-version>
-    <cglib-version>3.3.0</cglib-version>
+    <jgit-version>7.6.0.202603022253-r</jgit-version>
+    <spring-version>7.0.7</spring-version>
+    <spring-security-version>7.1.0-RC1</spring-security-version>
     <asm-version>9.9.1</asm-version>
     <!-- Level of Java compatibility, here 1.8+ -->
     <bouncycastle-compat>jdk18on</bouncycastle-compat>
-    <bouncycastle-version>1.83</bouncycastle-version>
+    <bouncycastle-version>1.84</bouncycastle-version>
     <better-files-version>3.9.2</better-files-version>
     <sourcecode-version>0.4.4</sourcecode-version>
     <quicklens-version>1.9.12</quicklens-version>
     <hikaricp-version>7.0.2</hikaricp-version>
     <nuprocess-version>3.0.0</nuprocess-version>
-    <postgresql-version>42.7.9</postgresql-version>
-    <json-path-version>2.10.0</json-path-version>
+    <postgresql-version>42.7.10</postgresql-version>
+    <json-path-version>3.0.0</json-path-version>
     <json-smart-version>2.6.0</json-smart-version>
     <scalaj-version>2.5.0</scalaj-version>
     <unboundid-version>7.0.4</unboundid-version>
     <fastparse-version>3.1.1</fastparse-version>
     <config-version>1.4.5</config-version>
     <caffeine-version>3.2.3</caffeine-version>
-    <jgrapht-version>1.5.2</jgrapht-version>
+    <jgrapht-version>1.5.3</jgrapht-version>
     <reflections-version>0.10.2</reflections-version>
-    <graalvm-version>25.0.2</graalvm-version>
-    <chimney-version>1.8.2</chimney-version>
-    <chimney-macro-version>2.0.2</chimney-macro-version>
+    <graalvm-version>25.0.3</graalvm-version>
+    <chimney-version>1.9.0</chimney-version>
+    <chimney-macro-version>2.1.0</chimney-macro-version>
     <cron4s-version>0.8.2</cron4s-version>
-    <ipaddress-version>5.6.1</ipaddress-version>
-    <snakeyaml-version>2.5</snakeyaml-version>
+    <ipaddress-version>5.6.2</ipaddress-version>
+    <snakeyaml-version>2.6</snakeyaml-version>
 
     <zio-http-version>2.0.0-RC11</zio-http-version> <!-- used in datasources -->
 
@@ -421,16 +420,16 @@ limitations under the License.
     <specs2-version>4.23.0</specs2-version>
     <junit-version>4.13.2</junit-version>
     <cats-version>2.13.0</cats-version>
-    <ip4s-version>3.7.0</ip4s-version>
-    <doobie-version>1.0.0-RC11</doobie-version>
-    <cats-effect-version>3.6.1</cats-effect-version>
+    <ip4s-version>3.8.0</ip4s-version>
+    <doobie-version>1.0.0-RC12</doobie-version>
+    <cats-effect-version>3.7.0</cats-effect-version>
     <dev-zio-version>2.1.24</dev-zio-version>
     <zio-cats-version>23.1.0.13</zio-cats-version> <!-- gives fs2 3.10.2, but doobie 1.0.0-RC5 is in 3.9.3 -->
-    <zio-json-version>0.8.0</zio-json-version>
+    <zio-json-version>0.9.2</zio-json-version>
     <izumi-version>3.0.9</izumi-version>
     <magnolia-version>1.3.18</magnolia-version>
     <difflicious-version>0.4.4</difflicious-version>
-    <enumeratum-version>1.9.4</enumeratum-version>
+    <enumeratum-version>1.9.7</enumeratum-version>
 
     <!--
       Hack to make scalac jvm parameters like RAM configurable.
@@ -471,11 +470,6 @@ limitations under the License.
         <artifactId>jakarta.servlet-api</artifactId>
         <version>${servlet-version}</version>
         <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.scala-lang</groupId>
-        <artifactId>scala-library</artifactId>
-        <version>${scala2-version}</version>
       </dependency>
       <dependency>
         <groupId>org.scala-lang</groupId>
@@ -725,18 +719,6 @@ limitations under the License.
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <!-- Needed to use spring configuration by annotation -->
-      <dependency>
-        <groupId>cglib</groupId>
-        <artifactId>cglib</artifactId>
-        <version>${cglib-version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/apidata/JsonResponseObjects.scala
@@ -101,7 +101,6 @@ import io.scalaland.chimney.dsl.*
 import java.time.Instant
 import java.time.LocalTime
 import zio.*
-import zio.Tag as _
 import zio.json.*
 import zio.json.ast.Json
 import zio.json.internal.Write

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/UpdateDynamicGroups.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/batch/UpdateDynamicGroups.scala
@@ -47,7 +47,6 @@ import com.normation.rudder.domain.logger.DynamicGroupLoggerPure
 import com.normation.rudder.domain.logger.ScheduledJobLogger
 import com.normation.rudder.domain.nodes.NodeGroupId
 import com.normation.rudder.services.queries.*
-import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.utils.ParseMaxParallelism
 import com.normation.utils.DateFormaterService

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NewNodeManager.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/NewNodeManager.scala
@@ -69,7 +69,7 @@ import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
 import com.normation.zio.*
 import com.softwaremill.quicklens.*
-import zio.{System as _, *}
+import zio.*
 import zio.syntax.*
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/PurgeDeletedNodes.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/nodes/PurgeDeletedNodes.scala
@@ -47,7 +47,7 @@ import com.normation.ldap.sdk.BuildFilter.*
 import com.normation.rudder.domain.logger.NodeLoggerPure
 import com.normation.rudder.services.nodes.NodeInfoService.A_MOD_TIMESTAMP
 import org.joda.time.DateTime
-import zio.{System as _, *}
+import zio.*
 
 trait PurgeDeletedNodes {
 

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/fetchinfo/FetchAllInfoService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/policies/fetchinfo/FetchAllInfoService.scala
@@ -79,7 +79,6 @@ import java.time.Instant
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 import zio.*
-import zio.System as _
 import zio.syntax.*
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/queries/LdapQueryProcessor.scala
@@ -53,12 +53,12 @@ import com.normation.rudder.domain.queries.CriterionComposition.*
 import com.normation.rudder.facts.nodes.CoreNodeFact
 import com.normation.rudder.repository.ldap.LDAPEntityMapper
 import com.normation.zio.currentTimeMillis
-import com.unboundid.ldap.sdk.{LDAPConnection as _, SearchScope as _, *}
+import com.unboundid.ldap.sdk.{SearchScope as _, *}
 import com.unboundid.ldap.sdk.DereferencePolicy.NEVER
 import java.util.regex.Pattern
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import zio.{System as _, *}
+import zio.*
 import zio.syntax.*
 
 /*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ComputeNodeStatusReportService.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ComputeNodeStatusReportService.scala
@@ -60,7 +60,7 @@ import com.normation.utils.DateFormaterService
 import com.normation.zio.*
 import com.softwaremill.quicklens.*
 import org.joda.time.*
-import zio.{System as _, *}
+import zio.*
 import zio.syntax.*
 
 /*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeStatusReportRepository.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/NodeStatusReportRepository.scala
@@ -54,7 +54,7 @@ import doobie.*
 import doobie.implicits.*
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
-import zio.{System as _, *}
+import zio.*
 import zio.interop.catz.*
 
 /*

--- a/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
+++ b/webapp/sources/rudder/rudder-core/src/main/scala/com/normation/rudder/services/reports/ReportingServiceImpl.scala
@@ -45,7 +45,7 @@ import com.normation.rudder.domain.policies.RuleId
 import com.normation.rudder.domain.reports.*
 import com.normation.rudder.domain.reports.NodeStatusReport.*
 import com.normation.rudder.tenants.QueryContext
-import zio.{System as _, *}
+import zio.*
 
 object ReportingServiceUtils {
 

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitRepositoryTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/cfclerk/services/JGitRepositoryTest.scala
@@ -77,7 +77,7 @@ import org.specs2.runner.JUnitRunner
 import org.specs2.specification.AfterAll
 import scala.annotation.nowarn
 import scala.util.Random
-import zio.{System as _, *}
+import zio.*
 import zio.syntax.*
 
 /**

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/rudder/services/queries/TestNodeFactQueryProcessor.scala
@@ -58,7 +58,7 @@ import net.liftweb.common.Failure
 import org.junit.*
 import org.junit.runner.RunWith
 import org.junit.runners.BlockJUnit4ClassRunner
-import zio.{test as _, *}
+import zio.*
 import zio.syntax.*
 import zio.test.*
 import zio.test.Assertion.*

--- a/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/utils/RepetitionComputerTest.scala
+++ b/webapp/sources/rudder/rudder-core/src/test/scala/com/normation/utils/RepetitionComputerTest.scala
@@ -37,7 +37,7 @@
 
 package com.normation.utils
 
-import org.joda.time.{Days as _, *}
+import org.joda.time.*
 import org.joda.time.format.*
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/webapp/sources/rudder/rudder-rest/pom.xml
+++ b/webapp/sources/rudder/rudder-rest/pom.xml
@@ -111,7 +111,7 @@ along with Rudder.  If not, see <http://www.gnu.org/licenses/>.
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-fileupload2-jakarta-servlet5</artifactId>
+      <artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
       <version>${commons-fileupload}</version>
     </dependency>
     <dependency>

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -37,7 +37,7 @@
 
 package com.normation.rudder.rest.lift
 
-import com.normation.errors.{Unexpected as _, *}
+import com.normation.errors.*
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.api.ApiVersion
 import com.normation.rudder.domain.logger.TimingDebugLoggerPure

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/MockServices.scala
@@ -110,8 +110,6 @@ import org.joda.time.DateTime
 import scala.collection.MapView
 import scala.collection.immutable.SortedMap
 import zio.*
-import zio.System as _
-import zio.Tag as _
 import zio.json.ast.Json
 import zio.syntax.*
 

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/AppConfigAuth.scala
@@ -335,9 +335,7 @@ class AppConfigAuth extends ApplicationContextAware {
   @Bean def checkUsersFile: CheckUsersFile = new CheckUsersFile(rudderUserListProvider)
 
   @Bean def fileAuthenticationProvider: AuthenticationProvider = {
-    @nowarn("cat=deprecation")
-    val provider = new DaoAuthenticationProvider()
-    provider.setUserDetailsService(rudderUserDetailsService): @nowarn("cat=deprecation")
+    val provider = new DaoAuthenticationProvider(rudderUserDetailsService)
     provider.setPasswordEncoder(rudderUserDetailsService.authConfigProvider.authConfig.encoder)
 
     // we need to register a callback to check and update users file and a callback to update password encoder when needed
@@ -403,11 +401,7 @@ class AppConfigAuth extends ApplicationContextAware {
                                EventTrace(com.normation.rudder.domain.eventlog.RudderEventActor, DateTime.now())
                              )
     } yield {
-      @nowarn("cat=deprecation")
-      val provider = new DaoAuthenticationProvider()
-      provider.setUserDetailsService(new RudderInMemoryUserDetailsService(authConfigProvider, rootAccountUserRepo)): @nowarn(
-        "cat=deprecation"
-      )
+      val provider = new DaoAuthenticationProvider(new RudderInMemoryUserDetailsService(authConfigProvider, rootAccountUserRepo))
       provider.setPasswordEncoder(encoder) // force password encoder to the one we want
       provider
     }).runNow

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/ShowNodeDetailsFromNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/components/ShowNodeDetailsFromNode.scala
@@ -55,7 +55,6 @@ import com.normation.rudder.repository.FullNodeGroupCategory
 import com.normation.rudder.score.ComplianceScore
 import com.normation.rudder.score.GlobalScore
 import com.normation.rudder.score.ScoreValue.NoScore
-import com.normation.rudder.tenants.ChangeContext
 import com.normation.rudder.tenants.QueryContext
 import com.normation.rudder.web.ChooseTemplate
 import com.normation.rudder.web.model.JsNodeId


### PR DESCRIPTION
https://issues.rudder.io/issues/28806

Notable: 

- we can't update jakarta upload because of change in `setMaxSize` method name, 
- scalac becomes better at discovering what is unused
- cglib doesn't seem to be used anymore
- spring-security major version update was not that hard