### PR TITLE
Fixes #28775: Rule deletion/disable/enable has no notice about change requests when workflow are enabled

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
@@ -20,6 +20,7 @@ import Rules.View exposing (view)
 import Rules.ViewUtils exposing (..)
 
 import Ui.Datatable exposing (SortOrder(..), Category, SubCategories(..))
+import Rules.ChangeRequest exposing (ChangeRequestSettings)
 
 
 -- PORTS / SUBSCRIPTIONS
@@ -350,13 +351,25 @@ update msg model =
           ({model | mode = RuleForm  details}, initTooltips "")
         _ -> (model, Cmd.none)
 
-    DisableRule ->
+    SaveEnabledRule ->
       case model.mode of
         RuleForm details ->
           let
             rule     = details.originRule
             cmdAction = case rule of
-              Just oR -> saveDisableAction {oR | enabled = not oR.enabled} model
+              Just oR -> saveStatusAction {oR | enabled = True} model
+              Nothing -> initTooltips ""
+          in
+            (model, cmdAction)
+        _   -> (model, Cmd.none)
+
+    SaveDisabledRule ->
+      case model.mode of
+        RuleForm details ->
+          let
+            rule     = details.originRule
+            cmdAction = case rule of
+              Just oR -> saveStatusAction {oR | enabled = False} model
               Nothing -> initTooltips ""
           in
             (model, cmdAction)
@@ -514,15 +527,13 @@ update msg model =
         (newModel, Cmd.none)
 
     OpenDeletionPopup rule ->
-      case model.mode of
-        RuleForm rd ->
-          let
-            ui = model.ui
-            crSettings = case ui.crSettings of
-              Just cr -> Just { cr | changeRequestName = ("Delete Rule '" ++ rd.rule.name ++ "'") }
-              Nothing -> Nothing
-          in
-            ( { model | ui = {ui | modal = DeletionValidation rule crSettings, crSettings = crSettings} } , Cmd.none )
+      case ( model.mode, model.ui.crSettings ) of
+        ( RuleForm _, Just cr ) ->
+          deleteRuleModalState rule cr model
+
+        ( RuleForm _, Nothing ) ->
+          ( model |> setModalState (DeletionValidation rule Nothing) , Cmd.none )
+
         _ -> (model, Cmd.none)
 
     OpenDeletionPopupCat category ->
@@ -533,29 +544,42 @@ update msg model =
             ( { model | ui = {ui | modal = DeletionValidationCat category } } , Cmd.none )
         _ -> (model, Cmd.none)
 
-    OpenDeactivationPopup rule ->
-      case model.mode of
-        RuleForm rd ->
-          let
-            ui = model.ui
-            crSettings = case ui.crSettings of
-              Just cr -> Just { cr | changeRequestName = ("Deactivate Rule '" ++ rd.rule.name ++ "'")}
-              Nothing -> Nothing
-          in
-            ( { model | ui = {ui | modal = DeactivationValidation rule crSettings, crSettings = crSettings}} , Cmd.none )
-        _ -> (model, Cmd.none)
+    OpenDisablePopup ->
+      case ( model.mode, model.ui.crSettings ) of
+        ( RuleForm { rule }, Just cr ) ->
+          disableRuleModalState rule cr model
 
