### PR TITLE
Fixes #26574: Missing edit button on node documentation

### DIFF
--- a/webapp/sources/api-doc/components/schemas/node-full.yml
+++ b/webapp/sources/api-doc/components/schemas/node-full.yml
@@ -44,7 +44,7 @@ properties:
   description:
     type: string
     example: ""
-    description: A human intended description of the node (not used)
+    description: A human intended description of the node
   ipAddresses:
     type: array
     description: IP addresses of the node (IPv4 and IPv6)

--- a/webapp/sources/api-doc/components/schemas/node-settings.yml
+++ b/webapp/sources/api-doc/components/schemas/node-settings.yml
@@ -38,3 +38,7 @@ properties:
     example: enabled
   agentKey:
     $ref: agent-key.yml
+  documentation:
+    type: string
+    description: Human-readable node documentation.
+    example: Rudder root node

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeDescription.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeDescription.elm
@@ -1,0 +1,98 @@
+port module NodeDescription exposing (..)
+
+import Browser
+import Http
+import NodeDescription.ApiCalls exposing (saveNodeDescription)
+import NodeDescription.DataTypes exposing (..)
+import NodeDescription.Init exposing (..)
+import NodeDescription.View exposing (..)
+
+
+port successNotification : String -> Cmd msg
+
+
+port errorNotification : String -> Cmd msg
+
+
+subscriptions : Model -> Sub Msg
+subscriptions _ =
+    Sub.none
+
+
+main =
+    Browser.element
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = subscriptions
+        }
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        GetNodeDescription result ->
+            case result of
+                Ok description ->
+                    ( { model | currentDescription = description, newDescription = description }, Cmd.none )
+
+                Err error ->
+                    processApiError "fetching node description" error model
+
+        SetNodeDescription result ->
+            case result of
+                Ok description ->
+                    ( { model | currentDescription = description, newDescription = description }, successNotification "Node description modified successfully" )
+
+                Err error ->
+                    processApiError "modifying node description" error model
+
+        EditNodeDescription newDescription ->
+            ( { model | newDescription = newDescription }, Cmd.none )
+
+        ToggleMode ->
+            case model.editMode of
+                NoNodeWriteAuth ->
+                    ( model, Cmd.none )
+
+                HasNodeWriteAuth Read ->
+                    ( { model | editMode = HasNodeWriteAuth Write }, Cmd.none )
+
+                HasNodeWriteAuth Write ->
+                    update SubmitDescription { model | editMode = HasNodeWriteAuth Read }
+
+        SubmitDescription ->
+            if model.currentDescription == model.newDescription then
+                ( model, Cmd.none )
+
+            else
+                ( model, saveNodeDescription model )
+
+
+processApiError : String -> Http.Error -> Model -> ( Model, Cmd Msg )
+processApiError apiName err model =
+    let
+        message =
+            case err of
+                Http.BadUrl url ->
+                    "The URL " ++ url ++ " was invalid"
+
+                Http.Timeout ->
+                    "Unable to reach the server, try again"
+
+                Http.NetworkError ->
+                    "Unable to reach the server, check your network connection"
+
+                Http.BadStatus 500 ->
+                    "The server had a problem, try again later"
+
+                Http.BadStatus 400 ->
+                    "Verify your information and try again"
+
+                Http.BadStatus _ ->
+                    "Unknown error"
+
+                Http.BadBody errorMessage ->
+                    errorMessage
+    in
+    ( model, errorNotification ("Error when " ++ apiName ++ ", details: \n" ++ message) )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeDescription/ApiCalls.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeDescription/ApiCalls.elm
@@ -1,0 +1,38 @@
+module NodeDescription.ApiCalls exposing (getNodeDescription, getUrl, saveNodeDescription)
+
+import Http exposing (..)
+import NodeDescription.DataTypes exposing (..)
+import NodeDescription.JsonDecoder exposing (..)
+import NodeDescription.JsonEncoder exposing (..)
+import Url.Builder exposing (QueryParameter)
+
+
+getUrl : Model -> List String -> List QueryParameter -> String
+getUrl model url p =
+    Url.Builder.relative (model.contextPath :: "secure" :: "api" :: url) p
+
+
+getNodeDescription : Model -> Cmd Msg
+getNodeDescription model =
+    request
+        { method = "GET"
+        , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+        , url = getUrl model [ "nodes", model.nodeId.value ] []
+        , body = emptyBody
+        , expect = expectJson GetNodeDescription decodeGetDescription
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+
+
+saveNodeDescription : Model -> Cmd Msg
+saveNodeDescription model =
+    request
+        { method = "POST"
+        , headers = [ header "X-Requested-With" "XMLHttpRequest" ]
+        , url = getUrl model [ "nodes", model.nodeId.value ] []
+        , body = encodeNodeDescription model |> jsonBody
+        , expect = expectJson SetNodeDescription decodeSetDescription
+        , timeout = Nothing
+        , tracker = Nothing
+        }

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeDescription/DataTypes.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeDescription/DataTypes.elm
@@ -1,0 +1,31 @@
+module NodeDescription.DataTypes exposing (..)
+
+import Http exposing (Error)
+import NodeCompliance.DataTypes exposing (NodeId)
+
+
+type alias Model =
+    { nodeId : NodeId
+    , contextPath : String
+    , currentDescription : String -- in this app, "description" and "documentation" denote the same field
+    , newDescription : String
+    , editMode : EditMode
+    }
+
+
+type EditMode
+    = NoNodeWriteAuth
+    | HasNodeWriteAuth Mode
+
+
+type Mode
+    = Read
+    | Write
+
+
+type Msg
+    = GetNodeDescription (Result Error String)
+    | SetNodeDescription (Result Error String)
+    | EditNodeDescription String
+    | ToggleMode
+    | SubmitDescription

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeDescription/Init.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeDescription/Init.elm
@@ -1,0 +1,21 @@
+module NodeDescription.Init exposing (init)
+
+import NodeCompliance.DataTypes exposing (NodeId)
+import NodeDescription.ApiCalls exposing (..)
+import NodeDescription.DataTypes exposing (EditMode(..), Mode(..), Model, Msg)
+
+
+init : { nodeId : String, contextPath : String, nodeWrite : Bool } -> ( Model, Cmd Msg )
+init flags =
+    let
+        mode =
+            if flags.nodeWrite then
+                HasNodeWriteAuth Read
+
+            else
+                NoNodeWriteAuth
+
+        initModel =
+            Model (NodeId flags.nodeId) flags.contextPath "" "" mode
+    in
+    ( initModel, Cmd.batch [ getNodeDescription initModel ] )

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeDescription/JsonDecoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeDescription/JsonDecoder.elm
@@ -1,0 +1,19 @@
+module NodeDescription.JsonDecoder exposing (decodeGetDescription, decodeSetDescription)
+
+import Json.Decode exposing (Decoder, at, field, index, string, succeed)
+import Json.Decode.Field exposing (optional)
+
+
+decodeGetDescription : Decoder String
+decodeGetDescription =
+    let
+        continuation : Maybe String -> Decoder String
+        continuation =
+            Maybe.withDefault "" >> succeed
+    in
+    at [ "data", "nodes" ] (index 0 (optional "description" string continuation))
+
+
+decodeSetDescription : Decoder String
+decodeSetDescription =
+    at [ "data" ] (field "documentation" string)

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeDescription/JsonEncoder.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeDescription/JsonEncoder.elm
@@ -1,0 +1,9 @@
+module NodeDescription.JsonEncoder exposing (encodeNodeDescription)
+
+import Json.Encode as Encode exposing (list, object, string)
+import NodeDescription.DataTypes exposing (Model)
+
+
+encodeNodeDescription : Model -> Encode.Value
+encodeNodeDescription model =
+    object [ ( "documentation", string model.newDescription ) ]

--- a/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeDescription/View.elm
+++ b/webapp/sources/rudder/rudder-web/src/main/elm/sources/NodeDescription/View.elm
@@ -1,0 +1,77 @@
+module NodeDescription.View exposing (view)
+
+import Dom exposing (addClass, appendNodeList, element)
+import Html exposing (Html, div, i, label, span, text, textarea)
+import Html.Attributes exposing (class, for, id, maxlength, name, title)
+import Html.Events exposing (onClick, onInput)
+import Markdown
+import NodeDescription.DataTypes exposing (..)
+
+
+view : Model -> Html Msg
+view model =
+    div [] [ descriptionTextArea model ]
+
+
+descriptionTextArea : Model -> Html Msg
+descriptionTextArea model =
+    let
+        inputClass =
+            "form-control col-xs-12"
+
+        textArea =
+            case model.editMode of
+                HasNodeWriteAuth Write ->
+                    textarea
+                        [ name "node-description"
+                        , id "node-description"
+                        , maxlength 255
+                        , onInput EditNodeDescription
+                        , class inputClass
+                        ]
+                        [ text model.newDescription ]
+
+                _ ->
+                    Dom.render
+                        (element "div"
+                            |> addClass "markdown"
+                            |> appendNodeList (Markdown.toHtml Nothing model.newDescription)
+                        )
+
+        editButtons =
+            case model.editMode of
+                NoNodeWriteAuth ->
+                    text ""
+
+                HasNodeWriteAuth Read ->
+                    i
+                        [ class "fa fa-pencil ms-2 text-primary cursorPointer edit-node-documentation"
+                        , onClick ToggleMode
+                        , title "Edit node documentation"
+                        ]
+                        []
+
+                HasNodeWriteAuth Write ->
+                    i
+                        [ class "fa fa-check ms-2 text-primary cursorPointer save-node-documentation"
+                        , onClick ToggleMode
+                        , title "Save node documentation"
+                        ]
+                        []
+    in
+    div
+        [ id "node-description" ]
+        [ div
+            [ class "row" ]
+            [ label
+                [ for "node-description-label", class "col-xs-12" ]
+                [ span [ class "fw-normal" ]
+                    [ text "Documentation"
+                    , editButtons
+                    ]
+                ]
+            , div
+                [ class "col-xs-12" ]
+                [ textArea ]
+            ]
+        ]

--- a/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
+++ b/webapp/sources/rudder/rudder-web/src/main/scala/com/normation/rudder/web/services/DisplayNode.scala
@@ -275,7 +275,7 @@ object DisplayNode extends Loggable {
           <button class="nav-link" data-bs-toggle="tab" data-bs-target={
         htmlId_#(jsId, "sd_fs_")
       } type="button" role="tab" aria-controls={htmlId_#(jsId, "sd_fs_")}>File systems</button>
-      </li> ::
+        </li> ::
       <li class="nav-item">
           <button class="nav-link" data-bs-toggle="tab" data-bs-target={
         htmlId_#(jsId, "sd_net_")
@@ -507,30 +507,30 @@ object DisplayNode extends Loggable {
     }
 
     <div class="header-title">
-    <div class={"os-logo " ++ sm.node.main.osDetails.os.name.toLowerCase()} data-bs-toggle="tooltip" title={osTooltip}></div>
-    <h1>
-      <div id="nodeHeaderInfo">
-        <span>{sm.node.main.hostname}</span>
-        <span class="machine-os-info">
-          <span class="machine-info">{sm.node.main.osDetails.fullName}</span>
-          <span class="machine-info ram">{sm.node.ram.map(_.toStringMo).getOrElse("-")}</span>
-          <span class="fa fa-info-circle icon-info me-1" data-bs-toggle="tooltip" data-bs-placement="bottom" title={
+      <div class={"os-logo " ++ sm.node.main.osDetails.os.name.toLowerCase()} data-bs-toggle="tooltip" title={osTooltip}></div>
+      <h1>
+        <div id="nodeHeaderInfo">
+          <span>{sm.node.main.hostname}</span>
+          <span class="machine-os-info">
+            <span class="machine-info">{sm.node.main.osDetails.fullName}</span>
+            <span class="machine-info ram">{sm.node.ram.map(_.toStringMo).getOrElse("-")}</span>
+            <span class="fa fa-info-circle icon-info me-1" data-bs-toggle="tooltip" data-bs-placement="bottom" title={
       machineTooltip
     }></span>
-        </span>
-        {nodeStateIcon}
+          </span>
+          {nodeStateIcon}
+        </div>
+        <div class="header-subtitle">
+          <a class="clipboard" title="Copy to clipboard" onclick={s"copy('${sm.node.main.id.value}')"}>
+            <span id="nodeHeaderId">{sm.node.main.id.value}</span>
+            <i class="ion ion-clipboard"></i>
+          </a>
+        </div>
+      </h1>
+      <div class="header-buttons">
+        {deleteBtn}
       </div>
-      <div class="header-subtitle">
-        <a class="clipboard" title="Copy to clipboard" onclick={s"copy('${sm.node.main.id.value}')"}>
-          <span id="nodeHeaderId">{sm.node.main.id.value}</span>
-          <i class="ion ion-clipboard"></i>
-        </a>
-      </div>
-    </h1>
-    <div class="header-buttons">
-      {deleteBtn}
     </div>
-  </div>
   }
 
   // mimic the content of server_details/ShowNodeDetailsFromNode
@@ -661,15 +661,28 @@ object DisplayNode extends Loggable {
         .getOrElse("none available")
     }
           </div>
-          
+
         </div>
         <div class="rudder-info">
           <h3>Documentation</h3>
-          <div class="markdown" id="nodeDocumentation">
-          </div>
           {
+      <div id="nodedocumentation-app"></div> ++
       WithNonce.scriptWithNonce(
-        Script(OnLoad(JsRaw(s"generateMarkdown(${Str(nodeFact.documentation.getOrElse("")).toJsCmd}, '#nodeDocumentation')")))
+        Script(OnLoad(JsRaw((s"""
+                                |const nodeDocumentation = document.getElementById("nodedocumentation-app")
+                                |const initValues = {
+                                |  nodeId : "${nodeFact.id.value}",
+                                |  contextPath : contextPath,
+                                |  nodeWrite : CanWriteNode
+                                |};
+                                |const app = Elm.NodeDescription.init({node: nodeDocumentation, flags: initValues});
+                                |app.ports.errorNotification.subscribe(function(str) {
+                                |  createErrorNotification(str)
+                                |});
+                                |app.ports.successNotification.subscribe(function(str) {
+                                |  createSuccessNotification(str)
+                                |});
+                                |""".stripMargin))))
       )
     }
         </div>
@@ -700,16 +713,16 @@ object DisplayNode extends Loggable {
       }
       s"${nodeFact.rudderAgent.agentType.displayName} (${nodeFact.rudderAgent.version.value} with ${capabilities})"
     }
-            </div>
-            {displayPolicyServerInfos(nodeFact.toFullInventory)}
-            <div>
-              {
+        </div>
+        {displayPolicyServerInfos(nodeFact.toFullInventory)}
+        <div>
+          {
       creationDate.map { creation =>
         <xml:group><label>Accepted since:</label> {DateFormaterService.getDisplayDate(creation)}</xml:group>
       }.getOrElse(NodeSeq.Empty)
     }
-            </div>
-            {displaySecurityInfo(nodeFact)}
+        </div>
+        {displaySecurityInfo(nodeFact)}
       </div>
     </div>
   }
@@ -768,7 +781,7 @@ object DisplayNode extends Loggable {
               <div><label>Security token fingerprint (sha1): </label> <samp>{
                 SHA1.hash(cert.getEncoded).grouped(2).mkString(":")
               }</samp></div>
-                    <div><label>Security token expiration date: </label> {
+                <div><label>Security token expiration date: </label> {
                 DateFormaterService.getDisplayDate(new DateTime(cert.getNotAfter, DateTimeZone.UTC))
               }</div>
             )
@@ -962,20 +975,20 @@ object DisplayNode extends Loggable {
           </div>
         case Full(seq)                                       =>
           <table cellspacing="0" id={htmlId(jsId, eltName + "_")} class="tablewidth">
-          {
+            {
             title match {
               case None        => NodeSeq.Empty
               case Some(title) => <div style="text-align:center"><b>{title}</b></div>
             }
           }
-          <thead>
-          <tr class="head">
-          </tr>
-            <tr class="head">{
+            <thead>
+              <tr class="head">
+              </tr>
+              <tr class="head">{
             columns.map(h => <th>{h._1}</th>).toSeq
           }</tr>
-          </thead>
-          <tbody class="toggle-color">{
+            </thead>
+            <tbody class="toggle-color">{
             seq.flatMap(x =>
               <tr>{columns.flatMap { case (header, renderLine) => <td class="text-break">{renderLine(x)}</td> }}</tr>
             )
@@ -1174,12 +1187,12 @@ object DisplayNode extends Loggable {
           <td>
             <pre class="json-inventory-vars">{value}</pre>
           </td>
-          <td>
-            <span class="ion ion-clipboard copy-actions" onclick={s"copy('${value}')"}></span>
-          </td>
+            <td>
+              <span class="ion ion-clipboard copy-actions" onclick={s"copy('${value}')"}></span>
+            </td>
         }
       }
-     </tr>
+      </tr>
     }
 
     val os = sm.node.main.osDetails.transformInto[OsDetailsJson]

--- a/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/server/server_details.html
+++ b/webapp/sources/rudder/rudder-web/src/main/webapp/templates-hidden/server/server_details.html
@@ -67,6 +67,7 @@
   <div class="main-header">
     <head_merge>
       <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-nodeproperties.js"></script>
+      <script data-lift="with-cached-resource" src="/javascript/rudder/elm/rudder-nodedescription.js"></script>
       <script data-lift="with-nonce">
         var CanWriteNode = false;
         var CanReadNode  = false;


### PR DESCRIPTION
https://issues.rudder.io/issues/26574

This PR aims to add a text input on every node's page so that its documentation can be modified

read mode :

<img width="1119" height="680" alt="image" src="https://github.com/user-attachments/assets/39d4dca0-d27a-4c3d-9a39-6ccf96eefc41" />

edit mode : 

<img width="1119" height="680" alt="image" src="https://github.com/user-attachments/assets/c3cf2d59-709b-45a1-8854-0060eb12e5ba" />
