### PR TITLE
Fixes #28802: Export Rule compliance by directive to CSV

### DIFF
--- a/webapp/sources/.scalafmt.conf
+++ b/webapp/sources/.scalafmt.conf
@@ -12,6 +12,7 @@ runner.dialectOverride.allowGivenUsing = true
 runner.dialectOverride.allowOpaqueTypes = true
 runner.dialectOverride.allowTraitParameters = true
 runner.dialectOverride.allowTypeLambdas = true
+runner.dialectOverride.allowDependentFunctionTypes = true
 
 rewrite.scala3.convertToNewSyntax = true
 

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/ApiDatastructures.scala
@@ -276,6 +276,7 @@ trait StartsAtVersion20 extends EndpointSchema { val versions: ApiV.From = ApiV.
 trait StartsAtVersion21 extends EndpointSchema { val versions: ApiV.From = ApiV.From(21) } // Rudder 8.3
 trait StartsAtVersion22 extends EndpointSchema { val versions: ApiV.From = ApiV.From(22) } // Rudder 9.0
 trait StartsAtVersion23 extends EndpointSchema { val versions: ApiV.From = ApiV.From(23) } // Rudder 9.1
+trait StartsAtVersion24 extends EndpointSchema { val versions: ApiV.From = ApiV.From(24) } // Rudder 9.2
 
 // utility extension trait to define the kind of API
 trait PublicApi   extends EndpointSchema { val kind: ApiKind.Public.type = ApiKind.Public     }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/EndpointsDefinition.scala
@@ -1052,6 +1052,14 @@ object RuleApi       extends Enum[RuleApi] with ApiModuleProvider[RuleApi]      
     val authz:                  List[AuthorizationType] = AuthorizationType.Rule.Write :: Nil
   }
 
+  case object GetRuleComplianceByDirective extends RuleApi with OneParam with StartsAtVersion24 with SortIndex {
+    val z: Int = implicitly[Line].value
+    val description    = "Get compliance by directive for the given rule"
+    val (action, path) = GET / "rules" / "{id}" / "compliance" / "byDirective"
+    override def dataContainer: Option[String]          = None
+    val authz:                  List[AuthorizationType] = AuthorizationType.Compliance.Read :: Nil
+  }
+
   def endpoints: List[RuleApi] = values.toList.sortBy(_.z)
 
   def values = findValues

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/data/Compliance.scala
@@ -41,6 +41,8 @@ import cats.Order
 import cats.data.NonEmptyList
 import cats.syntax.list.*
 import com.normation.cfclerk.domain.ReportingLogic
+import com.normation.errors.Inconsistency
+import com.normation.errors.IOResult
 import com.normation.inventory.domain.NodeId
 import com.normation.rudder.domain.policies.DirectiveId
 import com.normation.rudder.domain.policies.RuleId
@@ -48,6 +50,7 @@ import com.normation.rudder.domain.reports.*
 import com.normation.rudder.domain.reports.ReportType.*
 import com.normation.rudder.reports.ComplianceModeName
 import com.normation.rudder.web.services.ComputePolicyMode.ComputedPolicyMode
+import com.normation.utils.Csv
 import enumeratum.*
 import fs2.Chunk
 import io.scalaland.chimney.*
@@ -57,6 +60,7 @@ import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.QuoteMode
 import scala.collection.immutable
 import zio.json.JsonEncoder
