### PR TITLE
Fixes #28763: Use a select input for parameters that require one rather than a text input

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewMethod.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Editor/ViewMethod.elm
@@ -78,38 +78,68 @@ showParam model call state methodParam params =
                                                              Nothing
                                                 ) constraintErrors
       _ -> []
+    parameterInput =
+      let
+        commonAttributes =
+          [ stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
+          , onFocus DisableDragDrop
+          , readonly (not model.hasWriteRights)
+          , class "form-control"
+          , id ("param-" ++ methodParam.name.value)
+          , value displayedValue
+          , onInput (MethodCallParameterModified call methodParam.name)
+          -- to deactivate plugin "Grammarly" or "Language Tool" from
+          -- adding HTML that make disapear textarea (see  https://issues.rudder.io/issues/21172)
+          , attribute "data-gramm" "false"
+          , attribute "data-gramm_editor" "false"
+          , attribute "data-enable-grammarly" "false"
+          , spellcheck False
+          ]
+      in
+        case methodParam.constraints.select of
+          Nothing ->
+            [ element "textarea"
+              |> addAttributeList ((rows  1) :: commonAttributes)
+            ]
+
+          Just list ->
+            let
+              datalistId = "param-" ++ methodParam.name.value ++ "-options"
+            in
+              [ element "input"
+                |> addAttributeList ((attribute "list" datalistId) :: commonAttributes)
+              , element "datalist"
+                |> addAttribute (id datalistId)
+                |> appendChildList
+                  ( list
+                  |> List.filter (\opt -> not (String.isEmpty opt.value))
+                  |> List.map
+                    (\opt ->
+                      element "option"
+                        |> addAttributeList
+                          [ value opt.value
+                          ]
+                    )
+                  )
+              ]
   in
     element "div"
       |> addClass "form-group method-parameter"
       |> appendChildList
-        [ element "label"
-          |> addAttribute (for "param-index")
-          |> appendChildList
-            [ element "span"
-              |> appendChild (element "span" |> appendText (String.Extra.toTitleCase methodParam.name.value))
-              |> appendChild isMandatory
-              |> appendChild (element "span" |> appendText " -")
-              |> appendChild (element "span" |> addClass "badge badge-secondary d-inline-flex align-items-center" |> appendText methodParam.type_)
-            , element "small" |> appendText (" " ++ methodParam.description) |> addClass "ms-2"
-            ]
-        , element "textarea"
-          |> addAttributeList
-            [ stopPropagationOn "mousedown" (Json.Decode.succeed (DisableDragDrop, True))
-            , onFocus DisableDragDrop
-            , readonly (not model.hasWriteRights)
-            , name "param"
-            , class "form-control"
-            , rows  1
-            , value displayedValue
-            , onInput  (MethodCallParameterModified call methodParam.name)
-            -- to deactivate plugin "Grammarly" or "Language Tool" from
-            -- adding HTML that make disapear textarea (see  https://issues.rudder.io/issues/21172)
-            , attribute "data-gramm" "false"
-            , attribute "data-gramm_editor" "false"
-            , attribute "data-enable-grammarly" "false"
-            , spellcheck False
-            ]
-        ]
+        ( List.append
+          [ element "label"
+            |> addClass "mb-1 d-inline-flex align-items-baseline"
+            |> addAttribute (for ("param-" ++ methodParam.name.value))
+            |> appendChildList
+              [ element "span"
+                |> appendChild (element "span" |> appendText (String.Extra.toTitleCase methodParam.name.value))
+                |> appendChild isMandatory
+                |> appendChild (element "span" |> appendText "•" |> addClass "text-secondary mx-1")
+              , element "small" |> appendText methodParam.description |> addClass "text-secondary fw-medium"
+              ]
+          ]
+          parameterInput
+        )
       |> appendChildConditional ( element "ul"
         |> addClass "list-unstyled"
         |> appendChildList (errors |> List.map (\e -> element "li" |> addClass "text-danger" |> appendText e))
@@ -160,11 +190,18 @@ checkConstraintOnParameter call constraint =
                                        [ConstraintError { id = call.id, message = ("Parameter '" ++ call.id.value ++"' cannot match the following regexp: " ++ (Maybe.withDefault "" constraint.notMatchRegex) ) }]
                                     else
                                       []
-    checkSelect = Maybe.map ( \ select -> if List.any ( .value >> (==) (displayValue call.value) ) select then
+
+    checkVariableUsage = case Regex.fromString "^\\${.*}$" of
+        Nothing -> False
+        Just regex -> Regex.contains regex (displayValue call.value)
+
+    checkSelect = Maybe.map ( \ select -> if (List.any ( .value >> (==) (displayValue call.value) ) select) || checkVariableUsage then
                      []
                    else
-                     [ConstraintError { id = call.id, message =  ( "Parameter '" ++ call.id.value ++ "' must equal one of the values from the following list: " ++ (String.join ", " (select |> List.map .value)) )} ]
+                     [ConstraintError { id = call.id, message =  ( "Parameter '" ++ call.id.value ++ "' must equal one of the values from the following list: " ++ (String.join ", " (select |> List.filter (\c -> not (String.isEmpty c.value)) |> List.map .value)) ++ ", or use a variable that contains one of these values." )} ]
                   ) constraint.select |> Maybe.withDefault []
+
+
     checks = [ checkEmpty, checkWhiteSpace, checkMax, checkMin, checkRegex, notRegexCheck, checkSelect ] |> List.concat
   in
     if List.isEmpty checks then ValidState else InvalidState checks

--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-technique-editor.scss
@@ -173,22 +173,12 @@ body > .container-fluid {
   margin: 10px;
 }
 
-body > .ng-toast {
-  margin-top: 5px;
-}
-.ng-toast.ng-toast--right .ng-toast__list {
-  margin-right: 55px;
-}
 .alert.alert-dismissible pre {
   white-space: normal;
 }
-.rudder-template textarea.form-control{
-  min-height: unset;
-  line-height: 1.5;
-}
 .rudder-template .method textarea.form-control{
-  display: block;
   overflow: auto;
+  min-height: 34px;
   max-height: 200px;
 }
 
@@ -430,9 +420,6 @@ $drop-zone-marker-height : 6px;
 }
 
 /* FILEMANAGER */
-.ng-hide{
-  display: none !important;
-}
 .filemanager-container nav.navbar.navbar-inverse {
   border: none !important;
   border-bottom-left-radius: 0;
@@ -476,10 +463,6 @@ $drop-zone-marker-height : 6px;
 }
 .filemanager-container nav.navbar .btn.btn-flat:hover {
   opacity: 1;
-}
-.filemanager-container .sortorder.ng-hide{
-  display: inline-block !important;
-  visibility: hidden !important;
 }
 .filemanager-container .dropdown-menu > li > a{
   padding: 10px 20px;
@@ -852,10 +835,6 @@ button.btn.clipboard:hover {
   height: auto;
   padding: 6px;
 }
-.method-details label > small {
-  opacity: .6;
-  font-size: 12px;
-}
 .method-details .tabs-list{
   border-bottom: 1px solid rudder.$border-color-default;
   width: 100% ;
@@ -1041,12 +1020,6 @@ ul li.hide-method {
 }
 #methods .method .method-info .btn-holder + .row > div:first-child{
   padding-right: 70px;
-}
-#methods .method .method-info label {
-  margin-bottom: 4px;
-  word-break: keep-all;
-  display: inline-flex;
-  align-items: baseline;
 }
 .method .cursorMove {
   background-color: rudder.$bg-dark-gray;


### PR DESCRIPTION
https://issues.rudder.io/issues/28763

Replacing previous PR: https://github.com/Normation/rudder/pull/7095

For parameters where the values are limited to a list of possible options, the `<input type="text">` tag has been replaced with a `<select>` tag, in order to prevent errors and make selection easier.

Bonus:
- The "string" label next tho the parameter name has been removed because he has no purposes.
- I removed some unused css

### Before:
<img width="1048" height="493" alt="select-param-before" src="https://github.com/user-attachments/assets/fe7403b2-4f94-48c9-ad19-02d3f611932d" />

### After:
https://github.com/user-attachments/assets/ee9728f1-430b-42ae-a514-40efbd152b8d

----------
### EDIT:

:warning: **Actually, we can't use a `<select>` here because it prevents the user from using variables (technique parameters, iterators, etc.)**. So instead, we now use a `<datalist>` combined with a  `<input type="text">`!
This allows the user to select one of the suggested values directly, but also to use variables freely.

This is what it looks like (datalist display may vary from one browser to another):
<img width="1048" height="479" alt="Capture d’écran du 2026-04-29 10-50-55" src="https://github.com/user-attachments/assets/ce2129ad-6711-4260-a5d7-aa6c16883260" />

So now, there is no more error when user try to use a variable (for now we don't check if the variable exists, we only check the syntax):
<img width="985" height="114" alt="param-check-2" src="https://github.com/user-attachments/assets/b88b0393-e1f8-4561-b66e-a44f266eec5a" />

Alos, the error message has been updated:
<img width="985" height="164" alt="param-check-1" src="https://github.com/user-attachments/assets/846c7e51-fe7c-44ab-a2a3-44e2dbbcd03b" />
