### PR TITLE
Fixes #28823: Change logs : undefined timezones in dates

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
+++ b/webapp/sources/rudder/rudder-web/src/main/javascript/rudder/rudder.js
@@ -757,7 +757,7 @@ function changeTimezone(date, ianatz) {
  */
 function displayDateTime(date = new Date(), timeZone = dateOptions.timeZone) {
   // get current offset
-  const format = Intl.DateTimeFormat(undefined, { timeZone, timeZoneName: "longOffset" });
+  const format = Intl.DateTimeFormat("en", { timeZone, timeZoneName: "longOffset" });
   const [_, gmtOffset] = format.format(date).split("GMT")
   const offset = gmtOffset == "" ? "Z" : gmtOffset
   return date.toISOString().replace('T', ' ').replace(/\..*$/, offset);


### PR DESCRIPTION
https://issues.rudder.io/issues/28823

The local formatter relies on `GMT±HH:mm` format, which is not the case for e.g. `fr` locale (which has `UTC` instead of `GMT`, it breaks wherer we do `.split("GMT")`). We can just make the formatter a locale-specific one for the code block