+import zio.syntax.ToZio
 
 /**
  * Here, we want to present two views of compliance:
@@ -454,9 +458,8 @@ object CsvCompliance {
 
   def recurseComponent(
       component: ByRuleComponentCompliance,
-      block:     List[String]
-  ): Seq[(List[String], String, String, String, String, String)] = {
-    import com.normation.rudder.rest.data.ComplianceApiData.*
+      block:     List[ComponentField]
+  ): Seq[RuleComponentResult] = {
 
     component match {
       case component: ByRuleValueCompliance =>
@@ -464,18 +467,18 @@ object CsvCompliance {
           node.values.flatMap { value =>
             value.messages.map { report =>
               (
-                block,
-                component.name,
-                node.name,
-                value.componentValue,
-                report.reportType.serialize,
-                report.message.getOrElse("")
+                BlockField(block),
+                ComponentField(component),
+                NodeField(node),
+                ValueField(value),
+                StatusField(report),
+                MessageField(report)
               )
             }
           }
         }
       case component: ByRuleBlockCompliance =>
-        component.subComponents.flatMap(c => recurseComponent(c, block ::: (component.name :: Nil)))
+        component.subComponents.flatMap(c => recurseComponent(c, block ::: (ComponentField(component) :: Nil)))
     }
   }
 
@@ -486,14 +489,93 @@ object CsvCompliance {
           c                                            <- r.components
           (block, component, node, value, status, msg) <- recurseComponent(c, Nil)
         } yield {
-          List(r.name, block.mkString(","), component, node, value, status, msg)
+          List(r.name, block, component, node, value, status, msg)
         }
       }
-      // csvFormat take care of the line separator
+      // csvFormat takes care of line separators
       val out      = new lang.StringBuilder()
       csvFormat.printRecord(out, "Rule", "Block", "Component", "Node", "Value", "Status", "Message")
       csvLines.foreach(l => csvFormat.printRecord(out, l*))
       out.toString
+    }
+  }
+
+  /** Trait that contains Csv[A] and Csv.Header.One[A] instances 
+   * that are common to all values that can be converted to CSV */
+  trait CsvField[A <: String] {
+    given Csv[A] = Csv.instance(a => a)
+    given Csv.Header.One[A] with {}
+  }
+
+  opaque type DirectiveField = String
+  object DirectiveField extends CsvField[DirectiveField] {
+    def apply(directive: ByRuleDirectiveCompliance) = directive.name
+  }
+
+  opaque type BlockField = String
+  object BlockField extends CsvField[BlockField] {
+    def apply(block: List[ComponentField]) = block.mkString(",")
+  }
+
+  opaque type ComponentField = String
+  object ComponentField extends CsvField[ComponentField] {
+    def apply(value: ByRuleValueCompliance) = value.name
+    def apply(block: ByRuleBlockCompliance) = block.name
+  }
+
+  opaque type NodeField = String
+  object NodeField extends CsvField[NodeField] {
+    def apply(node: ByRuleNodeCompliance) = node.name
+  }
+
+  opaque type ValueField = String
+  object ValueField extends CsvField[ValueField] {
+    def apply(value: ComponentValueStatusReport) = value.componentValue
+  }
+
+  opaque type StatusField = String
+  object StatusField extends CsvField[StatusField] {
+    import com.normation.rudder.rest.data.ComplianceApiData.serialize
+    def apply(report: MessageStatusReport) = report.reportType.serialize
+  }
+
+  opaque type MessageField = String
+  object MessageField extends CsvField[MessageField] {
+    def apply(report: MessageStatusReport) = report.message.getOrElse("")
+  }
+
+  type RuleComponentResult =
+    (block: BlockField, component: ComponentField, node: NodeField, value: ValueField, status: StatusField, message: MessageField)
+
+  case class RuleComplianceCsv(
+      directive: DirectiveField,
+      block:     BlockField,
+      component: ComponentField,
+      node:      NodeField,
+      value:     ValueField,
+      status:    StatusField,
+      message:   MessageField
+  ) derives Csv
+  object RuleComplianceCsv {
+    import com.normation.rudder.rest.data.CsvCompliance.RuleComponentResult
+
+    given (using directive: ByRuleDirectiveCompliance): Transformer[RuleComponentResult, RuleComplianceCsv] = {
+      Transformer
+        .define[RuleComponentResult, RuleComplianceCsv]
+        .withFieldConst(_.directive, DirectiveField(directive))
+        .buildTransformer
+    }
+
+    given Transformer[ByRuleRuleCompliance, Seq[RuleComplianceCsv]] = (rule: ByRuleRuleCompliance) => {
+      rule.directives.flatMap(d => {
+        for {
+          c   <- d.components
+          res <- recurseComponent(c, Nil)
+        } yield {
+          given ByRuleDirectiveCompliance = d
+          res.transformInto[RuleComplianceCsv]
+        }
+      })
     }
   }
 }
@@ -921,6 +1003,30 @@ object ComplianceApiData {
         .withFieldRenamed(_.compliance, _.complianceDetails)
         .buildTransformer
     }
+
+    final case class RuleComplianceByDirectiveJson(
+        id:                RuleId,
+        name:              String,
+        compliance:        Double,
+        mode:              ComplianceModeName,
+        policyMode:        ComputedPolicyMode,
+        complianceDetails: ComplianceSerializable,
+        directives:        Option[Seq[ByRuleDirectiveComplianceApi]]
+    ) derives JsonEncoder
+
+    given ruleComplianceByDirectiveJson(using
+        precision: CompliancePrecision,
+        level:     Int
+    ): Transformer[ByRuleRuleCompliance, RuleComplianceByDirectiveJson] = {
+      Transformer
+        .define[ByRuleRuleCompliance, RuleComplianceByDirectiveJson]
+        .withFieldRenamed(_.compliance, _.complianceDetails)
+        .withFieldComputed(
+          _.directives,
+          x => if (level < 2) None else Some(x.directives.map(_.transformInto[ByRuleDirectiveComplianceApi]))
+        )
+        .buildTransformer
+    }
   }
 
   // GROUPS
@@ -1172,4 +1278,47 @@ object ComplianceApiData {
 
   }
 
