### PR TITLE
Fixes #28863: Datatables page number is not highlighted in footer

### DIFF
--- a/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.scss
+++ b/webapp/sources/rudder/rudder-web/src/main/style/rudder/rudder-datatable.scss
@@ -451,6 +451,11 @@ tr.parametersDescription {
   background-color: #fff;
   transition-property: background-color;
   transition-duration: .2s;
+
+  &.current,
+  &.current:hover {
+    background-color: $rudder-bg-gray;
+  }
 }
 .dataTables_paginate > .ui-button:hover,
 .dataTables_paginate > span > .ui-button:hover,


### PR DESCRIPTION
https://issues.rudder.io/issues/28863

~Added the gradient from Datatables' own CSS : https://github.com/DataTables/DataTablesSrc/blob/8a442bf764f44025d488848f6d7a80c020d0363a/css/dataTables.dataTables.scss#L316-L324~

Using our gray background

Result : 

<img width="655" height="67" alt="Screenshot From 2026-05-07 15-06-18" src="https://github.com/user-attachments/assets/a6625fba-1760-491a-9150-9194900a3d7d" />
