### PR TITLE
Fixes #28856: There is no documentation on special tenants value

### DIFF
--- a/webapp/sources/api-doc/components/schemas/api-account-new.yml
+++ b/webapp/sources/api-doc/components/schemas/api-account-new.yml
@@ -39,9 +39,7 @@ properties:
     format: rfc3339
     example: 2025-05-10T23:59:59Z
   tenants:
-    description: a comma separated list of tenants allowed for that account. See tenant documentation for syntax.
-    type: string
-    example: "*"
+    $ref: './tenant-ids.yml'
   authorizationType:
     description: >-
       Authorization type for that account: 

--- a/webapp/sources/api-doc/components/schemas/api-account-update.yml
+++ b/webapp/sources/api-doc/components/schemas/api-account-update.yml
@@ -32,9 +32,7 @@ properties:
     format: rfc3339
     example: 2025-05-10T23:59:59Z
   tenants:
-    description: a comma separated list of tenants allowed for that account. See tenant documentation for syntax.
-    type: string
-    example: "*"
+    $ref: './tenant-ids.yml'
   authorizationType:
     description: >-
       Authorization type for that account: 

--- a/webapp/sources/api-doc/components/schemas/api-account.yml
+++ b/webapp/sources/api-doc/components/schemas/api-account.yml
@@ -56,9 +56,7 @@ properties:
     format: rfc3339
     example: 2025-02-12T10:55:00Z
   tenants:
-    description: a comma separated list of tenants allowed for that account. See tenant documentation for syntax.
-    type: string
-    example: "*"
+    $ref: './tenant-ids.yml'
   authorizationType:
     description: >-
       Authorization type for that account: 

--- a/webapp/sources/api-doc/components/schemas/tenant-ids.yml
+++ b/webapp/sources/api-doc/components/schemas/tenant-ids.yml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: CC-BY-SA-2.0
+# SPDX-FileCopyrightText: 2013-2026 Normation SAS
+type: string
+description: a comma separated list of tenant IDs (validated with non empty alpha-num and hyphen) allowed for that account, or special value "\*" / "-".
+oneOf:
+  - const: '*'
+  - const: '-'
+  - pattern: '^([A-Za-z0-9][A-Za-z0-9_-]*)(,([A-Za-z0-9][A-Za-z0-9_-]*))*$'
+example: '*'

--- a/webapp/sources/rudder/rudder-web/src/main/resources/demo-rudder-users.xml
+++ b/webapp/sources/rudder/rudder-web/src/main/resources/demo-rudder-users.xml
@@ -94,6 +94,6 @@
 
 <authentication hash="argon2id" case-sensitivity="true">
   <!--
-    <user name="NAME" password="REPLACE_BY_HASH" permissions="ROLE" />
+    <user name="NAME" password="REPLACE_BY_HASH" permissions="ROLE" tenants="*" />
   -->
 </authentication>


### PR DESCRIPTION
https://issues.rudder.io/issues/28856

* Add a special `tenant-ids` schema in API doc, and the expected format (used only in API accounts for now, but it should later be used in user management too) : 
 
<img width="1669" height="378" alt="Screenshot From 2026-05-21 16-30-33" src="https://github.com/user-attachments/assets/94df85d4-122c-4f24-8059-31b80e1c19c4" />

* Mention the default `tenant="*"` in the demo users.xml file