+}
+
+object ComplianceUtils {
+  def extractComplianceLevel(params: Map[String, List[String]]): IOResult[Option[Int]] = {
+    params.get("level") match {
+      case None | Some(Nil) => None.succeed
+      case Some(h :: tail)  => // only take into account the first level param is several are passed
+        try {
+          Some(h.toInt).succeed
+        } catch {
+          case ex: NumberFormatException =>
+            Inconsistency(s"level (displayed level of compliance details) must be an integer, was: '${h}'").fail
+        }
+    }
+  }
+
+  def extractPercentPrecision(params: Map[String, List[String]]): IOResult[Option[CompliancePrecision]] = {
+    params.get("precision") match {
+      case None | Some(Nil) => None.succeed
+      case Some(h :: tail)  => // only take into account the first level param is several are passed
+        for {
+          extracted <- try {
+                         h.toInt.succeed
+                       } catch {
+                         case ex: NumberFormatException =>
+                           Inconsistency(s"percent precision must be an integer, was: '${h}'").fail
+                       }
+          level     <- CompliancePrecision.fromPrecision(extracted).toIO
+        } yield {
+          Some(level)
+        }
+
+    }
+  }
+
+  def extractComplianceFormat(params: Map[String, List[String]]): IOResult[ComplianceFormat] = {
+    params.get("format") match {
+      case None | Some(Nil) | Some("" :: Nil) =>
+        ComplianceFormat.JSON.succeed // by default if no there is no format, should I choose the only one available ?
+      case Some(format :: _)                  =>
+        ComplianceFormat.fromValue(format).left.map(Inconsistency.apply).toIO
+    }
+  }
 }

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/ComplianceApi.scala
@@ -96,45 +96,6 @@ class ComplianceApi(
     readDirective:     RoDirectiveRepository
 ) extends LiftApiModuleProvider[API] {
 
-  def extractComplianceLevel(params: Map[String, List[String]]): IOResult[Option[Int]] = {
-    params.get("level") match {
-      case None | Some(Nil) => None.succeed
-      case Some(h :: tail)  => // only take into account the first level param is several are passed
-        try { Some(h.toInt).succeed }
-        catch {
-          case ex: NumberFormatException =>
-            Inconsistency(s"level (displayed level of compliance details) must be an integer, was: '${h}'").fail
-        }
-    }
-  }
-
-  def extractPercentPrecision(params: Map[String, List[String]]): IOResult[Option[CompliancePrecision]] = {
-    params.get("precision") match {
-      case None | Some(Nil) => None.succeed
-      case Some(h :: tail)  => // only take into account the first level param is several are passed
-        for {
-          extracted <- try { h.toInt.succeed }
-                       catch {
-                         case ex: NumberFormatException =>
-                           Inconsistency(s"percent precision must be an integer, was: '${h}'").fail
-                       }
-          level     <- CompliancePrecision.fromPrecision(extracted).toIO
-        } yield {
-          Some(level)
-        }
-
-    }
-  }
-
-  def extractComplianceFormat(params: Map[String, List[String]]): IOResult[ComplianceFormat] = {
-    params.get("format") match {
-      case None | Some(Nil) | Some("" :: Nil) =>
-        ComplianceFormat.JSON.succeed // by default if no there is no format, should I choose the only one available ?
-      case Some(format :: _)                  =>
-        ComplianceFormat.fromValue(format).left.map(Inconsistency.apply).toIO
-    }
-  }
-
   def schemas: ApiModuleProvider[API] = API
 
   /*
@@ -175,8 +136,8 @@ class ComplianceApi(
       given qc: QueryContext = authzToken.qc
 
       (for {
-        level     <- extractComplianceLevel(req.params)
-        precision <- extractPercentPrecision(req.params)
+        level     <- ComplianceUtils.extractComplianceLevel(req.params)
+        precision <- ComplianceUtils.extractPercentPrecision(req.params)
         rules     <- complianceService.getRulesCompliance(level)
       } yield {
         // by default, all details are displayed
@@ -204,8 +165,8 @@ class ComplianceApi(
       (for {
         t1 <- currentTimeMillis
 
-        level     <- extractComplianceLevel(req.params)
-        precision <- extractPercentPrecision(req.params)
+        level     <- ComplianceUtils.extractComplianceLevel(req.params)
+        precision <- ComplianceUtils.extractPercentPrecision(req.params)
         id        <- RuleId.parse(ruleId).toIO.chainError(s"Parameter '${ruleId}' doesn't have a valid rule ID format'")
 
         rule <- complianceService.getRuleCompliance(id, level)
@@ -237,10 +198,10 @@ class ComplianceApi(
       given qc: QueryContext = authzToken.qc
 
       (for {
-        level     <- extractComplianceLevel(req.params)
+        level     <- ComplianceUtils.extractComplianceLevel(req.params)
         t1        <- currentTimeMillis
-        precision <- extractPercentPrecision(req.params)
-        format    <- extractComplianceFormat(req.params)
+        precision <- ComplianceUtils.extractPercentPrecision(req.params)
+        format    <- ComplianceUtils.extractComplianceFormat(req.params)
         id        <- DirectiveId.parse(directiveId).toIO
         d         <- readDirective.getDirective(id.uid).notOptional(s"Directive with id '${id.serialize}' not found'")
         t2        <- currentTimeMillis
@@ -254,7 +215,7 @@ class ComplianceApi(
         .toLiftResponseGeneric(params, schema, IdTrace.Const(None)) { (level, precision, format, directive) =>
           format match {
             case ComplianceFormat.CSV =>
-              PlainTextResponse(directive.toCsv) // CSVFormat take cares of line separator
+              PlainTextResponse(directive.toCsv) // CSVFormat takes care of line separators
 
             case ComplianceFormat.JSON =>
               // by default, all details are displayed
@@ -286,9 +247,9 @@ class ComplianceApi(
       given qc: QueryContext = authzToken.qc
 
       (for {
-        level      <- extractComplianceLevel(req.params)
+        level      <- ComplianceUtils.extractComplianceLevel(req.params)
         t1         <- currentTimeMillis
-        precision  <- extractPercentPrecision(req.params)
+        precision  <- ComplianceUtils.extractPercentPrecision(req.params)
         t2         <- currentTimeMillis
         _          <- TimingDebugLoggerPure.trace(s"API DirectivesCompliance - getting query param in ${t2 - t1} ms")
         t4         <- currentTimeMillis
@@ -322,7 +283,7 @@ class ComplianceApi(
       given qc: QueryContext = authzToken.qc
 
       (for {
-        precision <- extractPercentPrecision(req.params)
+        precision <- ComplianceUtils.extractPercentPrecision(req.params)
         targets    = req.params.getOrElse("groups", List.empty).flatMap { nodeGroups =>
                        nodeGroups.split(",").toList.flatMap(parseSimpleTargetOrNodeGroupId(_).toOption)
                      }
@@ -362,8 +323,8 @@ class ComplianceApi(
       given qc: QueryContext = authzToken.qc
 
       (for {
-        level     <- extractComplianceLevel(req.params)
-        precision <- extractPercentPrecision(req.params)
+        level     <- ComplianceUtils.extractComplianceLevel(req.params)
+        precision <- ComplianceUtils.extractPercentPrecision(req.params)
         target    <- parseSimpleTargetOrNodeGroupId(groupId).chainError("Could not parse the node group id or group target").toIO
         group     <- complianceService.getNodeGroupCompliance(target, level)
       } yield {
@@ -393,8 +354,8 @@ class ComplianceApi(
       given qc: QueryContext = authzToken.qc
 
       (for {
-        level     <- extractComplianceLevel(req.params)
-        precision <- extractPercentPrecision(req.params)
+        level     <- ComplianceUtils.extractComplianceLevel(req.params)
+        precision <- ComplianceUtils.extractPercentPrecision(req.params)
         target    <- parseSimpleTargetOrNodeGroupId(groupId).chainError("Could not parse the node group id or group target").toIO
         group     <- complianceService.getNodeGroupCompliance(target, level, isGlobalCompliance = false)
       } yield {
@@ -423,8 +384,8 @@ class ComplianceApi(
       given qc: QueryContext = authzToken.qc
 
       (for {
-        level     <- extractComplianceLevel(req.params)
-        precision <- extractPercentPrecision(req.params)
+        level     <- ComplianceUtils.extractComplianceLevel(req.params)
+        precision <- ComplianceUtils.extractPercentPrecision(req.params)
         nodes     <- complianceService.getNodesCompliance(PolicyTypeName.rudderBase)
       } yield {
         given l: Int                 = level.getOrElse(10)
@@ -449,8 +410,8 @@ class ComplianceApi(
       given qc: QueryContext = authzToken.qc
 
       (for {
-        level     <- extractComplianceLevel(req.params)
-        precision <- extractPercentPrecision(req.params)
+        level     <- ComplianceUtils.extractComplianceLevel(req.params)
+        precision <- ComplianceUtils.extractPercentPrecision(req.params)
         node      <- complianceService.getNodeCompliance(NodeId(nodeId), PolicyTypeName.rudderBase)
       } yield {
         given l: Int                 = level.getOrElse(10)
@@ -475,8 +436,8 @@ class ComplianceApi(
       given qc: QueryContext = authzToken.qc
 
       (for {
-        level     <- extractComplianceLevel(req.params)
-        precision <- extractPercentPrecision(req.params)
+        level     <- ComplianceUtils.extractComplianceLevel(req.params)
+        precision <- ComplianceUtils.extractPercentPrecision(req.params)
         node      <- complianceService.getNodeCompliance(NodeId(nodeId), PolicyTypeName.rudderSystem)
       } yield {
         given l: Int                 = level.getOrElse(10)
@@ -500,7 +461,7 @@ class ComplianceApi(
       given qc: QueryContext = authzToken.qc
 
       (for {
-        precision     <- extractPercentPrecision(req.params)
+        precision     <- ComplianceUtils.extractPercentPrecision(req.params)
         optCompliance <- complianceService.getGlobalCompliance()
       } yield {
         given p: CompliancePrecision = precision.getOrElse(CompliancePrecision.Level2)

--- a/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
+++ b/webapp/sources/rudder/rudder-rest/src/main/scala/com/normation/rudder/rest/lift/RuleApi.scala
@@ -50,10 +50,16 @@ import com.normation.rudder.batch.AsyncDeploymentActor
 import com.normation.rudder.batch.AutomaticStartDeployment
 import com.normation.rudder.configuration.ConfigurationRepository
 import com.normation.rudder.domain.logger.ConfigurationLoggerPure
+import com.normation.rudder.domain.logger.TimingDebugLoggerPure
 import com.normation.rudder.domain.policies.*
+import com.normation.rudder.domain.reports.CompliancePrecision
 import com.normation.rudder.facts.nodes.*
 import com.normation.rudder.repository.*
 import com.normation.rudder.rest.{RuleApi as API, *}
+import com.normation.rudder.rest.data.ComplianceApiData
+import com.normation.rudder.rest.data.ComplianceFormat
+import com.normation.rudder.rest.data.ComplianceUtils
+import com.normation.rudder.rest.data.CsvCompliance.RuleComplianceCsv
 import com.normation.rudder.rest.syntax.*
 import com.normation.rudder.rule.category.*
 import com.normation.rudder.services.policies.RuleApplicationStatusService
@@ -61,17 +67,21 @@ import com.normation.rudder.services.workflows.*
 import com.normation.rudder.tenants.*
 import com.normation.rudder.web.services.ComputePolicyMode
 import com.normation.rudder.web.services.ComputePolicyMode.ComputedPolicyMode
+import com.normation.utils.Csv.toCsv
 import com.normation.utils.StringUuidGenerator
+import io.scalaland.chimney.syntax.transformInto
 import net.liftweb.http.LiftResponse
+import net.liftweb.http.PlainTextResponse
 import net.liftweb.http.Req
 import scala.collection.MapView
 import zio.*
 import zio.syntax.*
 
 class RuleApi(
-    zioJsonExtractor: ZioJsonExtractor,
-    service:          RuleApiService14,
-    uuidGen:          StringUuidGenerator
+    zioJsonExtractor:  ZioJsonExtractor,
+    service:           RuleApiService14,
+    uuidGen:           StringUuidGenerator,
+    complianceService: ComplianceAPIService
 ) extends LiftApiModuleProvider[API] {
 
   def schemas: ApiModuleProvider[API] = API
@@ -90,6 +100,7 @@ class RuleApi(
       case API.DeleteRuleCategory              => DeleteRuleCategory
       case API.LoadRuleRevisionForGeneration   => LoadRuleRevisionForGeneration
       case API.UnloadRuleRevisionForGeneration => UnloadRuleRevisionForGeneration
+      case API.GetRuleComplianceByDirective    => GetRuleComplianceByDirective
     }
   }
 
@@ -286,6 +297,56 @@ class RuleApi(
         rid <- RuleId.parse(id).toIO
         res <- service.unloadRule(rid, params, authzToken.qc.actor)
       } yield res).toLiftResponseOne(params, schema, s => Some(s.serialize))
+    }
+  }
+
+  object GetRuleComplianceByDirective extends LiftApiModule {
+    override val schema: OneParam = API.GetRuleComplianceByDirective
+
+    override def process(
+        version:    ApiVersion,
+        path:       ApiPath,
+        ruleId:     String,
+        req:        Req,
+        params:     DefaultParams,
+        authzToken: AuthzToken
+    ): LiftResponse = {
+      given qc: QueryContext = authzToken.qc
+
+      import ComplianceApi.*
+
+      (for {
+        t1 <- Clock.instant
+
+        level     <- ComplianceUtils.extractComplianceLevel(req.params)
+        precision <- ComplianceUtils.extractPercentPrecision(req.params)
+        format    <- ComplianceUtils.extractComplianceFormat(req.params)
+        id        <- RuleId.parse(ruleId).toIO.chainError(s"Parameter '${ruleId}' doesn't have a valid rule ID format'")
+
+        rule <- complianceService.getRuleCompliance(id, level)
+
+        t2 <- Clock.instant
+        _  <- TimingDebugLoggerPure.trace(
+                s"API GetRuleId - getting rule compliance in ${Duration.fromInterval(t1, t2).toString} ms"
+              )
+
+      } yield (level, precision, format, rule))
+        .toLiftResponseGeneric(params, schema, IdTrace.Const(None)) { (level, precision, format, rule) =>
+          format match {
+            case ComplianceFormat.CSV  =>
+              PlainTextResponse(rule.transformInto[Seq[RuleComplianceCsv]].toCsv) // CSVFormat takes care of line separators
+            case ComplianceFormat.JSON =>
+              // by default, all details are displayed
+              given l:        Int                 = level.getOrElse(10)
+              given p:        CompliancePrecision = precision.getOrElse(CompliancePrecision.Level2)
+              given prettify: Boolean             = params.prettify
+
+              val complianceByDirective = rule
+                .transformInto[ComplianceApiData.JsonByRuleCompliance.RuleComplianceByDirectiveJson]
+
+              RudderJsonResponse.successOne(RudderJsonResponse.toResponseSchema(schema), complianceByDirective, None)
+          }
+        }
     }
   }
 

--- a/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_rules.yml
+++ b/webapp/sources/rudder/rudder-rest/src/test/resources/api/api_rules.yml
@@ -1098,3 +1098,120 @@ response:
         }
       }
     }
+---
+description: Get rule compliance by directive
+method: GET
+url: /api/latest/rules/br6/compliance/byDirective
+params:
+  format: json
+response:
+  code: 200
+  content: >-
+    {
+      "action":"getRuleComplianceByDirective",
+      "result":"success",
+      "data" : {
+        "id" : "br6",
+        "name" : "R6",
+        "compliance" : 100.0,
+        "mode" : "full-compliance",
+        "policyMode" : "enforce",
+        "complianceDetails" : {
+          "successAlreadyOK" : 100.0
+        },
+        "directives" : [
+          {
+            "id" : "directive-copyGitFile",
+            "name" : "directive-copyGitFile",
+            "compliance" : 100.0,
+            "policyMode" : "enforce",
+            "complianceDetails" : {
+              "successAlreadyOK" : 100.0
+            },
+            "components" : [
+              {
+                "name" : "directive-copyGitFile-component-br6-bn4",
+                "compliance" : 100.0,
+                "complianceDetails" : {
+                  "successAlreadyOK" : 100.0
+                },
+                "nodes" : [
+                  {
+                    "id" : "bn4",
+                    "name" : "node1.localhost",
+                    "compliance" : 100.0,
+                    "policyMode" : "enforce",
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "values" : [
+                      {
+                        "value" : "directive-copyGitFile-component-value-br6-bn4",
+                        "reports" : [
+                          {
+                            "status" : "successAlreadyOK"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name" : "directive-copyGitFile-component-br6-bn5",
+                "compliance" : 100.0,
+                "complianceDetails" : {
+                  "successAlreadyOK" : 100.0
+                },
+                "nodes" : [
+                  {
+                    "id" : "bn5",
+                    "name" : "node1.localhost",
+                    "compliance" : 100.0,
+                    "policyMode" : "enforce",
+                    "complianceDetails" : {
+                      "successAlreadyOK" : 100.0
+                    },
+                    "values" : [
+                      {
+                        "value" : "directive-copyGitFile-component-value-br6-bn5",
+                        "reports" : [
+                          {
+                            "status" : "successAlreadyOK"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id" : "e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+            "name" : "directive e9a1a909-2490-4fc9-95c3-9d0aa01717c9",
+            "compliance" : 0.0,
+            "policyMode" : "skipped",
+            "complianceDetails" : {},
+            "skippedDetails" : {
+              "overridingRuleId" : "br5",
+              "overridingRuleName" : "R5"
+            },
+            "components" : []
+          }
+        ]
+      }
+    }
+---
+description: Get rule compliance by directive
+method: GET
+url: /api/latest/rules/br6/compliance/byDirective
+params:
+  format: csv
+response:
+  code: 200
+  type: text
+  content: |
+    "Directive","Block","Component","Node","Value","Status","Message"
+    "directive-copyGitFile","","directive-copyGitFile-component-br6-bn4","node1.localhost","directive-copyGitFile-component-value-br6-bn4","successAlreadyOK",""
+    "directive-copyGitFile","","directive-copyGitFile-component-br6-bn5","node1.localhost","directive-copyGitFile-component-value-br6-bn5","successAlreadyOK",""

--- a/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
+++ b/webapp/sources/rudder/rudder-rest/src/test/scala/com/normation/rudder/rest/RestTestSetUp.scala
@@ -1040,7 +1040,7 @@ class RestTestSetUp(val apiVersions: List[ApiVersion] = SupportedApiVersion.apiV
       uuidGen,
       directiveApiService14
     ),
-    new RuleApi(zioJsonExtractor, ruleApiService14, uuidGen),
+    new RuleApi(zioJsonExtractor, ruleApiService14, uuidGen, mockCompliance.complianceAPIService),
     new RulesInternalApi(ruleInternalApiService, ruleApiService14),
     new GroupsInternalApi(groupInternalApiService),
     new NodeApi(

--- a/webapp/sources/rudder/rudder-web/src/main/elm/elm.json
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/elm.json
@@ -36,6 +36,7 @@
             "hecrj/html-parser": "2.4.0",
             "isaacseymour/deprecated-time": "1.0.0",
             "jinjor/elm-debounce": "3.0.0",
+            "justinmimbs/date": "4.1.0",
             "justinmimbs/time-extra": "1.2.0",
             "justinmimbs/timezone-data": "11.1.0",
             "jzxhuang/http-extras": "2.1.0",
@@ -60,7 +61,6 @@
             "TSFoster/elm-md5": "2.0.1",
             "TSFoster/elm-sha1": "2.1.1",
             "danfishgold/base64-bytes": "1.1.0",
-            "justinmimbs/date": "4.1.0",
             "kuon/elm-string-normalize": "1.0.6",
             "rtfeldman/elm-hex": "1.0.0"
         }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
@@ -2,8 +2,10 @@ port module Rules exposing (..)
 
 import Browser
 import Browser.Navigation as Nav
+import Date
 import Dict
 import Dict.Extra
+import File.Download
 import Http exposing (..)
 import Result
 import List.Extra
@@ -13,15 +15,11 @@ import Rudder.Filters
 import Rudder.Table exposing (OutMsg(..))
 import Rules.ChangeRequest exposing (initCrSettings)
 import Task
-import Time
-import Time.DateTime
-import Time.Iso8601
 import UUID
 import Json.Encode exposing (..)
-
 import Rules.ApiCalls exposing (..)
 import Rules.DataTypes exposing (..)
-import Rules.Init exposing (entryToStringList, init)
+import Rules.Init exposing (init)
 import Rules.View exposing (view)
 import Rules.ViewUtils exposing (..)
 
@@ -724,19 +722,33 @@ update msg model =
       in
       handleOutMsg model groupsTable tabMsg outMsgOpt
 
-    ExportCsvWithCurrentDate time ->
+    -- Export full rules table to CSV
+    ExportCsvWithCurrentDate date ->
       let
-        timeStr =
-          time
-          |> Time.DateTime.fromPosix
-          |> Time.Iso8601.fromDateTime
-          -- remove millis
-          |> String.toList |> List.take 10 |> String.fromList
+        timeStr = date |> Date.format "yyyy-MM-dd"
         filename = "rudder_rules_" ++ timeStr
         (groupsTable, tabMsg, outMsgOpt) =
             Rudder.Table.updateExportToCsv model.rulesTable filename
       in
       handleOutMsg model groupsTable tabMsg outMsgOpt
+
+    -- Export compliance sorted by directive of a single rule to CSV
+    ExportRuleComplianceByDirective ruleId date ->
+        let
+          timeStr = date |> Date.format "yyyy-MM-dd"
+          filename = "rudder_rule_" ++ (ruleId.value) ++ "_compliance_by_directive_" ++ timeStr ++ ".csv"
+          cmd = getRuleComplianceByDirective ruleId filename model
+        in
+        (model, cmd)
+
+    RuleComplianceCsvExported filename res ->
+      case res of
+        Ok content ->
+          (model, File.Download.string filename "text/csv" content)
+        Err err ->
+          processApiError "Export rule compliance" err model
+
+
 
 toRuleWithCompliance : Model -> Rule -> RuleWithCompliance
 toRuleWithCompliance model rule =
@@ -794,7 +806,7 @@ handleOutMsg model groupsTable tabMsg outMsgOpt =
             (newModel, Cmd.batch [newMsg, tabMsg])
 
         Just CsvExportRequested ->
-            (model, Task.perform ExportCsvWithCurrentDate Time.now)
+            (model, Task.perform ExportCsvWithCurrentDate Date.today)
 
         _ ->
             ( {model | rulesTable = groupsTable}, tabMsg )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ApiCalls.elm
@@ -414,3 +414,19 @@ deleteCategory category model =
         }
   in
    req
+
+getRuleComplianceByDirective : RuleId -> String -> Model -> Cmd Msg
+getRuleComplianceByDirective ruleId filename model =
+  let
+    req =
+      request
+        { method  = "GET"
+        , headers = [header "X-Requested-With" "XMLHttpRequest"]
+        , url     = getUrl model [ "rules", ruleId.value, "compliance", "byDirective" ] [ Url.Builder.string "format" "csv"]
+        , body    = emptyBody
+        , expect  = expectString (RuleComplianceCsvExported filename)
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+  in
+    req

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
@@ -1,11 +1,11 @@
 module Rules.DataTypes exposing (..)
 
 import Compliance.DataTypes exposing (..)
+import Date
 import Dict exposing (Dict)
 import Http exposing (Error)
 import Rudder.Table
 import Rules.ChangeRequest exposing (ChangeRequest, ChangeRequestSettings)
-import Time
 import Time.ZonedDateTime exposing (ZonedDateTime)
 
 import Ui.Datatable exposing (TableFilters, SortOrder, Category, getAllElems, getAllCats, getSubElems)
@@ -383,4 +383,6 @@ type Msg
     | RefreshReportsTable RuleId
     | UpdateCrSettings ChangeRequestSettings
     | RudderTableMsg (Rudder.Table.Msg Msg)
-    | ExportCsvWithCurrentDate Time.Posix
+    | ExportCsvWithCurrentDate Date.Date
+    | ExportRuleComplianceByDirective RuleId Date.Date
+    | RuleComplianceCsvExported String (Result Error String)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabDirectives.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabDirectives.elm
@@ -1,5 +1,6 @@
 module Rules.ViewTabDirectives exposing (..)
 
+import Date as Time
 import Dict
 import Dict.Extra
 import Html exposing (..)
@@ -11,6 +12,7 @@ import List
 import Maybe.Extra
 import Set
 import NaturalOrdering as N exposing (compareOn)
+import Task
 import Tuple3
 
 import Rules.DataTypes exposing (..)
@@ -131,9 +133,10 @@ directivesTab model details =
           ]
       else
         text ""
-    (complianceFilterBtn, complianceFilterContainer) =
+    (complianceFilterBtn, exportComplianceToCsvBtn, complianceFilterContainer) =
       if noCompliance then
         ( text ""
+        , text ""
         , text ""
         )
       else
@@ -141,6 +144,9 @@ directivesTab model details =
           [ text ((if complianceFilters.showComplianceFilters then "Hide " else "Show ") ++ "compliance filters")
           , i [class ("fa " ++ (if complianceFilters.showComplianceFilters then "fa-minus" else "fa-plus"))][]
           ]
+        , button
+            [class "btn btn-sm btn-primary btn-export me-2", onClick (CallApi model.ui.saving (\_ -> Task.perform (ExportRuleComplianceByDirective rule.id) Time.today)) ]
+            [ text "Export " , i [ class "fa fa-download" ] [] ]
         , displayComplianceFilters complianceFilters UpdateComplianceFilters
         )
 
@@ -153,7 +159,9 @@ directivesTab model details =
             [ input [type_ "text", placeholder "Filter", class "input-sm form-control", value filter
             , onInput (\s -> UpdateDirectiveFilters {directiveFilters | tableFilters = {tableFilters | filter = s}} )][]
             , complianceFilterBtn
-            , button [class "btn btn-default btn-sm btn-refresh", onCustomClick (RefreshComplianceTable rule.id)][i [class "fa fa-refresh"][]]
+            , div [class "ms-auto my-auto"]
+              [ exportComplianceToCsvBtn
+              , button [class "btn btn-default btn-sm btn-refresh", onCustomClick (RefreshComplianceTable rule.id)][i [class "fa fa-refresh"][]]]
             ]
           , complianceFilterContainer
           ]
@@ -229,7 +237,7 @@ directivesTab model details =
       div[class "tab-table-content"]
       ( List.append
         [ div [class "table-title mb-3"]
-          [ h4 [class "mb-0"][text "Compliance by directives"]
+          [ h4 [class "mb-0"][text "Compliance by directive"]
           , ( if model.ui.hasWriteRights then
               button [class "btn btn-default btn-icon", onClick (UpdateRuleForm {details | ui = {ui | editDirectives = True }})][text "Select ", i[class "fa fa-plus-circle"][]]
             else

--- a/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/bootstrap/liftweb/RudderConfig.scala
@@ -2362,7 +2362,8 @@ object RudderConfigInit {
           new RuleApi(
             zioJsonExtractor,
             ruleApiService13,
-            stringUuidGenerator
+            stringUuidGenerator,
+            complianceAPIService
           ),
           new SystemApi(
             systemApiService11,


### PR DESCRIPTION
https://issues.rudder.io/issues/28802

This PR aims to add an "export to CSV" button for rules when sorted by directive.

<img width="1132" height="358" alt="image" src="https://github.com/user-attachments/assets/495c8be8-3b6b-412d-bdf6-d8e592f0189c" />

commit history : 
1. define new datatypes and extend existing `GetRuleId` of the Compliance Api so that it can return the complianc of a given rule by directive in csv format, and add a button that calls this endpoint in the Elm app
2. use opaque types instead of strings for new CSV datatypes
3. refactoring of CSV datatypes + return the `GetRuleId` endpoint to the way it was before and create a new endpoint to return the compliance of a given rule to CSV : `GetNodeGroupComplianceTargetId`
4. move the new endpoint to the Rule Api
5. refactoring of util functions for compliance endpoints
6. refactoring of util functions for compliance endpoints
7. modify the format of the JSON response of the new endpoint so that it only returns the `byDirective` sort, and add a test in `api_rules.yml`
8. add a test `api_rules.yml` for the CSV response of the new endpoint