-    OpenSaveAuditMsgPopup rule crSettings ->
-      case model.mode of
-        RuleForm rd ->
-          let
-            ui = model.ui
-            creation = (isNothing rd.originRule)
-            action = if creation then "Create" else "Update"
-            newCrSettings = { crSettings | changeRequestName = (action ++ " Rule '" ++ rd.rule.name ++ "'")}
-          in
-            ( { model | ui = {ui | modal = SaveAuditMsg creation rule rd.originRule newCrSettings, crSettings = (Just newCrSettings)}} , Cmd.none )
-        _ -> (model, Cmd.none)
+        ( RuleForm { rule }, Nothing ) ->
+          ( model |> setModalState (DisableValidation rule Nothing) , Cmd.none )
+
+        _ ->
+          ( model, Cmd.none )
+
+    OpenEnablePopup ->
+      case ( model.mode, model.ui.crSettings ) of
+        ( RuleForm { rule }, Just cr ) ->
+          enableRuleModalState rule cr model
+
+        ( RuleForm { rule }, Nothing ) ->
+          ( model |> setModalState (EnableValidation rule Nothing) , Cmd.none )
+
+        _ ->
+          ( model, Cmd.none )
+
+    SaveRule rule ->
+      case ( model.mode, model.ui.crSettings ) of
+        ( RuleForm rd, Just cr ) ->
+          if cr.enableChangeMessage || cr.enableChangeRequest then
+            saveRuleModalState rd cr model
+
+          else
+            update (CallApi True (saveRuleDetails rule (Maybe.Extra.isNothing rd.originRule))) model
+
+        ( RuleForm rd, Nothing ) ->
+          update (CallApi True (saveRuleDetails rule (Maybe.Extra.isNothing rd.originRule))) model
+
+        _ ->
+          ( model, Cmd.none )
 
     ClosePopup callback ->
       let
@@ -663,7 +687,8 @@ update msg model =
         ui = model.ui
         newModalState = case ui.modal of
           SaveAuditMsg c r oR s      -> SaveAuditMsg c r oR settings
-          DeactivationValidation r s -> DeactivationValidation r (Just settings)
+          DisableValidation r s -> DisableValidation r (Just settings)
+          EnableValidation r s -> EnableValidation r (Just settings)
           DeletionValidation  r s    -> DeletionValidation r (Just settings)
           _ -> ui.modal
       in
@@ -695,3 +720,51 @@ processApiError apiName err model =
 
 getUrl : Model -> String
 getUrl model = model.contextPath ++ "/secure/configurationManager/ruleManagement"
+
+
+saveRuleModalState : RuleDetails -> ChangeRequestSettings -> Model -> ( Model, Cmd msg )
+saveRuleModalState { originRule, rule } crSettings model =
+  let
+    creation = (isNothing originRule)
+    action = if creation then "Create" else "Update"
+    newCrSettings = { crSettings | changeRequestName = (action ++ " Rule '" ++ rule.name ++ "'")}
+    state = SaveAuditMsg creation rule originRule newCrSettings
+  in
+  ( model |> setModalState state |> setCrSettings newCrSettings, Cmd.none )
+
+
+deleteRuleModalState : Rule -> ChangeRequestSettings -> Model -> ( Model, Cmd msg )
+deleteRuleModalState rule crSettings model =
+  let
+    newCrSettings = { crSettings | changeRequestName = ("Delete Rule '" ++ rule.name ++ "'") }
+    state = DeletionValidation rule (Just newCrSettings)
+  in
+  ( model |> setModalState state |> setCrSettings newCrSettings, Cmd.none )
+
+
+disableRuleModalState : Rule -> ChangeRequestSettings -> Model -> ( Model, Cmd msg )
+disableRuleModalState rule crSettings model =
+  let
+    newCrSettings = { crSettings | changeRequestName = ("Disable Rule '" ++ rule.name ++ "'") }
+    state = DisableValidation rule (Just newCrSettings)
+  in
+  ( model |> setModalState state |> setCrSettings newCrSettings, Cmd.none )
+
+
+enableRuleModalState : Rule -> ChangeRequestSettings -> Model -> ( Model, Cmd msg )
+enableRuleModalState rule crSettings model =
+  let
+    newCrSettings = { crSettings | changeRequestName = ("Enable Rule '" ++ rule.name ++ "'") }
+    state = EnableValidation rule (Just newCrSettings)
+  in
+  ( model |> setModalState state |> setCrSettings newCrSettings, Cmd.none )
+
+
+setModalState : ModalState -> Model -> Model
+setModalState state ({ ui } as model) =
+  { model | ui = { ui | modal = state } }
+
+
+setCrSettings : ChangeRequestSettings -> Model -> Model
+setCrSettings settings ({ ui } as model) =
+  { model | ui = { ui | crSettings = Just settings } }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules.elm
@@ -404,19 +404,7 @@ update msg model =
                 ( Just { cr | message = "" }
                 , ( if cr.enableChangeRequest then
                   case ruleDetails.changeRequestId of
-                    Just id ->
-                      let
-                        message = "Change request #"++ id ++" successfully created."
-                        linkUrl = model.contextPath ++ "/secure/configurationManager/changes/changeRequest/" ++ id
-                        linkTxt = "See details of change request #" ++ id
-                        encodeToastInfo =
-                          object
-                          [ ("message", string message)
-                          , ("linkUrl", string linkUrl)
-                          , ("linkTxt", string linkTxt)
-                          ]
-                      in
-                        linkSuccessNotification encodeToastInfo
+                    Just id -> crNotification model.contextPath id
                     Nothing -> defaultNotif
                   else
                   defaultNotif
@@ -482,20 +470,48 @@ update msg model =
     SaveCategoryResult (Err err) ->
       processApiError "Saving Category" err model
 
-    DeleteRule (Ok (ruleId, ruleName)) ->
-      case model.mode of
-        RuleForm r ->
+    DeleteRule (Ok { changeRequestId, id, name }) ->
+      let
+        ui = model.ui
+        defaultNotification = successNotification ("Rule '"++ name ++"' successfully deleted")
+      in
+      case ( model.mode, model.ui.crSettings ) of
+        ( RuleForm r, Just s ) ->
           let
-            newMode  = if r.rule.id == ruleId then RuleTable else model.mode
-            ui = model.ui
-            crSettings = case ui.crSettings of
-              Just s  -> Just { s | message = ""}
-              Nothing -> Nothing
+            changeRequestNotification =
+              case changeRequestId of
+                Just crId -> crNotification model.contextPath crId
+                Nothing -> defaultNotification
 
-            newModel = { model | mode = newMode, ui = { ui | crSettings = crSettings} }
+            ( mode, crSettings, cmd ) =
+              if r.rule.id == id && not s.enableChangeRequest then
+                ( RuleTable
+                , Just { s | message = ""}
+                , Cmd.batch [defaultNotification, getRulesTree model, pushUrl ("", "") ]
+                )
+
+              else if s.enableChangeRequest then
+                ( model.mode
+                , Just { s | message = ""}
+                , changeRequestNotification
+                )
+
+              else
+                ( model.mode
+                , Just { s | message = ""}
+                , Cmd.batch [defaultNotification, getRulesTree model, pushUrl ("", "") ]
+                )
           in
-            (newModel, Cmd.batch [successNotification ("Successfully deleted rule '" ++ ruleName ++  "' (id: "++ ruleId.value ++")"), getRulesTree newModel, pushUrl ("", "") ])
-        _ -> (model, Cmd.none)
+          ( { model | mode = mode, ui = { ui | crSettings = crSettings} }, cmd )
+
+        ( RuleForm r, Nothing ) ->
+          let
+            newMode = if r.rule.id == id then RuleTable else model.mode
+          in
+          ( { model | mode = newMode }, Cmd.batch [defaultNotification, getRulesTree model, pushUrl ("", "") ] )
+
+        _ ->
+          (model, Cmd.none)
 
     DeleteRule (Err err) ->
       processApiError "Deleting Rule" err model
@@ -768,3 +784,19 @@ setModalState state ({ ui } as model) =
 setCrSettings : ChangeRequestSettings -> Model -> Model
 setCrSettings settings ({ ui } as model) =
   { model | ui = { ui | crSettings = Just settings } }
+
+
+crNotification : String -> String -> Cmd Msg
+crNotification contextPath crId =
+  let
+    message = "Change request #"++ crId ++" successfully created."
+    linkUrl = contextPath ++ "/secure/configurationManager/changes/changeRequest/" ++ crId
+    linkTxt = "See details of change request #" ++ crId
+    encodeToastInfo =
+      object
+      [ ("message", string message)
+      , ("linkUrl", string linkUrl)
+      , ("linkTxt", string linkTxt)
+      ]
+  in
+    linkSuccessNotification encodeToastInfo

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ApiCalls.elm
@@ -350,10 +350,9 @@ saveRuleDetails ruleDetails creation model =
   in
     req
 
-saveDisableAction : Rule -> Model ->  Cmd Msg
-saveDisableAction ruleDetails model =
+saveStatusAction : Rule -> Model ->  Cmd Msg
+saveStatusAction ruleDetails model =
   let
-    changeAction = "Disable "
     req =
       request
         { method  = "POST"

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
@@ -32,9 +32,18 @@ type alias Tag =
 type ModalState
     = NoModal
     | DeletionValidation Rule (Maybe ChangeRequestSettings)
-    | DeactivationValidation Rule (Maybe ChangeRequestSettings)
+    | DisableValidation Rule (Maybe ChangeRequestSettings)
+    | EnableValidation Rule (Maybe ChangeRequestSettings)
     | DeletionValidationCat (Category Rule)
     | SaveAuditMsg Bool Rule (Maybe Rule) ChangeRequestSettings
+
+
+type ModalAction
+    = Delete
+    | Create
+    | Update
+    | Disable
+    | Enable
 
 
 type RuleTarget
@@ -336,12 +345,14 @@ type Msg
     | GetTechniquesTreeResult (Result Error ( Category Technique, List Technique ))
     | DeleteRule (Result Error ( RuleId, String ))
     | DeleteCategory (Result Error ( String, String ))
-    | DisableRule
+    | SaveDisabledRule
+    | SaveEnabledRule
     | CloneRule Rule RuleId
-    | OpenDeletionPopup Rule
     | OpenDeletionPopupCat (Category Rule)
-    | OpenDeactivationPopup Rule
-    | OpenSaveAuditMsgPopup Rule ChangeRequestSettings
+    | OpenDeletionPopup Rule
+    | OpenDisablePopup
+    | OpenEnablePopup
+    | SaveRule Rule
     | ClosePopup Msg
     | Ignore
     | ToggleRow String String

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/DataTypes.elm
@@ -343,7 +343,7 @@ type Msg
     | GetRuleChanges (Result Error (Dict String (List Changes)))
     | GetRepairedReportsResult RuleId ZonedDateTime ZonedDateTime (Result Error (List RepairedReport))
     | GetTechniquesTreeResult (Result Error ( Category Technique, List Technique ))
-    | DeleteRule (Result Error ( RuleId, String ))
+    | DeleteRule (Result Error Rule)
     | DeleteCategory (Result Error ( String, String ))
     | SaveDisabledRule
     | SaveEnabledRule

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/JsonDecoder.elm
@@ -98,13 +98,9 @@ toTags lst =
     succeed
       ( List.map (\t -> Tag (Tuple.first t) (Tuple.second t)) concatList )
 
-decodeDeleteRuleResponse : Decoder (RuleId,String)
+decodeDeleteRuleResponse : Decoder Rule
 decodeDeleteRuleResponse =
-  at ["data", "rules" ](index 0
-  ( succeed Tuple.pair
-     |> required "id" (map RuleId string)
-     |> required "displayName" string
-  ))
+  at ["data", "rules" ] (index 0 decodeRule)
 
 decodeIdCategory: Decoder (String, String)
 decodeIdCategory =

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/View.elm
@@ -132,107 +132,36 @@ view model =
       CategoryForm details ->
         (editionTemplateCat model details)
 
-    changeAuditForm : ChangeRequestSettings -> Html Msg
-    changeAuditForm crSettings =
-      if crSettings.enableChangeMessage || crSettings.enableChangeRequest then
-        div []
-        [ h4 [class "audit-title"] [text "Change audit log"]
-        , ( if crSettings.enableChangeRequest then
-          div[class "form-group"]
-          [ label[]
-             [ text "Change request title"
-            ]
-            , input [type_ "text", class "form-control", onInput (\s -> UpdateCrSettings {crSettings | changeRequestName = s}), value crSettings.changeRequestName ][]
-          ]
-          else
-          text ""
-          )
-        , div[class "form-group"]
-          [ label[]
-            [ text "Change audit message"
-            , text (if crSettings.enableChangeMessage && crSettings.mandatoryChangeMessage then " (required)" else "")
-            ]
-            , textarea [class "form-control", placeholder crSettings.changeMessagePrompt, onInput (\s -> UpdateCrSettings {crSettings | message = s}), value crSettings.message ][]
-          ]
-        ]
-      else
-        text ""
-
     modal = case model.ui.modal of
       NoModal -> text ""
       DeletionValidation rule crSettings ->
-        let
-          (auditForm, btnDisabled) = case crSettings of
-            Just s  ->
-              ( changeAuditForm s
-              , (s.mandatoryChangeMessage && String.isEmpty s.message)
-              )
-            Nothing ->
-              ( text ""
-              , False
-              )
-        in
-          div [ tabindex -1, class "modal fade show", style "display" "block" ]
-          [ div [class "modal-backdrop fade show", onClick (ClosePopup Ignore)][]
-          , div [ class "modal-dialog" ] [
-              div [ class "modal-content" ] [
-                div [ class "modal-header" ] [
-                  h5 [ class "modal-title" ] [ text "Delete Rule"]
-                , button [type_ "button", class "btn-close", onClick (ClosePopup Ignore), attribute "aria-label" "Close"][]
-                ]
-              , div [ class "modal-body" ]
-                [ h4 [class "text-center"][text ("Are you sure you want to Delete rule '"++ rule.name ++"'?")]
-                , auditForm
-                ]
-              , div [ class "modal-footer" ] [
-                  button [ class "btn btn-default", onClick (ClosePopup Ignore) ]
-                  [ text "Cancel " ]
-                , button [ class "btn btn-danger", onClick (ClosePopup (CallApi False (deleteRule rule))), disabled btnDisabled ]
-                  [ text "Delete "
-                  , i [ class "fa fa-times-circle" ] []
-                  ]
-                ]
-              ]
-            ]
-          ]
-      DeactivationValidation rule crSettings ->
-        let
-          (txtDisabled, iconDisabled) = if rule.enabled then ("Disable", "fa fa-ban") else ("Enable", "fa fa-check-circle")
-          (auditForm, btnDisabled) = case crSettings of
-            Just s  ->
-              ( changeAuditForm s
-              , (s.mandatoryChangeMessage && String.isEmpty s.message)
-              )
-            Nothing ->
-              ( text ""
-              , False
-              )
+        viewModal
+        { action = Delete
+        , ruleName = rule.name
+        , crSettings = crSettings
+        , btnMsg = ClosePopup (CallApi False (deleteRule rule))
+        , btnClass = "btn btn-danger"
+        , btnIconClass = "fa fa-times-circle"
+        }
+      DisableValidation rule crSettings ->
+        viewModal
+        { action = Disable
+        , ruleName = rule.name
+        , crSettings = crSettings
+        , btnMsg = ClosePopup SaveDisabledRule
+        , btnClass = "btn btn-primary"
+        , btnIconClass = "fa fa-ban"
+        }
+      EnableValidation rule crSettings ->
+        viewModal
+        { action = Enable
+        , ruleName = rule.name
+        , crSettings = crSettings
+        , btnMsg = ClosePopup SaveEnabledRule
+        , btnClass = "btn btn-primary"
+        , btnIconClass = "fa fa-check-circle"
+        }
 
-        in
-          div [ tabindex -1, class "modal fade show", style "display" "block" ]
-          [ div [class "modal-backdrop fade show", onClick (ClosePopup Ignore)][]
-          , div [ class "modal-dialog" ] [
-              div [ class "modal-content" ]  [
-                div [ class "modal-header" ] [
-                  h5[ class "modal-title" ] [ text (txtDisabled ++" Rule")]
-                , button [type_ "button", class "btn-close", onClick (ClosePopup Ignore), attribute "aria-label" "Close"][]
-                ]
-              , div [ class "modal-body" ]
-                [ h4 [class "text-center"][text ("Are you sure you want to "++ String.toLower txtDisabled ++" rule '"++ rule.name ++"'?")]
-                , auditForm
-                ]
-              , div [ class "modal-footer" ] [
-                  button [ class "btn btn-default", onClick (ClosePopup Ignore) ]
-                  [ text "Cancel "
-                  ]
-                , button [ class "btn btn-primary", onClick (ClosePopup DisableRule), disabled btnDisabled ]
-                  [ text (txtDisabled ++ " ")
-                  , i [ class iconDisabled ] []
-                  ]
-                ]
-              ]
-            ]
-          ]
       DeletionValidationCat category ->
         div [ tabindex -1, class "modal fade show", style "display" "block" ]
          [ div [class "modal-backdrop fade show", onClick (ClosePopup Ignore)][]
@@ -257,49 +186,14 @@ view model =
            ]
          ]
       SaveAuditMsg creation rule originRule crSettings ->
-        let
-          action = if creation then "Create" else "Update"
-          saveBtnClass = if crSettings.enableChangeRequest then "btn-primary" else "btn-success"
-        in
-          div [ tabindex -1, class "modal fade show", style "display" "block" ]
-          [ div [class "modal-backdrop fade show", onClick (ClosePopup Ignore)][]
-          , div [ class "modal-dialog" ]
-            [ div [ class "modal-content" ]
-              [ div [ class "modal-header" ]
-                [ h5 [ class "modal-title" ] [ text (action ++" Rule")]
-                , button [type_ "button", class "btn-close", onClick (ClosePopup Ignore), attribute "aria-label" "Close"][]
-                ]
-              , div [ class "modal-body" ]
-                [ h4 [class "text-center"]
-                  [ text "Are you sure that you want to "
-                  , text (String.toLower action)
-                  , text " this rule ?"
-                  ]
-                , if crSettings.enableChangeRequest then
-                    div [class "text-center alert alert-info"]
-                    [ i [ class "fa fa-info-circle" ] []
-                    , text "Workflows are enabled, your change has to be validated in a change request"
-                    ]
-                  else
-                    text ""
-                , changeAuditForm crSettings
-                ]
-              , div [ class "modal-footer" ]
-                [ button [ class "btn btn-default", onClick (ClosePopup Ignore) ]
-                  [ text "Cancel "
-                  ]
-                , button [ class ("btn " ++ saveBtnClass), onClick (ClosePopup (CallApi True (saveRuleDetails rule (isNothing originRule)))), disabled (crSettings.mandatoryChangeMessage && String.isEmpty crSettings.message) ]
-                  ( if crSettings.enableChangeRequest then
-                    [ text "Open request"
-                    ]
-                  else
-                    [ text action
-                    ]
-                  )
-                ]
-              ]
-            ]
-          ]
+        viewModal
+        { action = if creation then Create else Update
+        , ruleName = rule.name
+        , crSettings = Just crSettings
+        , btnMsg = ClosePopup (CallApi True (saveRuleDetails rule (isNothing originRule)))
+        , btnClass = "btn btn-success"
+        , btnIconClass = ""
+        }
   in
     div [class "rudder-template"]
     [ div [class "template-sidebar sidebar-left"]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRuleDetails.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewRuleDetails.elm
@@ -43,7 +43,7 @@ editionTemplate model details =
       case originRule of
         Just or ->
           let
-            (txtDisabled, iconDisabled) = if rule.enabled then ("Disable", "fa fa-ban") else ("Enable", "fa fa-check-circle")
+            (txtDisabled, iconDisabled, editMsg) = if rule.enabled then ("Disable", "fa fa-ban", OpenDisablePopup) else ("Enable", "fa fa-check-circle", OpenEnablePopup)
           in
             (
             [ button [ class "btn btn-default dropdown-toggle" , attribute "data-bs-toggle" "dropdown" ]
@@ -58,7 +58,7 @@ editionTemplate model details =
                   ]
                 ]
               , li []
-                [ a [ class "dropdown-item", onClick (OpenDeactivationPopup rule)]
+                [ a [ class "dropdown-item", onClick editMsg]
                   [ i [ class iconDisabled] []
                   , text txtDisabled
                   ]
@@ -150,25 +150,6 @@ editionTemplate model details =
     nbDirectives = case originRule of
       Just oR -> Maybe.withDefault 0 details.numberOfDirectives
       Nothing -> 0
-
-    saveAction =
-      let
-        defaultAction = checkAction (CallApi True (saveRuleDetails rule (Maybe.Extra.isNothing details.originRule)))
-        checkAction action =
-          if String.isEmpty (String.trim rule.name) then
-            Ignore
-          else
-            action
-      in
-        case model.ui.crSettings of
-          Just cr ->
-            if cr.enableChangeMessage || cr.enableChangeRequest then
-              checkAction (OpenSaveAuditMsgPopup rule cr)
-            else
-              defaultAction
-          Nothing ->
-            defaultAction
-
   in
     div [class "main-container"]
     [ div [class "main-header "]
@@ -183,7 +164,7 @@ editionTemplate model details =
           :: (
             if model.ui.hasWriteRights then
               [ div [ class "btn-group" ]  topButtons
-              , btnSave model.ui.saving (String.isEmpty (String.trim rule.name)) saveAction
+              , btnSave model.ui.saving (String.isEmpty (String.trim rule.name)) (SaveRule rule)
               ]
             else
               []

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabNodes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewTabNodes.elm
@@ -92,7 +92,7 @@ nodesTab model details =
             , tbody []
               ( if (List.length childs) <= 0 then
                 [ tr[]
-                  [ td[class "empty", colspan 2][i [class"fa fa-exclamation-triangle"][], text "This rule is not applied on any Node."] ]
+                  [ td[class "empty", colspan 2][i [class"fa fa-exclamation-triangle"][], text "This rule is not applied on any node."] ]
                 ]
               else if List.length nodesChildren == 0 then
                 [ tr[]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewUtils.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/Rules/ViewUtils.elm
@@ -5,7 +5,7 @@ import Dict exposing (Dict)
 import Either exposing (Either(..))
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import Html.Events exposing (custom, onClick)
+import Html.Events exposing (custom, onClick, onInput)
 import Json.Decode as Decode
 import List
 import List.Extra
@@ -19,6 +19,7 @@ import Compliance.DataTypes exposing (..)
 import Compliance.Html exposing (buildComplianceBar)
 import Compliance.Utils exposing (..)
 import Ui.Datatable exposing (SortOrder(..), sortTable, thClass, Category, getAllCats, getAllElems, getSubElems)
+import Rules.ChangeRequest exposing (ChangeRequestSettings)
 
 
 onCustomClick : msg -> Html.Attribute msg
@@ -1076,3 +1077,124 @@ buildListCategories sep categoryId parentId c =
           List.append currentOption listCategories
     in
       newList
+
+
+viewCrSettingsAlert : ChangeRequestSettings -> Html Msg
+viewCrSettingsAlert cr =
+    if cr.enableChangeRequest then
+        div [class "text-center alert alert-info"]
+        [ i [ class "fa fa-info-circle" ] []
+        , text "Workflows are enabled, your change has to be validated in a change request"
+        ]
+    else
+        text ""
+
+
+actionText : ModalAction -> String
+actionText action =
+    case action of
+        Delete ->
+            "Delete"
+
+        Update ->
+            "Update"
+
+        Create ->
+            "Create"
+
+        Enable ->
+            "Enable"
+
+        Disable ->
+            "Disable"
+
+
+viewChangeAuditForm : ChangeRequestSettings -> Html Msg
+viewChangeAuditForm crSettings =
+    if crSettings.enableChangeMessage || crSettings.enableChangeRequest then
+      div []
+      [ if crSettings.enableChangeRequest then
+          div [class "text-center alert alert-info"]
+          [ i [ class "fa fa-info-circle" ] []
+          , text "Workflows are enabled, your change has to be validated in a change request"
+          ]
+        else
+          text ""
+      , h4 [class "audit-title"] [text "Change audit log"]
+      , ( if crSettings.enableChangeRequest then
+        div[class "form-group"]
+        [ label[]
+           [ text "Change request title"
+          ]
+          , input [type_ "text", class "form-control", onInput (\s -> UpdateCrSettings {crSettings | changeRequestName = s}), value crSettings.changeRequestName ][]
+        ]
+        else
+        text ""
+        )
+      , div[class "form-group"]
+        [ label[]
+          [ text "Change audit message"
+          , text (if crSettings.enableChangeMessage && crSettings.mandatoryChangeMessage then " (required)" else "")
+          ]
+          , textarea [class "form-control", placeholder crSettings.changeMessagePrompt, onInput (\s -> UpdateCrSettings {crSettings | message = s}), value crSettings.message ][]
+        ]
+      ]
+    else
+      text ""
+
+viewModal :
+    { action : ModalAction
+    , ruleName : String
+    , crSettings : Maybe ChangeRequestSettings
+    , btnMsg : Msg
+    , btnClass : String
+    , btnIconClass : String } -> Html Msg
+viewModal { action, ruleName, crSettings, btnMsg, btnClass, btnIconClass } =
+    let
+        ( auditForm, btnDisabled, changeRequestEnabled ) =
+            case crSettings of
+                Just s  ->
+                    ( viewChangeAuditForm s
+                    , (s.mandatoryChangeMessage && String.isEmpty s.message)
+                    , s.enableChangeRequest
+                    )
+
+                Nothing ->
+                    ( text ""
+                    , False
+                    , False
+                    )
+
+        buttonAttrs =
+            if changeRequestEnabled then
+                [ disabled btnDisabled, class "btn btn-primary", onClick btnMsg ]
+
+            else
+                [ disabled btnDisabled, class btnClass, onClick btnMsg ]
+
+        buttonHtml =
+            if changeRequestEnabled then
+                [ text "Open request" ]
+
+            else
+                [ text (actionText action), text " ", i [ class btnIconClass ] [] ]
+    in
+    div [ tabindex -1, class "modal fade show d-block" ]
+    [ div [class "modal-backdrop fade show", onClick (ClosePopup Ignore)][]
+    , div [ class "modal-dialog" ] [
+        div [ class "modal-content" ]  [
+          div [ class "modal-header" ] [
+            h5[ class "modal-title" ] [ text (actionText action ++ " rule")]
+          , button [type_ "button", class "btn-close", onClick (ClosePopup Ignore), attribute "aria-label" "Close"][]
+          ]
+        , div [ class "modal-body" ]
+          [ h4 [class "text-center"][text ("Are you sure you want to "++ String.toLower (actionText action) ++" rule '"++ ruleName ++"'?")]
+          , auditForm
+          ]
+        , div [ class "modal-footer" ]
+          [ button [ class "btn btn-default", onClick (ClosePopup Ignore) ] [ text "Cancel" ]
+          , button ((disabled btnDisabled) :: buttonAttrs) buttonHtml
+          ]
+        ]
+      ]
+    ]


### PR DESCRIPTION
https://issues.rudder.io/issues/28775

* There was many inconsistencies with all Modal, which is fixed by having a single `viewModal` :
  * it enforces that the button is always a `btn-primary` with `"Open request"` text, and there is an alert message when change requests are enabled
  * it has the logic of checking if the mandatory (or not) input message 

* Fixing the behavior consists in reading the `changeRequestId` from the result of the "DELETE API call" (the same exact thing is done for rule updates)
---
**Further improvements:**
* this PR only changes the Create/Update/Disable/Enable/Delete action modal, but we should take "Delete category" modal into account
* we could make a separate module `Modal.elm`, but it would have made the diff harder, and I do not know if `ModalState` should belong there